### PR TITLE
Stream Codex CLI incremental events through SSE to Chat UI

### DIFF
--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -5,7 +5,7 @@
     import ChatSidebar from '../components/ChatSidebar.svelte';
     import ChatMessage from '../components/ChatMessage.svelte';
     import ChatInput from '../components/ChatInput.svelte';
-    import { api } from '../lib/api.js';
+    import { api, sse } from '../lib/api.js';
     import {
         parseBrokerMessage, groupByAgent, sortMessages,
         latestAssistantTimestamp, userContentMatches,
@@ -96,6 +96,7 @@
     ];
 
     let chatPollInterval;
+    let streamEventSource = null;
     let chatRefreshSeq = 0;
     let sessionSwitchSeq = 0;
     let currentHistorySource = { kind: null, sessionId: null };
@@ -521,6 +522,51 @@
         if (activityPollInterval) { clearInterval(activityPollInterval); activityPollInterval = null; }
     }
 
+    function stopStreamEvents() {
+        if (streamEventSource) {
+            streamEventSource.close();
+            streamEventSource = null;
+        }
+    }
+
+    function startStreamEvents() {
+        stopStreamEvents();
+        if (!activeAgent || !activeSession || !canUseStreamingChat) return;
+        const label = activeSessionRecord?._streaming_label || activeSession?.split('-').slice(1).join('-') || 'main';
+        streamEventSource = sse(`/agents/${activeAgent}/streaming/events?label=${encodeURIComponent(label)}`);
+        streamEventSource.onmessage = async (evt) => {
+            let data = null;
+            try { data = JSON.parse(evt.data || '{}'); } catch { return; }
+            if (!data || !data.type) return;
+            if (data.type === 'assistant_delta') {
+                const delta = String(data.delta || '');
+                if (!delta) return;
+                const idx = localMessages.findIndex((m) => m._localKind === 'pending-assistant-stream');
+                if (idx >= 0) {
+                    const updated = [...localMessages];
+                    updated[idx] = { ...updated[idx], content: `${updated[idx].content || ''}${delta}` };
+                    localMessages = updated;
+                } else {
+                    addLocalMessage({ role: 'assistant', content: delta, _localKind: 'pending-assistant-stream', _sentAt: Date.now() / 1000 });
+                }
+                await tick();
+                scrollToBottom();
+            } else if (data.type === 'tool_use') {
+                const labelText = String(data.label || data.tool || '');
+                if (labelText) {
+                    thinkingActivity = labelText;
+                    activityLog = [...activityLog, labelText].slice(-20);
+                }
+            } else if (data.type === 'turn_completed' || data.type === 'turn_failed') {
+                localMessages = localMessages.filter((m) => m._localKind !== 'pending-assistant-stream');
+                if (data.type === 'turn_failed' && data.error) {
+                    addLocalMessage({ role: 'system', content: `Codex turn failed: ${data.error}` });
+                }
+                await refreshChat();
+            }
+        };
+    }
+
     // ── Session Meta Polling ──────────────────────────────
 
     function formatUptime(seconds) {
@@ -613,6 +659,7 @@
 
         stopChatPolling();
         stopActivityPolling();
+        stopStreamEvents();
         chatRefreshSeq += 1;
         const switchSeq = ++sessionSwitchSeq;
         activeSession = id;
@@ -639,6 +686,7 @@
         scrollToBottom();
         startChatPolling();
         startActivityPolling();
+        startStreamEvents();
     }
 
     // ── Send Message ───────────────────────────────────────
@@ -1000,6 +1048,7 @@
         clearInterval(refreshInterval);
         stopChatPolling();
         stopActivityPolling();
+        stopStreamEvents();
         stopSessionMetaPolling();
         document.removeEventListener('click', handleGlobalClick);
     });

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2160,6 +2160,20 @@ def create_api(
 
         return wake_ctx
 
+    _stream_event_subscribers: dict[str, set[asyncio.Queue]] = {}
+
+    async def _publish_stream_event(session_stream_id: str, event: dict) -> None:
+        """Broadcast an incremental stream event to active SSE subscribers."""
+        subscribers = list(_stream_event_subscribers.get(session_stream_id, set()))
+        if not subscribers:
+            return
+        for queue in subscribers:
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                # Drop stale updates for slow clients; final turn still persists.
+                pass
+
     async def _make_streaming_response_callback():
         """Create a response callback that routes through the broker."""
         async def _on_response(turn_result):
@@ -2179,6 +2193,18 @@ def create_api(
                     fallback_enabled=agent.plain_text_fallback,
                 )
         return _on_response
+
+    async def _make_streaming_event_callback(agent_name: str, label: str):
+        """Create a callback for incremental codex event streaming to the web UI."""
+        session_stream_id = f"{agent_name}-{label}"
+
+        async def _on_stream_event(event: dict):
+            await _publish_stream_event(session_stream_id, {
+                "session_id": session_stream_id,
+                **(event or {}),
+            })
+
+        return _on_stream_event
 
     async def _make_streaming_session_id_callback(agent_name: str, label: str):
         """Persist a streaming session ID when captured from the SDK.
@@ -2372,12 +2398,15 @@ def create_api(
         is_codex = resolved_provider_url == "codex_cli"
         SessionClass = CodexSession if is_codex else StreamingSession  # noqa: N806
 
-        ss = SessionClass(
-            config,
-            response_callback=callback,
-            conversation_store=store,
-            cost_callback=_make_cost_callback(agents),
-        )
+        init_kwargs = {
+            "response_callback": callback,
+            "conversation_store": store,
+            "cost_callback": _make_cost_callback(agents),
+        }
+        if is_codex:
+            init_kwargs["stream_event_callback"] = await _make_streaming_event_callback(agent_name, label)
+
+        ss = SessionClass(config, **init_kwargs)
         ss._on_session_id = sid_callback
         await ss.connect()
         broker.register_streaming(agent_name, ss, label=label)
@@ -6561,6 +6590,30 @@ def create_api(
         prompt = f"[web | dm | Admin | web | {ts}]\n{content}"
         await streaming.send(prompt, platform="web", chat_id="web")
         return {"sent": True, "agent": name}
+
+    @app.get("/agents/{agent_name}/streaming/events")
+    async def stream_agent_events(agent_name: str, label: str = "main"):
+        """SSE stream for incremental agent events (Codex CLI partials/tool calls)."""
+        session_stream_id = f"{agent_name}-{label}"
+        queue: asyncio.Queue = asyncio.Queue(maxsize=200)
+        _stream_event_subscribers.setdefault(session_stream_id, set()).add(queue)
+
+        async def event_generator():
+            try:
+                while True:
+                    try:
+                        payload = await asyncio.wait_for(queue.get(), timeout=10.0)
+                        yield f"data: {json.dumps(payload)}\n\n"
+                    except asyncio.TimeoutError:
+                        yield f"data: {json.dumps({'type': 'ping', 'session_id': session_stream_id, 'timestamp': time.time()})}\n\n"
+            finally:
+                subs = _stream_event_subscribers.get(session_stream_id)
+                if subs:
+                    subs.discard(queue)
+                    if not subs:
+                        _stream_event_subscribers.pop(session_stream_id, None)
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream")
 
     @app.post("/agents/{name}/upload")
     async def upload_file_to_agent(name: str, file: UploadFile):

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -60,11 +60,13 @@ class CodexSession:
         response_callback=None,     # async fn(StreamingTurnResult)
         conversation_store=None,    # ConversationStore for history logging
         cost_callback=None,         # fn(agent_name, cost_usd, input_tokens, output_tokens, session_id)
+        stream_event_callback=None,  # async fn(event: dict) for incremental UI streaming
     ) -> None:
         self._config = config
         self._response_callback = response_callback
         self._cost_callback = cost_callback
         self._conversation_store = conversation_store
+        self._stream_event_callback = stream_event_callback
         self._connected = False
         self._processing = False  # True while a codex exec is running
         self._message_queue: asyncio.Queue[tuple[str, str, str, str]] = asyncio.Queue()
@@ -321,7 +323,7 @@ class CodexSession:
                         event = json.loads(line)
                     except json.JSONDecodeError:
                         continue
-                    self._handle_event(event, result)
+                    await self._handle_event(event, result)
 
             await asyncio.wait_for(_read_and_parse(), timeout=600)
 
@@ -345,6 +347,7 @@ class CodexSession:
             result.failed = True
             result.errors.append("codex exec timed out after 600s")
             _log(f"codex[{self.agent_name}]: exec timed out")
+            await self._emit_stream_event({"type": "turn_failed", "agent": self.agent_name, "session_id": self.id, "error": "codex exec timed out after 600s"})
             if proc:
                 proc.kill()
                 await proc.wait()
@@ -352,6 +355,7 @@ class CodexSession:
             result.failed = True
             result.errors.append(str(e))
             _log(f"codex[{self.agent_name}]: exec exception: {e}")
+            await self._emit_stream_event({"type": "turn_failed", "agent": self.agent_name, "session_id": self.id, "error": str(e)})
             if proc:
                 try:
                     proc.kill()
@@ -363,7 +367,16 @@ class CodexSession:
 
         return result
 
-    def _handle_event(self, event: dict, result: CodexTurnResult) -> None:
+    async def _emit_stream_event(self, event: dict) -> None:
+        """Best-effort incremental stream event forwarding for UI consumers."""
+        if not self._stream_event_callback:
+            return
+        try:
+            await self._stream_event_callback(event)
+        except Exception as e:
+            _log(f"codex[{self.agent_name}]: stream event callback error: {e}")
+
+    async def _handle_event(self, event: dict, result: CodexTurnResult) -> None:
         """Parse a single JSONL event and update result + activity tracking."""
         event_type = event.get("type", "")
 
@@ -374,8 +387,7 @@ class CodexSession:
                 self.session_id = thread_id
                 result.thread_id = thread_id
                 _log(f"codex[{self.agent_name}]: thread_id={thread_id[:12]}")
-                # Note: _on_session_id is async but we're in a sync method.
-                # It will be called after _exec_codex returns if needed.
+                # _on_session_id callback is fired by the worker after _exec_codex returns.
                 self._pending_session_id_update = thread_id
 
         elif event_type == "item.completed":
@@ -386,6 +398,13 @@ class CodexSession:
                 text = item.get("text", "")
                 if text:
                     result.text_parts.append(text)
+                    self._current_thinking = text
+                    await self._emit_stream_event({
+                        "type": "assistant_delta",
+                        "agent": self.agent_name,
+                        "session_id": self.id,
+                        "delta": text,
+                    })
 
             elif item_type == "command_execution":
                 cmd_str = item.get("command", "")
@@ -400,6 +419,13 @@ class CodexSession:
                 desc = cmd_str[:60] if cmd_str else "command"
                 self._current_activity = f"Bash — {desc}"
                 self._activity_log.append(f"Bash — {desc}")
+                await self._emit_stream_event({
+                    "type": "tool_use",
+                    "agent": self.agent_name,
+                    "session_id": self.id,
+                    "tool": "Bash",
+                    "label": f"Bash — {desc}",
+                })
 
             elif item_type == "file_edit":
                 filepath = item.get("filepath", "")
@@ -410,6 +436,13 @@ class CodexSession:
                 fname = filepath.rsplit("/", 1)[-1] if filepath else ""
                 self._current_activity = f"Edit — {fname}"
                 self._activity_log.append(f"Edit — {fname}")
+                await self._emit_stream_event({
+                    "type": "tool_use",
+                    "agent": self.agent_name,
+                    "session_id": self.id,
+                    "tool": "Edit",
+                    "label": f"Edit — {fname}",
+                })
 
             elif item_type == "file_read":
                 filepath = item.get("filepath", "")
@@ -420,6 +453,13 @@ class CodexSession:
                 fname = filepath.rsplit("/", 1)[-1] if filepath else ""
                 self._current_activity = f"Read — {fname}"
                 self._activity_log.append(f"Read — {fname}")
+                await self._emit_stream_event({
+                    "type": "tool_use",
+                    "agent": self.agent_name,
+                    "session_id": self.id,
+                    "tool": "Read",
+                    "label": f"Read — {fname}",
+                })
 
             elif item_type == "mcp_tool_call":
                 tool_name = item.get("tool_name", "")
@@ -430,10 +470,23 @@ class CodexSession:
                 })
                 self._current_activity = tool_name
                 self._activity_log.append(tool_name)
+                await self._emit_stream_event({
+                    "type": "tool_use",
+                    "agent": self.agent_name,
+                    "session_id": self.id,
+                    "tool": tool_name,
+                    "label": tool_name,
+                })
 
             elif item_type == "error":
                 err_msg = item.get("message", "unknown error")
                 result.errors.append(err_msg)
+                await self._emit_stream_event({
+                    "type": "turn_error",
+                    "agent": self.agent_name,
+                    "session_id": self.id,
+                    "error": err_msg,
+                })
 
         elif event_type == "item.started":
             item = event.get("item", {})
@@ -447,14 +500,38 @@ class CodexSession:
             result.input_tokens = usage.get("input_tokens", 0)
             result.output_tokens = usage.get("output_tokens", 0)
             result.cached_input_tokens = usage.get("cached_input_tokens", 0)
+            await self._emit_stream_event({
+                "type": "turn_completed",
+                "agent": self.agent_name,
+                "session_id": self.id,
+                "usage": {
+                    "input_tokens": result.input_tokens,
+                    "output_tokens": result.output_tokens,
+                    "cached_input_tokens": result.cached_input_tokens,
+                },
+            })
 
         elif event_type == "turn.failed":
             result.failed = True
             err = event.get("error", {})
-            result.errors.append(err.get("message", "turn failed"))
+            err_msg = err.get("message", "turn failed")
+            result.errors.append(err_msg)
+            await self._emit_stream_event({
+                "type": "turn_failed",
+                "agent": self.agent_name,
+                "session_id": self.id,
+                "error": err_msg,
+            })
 
         elif event_type == "error":
-            result.errors.append(event.get("message", "unknown error"))
+            err_msg = event.get("message", "unknown error")
+            result.errors.append(err_msg)
+            await self._emit_stream_event({
+                "type": "turn_error",
+                "agent": self.agent_name,
+                "session_id": self.id,
+                "error": err_msg,
+            })
 
     async def force_restart(self) -> bool:
         """Force a context restart — clear codex session, start fresh."""


### PR DESCRIPTION
### Motivation
- Codex CLI already emits JSONL `item`/`turn` events incrementally but the daemon buffered them until turn end, preventing partial-text streaming in the web UI.
- Forwarding incremental events (assistant partials, tool calls, errors) enables near-real-time visibility into agent progress without reimplementing the CLI execution loop.

### Description
- Emit incremental Codex events from `CodexSession` by adding a `stream_event_callback` and making JSONL event handling asynchronous; `agent_message`, `command_execution`, `file_read`/`file_edit`, `mcp_tool_call`, `turn.completed`, and failure/error events are forwarded as `assistant_delta`, `tool_use`, `turn_completed`, or `turn_failed` while still accumulating the final `CodexTurnResult` for history and routing (`src/pinky_daemon/codex_session.py`).
- Add an in-memory SSE fanout and a new endpoint `GET /agents/{agent_name}/streaming/events` that serves per-session SSE queues, with bounded queue sizes to drop stale incremental updates for slow clients (`src/pinky_daemon/api.py`).
- Wire Codex-backed sessions to publish into the SSE fanout by supplying `stream_event_callback` only for Codex provider sessions when creating sessions (`src/pinky_daemon/api.py`).
- Update the frontend `Chat.svelte` to subscribe to the new SSE stream via `sse()` and render `assistant_delta` chunks as a temporary `pending-assistant-stream` local message, surface `tool_use` events in the thinking/activity panel, and remove/refresh pending partials on `turn_completed`/`turn_failed` (`frontend-svelte/src/pages/Chat.svelte`).
- Implement conservative backpressure behavior: SSE queues are bounded and will drop stale incremental events rather than block agent execution.

### Testing
- Ran `python -m py_compile src/pinky_daemon/api.py src/pinky_daemon/codex_session.py` and the files compiled successfully.
- Built the frontend with `npm --prefix frontend-svelte run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da79870a048333ba63ad0607340e5b)