### PR TITLE
Fix CodexSession crashes: _client guard + resume -C flag

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2246,7 +2246,7 @@ def create_api(
         Uses a cache to avoid blocking callers when the SDK is busy.
         Returns cached data if a fresh fetch times out.
         """
-        if not ss or not ss.is_connected or not ss._client:
+        if not ss or not ss.is_connected or not getattr(ss, '_client', None):
             return {}
 
         sid = ss.session_id or ""

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -274,12 +274,16 @@ class CodexSession:
         if self.codex_session_id:
             cmd.extend(["resume", self.codex_session_id])
 
+        is_resume = bool(self.codex_session_id)
+
         cmd.extend(["--json", "--full-auto"])
 
         if self._codex_model:
             cmd.extend(["-m", self._codex_model])
 
-        cmd.extend(["-C", self._working_dir])
+        # -C (working dir) is only valid for new sessions, not resume
+        if not is_resume:
+            cmd.extend(["-C", self._working_dir])
 
         # Pass prompt via stdin to avoid shell escaping issues
         cmd.append("-")


### PR DESCRIPTION
## Summary
- Guard `ss._client` access with `getattr` in `_streaming_context_info` — CodexSession has no `_client` attribute, causing repeated `AttributeError` spam in logs
- Only pass `-C` working dir flag on new `codex exec`, not on `codex exec resume` where it's unsupported — was causing exit code 2 and failed turns

Fixes Murzik (first Codex agent) failing to respond after initial wake message.

## Test plan
- [ ] Codex agent responds to messages after wake (resume path works)
- [ ] No more `_client` AttributeError in daemon logs
- [x] Frontend builds clean

🤖 Opened by Barsik