### PR TITLE
[codex] Fix multiline @channel routing

### DIFF
--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -291,34 +291,57 @@ class MessageBroker:
                 await self._broadcast(agent_name, body)
             return
 
-        # Scan all lines for @channel: directives (agents sometimes put them mid-response)
-        channel_lines = []
-        other_lines = []
-        for line in lines:
-            if line.strip().lower().startswith("@channel:"):
-                channel_lines.append(line.strip())
-            else:
-                other_lines.append(line)
+        # Scan all lines for @channel: directives (agents sometimes put them mid-response).
+        # Support both "@channel:<target> body" and the documented two-line form:
+        # "@channel:<target>\n<body>".
+        channel_blocks: list[tuple[str, str]] = []
+        other_lines: list[str] = []
+        idx = 0
 
-        if channel_lines:
-            for ch_line in channel_lines:
-                after_prefix = ch_line[9:].strip()
-                if " " in after_prefix:
-                    target, body = after_prefix.split(" ", 1)
+        while idx < len(lines):
+            raw_line = lines[idx]
+            stripped_line = raw_line.strip()
+            if not stripped_line.lower().startswith("@channel:"):
+                other_lines.append(raw_line)
+                idx += 1
+                continue
+
+            after_prefix = stripped_line[9:].strip()
+            target = ""
+            body_lines: list[str] = []
+
+            if " " in after_prefix:
+                target, inline_body = after_prefix.split(" ", 1)
+                if inline_body:
+                    body_lines.append(inline_body)
+            else:
+                target = after_prefix
+
+            idx += 1
+            if not body_lines:
+                while idx < len(lines) and not lines[idx].strip().lower().startswith("@channel:"):
+                    body_lines.append(lines[idx])
+                    idx += 1
+
+            if target:
+                channel_blocks.append((target, "\n".join(body_lines).strip()))
+
+        if channel_blocks:
+            for target, body in channel_blocks:
+                if not body:
+                    _log(f"broker: {agent_name} targeted channel {target} with empty body")
+                    continue
+
+                resolved = self._resolve_channel(agent_name, target)
+                if resolved:
+                    r_platform, r_chat_id = resolved
+                    if self._send_callback:
+                        await self._send_callback(agent_name, r_platform, r_chat_id, body)
+                    _log(f"broker: {agent_name} targeted channel {target} -> {r_chat_id}")
                 else:
-                    target = after_prefix
-                    body = ""
-                if target and body:
-                    resolved = self._resolve_channel(agent_name, target)
-                    if resolved:
-                        r_platform, r_chat_id = resolved
-                        if self._send_callback:
-                            await self._send_callback(agent_name, r_platform, r_chat_id, body)
-                        _log(f"broker: {agent_name} targeted channel {target} -> {r_chat_id}")
-                    else:
-                        _log(f"broker: {agent_name} targeted unknown channel '{target}', falling back to default")
-                        if self._send_callback and chat_id:
-                            await self._send_callback(agent_name, platform, chat_id, ch_line)
+                    _log(f"broker: {agent_name} targeted unknown channel '{target}', falling back to default")
+                    other_lines.append(f"@channel:{target}\n{body}")
+
             # If there's non-channel content too, send it to the triggering chat
             other_text = "\n".join(other_lines).strip()
             if other_text and "[no reply]" not in other_text.lower() and chat_id:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,83 @@
+"""Tests for pinky_daemon.message broker routing."""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.broker import MessageBroker
+from pinky_daemon.sessions import SessionManager
+
+
+class TestMessageBrokerRouting:
+    def _make_broker(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        registry = AgentRegistry(db_path=f"{tmpdir.name}/agents.db")
+        registry.register("barsik", model="sonnet", working_dir=tmpdir.name)
+
+        sent_messages: list[tuple[str, str, str, str]] = []
+
+        async def send_callback(agent_name: str, platform: str, chat_id: str, content: str):
+            sent_messages.append((agent_name, platform, chat_id, content))
+
+        broker = MessageBroker(registry, SessionManager(), send_callback=send_callback)
+        return tmpdir, registry, broker, sent_messages
+
+    @pytest.mark.asyncio
+    async def test_route_response_targets_newline_channel_block(self):
+        tmpdir, registry, broker, sent_messages = self._make_broker()
+        try:
+            registry.approve_user("barsik", "6770805286", display_name="Brad", approved_by="test")
+
+            await broker.route_response(
+                "barsik",
+                "web",
+                "web",
+                "@channel:6770805286\nPing from Barsik",
+            )
+
+            assert sent_messages == [
+                ("barsik", "telegram", "6770805286", "Ping from Barsik"),
+            ]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_response_targets_multiple_newline_channel_blocks(self):
+        tmpdir, registry, broker, sent_messages = self._make_broker()
+        try:
+            registry.approve_user("barsik", "111", display_name="Brad", approved_by="test")
+            registry.approve_user("barsik", "222", display_name="Oleg", approved_by="test")
+
+            await broker.route_response(
+                "barsik",
+                "web",
+                "web",
+                "@channel:111\nFirst ping\n@channel:222\nSecond ping",
+            )
+
+            assert sent_messages == [
+                ("barsik", "telegram", "111", "First ping"),
+                ("barsik", "telegram", "222", "Second ping"),
+            ]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_response_falls_back_with_unknown_newline_channel_block(self):
+        tmpdir, registry, broker, sent_messages = self._make_broker()
+        try:
+            await broker.route_response(
+                "barsik",
+                "web",
+                "web",
+                "@channel:missing-user\nFallback body",
+            )
+
+            assert sent_messages == [
+                ("barsik", "web", "web", "@channel:missing-user\nFallback body"),
+            ]
+        finally:
+            tmpdir.cleanup()


### PR DESCRIPTION
## Summary
- fix `@channel:` parsing in the broker so the documented multiline form (`@channel:<target>` on one line, message body below) routes to the resolved channel instead of falling back to the origin chat
- parse repeated `@channel:` blocks sequentially so multiple targeted messages in one response stay separated
- add focused broker tests for multiline target routing, repeated channel blocks, and unknown-target fallback behavior

## Root cause
`MessageBroker.route_response()` documented newline-form channel routing, but the implementation only delivered targeted messages when the body appeared on the same line as the directive. When an agent replied with:

```text
@channel:6770805286
Ping from Barsik
```

the broker treated the directive line as metadata only and sent `Ping from Barsik` back to the triggering chat instead of to Telegram DM `6770805286`.

## Validation
- `PYTHONPATH=/tmp/PinkyBot-issue21/src pytest tests/test_broker.py -q`
- `PYTHONPATH=/tmp/PinkyBot-issue21/src python3 -m compileall src/pinky_daemon/broker.py tests/test_broker.py`

## Notes
A broader `tests/test_api.py -q` run in this checkout still shows unrelated failures in `TestSession.test_send_resumes_after_first` and `TestAPI.test_list_sessions` that this patch does not touch.

Closes #21