### PR TITLE
Centralize onboarding CTA and clarify wizard flow

### DIFF
--- a/frontend-svelte/src/pages/Onboarding.svelte
+++ b/frontend-svelte/src/pages/Onboarding.svelte
@@ -55,6 +55,8 @@
     let platformTestResult = null;
     let platformTesting = false;
     let configuredPlatforms = [];
+    $: hasAnyAgent = agentCreated || existingAgents.length > 0;
+    $: hasConfiguredChannel = platformConfigured || configuredPlatforms.length > 0;
 
     // Load data for current step
     async function loadStepData() {
@@ -305,6 +307,19 @@
     function next() {
         if (step < totalSteps - 1) { step++; loadStepData(); }
     }
+    async function handlePrimaryAction() {
+        if (step === totalSteps - 1) return completeOnboarding();
+        if (step === 3) return saveProfile(true);
+        if (step === 4) {
+            if (hasAnyAgent) return next();
+            return createAgent();
+        }
+        if (step === 5) {
+            if (hasConfiguredChannel) return next();
+            return configurePlatform();
+        }
+        return next();
+    }
 
     function keyLabel(k) {
         return k.replace('_API_KEY', '').replace(/_/g, ' ');
@@ -434,9 +449,7 @@
                 <div class="wizard-label">{$_('onboarding.comm_style')} <span style="color:var(--text-muted);font-weight:400;text-transform:none">({$_('common.optional')})</span></div>
                 <input type="text" class="wizard-input" bind:value={ownerCommStyle} placeholder="e.g. direct, casual, concise">
 
-                <button class="wizard-btn wizard-btn-primary" style="margin-top:0.5rem" on:click={() => saveProfile(true)} disabled={loading}>
-                    {loading ? $_('common.saving') : $_('common.next') + ' →'}
-                </button>
+                <div class="wizard-hint">Save and continue from the bottom right when you are ready.</div>
 
             {:else if step === 4}
                 <!-- Create Agent -->
@@ -479,9 +492,7 @@
                         <strong>{agentDisplayName || agentName}</strong> {$_('onboarding.agent_created')}
                     </div>
                 {:else}
-                    <button class="wizard-btn wizard-btn-primary" on:click={createAgent} disabled={loading || !agentDisplayName.trim()}>
-                        {loading ? $_('tasks.creating') : $_('onboarding.create_agent')}
-                    </button>
+                    <div class="wizard-hint">Create and continue from the bottom right when you are ready.</div>
                 {/if}
 
             {:else if step === 5}
@@ -525,10 +536,6 @@
                             {platformTesting ? $_('onboarding.testing') : $_('onboarding.test')}
                         </button>
                     </div>
-                {:else}
-                    <button class="wizard-btn wizard-btn-primary" on:click={configurePlatform} disabled={loading || !platformToken.trim()}>
-                        {loading ? $_('onboarding.configuring') : $_('onboarding.configure')}
-                    </button>
                 {/if}
 
                 <!-- Approved Users -->
@@ -625,13 +632,19 @@
                 <div></div>
             {/if}
             {#if step === totalSteps - 1}
-                <button class="wizard-btn wizard-btn-primary" on:click={completeOnboarding} disabled={loading}>
+                <button class="wizard-btn wizard-btn-primary" on:click={handlePrimaryAction} disabled={loading}>
                     {loading ? $_('onboarding.finishing') : $_('onboarding.go_to_dashboard')}
                 </button>
             {:else if step === 0}
-                <button class="wizard-btn wizard-btn-primary" on:click={next}>{$_('onboarding.lets_go')}</button>
+                <button class="wizard-btn wizard-btn-primary" on:click={handlePrimaryAction}>{$_('onboarding.lets_go')}</button>
             {:else}
-                <button class="wizard-btn wizard-btn-primary" on:click={next}>{$_('common.next')}</button>
+                <button
+                    class="wizard-btn wizard-btn-primary"
+                    on:click={handlePrimaryAction}
+                    disabled={loading || (step === 3 && !ownerName.trim()) || (step === 4 && !hasAnyAgent && !agentDisplayName.trim()) || (step === 5 && !hasConfiguredChannel && !platformToken.trim())}
+                >
+                    {step === 3 ? (loading ? $_('common.saving') : $_('common.next')) : step === 4 && !hasAnyAgent ? (loading ? $_('tasks.creating') : $_('onboarding.create_agent')) : step === 5 && !hasConfiguredChannel ? (loading ? $_('onboarding.configuring') : $_('onboarding.configure')) : $_('common.next')}
+                </button>
             {/if}
         </div>
     </div>


### PR DESCRIPTION
### Motivation
- The onboarding wizard had duplicated/conflicting primary actions (in-step buttons + footer Next) that made progression confusing and error-prone.  
- The goal is to make the primary CTA deterministic per step, prevent accidental progression without required inputs, and make the flow clearer for fresh and partially-configured installs.

### Description
- Added derived state variables `hasAnyAgent` and `hasConfiguredChannel` to reflect whether an agent or a channel is already present.  
- Introduced a centralized `handlePrimaryAction()` that performs the correct action per step (save profile, create agent, configure channel, complete onboarding, or advance).  
- Removed duplicated in-step primary buttons for Profile and Agent steps and replaced them with guidance copy pointing to the unified bottom-right CTA.  
- Updated the footer CTA to use `handlePrimaryAction`, with conditional disabling and dynamic labels so the primary button performs appropriate actions and prevents invalid progression.  
- Modified file: `frontend-svelte/src/pages/Onboarding.svelte`.

### Testing
- Ran the frontend production build with `cd frontend-svelte && npm run build`, which completed successfully.  
- The build emitted non-blocking Vite/Svelte warnings about chunk size and an SSR button-in-button placement warning, but these were not blocking and the build finished OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84a6000dc8333b306be0081228c56)