### PR TITLE
Fix SDK session resume crash with invalid session IDs

### DIFF
--- a/src/pinky_daemon/sessions.py
+++ b/src/pinky_daemon/sessions.py
@@ -374,15 +374,30 @@ class Session:
 
             start = time.time()
 
-            # Use real SDK session ID for resume if available
-            resume_id = self._sdk_session_id if self._sdk_session_id else self.id
+            # Only resume if we have a real SDK session ID (UUID from prior query)
+            # Using arbitrary IDs (like "barsik-main") crashes the SDK subprocess
+            can_resume = not is_first and bool(self._sdk_session_id)
+            resume_id = self._sdk_session_id if can_resume else ""
 
             result = await self._runner.run(
                 content,
                 session_id=resume_id,
-                resume=not is_first,
-                system_prompt=system_prompt,
+                resume=can_resume,
+                system_prompt=system_prompt if not can_resume else "",
             )
+
+            # If resume failed, retry as fresh conversation
+            if not result.ok and can_resume:
+                _log(f"session {self.id}: resume failed, retrying as fresh conversation")
+                self._sdk_session_id = ""
+                system_prompt = self._build_restart_prompt()
+                result = await self._runner.run(
+                    content,
+                    session_id="",
+                    resume=False,
+                    system_prompt=system_prompt,
+                )
+
             elapsed_ms = int((time.time() - start) * 1000)
 
             # Capture real session ID from SDK


### PR DESCRIPTION
## Summary
- Fix the actual root cause of empty agent responses in chat UI
- Session manager was passing IDs like "barsik-main" to the SDK's `resume` parameter, which expects a UUID from a prior query
- This crashed the Claude Code subprocess with exit code 1 on every message after the first
- Now only attempts resume with a real SDK session ID, and auto-retries as fresh conversation if resume fails

## Root cause
```
sdk-runner: query len=4 session=barsik-main
Fatal error in message reader: Command failed with exit code 1 (exit code: 1)
```
The SDK's `options.resume` needs a valid UUID, not an arbitrary session name.

## Test plan
- [ ] Create a new agent and send it messages — verify responses work
- [ ] Send multiple messages in a row — verify resume works correctly
- [ ] Restart the daemon mid-conversation — verify recovery works (fresh conversation instead of crash)
- [ ] Check logs for "resume failed, retrying as fresh conversation" on recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)