### PR TITLE
ci: Tier B — Python matrix (3.11/3.12/3.13) + CodeQL weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,19 @@ jobs:
         run: ruff check .
 
   test:
-    name: Test (Python)
+    name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           cache: pip
 
       - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, beta]
+  pull_request:
+    branches: [main, beta]
+  schedule:
+    # Weekly — Monday 08:00 UTC (Sunday 01:00 PT / 00:00 PST)
+    - cron: "0 8 * * 1"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main, beta]
   schedule:
-    # Weekly — Monday 08:00 UTC (Sunday 01:00 PT / 00:00 PST)
+    # Weekly — Monday 08:00 UTC (Monday 01:00 PDT / 00:00 PST)
     - cron: "0 8 * * 1"
 
 concurrency:


### PR DESCRIPTION
## Summary
- Test job fans out across Python **3.11, 3.12, 3.13** with `fail-fast: false` so one version failure doesn't mask the others.
- New `codeql.yml` runs `security-and-quality` queries for Python + JavaScript/TypeScript on push, PR, and weekly (Mon 08:00 UTC).
- `build-mode: none` — no compilation step needed for either language.
- `pyproject.toml` already declares 3.11–3.14 support via classifiers; no changes needed there.

## Test plan
- [ ] CI run on this PR: all 3 Python versions pass `pytest`
- [ ] Lint and frontend jobs still green (unchanged)
- [ ] CodeQL analysis completes for both languages without errors
- [ ] Verify weekly cron fires next Monday (post-merge observation)

## Scope / out of scope
- **In scope:** CI matrix, CodeQL setup
- **Out of scope:** E501 sweep, ruff format adoption, Tier C (tag-driven release + PyPI + changelog)

🤖 Opened by Barsik