### PR TITLE
feat(federation): sealed_box_v1 crypto primitives (#250)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
     "uvicorn>=0.44",
     "claude-agent-sdk>=0.1.58",
     "Pillow>=10.0",
+    # Federation crypto (sealed_box_v1): X25519, Ed25519, HKDF, XChaCha20-Poly1305.
+    "cryptography>=41.0",
+    "pynacl>=1.5",
 ]
 
 [project.optional-dependencies]
@@ -66,7 +69,7 @@ dev = [
 pinky = "pinky_cli.__main__:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/pinky_memory", "src/pinky_outreach", "src/pinky_messaging", "src/pinky_daemon", "src/pinky_cli", "src/pinky_self", "src/pinky_calendar", "src/pinky_hub", "src/pinky_web"]
+packages = ["src/pinky_memory", "src/pinky_outreach", "src/pinky_messaging", "src/pinky_daemon", "src/pinky_cli", "src/pinky_self", "src/pinky_calendar", "src/pinky_hub", "src/pinky_web", "src/pinky_federation"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/pinky_federation/__init__.py
+++ b/src/pinky_federation/__init__.py
@@ -1,0 +1,61 @@
+"""PinkyBot federation — sealed-box-v1 crypto and envelope primitives.
+
+This package implements the reference crypto layer for PinkyBot federation v0.2:
+
+- X25519 encryption keypairs (per-tenant, per-device)
+- Ed25519 signing keypairs (per-tenant, client-owned)
+- `sealed_box_v1`: authenticated ephemeral-X25519 + XChaCha20-Poly1305 + Ed25519 sender signature
+- Versioned envelope serialization suitable for relay transport
+- Deterministic fingerprints for TOFU pinning and UX display
+
+Nothing in this package talks to a network. Higher layers (transport, invite,
+attachments) consume these primitives.
+"""
+
+from pinky_federation.envelope import (
+    Envelope,
+    EnvelopeError,
+    EnvelopeVersion,
+)
+from pinky_federation.errors import (
+    CryptoError,
+    DecryptionError,
+    SignatureError,
+)
+from pinky_federation.fingerprint import (
+    FINGERPRINT_BYTES,
+    canonical_address,
+    fingerprint,
+    format_fingerprint,
+)
+from pinky_federation.keys import (
+    EncryptionKeyPair,
+    EncryptionPublicKey,
+    SigningKeyPair,
+    SigningPublicKey,
+)
+from pinky_federation.sealed_box import (
+    SEALED_BOX_VERSION,
+    seal,
+    unseal,
+)
+
+__all__ = [
+    "CryptoError",
+    "DecryptionError",
+    "Envelope",
+    "EnvelopeError",
+    "EnvelopeVersion",
+    "EncryptionKeyPair",
+    "EncryptionPublicKey",
+    "FINGERPRINT_BYTES",
+    "SEALED_BOX_VERSION",
+    "SignatureError",
+    "SigningKeyPair",
+    "SigningPublicKey",
+    "canonical_address",
+    "fingerprint",
+    "format_fingerprint",
+    "seal",
+    "unseal",
+]

--- a/src/pinky_federation/envelope.py
+++ b/src/pinky_federation/envelope.py
@@ -1,0 +1,156 @@
+"""Envelope wire format for federation v0.2.
+
+An envelope is the single unit that moves through the relay. It contains
+everything a recipient needs to authenticate and decrypt a sealed-box-v1
+message, *given* their own private key and a trust-store entry for the
+sender fingerprint.
+
+Wire format (v1), all integers big-endian:
+
+    magic        4   b"PFv1"
+    version      1   == 1
+    flags        1   reserved, must be 0
+    sender_fp    16  fingerprint bytes
+    recipient_fp 16  fingerprint bytes
+    eph_pk       32  ephemeral X25519 public key
+    nonce        24  XChaCha20-Poly1305 nonce
+    sig          64  Ed25519 signature
+    ct_len       4   length of ciphertext in bytes
+    ciphertext   ct_len
+
+Fixed-length fields simplify parsing and test-vector generation; the only
+variable-length piece is the AEAD ciphertext, length-prefixed with a 32-bit
+big-endian integer (max 4 GiB — more than enough for in-relay messages).
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+from pinky_federation.errors import EnvelopeError
+from pinky_federation.fingerprint import FINGERPRINT_BYTES
+from pinky_federation.keys import ED25519_SIG_BYTES, X25519_KEY_BYTES
+
+_MAGIC = b"PFv1"
+_NONCE_BYTES = 24
+_CT_LEN_FIELD_BYTES = 4
+#: Hard cap on ciphertext size (16 MiB). Larger blobs belong in the attachment
+#: pipeline, not the main envelope.
+MAX_CIPHERTEXT_BYTES = 16 * 1024 * 1024
+
+# Offsets within the fixed-size header.
+_HDR_MAGIC_END = len(_MAGIC)
+_HDR_VERSION = _HDR_MAGIC_END
+_HDR_FLAGS = _HDR_VERSION + 1
+_HDR_SENDER_FP = _HDR_FLAGS + 1
+_HDR_RECIPIENT_FP = _HDR_SENDER_FP + FINGERPRINT_BYTES
+_HDR_EPH_PK = _HDR_RECIPIENT_FP + FINGERPRINT_BYTES
+_HDR_NONCE = _HDR_EPH_PK + X25519_KEY_BYTES
+_HDR_SIG = _HDR_NONCE + _NONCE_BYTES
+_HDR_CT_LEN = _HDR_SIG + ED25519_SIG_BYTES
+_HDR_FIXED = _HDR_CT_LEN + _CT_LEN_FIELD_BYTES  # 142 bytes
+
+
+class EnvelopeVersion(enum.IntEnum):
+    """Wire-protocol version for sealed-box envelopes."""
+
+    V1 = 1
+
+
+@dataclass(frozen=True)
+class Envelope:
+    """Parsed sealed-box envelope.
+
+    Field sizes are validated in ``__post_init__``; instances constructed via
+    :meth:`from_bytes` are guaranteed well-shaped.
+    """
+
+    version: EnvelopeVersion
+    sender_fingerprint: bytes
+    recipient_fingerprint: bytes
+    ephemeral_public: bytes
+    nonce: bytes
+    signature: bytes
+    ciphertext: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.version, EnvelopeVersion):
+            raise ValueError("version must be EnvelopeVersion")
+        self._check_len("sender_fingerprint", self.sender_fingerprint, FINGERPRINT_BYTES)
+        self._check_len("recipient_fingerprint", self.recipient_fingerprint, FINGERPRINT_BYTES)
+        self._check_len("ephemeral_public", self.ephemeral_public, X25519_KEY_BYTES)
+        self._check_len("nonce", self.nonce, _NONCE_BYTES)
+        self._check_len("signature", self.signature, ED25519_SIG_BYTES)
+        if not isinstance(self.ciphertext, (bytes, bytearray)):
+            raise ValueError("ciphertext must be bytes")
+        if len(self.ciphertext) > MAX_CIPHERTEXT_BYTES:
+            raise ValueError("ciphertext exceeds MAX_CIPHERTEXT_BYTES")
+
+    @staticmethod
+    def _check_len(name: str, val: bytes, expected: int) -> None:
+        if not isinstance(val, (bytes, bytearray)) or len(val) != expected:
+            raise ValueError(f"{name} must be {expected} bytes")
+
+    # -- Serialization --------------------------------------------------------
+
+    def to_bytes(self) -> bytes:
+        parts = [
+            _MAGIC,
+            bytes([self.version.value]),
+            bytes([0]),  # flags reserved
+            bytes(self.sender_fingerprint),
+            bytes(self.recipient_fingerprint),
+            bytes(self.ephemeral_public),
+            bytes(self.nonce),
+            bytes(self.signature),
+            len(self.ciphertext).to_bytes(_CT_LEN_FIELD_BYTES, "big"),
+            bytes(self.ciphertext),
+        ]
+        return b"".join(parts)
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> Envelope:
+        if not isinstance(data, (bytes, bytearray)):
+            raise EnvelopeError("envelope must be bytes")
+        if len(data) < _HDR_FIXED:
+            raise EnvelopeError("envelope shorter than fixed header")
+        if data[: _HDR_MAGIC_END] != _MAGIC:
+            raise EnvelopeError("envelope magic mismatch")
+
+        version_byte = data[_HDR_VERSION]
+        try:
+            version = EnvelopeVersion(version_byte)
+        except ValueError as exc:
+            raise EnvelopeError(f"unsupported envelope version: {version_byte}") from exc
+
+        flags = data[_HDR_FLAGS]
+        if flags != 0:
+            raise EnvelopeError(f"unsupported envelope flags: 0x{flags:02x}")
+
+        sender_fp = bytes(data[_HDR_SENDER_FP:_HDR_RECIPIENT_FP])
+        recipient_fp = bytes(data[_HDR_RECIPIENT_FP:_HDR_EPH_PK])
+        eph_pk = bytes(data[_HDR_EPH_PK:_HDR_NONCE])
+        nonce = bytes(data[_HDR_NONCE:_HDR_SIG])
+        signature = bytes(data[_HDR_SIG:_HDR_CT_LEN])
+
+        ct_len = int.from_bytes(data[_HDR_CT_LEN:_HDR_FIXED], "big")
+        if ct_len > MAX_CIPHERTEXT_BYTES:
+            raise EnvelopeError("ciphertext length exceeds MAX_CIPHERTEXT_BYTES")
+        expected_end = _HDR_FIXED + ct_len
+        if len(data) != expected_end:
+            raise EnvelopeError(
+                f"envelope length mismatch: header says ct_len={ct_len}, "
+                f"total_expected={expected_end}, got={len(data)}"
+            )
+        ciphertext = bytes(data[_HDR_FIXED:expected_end])
+
+        return cls(
+            version=version,
+            sender_fingerprint=sender_fp,
+            recipient_fingerprint=recipient_fp,
+            ephemeral_public=eph_pk,
+            nonce=nonce,
+            signature=signature,
+            ciphertext=ciphertext,
+        )

--- a/src/pinky_federation/errors.py
+++ b/src/pinky_federation/errors.py
@@ -1,0 +1,25 @@
+"""Exceptions raised by the federation crypto layer.
+
+Rules:
+- Never include private key material in exception messages.
+- Keep error types narrow so higher layers can handle them distinctly
+  (e.g. TOFU mismatch vs tampered ciphertext vs unknown version).
+"""
+
+from __future__ import annotations
+
+
+class CryptoError(Exception):
+    """Base class for all federation crypto failures."""
+
+
+class DecryptionError(CryptoError):
+    """Ciphertext could not be decrypted (tamper, wrong key, or corruption)."""
+
+
+class SignatureError(CryptoError):
+    """Ed25519 sender signature did not verify."""
+
+
+class EnvelopeError(CryptoError):
+    """Envelope bytes failed structural parsing or version check."""

--- a/src/pinky_federation/fingerprint.py
+++ b/src/pinky_federation/fingerprint.py
@@ -1,0 +1,107 @@
+"""Deterministic fingerprints for federation identities.
+
+A fingerprint uniquely identifies the tuple *(canonical address, signing pubkey,
+encryption pubkey)*. It is used for:
+
+- TOFU pinning (stored on first receive, verified on subsequent receives)
+- Short UX display strings ("Verify: `a1b2 c3d4 … f7e8`")
+- Addressing senders in the wire envelope (so receivers can look up trust)
+
+Design:
+
+- Input canonicalization is strict — the same tenant address must produce
+  identical bytes regardless of case, whitespace, or surrounding noise.
+- The hash is domain-separated with a version string, so we can rotate the
+  scheme without fingerprint collisions across versions.
+- We use SHA-256 truncated to 16 bytes (128 bits). That is comfortably above
+  the preimage/collision bar for TOFU and short enough for display.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from pinky_federation.keys import (
+    EncryptionPublicKey,
+    SigningPublicKey,
+)
+
+#: Fingerprint length in bytes. 16 bytes = 128 bits.
+FINGERPRINT_BYTES = 16
+
+_FP_DOMAIN = b"pinky-federation/fingerprint/v1"
+
+
+def canonical_address(address: str) -> str:
+    """Canonicalize a federation address (``user@host`` style).
+
+    Rules:
+
+    - Strip surrounding whitespace.
+    - Lowercase the entire string (federation addresses are case-insensitive
+      in both the local part and host, per our spec; real email is
+      case-sensitive in the local part, but we want TOFU to be forgiving).
+    - Reject empty strings and strings containing control bytes or whitespace
+      after stripping.
+    """
+    if not isinstance(address, str):
+        raise TypeError("address must be str")
+    cleaned = address.strip().lower()
+    if not cleaned:
+        raise ValueError("address must not be empty")
+    for ch in cleaned:
+        if ch.isspace() or ord(ch) < 0x20:
+            raise ValueError("address must not contain whitespace or control chars")
+    return cleaned
+
+
+def fingerprint(
+    address: str,
+    signing_key: SigningPublicKey,
+    encryption_key: EncryptionPublicKey,
+) -> bytes:
+    """Compute the 16-byte fingerprint for a federation identity.
+
+    The hash input is:
+
+        FP_DOMAIN || u16(len(addr)) || utf8(addr) ||
+        u8(len(sig_pk)) || sig_pk || u8(len(enc_pk)) || enc_pk
+
+    Length-prefixing prevents cross-field ambiguity (otherwise concatenation
+    would let two different identities produce the same hash input).
+    """
+    addr = canonical_address(address).encode("utf-8")
+    sig_pk = signing_key.to_bytes()
+    enc_pk = encryption_key.to_bytes()
+
+    h = hashlib.sha256()
+    h.update(_FP_DOMAIN)
+    h.update(len(addr).to_bytes(2, "big"))
+    h.update(addr)
+    h.update(len(sig_pk).to_bytes(1, "big"))
+    h.update(sig_pk)
+    h.update(len(enc_pk).to_bytes(1, "big"))
+    h.update(enc_pk)
+    return h.digest()[:FINGERPRINT_BYTES]
+
+
+def format_fingerprint(fp: bytes, *, groups: int = 4, group_size: int = 4) -> str:
+    """Format *fp* as a human-readable grouped hex string.
+
+    Default layout: ``"a1b2 c3d4 e5f6 …"`` with 4-char groups separated by
+    spaces. Accepts any fingerprint length that is a multiple of ``group_size``.
+    """
+    if not isinstance(fp, (bytes, bytearray)):
+        raise TypeError("fp must be bytes")
+    if groups <= 0 or group_size <= 0:
+        raise ValueError("groups and group_size must be positive")
+    hex_str = fp.hex()
+    # Break into group_size-char chunks, then join the requested number of
+    # groups with spaces. Any remainder past `groups * group_size` chars is
+    # dropped — callers wanting the full hex should use fp.hex() directly.
+    chunks: list[str] = []
+    for i in range(0, len(hex_str), group_size):
+        chunks.append(hex_str[i : i + group_size])
+        if len(chunks) == groups:
+            break
+    return " ".join(chunks)

--- a/src/pinky_federation/keys.py
+++ b/src/pinky_federation/keys.py
@@ -1,0 +1,186 @@
+"""Federation keypair types.
+
+We use:
+- **X25519** for encryption keypairs (Diffie-Hellman with ephemeral sender keys).
+- **Ed25519** for signing keypairs (tenant identity + per-message sender auth).
+
+All private key bytes stay inside their keypair objects. Raw-bytes accessors
+(`.private_bytes_insecure()`) are intentionally verbose so grep can flag callers.
+
+No key material is written to `repr()` or logs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nacl.bindings import (
+    crypto_scalarmult,
+    crypto_scalarmult_base,
+)
+from nacl.public import PrivateKey as _NaclX25519Private
+from nacl.signing import SigningKey as _NaclEd25519Signing
+from nacl.signing import VerifyKey as _NaclEd25519Verify
+
+from pinky_federation.errors import SignatureError
+
+X25519_KEY_BYTES = 32
+ED25519_KEY_BYTES = 32
+ED25519_SIG_BYTES = 64
+
+
+# -- Encryption (X25519) ------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EncryptionPublicKey:
+    """X25519 public key (32 bytes).
+
+    Safe to share, serialize, and log. Equality + hashing are on raw bytes.
+    """
+
+    raw: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.raw, bytes) or len(self.raw) != X25519_KEY_BYTES:
+            raise ValueError(f"X25519 public key must be {X25519_KEY_BYTES} bytes")
+
+    def to_bytes(self) -> bytes:
+        return self.raw
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> EncryptionPublicKey:
+        return cls(bytes(data))
+
+    def __repr__(self) -> str:
+        return f"EncryptionPublicKey(<{self.raw[:4].hex()}…>)"
+
+
+class EncryptionKeyPair:
+    """X25519 private + public pair.
+
+    The private half never appears in `repr()` and never round-trips through
+    serialization unless a caller explicitly asks via
+    :meth:`private_bytes_insecure`.
+    """
+
+    __slots__ = ("_sk",)
+
+    def __init__(self, sk: _NaclX25519Private) -> None:
+        self._sk = sk
+
+    @classmethod
+    def generate(cls) -> EncryptionKeyPair:
+        return cls(_NaclX25519Private.generate())
+
+    @classmethod
+    def from_private_bytes(cls, data: bytes) -> EncryptionKeyPair:
+        if not isinstance(data, (bytes, bytearray)) or len(data) != X25519_KEY_BYTES:
+            raise ValueError(f"X25519 private key must be {X25519_KEY_BYTES} bytes")
+        return cls(_NaclX25519Private(bytes(data)))
+
+    @property
+    def public_key(self) -> EncryptionPublicKey:
+        return EncryptionPublicKey(bytes(self._sk.public_key))
+
+    def private_bytes_insecure(self) -> bytes:
+        """Return raw 32-byte private scalar. Use only for at-rest persistence."""
+        return bytes(self._sk)
+
+    def dh(self, peer_public: EncryptionPublicKey) -> bytes:
+        """Compute X25519 ECDH shared secret with *peer_public*.
+
+        Returns the raw 32-byte shared point. Callers MUST feed this through
+        an HKDF step before using it as a symmetric key.
+        """
+        if not isinstance(peer_public, EncryptionPublicKey):
+            raise TypeError("peer_public must be EncryptionPublicKey")
+        return crypto_scalarmult(self.private_bytes_insecure(), peer_public.raw)
+
+    def __repr__(self) -> str:
+        return f"EncryptionKeyPair(public={self.public_key!r})"
+
+
+def x25519_public_from_private(sk_bytes: bytes) -> bytes:
+    """Derive X25519 public from a raw private scalar (32 bytes)."""
+    if len(sk_bytes) != X25519_KEY_BYTES:
+        raise ValueError(f"X25519 private must be {X25519_KEY_BYTES} bytes")
+    return crypto_scalarmult_base(sk_bytes)
+
+
+# -- Signing (Ed25519) --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SigningPublicKey:
+    """Ed25519 verify key (32 bytes)."""
+
+    raw: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.raw, bytes) or len(self.raw) != ED25519_KEY_BYTES:
+            raise ValueError(f"Ed25519 public key must be {ED25519_KEY_BYTES} bytes")
+
+    def to_bytes(self) -> bytes:
+        return self.raw
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> SigningPublicKey:
+        return cls(bytes(data))
+
+    def verify(self, message: bytes, signature: bytes) -> None:
+        """Raise :class:`SignatureError` if *signature* is not valid for *message*.
+
+        The underlying library raises its own exception type; we normalize so
+        higher layers only catch our own exception hierarchy.
+        """
+        if len(signature) != ED25519_SIG_BYTES:
+            raise SignatureError("signature must be 64 bytes")
+        try:
+            _NaclEd25519Verify(self.raw).verify(message, signature)
+        except Exception as exc:  # noqa: BLE001 — normalize third-party types
+            raise SignatureError("Ed25519 signature did not verify") from exc
+
+    def __repr__(self) -> str:
+        return f"SigningPublicKey(<{self.raw[:4].hex()}…>)"
+
+
+class SigningKeyPair:
+    """Ed25519 signing + verify pair (tenant identity key)."""
+
+    __slots__ = ("_sk",)
+
+    def __init__(self, sk: _NaclEd25519Signing) -> None:
+        self._sk = sk
+
+    @classmethod
+    def generate(cls) -> SigningKeyPair:
+        return cls(_NaclEd25519Signing.generate())
+
+    @classmethod
+    def from_seed(cls, seed: bytes) -> SigningKeyPair:
+        """Construct from a 32-byte seed.
+
+        Only use this for persistence/recovery — never derive a seed from a
+        low-entropy source.
+        """
+        if not isinstance(seed, (bytes, bytearray)) or len(seed) != ED25519_KEY_BYTES:
+            raise ValueError(f"Ed25519 seed must be {ED25519_KEY_BYTES} bytes")
+        return cls(_NaclEd25519Signing(bytes(seed)))
+
+    @property
+    def public_key(self) -> SigningPublicKey:
+        return SigningPublicKey(bytes(self._sk.verify_key))
+
+    def seed_bytes_insecure(self) -> bytes:
+        """Return the raw 32-byte Ed25519 seed. Use only for at-rest persistence."""
+        return bytes(self._sk)
+
+    def sign(self, message: bytes) -> bytes:
+        """Sign *message* with Ed25519. Returns raw 64-byte signature."""
+        if not isinstance(message, (bytes, bytearray)):
+            raise TypeError("message must be bytes")
+        return bytes(self._sk.sign(bytes(message)).signature)
+
+    def __repr__(self) -> str:
+        return f"SigningKeyPair(public={self.public_key!r})"

--- a/src/pinky_federation/sealed_box.py
+++ b/src/pinky_federation/sealed_box.py
@@ -1,0 +1,257 @@
+"""``sealed_box_v1`` — authenticated per-message envelope crypto.
+
+Protocol (v1):
+
+1. Sender generates an ephemeral X25519 keypair ``(eph_sk, eph_pk)``.
+2. Computes ``shared = X25519(eph_sk, recipient_enc_pk)``.
+3. Derives ``key = HKDF-SHA256(shared, salt=eph_pk||recipient_enc_pk, info="…/key")``.
+4. Picks a fresh 24-byte random nonce.
+5. Encrypts plaintext with XChaCha20-Poly1305 under (key, nonce), with AAD
+   covering protocol domain, version, both fingerprints, and ``eph_pk``.
+6. Signs a canonical "to-be-signed" byte string with the sender's Ed25519 key.
+   The signed bytes include the ciphertext, so tamper detection is
+   end-to-end even if the AEAD tag alone were somehow stripped.
+
+Properties:
+
+- **Forward secrecy** (for a given message) — the ephemeral private key is
+  discarded after use, so compromise of a long-term encryption key does not
+  retroactively decrypt past messages.
+- **Sender authenticity** — the Ed25519 signature binds a specific sender
+  identity to the envelope; the recipient's trust store resolves
+  ``sender_fingerprint`` → signing public key.
+- **Replay/cross-recipient resistance** — the AAD and signed bytes include
+  the recipient fingerprint, so an envelope can't be rebound to a different
+  recipient without invalidating the MAC and the signature.
+
+No state is kept in this module. Higher layers handle persistence and
+ratcheting (planned for v2).
+"""
+
+from __future__ import annotations
+
+import os
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from nacl.bindings import (
+    crypto_aead_xchacha20poly1305_ietf_decrypt,
+    crypto_aead_xchacha20poly1305_ietf_encrypt,
+    crypto_aead_xchacha20poly1305_ietf_KEYBYTES,
+    crypto_aead_xchacha20poly1305_ietf_NPUBBYTES,
+)
+
+from pinky_federation.envelope import (
+    Envelope,
+    EnvelopeVersion,
+)
+from pinky_federation.errors import (
+    DecryptionError,
+)
+from pinky_federation.fingerprint import (
+    FINGERPRINT_BYTES,
+)
+from pinky_federation.keys import (
+    EncryptionKeyPair,
+    EncryptionPublicKey,
+    SigningKeyPair,
+    SigningPublicKey,
+)
+
+#: Current sealed-box protocol version. Bumped only on breaking wire changes.
+SEALED_BOX_VERSION = EnvelopeVersion.V1
+
+_KEY_BYTES = crypto_aead_xchacha20poly1305_ietf_KEYBYTES  # 32
+_NONCE_BYTES = crypto_aead_xchacha20poly1305_ietf_NPUBBYTES  # 24
+
+_HKDF_INFO = b"pinky-federation/sealed_box_v1/key"
+_AAD_DOMAIN = b"pinky-federation/sealed_box_v1/aad"
+_SIG_DOMAIN = b"pinky-federation/sealed_box_v1/sig"
+
+
+def _derive_key(shared: bytes, eph_pk: bytes, recipient_enc_pk: bytes) -> bytes:
+    return HKDF(
+        algorithm=hashes.SHA256(),
+        length=_KEY_BYTES,
+        salt=eph_pk + recipient_enc_pk,
+        info=_HKDF_INFO,
+    ).derive(shared)
+
+
+def _build_aad(
+    version: int,
+    sender_fp: bytes,
+    recipient_fp: bytes,
+    eph_pk: bytes,
+) -> bytes:
+    if len(sender_fp) != FINGERPRINT_BYTES or len(recipient_fp) != FINGERPRINT_BYTES:
+        raise ValueError("fingerprints must be FINGERPRINT_BYTES bytes")
+    if len(eph_pk) != 32:
+        raise ValueError("eph_pk must be 32 bytes")
+    return b"".join(
+        [
+            _AAD_DOMAIN,
+            bytes([version]),
+            sender_fp,
+            recipient_fp,
+            eph_pk,
+        ]
+    )
+
+
+def _build_sig_tbs(
+    version: int,
+    sender_fp: bytes,
+    recipient_fp: bytes,
+    eph_pk: bytes,
+    nonce: bytes,
+    ciphertext: bytes,
+) -> bytes:
+    return b"".join(
+        [
+            _SIG_DOMAIN,
+            bytes([version]),
+            sender_fp,
+            recipient_fp,
+            eph_pk,
+            nonce,
+            len(ciphertext).to_bytes(4, "big"),
+            ciphertext,
+        ]
+    )
+
+
+def seal(
+    plaintext: bytes,
+    *,
+    sender_signing: SigningKeyPair,
+    sender_fingerprint: bytes,
+    recipient_encryption: EncryptionPublicKey,
+    recipient_fingerprint: bytes,
+    nonce: bytes | None = None,
+    ephemeral: EncryptionKeyPair | None = None,
+) -> Envelope:
+    """Encrypt + sign *plaintext* into a v1 envelope addressed to the recipient.
+
+    Arguments:
+        plaintext: Bytes to seal. May be empty.
+        sender_signing: Sender's long-term Ed25519 signing keypair.
+        sender_fingerprint: Sender identity fingerprint to embed in the envelope.
+        recipient_encryption: Recipient's long-term X25519 public key.
+        recipient_fingerprint: Recipient identity fingerprint.
+        nonce: Optional 24-byte override. ``None`` means generate fresh randomness.
+            **Only supply this for deterministic test vectors** — reusing a
+            nonce with the same key is catastrophic.
+        ephemeral: Optional ephemeral X25519 keypair override (same caveat).
+
+    The returned envelope is safe to serialize via ``envelope.to_bytes()``.
+    """
+    if not isinstance(plaintext, (bytes, bytearray)):
+        raise TypeError("plaintext must be bytes")
+    if not isinstance(sender_fingerprint, (bytes, bytearray)) or len(sender_fingerprint) != FINGERPRINT_BYTES:
+        raise ValueError(f"sender_fingerprint must be {FINGERPRINT_BYTES} bytes")
+    if not isinstance(recipient_fingerprint, (bytes, bytearray)) or len(recipient_fingerprint) != FINGERPRINT_BYTES:
+        raise ValueError(f"recipient_fingerprint must be {FINGERPRINT_BYTES} bytes")
+
+    eph = ephemeral if ephemeral is not None else EncryptionKeyPair.generate()
+    eph_pk = eph.public_key.to_bytes()
+
+    shared = eph.dh(recipient_encryption)
+    key = _derive_key(shared, eph_pk, recipient_encryption.to_bytes())
+
+    if nonce is None:
+        nonce_bytes = os.urandom(_NONCE_BYTES)
+    else:
+        if len(nonce) != _NONCE_BYTES:
+            raise ValueError(f"nonce must be {_NONCE_BYTES} bytes")
+        nonce_bytes = bytes(nonce)
+
+    aad = _build_aad(
+        SEALED_BOX_VERSION.value,
+        bytes(sender_fingerprint),
+        bytes(recipient_fingerprint),
+        eph_pk,
+    )
+    ciphertext = crypto_aead_xchacha20poly1305_ietf_encrypt(
+        bytes(plaintext), aad, nonce_bytes, key
+    )
+
+    sig_tbs = _build_sig_tbs(
+        SEALED_BOX_VERSION.value,
+        bytes(sender_fingerprint),
+        bytes(recipient_fingerprint),
+        eph_pk,
+        nonce_bytes,
+        ciphertext,
+    )
+    signature = sender_signing.sign(sig_tbs)
+
+    return Envelope(
+        version=SEALED_BOX_VERSION,
+        sender_fingerprint=bytes(sender_fingerprint),
+        recipient_fingerprint=bytes(recipient_fingerprint),
+        ephemeral_public=eph_pk,
+        nonce=nonce_bytes,
+        signature=signature,
+        ciphertext=ciphertext,
+    )
+
+
+def unseal(
+    envelope: Envelope,
+    *,
+    recipient_encryption: EncryptionKeyPair,
+    sender_signing_public: SigningPublicKey,
+) -> bytes:
+    """Verify + decrypt *envelope* using the recipient's private key.
+
+    ``sender_signing_public`` must be resolved by the caller from their local
+    trust store keyed on ``envelope.sender_fingerprint``. This function does
+    not talk to storage.
+
+    Raises:
+        SignatureError: Sender signature failed verification.
+        DecryptionError: AEAD tag did not match (tamper / wrong key / wrong version).
+    """
+    if envelope.version is not SEALED_BOX_VERSION:
+        raise DecryptionError(f"unsupported envelope version: {envelope.version}")
+
+    sig_tbs = _build_sig_tbs(
+        envelope.version.value,
+        envelope.sender_fingerprint,
+        envelope.recipient_fingerprint,
+        envelope.ephemeral_public,
+        envelope.nonce,
+        envelope.ciphertext,
+    )
+    # Raises SignatureError on failure (normalized inside SigningPublicKey).
+    sender_signing_public.verify(sig_tbs, envelope.signature)
+
+    shared = recipient_encryption.dh(EncryptionPublicKey(envelope.ephemeral_public))
+    key = _derive_key(
+        shared,
+        envelope.ephemeral_public,
+        recipient_encryption.public_key.to_bytes(),
+    )
+
+    aad = _build_aad(
+        envelope.version.value,
+        envelope.sender_fingerprint,
+        envelope.recipient_fingerprint,
+        envelope.ephemeral_public,
+    )
+    try:
+        plaintext = crypto_aead_xchacha20poly1305_ietf_decrypt(
+            envelope.ciphertext, aad, envelope.nonce, key
+        )
+    except Exception as exc:  # noqa: BLE001 — libsodium raises CryptoError
+        raise DecryptionError("AEAD decryption failed") from exc
+    return plaintext
+
+
+# Re-export for unit-test access. Not part of the public API.
+__test__ = {
+    "_derive_key": _derive_key,
+    "_build_aad": _build_aad,
+    "_build_sig_tbs": _build_sig_tbs,
+}

--- a/tests/pinky_federation/test_envelope.py
+++ b/tests/pinky_federation/test_envelope.py
@@ -1,0 +1,126 @@
+"""Envelope serialization tests: round-trip, header parsing, malformed inputs."""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_federation.envelope import (
+    MAX_CIPHERTEXT_BYTES,
+    Envelope,
+    EnvelopeVersion,
+)
+from pinky_federation.errors import EnvelopeError
+
+
+def _sample_envelope(ct: bytes = b"ciphertext-goes-here") -> Envelope:
+    return Envelope(
+        version=EnvelopeVersion.V1,
+        sender_fingerprint=b"\x01" * 16,
+        recipient_fingerprint=b"\x02" * 16,
+        ephemeral_public=b"\x03" * 32,
+        nonce=b"\x04" * 24,
+        signature=b"\x05" * 64,
+        ciphertext=ct,
+    )
+
+
+def test_envelope_round_trip() -> None:
+    env = _sample_envelope()
+    data = env.to_bytes()
+    restored = Envelope.from_bytes(data)
+    assert restored == env
+
+
+def test_envelope_serialized_length_matches_spec() -> None:
+    env = _sample_envelope(ct=b"")
+    data = env.to_bytes()
+    # 4 magic + 1 ver + 1 flags + 16 + 16 + 32 + 24 + 64 + 4 = 162 fixed header.
+    assert len(data) == 162
+    env2 = _sample_envelope(ct=b"x" * 100)
+    assert len(env2.to_bytes()) == 162 + 100
+
+
+def test_envelope_magic_check() -> None:
+    env = _sample_envelope()
+    data = bytearray(env.to_bytes())
+    data[0] = ord("Q")
+    with pytest.raises(EnvelopeError, match="magic"):
+        Envelope.from_bytes(bytes(data))
+
+
+def test_envelope_version_check() -> None:
+    env = _sample_envelope()
+    data = bytearray(env.to_bytes())
+    data[4] = 99  # version byte
+    with pytest.raises(EnvelopeError, match="unsupported envelope version"):
+        Envelope.from_bytes(bytes(data))
+
+
+def test_envelope_flags_must_be_zero() -> None:
+    env = _sample_envelope()
+    data = bytearray(env.to_bytes())
+    data[5] = 0x80  # flags byte
+    with pytest.raises(EnvelopeError, match="flags"):
+        Envelope.from_bytes(bytes(data))
+
+
+def test_envelope_short_header_rejected() -> None:
+    with pytest.raises(EnvelopeError, match="shorter than fixed header"):
+        Envelope.from_bytes(b"PFv1")
+
+
+def test_envelope_ct_length_mismatch_rejected() -> None:
+    env = _sample_envelope(ct=b"hello")
+    data = env.to_bytes()
+    # Truncate ciphertext but leave header ct_len untouched.
+    with pytest.raises(EnvelopeError, match="length mismatch"):
+        Envelope.from_bytes(data[:-1])
+
+
+def test_envelope_ct_length_too_large_rejected() -> None:
+    env = _sample_envelope(ct=b"hello")
+    data = bytearray(env.to_bytes())
+    # Rewrite ct_len field (last 4 bytes of the 162-byte fixed header) to overflow.
+    huge = (MAX_CIPHERTEXT_BYTES + 1).to_bytes(4, "big")
+    data[158:162] = huge
+    with pytest.raises(EnvelopeError, match="exceeds MAX_CIPHERTEXT_BYTES"):
+        Envelope.from_bytes(bytes(data))
+
+
+def test_envelope_construct_rejects_wrong_field_sizes() -> None:
+    with pytest.raises(ValueError):
+        Envelope(
+            version=EnvelopeVersion.V1,
+            sender_fingerprint=b"\x01" * 8,  # wrong size
+            recipient_fingerprint=b"\x02" * 16,
+            ephemeral_public=b"\x03" * 32,
+            nonce=b"\x04" * 24,
+            signature=b"\x05" * 64,
+            ciphertext=b"",
+        )
+
+
+def test_envelope_rejects_non_bytes_input() -> None:
+    with pytest.raises(EnvelopeError, match="must be bytes"):
+        Envelope.from_bytes("not bytes")  # type: ignore[arg-type]
+
+
+def test_envelope_deterministic_wire_vector() -> None:
+    """Lock the wire format for a fixed envelope.
+
+    If this hex changes, the wire protocol has changed — bump the version.
+    """
+    env = _sample_envelope(ct=b"hello")
+    expected = (
+        "50467631"  # magic "PFv1"
+        "01"  # version
+        "00"  # flags
+        + ("01" * 16)  # sender_fp
+        + ("02" * 16)  # recipient_fp
+        + ("03" * 32)  # eph_pk
+        + ("04" * 24)  # nonce
+        + ("05" * 64)  # signature
+        + "00000005"  # ct_len = 5
+        + "68656c6c6f"  # "hello"
+    )
+    assert env.to_bytes().hex() == expected

--- a/tests/pinky_federation/test_fingerprint.py
+++ b/tests/pinky_federation/test_fingerprint.py
@@ -1,0 +1,137 @@
+"""Fingerprint tests: canonicalization, determinism, collision resistance, display."""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_federation.fingerprint import (
+    FINGERPRINT_BYTES,
+    canonical_address,
+    fingerprint,
+    format_fingerprint,
+)
+from pinky_federation.keys import (
+    EncryptionKeyPair,
+    SigningKeyPair,
+)
+
+# -- canonical_address --------------------------------------------------------
+
+
+def test_canonical_address_strips_and_lowercases() -> None:
+    assert canonical_address("  Alice@Example.COM  ") == "alice@example.com"
+
+
+def test_canonical_address_rejects_empty() -> None:
+    with pytest.raises(ValueError):
+        canonical_address("")
+    with pytest.raises(ValueError):
+        canonical_address("   ")
+
+
+def test_canonical_address_rejects_whitespace_inside() -> None:
+    with pytest.raises(ValueError):
+        canonical_address("alice @example.com")
+
+
+def test_canonical_address_rejects_control_chars() -> None:
+    with pytest.raises(ValueError):
+        canonical_address("alice\x07@example.com")
+
+
+def test_canonical_address_rejects_non_string() -> None:
+    with pytest.raises(TypeError):
+        canonical_address(b"alice@example.com")  # type: ignore[arg-type]
+
+
+# -- fingerprint --------------------------------------------------------------
+
+
+def _sample_identity():
+    sig = SigningKeyPair.from_seed(b"\x01" * 32)
+    enc = EncryptionKeyPair.from_private_bytes(b"\x02" * 32)
+    return sig.public_key, enc.public_key
+
+
+def test_fingerprint_is_deterministic_for_same_inputs() -> None:
+    sig_pk, enc_pk = _sample_identity()
+    fp1 = fingerprint("alice@example.com", sig_pk, enc_pk)
+    fp2 = fingerprint("alice@example.com", sig_pk, enc_pk)
+    assert fp1 == fp2
+    assert len(fp1) == FINGERPRINT_BYTES
+
+
+def test_fingerprint_invariant_across_address_case_and_whitespace() -> None:
+    sig_pk, enc_pk = _sample_identity()
+    fp_lower = fingerprint("alice@example.com", sig_pk, enc_pk)
+    fp_upper = fingerprint("  ALICE@EXAMPLE.COM  ", sig_pk, enc_pk)
+    assert fp_lower == fp_upper
+
+
+def test_fingerprint_changes_with_address() -> None:
+    sig_pk, enc_pk = _sample_identity()
+    assert fingerprint("alice@example.com", sig_pk, enc_pk) != fingerprint(
+        "bob@example.com", sig_pk, enc_pk
+    )
+
+
+def test_fingerprint_changes_with_signing_key() -> None:
+    _, enc_pk = _sample_identity()
+    sig_a = SigningKeyPair.from_seed(b"\xaa" * 32).public_key
+    sig_b = SigningKeyPair.from_seed(b"\xbb" * 32).public_key
+    assert fingerprint("alice@example.com", sig_a, enc_pk) != fingerprint(
+        "alice@example.com", sig_b, enc_pk
+    )
+
+
+def test_fingerprint_changes_with_encryption_key() -> None:
+    sig_pk, _ = _sample_identity()
+    enc_a = EncryptionKeyPair.from_private_bytes(b"\xaa" * 32).public_key
+    enc_b = EncryptionKeyPair.from_private_bytes(b"\xbb" * 32).public_key
+    assert fingerprint("alice@example.com", sig_pk, enc_a) != fingerprint(
+        "alice@example.com", sig_pk, enc_b
+    )
+
+
+def test_fingerprint_known_vector_stable() -> None:
+    """Lock the fingerprint for a known (address, sig_pk, enc_pk) tuple.
+
+    If this test fails we have accidentally changed the fingerprint scheme —
+    which would invalidate every stored TOFU pin. Update this value only when
+    bumping the fingerprint domain string intentionally.
+    """
+    sig_pk, enc_pk = _sample_identity()
+    fp = fingerprint("alice@example.com", sig_pk, enc_pk)
+    assert fp.hex() == KNOWN_ALICE_FP_HEX
+
+
+# Expected fingerprint for:
+#   address       = "alice@example.com"
+#   signing seed  = b"\x01" * 32
+#   encryption sk = b"\x02" * 32
+# Pinned by test_fingerprint_known_vector_stable.
+KNOWN_ALICE_FP_HEX = "cdc6e694d8699f0fc18657242abade83"
+
+
+# -- format_fingerprint -------------------------------------------------------
+
+
+def test_format_fingerprint_groups_default() -> None:
+    fp = bytes.fromhex("a1b2c3d4e5f607080910111213141516")
+    out = format_fingerprint(fp)
+    # Default: 4 groups of 4 hex chars.
+    assert out == "a1b2 c3d4 e5f6 0708"
+
+
+def test_format_fingerprint_custom_groups() -> None:
+    fp = bytes.fromhex("a1b2c3d4e5f607080910111213141516")
+    assert format_fingerprint(fp, groups=2, group_size=8) == "a1b2c3d4 e5f60708"
+
+
+def test_format_fingerprint_rejects_invalid_params() -> None:
+    with pytest.raises(TypeError):
+        format_fingerprint("not bytes")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        format_fingerprint(b"\x00" * 16, groups=0)
+    with pytest.raises(ValueError):
+        format_fingerprint(b"\x00" * 16, group_size=0)

--- a/tests/pinky_federation/test_keys.py
+++ b/tests/pinky_federation/test_keys.py
@@ -1,0 +1,132 @@
+"""Key primitive tests: generation, serialization, DH correctness, repr safety."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pinky_federation.errors import SignatureError
+from pinky_federation.keys import (
+    ED25519_KEY_BYTES,
+    ED25519_SIG_BYTES,
+    X25519_KEY_BYTES,
+    EncryptionKeyPair,
+    EncryptionPublicKey,
+    SigningKeyPair,
+    SigningPublicKey,
+    x25519_public_from_private,
+)
+
+# -- Encryption keys ----------------------------------------------------------
+
+
+def test_encryption_keypair_generate_produces_unique_keys() -> None:
+    a = EncryptionKeyPair.generate()
+    b = EncryptionKeyPair.generate()
+    assert a.public_key.raw != b.public_key.raw
+    assert a.private_bytes_insecure() != b.private_bytes_insecure()
+
+
+def test_encryption_public_key_length_validation() -> None:
+    with pytest.raises(ValueError):
+        EncryptionPublicKey(b"\x00" * 31)
+    with pytest.raises(ValueError):
+        EncryptionPublicKey(b"\x00" * 33)
+
+
+def test_encryption_keypair_round_trip_private_bytes() -> None:
+    original = EncryptionKeyPair.generate()
+    restored = EncryptionKeyPair.from_private_bytes(original.private_bytes_insecure())
+    # Public keys must match exactly after reconstruction from private bytes.
+    assert restored.public_key.raw == original.public_key.raw
+
+
+def test_encryption_repr_hides_private_material() -> None:
+    kp = EncryptionKeyPair.generate()
+    text = repr(kp)
+    # Private scalar never appears in repr; only a short public prefix does.
+    assert kp.private_bytes_insecure().hex() not in text
+    assert kp.public_key.raw.hex() not in text  # only a prefix shown
+
+
+def test_dh_produces_symmetric_shared_secret() -> None:
+    alice = EncryptionKeyPair.generate()
+    bob = EncryptionKeyPair.generate()
+    s1 = alice.dh(bob.public_key)
+    s2 = bob.dh(alice.public_key)
+    assert s1 == s2
+    assert len(s1) == X25519_KEY_BYTES
+
+
+def test_dh_rejects_wrong_type() -> None:
+    alice = EncryptionKeyPair.generate()
+    with pytest.raises(TypeError):
+        alice.dh(b"\x00" * 32)  # type: ignore[arg-type]
+
+
+def test_x25519_public_from_private_matches_keypair() -> None:
+    sk_bytes = os.urandom(32)
+    derived = x25519_public_from_private(sk_bytes)
+    kp = EncryptionKeyPair.from_private_bytes(sk_bytes)
+    assert derived == kp.public_key.raw
+
+
+# -- Signing keys -------------------------------------------------------------
+
+
+def test_signing_keypair_sign_verify_round_trip() -> None:
+    kp = SigningKeyPair.generate()
+    msg = b"hello federation"
+    sig = kp.sign(msg)
+    assert len(sig) == ED25519_SIG_BYTES
+    # Should not raise.
+    kp.public_key.verify(msg, sig)
+
+
+def test_signing_verify_rejects_tampered_message() -> None:
+    kp = SigningKeyPair.generate()
+    sig = kp.sign(b"original")
+    with pytest.raises(SignatureError):
+        kp.public_key.verify(b"tampered", sig)
+
+
+def test_signing_verify_rejects_wrong_key() -> None:
+    kp = SigningKeyPair.generate()
+    other = SigningKeyPair.generate()
+    sig = kp.sign(b"hi")
+    with pytest.raises(SignatureError):
+        other.public_key.verify(b"hi", sig)
+
+
+def test_signing_verify_rejects_wrong_sig_length() -> None:
+    kp = SigningKeyPair.generate()
+    with pytest.raises(SignatureError):
+        kp.public_key.verify(b"hi", b"\x00" * 63)
+
+
+def test_signing_from_seed_is_deterministic() -> None:
+    seed = b"\x42" * ED25519_KEY_BYTES
+    a = SigningKeyPair.from_seed(seed)
+    b = SigningKeyPair.from_seed(seed)
+    assert a.public_key.raw == b.public_key.raw
+    # Signatures over the same message must match byte-for-byte (Ed25519 is deterministic).
+    assert a.sign(b"msg") == b.sign(b"msg")
+
+
+def test_signing_repr_hides_seed() -> None:
+    kp = SigningKeyPair.generate()
+    assert kp.seed_bytes_insecure().hex() not in repr(kp)
+
+
+def test_signing_public_round_trip() -> None:
+    kp = SigningKeyPair.generate()
+    raw = kp.public_key.to_bytes()
+    restored = SigningPublicKey.from_bytes(raw)
+    assert restored.raw == raw
+
+
+def test_signing_sign_rejects_non_bytes() -> None:
+    kp = SigningKeyPair.generate()
+    with pytest.raises(TypeError):
+        kp.sign("not bytes")  # type: ignore[arg-type]

--- a/tests/pinky_federation/test_sealed_box.py
+++ b/tests/pinky_federation/test_sealed_box.py
@@ -1,0 +1,414 @@
+"""Sealed-box-v1 end-to-end tests: round-trip, tamper detection, test vectors."""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_federation.envelope import Envelope
+from pinky_federation.errors import DecryptionError, SignatureError
+from pinky_federation.keys import (
+    EncryptionKeyPair,
+    SigningKeyPair,
+    SigningPublicKey,
+)
+from pinky_federation.sealed_box import (
+    SEALED_BOX_VERSION,
+    seal,
+    unseal,
+)
+
+# -- Fixtures -----------------------------------------------------------------
+
+
+@pytest.fixture
+def alice_signing() -> SigningKeyPair:
+    return SigningKeyPair.from_seed(b"\x11" * 32)
+
+
+@pytest.fixture
+def bob_encryption() -> EncryptionKeyPair:
+    return EncryptionKeyPair.from_private_bytes(b"\x22" * 32)
+
+
+@pytest.fixture
+def alice_fp() -> bytes:
+    return b"\xa1" * 16
+
+
+@pytest.fixture
+def bob_fp() -> bytes:
+    return b"\xb0" * 16
+
+
+# -- Round-trip ---------------------------------------------------------------
+
+
+def test_seal_unseal_round_trip(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    plaintext = b"hello bob, this is alice"
+    env = seal(
+        plaintext,
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    assert isinstance(env, Envelope)
+    assert env.version is SEALED_BOX_VERSION
+    assert env.sender_fingerprint == alice_fp
+    assert env.recipient_fingerprint == bob_fp
+
+    out = unseal(
+        env,
+        recipient_encryption=bob_encryption,
+        sender_signing_public=alice_signing.public_key,
+    )
+    assert out == plaintext
+
+
+def test_seal_empty_plaintext_round_trip(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    out = unseal(
+        env,
+        recipient_encryption=bob_encryption,
+        sender_signing_public=alice_signing.public_key,
+    )
+    assert out == b""
+
+
+def test_envelope_wire_round_trip_after_seal(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"across the wire",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    restored = Envelope.from_bytes(env.to_bytes())
+    out = unseal(
+        restored,
+        recipient_encryption=bob_encryption,
+        sender_signing_public=alice_signing.public_key,
+    )
+    assert out == b"across the wire"
+
+
+# -- Tamper detection ---------------------------------------------------------
+
+
+def test_unseal_rejects_tampered_ciphertext(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    # Flip a ciphertext bit — AEAD should reject.
+    tampered_ct = bytearray(env.ciphertext)
+    tampered_ct[0] ^= 0x01
+    tampered = Envelope(
+        version=env.version,
+        sender_fingerprint=env.sender_fingerprint,
+        recipient_fingerprint=env.recipient_fingerprint,
+        ephemeral_public=env.ephemeral_public,
+        nonce=env.nonce,
+        signature=env.signature,
+        ciphertext=bytes(tampered_ct),
+    )
+    # Signature covers ciphertext, so the first failure is actually SignatureError.
+    with pytest.raises(SignatureError):
+        unseal(
+            tampered,
+            recipient_encryption=bob_encryption,
+            sender_signing_public=alice_signing.public_key,
+        )
+
+
+def test_unseal_rejects_wrong_sender_pubkey(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    impostor = SigningKeyPair.generate().public_key
+    with pytest.raises(SignatureError):
+        unseal(
+            env,
+            recipient_encryption=bob_encryption,
+            sender_signing_public=impostor,
+        )
+
+
+def test_unseal_rejects_wrong_recipient_key(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    mallory = EncryptionKeyPair.generate()
+    # Wrong recipient → AEAD key mismatch → DecryptionError (signature still valid).
+    with pytest.raises(DecryptionError):
+        unseal(
+            env,
+            recipient_encryption=mallory,
+            sender_signing_public=alice_signing.public_key,
+        )
+
+
+def test_unseal_rejects_rebound_recipient_fingerprint(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    # Attacker swaps recipient_fingerprint without re-signing → sig fails.
+    rebound = Envelope(
+        version=env.version,
+        sender_fingerprint=env.sender_fingerprint,
+        recipient_fingerprint=b"\xcc" * 16,
+        ephemeral_public=env.ephemeral_public,
+        nonce=env.nonce,
+        signature=env.signature,
+        ciphertext=env.ciphertext,
+    )
+    with pytest.raises(SignatureError):
+        unseal(
+            rebound,
+            recipient_encryption=bob_encryption,
+            sender_signing_public=alice_signing.public_key,
+        )
+
+
+def test_unseal_rejects_replayed_sender_fingerprint(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    rebound = Envelope(
+        version=env.version,
+        sender_fingerprint=b"\xee" * 16,
+        recipient_fingerprint=env.recipient_fingerprint,
+        ephemeral_public=env.ephemeral_public,
+        nonce=env.nonce,
+        signature=env.signature,
+        ciphertext=env.ciphertext,
+    )
+    with pytest.raises(SignatureError):
+        unseal(
+            rebound,
+            recipient_encryption=bob_encryption,
+            sender_signing_public=alice_signing.public_key,
+        )
+
+
+def test_unseal_rejects_unsupported_version(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    # Force an unknown version number past IntEnum validation.
+    bogus = object.__new__(Envelope)
+    object.__setattr__(bogus, "version", object())  # not EnvelopeVersion
+    object.__setattr__(bogus, "sender_fingerprint", env.sender_fingerprint)
+    object.__setattr__(bogus, "recipient_fingerprint", env.recipient_fingerprint)
+    object.__setattr__(bogus, "ephemeral_public", env.ephemeral_public)
+    object.__setattr__(bogus, "nonce", env.nonce)
+    object.__setattr__(bogus, "signature", env.signature)
+    object.__setattr__(bogus, "ciphertext", env.ciphertext)
+    with pytest.raises(DecryptionError, match="unsupported envelope version"):
+        unseal(
+            bogus,  # type: ignore[arg-type]
+            recipient_encryption=bob_encryption,
+            sender_signing_public=alice_signing.public_key,
+        )
+
+
+# -- Input validation --------------------------------------------------------
+
+
+def test_seal_rejects_wrong_fingerprint_sizes(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    bob_fp: bytes,
+) -> None:
+    with pytest.raises(ValueError, match="sender_fingerprint"):
+        seal(
+            b"x",
+            sender_signing=alice_signing,
+            sender_fingerprint=b"\x00" * 8,
+            recipient_encryption=bob_encryption.public_key,
+            recipient_fingerprint=bob_fp,
+        )
+    with pytest.raises(ValueError, match="recipient_fingerprint"):
+        seal(
+            b"x",
+            sender_signing=alice_signing,
+            sender_fingerprint=b"\x00" * 16,
+            recipient_encryption=bob_encryption.public_key,
+            recipient_fingerprint=b"\x00" * 8,
+        )
+
+
+def test_seal_rejects_non_bytes_plaintext(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    with pytest.raises(TypeError):
+        seal(
+            "not bytes",  # type: ignore[arg-type]
+            sender_signing=alice_signing,
+            sender_fingerprint=alice_fp,
+            recipient_encryption=bob_encryption.public_key,
+            recipient_fingerprint=bob_fp,
+        )
+
+
+def test_seal_nonce_override_requires_correct_size(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    with pytest.raises(ValueError, match="nonce"):
+        seal(
+            b"x",
+            sender_signing=alice_signing,
+            sender_fingerprint=alice_fp,
+            recipient_encryption=bob_encryption.public_key,
+            recipient_fingerprint=bob_fp,
+            nonce=b"\x00" * 8,
+        )
+
+
+# -- Deterministic test vector (for relay compat tests) -----------------------
+
+
+def test_deterministic_vector_stable(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    """Fully deterministic seal() output.
+
+    Purpose: lock the exact wire bytes so the Python relay and any future
+    clients can cross-verify. If this hex changes, the protocol has changed.
+
+    Inputs:
+        sender signing seed    = 0x11 * 32
+        recipient encryption sk = 0x22 * 32
+        ephemeral encryption sk = 0x33 * 32
+        sender_fp              = 0xa1 * 16
+        recipient_fp           = 0xb0 * 16
+        nonce                  = 0x44 * 24
+        plaintext              = b"hello bob"
+    """
+    ephemeral = EncryptionKeyPair.from_private_bytes(b"\x33" * 32)
+    env = seal(
+        b"hello bob",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+        nonce=b"\x44" * 24,
+        ephemeral=ephemeral,
+    )
+    wire = env.to_bytes()
+    assert wire.hex() == KNOWN_VECTOR_HEX
+
+    # And it must round-trip.
+    out = unseal(
+        env,
+        recipient_encryption=bob_encryption,
+        sender_signing_public=alice_signing.public_key,
+    )
+    assert out == b"hello bob"
+
+
+# Expected wire bytes for the deterministic vector above. Pinned by
+# test_deterministic_vector_stable. Update only on intentional protocol bumps.
+KNOWN_VECTOR_HEX = (
+    "504676310100"
+    + ("a1" * 16)  # sender_fp
+    + ("b0" * 16)  # recipient_fp
+    + "7b0d47d93427f8311160781c7c733fd89f88970aef490d8aa0ee19a4cb8a1b14"  # eph_pk
+    + ("44" * 24)  # nonce
+    + "65b3193d2dbf9fbee57daecda9bfbdd2b030835b13b42e6d7994747e1f6436c4"
+    + "c2c17ad573b2e788a03c6f647d2210d4df354a58c4bd4d4d52aac152933b0c05"  # sig
+    + "00000019"  # ct_len = 25
+    + "30065ea9d478499236d899a67f530cb513b720dfcc3704f4b2"  # ciphertext
+)
+
+
+def test_deterministic_vector_sender_pubkey_matches_seed(
+    alice_signing: SigningKeyPair,
+) -> None:
+    """Sanity check so the vector above is easy to reconstruct in other languages."""
+    expected = SigningKeyPair.from_seed(b"\x11" * 32).public_key.to_bytes()
+    assert alice_signing.public_key.to_bytes() == expected
+    assert isinstance(alice_signing.public_key, SigningPublicKey)


### PR DESCRIPTION
## Summary

Implements **P-01** of the federation v0.2 spec — the crypto foundation that every later federation flow (transport, invite, attachments, rotation) depends on.

- `keys.py` — X25519 + Ed25519 keypairs, DH, seed-based reconstruction. Private material never in `repr()`.
- `sealed_box.py` — ephemeral-X25519 + HKDF-SHA256 + XChaCha20-Poly1305 + Ed25519 sender signature. AAD and signature both commit to sender + recipient fingerprints + ephemeral pubkey.
- `envelope.py` — versioned binary wire format, 162-byte fixed header, length-prefixed ciphertext, 16 MiB hard cap.
- `fingerprint.py` — length-prefixed SHA-256 over canonical address + both public keys, truncated to 128 bits.
- `errors.py` — narrow `CryptoError` hierarchy.

## Acceptance criteria (from #250)

- [x] Versioned envelope builder + parser for `sealed_box_v1`
- [x] X25519 + Ed25519 keygen, sign, verify, encrypt, decrypt all round-trip locally
- [x] Fingerprints deterministic and stable for a given canonical address + key
- [x] Deterministic test vectors emitted (one for fingerprint, one for full envelope) for relay/client cross-verification
- [x] No private material written to logs or `repr()` (asserted in tests)

## Security model covered by tests

| Threat | Test |
|---|---|
| Ciphertext tamper | `test_unseal_rejects_tampered_ciphertext` |
| Impostor sender pubkey | `test_unseal_rejects_wrong_sender_pubkey` |
| Wrong recipient | `test_unseal_rejects_wrong_recipient_key` |
| Rebind to different recipient fp | `test_unseal_rejects_rebound_recipient_fingerprint` |
| Rebind to different sender fp | `test_unseal_rejects_replayed_sender_fingerprint` |
| Unknown version | `test_unseal_rejects_unsupported_version` |
| Envelope magic / flags / length tampering | `test_envelope_*` |
| Private material in repr | `test_*_repr_hides_*` |

## Draft — why?

Opened as a draft so Brad can review the crypto construction before P-02 (state store + key persistence) lands on top. No downstream code imports this package yet.

## Test plan
- [x] `pytest tests/pinky_federation/` — 54 new tests, all green
- [x] `pytest tests/` — 1526 total, green
- [x] `ruff check src/pinky_federation tests/pinky_federation` — clean
- [ ] Architecture sanity review by @murzik before un-drafting
- [ ] Confirm `cryptography` + `pynacl` land in CI matrix builds (Python 3.11/3.12/3.13)

Refs: umbrella #249, P-02 #251 (next).

🤖 Opened by Barsik