### PR TITLE
Promote beta → main: shared UI components (#196)

### DIFF
--- a/frontend-svelte/src/app.css
+++ b/frontend-svelte/src/app.css
@@ -355,6 +355,13 @@ a { color: var(--text-primary); text-decoration: none; }
 .btn-success { background: var(--tone-success-bg); color: var(--tone-success-text); }
 .btn-success:hover { background: var(--green); color: #fff; }
 .btn-sm { padding: 0.25rem 0.55rem; font-size: 0.65rem; }
+.btn:disabled, .btn-primary:disabled, .btn-danger:disabled, .btn-success:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
+    box-shadow: none;
+    transform: none;
+}
 
 /* Form inputs — surface-dim bg, no border */
 .form-input,

--- a/frontend-svelte/src/components/FormField.svelte
+++ b/frontend-svelte/src/components/FormField.svelte
@@ -1,0 +1,55 @@
+<script>
+    /**
+     * FormField — labeled form input with consistent styling.
+     * Replaces the repeated pattern of div > label-div + input.
+     *
+     * Usage:
+     *   <FormField label="API Key">
+     *     <input type="password" class="form-input" bind:value={key} />
+     *   </FormField>
+     *
+     *   <FormField label="Model" hint="e.g. claude-sonnet-4-5">
+     *     <input type="text" class="form-input" bind:value={model} />
+     *   </FormField>
+     */
+
+    /** @type {string} */
+    export let label = '';
+
+    /** @type {string} optional hint text below input */
+    export let hint = '';
+
+    /** @type {string} optional inline style on wrapper */
+    export let style = '';
+</script>
+
+<div class="form-field" style={style}>
+    {#if label}
+        <div class="form-field-label">{label}</div>
+    {/if}
+    <slot />
+    {#if hint}
+        <div class="form-field-hint">{hint}</div>
+    {/if}
+</div>
+
+<style>
+    .form-field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+    .form-field-label {
+        font-family: var(--font-grotesk);
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        color: var(--gray-mid);
+        letter-spacing: 0.03em;
+    }
+    .form-field-hint {
+        font-size: 0.72rem;
+        color: var(--text-muted);
+        margin-top: 0.1rem;
+    }
+</style>

--- a/frontend-svelte/src/components/ProviderConfig.svelte
+++ b/frontend-svelte/src/components/ProviderConfig.svelte
@@ -1,0 +1,230 @@
+<script>
+    /**
+     * ProviderConfig — unified provider configuration form.
+     *
+     * Used in:
+     *   - Settings (global provider add/edit)
+     *   - Agents (per-agent provider config)
+     *
+     * Modes:
+     *   - "agent": shows global ref dropdown, anthropic preset, preset buttons
+     *   - "global": shows name field, simpler preset buttons (no anthropic/codex)
+     */
+    import { _ } from 'svelte-i18n';
+    import FormField from './FormField.svelte';
+    import { createEventDispatcher } from 'svelte';
+
+    const dispatch = createEventDispatcher();
+
+    /** @type {'agent' | 'global'} */
+    export let mode = 'agent';
+
+    // Bound values
+    export let providerUrl = '';
+    export let providerKey = '';
+    export let providerModel = '';
+    export let providerPreset = 'anthropic';
+    export let providerRef = '';   // agent mode only
+    export let providerName = '';  // global mode only
+
+    /** @type {Array<{id: string, name: string, provider_model?: string}>} */
+    export let globalProviders = [];
+
+    /** @type {boolean} */
+    export let dirty = false;
+
+    // Preset definitions
+    const PRESETS = {
+        anthropic:   { url: '',                                   key: '',       model: '' },
+        ollama:      { url: 'http://localhost:11434',             key: 'ollama', model: '' },
+        openrouter:  { url: 'https://openrouter.ai/api',         key: '',       model: 'anthropic/claude-sonnet-4-5' },
+        deepseek:    { url: 'https://api.deepseek.com/anthropic', key: '',      model: 'deepseek-chat' },
+        zai:         { url: 'https://api.z.ai/api/anthropic',    key: '',       model: 'glm-5.1' },
+        codex_cli:   { url: 'codex_cli',                         key: '',       model: '' },
+        custom:      { url: '',                                   key: '',       model: '' },
+    };
+
+    // Which presets to show per mode
+    $: presetList = mode === 'agent'
+        ? ['anthropic', 'ollama', 'openrouter', 'deepseek', 'zai', 'codex_cli', 'custom']
+        : ['ollama', 'openrouter', 'deepseek', 'zai', 'custom'];
+
+    // Preset label lookup
+    const PRESET_LABELS = {
+        anthropic:  'agents_extra.provider_preset_anthropic',
+        ollama:     'agents_extra.provider_preset_ollama',
+        openrouter: 'agents_extra.provider_preset_openrouter',
+        deepseek:   'agents_extra.provider_preset_deepseek',
+        zai:        'agents_extra.provider_preset_zai',
+        codex_cli:  'agents_extra.provider_preset_codex_cli',
+        custom:     'agents_extra.provider_preset_custom',
+    };
+
+    // Which fields each preset needs
+    $: showUrlAndKey = providerPreset === 'ollama' || providerPreset === 'custom';
+    $: showKeyOnly = providerPreset === 'openrouter' || providerPreset === 'deepseek' || providerPreset === 'zai';
+    $: showModel = providerPreset !== 'anthropic';
+    $: refActive = mode === 'agent' && !!providerRef;
+
+    export function applyPreset(preset) {
+        providerPreset = preset;
+        if (mode === 'agent') providerRef = '';
+        const p = PRESETS[preset];
+        if (p) {
+            providerUrl = p.url;
+            providerKey = p.key;
+            providerModel = p.model;
+        }
+        dirty = true;
+        dispatch('change');
+    }
+
+    export function selectGlobalProvider(id) {
+        providerRef = id;
+        if (id) {
+            providerUrl = '';
+            providerKey = '';
+            providerModel = '';
+            providerPreset = 'anthropic';
+        }
+        dirty = true;
+        dispatch('change');
+    }
+
+    export function detectPreset(url) {
+        if (!url) return 'anthropic';
+        if (url === 'http://localhost:11434') return 'ollama';
+        if (url === 'https://api.z.ai/api/anthropic') return 'zai';
+        if (url === 'https://openrouter.ai/api') return 'openrouter';
+        if (url === 'https://api.deepseek.com/anthropic') return 'deepseek';
+        if (url === 'codex_cli') return 'codex_cli';
+        return 'custom';
+    }
+
+    function markDirty() {
+        dirty = true;
+        dispatch('change');
+    }
+
+    // Preset-specific descriptions
+    const PRESET_DESCS = {
+        openrouter: 'agents_extra.openrouter_desc',
+        codex_cli:  'agents_extra.codex_cli_desc',
+        deepseek:   'agents_extra.deepseek_desc',
+        zai:        'agents_extra.zai_desc',
+    };
+
+    // Preset-specific model hints
+    const MODEL_HINTS = {
+        openrouter: 'agents_extra.openrouter_model_examples',
+        deepseek:   'agents_extra.deepseek_model_options',
+        zai:        'agents_extra.zai_model_options',
+        codex_cli:  'agents_extra.codex_cli_model_options',
+    };
+
+    // Model placeholder per preset
+    const MODEL_PLACEHOLDERS = {
+        openrouter: 'anthropic/claude-sonnet-4-5',
+        deepseek:   'deepseek-chat',
+        zai:        'glm-5.1',
+        codex_cli:  'gpt-5.4 (default)',
+        ollama:     '',
+        custom:     '',
+    };
+
+    // Key placeholder per preset
+    const KEY_PLACEHOLDERS = {
+        openrouter: 'sk-or-...',
+        deepseek:   'sk-...',
+        zai:        'sk-...',
+        ollama:     'ollama or your key',
+        custom:     'API key',
+    };
+</script>
+
+<div class="provider-config">
+    <!-- Global provider name (global mode only) -->
+    {#if mode === 'global'}
+        <FormField label="Name" style="margin-bottom:0.75rem">
+            <input type="text" class="form-input" bind:value={providerName} on:input={markDirty} placeholder="My provider" style="width:100%;max-width:320px">
+        </FormField>
+    {/if}
+
+    <!-- Global provider ref dropdown (agent mode only) -->
+    {#if mode === 'agent' && globalProviders.length > 0}
+        <div style="margin-bottom:0.75rem">
+            <FormField label={$_('agents_extra.global_provider_label')}>
+                <select class="form-select" value={providerRef} on:change={(e) => selectGlobalProvider(e.target.value)} style="width:100%;max-width:320px">
+                    <option value="">{$_('agents_extra.global_provider_none')}</option>
+                    {#each globalProviders as gp}
+                        <option value={gp.id}>{gp.name}{gp.provider_model ? ' · ' + gp.provider_model : ''}</option>
+                    {/each}
+                </select>
+            </FormField>
+        </div>
+    {/if}
+
+    <!-- Preset buttons + fields (dimmed when global ref is active) -->
+    <div style="{refActive ? 'opacity:0.4;pointer-events:none' : ''}">
+        <div style="display:flex;gap:0.4rem;flex-wrap:wrap">
+            {#each presetList as preset}
+                <button
+                    class="btn btn-sm"
+                    class:btn-primary={providerPreset === preset}
+                    style={providerPreset !== preset ? 'background:var(--surface-3);color:var(--text-muted)' : ''}
+                    on:click={() => applyPreset(preset)}
+                >{$_(PRESET_LABELS[preset] || preset)}</button>
+            {/each}
+        </div>
+
+        <!-- Preset description -->
+        {#if PRESET_DESCS[providerPreset]}
+            <div class="preset-desc">{$_(PRESET_DESCS[providerPreset])}</div>
+        {/if}
+
+        <!-- Provider fields -->
+        {#if providerPreset !== 'anthropic'}
+            <div class="provider-fields">
+                {#if showUrlAndKey}
+                    <FormField label={$_('agents_extra.base_url_label')}>
+                        <input type="text" class="form-input" bind:value={providerUrl} on:input={markDirty} placeholder="http://localhost:11434" style="width:100%">
+                    </FormField>
+                {/if}
+
+                {#if showUrlAndKey || showKeyOnly}
+                    <FormField label={$_('agents_extra.api_key_label')}>
+                        <input type="password" class="form-input" bind:value={providerKey} on:input={markDirty} placeholder={KEY_PLACEHOLDERS[providerPreset] || 'API key'} style="width:100%">
+                    </FormField>
+                {/if}
+
+                {#if showModel}
+                    <FormField label={$_('agents_extra.model_label')} hint={MODEL_HINTS[providerPreset] ? $_(MODEL_HINTS[providerPreset]) : ''}>
+                        <input type="text" class="form-input" bind:value={providerModel} on:input={markDirty} placeholder={MODEL_PLACEHOLDERS[providerPreset] || ''} style="width:100%">
+                    </FormField>
+                {/if}
+            </div>
+        {/if}
+    </div>
+</div>
+
+<style>
+    .provider-config {
+        padding: 1rem 1.5rem;
+        background: var(--surface-2);
+        border-radius: var(--radius-lg);
+    }
+    .preset-desc {
+        margin-top: 0.75rem;
+        padding: 0.6rem 0.75rem;
+        background: var(--surface-1);
+        border-radius: var(--radius-md);
+        font-size: 0.78rem;
+        color: var(--text-muted);
+    }
+    .provider-fields {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-top: 0.75rem;
+    }
+</style>

--- a/frontend-svelte/src/components/SectionHeader.svelte
+++ b/frontend-svelte/src/components/SectionHeader.svelte
@@ -1,0 +1,62 @@
+<script>
+    import { _ } from 'svelte-i18n';
+
+    /** @type {string} */
+    export let title = '';
+
+    /** @type {string} i18n key — if set, overrides title */
+    export let i18nKey = '';
+
+    /** @type {Function|null} refresh handler — shows refresh button when set */
+    export let onRefresh = null;
+
+    /** @type {string} optional extra style */
+    export let style = '';
+
+    /** @type {'section' | 'detail'} */
+    export let variant = 'section';
+</script>
+
+{#if variant === 'section'}
+    <div class="section-header" style={style}>
+        <div class="section-title">{i18nKey ? $_(`${i18nKey}`) : title}</div>
+        <div class="section-actions">
+            <slot name="actions" />
+            {#if onRefresh}
+                <button class="btn btn-sm" on:click={onRefresh}>{$_('common.refresh')}</button>
+            {/if}
+        </div>
+    </div>
+{:else}
+    <div class="detail-section-header" style={style}>
+        <span class="detail-section-title">{i18nKey ? $_(`${i18nKey}`) : title}</span>
+        <div class="section-actions">
+            <slot name="actions" />
+            {#if onRefresh}
+                <button class="btn btn-sm" on:click={onRefresh}>{$_('common.refresh')}</button>
+            {/if}
+        </div>
+    </div>
+{/if}
+
+<style>
+    .section-actions {
+        display: flex;
+        gap: 0.4rem;
+        align-items: center;
+    }
+    .detail-section-header {
+        padding: 1rem 1.5rem;
+        background: var(--surface-2);
+        border-radius: var(--radius-lg);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+    .detail-section-title {
+        font-family: var(--font-grotesk);
+        font-size: 0.8rem;
+        font-weight: 700;
+        text-transform: uppercase;
+    }
+</style>

--- a/frontend-svelte/src/components/StatusBadge.svelte
+++ b/frontend-svelte/src/components/StatusBadge.svelte
@@ -1,0 +1,28 @@
+<script>
+    /**
+     * StatusBadge — semantic status indicator with color variants.
+     *
+     * Usage:
+     *   <StatusBadge status="on" label="Running" />
+     *   <StatusBadge status="off" />
+     *   <StatusBadge status="warn" label="Degraded" />
+     *   <StatusBadge variant="model" label="opus" />
+     */
+
+    /** @type {string} status key — maps to badge-{status} class */
+    export let status = '';
+
+    /** @type {string} display text — defaults to status if not set */
+    export let label = '';
+
+    /** @type {string} optional variant override (e.g. 'model', 'mcp', 'builtin') */
+    export let variant = '';
+
+    /** @type {string} optional inline style */
+    export let style = '';
+
+    $: cssClass = variant ? `badge badge-${variant}` : (status ? `badge badge-${status}` : 'badge');
+    $: displayText = label || status;
+</script>
+
+<span class={cssClass} style={style}>{displayText}</span>

--- a/frontend-svelte/src/components/TabBar.svelte
+++ b/frontend-svelte/src/components/TabBar.svelte
@@ -1,0 +1,118 @@
+<script>
+    import { _ } from 'svelte-i18n';
+
+    /** @type {Array<{id: string, label?: string, badge?: string}>} */
+    export let tabs = [];
+
+    /** @type {string} */
+    export let active = '';
+
+    /** @type {string} i18n prefix — tabs rendered as $_(`${i18nPrefix}${tab.id}`) */
+    export let i18nPrefix = '';
+
+    /** @type {'page' | 'detail'} */
+    export let variant = 'page';
+
+    import { createEventDispatcher } from 'svelte';
+    const dispatch = createEventDispatcher();
+
+    function select(id) {
+        active = id;
+        dispatch('change', id);
+    }
+</script>
+
+{#if variant === 'page'}
+    <div class="tab-bar">
+        {#each tabs as tab}
+            <button
+                class="tab-btn"
+                class:active={active === tab.id}
+                on:click={() => select(tab.id)}
+            >
+                {tab.label || (i18nPrefix ? $_(`${i18nPrefix}${tab.id}`) : tab.id)}
+                {#if tab.badge}<span class="tab-badge">{tab.badge}</span>{/if}
+            </button>
+        {/each}
+    </div>
+{:else}
+    <div class="detail-tabs">
+        {#each tabs as tab}
+            <button
+                class="detail-tab"
+                class:active={active === tab.id}
+                on:click={() => select(tab.id)}
+            >
+                {tab.label || (i18nPrefix ? $_(`${i18nPrefix}${tab.id}`) : tab.id)}
+                {#if tab.badge}<span class="tab-badge">{tab.badge}</span>{/if}
+            </button>
+        {/each}
+    </div>
+{/if}
+
+<style>
+    /* Page-level tabs (Settings, Tasks, KB, etc.) */
+    .tab-bar {
+        display: flex;
+        gap: 0.4rem;
+        margin-bottom: 1.5rem;
+        flex-wrap: wrap;
+    }
+    .tab-btn {
+        padding: 0.4rem 1rem;
+        font-size: 0.85rem;
+        font-weight: 600;
+        font-family: var(--font-grotesk);
+        background: none;
+        border: none;
+        border-radius: 4px;
+        color: var(--text-primary, #111);
+        cursor: pointer;
+        letter-spacing: 0.02em;
+        transition: background 0.12s;
+    }
+    .tab-btn:hover { background: rgba(0,0,0,0.06); }
+    .tab-btn.active {
+        background: var(--accent, #f5c842);
+        color: #000;
+    }
+
+    /* Detail-level tabs (Agent detail panel) */
+    .detail-tabs {
+        display: flex;
+        gap: 0.25rem;
+        padding: 0 1rem;
+        border-bottom: 1px solid var(--border);
+        margin-bottom: 0.5rem;
+        margin-top: 0.5rem;
+    }
+    .detail-tab {
+        font-family: var(--font-grotesk);
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        padding: 0.5rem 0.75rem;
+        border: none;
+        background: none;
+        color: var(--gray-mid);
+        cursor: pointer;
+        border-bottom: 2px solid transparent;
+        margin-bottom: -1px;
+        position: relative;
+    }
+    .detail-tab:hover { color: var(--text); }
+    .detail-tab.active { color: var(--text); border-bottom-color: var(--accent); }
+
+    .tab-badge {
+        display: inline-block;
+        margin-left: 0.3rem;
+        font-size: 0.65rem;
+        padding: 0.1rem 0.35rem;
+        border-radius: 999px;
+        background: var(--accent);
+        color: #000;
+        font-weight: 700;
+        vertical-align: middle;
+    }
+</style>

--- a/frontend-svelte/src/components/TimezoneSelect.svelte
+++ b/frontend-svelte/src/components/TimezoneSelect.svelte
@@ -1,0 +1,36 @@
+<script>
+    /**
+     * TimezoneSelect — consolidated timezone picker.
+     * Replaces 3+ independent timezone selectors across Settings and Agents.
+     */
+
+    /** @type {string} */
+    export let value = '';
+
+    /** @type {string} */
+    export let style = '';
+
+    import { createEventDispatcher } from 'svelte';
+    const dispatch = createEventDispatcher();
+
+    const commonTimezones = [
+        'America/Los_Angeles', 'America/Denver', 'America/Chicago', 'America/New_York',
+        'America/Anchorage', 'Pacific/Honolulu', 'America/Phoenix',
+        'America/Toronto', 'America/Vancouver', 'America/Sao_Paulo',
+        'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Moscow',
+        'Asia/Tokyo', 'Asia/Shanghai', 'Asia/Kolkata', 'Asia/Dubai',
+        'Australia/Sydney', 'Pacific/Auckland', 'UTC',
+    ];
+
+    function onChange(e) {
+        value = e.target.value;
+        dispatch('change', value);
+    }
+</script>
+
+<select class="form-select" style={style} value={value} on:change={onChange}>
+    <option value="">—</option>
+    {#each commonTimezones as tz}
+        <option value={tz}>{tz}</option>
+    {/each}
+</select>

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -7,6 +7,7 @@
     import StatusBadge from '../components/StatusBadge.svelte';
     import ProviderConfig from '../components/ProviderConfig.svelte';
     import FormField from '../components/FormField.svelte';
+    import TimezoneSelect from '../components/TimezoneSelect.svelte';
     import { api } from '../lib/api.js';
     import { toast } from '../lib/stores.js';
     import { timeAgo, contextClass } from '../lib/utils.js';
@@ -1598,16 +1599,14 @@
                     </label>
                     {#if voiceReply}
                     <div style="display:flex;gap:1rem;flex-wrap:wrap">
-                        <div style="flex:1;min-width:140px">
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.3rem">{$_('agents_extra.tts_provider_label')}</div>
+                        <FormField label={$_('agents_extra.tts_provider_label')} style="flex:1;min-width:140px">
                             <select class="form-select" bind:value={ttsProvider} on:change={() => voiceDirty = true} style="width:100%">
                                 <option value="openai">OpenAI</option>
                                 <option value="elevenlabs">ElevenLabs</option>
                                 <option value="deepgram">Deepgram</option>
                             </select>
-                        </div>
-                        <div style="flex:1;min-width:140px">
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.3rem">{$_('agents_extra.voice_label')}</div>
+                        </FormField>
+                        <FormField label={$_('agents_extra.voice_label')} style="flex:1;min-width:140px">
                             {#if ttsProvider === 'openai'}
                                 <select class="form-select" bind:value={ttsVoice} on:change={() => voiceDirty = true} style="width:100%">
                                     <option value="">Default</option>
@@ -1640,9 +1639,8 @@
                                     <option value="aura-zeus-en">Zeus (M)</option>
                                 </select>
                             {/if}
-                        </div>
-                        <div style="flex:1;min-width:140px">
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.3rem">{$_('agents_extra.model_label')}</div>
+                        </FormField>
+                        <FormField label={$_('agents_extra.model_label')} style="flex:1;min-width:140px">
                             {#if ttsProvider === 'openai'}
                                 <select class="form-select" bind:value={ttsModel} on:change={() => voiceDirty = true} style="width:100%">
                                     <option value="">Default (tts-1)</option>
@@ -1663,16 +1661,15 @@
                             {:else}
                                 <input type="text" class="form-input" bind:value={ttsModel} on:input={() => voiceDirty = true} placeholder="Model ID" style="width:100%">
                             {/if}
-                        </div>
+                        </FormField>
                     </div>
                     <div style="display:flex;gap:1rem;flex-wrap:wrap">
-                        <div style="min-width:140px">
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.3rem">{$_('agents_extra.transcription_provider_label')}</div>
+                        <FormField label={$_('agents_extra.transcription_provider_label')} style="min-width:140px">
                             <select class="form-select" bind:value={transcribeProvider} on:change={() => voiceDirty = true}>
                                 <option value="openai">OpenAI Whisper</option>
                                 <option value="deepgram">Deepgram Nova</option>
                             </select>
-                        </div>
+                        </FormField>
                     </div>
                     {/if}
                 </div>
@@ -1694,35 +1691,20 @@
                     </label>
                     {#if dreamEnabled}
                     <div style="display:flex;gap:1rem;flex-wrap:wrap">
-                        <div style="flex:1;min-width:140px">
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.3rem">{$_('agents_extra.dream_schedule_label')}</div>
+                        <FormField label={$_('agents_extra.dream_schedule_label')} style="flex:1;min-width:140px">
                             <input type="text" class="form-input" bind:value={dreamSchedule} on:input={() => dreamDirty = true} placeholder="0 3 * * *" style="width:100%">
-                        </div>
-                        <div style="flex:1;min-width:140px">
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.3rem">{$_('agents_extra.dream_timezone_label')}</div>
-                            <select class="form-select" bind:value={dreamTimezone} on:change={() => dreamDirty = true} style="width:100%">
-                                <option value="America/Los_Angeles">Pacific (LA)</option>
-                                <option value="America/Denver">Mountain (Denver)</option>
-                                <option value="America/Chicago">Central (Chicago)</option>
-                                <option value="America/New_York">Eastern (NYC)</option>
-                                <option value="Europe/London">London</option>
-                                <option value="Europe/Berlin">Berlin</option>
-                                <option value="Europe/Moscow">Moscow</option>
-                                <option value="Asia/Tokyo">Tokyo</option>
-                                <option value="Asia/Shanghai">Shanghai</option>
-                                <option value="Australia/Sydney">Sydney</option>
-                                <option value="UTC">UTC</option>
-                            </select>
-                        </div>
-                        <div style="flex:1;min-width:140px">
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.3rem">{$_('agents_extra.dream_model_label')}</div>
+                        </FormField>
+                        <FormField label={$_('agents_extra.dream_timezone_label')} style="flex:1;min-width:140px">
+                            <TimezoneSelect bind:value={dreamTimezone} on:change={() => dreamDirty = true} style="width:100%" />
+                        </FormField>
+                        <FormField label={$_('agents_extra.dream_model_label')} style="flex:1;min-width:140px">
                             <select class="form-select" bind:value={dreamModel} on:change={() => dreamDirty = true} style="width:100%">
                                 <option value="">{$_('agents_extra.dream_model_default')}</option>
                                 <option value="opus">Opus</option>
                                 <option value="sonnet">Sonnet</option>
                                 <option value="haiku">Haiku</option>
                             </select>
-                        </div>
+                        </FormField>
                     </div>
                     {/if}
                 </div>

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -1454,9 +1454,9 @@
                 {:else}
                     {#each tokens as t}
                         <div class="token-item">
-                            <span class="badge badge-model">{t.platform}</span>
-                            <span class="badge badge-{t.token_set ? 'on' : 'off'}">{t.token_set ? $_('agents.token_set') : $_('agents.token_missing')}</span>
-                            <span class="badge badge-{t.enabled ? 'on' : 'off'}">{t.enabled ? $_('common.enabled') : $_('common.disabled')}</span>
+                            <StatusBadge variant="model" label={t.platform} />
+                            <StatusBadge status={t.token_set ? 'on' : 'off'} label={t.token_set ? $_('agents.token_set') : $_('agents.token_missing')} />
+                            <StatusBadge status={t.enabled ? 'on' : 'off'} label={t.enabled ? $_('common.enabled') : $_('common.disabled')} />
                             <span style="flex:1"></span>
                             <button class="btn btn-sm btn-danger" on:click={() => removeToken(t.platform)}>{$_('agents_extra.bot_token_remove')}</button>
                         </div>
@@ -1831,7 +1831,7 @@
                             <span class="badge" style="{sourceStyle};font-size:0.6rem">{srv.source}</span>
                             <span class="badge badge-model" style="font-size:0.6rem">{srv.server_type || 'stdio'}</span>
                             {#if srv.source === 'custom'}
-                                <span class="badge badge-{srv.enabled ? 'on' : 'off'}">{srv.enabled ? $_('common.enabled') : $_('common.disabled')}</span>
+                                <StatusBadge status={srv.enabled ? 'on' : 'off'} label={srv.enabled ? $_('common.enabled') : $_('common.disabled')} />
                             {/if}
                             <span style="flex:1"></span>
                             {#if srv.source === 'custom'}
@@ -1856,7 +1856,7 @@
                         <div class="token-item">
                             <span class="badge badge-{t.trigger_type === 'webhook' ? 'model' : t.trigger_type === 'url' ? 'running' : 'off'}">{t.trigger_type}</span>
                             <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:600;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{t.name || t.trigger_type}</span>
-                            <span class="badge badge-{t.enabled ? 'on' : 'off'}">{t.enabled ? $_('common.on') : $_('common.off')}</span>
+                            <StatusBadge status={t.enabled ? 'on' : 'off'} label={t.enabled ? $_('common.on') : $_('common.off')} />
                             {#if t.fire_count > 0}
                                 <span style="font-family:var(--font-body);font-size:0.7rem;color:var(--text-muted)">{t.fire_count}× fired</span>
                             {/if}
@@ -1906,7 +1906,7 @@
                     {#each streamingSessions as ss}
                         <div class="token-item">
                             <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700">{ss.label}</span>
-                            <span class="badge badge-{ss.connected ? 'on' : 'off'}">{ss.connected ? $_('agents.connected') : $_('agents.disconnected')}</span>
+                            <StatusBadge status={ss.connected ? 'on' : 'off'} label={ss.connected ? $_('agents.connected') : $_('agents.disconnected')} />
                             {#if ss.stats?.pending_responses > 0}<span class="badge" style="background:#fef3c7;color:#92400e">{ss.stats.pending_responses} pending</span>{/if}
                             <span style="flex:1"></span>
                             {#if ss.label !== 'main'}<button class="btn btn-sm btn-danger" on:click={() => deleteStreamingSession(ss.label)}>X</button>{/if}

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -2,6 +2,11 @@
     import { onMount, onDestroy } from 'svelte';
     import { _ } from 'svelte-i18n';
     import Modal from '../components/Modal.svelte';
+    import TabBar from '../components/TabBar.svelte';
+    import SectionHeader from '../components/SectionHeader.svelte';
+    import StatusBadge from '../components/StatusBadge.svelte';
+    import ProviderConfig from '../components/ProviderConfig.svelte';
+    import FormField from '../components/FormField.svelte';
     import { api } from '../lib/api.js';
     import { toast } from '../lib/stores.js';
     import { timeAgo, contextClass } from '../lib/utils.js';
@@ -555,47 +560,7 @@
         dreamDirty = false;
         toast('Dream config saved');
     }
-    function applyProviderPreset(preset) {
-        providerPreset = preset;
-        providerRef = ''; // switching to agent-specific config clears global ref
-        if (preset === 'anthropic') {
-            providerUrl = '';
-            providerKey = '';
-            providerModel = '';
-        } else if (preset === 'ollama') {
-            providerUrl = 'http://localhost:11434';
-            providerKey = 'ollama';
-        } else if (preset === 'zai') {
-            providerUrl = 'https://api.z.ai/api/anthropic';
-            providerKey = '';
-            providerModel = 'glm-5.1';
-        } else if (preset === 'openrouter') {
-            providerUrl = 'https://openrouter.ai/api';
-            providerKey = '';
-            providerModel = 'anthropic/claude-sonnet-4-5';
-        } else if (preset === 'deepseek') {
-            providerUrl = 'https://api.deepseek.com/anthropic';
-            providerKey = '';
-            providerModel = 'deepseek-chat';
-        } else if (preset === 'codex_cli') {
-            providerUrl = 'codex_cli';
-            providerKey = '';  // Uses OPENAI_API_KEY env var by default
-            providerModel = '';  // Uses codex default model
-        }
-        providerDirty = true;
-    }
-
-    function selectGlobalProvider(id) {
-        providerRef = id;
-        if (id) {
-            // Clear agent-specific fields — they become inactive when ref is set
-            providerUrl = '';
-            providerKey = '';
-            providerModel = '';
-            providerPreset = 'anthropic';
-        }
-        providerDirty = true;
-    }
+    // Provider preset/selection logic moved to ProviderConfig component
     async function saveProvider() {
         await api('PUT', `/agents/${currentAgent}/provider`, {
             provider_url: providerUrl,
@@ -1470,9 +1435,7 @@
             <!-- Connections: Bot Tokens, Users (approved + pending), Group Chats -->
 
             <!-- Bot Tokens -->
-            <div class="detail-section-header">
-                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">{$_('agents.bot_tokens')}</span>
-            </div>
+            <SectionHeader title={$_('agents.bot_tokens')} variant="detail" />
             <div style="padding:0.75rem 1.5rem;background:var(--surface-2);border-radius:var(--radius-lg);margin-top:0.5rem">
                 <div style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap">
                     <select class="form-select" bind:value={tokenPlatform}>
@@ -1501,10 +1464,11 @@
             </div>
 
             <!-- Users (approved + pending merged) -->
-            <div class="detail-section-header" style="margin-top:0.5rem">
-                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">{$_('agents.users')}</span>
-                {#if pendingUserCount > 0}<span class="badge" style="background:#fef3c7;color:#92400e;margin-left:0.5rem">{$_('agents.pending_count', { values: { count: pendingUserCount } })}</span>{/if}
-            </div>
+            <SectionHeader title={$_('agents.users')} variant="detail" style="margin-top:0.5rem">
+                <svelte:fragment slot="actions">
+                    {#if pendingUserCount > 0}<span class="badge" style="background:#fef3c7;color:#92400e">{$_('agents.pending_count', { values: { count: pendingUserCount } })}</span>{/if}
+                </svelte:fragment>
+            </SectionHeader>
             <div style="padding:0.75rem 1.5rem;background:var(--surface-2);border-radius:var(--radius-lg);margin-top:0.5rem">
                 <div style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap">
                     <input type="text" class="form-input" bind:value={newUserChatId} placeholder={$_('agents.chat_id')} style="width:130px">
@@ -1571,10 +1535,9 @@
 
             <!-- Group Chats -->
             {#if groupChats.length > 0}
-            <div class="detail-section-header" style="margin-top:0.5rem">
-                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">{$_('agents.group_chats')}</span>
-                <span class="badge" style="margin-left:0.5rem">{groupChats.length}</span>
-            </div>
+            <SectionHeader title={$_('agents.group_chats')} variant="detail" style="margin-top:0.5rem">
+                <span slot="actions" class="badge">{groupChats.length}</span>
+            </SectionHeader>
             <div>
                 {#each groupChats as gc}
                     <div class="token-item">
@@ -1601,118 +1564,33 @@
 
             {#if activeTab === 'model'}
             <!-- Model Provider -->
-            <div class="detail-section-header">
-                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">{$_('agents.model_provider')}</span>
-                {#if providerDirty}<button class="btn btn-sm btn-primary" on:click={saveProvider}>{$_('common.save')}</button>{/if}
-            </div>
-            <div style="padding:1rem 1.5rem;background:var(--surface-2);border-radius:var(--radius-lg);margin-top:0.5rem">
-                {#if globalProviders.length > 0}
-                <div style="margin-bottom:0.75rem">
-                    <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.global_provider_label')}</div>
-                    <select class="form-select" value={providerRef} on:change={(e) => selectGlobalProvider(e.target.value)} style="width:100%;max-width:320px">
-                        <option value="">{$_('agents_extra.global_provider_none')}</option>
-                        {#each globalProviders as gp}
-                            <option value={gp.id}>{gp.name}{gp.provider_model ? ' · ' + gp.provider_model : ''}</option>
-                        {/each}
-                    </select>
-                </div>
-                {/if}
-                <div style="{providerRef ? 'opacity:0.4;pointer-events:none' : ''}">
-                    <div style="display:flex;gap:0.4rem;margin-top:0;flex-wrap:wrap">
-                        <button class="btn btn-sm" class:btn-primary={providerPreset === 'anthropic'} style={providerPreset !== 'anthropic' ? 'background:var(--surface-3);color:var(--text-muted)' : ''} on:click={() => applyProviderPreset('anthropic')}>{$_('agents_extra.provider_preset_anthropic')}</button>
-                        <button class="btn btn-sm" class:btn-primary={providerPreset === 'ollama'} style={providerPreset !== 'ollama' ? 'background:var(--surface-3);color:var(--text-muted)' : ''} on:click={() => applyProviderPreset('ollama')}>{$_('agents_extra.provider_preset_ollama')}</button>
-                        <button class="btn btn-sm" class:btn-primary={providerPreset === 'openrouter'} style={providerPreset !== 'openrouter' ? 'background:var(--surface-3);color:var(--text-muted)' : ''} on:click={() => applyProviderPreset('openrouter')}>{$_('agents_extra.provider_preset_openrouter')}</button>
-                        <button class="btn btn-sm" class:btn-primary={providerPreset === 'deepseek'} style={providerPreset !== 'deepseek' ? 'background:var(--surface-3);color:var(--text-muted)' : ''} on:click={() => applyProviderPreset('deepseek')}>{$_('agents_extra.provider_preset_deepseek')}</button>
-                        <button class="btn btn-sm" class:btn-primary={providerPreset === 'zai'} style={providerPreset !== 'zai' ? 'background:var(--surface-3);color:var(--text-muted)' : ''} on:click={() => applyProviderPreset('zai')}>{$_('agents_extra.provider_preset_zai')}</button>
-                        <button class="btn btn-sm" class:btn-primary={providerPreset === 'codex_cli'} style={providerPreset !== 'codex_cli' ? 'background:var(--surface-3);color:var(--text-muted)' : ''} on:click={() => applyProviderPreset('codex_cli')}>{$_('agents_extra.provider_preset_codex_cli')}</button>
-                        <button class="btn btn-sm" class:btn-primary={providerPreset === 'custom'} style={providerPreset !== 'custom' ? 'background:var(--surface-3);color:var(--text-muted)' : ''} on:click={() => { providerPreset = 'custom'; providerRef = ''; providerDirty = true; }}>{$_('agents_extra.provider_preset_custom')}</button>
-                    </div>
-                    {#if providerPreset === 'openrouter'}
-                    <div style="margin-top:0.75rem;padding:0.6rem 0.75rem;background:var(--surface-1);border-radius:var(--radius-md);font-size:0.78rem;color:var(--text-muted)">
-                        {$_('agents_extra.openrouter_desc')}
-                    </div>
-                    <div style="display:flex;flex-direction:column;gap:0.5rem;margin-top:0.75rem">
-                        <div>
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.openrouter_api_key_label')}</div>
-                            <input type="password" class="form-input" bind:value={providerKey} on:input={() => providerDirty = true} placeholder="sk-or-..." style="width:100%">
-                        </div>
-                        <div>
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.openrouter_model_label')}</div>
-                            <input type="text" class="form-input" bind:value={providerModel} on:input={() => providerDirty = true} placeholder="anthropic/claude-sonnet-4-5" style="width:100%">
-                            <div style="font-size:0.72rem;color:var(--text-muted);margin-top:0.25rem">{$_('agents_extra.openrouter_model_examples')}</div>
-                        </div>
-                    </div>
-                    {/if}
-                    {#if providerPreset === 'codex_cli'}
-                    <div style="margin-top:0.75rem;padding:0.6rem 0.75rem;background:var(--surface-1);border-radius:var(--radius-md);font-size:0.78rem;color:var(--text-muted)">
-                        {$_('agents_extra.codex_cli_desc')}
-                    </div>
-                    <div style="display:flex;flex-direction:column;gap:0.5rem;margin-top:0.75rem">
-                        <div>
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.model_label')}</div>
-                            <input type="text" class="form-input" bind:value={providerModel} on:input={() => providerDirty = true} placeholder="gpt-5.4 (default)" style="width:100%">
-                            <div style="font-size:0.72rem;color:var(--text-muted);margin-top:0.25rem">{$_('agents_extra.codex_cli_model_options')}</div>
-                        </div>
-                    </div>
-                    {/if}
-                    {#if providerPreset === 'deepseek'}
-                    <div style="margin-top:0.75rem;padding:0.6rem 0.75rem;background:var(--surface-1);border-radius:var(--radius-md);font-size:0.78rem;color:var(--text-muted)">
-                        {$_('agents_extra.deepseek_desc')}
-                    </div>
-                    <div style="display:flex;flex-direction:column;gap:0.5rem;margin-top:0.75rem">
-                        <div>
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.api_key_label')}</div>
-                            <input type="password" class="form-input" bind:value={providerKey} on:input={() => providerDirty = true} placeholder={$_('agents_extra.deepseek_api_key_placeholder')} style="width:100%">
-                        </div>
-                        <div>
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.model_label')}</div>
-                            <input type="text" class="form-input" bind:value={providerModel} on:input={() => providerDirty = true} placeholder="deepseek-chat" style="width:100%">
-                            <div style="font-size:0.72rem;color:var(--text-muted);margin-top:0.25rem">{$_('agents_extra.deepseek_model_options')}</div>
-                        </div>
-                    </div>
-                    {/if}
-                    {#if providerPreset === 'zai'}
-                    <div style="margin-top:0.75rem;padding:0.6rem 0.75rem;background:var(--surface-1);border-radius:var(--radius-md);font-size:0.78rem;color:var(--text-muted)">
-                        {$_('agents_extra.zai_desc')}
-                    </div>
-                    <div style="display:flex;flex-direction:column;gap:0.5rem;margin-top:0.75rem">
-                        <div>
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.api_key_label')}</div>
-                            <input type="password" class="form-input" bind:value={providerKey} on:input={() => providerDirty = true} placeholder={$_('agents_extra.zai_api_key_placeholder')} style="width:100%">
-                        </div>
-                        <div>
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.model_label')}</div>
-                            <input type="text" class="form-input" bind:value={providerModel} on:input={() => providerDirty = true} placeholder="glm-5.1" style="width:100%">
-                            <div style="font-size:0.72rem;color:var(--text-muted);margin-top:0.25rem">{$_('agents_extra.zai_model_options')}</div>
-                        </div>
-                    </div>
-                    {/if}
-                    {#if providerPreset === 'ollama' || providerPreset === 'custom'}
-                    <div style="display:flex;flex-direction:column;gap:0.5rem;margin-top:0.75rem">
-                        <div>
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.base_url_label')}</div>
-                            <input type="text" class="form-input" bind:value={providerUrl} on:input={() => providerDirty = true} placeholder="http://localhost:11434" style="width:100%">
-                        </div>
-                        <div>
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.api_key_label')}</div>
-                            <input type="password" class="form-input" bind:value={providerKey} on:input={() => providerDirty = true} placeholder="ollama or your key" style="width:100%">
-                        </div>
-                        <div>
-                            <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('agents_extra.model_override_label')}</div>
-                            <input type="text" class="form-input" bind:value={providerModel} on:input={() => providerDirty = true} placeholder={$_('agents_extra.model_override_placeholder')} style="width:100%">
-                        </div>
-                    </div>
-                    {/if}
-                </div>
+            <SectionHeader title={$_('agents.model_provider')} variant="detail">
+                <svelte:fragment slot="actions">
+                    {#if providerDirty}<button class="btn btn-sm btn-primary" on:click={saveProvider}>{$_('common.save')}</button>{/if}
+                </svelte:fragment>
+            </SectionHeader>
+            <div style="margin-top:0.5rem">
+                <ProviderConfig
+                    mode="agent"
+                    bind:providerUrl
+                    bind:providerKey
+                    bind:providerModel
+                    bind:providerPreset
+                    bind:providerRef
+                    bind:dirty={providerDirty}
+                    {globalProviders}
+                    on:change={() => providerDirty = true}
+                />
             </div>
             {/if}<!-- end model tab -->
 
             {#if activeTab === 'behavior'}
             <!-- Voice Config -->
-            <div class="detail-section-header">
-                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">{$_('agents.voice')}</span>
-                {#if voiceDirty}<button class="btn btn-sm btn-primary" on:click={saveVoiceConfig}>{$_('common.save')}</button>{/if}
-            </div>
+            <SectionHeader title={$_('agents.voice')} variant="detail">
+                <svelte:fragment slot="actions">
+                    {#if voiceDirty}<button class="btn btn-sm btn-primary" on:click={saveVoiceConfig}>{$_('common.save')}</button>{/if}
+                </svelte:fragment>
+            </SectionHeader>
             <div style="padding:1rem 1.5rem;background:var(--surface-2);border-radius:var(--radius-lg);margin-top:0.5rem">
                 <div style="margin-top:0;display:flex;flex-direction:column;gap:0.8rem">
                     <label style="display:flex;align-items:center;gap:0.5rem;font-family:var(--font-grotesk);font-size:0.8rem;cursor:pointer">
@@ -1801,10 +1679,11 @@
             </div>
 
             <!-- Dreaming Config -->
-            <div class="detail-section-header" style="margin-top:0.5rem">
-                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">{$_('agents.dreaming')}</span>
-                {#if dreamDirty}<button class="btn btn-sm btn-primary" on:click={saveDreamConfig}>{$_('common.save')}</button>{/if}
-            </div>
+            <SectionHeader title={$_('agents.dreaming')} variant="detail" style="margin-top:0.5rem">
+                <svelte:fragment slot="actions">
+                    {#if dreamDirty}<button class="btn btn-sm btn-primary" on:click={saveDreamConfig}>{$_('common.save')}</button>{/if}
+                </svelte:fragment>
+            </SectionHeader>
             <div style="padding:1rem 1.5rem;background:var(--surface-2);border-radius:var(--radius-lg);margin-top:0.5rem">
                 <div style="display:flex;flex-direction:column;gap:0.8rem">
                     <label style="display:flex;align-items:center;gap:0.5rem;font-family:var(--font-grotesk);font-size:0.8rem;cursor:pointer">
@@ -2011,10 +1890,9 @@
             </div>
 
             <!-- Schedules / Cron Jobs -->
-            <div class="detail-section-header" style="margin-top:0.5rem">
-                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">{$_('agents.cron_jobs')}</span>
-                <button class="btn btn-sm btn-primary" on:click={() => cronModalOpen = true}>+ {$_('agents.cron_job')}</button>
-            </div>
+            <SectionHeader title={$_('agents.cron_jobs')} variant="detail" style="margin-top:0.5rem">
+                <button slot="actions" class="btn btn-sm btn-primary" on:click={() => cronModalOpen = true}>+ {$_('agents.cron_job')}</button>
+            </SectionHeader>
             <div>
                 {#if schedules.length === 0}
                     <div class="empty" style="padding:0.8rem 1.5rem;font-size:0.8rem">{$_('agents.no_schedules')}</div>
@@ -2036,10 +1914,9 @@
 
             {#if activeTab === 'runtime'}
             <!-- Live Sessions (formerly Streaming Sessions) -->
-            <div class="detail-section-header">
-                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">{$_('agents.live_sessions')}</span>
-                <button class="btn btn-sm btn-primary" on:click={createStreamingSession}>+ {$_('agents.session')}</button>
-            </div>
+            <SectionHeader title={$_('agents.live_sessions')} variant="detail">
+                <button slot="actions" class="btn btn-sm btn-primary" on:click={createStreamingSession}>+ {$_('agents.session')}</button>
+            </SectionHeader>
             <div>
                 {#if streamingSessions.length === 0}
                     <div class="empty">{$_('agents.no_live_sessions')}</div>
@@ -2057,9 +1934,7 @@
             </div>
 
             <!-- Conversations (formerly Active Sessions) -->
-            <div class="detail-section-header" style="margin-top:0.5rem">
-                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">{$_('agents.conversations')}</span>
-            </div>
+            <SectionHeader title={$_('agents.conversations')} variant="detail" style="margin-top:0.5rem" />
             <div>
                 {#if agentSessions.length === 0}
                     <div class="empty">{$_('agents.no_conversations')}</div>

--- a/frontend-svelte/src/pages/Memories.svelte
+++ b/frontend-svelte/src/pages/Memories.svelte
@@ -2,6 +2,7 @@
     import { onMount } from 'svelte';
     import { _ } from 'svelte-i18n';
     import Modal from '../components/Modal.svelte';
+    import TabBar from '../components/TabBar.svelte';
     import { api } from '../lib/api.js';
     import { toast } from '../lib/stores.js';
     import { escapeHtml } from '../lib/utils.js';
@@ -210,11 +211,7 @@
 
     <!-- Tabs -->
     {#if currentAgent}
-        <div class="tab-bar">
-            <button class="tab-btn" class:active={activeTab === 'memories'} on:click={() => switchTab('memories')}>{$_('memories.tab_memories')}</button>
-            <button class="tab-btn" class:active={activeTab === 'chat'} on:click={() => switchTab('chat')}>{$_('memories.tab_chat')}</button>
-            <button class="tab-btn" class:active={activeTab === 'dreams'} on:click={() => switchTab('dreams')}>{$_('memories.tab_dreams')}</button>
-        </div>
+        <TabBar tabs={[{id:'memories'},{id:'chat'},{id:'dreams'}]} active={activeTab} i18nPrefix="memories.tab_" on:change={(e) => switchTab(e.detail)} />
     {/if}
 
     <!-- Search bar (context-aware) -->

--- a/frontend-svelte/src/pages/Settings.svelte
+++ b/frontend-svelte/src/pages/Settings.svelte
@@ -66,6 +66,13 @@
     let ownerCommStyle = '';
     let ownerRole = '';
     let ownerLocale = '';
+    let ownerProfileDirty = false;
+    let ownerProfileSnapshot = {};
+
+    function markOwnerDirty() {
+        const current = JSON.stringify({ ownerName, ownerPronouns, ownerTimezone, ownerLanguages, ownerCommStyle, ownerRole, ownerLocale });
+        ownerProfileDirty = current !== JSON.stringify(ownerProfileSnapshot);
+    }
 
     // Heartbeat/Wake settings
     let heartbeatSettings = [];
@@ -324,6 +331,8 @@
             ownerCommStyle = data.comm_style || '';
             ownerRole = data.role || '';
             ownerLocale = data.locale || '';
+            ownerProfileSnapshot = { ownerName, ownerPronouns, ownerTimezone, ownerLanguages, ownerCommStyle, ownerRole, ownerLocale };
+            ownerProfileDirty = false;
         } catch { /* endpoint may not exist on older backends */ }
     }
     async function saveOwnerProfile() {
@@ -336,6 +345,8 @@
             role: ownerRole,
             locale: ownerLocale,
         });
+        ownerProfileSnapshot = { ownerName, ownerPronouns, ownerTimezone, ownerLanguages, ownerCommStyle, ownerRole, ownerLocale };
+        ownerProfileDirty = false;
         if (ownerLocale) {
             const { setLocale } = await import('../lib/i18n.js');
             await setLocale(ownerLocale);
@@ -683,19 +694,19 @@
                 <div>
                     <div style="font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em">{$_('settings.ui_password_source')}</div>
                     <div style="margin-top:0.35rem">
-                        <span class="badge badge-{uiAuthStatus.password_source === 'unset' ? 'off' : 'on'}">{uiAuthStatus.password_source || 'loading'}</span>
+                        <StatusBadge status={uiAuthStatus.password_source === 'unset' ? 'off' : 'on'} label={uiAuthStatus.password_source || 'loading'} />
                     </div>
                 </div>
                 <div>
                     <div style="font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em">{$_('settings.ui_session_secret')}</div>
                     <div style="margin-top:0.35rem">
-                        <span class="badge badge-{uiAuthStatus.session_secret_configured ? 'on' : 'off'}">{uiAuthStatus.session_secret_configured ? $_('settings.ui_configured') : $_('settings.ui_missing')}</span>
+                        <StatusBadge status={uiAuthStatus.session_secret_configured ? 'on' : 'off'} label={uiAuthStatus.session_secret_configured ? $_('settings.ui_configured') : $_('settings.ui_missing')} />
                     </div>
                 </div>
                 <div>
                     <div style="font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em">{$_('settings.ui_setup_label')}</div>
                     <div style="margin-top:0.35rem">
-                        <span class="badge badge-{uiAuthStatus.setup_required ? 'off' : 'on'}">{uiAuthStatus.setup_required ? $_('settings.ui_required') : $_('settings.ui_complete')}</span>
+                        <StatusBadge status={uiAuthStatus.setup_required ? 'off' : 'on'} label={uiAuthStatus.setup_required ? $_('settings.ui_required') : $_('settings.ui_complete')} />
                     </div>
                 </div>
                 <div>
@@ -859,7 +870,7 @@
                         {#each Object.entries(apiKeys) as [name, info]}
                             <tr>
                                 <td class="mono">{name.replace('_API_KEY', '')}</td>
-                                <td><span class="badge badge-{info.configured ? 'on' : 'off'}">{info.configured ? $_('settings.configured') : $_('settings.not_set')}</span></td>
+                                <td><StatusBadge status={info.configured ? 'on' : 'off'} label={info.configured ? $_('settings.configured') : $_('settings.not_set')} /></td>
                                 <td style="font-size:0.8rem;color:var(--gray-mid)">{info.source}</td>
                                 <td class="mono" style="font-size:0.75rem">{info.preview || '--'}</td>
                                 <td>
@@ -1139,12 +1150,12 @@
                         {#each skills as s}
                             <tr style={!s.enabled ? 'opacity:0.5' : ''}>
                                 <td class="mono" style="font-weight:600">{s.name}</td>
-                                <td><span class="badge badge-model">{s.skill_type}</span></td>
+                                <td><StatusBadge variant="model" label={s.skill_type} /></td>
                                 <td><span class="badge" style="background:var(--gray-mid);color:#fff">{s.category}</span></td>
-                                <td><span class="badge badge-{s.shared ? 'on' : 'off'}">{s.shared ? $_('settings.skill_yes') : $_('settings.skill_no')}</span></td>
-                                <td><span class="badge badge-{s.self_assignable ? 'on' : 'off'}">{s.self_assignable ? $_('settings.skill_yes') : $_('settings.skill_no')}</span></td>
+                                <td><StatusBadge status={s.shared ? 'on' : 'off'} label={s.shared ? $_('settings.skill_yes') : $_('settings.skill_no')} /></td>
+                                <td><StatusBadge status={s.self_assignable ? 'on' : 'off'} label={s.self_assignable ? $_('settings.skill_yes') : $_('settings.skill_no')} /></td>
                                 <td style="font-size:0.75rem;font-family:var(--font-grotesk);max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{(s.tool_patterns || []).join(', ') || '--'}</td>
-                                <td><span class="badge badge-{s.enabled ? 'on' : 'off'}">{s.enabled ? $_('settings.skill_enabled') : $_('settings.skill_off')}</span></td>
+                                <td><StatusBadge status={s.enabled ? 'on' : 'off'} label={s.enabled ? $_('settings.skill_enabled') : $_('settings.skill_off')} /></td>
                                 <td>
                                     <div style="display:flex;gap:0.3rem">
                                         <button class="btn btn-sm" on:click={() => toggleSkill(s.name, !s.enabled)}>{s.enabled ? $_('common.disable') : $_('common.enable')}</button>
@@ -1298,30 +1309,34 @@
     <!-- Owner Profile -->
     {#if activeTab === 'system'}
     <div class="section">
-        <SectionHeader i18nKey="settings.owner_profile" onRefresh={loadOwnerProfile} />
+        <SectionHeader i18nKey="settings.owner_profile" onRefresh={loadOwnerProfile}>
+            <svelte:fragment slot="actions">
+                {#if ownerProfileDirty}<span class="badge badge-model" style="font-size:0.65rem">unsaved</span>{/if}
+            </svelte:fragment>
+        </SectionHeader>
         <div style="padding:1.5rem;background:var(--gray-light)">
             <p style="margin:0 0 0.8rem 0;font-size:0.85rem;color:var(--gray-mid)">{$_('settings.owner_profile_desc')}</p>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.8rem;margin-bottom:0.8rem">
                 <FormField label={$_('settings.owner_name_label')}>
-                    <input type="text" class="form-input" bind:value={ownerName} placeholder={$_('settings.owner_name_placeholder')} style="width:100%">
+                    <input type="text" class="form-input" bind:value={ownerName} on:input={markOwnerDirty} placeholder={$_('settings.owner_name_placeholder')} style="width:100%">
                 </FormField>
                 <FormField label={$_('settings.owner_pronouns_label')}>
-                    <input type="text" class="form-input" bind:value={ownerPronouns} placeholder={$_('settings.owner_pronouns_placeholder')} style="width:100%">
+                    <input type="text" class="form-input" bind:value={ownerPronouns} on:input={markOwnerDirty} placeholder={$_('settings.owner_pronouns_placeholder')} style="width:100%">
                 </FormField>
                 <FormField label={$_('settings.owner_timezone_label')}>
-                    <input type="text" class="form-input" bind:value={ownerTimezone} placeholder={$_('settings.owner_timezone_placeholder')} style="width:100%">
+                    <input type="text" class="form-input" bind:value={ownerTimezone} on:input={markOwnerDirty} placeholder={$_('settings.owner_timezone_placeholder')} style="width:100%">
                 </FormField>
                 <FormField label={$_('settings.owner_role_label')}>
-                    <input type="text" class="form-input" bind:value={ownerRole} placeholder={$_('settings.owner_role_placeholder')} style="width:100%">
+                    <input type="text" class="form-input" bind:value={ownerRole} on:input={markOwnerDirty} placeholder={$_('settings.owner_role_placeholder')} style="width:100%">
                 </FormField>
                 <FormField label={$_('settings.owner_languages_label')}>
-                    <input type="text" class="form-input" bind:value={ownerLanguages} placeholder={$_('settings.owner_languages_placeholder')} style="width:100%">
+                    <input type="text" class="form-input" bind:value={ownerLanguages} on:input={markOwnerDirty} placeholder={$_('settings.owner_languages_placeholder')} style="width:100%">
                 </FormField>
                 <FormField label={$_('settings.owner_comm_style_label')}>
-                    <input type="text" class="form-input" bind:value={ownerCommStyle} placeholder={$_('settings.owner_comm_style_placeholder')} style="width:100%">
+                    <input type="text" class="form-input" bind:value={ownerCommStyle} on:input={markOwnerDirty} placeholder={$_('settings.owner_comm_style_placeholder')} style="width:100%">
                 </FormField>
                 <FormField label={$_('settings.owner_ui_language_label')}>
-                    <select class="form-input" bind:value={ownerLocale} style="width:100%">
+                    <select class="form-input" bind:value={ownerLocale} on:change={markOwnerDirty} style="width:100%">
                         <option value="">{$_('settings.owner_ui_language_default')}</option>
                         {#each SUPPORTED_LOCALES as loc}
                             <option value={loc.code}>{loc.label}</option>
@@ -1329,7 +1344,7 @@
                     </select>
                 </FormField>
             </div>
-            <button class="btn btn-primary" on:click={saveOwnerProfile}>{$_('settings.save_profile')}</button>
+            <button class="btn btn-primary" on:click={saveOwnerProfile} disabled={!ownerProfileDirty}>{$_('settings.save_profile')}</button>
         </div>
     </div>
 
@@ -1384,9 +1399,9 @@
                         {#each allTokens as t}
                             <tr>
                                 <td class="mono">{t.agent_name}</td>
-                                <td><span class="badge badge-model">{t.platform}</span></td>
-                                <td><span class="badge badge-{t.token_set ? 'on' : 'off'}">{t.token_set ? $_('settings.tokens_set') : $_('settings.tokens_missing')}</span></td>
-                                <td><span class="badge badge-{t.enabled ? 'on' : 'off'}">{t.enabled ? $_('settings.tokens_enabled') : $_('settings.tokens_disabled')}</span></td>
+                                <td><StatusBadge variant="model" label={t.platform} /></td>
+                                <td><StatusBadge status={t.token_set ? 'on' : 'off'} label={t.token_set ? $_('settings.tokens_set') : $_('settings.tokens_missing')} /></td>
+                                <td><StatusBadge status={t.enabled ? 'on' : 'off'} label={t.enabled ? $_('settings.tokens_enabled') : $_('settings.tokens_disabled')} /></td>
                                 <td>
                                     <button class="btn btn-sm btn-danger" on:click={async () => { if (!confirm(`Remove ${t.platform} token from ${t.agent_name}?`)) return; await api('DELETE', `/agents/${t.agent_name}/tokens/${t.platform}`); toast('Token removed'); loadAllTokens(); }}>{$_('settings.tokens_remove')}</button>
                                 </td>
@@ -1563,10 +1578,10 @@
                         {#each providers as p}
                             <tr>
                                 <td style="font-weight:600;font-family:var(--font-grotesk)">{p.name}</td>
-                                <td><span class="badge badge-model">{p.preset || 'custom'}</span></td>
+                                <td><StatusBadge variant="model" label={p.preset || 'custom'} /></td>
                                 <td style="font-size:0.75rem;font-family:var(--font-grotesk);max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title={p.provider_url}>{p.provider_url || '—'}</td>
                                 <td style="font-size:0.75rem;font-family:var(--font-grotesk)">{p.provider_model || '—'}</td>
-                                <td><span class="badge badge-{p.provider_key ? 'on' : 'off'}">{p.provider_key ? $_('settings.prov_key_set') : $_('settings.prov_key_none')}</span></td>
+                                <td><StatusBadge status={p.provider_key ? 'on' : 'off'} label={p.provider_key ? $_('settings.prov_key_set') : $_('settings.prov_key_none')} /></td>
                                 <td>
                                     <div style="display:flex;gap:0.3rem">
                                         <button class="btn btn-sm" on:click={() => openEditProvider(p)}>{$_('common.edit')}</button>

--- a/frontend-svelte/src/pages/Settings.svelte
+++ b/frontend-svelte/src/pages/Settings.svelte
@@ -1302,39 +1302,32 @@
         <div style="padding:1.5rem;background:var(--gray-light)">
             <p style="margin:0 0 0.8rem 0;font-size:0.85rem;color:var(--gray-mid)">{$_('settings.owner_profile_desc')}</p>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.8rem;margin-bottom:0.8rem">
-                <div>
-                    <label style="display:block;font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em;margin-bottom:0.3rem">{$_('settings.owner_name_label')}</label>
+                <FormField label={$_('settings.owner_name_label')}>
                     <input type="text" class="form-input" bind:value={ownerName} placeholder={$_('settings.owner_name_placeholder')} style="width:100%">
-                </div>
-                <div>
-                    <label style="display:block;font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em;margin-bottom:0.3rem">{$_('settings.owner_pronouns_label')}</label>
+                </FormField>
+                <FormField label={$_('settings.owner_pronouns_label')}>
                     <input type="text" class="form-input" bind:value={ownerPronouns} placeholder={$_('settings.owner_pronouns_placeholder')} style="width:100%">
-                </div>
-                <div>
-                    <label style="display:block;font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em;margin-bottom:0.3rem">{$_('settings.owner_timezone_label')}</label>
+                </FormField>
+                <FormField label={$_('settings.owner_timezone_label')}>
                     <input type="text" class="form-input" bind:value={ownerTimezone} placeholder={$_('settings.owner_timezone_placeholder')} style="width:100%">
-                </div>
-                <div>
-                    <label style="display:block;font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em;margin-bottom:0.3rem">{$_('settings.owner_role_label')}</label>
+                </FormField>
+                <FormField label={$_('settings.owner_role_label')}>
                     <input type="text" class="form-input" bind:value={ownerRole} placeholder={$_('settings.owner_role_placeholder')} style="width:100%">
-                </div>
-                <div>
-                    <label style="display:block;font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em;margin-bottom:0.3rem">{$_('settings.owner_languages_label')}</label>
+                </FormField>
+                <FormField label={$_('settings.owner_languages_label')}>
                     <input type="text" class="form-input" bind:value={ownerLanguages} placeholder={$_('settings.owner_languages_placeholder')} style="width:100%">
-                </div>
-                <div>
-                    <label style="display:block;font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em;margin-bottom:0.3rem">{$_('settings.owner_comm_style_label')}</label>
+                </FormField>
+                <FormField label={$_('settings.owner_comm_style_label')}>
                     <input type="text" class="form-input" bind:value={ownerCommStyle} placeholder={$_('settings.owner_comm_style_placeholder')} style="width:100%">
-                </div>
-                <div>
-                    <label style="display:block;font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em;margin-bottom:0.3rem">{$_('settings.owner_ui_language_label')}</label>
+                </FormField>
+                <FormField label={$_('settings.owner_ui_language_label')}>
                     <select class="form-input" bind:value={ownerLocale} style="width:100%">
                         <option value="">{$_('settings.owner_ui_language_default')}</option>
                         {#each SUPPORTED_LOCALES as loc}
                             <option value={loc.code}>{loc.label}</option>
                         {/each}
                     </select>
-                </div>
+                </FormField>
             </div>
             <button class="btn btn-primary" on:click={saveOwnerProfile}>{$_('settings.save_profile')}</button>
         </div>

--- a/frontend-svelte/src/pages/Settings.svelte
+++ b/frontend-svelte/src/pages/Settings.svelte
@@ -5,6 +5,12 @@
     import { toast } from '../lib/stores.js';
     import { timeAgo } from '../lib/utils.js';
     import { SUPPORTED_LOCALES } from '../lib/i18n.js';
+    import TabBar from '../components/TabBar.svelte';
+    import SectionHeader from '../components/SectionHeader.svelte';
+    import StatusBadge from '../components/StatusBadge.svelte';
+    import TimezoneSelect from '../components/TimezoneSelect.svelte';
+    import FormField from '../components/FormField.svelte';
+    import ProviderConfig from '../components/ProviderConfig.svelte';
 
     async function rerunOnboarding() {
         await api('POST', '/system/onboarding-reset').catch((e) => { toast('Failed to reset onboarding', 'error'); });
@@ -13,14 +19,7 @@
 
     // Timezone
     let defaultTimezone = '';
-    const commonTimezones = [
-        'America/Los_Angeles', 'America/Denver', 'America/Chicago', 'America/New_York',
-        'America/Anchorage', 'Pacific/Honolulu', 'America/Phoenix',
-        'America/Toronto', 'America/Vancouver', 'America/Sao_Paulo',
-        'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Moscow',
-        'Asia/Tokyo', 'Asia/Shanghai', 'Asia/Kolkata', 'Asia/Dubai',
-        'Australia/Sydney', 'Pacific/Auckland', 'UTC',
-    ];
+    // Timezone list moved to TimezoneSelect component
 
     // Primary user
     let primaryChatId = '';
@@ -583,23 +582,8 @@
     let provFormKey = '';
     let provFormModel = '';
 
-    const PROVIDER_PRESETS = [
-        { id: 'ollama',    label: 'Ollama (local)',      url: 'http://localhost:11434', key: 'ollama', model: '' },
-        { id: 'openrouter',label: 'OpenRouter',          url: 'https://openrouter.ai/api', key: '', model: 'anthropic/claude-sonnet-4-5' },
-        { id: 'deepseek',  label: 'DeepSeek',            url: 'https://api.deepseek.com/anthropic', key: '', model: 'deepseek-chat' },
-        { id: 'zai',       label: 'Z.ai (GLM)',          url: 'https://api.z.ai/api/anthropic', key: '', model: 'glm-5.1' },
-        { id: 'custom',    label: 'Custom',              url: '', key: '', model: '' },
-    ];
-
-    function applyProvFormPreset(presetId) {
-        provFormPreset = presetId;
-        const p = PROVIDER_PRESETS.find(x => x.id === presetId);
-        if (!p || presetId === 'custom') return;
-        provFormUrl = p.url;
-        provFormKey = p.key;
-        provFormModel = p.model;
-    }
-
+    // Provider presets and helpers moved to ProviderConfig component
+    let providerConfigRef;
     function detectProvFormPreset(url) {
         if (!url) return 'custom';
         if (url === 'http://localhost:11434') return 'ollama';
@@ -690,20 +674,10 @@
 
 <div class="content">
     <!-- Tab Bar -->
-    <div class="tab-bar">
-        {#each tabs as tab}
-            <button
-                class="tab-btn {activeTab === tab.id ? 'active' : ''}"
-                on:click={() => activeTab = tab.id}
-            >{$_(`settings.tab_${tab.id}`)}</button>
-        {/each}
-    </div>
+    <TabBar {tabs} active={activeTab} i18nPrefix="settings.tab_" on:change={(e) => activeTab = e.detail} />
     {#if activeTab === 'access'}
     <div class="section">
-        <div class="section-header">
-            <div class="section-title">{$_('settings.ui_access')}</div>
-            <button class="btn btn-sm" on:click={loadUiAuthStatus}>{$_('common.refresh')}</button>
-        </div>
+        <SectionHeader i18nKey="settings.ui_access" onRefresh={loadUiAuthStatus} />
         <div style="padding:1.5rem;background:var(--surface-2);border-radius:var(--radius-lg) var(--radius-lg) 0 0">
             <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:1rem">
                 <div>
@@ -758,10 +732,7 @@
     <!-- Software Update -->
     {#if activeTab === 'system'}
     <div class="section">
-        <div class="section-header">
-            <div class="section-title">{$_('settings.software_update')}</div>
-            <button class="btn btn-sm" on:click={loadServerInfo}>{$_('common.refresh')}</button>
-        </div>
+        <SectionHeader i18nKey="settings.software_update" onRefresh={loadServerInfo} />
         <div style="padding:1.5rem;background:var(--gray-light)">
             <div style="display:flex;gap:2rem;flex-wrap:wrap;margin-bottom:1.2rem">
                 <div>
@@ -823,15 +794,11 @@
 
     <!-- Default Timezone -->
     <div class="section">
-        <div class="section-header"><div class="section-title">{$_('settings.default_timezone')}</div></div>
+        <SectionHeader i18nKey="settings.default_timezone" />
         <div style="padding:1.5rem;background:var(--gray-light)">
             <p style="margin:0 0 0.8rem 0;font-size:0.85rem;color:var(--gray-mid)">{$_('settings.timezone_desc')}</p>
             <div class="form-inline">
-                <select class="form-select" style="max-width:300px" bind:value={defaultTimezone} on:change={saveTimezone}>
-                    {#each commonTimezones as tz}
-                        <option value={tz}>{tz}</option>
-                    {/each}
-                </select>
+                <TimezoneSelect bind:value={defaultTimezone} on:change={saveTimezone} style="max-width:300px" />
                 <span style="font-family:var(--font-grotesk);font-size:0.8rem;color:var(--gray-mid)">{defaultTimezone}</span>
             </div>
         </div>
@@ -867,10 +834,7 @@
     {#if activeTab === 'account'}
     <!-- API Keys -->
     <div class="section">
-        <div class="section-header">
-            <div class="section-title">{$_('settings.api_keys')}</div>
-            <button class="btn btn-sm" on:click={loadApiKeys}>{$_('common.refresh')}</button>
-        </div>
+        <SectionHeader i18nKey="settings.api_keys" onRefresh={loadApiKeys} />
         <div style="padding:1.5rem;background:var(--surface-2);border-radius:var(--radius-lg) var(--radius-lg) 0 0">
             <p style="margin:0 0 0.8rem 0;font-size:0.85rem;color:var(--gray-mid)">{$_('settings.api_keys_desc')}</p>
             <div class="form-inline">
@@ -913,10 +877,7 @@
 
     <!-- Calendar -->
     <div class="section">
-        <div class="section-header">
-            <div class="section-title">{$_('settings.calendar')}</div>
-            <button class="btn btn-sm" on:click={() => { loadCalendarStatus(); loadCalendarAgentStatuses(); }}>{$_('common.refresh')}</button>
-        </div>
+        <SectionHeader i18nKey="settings.calendar" onRefresh={() => { loadCalendarStatus(); loadCalendarAgentStatuses(); }} />
 
         <!-- Inner tab bar -->
         <div style="padding:0.8rem 1.2rem 0;background:var(--surface-2);display:flex;gap:0.3rem;border-bottom:1px solid var(--border)">
@@ -1108,10 +1069,7 @@
     <!-- Skill Catalog -->
     {#if activeTab === 'agents'}
     <div class="section">
-        <div class="section-header">
-            <div class="section-title">{$_('settings.skill_catalog')}</div>
-            <button class="btn btn-sm" on:click={refreshSkills}>{$_('common.refresh')}</button>
-        </div>
+        <SectionHeader i18nKey="settings.skill_catalog" onRefresh={refreshSkills} />
         <div style="padding:1.5rem;background:var(--surface-2);border-radius:var(--radius-lg) var(--radius-lg) 0 0">
             <div class="form-inline" style="margin-bottom:0.8rem">
                 <input type="text" class="form-input" bind:value={skillName} placeholder={$_('settings.skill_name_placeholder')} style="max-width:200px">
@@ -1205,10 +1163,7 @@
 
     <!-- Heartbeat & Wake Settings -->
     <div class="section">
-        <div class="section-header">
-            <div class="section-title">{$_('settings.heartbeat_wake')}</div>
-            <button class="btn btn-sm" on:click={loadHeartbeatSettings}>{$_('common.refresh')}</button>
-        </div>
+        <SectionHeader i18nKey="settings.heartbeat_wake" onRefresh={loadHeartbeatSettings} />
         <div class="section-body">
             {#if heartbeatSettings.length === 0}
                 <div class="empty">{$_('settings.hb_no_agents')}</div>
@@ -1310,7 +1265,7 @@
     <!-- Primary User -->
     {#if activeTab === 'access'}
     <div class="section">
-        <div class="section-header"><div class="section-title">{$_('settings.primary_user')}</div></div>
+        <SectionHeader i18nKey="settings.primary_user" />
         <div style="padding:1.5rem;background:var(--gray-light)">
             <p style="margin:0 0 0.8rem 0;font-size:0.85rem;color:var(--gray-mid)">{$_('settings.primary_user_desc')}</p>
             <div class="form-inline">
@@ -1343,10 +1298,7 @@
     <!-- Owner Profile -->
     {#if activeTab === 'system'}
     <div class="section">
-        <div class="section-header">
-            <div class="section-title">{$_('settings.owner_profile')}</div>
-            <button class="btn btn-sm" on:click={loadOwnerProfile}>{$_('common.refresh')}</button>
-        </div>
+        <SectionHeader i18nKey="settings.owner_profile" onRefresh={loadOwnerProfile} />
         <div style="padding:1.5rem;background:var(--gray-light)">
             <p style="margin:0 0 0.8rem 0;font-size:0.85rem;color:var(--gray-mid)">{$_('settings.owner_profile_desc')}</p>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.8rem;margin-bottom:0.8rem">
@@ -1393,7 +1345,7 @@
     <!-- All Approved Users (cross-agent) -->
     {#if activeTab === 'access'}
     <div class="section">
-        <div class="section-header"><div class="section-title">{$_('settings.approved_users')}</div></div>
+        <SectionHeader i18nKey="settings.approved_users" />
         <div class="section-body">
             {#if allApprovedUsers.length === 0}
                 <div class="empty">{$_('settings.approved_no_users')}</div>
@@ -1428,7 +1380,7 @@
 
     <!-- All Bot Tokens (cross-agent) -->
     <div class="section">
-        <div class="section-header"><div class="section-title">{$_('settings.bot_tokens_all')}</div></div>
+        <SectionHeader i18nKey="settings.bot_tokens_all" />
         <div class="section-body">
             {#if allTokens.length === 0}
                 <div class="empty">{$_('settings.tokens_no_tokens')}</div>
@@ -1491,7 +1443,7 @@
 
     <!-- Setup Wizard -->
     <div class="section">
-        <div class="section-header"><div class="section-title">{$_('settings.setup_wizard')}</div></div>
+        <SectionHeader i18nKey="settings.setup_wizard" />
         <div style="padding:1.5rem;background:var(--gray-light);display:flex;align-items:center;gap:1rem;flex-wrap:wrap">
             <p style="margin:0;font-size:0.85rem;color:var(--gray-mid);flex:1">{$_('settings.setup_wizard_desc')}</p>
             <button class="btn btn-primary" on:click={rerunOnboarding}>{$_('settings.run_setup_wizard')}</button>
@@ -1504,10 +1456,7 @@
 
     <!-- Anthropic Account (top of providers tab) -->
     <div class="section">
-        <div class="section-header">
-            <div class="section-title">{$_('settings.anthropic_account')}</div>
-            <button class="btn btn-sm" on:click={loadAccountInfo}>{$_('common.refresh')}</button>
-        </div>
+        <SectionHeader i18nKey="settings.anthropic_account" onRefresh={loadAccountInfo} />
         <div style="padding:1.5rem;background:var(--gray-light)">
             <div style="display:flex;gap:2rem;flex-wrap:wrap;margin-bottom:1rem">
                 <div>
@@ -1578,50 +1527,26 @@
     </div>
 
     <div class="section" style="margin-top:0.5rem">
-        <div class="section-header">
-            <div class="section-title">{$_('settings.global_providers')}</div>
-            <button class="btn btn-sm btn-primary" on:click={openAddProvider}>+ {$_('settings.add_provider')}</button>
-        </div>
+        <SectionHeader i18nKey="settings.global_providers">
+            <button slot="actions" class="btn btn-sm btn-primary" on:click={openAddProvider}>+ {$_('settings.add_provider')}</button>
+        </SectionHeader>
 
         {#if providerFormVisible}
-        <div style="padding:1.5rem;background:var(--surface-2);border-radius:var(--radius-lg);margin-bottom:0.5rem">
-            <div style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase;margin-bottom:0.75rem">
+        <div style="margin-bottom:0.5rem">
+            <div style="padding:0.75rem 1.5rem 0;background:var(--surface-2);border-radius:var(--radius-lg) var(--radius-lg) 0 0;font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">
                 {editingProvider ? $_('settings.prov_edit_title') : $_('settings.prov_add_title')}
             </div>
-            <div style="display:flex;flex-direction:column;gap:0.6rem">
-                <div>
-                    <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('settings.prov_name_label')}</div>
-                    <input type="text" class="form-input" bind:value={provFormName} placeholder={$_('settings.prov_name_placeholder')} style="width:100%;max-width:300px">
-                </div>
-                <div>
-                    <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.35rem">{$_('settings.prov_preset_label')}</div>
-                    <div style="display:flex;gap:0.4rem;flex-wrap:wrap">
-                        {#each PROVIDER_PRESETS as preset}
-                            <button
-                                class="btn btn-sm"
-                                class:btn-primary={provFormPreset === preset.id}
-                                style={provFormPreset !== preset.id ? 'background:var(--surface-3);color:var(--text-muted)' : ''}
-                                on:click={() => applyProvFormPreset(preset.id)}
-                            >{preset.label}</button>
-                        {/each}
-                    </div>
-                </div>
-                <div>
-                    <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('settings.prov_url_label')}</div>
-                    <input type="text" class="form-input" bind:value={provFormUrl} placeholder={$_('settings.prov_url_placeholder')} style="width:100%;max-width:420px">
-                </div>
-                <div>
-                    <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('settings.prov_key_label')}</div>
-                    <input type="password" class="form-input" bind:value={provFormKey} placeholder={$_('settings.prov_key_placeholder')} style="width:100%;max-width:420px">
-                </div>
-                <div>
-                    <div style="font-family:var(--font-grotesk);font-size:0.7rem;font-weight:700;text-transform:uppercase;color:var(--gray-mid);margin-bottom:0.25rem">{$_('settings.prov_model_label')}</div>
-                    <input type="text" class="form-input" bind:value={provFormModel} placeholder={$_('settings.prov_model_placeholder')} style="width:100%;max-width:420px">
-                </div>
-                <div style="display:flex;gap:0.5rem;margin-top:0.25rem">
-                    <button class="btn btn-primary" on:click={saveProvider}>{$_('common.save')}</button>
-                    <button class="btn" on:click={cancelProviderForm}>{$_('common.cancel')}</button>
-                </div>
+            <ProviderConfig
+                mode="global"
+                bind:providerUrl={provFormUrl}
+                bind:providerKey={provFormKey}
+                bind:providerModel={provFormModel}
+                bind:providerPreset={provFormPreset}
+                bind:providerName={provFormName}
+            />
+            <div style="padding:0 1.5rem 1rem;background:var(--surface-2);border-radius:0 0 var(--radius-lg) var(--radius-lg);display:flex;gap:0.5rem">
+                <button class="btn btn-primary" on:click={saveProvider}>{$_('common.save')}</button>
+                <button class="btn" on:click={cancelProviderForm}>{$_('common.cancel')}</button>
             </div>
         </div>
         {/if}
@@ -1668,30 +1593,7 @@
 </div>
 
 <style>
-    .tab-bar {
-        display: flex;
-        gap: 0.4rem;
-        margin-bottom: 1.5rem;
-        flex-wrap: wrap;
-    }
-    .tab-btn {
-        padding: 0.4rem 1rem;
-        font-size: 0.85rem;
-        font-weight: 600;
-        font-family: var(--font-grotesk);
-        background: none;
-        border: none;
-        border-radius: 4px;
-        color: var(--text-primary, #111);
-        cursor: pointer;
-        letter-spacing: 0.02em;
-        transition: background 0.12s;
-    }
-    .tab-btn:hover { background: rgba(0,0,0,0.06); }
-    .tab-btn.active {
-        background: var(--accent, #f5c842);
-        color: #000;
-    }
+    /* Tab styles moved to TabBar component */
     .cal-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; margin-left: 4px; vertical-align: middle; }
     .cal-dot-on { background: #22c55e; }
     .form-inline { display: flex; gap: 0.8rem; align-items: center; flex-wrap: wrap; }

--- a/frontend-svelte/src/pages/Tasks.svelte
+++ b/frontend-svelte/src/pages/Tasks.svelte
@@ -2,6 +2,7 @@
     import { onMount, onDestroy } from 'svelte';
     import { _ } from 'svelte-i18n';
     import Modal from '../components/Modal.svelte';
+    import TabBar from '../components/TabBar.svelte';
     import { api } from '../lib/api.js';
     import { toast } from '../lib/stores.js';
     import { timeAgo, TASK_STATUSES } from '../lib/utils.js';
@@ -340,11 +341,7 @@
     </div>
 
     <!-- Tabs -->
-    <div class="tab-bar">
-        <button class="tab-btn" class:active={activeTab === 'board'} on:click={() => switchTab('board')}>{$_('tasks.tab_board')}</button>
-        <button class="tab-btn" class:active={activeTab === 'projects'} on:click={() => switchTab('projects')}>{$_('tasks.tab_projects')}</button>
-        <button class="tab-btn" class:active={activeTab === 'cron'} on:click={() => switchTab('cron')}>{$_('tasks.tab_cron')}</button>
-    </div>
+    <TabBar tabs={[{id:'board'},{id:'projects'},{id:'cron'}]} active={activeTab} i18nPrefix="tasks.tab_" on:change={(e) => switchTab(e.detail)} />
 
     <!-- Board Tab -->
     {#if activeTab === 'board'}


### PR DESCRIPTION
## Summary
- **Shared UI components (PRs #197, #198, #199 — closes #196):** Extracted 6 reusable components (TabBar, SectionHeader, StatusBadge, FormField, TimezoneSelect, ProviderConfig), adopted across Settings, Agents, Tasks, and Memories pages. ~400 lines deduped, -16KB bundle size. Added owner profile dirty tracking and global disabled button styling.

## Test plan
- [x] All 1329 tests passing on beta
- [ ] CI passes on this PR
- [ ] Mac Mini deploy after merge

🤖 Opened by Barsik