### PR TITLE
fix: mock _find_claude_binary in CI tests

### DIFF
--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -387,12 +387,14 @@ class TestResolveEnv:
 class TestDaemon:
     def test_create_daemon(self):
         config = DaemonConfig()
-        daemon = Daemon(config)
+        with patch("pinky_daemon.claude_runner._find_claude_binary", return_value="/usr/bin/claude"):
+            daemon = Daemon(config)
         assert daemon.is_running is False
 
     def test_stats(self):
         config = DaemonConfig()
-        daemon = Daemon(config)
+        with patch("pinky_daemon.claude_runner._find_claude_binary", return_value="/usr/bin/claude"):
+            daemon = Daemon(config)
         stats = daemon.stats
         assert stats["running"] is False
         assert stats["pollers"] == 0


### PR DESCRIPTION
## Summary

- `TestDaemon.test_create_daemon` and `test_stats` were failing in CI because GitHub Actions runners don't have Claude Code CLI installed
- Fix: patch `_find_claude_binary` with a mock path in those two tests
- This has been failing since the CI workflow was introduced — unrelated to the i18n PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)