### PR TITLE
Fix empty agent responses in chat UI

### DIFF
--- a/src/pinky_daemon/sdk_runner.py
+++ b/src/pinky_daemon/sdk_runner.py
@@ -170,8 +170,9 @@ class SDKRunner:
 
                 elif isinstance(message, ResultMessage):
                     # Prefer ResultMessage over AssistantMessage to avoid duplicates
-                    got_result = True
+                    # Only suppress AssistantMessage if ResultMessage has actual content
                     if hasattr(message, "result") and message.result:
+                        got_result = True
                         output_parts.clear()
                         output_parts.append(message.result)
                     if hasattr(message, "session_id"):


### PR DESCRIPTION
## Summary
- Fix bug where agent responses show as empty boxes with only timing info (e.g. "1.5s") but no text content
- Root cause: `ResultMessage` with empty `result` field was setting `got_result = True`, which blocked `AssistantMessage` text from being captured
- One-line fix: only suppress `AssistantMessage` fallback when `ResultMessage` actually has content

## What was happening
1. Claude SDK streams `AssistantMessage` blocks (with actual text) followed by `ResultMessage`
2. When `ResultMessage.result` was empty/null, the flag still blocked `AssistantMessage` processing
3. Output ended up empty, but `duration_ms` was still calculated and rendered — hence the empty boxes with timing

## Test plan
- [ ] Chat with an agent (Barsik or any) — verify responses now show text content
- [ ] Verify timing metadata still appears alongside the response
- [ ] Verify no duplicate text (the original reason for the `got_result` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)