### PR TITLE
ci: skip deploy gracefully when secrets not configured

### DIFF
--- a/.github/workflows/ci-stable.yml
+++ b/.github/workflows/ci-stable.yml
@@ -54,6 +54,10 @@ jobs:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         run: |
+          if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_USER" ] || [ -z "$DEPLOY_KEY" ]; then
+            echo "⚠️ Deploy secrets not configured — skipping SSH deploy."
+            exit 0
+          fi
           echo "$DEPLOY_KEY" > /tmp/deploy_key
           chmod 600 /tmp/deploy_key
           ssh -i /tmp/deploy_key -o StrictHostKeyChecking=no \


### PR DESCRIPTION
Deploy step now exits 0 with a warning when DEPLOY_HOST/USER/KEY secrets are missing, instead of failing the whole workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)