### PR TITLE
Consolidate pinky-memory into shared SSE server

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1015,29 +1015,23 @@ def _write_mcp_json(
     - pinky-messaging: outbound messaging through the broker
     Plus any MCP servers from assigned skills.
 
-    When PINKY_SHARED_MCP=1, pinky-self and pinky-messaging use SSE transport
-    pointing at the shared MCP server instead of spawning per-agent stdio processes.
-    Memory stays stdio (per-agent DB) for now.
+    When PINKY_SHARED_MCP=1, all three core servers use SSE transport pointing
+    at the shared MCP server. Memory uses a per-agent store pool for DB isolation.
     """
     pinky_src = str(Path(__file__).resolve().parent.parent)
     mcp_config: dict = {"mcpServers": {}}
-
-    # Memory: per-agent SQLite long-term memory with vector search
-    # Always stdio — each agent has its own memory.db
-    data_dir = work_dir / "data"
-    data_dir.mkdir(parents=True, exist_ok=True)
-    db_path = str(data_dir / "memory.db")
-    mcp_config["mcpServers"]["pinky-memory"] = {
-        "command": sys.executable,
-        "args": ["-m", "pinky_memory", "--db", db_path],
-        "cwd": pinky_src,
-    }
 
     if SHARED_MCP_ENABLED:
         # Shared SSE mode: point at the shared HTTP server with agent identity header
         shared_base = f"http://{SHARED_MCP_HOST}:{SHARED_MCP_PORT}"
         agent_headers = {"X-Agent-Name": agent_name}
 
+        # Memory: per-agent SQLite via shared SSE server (store pool)
+        mcp_config["mcpServers"]["pinky-memory"] = {
+            "type": "sse",
+            "url": f"{shared_base}/mcp/memory/sse",
+            "headers": agent_headers,
+        }
         mcp_config["mcpServers"]["pinky-self"] = {
             "type": "sse",
             "url": f"{shared_base}/mcp/self/sse",
@@ -1049,6 +1043,16 @@ def _write_mcp_json(
             "headers": agent_headers,
         }
     else:
+        # Memory: per-agent SQLite long-term memory with vector search (stdio)
+        data_dir = work_dir / "data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        db_path = str(data_dir / "memory.db")
+        mcp_config["mcpServers"]["pinky-memory"] = {
+            "command": sys.executable,
+            "args": ["-m", "pinky_memory", "--db", db_path],
+            "cwd": pinky_src,
+        }
+
         # Stdio mode: spawn per-agent processes (original behavior)
         # Pinky-self: heartbeat_ack, schedules, self-management
         tool_gates = _get_agent_tool_gates(agent_name, skill_store)
@@ -7049,7 +7053,20 @@ def create_api(
 
         # Start shared MCP server BEFORE agent sessions so SSE URLs are ready
         if SHARED_MCP_ENABLED:
-            shared_mcp_manager = SharedMcpManager(api_url="http://localhost:8888")
+            def _resolve_memory_db(agent_name: str) -> str:
+                """Resolve agent_name -> memory DB path for the shared store pool."""
+                agent = agents.get(agent_name)
+                if not agent:
+                    raise ValueError(f"Unknown agent: {agent_name}")
+                db_path = str(Path(agent.working_dir) / "data" / "memory.db")
+                # Ensure data dir exists (agent may not have used memory yet)
+                Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+                return db_path
+
+            shared_mcp_manager = SharedMcpManager(
+                api_url="http://localhost:8888",
+                memory_db_resolver=_resolve_memory_db,
+            )
             await shared_mcp_manager.start()
             _log(f"startup: shared MCP server started on {shared_mcp_manager.url}")
 

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -16,6 +16,7 @@ import re
 import sys
 import threading
 import time
+from collections.abc import Callable
 from contextvars import ContextVar
 
 # Valid agent name pattern — lowercase alphanumeric, hyphens, underscores
@@ -199,6 +200,67 @@ SHARED_MCP_PORT = 8890
 SHARED_MCP_HOST = "127.0.0.1"
 
 
+class MemoryStorePool:
+    """Thread-safe pool of per-agent ReflectionStore instances.
+
+    Lazily creates and caches stores when an agent's memory is first accessed.
+    Uses a callback to resolve agent_name -> db_path, so it doesn't need
+    direct access to the agent registry.
+    """
+
+    def __init__(self, db_path_resolver: "Callable[[str], str]"):
+        """
+        Args:
+            db_path_resolver: Callable that maps agent_name -> SQLite DB path.
+                              Should raise ValueError for unknown agents.
+        """
+        self._db_path_resolver = db_path_resolver
+        self._stores: dict[str, object] = {}  # agent_name -> ReflectionStore
+        self._lock = threading.Lock()
+
+    def get_store(self, agent_name: str) -> object:
+        """Get or create the ReflectionStore for an agent (thread-safe)."""
+        # Fast path: already cached
+        store = self._stores.get(agent_name)
+        if store is not None:
+            return store
+
+        # Slow path: create under lock
+        with self._lock:
+            # Double-check after acquiring lock
+            store = self._stores.get(agent_name)
+            if store is not None:
+                return store
+
+            from pinky_memory.store import ReflectionStore
+
+            db_path = self._db_path_resolver(agent_name)
+            _log(f"[shared-mcp] Opening memory store for agent '{agent_name}': {db_path}")
+            store = ReflectionStore(db_path=db_path)
+            self._stores[agent_name] = store
+            return store
+
+    def remove_store(self, agent_name: str) -> None:
+        """Remove and close a cached store (e.g. when agent is deleted)."""
+        with self._lock:
+            store = self._stores.pop(agent_name, None)
+            if store is not None:
+                try:
+                    store.close()  # type: ignore[union-attr]
+                except Exception:
+                    pass
+
+    def close_all(self) -> None:
+        """Close all cached stores (shutdown)."""
+        with self._lock:
+            for name, store in self._stores.items():
+                try:
+                    store.close()  # type: ignore[union-attr]
+                except Exception:
+                    pass
+            self._stores.clear()
+
+
 class SharedMcpManager:
     """Manages the shared MCP server lifecycle within the daemon process.
 
@@ -214,10 +276,13 @@ class SharedMcpManager:
         host: str = SHARED_MCP_HOST,
         port: int = SHARED_MCP_PORT,
         api_url: str = "http://localhost:8888",
+        memory_db_resolver: "Callable[[str], str] | None" = None,
     ):
         self._host = host
         self._port = port
         self._api_url = api_url
+        self._memory_db_resolver = memory_db_resolver
+        self._memory_pool: MemoryStorePool | None = None
         self._server = None  # uvicorn.Server instance
         self._thread: threading.Thread | None = None
         self._running = False
@@ -259,12 +324,25 @@ class SharedMcpManager:
             api_url=self._api_url,
         )
 
-        # Note: pinky-memory is NOT included yet — it needs a store object
-        # per-agent, which requires a different approach. Phase 3.
         mcp_servers = {
             "self": self_mcp,
             "messaging": messaging_mcp,
         }
+
+        # Shared pinky-memory: per-agent store pool with lazy creation
+        if self._memory_db_resolver:
+            from pinky_memory.embeddings import build_embedding_client
+            from pinky_memory.server import create_server as create_memory_server
+
+            self._memory_pool = MemoryStorePool(self._memory_db_resolver)
+            embedder = build_embedding_client()
+
+            memory_mcp = create_memory_server(
+                store_factory=self._memory_pool.get_store,
+                embedder=embedder,
+            )
+            mcp_servers["memory"] = memory_mcp
+            _log("[shared-mcp] pinky-memory included (per-agent store pool)")
 
         return create_shared_app(mcp_servers)
 
@@ -306,6 +384,9 @@ class SharedMcpManager:
             self._server.should_exit = True
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=5)
+        if self._memory_pool:
+            self._memory_pool.close_all()
+            self._memory_pool = None
         _log("[shared-mcp] Stopped")
 
     @property

--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from mcp.server.fastmcp import FastMCP
@@ -27,12 +28,34 @@ def _log(msg: str) -> None:
 
 
 def create_server(
-    store: ReflectionStore,
-    embedder: EmbeddingClient | NoOpEmbeddingClient,
+    store: ReflectionStore | None = None,
+    embedder: EmbeddingClient | NoOpEmbeddingClient | None = None,
     *,
+    store_factory: Callable[[str], ReflectionStore] | None = None,
     host: str = "127.0.0.1",
     port: int = 8000,
 ) -> FastMCP:
+    """Create the pinky-memory MCP server.
+
+    Two modes:
+    - **stdio** (per-agent): pass ``store`` and ``embedder`` directly.
+    - **shared SSE**: pass ``store_factory`` (agent_name -> store) and ``embedder``.
+      Each tool call resolves the agent from ContextVar and gets the right store.
+    """
+    if store is None and store_factory is None:
+        raise ValueError("Either store or store_factory must be provided")
+
+    def _get_store() -> "ReflectionStore":
+        """Resolve the correct store for the current request."""
+        if store is not None:
+            return store
+        # Shared mode: resolve agent from ContextVar
+        from pinky_daemon.shared_mcp import get_current_agent
+        agent = get_current_agent()
+        if not agent:
+            raise ValueError("No agent identified in shared mode — missing X-Agent-Name header?")
+        return store_factory(agent)  # type: ignore[misc]
+
     mcp = FastMCP("pinky-memory", host=host, port=port)
 
     @mcp.tool()
@@ -85,11 +108,12 @@ def create_server(
         )
 
         # Insert
-        ref = store.insert(ref)
+        s = _get_store()
+        ref = s.insert(ref)
 
         # Handle supersession (after insert so we have ref.id)
         if input_data.supersedes:
-            store.deactivate_superseded(input_data.supersedes, superseded_by=ref.id)
+            s.deactivate_superseded(input_data.supersedes, superseded_by=ref.id)
         _log(f"reflect: stored {ref.id} type={ref.type.value}")
 
         return json.dumps({
@@ -124,11 +148,12 @@ def create_server(
 
         results: list[Reflection] = []
 
+        s = _get_store()
         if input_data.query:
             # Try vector search first
             query_embedding = embedder.embed(input_data.query)
             if query_embedding:
-                results = store.search_by_embedding(
+                results = s.search_by_embedding(
                     query_embedding=query_embedding,
                     limit=input_data.limit,
                     active_only=input_data.active_only,
@@ -140,7 +165,7 @@ def create_server(
 
             # Fall back to keyword search if no vector results
             if not results:
-                results = store.search_by_keyword(
+                results = s.search_by_keyword(
                     query=input_data.query,
                     limit=input_data.limit,
                     active_only=input_data.active_only,
@@ -151,7 +176,7 @@ def create_server(
                 )
         else:
             # No query — browse by filters using keyword search with empty query
-            results = store.search_by_keyword(
+            results = s.search_by_keyword(
                 query="",
                 limit=input_data.limit,
                 active_only=input_data.active_only,
@@ -160,6 +185,7 @@ def create_server(
                 min_weight=input_data.min_weight,
                 entity_filter=input_data.entity,
             )
+        del s  # release reference
 
         _log(f"recall: found {len(results)} results for query={input_data.query!r}")
 
@@ -214,7 +240,7 @@ def create_server(
             project=project,
         )
 
-        stats = store.introspect(
+        stats = _get_store().introspect(
             timeframe=input_data.timeframe,
             type_filter=input_data.type,
             project_filter=input_data.project,
@@ -234,13 +260,14 @@ def create_server(
     @mcp.tool()
     def memory_links(reflection_id: str) -> str:
         """Get memories linked to a specific reflection — related insights, follow-ups, contradictions."""
-        links = store.get_links(reflection_id)
+        s = _get_store()
+        links = s.get_links(reflection_id)
         if not links:
             return json.dumps({"count": 0, "links": []})
 
         result_links = []
         for link in links:
-            neighbor = store.get(link.target_id)
+            neighbor = s.get(link.target_id)
             result_links.append({
                 "id": link.target_id,
                 "similarity": round(link.similarity, 4),
@@ -309,7 +336,7 @@ def create_server(
         filter_kwargs["offset"] = offset
 
         filters = MemoryQueryFilters(**filter_kwargs)
-        results, total = store.query(filters)
+        results, total = _get_store().query(filters)
 
         _log(f"memory_query: {total} total, returning {len(results)}")
 

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -11,6 +11,7 @@ from pinky_daemon.shared_mcp import (
     SHARED_MCP_PORT,
     AgentNameMiddleware,
     LazyAgentName,
+    MemoryStorePool,
     SharedMcpManager,
     _current_agent,
     create_shared_app,
@@ -355,9 +356,10 @@ class TestWriteMcpJsonSharedMode:
             assert "/mcp/messaging/sse" in servers["pinky-messaging"]["url"]
             assert servers["pinky-messaging"]["headers"]["X-Agent-Name"] == "barsik"
 
-            # pinky-memory should still be stdio
-            assert "command" in servers["pinky-memory"]
-            assert "type" not in servers["pinky-memory"]
+            # pinky-memory should also be SSE (shared store pool)
+            assert servers["pinky-memory"]["type"] == "sse"
+            assert "/mcp/memory/sse" in servers["pinky-memory"]["url"]
+            assert servers["pinky-memory"]["headers"]["X-Agent-Name"] == "barsik"
         finally:
             api_mod.SHARED_MCP_ENABLED = original
 
@@ -376,5 +378,83 @@ class TestWriteMcpJsonSharedMode:
                 config = json.loads((work_dir / ".mcp.json").read_text())
                 assert config["mcpServers"]["pinky-self"]["headers"]["X-Agent-Name"] == name
                 assert config["mcpServers"]["pinky-messaging"]["headers"]["X-Agent-Name"] == name
+                assert config["mcpServers"]["pinky-memory"]["headers"]["X-Agent-Name"] == name
         finally:
             api_mod.SHARED_MCP_ENABLED = original
+
+
+class TestMemoryStorePool:
+    """Tests for the MemoryStorePool used in shared SSE mode."""
+
+    def test_lazy_creation(self, tmp_path):
+        """Stores are created lazily on first access."""
+        db_paths = {}
+
+        def resolver(agent_name):
+            db_path = str(tmp_path / agent_name / "memory.db")
+            (tmp_path / agent_name).mkdir(exist_ok=True)
+            db_paths[agent_name] = db_path
+            return db_path
+
+        pool = MemoryStorePool(resolver)
+
+        # No stores created yet
+        assert len(pool._stores) == 0
+
+        # First access creates the store
+        store1 = pool.get_store("barsik")
+        assert store1 is not None
+        assert len(pool._stores) == 1
+        assert "barsik" in db_paths
+
+        # Second access returns the same instance
+        store2 = pool.get_store("barsik")
+        assert store1 is store2
+        assert len(pool._stores) == 1
+
+        # Different agent gets a different store
+        store3 = pool.get_store("pushok")
+        assert store3 is not store1
+        assert len(pool._stores) == 2
+
+        pool.close_all()
+
+    def test_remove_store(self, tmp_path):
+        """Removing a store closes it and removes from cache."""
+        def resolver(agent_name):
+            db_path = str(tmp_path / f"{agent_name}.db")
+            return db_path
+
+        pool = MemoryStorePool(resolver)
+        pool.get_store("barsik")
+        assert "barsik" in pool._stores
+
+        pool.remove_store("barsik")
+        assert "barsik" not in pool._stores
+
+        # Removing non-existent agent is a no-op
+        pool.remove_store("nonexistent")
+
+        pool.close_all()
+
+    def test_close_all(self, tmp_path):
+        """close_all closes all stores and clears cache."""
+        def resolver(agent_name):
+            return str(tmp_path / f"{agent_name}.db")
+
+        pool = MemoryStorePool(resolver)
+        pool.get_store("barsik")
+        pool.get_store("pushok")
+        assert len(pool._stores) == 2
+
+        pool.close_all()
+        assert len(pool._stores) == 0
+
+    def test_resolver_error(self, tmp_path):
+        """ValueError from resolver propagates."""
+        def resolver(agent_name):
+            raise ValueError(f"Unknown agent: {agent_name}")
+
+        pool = MemoryStorePool(resolver)
+        with pytest.raises(ValueError, match="Unknown agent"):
+            pool.get_store("nonexistent")

--- a/tests/test_shared_mcp_integration.py
+++ b/tests/test_shared_mcp_integration.py
@@ -210,27 +210,41 @@ class TestMcpJsonConfigIsolation:
         finally:
             api_mod.SHARED_MCP_ENABLED = original
 
-    def test_memory_always_per_agent(self, tmp_path):
-        """pinky-memory should always be stdio with per-agent DB path."""
+    def test_memory_per_agent_isolation(self, tmp_path):
+        """pinky-memory uses per-agent isolation in both modes."""
         import pinky_daemon.api as api_mod
 
         original = api_mod.SHARED_MCP_ENABLED
-        for mode in [True, False]:
-            api_mod.SHARED_MCP_ENABLED = mode
-            try:
-                for name in ["barsik", "pushok"]:
-                    work_dir = tmp_path / f"{name}_{mode}"
-                    work_dir.mkdir()
-                    api_mod._write_mcp_json(work_dir, name)
-                    config = json.loads((work_dir / ".mcp.json").read_text())
-                    mem = config["mcpServers"]["pinky-memory"]
-                    # Always stdio
-                    assert "command" in mem
-                    assert "type" not in mem
-                    # DB path includes agent work dir
-                    assert "memory.db" in " ".join(mem["args"])
-            finally:
-                api_mod.SHARED_MCP_ENABLED = original
+
+        # Stdio mode: per-agent subprocess with DB path in args
+        api_mod.SHARED_MCP_ENABLED = False
+        try:
+            for name in ["barsik", "pushok"]:
+                work_dir = tmp_path / f"{name}_stdio"
+                work_dir.mkdir()
+                api_mod._write_mcp_json(work_dir, name)
+                config = json.loads((work_dir / ".mcp.json").read_text())
+                mem = config["mcpServers"]["pinky-memory"]
+                assert "command" in mem
+                assert "type" not in mem
+                assert "memory.db" in " ".join(mem["args"])
+        finally:
+            api_mod.SHARED_MCP_ENABLED = original
+
+        # SSE mode: shared server, per-agent via X-Agent-Name header
+        api_mod.SHARED_MCP_ENABLED = True
+        try:
+            for name in ["barsik", "pushok"]:
+                work_dir = tmp_path / f"{name}_sse"
+                work_dir.mkdir()
+                api_mod._write_mcp_json(work_dir, name)
+                config = json.loads((work_dir / ".mcp.json").read_text())
+                mem = config["mcpServers"]["pinky-memory"]
+                assert mem["type"] == "sse"
+                assert "/mcp/memory/sse" in mem["url"]
+                assert mem["headers"]["X-Agent-Name"] == name
+        finally:
+            api_mod.SHARED_MCP_ENABLED = original
 
 
 class TestDisallowedToolsIsolation:

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -199,14 +199,19 @@ class TestSharedMcpConcurrencyArchitecture:
         source = inspect.getsource(create_server)
         assert "sqlite3" not in source
 
-    def test_memory_stays_per_agent_stdio(self):
-        """pinky-memory is NOT in the shared server — per-agent DB isolation."""
+    def test_memory_uses_per_agent_store_pool(self):
+        """pinky-memory in shared server uses per-agent store pool (not single DB)."""
         from pinky_daemon.shared_mcp import SharedMcpManager
-        mgr = SharedMcpManager()
-        app = mgr._create_app()
-        # The shared app should NOT include memory
-        # (memory needs per-agent store, stays stdio)
-        # We verify by checking that _create_app doesn't import pinky_memory
-        import inspect
-        source = inspect.getsource(mgr._create_app)
-        assert "pinky_memory" not in source
+
+        # Without resolver: no memory in shared server
+        mgr_no_mem = SharedMcpManager()
+        app = mgr_no_mem._create_app()
+        assert mgr_no_mem._memory_pool is None
+
+        # With resolver: memory is included with per-agent store pool
+        def fake_resolver(name):
+            return f"/tmp/{name}/memory.db"
+
+        mgr_with_mem = SharedMcpManager(memory_db_resolver=fake_resolver)
+        app = mgr_with_mem._create_app()
+        assert mgr_with_mem._memory_pool is not None


### PR DESCRIPTION
## Summary

Closes #188. Moves pinky-memory from per-agent stdio subprocesses to the shared SSE server (port 8890), completing the MCP consolidation. All three core MCP servers now run in a single process.

- **`pinky_memory/server.py`**: `create_server()` now accepts an optional `store_factory` callable. In shared SSE mode, each tool resolves the agent from `ContextVar` and gets the right `ReflectionStore` via the factory. Stdio mode (single store) is fully backward-compatible.
- **`shared_mcp.py`**: Added `MemoryStorePool` — a thread-safe, lazily-created cache of per-agent `ReflectionStore` instances. `SharedMcpManager` accepts a `memory_db_resolver` callback and mounts memory at `/mcp/memory/sse`.
- **`api.py`**: `_write_mcp_json()` writes SSE config for memory when `PINKY_SHARED_MCP=1`. `on_startup` passes a DB path resolver that maps agent names to their `{working_dir}/data/memory.db`.
- **Tests**: Updated 3 tests that asserted "memory stays stdio". Added `TestMemoryStorePool` with 4 tests covering lazy creation, removal, cleanup, and error handling.

## Impact

- Eliminates **~15 stdio subprocesses** at steady state (one Python process per agent)
- Single shared `EmbeddingClient` instead of 15 idle OpenAI clients  
- Faster agent startup — no subprocess spawn for memory
- Per-agent DB isolation fully preserved (separate SQLite files, no schema changes)

## Test plan

- [x] All 1308 tests pass (0 failures)
- [x] Both server modes tested: stdio (backward compat) + store_factory (shared)
- [x] MemoryStorePool: lazy creation, caching, removal, close_all, resolver errors
- [x] `.mcp.json` generation verified for both shared and stdio modes
- [ ] Manual smoke test on staging with PINKY_SHARED_MCP=1

🤖 Opened by Barsik