### PR TITLE
Add KB raw source edit and delete (closes #177)

### DIFF
--- a/frontend-svelte/src/pages/KnowledgeBase.svelte
+++ b/frontend-svelte/src/pages/KnowledgeBase.svelte
@@ -326,6 +326,69 @@
         ingestTags = ''; ingestNotes = '';
     }
 
+    // --- Delete raw source ---
+    let deleteConfirmId = '';
+
+    async function deleteSource(sourceId) {
+        if (deleteConfirmId !== sourceId) {
+            deleteConfirmId = sourceId;
+            return; // First click — show confirm state
+        }
+        try {
+            await api('DELETE', `/kb/raw/${sourceId}`);
+            toast('Source deleted');
+            detailModalOpen = false;
+            deleteConfirmId = '';
+            refresh();
+        } catch (e) {
+            toast(`Delete failed: ${e.message}`, 'error');
+        }
+    }
+
+    // --- Edit raw source ---
+    let editModalOpen = false;
+    let editId = '';
+    let editTitle = '';
+    let editTags = '';
+    let editType = 'note';
+    let editUrl = '';
+    let editNotes = '';
+    let editContent = '';
+    let saving = false;
+
+    function openEditModal(source, content) {
+        editId = source.id;
+        editTitle = source.title || '';
+        editTags = (source.tags || []).join(', ');
+        editType = source.source_type || 'note';
+        editUrl = source.source_url || '';
+        editNotes = source.owner_notes || '';
+        editContent = content || '';
+        editModalOpen = true;
+    }
+
+    async function saveEdit() {
+        if (saving) return;
+        saving = true;
+        try {
+            const body = {};
+            if (editTitle.trim()) body.title = editTitle.trim();
+            if (editTags.trim()) body.tags = editTags.split(',').map(t => t.trim()).filter(Boolean);
+            if (editType) body.source_type = editType;
+            if (editUrl.trim()) body.source_url = editUrl.trim();
+            body.owner_notes = editNotes.trim();
+            if (editContent.trim()) body.content = editContent.trim();
+
+            await api('PUT', `/kb/raw/${editId}`, body);
+            toast('Source updated');
+            editModalOpen = false;
+            detailModalOpen = false;
+            refresh();
+        } catch (e) {
+            toast(`Update failed: ${e.message}`, 'error');
+        } finally { saving = false; }
+    }
+
     // --- Pagination ---
 
     function nextPage() {
@@ -743,6 +806,22 @@
             </div>
         {/if}
 
+        {#if detailKind === 'raw'}
+            <div class="detail-actions">
+                <button class="action-btn edit-btn" on:click={() => openEditModal(detailItem, detailContent)}
+                    title="Edit source">
+                    <span class="material-symbols-outlined" style="font-size:15px">edit</span> Edit
+                </button>
+                <button class="action-btn delete-btn"
+                    class:confirm={deleteConfirmId === detailItem?.id}
+                    on:click={() => deleteSource(detailItem?.id)}
+                    title={deleteConfirmId === detailItem?.id ? 'Click again to confirm' : 'Delete source'}>
+                    <span class="material-symbols-outlined" style="font-size:15px">delete</span>
+                    {deleteConfirmId === detailItem?.id ? 'Confirm delete?' : 'Delete'}
+                </button>
+            </div>
+        {/if}
+
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div class="detail-content" on:click={handleWikiLinkClick}>
@@ -833,6 +912,53 @@
         <button class="btn" on:click={() => ingestModalOpen = false}>Cancel</button>
         <button class="btn btn-primary" on:click={submitIngest} disabled={ingesting}>
             {ingesting ? 'Filing...' : 'File source'}
+        </button>
+    </div>
+</Modal>
+
+<!-- Edit raw source modal -->
+<Modal bind:show={editModalOpen} title="Edit source" maxWidth="600px">
+    <div class="ingest-form">
+        <label>
+            <span class="field-label">Title</span>
+            <input type="text" bind:value={editTitle} placeholder="Title" />
+        </label>
+
+        <label>
+            <span class="field-label">URL</span>
+            <input type="url" bind:value={editUrl} placeholder="https://..." />
+        </label>
+
+        <label>
+            <span class="field-label">Content</span>
+            <textarea bind:value={editContent} rows="10" placeholder="Source content..."></textarea>
+        </label>
+
+        <div class="form-row">
+            <label class="form-half">
+                <span class="field-label">Type</span>
+                <select bind:value={editType}>
+                    {#each SOURCE_TYPES as t}
+                        <option value={t}>{t.replace('_', ' ')}</option>
+                    {/each}
+                </select>
+            </label>
+            <label class="form-half">
+                <span class="field-label">Tags</span>
+                <input type="text" bind:value={editTags} placeholder="ai, tools, research" />
+            </label>
+        </div>
+
+        <label>
+            <span class="field-label">Notes</span>
+            <input type="text" bind:value={editNotes} placeholder="Why is this worth filing?" />
+        </label>
+    </div>
+
+    <div slot="footer">
+        <button class="btn" on:click={() => editModalOpen = false}>Cancel</button>
+        <button class="btn btn-primary" on:click={saveEdit} disabled={saving}>
+            {saving ? 'Saving...' : 'Save changes'}
         </button>
     </div>
 </Modal>
@@ -1093,6 +1219,28 @@
         flex-wrap: wrap;
         margin-bottom: 12px;
     }
+    .detail-actions {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 12px;
+    }
+    .action-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 10px;
+        font-size: 12px;
+        font-family: inherit;
+        border: 1px solid var(--c-border, #333);
+        border-radius: 4px;
+        background: transparent;
+        color: var(--c-text-secondary, #999);
+        cursor: pointer;
+        transition: all 0.15s;
+    }
+    .action-btn:hover { background: var(--c-surface-hover, #1a1a1a); color: var(--c-text, #eee); }
+    .action-btn.delete-btn:hover { border-color: #c44; color: #c44; }
+    .action-btn.delete-btn.confirm { border-color: #c44; color: #c44; background: rgba(204,68,68,0.1); }
     .source-link {
         display: flex;
         align-items: center;

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -947,6 +947,7 @@ GATE_TOOL_NAMES: dict[str, list[str]] = {
     "kb": [
         "kb_ingest", "kb_search", "kb_get_wiki", "kb_stats",
         "kb_run_librarian", "kb_save_wiki", "kb_delete_wiki",
+        "kb_delete_raw", "kb_update_raw",
     ],
 }
 
@@ -9724,7 +9725,8 @@ def create_api(
     ):
         """List raw sources with optional filters."""
         sources = kb.list_raw(tag=tag, source_type=source_type, limit=limit, offset=offset)
-        return {"sources": [s.to_dict() for s in sources]}
+        total = kb.count_raw(tag=tag, source_type=source_type)
+        return {"sources": [s.to_dict() for s in sources], "total": total}
 
     @app.get("/kb/raw/{source_id}")
     async def kb_get_raw(source_id: str, include_content: bool = False):
@@ -9736,6 +9738,26 @@ def create_api(
         if include_content:
             result["content"] = kb.get_raw_content(source_id)
         return result
+
+    @app.delete("/kb/raw/{source_id}")
+    async def kb_delete_raw(source_id: str):
+        """Delete a raw source (file + DB + FTS)."""
+        deleted = kb.delete_raw(source_id)
+        if not deleted:
+            raise HTTPException(404, f"Raw source '{source_id}' not found")
+        return {"deleted": True, "source_id": source_id}
+
+    @app.put("/kb/raw/{source_id}")
+    async def kb_update_raw(source_id: str, req: dict):
+        """Update fields on a raw source (title, content, tags, source_type, source_url)."""
+        allowed = {"title", "content", "tags", "source_type", "source_url", "owner_notes"}
+        updates = {k: v for k, v in req.items() if k in allowed}
+        if not updates:
+            raise HTTPException(400, "No valid fields to update")
+        updated = kb.update_raw(source_id, **updates)
+        if not updated:
+            raise HTTPException(404, f"Raw source '{source_id}' not found")
+        return updated.to_dict(include_preview=True)
 
     @app.get("/kb/wiki")
     async def kb_list_wiki(limit: int = 100, offset: int = 0):

--- a/src/pinky_daemon/kb_store.py
+++ b/src/pinky_daemon/kb_store.py
@@ -65,6 +65,24 @@ def _content_preview(content: str) -> str:
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)", re.DOTALL)
 
 
+def _parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Parse YAML frontmatter and body from a markdown file.
+
+    Returns:
+        (frontmatter_dict, body_text) — body has the '# Title' header stripped.
+    """
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+    fm = yaml.safe_load(m.group(1)) or {}
+    body = m.group(2).strip()
+    # Strip leading '# Title' line if present
+    body_lines = body.split("\n", 1)
+    if body_lines and body_lines[0].startswith("# "):
+        body = body_lines[1].strip() if len(body_lines) > 1 else ""
+    return fm, body
+
+
 @dataclass
 class RawSource:
     id: str
@@ -370,6 +388,153 @@ class KBStore:
         if not full_path.exists():
             return None
         return full_path.read_text(encoding="utf-8")
+
+    def delete_raw(self, source_id: str) -> bool:
+        """Delete a raw source (file, DB row, and FTS entry).
+
+        Returns:
+            True if the source existed and was deleted.
+        """
+        source = self.get_raw(source_id)
+        if not source:
+            return False
+
+        # Remove file
+        full_path = self.kb_dir / source.file_path
+        if full_path.exists():
+            full_path.unlink()
+
+        # Remove DB + FTS
+        conn = self._conn()
+        try:
+            conn.execute("DELETE FROM raw_sources WHERE id = ?", (source_id,))
+            conn.execute(
+                "DELETE FROM fts_content WHERE ref_id = ? AND kind = 'raw'", (source_id,)
+            )
+            conn.commit()
+            _log(f"[KB] Deleted raw source: {source_id}")
+        finally:
+            conn.close()
+
+        return True
+
+    def update_raw(
+        self,
+        source_id: str,
+        *,
+        title: str | None = None,
+        content: str | None = None,
+        tags: list[str] | None = None,
+        source_url: str | None = None,
+        source_type: str | None = None,
+        owner_notes: str | None = None,
+    ) -> RawSource | None:
+        """Update fields on an existing raw source.
+
+        Only provided (non-None) fields are updated. Rewrites the markdown file
+        and updates the DB row + FTS index.
+
+        Returns:
+            The updated RawSource, or None if not found.
+        """
+        source = self.get_raw(source_id)
+        if not source:
+            return None
+
+        full_path = self.kb_dir / source.file_path
+        if not full_path.exists():
+            return None
+
+        # Read existing file to get current frontmatter + body
+        raw_text = full_path.read_text(encoding="utf-8")
+        fm, body = _parse_frontmatter(raw_text)
+
+        # Apply updates to frontmatter
+        if title is not None:
+            fm["title"] = title
+        if tags is not None:
+            fm["tags"] = tags
+        if source_url is not None:
+            fm["source_url"] = source_url
+        if source_type is not None:
+            fm["source_type"] = source_type
+        if owner_notes is not None:
+            if owner_notes:
+                fm["owner_notes"] = owner_notes
+            else:
+                fm.pop("owner_notes", None)
+
+        # Apply content update — rebuild body section
+        if content is not None:
+            body = content
+
+        # Rebuild the file
+        new_title = fm.get("title", source.title)
+        fm_yaml = yaml.dump(fm, default_flow_style=False, allow_unicode=True)
+        full_content = f"---\n{fm_yaml}---\n\n# {new_title}\n\n{body}"
+        full_path.write_text(full_content, encoding="utf-8")
+
+        c_hash = _content_hash(full_content)
+        c_preview = _content_preview(full_content)
+
+        # Update DB
+        new_tags = fm.get("tags", source.tags)
+        new_type = fm.get("source_type", source.source_type)
+        new_url = fm.get("source_url", source.source_url)
+
+        conn = self._conn()
+        try:
+            conn.execute(
+                """UPDATE raw_sources
+                   SET title = ?, source_url = ?, source_type = ?,
+                       tags = ?, content_hash = ?, content_preview = ?
+                   WHERE id = ?""",
+                (
+                    new_title, new_url, new_type,
+                    json.dumps(new_tags), c_hash, c_preview,
+                    source_id,
+                ),
+            )
+
+            # Update FTS — delete + re-insert (FTS5 doesn't support UPDATE)
+            conn.execute(
+                "DELETE FROM fts_content WHERE ref_id = ? AND kind = 'raw'", (source_id,)
+            )
+            conn.execute(
+                "INSERT INTO fts_content (ref_id, kind, title, body, tags) VALUES (?,?,?,?,?)",
+                (
+                    source_id, "raw", new_title, body,
+                    " ".join(new_tags) if isinstance(new_tags, list) else "",
+                ),
+            )
+
+            conn.commit()
+            _log(f"[KB] Updated raw source: {source_id}")
+        finally:
+            conn.close()
+
+        return self.get_raw(source_id)
+
+    def count_raw(
+        self,
+        *,
+        tag: str | None = None,
+        source_type: str | None = None,
+    ) -> int:
+        """Count raw sources matching the given filters."""
+        conn = self._conn()
+        try:
+            query = "SELECT COUNT(*) FROM raw_sources WHERE 1=1"
+            params: list = []
+            if tag:
+                query += " AND tags LIKE ?"
+                params.append(f'%"{tag}"%')
+            if source_type:
+                query += " AND source_type = ?"
+                params.append(source_type)
+            return conn.execute(query, params).fetchone()[0]
+        finally:
+            conn.close()
 
     def list_raw(
         self,

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -2235,6 +2235,48 @@ def create_server(
                 return f"Error: {result['error']}"
             return f"🗑️ Wiki page deleted: {slug}"
 
+        @mcp.tool()
+        def kb_delete_raw(source_id: str) -> str:
+            """Delete a raw KB source by ID (e.g. 'raw-2026-04-08-001')."""
+            result = _api("DELETE", f"/kb/raw/{source_id}")
+            if "error" in result:
+                return f"Error: {result['error']}"
+            return f"🗑️ Raw source deleted: {source_id}"
+
+        @mcp.tool()
+        def kb_update_raw(
+            source_id: str,
+            title: str = "",
+            content: str = "",
+            tags: str = "",
+            source_type: str = "",
+            source_url: str = "",
+            owner_notes: str = "",
+        ) -> str:
+            """Update fields on a raw KB source. Only non-empty fields are changed.
+
+            tags: comma-separated list (e.g. "ai, coding, tools").
+            """
+            body: dict = {}
+            if title:
+                body["title"] = title
+            if content:
+                body["content"] = content
+            if tags:
+                body["tags"] = [t.strip() for t in tags.split(",") if t.strip()]
+            if source_type:
+                body["source_type"] = source_type
+            if source_url:
+                body["source_url"] = source_url
+            if owner_notes:
+                body["owner_notes"] = owner_notes
+            if not body:
+                return "No fields to update — provide at least one field."
+            result = _api("PUT", f"/kb/raw/{source_id}", body=body)
+            if "error" in result:
+                return f"Error: {result['error']}"
+            return f"✅ Raw source updated: {source_id} — {result.get('title', '')}"
+
 
 
     def _register_extras_tools():

--- a/tests/test_kb_store.py
+++ b/tests/test_kb_store.py
@@ -1,0 +1,150 @@
+"""Tests for KB store — raw source CRUD operations."""
+
+import pytest
+
+from pinky_daemon.kb_store import KBStore, _parse_frontmatter
+
+
+@pytest.fixture
+def kb(tmp_path):
+    """Create a KBStore in a temp directory."""
+    return KBStore(str(tmp_path / "kb"))
+
+
+class TestParsesFrontmatter:
+    def test_basic(self):
+        text = "---\ntitle: Hello\ntags: [a, b]\n---\n\n# Hello\n\nBody text here."
+        fm, body = _parse_frontmatter(text)
+        assert fm["title"] == "Hello"
+        assert fm["tags"] == ["a", "b"]
+        assert body == "Body text here."
+
+    def test_no_frontmatter(self):
+        text = "Just plain text."
+        fm, body = _parse_frontmatter(text)
+        assert fm == {}
+        assert body == "Just plain text."
+
+    def test_empty_body(self):
+        text = "---\ntitle: Empty\n---\n\n# Empty\n\n"
+        fm, body = _parse_frontmatter(text)
+        assert fm["title"] == "Empty"
+        assert body == ""
+
+
+class TestIngest:
+    def test_ingest_creates_file_and_db(self, kb):
+        source = kb.ingest(title="Test Source", content="Hello world", tags=["test"])
+        assert source.id.startswith("raw-")
+        assert source.title == "Test Source"
+        assert source.tags == ["test"]
+
+        # File exists
+        full_path = kb.kb_dir / source.file_path
+        assert full_path.exists()
+        content = full_path.read_text()
+        assert "Hello world" in content
+        assert "Test Source" in content
+
+    def test_ingest_indexes_in_fts(self, kb):
+        kb.ingest(title="Searchable", content="unique keyword xyzzy", tags=["findme"])
+        results = kb.search("xyzzy")
+        assert len(results) == 1
+        assert results[0]["title"] == "Searchable"
+
+
+class TestDeleteRaw:
+    def test_delete_removes_everything(self, kb):
+        source = kb.ingest(title="To Delete", content="Bye bye", tags=["temp"])
+        assert kb.get_raw(source.id) is not None
+
+        deleted = kb.delete_raw(source.id)
+        assert deleted is True
+
+        # DB row gone
+        assert kb.get_raw(source.id) is None
+
+        # File gone
+        full_path = kb.kb_dir / source.file_path
+        assert not full_path.exists()
+
+        # FTS gone
+        results = kb.search("Bye bye")
+        assert len(results) == 0
+
+    def test_delete_nonexistent_returns_false(self, kb):
+        assert kb.delete_raw("raw-9999-01-01-999") is False
+
+    def test_delete_then_count(self, kb):
+        kb.ingest(title="Keep", content="a")
+        s2 = kb.ingest(title="Delete", content="b")
+        assert kb.count_raw() == 2
+
+        kb.delete_raw(s2.id)
+        assert kb.count_raw() == 1
+
+
+class TestUpdateRaw:
+    def test_update_title(self, kb):
+        source = kb.ingest(title="Old Title", content="Body text", tags=["a"])
+        updated = kb.update_raw(source.id, title="New Title")
+        assert updated is not None
+        assert updated.title == "New Title"
+
+        # File reflects change
+        content = kb.get_raw_content(source.id)
+        assert "# New Title" in content
+
+    def test_update_tags(self, kb):
+        source = kb.ingest(title="Tagged", content="Body", tags=["old"])
+        updated = kb.update_raw(source.id, tags=["new", "fresh"])
+        assert updated.tags == ["new", "fresh"]
+
+        # FTS updated — search for new tag
+        results = kb.search("fresh")
+        assert len(results) == 1
+
+    def test_update_content(self, kb):
+        source = kb.ingest(title="Content", content="Original body")
+        updated = kb.update_raw(source.id, content="Updated body text")
+        assert updated is not None
+
+        content = kb.get_raw_content(source.id)
+        assert "Updated body text" in content
+        assert "Original body" not in content
+
+        # FTS reflects new content
+        assert len(kb.search("Updated body")) == 1
+        assert len(kb.search("Original body")) == 0
+
+    def test_update_nonexistent_returns_none(self, kb):
+        assert kb.update_raw("raw-9999-01-01-999", title="Nope") is None
+
+    def test_update_preserves_unmodified_fields(self, kb):
+        source = kb.ingest(
+            title="Stable", content="Body",
+            tags=["keep"], source_type="article", source_url="https://example.com"
+        )
+        updated = kb.update_raw(source.id, title="Changed Title")
+        assert updated.source_type == "article"
+        assert updated.source_url == "https://example.com"
+        assert updated.tags == ["keep"]
+
+
+class TestCountRaw:
+    def test_count_all(self, kb):
+        assert kb.count_raw() == 0
+        kb.ingest(title="A", content="a")
+        kb.ingest(title="B", content="b")
+        assert kb.count_raw() == 2
+
+    def test_count_with_type_filter(self, kb):
+        kb.ingest(title="Article", content="a", source_type="article")
+        kb.ingest(title="Note", content="b", source_type="note")
+        assert kb.count_raw(source_type="article") == 1
+        assert kb.count_raw(source_type="note") == 1
+
+    def test_count_with_tag_filter(self, kb):
+        kb.ingest(title="A", content="a", tags=["python"])
+        kb.ingest(title="B", content="b", tags=["rust"])
+        assert kb.count_raw(tag="python") == 1


### PR DESCRIPTION
## Summary
- `KBStore.delete_raw()` — removes file + DB row + FTS entry
- `KBStore.update_raw()` — patches any field, rewrites markdown file, updates DB + FTS
- `KBStore.count_raw()` — filtered count for proper pagination
- `DELETE /kb/raw/{id}` and `PUT /kb/raw/{id}` API endpoints
- `GET /kb/raw` now returns `total` count
- `kb_delete_raw` and `kb_update_raw` MCP tools added to pinky-self
- Frontend: Edit/Delete buttons on source detail modal with two-click delete confirmation
- 16 new tests covering all CRUD operations + frontmatter parsing

## Test plan
- [x] 16 new unit tests for delete_raw, update_raw, count_raw, _parse_frontmatter
- [x] Frontend builds successfully
- [x] Lint passes on new code
- [ ] Full test suite (running in background)
- [ ] Manual test: delete a source from the UI
- [ ] Manual test: edit a source from the UI

Closes #177

🤖 Opened by Barsik