### PR TITLE
feat: tier 1 tool-call observability + codex StreamReader fix (#243)

### DIFF
--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -125,6 +125,7 @@ class AnalyticsStore:
                   duration_ms INTEGER,
                   success INTEGER,
                   error_type TEXT,
+                  status TEXT NOT NULL DEFAULT 'running',
                   metadata_json TEXT
                 );
 
@@ -213,6 +214,27 @@ class AnalyticsStore:
                 conn.execute(
                     "ALTER TABLE analytics_turn_usage ADD COLUMN user_message_snippet TEXT"
                 )
+            # Schema migration: add status enum to tool_calls
+            tc_cols = {
+                r[1] for r in conn.execute("PRAGMA table_info(analytics_tool_calls)").fetchall()
+            }
+            if "status" not in tc_cols:
+                conn.execute(
+                    "ALTER TABLE analytics_tool_calls "
+                    "ADD COLUMN status TEXT NOT NULL DEFAULT 'running'"
+                )
+                # Backfill: closed rows (ended_at set) get ok/error from success;
+                # open rows (ended_at null) remain 'running'.
+                conn.execute(
+                    "UPDATE analytics_tool_calls "
+                    "SET status = CASE WHEN success=1 THEN 'ok' ELSE 'error' END "
+                    "WHERE ended_at IS NOT NULL"
+                )
+            # Index on status must be created *after* the migration adds the column.
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_atc_status_started "
+                "ON analytics_tool_calls(status, started_at)"
+            )
 
     def _seed_default_pricing(self, conn) -> None:
         row = conn.execute("SELECT COUNT(*) AS count FROM analytics_model_pricing").fetchone()
@@ -387,8 +409,8 @@ class AnalyticsStore:
                 """
                 INSERT INTO analytics_tool_calls (
                   session_id, agent_name, turn_seq, tool_call_key, tool_name,
-                  tool_namespace, started_at, metadata_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                  tool_namespace, started_at, status, metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?)
                 """,
                 (
                     session_id,
@@ -413,8 +435,15 @@ class AnalyticsStore:
         error_type: str = "",
         metadata: dict | None = None,
         ts: str | None = None,
+        status: str = "",
     ) -> None:
+        """Finalize a tool call row.
+
+        status override takes precedence; otherwise derived from success
+        (ok when success else error). Valid values: ok | error | cancelled | timeout.
+        """
         when = ts or _utcnow()
+        final_status = status or ("ok" if success else "error")
         with self._connect() as conn:
             row = conn.execute(
                 """
@@ -436,7 +465,8 @@ class AnalyticsStore:
                 conn.execute(
                     """
                     UPDATE analytics_tool_calls
-                    SET ended_at=?, duration_ms=?, success=?, error_type=?, metadata_json=?
+                    SET ended_at=?, duration_ms=?, success=?, error_type=?,
+                        status=?, metadata_json=?
                     WHERE id=?
                     """,
                     (
@@ -444,11 +474,114 @@ class AnalyticsStore:
                         duration_ms,
                         1 if success else 0,
                         error_type or None,
+                        final_status,
                         json.dumps(merged) if merged else None,
                         row["id"],
                     ),
                 )
             self._mark_dirty(conn, agent_name=agent_name, ts=when, reason="tool_finish")
+
+    def sweep_orphan_tool_calls(
+        self,
+        *,
+        older_than_seconds: int = 3600,
+        now_ts: str | None = None,
+    ) -> int:
+        """Mark tool calls still in 'running' older than threshold as 'orphan'.
+
+        Runs on a schedule to close out rows where finish_tool_call never fired
+        (crash, process kill, exceptions). Sets ended_at=now, duration_ms computed,
+        success=0, error_type='orphan', status='orphan'. Returns count updated.
+        """
+        when = now_ts or _utcnow()
+        cutoff = datetime.fromisoformat(when.replace("Z", "+00:00")) - timedelta(
+            seconds=max(1, older_than_seconds)
+        )
+        cutoff_str = cutoff.isoformat().replace("+00:00", "Z")
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, started_at FROM analytics_tool_calls
+                WHERE status='running' AND started_at < ?
+                """,
+                (cutoff_str,),
+            ).fetchall()
+            count = 0
+            finished_at = datetime.fromisoformat(when.replace("Z", "+00:00"))
+            for row in rows:
+                started_at = datetime.fromisoformat(row["started_at"].replace("Z", "+00:00"))
+                duration_ms = max(0, int((finished_at - started_at).total_seconds() * 1000))
+                conn.execute(
+                    """
+                    UPDATE analytics_tool_calls
+                    SET ended_at=?, duration_ms=?, success=0,
+                        error_type='orphan', status='orphan'
+                    WHERE id=?
+                    """,
+                    (when, duration_ms, row["id"]),
+                )
+                count += 1
+            return count
+
+    def prune_tool_calls(self, *, retention_days: int = 30, now_ts: str | None = None) -> int:
+        """Delete tool_calls rows older than retention_days. Returns deleted count."""
+        when = now_ts or _utcnow()
+        cutoff = datetime.fromisoformat(when.replace("Z", "+00:00")) - timedelta(
+            days=max(1, retention_days)
+        )
+        cutoff_str = cutoff.isoformat().replace("+00:00", "Z")
+        with self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM analytics_tool_calls WHERE started_at < ?",
+                (cutoff_str,),
+            )
+            return cur.rowcount or 0
+
+    def get_recent_tool_calls(
+        self,
+        *,
+        agent_name: str = "",
+        session_id: str = "",
+        limit: int = 20,
+    ) -> list[dict]:
+        """Return most-recent tool_calls filtered by agent and/or session.
+
+        Primary investigative helper for 'what happened before this agent got stuck'.
+        Returns newest-first, deserialized metadata.
+        """
+        clauses = []
+        params: list = []
+        if agent_name:
+            clauses.append("agent_name = ?")
+            params.append(agent_name)
+        if session_id:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(max(1, min(limit, 500)))
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT id, session_id, agent_name, turn_seq, tool_call_key,
+                       tool_name, tool_namespace, started_at, ended_at,
+                       duration_ms, success, error_type, status, metadata_json
+                FROM analytics_tool_calls
+                {where}
+                ORDER BY started_at DESC, id DESC
+                LIMIT ?
+                """,
+                params,
+            ).fetchall()
+        out: list[dict] = []
+        for row in rows:
+            item = dict(row)
+            raw = item.pop("metadata_json", None)
+            try:
+                item["metadata"] = json.loads(raw) if raw else {}
+            except Exception:
+                item["metadata"] = {}
+            out.append(item)
+        return out
 
     def get_overview(self, range_name: str = "7d") -> dict:
         start_ts, end_ts = _range_bounds(range_name)

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -366,21 +366,26 @@ class CodexSession:
 
             # Stream stdout line-by-line for real-time activity tracking.
             # Defensive: skip-and-continue on a single oversized line rather
-            # than letting LimitOverrunError tear down the whole session.
+            # than letting the session tear down.
+            #
+            # StreamReader.readline() catches LimitOverrunError internally,
+            # drains its buffer past the separator, and re-raises as
+            # ValueError("Separator is not found, and chunk exceed the limit").
+            # So we catch ValueError (narrowly filtered by message) rather
+            # than LimitOverrunError, and no manual buffer drain is needed.
             async def _read_and_parse():
                 while True:
                     try:
                         raw_line = await proc.stdout.readline()
-                    except asyncio.LimitOverrunError as exc:
+                    except ValueError as exc:
+                        msg = str(exc)
+                        if "Separator is not found" not in msg and "chunk exceed" not in msg:
+                            # Unrelated ValueError — don't swallow it
+                            raise
                         _log(
                             f"codex[{self.agent_name}]: oversized stdout line "
-                            f"(consumed={exc.consumed}B) — skipping"
+                            f"({msg}) — skipping"
                         )
-                        # Drain the oversized chunk so the stream can recover.
-                        try:
-                            await proc.stdout.read(exc.consumed)
-                        except Exception:
-                            pass
                         continue
                     if not raw_line:
                         break
@@ -497,7 +502,9 @@ class CodexSession:
                 self._analytics_finish_tool_call(
                     tool_call_key=item.get("id", ""),
                     success=(exit_code == 0 if exit_code is not None else True),
-                    metadata={"command": cmd_str, "exit_code": exit_code},
+                    # PII-safe: no raw command string. arg_keys records that
+                    # Bash has one argument ("command"); exit_code is numeric.
+                    metadata={"arg_keys": ["command"], "exit_code": exit_code},
                 )
 
             elif item_type == "file_edit":
@@ -519,7 +526,8 @@ class CodexSession:
                 self._analytics_finish_tool_call(
                     tool_call_key=item.get("id", ""),
                     success=True,
-                    metadata={"file_path": filepath},
+                    # PII-safe: no raw filepath.
+                    metadata={"arg_keys": ["file_path"]},
                 )
 
             elif item_type == "file_read":
@@ -541,7 +549,8 @@ class CodexSession:
                 self._analytics_finish_tool_call(
                     tool_call_key=item.get("id", ""),
                     success=True,
-                    metadata={"file_path": filepath},
+                    # PII-safe: no raw filepath.
+                    metadata={"arg_keys": ["file_path"]},
                 )
 
             elif item_type == "mcp_tool_call":
@@ -563,7 +572,10 @@ class CodexSession:
                 self._analytics_finish_tool_call(
                     tool_call_key=item.get("id", ""),
                     success=True,
-                    metadata={"tool_input": tool_input if isinstance(tool_input, dict) else {}},
+                    # PII-safe: record argument key names only, not values.
+                    metadata={
+                        "arg_keys": sorted(tool_input.keys()) if isinstance(tool_input, dict) else []
+                    },
                 )
 
             elif item_type in ("function_call", "tool_call", "tool_use"):
@@ -601,7 +613,10 @@ class CodexSession:
                 self._analytics_finish_tool_call(
                     tool_call_key=item.get("id", ""),
                     success=True,
-                    metadata={"tool_input": tool_input if isinstance(tool_input, dict) else {}},
+                    # PII-safe: record argument key names only, not values.
+                    metadata={
+                        "arg_keys": sorted(tool_input.keys()) if isinstance(tool_input, dict) else []
+                    },
                 )
 
             elif item_type == "error":
@@ -996,20 +1011,26 @@ class CodexSession:
             _log(f"codex[{self.agent_name}]: analytics tool finish failed: {e}")
 
     def _tool_metadata_from_item(self, item: dict) -> tuple[str, str, dict]:
+        """Return (tool_name, namespace, metadata) for analytics.
+
+        PII-safety: metadata records argument key names (``arg_keys``) only,
+        never raw values. Commands, file paths, and tool inputs can contain
+        user data, secrets, or PII and must not leak into analytics.
+        """
         item_type = item.get("type", "")
         if item_type == "command_execution":
             # Bash has a single implicit arg: command
-            return "Bash", "", {"command": item.get("command", ""), "arg_keys": ["command"]}
+            return "Bash", "", {"arg_keys": ["command"]}
         if item_type == "file_edit":
-            return "Edit", "", {"file_path": item.get("filepath", ""), "arg_keys": ["file_path"]}
+            return "Edit", "", {"arg_keys": ["file_path"]}
         if item_type == "file_read":
-            return "Read", "", {"file_path": item.get("filepath", ""), "arg_keys": ["file_path"]}
+            return "Read", "", {"arg_keys": ["file_path"]}
         if item_type == "mcp_tool_call":
             tool_name = item.get("tool_name", "")
             namespace = tool_name.split(".", 1)[0] if "." in tool_name else ""
             tool_input = item.get("input", {})
             arg_keys = sorted(tool_input.keys()) if isinstance(tool_input, dict) else []
-            return tool_name, namespace, {"tool_input": tool_input, "arg_keys": arg_keys}
+            return tool_name, namespace, {"arg_keys": arg_keys}
         if item_type in ("function_call", "tool_call", "tool_use"):
             tool_name = (
                 item.get("tool_name", "")
@@ -1018,5 +1039,5 @@ class CodexSession:
             )
             tool_input = item.get("input", {})
             arg_keys = sorted(tool_input.keys()) if isinstance(tool_input, dict) else []
-            return tool_name or item_type, "", {"tool_input": tool_input, "arg_keys": arg_keys}
+            return tool_name or item_type, "", {"arg_keys": arg_keys}
         return "", "", {}

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -344,6 +344,9 @@ class CodexSession:
 
         proc = None
         try:
+            # limit=10MB — codex emits large tool-result events that exceed
+            # asyncio's default 64KB StreamReader limit and kill the session
+            # with LimitOverrunError. 10MB is comfortably above observed max.
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdin=asyncio.subprocess.PIPE,
@@ -351,6 +354,7 @@ class CodexSession:
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
                 cwd=self._working_dir,
+                limit=10 * 1024 * 1024,
             )
             self._current_proc = proc
 
@@ -360,10 +364,27 @@ class CodexSession:
             proc.stdin.close()
             await proc.stdin.wait_closed()
 
-            # Stream stdout line-by-line for real-time activity tracking
+            # Stream stdout line-by-line for real-time activity tracking.
+            # Defensive: skip-and-continue on a single oversized line rather
+            # than letting LimitOverrunError tear down the whole session.
             async def _read_and_parse():
-                async for raw_line in proc.stdout:
-                    line = raw_line.decode().strip()
+                while True:
+                    try:
+                        raw_line = await proc.stdout.readline()
+                    except asyncio.LimitOverrunError as exc:
+                        _log(
+                            f"codex[{self.agent_name}]: oversized stdout line "
+                            f"(consumed={exc.consumed}B) — skipping"
+                        )
+                        # Drain the oversized chunk so the stream can recover.
+                        try:
+                            await proc.stdout.read(exc.consumed)
+                        except Exception:
+                            pass
+                        continue
+                    if not raw_line:
+                        break
+                    line = raw_line.decode(errors="replace").strip()
                     if not line:
                         continue
                     try:
@@ -977,20 +998,25 @@ class CodexSession:
     def _tool_metadata_from_item(self, item: dict) -> tuple[str, str, dict]:
         item_type = item.get("type", "")
         if item_type == "command_execution":
-            return "Bash", "", {"command": item.get("command", "")}
+            # Bash has a single implicit arg: command
+            return "Bash", "", {"command": item.get("command", ""), "arg_keys": ["command"]}
         if item_type == "file_edit":
-            return "Edit", "", {"file_path": item.get("filepath", "")}
+            return "Edit", "", {"file_path": item.get("filepath", ""), "arg_keys": ["file_path"]}
         if item_type == "file_read":
-            return "Read", "", {"file_path": item.get("filepath", "")}
+            return "Read", "", {"file_path": item.get("filepath", ""), "arg_keys": ["file_path"]}
         if item_type == "mcp_tool_call":
             tool_name = item.get("tool_name", "")
             namespace = tool_name.split(".", 1)[0] if "." in tool_name else ""
-            return tool_name, namespace, {"tool_input": item.get("input", {})}
+            tool_input = item.get("input", {})
+            arg_keys = sorted(tool_input.keys()) if isinstance(tool_input, dict) else []
+            return tool_name, namespace, {"tool_input": tool_input, "arg_keys": arg_keys}
         if item_type in ("function_call", "tool_call", "tool_use"):
             tool_name = (
                 item.get("tool_name", "")
                 or item.get("name", "")
                 or item.get("function", {}).get("name", "")
             )
-            return tool_name or item_type, "", {"tool_input": item.get("input", {})}
+            tool_input = item.get("input", {})
+            arg_keys = sorted(tool_input.keys()) if isinstance(tool_input, dict) else []
+            return tool_name or item_type, "", {"tool_input": tool_input, "arg_keys": arg_keys}
         return "", "", {}

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -632,7 +632,9 @@ class CodexSession:
                     tool_call_key=item.get("id", ""),
                     success=False,
                     error_type="item_error",
-                    metadata={"message": err_msg},
+                    # PII-safe: error_type is captured above; err_msg may contain
+                    # file paths / command output / user data, so strip it here.
+                    metadata={"arg_keys": []},
                 )
 
             else:

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -459,10 +459,15 @@ class StreamingSession:
                                     parts = block.name.split("__", 2)
                                     if len(parts) >= 3:
                                         tool_ns = parts[1]
+                                # Capture arg key names only (no values) — PII-safe
+                                arg_keys: list[str] = []
+                                if isinstance(block.input, dict):
+                                    arg_keys = sorted(block.input.keys())
                                 self._analytics_start_tool_call(
                                     tool_call_key=tool_call_key,
                                     tool_name=block.name,
                                     tool_namespace=tool_ns,
+                                    metadata={"arg_keys": arg_keys} if arg_keys else None,
                                 )
                             elif isinstance(block, ToolResultBlock):
                                 # Attach result to the last matching tool use

--- a/tests/test_analytics_store.py
+++ b/tests/test_analytics_store.py
@@ -1,0 +1,330 @@
+"""Tests for pinky_daemon.analytics_store.AnalyticsStore — Tier 1 observability.
+
+Covers the stuck-session observability additions:
+- status enum lifecycle (running -> ok / error)
+- arg_keys captured in metadata_json (PII-safe: key names only, no values)
+- sweep_orphan_tool_calls closing out stale 'running' rows
+- prune_tool_calls retention
+- get_recent_tool_calls investigative helper
+- schema migration backfill on pre-existing DBs without status column
+
+Uses tmp_path for isolated SQLite DBs.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pinky_daemon.analytics_store import AnalyticsStore
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _store(tmp_path: Path) -> AnalyticsStore:
+    return AnalyticsStore(str(tmp_path / "analytics.db"))
+
+
+def _seed_session(store: AnalyticsStore, session_id: str = "sess1", agent: str = "barsik") -> None:
+    store.ensure_session_fact(
+        session_id=session_id,
+        agent_name=agent,
+        session_label="test",
+        provider="anthropic",
+        model="claude-sonnet-4",
+    )
+
+
+def _iso(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+# ── status enum lifecycle ──────────────────────────────────────────────────────
+
+class TestStatusEnum:
+    def test_start_sets_status_running(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k1", tool_name="Read",
+        )
+        rows = store.get_recent_tool_calls(agent_name="barsik")
+        assert len(rows) == 1
+        assert rows[0]["status"] == "running"
+        assert rows[0]["ended_at"] is None
+
+    def test_finish_success_sets_status_ok(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k1", tool_name="Read",
+        )
+        store.finish_tool_call(
+            session_id="sess1", agent_name="barsik",
+            tool_call_key="k1", success=True,
+        )
+        rows = store.get_recent_tool_calls(agent_name="barsik")
+        assert rows[0]["status"] == "ok"
+        assert rows[0]["success"] == 1
+
+    def test_finish_failure_sets_status_error(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k1", tool_name="Bash",
+        )
+        store.finish_tool_call(
+            session_id="sess1", agent_name="barsik",
+            tool_call_key="k1", success=False, error_type="nonzero_exit",
+        )
+        rows = store.get_recent_tool_calls(agent_name="barsik")
+        assert rows[0]["status"] == "error"
+        assert rows[0]["error_type"] == "nonzero_exit"
+
+    def test_finish_explicit_status_override(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k1", tool_name="Edit",
+        )
+        store.finish_tool_call(
+            session_id="sess1", agent_name="barsik",
+            tool_call_key="k1", success=False, status="cancelled",
+        )
+        rows = store.get_recent_tool_calls(agent_name="barsik")
+        assert rows[0]["status"] == "cancelled"
+
+
+# ── arg_keys in metadata ───────────────────────────────────────────────────────
+
+class TestArgKeysMetadata:
+    def test_arg_keys_round_trip(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k1", tool_name="Edit",
+            metadata={"arg_keys": ["file_path", "new_string", "old_string"]},
+        )
+        store.finish_tool_call(
+            session_id="sess1", agent_name="barsik",
+            tool_call_key="k1", success=True,
+        )
+        rows = store.get_recent_tool_calls(agent_name="barsik")
+        assert rows[0]["metadata"]["arg_keys"] == [
+            "file_path", "new_string", "old_string",
+        ]
+
+    def test_finish_merges_metadata(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k1", tool_name="Bash",
+            metadata={"arg_keys": ["command"]},
+        )
+        store.finish_tool_call(
+            session_id="sess1", agent_name="barsik",
+            tool_call_key="k1", success=True,
+            metadata={"exit_code": 0},
+        )
+        rows = store.get_recent_tool_calls(agent_name="barsik")
+        meta = rows[0]["metadata"]
+        assert meta["arg_keys"] == ["command"]
+        assert meta["exit_code"] == 0
+
+
+# ── orphan sweep ───────────────────────────────────────────────────────────────
+
+class TestOrphanSweep:
+    def test_sweep_closes_stale_running_rows(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        # Start a tool call "2 hours ago"
+        old_ts = _iso(datetime.now(UTC) - timedelta(hours=2))
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k_old", tool_name="WebFetch", ts=old_ts,
+        )
+        # Fresh running row — must not be touched
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=2,
+            tool_call_key="k_new", tool_name="Read",
+        )
+        count = store.sweep_orphan_tool_calls(older_than_seconds=3600)
+        assert count == 1
+
+        rows = store.get_recent_tool_calls(agent_name="barsik", limit=10)
+        by_key = {r["tool_call_key"]: r for r in rows}
+        assert by_key["k_old"]["status"] == "orphan"
+        assert by_key["k_old"]["error_type"] == "orphan"
+        assert by_key["k_old"]["success"] == 0
+        assert by_key["k_old"]["ended_at"] is not None
+        assert by_key["k_old"]["duration_ms"] is not None
+        assert by_key["k_new"]["status"] == "running"
+
+    def test_sweep_skips_already_finished(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        old_ts = _iso(datetime.now(UTC) - timedelta(hours=2))
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k1", tool_name="Read", ts=old_ts,
+        )
+        store.finish_tool_call(
+            session_id="sess1", agent_name="barsik",
+            tool_call_key="k1", success=True,
+        )
+        count = store.sweep_orphan_tool_calls(older_than_seconds=3600)
+        assert count == 0
+
+
+# ── retention prune ────────────────────────────────────────────────────────────
+
+class TestPruneToolCalls:
+    def test_prune_deletes_old_rows(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        old_ts = _iso(datetime.now(UTC) - timedelta(days=45))
+        new_ts = _iso(datetime.now(UTC) - timedelta(days=5))
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k_old", tool_name="Read", ts=old_ts,
+        )
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=2,
+            tool_call_key="k_new", tool_name="Read", ts=new_ts,
+        )
+        deleted = store.prune_tool_calls(retention_days=30)
+        assert deleted == 1
+        rows = store.get_recent_tool_calls(agent_name="barsik")
+        assert len(rows) == 1
+        assert rows[0]["tool_call_key"] == "k_new"
+
+    def test_prune_keeps_all_within_window(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k1", tool_name="Read",
+        )
+        deleted = store.prune_tool_calls(retention_days=30)
+        assert deleted == 0
+
+
+# ── get_recent_tool_calls ──────────────────────────────────────────────────────
+
+class TestGetRecentToolCalls:
+    def test_returns_newest_first(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        for i in range(3):
+            ts = _iso(datetime.now(UTC) - timedelta(minutes=10 - i))
+            store.start_tool_call(
+                session_id="sess1", agent_name="barsik", turn_seq=i,
+                tool_call_key=f"k{i}", tool_name="Read", ts=ts,
+            )
+        rows = store.get_recent_tool_calls(agent_name="barsik")
+        assert [r["tool_call_key"] for r in rows] == ["k2", "k1", "k0"]
+
+    def test_filters_by_agent(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store, agent="barsik")
+        _seed_session(store, session_id="sess2", agent="murzik")
+        store.start_tool_call(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            tool_call_key="b1", tool_name="Read",
+        )
+        store.start_tool_call(
+            session_id="sess2", agent_name="murzik", turn_seq=1,
+            tool_call_key="m1", tool_name="Bash",
+        )
+        barsik_rows = store.get_recent_tool_calls(agent_name="barsik")
+        assert len(barsik_rows) == 1
+        assert barsik_rows[0]["tool_call_key"] == "b1"
+
+    def test_filters_by_session(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store, session_id="sA")
+        _seed_session(store, session_id="sB")
+        store.start_tool_call(
+            session_id="sA", agent_name="barsik", turn_seq=1,
+            tool_call_key="a1", tool_name="Read",
+        )
+        store.start_tool_call(
+            session_id="sB", agent_name="barsik", turn_seq=1,
+            tool_call_key="b1", tool_name="Bash",
+        )
+        rows = store.get_recent_tool_calls(session_id="sA")
+        assert len(rows) == 1
+        assert rows[0]["tool_call_key"] == "a1"
+
+    def test_respects_limit(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        for i in range(10):
+            store.start_tool_call(
+                session_id="sess1", agent_name="barsik", turn_seq=i,
+                tool_call_key=f"k{i}", tool_name="Read",
+            )
+        rows = store.get_recent_tool_calls(agent_name="barsik", limit=3)
+        assert len(rows) == 3
+
+
+# ── schema migration ──────────────────────────────────────────────────────────
+
+class TestSchemaMigration:
+    def test_adds_status_column_to_preexisting_db(self, tmp_path):
+        """Simulate a DB created before the status column existed and verify
+        AnalyticsStore.__init__ migrates it and backfills status values."""
+        db_path = tmp_path / "legacy.db"
+        # Manually build pre-migration schema (no status column)
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE analytics_tool_calls (
+                  id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  session_id TEXT NOT NULL,
+                  agent_name TEXT NOT NULL,
+                  turn_seq INTEGER,
+                  tool_call_key TEXT,
+                  tool_name TEXT NOT NULL,
+                  tool_namespace TEXT,
+                  started_at TEXT NOT NULL,
+                  ended_at TEXT,
+                  duration_ms INTEGER,
+                  success INTEGER,
+                  error_type TEXT,
+                  metadata_json TEXT
+                );
+                """
+            )
+            # Closed OK row — should backfill to 'ok'
+            conn.execute(
+                "INSERT INTO analytics_tool_calls "
+                "(session_id, agent_name, tool_name, started_at, ended_at, success) "
+                "VALUES ('s1','barsik','Read','2026-04-01T00:00:00Z',"
+                "'2026-04-01T00:00:01Z',1)"
+            )
+            # Closed failed row — backfill to 'error'
+            conn.execute(
+                "INSERT INTO analytics_tool_calls "
+                "(session_id, agent_name, tool_name, started_at, ended_at, success) "
+                "VALUES ('s1','barsik','Bash','2026-04-01T00:00:02Z',"
+                "'2026-04-01T00:00:03Z',0)"
+            )
+            # Still-open row — should stay 'running'
+            conn.execute(
+                "INSERT INTO analytics_tool_calls "
+                "(session_id, agent_name, tool_name, started_at) "
+                "VALUES ('s1','barsik','Edit','2026-04-01T00:00:04Z')"
+            )
+
+        # Open through AnalyticsStore — should trigger migration
+        store = AnalyticsStore(str(db_path))
+        rows = store.get_recent_tool_calls(agent_name="barsik", limit=10)
+        statuses = {r["tool_name"]: r["status"] for r in rows}
+        assert statuses == {"Read": "ok", "Bash": "error", "Edit": "running"}


### PR DESCRIPTION
## Summary

Ships Tier 1 of #243 (stuck-session observability) plus a small defensive fix for a known murzik silent-hang cause. Folded together per Brad — both touch the same session-instrumentation surface.

### Tier 1 observability
- **`status` enum** on `analytics_tool_calls` (`running` | `ok` | `error` | `cancelled` | `timeout` | `orphan`) with SQLite migration + backfill for legacy DBs
- **`sweep_orphan_tool_calls(older_than_seconds)`** — closes out `running` rows stuck past threshold (crash, kill, exception escapes)
- **`prune_tool_calls(retention_days)`** — 30d default bounded storage
- **`get_recent_tool_calls(agent_name, session_id, limit)`** — the investigative helper: *"what were the last N tool calls before the agent got stuck?"*
- **`arg_keys` in metadata_json** — captured at start/finish hooks in both `streaming_session.py` and `codex_session.py`. Key names only, no values — avoids PII/credential leakage per #243 spec

### Murzik StreamReader fix
- Raise `asyncio.create_subprocess_exec` StreamReader `limit` from default 64KB → 10MB. Codex emits large tool-result events (big file reads, diffs) that were overflowing and killing sessions silently with `LimitOverrunError`
- Single-line recovery: wrap `readline()` in `try/except ValueError` filtered by message. `StreamReader.readline()` internally catches `LimitOverrunError`, drains its buffer past the separator, and re-raises as `ValueError("Separator is not found, and chunk exceed the limit")`, so catching `LimitOverrunError` directly is dead code. A single oversized line now gets logged + skipped, session survives.

### Review-round fixes (address murzik's findings on initial push)
- **StreamReader recovery path** now catches `ValueError` (narrowly filtered by message) instead of `asyncio.LimitOverrunError`, since CPython's `StreamReader.readline()` does the exception conversion internally. Unrelated `ValueError`s still propagate.
- **PII-safety in Codex analytics path** made real. Initial implementation returned raw `command` / `file_path` / `tool_input` values *alongside* `arg_keys`, not instead of. Stripped raw values from all five `_analytics_finish_tool_call` call sites in `_handle_event` and all four returns of `_tool_metadata_from_item`. `exit_code` (numeric) retained. Claude SDK path in `streaming_session.py` was already clean — so the cross-session PII claim is now accurate.

## Test plan
- [x] `pytest tests/test_analytics_store.py` — 15/15 new tests pass (status lifecycle, arg_keys round-trip, orphan sweep, retention prune, get_recent_tool_calls filtering, schema migration backfill)
- [x] `pytest` full suite — 1464 passed, 1 skipped after review fixes
- [x] `ruff check` on touched files — zero new errors vs baseline
- [ ] Deploy to Mac Mini and confirm migration is no-op on existing prod DB
- [ ] Watch one murzik session handle a large file read without disconnect

🤖 Opened by Barsik
