### PR TITLE
Add agent lifecycle controls and messaging routing updates

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -674,6 +674,26 @@ def create_api(
                     except Exception as e2:
                         _log(f"broker-send: plain also failed for {agent_name} -> {chat_id}: {e2}")
 
+    async def _broker_react(
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+    ):
+        """Add a reaction on behalf of an agent."""
+        if platform != "telegram":
+            return
+
+        adapter = _get_tg_adapter(agent_name)
+        if not adapter:
+            return
+
+        try:
+            adapter.set_reaction(chat_id, int(message_id), emoji)
+        except Exception as e:
+            _log(f"broker-react: failed for {agent_name} -> {chat_id}:{message_id} {emoji}: {e}")
+
     async def _broker_typing(agent_name: str, platform: str, chat_id: str):
         """Show typing indicator on the platform."""
         if platform == "telegram":
@@ -684,7 +704,13 @@ def create_api(
                 except Exception:
                     pass
 
-    broker = MessageBroker(agents, manager, send_callback=_broker_send, typing_callback=_broker_typing)
+    broker = MessageBroker(
+        agents,
+        manager,
+        send_callback=_broker_send,
+        reaction_callback=_broker_react,
+        typing_callback=_broker_typing,
+    )
     _broker_pollers: list = []  # Track active broker pollers
 
     app.state.manager = manager
@@ -721,9 +747,21 @@ def create_api(
 
     async def _make_streaming_response_callback():
         """Create a response callback that routes through the broker."""
-        async def _on_response(agent_name: str, platform: str, chat_id: str, response: str):
+        async def _on_response(
+            agent_name: str,
+            platform: str,
+            chat_id: str,
+            response: str,
+            message_id: str = "",
+        ):
             if chat_id and response:
-                await broker.route_response(agent_name, platform, chat_id, response)
+                await broker.route_response(
+                    agent_name,
+                    platform,
+                    chat_id,
+                    response,
+                    message_id=message_id,
+                )
         return _on_response
 
     async def _make_streaming_session_id_callback(agent_name: str, label: str):

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -56,11 +56,13 @@ class MessageBroker:
         session_manager,  # SessionManager — avoid circular import
         *,
         send_callback=None,  # async fn(agent_name, platform, chat_id, content) → send reply
+        reaction_callback=None,  # async fn(agent_name, platform, chat_id, message_id, emoji)
         typing_callback=None,  # async fn(agent_name, platform, chat_id) → show typing indicator
     ) -> None:
         self._registry = registry
         self._sessions = session_manager
         self._send_callback = send_callback
+        self._reaction_callback = reaction_callback
         self._typing_callback = typing_callback
         self._stats = {"routed": 0, "pending": 0, "denied": 0, "errors": 0}
 
@@ -72,6 +74,25 @@ class MessageBroker:
     def send_callback(self):
         """Expose the send callback for direct use by scheduler etc."""
         return self._send_callback
+
+    async def _send_message(self, agent_name: str, platform: str, chat_id: str, content: str) -> None:
+        """Send a message if the outbound callback is configured."""
+        if self._send_callback:
+            await self._send_callback(agent_name, platform, chat_id, content)
+
+    async def _add_reaction(
+        self,
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+    ) -> bool:
+        """Add a reaction if the outbound callback is configured."""
+        if not (self._reaction_callback and message_id and emoji):
+            return False
+        await self._reaction_callback(agent_name, platform, chat_id, message_id, emoji)
+        return True
 
     async def handle_inbound(self, message: BrokerMessage) -> None:
         """Handle an incoming platform message. Non-blocking."""
@@ -223,11 +244,10 @@ class MessageBroker:
         if not streaming or not streaming.is_connected:
             _log(f"broker: streaming session for {agent_name} not connected, dropping message")
             self._stats["errors"] += 1
-            if self._send_callback:
-                await self._send_callback(
-                    agent_name, message.platform, message.chat_id,
-                    f"⚠️ {agent_name} is not running right now. Try again later.",
-                )
+            await self._send_message(
+                agent_name, message.platform, message.chat_id,
+                f"⚠️ {agent_name} is not running right now. Try again later.",
+            )
             return
 
         # Show typing indicator
@@ -239,7 +259,12 @@ class MessageBroker:
 
         # Format and send — non-blocking
         prompt = self._format_prompt(message)
-        await streaming.send(prompt, platform=message.platform, chat_id=message.chat_id)
+        await streaming.send(
+            prompt,
+            platform=message.platform,
+            chat_id=message.chat_id,
+            message_id=message.message_id,
+        )
         self._stats["routed"] += 1
         _log(f"broker: streamed message to {agent_name} (non-blocking)")
 
@@ -263,12 +288,21 @@ class MessageBroker:
     # ── Response Routing ───────────────────────────────────
 
     async def route_response(
-        self, agent_name: str, platform: str, chat_id: str, response: str,
+        self,
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        response: str,
+        *,
+        message_id: str = "",
     ) -> None:
         """Parse agent response for routing directives and deliver.
 
         Protocol:
         - '[no reply]' (full response) → suppress
+        - '@react:<emoji>' → react to the triggering message
+        - '@react:<message_id> <emoji>' → react to a specific message in the current chat
+        - '@react:<channel-or-id> <message_id> <emoji>' → react in another known channel
         - '@channel:<alias-or-id>\\n<body>' → resolve and send to that channel
         - '@all\\n<body>' → broadcast to all active channels
         - Plain text → send to (platform, chat_id) that triggered this turn
@@ -291,17 +325,35 @@ class MessageBroker:
                 await self._broadcast(agent_name, body)
             return
 
-        # Scan all lines for @channel: directives (agents sometimes put them mid-response).
+        # Scan all lines for routing directives (agents sometimes put them mid-response).
         # Support both "@channel:<target> body" and the documented two-line form:
         # "@channel:<target>\n<body>".
         channel_blocks: list[tuple[str, str]] = []
+        reaction_actions: list[tuple[str, str, str, str]] = []
         other_lines: list[str] = []
         idx = 0
 
         while idx < len(lines):
             raw_line = lines[idx]
             stripped_line = raw_line.strip()
-            if not stripped_line.lower().startswith("@channel:"):
+            lowered = stripped_line.lower()
+
+            if lowered.startswith("@react:"):
+                parsed = self._parse_reaction_directive(
+                    agent_name,
+                    platform,
+                    chat_id,
+                    message_id,
+                    stripped_line,
+                )
+                if parsed:
+                    reaction_actions.append(parsed)
+                else:
+                    other_lines.append(raw_line)
+                idx += 1
+                continue
+
+            if not lowered.startswith("@channel:"):
                 other_lines.append(raw_line)
                 idx += 1
                 continue
@@ -319,12 +371,37 @@ class MessageBroker:
 
             idx += 1
             if not body_lines:
-                while idx < len(lines) and not lines[idx].strip().lower().startswith("@channel:"):
+                while idx < len(lines):
+                    next_line = lines[idx].strip().lower()
+                    if next_line.startswith("@channel:") or next_line.startswith("@react:"):
+                        break
                     body_lines.append(lines[idx])
                     idx += 1
 
             if target:
                 channel_blocks.append((target, "\n".join(body_lines).strip()))
+
+        reacted = False
+        for reaction_platform, reaction_chat_id, reaction_message_id, emoji in reaction_actions:
+            try:
+                did_react = await self._add_reaction(
+                    agent_name,
+                    reaction_platform,
+                    reaction_chat_id,
+                    reaction_message_id,
+                    emoji,
+                )
+                reacted = reacted or did_react
+                if did_react:
+                    _log(
+                        f"broker: {agent_name} reacted {emoji} "
+                        f"to {reaction_platform}:{reaction_chat_id}:{reaction_message_id}"
+                    )
+            except Exception as e:
+                _log(
+                    f"broker: failed reaction for {agent_name} "
+                    f"{reaction_platform}:{reaction_chat_id}:{reaction_message_id}: {e}"
+                )
 
         if channel_blocks:
             for target, body in channel_blocks:
@@ -335,8 +412,7 @@ class MessageBroker:
                 resolved = self._resolve_channel(agent_name, target)
                 if resolved:
                     r_platform, r_chat_id = resolved
-                    if self._send_callback:
-                        await self._send_callback(agent_name, r_platform, r_chat_id, body)
+                    await self._send_message(agent_name, r_platform, r_chat_id, body)
                     _log(f"broker: {agent_name} targeted channel {target} -> {r_chat_id}")
                 else:
                     _log(f"broker: {agent_name} targeted unknown channel '{target}', falling back to default")
@@ -345,13 +421,47 @@ class MessageBroker:
             # If there's non-channel content too, send it to the triggering chat
             other_text = "\n".join(other_lines).strip()
             if other_text and "[no reply]" not in other_text.lower() and chat_id:
-                if self._send_callback:
-                    await self._send_callback(agent_name, platform, chat_id, other_text)
+                await self._send_message(agent_name, platform, chat_id, other_text)
             return
 
-        # Default: send to the triggering chat
-        if self._send_callback and chat_id:
-            await self._send_callback(agent_name, platform, chat_id, response)
+        # Default: send to the triggering chat, excluding handled reaction directives.
+        other_text = "\n".join(other_lines).strip() if reaction_actions else response
+        if other_text and chat_id:
+            await self._send_message(agent_name, platform, chat_id, other_text)
+        elif reacted:
+            _log(f"broker: {agent_name} handled response via reaction only")
+
+    def _parse_reaction_directive(
+        self,
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        default_message_id: str,
+        line: str,
+    ) -> tuple[str, str, str, str] | None:
+        """Parse '@react:' into (platform, chat_id, message_id, emoji)."""
+        raw = line[7:].strip()
+        if not raw:
+            return None
+
+        parts = raw.split()
+        if len(parts) == 1:
+            if not default_message_id:
+                _log(f"broker: {agent_name} requested reaction without a source message_id")
+                return None
+            return (platform, chat_id, default_message_id, parts[0])
+
+        if len(parts) == 2:
+            return (platform, chat_id, parts[0], parts[1])
+
+        target = parts[0]
+        resolved = self._resolve_channel(agent_name, target)
+        if not resolved:
+            _log(f"broker: {agent_name} targeted unknown reaction channel '{target}'")
+            return None
+
+        r_platform, r_chat_id = resolved
+        return (r_platform, r_chat_id, parts[1], " ".join(parts[2:]))
 
     def _resolve_channel(self, agent_name: str, target: str) -> tuple[str, str] | None:
         """Resolve a channel alias or chat_id to (platform, chat_id)."""
@@ -385,7 +495,7 @@ class MessageBroker:
         for u in users:
             if u.status == "approved":
                 try:
-                    await self._send_callback(agent_name, "telegram", u.chat_id, body)
+                    await self._send_message(agent_name, "telegram", u.chat_id, body)
                 except Exception as e:
                     _log(f"broker: broadcast to user {u.chat_id} failed: {e}")
 
@@ -393,7 +503,7 @@ class MessageBroker:
         groups = self._registry.list_group_chats(agent_name)
         for g in groups:
             try:
-                await self._send_callback(agent_name, g["platform"], g["chat_id"], body)
+                await self._send_message(agent_name, g["platform"], g["chat_id"], body)
             except Exception as e:
                 _log(f"broker: broadcast to group {g['chat_id']} failed: {e}")
 
@@ -418,6 +528,8 @@ class MessageBroker:
         lines.append("## Response Routing")
         lines.append("- Default: your response goes to whoever messaged you")
         lines.append("- Target a specific channel: start response with @channel:<name-or-id>")
+        lines.append("- React to the current message: respond with @react:<emoji>")
+        lines.append("- React to a specific message: @react:<message_id> <emoji>")
         lines.append("- Broadcast to all: start response with @all")
         lines.append("- Suppress reply: respond with just [no reply]")
 

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -71,7 +71,7 @@ class StreamingSession:
         self._reader_task: asyncio.Task | None = None
         self._connected = False
         self._last_response = ""
-        self._pending_chats: list[tuple[str, str]] = []  # Queue of (platform, chat_id) awaiting response
+        self._pending_chats: list[tuple[str, str, str]] = []  # Queue of (platform, chat_id, message_id)
 
         self.agent_name = config.agent_name
         self.session_id = config.resume_session_id  # CC session ID (persisted across restarts)
@@ -163,13 +163,20 @@ class StreamingSession:
         except Exception as e:
             _log(f"streaming[{self.agent_name}]: wake prompt failed: {e}")
 
-    async def send(self, prompt: str, platform: str = "", chat_id: str = "") -> None:
+    async def send(
+        self,
+        prompt: str,
+        platform: str = "",
+        chat_id: str = "",
+        message_id: str = "",
+    ) -> None:
         """Send a message to the agent. Non-blocking — returns immediately.
 
         Args:
             prompt: The formatted message to send.
             platform: The platform the message came from (e.g. 'telegram').
             chat_id: The chat_id to route the response back to.
+            message_id: The source message_id to route reactions back to.
         """
         if not self._connected or not self._client:
             _log(f"streaming[{self.agent_name}]: not connected, dropping message")
@@ -191,7 +198,7 @@ class StreamingSession:
         try:
             await self._client.query(prompt)
             if chat_id:
-                self._pending_chats.append((platform, chat_id))
+                self._pending_chats.append((platform, chat_id, message_id))
             _log(f"streaming[{self.agent_name}]: sent message (chat={chat_id})")
         except Exception as e:
             self._stats["errors"] += 1
@@ -259,14 +266,21 @@ class StreamingSession:
                     if msg.num_turns and msg.num_turns > 0:
                         _log(f"streaming[{self.agent_name}]: result — turns={msg.num_turns}, cost=${msg.total_cost_usd or 0:.4f}, model_usage={msg.model_usage}")
 
-                    # Get the (platform, chat_id) for this response
-                    resp_platform, resp_chat_id = self._pending_chats.pop(0) if self._pending_chats else ("", "")
+                    # Get the routing info for this response
+                    if self._pending_chats:
+                        resp_platform, resp_chat_id, resp_message_id = self._pending_chats.pop(0)
+                    else:
+                        resp_platform, resp_chat_id, resp_message_id = ("", "", "")
 
                     # Turn complete — fire response callback
                     if self._last_response and self._response_callback:
                         try:
                             await self._response_callback(
-                                self.agent_name, resp_platform, resp_chat_id, self._last_response,
+                                self.agent_name,
+                                resp_platform,
+                                resp_chat_id,
+                                self._last_response,
+                                resp_message_id,
                             )
                         except Exception as e:
                             _log(f"streaming[{self.agent_name}]: callback error: {e}")

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -18,16 +18,31 @@ class TestMessageBrokerRouting:
         registry.register("barsik", model="sonnet", working_dir=tmpdir.name)
 
         sent_messages: list[tuple[str, str, str, str]] = []
+        reactions: list[tuple[str, str, str, str, str]] = []
 
         async def send_callback(agent_name: str, platform: str, chat_id: str, content: str):
             sent_messages.append((agent_name, platform, chat_id, content))
 
-        broker = MessageBroker(registry, SessionManager(), send_callback=send_callback)
-        return tmpdir, registry, broker, sent_messages
+        async def reaction_callback(
+            agent_name: str,
+            platform: str,
+            chat_id: str,
+            message_id: str,
+            emoji: str,
+        ):
+            reactions.append((agent_name, platform, chat_id, message_id, emoji))
+
+        broker = MessageBroker(
+            registry,
+            SessionManager(),
+            send_callback=send_callback,
+            reaction_callback=reaction_callback,
+        )
+        return tmpdir, registry, broker, sent_messages, reactions
 
     @pytest.mark.asyncio
     async def test_route_response_targets_newline_channel_block(self):
-        tmpdir, registry, broker, sent_messages = self._make_broker()
+        tmpdir, registry, broker, sent_messages, _ = self._make_broker()
         try:
             registry.approve_user("barsik", "6770805286", display_name="Brad", approved_by="test")
 
@@ -46,7 +61,7 @@ class TestMessageBrokerRouting:
 
     @pytest.mark.asyncio
     async def test_route_response_targets_multiple_newline_channel_blocks(self):
-        tmpdir, registry, broker, sent_messages = self._make_broker()
+        tmpdir, registry, broker, sent_messages, _ = self._make_broker()
         try:
             registry.approve_user("barsik", "111", display_name="Brad", approved_by="test")
             registry.approve_user("barsik", "222", display_name="Oleg", approved_by="test")
@@ -67,7 +82,7 @@ class TestMessageBrokerRouting:
 
     @pytest.mark.asyncio
     async def test_route_response_falls_back_with_unknown_newline_channel_block(self):
-        tmpdir, registry, broker, sent_messages = self._make_broker()
+        tmpdir, registry, broker, sent_messages, _ = self._make_broker()
         try:
             await broker.route_response(
                 "barsik",
@@ -78,6 +93,85 @@ class TestMessageBrokerRouting:
 
             assert sent_messages == [
                 ("barsik", "web", "web", "@channel:missing-user\nFallback body"),
+            ]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_response_reacts_to_triggering_message(self):
+        tmpdir, registry, broker, sent_messages, reactions = self._make_broker()
+        try:
+            await broker.route_response(
+                "barsik",
+                "telegram",
+                "6770805286",
+                "@react:👍",
+                message_id="42",
+            )
+
+            assert sent_messages == []
+            assert reactions == [
+                ("barsik", "telegram", "6770805286", "42", "👍"),
+            ]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_response_reacts_and_sends_remaining_text(self):
+        tmpdir, registry, broker, sent_messages, reactions = self._make_broker()
+        try:
+            await broker.route_response(
+                "barsik",
+                "telegram",
+                "6770805286",
+                "@react:42 ✅\nOn it.",
+                message_id="41",
+            )
+
+            assert reactions == [
+                ("barsik", "telegram", "6770805286", "42", "✅"),
+            ]
+            assert sent_messages == [
+                ("barsik", "telegram", "6770805286", "On it."),
+            ]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_response_reacts_in_target_channel(self):
+        tmpdir, registry, broker, sent_messages, reactions = self._make_broker()
+        try:
+            registry.approve_user("barsik", "6770805286", display_name="Brad", approved_by="test")
+
+            await broker.route_response(
+                "barsik",
+                "telegram",
+                "999",
+                "@react:Brad 55 🔥",
+                message_id="41",
+            )
+
+            assert sent_messages == []
+            assert reactions == [
+                ("barsik", "telegram", "6770805286", "55", "🔥"),
+            ]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_response_reaction_falls_back_without_message_id(self):
+        tmpdir, registry, broker, sent_messages, reactions = self._make_broker()
+        try:
+            await broker.route_response(
+                "barsik",
+                "telegram",
+                "6770805286",
+                "@react:👍",
+            )
+
+            assert reactions == []
+            assert sent_messages == [
+                ("barsik", "telegram", "6770805286", "@react:👍"),
             ]
         finally:
             tmpdir.cleanup()

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -264,6 +264,6 @@ class TestOutreachServerDiscord:
         tool_names = {t.name for t in server._tool_manager.list_tools()}
         expected = {
             "send_message", "check_messages", "send_photo",
-            "send_document", "get_chat_info", "add_reaction", "bot_info",
+            "send_document", "get_chat_info", "add_reaction", "download_file", "bot_info",
         }
         assert expected == tool_names

--- a/tests/test_outreach.py
+++ b/tests/test_outreach.py
@@ -325,6 +325,7 @@ class TestOutreachServer:
             "send_document",
             "get_chat_info",
             "add_reaction",
+            "download_file",
             "bot_info",
         }
         assert expected == tool_names

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -293,6 +293,6 @@ class TestOutreachServerSlack:
         tool_names = {t.name for t in server._tool_manager.list_tools()}
         expected = {
             "send_message", "check_messages", "send_photo",
-            "send_document", "get_chat_info", "add_reaction", "bot_info",
+            "send_document", "get_chat_info", "add_reaction", "download_file", "bot_info",
         }
         assert expected == tool_names


### PR DESCRIPTION
## Summary
- add agent/session lifecycle updates across the daemon, API, scheduler, and session management paths
- update settings UI and soul template wiring to support the new lifecycle behavior
- refresh agent registry and template handling, including related frontend build outputs
- expand automated coverage for agent registry, API, and scheduler flows

## Testing
- `python3 -m pytest tests/test_agent_registry.py tests/test_api.py tests/test_scheduler.py`