### PR TITLE
feat: clock-aligned heartbeat system with auto-sleep and settings UI

### DIFF
--- a/frontend-svelte/src/pages/Settings.svelte
+++ b/frontend-svelte/src/pages/Settings.svelte
@@ -44,6 +44,13 @@
     let selectedSession = '';
     let sessionSkills = [];
 
+    // Heartbeat/Wake settings
+    let heartbeatSettings = [];
+    let editingAgent = null;
+    let editWakeInterval = 1800;
+    let editClockAligned = true;
+    let editAutoSleepHours = 8;
+
     function typeClass(type) {
         if (type === 'mcp_tool') return 'mcp';
         if (type === 'builtin') return 'builtin';
@@ -180,6 +187,35 @@
         allApprovedUsers = data.users || [];
     }
 
+    async function loadHeartbeatSettings() {
+        const data = await api('GET', '/settings/heartbeat');
+        heartbeatSettings = data.agents || [];
+    }
+
+    function formatWakeInterval(seconds) {
+        if (!seconds || seconds <= 0) return 'Disabled';
+        if (seconds >= 3600) return (seconds / 3600) + 'h';
+        return (seconds / 60) + 'm';
+    }
+
+    function openWakeEdit(agent) {
+        editingAgent = agent.name;
+        editWakeInterval = agent.wake_interval || 0;
+        editClockAligned = agent.clock_aligned !== false;
+        editAutoSleepHours = agent.auto_sleep_hours ?? 8;
+    }
+
+    async function saveWakeSettings() {
+        await api('PUT', `/agents/${editingAgent}`, {
+            wake_interval: editWakeInterval,
+            clock_aligned: editClockAligned,
+            auto_sleep_hours: editAutoSleepHours,
+        });
+        editingAgent = null;
+        toast(`Wake settings saved for ${editingAgent}`);
+        loadHeartbeatSettings();
+    }
+
     onMount(() => {
         loadTimezone();
         loadPrimaryUser();
@@ -188,6 +224,7 @@
         refreshPlatforms();
         refreshSkills();
         refreshSessions();
+        loadHeartbeatSettings();
     });
 </script>
 
@@ -207,6 +244,109 @@
             </div>
         </div>
     </div>
+
+    <!-- Heartbeat & Wake Settings -->
+    <div class="section">
+        <div class="section-header">
+            <div class="section-title">Heartbeat & Wake Settings</div>
+            <button class="btn btn-sm" on:click={loadHeartbeatSettings}>Refresh</button>
+        </div>
+        <div class="section-body">
+            {#if heartbeatSettings.length === 0}
+                <div class="empty">No agents found.</div>
+            {:else}
+                <table class="data-table">
+                    <thead><tr><th>Agent</th><th>Wake Interval</th><th>Clock Aligned</th><th>Auto Sleep</th><th>Heartbeat</th><th>Schedules</th><th>Actions</th></tr></thead>
+                    <tbody>
+                        {#each heartbeatSettings as a}
+                            <tr>
+                                <td class="mono">{a.display_name}</td>
+                                <td>
+                                    <span class="badge badge-{a.wake_interval > 0 ? 'on' : 'off'}">
+                                        {formatWakeInterval(a.wake_interval)}
+                                    </span>
+                                </td>
+                                <td>
+                                    <span class="badge badge-{a.clock_aligned ? 'on' : 'off'}">
+                                        {a.clock_aligned ? 'Yes' : 'No'}
+                                    </span>
+                                </td>
+                                <td>
+                                    <span class="badge badge-{a.auto_sleep_hours > 0 ? 'on' : 'off'}">
+                                        {a.auto_sleep_hours > 0 ? a.auto_sleep_hours + 'h' : 'Off'}
+                                    </span>
+                                </td>
+                                <td>
+                                    {#if a.latest_heartbeat}
+                                        <span class="badge badge-{a.latest_heartbeat.status === 'alive' ? 'on' : a.latest_heartbeat.status === 'stale' ? 'model' : 'off'}">
+                                            {a.latest_heartbeat.status}
+                                        </span>
+                                        <span style="font-size:0.7rem;color:var(--gray-mid);margin-left:0.3rem">{timeAgo(a.latest_heartbeat.timestamp)}</span>
+                                    {:else}
+                                        <span style="color:var(--gray-mid);font-size:0.8rem">--</span>
+                                    {/if}
+                                </td>
+                                <td>
+                                    <span style="font-family:var(--font-mono);font-size:0.8rem">{a.schedules?.length || 0}</span>
+                                </td>
+                                <td>
+                                    <button class="btn btn-sm" on:click={() => openWakeEdit(a)}>Edit</button>
+                                </td>
+                            </tr>
+                        {/each}
+                    </tbody>
+                </table>
+            {/if}
+        </div>
+    </div>
+
+    <!-- Wake Settings Editor -->
+    {#if editingAgent}
+        <div class="section">
+            <div class="section-header">
+                <div class="section-title">Edit Wake Settings: {editingAgent}</div>
+                <button class="btn btn-sm" on:click={() => editingAgent = null}>Cancel</button>
+            </div>
+            <div style="padding:1.5rem;background:var(--gray-light)">
+                <div class="form-inline" style="margin-bottom:1rem">
+                    <div class="form-row">
+                        <span class="form-label">Wake Interval</span>
+                        <select class="form-select" bind:value={editWakeInterval}>
+                            <option value={0}>Disabled</option>
+                            <option value={900}>15 min</option>
+                            <option value={1800}>30 min</option>
+                            <option value={3600}>1 hour</option>
+                            <option value={7200}>2 hours</option>
+                        </select>
+                    </div>
+                    <div class="form-row">
+                        <span class="form-label">Clock Aligned</span>
+                        <select class="form-select" bind:value={editClockAligned}>
+                            <option value={true}>Yes (wake at :00, :30, etc.)</option>
+                            <option value={false}>No (interval from last activity)</option>
+                        </select>
+                    </div>
+                    <div class="form-row">
+                        <span class="form-label">Auto Sleep (hours idle)</span>
+                        <select class="form-select" bind:value={editAutoSleepHours}>
+                            <option value={0}>Disabled</option>
+                            <option value={2}>2 hours</option>
+                            <option value={4}>4 hours</option>
+                            <option value={6}>6 hours</option>
+                            <option value={8}>8 hours</option>
+                            <option value={12}>12 hours</option>
+                            <option value={24}>24 hours</option>
+                        </select>
+                    </div>
+                </div>
+                <p style="margin:0 0 1rem 0;font-size:0.8rem;color:var(--gray-mid)">
+                    Clock-aligned wakes fire at wall-clock boundaries (e.g., 1:00, 1:30, 2:00 for 30m).
+                    Auto-sleep puts the agent to sleep after the specified idle period. Cron schedules still wake agents during sleep.
+                </p>
+                <button class="btn btn-primary" on:click={saveWakeSettings}>Save</button>
+            </div>
+        </div>
+    {/if}
 
     <!-- Primary User -->
     <div class="section">

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -58,6 +58,9 @@ class Agent:
     enabled: bool = True
     auto_start: bool = False  # Auto-spawn main session on server boot
     heartbeat_interval: int = 0  # Seconds between heartbeats (0 = disabled)
+    wake_interval: int = 0  # Seconds between wake checks (0 = disabled, 1800 = 30m, 3600 = 1h)
+    clock_aligned: bool = True  # Align wakes to wall clock (:00, :30 for 30m; :00 for 1h)
+    auto_sleep_hours: int = 8  # Auto-sleep after N hours inactive (0 = disabled)
     role: str = ""  # Agent role: sidekick, lead, worker, specialist
     status: str = "active"  # active or retired
     retired_at: float = 0.0  # When was this agent retired
@@ -86,6 +89,9 @@ class Agent:
             "enabled": self.enabled,
             "auto_start": self.auto_start,
             "heartbeat_interval": self.heartbeat_interval,
+            "wake_interval": self.wake_interval,
+            "clock_aligned": self.clock_aligned,
+            "auto_sleep_hours": self.auto_sleep_hours,
             "role": self.role,
             "status": self.status,
             "retired_at": self.retired_at,
@@ -443,6 +449,9 @@ class AgentRegistry:
             ("status", "TEXT NOT NULL DEFAULT 'active'"),
             ("retired_at", "REAL NOT NULL DEFAULT 0"),
             ("streaming_session_id", "TEXT NOT NULL DEFAULT ''"),
+            ("wake_interval", "INTEGER NOT NULL DEFAULT 0"),
+            ("clock_aligned", "INTEGER NOT NULL DEFAULT 1"),
+            ("auto_sleep_hours", "INTEGER NOT NULL DEFAULT 8"),
         ]
         for col, typedef in migrations:
             if col not in existing:
@@ -504,7 +513,8 @@ class AgentRegistry:
             for key in ("display_name", "model", "soul", "system_prompt", "working_dir",
                         "permission_mode", "max_turns", "timeout", "restart_threshold_pct",
                         "auto_restart", "parent", "max_sessions", "enabled",
-                        "auto_start", "heartbeat_interval", "role"):
+                        "auto_start", "heartbeat_interval", "wake_interval",
+                        "clock_aligned", "auto_sleep_hours", "role"):
                 if key in kwargs:
                     updates[key] = kwargs[key]
 
@@ -518,6 +528,8 @@ class AgentRegistry:
                 updates["enabled"] = int(updates["enabled"])
             if "auto_start" in updates:
                 updates["auto_start"] = int(updates["auto_start"])
+            if "clock_aligned" in updates:
+                updates["clock_aligned"] = int(updates["clock_aligned"])
 
             if updates:
                 updates["updated_at"] = now
@@ -554,6 +566,9 @@ class AgentRegistry:
                 enabled=kwargs.get("enabled", True),
                 auto_start=kwargs.get("auto_start", False),
                 heartbeat_interval=kwargs.get("heartbeat_interval", 0),
+                wake_interval=kwargs.get("wake_interval", 0),
+                clock_aligned=kwargs.get("clock_aligned", True),
+                auto_sleep_hours=kwargs.get("auto_sleep_hours", 8),
                 role=kwargs.get("role", ""),
                 created_at=now,
                 updated_at=now,
@@ -564,9 +579,10 @@ class AgentRegistry:
                     system_prompt, working_dir,
                     permission_mode, allowed_tools, max_turns, timeout,
                     restart_threshold_pct, auto_restart, parent, groups,
-                    max_sessions, enabled, auto_start, heartbeat_interval, role,
+                    max_sessions, enabled, auto_start, heartbeat_interval,
+                    wake_interval, clock_aligned, auto_sleep_hours, role,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -574,6 +590,7 @@ class AgentRegistry:
                  agent.restart_threshold_pct, int(agent.auto_restart),
                  agent.parent, json.dumps(agent.groups), agent.max_sessions,
                  int(agent.enabled), int(agent.auto_start), agent.heartbeat_interval,
+                 agent.wake_interval, int(agent.clock_aligned), agent.auto_sleep_hours,
                  agent.role, agent.created_at, agent.updated_at),
             )
             self._db.commit()
@@ -586,7 +603,8 @@ class AgentRegistry:
         "permission_mode, allowed_tools, max_turns, timeout, "
         "restart_threshold_pct, auto_restart, parent, groups, "
         "max_sessions, enabled, auto_start, heartbeat_interval, role, "
-        "created_at, updated_at, users, boundaries, status, retired_at"
+        "created_at, updated_at, users, boundaries, status, retired_at, "
+        "wake_interval, clock_aligned, auto_sleep_hours"
     )
 
     def get(self, name: str) -> Agent | None:
@@ -1486,6 +1504,9 @@ class AgentRegistry:
             boundaries=row[22] if len(row) > 22 else "",
             status=row[23] if len(row) > 23 else "active",
             retired_at=row[24] if len(row) > 24 else 0.0,
+            wake_interval=row[25] if len(row) > 25 else 0,
+            clock_aligned=bool(row[26]) if len(row) > 26 else True,
+            auto_sleep_hours=row[27] if len(row) > 27 else 8,
         )
 
     def close(self) -> None:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -278,6 +278,9 @@ class UpdateAgentRequest(BaseModel):
     groups: list[str] | None = None
     enabled: bool | None = None
     restart_threshold_pct: float | None = None
+    wake_interval: int | None = None  # Seconds (0=disabled, 1800=30m, 3600=1h)
+    clock_aligned: bool | None = None  # Align to wall clock boundaries
+    auto_sleep_hours: int | None = None  # Auto-sleep after N hours idle (0=disabled)
 
 
 class AddDirectiveRequest(BaseModel):
@@ -2570,6 +2573,31 @@ def create_api(
             "enabled_schedules": sum(1 for s in all_schedules if s.enabled),
             "auto_start_agents": [a.name for a in auto_start],
         }
+
+    @app.get("/settings/heartbeat")
+    async def get_heartbeat_settings():
+        """Get heartbeat/wake/sleep settings for all agents."""
+        all_agents = agents.list(include_retired=False)
+        heartbeats = agents.get_all_latest_heartbeats()
+        hb_map = {h.agent_name: h.to_dict() for h in heartbeats}
+        all_schedules = agents.get_all_schedules(enabled_only=False)
+
+        result = []
+        for a in all_agents:
+            agent_schedules = [s.to_dict() for s in all_schedules if s.agent_name == a.name]
+            result.append({
+                "name": a.name,
+                "display_name": a.display_name or a.name,
+                "enabled": a.enabled,
+                "status": a.status,
+                "heartbeat_interval": a.heartbeat_interval,
+                "wake_interval": a.wake_interval,
+                "clock_aligned": a.clock_aligned,
+                "auto_sleep_hours": a.auto_sleep_hours,
+                "latest_heartbeat": hb_map.get(a.name),
+                "schedules": agent_schedules,
+            })
+        return {"agents": result, "scheduler_running": scheduler.running}
 
     # ── Autonomy Engine ────────────────────────────────────
 

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -110,7 +110,15 @@ def next_cron_description(cron_expr: str) -> str:
 # ── Scheduler ────────────────────────────────────────────────
 
 class AgentScheduler:
-    """Background scheduler for agent wake schedules and heartbeats."""
+    """Background scheduler for agent wake schedules and heartbeats.
+
+    Supports clock-aligned wakes: agents wake at wall-clock boundaries
+    (e.g., :00/:30 for 30m interval, :00 for 1h) instead of arbitrary
+    intervals from last activity.
+
+    Also supports auto-sleep: agents are put to sleep after a configurable
+    number of hours with no activity.
+    """
 
     def __init__(
         self,
@@ -119,6 +127,7 @@ class AgentScheduler:
         wake_callback=None,
         heartbeat_callback=None,
         direct_send_callback=None,
+        auto_sleep_callback=None,
         streaming_sessions_fn=None,
         tick_interval: int = 30,
     ) -> None:
@@ -126,11 +135,13 @@ class AgentScheduler:
         self._wake_callback = wake_callback  # async fn(agent_name, session_id, prompt)
         self._heartbeat_callback = heartbeat_callback  # async fn(agent_name, session_id)
         self._direct_send_callback = direct_send_callback  # async fn(agent_name, platform, chat_id, message)
+        self._auto_sleep_callback = auto_sleep_callback  # async fn(agent_name, reason)
         self._streaming_sessions_fn = streaming_sessions_fn  # fn() -> dict[name, StreamingSession]
         self._tick_interval = tick_interval
         self._running = False
         self._task: asyncio.Task | None = None
         self._last_check_minute: int = -1  # Prevent double-firing within same minute
+        self._last_clock_slot: dict[str, int] = {}  # agent_name -> last fired clock slot (minutes since midnight)
 
     async def start(self) -> None:
         """Start the scheduler background loop."""
@@ -162,14 +173,20 @@ class AgentScheduler:
             await asyncio.sleep(self._tick_interval)
 
     async def _tick(self) -> None:
-        """Single scheduler tick — check schedules, heartbeats, and idle sessions."""
+        """Single scheduler tick — check schedules, heartbeats, clock-aligned wakes, auto-sleep, and idle sessions."""
         now = time.time()
 
         # Check cron schedules
         await self._check_schedules(now)
 
+        # Check clock-aligned wakes
+        await self._check_clock_aligned_wakes(now)
+
         # Check heartbeat health
         await self._check_heartbeats(now)
+
+        # Check auto-sleep (idle too long)
+        await self._check_auto_sleep(now)
 
         # Check for idle streaming sessions
         await self._check_idle_sessions(now)
@@ -288,6 +305,104 @@ class AgentScheduler:
                         await ss.idle_sleep()
                     except Exception as e:
                         _log(f"scheduler: idle sleep failed for {name}/{label}: {e}")
+
+    async def _check_clock_aligned_wakes(self, now: float) -> None:
+        """Check agents with clock-aligned wake intervals and fire if a new slot is due.
+
+        For a 30m interval, wakes at :00 and :30 each hour.
+        For a 60m interval, wakes at :00 each hour.
+        For a 15m interval, wakes at :00, :15, :30, :45.
+        """
+        agents = self._registry.list(enabled_only=True)
+
+        for agent in agents:
+            if agent.wake_interval <= 0:
+                continue
+
+            interval_minutes = agent.wake_interval // 60
+            if interval_minutes <= 0:
+                continue
+
+            # Get current time in a reasonable timezone
+            try:
+                tz = ZoneInfo("America/Los_Angeles")
+            except (KeyError, ValueError):
+                tz = ZoneInfo("UTC")
+
+            dt = datetime.fromtimestamp(now, tz=tz)
+            current_minutes = dt.hour * 60 + dt.minute
+
+            if agent.clock_aligned:
+                # Clock-aligned: fire at wall-clock boundaries
+                current_slot = (current_minutes // interval_minutes) * interval_minutes
+                last_slot = self._last_clock_slot.get(agent.name, -1)
+
+                if current_slot == last_slot:
+                    continue  # Already fired this slot
+
+                self._last_clock_slot[agent.name] = current_slot
+                _log(f"scheduler: clock-aligned wake for '{agent.name}' at :{dt.minute:02d} (slot {current_slot}, interval {interval_minutes}m)")
+            else:
+                # Legacy: interval-based from last activity
+                hb = self._registry.get_latest_heartbeat(agent.name)
+                last_active = hb.timestamp if hb else 0
+                if last_active > 0 and (now - last_active) < agent.wake_interval:
+                    continue
+
+            if self._wake_callback:
+                try:
+                    session_id = f"{agent.name}-main"
+                    await self._wake_callback(
+                        agent.name, session_id,
+                        f"Clock-aligned wake ({interval_minutes}m interval)",
+                    )
+                except Exception as e:
+                    _log(f"scheduler: clock-aligned wake failed for {agent.name}: {e}")
+
+    async def _check_auto_sleep(self, now: float) -> None:
+        """Auto-sleep agents that have been idle beyond their auto_sleep_hours threshold."""
+        if not self._streaming_sessions_fn:
+            return
+
+        agents = self._registry.list(enabled_only=True)
+
+        for agent in agents:
+            if agent.auto_sleep_hours <= 0:
+                continue
+
+            threshold_seconds = agent.auto_sleep_hours * 3600
+
+            # Check streaming sessions for this agent
+            try:
+                sessions = self._streaming_sessions_fn()
+            except Exception:
+                continue
+
+            agent_sessions = sessions.get(agent.name, {})
+            if not agent_sessions:
+                continue
+
+            for label, ss in agent_sessions.items():
+                if not ss.is_connected:
+                    continue
+
+                idle_seconds = now - ss.last_active
+                if idle_seconds >= threshold_seconds:
+                    _log(f"scheduler: auto-sleep for '{agent.name}/{label}' — idle {idle_seconds / 3600:.1f}h (threshold: {agent.auto_sleep_hours}h)")
+                    if self._auto_sleep_callback:
+                        try:
+                            await self._auto_sleep_callback(
+                                agent.name,
+                                f"Auto-sleep: idle for {idle_seconds / 3600:.1f}h (threshold: {agent.auto_sleep_hours}h)",
+                            )
+                        except Exception as e:
+                            _log(f"scheduler: auto-sleep callback failed for {agent.name}: {e}")
+                    else:
+                        # Fallback: use idle_sleep on the session directly
+                        try:
+                            await ss.idle_sleep()
+                        except Exception as e:
+                            _log(f"scheduler: auto-sleep idle_sleep failed for {agent.name}/{label}: {e}")
 
     async def fire_now(self, agent_name: str, prompt: str = "") -> bool:
         """Manually trigger a wake for an agent."""


### PR DESCRIPTION
## Summary
- **Clock-aligned wakes**: Agents wake on wall-clock boundaries (`:00`/`:30` for 30m, `:00` for 1h) instead of arbitrary intervals. New `wake_interval`, `clock_aligned` fields on agent config
- **Auto-sleep**: Agents auto-sleep after configurable idle hours (default 8h, `auto_sleep_hours` field). Cron schedules still wake agents through sleep
- **Settings panel**: New Heartbeat & Wake Settings section in Settings page with per-agent config editing

## Changes
- `agent_registry.py` — 3 new agent columns: `wake_interval` (seconds), `clock_aligned` (bool), `auto_sleep_hours` (int). Auto-migrates existing DBs
- `scheduler.py` — `_check_clock_aligned_wakes()` fires at wall-clock slot boundaries, `_check_auto_sleep()` sleeps idle agents. New `auto_sleep_callback` param
- `api.py` — `GET /settings/heartbeat` endpoint for consolidated view, `UpdateAgentRequest` extended with new fields
- `Settings.svelte` — Heartbeat & Wake Settings table with inline edit modal (interval, clock alignment, auto-sleep)

## Test plan
- [ ] Verify agents wake at clock boundaries (1:00, 1:30, 2:00 for 30m)
- [ ] Verify auto-sleep triggers after configured idle hours
- [ ] Verify cron schedules still wake sleeping agents
- [ ] Test Settings UI — view and edit wake config per agent
- [ ] Verify DB migration adds new columns without data loss
- [ ] Confirm 409 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)