### PR TITLE
UX Phase 3: wizard advanced fields, split automation tab, provider provenance

### DIFF
--- a/frontend-svelte/src/locales/en.json
+++ b/frontend-svelte/src/locales/en.json
@@ -551,6 +551,8 @@
     "tab_model": "Model",
     "tab_behavior": "Behavior",
     "tab_automation": "Automation",
+    "tab_tools": "Tools",
+    "tab_scheduling": "Scheduling",
     "tab_runtime": "Runtime",
     "agent_label": "Agent",
     "main_agent_badge": "Main Agent",

--- a/frontend-svelte/src/locales/en.json
+++ b/frontend-svelte/src/locales/en.json
@@ -1103,6 +1103,14 @@
     "import_close_bg": "Close (import continues in background)",
     "import_upload_label": "Upload",
     "import_preview_label": "Preview",
-    "import_confirm_label": "Confirm"
+    "import_confirm_label": "Confirm",
+    "provider_using_global": "Using global provider:",
+    "provider_change_hint": "Change in Settings → Providers",
+    "effort_label": "Thinking Effort",
+    "advanced_settings": "Advanced Settings",
+    "advanced_max_turns": "Max Turns",
+    "advanced_timeout": "Timeout (sec)",
+    "advanced_max_sessions": "Max Sessions",
+    "advanced_plain_text": "Plain text fallback (send text when no tool used)"
   }
 }

--- a/frontend-svelte/src/locales/es.json
+++ b/frontend-svelte/src/locales/es.json
@@ -551,6 +551,8 @@
     "tab_model": "Modelo",
     "tab_behavior": "Comportamiento",
     "tab_automation": "Automatización",
+    "tab_tools": "Herramientas",
+    "tab_scheduling": "Programación",
     "tab_runtime": "Tiempo de ejecución",
     "agent_label": "Agente",
     "main_agent_badge": "Agente principal",

--- a/frontend-svelte/src/locales/es.json
+++ b/frontend-svelte/src/locales/es.json
@@ -1103,6 +1103,14 @@
     "import_close_bg": "Cerrar (la importación continúa en segundo plano)",
     "import_upload_label": "Subir",
     "import_preview_label": "Vista previa",
-    "import_confirm_label": "Confirmar"
+    "import_confirm_label": "Confirmar",
+    "provider_using_global": "Usando proveedor global:",
+    "provider_change_hint": "Cambiar en Configuración → Proveedores",
+    "effort_label": "Esfuerzo de pensamiento",
+    "advanced_settings": "Configuración avanzada",
+    "advanced_max_turns": "Turnos máx.",
+    "advanced_timeout": "Tiempo límite (seg)",
+    "advanced_max_sessions": "Sesiones máx.",
+    "advanced_plain_text": "Respuesta de texto plano (enviar texto sin herramientas)"
   }
 }

--- a/frontend-svelte/src/locales/ja.json
+++ b/frontend-svelte/src/locales/ja.json
@@ -1103,6 +1103,14 @@
     "import_close_bg": "閉じる（インポートはバックグラウンドで継続）",
     "import_upload_label": "アップロード",
     "import_preview_label": "プレビュー",
-    "import_confirm_label": "確認"
+    "import_confirm_label": "確認",
+    "provider_using_global": "グローバルプロバイダー使用中:",
+    "provider_change_hint": "設定 → プロバイダーで変更",
+    "effort_label": "思考の深さ",
+    "advanced_settings": "詳細設定",
+    "advanced_max_turns": "最大ターン数",
+    "advanced_timeout": "タイムアウト（秒）",
+    "advanced_max_sessions": "最大セッション数",
+    "advanced_plain_text": "プレーンテキスト応答（ツール未使用時にテキスト送信）"
   }
 }

--- a/frontend-svelte/src/locales/ja.json
+++ b/frontend-svelte/src/locales/ja.json
@@ -551,6 +551,8 @@
     "tab_model": "モデル",
     "tab_behavior": "動作",
     "tab_automation": "自動化",
+    "tab_tools": "ツール",
+    "tab_scheduling": "スケジュール",
     "tab_runtime": "ランタイム",
     "agent_label": "エージェント",
     "main_agent_badge": "メインエージェント",

--- a/frontend-svelte/src/locales/ko.json
+++ b/frontend-svelte/src/locales/ko.json
@@ -551,6 +551,8 @@
     "tab_model": "모델",
     "tab_behavior": "동작",
     "tab_automation": "자동화",
+    "tab_tools": "도구",
+    "tab_scheduling": "일정",
     "tab_runtime": "런타임",
     "agent_label": "에이전트",
     "main_agent_badge": "메인 에이전트",

--- a/frontend-svelte/src/locales/ko.json
+++ b/frontend-svelte/src/locales/ko.json
@@ -1103,6 +1103,14 @@
     "import_close_bg": "닫기 (가져오기는 백그라운드에서 계속됩니다)",
     "import_upload_label": "업로드",
     "import_preview_label": "미리보기",
-    "import_confirm_label": "확인"
+    "import_confirm_label": "확인",
+    "provider_using_global": "글로벌 프로바이더 사용 중:",
+    "provider_change_hint": "설정 → 프로바이더에서 변경",
+    "effort_label": "사고 깊이",
+    "advanced_settings": "고급 설정",
+    "advanced_max_turns": "최대 턴 수",
+    "advanced_timeout": "타임아웃 (초)",
+    "advanced_max_sessions": "최대 세션 수",
+    "advanced_plain_text": "일반 텍스트 응답 (도구 미사용 시 텍스트 전송)"
   }
 }

--- a/frontend-svelte/src/locales/ru.json
+++ b/frontend-svelte/src/locales/ru.json
@@ -551,6 +551,8 @@
     "tab_model": "Модель",
     "tab_behavior": "Поведение",
     "tab_automation": "Автоматизация",
+    "tab_tools": "Инструменты",
+    "tab_scheduling": "Расписание",
     "tab_runtime": "Рантайм",
     "agent_label": "Агент",
     "main_agent_badge": "Основной агент",

--- a/frontend-svelte/src/locales/ru.json
+++ b/frontend-svelte/src/locales/ru.json
@@ -1103,6 +1103,14 @@
     "import_close_bg": "Закрыть (импорт продолжается в фоне)",
     "import_upload_label": "Загрузка",
     "import_preview_label": "Предпросмотр",
-    "import_confirm_label": "Подтверждение"
+    "import_confirm_label": "Подтверждение",
+    "provider_using_global": "Используется глобальный провайдер:",
+    "provider_change_hint": "Изменить в Настройки → Провайдеры",
+    "effort_label": "Глубина мышления",
+    "advanced_settings": "Расширенные настройки",
+    "advanced_max_turns": "Макс. шагов",
+    "advanced_timeout": "Таймаут (сек)",
+    "advanced_max_sessions": "Макс. сессий",
+    "advanced_plain_text": "Текстовый ответ (отправлять текст без инструментов)"
   }
 }

--- a/frontend-svelte/src/locales/uk.json
+++ b/frontend-svelte/src/locales/uk.json
@@ -1103,6 +1103,14 @@
     "import_close_bg": "Закрити (імпорт продовжується у фоні)",
     "import_upload_label": "Завантаження",
     "import_preview_label": "Попередній перегляд",
-    "import_confirm_label": "Підтвердити"
+    "import_confirm_label": "Підтвердити",
+    "provider_using_global": "Використовується глобальний провайдер:",
+    "provider_change_hint": "Змінити в Налаштування → Провайдери",
+    "effort_label": "Глибина мислення",
+    "advanced_settings": "Розширені налаштування",
+    "advanced_max_turns": "Макс. кроків",
+    "advanced_timeout": "Таймаут (сек)",
+    "advanced_max_sessions": "Макс. сесій",
+    "advanced_plain_text": "Текстова відповідь (надсилати текст без інструментів)"
   }
 }

--- a/frontend-svelte/src/locales/uk.json
+++ b/frontend-svelte/src/locales/uk.json
@@ -551,6 +551,8 @@
     "tab_model": "Модель",
     "tab_behavior": "Поведінка",
     "tab_automation": "Автоматизація",
+    "tab_tools": "Інструменти",
+    "tab_scheduling": "Розклад",
     "tab_runtime": "Виконання",
     "agent_label": "Агент",
     "main_agent_badge": "Головний агент",

--- a/frontend-svelte/src/locales/zh.json
+++ b/frontend-svelte/src/locales/zh.json
@@ -551,6 +551,8 @@
     "tab_model": "模型",
     "tab_behavior": "行为",
     "tab_automation": "自动化",
+    "tab_tools": "工具",
+    "tab_scheduling": "调度",
     "tab_runtime": "运行时",
     "agent_label": "智能体",
     "main_agent_badge": "主智能体",

--- a/frontend-svelte/src/locales/zh.json
+++ b/frontend-svelte/src/locales/zh.json
@@ -1103,6 +1103,14 @@
     "import_close_bg": "关闭（导入在后台继续）",
     "import_upload_label": "上传",
     "import_preview_label": "预览",
-    "import_confirm_label": "确认"
+    "import_confirm_label": "确认",
+    "provider_using_global": "正在使用全局提供商：",
+    "provider_change_hint": "在设置 → 提供商中更改",
+    "effort_label": "思考深度",
+    "advanced_settings": "高级设置",
+    "advanced_max_turns": "最大轮次",
+    "advanced_timeout": "超时（秒）",
+    "advanced_max_sessions": "最大会话数",
+    "advanced_plain_text": "纯文本回复（未使用工具时发送文本）"
   }
 }

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -142,7 +142,8 @@
         { id: 'connections' },
         { id: 'model' },
         { id: 'behavior' },
-        { id: 'automation' },
+        { id: 'tools' },
+        { id: 'scheduling' },
         { id: 'runtime' },
     ];
 
@@ -196,6 +197,11 @@
     let wizAutoStart = true;
     let wizHeartbeatInterval = 300;
     let wizThinkingEffort = 'medium';
+    let wizShowAdvanced = false;
+    let wizMaxTurns = 0;
+    let wizTimeout = 300;
+    let wizMaxSessions = 5;
+    let wizPlainTextFallback = false;
     let wizCustomSoul = '';
     let wizTelegramToken = '';
     let wizDiscordToken = '';
@@ -967,7 +973,7 @@
 
     // Wizard
     let wizPronouns = '';
-    function openWizard() { wizStep = -1; importMode = false; importStep = 1; importFiles = { workspace: null, config: null, lock: null }; importDirPath = ''; importParseId = null; importPreview = null; importLoading = false; importTaskId = null; importProgress = { total: 0, imported: 0, failed: 0, done: false }; importDragover = false; importError = null; importAgentName = null; if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizName = ''; wizDisplayName = ''; wizPronouns = ''; wizModel = 'opus'; wizProviderRef = ''; wizCustomProvider = false; wizProviderPreset = 'anthropic'; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; wizMode = 'bypassPermissions'; wizHeart = 'sidekick'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizThinkingEffort = 'medium'; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; globalProviders = api('GET', '/providers').then(d => globalProviders = d || []).catch(() => []); wizardOpen = true; }
+    function openWizard() { wizStep = -1; importMode = false; importStep = 1; importFiles = { workspace: null, config: null, lock: null }; importDirPath = ''; importParseId = null; importPreview = null; importLoading = false; importTaskId = null; importProgress = { total: 0, imported: 0, failed: 0, done: false }; importDragover = false; importError = null; importAgentName = null; if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizName = ''; wizDisplayName = ''; wizPronouns = ''; wizModel = 'opus'; wizProviderRef = ''; wizCustomProvider = false; wizProviderPreset = 'anthropic'; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; wizMode = 'bypassPermissions'; wizHeart = 'sidekick'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizThinkingEffort = 'medium'; wizShowAdvanced = false; wizMaxTurns = 0; wizTimeout = 300; wizMaxSessions = 5; wizPlainTextFallback = false; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; globalProviders = api('GET', '/providers').then(d => globalProviders = d || []).catch(() => []); wizardOpen = true; }
     function closeWizard() { if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizardOpen = false; }
 
     // Import (OpenClaw migration) helpers
@@ -1083,7 +1089,7 @@
         let soul = soulResp.soul;
         // Determine the model alias to register — use 'opus' default if using a provider
         const registerModel = (!wizProviderRef && !wizCustomProvider && wizProviderUrl !== 'codex_cli') ? wizModel : (wizProviderModel || 'sonnet');
-        await api('POST', '/agents', { name: wizName, display_name: wizDisplayName, model: registerModel, permission_mode: wizMode, soul, role: wizRole, auto_start: wizAutoStart, heartbeat_interval: wizHeartbeatInterval, thinking_effort: wizThinkingEffort });
+        await api('POST', '/agents', { name: wizName, display_name: wizDisplayName, model: registerModel, permission_mode: wizMode, soul, role: wizRole, auto_start: wizAutoStart, heartbeat_interval: wizHeartbeatInterval, thinking_effort: wizThinkingEffort, max_turns: wizMaxTurns, timeout: wizTimeout, max_sessions: wizMaxSessions, plain_text_fallback: wizPlainTextFallback });
         // Apply provider config if a global provider, custom endpoint, or Codex was selected
         if (wizProviderRef || wizCustomProvider || wizProviderUrl === 'codex_cli') {
             await api('PUT', `/agents/${wizName}/provider`, {
@@ -1735,6 +1741,17 @@
                 />
             </div>
 
+            {#if providerRef}
+                {@const refProvider = globalProviders.find(p => p.id === providerRef)}
+                {#if refProvider}
+                <div style="padding:0.6rem 1rem;background:var(--tone-info-bg,#1e3a5f);border-radius:var(--radius-lg);margin-top:0.5rem;font-size:0.78rem;color:var(--tone-info-text,#93c5fd);display:flex;align-items:center;gap:0.5rem">
+                    <span>🔗</span>
+                    <span>Using global provider: <strong>{refProvider.name}</strong>{refProvider.provider_model ? ' · ' + refProvider.provider_model : ''}</span>
+                    <span style="color:var(--gray-mid);font-size:0.7rem;margin-left:auto">Change in Settings → Providers</span>
+                </div>
+                {/if}
+            {/if}
+
             <!-- Thinking Effort -->
             <SectionHeader title="Thinking Effort" variant="detail" style="margin-top:0.5rem">
                 <svelte:fragment slot="actions">
@@ -1883,7 +1900,7 @@
 
             {/if}<!-- end behavior tab -->
 
-            {#if activeTab === 'automation'}
+            {#if activeTab === 'tools'}
             <!-- Skills -->
             <div style="padding:1rem 1.5rem;background:var(--surface-2);border-radius:var(--radius-lg);margin-top:0.5rem">
                 <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
@@ -2014,6 +2031,9 @@
                 {/if}
             </div>
 
+            {/if}<!-- end tools tab -->
+
+            {#if activeTab === 'scheduling'}
             <!-- Triggers -->
             <div style="padding:1rem 1.5rem;background:var(--surface-2);border-radius:var(--radius-lg);margin-top:0.5rem;display:flex;justify-content:space-between;align-items:center">
                 <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700;text-transform:uppercase">{$_('agents.triggers')}</span>
@@ -2064,7 +2084,7 @@
                     {/each}
                 {/if}
             </div>
-            {/if}<!-- end automation tab -->
+            {/if}<!-- end scheduling tab -->
 
             {#if activeTab === 'runtime'}
             <!-- Live Sessions (formerly Streaming Sessions) -->
@@ -2519,6 +2539,33 @@
                         {#if wizHeart === 'custom'}
                             <textarea class="wizard-input" bind:value={wizCustomSoul} rows="5" placeholder="Write your agent's soul..."></textarea>
                         {/if}
+                        <!-- Advanced Settings -->
+                        <div style="margin-top:1.2rem">
+                            <button class="btn btn-sm" style="color:var(--gray-mid);font-size:0.75rem" on:click={() => wizShowAdvanced = !wizShowAdvanced}>
+                                {wizShowAdvanced ? '▾' : '▸'} Advanced Settings
+                            </button>
+                            {#if wizShowAdvanced}
+                            <div style="margin-top:0.5rem;padding:1rem;background:var(--surface-1);border-radius:var(--radius-lg);display:flex;flex-direction:column;gap:0.8rem">
+                                <div style="display:flex;gap:1rem;flex-wrap:wrap">
+                                    <div style="flex:1;min-width:120px">
+                                        <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">Max Turns</div>
+                                        <input type="number" class="wizard-input" style="margin:0" bind:value={wizMaxTurns} min="0" placeholder="0 = unlimited">
+                                    </div>
+                                    <div style="flex:1;min-width:120px">
+                                        <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">Timeout (sec)</div>
+                                        <input type="number" class="wizard-input" style="margin:0" bind:value={wizTimeout} min="30" placeholder="300">
+                                    </div>
+                                    <div style="flex:1;min-width:120px">
+                                        <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">Max Sessions</div>
+                                        <input type="number" class="wizard-input" style="margin:0" bind:value={wizMaxSessions} min="1" max="20" placeholder="5">
+                                    </div>
+                                </div>
+                                <label style="display:flex;align-items:center;gap:0.5rem;font-family:var(--font-grotesk);font-size:0.78rem;cursor:pointer">
+                                    <input type="checkbox" bind:checked={wizPlainTextFallback}> Plain text fallback (send text when no tool used)
+                                </label>
+                            </div>
+                            {/if}
+                        </div>
                     {:else if wizStep === 3}
                         <div class="wizard-label">Outreach</div>
                         <div class="wizard-hint">Connect to the outside world. All optional.</div>
@@ -2572,6 +2619,19 @@
                             Auto-Start: <span class="val">{wizAutoStart ? 'Yes' : 'No'}</span><br>
                             Heartbeat: <span class="val">{wizHeartbeatInterval ? wizHeartbeatInterval + 's' : 'Disabled'}</span><br>
                             Outreach: <span class="val">{wizSummaryPlatforms.length ? wizSummaryPlatforms.join(', ') : 'None (local only)'}</span>
+                            {#if wizThinkingEffort !== 'medium'}
+                            <br>Effort: <span class="val">{wizThinkingEffort.toUpperCase()}</span>
+                            {/if}
+                            {#if wizShowAdvanced && (wizMaxTurns || wizTimeout !== 300 || wizMaxSessions !== 5 || wizPlainTextFallback)}
+                            <br>Advanced: <span class="val">
+                                {[
+                                    wizMaxTurns ? `${wizMaxTurns} max turns` : '',
+                                    wizTimeout !== 300 ? `${wizTimeout}s timeout` : '',
+                                    wizMaxSessions !== 5 ? `${wizMaxSessions} max sessions` : '',
+                                    wizPlainTextFallback ? 'plain text fallback' : '',
+                                ].filter(Boolean).join(', ')}
+                            </span>
+                            {/if}
                         </div>
                     {/if}
                 </div>

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -1746,14 +1746,14 @@
                 {#if refProvider}
                 <div style="padding:0.6rem 1rem;background:var(--tone-info-bg,#1e3a5f);border-radius:var(--radius-lg);margin-top:0.5rem;font-size:0.78rem;color:var(--tone-info-text,#93c5fd);display:flex;align-items:center;gap:0.5rem">
                     <span>🔗</span>
-                    <span>Using global provider: <strong>{refProvider.name}</strong>{refProvider.provider_model ? ' · ' + refProvider.provider_model : ''}</span>
-                    <span style="color:var(--gray-mid);font-size:0.7rem;margin-left:auto">Change in Settings → Providers</span>
+                    <span>{$_('agents_extra.provider_using_global')} <strong>{refProvider.name}</strong>{refProvider.provider_model ? ' · ' + refProvider.provider_model : ''}</span>
+                    <span style="color:var(--gray-mid);font-size:0.7rem;margin-left:auto">{$_('agents_extra.provider_change_hint')}</span>
                 </div>
                 {/if}
             {/if}
 
             <!-- Thinking Effort -->
-            <SectionHeader title="Thinking Effort" variant="detail" style="margin-top:0.5rem">
+            <SectionHeader title={$_('agents_extra.effort_label')} variant="detail" style="margin-top:0.5rem">
                 <svelte:fragment slot="actions">
                     {#if thinkingEffortDirty}<button class="btn btn-sm btn-primary" on:click={saveThinkingEffort}>Save</button>{/if}
                 </svelte:fragment>
@@ -2514,7 +2514,7 @@
                         {/if}
 
                         <!-- Thinking Effort -->
-                        <div class="wizard-label" style="margin-top:1rem">Thinking Effort</div>
+                        <div class="wizard-label" style="margin-top:1rem">{$_('agents_extra.effort_label')}</div>
                         <div class="wizard-hint">How hard the model thinks before responding.</div>
                         <div class="wizard-options" style="grid-template-columns:repeat(4,1fr)">
                             {#each [['low','LOW','Fast, simple.'],['medium','MEDIUM','Balanced.'],['high','HIGH','Thorough.'],['max','MAX','Deep reasoning.']] as [val, title, desc]}
@@ -2542,26 +2542,26 @@
                         <!-- Advanced Settings -->
                         <div style="margin-top:1.2rem">
                             <button class="btn btn-sm" style="color:var(--gray-mid);font-size:0.75rem" on:click={() => wizShowAdvanced = !wizShowAdvanced}>
-                                {wizShowAdvanced ? '▾' : '▸'} Advanced Settings
+                                {wizShowAdvanced ? '▾' : '▸'} {$_('agents_extra.advanced_settings')}
                             </button>
                             {#if wizShowAdvanced}
                             <div style="margin-top:0.5rem;padding:1rem;background:var(--surface-1);border-radius:var(--radius-lg);display:flex;flex-direction:column;gap:0.8rem">
                                 <div style="display:flex;gap:1rem;flex-wrap:wrap">
                                     <div style="flex:1;min-width:120px">
-                                        <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">Max Turns</div>
+                                        <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">{$_('agents_extra.advanced_max_turns')}</div>
                                         <input type="number" class="wizard-input" style="margin:0" bind:value={wizMaxTurns} min="0" placeholder="0 = unlimited">
                                     </div>
                                     <div style="flex:1;min-width:120px">
-                                        <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">Timeout (sec)</div>
+                                        <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">{$_('agents_extra.advanced_timeout')}</div>
                                         <input type="number" class="wizard-input" style="margin:0" bind:value={wizTimeout} min="30" placeholder="300">
                                     </div>
                                     <div style="flex:1;min-width:120px">
-                                        <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">Max Sessions</div>
+                                        <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">{$_('agents_extra.advanced_max_sessions')}</div>
                                         <input type="number" class="wizard-input" style="margin:0" bind:value={wizMaxSessions} min="1" max="20" placeholder="5">
                                     </div>
                                 </div>
                                 <label style="display:flex;align-items:center;gap:0.5rem;font-family:var(--font-grotesk);font-size:0.78rem;cursor:pointer">
-                                    <input type="checkbox" bind:checked={wizPlainTextFallback}> Plain text fallback (send text when no tool used)
+                                    <input type="checkbox" bind:checked={wizPlainTextFallback}> {$_('agents_extra.advanced_plain_text')}
                                 </label>
                             </div>
                             {/if}


### PR DESCRIPTION
## Summary
Final batch of UX audit fixes for the Agents page:

- **Wizard Advanced Settings**: Collapsible section in Heart step with max_turns, timeout, max_sessions, plain_text_fallback. Sent atomically in initial POST. Summary step shows non-default values.
- **Split automation tab**: "Automation" → "Tools" (skills, MCP servers) + "Scheduling" (triggers, cron jobs). Better separation of concerns.
- **Provider provenance**: Model tab shows "🔗 Using global provider: X" banner when agent references a global provider, with hint to change in Settings → Providers.
- **i18n**: Added tab_tools + tab_scheduling keys in all 7 locales.
- **JSON editors**: Verified already working correctly — try/catch preserves input on parse errors.

## Test plan
- [ ] Create agent via wizard → verify "Advanced Settings" toggle in Heart step
- [ ] Set non-default advanced values → verify they appear in summary step
- [ ] Create agent with advanced values → verify they persist (check via API or edit page)
- [ ] Agent detail → verify "Tools" and "Scheduling" tabs replace old "Automation"
- [ ] Tools tab → skills + MCP servers present
- [ ] Scheduling tab → triggers + cron jobs present
- [ ] Agent using global provider → Model tab shows provenance banner
- [ ] Agent with custom/no provider → no provenance banner

🤖 Opened by Barsik