### PR TITLE
fix: voice notes not reaching transcription

### DIFF
--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -226,6 +226,7 @@ class BrokerTelegramPoller:
                 chat_title=msg.metadata.get("chat_title", ""),
                 is_group=is_group,
                 metadata=msg.metadata,
+                attachments=msg.metadata.get("attachments", []),
             )
 
             _log(


### PR DESCRIPTION
## Summary
- The Telegram poller was building `BrokerMessage` without passing `attachments`
- Voice notes (and all attachments) were in `msg.metadata["attachments"]` but never mapped to the `BrokerMessage.attachments` field
- The broker's voice handling checks `message.attachments` — always empty, so transcription never triggered

One-line fix: add `attachments=msg.metadata.get("attachments", [])` to the BrokerMessage constructor in the poller.

## Test plan
- [ ] Send a voice note to a PinkyBot agent via Telegram
- [ ] Verify transcription appears in agent's message as `[Voice transcript]: ...`
- [ ] Verify auto-reply TTS works if `voice_reply` is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)