### PR TITLE
Promote beta: tool description trim, pre-load expansion, lint fixes

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -383,6 +383,7 @@ class AgentContext:
     notes: str = ""  # Freeform notes
     blockers: list[str] = field(default_factory=list)
     priority_items: list[str] = field(default_factory=list)
+    wake_action: str = ""  # Required first action on wake-up
     metadata: dict = field(default_factory=dict)
     updated_at: float = 0.0
     updated_by: str = ""  # session ID that saved this
@@ -395,6 +396,7 @@ class AgentContext:
             "notes": self.notes,
             "blockers": self.blockers,
             "priority_items": self.priority_items,
+            "wake_action": self.wake_action,
             "metadata": self.metadata,
             "updated_at": self.updated_at,
             "updated_by": self.updated_by,
@@ -403,6 +405,8 @@ class AgentContext:
     def to_prompt(self) -> str:
         """Format as a system prompt section for injection on restart."""
         parts = []
+        if self.wake_action:
+            parts.append(f"## ⚡ Wake Action (do this FIRST)\n{self.wake_action}")
         if self.task:
             parts.append(f"## Continuation\nYou were working on: {self.task}")
         if self.context:
@@ -712,6 +716,16 @@ class AgentRegistry:
         if "timezone" not in au_existing:
             self._db.execute("ALTER TABLE approved_users ADD COLUMN timezone TEXT NOT NULL DEFAULT ''")
             _log("agent_registry: migrated — added timezone to approved_users")
+
+        # Migrate agent_contexts table
+        ctx_existing = {
+            row[1] for row in self._db.execute("PRAGMA table_info(agent_contexts)").fetchall()
+        }
+        if "wake_action" not in ctx_existing:
+            self._db.execute(
+                "ALTER TABLE agent_contexts ADD COLUMN wake_action TEXT NOT NULL DEFAULT ''"
+            )
+            _log("agent_registry: migrated — added wake_action to agent_contexts")
 
         # Seed main_agent default
         if not self.get_setting("main_agent"):
@@ -1689,6 +1703,7 @@ except Exception:
         task: str = "", context: str = "", notes: str = "",
         blockers: list[str] | None = None,
         priority_items: list[str] | None = None,
+        wake_action: str = "",
         metadata: dict | None = None,
         updated_by: str = "",
     ) -> AgentContext:
@@ -1700,16 +1715,18 @@ except Exception:
         now = time.time()
         self._db.execute(
             """INSERT INTO agent_contexts
-               (agent_name, task, context, notes, blockers, priority_items, metadata, updated_at, updated_by)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+               (agent_name, task, context, notes, blockers, priority_items,
+                wake_action, metadata, updated_at, updated_by)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT (agent_name) DO UPDATE SET
                 task=excluded.task, context=excluded.context, notes=excluded.notes,
                 blockers=excluded.blockers, priority_items=excluded.priority_items,
+                wake_action=excluded.wake_action,
                 metadata=excluded.metadata, updated_at=excluded.updated_at,
                 updated_by=excluded.updated_by""",
             (agent_name, task, context, notes,
              json.dumps(blockers or []), json.dumps(priority_items or []),
-             json.dumps(metadata or {}), now, updated_by),
+             wake_action, json.dumps(metadata or {}), now, updated_by),
         )
         self._db.commit()
         _log(f"agents: saved context for {agent_name}")
@@ -1719,7 +1736,7 @@ except Exception:
         """Get the saved continuation context for an agent."""
         row = self._db.execute(
             """SELECT agent_name, task, context, notes, blockers, priority_items,
-                      metadata, updated_at, updated_by
+                      wake_action, metadata, updated_at, updated_by
                FROM agent_contexts WHERE agent_name=?""",
             (agent_name,),
         ).fetchone()
@@ -1728,7 +1745,8 @@ except Exception:
         return AgentContext(
             agent_name=row[0], task=row[1], context=row[2], notes=row[3],
             blockers=json.loads(row[4]), priority_items=json.loads(row[5]),
-            metadata=json.loads(row[6]), updated_at=row[7], updated_by=row[8],
+            wake_action=row[6], metadata=json.loads(row[7]),
+            updated_at=row[8], updated_by=row[9],
         )
 
     def clear_context(self, agent_name: str) -> bool:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1015,29 +1015,23 @@ def _write_mcp_json(
     - pinky-messaging: outbound messaging through the broker
     Plus any MCP servers from assigned skills.
 
-    When PINKY_SHARED_MCP=1, pinky-self and pinky-messaging use SSE transport
-    pointing at the shared MCP server instead of spawning per-agent stdio processes.
-    Memory stays stdio (per-agent DB) for now.
+    When PINKY_SHARED_MCP=1, all three core servers use SSE transport pointing
+    at the shared MCP server. Memory uses a per-agent store pool for DB isolation.
     """
     pinky_src = str(Path(__file__).resolve().parent.parent)
     mcp_config: dict = {"mcpServers": {}}
-
-    # Memory: per-agent SQLite long-term memory with vector search
-    # Always stdio — each agent has its own memory.db
-    data_dir = work_dir / "data"
-    data_dir.mkdir(parents=True, exist_ok=True)
-    db_path = str(data_dir / "memory.db")
-    mcp_config["mcpServers"]["pinky-memory"] = {
-        "command": sys.executable,
-        "args": ["-m", "pinky_memory", "--db", db_path],
-        "cwd": pinky_src,
-    }
 
     if SHARED_MCP_ENABLED:
         # Shared SSE mode: point at the shared HTTP server with agent identity header
         shared_base = f"http://{SHARED_MCP_HOST}:{SHARED_MCP_PORT}"
         agent_headers = {"X-Agent-Name": agent_name}
 
+        # Memory: per-agent SQLite via shared SSE server (store pool)
+        mcp_config["mcpServers"]["pinky-memory"] = {
+            "type": "sse",
+            "url": f"{shared_base}/mcp/memory/sse",
+            "headers": agent_headers,
+        }
         mcp_config["mcpServers"]["pinky-self"] = {
             "type": "sse",
             "url": f"{shared_base}/mcp/self/sse",
@@ -1049,6 +1043,16 @@ def _write_mcp_json(
             "headers": agent_headers,
         }
     else:
+        # Memory: per-agent SQLite long-term memory with vector search (stdio)
+        data_dir = work_dir / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        db_path = str(data_dir / "memory.db")
+        mcp_config["mcpServers"]["pinky-memory"] = {
+            "command": sys.executable,
+            "args": ["-m", "pinky_memory", "--db", db_path],
+            "cwd": pinky_src,
+        }
+
         # Stdio mode: spawn per-agent processes (original behavior)
         # Pinky-self: heartbeat_ack, schedules, self-management
         tool_gates = _get_agent_tool_gates(agent_name, skill_store)
@@ -7049,7 +7053,20 @@ def create_api(
 
         # Start shared MCP server BEFORE agent sessions so SSE URLs are ready
         if SHARED_MCP_ENABLED:
-            shared_mcp_manager = SharedMcpManager(api_url="http://localhost:8888")
+            def _resolve_memory_db(agent_name: str) -> str:
+                """Resolve agent_name -> memory DB path for the shared store pool."""
+                agent = agents.get(agent_name)
+                if not agent:
+                    raise ValueError(f"Unknown agent: {agent_name}")
+                db_path = str(Path(agent.working_dir) / "data" / "memory.db")
+                # Ensure data dir exists (agent may not have used memory yet)
+                Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+                return db_path
+
+            shared_mcp_manager = SharedMcpManager(
+                api_url="http://localhost:8888",
+                memory_db_resolver=_resolve_memory_db,
+            )
             await shared_mcp_manager.start()
             _log(f"startup: shared MCP server started on {shared_mcp_manager.url}")
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -709,6 +709,7 @@ class SetContextRequest(BaseModel):
     notes: str = ""
     blockers: list[str] = Field(default_factory=list)
     priority_items: list[str] = Field(default_factory=list)
+    wake_action: str = ""
     metadata: dict = Field(default_factory=dict)
 
 
@@ -6816,6 +6817,7 @@ def create_api(
             agent_name,
             task=req.task, context=req.context, notes=req.notes,
             blockers=req.blockers, priority_items=req.priority_items,
+            wake_action=req.wake_action,
             metadata=req.metadata, updated_by=session_id,
         )
         return ctx.to_dict()

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -16,6 +16,7 @@ import re
 import sys
 import threading
 import time
+from collections.abc import Callable
 from contextvars import ContextVar
 
 # Valid agent name pattern — lowercase alphanumeric, hyphens, underscores
@@ -199,6 +200,67 @@ SHARED_MCP_PORT = 8890
 SHARED_MCP_HOST = "127.0.0.1"
 
 
+class MemoryStorePool:
+    """Thread-safe pool of per-agent ReflectionStore instances.
+
+    Lazily creates and caches stores when an agent's memory is first accessed.
+    Uses a callback to resolve agent_name -> db_path, so it doesn't need
+    direct access to the agent registry.
+    """
+
+    def __init__(self, db_path_resolver: "Callable[[str], str]"):
+        """
+        Args:
+            db_path_resolver: Callable that maps agent_name -> SQLite DB path.
+                              Should raise ValueError for unknown agents.
+        """
+        self._db_path_resolver = db_path_resolver
+        self._stores: dict[str, object] = {}  # agent_name -> ReflectionStore
+        self._lock = threading.Lock()
+
+    def get_store(self, agent_name: str) -> object:
+        """Get or create the ReflectionStore for an agent (thread-safe)."""
+        # Fast path: already cached
+        store = self._stores.get(agent_name)
+        if store is not None:
+            return store
+
+        # Slow path: create under lock
+        with self._lock:
+            # Double-check after acquiring lock
+            store = self._stores.get(agent_name)
+            if store is not None:
+                return store
+
+            from pinky_memory.store import ReflectionStore
+
+            db_path = self._db_path_resolver(agent_name)
+            _log(f"[shared-mcp] Opening memory store for agent '{agent_name}': {db_path}")
+            store = ReflectionStore(db_path=db_path)
+            self._stores[agent_name] = store
+            return store
+
+    def remove_store(self, agent_name: str) -> None:
+        """Remove and close a cached store (e.g. when agent is deleted)."""
+        with self._lock:
+            store = self._stores.pop(agent_name, None)
+            if store is not None:
+                try:
+                    store.close()  # type: ignore[union-attr]
+                except Exception:
+                    pass
+
+    def close_all(self) -> None:
+        """Close all cached stores (shutdown)."""
+        with self._lock:
+            for name, store in self._stores.items():
+                try:
+                    store.close()  # type: ignore[union-attr]
+                except Exception:
+                    pass
+            self._stores.clear()
+
+
 class SharedMcpManager:
     """Manages the shared MCP server lifecycle within the daemon process.
 
@@ -214,10 +276,13 @@ class SharedMcpManager:
         host: str = SHARED_MCP_HOST,
         port: int = SHARED_MCP_PORT,
         api_url: str = "http://localhost:8888",
+        memory_db_resolver: "Callable[[str], str] | None" = None,
     ):
         self._host = host
         self._port = port
         self._api_url = api_url
+        self._memory_db_resolver = memory_db_resolver
+        self._memory_pool: MemoryStorePool | None = None
         self._server = None  # uvicorn.Server instance
         self._thread: threading.Thread | None = None
         self._running = False
@@ -259,12 +324,25 @@ class SharedMcpManager:
             api_url=self._api_url,
         )
 
-        # Note: pinky-memory is NOT included yet — it needs a store object
-        # per-agent, which requires a different approach. Phase 3.
         mcp_servers = {
             "self": self_mcp,
             "messaging": messaging_mcp,
         }
+
+        # Shared pinky-memory: per-agent store pool with lazy creation
+        if self._memory_db_resolver:
+            from pinky_memory.embeddings import build_embedding_client
+            from pinky_memory.server import create_server as create_memory_server
+
+            self._memory_pool = MemoryStorePool(self._memory_db_resolver)
+            embedder = build_embedding_client()
+
+            memory_mcp = create_memory_server(
+                store_factory=self._memory_pool.get_store,
+                embedder=embedder,
+            )
+            mcp_servers["memory"] = memory_mcp
+            _log("[shared-mcp] pinky-memory included (per-agent store pool)")
 
         return create_shared_app(mcp_servers)
 
@@ -306,6 +384,9 @@ class SharedMcpManager:
             self._server.should_exit = True
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=5)
+        if self._memory_pool:
+            self._memory_pool.close_all()
+            self._memory_pool = None
         _log("[shared-mcp] Stopped")
 
     @property

--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -48,25 +48,10 @@ def create_server(
         source_channel: str | None = None,
         source_message_ids: list[str] | None = None,
     ) -> str:
-        """Persist a cross-session insight to long-term vector memory.
-
-        WHEN TO USE: You learned something worth remembering beyond this session —
-        owner preferences, project patterns, key decisions, interaction styles,
-        or facts about people. Call this as soon as you notice the insight.
-        NOT FOR: Active task state (use save_my_context), things derivable from
-        code or git history, or ephemeral conversation details.
-
-        Args:
-            content: The reflection content to store.
-            type: One of: insight, project_state, interaction_pattern, continuation, fact.
-            context: Additional context about when/why this was noted.
-            project: Project name this relates to (empty for general).
-            salience: Importance 1-5 (1=low, 5=critical). Default 3.
-            supersedes: ID of a previous reflection this replaces.
-            entities: Person names to tag this memory with (e.g. ["terry", "kyle"]).
-            source_session_id: Session that produced this reflection (e.g. "telegram:6770805286").
-            source_channel: Channel name (e.g. "telegram").
-            source_message_ids: Message IDs that produced this reflection.
+        """Store a cross-session insight to long-term memory. Call when you learn
+        something worth remembering — preferences, patterns, decisions, facts about people.
+        Not for task state (use save_my_context) or ephemeral details.
+        type: insight | project_state | interaction_pattern | continuation | fact. salience: 1-5.
         """
         input_data = ReflectInput(
             content=content,
@@ -124,23 +109,8 @@ def create_server(
         limit: int = 10,
         active_only: bool = True,
     ) -> str:
-        """Search long-term memory by meaning or filters.
-
-        WHEN TO USE: You need to remember something from a past session — what
-        you know about a person, a project decision, an owner preference, or any
-        previously stored insight. Semantic search (query) finds related memories
-        even with different wording; filters narrow by type/project/entity.
-        NOT FOR: Conversation history from this session (use search_history),
-        current task state (use load_my_context), or memory statistics (use introspect).
-
-        Args:
-            query: Natural language search query. Leave empty to browse by filters.
-            type: Filter by type: insight, project_state, interaction_pattern, continuation, fact.
-            project: Filter by project name.
-            entity: Filter by person name (e.g. "terry"). Returns only reflections tagged with this entity.
-            min_weight: Minimum weight threshold (0.0-1.0).
-            limit: Maximum results to return (1-50, default 10).
-            active_only: Only return active (non-superseded) reflections.
+        """Search long-term memory by meaning (semantic) or structured filters.
+        Finds related memories even with different wording. Leave query empty to browse by filters.
         """
         input_data = RecallInput(
             query=query,
@@ -237,18 +207,7 @@ def create_server(
         type: str = "",
         project: str = "",
     ) -> str:
-        """Get memory statistics and pattern overview.
-
-        WHEN TO USE: You want to understand your memory landscape — how many
-        memories by type/project, salience distribution, growth over time.
-        Good for memory health checks and understanding knowledge coverage.
-        NOT FOR: Finding a specific memory (use recall), or exact filtering (use memory_query).
-
-        Args:
-            timeframe: Time window: day, week, month, or all.
-            type: Filter by reflection type.
-            project: Filter by project name.
-        """
+        """Get memory statistics — counts by type/project, salience distribution, growth over time."""
         input_data = IntrospectInput(
             timeframe=timeframe,
             type=ReflectionType(type) if type else None,
@@ -274,16 +233,7 @@ def create_server(
 
     @mcp.tool()
     def memory_links(reflection_id: str) -> str:
-        """Explore the memory graph around a specific reflection.
-
-        WHEN TO USE: You found a relevant memory via recall and want to see
-        what's connected to it — related insights, follow-up facts, or
-        contradicting observations. Useful for building a fuller picture.
-        NOT FOR: Initial memory search (start with recall).
-
-        Args:
-            reflection_id: The ID of the reflection to get links for.
-        """
+        """Get memories linked to a specific reflection — related insights, follow-ups, contradictions."""
         links = store.get_links(reflection_id)
         if not links:
             return json.dumps({"count": 0, "links": []})
@@ -322,31 +272,9 @@ def create_server(
         limit: int = 20,
         offset: int = 0,
     ) -> str:
-        """Run exact-match queries against memory with structured filters.
-
-        WHEN TO USE: You need precise filtering that semantic search can't do —
-        memories by date range, salience threshold, review status, or using
-        presets like "stale_projects" or "high_value". Good for memory
-        maintenance, audits, and browsing by criteria.
-        NOT FOR: Finding memories by meaning or topic (use recall).
-
-        Args:
-            preset: Named shortcut (recent_insights, stale_projects, high_value, orphans, due_review, by_project).
-            type: Filter by type: fact, insight, project_state, interaction_pattern, continuation.
-            project: Filter by project name (partial match).
-            entity: Filter by entity/person name.
-            salience_min: Minimum salience (1-5).
-            salience_max: Maximum salience (1-5).
-            active: Only active memories (default True).
-            created_after: ISO date: only memories created after this date.
-            created_before: ISO date: only memories created before this date.
-            accessed_after: ISO date: only memories accessed after this date.
-            due_for_review: Only memories due for spaced review.
-            has_links: Filter by whether memory has links (True/False/None=any).
-            sort_by: Sort field: created_at, accessed_at, salience, access_count.
-            sort_dir: Sort direction: asc or desc.
-            limit: Max results (1-100, default 20).
-            offset: Skip first N results (for pagination).
+        """Query memory with exact-match structured filters (dates, salience, review status).
+        For semantic/meaning search, use recall() instead.
+        Presets: recent_insights, stale_projects, high_value, orphans, due_review, by_project.
         """
         if preset and preset not in PRESET_NAMES:
             return json.dumps({"error": f"Unknown preset '{preset}'. Valid: {', '.join(sorted(PRESET_NAMES))}"})

--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from mcp.server.fastmcp import FastMCP
@@ -27,12 +28,34 @@ def _log(msg: str) -> None:
 
 
 def create_server(
-    store: ReflectionStore,
-    embedder: EmbeddingClient | NoOpEmbeddingClient,
+    store: ReflectionStore | None = None,
+    embedder: EmbeddingClient | NoOpEmbeddingClient | None = None,
     *,
+    store_factory: Callable[[str], ReflectionStore] | None = None,
     host: str = "127.0.0.1",
     port: int = 8000,
 ) -> FastMCP:
+    """Create the pinky-memory MCP server.
+
+    Two modes:
+    - **stdio** (per-agent): pass ``store`` and ``embedder`` directly.
+    - **shared SSE**: pass ``store_factory`` (agent_name -> store) and ``embedder``.
+      Each tool call resolves the agent from ContextVar and gets the right store.
+    """
+    if store is None and store_factory is None:
+        raise ValueError("Either store or store_factory must be provided")
+
+    def _get_store() -> "ReflectionStore":
+        """Resolve the correct store for the current request."""
+        if store is not None:
+            return store
+        # Shared mode: resolve agent from ContextVar
+        from pinky_daemon.shared_mcp import get_current_agent
+        agent = get_current_agent()
+        if not agent:
+            raise ValueError("No agent identified in shared mode — missing X-Agent-Name header?")
+        return store_factory(agent)  # type: ignore[misc]
+
     mcp = FastMCP("pinky-memory", host=host, port=port)
 
     @mcp.tool()
@@ -85,11 +108,12 @@ def create_server(
         )
 
         # Insert
-        ref = store.insert(ref)
+        s = _get_store()
+        ref = s.insert(ref)
 
         # Handle supersession (after insert so we have ref.id)
         if input_data.supersedes:
-            store.deactivate_superseded(input_data.supersedes, superseded_by=ref.id)
+            s.deactivate_superseded(input_data.supersedes, superseded_by=ref.id)
         _log(f"reflect: stored {ref.id} type={ref.type.value}")
 
         return json.dumps({
@@ -124,11 +148,12 @@ def create_server(
 
         results: list[Reflection] = []
 
+        s = _get_store()
         if input_data.query:
             # Try vector search first
             query_embedding = embedder.embed(input_data.query)
             if query_embedding:
-                results = store.search_by_embedding(
+                results = s.search_by_embedding(
                     query_embedding=query_embedding,
                     limit=input_data.limit,
                     active_only=input_data.active_only,
@@ -140,7 +165,7 @@ def create_server(
 
             # Fall back to keyword search if no vector results
             if not results:
-                results = store.search_by_keyword(
+                results = s.search_by_keyword(
                     query=input_data.query,
                     limit=input_data.limit,
                     active_only=input_data.active_only,
@@ -151,7 +176,7 @@ def create_server(
                 )
         else:
             # No query — browse by filters using keyword search with empty query
-            results = store.search_by_keyword(
+            results = s.search_by_keyword(
                 query="",
                 limit=input_data.limit,
                 active_only=input_data.active_only,
@@ -160,6 +185,7 @@ def create_server(
                 min_weight=input_data.min_weight,
                 entity_filter=input_data.entity,
             )
+        del s  # release reference
 
         _log(f"recall: found {len(results)} results for query={input_data.query!r}")
 
@@ -214,7 +240,7 @@ def create_server(
             project=project,
         )
 
-        stats = store.introspect(
+        stats = _get_store().introspect(
             timeframe=input_data.timeframe,
             type_filter=input_data.type,
             project_filter=input_data.project,
@@ -234,13 +260,14 @@ def create_server(
     @mcp.tool()
     def memory_links(reflection_id: str) -> str:
         """Get memories linked to a specific reflection — related insights, follow-ups, contradictions."""
-        links = store.get_links(reflection_id)
+        s = _get_store()
+        links = s.get_links(reflection_id)
         if not links:
             return json.dumps({"count": 0, "links": []})
 
         result_links = []
         for link in links:
-            neighbor = store.get(link.target_id)
+            neighbor = s.get(link.target_id)
             result_links.append({
                 "id": link.target_id,
                 "similarity": round(link.similarity, 4),
@@ -309,7 +336,7 @@ def create_server(
         filter_kwargs["offset"] = offset
 
         filters = MemoryQueryFilters(**filter_kwargs)
-        results, total = store.query(filters)
+        results, total = _get_store().query(filters)
 
         _log(f"memory_query: {total} total, returning {len(results)}")
 

--- a/src/pinky_messaging/server.py
+++ b/src/pinky_messaging/server.py
@@ -61,13 +61,7 @@ def create_server(
         text: str,
         parse_mode: str = "",
     ) -> str:
-        """Quote-reply to a specific inbound message by message_id.
-
-        WHEN TO USE: You want your response to appear as a threaded reply
-        linked to a specific message (the user sees it quoted). Requires
-        a message_id from an inbound message.
-        NOT FOR: Sending a standalone message (use send), or just
-        acknowledging without text (use react)."""
+        """Quote-reply to a specific inbound message. The user sees your response linked to the original."""
         result = _api("POST", "/broker/thread", {
             "agent_name": agent_name,
             "message_id": message_id,
@@ -83,13 +77,7 @@ def create_server(
         text: str,
         parse_mode: str = "",
     ) -> str:
-        """Send a new standalone message to a specific chat/channel.
-
-        WHEN TO USE: You want to send a message that isn't a reply to anything —
-        proactive outreach, scheduled updates, or responding in a channel.
-        Requires chat_id and platform. Use chat IDs, not display names.
-        NOT FOR: Replying to a specific message (use thread), reacting with
-        emoji (use react), or messaging all channels (use broadcast)."""
+        """Send a standalone message to a chat/channel. Use chat IDs, not display names."""
         result = _api("POST", "/broker/send", {
             "agent_name": agent_name,
             "platform": platform,
@@ -104,11 +92,7 @@ def create_server(
         message_id: str,
         emoji: str,
     ) -> str:
-        """Add an emoji reaction to a specific inbound message.
-
-        WHEN TO USE: You want to acknowledge a message without a full text
-        reply — thumbs up, heart, laugh, etc. Lightweight acknowledgment.
-        NOT FOR: Sending a text response (use send or thread)."""
+        """React to an inbound message with an emoji. Lightweight acknowledgment without a text reply."""
         result = _api("POST", "/broker/react", {
             "agent_name": agent_name,
             "message_id": message_id,
@@ -124,11 +108,7 @@ def create_server(
         chat_id: str = "",
         platform: str = "telegram",
     ) -> str:
-        """Send an image file to a chat, optionally as a reply.
-
-        WHEN TO USE: You have an image file on disk to share. Provide
-        message_id to send as a reply, or chat_id+platform to send standalone.
-        NOT FOR: Text messages (use send), documents/PDFs (use send_document)."""
+        """Send an image file. Provide message_id to reply, or chat_id+platform for standalone."""
         result = _api("POST", "/broker/send-photo", {
             "agent_name": agent_name,
             "message_id": message_id,
@@ -147,11 +127,7 @@ def create_server(
         chat_id: str = "",
         platform: str = "telegram",
     ) -> str:
-        """Send a file/document to a chat, optionally as a reply.
-
-        WHEN TO USE: You have a non-image file to share (PDF, code, research
-        export, etc.). Provide message_id to reply, or chat_id+platform standalone.
-        NOT FOR: Images (use send_photo), text messages (use send)."""
+        """Send a file/document (PDF, code, etc.). Provide message_id to reply, or chat_id+platform for standalone."""
         result = _api("POST", "/broker/send-document", {
             "agent_name": agent_name,
             "message_id": message_id,
@@ -172,13 +148,7 @@ def create_server(
         voice: str = "",
         model: str = "",
     ) -> str:
-        """Convert text to speech and send as a voice message.
-
-        WHEN TO USE: You want to send an audio/voice message — the text is
-        synthesized into speech via TTS. Good for personal greetings, voice
-        notes, or when the user prefers audio.
-        NOT FOR: Sending text (use send), or sending an existing audio file
-        (use send_document)."""
+        """Convert text to speech via TTS and send as a voice message."""
         result = _api("POST", "/broker/send-voice", {
             "agent_name": agent_name,
             "message_id": message_id,
@@ -199,12 +169,7 @@ def create_server(
         chat_id: str = "",
         platform: str = "telegram",
     ) -> str:
-        """Search Giphy for a GIF and send it to a chat.
-
-        WHEN TO USE: You want to send a fun/expressive GIF reaction. Searches
-        Giphy by query and sends the top result. Good for humor, celebration,
-        or casual acknowledgment.
-        NOT FOR: Sending a specific image file (use send_photo)."""
+        """Search Giphy and send the top result as a GIF."""
         result = _api("POST", "/broker/send-gif", {
             "agent_name": agent_name,
             "message_id": message_id,
@@ -219,11 +184,7 @@ def create_server(
     def broadcast(
         text: str,
     ) -> str:
-        """Send the same message to ALL your active channels at once.
-
-        WHEN TO USE: You have an announcement, alert, or status update that
-        should reach every configured channel simultaneously.
-        NOT FOR: Messaging a specific user/chat (use send with chat_id)."""
+        """Send the same message to ALL active channels at once."""
         result = _api("POST", "/broker/broadcast", {
             "agent_name": agent_name,
             "content": text,

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -117,45 +117,11 @@ def create_server(
             target_channel: str = "",
             one_shot: bool = False,
         ) -> str:
-            """Set a cron-based schedule. Two modes:
-
-            MODE 1 — Wake (default): The prompt is sent TO YOU as input. You wake up,
-            read the prompt, and act on it. Use this for tasks where you need to think,
-            use tools, or compose a response.
-
-            Example: set_wake_schedule(cron="0 8 * * *", name="morning_check",
-                     prompt="Check inbox, summarize overnight messages, then use send(chat_id='6770805286', platform='telegram', text='...') to send Brad a status update.")
-
-            MODE 2 — Direct Send: The prompt is sent DIRECTLY to a chat as a message,
-            bypassing you entirely. Use this for simple scheduled messages that don't
-            need any processing.
-
-            Example: set_wake_schedule(cron="0 9 * * 1-5", name="standup_reminder",
-                     prompt="Good morning! Time for standup.", direct_send=True, target_channel="6770805286")
-
-            ONE-SHOT: Set one_shot=True to auto-disable the schedule after it fires once.
-            Useful for deferred tasks, reminders, or one-time wake-ups.
-
-            Example: set_wake_schedule(cron="0 14 * * *", name="deploy_reminder",
-                     prompt="Deploy the new build", one_shot=True)
-
-            IMPORTANT:
-            - In wake mode, the prompt is an INSTRUCTION to you, not a message to send.
-              To send a message to someone, your prompt should tell you to do that.
-            - Use your Pinky MCP tools in your response, not Claude Code built-in tools.
-            - For outbound chat messages, use explicit pinky-messaging tools like
-              send(chat_id, platform, text) or thread(message_id, text) for quoting.
-            - When using send(...), use chat IDs (e.g. "6770805286"), not display names.
-
-            Args:
-                cron: Cron expression (e.g. "0 8 * * *" for daily at 8am,
-                      "*/30 * * * *" for every 30 min, "0 9 * * 1-5" for weekdays 9am).
-                name: Human-friendly schedule name (e.g. "morning_check").
-                prompt: Wake mode: instruction for you. Direct mode: message to send.
-                timezone: Timezone for the schedule (default: America/Los_Angeles).
-                direct_send: If true, prompt is sent directly as a message (no agent processing).
-                target_channel: Chat ID for direct_send mode (e.g. "6770805286").
-                one_shot: If true, schedule auto-disables after firing once.
+            """Set a cron schedule. Default: prompt sent TO YOU as input (wake mode).
+            direct_send=True: prompt sent as message to target_channel (no agent processing).
+            one_shot=True: auto-disables after one fire.
+            In wake mode, the prompt is an instruction — to send a message, tell yourself to call send().
+            Use chat IDs not display names.
             """
             result = _api("POST", f"/agents/{agent_name}/schedules", {
                 "name": name or "self_scheduled",
@@ -174,11 +140,7 @@ def create_server(
 
         @mcp.tool()
         def list_my_schedules() -> str:
-            """List all your cron schedules with status and last run time.
-
-            WHEN TO USE: You want to see what schedules you have set up, check if
-            they're enabled, or find a schedule ID to remove.
-            """
+            """List all your cron schedules with status and last run time."""
             result = _api("GET", f"/agents/{agent_name}/schedules?enabled_only=false")
             schedules = result.get("schedules", [])
             if not schedules:
@@ -193,14 +155,7 @@ def create_server(
 
         @mcp.tool()
         def remove_wake_schedule(schedule_id: int) -> str:
-            """Delete a wake schedule by ID.
-
-            WHEN TO USE: A schedule is no longer needed. Get the ID from
-            list_my_schedules first.
-
-            Args:
-                schedule_id: The schedule ID to remove (from list_my_schedules).
-            """
+            """Delete a wake schedule by ID (from list_my_schedules)."""
             result = _api("DELETE", f"/agents/{agent_name}/schedules/{schedule_id}")
             if result.get("deleted"):
                 return f"Schedule #{schedule_id} removed."
@@ -217,19 +172,9 @@ def create_server(
         blockers: list[str] | None = None,
         priority_items: list[str] | None = None,
     ) -> str:
-        """Snapshot your current working state for restoration after restart/sleep.
-
-        WHEN TO USE: Before calling context_restart, request_sleep, or when
-        context is getting high. Also required by the restart guard — you
-        MUST call this before any restart or sleep will be allowed.
-        NOT FOR: Long-term memory (use reflect for cross-session insights).
-
-        Args:
-            task: What you were working on (brief description).
-            context: Key context/state that must be preserved.
-            notes: Freeform notes for your future self.
-            blockers: List of things blocking progress.
-            priority_items: What to do first when you wake up.
+        """Snapshot working state for restoration after restart/sleep.
+        Required by restart guard — MUST call before context_restart or request_sleep.
+        Not for long-term memory (use reflect).
         """
         result = _api("PUT", f"/agents/{agent_name}/context", {
             "task": task,
@@ -245,12 +190,7 @@ def create_server(
 
     @mcp.tool()
     def load_my_context() -> str:
-        """Restore your working state from before the last restart/sleep.
-
-        WHEN TO USE: On wake-up or after a context restart — call this first
-        to pick up where you left off (task, notes, blockers, priorities).
-        NOT FOR: Searching long-term memory (use recall).
-        """
+        """Restore working state from before last restart/sleep. Call on wake-up to pick up where you left off."""
         result = _api("GET", f"/agents/{agent_name}/context")
         if result.get("context") is None:
             return "No saved context. This is a fresh start."
@@ -279,17 +219,7 @@ def create_server(
 
     @mcp.tool()
     def get_next_task(agent_name_override: str = "") -> str:
-        """Get the highest-priority unblocked task assigned to you (or the specified agent).
-
-        WHEN TO USE: You want to know what to work on next. Respects blocked_by
-        dependencies — skips tasks where any blocker task isn't completed yet.
-        Call this on wake-up after loading context, or whenever you finish a task.
-        NOT FOR: Creating new tasks (use create_task), checking inbox (use check_inbox),
-        claiming unassigned tasks (use claim_task).
-
-        Args:
-            agent_name_override: Agent name to query for (defaults to yourself).
-        """
+        """Get your highest-priority unblocked task. Respects blocked_by dependencies."""
         target = agent_name_override or agent_name
         result = _api("GET", f"/tasks?assigned_agent={target}&status=pending&limit=50")
         tasks = result if isinstance(result, list) else result.get("tasks", [])
@@ -329,13 +259,7 @@ def create_server(
 
     @mcp.tool()
     def claim_task(task_id: int) -> str:
-        """Assign an unassigned task to yourself and set it to in_progress.
-
-        WHEN TO USE: get_next_task returned an unassigned task you want to work on.
-
-        Args:
-            task_id: The task ID to claim.
-        """
+        """Assign an unassigned task to yourself and set it to in_progress."""
         result = _api("POST", f"/tasks/claim/{task_id}?agent_name={agent_name}")
         if "error" in result:
             return f"Failed to claim task: {result['error']}"
@@ -343,15 +267,7 @@ def create_server(
 
     @mcp.tool()
     def complete_task(task_id: int, summary: str = "") -> str:
-        """Mark a task as done and notify its creator.
-
-        WHEN TO USE: You finished the work for a task. Include a summary of
-        what was done so the creator has context.
-
-        Args:
-            task_id: The task ID to complete.
-            summary: Brief summary of what was done / results.
-        """
+        """Mark a task as done and notify its creator. Include a summary of what was done."""
         result = _api("POST", f"/tasks/complete/{task_id}?agent_name={agent_name}&summary={urllib.request.quote(summary)}")
         if "error" in result:
             return f"Failed to complete task: {result['error']}"
@@ -359,15 +275,7 @@ def create_server(
 
     @mcp.tool()
     def block_task(task_id: int, reason: str = "") -> str:
-        """Flag a task as blocked and record why.
-
-        WHEN TO USE: You can't make progress on a task — waiting on another
-        agent, missing information, or need owner input. Always include a reason.
-
-        Args:
-            task_id: The task ID to block.
-            reason: Why the task is blocked.
-        """
+        """Flag a task as blocked. Always include a reason."""
         result = _api("POST", f"/tasks/block/{task_id}?agent_name={agent_name}&reason={urllib.request.quote(reason)}")
         if "error" in result:
             return f"Failed to block task: {result['error']}"
@@ -381,19 +289,8 @@ def create_server(
         assigned_agent: str = "",
         tags: list[str] | None = None,
     ) -> str:
-        """Create a new task for yourself or delegate to another agent.
-
-        WHEN TO USE: You have work to track, or you want to delegate work to
-        another agent. Set assigned_agent to target a specific agent, or leave
-        empty to self-assign.
-        NOT FOR: Messaging another agent directly (use send_to_agent).
-
-        Args:
-            title: Task title / what needs to be done.
-            description: Detailed description, acceptance criteria.
-            priority: low, normal, high, or urgent.
-            assigned_agent: Agent name to assign to (leave empty for self, or name a worker).
-            tags: Tags for categorization.
+        """Create a task for yourself or delegate to another agent.
+        Leave assigned_agent empty to self-assign.
         """
         result = _api("POST", "/tasks", {
             "title": title,
@@ -411,20 +308,9 @@ def create_server(
     def _register_tasks_admin_tools():
         @mcp.tool()
         def decompose_project(project_id: int, tasks: list[dict], description: str = "") -> str:
-            """Decompose a project into tasks (PRD-style breakdown).
-
-            WHEN TO USE: You've planned a project and want to create all its tasks
-            in one shot from a structured breakdown. The AI does the reasoning;
-            this tool just persists the result.
-            NOT FOR: Creating a single task (use create_task), ad-hoc bulk imports
-            (use bulk_create_tasks).
-
-            Args:
-                project_id: The project to attach tasks to.
-                tasks: List of task dicts — title (required), description, priority
-                       (low/normal/high/urgent), tags (list of strings), assigned_agent,
-                       milestone_id, sprint_id, blocked_by (list of task IDs).
-                description: Optional updated project description to persist.
+            """Create all tasks for a project from a structured breakdown.
+            Each task dict needs title (required), plus optional description, priority, tags,
+            assigned_agent, milestone_id, sprint_id, blocked_by.
             """
             if description:
                 _api("PUT", f"/projects/{project_id}", {"description": description})
@@ -462,17 +348,8 @@ def create_server(
 
         @mcp.tool()
         def bulk_create_tasks(project_id: int, tasks: list[dict]) -> str:
-            """Create multiple tasks for a project at once.
-
-            WHEN TO USE: You've decomposed a project into subtasks and want to create
-            them all in one shot. Ideal after planning a sprint or milestone breakdown.
-            NOT FOR: Creating a single task (use create_task), updating existing tasks.
-
-            Args:
-                project_id: The project to attach all tasks to.
-                tasks: List of task dicts, each with keys:
-                       title (required), description, priority (low/normal/high/urgent),
-                       tags (list of strings), assigned_agent.
+            """Create multiple tasks for a project at once. Each task dict needs title (required),
+            plus optional description, priority, tags, assigned_agent.
             """
             created = []
             failed = []
@@ -505,19 +382,8 @@ def create_server(
 
         @mcp.tool()
         def get_presentation_template(variant: str = "default") -> str:
-            """Return the branded base HTML/CSS shell for building a new presentation.
-
-            WHEN TO USE: Always call this before create_presentation(). It gives you
-            the canonical brand template — colors, fonts, nav, transitions — so you
-            only need to add slide content. Load the brand-presentation skill first
-            for the full style guide.
-            NOT FOR: Fetching an existing presentation (use list_presentations).
-
-            Args:
-                variant: Template variant — "default" (dark, purple accent),
-                         "minimal" (no transitions, print-safe),
-                         "figma" (light, Inter font, Figma design aesthetic),
-                         "stitch" (Material You, Google Blue, rounded cards).
+            """Get the branded HTML/CSS template shell for a new presentation.
+            Call before create_presentation(). Variants: default, minimal, figma, stitch.
             """
             template_default = '''<!DOCTYPE html>
     <html lang="en">
@@ -970,21 +836,7 @@ def create_server(
             research_topic_id: int = 0,
             tags: str = "",
         ) -> str:
-            """Create a new presentation with full HTML content and publish it to the gallery.
-
-            WHEN TO USE: You've generated a polished HTML presentation and want to
-            publish it so the owner can view and share it. Always provide complete,
-            self-contained HTML with inline CSS.
-            NOT FOR: Updating an existing presentation (use update_presentation).
-
-            Args:
-                title: Presentation title shown in the gallery.
-                html_content: Complete, self-contained HTML document with inline CSS.
-                              May use stable CDN scripts (e.g. reveal.js).
-                description: Short description of what this presentation covers.
-                research_topic_id: Research topic ID this was generated from (0 = none).
-                tags: Comma-separated tags, e.g. "quarterly,finance,charts".
-            """
+            """Publish a new HTML presentation to the gallery. Provide complete self-contained HTML with inline CSS."""
             tags_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
             body = {
                 "title": title,
@@ -1012,17 +864,7 @@ def create_server(
             html_content: str,
             description: str = "",
         ) -> str:
-            """Update an existing presentation with new HTML content (creates a new version).
-
-            WHEN TO USE: You want to revise a presentation you've already published
-            or incorporate feedback. Old versions are preserved and can be restored.
-            NOT FOR: Creating a new presentation (use create_presentation).
-
-            Args:
-                presentation_id: The integer ID of the presentation to update.
-                html_content: New complete HTML content replacing the current version.
-                description: Optional note describing what changed in this version.
-            """
+            """Update an existing presentation with new HTML (creates a new version). Old versions are preserved."""
             body = {
                 "html_content": html_content,
                 "description": description,
@@ -1039,12 +881,7 @@ def create_server(
 
         @mcp.tool()
         def list_presentations(limit: int = 20) -> str:
-            """List recent presentations in the gallery.
-
-            WHEN TO USE: You want to see what presentations exist before creating a
-            new one, or need a presentation ID to update.
-            NOT FOR: Creating or updating presentations.
-            """
+            """List recent presentations in the gallery."""
             result = _api("GET", f"/presentations?limit={limit}")
             if "error" in result:
                 return f"Failed to fetch presentations: {result['error']}"
@@ -1064,14 +901,7 @@ def create_server(
 
     @mcp.tool()
     def who_am_i() -> str:
-        """Check your own identity, model, session, and configuration.
-
-        WHEN TO USE: You need to know what model you're running, your session ID,
-        context usage, group memberships, or working directory. Good for
-        self-introduction or debugging.
-        NOT FOR: Health diagnostics (use check_my_health), context details
-        (use context_status).
-        """
+        """Check your identity, model, session ID, context usage, and groups."""
         agent_info = _api("GET", f"/agents/{agent_name}")
         if "error" in agent_info:
             return f"Name: {agent_name}\n(Could not fetch full details: {agent_info['error']})"
@@ -1115,13 +945,7 @@ def create_server(
 
     @mcp.tool()
     def get_owner_profile() -> str:
-        """Get your owner/operator's profile for personalization.
-
-        WHEN TO USE: You need the owner's name, timezone, pronouns, communication
-        style, or identity code word — to personalize messages, schedule things
-        in their timezone, or verify identity.
-        NOT FOR: Your own config (use who_am_i).
-        """
+        """Get your owner's profile — name, timezone, pronouns, communication style, languages."""
         result = _api("GET", "/settings/owner-profile")
         if "error" in result:
             return f"Could not fetch owner profile: {result['error']}"
@@ -1147,13 +971,7 @@ def create_server(
 
     @mcp.tool()
     def check_my_health() -> str:
-        """Run a full health diagnostic — session, context, heartbeat, tasks, costs.
-
-        WHEN TO USE: Routine health check, or when something feels wrong.
-        Returns a recommendation (e.g. "restart needed", "healthy").
-        NOT FOR: Just checking context usage (use context_status), or
-        your identity (use who_am_i).
-        """
+        """Full health diagnostic — session, context, heartbeat, tasks, costs. Returns a recommendation."""
         result = _api("GET", f"/agents/{agent_name}/health")
         if "error" in result:
             return f"Health check failed: {result['error']}"
@@ -1190,13 +1008,7 @@ def create_server(
 
     @mcp.tool()
     def context_status() -> str:
-        """Check context window usage, token counts, cost, and saved state.
-
-        WHEN TO USE: You want to know how full your context is and whether a
-        restart is needed. Also shows your saved continuation state. Good for
-        deciding whether to call context_restart or save_my_context.
-        NOT FOR: Full health check (use check_my_health), identity info (use who_am_i).
-        """
+        """Check context window usage, token counts, cost, and saved continuation state."""
         parts = []
 
         # Streaming session info
@@ -1267,13 +1079,8 @@ def create_server(
 
     @mcp.tool()
     def context_restart() -> str:
-        """Restart your session with a fresh context window.
-
-        WHEN TO USE: context_status shows >70% usage, or you need a clean slate.
-        Conversation history is lost but soul/personality and MCP tools persist.
-        IMPORTANT: You MUST call save_my_context() first — the restart guard
-        blocks restart without a recent save.
-        NOT FOR: Just saving state (use save_my_context), or sleeping (use request_sleep).
+        """Restart session with fresh context. You MUST call save_my_context() first.
+        History is lost but soul/tools persist.
         """
         result = _api("POST", f"/agents/{agent_name}/streaming/restart")
         if "error" in result:
@@ -1287,17 +1094,8 @@ def create_server(
 
     @mcp.tool()
     def request_sleep(wake_cron: str = "", wake_prompt: str = "") -> str:
-        """Shut down your session to conserve resources until next wake.
-
-        WHEN TO USE: You have no pending work and want to save compute. Closes
-        your session entirely. You'll wake via existing schedules, inbound
-        messages, or the optional wake_cron you provide here.
-        IMPORTANT: Requires a recent save_my_context() call.
-        NOT FOR: Context restart (use context_restart — keeps you running).
-
-        Args:
-            wake_cron: Optional cron expression for when to wake up (e.g. "0 8 * * *").
-            wake_prompt: What to do when woken from this sleep.
+        """Shut down session to conserve resources. Requires save_my_context() first.
+        Optionally set a wake_cron to auto-wake later.
         """
         # Set a wake schedule if requested
         if wake_cron:
@@ -1318,16 +1116,8 @@ def create_server(
 
     @mcp.tool()
     def send_heartbeat(status: str = "ok", context_pct: float = 0.0, notes: str = "") -> str:
-        """Signal your heartbeat status to the system.
-
-        WHEN TO USE: When the daemon sends a heartbeat trigger. Call this instead
-        of responding with HEARTBEAT_OK text. Also call during long-running tasks.
-
-        Args:
-            status: Your current status — "ok" (idle/available), "busy" (mid-task),
-                    "finishing" (wrapping up).
-            context_pct: Your current context window usage percentage (0-100).
-            notes: Optional note about what you're doing or any flags.
+        """Signal heartbeat status. Call on heartbeat triggers and during long tasks.
+        status: ok | busy | finishing.
         """
         result = _api("POST", f"/agents/{agent_name}/heartbeat", {
             "session_id": f"{agent_name}-main",
@@ -1343,17 +1133,8 @@ def create_server(
 
     @mcp.tool()
     def set_thinking_effort(level: str) -> str:
-        """Set your thinking effort level for this session.
-
-        WHEN TO USE: You're about to tackle a task and want to match your
-        thinking depth to its complexity. Switch proactively — don't use
-        max for a heartbeat, don't use low for a code review.
-
-        Args:
-            level: Effort level — "low" (acks, status, simple lookups),
-                   "medium" (standard work, default), "high" (architecture,
-                   debugging, complex reasoning), "max" (critical deep analysis).
-                   Use "auto" to clear override and revert to your default.
+        """Set thinking effort for this session. Match depth to task complexity.
+        level: low | medium | high | max | auto (clears override).
         """
         if level not in ("low", "medium", "high", "max", "auto"):
             return f"Invalid level: {level}. Use low, medium, high, max, or auto."
@@ -1378,18 +1159,7 @@ def create_server(
             sources: str = "",
             key_findings: str = "",
         ) -> str:
-            """Submit your research findings for an assigned topic.
-
-            WHEN TO USE: You've completed research on a topic assigned to you and
-            want to submit the brief for review or publication.
-
-            Args:
-                topic_id: ID of the research topic
-                content: Full markdown content of the research brief
-                summary: One-paragraph summary of findings
-                sources: Comma-separated list of sources consulted
-                key_findings: Comma-separated list of key findings
-            """
+            """Submit research findings for an assigned topic."""
             sources_list = [s.strip() for s in sources.split(",") if s.strip()] if sources else []
             findings_list = [f.strip() for f in key_findings.split(",") if f.strip()] if key_findings else []
             result = _api("POST", f"/research/{topic_id}/brief", {
@@ -1411,18 +1181,7 @@ def create_server(
             comments: str = "",
             confidence: int = 3,
         ) -> str:
-            """Review another agent's research brief (approve/request changes/reject).
-
-            WHEN TO USE: A research topic is in_review and you're assigned as a
-            reviewer, or you want to provide feedback on a brief.
-
-            Args:
-                topic_id: ID of the research topic
-                brief_id: ID of the specific brief to review
-                verdict: Your verdict — approve, request_changes, or reject
-                comments: Your review comments (markdown)
-                confidence: How confident you are in your review (1-5)
-            """
+            """Review another agent's research brief. verdict: approve | request_changes | reject."""
             result = _api("POST", f"/research/{topic_id}/reviews", {
                 "brief_id": brief_id,
                 "reviewer_agent": agent_name,
@@ -1436,12 +1195,7 @@ def create_server(
 
         @mcp.tool()
         def get_my_research_assignments() -> str:
-            """See your research assignments and open topics you can claim.
-
-            WHEN TO USE: Checking what research work is waiting for you, or looking
-            for open topics to volunteer for. Shows your assignments, review duties,
-            and unclaimed topics.
-            """
+            """See your research assignments, review duties, and open topics to claim."""
             all_topics = _api("GET", "/research")
             if "error" in all_topics:
                 return f"Failed to fetch: {all_topics['error']}"
@@ -1475,14 +1229,7 @@ def create_server(
 
         @mcp.tool()
         def claim_research_topic(topic_id: int) -> str:
-            """Volunteer to research an open topic by assigning it to yourself.
-
-            WHEN TO USE: get_my_research_assignments showed an open topic you want
-            to work on.
-
-            Args:
-                topic_id: ID of the open topic to claim
-            """
+            """Claim an open research topic by assigning it to yourself."""
             result = _api("POST", f"/research/{topic_id}/assign", {
                 "agent_name": agent_name,
             })
@@ -1499,20 +1246,7 @@ def create_server(
             scope: str = "",
             auto_assign: bool = True,
         ) -> str:
-            """Create a new research topic and optionally self-assign it.
-
-            WHEN TO USE: You've identified something worth researching — a question,
-            trend, or investigation. Creates the topic in the pipeline for you or
-            another agent to work on.
-
-            Args:
-                title: Research question or topic title
-                description: Full description of what to research
-                priority: low, normal, high, or urgent
-                tags: Comma-separated tags for categorization
-                scope: Boundaries or constraints for the research
-                auto_assign: If true, automatically assign the topic to yourself
-            """
+            """Create a research topic and optionally self-assign it (auto_assign=True by default)."""
             tags_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
             result = _api("POST", "/research", {
                 "title": title,
@@ -1541,16 +1275,7 @@ def create_server(
 
         @mcp.tool()
         def publish_research(topic_id: int) -> str:
-            """Publish a research topic directly, skipping peer review.
-
-            WHEN TO USE: The research is time-sensitive, solo, or already validated
-            and doesn't need formal peer review. Publishes the latest brief as final.
-            NOT FOR: Research that should be reviewed first (use submit_research_brief
-            and let reviewers weigh in).
-
-            Args:
-                topic_id: ID of the research topic to publish
-            """
+            """Publish a research topic directly, skipping peer review."""
             result = _api("POST", f"/research/{topic_id}/publish")
             if "error" in result:
                 return f"Failed to publish: {result['error']}"
@@ -1561,16 +1286,7 @@ def create_server(
             status: str = "",
             limit: int = 20,
         ) -> str:
-            """Browse all research topics, optionally filtered by status.
-
-            WHEN TO USE: You want an overview of the research pipeline — all topics
-            across all agents. Use status filter to narrow (open, assigned, in_review,
-            published, archived).
-
-            Args:
-                status: Filter by status (open, assigned, in_review, published, archived). Empty = all.
-                limit: Max results to return.
-            """
+            """Browse all research topics. Filter by status: open, assigned, in_review, published, archived."""
             params = f"?limit={limit}"
             if status:
                 params += f"&status={status}"
@@ -1595,14 +1311,7 @@ def create_server(
 
         @mcp.tool()
         def get_research_detail(topic_id: int) -> str:
-            """Get full detail on a research topic — briefs, reviews, and metadata.
-
-            WHEN TO USE: You need the complete picture of a specific research topic
-            before reviewing, continuing work, or sharing findings.
-
-            Args:
-                topic_id: ID of the research topic.
-            """
+            """Get full detail on a research topic — briefs, reviews, and metadata."""
             result = _api("GET", f"/research/{topic_id}")
             if "error" in result:
                 return f"Failed to get topic: {result['error']}"
@@ -1638,16 +1347,7 @@ def create_server(
 
         @mcp.tool()
         def export_research_pdf(topic_id: int) -> str:
-            """Export a research brief as a formatted PDF.
-
-            WHEN TO USE: You want to share research findings as a PDF — generates
-            from the latest brief including peer reviews. Returns a file path you
-            can send via send_document from pinky-messaging.
-            NOT FOR: General markdown-to-PDF (use render_pdf).
-
-            Args:
-                topic_id: ID of the research topic to export
-            """
+            """Export a research brief as a formatted PDF. Returns a file path for send_document."""
             import urllib.error as _ue
             import urllib.request as _ur
             url = f"{api_url}/research/{topic_id}/export?format=pdf"
@@ -1682,25 +1382,8 @@ def create_server(
         reply_to: int | None = None,
         priority: str = "normal",
     ) -> str:
-        """Send a direct message to another agent (delivered or queued).
-
-        WHEN TO USE: You need to communicate with another agent -- ask a question,
-        share findings, coordinate work, or REPLY to a message you received from
-        them. Goes into their context like a user message. If they're offline,
-        it's queued in their inbox.
-        IMPORTANT: When you receive a message from another agent, always reply via
-        send_to_agent -- do NOT message the owner unless the situation specifically
-        requires human attention. For system-level issues, escalate to the main
-        agent instead.
-        NOT FOR: Delegating tracked work (use create_task), sending files
-        (use send_file_to_agent), messaging a human user (use send from pinky-messaging).
-
-        Args:
-            to: The agent name to message (e.g., "barsik", "oleg").
-            message: The message content.
-            content_type: Message type — "text", "task_request", "task_response", "status".
-            reply_to: Optional message ID to reply to (for threading).
-            priority: "normal", "high", or "urgent".
+        """Message another agent (delivered immediately or queued if offline).
+        Reply to agent messages here — don't message the owner unless human attention is needed.
         """
         priority_map = {"normal": 0, "high": 1, "urgent": 2}
         result = _api("POST", f"/agents/{to}/message", {
@@ -1722,18 +1405,7 @@ def create_server(
         file_path: str,
         description: str = "",
     ) -> str:
-        """Transfer a file to another agent via shared directory.
-
-        WHEN TO USE: You need to share a file (research PDF, code, data) with
-        another agent. Copies it to a shared location and notifies them.
-        NOT FOR: Sending text messages (use send_to_agent), sending files to
-        a human user (use send_document from pinky-messaging).
-
-        Args:
-            to_agent: Name of the recipient agent/session.
-            file_path: Absolute path to the file to send.
-            description: Optional description of what the file is.
-        """
+        """Transfer a file to another agent via shared directory. Copies and notifies them."""
         if not os.path.isabs(file_path):
             return json.dumps({"error": "file_path must be an absolute path"})
         if not os.path.isfile(file_path):
@@ -1777,11 +1449,7 @@ def create_server(
 
     @mcp.tool()
     def list_agents() -> str:
-        """List all other agents and whether they're online.
-
-        WHEN TO USE: You want to see who else is available — before delegating
-        work, coordinating, or checking the multi-agent landscape.
-        NOT FOR: Checking one specific agent (use agent_status)."""
+        """List all other agents and their online status."""
         result = _api("GET", "/agents")
         if "error" in result:
             return f"Failed to list agents: {result['error']}"
@@ -1819,18 +1487,7 @@ def create_server(
 
     @mcp.tool()
     def check_inbox(unread_only: bool = True, limit: int = 20) -> str:
-        """Read messages from other agents (queued while you were offline or asleep).
-
-        WHEN TO USE: On wake-up (after load_my_context), or periodically during
-        work to see if another agent sent you something. Messages are auto-marked
-        as read when retrieved.
-        NOT FOR: Checking messages from human users (those arrive in your context
-        via the broker), or searching past conversations (use search_history).
-
-        Args:
-            unread_only: Only show unread messages (default True).
-            limit: Maximum messages to return (default 20).
-        """
+        """Read queued messages from other agents. Messages are auto-marked as read when retrieved."""
         result = _api(
             "GET",
             f"/sessions/{agent_name}/inbox?unread_only={'true' if unread_only else 'false'}&limit={limit}",
@@ -1870,15 +1527,7 @@ def create_server(
 
     @mcp.tool()
     def agent_status(name: str) -> str:
-        """Check if a specific agent is online before messaging or delegating.
-
-        WHEN TO USE: You want to know if a specific agent is available before
-        sending them a message or task. Shows presence and last seen time.
-        NOT FOR: Listing all agents (use list_agents).
-
-        Args:
-            name: The agent name to check (e.g., "barsik").
-        """
+        """Check if a specific agent is online. Shows presence and last seen time."""
         result = _api("GET", f"/agents/{name}/presence")
         if "error" in result:
             return f"Agent '{name}' not found."
@@ -1899,17 +1548,7 @@ def create_server(
 
     @mcp.tool()
     def search_history(query: str, context_messages: int = 3) -> str:
-        """Search your past conversation messages by keyword.
-
-        WHEN TO USE: You need to find something said in a previous conversation —
-        a decision, instruction, or detail from your chat history.
-        NOT FOR: Long-term memory search (use recall from pinky-memory), or
-        checking agent-to-agent messages (use check_inbox).
-
-        Args:
-            query: Search term to find in past messages.
-            context_messages: Number of messages before/after each match to include (default 3).
-        """
+        """Search past conversation messages by keyword."""
         # Search across all agent sessions via the agent chat-history endpoint
         result = _api("GET", f"/agents/{agent_name}/chat-history?q={query}&limit=30")
         messages = result.get("messages", [])
@@ -1933,12 +1572,7 @@ def create_server(
 
     @mcp.tool()
     def list_my_skills() -> str:
-        """See what skills you currently have equipped.
-
-        WHEN TO USE: You want to check which skills are active and available
-        to you, including their categories and how they were assigned.
-        NOT FOR: Browsing skills you don't have (use list_available_skills).
-        """
+        """List your currently equipped skills."""
         result = _api("GET", f"/agents/{agent_name}/skills")
         if "error" in result:
             return f"Failed to list skills: {result['error']}"
@@ -1962,16 +1596,7 @@ def create_server(
 
     @mcp.tool()
     def load_skill(skill_name: str) -> str:
-        """Load a skill's full instructions into your context.
-
-        WHEN TO USE: Your CLAUDE.md lists a skill by name/description but you
-        need the full body to actually use it. Call this before executing a
-        skill's workflow for the first time in a session.
-        NOT FOR: Adding a new skill to yourself (use add_skill).
-
-        Args:
-            skill_name: The skill name from your Available Skills list.
-        """
+        """Load a skill's full instructions into context. Call before using a skill for the first time."""
         result = _api("GET", f"/skills/{skill_name}")
         if "error" in result:
             status = result.get("status", 500)
@@ -1992,16 +1617,7 @@ def create_server(
     def _register_skill_admin_tools():
         @mcp.tool()
         def list_available_skills(category: str = "") -> str:
-            """Browse skills you don't have yet that you can self-assign.
-
-            WHEN TO USE: You need a capability you don't currently have, or want
-            to explore what's available. Shows self-assignable skills only.
-            NOT FOR: Checking your current skills (use list_my_skills), or loading
-            a skill's instructions (use load_skill).
-
-            Args:
-                category: Filter by category (e.g. 'productivity', 'development'). Empty = all.
-            """
+            """Browse self-assignable skills you don't have yet."""
             params = "self_assignable=true"
             if category:
                 params += f"&category={category}"
@@ -2031,16 +1647,7 @@ def create_server(
 
         @mcp.tool()
         def add_skill(skill_name: str) -> str:
-            """Equip a skill from the catalog and restart to activate its tools.
-
-            WHEN TO USE: You found a skill via list_available_skills that you need.
-            Only works for self-assignable skills. Session restarts automatically
-            to activate new MCP tools — context is auto-saved.
-            NOT FOR: Just reading a skill's instructions (use load_skill).
-
-            Args:
-                skill_name: The skill name from list_available_skills().
-            """
+            """Equip a skill and restart to activate its tools. Only works for self-assignable skills."""
             # Assign the skill
             result = _api(
                 "POST",
@@ -2077,15 +1684,7 @@ def create_server(
 
         @mcp.tool()
         def remove_skill(skill_name: str) -> str:
-            """Unequip a skill and restart to deactivate its tools.
-
-            WHEN TO USE: You no longer need a skill and want to reduce tool clutter.
-            Cannot remove core skills (pinky-memory, pinky-self, pinky-messaging, file-access).
-            Session restarts to deactivate MCP tools.
-
-            Args:
-                skill_name: The skill to remove.
-            """
+            """Unequip a skill and restart to deactivate its tools. Cannot remove core skills."""
             # Remove the skill
             result = _api("DELETE", f"/agents/{agent_name}/skills/{skill_name}")
             if "error" in result:
@@ -2114,13 +1713,7 @@ def create_server(
 
         @mcp.tool()
         def discover_skills() -> str:
-            """Scan for new SKILL.md files and plugins on the filesystem.
-
-            WHEN TO USE: New skills were added to the skills directory (manually or
-            via git) and need to be registered in the catalog. Also discovers plugins.
-            NOT FOR: Installing from a git URL (use install_skill), or creating from
-            scratch (use create_skill).
-            """
+            """Scan filesystem for new SKILL.md files and plugins, register them in the catalog."""
             # Discover SKILL.md files
             skill_result = _api("POST", "/skills/discover")
             if "error" in skill_result:
@@ -2155,22 +1748,7 @@ def create_server(
 
         @mcp.tool()
         def install_skill(url: str) -> str:
-            """Clone a skill from a git repo, register it, and assign it to you.
-
-            WHEN TO USE: You want to install a published skill from GitHub or another
-            git host. Clones, finds SKILL.md files (agentskills.io standard),
-            registers them, and assigns them to you.
-            NOT FOR: Skills already on disk (use discover_skills), or creating a
-            new skill from scratch (use create_skill).
-
-            Examples:
-                install_skill("https://github.com/anthropics/skills")
-                install_skill("https://github.com/someone/my-skill")
-                install_skill("https://github.com/org/skills/tree/main/data-analysis")
-
-            Args:
-                url: Git repository URL (GitHub, GitLab, etc.)
-            """
+            """Clone a skill from a git repo URL, register SKILL.md files, and assign to you."""
             result = _api("POST", "/skills/from-git", {
                 "url": url,
                 "agent_name": agent_name,
@@ -2204,17 +1782,8 @@ def create_server(
 
         @mcp.tool()
         def create_skill(name: str, description: str, instructions: str) -> str:
-            """Author a new skill from scratch and assign it to yourself.
-
-            WHEN TO USE: You want to capture a reusable workflow, domain expertise,
-            or specialized procedure as a skill. Creates a SKILL.md (agentskills.io
-            standard), registers it, and assigns it to you.
-            NOT FOR: Installing an existing skill (use install_skill or add_skill).
-
-            Args:
-                name: Skill name (lowercase, hyphens, e.g. 'data-analysis').
-                description: What the skill does and when to use it (1-2 sentences).
-                instructions: The full skill instructions in markdown.
+            """Create a new skill from scratch (SKILL.md), register it, and assign to yourself.
+            name: lowercase with hyphens (e.g. 'data-analysis').
             """
             # Build SKILL.md content
             skill_md = f"---\nname: {name}\ndescription: {description}\n---\n\n{instructions}"
@@ -2251,23 +1820,8 @@ def create_server(
             skill_name: str,
             auto_install: bool = False,
         ) -> str:
-            """Auto-draft a reusable SKILL.md from a just-completed complex task.
-
-            WHEN TO USE: After finishing a non-trivial multi-step task, call this to
-            capture the approach as a reusable skill. This makes you progressively
-            smarter at recurring task types — each successful workflow becomes a
-            repeatable template.
-            BEST PRACTICE: Call after any task that took 3+ steps, involved a novel
-            approach, or is likely to recur.
-            NOT FOR: Simple single-step tasks or one-off requests unlikely to repeat.
-
-            Args:
-                task_description: What the task was — context, goal, why it mattered.
-                steps_taken: Key steps / approach taken (bullet points or prose).
-                outcome: What was produced or achieved.
-                skill_name: Slug for the skill (lowercase, hyphens, e.g. 'data-analysis').
-                auto_install: If True, immediately register and assign this skill
-                              without waiting for manual approval. Default False (draft only).
+            """Auto-draft a SKILL.md from a completed multi-step task. Call after tasks with 3+ steps.
+            auto_install=True registers immediately; default is draft-only for review.
             """
             # Build the SKILL.md content from the task info
             skill_md = f"""---
@@ -2344,14 +1898,7 @@ def create_server(
 
         @mcp.tool()
         def check_for_updates() -> str:
-            """Check for pending PinkyBot code updates (dry run, no changes).
-
-            WHEN TO USE: You want to see if there are new commits on the remote
-            before deciding to update. Safe — doesn't apply anything.
-            Stable channel checks against the latest GitHub Release tag.
-            Beta channel checks against HEAD of the beta branch.
-            NOT FOR: Actually updating (use update_and_restart).
-            """
+            """Check for pending code updates (dry run, no changes applied)."""
             result = _api("POST", "/admin/update?dry_run=true")
             if "error" in result:
                 return f"Failed to check for updates: {result['error']}"
@@ -2378,19 +1925,7 @@ def create_server(
 
         @mcp.tool()
         def update_and_restart(branch: str = "") -> str:
-            """Pull latest code, rebuild if needed, and restart the daemon.
-
-            WHEN TO USE: check_for_updates showed a new release or pending commits
-            and you want to apply them. Stable channel checks out the latest
-            GitHub Release tag. Beta channel pulls HEAD of beta branch.
-            Rebuilds deps/frontend if changed and restarts.
-            NOT FOR: Just checking what's available (use check_for_updates), or
-            restarting without updating (use restart_daemon).
-
-            Args:
-                branch: Override branch/channel. Empty = auto-detect from
-                        PINKYBOT_CHANNEL env var (stable→release tags, beta→beta branch).
-            """
+            """Pull latest code, rebuild if needed, and restart the daemon."""
             url = "/admin/update"
             if branch:
                 url += f"?branch={branch}"
@@ -2427,13 +1962,7 @@ def create_server(
 
         @mcp.tool()
         def restart_daemon() -> str:
-            """Restart the daemon process without pulling code updates.
-
-            WHEN TO USE: You need a clean restart to pick up config changes or
-            recover from errors, but don't need new code. Session resumes automatically.
-            NOT FOR: Updating code (use update_and_restart), or restarting just
-            your context (use context_restart).
-            """
+            """Restart the daemon without pulling code updates. Session resumes automatically."""
             result = _api("POST", "/admin/restart")
             if "error" in result:
                 return f"Restart failed: {result['error']}"
@@ -2453,34 +1982,11 @@ def create_server(
             condition_value: str = "",
             interval_seconds: int = 300,
         ) -> str:
-            """Create a trigger that wakes this agent when it fires.
-
-            trigger_type: 'webhook' (returns a URL to give to external services) or
-            'url' (polls a URL on an interval and fires when a condition is met).
-
-            For webhook type: returns the secret webhook URL to configure in external services.
-            For url type: provide url, condition, condition_value, interval_seconds.
-
-            condition options (url type):
-              - 'status_changed'      — fires when HTTP status code changes
-              - 'status_is'          — fires when status equals condition_value (e.g. "200")
-              - 'body_contains'      — fires when body contains condition_value string
-              - 'json_field_equals'  — condition_value: JSON {"path": "a.b", "value": "x"}
-              - 'json_field_changed' — condition_value: JSON {"path": "a.b"}
-
-            prompt_template: what to inject when trigger fires.
-              Supports {{body.field}} for webhook payloads and url responses.
-              Leave empty for a sensible default.
-
-            Examples:
-              create_trigger(name="github-prs", trigger_type="webhook",
-                             prompt_template="New PR: {{body.pull_request.title}}")
-
-              create_trigger(name="status-page", trigger_type="url",
-                             url="https://status.example.com/api/status.json",
-                             condition="json_field_changed",
-                             condition_value='{"path": "status.indicator"}',
-                             interval_seconds=60)
+            """Create a webhook or URL-polling trigger that wakes you when it fires.
+            'webhook': returns URL for external services to POST to.
+            'url': polls a URL; fires on condition match.
+            Conditions: status_changed, status_is, body_contains, json_field_equals, json_field_changed.
+            prompt_template supports {{body.field}} substitution.
             """
             body = {
                 "name": name,
@@ -2509,11 +2015,7 @@ def create_server(
 
         @mcp.tool()
         async def list_triggers() -> str:
-            """List all triggers assigned to this agent.
-
-            WHEN TO USE: Check what triggers are active, find a trigger ID to
-            delete or test, or verify a trigger was created successfully.
-            """
+            """List all triggers assigned to this agent."""
             result = _api("GET", f"/agents/{agent_name}/triggers")
             if "error" in result:
                 return f"Error: {result['error']}"
@@ -2533,13 +2035,7 @@ def create_server(
 
         @mcp.tool()
         async def delete_trigger(trigger_id: int) -> str:
-            """Delete a trigger by ID. For webhooks, the token is immediately invalidated.
-
-            WHEN TO USE: A trigger is no longer needed. Get the ID from list_triggers first.
-
-            Args:
-                trigger_id: The trigger ID to delete (from list_triggers).
-            """
+            """Delete a trigger by ID. Webhook tokens are immediately invalidated."""
             result = _api("DELETE", f"/agents/{agent_name}/triggers/{trigger_id}")
             if "error" in result:
                 return f"Error: {result['error']}"
@@ -2547,14 +2043,7 @@ def create_server(
 
         @mcp.tool()
         async def test_trigger(trigger_id: int) -> str:
-            """Manually fire a trigger to test it.
-
-            WHEN TO USE: Verify that a trigger is wired up correctly and the prompt
-            template looks right. Does not affect fire_count or last_fired_at.
-
-            Args:
-                trigger_id: The trigger ID to test (from list_triggers).
-            """
+            """Manually fire a trigger to test it. Does not affect fire_count."""
             result = _api("POST", f"/agents/{agent_name}/triggers/{trigger_id}/test")
             if "error" in result:
                 return f"Error: {result['error']}"
@@ -2576,27 +2065,9 @@ def create_server(
             notes: str = "",
             source_type: str = "",
         ) -> str:
-            """File a new source into the project knowledge base.
-
-            WHEN TO USE: The user shares a link, article, idea, or document they
-            want to remember. Also use when filing noteworthy tweets, research
-            findings, or conversation highlights for future reference.
-            NOT FOR: Atomic session memories (use reflect), task tracking (use
-            create_task), or conversation history (use search_history).
-
-            IMPORTANT: Always include full source URLs as markdown links in the
-            content — e.g. [Title](https://...). Never just name a source without
-            linking it. This applies to news digests, research, articles, and any
-            content that references external sources.
-
-            Args:
-                url: URL to scrape and file (uses pinky-web). Provide url OR text.
-                text: Raw text/markdown content to file. Provide text OR url.
-                title: Title for the source (auto-generated from content if empty).
-                tags: Comma-separated tags (e.g. "ai, karpathy, knowledge-management").
-                notes: Owner's notes about why this is worth keeping.
-                source_type: One of: tweet_thread, article, pdf, conversation, note, link.
-                             Auto-detected if empty.
+            """File a source (link, article, note) into the knowledge base. Provide url OR text.
+            Always include full source URLs as markdown links in content.
+            source_type auto-detected from URL if empty.
             """
             if not url and not text:
                 return "Error: provide either url or text to file."
@@ -2658,18 +2129,7 @@ def create_server(
 
         @mcp.tool()
         def kb_search(query: str, scope: str = "all") -> str:
-            """Search the project knowledge base.
-
-            WHEN TO USE: You need to find what's been filed in the KB about a topic.
-            Use before answering questions about research topics, people, or
-            previously filed articles. Also useful to avoid filing duplicates.
-            NOT FOR: Session memories (use recall), conversation history (use
-            search_history), or task lookup (use get_next_task).
-
-            Args:
-                query: Natural language search query.
-                scope: "all" (default), "raw" (source documents only), or "wiki" (wiki pages only).
-            """
+            """Search the knowledge base. scope: all | raw | wiki."""
             result = _api("GET", f"/kb/search?q={query}&scope={scope}&limit=15")
             if "error" in result:
                 return f"Error: {result['error']}"
@@ -2688,17 +2148,7 @@ def create_server(
 
         @mcp.tool()
         def kb_get_wiki(topic: str) -> str:
-            """Get a wiki page for context injection.
-
-            WHEN TO USE: You need dense, pre-organized context about a topic
-            before starting a task. Wiki pages are more structured and complete
-            than individual recall() results.
-            NOT FOR: Raw source documents (use kb_search with scope='raw'),
-            or quick factual lookups (use recall).
-
-            Args:
-                topic: Wiki page slug (e.g. "topics/llm-knowledge-bases" or "people/andrej-karpathy").
-            """
+            """Get a wiki page by slug (e.g. "topics/llm-knowledge-bases")."""
             result = _api("GET", f"/kb/wiki/{topic}?include_content=true")
             if "error" in result:
                 return f"No wiki page found for: {topic}"
@@ -2710,13 +2160,7 @@ def create_server(
 
         @mcp.tool()
         def kb_stats() -> str:
-            """Get knowledge base overview statistics.
-
-            WHEN TO USE: Quick check on what's in the KB — how many sources,
-            top tags, last activity. Good for status reports or when the user
-            asks "what do we have in the knowledge base?"
-            NOT FOR: Searching specific content (use kb_search).
-            """
+            """Get KB overview — source count, wiki count, top tags, last activity."""
             result = _api("GET", "/kb/stats")
             if "error" in result:
                 return f"Error: {result['error']}"
@@ -2742,12 +2186,7 @@ def create_server(
 
         @mcp.tool()
         def kb_run_librarian() -> str:
-            """Manually trigger the KB librarian to curate wiki pages now.
-
-            WHEN TO USE: You want to immediately process new raw sources into
-            wiki pages without waiting for the auto-trigger debounce.
-            NOT FOR: Routine curation (that happens automatically after ingest).
-            """
+            """Manually trigger the KB librarian to curate wiki pages now."""
             result = _api("POST", "/kb/librarian/run")
             if "error" in result:
                 return f"Error: {result['error']}"
@@ -2764,18 +2203,8 @@ def create_server(
             sources: str = "",
             related: str = "",
         ) -> str:
-            """Create or update a wiki page in the knowledge base.
-
-            WHEN TO USE: You need to create a new wiki page or update an existing
-            one with curated content synthesized from raw sources.
-            NOT FOR: Filing raw sources (use kb_ingest).
-
-            Args:
-                slug: Page path (e.g. "topics/claude-code" or "people/boris-cherny").
-                title: Page title.
-                content: Full markdown body for the page.
-                sources: Comma-separated raw source IDs that contributed (e.g. "raw-2026-04-08-001,raw-2026-04-08-002").
-                related: Comma-separated slugs of related wiki pages (e.g. "topics/anthropic,people/boris-cherny").
+            """Create or update a wiki page. slug is the page path (e.g. "topics/claude-code").
+            sources/related are comma-separated IDs/slugs.
             """
             source_list = [s.strip() for s in sources.split(",") if s.strip()] if sources else []
             related_list = [r.strip() for r in related.split(",") if r.strip()] if related else []
@@ -2792,15 +2221,7 @@ def create_server(
 
         @mcp.tool()
         def kb_delete_wiki(slug: str) -> str:
-            """Delete a wiki page from the knowledge base.
-
-            WHEN TO USE: Merging duplicate wiki pages — delete the redundant one
-            after moving its content to the target page.
-            NOT FOR: Deleting raw sources (those are permanent).
-
-            Args:
-                slug: The wiki page slug to delete (e.g. "topics/old-page").
-            """
+            """Delete a wiki page by slug."""
             result = _api("DELETE", f"/kb/wiki/{slug}")
             if "error" in result:
                 return f"Error: {result['error']}"
@@ -2813,13 +2234,7 @@ def create_server(
 
         @mcp.tool()
         def get_attribution() -> str:
-            """Get the standard attribution footer for GitHub issues and PRs.
-
-            WHEN TO USE: You are about to create a GitHub issue or PR and need
-            the correct attribution footer to append to the body.
-            Returns a ready-to-paste string like: 🤖 Opened by Barsik
-            NOT FOR: General identity info (use who_am_i).
-            """
+            """Get the attribution footer for GitHub issues/PRs (e.g. "🤖 Opened by Barsik")."""
             agent_info = _api("GET", f"/agents/{agent_name}")
             if "error" in agent_info:
                 display = agent_name.capitalize()
@@ -2836,18 +2251,7 @@ def create_server(
             filename: str = "document.pdf",
             title: str = "Document",
         ) -> str:
-            """Convert arbitrary markdown text into a PDF file.
-
-            WHEN TO USE: You need to generate a PDF from any markdown content —
-            reports, summaries, documentation. Returns a file path you can send
-            via send_document from pinky-messaging.
-            NOT FOR: Research briefs (use export_research_pdf for those).
-
-            Args:
-                content: Markdown content to render as PDF.
-                filename: Output filename (default: document.pdf).
-                title: Document title for the PDF header.
-            """
+            """Render markdown to PDF. Returns a file path for send_document."""
             result = _api("POST", "/render/pdf", {
                 "content": content,
                 "filename": filename,
@@ -2859,21 +2263,7 @@ def create_server(
 
         @mcp.tool()
         def spawn_clone(task: str, title: str = "") -> str:
-            """Fork yourself and spawn a worker clone to tackle a task in parallel.
-
-            WHEN TO USE: You have a large or parallelizable task that can be split
-            into independent sub-tasks. Each clone inherits your full conversation
-            context (same history), then runs the given task autonomously and reports
-            back through the normal message broker.
-            NOT FOR: Simple sequential tasks — just do those yourself.
-
-            Args:
-                task: The prompt/task for the worker clone to execute.
-                title: Optional label for the forked session (helps in session list).
-
-            Returns:
-                Worker session ID and fork info.
-            """
+            """Fork your session and spawn a parallel worker clone. The clone runs autonomously and reports back."""
             result = _api("POST", f"/agents/{agent_name}/clone-worker", {
                 "task": task,
                 "title": title,
@@ -2890,15 +2280,7 @@ def create_server(
 
         @mcp.tool()
         def get_agent_card(name: str) -> str:
-            """See another agent's capabilities, role, model, and groups.
-
-            WHEN TO USE: You need to know what another agent can do before
-            delegating work or asking for help — their role, model, and capabilities.
-            NOT FOR: Just checking if they're online (use agent_status).
-
-            Args:
-                name: The agent name (e.g., "barsik").
-            """
+            """See another agent's capabilities, role, model, and groups."""
             result = _api("GET", f"/agents/{name}/card")
             if "error" in result:
                 return f"Agent '{name}' not found."

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -171,10 +171,15 @@ def create_server(
         notes: str = "",
         blockers: list[str] | None = None,
         priority_items: list[str] | None = None,
+        wake_action: str = "",
     ) -> str:
         """Snapshot working state for restoration after restart/sleep.
         Required by restart guard — MUST call before context_restart or request_sleep.
         Not for long-term memory (use reflect).
+
+        wake_action: Required first thing to do on wake-up. Injected prominently
+        at the top of the saved state so the agent acts on it immediately.
+        Example: "Report deploy results to Brad on telegram"
         """
         result = _api("PUT", f"/agents/{agent_name}/context", {
             "task": task,
@@ -182,6 +187,7 @@ def create_server(
             "notes": notes,
             "blockers": blockers or [],
             "priority_items": priority_items or [],
+            "wake_action": wake_action,
             "metadata": {"source": "save_my_context", "server": "pinky-self"},
         })
         if "error" in result:
@@ -203,6 +209,8 @@ def create_server(
             parts.append(f"Saved: {_format_timestamp(updated_at)} ({age} ago)")
         if freshness.get("stale_warning"):
             parts.append("WARNING: Saved context is old. Verify it against current work before trusting it.")
+        if ctx.get("wake_action"):
+            parts.append(f"⚡ WAKE ACTION (do this FIRST): {ctx['wake_action']}")
         if ctx.get("task"):
             parts.append(f"Task: {ctx['task']}")
         if ctx.get("context"):

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -11,6 +11,7 @@ from pinky_daemon.shared_mcp import (
     SHARED_MCP_PORT,
     AgentNameMiddleware,
     LazyAgentName,
+    MemoryStorePool,
     SharedMcpManager,
     _current_agent,
     create_shared_app,
@@ -355,9 +356,10 @@ class TestWriteMcpJsonSharedMode:
             assert "/mcp/messaging/sse" in servers["pinky-messaging"]["url"]
             assert servers["pinky-messaging"]["headers"]["X-Agent-Name"] == "barsik"
 
-            # pinky-memory should still be stdio
-            assert "command" in servers["pinky-memory"]
-            assert "type" not in servers["pinky-memory"]
+            # pinky-memory should also be SSE (shared store pool)
+            assert servers["pinky-memory"]["type"] == "sse"
+            assert "/mcp/memory/sse" in servers["pinky-memory"]["url"]
+            assert servers["pinky-memory"]["headers"]["X-Agent-Name"] == "barsik"
         finally:
             api_mod.SHARED_MCP_ENABLED = original
 
@@ -376,5 +378,83 @@ class TestWriteMcpJsonSharedMode:
                 config = json.loads((work_dir / ".mcp.json").read_text())
                 assert config["mcpServers"]["pinky-self"]["headers"]["X-Agent-Name"] == name
                 assert config["mcpServers"]["pinky-messaging"]["headers"]["X-Agent-Name"] == name
+                assert config["mcpServers"]["pinky-memory"]["headers"]["X-Agent-Name"] == name
         finally:
             api_mod.SHARED_MCP_ENABLED = original
+
+
+class TestMemoryStorePool:
+    """Tests for the MemoryStorePool used in shared SSE mode."""
+
+    def test_lazy_creation(self, tmp_path):
+        """Stores are created lazily on first access."""
+        db_paths = {}
+
+        def resolver(agent_name):
+            db_path = str(tmp_path / agent_name / "memory.db")
+            (tmp_path / agent_name).mkdir(exist_ok=True)
+            db_paths[agent_name] = db_path
+            return db_path
+
+        pool = MemoryStorePool(resolver)
+
+        # No stores created yet
+        assert len(pool._stores) == 0
+
+        # First access creates the store
+        store1 = pool.get_store("barsik")
+        assert store1 is not None
+        assert len(pool._stores) == 1
+        assert "barsik" in db_paths
+
+        # Second access returns the same instance
+        store2 = pool.get_store("barsik")
+        assert store1 is store2
+        assert len(pool._stores) == 1
+
+        # Different agent gets a different store
+        store3 = pool.get_store("pushok")
+        assert store3 is not store1
+        assert len(pool._stores) == 2
+
+        pool.close_all()
+
+    def test_remove_store(self, tmp_path):
+        """Removing a store closes it and removes from cache."""
+        def resolver(agent_name):
+            db_path = str(tmp_path / f"{agent_name}.db")
+            return db_path
+
+        pool = MemoryStorePool(resolver)
+        pool.get_store("barsik")
+        assert "barsik" in pool._stores
+
+        pool.remove_store("barsik")
+        assert "barsik" not in pool._stores
+
+        # Removing non-existent agent is a no-op
+        pool.remove_store("nonexistent")
+
+        pool.close_all()
+
+    def test_close_all(self, tmp_path):
+        """close_all closes all stores and clears cache."""
+        def resolver(agent_name):
+            return str(tmp_path / f"{agent_name}.db")
+
+        pool = MemoryStorePool(resolver)
+        pool.get_store("barsik")
+        pool.get_store("pushok")
+        assert len(pool._stores) == 2
+
+        pool.close_all()
+        assert len(pool._stores) == 0
+
+    def test_resolver_error(self, tmp_path):
+        """ValueError from resolver propagates."""
+        def resolver(agent_name):
+            raise ValueError(f"Unknown agent: {agent_name}")
+
+        pool = MemoryStorePool(resolver)
+        with pytest.raises(ValueError, match="Unknown agent"):
+            pool.get_store("nonexistent")

--- a/tests/test_shared_mcp_integration.py
+++ b/tests/test_shared_mcp_integration.py
@@ -210,27 +210,41 @@ class TestMcpJsonConfigIsolation:
         finally:
             api_mod.SHARED_MCP_ENABLED = original
 
-    def test_memory_always_per_agent(self, tmp_path):
-        """pinky-memory should always be stdio with per-agent DB path."""
+    def test_memory_per_agent_isolation(self, tmp_path):
+        """pinky-memory uses per-agent isolation in both modes."""
         import pinky_daemon.api as api_mod
 
         original = api_mod.SHARED_MCP_ENABLED
-        for mode in [True, False]:
-            api_mod.SHARED_MCP_ENABLED = mode
-            try:
-                for name in ["barsik", "pushok"]:
-                    work_dir = tmp_path / f"{name}_{mode}"
-                    work_dir.mkdir()
-                    api_mod._write_mcp_json(work_dir, name)
-                    config = json.loads((work_dir / ".mcp.json").read_text())
-                    mem = config["mcpServers"]["pinky-memory"]
-                    # Always stdio
-                    assert "command" in mem
-                    assert "type" not in mem
-                    # DB path includes agent work dir
-                    assert "memory.db" in " ".join(mem["args"])
-            finally:
-                api_mod.SHARED_MCP_ENABLED = original
+
+        # Stdio mode: per-agent subprocess with DB path in args
+        api_mod.SHARED_MCP_ENABLED = False
+        try:
+            for name in ["barsik", "pushok"]:
+                work_dir = tmp_path / f"{name}_stdio"
+                work_dir.mkdir()
+                api_mod._write_mcp_json(work_dir, name)
+                config = json.loads((work_dir / ".mcp.json").read_text())
+                mem = config["mcpServers"]["pinky-memory"]
+                assert "command" in mem
+                assert "type" not in mem
+                assert "memory.db" in " ".join(mem["args"])
+        finally:
+            api_mod.SHARED_MCP_ENABLED = original
+
+        # SSE mode: shared server, per-agent via X-Agent-Name header
+        api_mod.SHARED_MCP_ENABLED = True
+        try:
+            for name in ["barsik", "pushok"]:
+                work_dir = tmp_path / f"{name}_sse"
+                work_dir.mkdir()
+                api_mod._write_mcp_json(work_dir, name)
+                config = json.loads((work_dir / ".mcp.json").read_text())
+                mem = config["mcpServers"]["pinky-memory"]
+                assert mem["type"] == "sse"
+                assert "/mcp/memory/sse" in mem["url"]
+                assert mem["headers"]["X-Agent-Name"] == name
+        finally:
+            api_mod.SHARED_MCP_ENABLED = original
 
 
 class TestDisallowedToolsIsolation:

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -199,14 +199,19 @@ class TestSharedMcpConcurrencyArchitecture:
         source = inspect.getsource(create_server)
         assert "sqlite3" not in source
 
-    def test_memory_stays_per_agent_stdio(self):
-        """pinky-memory is NOT in the shared server — per-agent DB isolation."""
+    def test_memory_uses_per_agent_store_pool(self):
+        """pinky-memory in shared server uses per-agent store pool (not single DB)."""
         from pinky_daemon.shared_mcp import SharedMcpManager
-        mgr = SharedMcpManager()
-        app = mgr._create_app()
-        # The shared app should NOT include memory
-        # (memory needs per-agent store, stays stdio)
-        # We verify by checking that _create_app doesn't import pinky_memory
-        import inspect
-        source = inspect.getsource(mgr._create_app)
-        assert "pinky_memory" not in source
+
+        # Without resolver: no memory in shared server
+        mgr_no_mem = SharedMcpManager()
+        app = mgr_no_mem._create_app()
+        assert mgr_no_mem._memory_pool is None
+
+        # With resolver: memory is included with per-agent store pool
+        def fake_resolver(name):
+            return f"/tmp/{name}/memory.db"
+
+        mgr_with_mem = SharedMcpManager(memory_db_resolver=fake_resolver)
+        app = mgr_with_mem._create_app()
+        assert mgr_with_mem._memory_pool is not None


### PR DESCRIPTION
## Summary
- **Tool description trim** (870d0b6): Strip verbose WHEN TO USE / NOT FOR blocks from 79 MCP tool docstrings. ~10,550 → ~1,764 description tokens (-83%). Eliminates ToolSearch dependency for all pinky-* tools.
- **Pre-load expansion** (344902d): Expand tool pre-load list from 7 → 18 core tools in wake prompt.
- **Docs removal** (2bcbec1): Remove docs/ from repo and gitignore it.
- **Shared MCP fixes**: Run uvicorn in separate thread to avoid event loop blocking, add ToolSearch pre-load instruction.
- **Lint/quality**: Suppress ruff N801/N806, fix import sorting, fix silent exception swallowing, fix unsafe HTTP decode.
- **UX**: Confirm dialogs on destructive actions.

## Test plan
- [x] Verified trimmed descriptions load without ToolSearch after daemon restart
- [x] All pinky-* tools (messaging, self, memory) callable directly
- [x] Tests pass on beta

🤖 Opened by Barsik