### PR TITLE
Soft-delete: retire agents instead of permanent deletion

### DIFF
--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -6,8 +6,15 @@
 
     let agentList = [];
     let agentCount = 0;
+    let retiredList = [];
+    let retiredCount = 0;
     let currentAgent = '';
     let refreshInterval;
+
+    // Retire modal state
+    let retireModalOpen = false;
+    let pendingRetireAgent = '';
+    let retireConfirmInput = '';
 
     // Detail panel state
     let detailOpen = false;
@@ -70,13 +77,41 @@
         } catch (e) {
             console.error('Failed to refresh agents:', e);
         }
+        try {
+            const retired = await api('GET', '/agents/retired');
+            retiredList = retired.agents || [];
+            retiredCount = retired.count;
+        } catch (e) {
+            retiredList = [];
+            retiredCount = 0;
+        }
     }
 
-    async function deleteAgent(name) {
-        if (!confirm(`Delete agent "${name}" and all its directives/tokens?`)) return;
+    function openRetireModal(name) {
+        pendingRetireAgent = name;
+        retireConfirmInput = '';
+        retireModalOpen = true;
+    }
+
+    function closeRetireModal() {
+        retireModalOpen = false;
+        pendingRetireAgent = '';
+        retireConfirmInput = '';
+    }
+
+    async function confirmRetire() {
+        if (!pendingRetireAgent || retireConfirmInput !== pendingRetireAgent) return;
+        const name = pendingRetireAgent;
+        closeRetireModal();
         await api('DELETE', `/agents/${name}`);
-        toast(`${name} deleted`);
+        toast(`${name} retired`);
         if (currentAgent === name) closeDetail();
+        refreshAgents();
+    }
+
+    async function restoreAgent(name) {
+        await api('POST', `/agents/${name}/restore`);
+        toast(`${name} restored`);
         refreshAgents();
     }
 
@@ -200,7 +235,7 @@
                             </div>
                             <div class="agent-actions">
                                 <button class="btn btn-sm btn-primary" on:click={() => openDetail(a.name)}>Configure</button>
-                                <button class="btn btn-sm btn-danger" on:click={() => deleteAgent(a.name)}>Delete</button>
+                                <button class="btn-danger-text" on:click={() => openRetireModal(a.name)}>retire</button>
                             </div>
                         </div>
                     {/each}
@@ -208,6 +243,53 @@
             {/if}
         </div>
     </div>
+
+    <!-- Retired Agents -->
+    {#if retiredCount > 0}
+        <div class="section">
+            <div class="section-header">
+                <div class="section-title" style="color:var(--gray-mid)">Retired <span style="font-weight:400">({retiredCount})</span></div>
+            </div>
+            <div class="section-body">
+                <div class="agent-grid">
+                    {#each retiredList as a}
+                        <div class="agent-card" style="opacity:0.6;border-style:dashed">
+                            <div class="agent-name">{a.display_name || a.name}</div>
+                            <div class="agent-meta">
+                                <span class="badge" style="background:#fef2f2;color:var(--red)">Retired</span>
+                                <span class="badge badge-model">{a.model}</span>
+                                {#if a.role}<span class="badge" style="background:var(--gray-light);color:var(--gray-dark)">{a.role}</span>{/if}
+                            </div>
+                            <div class="agent-stats">
+                                <span>retired {timeAgo(a.retired_at)}</span>
+                                <span>created {timeAgo(a.created_at)}</span>
+                            </div>
+                            <div class="agent-actions">
+                                <button class="btn btn-sm btn-success" on:click={() => restoreAgent(a.name)}>Restore</button>
+                            </div>
+                        </div>
+                    {/each}
+                </div>
+            </div>
+        </div>
+    {/if}
+
+    <!-- Retire Confirmation Modal -->
+    {#if retireModalOpen}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <div class="delete-modal-overlay active" on:click|self={closeRetireModal}>
+            <div class="delete-modal">
+                <h3>Retire Agent</h3>
+                <p>This will retire <strong style="color:var(--red)">{pendingRetireAgent}</strong> and disable all its sessions. The agent's data will be preserved and can be restored later.</p>
+                <p>Type the agent name to confirm:</p>
+                <input type="text" bind:value={retireConfirmInput} autocomplete="off" spellcheck="false" placeholder="agent name">
+                <div class="modal-actions">
+                    <button class="btn btn-sm" on:click={closeRetireModal}>Cancel</button>
+                    <button class="btn btn-sm btn-confirm-delete" class:ready={retireConfirmInput === pendingRetireAgent} disabled={retireConfirmInput !== pendingRetireAgent} on:click={confirmRetire}>Retire</button>
+                </div>
+            </div>
+        </div>
+    {/if}
 
     <!-- Agent Detail Panel -->
     {#if detailOpen}
@@ -551,6 +633,18 @@
     .wizard-summary { font-family: var(--font-mono); font-size: 0.85rem; line-height: 2; }
     .wizard-summary :global(.val) { color: var(--yellow); font-weight: 700; }
     .val { color: var(--yellow); font-weight: 700; }
+
+    .btn-danger-text { background: none; border: none; color: var(--gray-mid); font-size: 0.6rem; cursor: pointer; padding: 0.2rem 0.4rem; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.05em; }
+    .btn-danger-text:hover { color: var(--red); }
+
+    .delete-modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 1000; display: flex; align-items: center; justify-content: center; }
+    .delete-modal { background: var(--white); border: var(--border); padding: 1.5rem; max-width: 400px; width: 90%; }
+    .delete-modal h3 { font-family: var(--font-mono); font-size: 0.9rem; margin-bottom: 0.75rem; text-transform: uppercase; }
+    .delete-modal p { font-size: 0.8rem; color: var(--gray-dark); margin-bottom: 1rem; line-height: 1.4; }
+    .delete-modal input { width: 100%; padding: 0.5rem; border: var(--border); font-family: var(--font-mono); font-size: 0.8rem; margin-bottom: 1rem; }
+    .modal-actions { display: flex; gap: 0.5rem; justify-content: flex-end; }
+    .btn-confirm-delete { background: var(--gray-light); color: var(--gray-mid); border: 2px solid var(--gray-light); cursor: not-allowed; }
+    .btn-confirm-delete.ready { background: var(--red); color: var(--white); border-color: var(--red); cursor: pointer; }
 
     @media (max-width: 900px) {
         .agent-grid { grid-template-columns: 1fr; }

--- a/frontend/agents.html
+++ b/frontend/agents.html
@@ -207,6 +207,16 @@
             </div>
         </div>
 
+        <!-- Retired Agents -->
+        <div class="section" id="retiredSection" style="display:none">
+            <div class="section-header">
+                <div class="section-title" style="color:var(--gray-mid)">Retired <span style="font-weight:400" id="retiredCount">(0)</span></div>
+            </div>
+            <div class="section-body">
+                <div class="agent-grid" id="retiredGrid"></div>
+            </div>
+        </div>
+
         <!-- Agent Detail Panel -->
         <div class="section detail-panel" id="detailPanel">
             <div class="section-header">
@@ -895,7 +905,36 @@
                         </div>
                         <div class="agent-actions">
                             <button class="btn btn-sm btn-primary" onclick="openDetail('${a.name}')">Configure</button>
-                            <button class="btn-danger-text" onclick="openDeleteModal('${a.name}')">delete</button>
+                            <button class="btn-danger-text" onclick="openDeleteModal('${a.name}')">retire</button>
+                        </div>
+                    </div>
+                `).join('');
+            }
+
+            // Load retired agents
+            const retired = await api('GET', '/agents/retired');
+            const retiredSection = document.getElementById('retiredSection');
+            const retiredGrid = document.getElementById('retiredGrid');
+            document.getElementById('retiredCount').textContent = `(${retired.count})`;
+
+            if (retired.count === 0) {
+                retiredSection.style.display = 'none';
+            } else {
+                retiredSection.style.display = 'block';
+                retiredGrid.innerHTML = retired.agents.map(a => `
+                    <div class="agent-card" style="opacity:0.6;border-style:dashed">
+                        <div class="agent-name">${a.display_name || a.name}</div>
+                        <div class="agent-meta">
+                            <span class="badge" style="background:#fef2f2;color:var(--red)">Retired</span>
+                            <span class="badge badge-model">${a.model}</span>
+                            ${a.role ? `<span class="badge" style="background:var(--gray-light);color:var(--gray-dark)">${a.role}</span>` : ''}
+                        </div>
+                        <div class="agent-stats">
+                            <span>retired ${timeAgo(a.retired_at)}</span>
+                            <span>created ${timeAgo(a.created_at)}</span>
+                        </div>
+                        <div class="agent-actions">
+                            <button class="btn btn-sm btn-success" onclick="restoreAgent('${a.name}')">Restore</button>
                         </div>
                     </div>
                 `).join('');
@@ -938,8 +977,14 @@
             const name = pendingDeleteAgent;
             closeDeleteModal();
             await api('DELETE', `/agents/${name}`);
-            toast(`${name} deleted`);
+            toast(`${name} retired`);
             if (currentAgent === name) closeDetail();
+            refreshAgents();
+        }
+
+        async function restoreAgent(name) {
+            await api('POST', `/agents/${name}/restore`);
+            toast(`${name} restored`);
             refreshAgents();
         }
 
@@ -1218,13 +1263,13 @@
 <!-- Delete Confirmation Modal -->
 <div class="delete-modal-overlay" id="deleteModal" onclick="if(event.target===this)closeDeleteModal()">
     <div class="delete-modal">
-        <h3>Delete Agent</h3>
-        <p>This will permanently delete <strong id="deleteAgentLabel"></strong> and all its directives, tokens, and schedules. This cannot be undone.</p>
+        <h3>Retire Agent</h3>
+        <p>This will retire <strong id="deleteAgentLabel"></strong> and disable all its sessions. The agent's data (directives, tokens, schedules) will be preserved and can be restored later.</p>
         <p>Type the agent name to confirm:</p>
         <input type="text" id="deleteConfirmInput" autocomplete="off" spellcheck="false" placeholder="agent name">
         <div class="modal-actions">
             <button class="btn btn-sm" onclick="closeDeleteModal()">Cancel</button>
-            <button class="btn btn-sm btn-confirm-delete" id="deleteConfirmBtn" disabled onclick="confirmDelete()">Delete</button>
+            <button class="btn btn-sm btn-confirm-delete" id="deleteConfirmBtn" disabled onclick="confirmDelete()">Retire</button>
         </div>
     </div>
 </div>

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -59,6 +59,8 @@ class Agent:
     auto_start: bool = False  # Auto-spawn main session on server boot
     heartbeat_interval: int = 0  # Seconds between heartbeats (0 = disabled)
     role: str = ""  # Agent role: sidekick, lead, worker, specialist
+    status: str = "active"  # active or retired
+    retired_at: float = 0.0  # When was this agent retired
     created_at: float = 0.0
     updated_at: float = 0.0
 
@@ -85,6 +87,8 @@ class Agent:
             "auto_start": self.auto_start,
             "heartbeat_interval": self.heartbeat_interval,
             "role": self.role,
+            "status": self.status,
+            "retired_at": self.retired_at,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }
@@ -347,6 +351,8 @@ class AgentRegistry:
             ("role", "TEXT NOT NULL DEFAULT ''"),
             ("users", "TEXT NOT NULL DEFAULT ''"),
             ("boundaries", "TEXT NOT NULL DEFAULT ''"),
+            ("status", "TEXT NOT NULL DEFAULT 'active'"),
+            ("retired_at", "REAL NOT NULL DEFAULT 0"),
         ]
         for col, typedef in migrations:
             if col not in existing:
@@ -468,7 +474,7 @@ class AgentRegistry:
         "permission_mode, allowed_tools, max_turns, timeout, "
         "restart_threshold_pct, auto_restart, parent, groups, "
         "max_sessions, enabled, auto_start, heartbeat_interval, role, "
-        "created_at, updated_at, users, boundaries"
+        "created_at, updated_at, users, boundaries, status, retired_at"
     )
 
     def get(self, name: str) -> Agent | None:
@@ -481,10 +487,14 @@ class AgentRegistry:
             return None
         return self._row_to_agent(row)
 
-    def list(self, *, parent: str = "", group: str = "", enabled_only: bool = False) -> list[Agent]:
-        """List agents with optional filters."""
+    def list(self, *, parent: str = "", group: str = "", enabled_only: bool = False,
+             include_retired: bool = False) -> list[Agent]:
+        """List agents with optional filters. Excludes retired agents by default."""
         sql = f"SELECT {self._AGENT_COLUMNS} FROM agents WHERE 1=1"
         params: list = []
+
+        if not include_retired:
+            sql += " AND (status IS NULL OR status != 'retired')"
 
         if parent:
             sql += " AND parent=?"
@@ -501,8 +511,40 @@ class AgentRegistry:
 
         return agents
 
+    def list_retired(self) -> list[Agent]:
+        """List only retired agents."""
+        sql = f"SELECT {self._AGENT_COLUMNS} FROM agents WHERE status='retired' ORDER BY retired_at DESC"
+        rows = self._db.execute(sql).fetchall()
+        return [self._row_to_agent(r) for r in rows]
+
+    def retire(self, name: str) -> bool:
+        """Retire an agent (soft delete). Preserves all data."""
+        now = time.time()
+        cursor = self._db.execute(
+            "UPDATE agents SET status='retired', enabled=0, retired_at=?, updated_at=? WHERE name=?",
+            (now, now, name),
+        )
+        self._db.commit()
+        if cursor.rowcount > 0:
+            _log(f"agents: retired {name}")
+            return True
+        return False
+
+    def restore(self, name: str) -> bool:
+        """Restore a retired agent back to active."""
+        now = time.time()
+        cursor = self._db.execute(
+            "UPDATE agents SET status='active', enabled=1, retired_at=0, updated_at=? WHERE name=?",
+            (now, name),
+        )
+        self._db.commit()
+        if cursor.rowcount > 0:
+            _log(f"agents: restored {name}")
+            return True
+        return False
+
     def delete(self, name: str) -> bool:
-        """Delete an agent and all its directives/tokens (cascade)."""
+        """Permanently delete an agent and all its directives/tokens (cascade)."""
         cursor = self._db.execute("DELETE FROM agents WHERE name=?", (name,))
         self._db.commit()
         if cursor.rowcount > 0:
@@ -907,6 +949,8 @@ class AgentRegistry:
             updated_at=row[20] if len(row) > 20 else row[17],
             users=row[21] if len(row) > 21 else "",
             boundaries=row[22] if len(row) > 22 else "",
+            status=row[23] if len(row) > 23 else "active",
+            retired_at=row[24] if len(row) > 24 else 0.0,
         )
 
     def close(self) -> None:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1135,6 +1135,12 @@ def create_api(
         result = agents.list(group=group, enabled_only=enabled_only)
         return {"agents": [a.to_dict() for a in result], "count": len(result)}
 
+    @app.get("/agents/retired")
+    async def list_retired_agents():
+        """List all retired agents."""
+        result = agents.list_retired()
+        return {"agents": [a.to_dict() for a in result], "count": len(result)}
+
     @app.get("/agents/{name}")
     async def get_agent(name: str):
         """Get an agent by name."""
@@ -1155,12 +1161,20 @@ def create_api(
         return agent.to_dict()
 
     @app.delete("/agents/{name}")
-    async def delete_agent(name: str):
-        """Delete an agent and all its directives/tokens."""
-        deleted = agents.delete(name)
-        if not deleted:
+    async def retire_agent(name: str):
+        """Retire an agent (soft delete). Preserves all data for restoration."""
+        retired = agents.retire(name)
+        if not retired:
             raise HTTPException(404, f"Agent '{name}' not found")
-        return {"deleted": True, "name": name}
+        return {"retired": True, "name": name}
+
+    @app.post("/agents/{name}/restore")
+    async def restore_agent(name: str):
+        """Restore a retired agent back to active."""
+        restored = agents.restore(name)
+        if not restored:
+            raise HTTPException(404, f"Agent '{name}' not found")
+        return {"restored": True, "name": name}
 
     # ── Agent Directives ────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- DELETE endpoint now retires agents (soft delete) instead of permanently removing them — all data preserved
- New "Retired" section in Agents UI shows archived agents with a one-click Restore button
- Retired agents are filtered out of the main list but stay in the DB with all directives, tokens, and schedules intact
- Both classic HTML and Svelte frontends updated

## API changes
- `DELETE /agents/{name}` — now retires instead of deleting
- `GET /agents/retired` — list retired agents
- `POST /agents/{name}/restore` — restore a retired agent

## Test plan
- [ ] Retire an agent via the UI — verify it disappears from main list
- [ ] Verify retired agent appears in the "Retired" section with dashed border
- [ ] Click Restore on a retired agent — verify it returns to the active list
- [ ] Verify all directives, tokens, and schedules are preserved through retire/restore cycle
- [ ] Test the API endpoints directly (curl)
- [ ] Verify existing agents get status='active' via migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)