### PR TITLE
Add Telegram approved users management

### DIFF
--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -139,6 +139,7 @@
         loadFiles();
         loadSchedules();
         loadSessions();
+        loadApprovedUsers();
     }
 
     function closeDetail() { currentAgent = ''; detailOpen = false; }
@@ -184,6 +185,21 @@
     async function removeSchedule(id) { if (!confirm('Remove this schedule?')) return; await api('DELETE', `/agents/${currentAgent}/schedules/${id}`); toast('Schedule removed'); loadSchedules(); }
 
     async function loadSessions() { const data = await api('GET', `/agents/${currentAgent}/sessions`); agentSessions = data.sessions || []; }
+
+    // Approved users
+    let approvedUsers = [];
+    let newUserChatId = '';
+    let newUserName = '';
+    async function loadApprovedUsers() { const data = await api('GET', `/agents/${currentAgent}/approved-users`); approvedUsers = data.users || []; }
+    async function approveUser() {
+        if (!newUserChatId.trim()) { toast('Enter a chat ID', 'error'); return; }
+        await api('POST', `/agents/${currentAgent}/approved-users`, { chat_id: newUserChatId.trim(), display_name: newUserName.trim() });
+        toast(`User ${newUserName || newUserChatId} approved`);
+        newUserChatId = ''; newUserName = '';
+        loadApprovedUsers();
+    }
+    async function denyUser(chatId) { await api('PUT', `/agents/${currentAgent}/approved-users/${chatId}/deny`); toast('User denied'); loadApprovedUsers(); }
+    async function revokeUser(chatId) { await api('DELETE', `/agents/${currentAgent}/approved-users/${chatId}`); toast('User revoked'); loadApprovedUsers(); }
 
     // Wizard
     function openWizard() { wizStep = 0; wizName = ''; wizDisplayName = ''; wizModel = 'opus'; wizMode = 'bypassPermissions'; wizHeart = 'worker'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; wizardOpen = true; }
@@ -416,6 +432,36 @@
                             <span class="badge badge-{t.enabled ? 'on' : 'off'}">{t.enabled ? 'Enabled' : 'Disabled'}</span>
                             <span style="flex:1"></span>
                             <button class="btn btn-sm btn-danger" on:click={() => removeToken(t.platform)}>Remove</button>
+                        </div>
+                    {/each}
+                {/if}
+            </div>
+
+            <!-- Approved Users -->
+            <div style="border-top:var(--border);padding:1rem 1.5rem;background:var(--gray-light)">
+                <span style="font-family:var(--font-mono);font-size:0.8rem;font-weight:700;text-transform:uppercase">Approved Users</span>
+                <div style="display:flex;gap:0.5rem;align-items:center;margin-top:0.5rem;flex-wrap:wrap">
+                    <input type="text" class="form-input" bind:value={newUserChatId} placeholder="Chat ID" style="width:130px">
+                    <input type="text" class="form-input" bind:value={newUserName} placeholder="Display name (optional)" style="flex:1;min-width:120px">
+                    <button class="btn btn-primary" on:click={approveUser}>Approve</button>
+                </div>
+            </div>
+            <div>
+                {#if approvedUsers.length === 0}
+                    <div class="empty">No approved users.</div>
+                {:else}
+                    {#each approvedUsers as u}
+                        <div class="token-item">
+                            <span style="font-family:var(--font-mono);font-size:0.8rem;font-weight:700">{u.display_name || u.chat_id}</span>
+                            {#if u.display_name}<span style="font-family:var(--font-mono);font-size:0.7rem;color:var(--gray-mid)">{u.chat_id}</span>{/if}
+                            <span class="badge badge-{u.status === 'approved' ? 'on' : u.status === 'denied' ? 'off' : 'model'}">{u.status}</span>
+                            <span style="flex:1"></span>
+                            {#if u.status === 'denied'}
+                                <button class="btn btn-sm btn-success" on:click={() => { api('POST', `/agents/${currentAgent}/approved-users`, { chat_id: u.chat_id, display_name: u.display_name }).then(() => { toast('User approved'); loadApprovedUsers(); }); }}>Approve</button>
+                            {:else}
+                                <button class="btn btn-sm" on:click={() => denyUser(u.chat_id)}>Deny</button>
+                            {/if}
+                            <button class="btn btn-sm btn-danger" on:click={() => revokeUser(u.chat_id)}>Revoke</button>
                         </div>
                     {/each}
                 {/if}

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -139,6 +139,32 @@ class AgentToken:
 
 
 @dataclass
+class ApprovedUser:
+    """An approved Telegram user for an agent."""
+
+    id: int = 0
+    agent_name: str = ""
+    chat_id: str = ""  # Telegram chat/user ID
+    display_name: str = ""  # Human-friendly name
+    status: str = "approved"  # approved, denied, pending
+    approved_by: str = ""  # Who approved this user
+    created_at: float = 0.0
+    updated_at: float = 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "agent_name": self.agent_name,
+            "chat_id": self.chat_id,
+            "display_name": self.display_name,
+            "status": self.status,
+            "approved_by": self.approved_by,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
 class AgentSchedule:
     """A cron-based wake schedule for an agent."""
 
@@ -330,6 +356,19 @@ class AgentRegistry:
                 updated_at REAL NOT NULL DEFAULT 0,
                 updated_by TEXT NOT NULL DEFAULT '',
                 FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS approved_users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_name TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                display_name TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL DEFAULT 'approved',
+                approved_by TEXT NOT NULL DEFAULT '',
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
+                UNIQUE(agent_name, chat_id)
             );
 
             CREATE INDEX IF NOT EXISTS idx_heartbeats_agent
@@ -931,6 +970,81 @@ class AgentRegistry:
         )
         self._db.commit()
         return cursor.rowcount > 0
+
+    # ── Approved Users ─────────────────────────────────────
+
+    def approve_user(
+        self, agent_name: str, chat_id: str,
+        display_name: str = "", approved_by: str = "",
+    ) -> ApprovedUser:
+        """Approve a Telegram user for an agent (insert or update to approved)."""
+        now = time.time()
+        self._db.execute(
+            """INSERT INTO approved_users
+               (agent_name, chat_id, display_name, status, approved_by, created_at, updated_at)
+               VALUES (?, ?, ?, 'approved', ?, ?, ?)
+               ON CONFLICT (agent_name, chat_id)
+               DO UPDATE SET status='approved', display_name=excluded.display_name,
+                            approved_by=excluded.approved_by, updated_at=excluded.updated_at""",
+            (agent_name, chat_id, display_name, approved_by, now, now),
+        )
+        self._db.commit()
+        _log(f"agents: approved user {chat_id} for {agent_name}")
+        row = self._db.execute(
+            "SELECT id, agent_name, chat_id, display_name, status, approved_by, created_at, updated_at "
+            "FROM approved_users WHERE agent_name=? AND chat_id=?",
+            (agent_name, chat_id),
+        ).fetchone()
+        return ApprovedUser(
+            id=row[0], agent_name=row[1], chat_id=row[2], display_name=row[3],
+            status=row[4], approved_by=row[5], created_at=row[6], updated_at=row[7],
+        )
+
+    def deny_user(self, agent_name: str, chat_id: str) -> bool:
+        """Set a user's status to denied."""
+        now = time.time()
+        cursor = self._db.execute(
+            """INSERT INTO approved_users
+               (agent_name, chat_id, status, created_at, updated_at)
+               VALUES (?, ?, 'denied', ?, ?)
+               ON CONFLICT (agent_name, chat_id)
+               DO UPDATE SET status='denied', updated_at=excluded.updated_at""",
+            (agent_name, chat_id, now, now),
+        )
+        self._db.commit()
+        return cursor.rowcount > 0
+
+    def revoke_user(self, agent_name: str, chat_id: str) -> bool:
+        """Remove an approved user record entirely."""
+        cursor = self._db.execute(
+            "DELETE FROM approved_users WHERE agent_name=? AND chat_id=?",
+            (agent_name, chat_id),
+        )
+        self._db.commit()
+        return cursor.rowcount > 0
+
+    def list_approved_users(self, agent_name: str) -> list[ApprovedUser]:
+        """List all approved users for an agent."""
+        rows = self._db.execute(
+            "SELECT id, agent_name, chat_id, display_name, status, approved_by, created_at, updated_at "
+            "FROM approved_users WHERE agent_name=? ORDER BY created_at ASC",
+            (agent_name,),
+        ).fetchall()
+        return [
+            ApprovedUser(
+                id=r[0], agent_name=r[1], chat_id=r[2], display_name=r[3],
+                status=r[4], approved_by=r[5], created_at=r[6], updated_at=r[7],
+            )
+            for r in rows
+        ]
+
+    def is_user_approved(self, agent_name: str, chat_id: str) -> bool:
+        """Check if a user is approved for an agent."""
+        row = self._db.execute(
+            "SELECT status FROM approved_users WHERE agent_name=? AND chat_id=?",
+            (agent_name, chat_id),
+        ).fetchone()
+        return row is not None and row[0] == "approved"
 
     # ── Helpers ──────────────────────────────────────────────
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -290,6 +290,14 @@ class SetAgentTokenRequest(BaseModel):
     settings: dict = Field(default_factory=dict)
 
 
+class ApproveUserRequest(BaseModel):
+    """Approve a Telegram user for an agent."""
+
+    chat_id: str
+    display_name: str = ""
+    approved_by: str = ""
+
+
 class SpawnSessionRequest(BaseModel):
     """Spawn a new session from an agent's config."""
 
@@ -1240,6 +1248,36 @@ def create_api(
         if not agents.remove_token(name, platform):
             raise HTTPException(404, "Token not found")
         return {"deleted": True, "agent": name, "platform": platform}
+
+    # ── Approved Users ──────────────────────────────────────
+
+    @app.get("/agents/{name}/approved-users")
+    async def list_approved_users(name: str):
+        """List approved users for an agent."""
+        if not agents.get(name):
+            raise HTTPException(404, f"Agent '{name}' not found")
+        users = agents.list_approved_users(name)
+        return {"users": [u.to_dict() for u in users], "count": len(users)}
+
+    @app.post("/agents/{name}/approved-users")
+    async def approve_user(name: str, req: ApproveUserRequest):
+        """Approve a user for this agent."""
+        if not agents.get(name):
+            raise HTTPException(404, f"Agent '{name}' not found")
+        user = agents.approve_user(name, req.chat_id, req.display_name or "", req.approved_by or "admin")
+        return user.to_dict()
+
+    @app.put("/agents/{name}/approved-users/{chat_id}/deny")
+    async def deny_user(name: str, chat_id: str):
+        """Deny a user."""
+        agents.deny_user(name, chat_id)
+        return {"denied": True, "chat_id": chat_id}
+
+    @app.delete("/agents/{name}/approved-users/{chat_id}")
+    async def revoke_user(name: str, chat_id: str):
+        """Revoke an approved user."""
+        agents.revoke_user(name, chat_id)
+        return {"revoked": True, "chat_id": chat_id}
 
     # ── Spawn Session from Agent ────────────────────────────
 


### PR DESCRIPTION
## Summary
Backend + Frontend for managing approved Telegram users per agent.

**Backend:**
- New `approved_users` table with CRUD methods in agent registry
- 4 API endpoints: list, approve, deny, revoke
- Unique constraint on (agent_name, chat_id)

**Frontend (Svelte Agents page):**
- New "Approved Users" section in agent detail panel
- Add user form with chat ID and display name fields
- User list with status badges (approved/denied/pending)
- Approve, Deny, and Revoke action buttons

## Test plan
- [ ] Open agent detail — verify "Approved Users" section appears
- [ ] Add a user by chat ID — verify it appears in the list as "approved"
- [ ] Click Deny — verify status changes
- [ ] Click Approve on denied user — verify it re-approves
- [ ] Click Revoke — verify user is removed from list

🤖 Generated with [Claude Code](https://claude.com/claude-code)