### PR TITLE
Promote beta → main: default provider inheritance

### DIFF
--- a/frontend-svelte/src/locales/en.json
+++ b/frontend-svelte/src/locales/en.json
@@ -921,7 +921,9 @@
     "toast_primary_user_set": "Primary user set — auto-approved across all agents",
     "toast_ui_password_updated": "UI password updated",
     "toast_skill_registered": "Skill registered",
-    "confirm_apply_update": "Apply update and restart the daemon?"
+    "confirm_apply_update": "Apply update and restart the daemon?",
+    "default_provider": "Default provider for agents",
+    "default_provider_none": "None (Anthropic default)"
   },
   "agents_extra": {
     "file_edit_save": "Save",

--- a/frontend-svelte/src/locales/es.json
+++ b/frontend-svelte/src/locales/es.json
@@ -921,7 +921,9 @@
     "toast_primary_user_set": "Usuario principal establecido — aprobado automáticamente en todos los agentes",
     "toast_ui_password_updated": "Contraseña de interfaz actualizada",
     "toast_skill_registered": "Habilidad registrada",
-    "confirm_apply_update": "¿Aplicar la actualización y reiniciar el daemon?"
+    "confirm_apply_update": "¿Aplicar la actualización y reiniciar el daemon?",
+    "default_provider": "Default provider for agents",
+    "default_provider_none": "None (Anthropic default)"
   },
   "agents_extra": {
     "file_edit_save": "Guardar",

--- a/frontend-svelte/src/locales/es.json
+++ b/frontend-svelte/src/locales/es.json
@@ -922,8 +922,8 @@
     "toast_ui_password_updated": "Contraseña de interfaz actualizada",
     "toast_skill_registered": "Habilidad registrada",
     "confirm_apply_update": "¿Aplicar la actualización y reiniciar el daemon?",
-    "default_provider": "Default provider for agents",
-    "default_provider_none": "None (Anthropic default)"
+    "default_provider": "Proveedor predeterminado para agentes",
+    "default_provider_none": "Ninguno (Anthropic por defecto)"
   },
   "agents_extra": {
     "file_edit_save": "Guardar",

--- a/frontend-svelte/src/locales/ja.json
+++ b/frontend-svelte/src/locales/ja.json
@@ -921,7 +921,9 @@
     "toast_primary_user_set": "プライマリユーザーを設定しました — 全エージェントで自動承認されます",
     "toast_ui_password_updated": "UIパスワードを更新しました",
     "toast_skill_registered": "スキルを登録しました",
-    "confirm_apply_update": "更新を適用してデーモンを再起動しますか？"
+    "confirm_apply_update": "更新を適用してデーモンを再起動しますか？",
+    "default_provider": "Default provider for agents",
+    "default_provider_none": "None (Anthropic default)"
   },
   "agents_extra": {
     "file_edit_save": "保存",

--- a/frontend-svelte/src/locales/ja.json
+++ b/frontend-svelte/src/locales/ja.json
@@ -922,8 +922,8 @@
     "toast_ui_password_updated": "UIパスワードを更新しました",
     "toast_skill_registered": "スキルを登録しました",
     "confirm_apply_update": "更新を適用してデーモンを再起動しますか？",
-    "default_provider": "Default provider for agents",
-    "default_provider_none": "None (Anthropic default)"
+    "default_provider": "エージェントのデフォルトプロバイダー",
+    "default_provider_none": "なし（Anthropicデフォルト）"
   },
   "agents_extra": {
     "file_edit_save": "保存",

--- a/frontend-svelte/src/locales/ko.json
+++ b/frontend-svelte/src/locales/ko.json
@@ -921,7 +921,9 @@
     "toast_primary_user_set": "기본 사용자가 설정되었습니다 — 모든 에이전트에서 자동 승인됩니다",
     "toast_ui_password_updated": "UI 비밀번호가 업데이트되었습니다",
     "toast_skill_registered": "스킬이 등록되었습니다",
-    "confirm_apply_update": "업데이트를 적용하고 데몬을 재시작하시겠습니까?"
+    "confirm_apply_update": "업데이트를 적용하고 데몬을 재시작하시겠습니까?",
+    "default_provider": "Default provider for agents",
+    "default_provider_none": "None (Anthropic default)"
   },
   "agents_extra": {
     "file_edit_save": "저장",

--- a/frontend-svelte/src/locales/ko.json
+++ b/frontend-svelte/src/locales/ko.json
@@ -922,8 +922,8 @@
     "toast_ui_password_updated": "UI 비밀번호가 업데이트되었습니다",
     "toast_skill_registered": "스킬이 등록되었습니다",
     "confirm_apply_update": "업데이트를 적용하고 데몬을 재시작하시겠습니까?",
-    "default_provider": "Default provider for agents",
-    "default_provider_none": "None (Anthropic default)"
+    "default_provider": "에이전트 기본 제공자",
+    "default_provider_none": "없음 (Anthropic 기본값)"
   },
   "agents_extra": {
     "file_edit_save": "저장",

--- a/frontend-svelte/src/locales/ru.json
+++ b/frontend-svelte/src/locales/ru.json
@@ -921,7 +921,9 @@
     "toast_primary_user_set": "Основной пользователь назначен — автоматически одобрен для всех агентов",
     "toast_ui_password_updated": "Пароль интерфейса обновлён",
     "toast_skill_registered": "Навык зарегистрирован",
-    "confirm_apply_update": "Применить обновление и перезапустить демон?"
+    "confirm_apply_update": "Применить обновление и перезапустить демон?",
+    "default_provider": "Default provider for agents",
+    "default_provider_none": "None (Anthropic default)"
   },
   "agents_extra": {
     "file_edit_save": "Сохранить",
@@ -1077,15 +1079,15 @@
     "import_boundaries_field": "Границы",
     "import_memory_section": "Память",
     "import_memories_count": "{count} воспоминаний",
-    "import_memory_unavailable": "Хранилище памяти недоступно — {count} воспоминаний показано в предпросмотре, но импортировано не будет. Убедитесь, что pinky_memory запущен.",
+    "import_memory_unavailable": "Хранилище памяти недоступно — {count} воспоминаний показано в предпросмотре, но импортировано не будет.",
     "import_no_memory": "Память не найдена.",
     "import_connections_section": "Подключения",
     "import_no_connections": "Подключения не найдены.",
     "import_automation_section": "Автоматизация",
     "import_schedules_field": "Расписания",
-    "import_schedules_count": "{count} задач{plural}",
+    "import_schedules_count": "{count} расписани{plural}",
     "import_none_detected": "Не обнаружено.",
-    "import_warnings_title": "{count} элемент{plural} требует внимания перед миграцией",
+    "import_warnings_title": "{count} элемент{plural} требует{singular_s} внимания перед миграцией",
     "import_creating_agent": "Создание агента...",
     "import_agent_ready": "Агент {name} готов!",
     "import_agent_renamed_note": "Агент создан как «{name}» — переименуйте его в настройках после создания.",
@@ -1097,12 +1099,6 @@
     "import_close_bg": "Закрыть (импорт продолжается в фоне)",
     "import_upload_label": "Загрузка",
     "import_preview_label": "Предпросмотр",
-    "import_confirm_label": "Подтверждение",
-    "import_or_upload": "или загрузить zip",
-    "import_memory_unavailable": "Хранилище памяти недоступно — {count} воспоминаний показано в предпросмотре, но импортировано не будет.",
-    "import_memories_partial": "{imported} воспоминаний импортировано, {failed} не удалось.",
-    "import_memories_success": "{count} воспоминаний успешно импортировано.",
-    "import_schedules_count": "{count} расписани{plural}",
-    "import_warnings_title": "{count} элемент{plural} требует{singular_s} внимания перед миграцией"
+    "import_confirm_label": "Подтверждение"
   }
 }

--- a/frontend-svelte/src/locales/ru.json
+++ b/frontend-svelte/src/locales/ru.json
@@ -922,8 +922,8 @@
     "toast_ui_password_updated": "Пароль интерфейса обновлён",
     "toast_skill_registered": "Навык зарегистрирован",
     "confirm_apply_update": "Применить обновление и перезапустить демон?",
-    "default_provider": "Default provider for agents",
-    "default_provider_none": "None (Anthropic default)"
+    "default_provider": "Провайдер по умолчанию для агентов",
+    "default_provider_none": "Нет (Anthropic по умолчанию)"
   },
   "agents_extra": {
     "file_edit_save": "Сохранить",

--- a/frontend-svelte/src/locales/uk.json
+++ b/frontend-svelte/src/locales/uk.json
@@ -921,7 +921,9 @@
     "toast_primary_user_set": "Основного користувача встановлено — автоматично схвалено для всіх агентів",
     "toast_ui_password_updated": "Пароль інтерфейсу оновлено",
     "toast_skill_registered": "Скіл зареєстровано",
-    "confirm_apply_update": "Застосувати оновлення та перезапустити демон?"
+    "confirm_apply_update": "Застосувати оновлення та перезапустити демон?",
+    "default_provider": "Default provider for agents",
+    "default_provider_none": "None (Anthropic default)"
   },
   "agents_extra": {
     "file_edit_save": "Зберегти",

--- a/frontend-svelte/src/locales/uk.json
+++ b/frontend-svelte/src/locales/uk.json
@@ -922,8 +922,8 @@
     "toast_ui_password_updated": "Пароль інтерфейсу оновлено",
     "toast_skill_registered": "Скіл зареєстровано",
     "confirm_apply_update": "Застосувати оновлення та перезапустити демон?",
-    "default_provider": "Default provider for agents",
-    "default_provider_none": "None (Anthropic default)"
+    "default_provider": "Провайдер за замовчуванням для агентів",
+    "default_provider_none": "Немає (Anthropic за замовчуванням)"
   },
   "agents_extra": {
     "file_edit_save": "Зберегти",

--- a/frontend-svelte/src/locales/zh.json
+++ b/frontend-svelte/src/locales/zh.json
@@ -922,8 +922,8 @@
     "toast_ui_password_updated": "界面密码已更新",
     "toast_skill_registered": "技能已注册",
     "confirm_apply_update": "应用更新并重启守护进程？",
-    "default_provider": "Default provider for agents",
-    "default_provider_none": "None (Anthropic default)"
+    "default_provider": "智能体默认提供商",
+    "default_provider_none": "无（Anthropic 默认）"
   },
   "agents_extra": {
     "file_edit_save": "保存",

--- a/frontend-svelte/src/locales/zh.json
+++ b/frontend-svelte/src/locales/zh.json
@@ -921,7 +921,9 @@
     "toast_primary_user_set": "主要用户已设置 — 在所有智能体中自动授权",
     "toast_ui_password_updated": "界面密码已更新",
     "toast_skill_registered": "技能已注册",
-    "confirm_apply_update": "应用更新并重启守护进程？"
+    "confirm_apply_update": "应用更新并重启守护进程？",
+    "default_provider": "Default provider for agents",
+    "default_provider_none": "None (Anthropic default)"
   },
   "agents_extra": {
     "file_edit_save": "保存",

--- a/frontend-svelte/src/pages/Settings.svelte
+++ b/frontend-svelte/src/pages/Settings.svelte
@@ -585,6 +585,7 @@
 
     // Global providers
     let providers = [];
+    let defaultProviderId = '';
     let providerFormVisible = false;
     let editingProvider = null; // null = adding new, object = editing existing
     let provFormName = '';
@@ -606,6 +607,17 @@
 
     async function loadProviders() {
         providers = await api('GET', '/providers').catch(() => []);
+        const defaultProvider = await api('GET', '/settings/default-provider').catch(() => ({ provider_id: '' }));
+        defaultProviderId = defaultProvider.provider_id || '';
+    }
+
+    async function saveDefaultProvider() {
+        try {
+            await api('PUT', '/settings/default-provider', { provider_id: defaultProviderId });
+            toast('Default provider saved');
+        } catch (e) {
+            toast(e.message || 'Failed to save default provider', 'error');
+        }
     }
 
     function openAddProvider() {
@@ -662,6 +674,10 @@
     async function deleteProvider(p) {
         if (!confirm(`Delete provider "${p.name}"? Agents using it will fall back to Anthropic defaults.`)) return;
         await api('DELETE', `/providers/${p.id}`);
+        if (defaultProviderId === p.id) {
+            defaultProviderId = '';
+            await api('PUT', '/settings/default-provider', { provider_id: '' }).catch(() => {});
+        }
         toast('Provider deleted');
         await loadProviders();
     }
@@ -1538,6 +1554,19 @@
         <SectionHeader i18nKey="settings.global_providers">
             <button slot="actions" class="btn btn-sm btn-primary" on:click={openAddProvider}>+ {$_('settings.add_provider')}</button>
         </SectionHeader>
+        <div style="padding:0 1.5rem 1rem;background:var(--surface-2);border-radius:var(--radius-lg) var(--radius-lg) 0 0;display:flex;gap:0.7rem;align-items:end;flex-wrap:wrap">
+            <div style="min-width:300px">
+                <FormField label="Default provider for agents">
+                    <select class="form-select" bind:value={defaultProviderId}>
+                        <option value="">None (Anthropic default)</option>
+                        {#each providers as p}
+                            <option value={p.id}>{p.name}{p.provider_model ? ` · ${p.provider_model}` : ''}</option>
+                        {/each}
+                    </select>
+                </FormField>
+            </div>
+            <button class="btn btn-sm btn-primary" on:click={saveDefaultProvider}>Save default</button>
+        </div>
 
         {#if providerFormVisible}
         <div style="margin-bottom:0.5rem">

--- a/frontend-svelte/src/pages/Settings.svelte
+++ b/frontend-svelte/src/pages/Settings.svelte
@@ -586,6 +586,7 @@
     // Global providers
     let providers = [];
     let defaultProviderId = '';
+    let defaultProviderSavedId = '';
     let providerFormVisible = false;
     let editingProvider = null; // null = adding new, object = editing existing
     let provFormName = '';
@@ -609,11 +610,13 @@
         providers = await api('GET', '/providers').catch(() => []);
         const defaultProvider = await api('GET', '/settings/default-provider').catch(() => ({ provider_id: '' }));
         defaultProviderId = defaultProvider.provider_id || '';
+        defaultProviderSavedId = defaultProviderId;
     }
 
     async function saveDefaultProvider() {
         try {
             await api('PUT', '/settings/default-provider', { provider_id: defaultProviderId });
+            defaultProviderSavedId = defaultProviderId;
             toast('Default provider saved');
         } catch (e) {
             toast(e.message || 'Failed to save default provider', 'error');
@@ -676,6 +679,7 @@
         await api('DELETE', `/providers/${p.id}`);
         if (defaultProviderId === p.id) {
             defaultProviderId = '';
+            defaultProviderSavedId = '';
             await api('PUT', '/settings/default-provider', { provider_id: '' }).catch(() => {});
         }
         toast('Provider deleted');
@@ -1556,16 +1560,16 @@
         </SectionHeader>
         <div style="padding:0 1.5rem 1rem;background:var(--surface-2);border-radius:var(--radius-lg) var(--radius-lg) 0 0;display:flex;gap:0.7rem;align-items:end;flex-wrap:wrap">
             <div style="min-width:300px">
-                <FormField label="Default provider for agents">
+                <FormField label={$_('settings.default_provider')}>
                     <select class="form-select" bind:value={defaultProviderId}>
-                        <option value="">None (Anthropic default)</option>
+                        <option value="">{$_('settings.default_provider_none')}</option>
                         {#each providers as p}
                             <option value={p.id}>{p.name}{p.provider_model ? ` · ${p.provider_model}` : ''}</option>
                         {/each}
                     </select>
                 </FormField>
             </div>
-            <button class="btn btn-sm btn-primary" on:click={saveDefaultProvider}>Save default</button>
+            <button class="btn btn-sm btn-primary" on:click={saveDefaultProvider} disabled={defaultProviderId === defaultProviderSavedId}>{$_('common.save')}</button>
         </div>
 
         {#if providerFormVisible}

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -373,6 +373,12 @@ class SetMainAgentRequest(BaseModel):
     agent: str
 
 
+class SetDefaultProviderRequest(BaseModel):
+    """Set the default global provider used by agents without explicit provider config."""
+
+    provider_id: str = ""
+
+
 # ── Agent Models ─────────────────────────────────────────────
 
 
@@ -1978,24 +1984,29 @@ def create_api(
         """Resolve (provider_url, provider_key, provider_model) for an agent.
 
         If the agent has a provider_ref set and no explicit provider_url, looks up
-        the global provider from the providers table. Agent-level fields win if set.
+        the global provider from the providers table. If provider_ref is empty and
+        no explicit provider fields are set, falls back to the system default
+        provider (`default_provider_ref`) from settings. Agent-level fields win.
         Returns (url, key, model) — any may be empty string.
         """
         url = agent.provider_url or ""
         key = agent.provider_key or ""
         model = agent.provider_model or ""
-        if agent.provider_ref and not url:
+        provider_ref = (agent.provider_ref or "").strip()
+        if not provider_ref and not url and not key and not model:
+            provider_ref = (agents.get_setting("default_provider_ref", "") or "").strip()
+        if provider_ref and not url:
             try:
                 row = agents._db.execute(
                     "SELECT provider_url, provider_key, provider_model FROM providers WHERE id=?",
-                    (agent.provider_ref,),
+                    (provider_ref,),
                 ).fetchone()
                 if row:
                     url = row[0] or ""
                     key = row[1] or ""
                     model = row[2] or ""
             except Exception as e:
-                _log(f"api: could not resolve provider_ref {agent.provider_ref}: {e}")
+                _log(f"api: could not resolve provider_ref {provider_ref}: {e}")
         return url, key, model
 
     def _get_streaming_restart_guard(agent_name: str, ss) -> dict:
@@ -7747,6 +7758,34 @@ def create_api(
             raise HTTPException(404, f"Agent '{req.agent}' not found")
         agents.set_main_agent(req.agent)
         return {"agent": req.agent}
+
+    @app.get("/settings/default-provider")
+    async def get_default_provider_setting():
+        """Get the default global provider id used by unconfigured agents."""
+        provider_id = (agents.get_setting("default_provider_ref", "") or "").strip()
+        provider = None
+        if provider_id:
+            row = agents._db.execute(
+                "SELECT id, name, preset, provider_url, provider_key, provider_model, created_at, updated_at "
+                "FROM providers WHERE id=?",
+                (provider_id,),
+            ).fetchone()
+            if row:
+                provider = _provider_row_to_dict(row)
+            else:
+                provider_id = ""
+        return {"provider_id": provider_id, "provider": provider}
+
+    @app.put("/settings/default-provider")
+    async def set_default_provider_setting(req: SetDefaultProviderRequest):
+        """Set/clear the default global provider used by unconfigured agents."""
+        provider_id = (req.provider_id or "").strip()
+        if provider_id:
+            row = agents._db.execute("SELECT id FROM providers WHERE id=?", (provider_id,)).fetchone()
+            if not row:
+                raise HTTPException(404, f"Provider '{provider_id}' not found")
+        agents.set_setting("default_provider_ref", provider_id)
+        return {"provider_id": provider_id}
 
     @app.get("/system/auth")
     async def get_auth_status():

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -112,6 +112,38 @@ CONTEXT_ACTIVITY_SAVE_BUFFER_SECONDS = 5 * 60
 CONTEXT_STALE_WARNING_SECONDS = 12 * 60 * 60
 
 
+def resolve_provider_config(
+    *,
+    agent_provider_url: str,
+    agent_provider_key: str,
+    agent_provider_model: str,
+    agent_provider_ref: str,
+    default_provider_ref: str,
+    db,
+) -> tuple[str, str, str]:
+    """Resolve effective provider tuple (url, key, model) with deterministic precedence."""
+    url = (agent_provider_url or "").strip()
+    key = (agent_provider_key or "").strip()
+    model = (agent_provider_model or "").strip()
+    provider_ref = (agent_provider_ref or "").strip()
+
+    # Agent with no explicit provider fields inherits system default provider.
+    if not provider_ref and not url and not key and not model:
+        provider_ref = (default_provider_ref or "").strip()
+
+    # Agent explicit URL always wins; refs are only used when URL is empty.
+    if provider_ref and not url:
+        row = db.execute(
+            "SELECT provider_url, provider_key, provider_model FROM providers WHERE id=?",
+            (provider_ref,),
+        ).fetchone()
+        if row:
+            url = row[0] or ""
+            key = row[1] or ""
+            model = row[2] or ""
+    return url, key, model
+
+
 class CreateSessionRequest(BaseModel):
     """Create a new Claude Code session."""
 
@@ -1989,25 +2021,18 @@ def create_api(
         provider (`default_provider_ref`) from settings. Agent-level fields win.
         Returns (url, key, model) — any may be empty string.
         """
-        url = agent.provider_url or ""
-        key = agent.provider_key or ""
-        model = agent.provider_model or ""
-        provider_ref = (agent.provider_ref or "").strip()
-        if not provider_ref and not url and not key and not model:
-            provider_ref = (agents.get_setting("default_provider_ref", "") or "").strip()
-        if provider_ref and not url:
-            try:
-                row = agents._db.execute(
-                    "SELECT provider_url, provider_key, provider_model FROM providers WHERE id=?",
-                    (provider_ref,),
-                ).fetchone()
-                if row:
-                    url = row[0] or ""
-                    key = row[1] or ""
-                    model = row[2] or ""
-            except Exception as e:
-                _log(f"api: could not resolve provider_ref {provider_ref}: {e}")
-        return url, key, model
+        try:
+            return resolve_provider_config(
+                agent_provider_url=agent.provider_url or "",
+                agent_provider_key=agent.provider_key or "",
+                agent_provider_model=agent.provider_model or "",
+                agent_provider_ref=agent.provider_ref or "",
+                default_provider_ref=agents.get_setting("default_provider_ref", "") or "",
+                db=agents._db,
+            )
+        except Exception as e:
+            _log(f"api: could not resolve provider config for {agent.name}: {e}")
+            return agent.provider_url or "", agent.provider_key or "", agent.provider_model or ""
 
     def _get_streaming_restart_guard(agent_name: str, ss) -> dict:
         """Build a restart guard for a live streaming session."""
@@ -5121,6 +5146,15 @@ def create_api(
             "updated_at": row[7],
         }
 
+    def _provider_public_row_to_dict(row) -> dict:
+        """Provider info safe for lightweight settings dropdowns."""
+        return {
+            "id": row[0],
+            "name": row[1],
+            "preset": row[2],
+            "provider_model": row[5],
+        }
+
     @app.get("/providers")
     async def list_providers():
         """List all global named providers."""
@@ -7771,7 +7805,7 @@ def create_api(
                 (provider_id,),
             ).fetchone()
             if row:
-                provider = _provider_row_to_dict(row)
+                provider = _provider_public_row_to_dict(row)
             else:
                 provider_id = ""
         return {"provider_id": provider_id, "provider": provider}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import sys
 import tempfile
 import time
@@ -2820,3 +2821,87 @@ class TestProviders:
         client = self._make_client()
         resp = client.post("/providers", json={"name": "no-url"})
         assert resp.status_code == 400
+
+    def test_default_provider_setting_redacts_key(self):
+        client = self._make_client()
+        create = client.post("/providers", json={
+            "name": "shared",
+            "preset": "openrouter",
+            "provider_url": "https://openrouter.ai/api",
+            "provider_key": "super-secret",
+            "provider_model": "anthropic/claude-sonnet-4-5",
+        })
+        assert create.status_code == 200
+        provider_id = create.json()["id"]
+
+        set_resp = client.put("/settings/default-provider", json={"provider_id": provider_id})
+        assert set_resp.status_code == 200
+
+        get_resp = client.get("/settings/default-provider")
+        assert get_resp.status_code == 200
+        payload = get_resp.json()
+        assert payload["provider_id"] == provider_id
+        assert payload["provider"]["id"] == provider_id
+        assert "provider_key" not in payload["provider"]
+        assert "provider_url" not in payload["provider"]
+
+    def test_resolver_uses_default_provider_when_agent_unconfigured(self):
+        from pinky_daemon.api import resolve_provider_config
+        db = sqlite3.connect(":memory:")
+        db.execute("CREATE TABLE providers (id TEXT PRIMARY KEY, provider_url TEXT, provider_key TEXT, provider_model TEXT)")
+        db.execute(
+            "INSERT INTO providers (id, provider_url, provider_key, provider_model) VALUES (?, ?, ?, ?)",
+            ("default", "http://localhost:11434", "ollama", "llama3.2"),
+        )
+        db.commit()
+        url, key, model = resolve_provider_config(
+            agent_provider_url="",
+            agent_provider_key="",
+            agent_provider_model="",
+            agent_provider_ref="",
+            default_provider_ref="default",
+            db=db,
+        )
+        assert (url, key, model) == ("http://localhost:11434", "ollama", "llama3.2")
+
+    def test_resolver_agent_ref_overrides_system_default(self):
+        from pinky_daemon.api import resolve_provider_config
+        db = sqlite3.connect(":memory:")
+        db.execute("CREATE TABLE providers (id TEXT PRIMARY KEY, provider_url TEXT, provider_key TEXT, provider_model TEXT)")
+        db.execute(
+            "INSERT INTO providers (id, provider_url, provider_key, provider_model) VALUES (?, ?, ?, ?)",
+            ("default", "https://openrouter.ai/api", "k1", "anthropic/claude-sonnet-4-5"),
+        )
+        db.execute(
+            "INSERT INTO providers (id, provider_url, provider_key, provider_model) VALUES (?, ?, ?, ?)",
+            ("agent", "https://api.deepseek.com/anthropic", "k2", "deepseek-chat"),
+        )
+        db.commit()
+        url, key, model = resolve_provider_config(
+            agent_provider_url="",
+            agent_provider_key="",
+            agent_provider_model="",
+            agent_provider_ref="agent",
+            default_provider_ref="default",
+            db=db,
+        )
+        assert (url, key, model) == ("https://api.deepseek.com/anthropic", "k2", "deepseek-chat")
+
+    def test_resolver_agent_explicit_fields_override_refs(self):
+        from pinky_daemon.api import resolve_provider_config
+        db = sqlite3.connect(":memory:")
+        db.execute("CREATE TABLE providers (id TEXT PRIMARY KEY, provider_url TEXT, provider_key TEXT, provider_model TEXT)")
+        db.execute(
+            "INSERT INTO providers (id, provider_url, provider_key, provider_model) VALUES (?, ?, ?, ?)",
+            ("agent", "https://openrouter.ai/api", "k1", "anthropic/claude-sonnet-4-5"),
+        )
+        db.commit()
+        url, key, model = resolve_provider_config(
+            agent_provider_url="https://api.deepseek.com/anthropic",
+            agent_provider_key="",
+            agent_provider_model="deepseek-chat",
+            agent_provider_ref="agent",
+            default_provider_ref="",
+            db=db,
+        )
+        assert (url, key, model) == ("https://api.deepseek.com/anthropic", "", "deepseek-chat")


### PR DESCRIPTION
## Summary
- Default global provider setting: agents without explicit provider config inherit from a system-wide default (#205)
- New endpoints: `GET/PUT /settings/default-provider`
- Resolver extracted to pure testable `resolve_provider_config()` function
- Provider key redacted from settings GET response
- UI: dropdown in Settings → Providers with dirty tracking
- Translations for all 7 locales
- 4 new tests covering resolver precedence chain
- Fix: i18n key namespace for wizard name placeholder

🤖 Opened by Barsik