### PR TITLE
Promote beta → main: settings centralization (#207)

### DIFF
--- a/frontend-dist/index.html
+++ b/frontend-dist/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Pinky -- Personal AI Companion</title>
-    <script type="module" crossorigin src="/assets/index-CCN0ZLNe.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DBiwFttR.css">
+    <script type="module" crossorigin src="/assets/index-BMuAAnoI.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CnwV0VvX.css">
   </head>
   <body>
     <div id="app"></div>

--- a/frontend-svelte/src/components/ProviderConfig.svelte
+++ b/frontend-svelte/src/components/ProviderConfig.svelte
@@ -3,12 +3,11 @@
      * ProviderConfig — unified provider configuration form.
      *
      * Used in:
-     *   - Settings (global provider add/edit)
-     *   - Agents (per-agent provider config)
+     *   - Settings (global provider add/edit) — mode="global"
+     *   - Agents (per-agent provider config) — mode="agent"
      *
-     * Modes:
-     *   - "agent": shows global ref dropdown, anthropic preset, preset buttons
-     *   - "global": shows name field, simpler preset buttons (no anthropic/codex)
+     * Agent mode: single dropdown of configured providers + "Anthropic (Default)" + "Custom..."
+     * Global mode: preset buttons + name field for creating/editing providers
      */
     import { _ } from 'svelte-i18n';
     import FormField from './FormField.svelte';
@@ -44,10 +43,8 @@
         custom:      { url: '',                                   key: '',       model: '' },
     };
 
-    // Which presets to show per mode
-    $: presetList = mode === 'agent'
-        ? ['anthropic', 'ollama', 'openrouter', 'deepseek', 'zai', 'codex_cli', 'custom']
-        : ['ollama', 'openrouter', 'deepseek', 'zai', 'custom'];
+    // Global mode: which presets to show as buttons
+    const GLOBAL_PRESETS = ['ollama', 'openrouter', 'deepseek', 'zai', 'custom'];
 
     // Preset label lookup
     const PRESET_LABELS = {
@@ -64,7 +61,38 @@
     $: showUrlAndKey = providerPreset === 'ollama' || providerPreset === 'custom';
     $: showKeyOnly = providerPreset === 'openrouter' || providerPreset === 'deepseek' || providerPreset === 'zai';
     $: showModel = providerPreset !== 'anthropic';
-    $: refActive = mode === 'agent' && !!providerRef;
+
+    // Agent mode: derive the selected value for the unified dropdown
+    // "anthropic" = default, provider ID = global provider, "custom" = manual config
+    $: agentSelection = providerRef ? providerRef : (providerUrl ? 'custom' : 'anthropic');
+    $: isCustomAgent = mode === 'agent' && agentSelection === 'custom';
+
+    function handleAgentSelect(value) {
+        if (value === 'anthropic') {
+            // Anthropic default — clear everything
+            providerRef = '';
+            providerUrl = '';
+            providerKey = '';
+            providerModel = '';
+            providerPreset = 'anthropic';
+        } else if (value === 'custom') {
+            // Custom — clear ref, let user fill in fields
+            providerRef = '';
+            providerPreset = 'custom';
+            providerUrl = '';
+            providerKey = '';
+            providerModel = '';
+        } else {
+            // Global provider selected by ID
+            providerRef = value;
+            providerUrl = '';
+            providerKey = '';
+            providerModel = '';
+            providerPreset = 'anthropic';
+        }
+        dirty = true;
+        dispatch('change');
+    }
 
     export function applyPreset(preset) {
         providerPreset = preset;
@@ -80,15 +108,9 @@
     }
 
     export function selectGlobalProvider(id) {
-        providerRef = id;
-        if (id) {
-            providerUrl = '';
-            providerKey = '';
-            providerModel = '';
-            providerPreset = 'anthropic';
+        if (mode === 'agent') {
+            handleAgentSelect(id || 'anthropic');
         }
-        dirty = true;
-        dispatch('change');
     }
 
     export function detectPreset(url) {
@@ -143,31 +165,40 @@
 </script>
 
 <div class="provider-config">
-    <!-- Global provider name (global mode only) -->
-    {#if mode === 'global'}
+    {#if mode === 'agent'}
+        <!-- Agent mode: single dropdown of providers -->
+        <FormField label={$_('agents_extra.global_provider_label')}>
+            <select class="form-select" value={agentSelection} on:change={(e) => handleAgentSelect(e.target.value)} style="width:100%;max-width:400px">
+                <option value="anthropic">{$_('settings.default_provider_none')}</option>
+                {#each globalProviders as gp}
+                    <option value={gp.id}>{gp.name}{gp.provider_model ? ' · ' + gp.provider_model : ''}</option>
+                {/each}
+                <option value="custom">{$_('agents_extra.provider_preset_custom')}</option>
+            </select>
+        </FormField>
+
+        <!-- Custom fields (only when "Custom..." is selected) -->
+        {#if isCustomAgent}
+            <div class="provider-fields">
+                <FormField label={$_('agents_extra.base_url_label')}>
+                    <input type="text" class="form-input" bind:value={providerUrl} on:input={markDirty} placeholder="http://localhost:11434" style="width:100%">
+                </FormField>
+                <FormField label={$_('agents_extra.api_key_label')}>
+                    <input type="password" class="form-input" bind:value={providerKey} on:input={markDirty} placeholder="API key" style="width:100%">
+                </FormField>
+                <FormField label={$_('agents_extra.model_label')}>
+                    <input type="text" class="form-input" bind:value={providerModel} on:input={markDirty} placeholder="model name" style="width:100%">
+                </FormField>
+            </div>
+        {/if}
+    {:else}
+        <!-- Global mode: name field + preset buttons -->
         <FormField label="Name" style="margin-bottom:0.75rem">
             <input type="text" class="form-input" bind:value={providerName} on:input={markDirty} placeholder="My provider" style="width:100%;max-width:320px">
         </FormField>
-    {/if}
 
-    <!-- Global provider ref dropdown (agent mode only) -->
-    {#if mode === 'agent' && globalProviders.length > 0}
-        <div style="margin-bottom:0.75rem">
-            <FormField label={$_('agents_extra.global_provider_label')}>
-                <select class="form-select" value={providerRef} on:change={(e) => selectGlobalProvider(e.target.value)} style="width:100%;max-width:320px">
-                    <option value="">{$_('agents_extra.global_provider_none')}</option>
-                    {#each globalProviders as gp}
-                        <option value={gp.id}>{gp.name}{gp.provider_model ? ' · ' + gp.provider_model : ''}</option>
-                    {/each}
-                </select>
-            </FormField>
-        </div>
-    {/if}
-
-    <!-- Preset buttons + fields (dimmed when global ref is active) -->
-    <div style="{refActive ? 'opacity:0.4;pointer-events:none' : ''}">
         <div style="display:flex;gap:0.4rem;flex-wrap:wrap">
-            {#each presetList as preset}
+            {#each GLOBAL_PRESETS as preset}
                 <button
                     class="btn btn-sm"
                     class:btn-primary={providerPreset === preset}
@@ -204,7 +235,7 @@
                 {/if}
             </div>
         {/if}
-    </div>
+    {/if}
 </div>
 
 <style>

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -81,6 +81,10 @@
     let newDirectivePriority = 0;
     let tokenPlatform = 'telegram';
     let tokenValue = '';
+    let tokenMode = 'global'; // 'global' or 'manual'
+    let tokenRefId = '';
+    let globalBotTokens = [];
+    $: platformBotTokens = globalBotTokens.filter(bt => bt.platform === tokenPlatform);
 
     // Voice config state
     let voiceReply = false;
@@ -193,6 +197,9 @@
     let wizTelegramToken = '';
     let wizDiscordToken = '';
     let wizSlackToken = '';
+    let wizTelegramRef = '';
+    let wizDiscordRef = '';
+    let wizSlackRef = '';
 
     // Import (OpenClaw migration) state
     let importMode = false;
@@ -518,6 +525,7 @@
         }
         providerDirty = false;
         globalProviders = await api('GET', '/providers').catch(() => []);
+        globalBotTokens = await api('GET', '/bot-tokens').catch(() => []);
         // Clear stale ref if the referenced provider no longer exists
         if (providerRef && !globalProviders.find(p => p.id === providerRef)) providerRef = '';
         detailOpen = true;
@@ -580,7 +588,19 @@
     async function toggleDirective(id, active) { await api('POST', `/agents/${currentAgent}/directives/${id}/toggle?active=${active}`); loadDirectives(); }
 
     async function loadTokens() { const data = await api('GET', `/agents/${currentAgent}/tokens`); tokens = data.tokens || []; }
-    async function setToken() { if (!tokenValue) { toast('Enter a token', 'error'); return; } await api('PUT', `/agents/${currentAgent}/tokens/${tokenPlatform}`, { token: tokenValue }); tokenValue = ''; toast(`${tokenPlatform} token set`); loadTokens(); }
+    async function setToken() {
+        const hasGlobalTokens = globalBotTokens.some(bt => bt.platform === tokenPlatform);
+        const useRef = hasGlobalTokens && tokenRefId && tokenRefId !== '__manual__';
+        if (useRef) {
+            await api('PUT', `/agents/${currentAgent}/tokens/${tokenPlatform}`, { token: '', token_ref: tokenRefId });
+        } else {
+            if (!tokenValue) { toast('Enter a token', 'error'); return; }
+            await api('PUT', `/agents/${currentAgent}/tokens/${tokenPlatform}`, { token: tokenValue, token_ref: '' });
+        }
+        tokenValue = ''; tokenRefId = '';
+        toast(`${tokenPlatform} token set`);
+        loadTokens();
+    }
     async function removeToken(platform) { if (!confirm(`Remove ${platform} token?`)) return; await api('DELETE', `/agents/${currentAgent}/tokens/${platform}`); toast(`${platform} token removed`); loadTokens(); }
 
     // MCP Servers
@@ -978,9 +998,12 @@
                 provider_ref: wizProviderRef,
             });
         }
-        if (wizTelegramToken) await api('PUT', `/agents/${wizName}/tokens/telegram`, { token: wizTelegramToken });
-        if (wizDiscordToken) await api('PUT', `/agents/${wizName}/tokens/discord`, { token: wizDiscordToken });
-        if (wizSlackToken) await api('PUT', `/agents/${wizName}/tokens/slack`, { token: wizSlackToken });
+        if (wizTelegramToken || (wizTelegramRef && wizTelegramRef !== '__manual__'))
+            await api('PUT', `/agents/${wizName}/tokens/telegram`, { token: wizTelegramToken, token_ref: (wizTelegramRef && wizTelegramRef !== '__manual__') ? wizTelegramRef : '' });
+        if (wizDiscordToken || (wizDiscordRef && wizDiscordRef !== '__manual__'))
+            await api('PUT', `/agents/${wizName}/tokens/discord`, { token: wizDiscordToken, token_ref: (wizDiscordRef && wizDiscordRef !== '__manual__') ? wizDiscordRef : '' });
+        if (wizSlackToken || (wizSlackRef && wizSlackRef !== '__manual__'))
+            await api('PUT', `/agents/${wizName}/tokens/slack`, { token: wizSlackToken, token_ref: (wizSlackRef && wizSlackRef !== '__manual__') ? wizSlackRef : '' });
         const label = wizAutoStart ? 'main' : 'chat';
         await api('POST', `/agents/${wizName}/streaming-sessions?label=${encodeURIComponent(label)}`);
         closeWizard();
@@ -988,7 +1011,11 @@
         refreshAgents();
     }
 
-    $: wizSummaryPlatforms = [wizTelegramToken && 'Telegram', wizDiscordToken && 'Discord', wizSlackToken && 'Slack'].filter(Boolean);
+    $: wizSummaryPlatforms = [
+        (wizTelegramToken || (wizTelegramRef && wizTelegramRef !== '__manual__')) && 'Telegram',
+        (wizDiscordToken || (wizDiscordRef && wizDiscordRef !== '__manual__')) && 'Discord',
+        (wizSlackToken || (wizSlackRef && wizSlackRef !== '__manual__')) && 'Slack',
+    ].filter(Boolean);
 
     onMount(() => { refreshAgents(); refreshInterval = setInterval(refreshAgents, 15000); });
     onDestroy(() => { clearInterval(refreshInterval); });
@@ -1439,12 +1466,23 @@
             <SectionHeader title={$_('agents.bot_tokens')} variant="detail" />
             <div style="padding:0.75rem 1.5rem;background:var(--surface-2);border-radius:var(--radius-lg);margin-top:0.5rem">
                 <div style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap">
-                    <select class="form-select" bind:value={tokenPlatform}>
+                    <select class="form-select" bind:value={tokenPlatform} style="width:130px">
                         <option value="telegram">Telegram</option>
                         <option value="discord">Discord</option>
                         <option value="slack">Slack</option>
                     </select>
-                    <input type="password" class="form-input" bind:value={tokenValue} placeholder={$_('agents.bot_token_placeholder')} style="flex:1;min-width:120px">
+                    {#if platformBotTokens.length > 0}
+                        <select class="form-select" bind:value={tokenRefId} on:change={() => { tokenMode = tokenRefId === '__manual__' ? 'manual' : 'global'; if (tokenMode === 'global') tokenValue = ''; }} style="flex:1;min-width:160px">
+                            <option value="">Select token...</option>
+                            {#each platformBotTokens as bt}
+                                <option value={bt.id}>{bt.name}</option>
+                            {/each}
+                            <option value="__manual__">Enter manually...</option>
+                        </select>
+                    {/if}
+                    {#if tokenRefId === '__manual__' || platformBotTokens.length === 0}
+                        <input type="password" class="form-input" bind:value={tokenValue} placeholder={$_('agents.bot_token_placeholder')} style="flex:1;min-width:120px">
+                    {/if}
                     <button class="btn btn-primary" on:click={setToken}>{$_('common.set')}</button>
                 </div>
             </div>
@@ -1455,7 +1493,12 @@
                     {#each tokens as t}
                         <div class="token-item">
                             <StatusBadge variant="model" label={t.platform} />
-                            <StatusBadge status={t.token_set ? 'on' : 'off'} label={t.token_set ? $_('agents.token_set') : $_('agents.token_missing')} />
+                            {#if t.token_ref}
+                                {@const refName = globalBotTokens.find(bt => bt.id === t.token_ref)?.name || t.token_ref}
+                                <StatusBadge status="on" label={refName} />
+                            {:else}
+                                <StatusBadge status={t.token_set ? 'on' : 'off'} label={t.token_set ? $_('agents.token_set') : $_('agents.token_missing')} />
+                            {/if}
                             <StatusBadge status={t.enabled ? 'on' : 'off'} label={t.enabled ? $_('common.enabled') : $_('common.disabled')} />
                             <span style="flex:1"></span>
                             <button class="btn btn-sm btn-danger" on:click={() => removeToken(t.platform)}>{$_('agents_extra.bot_token_remove')}</button>
@@ -2319,12 +2362,38 @@
                     {:else if wizStep === 3}
                         <div class="wizard-label">Outreach</div>
                         <div class="wizard-hint">Connect to the outside world. All optional.</div>
-                        <div style="margin-bottom:1.5rem"><span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;color:var(--yellow)">TELEGRAM</span>
-                            <input type="password" class="wizard-input" bind:value={wizTelegramToken} placeholder="Bot token..."></div>
-                        <div style="margin-bottom:1.5rem"><span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;color:var(--yellow)">DISCORD</span>
-                            <input type="password" class="wizard-input" bind:value={wizDiscordToken} placeholder="Discord bot token..."></div>
-                        <div><span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;color:var(--yellow)">SLACK</span>
-                            <input type="password" class="wizard-input" bind:value={wizSlackToken} placeholder="xoxb-..."></div>
+                        {#each ['telegram', 'discord', 'slack'] as wizPlatform}
+                            {@const pLabel = wizPlatform.toUpperCase()}
+                            {@const pTokens = globalBotTokens.filter(bt => bt.platform === wizPlatform)}
+                            <div style="margin-bottom:1.5rem">
+                                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;color:var(--yellow)">{pLabel}</span>
+                                {#if pTokens.length > 0}
+                                    <select class="wizard-input" style="margin-bottom:0"
+                                        value={wizPlatform === 'telegram' ? wizTelegramRef : wizPlatform === 'discord' ? wizDiscordRef : wizSlackRef}
+                                        on:change={(e) => {
+                                            const v = e.target.value;
+                                            if (wizPlatform === 'telegram') { wizTelegramRef = v; if (v && v !== '__manual__') wizTelegramToken = ''; }
+                                            else if (wizPlatform === 'discord') { wizDiscordRef = v; if (v && v !== '__manual__') wizDiscordToken = ''; }
+                                            else { wizSlackRef = v; if (v && v !== '__manual__') wizSlackToken = ''; }
+                                        }}>
+                                        <option value="">None</option>
+                                        {#each pTokens as bt}
+                                            <option value={bt.id}>{bt.name}</option>
+                                        {/each}
+                                        <option value="__manual__">Enter manually...</option>
+                                    </select>
+                                {/if}
+                                {#if pTokens.length === 0 || (wizPlatform === 'telegram' ? wizTelegramRef : wizPlatform === 'discord' ? wizDiscordRef : wizSlackRef) === '__manual__'}
+                                    {#if wizPlatform === 'telegram'}
+                                        <input type="password" class="wizard-input" bind:value={wizTelegramToken} placeholder="Bot token..." style={pTokens.length > 0 ? 'margin-top:0.25rem' : ''}>
+                                    {:else if wizPlatform === 'discord'}
+                                        <input type="password" class="wizard-input" bind:value={wizDiscordToken} placeholder="Discord bot token..." style={pTokens.length > 0 ? 'margin-top:0.25rem' : ''}>
+                                    {:else}
+                                        <input type="password" class="wizard-input" bind:value={wizSlackToken} placeholder="xoxb-..." style={pTokens.length > 0 ? 'margin-top:0.25rem' : ''}>
+                                    {/if}
+                                {/if}
+                            </div>
+                        {/each}
                     {:else if wizStep === 4}
                         <div class="wizard-label">Ready to Deploy</div>
                         <div class="wizard-summary">

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -2253,57 +2253,47 @@
                     {:else if wizStep === 1}
                         <div class="wizard-label">Brain</div>
                         <div class="wizard-hint">Pick the thinking engine.</div>
-                        <div class="wizard-options">
-                            {#each [['opus','OPUS','Maximum intelligence.'],['sonnet','SONNET','Fast + smart. Daily driver.'],['haiku','HAIKU','Lightning fast. Simple tasks.']] as [val, title, desc]}
-                                <div class="wizard-option" class:selected={wizModel === val && !wizProviderRef && !wizCustomProvider}
-                                     on:click={() => { wizModel = val; wizProviderRef = ''; wizCustomProvider = false; }}>
-                                    <div class="wizard-option-title">{title}</div>
-                                    <div class="wizard-option-desc">{desc}</div>
-                                </div>
-                            {/each}
+
+                        <!-- Provider dropdown -->
+                        <div style="margin-bottom:1rem">
+                            <select class="wizard-input" style="margin:0" value={wizProviderRef || (wizCustomProvider ? '__custom__' : '__anthropic__')}
+                                on:change={(e) => {
+                                    const v = e.target.value;
+                                    if (v === '__anthropic__') { wizProviderRef = ''; wizCustomProvider = false; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; if (!wizModel) wizModel = 'opus'; }
+                                    else if (v === '__custom__') { wizCustomProvider = true; wizProviderRef = ''; wizModel = ''; }
+                                    else { wizProviderRef = v; wizCustomProvider = false; wizModel = ''; wizProviderUrl = ''; wizProviderKey = ''; }
+                                }}>
+                                <option value="__anthropic__">{$_('settings.default_provider_none')}</option>
+                                {#each globalProviders as gp}
+                                    <option value={gp.id}>{gp.name}{gp.provider_model ? ' · ' + gp.provider_model : ''}</option>
+                                {/each}
+                                <option value="__custom__">{$_('agents_extra.provider_preset_custom')}</option>
+                            </select>
                         </div>
 
-                        {#if globalProviders.length > 0}
-                            <div class="wizard-label" style="margin-top:1rem">Your Providers</div>
+                        <!-- Model tier buttons (for Anthropic default) -->
+                        {#if !wizProviderRef && !wizCustomProvider}
                             <div class="wizard-options">
-                                {#each globalProviders as gp}
-                                    <div class="wizard-option" class:selected={wizProviderRef === gp.id}
-                                         on:click={() => { wizProviderRef = gp.id; wizModel = ''; wizCustomProvider = false; wizProviderUrl = ''; wizProviderKey = ''; }}>
-                                        <div class="wizard-option-title">{gp.name.toUpperCase()}</div>
-                                        <div class="wizard-option-desc">{gp.preset || 'custom'}</div>
+                                {#each [['opus','OPUS','Maximum intelligence.'],['sonnet','SONNET','Fast + smart. Daily driver.'],['haiku','HAIKU','Lightning fast. Simple tasks.']] as [val, title, desc]}
+                                    <div class="wizard-option" class:selected={wizModel === val}
+                                         on:click={() => { wizModel = val; }}>
+                                        <div class="wizard-option-title">{title}</div>
+                                        <div class="wizard-option-desc">{desc}</div>
                                     </div>
                                 {/each}
                             </div>
-                            {#if wizProviderRef}
-                                <input type="text" class="wizard-input" bind:value={wizProviderModel}
-                                    placeholder="Model string, e.g. glm-5.1, gpt-4o"
-                                    style="margin-top:0.5rem">
-                            {/if}
                         {/if}
 
-                        <div class="wizard-options" style="margin-top:0.75rem">
-                            <div class="wizard-option" class:selected={wizCustomProvider}
-                                 on:click={() => { wizCustomProvider = !wizCustomProvider; if (wizCustomProvider) { wizModel = ''; wizProviderRef = ''; } }}>
-                                <div class="wizard-option-title">CUSTOM</div>
-                                <div class="wizard-option-desc">Bring your own endpoint.</div>
-                            </div>
-                        </div>
+                        <!-- Model string for global provider -->
+                        {#if wizProviderRef}
+                            <input type="text" class="wizard-input" bind:value={wizProviderModel}
+                                placeholder="Model string (e.g. glm-5.1, gpt-4o)"
+                                style="margin-top:0.5rem">
+                        {/if}
+
+                        <!-- Custom provider fields -->
                         {#if wizCustomProvider}
-                            <div style="margin-top:0.75rem;display:flex;flex-direction:column;gap:0.5rem">
-                                <div style="display:flex;flex-wrap:wrap;gap:0.4rem;margin-bottom:0.25rem">
-                                    {#each [['anthropic','Anthropic'],['zai','Z.ai'],['openrouter','OpenRouter'],['deepseek','DeepSeek'],['ollama','Ollama'],['codex_cli','Codex CLI']] as [preset, label]}
-                                        <button class="wizard-btn" style="padding:0.3rem 0.75rem;font-size:0.7rem;{wizProviderPreset===preset?'background:var(--accent);color:#000':''}"
-                                            on:click={() => {
-                                                wizProviderPreset = preset;
-                                                if (preset === 'zai') { wizProviderUrl = 'https://api.z.ai/api/anthropic'; wizProviderModel = wizProviderModel || 'glm-5.1'; }
-                                                else if (preset === 'ollama') { wizProviderUrl = 'http://localhost:11434'; }
-                                                else if (preset === 'openrouter') { wizProviderUrl = 'https://openrouter.ai/api'; wizProviderModel = wizProviderModel || 'anthropic/claude-sonnet-4-5'; }
-                                                else if (preset === 'deepseek') { wizProviderUrl = 'https://api.deepseek.com/anthropic'; wizProviderModel = wizProviderModel || 'deepseek-chat'; }
-                                                else if (preset === 'codex_cli') { wizProviderUrl = 'codex_cli'; wizProviderModel = ''; }
-                                                else { wizProviderUrl = ''; }
-                                            }}>{label}</button>
-                                    {/each}
-                                </div>
+                            <div style="display:flex;flex-direction:column;gap:0.5rem">
                                 <input type="text" class="wizard-input" bind:value={wizProviderUrl}
                                     placeholder="Provider URL (e.g. https://api.z.ai/api/anthropic)" style="margin:0">
                                 <input type="password" class="wizard-input" bind:value={wizProviderKey}
@@ -2344,7 +2334,7 @@
                                 {#if wizProviderRef}
                                     {(globalProviders.find(p => p.id === wizProviderRef)?.name || wizProviderRef).toUpperCase()}{wizProviderModel ? ' / ' + wizProviderModel : ''}
                                 {:else if wizCustomProvider}
-                                    Custom{wizProviderModel ? ': ' + wizProviderModel : ''}
+                                    Custom{wizProviderUrl ? ' · ' + wizProviderUrl : ''}{wizProviderModel ? ' / ' + wizProviderModel : ''}
                                 {:else}
                                     {wizModel.toUpperCase()}
                                 {/if}

--- a/frontend-svelte/src/pages/Settings.svelte
+++ b/frontend-svelte/src/pages/Settings.svelte
@@ -29,6 +29,13 @@
     let allTokens = [];
     let allApprovedUsers = [];
 
+    // Global bot tokens
+    let globalBotTokens = [];
+    let botTokenFormVisible = false;
+    let botTokenName = '';
+    let botTokenPlatform = 'telegram';
+    let botTokenValue = '';
+
     // Platforms
     let platforms = [];
     let platformSelect = 'telegram';
@@ -311,6 +318,23 @@
         toast($_('settings.toast_primary_user_set'));
         loadPrimaryUser();
         loadAllApprovedUsers();
+    }
+    async function loadGlobalBotTokens() {
+        globalBotTokens = await api('GET', '/bot-tokens').catch(() => []);
+    }
+    async function addGlobalBotToken() {
+        if (!botTokenName.trim()) { toast('Enter a name', 'error'); return; }
+        await api('POST', '/bot-tokens', { name: botTokenName.trim(), platform: botTokenPlatform, token: botTokenValue });
+        botTokenName = ''; botTokenValue = ''; botTokenFormVisible = false;
+        toast('Bot token added');
+        loadGlobalBotTokens();
+    }
+    async function deleteGlobalBotToken(id, name) {
+        if (!confirm(`Delete bot token "${name}"? Agents using it will lose their token.`)) return;
+        await api('DELETE', `/bot-tokens/${id}`);
+        toast('Bot token deleted');
+        loadGlobalBotTokens();
+        loadAllTokens();
     }
     async function loadAllTokens() {
         const data = await api('GET', '/system/all-tokens');
@@ -692,6 +716,7 @@
         loadTimezone();
         loadPrimaryUser();
         loadAllTokens();
+        loadGlobalBotTokens();
         loadAllApprovedUsers();
         loadHeartbeatSettings().then(loadCalendarAgentStatuses);
         loadOwnerProfile();
@@ -1402,6 +1427,48 @@
                         {/each}
                     </tbody>
                 </table>
+            {/if}
+        </div>
+    </div>
+
+    <!-- Global Bot Tokens -->
+    <div class="section">
+        <SectionHeader title="Global Bot Tokens">
+            <button slot="actions" class="btn btn-sm btn-primary" on:click={() => { botTokenFormVisible = !botTokenFormVisible; }}>+ Add Token</button>
+        </SectionHeader>
+        <div class="section-body">
+            {#if botTokenFormVisible}
+                <div style="display:flex;gap:0.5rem;flex-wrap:wrap;align-items:end;margin-bottom:1rem">
+                    <FormField label="Name">
+                        <input type="text" class="form-input" bind:value={botTokenName} placeholder="My Telegram Bot" style="width:180px">
+                    </FormField>
+                    <FormField label="Platform">
+                        <select class="form-select" bind:value={botTokenPlatform} style="width:130px">
+                            <option value="telegram">Telegram</option>
+                            <option value="discord">Discord</option>
+                            <option value="slack">Slack</option>
+                        </select>
+                    </FormField>
+                    <FormField label="Token">
+                        <input type="password" class="form-input" bind:value={botTokenValue} placeholder="Bot token..." style="width:260px">
+                    </FormField>
+                    <button class="btn btn-sm btn-primary" on:click={addGlobalBotToken}>Save</button>
+                    <button class="btn btn-sm" on:click={() => { botTokenFormVisible = false; }} style="background:var(--surface-3);color:var(--text-muted)">Cancel</button>
+                </div>
+            {/if}
+
+            {#if globalBotTokens.length === 0 && !botTokenFormVisible}
+                <div class="empty">No global bot tokens. Add one above — agents can reference them instead of storing tokens individually.</div>
+            {:else}
+                {#each globalBotTokens as bt}
+                    <div style="display:flex;align-items:center;gap:0.75rem;padding:0.5rem 0;border-bottom:1px solid var(--border)">
+                        <span class="mono" style="font-weight:600;min-width:120px">{bt.name}</span>
+                        <StatusBadge variant="model" label={bt.platform} />
+                        <StatusBadge status={bt.token_set ? 'on' : 'off'} label={bt.token_set ? 'Set' : 'Missing'} />
+                        <span style="flex:1"></span>
+                        <button class="btn btn-sm btn-danger" on:click={() => deleteGlobalBotToken(bt.id, bt.name)}>Delete</button>
+                    </div>
+                {/each}
             {/if}
         </div>
     </div>

--- a/frontend-svelte/src/pages/Settings.svelte
+++ b/frontend-svelte/src/pages/Settings.svelte
@@ -1395,7 +1395,7 @@
 
     {/if}
 
-    <!-- All Approved Users (cross-agent) -->
+    <!-- User Access Matrix (cross-agent) -->
     {#if activeTab === 'access'}
     <div class="section">
         <SectionHeader i18nKey="settings.approved_users" />
@@ -1403,30 +1403,30 @@
             {#if allApprovedUsers.length === 0}
                 <div class="empty">{$_('settings.approved_no_users')}</div>
             {:else}
-                <table class="data-table">
-                    <thead><tr><th>{$_('settings.approved_agent_col')}</th><th>{$_('settings.approved_user_col')}</th><th>{$_('settings.approved_chat_id_col')}</th><th>{$_('settings.approved_status_col')}</th><th>{$_('settings.approved_timezone_col')}</th><th>{$_('settings.approved_actions_col')}</th></tr></thead>
-                    <tbody>
-                        {#each allApprovedUsers as u}
-                            <tr>
-                                <td class="mono">{u.agent_name}</td>
-                                <td class="mono">{u.display_name || '--'}</td>
-                                <td class="mono" style="font-size:0.75rem">{u.chat_id}</td>
-                                <td><span class="badge badge-{u.status === 'approved' ? 'on' : u.status === 'denied' ? 'off' : 'model'}">{u.status}</span></td>
-                                <td class="mono" style="font-size:0.75rem">{u.timezone || '--'}</td>
-                                <td>
-                                    <div style="display:flex;gap:0.3rem">
-                                        {#if u.status === 'approved'}
-                                            <button class="btn btn-sm" on:click={async () => { await api('PUT', `/agents/${u.agent_name}/approved-users/${u.chat_id}/deny`); toast(`Denied ${u.display_name || u.chat_id} for ${u.agent_name}`); loadAllApprovedUsers(); }}>{$_('settings.deny')}</button>
-                                        {:else if u.status === 'denied'}
-                                            <button class="btn btn-sm btn-success" on:click={async () => { await api('POST', `/agents/${u.agent_name}/approved-users`, { chat_id: u.chat_id, display_name: u.display_name }); toast(`Approved ${u.display_name || u.chat_id} for ${u.agent_name}`); loadAllApprovedUsers(); }}>{$_('settings.approve')}</button>
-                                        {/if}
-                                        <button class="btn btn-sm btn-danger" on:click={async () => { if (!confirm(`Revoke ${u.display_name || u.chat_id} from ${u.agent_name}?`)) return; await api('DELETE', `/agents/${u.agent_name}/approved-users/${u.chat_id}`); toast('User revoked'); loadAllApprovedUsers(); }}>{$_('settings.revoke')}</button>
-                                    </div>
-                                </td>
-                            </tr>
-                        {/each}
-                    </tbody>
-                </table>
+                {@const agentGroups = Object.entries(
+                    allApprovedUsers.reduce((acc, u) => {
+                        (acc[u.agent_name] = acc[u.agent_name] || []).push(u);
+                        return acc;
+                    }, {})
+                ).sort((a, b) => a[0].localeCompare(b[0]))}
+                {#each agentGroups as [agentName, users]}
+                    <div style="margin-bottom:1rem;padding:0.75rem 1rem;background:var(--surface-2);border-radius:var(--radius-lg)">
+                        <div style="font-family:var(--font-grotesk);font-size:0.75rem;font-weight:700;text-transform:uppercase;color:var(--yellow);margin-bottom:0.5rem">{agentName}</div>
+                        <div style="display:flex;flex-wrap:wrap;gap:0.4rem">
+                            {#each users as u}
+                                <div class="user-access-chip" class:approved={u.status === 'approved'} class:denied={u.status === 'denied'} class:pending={u.status === 'pending'}>
+                                    <span class="user-access-name">{u.display_name || u.chat_id}</span>
+                                    <span class="user-access-status">{u.status}</span>
+                                    {#if u.status === 'approved'}
+                                        <button class="user-access-action" title="Deny" on:click={async () => { await api('PUT', `/agents/${u.agent_name}/approved-users/${u.chat_id}/deny`); toast(`Denied ${u.display_name || u.chat_id} for ${u.agent_name}`); loadAllApprovedUsers(); }}>✕</button>
+                                    {:else if u.status === 'denied' || u.status === 'pending'}
+                                        <button class="user-access-action approve" title="Approve" on:click={async () => { await api('POST', `/agents/${u.agent_name}/approved-users`, { chat_id: u.chat_id, display_name: u.display_name }); toast(`Approved ${u.display_name || u.chat_id} for ${u.agent_name}`); loadAllApprovedUsers(); }}>✓</button>
+                                    {/if}
+                                </div>
+                            {/each}
+                        </div>
+                    </div>
+                {/each}
             {/if}
         </div>
     </div>
@@ -1709,6 +1709,16 @@
 
     .visibility-chip { display: flex; align-items: center; gap: 0.3rem; padding: 0.35rem 0.65rem; border-radius: 999px; font-family: var(--font-grotesk); font-size: 0.78rem; cursor: pointer; border: 1px solid var(--surface-3, #ddd); background: var(--surface-2, #f5f5f5); color: var(--text-muted, #999); transition: all 0.15s; }
     .visibility-chip.visible { background: var(--accent, #7c6af7); color: var(--accent-contrast, #fff); border-color: var(--accent, #7c6af7); }
+
+    .user-access-chip { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.3rem 0.6rem; border-radius: 999px; font-family: var(--font-grotesk); font-size: 0.75rem; border: 1px solid var(--surface-3); background: var(--surface-1); }
+    .user-access-chip.approved { border-color: var(--green, #22c55e); background: rgba(34, 197, 94, 0.1); }
+    .user-access-chip.denied { border-color: var(--red, #ef4444); background: rgba(239, 68, 68, 0.1); opacity: 0.7; }
+    .user-access-chip.pending { border-color: var(--yellow, #eab308); background: rgba(234, 179, 8, 0.1); }
+    .user-access-name { font-weight: 600; }
+    .user-access-status { font-size: 0.65rem; text-transform: uppercase; color: var(--text-muted); }
+    .user-access-action { background: none; border: none; cursor: pointer; font-size: 0.8rem; padding: 0 0.15rem; color: var(--text-muted); opacity: 0.6; transition: opacity 0.15s; }
+    .user-access-action:hover { opacity: 1; }
+    .user-access-action.approve { color: var(--green, #22c55e); }
 
     @media (max-width: 900px) {
         .form-inline { flex-direction: column; align-items: stretch; }

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -266,6 +266,7 @@ class AgentToken:
     enabled: bool = True
     settings: dict = field(default_factory=dict)
     updated_at: float = 0.0
+    token_ref: str = ""  # reference to global bot_tokens.id
 
     def to_dict(self) -> dict:
         return {
@@ -275,6 +276,7 @@ class AgentToken:
             "enabled": self.enabled,
             "settings": self.settings,
             "updated_at": self.updated_at,
+            "token_ref": self.token_ref,
         }
 
 
@@ -638,6 +640,15 @@ class AgentRegistry:
                 created_at REAL NOT NULL DEFAULT 0,
                 updated_at REAL NOT NULL DEFAULT 0
             );
+
+            CREATE TABLE IF NOT EXISTS bot_tokens (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                platform TEXT NOT NULL DEFAULT 'telegram',
+                token TEXT NOT NULL DEFAULT '',
+                created_at REAL NOT NULL DEFAULT 0,
+                updated_at REAL NOT NULL DEFAULT 0
+            );
         """)
         self._db.commit()
         self._migrate()
@@ -708,6 +719,16 @@ class AgentRegistry:
             if col not in hb_existing:
                 self._db.execute(f"ALTER TABLE agent_heartbeats ADD COLUMN {col} {typedef}")
                 _log(f"agent_registry: migrated — added {col} to agent_heartbeats")
+
+        # Migrate agent_tokens table
+        at_existing = {
+            row[1] for row in self._db.execute("PRAGMA table_info(agent_tokens)").fetchall()
+        }
+        if "token_ref" not in at_existing:
+            self._db.execute(
+                "ALTER TABLE agent_tokens ADD COLUMN token_ref TEXT NOT NULL DEFAULT ''"
+            )
+            _log("agent_registry: migrated — added token_ref to agent_tokens")
 
         # Migrate approved_users table
         au_existing = {
@@ -1343,14 +1364,16 @@ except Exception:
         now = time.time()
         enabled = kwargs.get("enabled", True)
         settings = kwargs.get("settings", {})
+        token_ref = kwargs.get("token_ref", "")
 
         self._db.execute(
-            """INSERT INTO agent_tokens (agent_name, platform, token, enabled, settings, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?)
+            """INSERT INTO agent_tokens (agent_name, platform, token, enabled, settings, token_ref, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT (agent_name, platform)
                DO UPDATE SET token=excluded.token, enabled=excluded.enabled,
-                            settings=excluded.settings, updated_at=excluded.updated_at""",
-            (agent_name, platform, token, int(enabled), json.dumps(settings), now),
+                            settings=excluded.settings, token_ref=excluded.token_ref,
+                            updated_at=excluded.updated_at""",
+            (agent_name, platform, token, int(enabled), json.dumps(settings), token_ref, now),
         )
         self._db.commit()
         return self.get_token(agent_name, platform)  # type: ignore
@@ -1358,33 +1381,52 @@ except Exception:
     def get_token(self, agent_name: str, platform: str) -> AgentToken | None:
         """Get token config for an agent+platform (token value never exposed)."""
         row = self._db.execute(
-            "SELECT agent_name, platform, token, enabled, settings, updated_at FROM agent_tokens WHERE agent_name=? AND platform=?",
+            "SELECT agent_name, platform, token, enabled, settings, updated_at, token_ref"
+            " FROM agent_tokens WHERE agent_name=? AND platform=?",
             (agent_name, platform),
         ).fetchone()
         if not row:
             return None
+        token_ref = row[6] if len(row) > 6 else ""
         return AgentToken(
-            agent_name=row[0], platform=row[1], token_set=bool(row[2]),
+            agent_name=row[0], platform=row[1], token_set=bool(row[2]) or bool(token_ref),
             enabled=bool(row[3]), settings=json.loads(row[4]), updated_at=row[5],
+            token_ref=token_ref,
         )
 
     def get_raw_token(self, agent_name: str, platform: str) -> str:
-        """Get the actual token value (internal use only)."""
+        """Get the actual token value (internal use only).
+
+        Resolution order: inline token → token_ref → empty string.
+        """
         row = self._db.execute(
-            "SELECT token FROM agent_tokens WHERE agent_name=? AND platform=?",
+            "SELECT token, token_ref FROM agent_tokens WHERE agent_name=? AND platform=?",
             (agent_name, platform),
         ).fetchone()
-        return row[0] if row else ""
+        if not row:
+            return ""
+        inline_token = row[0] or ""
+        token_ref = row[1] if len(row) > 1 else ""
+        if inline_token:
+            return inline_token
+        if token_ref:
+            ref_row = self._db.execute(
+                "SELECT token FROM bot_tokens WHERE id=?", (token_ref,)
+            ).fetchone()
+            return ref_row[0] if ref_row else ""
+        return ""
 
     def list_tokens(self, agent_name: str) -> list[AgentToken]:
         """List all tokens for an agent."""
         rows = self._db.execute(
-            "SELECT agent_name, platform, token, enabled, settings, updated_at FROM agent_tokens WHERE agent_name=? ORDER BY platform",
+            "SELECT agent_name, platform, token, enabled, settings, updated_at, token_ref"
+            " FROM agent_tokens WHERE agent_name=? ORDER BY platform",
             (agent_name,),
         ).fetchall()
         return [
-            AgentToken(agent_name=r[0], platform=r[1], token_set=bool(r[2]),
-                       enabled=bool(r[3]), settings=json.loads(r[4]), updated_at=r[5])
+            AgentToken(agent_name=r[0], platform=r[1], token_set=bool(r[2]) or bool(r[6] if len(r) > 6 else ""),
+                       enabled=bool(r[3]), settings=json.loads(r[4]), updated_at=r[5],
+                       token_ref=r[6] if len(r) > 6 else "")
             for r in rows
         ]
 
@@ -2181,6 +2223,84 @@ except Exception:
             }
             for r in rows
         ]
+
+    # ── Global Bot Tokens ─────────────────────────────────────
+
+    def list_bot_tokens(self) -> list[dict]:
+        """List all global bot tokens (token value redacted)."""
+        rows = self._db.execute(
+            "SELECT id, name, platform, token, created_at, updated_at"
+            " FROM bot_tokens ORDER BY name"
+        ).fetchall()
+        return [
+            {
+                "id": r[0], "name": r[1], "platform": r[2],
+                "token_set": bool(r[3]), "created_at": r[4], "updated_at": r[5],
+            }
+            for r in rows
+        ]
+
+    def create_bot_token(self, name: str, platform: str, token: str) -> dict:
+        """Create a new global bot token."""
+        import uuid
+        token_id = str(uuid.uuid4())[:8]
+        now = time.time()
+        self._db.execute(
+            "INSERT INTO bot_tokens (id, name, platform, token, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (token_id, name, platform, token, now, now),
+        )
+        self._db.commit()
+        return {"id": token_id, "name": name, "platform": platform, "token_set": bool(token)}
+
+    def get_bot_token(self, token_id: str) -> dict | None:
+        """Get a global bot token by ID (redacted)."""
+        row = self._db.execute(
+            "SELECT id, name, platform, token, created_at, updated_at"
+            " FROM bot_tokens WHERE id=?",
+            (token_id,),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "id": row[0], "name": row[1], "platform": row[2],
+            "token_set": bool(row[3]), "created_at": row[4], "updated_at": row[5],
+        }
+
+    def get_raw_bot_token(self, token_id: str) -> str:
+        """Get the actual bot token value (internal use only)."""
+        row = self._db.execute(
+            "SELECT token FROM bot_tokens WHERE id=?", (token_id,)
+        ).fetchone()
+        return row[0] if row else ""
+
+    def update_bot_token(self, token_id: str, **kwargs) -> dict | None:
+        """Update a global bot token."""
+        updates = []
+        params = []
+        for field in ("name", "platform", "token"):
+            if field in kwargs:
+                updates.append(f"{field}=?")
+                params.append(kwargs[field])
+        if not updates:
+            return self.get_bot_token(token_id)
+        updates.append("updated_at=?")
+        params.append(time.time())
+        params.append(token_id)
+        self._db.execute(
+            f"UPDATE bot_tokens SET {', '.join(updates)} WHERE id=?", params
+        )
+        self._db.commit()
+        return self.get_bot_token(token_id)
+
+    def delete_bot_token(self, token_id: str) -> bool:
+        """Delete a global bot token. Clears refs in agent_tokens."""
+        self._db.execute(
+            "UPDATE agent_tokens SET token_ref='' WHERE token_ref=?", (token_id,)
+        )
+        cursor = self._db.execute("DELETE FROM bot_tokens WHERE id=?", (token_id,))
+        self._db.commit()
+        return cursor.rowcount > 0
 
     def list_all_approved_users(self) -> list[dict]:
         """List all approved users across all agents."""

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -548,7 +548,8 @@ _1M_MODELS = {"claude-sonnet-4-6", "claude-opus-4-6"}
 class SetAgentTokenRequest(BaseModel):
     """Set a bot token for an agent."""
 
-    token: str
+    token: str = ""
+    token_ref: str = ""
     enabled: bool = True
     settings: dict = Field(default_factory=dict)
 
@@ -5234,6 +5235,43 @@ def create_api(
             raise HTTPException(404, f"Provider '{provider_id}' not found")
         return {"deleted": True, "id": provider_id}
 
+    # ── Global Bot Tokens ──────────────────────────────────────────────
+
+    @app.get("/bot-tokens")
+    async def list_bot_tokens():
+        """List all global bot tokens (token values redacted)."""
+        return agents.list_bot_tokens()
+
+    @app.post("/bot-tokens")
+    async def create_bot_token(req: dict):
+        """Create a new global bot token."""
+        name = (req.get("name") or "").strip()
+        if not name:
+            raise HTTPException(400, "name is required")
+        platform = (req.get("platform") or "telegram").strip()
+        token = (req.get("token") or "").strip()
+        return agents.create_bot_token(name, platform, token)
+
+    @app.put("/bot-tokens/{token_id}")
+    async def update_bot_token(token_id: str, req: dict):
+        """Update a global bot token."""
+        existing = agents.get_bot_token(token_id)
+        if not existing:
+            raise HTTPException(404, f"Bot token '{token_id}' not found")
+        kwargs = {}
+        for field in ("name", "platform", "token"):
+            if field in req:
+                kwargs[field] = (req[field] or "").strip()
+        result = agents.update_bot_token(token_id, **kwargs)
+        return result
+
+    @app.delete("/bot-tokens/{token_id}")
+    async def delete_bot_token(token_id: str):
+        """Delete a global bot token. Clears refs in agent tokens."""
+        if not agents.delete_bot_token(token_id):
+            raise HTTPException(404, f"Bot token '{token_id}' not found")
+        return {"deleted": True, "id": token_id}
+
     @app.post("/agents/{name}/claude-md/rebuild")
     async def rebuild_claude_md(name: str):
         """Deprecated — CLAUDE.md is now agent-owned. Returns current file content."""
@@ -5361,10 +5399,14 @@ def create_api(
         """Set a bot token for an agent on a platform."""
         if not agents.get(name):
             raise HTTPException(404, f"Agent '{name}' not found")
-        token = agents.set_token(name, platform, req.token, enabled=req.enabled, settings=req.settings)
+        token = agents.set_token(
+            name, platform, req.token,
+            enabled=req.enabled, settings=req.settings, token_ref=req.token_ref,
+        )
 
         # Dynamically start/restart a broker poller for Telegram tokens
-        if platform == "telegram" and req.token:
+        raw_token = agents.get_raw_token(name, platform)
+        if platform == "telegram" and raw_token:
             try:
                 from pinky_daemon.pollers import BrokerTelegramPoller
                 from pinky_outreach.telegram import TelegramAdapter
@@ -5380,7 +5422,7 @@ def create_api(
                         _log(f"api: stopped old telegram poller for {name}")
                         break
 
-                adapter = TelegramAdapter(req.token, timeout=45.0)  # > poll_timeout (30s) to avoid racing
+                adapter = TelegramAdapter(raw_token, timeout=45.0)  # > poll_timeout (30s) to avoid racing
                 poller = BrokerTelegramPoller(
                     adapter, name, broker, registry=agents,
                 )


### PR DESCRIPTION
## Summary
- **Provider dropdown** — agent config + wizard use dropdown of configured providers instead of preset buttons
- **Global bot token registry** — new `bot_tokens` table, CRUD endpoints, Settings UI, agent/wizard dropdowns with platform filtering
- **User access matrix** — Settings shows agents as cards with user status chips (approve/deny inline)
- Token resolution: inline → ref → empty (mirrors provider pattern)
- Delete cascade: clears agent refs when global token deleted

## PRs/commits included
- Provider dropdown refactor (ProviderConfig + wizard Brain step)
- Global bot tokens backend + frontend
- User access matrix view
- Closes #207

## Test plan
- [x] 249 tests pass
- [x] Build compiles clean
- [x] i18n check passes

🤖 Opened by Barsik