### PR TITLE
Promote beta → main: shared UI components + name suggestions cleanup

### DIFF
--- a/frontend-svelte/src/locales/en.json
+++ b/frontend-svelte/src/locales/en.json
@@ -1010,7 +1010,7 @@
     "session_chat_btn": "Chat",
     "wiz_name_label": "Name",
     "wiz_name_hint": "What your agent goes by.",
-    "wiz_name_placeholder": "e.g. Oleg, Rex, Barsik",
+    "wiz_name_placeholder": "Agent name",
     "wiz_id_preview": "ID: {id}",
     "wiz_pronouns_label": "Pronouns",
     "wiz_pronouns_optional": "(optional)",

--- a/frontend-svelte/src/locales/es.json
+++ b/frontend-svelte/src/locales/es.json
@@ -1010,7 +1010,7 @@
     "session_chat_btn": "Chat",
     "wiz_name_label": "Nombre",
     "wiz_name_hint": "Cómo se llamará tu agente.",
-    "wiz_name_placeholder": "p. ej. Oleg, Rex, Barsik",
+    "wiz_name_placeholder": "Nombre del agente",
     "wiz_id_preview": "ID: {id}",
     "wiz_pronouns_label": "Pronombres",
     "wiz_pronouns_optional": "(opcional)",

--- a/frontend-svelte/src/locales/ja.json
+++ b/frontend-svelte/src/locales/ja.json
@@ -1010,7 +1010,7 @@
     "session_chat_btn": "チャット",
     "wiz_name_label": "名前",
     "wiz_name_hint": "エージェントの呼び名。",
-    "wiz_name_placeholder": "例: Oleg、Rex、Barsik",
+    "wiz_name_placeholder": "エージェント名",
     "wiz_id_preview": "ID: {id}",
     "wiz_pronouns_label": "代名詞",
     "wiz_pronouns_optional": "（任意）",

--- a/frontend-svelte/src/locales/ko.json
+++ b/frontend-svelte/src/locales/ko.json
@@ -1010,7 +1010,7 @@
     "session_chat_btn": "채팅",
     "wiz_name_label": "이름",
     "wiz_name_hint": "에이전트가 불릴 이름입니다.",
-    "wiz_name_placeholder": "예: Oleg, Rex, Barsik",
+    "wiz_name_placeholder": "에이전트 이름",
     "wiz_id_preview": "ID: {id}",
     "wiz_pronouns_label": "호칭",
     "wiz_pronouns_optional": "(선택사항)",

--- a/frontend-svelte/src/locales/ru.json
+++ b/frontend-svelte/src/locales/ru.json
@@ -1010,7 +1010,7 @@
     "session_chat_btn": "Чат",
     "wiz_name_label": "Имя",
     "wiz_name_hint": "Как будет называться ваш агент.",
-    "wiz_name_placeholder": "например, Олег, Рекс, Барсик",
+    "wiz_name_placeholder": "Имя агента",
     "wiz_id_preview": "ID: {id}",
     "wiz_pronouns_label": "Местоимения",
     "wiz_pronouns_optional": "(необязательно)",

--- a/frontend-svelte/src/locales/uk.json
+++ b/frontend-svelte/src/locales/uk.json
@@ -1010,7 +1010,7 @@
     "session_chat_btn": "Чат",
     "wiz_name_label": "Ім'я",
     "wiz_name_hint": "Як звуть вашого агента.",
-    "wiz_name_placeholder": "напр. Олег, Rex, Барсік",
+    "wiz_name_placeholder": "Ім'я агента",
     "wiz_id_preview": "ID: {id}",
     "wiz_pronouns_label": "Займенники",
     "wiz_pronouns_optional": "(необов'язково)",

--- a/frontend-svelte/src/locales/zh.json
+++ b/frontend-svelte/src/locales/zh.json
@@ -1010,7 +1010,7 @@
     "session_chat_btn": "聊天",
     "wiz_name_label": "名称",
     "wiz_name_hint": "智能体的称呼。",
-    "wiz_name_placeholder": "例如 Oleg、Rex、Barsik",
+    "wiz_name_placeholder": "代理名称",
     "wiz_id_preview": "ID：{id}",
     "wiz_pronouns_label": "代词",
     "wiz_pronouns_optional": "（可选）",

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -2246,7 +2246,7 @@
                     {#if wizStep === 0}
                         <div class="wizard-label">Name</div>
                         <div class="wizard-hint">What your agent goes by.</div>
-                        <input type="text" class="wizard-input" bind:value={wizDisplayName} on:input={() => { wizName = wizDisplayName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9_-]/g, ''); }} placeholder="e.g. Oleg, Rex, Barsik">
+                        <input type="text" class="wizard-input" bind:value={wizDisplayName} on:input={() => { wizName = wizDisplayName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9_-]/g, ''); }} placeholder={$_('agents.wiz_name_placeholder')}>
                         {#if wizDisplayName}<div class="wizard-id-preview">ID: {wizName}</div>{/if}
                         <div class="wizard-label" style="margin-top:0.5rem">Pronouns <span style="color:var(--gray-mid);font-weight:400;text-transform:none">(optional)</span></div>
                         <input type="text" class="wizard-input" bind:value={wizPronouns} placeholder="e.g. he/him, she/her, they/them">

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -2246,7 +2246,7 @@
                     {#if wizStep === 0}
                         <div class="wizard-label">Name</div>
                         <div class="wizard-hint">What your agent goes by.</div>
-                        <input type="text" class="wizard-input" bind:value={wizDisplayName} on:input={() => { wizName = wizDisplayName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9_-]/g, ''); }} placeholder={$_('agents.wiz_name_placeholder')}>
+                        <input type="text" class="wizard-input" bind:value={wizDisplayName} on:input={() => { wizName = wizDisplayName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9_-]/g, ''); }} placeholder={$_('agents_extra.wiz_name_placeholder')}>
                         {#if wizDisplayName}<div class="wizard-id-preview">ID: {wizName}</div>{/if}
                         <div class="wizard-label" style="margin-top:0.5rem">Pronouns <span style="color:var(--gray-mid);font-weight:400;text-transform:none">(optional)</span></div>
                         <input type="text" class="wizard-input" bind:value={wizPronouns} placeholder="e.g. he/him, she/her, they/them">

--- a/frontend-svelte/src/pages/Onboarding.svelte
+++ b/frontend-svelte/src/pages/Onboarding.svelte
@@ -429,10 +429,10 @@
             {:else if step === 3}
                 <!-- Owner Profile -->
                 <div class="wizard-label">{$_('onboarding.display_name')}</div>
-                <input type="text" class="wizard-input" bind:value={ownerName} placeholder="e.g. Brad">
+                <input type="text" class="wizard-input" bind:value={ownerName} placeholder="Your name">
 
                 <div class="wizard-label">{$_('onboarding.pronouns')} <span style="color:var(--text-muted);font-weight:400;text-transform:none">({$_('common.optional')})</span></div>
-                <input type="text" class="wizard-input" bind:value={ownerPronouns} placeholder="e.g. he/him, she/her, they/them">
+                <input type="text" class="wizard-input" bind:value={ownerPronouns} placeholder="he/him, she/her, they/them">
 
                 <div class="wizard-label">{$_('onboarding.timezone')}</div>
                 <select class="wizard-input" bind:value={ownerTimezone}>
@@ -442,10 +442,10 @@
                 </select>
 
                 <div class="wizard-label">{$_('onboarding.languages')} <span style="color:var(--text-muted);font-weight:400;text-transform:none">({$_('common.optional')})</span></div>
-                <input type="text" class="wizard-input" bind:value={ownerLanguages} placeholder="e.g. English, Spanish">
+                <input type="text" class="wizard-input" bind:value={ownerLanguages} placeholder="English, Spanish, etc.">
 
                 <div class="wizard-label">{$_('onboarding.comm_style')} <span style="color:var(--text-muted);font-weight:400;text-transform:none">({$_('common.optional')})</span></div>
-                <input type="text" class="wizard-input" bind:value={ownerCommStyle} placeholder="e.g. direct, casual, concise">
+                <input type="text" class="wizard-input" bind:value={ownerCommStyle} placeholder="direct, casual, concise">
 
                 <button class="wizard-btn wizard-btn-primary" style="margin-top:0.5rem" on:click={() => saveProfile(true)} disabled={loading}>
                     {loading ? $_('common.saving') : $_('common.next') + ' →'}
@@ -461,7 +461,7 @@
 
                 <div class="wizard-label">{$_('tasks.name')}</div>
                 <div class="wizard-hint">{$_('onboarding.agent_name_hint')}</div>
-                <input type="text" class="wizard-input" bind:value={agentDisplayName} on:input={() => { agentName = agentDisplayName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9_-]/g, ''); }} placeholder="e.g. Oleg, Rex, Barsik" disabled={agentCreated}>
+                <input type="text" class="wizard-input" bind:value={agentDisplayName} on:input={() => { agentName = agentDisplayName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9_-]/g, ''); }} placeholder="Agent name" disabled={agentCreated}>
                 {#if agentDisplayName && agentName.length >= 2}<div class="wizard-id-preview">ID: {agentName}</div>
                 {:else if agentDisplayName && agentName.length < 2}<div class="wizard-id-preview" style="color:var(--text-error, #c44)">Name too short — need at least 2 characters</div>
                 {/if}


### PR DESCRIPTION
## Summary
- **Shared UI components (#196, PRs #197-199):** 6 reusable components (TabBar, SectionHeader, StatusBadge, FormField, TimezoneSelect, ProviderConfig), adopted across 6 pages. ~400 lines deduped, -16KB bundle. Owner profile dirty tracking + global disabled button styling.
- **Remove name suggestions (#201):** Generic placeholders in agent wizard and onboarding across all 7 locales.

## Test plan
- [x] All 1329 tests passing on beta
- [ ] CI passes
- [ ] Mac Mini deploy after merge

🤖 Opened by Barsik