### PR TITLE
Show Claude version in Svelte SPA

### DIFF
--- a/frontend-svelte/src/components/Layout.svelte
+++ b/frontend-svelte/src/components/Layout.svelte
@@ -26,7 +26,7 @@
         window.addEventListener('hashchange', updatePath);
         try {
             const root = await api('GET', '/api');
-            statusText = `connected | v${root.version}`;
+            statusText = `connected | v${root.version} | Claude ${root.claude_version || '?'}`;
         } catch {
             statusText = 'disconnected';
         }


### PR DESCRIPTION
One-liner: update Layout.svelte to show claude_version from /api response.