### PR TITLE
Default timezone: machine-detected, user-selectable

### DIFF
--- a/frontend-svelte/src/pages/Settings.svelte
+++ b/frontend-svelte/src/pages/Settings.svelte
@@ -6,6 +6,17 @@
 
     function toast(msg, type = 'success') { toastMessage.set({ message: msg, type }); }
 
+    // Timezone
+    let defaultTimezone = '';
+    const commonTimezones = [
+        'America/Los_Angeles', 'America/Denver', 'America/Chicago', 'America/New_York',
+        'America/Anchorage', 'Pacific/Honolulu', 'America/Phoenix',
+        'America/Toronto', 'America/Vancouver', 'America/Sao_Paulo',
+        'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Moscow',
+        'Asia/Tokyo', 'Asia/Shanghai', 'Asia/Kolkata', 'Asia/Dubai',
+        'Australia/Sydney', 'Pacific/Auckland', 'UTC',
+    ];
+
     // Primary user
     let primaryChatId = '';
     let primaryDisplayName = '';
@@ -139,6 +150,15 @@
         loadSessionSkills();
     }
 
+    async function loadTimezone() {
+        const data = await api('GET', '/system/timezone');
+        defaultTimezone = data.timezone || 'UTC';
+    }
+    async function saveTimezone() {
+        await api('PUT', `/system/timezone?timezone=${encodeURIComponent(defaultTimezone)}`);
+        toast(`Timezone set to ${defaultTimezone}`);
+    }
+
     async function loadPrimaryUser() {
         const data = await api('GET', '/system/primary-user');
         primaryChatId = data.chat_id || '';
@@ -161,6 +181,7 @@
     }
 
     onMount(() => {
+        loadTimezone();
         loadPrimaryUser();
         loadAllTokens();
         loadAllApprovedUsers();
@@ -171,6 +192,22 @@
 </script>
 
 <div class="content" style="max-width:1200px">
+    <!-- Default Timezone -->
+    <div class="section">
+        <div class="section-header"><div class="section-title">Default Timezone</div></div>
+        <div style="padding:1.5rem;background:var(--gray-light)">
+            <p style="margin:0 0 0.8rem 0;font-size:0.85rem;color:var(--gray-mid)">Used for all message timestamps unless a user has a per-user timezone set.</p>
+            <div class="form-inline">
+                <select class="form-select" style="max-width:300px" bind:value={defaultTimezone} on:change={saveTimezone}>
+                    {#each commonTimezones as tz}
+                        <option value={tz}>{tz}</option>
+                    {/each}
+                </select>
+                <span style="font-family:var(--font-mono);font-size:0.8rem;color:var(--gray-mid)">{defaultTimezone}</span>
+            </div>
+        </div>
+    </div>
+
     <!-- Primary User -->
     <div class="section">
         <div class="section-header"><div class="section-title">Primary User</div></div>

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1344,6 +1344,28 @@ class AgentRegistry:
         )
         self._db.commit()
 
+    def get_default_timezone(self) -> str:
+        """Get the default timezone. Falls back to machine timezone, then UTC."""
+        tz = self.get_setting("default_timezone")
+        if tz:
+            return tz
+        # Detect machine timezone
+        try:
+            import subprocess
+            result = subprocess.run(
+                ["readlink", "/etc/localtime"],
+                capture_output=True, text=True, timeout=2,
+            )
+            if result.returncode == 0 and "zoneinfo/" in result.stdout:
+                return result.stdout.strip().split("zoneinfo/")[-1]
+        except Exception:
+            pass
+        return "UTC"
+
+    def set_default_timezone(self, timezone: str) -> None:
+        """Set the default timezone (IANA format)."""
+        self.set_setting("default_timezone", timezone)
+
     def get_primary_user(self) -> dict:
         """Get the primary user (auto-approved across all agents)."""
         chat_id = self.get_setting("primary_user_chat_id")

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1255,6 +1255,22 @@ def create_api(
 
     # ── System Settings ────────────────────────────────────
 
+    @app.get("/system/timezone")
+    async def get_default_timezone():
+        """Get the default timezone."""
+        return {"timezone": agents.get_default_timezone()}
+
+    @app.put("/system/timezone")
+    async def set_default_timezone(timezone: str):
+        """Set the default timezone (IANA format, e.g. 'America/Los_Angeles')."""
+        try:
+            from zoneinfo import ZoneInfo
+            ZoneInfo(timezone)
+        except Exception:
+            raise HTTPException(400, f"Invalid timezone: {timezone}")
+        agents.set_default_timezone(timezone)
+        return {"updated": True, "timezone": timezone}
+
     @app.get("/system/primary-user")
     async def get_primary_user():
         """Get the primary user (auto-approved across all agents)."""

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -157,16 +157,15 @@ class MessageBroker:
         from datetime import datetime, timezone as tz
 
         agent_name = message.agent_name
-        user_tz_str = self._registry.get_user_timezone(agent_name, message.chat_id)
-        if user_tz_str:
-            try:
-                from zoneinfo import ZoneInfo
-                user_tz = ZoneInfo(user_tz_str)
-                dt = datetime.fromtimestamp(message.timestamp, tz=user_tz)
-                ts = dt.strftime(f"%Y-%m-%d %H:%M:%S {user_tz_str}")
-            except Exception:
-                ts = datetime.fromtimestamp(message.timestamp, tz=tz.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-        else:
+        tz_str = (
+            self._registry.get_user_timezone(agent_name, message.chat_id)
+            or self._registry.get_default_timezone()
+        )
+        try:
+            from zoneinfo import ZoneInfo
+            dt = datetime.fromtimestamp(message.timestamp, tz=ZoneInfo(tz_str))
+            ts = dt.strftime(f"%Y-%m-%d %H:%M:%S {tz_str}")
+        except Exception:
             ts = datetime.fromtimestamp(message.timestamp, tz=tz.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
         msg_id = f" | msg_id:{message.message_id}" if message.message_id else ""
         if message.is_group:


### PR DESCRIPTION
## Summary
- Timestamps in agent prompts now use the system default timezone instead of UTC
- Auto-detects machine timezone on first use (e.g. `America/Los_Angeles`)
- Selectable in Settings page via dropdown of common timezones
- Per-user timezone still overrides when set (existing behavior preserved)

## Cascade: system default < per-user override
1. User has timezone set -> use it
2. No user timezone -> use system default
3. Both fail -> UTC fallback

## Test plan
- [ ] Fresh start: verify timestamps show machine timezone, not UTC
- [ ] Change timezone in Settings -> verify prompt timestamps update
- [ ] Set per-user timezone -> verify it overrides the default
- [ ] `pytest tests/` — 320 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)