### PR TITLE
Fix Codex response leaking into thinking block

### DIFF
--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -402,7 +402,6 @@ class CodexSession:
                 text = item.get("text", "")
                 if text:
                     result.text_parts.append(text)
-                    self._current_thinking = text
                     await self._emit_stream_event({
                         "type": "assistant_delta",
                         "agent": self.agent_name,
@@ -504,6 +503,8 @@ class CodexSession:
             result.input_tokens = usage.get("input_tokens", 0)
             result.output_tokens = usage.get("output_tokens", 0)
             result.cached_input_tokens = usage.get("cached_input_tokens", 0)
+            self._current_thinking = ""
+            self._current_activity = ""
             await self._emit_stream_event({
                 "type": "turn_completed",
                 "agent": self.agent_name,


### PR DESCRIPTION
## Summary
- Response text was being set as `_current_thinking`, causing it to appear in the THINKING panel below the actual message
- Clear thinking + activity state on turn.completed

## Test plan
- [ ] Codex agent response shows only in chat bubble, not duplicated in THINKING block

🤖 Opened by Barsik