### PR TITLE
Fix chat routing for named streaming sub-sessions

### DIFF
--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -47,6 +47,8 @@
     let sessionsList = [];
     let activeSession = null;
     let activeAgent = null;
+    let activeSessionLabel = 'main';
+    let activeSessionStreaming = false;
     let messages = [];
     let messageInput = '';
     let sending = false;
@@ -118,7 +120,30 @@
                 if (!matched) orphans.push(s);
             }
         }
+        for (const sessionGroup of Object.values(groups)) {
+            sessionGroup.sort((a, b) => {
+                const aMain = (a.label || '') === 'main' ? 1 : 0;
+                const bMain = (b.label || '') === 'main' ? 1 : 0;
+                if (aMain !== bMain) return bMain - aMain;
+                return (b.last_active || 0) - (a.last_active || 0);
+            });
+        }
         return { groups, orphans };
+    }
+
+    function inferAgentName(sessionId) {
+        if (!sessionId || !sessionId.includes('-')) return '';
+        return sessionId.split('-')[0];
+    }
+
+    function normalizeSessionLabel(raw) {
+        return (raw || '')
+            .trim()
+            .toLowerCase()
+            .replace(/\s+/g, '-')
+            .replace(/[^a-z0-9_-]/g, '')
+            .replace(/-+/g, '-')
+            .replace(/^[-_]+|[-_]+$/g, '');
     }
 
     async function refreshSessions() {
@@ -129,30 +154,74 @@
                 api('GET', '/conversations'),
             ]);
             agentsList = agentsData.agents || [];
-            // Merge session manager sessions with conversation store entries
-            const sessIds = new Set(sessData.map(s => s.id));
+            const convById = new Map((convsData.conversations || []).map(c => [c.session_id, c]));
+            const streamingResults = await Promise.all(
+                agentsList.map(agent =>
+                    api('GET', `/agents/${agent.name}/streaming-sessions`).catch(() => ({ sessions: [] }))
+                )
+            );
+
+            const knownIds = new Set();
+            const streamingSessions = [];
+            for (let i = 0; i < agentsList.length; i++) {
+                const agent = agentsList[i];
+                for (const ss of (streamingResults[i].sessions || [])) {
+                    const convo = convById.get(ss.id);
+                    knownIds.add(ss.id);
+                    streamingSessions.push({
+                        id: ss.id,
+                        label: ss.label || 'main',
+                        state: ss.connected ? 'streaming' : 'idle',
+                        model: agent.model || 'streaming',
+                        message_count: convo?.message_count ?? 0,
+                        last_active: convo?.last_message_at ?? 0,
+                        agent_name: agent.name,
+                        session_type: 'streaming',
+                        streaming: true,
+                        connected: !!ss.connected,
+                        stats: ss.stats || {},
+                    });
+                }
+            }
+
+            const standaloneSessions = (sessData || []).map(s => ({
+                ...s,
+                label: s.label || '',
+                streaming: false,
+            }));
+            standaloneSessions.forEach(s => knownIds.add(s.id));
+
             const convSessions = (convsData.conversations || [])
-                .filter(c => !sessIds.has(c.session_id))
+                .filter(c => !knownIds.has(c.session_id))
                 .map(c => ({
                     id: c.session_id,
-                    state: 'streaming',
-                    model: 'streaming',
+                    label: '',
+                    state: 'history',
+                    model: 'history',
                     message_count: c.message_count,
                     last_active: c.last_message_at,
-                    agent_name: c.session_id.split('-')[0],
-                    session_type: 'streaming',
+                    agent_name: inferAgentName(c.session_id),
+                    session_type: 'history',
+                    streaming: false,
                     _from_store: true,
                 }));
-            sessionsList = [...sessData, ...convSessions];
+
+            sessionsList = [...streamingSessions, ...standaloneSessions, ...convSessions];
             connected = true;
         } catch {
             connected = false;
         }
     }
 
-    async function selectSession(id, agentName) {
-        activeSession = id;
-        activeAgent = agentName || null;
+    async function selectSession(session) {
+        activeSession = session?.id || null;
+        activeAgent = session?.agent_name || null;
+        activeSessionLabel = session?.label || 'main';
+        activeSessionStreaming = !!session?.streaming;
+        agentWorking = false;
+        thinkingActivity = '';
+        activityLog = [];
+        wasWorking = false;
         hasMore = false;
         totalMessages = 0;
         olderPrepended = 0;
@@ -166,15 +235,12 @@
 
     async function refreshChat() {
         if (!activeSession) return;
-        const agentName = activeAgent || activeSession.split('-')[0];
+        const agentName = activeAgent || inferAgentName(activeSession);
 
-        // Conversation store ID — streaming sessions now use {agent}-main
-        const convId = `${agentName}-main`;
-
-        // Primary source: conversation store (streaming sessions log here)
+        // Primary source: conversation store
         let allMessages = [];
         try {
-            const streamHistory = await api('GET', `/conversations/${convId}/history?limit=${PAGE_SIZE}`);
+            const streamHistory = await api('GET', `/conversations/${activeSession}/history?limit=${PAGE_SIZE}`);
             allMessages = (streamHistory.messages || []).sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
             hasMore = streamHistory.has_more || false;
             totalMessages = streamHistory.total || allMessages.length;
@@ -193,25 +259,31 @@
 
         // Load agent config for model/nudge settings (only on first load)
         try {
-            const agentData = await api('GET', `/agents/${agentName}`);
-            if (agentData.model && !selectedModel) selectedModel = agentData.model;
-            if (agentData.restart_threshold_pct != null) contextNudgePct = agentData.restart_threshold_pct;
-            if (agentData.model) infoModel = agentData.model;
-        } catch {}
-
-        // Get context from streaming session (primary source)
-        let gotStreamingContext = false;
-        try {
-            const streamStatus = await api('GET', `/agents/${agentName}/streaming/status`);
-            if (streamStatus.connected) {
-                const ctx = streamStatus.context || {};
-                if (ctx.percentage != null) {
-                    infoContext = `${ctx.percentage}%`;
-                    infoContextPct = ctx.percentage;
-                    gotStreamingContext = true;
-                }
+            if (agentName) {
+                const agentData = await api('GET', `/agents/${agentName}`);
+                if (agentData.model && !selectedModel) selectedModel = agentData.model;
+                if (agentData.restart_threshold_pct != null) contextNudgePct = agentData.restart_threshold_pct;
+                if (agentData.model) infoModel = agentData.model;
             }
-        } catch {}
+        } catch {
+            infoModel = '--';
+        }
+
+        // Get context from the selected streaming session when available
+        let gotStreamingContext = false;
+        if (activeSessionStreaming && agentName) {
+            try {
+                const streamStatus = await api('GET', `/agents/${agentName}/streaming/status?label=${encodeURIComponent(activeSessionLabel)}`);
+                if (streamStatus.connected) {
+                    const ctx = streamStatus.context || {};
+                    if (ctx.percentage != null) {
+                        infoContext = `${ctx.percentage}%`;
+                        infoContextPct = ctx.percentage;
+                        gotStreamingContext = true;
+                    }
+                }
+            } catch {}
+        }
 
         // Fallback to session manager context if streaming unavailable
         if (!gotStreamingContext) {
@@ -242,12 +314,10 @@
     async function loadOlderMessages() {
         if (!activeSession || loadingOlder || !hasMore) return;
         loadingOlder = true;
-        const agentName = activeAgent || activeSession.split('-')[0];
-        const convId = `${agentName}-main`;
         // offset = total messages currently loaded
         const currentOffset = messages.length;
         try {
-            const older = await api('GET', `/conversations/${convId}/history?limit=${PAGE_SIZE}&offset=${currentOffset}`);
+            const older = await api('GET', `/conversations/${activeSession}/history?limit=${PAGE_SIZE}&offset=${currentOffset}`);
             const olderMsgs = (older.messages || []).sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
             if (olderMsgs.length > 0) {
                 const container = messagesContainer;
@@ -288,10 +358,10 @@
     function startActivityPolling() {
         stopActivityPolling();
         activityPollInterval = setInterval(async () => {
-            const agentName = activeAgent || (activeSession ? activeSession.split('-')[0] : null);
-            if (!agentName) return;
+            const agentName = activeAgent || (activeSession ? inferAgentName(activeSession) : null);
+            if (!agentName || !activeSessionStreaming) return;
             try {
-                const status = await api('GET', `/agents/${agentName}/streaming/status`);
+                const status = await api('GET', `/agents/${agentName}/streaming/status?label=${encodeURIComponent(activeSessionLabel)}`);
                 const activity = status?.stats?.current_activity || '';
                 const log = status?.stats?.activity_log || [];
                 const isWorking = !!activity;
@@ -332,21 +402,18 @@
         scrollToBottom();
 
         try {
-            const agentName = activeAgent || activeSession.split('-')[0];
-            // Try streaming chat endpoint first, fall back to session message
-            try {
-                await api('POST', `/agents/${agentName}/chat`, { content: text });
+            const agentName = activeAgent || inferAgentName(activeSession);
+            if (activeSessionStreaming && agentName) {
+                await api('POST', `/agents/${agentName}/chat?label=${encodeURIComponent(activeSessionLabel)}`, { content: text });
                 // Response comes async via streaming — poll for it
                 thinking = true;
                 thinkingActivity = '';
                 let attempts = 0;
                 while (attempts < 30) {
                     await new Promise(r => setTimeout(r, 1000));
-                    // Poll for activity and response in parallel
-                    const convId = `${agentName}-main`;
                     const [hist, status] = await Promise.all([
-                        api('GET', `/conversations/${convId}/history?limit=5`),
-                        api('GET', `/agents/${agentName}/streaming/status`).catch(() => null),
+                        api('GET', `/conversations/${activeSession}/history?limit=5`),
+                        api('GET', `/agents/${agentName}/streaming/status?label=${encodeURIComponent(activeSessionLabel)}`).catch(() => null),
                     ]);
                     if (status?.stats) {
                         thinkingActivity = status.stats.current_activity || '';
@@ -362,8 +429,7 @@
                 thinking = false;
                 thinkingActivity = '';
                 activityLog = [];
-            } catch {
-                // Fall back to old session message endpoint
+            } else {
                 const data = await api('POST', `/sessions/${activeSession}/message`, { content: text });
                 thinking = false;
                 messages = [...messages, { role: 'assistant', content: data.content }];
@@ -390,7 +456,7 @@
     let fileInput;
 
     async function handleFileUpload() {
-        if (!fileInput.files[0] || !activeAgent) return;
+        if (!fileInput.files[0] || !activeAgent || !activeSessionStreaming) return;
         const file = fileInput.files[0];
         const formData = new FormData();
         formData.append('file', file);
@@ -401,7 +467,7 @@
         scrollToBottom();
 
         try {
-            const resp = await fetch(`/agents/${activeAgent}/upload`, {
+            const resp = await fetch(`/agents/${activeAgent}/upload?label=${encodeURIComponent(activeSessionLabel)}`, {
                 method: 'POST',
                 body: formData,
             });
@@ -423,27 +489,25 @@
         restarting = true;
 
         try {
-            const savePrompt = 'Your session is about to be restarted. Save your current state now:\n\n' +
-                '1. Use your save_my_context or set wake context tool to persist what you were working on\n' +
-                '2. Include: current task, key context, any blockers, and what to do next\n' +
-                '3. Confirm when saved\n\n' +
-                'This is a context restart — your conversation will reset but your saved state will carry over.';
-
-            messages = [...messages, { role: 'system', content: 'Context restart initiated — asking agent to save state...', metadata: { checkpoint: 'context-restart' } }];
+            messages = [...messages, { role: 'system', content: 'Context restart initiated...', metadata: { checkpoint: 'context-restart' } }];
             await tick(); scrollToBottom();
 
-            const saveResult = await api('POST', `/sessions/${activeSession}/message`, { content: savePrompt });
-            messages = [...messages, { role: 'assistant', content: saveResult.content, duration_ms: saveResult.duration_ms }];
-            await tick(); scrollToBottom();
+            if (activeSessionStreaming && activeAgent) {
+                await api('POST', `/agents/${activeAgent}/streaming/restart?label=${encodeURIComponent(activeSessionLabel)}`);
+            } else {
+                const savePrompt = 'Your session is about to be restarted. Save your current state now:\n\n' +
+                    '1. Use your save_my_context or set wake context tool to persist what you were working on\n' +
+                    '2. Include: current task, key context, any blockers, and what to do next\n' +
+                    '3. Confirm when saved\n\n' +
+                    'This is a context restart — your conversation will reset but your saved state will carry over.';
 
-            await api('POST', `/sessions/${activeSession}/restart`);
+                const saveResult = await api('POST', `/sessions/${activeSession}/message`, { content: savePrompt });
+                messages = [...messages, { role: 'assistant', content: saveResult.content, duration_ms: saveResult.duration_ms }];
+                await tick(); scrollToBottom();
+                await api('POST', `/sessions/${activeSession}/restart`);
+            }
             await logCheckpoint('context-restart', 'Context restarted via UI');
-            messages = [...messages, { role: 'system', content: 'Session restarted. Sending wake prompt...', metadata: { checkpoint: 'context-restart' } }];
-            await tick(); scrollToBottom();
-
-            const wakePrompt = 'Session was restarted via context restart (UI). Check your wake context or saved context for continuation state. Pick up where you left off.';
-            const wakeResult = await api('POST', `/sessions/${activeSession}/message`, { content: wakePrompt });
-            messages = [...messages, { role: 'assistant', content: wakeResult.content, duration_ms: wakeResult.duration_ms }];
+            messages = [...messages, { role: 'system', content: 'Session restarted.', metadata: { checkpoint: 'context-restart' } }];
 
             await refreshChat();
             await refreshSessions();
@@ -456,21 +520,19 @@
     }
 
     async function logCheckpoint(type, detail) {
-        const agentName = activeAgent || activeSession?.split('-')[0];
-        const convId = agentName ? `${agentName}-main` : activeSession;
-        if (!convId) return;
+        if (!activeSession) return;
         try {
-            await api('POST', `/conversations/${convId}/checkpoint`, { type, detail });
+            await api('POST', `/conversations/${activeSession}/checkpoint`, { type, detail });
         } catch { /* best effort */ }
     }
 
     async function compactContext() {
-        if (!activeAgent || compacting) return;
+        if (!activeAgent || !activeSessionStreaming || compacting) return;
         compacting = true;
         messages = [...messages, { role: 'system', content: 'Compacting context...', metadata: { checkpoint: 'compact' } }];
         await tick(); scrollToBottom();
         try {
-            await api('POST', `/agents/${activeAgent}/streaming/compact`);
+            await api('POST', `/agents/${activeAgent}/streaming/compact?label=${encodeURIComponent(activeSessionLabel)}`);
             await logCheckpoint('compact', 'Context compacted');
             messages = [...messages, { role: 'system', content: 'Context compacted.', metadata: { checkpoint: 'compact' } }];
             await refreshChat();
@@ -482,13 +544,13 @@
     }
 
     async function archiveSession() {
-        if (!activeAgent || archiving) return;
+        if (!activeAgent || !activeSessionStreaming || archiving) return;
         if (!confirm('Archive this session? The agent will save its memory, then get a fresh context.')) return;
         archiving = true;
         messages = [...messages, { role: 'system', content: 'Archiving — asking agent to save memory...', metadata: { checkpoint: 'archive' } }];
         await tick(); scrollToBottom();
         try {
-            const result = await api('POST', `/agents/${activeAgent}/streaming/archive`);
+            const result = await api('POST', `/agents/${activeAgent}/streaming/archive?label=${encodeURIComponent(activeSessionLabel)}`);
             await logCheckpoint('archive', `Archived. ${result.old_turns} turns. Session: ${result.old_session_id}`);
             messages = [...messages, { role: 'system', content: `Archived. Old session had ${result.old_turns} turns. Fresh session started.`, metadata: { checkpoint: 'archive' } }];
             await refreshChat();
@@ -501,10 +563,10 @@
     }
 
     async function saveModel() {
-        if (!activeAgent || !selectedModel) return;
+        if (!activeAgent || !activeSessionStreaming || !selectedModel) return;
         savingModel = true;
         try {
-            const result = await api('POST', `/agents/${activeAgent}/streaming/model`, { model: selectedModel });
+            const result = await api('POST', `/agents/${activeAgent}/streaming/model?label=${encodeURIComponent(activeSessionLabel)}`, { model: selectedModel });
             if (result.restarted) {
                 messages = [...messages, { role: 'system', content: `Model changed to ${selectedModel} — session restarted for new context window (${result.old_turns} turns saved)` }];
                 await refreshChat();
@@ -537,9 +599,21 @@
     }
 
     async function spawnAgentSession(agentName) {
-        await api('POST', `/agents/${agentName}/streaming-sessions?label=chat`);
+        const requested = prompt('New session name:', 'chat');
+        if (requested === null) return;
+        const label = normalizeSessionLabel(requested);
+        if (!label) {
+            alert('Session name must contain letters or numbers.');
+            return;
+        }
+        if (label === 'main') {
+            alert('Use a different name. "main" already exists.');
+            return;
+        }
+        await api('POST', `/agents/${agentName}/streaming-sessions?label=${encodeURIComponent(label)}`);
         await refreshSessions();
-        selectSession(`${agentName}-chat`, agentName);
+        const created = sessionsList.find(s => s.id === `${agentName}-${label}`);
+        if (created) await selectSession(created);
     }
 
     onMount(() => {
@@ -571,20 +645,20 @@
             {#each agentsList as agent}
                 {@const aSessions = agentSessions.groups[agent.name] || []}
                 <div class="agent-group">
-                    <div class="agent-group-header" on:click={() => { if (aSessions.length > 0) selectSession(aSessions[0].id, agent.name); }}>
+                    <div class="agent-group-header" on:click={() => { if (aSessions.length > 0) selectSession(aSessions[0]); }}>
                         <span class="chat-working-dot" class:working={agent.working_status === 'working'} title={agent.working_status === 'working' ? 'Working' : 'Idle'}></span>
                         <span class="agent-name-text">{agent.display_name || agent.name}</span>
                         <span class="agent-model">{(agent.model || '').replace(/^claude-/i, '')}</span>
                         <button class="btn-new" on:click|stopPropagation={() => spawnAgentSession(agent.name)}>+</button>
                     </div>
                     {#each aSessions as s}
-                        {@const isMain = (s.session_type || '') === 'main'}
-                        {@const label = s.id.replace(new RegExp(`^${agent.name}-`), '').replace(/-?main$/, '') || 'main'}
+                        {@const isMain = (s.label || '') === 'main'}
+                        {@const label = s.label || s.id}
                         <div
                             class="session-item"
                             class:active={activeSession === s.id}
                             class:main-session={isMain}
-                            on:click={() => selectSession(s.id, agent.name)}
+                            on:click={() => selectSession(s)}
                         >
                             <span class="session-label">{label}</span>
                             <span class="session-count">{s.message_count}</span>
@@ -596,7 +670,7 @@
                 <div class="agent-group">
                     <div class="agent-group-header"><span style="color:var(--gray-mid)">Standalone</span></div>
                     {#each agentSessions.orphans as s}
-                        <div class="session-item" class:active={activeSession === s.id} on:click={() => selectSession(s.id, null)}>
+                        <div class="session-item" class:active={activeSession === s.id} on:click={() => selectSession(s)}>
                             <span class="session-label">{s.id}</span>
                             <span class="session-count">{s.message_count}</span>
                         </div>
@@ -615,17 +689,17 @@
                 <span>Messages: <strong>{infoMessages}</strong></span>
                 <span>Session: <strong>{infoSession}</strong></span>
                 <div class="chat-actions">
-                    <button class="btn-action" on:click={() => showSettings = !showSettings}>Model</button>
-                    <button class="btn-action" class:active-action={compacting} on:click={compactContext} disabled={compacting}>{compacting ? 'Compacting...' : 'Compact'}</button>
+                    <button class="btn-action" on:click={() => showSettings = !showSettings} disabled={!activeSessionStreaming}>Model</button>
+                    <button class="btn-action" class:active-action={compacting} on:click={compactContext} disabled={compacting || !activeSessionStreaming}>{compacting ? 'Compacting...' : 'Compact'}</button>
                     <button class="btn-restart" class:restarting on:click={contextRestart} disabled={restarting}>{restarting ? 'Restarting...' : 'Context Restart'}</button>
-                    <button class="btn-action btn-archive" class:active-action={archiving} on:click={archiveSession} disabled={archiving}>{archiving ? 'Archiving...' : 'Archive'}</button>
+                    <button class="btn-action btn-archive" class:active-action={archiving} on:click={archiveSession} disabled={archiving || !activeSessionStreaming}>{archiving ? 'Archiving...' : 'Archive'}</button>
                 </div>
             </div>
             {#if showSettings}
                 <div class="settings-bar">
                     <label class="setting-item">
                         <span>Model</span>
-                        <select bind:value={selectedModel} on:change={saveModel} disabled={savingModel}>
+                        <select bind:value={selectedModel} on:change={saveModel} disabled={savingModel || !activeSessionStreaming}>
                             {#each availableModels as m}
                                 <option value={m.value}>{m.label}</option>
                             {/each}
@@ -731,7 +805,7 @@
             </div>
             <div class="input-area">
                 <input type="file" bind:this={fileInput} on:change={handleFileUpload} style="display:none">
-                <button class="btn-upload" on:click={() => fileInput.click()} disabled={sending} title="Upload file">📎</button>
+                <button class="btn-upload" on:click={() => fileInput.click()} disabled={sending || !activeSessionStreaming} title={activeSessionStreaming ? 'Upload file' : 'File upload is available for streaming sessions only'}>📎</button>
                 <input type="text" bind:value={messageInput} placeholder="Type a message..." on:keydown={handleKeydown} disabled={sending}>
                 <button on:click={sendMessage} disabled={sending}>Send</button>
             </div>

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1053,8 +1053,8 @@ def create_api(
 
         return text
 
-    def _session_id_for_agent(agent_name: str) -> str:
-        return f"{agent_name}-main"
+    def _session_id_for_agent(agent_name: str, label: str = "main") -> str:
+        return f"{agent_name}-{label or 'main'}"
 
     def _record_outbound_message(
         agent_name: str,
@@ -1801,6 +1801,7 @@ def create_api(
         effective_model = resolved_provider_model or agent.model
         config = StreamingSessionConfig(
             agent_name=agent_name,
+            label=label,
             model=effective_model,
             working_dir=work_dir,
             allowed_tools=effective_tools,
@@ -4435,7 +4436,7 @@ def create_api(
                 resume_id=agents.get_streaming_session_id(name, label=label),
             )
             _log(f"api: created streaming session {name}/{label}")
-            return {"created": True, "agent": name, "label": label}
+            return {"created": True, "agent": name, "label": label, "id": _session_id_for_agent(name, label)}
         except Exception as e:
             raise HTTPException(500, f"Failed to create streaming session: {e}")
 
@@ -4838,12 +4839,17 @@ def create_api(
         await _broker_react(agent_name, platform, chat_id, message_id, emoji)
         return {"reacted": True}
 
-    @app.post("/agents/{name}/streaming/restart")
-    async def restart_streaming_session(name: str):
-        """Restart an agent's streaming session — fresh context, new CC session."""
-        ss = broker._get_streaming_session(name)
+    def _require_streaming_session(name: str, label: str = "main"):
+        resolved_label = label or "main"
+        ss = broker._get_streaming_session(name, label=resolved_label)
         if not ss:
-            raise HTTPException(404, f"No streaming session for '{name}'")
+            raise HTTPException(404, f"No streaming session '{resolved_label}' for '{name}'")
+        return ss, resolved_label
+
+    @app.post("/agents/{name}/streaming/restart")
+    async def restart_streaming_session(name: str, label: str = "main"):
+        """Restart an agent's streaming session — fresh context, new CC session."""
+        ss, label = _require_streaming_session(name, label)
 
         guard = _get_streaming_restart_guard(name, ss)
         if not guard["restart_safe"]:
@@ -4854,7 +4860,7 @@ def create_api(
 
         # Disconnect and clear persisted session ID
         await ss.disconnect()
-        agents.set_streaming_session_id(name, "", label="main")
+        agents.set_streaming_session_id(name, "", label=label)
 
         # Refresh wake context and reconnect fresh
         ss._config.wake_context = _build_streaming_wake_context(name)
@@ -4862,30 +4868,30 @@ def create_api(
         ss.session_id = ""
         try:
             await ss.connect()
-            _log(f"api: streaming session restarted for {name}")
+            _log(f"api: streaming session restarted for {name}/{label}")
         except Exception as e:
-            broker.unregister_streaming(name)
+            broker.unregister_streaming(name, label=label)
             raise HTTPException(500, f"Failed to restart: {e}")
 
         return {
             "restarted": True,
             "agent": name,
+            "label": label,
+            "id": ss.id,
             "old_session_id": old_session_id[:12] if old_session_id else "",
             "old_turns": old_turns,
         }
 
     @app.post("/agents/{name}/streaming/model")
-    async def set_streaming_model(name: str, req: SetModelRequest):
+    async def set_streaming_model(name: str, req: SetModelRequest, label: str = "main"):
         """Change the model on a running streaming session.
 
         If the context window size changes (e.g. 200k → 1M), automatically
         saves state and restarts the session. Otherwise switches mid-session.
         """
-        ss = broker._get_streaming_session(name)
-        if not ss:
-            raise HTTPException(404, f"No streaming session for '{name}'")
+        ss, label = _require_streaming_session(name, label)
         if not ss.is_connected or not ss._client:
-            raise HTTPException(409, f"Streaming session for '{name}' not connected")
+            raise HTTPException(409, f"Streaming session '{label}' for '{name}' not connected")
 
         # Check if context window would change
         old_max = 0
@@ -4905,7 +4911,7 @@ def create_api(
 
         if needs_restart:
             # Context window changes — need full restart
-            _log(f"api: model change {req.model} for {name} requires restart (window change)")
+            _log(f"api: model change {req.model} for {name}/{label} requires restart (window change)")
             guard = _get_streaming_restart_guard(name, ss)
             if not guard["restart_safe"]:
                 raise HTTPException(409, _guard_message("restart", guard))
@@ -4923,20 +4929,22 @@ def create_api(
             old_session_id = ss.session_id
             old_turns = ss._stats["turns"]
             await ss.disconnect()
-            agents.set_streaming_session_id(name, "", label="main")
+            agents.set_streaming_session_id(name, "", label=label)
             ss._config.resume_session_id = ""
             ss.session_id = ""
             ss._config.model = req.model
             try:
                 await ss.connect()
-                _log(f"api: restarted {name} with model {req.model}")
+                _log(f"api: restarted {name}/{label} with model {req.model}")
             except Exception as e:
-                broker.unregister_streaming(name)
+                broker.unregister_streaming(name, label=label)
                 raise HTTPException(500, f"Failed to restart: {e}")
 
             return {
                 "updated": True,
                 "agent": name,
+                "label": label,
+                "id": ss.id,
                 "model": req.model,
                 "restarted": True,
                 "old_session_id": old_session_id[:12] if old_session_id else "",
@@ -4946,40 +4954,36 @@ def create_api(
             # Same window class — hot swap
             try:
                 await ss._client.set_model(req.model)
-                _log(f"api: model hot-swapped to {req.model} for {name}")
+                _log(f"api: model hot-swapped to {req.model} for {name}/{label}")
             except Exception as e:
                 raise HTTPException(500, f"Failed to set model: {e}")
 
-            return {"updated": True, "agent": name, "model": req.model, "restarted": False}
+            return {"updated": True, "agent": name, "label": label, "id": ss.id, "model": req.model, "restarted": False}
 
     @app.post("/agents/{name}/streaming/compact")
-    async def compact_streaming_session(name: str):
+    async def compact_streaming_session(name: str, label: str = "main"):
         """Send /compact to an agent's streaming session to compress context."""
-        ss = broker._get_streaming_session(name)
-        if not ss:
-            raise HTTPException(404, f"No streaming session for '{name}'")
+        ss, label = _require_streaming_session(name, label)
         if not ss.is_connected:
-            raise HTTPException(409, f"Streaming session for '{name}' not connected")
+            raise HTTPException(409, f"Streaming session '{label}' for '{name}' not connected")
 
         try:
             await ss._client.query(
                 "Run /compact now to compress your conversation context. "
                 "Summarize key state before compacting."
             )
-            _log(f"api: compact requested for {name}")
+            _log(f"api: compact requested for {name}/{label}")
         except Exception as e:
             raise HTTPException(500, f"Compact failed: {e}")
 
-        return {"compacted": True, "agent": name}
+        return {"compacted": True, "agent": name, "label": label, "id": ss.id}
 
     @app.post("/agents/{name}/streaming/archive")
-    async def archive_streaming_session(name: str):
+    async def archive_streaming_session(name: str, label: str = "main"):
         """Archive session: nudge agent to save memory, then start fresh."""
-        ss = broker._get_streaming_session(name)
-        if not ss:
-            raise HTTPException(404, f"No streaming session for '{name}'")
+        ss, label = _require_streaming_session(name, label)
         if not ss.is_connected:
-            raise HTTPException(409, f"Streaming session for '{name}' not connected")
+            raise HTTPException(409, f"Streaming session '{label}' for '{name}' not connected")
 
         guard = _get_streaming_restart_guard(name, ss)
         if not guard["restart_safe"]:
@@ -4993,40 +4997,40 @@ def create_api(
                 "2. Summarize what you were working on so your next session can pick up\n\n"
                 "Do this now — your session will be reset after you confirm."
             )
-            _log(f"api: archive memory save requested for {name}")
+            _log(f"api: archive memory save requested for {name}/{label}")
         except Exception as e:
-            _log(f"api: archive memory save failed for {name}: {e}")
+            _log(f"api: archive memory save failed for {name}/{label}: {e}")
 
         # Step 2: Restart with fresh context
         old_session_id = ss.session_id
         old_turns = ss._stats["turns"]
 
         await ss.disconnect()
-        agents.set_streaming_session_id(name, "", label="main")
+        agents.set_streaming_session_id(name, "", label=label)
 
         ss._config.wake_context = _build_streaming_wake_context(name)
         ss._config.resume_session_id = ""
         ss.session_id = ""
         try:
             await ss.connect()
-            _log(f"api: archived and restarted session for {name}")
+            _log(f"api: archived and restarted session for {name}/{label}")
         except Exception as e:
-            broker.unregister_streaming(name)
+            broker.unregister_streaming(name, label=label)
             raise HTTPException(500, f"Failed to restart after archive: {e}")
 
         return {
             "archived": True,
             "agent": name,
+            "label": label,
+            "id": ss.id,
             "old_session_id": old_session_id[:12] if old_session_id else "",
             "old_turns": old_turns,
         }
 
     @app.get("/agents/{name}/streaming/status")
-    async def streaming_session_status(name: str):
+    async def streaming_session_status(name: str, label: str = "main"):
         """Get streaming session status for an agent."""
-        ss = broker._get_streaming_session(name)
-        if not ss:
-            raise HTTPException(404, f"No streaming session for '{name}'")
+        ss, label = _require_streaming_session(name, label)
         guard = _get_streaming_restart_guard(name, ss)
 
         # Try to get context usage from SDK
@@ -5054,6 +5058,8 @@ def create_api(
 
         return {
             "agent": name,
+            "label": label,
+            "id": ss.id,
             "session_id": ss.session_id[:12] if ss.session_id else "",
             "connected": ss.is_connected,
             "stats": ss.stats,
@@ -5093,7 +5099,7 @@ def create_api(
         }
 
     @app.post("/agents/{name}/chat")
-    async def chat_with_agent(name: str, req: dict):
+    async def chat_with_agent(name: str, req: dict, label: str = "main"):
         """Send a message from the web UI to an agent's streaming session.
 
         The message gets formatted with [web | dm | ...] metadata and routed
@@ -5108,9 +5114,9 @@ def create_api(
             raise HTTPException(400, "content is required")
 
         # Get streaming session
-        streaming = broker._get_streaming_session(name)
+        streaming, label = _require_streaming_session(name, label)
         if not streaming or not streaming.is_connected:
-            raise HTTPException(503, f"Agent '{name}' streaming session not connected")
+            raise HTTPException(503, f"Agent '{name}' streaming session '{label}' not connected")
 
         # Format with metadata like broker messages
         from datetime import datetime
@@ -5123,14 +5129,17 @@ def create_api(
 
         prompt = f"[web | dm | Admin | web | {ts}]\n{content}"
         await streaming.send(prompt, platform="web", chat_id="web")
-        return {"sent": True, "agent": name}
+        return {"sent": True, "agent": name, "label": label, "id": streaming.id}
 
     @app.post("/agents/{name}/upload")
-    async def upload_file_to_agent(name: str, file: UploadFile):
+    async def upload_file_to_agent(name: str, file: UploadFile, label: str = "main"):
         """Upload a file to an agent via the web UI."""
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
+        streaming, label = _require_streaming_session(name, label)
+        if not streaming.is_connected:
+            raise HTTPException(503, f"Agent '{name}' streaming session '{label}' not connected")
 
         # Save file to data/uploads/{agent_name}/
         upload_dir = f"data/uploads/{name}"
@@ -5157,23 +5166,10 @@ def create_api(
         except Exception:
             ts = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
 
-        msg = BrokerMessage(
-            platform="web",
-            chat_id="web",
-            sender_name="admin",
-            sender_id="web",
-            content=f"[web | dm | Admin | web | {ts}]\nFile uploaded: {filename} ({size} bytes)\nSaved to: {abs_path}",
-            agent_name=name,
-            attachments=[{
-                "type": "file",
-                "file_name": filename,
-                "file_size": size,
-                "path": abs_path,
-            }],
-        )
-        await broker.handle_inbound(msg)
+        prompt = f"[web | dm | Admin | web | {ts}]\nFile uploaded: {filename} ({size} bytes)\nSaved to: {abs_path}"
+        await streaming.send(prompt, platform="web", chat_id="web")
 
-        return {"uploaded": True, "filename": filename, "path": abs_path, "size": size}
+        return {"uploaded": True, "agent": name, "label": label, "id": streaming.id, "filename": filename, "path": abs_path, "size": size}
 
     # ── Spawn Session from Agent ────────────────────────────
 

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -338,7 +338,7 @@ class MessageBroker:
 
     # ── Streaming Session Support ─────────────────────────
 
-    def _get_streaming_session(self, agent_name: str, chat_id: str = ""):
+    def _get_streaming_session(self, agent_name: str, chat_id: str = "", *, label: str = ""):
         """Get the streaming session for an agent + channel.
 
         Looks up the channel→session assignment, falls back to 'main'.
@@ -346,6 +346,8 @@ class MessageBroker:
         sessions = self._streaming.get(agent_name, {})
         if not sessions:
             return None
+        if label:
+            return sessions.get(label)
         if chat_id:
             label = self._registry.get_channel_session(agent_name, chat_id)
             session = sessions.get(label)
@@ -750,7 +752,7 @@ class MessageBroker:
         """List streaming session labels and status for an agent."""
         sessions = self._streaming.get(agent_name, {})
         return [
-            {"label": label, "connected": s.is_connected, "stats": s.stats}
+            {"id": s.id, "label": label, "connected": s.is_connected, "stats": s.stats}
             for label, s in sessions.items()
         ]
 

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -42,6 +42,7 @@ def _log(msg: str) -> None:
 class StreamingSessionConfig:
     """Configuration for a streaming session."""
     agent_name: str = ""
+    label: str = "main"
     model: str = ""
     working_dir: str = "."
     allowed_tools: list[str] = field(default_factory=list)
@@ -177,6 +178,7 @@ class StreamingSession:
         self._pending_chats: list[tuple[str, str, str]] = []  # Queue of (platform, chat_id, message_id)
 
         self.agent_name = config.agent_name
+        self.label = config.label or "main"
         self.session_id = config.resume_session_id  # CC session ID (persisted across restarts)
         self.created_at = time.time()
         self.last_active = self.created_at
@@ -715,4 +717,4 @@ class StreamingSession:
 
     @property
     def id(self) -> str:
-        return f"{self.agent_name}-main"
+        return f"{self.agent_name}-{self.label}"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -383,9 +383,17 @@ class TestAPI:
         def __init__(self, total_tokens=0, max_tokens=200_000):
             self.total_tokens = total_tokens
             self.max_tokens = max_tokens
+            self.queries = []
+            self.models = []
 
         async def get_context_usage(self):
             return {"totalTokens": self.total_tokens, "maxTokens": self.max_tokens}
+
+        async def query(self, prompt):
+            self.queries.append(prompt)
+
+        async def set_model(self, model):
+            self.models.append(model)
 
     class _FakeStreamingSession:
         def __init__(self, agent_name: str, label: str = "main", *, connected: bool = True, total_tokens: int = 0, max_tokens: int = 200_000):
@@ -421,6 +429,39 @@ class TestAPI:
         async def connect(self):
             self.connect_calls += 1
             self.is_connected = True
+
+    @pytest.mark.asyncio
+    async def test_streaming_session_uses_label_specific_conversation_id(self):
+        from pinky_daemon.conversation_store import ConversationStore
+        from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
+
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        store = ConversationStore(path)
+        try:
+            worker = StreamingSession(
+                StreamingSessionConfig(agent_name="test-agent", label="worker"),
+                conversation_store=store,
+            )
+            main = StreamingSession(
+                StreamingSessionConfig(agent_name="test-agent", label="main"),
+                conversation_store=store,
+            )
+            worker._connected = True
+            worker._client = self._FakeContextClient()
+            main._connected = True
+            main._client = self._FakeContextClient()
+
+            await worker.send("worker hello", platform="web", chat_id="web")
+            await main.send("main hello", platform="web", chat_id="web")
+
+            worker_history = store.get_history("test-agent-worker")
+            main_history = store.get_history("test-agent-main")
+            assert [m.content for m in worker_history] == ["worker hello"]
+            assert [m.content for m in main_history] == ["main hello"]
+        finally:
+            store.close()
+            os.unlink(path)
 
     def test_root(self):
         client = self._make_client()
@@ -718,9 +759,75 @@ class TestAPI:
             with TestClient(app2) as client2:
                 resp = client2.get("/agents/test-agent/streaming-sessions")
                 assert resp.status_code == 200
-                labels = {item["label"] for item in resp.json()["sessions"]}
+                sessions = resp.json()["sessions"]
+                labels = {item["label"] for item in sessions}
                 assert "main" in labels
                 assert "worker" in labels
+                assert any(item["id"] == "test-agent-worker" for item in sessions)
+
+    def test_chat_endpoint_routes_to_selected_streaming_label(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                main = self._FakeStreamingSession("test-agent", "main")
+                worker = self._FakeStreamingSession("test-agent", "worker")
+                app.state.broker.register_streaming("test-agent", main, label="main")
+                app.state.broker.register_streaming("test-agent", worker, label="worker")
+
+                resp = client.post("/agents/test-agent/chat?label=worker", json={"content": "hello worker"})
+                assert resp.status_code == 200
+                assert resp.json()["label"] == "worker"
+                assert len(worker.sent) == 1
+                assert "hello worker" in worker.sent[0][0]
+                assert main.sent == []
+
+    def test_streaming_status_supports_selected_label_and_main_default(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                main = self._FakeStreamingSession("test-agent", "main", total_tokens=10)
+                worker = self._FakeStreamingSession("test-agent", "worker", total_tokens=20)
+                app.state.broker.register_streaming("test-agent", main, label="main")
+                app.state.broker.register_streaming("test-agent", worker, label="worker")
+
+                worker_resp = client.get("/agents/test-agent/streaming/status?label=worker")
+                assert worker_resp.status_code == 200
+                assert worker_resp.json()["label"] == "worker"
+                assert worker_resp.json()["id"] == "test-agent-worker"
+
+                main_resp = client.get("/agents/test-agent/streaming/status")
+                assert main_resp.status_code == 200
+                assert main_resp.json()["label"] == "main"
+                assert main_resp.json()["id"] == "test-agent-main"
+
+    def test_streaming_restart_uses_selected_label(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                main = self._FakeStreamingSession("test-agent", "main")
+                worker = self._FakeStreamingSession("test-agent", "worker")
+                app.state.broker.register_streaming("test-agent", main, label="main")
+                app.state.broker.register_streaming("test-agent", worker, label="worker")
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="worker-safe",
+                    metadata={"source": "save_my_context"},
+                    updated_by=worker.session_id,
+                )
+                worker.last_active = time.time()
+
+                resp = client.post("/agents/test-agent/streaming/restart?label=worker")
+                assert resp.status_code == 200
+                assert resp.json()["label"] == "worker"
+                assert worker.disconnect_calls == 1
+                assert worker.connect_calls == 1
+                assert main.disconnect_calls == 0
 
     def test_get_session(self):
         client = self._make_client()


### PR DESCRIPTION
## Summary
- route chat history, polling, uploads, restart/archive/compact, and model actions to the selected streaming session instead of always targeting `main`
- give streaming sessions stable `{agent}-{label}` ids and expose them from the API so the UI can treat sub-sessions as first-class chats
- prompt for a session name when creating a new chat session and normalize it into a safe label before opening it

## Testing
- `pytest tests/test_api.py -q`
- `npm run build`