### PR TITLE
Fix streaming session lifecycle regressions

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -34,6 +34,11 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+DEFAULT_HEARTBEAT_PROMPT = (
+    "Heartbeat, check to see what you can do, if nothing reply HEARTBEAT_OK."
+)
+
+
 @dataclass
 class Agent:
     """A named agent with persistent identity."""
@@ -434,6 +439,15 @@ class AgentRegistry:
                 UNIQUE(agent_name, chat_id)
             );
 
+            CREATE TABLE IF NOT EXISTS streaming_session_labels (
+                agent_name TEXT NOT NULL,
+                label TEXT NOT NULL DEFAULT 'main',
+                session_id TEXT NOT NULL DEFAULT '',
+                updated_at REAL NOT NULL DEFAULT 0,
+                PRIMARY KEY (agent_name, label),
+                FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE
+            );
+
             CREATE INDEX IF NOT EXISTS idx_heartbeats_agent
                 ON agent_heartbeats(agent_name, timestamp DESC);
             CREATE INDEX IF NOT EXISTS idx_schedules_agent
@@ -442,6 +456,8 @@ class AgentRegistry:
                 ON pending_messages(agent_name, chat_id, delivered);
             CREATE INDEX IF NOT EXISTS idx_group_chats_agent
                 ON group_chats(agent_name);
+            CREATE INDEX IF NOT EXISTS idx_streaming_session_labels_agent
+                ON streaming_session_labels(agent_name);
         """)
         self._db.commit()
         self._migrate()
@@ -1021,21 +1037,62 @@ class AgentRegistry:
 
     # ── Streaming Session Persistence ─────────────────────
 
-    def get_streaming_session_id(self, agent_name: str) -> str:
-        """Get the persisted streaming session ID for an agent."""
+    def get_streaming_session_id(self, agent_name: str, label: str = "main") -> str:
+        """Get the persisted streaming session ID for an agent label."""
         row = self._db.execute(
-            "SELECT streaming_session_id FROM agents WHERE name=?",
-            (agent_name,),
+            "SELECT session_id FROM streaming_session_labels WHERE agent_name=? AND label=?",
+            (agent_name, label),
         ).fetchone()
-        return (row[0] or "") if row else ""
+        if row:
+            return row[0] or ""
 
-    def set_streaming_session_id(self, agent_name: str, session_id: str) -> None:
-        """Persist the streaming session ID for an agent (survives daemon restarts)."""
+        if label == "main":
+            legacy = self._db.execute(
+                "SELECT streaming_session_id FROM agents WHERE name=?",
+                (agent_name,),
+            ).fetchone()
+            return (legacy[0] or "") if legacy else ""
+        return ""
+
+    def set_streaming_session_id(self, agent_name: str, session_id: str, label: str = "main") -> None:
+        """Persist the streaming session ID for an agent label."""
+        now = time.time()
         self._db.execute(
-            "UPDATE agents SET streaming_session_id=? WHERE name=?",
-            (session_id, agent_name),
+            """INSERT INTO streaming_session_labels (agent_name, label, session_id, updated_at)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(agent_name, label) DO UPDATE SET
+                   session_id=excluded.session_id,
+                   updated_at=excluded.updated_at""",
+            (agent_name, label, session_id, now),
         )
+        if label == "main":
+            self._db.execute(
+                "UPDATE agents SET streaming_session_id=? WHERE name=?",
+                (session_id, agent_name),
+            )
         self._db.commit()
+
+    def list_streaming_session_ids(self, agent_name: str) -> list[dict]:
+        """List persisted streaming session IDs for an agent."""
+        rows = self._db.execute(
+            """SELECT label, session_id, updated_at
+               FROM streaming_session_labels
+               WHERE agent_name=? AND session_id != ''
+               ORDER BY label""",
+            (agent_name,),
+        ).fetchall()
+        results = [
+            {"label": row[0], "session_id": row[1] or "", "updated_at": row[2]}
+            for row in rows
+            if row[1]
+        ]
+
+        if not any(item["label"] == "main" for item in results):
+            main_id = self.get_streaming_session_id(agent_name, "main")
+            if main_id:
+                results.insert(0, {"label": "main", "session_id": main_id, "updated_at": 0.0})
+
+        return results
 
     # ── Wake Context ───────────────────────────────────────
 
@@ -1414,6 +1471,14 @@ class AgentRegistry:
     def set_default_timezone(self, timezone: str) -> None:
         """Set the default timezone (IANA format)."""
         self.set_setting("default_timezone", timezone)
+
+    def get_heartbeat_prompt(self) -> str:
+        """Get the global heartbeat wake prompt."""
+        return self.get_setting("heartbeat_prompt", DEFAULT_HEARTBEAT_PROMPT)
+
+    def set_heartbeat_prompt(self, prompt: str) -> None:
+        """Set the global heartbeat wake prompt."""
+        self.set_setting("heartbeat_prompt", prompt.strip() or DEFAULT_HEARTBEAT_PROMPT)
 
     def get_primary_user(self) -> dict:
         """Get the primary user (auto-approved across all agents)."""

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -241,6 +241,12 @@ class ConfigurePlatformRequest(BaseModel):
     settings: dict = Field(default_factory=dict)
 
 
+class UpdateHeartbeatPromptRequest(BaseModel):
+    """Update the global heartbeat wake prompt."""
+
+    prompt: str
+
+
 # ── Agent Models ─────────────────────────────────────────────
 
 
@@ -681,6 +687,172 @@ def create_api(
     broker = MessageBroker(agents, manager, send_callback=_broker_send, typing_callback=_broker_typing)
     _broker_pollers: list = []  # Track active broker pollers
 
+    app.state.manager = manager
+    app.state.broker = broker
+    app.state.agents = agents
+    app.state.conversation_store = store
+    app.state.session_store = session_store
+
+    def _make_cost_callback(registry):
+        """Create a sync callback to persist per-turn cost data."""
+        def _record_cost(agent_name, cost_usd, input_tokens, output_tokens, session_id):
+            registry.record_cost(
+                agent_name,
+                cost_usd,
+                input_tokens,
+                output_tokens,
+                session_id=session_id,
+            )
+        return _record_cost
+
+    def _build_streaming_wake_context(agent_name: str) -> str:
+        """Build wake context for a streaming session."""
+        wake_ctx = ""
+        saved = agents.get_context(agent_name)
+        if saved:
+            ctx_prompt = saved.to_prompt()
+            if ctx_prompt:
+                wake_ctx = ctx_prompt
+
+        channel_ctx = broker.build_channel_context(agent_name)
+        if channel_ctx:
+            wake_ctx = f"{wake_ctx}\n\n{channel_ctx}" if wake_ctx else channel_ctx
+        return wake_ctx
+
+    async def _make_streaming_response_callback():
+        """Create a response callback that routes through the broker."""
+        async def _on_response(agent_name: str, platform: str, chat_id: str, response: str):
+            if chat_id and response:
+                await broker.route_response(agent_name, platform, chat_id, response)
+        return _on_response
+
+    async def _make_streaming_session_id_callback(agent_name: str, label: str):
+        """Persist a streaming session ID when captured from the SDK."""
+        async def _on_session_id(_agent_name: str, session_id: str):
+            agents.set_streaming_session_id(agent_name, session_id, label=label)
+            short_id = session_id[:12] if session_id else ""
+            _log(f"streaming[{agent_name}/{label}]: persisted session_id {short_id}")
+        return _on_session_id
+
+    async def _streaming_context_info(ss) -> dict:
+        """Best-effort context usage details for a streaming session."""
+        if not ss or not ss.is_connected or not ss._client:
+            return {}
+
+        try:
+            ctx = await ss._client.get_context_usage()
+            total = ctx.get("totalTokens", 0)
+            reported_max = ctx.get("maxTokens", 0)
+            actual_max = reported_max
+            if (ss._config.model or "") in _1M_MODELS and reported_max <= 200_000:
+                actual_max = 1_000_000
+            pct = round(total / actual_max * 100, 1) if actual_max > 0 else 0.0
+            return {
+                "total_tokens": total,
+                "max_tokens": actual_max,
+                "percentage": pct,
+            }
+        except Exception:
+            return {}
+
+    async def _streaming_health_info(agent_name: str, label: str = "main") -> dict | None:
+        """Return health-oriented session info for a streaming session."""
+        sessions = broker._streaming.get(agent_name, {})
+        ss = sessions.get(label)
+        if not ss:
+            return None
+
+        ctx = await _streaming_context_info(ss)
+        pct = ctx.get("percentage", 0.0)
+        return {
+            "id": f"{agent_name}-{label}",
+            "state": "connected" if ss.is_connected else "idle",
+            "context_used_pct": pct,
+            "message_count": ss._stats.get("messages_sent", 0) + ss._stats.get("turns", 0),
+            "needs_restart": bool(ctx) and pct >= ss._config.context_restart_pct,
+            "streaming": True,
+            "label": label,
+            "connected": ss.is_connected,
+            "sdk_session_id": ss.session_id[:12] if ss.session_id else "",
+        }
+
+    async def _start_streaming_session(
+        agent_name: str,
+        *,
+        label: str = "main",
+        resume_id: str = "",
+    ):
+        """Create, connect, and register a streaming session for an agent label."""
+        from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
+
+        agent = agents.get(agent_name)
+        if not agent or not agent.enabled:
+            return None
+
+        work_dir = str(Path(agent.working_dir).resolve()) if agent.working_dir else "."
+        restart_pct = int(agent.restart_threshold_pct) if agent.restart_threshold_pct else 80
+        warn_pct = max(restart_pct // 2, 20)
+
+        config = StreamingSessionConfig(
+            agent_name=agent_name,
+            model=agent.model,
+            working_dir=work_dir,
+            permission_mode=agent.permission_mode or "bypassPermissions",
+            max_turns=agent.max_turns,
+            system_prompt=agent.soul or "",
+            resume_session_id=resume_id,
+            wake_context=_build_streaming_wake_context(agent_name),
+            context_warn_pct=warn_pct,
+            context_restart_pct=restart_pct,
+        )
+
+        callback = await _make_streaming_response_callback()
+        sid_callback = await _make_streaming_session_id_callback(agent_name, label)
+        ss = StreamingSession(
+            config,
+            response_callback=callback,
+            conversation_store=store,
+            cost_callback=_make_cost_callback(agents),
+        )
+        ss._on_session_id = sid_callback
+        await ss.connect()
+        broker.register_streaming(agent_name, ss, label=label)
+        return ss
+
+    async def _ensure_streaming_session(agent_name: str, *, label: str = "main"):
+        """Return a connected streaming session for an agent label."""
+        sessions = broker._streaming.get(agent_name, {})
+        ss = sessions.get(label)
+        if ss:
+            if not ss.is_connected:
+                await ss.connect()
+            return ss
+
+        resume_id = agents.get_streaming_session_id(agent_name, label=label)
+        return await _start_streaming_session(agent_name, label=label, resume_id=resume_id)
+
+    async def _disconnect_streaming_sessions(agent_name: str) -> int:
+        """Disconnect and unregister all streaming sessions for an agent."""
+        persisted = agents.list_streaming_session_ids(agent_name)
+        sessions = dict(broker._streaming.get(agent_name, {}))
+        closed = 0
+
+        for label, ss in sessions.items():
+            try:
+                await ss.disconnect()
+            except Exception:
+                pass
+            closed += 1
+            agents.set_streaming_session_id(agent_name, "", label=label)
+
+        broker.unregister_streaming(agent_name)
+
+        for entry in persisted:
+            if entry["label"] not in sessions:
+                agents.set_streaming_session_id(agent_name, "", label=entry["label"])
+
+        return closed
+
     skills = SkillStore(db_path=db_path.replace(".db", "_skills.db"))
     outreach_config = OutreachConfigStore(db_path=db_path.replace(".db", "_outreach.db"))
     tasks = TaskStore(db_path=db_path.replace(".db", "_tasks.db"))
@@ -806,37 +978,8 @@ def create_api(
 
     @app.get("/sessions")
     async def list_sessions():
-        """List all active streaming sessions."""
-        results = []
-        for agent_name, sessions in broker._streaming.items():
-            for label, ss in sessions.items():
-                results.append({
-                    "id": f"{agent_name}-{label}",
-                    "state": "connected" if ss.is_connected else "idle",
-                    "model": ss._config.model,
-                    "created_at": 0,
-                    "last_active": getattr(ss, "last_active", 0),
-                    "message_count": ss._stats.get("messages_sent", 0) + ss._stats.get("turns", 0),
-                    "context_used_pct": 0,  # Fetched separately via /agents/{name}/streaming/status
-                    "session_type": label,
-                    "agent_name": agent_name,
-                    "usage": {
-                        "total_cost_usd": ss.usage.total_cost_usd,
-                        "total_turns": ss._stats.get("turns", 0),
-                        "total_queries": ss._stats.get("messages_sent", 0),
-                        "total_duration_ms": 0,
-                        "total_api_duration_ms": 0,
-                        "input_tokens": ss.usage.input_tokens,
-                        "output_tokens": ss.usage.output_tokens,
-                        "cache_read_tokens": getattr(ss.usage, "cache_read_tokens", 0),
-                        "cache_write_tokens": getattr(ss.usage, "cache_write_tokens", 0),
-                        "last_stop_reason": "",
-                        "last_usage": getattr(ss.usage, "last_usage", {}),
-                        "last_model_usage": {},
-                    },
-                    "permission_mode": ss._config.permission_mode,
-                })
-        return results
+        """List all active manager-backed ad-hoc sessions."""
+        return [SessionResponse(**s.to_dict()).model_dump() for s in manager.list()]
 
     @app.get("/sessions/{session_id}", response_model=SessionResponse)
     async def get_session(session_id: str):
@@ -1700,8 +1843,6 @@ def create_api(
     @app.post("/agents/{name}/streaming-sessions")
     async def create_streaming_session(name: str, label: str = "main"):
         """Create a new streaming session for an agent."""
-        from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
-
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
@@ -1712,32 +1853,12 @@ def create_api(
             if s["label"] == label:
                 raise HTTPException(409, f"Streaming session '{label}' already exists for {name}")
 
-        work_dir = str(Path(agent.working_dir).resolve()) if agent.working_dir else "."
-        restart_pct = int(agent.restart_threshold_pct) if agent.restart_threshold_pct else 80
-        warn_pct = max(restart_pct // 2, 20)
-
-        channel_ctx = broker.build_channel_context(name)
-
-        config = StreamingSessionConfig(
-            agent_name=name,
-            model=agent.model,
-            working_dir=work_dir,
-            permission_mode=agent.permission_mode or "bypassPermissions",
-            max_turns=agent.max_turns,
-            system_prompt=agent.soul or "",
-            wake_context=channel_ctx,
-            context_warn_pct=warn_pct,
-            context_restart_pct=restart_pct,
-        )
-
-        async def _on_response(agent_name: str, platform: str, chat_id: str, response: str):
-            if chat_id and response:
-                await broker.route_response(agent_name, platform, chat_id, response)
-
-        ss = StreamingSession(config, response_callback=_on_response, conversation_store=store)
         try:
-            await ss.connect()
-            broker.register_streaming(name, ss, label=label)
+            await _start_streaming_session(
+                name,
+                label=label,
+                resume_id=agents.get_streaming_session_id(name, label=label),
+            )
             _log(f"api: created streaming session {name}/{label}")
             return {"created": True, "agent": name, "label": label}
         except Exception as e:
@@ -1756,6 +1877,7 @@ def create_api(
             await ss.disconnect()
         except Exception:
             pass
+        agents.set_streaming_session_id(name, "", label=label)
         broker.unregister_streaming(name, label=label)
         return {"deleted": True, "agent": name, "label": label}
 
@@ -1784,7 +1906,7 @@ def create_api(
 
         # Disconnect and clear persisted session ID
         await ss.disconnect()
-        agents.set_streaming_session_id(name, "")
+        agents.set_streaming_session_id(name, "", label="main")
 
         # Reconnect fresh (no resume)
         ss._config.resume_session_id = ""
@@ -1849,7 +1971,7 @@ def create_api(
             old_session_id = ss.session_id
             old_turns = ss._stats["turns"]
             await ss.disconnect()
-            agents.set_streaming_session_id(name, "")
+            agents.set_streaming_session_id(name, "", label="main")
             ss._config.resume_session_id = ""
             ss.session_id = ""
             ss._config.model = req.model
@@ -1925,7 +2047,7 @@ def create_api(
         old_turns = ss._stats["turns"]
 
         await ss.disconnect()
-        agents.set_streaming_session_id(name, "")
+        agents.set_streaming_session_id(name, "", label="main")
 
         ss._config.resume_session_id = ""
         ss.session_id = ""
@@ -2314,8 +2436,11 @@ def create_api(
 
         # Find which session is saving (for updated_by)
         session_id = ""
+        streaming_main = broker._streaming.get(agent_name, {}).get("main")
+        if streaming_main and streaming_main.session_id:
+            session_id = streaming_main.session_id
         for s in manager.list():
-            if s.agent_name == agent_name and s.session_type == "main":
+            if not session_id and s.agent_name == agent_name and s.session_type == "main":
                 session_id = s.id
                 break
 
@@ -2354,18 +2479,21 @@ def create_api(
         if not agent:
             raise HTTPException(404, f"Agent '{agent_name}' not found")
 
-        # Close all sessions for this agent
+        streaming_closed = await _disconnect_streaming_sessions(agent_name)
+
+        # Close legacy manager-backed sessions for this agent
         closed = 0
         for s in list(manager.list()):
             if s.agent_name == agent_name:
                 manager.delete(s.id)
                 closed += 1
 
-        _log(f"api: agent {agent_name} entered deep sleep, closed {closed} session(s)")
+        total_closed = streaming_closed + closed
+        _log(f"api: agent {agent_name} entered deep sleep, closed {total_closed} session(s)")
         return {
             "agent": agent_name,
             "status": "sleeping",
-            "sessions_closed": closed,
+            "sessions_closed": total_closed,
             "context_saved": agents.get_context(agent_name) is not None,
         }
 
@@ -2373,86 +2501,35 @@ def create_api(
 
     @app.post("/agents/{agent_name}/wake")
     async def wake_agent(agent_name: str, prompt: str = ""):
-        """Manually trigger a wake for an agent's main session."""
+        """Manually trigger a wake for an agent's streaming main session."""
         agent = agents.get(agent_name)
         if not agent:
             raise HTTPException(404, f"Agent '{agent_name}' not found")
 
-        main_session = manager.get(f"{agent_name}-main")
-        if not main_session:
-            raise HTTPException(404, f"No main session for agent '{agent_name}'. Spawn one first.")
-
         wake_prompt = prompt or "Manual wake trigger"
         _log(f"api: waking agent {agent_name} with prompt: {wake_prompt[:80]}...")
 
-        msg = await main_session.send(wake_prompt)
-        store.append(f"{agent_name}-main", "user", wake_prompt)
-        if msg.content:
-            store.append(f"{agent_name}-main", "assistant", msg.content)
+        ss = await _ensure_streaming_session(agent_name, label="main")
+        if not ss:
+            raise HTTPException(503, f"Failed to start streaming main session for '{agent_name}'")
+        await ss.send(wake_prompt)
 
         return {
             "agent": agent_name,
-            "session_id": f"{agent_name}-main",
-            "response": msg.content,
-            "duration_ms": msg.duration_ms,
+            "session_id": ss.id,
+            "sent": True,
+            "connected": ss.is_connected,
         }
 
-    # ── Auto-spawn + Scheduler Startup ─────────────────────
-
-    async def _spawn_main_session(agent_name: str) -> str | None:
-        """Spawn a main session for an agent if one doesn't exist."""
-        existing = manager.get(f"{agent_name}-main")
-        if existing and existing.state != SessionState.closed:
-            return existing.id
-
-        agent = agents.get(agent_name)
-        if not agent or not agent.enabled:
-            return None
-
-        system_prompt = agents.build_system_prompt(agent_name)
-        work_dir = Path(agent.working_dir or default_working_dir).resolve()
-        work_dir.mkdir(parents=True, exist_ok=True)
-        claude_md = work_dir / "CLAUDE.md"
-        claude_md.write_text(system_prompt)
-
-        session = manager.create(
-            session_id=f"{agent_name}-main",
-            model=agent.model,
-            soul=agent.soul,
-            working_dir=str(work_dir),
-            allowed_tools=agent.allowed_tools or None,
-            max_turns=agent.max_turns,
-            timeout=agent.timeout,
-            system_prompt=system_prompt,
-            restart_threshold_pct=agent.restart_threshold_pct,
-            auto_restart=agent.auto_restart,
-            permission_mode=agent.permission_mode,
-            session_type="main",
-            agent_name=agent_name,
-        )
-        _log(f"api: auto-spawned main session {session.id} for agent {agent_name}")
-        return session.id
-
     async def _wake_callback(agent_name: str, session_id: str, prompt: str) -> None:
-        """Callback for the scheduler to wake an agent."""
-        session = manager.get(session_id)
-        if not session:
-            # Try to spawn if auto_start
-            spawned_id = await _spawn_main_session(agent_name)
-            if spawned_id:
-                session = manager.get(spawned_id)
-        if not session:
-            _log(f"scheduler: no session for {agent_name}, skipping wake")
+        """Callback for the scheduler/autonomy to wake an agent."""
+        del session_id  # Streaming is now the canonical main runtime.
+        ss = await _ensure_streaming_session(agent_name, label="main")
+        if not ss:
+            _log(f"scheduler: no streaming main session for {agent_name}, skipping wake")
             return
-        if session.state == SessionState.running:
-            _log(f"scheduler: session {session_id} is busy, skipping wake")
-            return
-
-        msg = await session.send(prompt)
-        store.append(session_id, "user", prompt)
-        if msg.content:
-            store.append(session_id, "assistant", msg.content)
-        _log(f"scheduler: woke {agent_name} via {session_id}")
+        await ss.send(prompt)
+        _log(f"scheduler: woke {agent_name} via streaming main")
 
     scheduler = AgentScheduler(
         agents,
@@ -2469,35 +2546,15 @@ def create_api(
 
     @app.on_event("startup")
     async def on_startup():
-        """Auto-spawn main sessions, start scheduler, start autonomy engine."""
-        # Auto-spawn main sessions for agents with auto_start=True
+        """Start broker pollers, streaming sessions, scheduler, and autonomy."""
         auto_start_agents = agents.list_auto_start_agents()
-        for agent in auto_start_agents:
-            try:
-                session_id = await _spawn_main_session(agent.name)
-                if session_id:
-                    _log(f"startup: main session ready for {agent.name} -> {session_id}")
-            except Exception as e:
-                _log(f"startup: failed to spawn main session for {agent.name}: {e}")
 
-        # Start the scheduler
-        await scheduler.start()
-
-        # Start autonomy engine
-        await autonomy.start()
-
-        # Start work loops for auto_start agents
-        for agent in auto_start_agents:
-            await autonomy.start_agent_loop(agent.name)
-
-        # Start broker pollers (for agents with platform tokens) and streaming sessions (for all enabled agents)
+        # Start broker pollers and streaming sessions for all enabled agents.
         from pinky_daemon.pollers import BrokerTelegramPoller
-        from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
         from pinky_outreach.telegram import TelegramAdapter
         all_agents = agents.list(enabled_only=True)
         streaming_count = 0
         for agent in all_agents:
-            # Start broker poller if agent has a Telegram token
             token = agents.get_raw_token(agent.name, "telegram")
             if token:
                 adapter = TelegramAdapter(token)
@@ -2508,75 +2565,26 @@ def create_api(
                 asyncio.create_task(poller.start())
                 _log(f"startup: broker poller started for {agent.name}")
 
-            # Start streaming session for ALL enabled agents
-            work_dir = str(Path(agent.working_dir).resolve()) if agent.working_dir else "."
-            resume_id = agents.get_streaming_session_id(agent.name)
+            persisted = agents.list_streaming_session_ids(agent.name)
+            labels_to_start = {entry["label"]: entry["session_id"] for entry in persisted if entry["session_id"]}
+            labels_to_start.setdefault("main", agents.get_streaming_session_id(agent.name, label="main"))
 
-            # Load saved continuation context for wake prompt
-            wake_ctx = ""
-            saved = agents.get_context(agent.name)
-            if saved:
-                ctx_prompt = saved.to_prompt()
-                if ctx_prompt:
-                    wake_ctx = ctx_prompt
+            for label, resume_id in labels_to_start.items():
+                try:
+                    await _start_streaming_session(agent.name, label=label, resume_id=resume_id)
+                    streaming_count += 1
+                    if resume_id:
+                        _log(f"startup: streaming session resumed for {agent.name}/{label} (session {resume_id[:12]})")
+                    else:
+                        _log(f"startup: streaming session connected for {agent.name}/{label} (new)")
+                except Exception as e:
+                    _log(f"startup: streaming session failed for {agent.name}/{label}: {e}")
 
-            # Append channel context (active channels + routing protocol)
-            channel_ctx = broker.build_channel_context(agent.name)
-            if channel_ctx:
-                wake_ctx = f"{wake_ctx}\n\n{channel_ctx}" if wake_ctx else channel_ctx
+        await scheduler.start()
+        await autonomy.start()
 
-            # Context thresholds: per-agent override or global defaults
-            restart_pct = int(agent.restart_threshold_pct) if agent.restart_threshold_pct else 80
-            warn_pct = max(restart_pct // 2, 20)  # Half of restart, min 20%
-
-            config = StreamingSessionConfig(
-                agent_name=agent.name,
-                model=agent.model,
-                working_dir=work_dir,
-                permission_mode=agent.permission_mode or "bypassPermissions",
-                max_turns=agent.max_turns,
-                system_prompt=agent.soul or "",
-                resume_session_id=resume_id,
-                wake_context=wake_ctx,
-                context_warn_pct=warn_pct,
-                context_restart_pct=restart_pct,
-            )
-
-            async def _make_streaming_callback(ag_name):
-                """Create a response callback that routes through the broker."""
-                async def _on_response(agent_name: str, platform: str, chat_id: str, response: str):
-                    if chat_id and response:
-                        await broker.route_response(agent_name, platform, chat_id, response)
-                return _on_response
-
-            async def _make_session_id_callback(ag_name):
-                """Persist session ID when captured from SDK."""
-                async def _on_session_id(agent_name: str, session_id: str):
-                    agents.set_streaming_session_id(agent_name, session_id)
-                    _log(f"startup: persisted session_id for {agent_name}: {session_id[:12]}")
-                return _on_session_id
-
-            def _make_cost_callback(registry):
-                """Create a sync callback to persist costs to DB."""
-                def _record_cost(agent_name, cost_usd, input_tokens, output_tokens, session_id):
-                    registry.record_cost(agent_name, cost_usd, input_tokens, output_tokens, session_id=session_id)
-                return _record_cost
-
-            callback = await _make_streaming_callback(agent.name)
-            sid_callback = await _make_session_id_callback(agent.name)
-            ss = StreamingSession(config, response_callback=callback, conversation_store=store,
-                                  cost_callback=_make_cost_callback(agents))
-            ss._on_session_id = sid_callback
-            try:
-                await ss.connect()
-                broker.register_streaming(agent.name, ss, label="main")
-                streaming_count += 1
-                if resume_id:
-                    _log(f"startup: streaming session resumed for {agent.name} (session {resume_id[:12]})")
-                else:
-                    _log(f"startup: streaming session connected for {agent.name} (new)")
-            except Exception as e:
-                _log(f"startup: streaming session failed for {agent.name}: {e}")
+        for agent in auto_start_agents:
+            await autonomy.start_agent_loop(agent.name)
 
         _log(f"startup: scheduler + autonomy running, {len(auto_start_agents)} agent(s) auto-started, {len(_broker_pollers)} broker poller(s), {streaming_count} streaming")
 
@@ -2634,7 +2642,20 @@ def create_api(
                 "latest_heartbeat": hb_map.get(a.name),
                 "schedules": agent_schedules,
             })
-        return {"agents": result, "scheduler_running": scheduler.running}
+        return {
+            "agents": result,
+            "scheduler_running": scheduler.running,
+            "heartbeat_prompt": agents.get_heartbeat_prompt(),
+        }
+
+    @app.put("/settings/heartbeat/prompt")
+    async def set_heartbeat_prompt(req: UpdateHeartbeatPromptRequest):
+        """Update the global heartbeat wake prompt."""
+        prompt = req.prompt.strip()
+        if not prompt:
+            raise HTTPException(400, "prompt is required")
+        agents.set_heartbeat_prompt(prompt)
+        return {"updated": True, "heartbeat_prompt": agents.get_heartbeat_prompt()}
 
     @app.get("/system/auth")
     async def get_auth_status():
@@ -3006,17 +3027,30 @@ def create_api(
         if not agent:
             raise HTTPException(404, f"Agent '{agent_name}' not found")
 
-        # Session info
-        main_session = manager.get(f"{agent_name}-main")
-        session_info = None
-        if main_session:
-            session_info = {
-                "id": main_session.id,
-                "state": main_session.state.value,
-                "context_used_pct": main_session.context_used_pct,
-                "message_count": main_session.message_count,
-                "needs_restart": main_session.needs_restart,
-            }
+        session_info = await _streaming_health_info(agent_name, label="main")
+        legacy_session = None
+        if not session_info:
+            main_session = manager.get(f"{agent_name}-main")
+            if main_session:
+                session_info = {
+                    "id": main_session.id,
+                    "state": main_session.state.value,
+                    "context_used_pct": main_session.context_used_pct,
+                    "message_count": main_session.message_count,
+                    "needs_restart": main_session.needs_restart,
+                    "streaming": False,
+                }
+        else:
+            main_session = manager.get(f"{agent_name}-main")
+            if main_session:
+                legacy_session = {
+                    "id": main_session.id,
+                    "state": main_session.state.value,
+                    "context_used_pct": main_session.context_used_pct,
+                    "message_count": main_session.message_count,
+                    "needs_restart": main_session.needs_restart,
+                    "streaming": False,
+                }
 
         # Heartbeat
         hb = agents.get_latest_heartbeat(agent_name)
@@ -3054,6 +3088,7 @@ def create_api(
             "enabled": agent.enabled,
             "role": agent.role,
             "session": session_info,
+            "legacy_session": legacy_session,
             "heartbeat": heartbeat_info,
             "tasks": task_info,
             "autonomy": {

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -140,7 +140,6 @@ class AgentScheduler:
         self._tick_interval = tick_interval
         self._running = False
         self._task: asyncio.Task | None = None
-        self._last_check_minute: int = -1  # Prevent double-firing within same minute
         self._last_clock_slot: dict[str, int] = {}  # agent_name -> last fired clock slot (minutes since midnight)
 
     async def start(self) -> None:
@@ -354,7 +353,7 @@ class AgentScheduler:
                     session_id = f"{agent.name}-main"
                     await self._wake_callback(
                         agent.name, session_id,
-                        f"Clock-aligned wake ({interval_minutes}m interval)",
+                        self._registry.get_heartbeat_prompt(),
                     )
                 except Exception as e:
                     _log(f"scheduler: clock-aligned wake failed for {agent.name}: {e}")

--- a/src/pinky_daemon/sessions.py
+++ b/src/pinky_daemon/sessions.py
@@ -374,10 +374,11 @@ class Session:
 
             start = time.time()
 
-            # Only resume if we have a real SDK session ID (UUID from prior query)
-            # Using arbitrary IDs (like "barsik-main") crashes the SDK subprocess
-            can_resume = not is_first and bool(self._sdk_session_id)
-            resume_id = self._sdk_session_id if can_resume else ""
+            can_resume = not is_first
+            resume_id = ""
+            if can_resume and self._runner_type == "sdk" and self._sdk_session_id:
+                # SDK sessions should prefer the real Claude session ID when we have it.
+                resume_id = self._sdk_session_id
 
             result = await self._runner.run(
                 content,

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -71,9 +71,7 @@ class StreamingSession:
         self._reader_task: asyncio.Task | None = None
         self._connected = False
         self._last_response = ""
-        self._last_chat_id = ""  # Track which chat to respond to
         self._pending_chats: list[tuple[str, str]] = []  # Queue of (platform, chat_id) awaiting response
-        self._lock = asyncio.Lock()
 
         self.agent_name = config.agent_name
         self.session_id = config.resume_session_id  # CC session ID (persisted across restarts)
@@ -83,7 +81,6 @@ class StreamingSession:
         self._stats = {"turns": 0, "messages_sent": 0, "errors": 0, "reconnects": 0, "auto_restarts": 0}
         self.account_info: dict = {}  # Populated from SDK init: email, subscriptionType, apiProvider
         self._on_session_id = None  # async fn(agent_name, session_id) — called when session_id is captured
-        self._on_force_restart = None  # async fn(agent_name) — called on auto-restart to persist context
         self._context_warned = False  # Track if we've already warned this session
 
     async def connect(self) -> None:
@@ -178,9 +175,6 @@ class StreamingSession:
             _log(f"streaming[{self.agent_name}]: not connected, dropping message")
             return
 
-        if chat_id:
-            self._pending_chats.append((platform, chat_id))
-
         self.last_active = time.time()
         self._stats["messages_sent"] += 1
 
@@ -196,6 +190,8 @@ class StreamingSession:
 
         try:
             await self._client.query(prompt)
+            if chat_id:
+                self._pending_chats.append((platform, chat_id))
             _log(f"streaming[{self.agent_name}]: sent message (chat={chat_id})")
         except Exception as e:
             self._stats["errors"] += 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import tempfile
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from pinky_daemon.claude_runner import RunResult
+from pinky_daemon.agent_registry import DEFAULT_HEARTBEAT_PROMPT
 from pinky_daemon.sessions import (
     Checkpoint,
     ContextStatus,
@@ -151,6 +155,27 @@ class TestSession:
         assert session.state == SessionState.closed
 
 
+class TestStreamingSession:
+    @pytest.mark.asyncio
+    async def test_failed_send_clears_pending_route(self):
+        from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
+
+        session = StreamingSession(StreamingSessionConfig(agent_name="test-agent"))
+        session._connected = True
+
+        class FailingClient:
+            async def query(self, prompt):
+                raise RuntimeError("boom")
+
+        session._client = FailingClient()
+        session._try_reconnect = AsyncMock()
+
+        await session.send("hello", platform="telegram", chat_id="chat-1")
+
+        assert session._pending_chats == []
+        session._try_reconnect.assert_awaited_once()
+
+
 # ── SessionManager ───────────────────────────────────────────
 
 
@@ -228,12 +253,58 @@ class TestSessionManager:
 
 class TestAPI:
     def _make_client(self):
-        import tempfile
-        fd, path = tempfile.mkstemp(suffix=".db")
-        import os; os.close(fd)
         from pinky_daemon.api import create_api
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
         app = create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
         return TestClient(app)
+
+    def _make_app(self, path: str):
+        from pinky_daemon.api import create_api
+        return create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
+
+    class _FakeContextClient:
+        def __init__(self, total_tokens=0, max_tokens=200_000):
+            self.total_tokens = total_tokens
+            self.max_tokens = max_tokens
+
+        async def get_context_usage(self):
+            return {"totalTokens": self.total_tokens, "maxTokens": self.max_tokens}
+
+    class _FakeStreamingSession:
+        def __init__(self, agent_name: str, label: str = "main", *, connected: bool = True, total_tokens: int = 0, max_tokens: int = 200_000):
+            self.agent_name = agent_name
+            self.label = label
+            self.session_id = f"{agent_name}-{label}-sdk"
+            self.created_at = time.time()
+            self.last_active = self.created_at
+            self.is_connected = connected
+            self._stats = {"messages_sent": 2, "turns": 3, "errors": 0, "reconnects": 0, "auto_restarts": 0}
+            self._config = SimpleNamespace(model="sonnet", context_restart_pct=80, permission_mode="bypassPermissions")
+            self.usage = SimpleNamespace(total_cost_usd=0.0, input_tokens=0, output_tokens=0)
+            self._client = TestAPI._FakeContextClient(total_tokens=total_tokens, max_tokens=max_tokens) if connected else None
+            self.sent: list[tuple[str, str, str]] = []
+            self.disconnect_calls = 0
+            self.connect_calls = 0
+
+        @property
+        def id(self) -> str:
+            return f"{self.agent_name}-{self.label}"
+
+        @property
+        def stats(self) -> dict:
+            return {**self._stats, "connected": self.is_connected, "pending_responses": 0, "cost_usd": 0.0, "account": {}}
+
+        async def send(self, prompt: str, platform: str = "", chat_id: str = ""):
+            self.sent.append((prompt, platform, chat_id))
+
+        async def disconnect(self):
+            self.disconnect_calls += 1
+            self.is_connected = False
+
+        async def connect(self):
+            self.connect_calls += 1
+            self.is_connected = True
 
     def test_root(self):
         client = self._make_client()
@@ -258,6 +329,30 @@ class TestAPI:
         assert resp.status_code == 200
         assert resp.json()["id"] == "my-session"
 
+    def test_get_heartbeat_settings_includes_prompt(self):
+        client = self._make_client()
+        resp = client.get("/settings/heartbeat")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["heartbeat_prompt"] == DEFAULT_HEARTBEAT_PROMPT
+
+    def test_update_heartbeat_prompt(self):
+        client = self._make_client()
+        resp = client.put("/settings/heartbeat/prompt", json={
+            "prompt": "Check for messages, otherwise reply HEARTBEAT_OK.",
+        })
+        assert resp.status_code == 200
+        assert resp.json()["heartbeat_prompt"] == "Check for messages, otherwise reply HEARTBEAT_OK."
+
+        settings = client.get("/settings/heartbeat")
+        assert settings.status_code == 200
+        assert settings.json()["heartbeat_prompt"] == "Check for messages, otherwise reply HEARTBEAT_OK."
+
+    def test_update_heartbeat_prompt_rejects_blank(self):
+        client = self._make_client()
+        resp = client.put("/settings/heartbeat/prompt", json={"prompt": "   "})
+        assert resp.status_code == 400
+
     def test_create_session_defaults(self):
         client = self._make_client()
         resp = client.post("/sessions", json={})
@@ -275,6 +370,113 @@ class TestAPI:
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 2
+
+    def test_list_sessions_excludes_streaming_sessions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/sessions", json={"session_id": "adhoc"})
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                fake = self._FakeStreamingSession("test-agent", "main")
+                app.state.broker.register_streaming("test-agent", fake, label="main")
+
+                resp = client.get("/sessions")
+                assert resp.status_code == 200
+                data = resp.json()
+                assert len(data) == 1
+                assert data[0]["id"] == "adhoc"
+
+    def test_sleep_disconnects_streaming_main(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                app.state.agents.set_streaming_session_id("test-agent", "persisted-main", label="main")
+                fake = self._FakeStreamingSession("test-agent", "main")
+                app.state.broker.register_streaming("test-agent", fake, label="main")
+
+                resp = client.post("/agents/test-agent/sleep")
+                assert resp.status_code == 200
+                assert resp.json()["status"] == "sleeping"
+                assert fake.disconnect_calls == 1
+                assert app.state.broker._streaming.get("test-agent") is None
+                assert app.state.agents.get_streaming_session_id("test-agent", label="main") == ""
+
+    def test_health_prefers_streaming_main(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                app.state.manager.create(session_id="test-agent-main", session_type="main", agent_name="test-agent")
+                fake = self._FakeStreamingSession("test-agent", "main", total_tokens=180_000)
+                app.state.broker.register_streaming("test-agent", fake, label="main")
+
+                resp = client.get("/agents/test-agent/health")
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["session"]["streaming"] is True
+                assert data["session"]["id"] == "test-agent-main"
+                assert data["session"]["needs_restart"] is True
+                assert data["legacy_session"]["streaming"] is False
+
+    def test_wake_creates_streaming_session_and_sends(self):
+        sent_prompts = []
+
+        async def fake_connect(self):
+            self._connected = True
+            if not self.session_id:
+                self.session_id = f"{self.agent_name}-sdk"
+            if self._on_session_id:
+                await self._on_session_id(self.agent_name, self.session_id)
+
+        async def fake_send(self, prompt: str, platform: str = "", chat_id: str = ""):
+            sent_prompts.append((self.agent_name, prompt, platform, chat_id))
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.streaming_session.StreamingSession.connect", new=fake_connect), \
+                patch("pinky_daemon.streaming_session.StreamingSession.send", new=fake_send):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+
+                resp = client.post("/agents/test-agent/wake?prompt=Wake+up")
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["sent"] is True
+                assert data["connected"] is True
+                assert "test-agent" in app.state.broker._streaming
+                assert app.state.broker._streaming["test-agent"]["main"].is_connected is True
+                assert sent_prompts[-1][1] == "Wake up"
+
+    def test_manual_streaming_session_persists_and_restores_labels(self):
+        async def fake_connect(self):
+            self._connected = True
+            if not self.session_id:
+                self.session_id = f"{self.agent_name}-sdk"
+            if self._on_session_id:
+                await self._on_session_id(self.agent_name, self.session_id)
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.streaming_session.StreamingSession.connect", new=fake_connect):
+            db_path = os.path.join(tmpdir, "test.db")
+            app1 = self._make_app(db_path)
+            with TestClient(app1) as client1:
+                client1.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                resp = client1.post("/agents/test-agent/streaming-sessions?label=worker")
+                assert resp.status_code == 200
+                assert app1.state.agents.get_streaming_session_id("test-agent", label="worker") == "test-agent-sdk"
+
+            app2 = self._make_app(db_path)
+            with TestClient(app2) as client2:
+                resp = client2.get("/agents/test-agent/streaming-sessions")
+                assert resp.status_code == 200
+                labels = {item["label"] for item in resp.json()["sessions"]}
+                assert "main" in labels
+                assert "worker" in labels
 
     def test_get_session(self):
         client = self._make_client()


### PR DESCRIPTION
## Summary
- restore classic `/sessions` behavior and manager-backed resume semantics
- make named-agent lifecycle streaming-first for sleep, wake, health, and startup
- persist manual streaming session ids by label and fix stale pending chat routing
- remove dead lifecycle fields and add regression coverage for routing and session lifecycle behavior

## Testing
- `pytest tests/test_api.py::TestStreamingSession::test_failed_send_clears_pending_route tests/test_api.py::TestSession::test_send_resumes_after_first tests/test_api.py::TestAPI::test_list_sessions tests/test_api.py::TestAPI::test_list_sessions_excludes_streaming_sessions tests/test_api.py::TestAPI::test_sleep_disconnects_streaming_main tests/test_api.py::TestAPI::test_health_prefers_streaming_main tests/test_api.py::TestAPI::test_wake_creates_streaming_session_and_sends tests/test_api.py::TestAPI::test_manual_streaming_session_persists_and_restores_labels tests/test_pinky_self.py -q`
- `pytest tests/test_api.py tests/test_session_store.py tests/test_conversation_store.py tests/test_scheduler.py tests/test_pinky_self.py -q`
- `pytest tests/test_agent_registry.py -q`
- `python3 -m py_compile src/pinky_daemon/api.py src/pinky_daemon/sessions.py src/pinky_daemon/streaming_session.py src/pinky_daemon/agent_registry.py src/pinky_daemon/scheduler.py tests/test_api.py`