### PR TITLE
Add outreach-enabled streaming sessions and lifecycle controls

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -783,7 +783,11 @@ def create_api(
         resume_id: str = "",
     ):
         """Create, connect, and register a streaming session for an agent label."""
-        from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
+        from pinky_daemon.streaming_session import (
+            DEFAULT_STREAMING_ALLOWED_TOOLS,
+            StreamingSession,
+            StreamingSessionConfig,
+        )
 
         agent = agents.get(agent_name)
         if not agent or not agent.enabled:
@@ -797,6 +801,7 @@ def create_api(
             agent_name=agent_name,
             model=agent.model,
             working_dir=work_dir,
+            allowed_tools=agent.allowed_tools or list(DEFAULT_STREAMING_ALLOWED_TOOLS),
             permission_mode=agent.permission_mode or "bypassPermissions",
             max_turns=agent.max_turns,
             system_prompt=agent.soul or "",

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -417,9 +417,11 @@ class MessageBroker:
         lines.append("")
         lines.append("## Response Routing")
         lines.append("- Default: your response goes to whoever messaged you")
+        lines.append("- For multi-step replies or progress updates in one turn, use the pinky-outreach send_message tool")
         lines.append("- Target a specific channel: start response with @channel:<name-or-id>")
         lines.append("- Broadcast to all: start response with @all")
         lines.append("- Suppress reply: respond with just [no reply]")
+        lines.append("- After using outreach tools for the full reply, end with [no reply] to avoid an extra broker echo")
 
         return "\n".join(lines)
 

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -22,6 +22,17 @@ from pinky_daemon.sessions import SessionUsage
 # Models with native 1M context (SDK reports 200k incorrectly)
 _1M_MODELS = {"claude-sonnet-4-6", "claude-opus-4-6"}
 
+DEFAULT_STREAMING_ALLOWED_TOOLS = [
+    "Read",
+    "Glob",
+    "Grep",
+    "mcp__memory__*",
+    "mcp__pinky-memory__*",
+    "mcp__pinky-self__*",
+    "mcp__outreach__*",
+    "mcp__pinky-outreach__*",
+]
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -101,11 +112,7 @@ class StreamingSession:
 
         options = ClaudeAgentOptions(
             cwd=self._config.working_dir,
-            allowed_tools=self._config.allowed_tools or [
-                "Read", "Glob", "Grep",
-                "mcp__pinky-memory__*",
-                "mcp__pinky-self__*",
-            ],
+            allowed_tools=self._config.allowed_tools or DEFAULT_STREAMING_ALLOWED_TOOLS,
             permission_mode=self._config.permission_mode,
             mcp_servers=mcp_servers or None,
         )
@@ -150,12 +157,18 @@ class StreamingSession:
 
         wake_prompt = (
             f"Session resumed after daemon restart.{ctx_block}\n\n"
-            "Pick up where you left off. Users will message you through Telegram — "
-            "just respond naturally and Pinky will route your replies back."
+            "Pick up where you left off. Users will message you through Telegram. "
+            "For a normal single reply, just answer naturally and Pinky will route it back. "
+            "For multiple messages or progress updates in one turn, use the pinky-outreach "
+            "send_message tool. If you fully handled the reply via outreach tools, end with "
+            "[no reply] so the broker does not echo an extra plain-text response."
             if is_resume else
             f"New session started.{ctx_block}\n\n"
-            "You're connected via Pinky's message broker. Users will message you through Telegram — "
-            "just respond naturally and Pinky will route your replies back."
+            "You're connected via Pinky's message broker. Users will message you through Telegram. "
+            "For a normal single reply, just answer naturally and Pinky will route it back. "
+            "For multiple messages or progress updates in one turn, use the pinky-outreach "
+            "send_message tool. If you fully handled the reply via outreach tools, end with "
+            "[no reply] so the broker does not echo an extra plain-text response."
         )
         try:
             await self._client.query(wake_prompt)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -452,6 +452,46 @@ class TestAPI:
                 assert app.state.broker._streaming["test-agent"]["main"].is_connected is True
                 assert sent_prompts[-1][1] == "Wake up"
 
+    def test_wake_streaming_session_defaults_include_outreach_tools(self):
+        async def fake_connect(self):
+            self._connected = True
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.streaming_session.StreamingSession.connect", new=fake_connect):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+
+                resp = client.post("/agents/barsik/wake?prompt=Wake")
+                assert resp.status_code == 200
+
+                session = app.state.broker._streaming["barsik"]["main"]
+                assert "mcp__pinky-outreach__*" in session._config.allowed_tools
+                assert "mcp__pinky-self__*" in session._config.allowed_tools
+                assert "Read" in session._config.allowed_tools
+
+    def test_wake_streaming_session_preserves_agent_allowed_tools(self):
+        async def fake_connect(self):
+            self._connected = True
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.streaming_session.StreamingSession.connect", new=fake_connect):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={
+                    "name": "barsik",
+                    "model": "sonnet",
+                    "allowed_tools": ["Read", "mcp__pinky-outreach__*"],
+                })
+
+                resp = client.post("/agents/barsik/wake?prompt=Wake")
+                assert resp.status_code == 200
+
+                session = app.state.broker._streaming["barsik"]["main"]
+                assert session._config.allowed_tools == ["Read", "mcp__pinky-outreach__*"]
+
     def test_manual_streaming_session_persists_and_restores_labels(self):
         async def fake_connect(self):
             self._connected = True


### PR DESCRIPTION
## Summary
- enable outreach tools for streaming agent sessions so agents can send multi-step replies within a single turn
- improve streaming session lifecycle handling across startup, wake, reconnect, and restart flows
- update agent settings/templates and related UI assets to reflect the new session behavior
- add and adjust API, registry, and scheduler coverage for the new lifecycle paths

## Testing
- `pytest tests/test_api.py -q`
- `pytest tests/test_broker.py -q`