### PR TITLE
fix(pii): scrub raw file_path from broker media endpoint metadata (#69)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6349,7 +6349,9 @@ def create_api(
             platform=platform,
             chat_id=chat_id,
             content=caption or "[photo]",
-            metadata={"tool": "send_photo", "source_message_id": source_message_id, "file_path": file_path, "delivery": result},
+            # PII-safe: record argument key names only, not the raw file_path.
+            # Matches the arg_keys pattern used in codex_session.py / streaming_session.py.
+            metadata={"tool": "send_photo", "source_message_id": source_message_id, "arg_keys": ["file_path"], "delivery": result},
         )
         return result
 
@@ -6378,7 +6380,9 @@ def create_api(
             platform=platform,
             chat_id=chat_id,
             content=caption or f"[document] {Path(file_path).name}",
-            metadata={"tool": "send_document", "source_message_id": source_message_id, "file_path": file_path, "delivery": result},
+            # PII-safe: record argument key names only, not the raw file_path.
+            # Matches the arg_keys pattern used in codex_session.py / streaming_session.py.
+            metadata={"tool": "send_document", "source_message_id": source_message_id, "arg_keys": ["file_path"], "delivery": result},
         )
         return result
 
@@ -6505,7 +6509,9 @@ def create_api(
             platform=platform,
             chat_id=chat_id,
             content=caption or f"[animation] {Path(file_path).name}",
-            metadata={"tool": "send_animation", "source_message_id": source_message_id, "file_path": file_path, "delivery": result},
+            # PII-safe: record argument key names only, not the raw file_path.
+            # Matches the arg_keys pattern used in codex_session.py / streaming_session.py.
+            metadata={"tool": "send_animation", "source_message_id": source_message_id, "arg_keys": ["file_path"], "delivery": result},
         )
         return result
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -884,6 +884,62 @@ class TestAPI:
                 assert history[-1].metadata["tool"] == "thread"
                 assert history[-1].metadata["source_message_id"] == "101"
 
+    def test_broker_media_endpoints_scrub_file_path_from_metadata(self):
+        """Regression: /broker/send-photo, /send-document, /send-animation must not
+        persist the raw file_path to conversation metadata. PR #244 scrubbed the
+        codex/claude analytics path to arg_keys-only; Task #69 extends that
+        guarantee to the outbound-message metadata written by these endpoints.
+        """
+        from pinky_outreach.telegram import TelegramAdapter
+
+        cases = [
+            ("/broker/send-photo", "send_photo", "send_photo", "/tmp/brads-private.png", "[photo]"),
+            ("/broker/send-document", "send_document", "send_document", "/home/brad/secret-doc.pdf", "[document] secret-doc.pdf"),
+            ("/broker/send-animation", "send_animation", "send_animation", "/tmp/brads-gif.gif", "[animation] brads-gif.gif"),
+        ]
+
+        for url, adapter_method, tool_name, file_path, expected_content in cases:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                db_path = os.path.join(tmpdir, "test.db")
+                app = self._make_app(db_path)
+                with TestClient(app) as client:
+                    client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                    app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                    with patch.object(
+                        TelegramAdapter,
+                        adapter_method,
+                        return_value=SimpleNamespace(message_id="999"),
+                    ):
+                        resp = client.post(
+                            url,
+                            json={
+                                "agent_name": "barsik",
+                                "platform": "telegram",
+                                "chat_id": "6770805286",
+                                "file_path": file_path,
+                            },
+                        )
+
+                    assert resp.status_code == 200, f"{url} returned {resp.status_code}: {resp.text}"
+
+                    history = app.state.conversation_store.get_history("barsik-main")
+                    assert history, f"{url} recorded no outbound message"
+                    entry = history[-1]
+                    assert entry.content == expected_content
+                    assert entry.metadata["tool"] == tool_name
+                    # PII-safe: only the arg_keys name, never the raw path.
+                    assert entry.metadata.get("arg_keys") == ["file_path"]
+                    assert "file_path" not in entry.metadata, (
+                        f"{url} leaked raw file_path into metadata: {entry.metadata}"
+                    )
+                    # Defense-in-depth: the raw value must not appear anywhere
+                    # in the serialized metadata blob.
+                    import json as _json
+                    assert file_path not in _json.dumps(entry.metadata), (
+                        f"{url} leaked raw file_path value into metadata payload"
+                    )
+
     def test_broker_thread_voice_context_auto_uses_voice_reply(self):
         class _UrlResp:
             def __enter__(self):


### PR DESCRIPTION
## Summary

Closes Task #69. Follow-up to #244's Tier 1 tool-call observability work, which scrubbed raw argument values from the codex/claude analytics paths but left the `_record_outbound_message` calls in three broker HTTP endpoints still persisting raw `file_path` into the conversation store's metadata column.

### Change
`src/pinky_daemon/api.py` — three sites (`/broker/send-photo`, `/broker/send-document`, `/broker/send-animation`):
- Before: `metadata={"tool": "send_photo", ..., "file_path": file_path, "delivery": result}`
- After:  `metadata={"tool": "send_photo", ..., "arg_keys": ["file_path"], "delivery": result}`

Matches the `arg_keys` convention already used by `codex_session.py` and `streaming_session.py`. Rendered content field (`content=caption or f"[document] {Path(file_path).name}"`) is unchanged — it only ever exposed the filename, never the full path.

### What this does NOT touch
- `/broker/send-gif` — records `query` (user search term, not a filesystem path) — out of scope for this task.
- `/broker/send-voice` — records `text` (the message being read aloud) — already part of the user-visible content, not a path; out of scope.
- `_analytics_finish_tool_call` paths in `codex_session.py` / `streaming_session.py` — already scrubbed in #244.

## Test plan

- [x] New regression test `test_broker_media_endpoints_scrub_file_path_from_metadata` — hits each of the three endpoints with a PII-flavored raw path (`/home/brad/secret-doc.pdf` etc.) and asserts:
  - Response 200
  - `entry.metadata["arg_keys"] == ["file_path"]`
  - `"file_path"` key absent from metadata dict
  - Raw path value absent from the serialized JSON blob (defense-in-depth)
- [x] Full suite: **1465 passed, 1 skipped** (139s)
- [x] `ruff check` clean on `src/pinky_daemon/api.py` and `tests/test_api.py`
- [ ] Pushok review — happy to take eyes on scope/shape

🤖 Opened by Barsik