### PR TITLE
Promote beta: per-agent temporal knowledge graph

### DIFF
--- a/frontend-svelte/src/locales/en.json
+++ b/frontend-svelte/src/locales/en.json
@@ -275,6 +275,7 @@
     "sort_salience": "Salience",
     "tab_chat": "Chat History",
     "tab_dreams": "Dreams",
+    "tab_graph": "Knowledge Graph",
     "type_continuation": "Continuation",
     "type_fact": "Fact",
     "type_insight": "Insight",

--- a/frontend-svelte/src/locales/es.json
+++ b/frontend-svelte/src/locales/es.json
@@ -275,6 +275,7 @@
     "sort_salience": "Relevancia",
     "tab_chat": "Historial de chat",
     "tab_dreams": "Sueños",
+    "tab_graph": "Grafo de Conocimiento",
     "type_continuation": "Continuación",
     "type_fact": "Hecho",
     "type_insight": "Perspectiva",

--- a/frontend-svelte/src/locales/ja.json
+++ b/frontend-svelte/src/locales/ja.json
@@ -275,6 +275,7 @@
     "sort_salience": "重要度",
     "tab_chat": "チャット履歴",
     "tab_dreams": "ドリーム",
+    "tab_graph": "ナレッジグラフ",
     "type_continuation": "継続",
     "type_fact": "ファクト",
     "type_insight": "インサイト",

--- a/frontend-svelte/src/locales/ko.json
+++ b/frontend-svelte/src/locales/ko.json
@@ -275,6 +275,7 @@
     "sort_salience": "중요도",
     "tab_chat": "채팅 기록",
     "tab_dreams": "꿈",
+    "tab_graph": "지식 그래프",
     "type_continuation": "연속",
     "type_fact": "사실",
     "type_insight": "인사이트",

--- a/frontend-svelte/src/locales/ru.json
+++ b/frontend-svelte/src/locales/ru.json
@@ -275,6 +275,7 @@
     "sort_salience": "По значимости",
     "tab_chat": "История чата",
     "tab_dreams": "Сны",
+    "tab_graph": "Граф знаний",
     "type_continuation": "Продолжение",
     "type_fact": "Факт",
     "type_insight": "Вывод",

--- a/frontend-svelte/src/locales/uk.json
+++ b/frontend-svelte/src/locales/uk.json
@@ -275,6 +275,7 @@
     "sort_salience": "Важливість",
     "tab_chat": "Історія чату",
     "tab_dreams": "Сни",
+    "tab_graph": "Граф знань",
     "type_continuation": "Продовження",
     "type_fact": "Факт",
     "type_insight": "Інсайт",

--- a/frontend-svelte/src/locales/zh.json
+++ b/frontend-svelte/src/locales/zh.json
@@ -275,6 +275,7 @@
     "sort_salience": "显著性",
     "tab_chat": "聊天记录",
     "tab_dreams": "梦境",
+    "tab_graph": "知识图谱",
     "type_continuation": "延续",
     "type_fact": "事实",
     "type_insight": "洞察",

--- a/frontend-svelte/src/pages/Memories.svelte
+++ b/frontend-svelte/src/pages/Memories.svelte
@@ -26,6 +26,17 @@
     let chatBefore = '';
     let chatRole = '';
 
+    // Knowledge Graph tab state
+    let kgNodes = [];
+    let kgEdges = [];
+    let kgStats = null;
+    let kgLoading = false;
+    let kgSimRunning = false;
+    let kgWidth = 800;
+    let kgHeight = 500;
+    let kgHoveredNode = null;
+    let kgDragNode = null;
+
     // Dreams tab state
     let dreamStates = [];
     let dreamLoading = false;
@@ -187,9 +198,107 @@
         } catch (e) { toast(`Dream failed: ${e.message || e}`, 'error'); }
     }
 
+    async function loadKnowledgeGraph() {
+        if (!currentAgent) return;
+        kgLoading = true;
+        try {
+            const [graphData, stats] = await Promise.all([
+                api('GET', `/agents/${currentAgent}/memory/kg-graph`),
+                api('GET', `/agents/${currentAgent}/memory/kg-stats`),
+            ]);
+            kgStats = stats;
+            if (graphData.nodes && graphData.nodes.length > 0) {
+                initKgGraph(graphData);
+            } else {
+                kgNodes = [];
+                kgEdges = [];
+            }
+        } catch (e) {
+            console.error('KG graph error:', e);
+            kgNodes = [];
+            kgEdges = [];
+        }
+        kgLoading = false;
+    }
+
+    function initKgGraph(data) {
+        const nodes = data.nodes.map(n => ({
+            ...n,
+            x: kgWidth / 2 + (Math.random() - 0.5) * 300,
+            y: kgHeight / 2 + (Math.random() - 0.5) * 200,
+            vx: 0, vy: 0,
+            r: Math.max(16, 12 + n.degree * 3),
+        }));
+        const nodeIds = new Set(nodes.map(n => n.id));
+        const edges = data.edges.filter(e => nodeIds.has(e.source) && nodeIds.has(e.target));
+        kgNodes = nodes;
+        kgEdges = edges;
+        runKgSimulation();
+    }
+
+    function runKgSimulation() {
+        if (kgSimRunning) return;
+        kgSimRunning = true;
+        let iteration = 0;
+        const maxIter = 200;
+        const centerX = kgWidth / 2;
+        const centerY = kgHeight / 2;
+
+        function tick() {
+            if (iteration >= maxIter) { kgSimRunning = false; return; }
+            iteration++;
+            const decay = 1 - iteration / maxIter;
+
+            // Repulsion
+            for (let i = 0; i < kgNodes.length; i++) {
+                for (let j = i + 1; j < kgNodes.length; j++) {
+                    const a = kgNodes[i], b = kgNodes[j];
+                    let dx = b.x - a.x, dy = b.y - a.y;
+                    let dist = Math.sqrt(dx * dx + dy * dy) || 1;
+                    const force = 800 / (dist * dist) * decay;
+                    const fx = dx / dist * force, fy = dy / dist * force;
+                    a.vx -= fx; a.vy -= fy;
+                    b.vx += fx; b.vy += fy;
+                }
+            }
+            // Attraction along edges
+            for (const e of kgEdges) {
+                const a = kgNodes.find(n => n.id === e.source);
+                const b = kgNodes.find(n => n.id === e.target);
+                if (!a || !b) continue;
+                let dx = b.x - a.x, dy = b.y - a.y;
+                let dist = Math.sqrt(dx * dx + dy * dy) || 1;
+                const force = (dist - 120) * 0.01 * decay;
+                const fx = dx / dist * force, fy = dy / dist * force;
+                a.vx += fx; a.vy += fy;
+                b.vx -= fx; b.vy -= fy;
+            }
+            // Center gravity + damping
+            for (const n of kgNodes) {
+                if (n === kgDragNode) continue;
+                n.vx += (centerX - n.x) * 0.005 * decay;
+                n.vy += (centerY - n.y) * 0.005 * decay;
+                n.vx *= 0.9; n.vy *= 0.9;
+                n.x += n.vx; n.y += n.vy;
+                n.x = Math.max(n.r + 10, Math.min(kgWidth - n.r - 10, n.x));
+                n.y = Math.max(n.r + 10, Math.min(kgHeight - n.r - 10, n.y));
+            }
+            kgNodes = kgNodes; // trigger reactivity
+            requestAnimationFrame(tick);
+        }
+        requestAnimationFrame(tick);
+    }
+
+    const KG_COLORS = {
+        person: '#ff6b9d', project: '#f5a623', tool: '#4a9eff',
+        concept: '#c678dd', agent: '#50c878', company: '#e06c75', unknown: '#888',
+    };
+    function kgNodeColor(node) { return KG_COLORS[node.type] || KG_COLORS.unknown; }
+
     function switchTab(tab) {
         activeTab = tab;
         if (tab === 'chat' && currentAgent && chatMessages.length === 0) loadChatHistory();
+        if (tab === 'graph' && currentAgent && kgNodes.length === 0 && !kgLoading) loadKnowledgeGraph();
         if (tab === 'dreams') loadDreamHistory();
     }
 
@@ -211,7 +320,7 @@
 
     <!-- Tabs -->
     {#if currentAgent}
-        <TabBar tabs={[{id:'memories'},{id:'chat'},{id:'dreams'}]} active={activeTab} i18nPrefix="memories.tab_" on:change={(e) => switchTab(e.detail)} />
+        <TabBar tabs={[{id:'memories'},{id:'graph'},{id:'chat'},{id:'dreams'}]} active={activeTab} i18nPrefix="memories.tab_" on:change={(e) => switchTab(e.detail)} />
     {/if}
 
     <!-- Search bar (context-aware) -->
@@ -321,6 +430,120 @@
             <button class="btn" on:click={prevPage} disabled={currentOffset === 0}>{$_('common.prev')}</button>
             <span class="controls-label" style="align-self:center">{$_('common.page_of', { values: { current: currentPage, total: totalPages } })}</span>
             <button class="btn" on:click={nextPage} disabled={currentOffset + PAGE_SIZE >= totalCount}>{$_('common.next')}</button>
+        </div>
+    {/if}
+
+    {:else if activeTab === 'graph'}
+    <!-- Knowledge Graph Tab -->
+    {#if kgLoading}
+        <div class="empty">Loading knowledge graph...</div>
+    {:else if kgNodes.length === 0}
+        <div class="empty" style="text-align:center;padding:3rem">
+            <span class="material-symbols-outlined" style="font-size:48px;opacity:0.3">hub</span>
+            <p style="margin-top:0.5rem">No knowledge graph data yet.</p>
+            <p style="font-size:0.78rem;color:var(--text-muted)">Use <code>kg_add()</code> to add entity relationships.</p>
+        </div>
+    {:else}
+        {#if kgStats}
+            <div class="stats-bar section" style="margin-bottom:1rem">
+                <div class="stat-item"><span class="stat-value">{kgStats.entities}</span><span class="stat-label">Entities</span></div>
+                <div class="stat-item"><span class="stat-value">{kgStats.triples_active}</span><span class="stat-label">Active Facts</span></div>
+                <div class="stat-item"><span class="stat-value">{kgStats.triples_total}</span><span class="stat-label">Total Facts</span></div>
+                <div class="stat-item"><span class="stat-value">{Object.keys(kgStats.predicates || {}).length}</span><span class="stat-label">Predicates</span></div>
+            </div>
+        {/if}
+        <div class="section" style="padding:1rem">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
+                <span style="font-family:var(--font-grotesk);font-size:0.72rem;color:var(--text-muted)">{kgNodes.length} nodes · {kgEdges.length} edges</span>
+                <button class="btn btn-sm" style="background:var(--surface-3);color:var(--text-muted);font-size:0.72rem" on:click={loadKnowledgeGraph}>Refresh</button>
+            </div>
+            <svg
+                width={kgWidth}
+                height={kgHeight}
+                style="background:rgba(0,0,0,0.2);border-radius:8px;cursor:grab;width:100%"
+                viewBox="0 0 {kgWidth} {kgHeight}"
+            >
+                <!-- Edges with labels -->
+                {#each kgEdges as edge}
+                    {@const src = kgNodes.find(n => n.id === edge.source)}
+                    {@const tgt = kgNodes.find(n => n.id === edge.target)}
+                    {#if src && tgt}
+                        <line
+                            x1={src.x} y1={src.y}
+                            x2={tgt.x} y2={tgt.y}
+                            stroke="rgba(255,255,255,0.2)"
+                            stroke-width="1.5"
+                        />
+                        <text
+                            x={(src.x + tgt.x) / 2}
+                            y={(src.y + tgt.y) / 2 - 4}
+                            text-anchor="middle"
+                            fill="rgba(255,255,255,0.35)"
+                            font-size="9px"
+                            font-family="monospace"
+                        >{edge.label}</text>
+                    {/if}
+                {/each}
+
+                <!-- Nodes -->
+                {#each kgNodes as node}
+                    <g
+                        style="cursor:pointer"
+                        on:mouseenter={() => kgHoveredNode = node}
+                        on:mouseleave={() => kgHoveredNode = null}
+                    >
+                        <circle
+                            cx={node.x} cy={node.y} r={node.r}
+                            fill={kgNodeColor(node)}
+                            stroke={kgHoveredNode === node ? '#fff' : 'rgba(255,255,255,0.2)'}
+                            stroke-width={kgHoveredNode === node ? 2.5 : 1}
+                            opacity={kgHoveredNode && kgHoveredNode !== node ? 0.4 : 0.9}
+                        />
+                        <text
+                            x={node.x} y={node.y + node.r + 14}
+                            text-anchor="middle"
+                            fill={kgHoveredNode === node ? '#fff' : 'rgba(255,255,255,0.6)'}
+                            font-size="11px"
+                            font-family="monospace"
+                        >
+                            {node.label.length > 20 ? node.label.slice(0, 18) + '...' : node.label}
+                        </text>
+                    </g>
+                {/each}
+
+                <!-- Tooltip -->
+                {#if kgHoveredNode}
+                    <rect
+                        x={kgHoveredNode.x + kgHoveredNode.r + 8}
+                        y={kgHoveredNode.y - 16}
+                        width={Math.max(140, kgHoveredNode.label.length * 7 + 60)}
+                        height="32"
+                        rx="4"
+                        fill="rgba(0,0,0,0.85)"
+                        stroke="rgba(255,255,255,0.2)"
+                    />
+                    <text
+                        x={kgHoveredNode.x + kgHoveredNode.r + 14}
+                        y={kgHoveredNode.y + 1}
+                        fill="#fff"
+                        font-size="12px"
+                        font-family="monospace"
+                    >
+                        {kgHoveredNode.label} ({kgHoveredNode.type}) · {kgHoveredNode.degree}
+                    </text>
+                {/if}
+            </svg>
+
+            <!-- Legend -->
+            <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-top:0.75rem;justify-content:center;font-family:var(--font-grotesk);font-size:0.72rem;color:var(--text-muted)">
+                {#each Object.entries(KG_COLORS).filter(([k]) => k !== 'unknown') as [type, color]}
+                    <span style="display:flex;align-items:center;gap:0.3rem">
+                        <span style="width:10px;height:10px;border-radius:50%;background:{color};display:inline-block"></span>
+                        {type.charAt(0).toUpperCase() + type.slice(1)}
+                    </span>
+                {/each}
+                <span style="font-size:0.65rem;color:var(--text-muted)">Node size = connections</span>
+            </div>
         </div>
     {/if}
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8934,6 +8934,68 @@ def create_api(
         store.close()
         return {"links": linked_memories, "count": len(linked_memories)}
 
+    @app.get("/agents/{agent_name}/memory/kg-graph")
+    async def get_memory_kg_graph(agent_name: str):
+        """Get the knowledge graph as nodes + edges for visualization."""
+        store = _get_memory_store(agent_name)
+        try:
+            entities = store.kg_entities_list(limit=500)
+            triples = store.kg_query(include_expired=False, limit=1000)
+        except Exception:
+            store.close()
+            return {"nodes": [], "edges": []}
+
+        # Build degree map
+        degree: dict[str, int] = {}
+        for t in triples:
+            degree[t["subject"]] = degree.get(t["subject"], 0) + 1
+            degree[t["object"]] = degree.get(t["object"], 0) + 1
+
+        # Entity name → type lookup
+        type_map = {e["name"]: e["type"] for e in entities}
+
+        # Build nodes from all entities mentioned in active triples
+        node_names: set[str] = set()
+        for t in triples:
+            node_names.add(t["subject"])
+            node_names.add(t["object"])
+
+        nodes = [
+            {
+                "id": name,
+                "label": name,
+                "type": type_map.get(name, "unknown"),
+                "degree": degree.get(name, 0),
+            }
+            for name in sorted(node_names)
+        ]
+
+        edges = [
+            {
+                "source": t["subject"],
+                "target": t["object"],
+                "label": t["predicate"],
+                "type": "kg",
+            }
+            for t in triples
+        ]
+
+        store.close()
+        return {"nodes": nodes, "edges": edges}
+
+    @app.get("/agents/{agent_name}/memory/kg-stats")
+    async def get_memory_kg_stats(agent_name: str):
+        """Get knowledge graph statistics for an agent."""
+        store = _get_memory_store(agent_name)
+        try:
+            stats = store.kg_stats()
+        except Exception:
+            store.close()
+            return {"entities": 0, "triples_total": 0, "triples_active": 0,
+                    "entity_types": {}, "predicates": {}}
+        store.close()
+        return stats
+
     # ── SSE Streaming Endpoints ───────────────────────────
 
     @app.get("/sessions/{session_id}/stream")

--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -363,4 +363,99 @@ def create_server(
             ],
         })
 
+    # ── Knowledge Graph Tools ──────────────────────────────
+
+    @mcp.tool()
+    def kg_add(
+        subject: str,
+        predicate: str,
+        object: str,
+        valid_from: str = "",
+        subject_type: str = "unknown",
+        object_type: str = "unknown",
+        confidence: float = 1.0,
+        source_reflection_id: str = "",
+    ) -> str:
+        """Add a fact to the knowledge graph. Creates entities automatically.
+        Example: kg_add("Brad", "uses", "SQLite", valid_from="2026-03")
+        Predicates: uses, works_on, prefers, manages, owns, knows, created, etc.
+        Entity types: person, project, tool, concept, agent, company, etc.
+        """
+        s = _get_store()
+        result = s.kg_add(
+            subject=subject, predicate=predicate, obj=object,
+            valid_from=valid_from, subject_type=subject_type,
+            object_type=object_type, confidence=confidence,
+            source_reflection_id=source_reflection_id,
+        )
+        _log(f"kg_add: ({subject}) --[{predicate}]--> ({object})")
+        return json.dumps(result)
+
+    @mcp.tool()
+    def kg_query(
+        entity: str = "",
+        predicate: str = "",
+        as_of: str = "",
+        include_expired: bool = False,
+        limit: int = 50,
+    ) -> str:
+        """Query the knowledge graph. Filter by entity, predicate, and/or point in time.
+        as_of: ISO date to see what was true at that time (e.g. "2026-01-15").
+        include_expired: also show facts that have ended.
+        """
+        s = _get_store()
+        results = s.kg_query(
+            entity=entity, predicate=predicate,
+            as_of=as_of, include_expired=include_expired, limit=limit,
+        )
+        _log(f"kg_query: entity={entity} predicate={predicate} → {len(results)} triples")
+        return json.dumps({"count": len(results), "triples": results})
+
+    @mcp.tool()
+    def kg_invalidate(
+        subject: str,
+        predicate: str,
+        object: str,
+        valid_to: str = "",
+    ) -> str:
+        """Mark a fact as no longer true. Sets the end date on matching triples.
+        Example: kg_invalidate("Brad", "uses", "Postgres", valid_to="2026-03")
+        If valid_to is empty, uses today's date.
+        """
+        s = _get_store()
+        count = s.kg_invalidate(
+            subject=subject, predicate=predicate, obj=object, valid_to=valid_to,
+        )
+        _log(f"kg_invalidate: ({subject}) --[{predicate}]--> ({object}) → {count} invalidated")
+        return json.dumps({"invalidated": count})
+
+    @mcp.tool()
+    def kg_timeline(entity: str, limit: int = 50) -> str:
+        """Get chronological history of all facts about an entity.
+        Shows active and expired facts in time order.
+        """
+        s = _get_store()
+        results = s.kg_timeline(entity=entity, limit=limit)
+        _log(f"kg_timeline: {entity} → {len(results)} facts")
+        return json.dumps({"entity": entity, "count": len(results), "timeline": results})
+
+    @mcp.tool()
+    def kg_connections(entity: str) -> str:
+        """Find all entities connected to a given entity.
+        Returns outgoing (entity → X) and incoming (X → entity) relationships.
+        """
+        s = _get_store()
+        result = s.kg_connections(entity=entity)
+        total = len(result["outgoing"]) + len(result["incoming"])
+        _log(f"kg_connections: {entity} → {total} connections")
+        return json.dumps({"entity": entity, **result})
+
+    @mcp.tool()
+    def kg_stats() -> str:
+        """Get knowledge graph statistics — entity count, triple count, predicates."""
+        s = _get_store()
+        result = s.kg_stats()
+        _log(f"kg_stats: {result['entities']} entities, {result['triples_active']} active triples")
+        return json.dumps(result)
+
     return mcp

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -154,6 +154,8 @@ class ReflectionStore:
         self._migrate_create_memory_events()
         # Migrate: reflection_links table (memory linking system)
         self._migrate_create_reflection_links()
+        # Migrate: knowledge graph tables (temporal entity-relationship graph)
+        self._migrate_create_knowledge_graph()
         # FTS5 index (separate try — graceful if FTS5 not compiled in)
         try:
             self._conn.executescript(_FTS5_SCHEMA)
@@ -2186,6 +2188,257 @@ class ReflectionStore:
             # Reload sqlite-vec extension after reconnect
             self._vec_available = False
             self._init_vec()
+
+    # ── Knowledge Graph ──────────────────────────────────────
+
+    def _migrate_create_knowledge_graph(self) -> None:
+        """Create the knowledge graph tables for temporal entity-relationship tracking."""
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS kg_entities (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL COLLATE NOCASE,
+                type TEXT NOT NULL DEFAULT 'unknown',
+                properties TEXT NOT NULL DEFAULT '{}',
+                created_at REAL NOT NULL,
+                UNIQUE(name)
+            );
+            CREATE INDEX IF NOT EXISTS idx_kg_entities_name ON kg_entities(name);
+            CREATE INDEX IF NOT EXISTS idx_kg_entities_type ON kg_entities(type);
+
+            CREATE TABLE IF NOT EXISTS kg_triples (
+                id TEXT PRIMARY KEY,
+                subject TEXT NOT NULL COLLATE NOCASE,
+                predicate TEXT NOT NULL COLLATE NOCASE,
+                object TEXT NOT NULL COLLATE NOCASE,
+                valid_from TEXT,
+                valid_to TEXT,
+                confidence REAL NOT NULL DEFAULT 1.0,
+                source_reflection_id TEXT DEFAULT '',
+                extracted_at REAL NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_kg_triples_subject ON kg_triples(subject);
+            CREATE INDEX IF NOT EXISTS idx_kg_triples_object ON kg_triples(object);
+            CREATE INDEX IF NOT EXISTS idx_kg_triples_predicate ON kg_triples(predicate);
+            CREATE INDEX IF NOT EXISTS idx_kg_triples_active
+                ON kg_triples(subject, predicate) WHERE valid_to IS NULL;
+        """)
+        self._conn.commit()
+
+    def _ensure_entity(self, name: str, entity_type: str = "unknown") -> str:
+        """Get or create an entity by name. Returns the entity ID."""
+        import time
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT id FROM kg_entities WHERE name = ?", (name,)
+            ).fetchone()
+            if row:
+                return row["id"]
+            eid = _generate_id()
+            self._conn.execute(
+                "INSERT INTO kg_entities (id, name, type, created_at) VALUES (?, ?, ?, ?)",
+                (eid, name, entity_type, time.time()),
+            )
+            self._conn.commit()
+            return eid
+
+    def kg_add(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        valid_from: str = "",
+        subject_type: str = "unknown",
+        object_type: str = "unknown",
+        confidence: float = 1.0,
+        source_reflection_id: str = "",
+    ) -> dict:
+        """Add a triple to the knowledge graph. Auto-creates entities."""
+        import time
+        self._ensure_entity(subject, subject_type)
+        self._ensure_entity(obj, object_type)
+        tid = _generate_id()
+        with self._lock:
+            self._conn.execute(
+                """INSERT INTO kg_triples
+                   (id, subject, predicate, object, valid_from, confidence,
+                    source_reflection_id, extracted_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (tid, subject, predicate, obj,
+                 valid_from or None, confidence,
+                 source_reflection_id, time.time()),
+            )
+            self._conn.commit()
+        return {
+            "id": tid, "subject": subject, "predicate": predicate,
+            "object": obj, "valid_from": valid_from or None,
+        }
+
+    def kg_query(
+        self,
+        entity: str = "",
+        predicate: str = "",
+        as_of: str = "",
+        include_expired: bool = False,
+        limit: int = 50,
+    ) -> list[dict]:
+        """Query the knowledge graph. Filter by entity, predicate, and/or time."""
+        conditions = []
+        params: list = []
+
+        if entity:
+            conditions.append("(t.subject = ? OR t.object = ?)")
+            params.extend([entity, entity])
+        if predicate:
+            conditions.append("t.predicate = ?")
+            params.append(predicate)
+        if not include_expired:
+            conditions.append("t.valid_to IS NULL")
+        if as_of:
+            conditions.append(
+                "(t.valid_from IS NULL OR t.valid_from <= ?)"
+            )
+            params.append(as_of)
+            if not include_expired:
+                # Override: show things valid at that point even if later expired
+                conditions = [c for c in conditions if "valid_to IS NULL" not in c]
+                conditions.append("(t.valid_to IS NULL OR t.valid_to > ?)")
+                params.append(as_of)
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+        params.append(limit)
+
+        rows = self._conn.execute(
+            f"""SELECT t.id, t.subject, t.predicate, t.object,
+                       t.valid_from, t.valid_to, t.confidence,
+                       t.source_reflection_id, t.extracted_at
+                FROM kg_triples t
+                WHERE {where}
+                ORDER BY t.extracted_at DESC
+                LIMIT ?""",
+            params,
+        ).fetchall()
+
+        return [
+            {
+                "id": r["id"], "subject": r["subject"],
+                "predicate": r["predicate"], "object": r["object"],
+                "valid_from": r["valid_from"], "valid_to": r["valid_to"],
+                "confidence": r["confidence"],
+                "source_reflection_id": r["source_reflection_id"],
+            }
+            for r in rows
+        ]
+
+    def kg_invalidate(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        valid_to: str = "",
+    ) -> int:
+        """Mark matching triples as ended. Returns count of invalidated triples."""
+        import time
+        from datetime import datetime as dt, timezone as tz
+        end_date = valid_to or dt.now(tz.utc).strftime("%Y-%m-%d")
+        with self._lock:
+            cursor = self._conn.execute(
+                """UPDATE kg_triples SET valid_to = ?
+                   WHERE subject = ? AND predicate = ? AND object = ?
+                   AND valid_to IS NULL""",
+                (end_date, subject, predicate, obj),
+            )
+            self._conn.commit()
+            return cursor.rowcount
+
+    def kg_timeline(self, entity: str, limit: int = 50) -> list[dict]:
+        """Get chronological history of all triples involving an entity."""
+        rows = self._conn.execute(
+            """SELECT id, subject, predicate, object,
+                      valid_from, valid_to, confidence, extracted_at
+               FROM kg_triples
+               WHERE subject = ? OR object = ?
+               ORDER BY COALESCE(valid_from, '') ASC, extracted_at ASC
+               LIMIT ?""",
+            (entity, entity, limit),
+        ).fetchall()
+        return [
+            {
+                "id": r["id"], "subject": r["subject"],
+                "predicate": r["predicate"], "object": r["object"],
+                "valid_from": r["valid_from"], "valid_to": r["valid_to"],
+                "confidence": r["confidence"], "active": r["valid_to"] is None,
+            }
+            for r in rows
+        ]
+
+    def kg_connections(self, entity: str, depth: int = 1) -> dict:
+        """Find all entities connected to a given entity (1 hop by default)."""
+        result: dict[str, list[dict]] = {"outgoing": [], "incoming": []}
+
+        out_rows = self._conn.execute(
+            """SELECT predicate, object, valid_from, valid_to
+               FROM kg_triples WHERE subject = ? AND valid_to IS NULL
+               ORDER BY predicate""",
+            (entity,),
+        ).fetchall()
+        for r in out_rows:
+            result["outgoing"].append({
+                "predicate": r["predicate"], "target": r["object"],
+                "valid_from": r["valid_from"],
+            })
+
+        in_rows = self._conn.execute(
+            """SELECT predicate, subject, valid_from, valid_to
+               FROM kg_triples WHERE object = ? AND valid_to IS NULL
+               ORDER BY predicate""",
+            (entity,),
+        ).fetchall()
+        for r in in_rows:
+            result["incoming"].append({
+                "predicate": r["predicate"], "source": r["subject"],
+                "valid_from": r["valid_from"],
+            })
+
+        return result
+
+    def kg_entities_list(self, entity_type: str = "", limit: int = 100) -> list[dict]:
+        """List all entities, optionally filtered by type."""
+        if entity_type:
+            rows = self._conn.execute(
+                "SELECT id, name, type, properties FROM kg_entities WHERE type = ? ORDER BY name LIMIT ?",
+                (entity_type, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT id, name, type, properties FROM kg_entities ORDER BY name LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [
+            {"id": r["id"], "name": r["name"], "type": r["type"],
+             "properties": json.loads(r["properties"])}
+            for r in rows
+        ]
+
+    def kg_stats(self) -> dict:
+        """Get knowledge graph statistics."""
+        entities = self._conn.execute("SELECT COUNT(*) FROM kg_entities").fetchone()[0]
+        triples = self._conn.execute("SELECT COUNT(*) FROM kg_triples").fetchone()[0]
+        active = self._conn.execute(
+            "SELECT COUNT(*) FROM kg_triples WHERE valid_to IS NULL"
+        ).fetchone()[0]
+        types = self._conn.execute(
+            "SELECT type, COUNT(*) as cnt FROM kg_entities GROUP BY type ORDER BY cnt DESC"
+        ).fetchall()
+        predicates = self._conn.execute(
+            "SELECT predicate, COUNT(*) as cnt FROM kg_triples WHERE valid_to IS NULL GROUP BY predicate ORDER BY cnt DESC"
+        ).fetchall()
+        return {
+            "entities": entities,
+            "triples_total": triples,
+            "triples_active": active,
+            "entity_types": {r["type"]: r["cnt"] for r in types},
+            "predicates": {r["predicate"]: r["cnt"] for r in predicates},
+        }
 
     def backup_corrupt(self) -> str:
         """Back up all DB files (.db, -wal, -shm) with a timestamp suffix.

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -394,3 +394,119 @@ class TestMemoryQuery:
         _tools(srv)["reflect"](content="solo", type="fact")
         result = json.loads(_tools(srv)["memory_query"](has_links=False))
         assert "total" in result
+
+
+# ── Knowledge Graph Tests ─────────────────────────────────────────────────────
+
+
+class TestKnowledgeGraph:
+    """Tests for the per-agent temporal knowledge graph."""
+
+    def test_kg_add_and_query(self, srv):
+        tools = _tools(srv)
+        result = json.loads(tools["kg_add"](
+            subject="Brad", predicate="uses", object="SQLite",
+            valid_from="2026-03", subject_type="person", object_type="tool",
+        ))
+        assert result["subject"] == "Brad"
+        assert result["predicate"] == "uses"
+        assert result["object"] == "SQLite"
+        assert result["id"]
+
+        query = json.loads(tools["kg_query"](entity="Brad"))
+        assert query["count"] == 1
+        assert query["triples"][0]["object"] == "SQLite"
+
+    def test_kg_invalidate(self, srv):
+        tools = _tools(srv)
+        tools["kg_add"](subject="Brad", predicate="uses", object="Postgres", valid_from="2025-01")
+        result = json.loads(tools["kg_invalidate"](
+            subject="Brad", predicate="uses", object="Postgres", valid_to="2026-03",
+        ))
+        assert result["invalidated"] == 1
+
+        # Should not appear in active query
+        query = json.loads(tools["kg_query"](entity="Brad"))
+        assert query["count"] == 0
+
+        # Should appear with include_expired
+        query = json.loads(tools["kg_query"](entity="Brad", include_expired=True))
+        assert query["count"] == 1
+        assert query["triples"][0]["valid_to"] == "2026-03"
+
+    def test_kg_timeline(self, srv):
+        tools = _tools(srv)
+        tools["kg_add"](subject="TOD", predicate="status", object="pitch", valid_from="2026-01")
+        tools["kg_add"](subject="TOD", predicate="status", object="contract", valid_from="2026-02")
+        tools["kg_add"](subject="TOD", predicate="status", object="deployed", valid_from="2026-03")
+
+        result = json.loads(tools["kg_timeline"](entity="TOD"))
+        assert result["count"] == 3
+        objects = [t["object"] for t in result["timeline"]]
+        assert objects == ["pitch", "contract", "deployed"]
+
+    def test_kg_connections(self, srv):
+        tools = _tools(srv)
+        tools["kg_add"](subject="Brad", predicate="manages", object="Barsik")
+        tools["kg_add"](subject="Brad", predicate="manages", object="Pushok")
+        tools["kg_add"](subject="Brad", predicate="works_with", object="Dmitriy")
+
+        result = json.loads(tools["kg_connections"](entity="Brad"))
+        assert len(result["outgoing"]) == 3
+        targets = {c["target"] for c in result["outgoing"]}
+        assert targets == {"Barsik", "Pushok", "Dmitriy"}
+
+    def test_kg_connections_incoming(self, srv):
+        tools = _tools(srv)
+        tools["kg_add"](subject="Brad", predicate="manages", object="Barsik")
+
+        result = json.loads(tools["kg_connections"](entity="Barsik"))
+        assert len(result["incoming"]) == 1
+        assert result["incoming"][0]["source"] == "Brad"
+
+    def test_kg_stats(self, srv):
+        tools = _tools(srv)
+        tools["kg_add"](subject="Brad", predicate="uses", object="SQLite",
+                        subject_type="person", object_type="tool")
+        tools["kg_add"](subject="Brad", predicate="manages", object="Barsik",
+                        subject_type="person", object_type="agent")
+
+        result = json.loads(tools["kg_stats"]())
+        assert result["entities"] >= 3  # Brad, SQLite, Barsik
+        assert result["triples_active"] == 2
+        assert "uses" in result["predicates"]
+        assert "manages" in result["predicates"]
+
+    def test_kg_query_as_of(self, srv):
+        tools = _tools(srv)
+        tools["kg_add"](subject="Brad", predicate="uses", object="Postgres", valid_from="2025-01")
+        tools["kg_invalidate"](subject="Brad", predicate="uses", object="Postgres", valid_to="2026-03")
+        tools["kg_add"](subject="Brad", predicate="uses", object="SQLite", valid_from="2026-03")
+
+        # As of Feb 2026 — should see Postgres
+        feb = json.loads(tools["kg_query"](entity="Brad", predicate="uses", as_of="2026-02-15"))
+        assert feb["count"] == 1
+        assert feb["triples"][0]["object"] == "Postgres"
+
+        # As of Apr 2026 — should see SQLite
+        apr = json.loads(tools["kg_query"](entity="Brad", predicate="uses", as_of="2026-04-15"))
+        assert apr["count"] == 1
+        assert apr["triples"][0]["object"] == "SQLite"
+
+    def test_kg_case_insensitive(self, srv):
+        tools = _tools(srv)
+        tools["kg_add"](subject="brad", predicate="uses", object="sqlite")
+
+        # Query with different case
+        result = json.loads(tools["kg_query"](entity="Brad"))
+        assert result["count"] == 1
+
+    def test_kg_duplicate_entity(self, srv):
+        tools = _tools(srv)
+        tools["kg_add"](subject="Brad", predicate="uses", object="SQLite", subject_type="person")
+        tools["kg_add"](subject="Brad", predicate="manages", object="Barsik", subject_type="person")
+
+        # Brad should exist only once
+        result = json.loads(tools["kg_stats"]())
+        brad_count = sum(1 for _ in [1])  # just verify no error
+        assert result["entities"] == 3  # Brad, SQLite, Barsik


### PR DESCRIPTION
## Summary
- Per-agent temporal knowledge graph in pinky-memory (SQLite)
- 6 new MCP tools: kg_add, kg_query, kg_invalidate, kg_timeline, kg_connections, kg_stats
- Force-directed graph visualization on Memories page (new Graph tab)
- Improved user access UX (tabbed view, confirm modals, admin always-approved)
- Bot tokens show assigned agents

## Test plan
- [x] 54 memory tests pass (9 new KG tests)
- [x] Frontend builds clean
- [x] i18n extract clean

🤖 Opened by Barsik