### PR TITLE
Improve wake context: timestamp, task summary, lazy skills

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1173,19 +1173,20 @@ except Exception:
             if safe_directives:
                 parts.append("\n## Active Directives\n" + "\n".join(safe_directives))
 
-        # Skill catalog — compact listing; full bodies loaded on demand via load_skill()
+        # Skill hint — minimal pointer; full catalog available on demand
         if skill_store:
             try:
                 materialized = skill_store.materialize_for_agent(agent_name)
                 catalog = materialized.get("catalog", [])
                 if catalog:
-                    lines = ["## Available Skills",
-                             "Use `load_skill(\"name\")` to load full instructions for a skill before using it.",
-                             ""]
-                    for entry in catalog:
-                        desc = entry.get("description", "")
-                        lines.append(f"- **{entry['name']}**: {desc}" if desc else f"- **{entry['name']}**")
-                    parts.append("\n".join(lines))
+                    names = [e["name"] for e in catalog]
+                    parts.append(
+                        f"## Skills\n"
+                        f"You have {len(catalog)} skills equipped. "
+                        f"Call `list_my_skills()` for descriptions, "
+                        f"`load_skill(\"name\")` for full instructions.\n\n"
+                        f"Equipped: {', '.join(names)}"
+                    )
             except Exception:
                 pass
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1745,12 +1745,34 @@ def create_api(
             for m in inbox_messages:
                 lines.append(f"  From {m.from_session}: {m.content}")
             inbox_ctx = (
-                "Unread agent messages in your inbox:\n"
+                f"Unread agent messages ({len(inbox_messages)}):\n"
                 + "\n".join(lines)
                 + "\nReply via send_to_agent, not by messaging the owner."
             )
             wake_ctx = f"{wake_ctx}\n\n{inbox_ctx}" if wake_ctx else inbox_ctx
             comms.mark_read(agent_name, [m.id for m in inbox_messages])
+
+        # Inject open task summary
+        try:
+            open_tasks = tasks.list(assigned_agent=agent_name)
+            if open_tasks:
+                in_progress = [t for t in open_tasks if t.status == "in_progress"]
+                pending = [t for t in open_tasks if t.status == "pending"]
+                blocked = [t for t in open_tasks if t.status == "blocked"]
+                task_parts = []
+                if in_progress:
+                    task_parts.append(f"{len(in_progress)} in progress")
+                if pending:
+                    task_parts.append(f"{len(pending)} pending")
+                if blocked:
+                    task_parts.append(f"{len(blocked)} blocked")
+                task_summary = f"Open tasks ({len(open_tasks)}): {', '.join(task_parts)}."
+                top_tasks = (in_progress + pending + blocked)[:5]
+                for t in top_tasks:
+                    task_summary += f"\n  [{t.status}] #{t.id}: {t.title}"
+                wake_ctx = f"{wake_ctx}\n\n{task_summary}" if wake_ctx else task_summary
+        except Exception:
+            pass  # Task store may not be initialized yet
 
         # Inject restart manifest entry if present — written by on_shutdown() before restart.
         # After reading, remove this agent's entry so it doesn't repeat on subsequent wakes.
@@ -1938,6 +1960,7 @@ def create_api(
             restart_guard=lambda session, _agent_name=agent_name: _get_streaming_restart_guard(_agent_name, session),
             context_warn_pct=warn_pct,
             context_restart_pct=restart_pct,
+            timezone=agents.get_owner_profile().get("timezone", "America/Los_Angeles"),
             subagents=subagents,
             provider_url=resolved_provider_url,
             provider_key=resolved_provider_key,

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -14,7 +14,9 @@ import asyncio
 import json
 import sys
 import time
+import zoneinfo
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 
 from pinky_daemon.sessions import SessionUsage
@@ -58,6 +60,7 @@ class StreamingSessionConfig:
     context_restart_pct: int = 80  # Force restart at this %
     restart_guard_cooldown_sec: int = 60  # Minimum gap between restart-block warnings
     idle_timeout: int = 3600  # Auto-sleep after this many seconds idle (0 = disabled)
+    timezone: str = "America/Los_Angeles"  # IANA timezone for wake timestamp
     subagents: dict = field(default_factory=dict)  # name -> AgentDefinition
     provider_url: str = ""   # ANTHROPIC_BASE_URL override (e.g. "http://localhost:11434" for Ollama)
     provider_key: str = ""   # ANTHROPIC_API_KEY override (empty = use env var)
@@ -267,18 +270,26 @@ class StreamingSession:
         if self._config.wake_context:
             ctx_block = f"\n\n── Saved State ──\n{self._config.wake_context}\n──────────────────"
 
+        # Current time for agent orientation
+        try:
+            _tz = zoneinfo.ZoneInfo(self._config.timezone or "America/Los_Angeles")
+            _now = datetime.now(_tz)
+            time_str = _now.strftime("%A, %B %-d, %Y at %-I:%M %p %Z")
+        except Exception:
+            time_str = datetime.now().strftime("%A, %B %-d, %Y at %-I:%M %p UTC")
+
         tools_hint = (
             "You have explicit pinky-messaging outreach tools: "
             "send, thread, react, send_gif, send_voice, send_photo, send_document, broadcast."
         )
         wake_prompt = (
-            f"Session resumed after daemon restart.{ctx_block}\n\n"
+            f"Session resumed after daemon restart. Current time: {time_str}.{ctx_block}\n\n"
             "Pick up where you left off. Users will message you through Telegram. "
             "Use send(chat_id, platform, text) for normal responses. "
             "Use thread(message_id, text) only when you want to quote/thread a specific message. "
             f"{tools_hint} If you do not call an outreach tool, Pinky may fall back to plain-text delivery based on agent settings."
             if is_resume else
-            f"New session started.{ctx_block}\n\n"
+            f"New session started. Current time: {time_str}.{ctx_block}\n\n"
             "You're connected via Pinky's message broker. Users will message you through Telegram. "
             "Use send(chat_id, platform, text) for normal responses. "
             "Use thread(message_id, text) only when you want to quote/thread a specific message. "


### PR DESCRIPTION
## Summary
- **Wake timestamp**: Agents now see full date/time with day of week on session start/resume, using owner's timezone
- **Task summary in wake context**: Wake context includes inbox count + top-5 open tasks with status breakdown (in_progress/pending/blocked)
- **Lazy skill catalog**: CLAUDE.md now lists just equipped skill names instead of full descriptions — saves ~tokens per prompt, full details via `list_my_skills()`

## Test plan
- [ ] Verify wake prompt includes correct timestamp with timezone
- [ ] Verify task summary appears in wake context when agent has open tasks
- [ ] Verify skill section in CLAUDE.md shows compact format
- [ ] All existing tests pass

🤖 Opened by Barsik