### PR TITLE
feat(federation): local state store + encrypted tenant key persistence (#251)

### DIFF
--- a/src/pinky_federation/__init__.py
+++ b/src/pinky_federation/__init__.py
@@ -1,4 +1,4 @@
-"""PinkyBot federation — sealed-box-v1 crypto and envelope primitives.
+"""PinkyBot federation — sealed-box-v1 crypto, envelope, and local state.
 
 This package implements the reference crypto layer for PinkyBot federation v0.2:
 
@@ -7,6 +7,8 @@ This package implements the reference crypto layer for PinkyBot federation v0.2:
 - `sealed_box_v1`: authenticated ephemeral-X25519 + XChaCha20-Poly1305 + Ed25519 sender signature
 - Versioned envelope serialization suitable for relay transport
 - Deterministic fingerprints for TOFU pinning and UX display
+- Local SQLite state store under ``data/federation/`` (P-02)
+- Encrypted-at-rest tenant signing key persistence with device-local key (P-02)
 
 Nothing in this package talks to a network. Higher layers (transport, invite,
 attachments) consume these primitives.
@@ -28,6 +30,12 @@ from pinky_federation.fingerprint import (
     fingerprint,
     format_fingerprint,
 )
+from pinky_federation.key_store import (
+    DEFAULT_DEVICE_KEY_PATH,
+    DEVICE_KEY_BYTES,
+    DeviceKey,
+    EncryptedTenantKeyStore,
+)
 from pinky_federation.keys import (
     EncryptionKeyPair,
     EncryptionPublicKey,
@@ -39,23 +47,95 @@ from pinky_federation.sealed_box import (
     seal,
     unseal,
 )
+from pinky_federation.state import (
+    DEFAULT_DB_PATH,
+    INBOX_ARCHIVED,
+    INBOX_NEW,
+    INBOX_READ,
+    INSTANCE_KEY_ACTIVE,
+    INSTANCE_KEY_DECRYPT_ONLY,
+    INSTANCE_KEY_KIND_ENCRYPTION,
+    INSTANCE_KEY_KIND_SIGNING,
+    INSTANCE_KEY_RETIRED,
+    INVITE_ACTIVE,
+    INVITE_EXPIRED,
+    INVITE_REDEEMED,
+    INVITE_REVOKED,
+    OUTBOX_FAILED,
+    OUTBOX_PENDING,
+    OUTBOX_SENT,
+    PEER_PIN_PINNED,
+    PEER_PIN_REJECTED,
+    PEER_PIN_ROTATED,
+    ROLE_MEMBER,
+    ROLE_OWNER,
+    AttachmentRecord,
+    FederationStateStore,
+    InboxRecord,
+    InstanceKeyRecord,
+    InviteRecord,
+    OutboxRecord,
+    PeerPinRecord,
+    TenantRecord,
+)
 
 __all__ = [
+    # Errors
     "CryptoError",
     "DecryptionError",
+    "SignatureError",
+    # Envelope
     "Envelope",
     "EnvelopeError",
     "EnvelopeVersion",
-    "EncryptionKeyPair",
-    "EncryptionPublicKey",
+    # Fingerprint
     "FINGERPRINT_BYTES",
-    "SEALED_BOX_VERSION",
-    "SignatureError",
-    "SigningKeyPair",
-    "SigningPublicKey",
     "canonical_address",
     "fingerprint",
     "format_fingerprint",
+    # Keys
+    "EncryptionKeyPair",
+    "EncryptionPublicKey",
+    "SigningKeyPair",
+    "SigningPublicKey",
+    # Sealed box
+    "SEALED_BOX_VERSION",
     "seal",
     "unseal",
+    # State store
+    "DEFAULT_DB_PATH",
+    "FederationStateStore",
+    "TenantRecord",
+    "InstanceKeyRecord",
+    "PeerPinRecord",
+    "OutboxRecord",
+    "InboxRecord",
+    "InviteRecord",
+    "AttachmentRecord",
+    # State constants
+    "INSTANCE_KEY_ACTIVE",
+    "INSTANCE_KEY_DECRYPT_ONLY",
+    "INSTANCE_KEY_RETIRED",
+    "INSTANCE_KEY_KIND_ENCRYPTION",
+    "INSTANCE_KEY_KIND_SIGNING",
+    "PEER_PIN_PINNED",
+    "PEER_PIN_ROTATED",
+    "PEER_PIN_REJECTED",
+    "OUTBOX_PENDING",
+    "OUTBOX_SENT",
+    "OUTBOX_FAILED",
+    "INBOX_NEW",
+    "INBOX_READ",
+    "INBOX_ARCHIVED",
+    "INVITE_ACTIVE",
+    "INVITE_REDEEMED",
+    "INVITE_EXPIRED",
+    "INVITE_REVOKED",
+    "ROLE_OWNER",
+    "ROLE_MEMBER",
+    # Encrypted key store
+    "DEFAULT_DEVICE_KEY_PATH",
+    "DEVICE_KEY_BYTES",
+    "DeviceKey",
+    "EncryptedTenantKeyStore",
 ]

--- a/src/pinky_federation/key_store.py
+++ b/src/pinky_federation/key_store.py
@@ -1,0 +1,298 @@
+"""Encrypted at-rest persistence for tenant signing keys.
+
+The tenant signing key (Ed25519) is the *identity* of a tenant. If it leaks,
+an attacker can impersonate the tenant indefinitely (federation v0.2 has no
+escrow, no recovery — by Brad's design decision Q3, key loss means starting
+over). This module exists so that key never sits on disk in plaintext.
+
+Layered design:
+
+- :class:`DeviceKey` — a 32-byte symmetric secret persisted at
+  ``data/federation/.device_key`` with mode ``0600``. Generated on first use
+  on this device; never copied off. This is the encryption key for tenant
+  signing seeds.
+- :class:`EncryptedTenantKeyStore` — uses a :class:`DeviceKey` to write
+  tenant signing seeds (32 bytes) into the ``tenant_signing_keys`` table
+  created by :mod:`pinky_federation.state`, encrypted with
+  XChaCha20-Poly1305. Reads decrypt only on explicit request.
+
+Discipline:
+
+- The seed is **never** logged. ``__repr__`` on this class never shows seed
+  bytes. Errors talk about "decrypt failure" without exposing material.
+- The seed is **never** included in :meth:`FederationStateStore.stats` or
+  any diagnostics; that table contributes a row count only.
+- Export of the raw seed is gated behind
+  :meth:`export_signing_seed_explicit` which requires a positional
+  acknowledgement flag — defensive against accidental "give me the key"
+  flows from generic settings/debug APIs.
+
+This layer does **not** touch ``instance_keys.encrypted_secret`` — those
+per-device receive keys have their own lifecycle and rotate freely. The
+device key here is also reusable for that table if a caller wants to
+encrypt instance secrets the same way (recommended).
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from nacl.bindings import (
+    crypto_aead_xchacha20poly1305_ietf_decrypt,
+    crypto_aead_xchacha20poly1305_ietf_encrypt,
+    crypto_aead_xchacha20poly1305_ietf_NPUBBYTES,
+)
+
+from pinky_federation.errors import DecryptionError
+from pinky_federation.keys import ED25519_KEY_BYTES, SigningKeyPair
+from pinky_federation.state import FederationStateStore
+
+DEVICE_KEY_BYTES = 32
+DEFAULT_DEVICE_KEY_PATH = "data/federation/.device_key"
+
+# AAD prefix binds ciphertext to its purpose so a raw blob from one
+# table can't be replayed against another decrypt path.
+_TENANT_SIGNING_AAD_PREFIX = b"pinky-fed/v1/tenant-signing-seed"
+_KDF_VERSION = 1  # bumped if we change AAD layout / cipher choice
+
+
+def _xchacha_nonce() -> bytes:
+    """Return a fresh 24-byte XChaCha20-Poly1305 nonce."""
+    return secrets.token_bytes(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES)
+
+
+# -- Device key ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeviceKey:
+    """A device-local 32-byte symmetric secret.
+
+    This wrapper never serializes its bytes via ``repr``. The bytes are
+    accessible via :meth:`material_insecure` for the encryption layer.
+    """
+
+    _material: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self._material, bytes) or len(self._material) != DEVICE_KEY_BYTES:
+            raise ValueError(f"device key must be {DEVICE_KEY_BYTES} bytes")
+
+    def material_insecure(self) -> bytes:
+        """Raw 32-byte device key. Never log this value."""
+        return self._material
+
+    def __repr__(self) -> str:
+        # Show a 4-byte tag for log debugging; never the full key.
+        return f"DeviceKey(<{self._material[:4].hex()}…>)"
+
+    @classmethod
+    def load_or_create(cls, path: str = DEFAULT_DEVICE_KEY_PATH) -> DeviceKey:
+        """Load the device key from *path*, generating it on first use.
+
+        The file is created with mode ``0600`` (owner read/write only). On
+        existing files we sanity-check size and warn (via raised error) if
+        permissions are looser than ``0600`` — we do NOT silently tighten,
+        because that may mask a real security problem.
+        """
+        p = Path(path)
+        if p.exists():
+            data = p.read_bytes()
+            if len(data) != DEVICE_KEY_BYTES:
+                raise ValueError(
+                    f"device key at {path!r} is {len(data)} bytes, expected {DEVICE_KEY_BYTES}"
+                )
+            mode = stat.S_IMODE(p.stat().st_mode)
+            # Owner-only; reject if group/other can read or write.
+            if mode & 0o077:
+                raise PermissionError(
+                    f"device key {path!r} has loose permissions {oct(mode)}; expected 0o600"
+                )
+            return cls(data)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        material = secrets.token_bytes(DEVICE_KEY_BYTES)
+        # Write with restrictive permissions atomically.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        fd = os.open(str(p), flags, 0o600)
+        try:
+            os.write(fd, material)
+        finally:
+            os.close(fd)
+        return cls(material)
+
+
+# -- Encrypted tenant key store --------------------------------------------
+
+
+@dataclass(frozen=True)
+class _StoredSeed:
+    encrypted_seed: bytes
+    nonce: bytes
+    kdf_version: int
+
+
+class EncryptedTenantKeyStore:
+    """Persists tenant signing seeds encrypted with the device key."""
+
+    __slots__ = ("_state", "_device_key")
+
+    def __init__(self, state: FederationStateStore, device_key: DeviceKey) -> None:
+        if not isinstance(state, FederationStateStore):
+            raise TypeError("state must be a FederationStateStore")
+        if not isinstance(device_key, DeviceKey):
+            raise TypeError("device_key must be a DeviceKey")
+        self._state = state
+        self._device_key = device_key
+
+    # -- writes --------------------------------------------------------
+
+    def put_signing_key(self, tenant_id: str, signing_keypair: SigningKeyPair) -> None:
+        """Encrypt and persist the seed for *signing_keypair* under *tenant_id*.
+
+        Raises ``ValueError`` if the tenant row does not yet exist — the
+        caller must have inserted into :meth:`FederationStateStore.upsert_tenant`
+        first so foreign keys hold.
+        """
+        if not isinstance(tenant_id, str) or not tenant_id:
+            raise ValueError("tenant_id must be a non-empty string")
+        if not isinstance(signing_keypair, SigningKeyPair):
+            raise TypeError("signing_keypair must be a SigningKeyPair")
+        if self._state.get_tenant(tenant_id) is None:
+            raise ValueError(
+                f"tenant {tenant_id!r} not registered; insert into tenants first"
+            )
+        seed = signing_keypair.seed_bytes_insecure()
+        try:
+            stored = self._encrypt_seed(tenant_id, seed)
+            self._state._db.execute(  # noqa: SLF001 — intentional cross-module write
+                """
+                INSERT INTO tenant_signing_keys
+                    (tenant_id, encrypted_seed, nonce, kdf_version, created_at)
+                VALUES (?, ?, ?, ?, strftime('%s','now'))
+                ON CONFLICT(tenant_id) DO UPDATE SET
+                    encrypted_seed=excluded.encrypted_seed,
+                    nonce=excluded.nonce,
+                    kdf_version=excluded.kdf_version
+                """,
+                (tenant_id, stored.encrypted_seed, stored.nonce, stored.kdf_version),
+            )
+            self._state._db.commit()  # noqa: SLF001
+        finally:
+            # Best-effort wipe of the seed copy we just used. Python doesn't
+            # let us truly zero memory but we drop the binding immediately.
+            del seed
+
+    # -- reads ---------------------------------------------------------
+
+    def has_signing_key(self, tenant_id: str) -> bool:
+        row = self._state._db.execute(  # noqa: SLF001
+            "SELECT 1 FROM tenant_signing_keys WHERE tenant_id = ?", (tenant_id,)
+        ).fetchone()
+        return row is not None
+
+    def get_signing_key(self, tenant_id: str) -> SigningKeyPair:
+        """Decrypt and return the signing keypair for *tenant_id*.
+
+        Raises :class:`KeyError` if no key is stored, and
+        :class:`pinky_federation.errors.DecryptionError` if the on-disk
+        ciphertext is corrupt or was encrypted under a different device key.
+        """
+        stored = self._load_stored_seed(tenant_id)
+        seed = self._decrypt_seed(tenant_id, stored)
+        try:
+            return SigningKeyPair.from_seed(seed)
+        finally:
+            del seed
+
+    def export_signing_seed_explicit(
+        self,
+        tenant_id: str,
+        *,
+        operator_acknowledged: bool,
+        reason: str,
+    ) -> bytes:
+        """Return the raw 32-byte seed.
+
+        This is the only path that yields raw key material outside the
+        :class:`SigningKeyPair` wrapper. It is intentionally awkward:
+
+        - ``operator_acknowledged`` must be passed positionally as a
+          keyword arg (``True``).
+        - ``reason`` must be a non-empty string and is logged via the audit
+          channel by callers (this layer does not log).
+
+        Generic settings/debug APIs that just want "give me everything"
+        should never call this — they should call :meth:`get_signing_key`
+        and never expose seed bytes.
+        """
+        if operator_acknowledged is not True:
+            raise PermissionError(
+                "export_signing_seed_explicit requires operator_acknowledged=True"
+            )
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("export_signing_seed_explicit requires a non-empty reason")
+        stored = self._load_stored_seed(tenant_id)
+        return self._decrypt_seed(tenant_id, stored)
+
+    # -- crypto internals ---------------------------------------------
+
+    def _encrypt_seed(self, tenant_id: str, seed: bytes) -> _StoredSeed:
+        if not isinstance(seed, bytes) or len(seed) != ED25519_KEY_BYTES:
+            raise ValueError(f"signing seed must be {ED25519_KEY_BYTES} bytes")
+        nonce = _xchacha_nonce()
+        aad = self._aad_for(tenant_id)
+        ct = crypto_aead_xchacha20poly1305_ietf_encrypt(
+            seed, aad, nonce, self._device_key.material_insecure()
+        )
+        return _StoredSeed(encrypted_seed=ct, nonce=nonce, kdf_version=_KDF_VERSION)
+
+    def _decrypt_seed(self, tenant_id: str, stored: _StoredSeed) -> bytes:
+        if stored.kdf_version != _KDF_VERSION:
+            raise DecryptionError(
+                f"unsupported kdf_version {stored.kdf_version} (this build supports {_KDF_VERSION})"
+            )
+        aad = self._aad_for(tenant_id)
+        try:
+            pt = crypto_aead_xchacha20poly1305_ietf_decrypt(
+                stored.encrypted_seed, aad, stored.nonce, self._device_key.material_insecure()
+            )
+        except Exception as exc:  # noqa: BLE001 — normalize to our error type
+            raise DecryptionError(
+                f"failed to decrypt signing seed for tenant {tenant_id!r}"
+            ) from exc
+        if len(pt) != ED25519_KEY_BYTES:
+            raise DecryptionError(
+                f"decrypted seed has wrong length: {len(pt)} != {ED25519_KEY_BYTES}"
+            )
+        return pt
+
+    def _load_stored_seed(self, tenant_id: str) -> _StoredSeed:
+        row = self._state._db.execute(  # noqa: SLF001
+            "SELECT encrypted_seed, nonce, kdf_version FROM tenant_signing_keys "
+            "WHERE tenant_id = ?",
+            (tenant_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"no signing key stored for tenant {tenant_id!r}")
+        return _StoredSeed(
+            encrypted_seed=bytes(row["encrypted_seed"]),
+            nonce=bytes(row["nonce"]),
+            kdf_version=int(row["kdf_version"]),
+        )
+
+    @staticmethod
+    def _aad_for(tenant_id: str) -> bytes:
+        # Bind ciphertext to (purpose, tenant_id) so a row from one tenant
+        # cannot be replayed under a different tenant_id.
+        return _TENANT_SIGNING_AAD_PREFIX + b"|" + tenant_id.encode("utf-8")
+
+    # -- discipline ---------------------------------------------------
+
+    def __repr__(self) -> str:
+        return (
+            f"EncryptedTenantKeyStore(state={self._state!r}, device_key={self._device_key!r})"
+        )

--- a/src/pinky_federation/state.py
+++ b/src/pinky_federation/state.py
@@ -1,0 +1,874 @@
+"""Federation state store — SQLite-backed local persistence.
+
+Owns the on-disk layout under ``data/federation/`` for the federation v0.2
+implementation. This module is the root storage dependency for TOFU peer
+pinning (P-03), transport (P-04), invite redemption (P-05), and attachment
+metadata (P-06).
+
+Tables:
+
+- ``tenants`` — tenant membership context (which tenants this instance belongs
+  to, role within each, public signing key for verification).
+- ``instance_keys`` — per-device receive keys (X25519 encryption + Ed25519
+  device signing) with lifecycle states ``active`` / ``decrypt_only`` /
+  ``retired``. Multiple keys may coexist during rotation; ``decrypt_only`` keys
+  cannot encrypt new outbound traffic but still decrypt inbound for in-flight
+  messages.
+- ``peer_pins`` — TOFU pin store keyed by canonical peer address. Stores both
+  long-term keys plus the 128-bit fingerprint for display/comparison.
+- ``outbox`` — pending outbound envelopes waiting for relay delivery.
+- ``inbox`` — received plaintext messages awaiting consumption by higher
+  layers (e.g. the messaging UI).
+- ``issued_invites`` — invite cache (token hash only — raw token never
+  persisted).
+- ``attachments`` — attachment metadata pointing at on-disk encrypted blobs.
+
+This module owns *only* the structure and CRUD. Encryption of tenant
+signing seeds is the job of ``key_store.py`` (which writes into the
+``tenant_signing_keys`` table that this module also creates).
+
+Nothing in this module talks to the network; nothing logs key material;
+nothing returns plaintext private keys. The signing-seed table is created
+here for schema cohesion, but its contents are opaque BLOBs from this
+layer's perspective — only ``key_store.EncryptedTenantKeyStore`` ever
+encrypts/decrypts them.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_DB_PATH = "data/federation/state.db"
+
+# Instance-key lifecycle states.
+INSTANCE_KEY_ACTIVE = "active"
+INSTANCE_KEY_DECRYPT_ONLY = "decrypt_only"
+INSTANCE_KEY_RETIRED = "retired"
+_VALID_INSTANCE_KEY_STATES = frozenset(
+    {INSTANCE_KEY_ACTIVE, INSTANCE_KEY_DECRYPT_ONLY, INSTANCE_KEY_RETIRED}
+)
+
+# Instance-key kinds.
+INSTANCE_KEY_KIND_ENCRYPTION = "encryption"  # X25519
+INSTANCE_KEY_KIND_SIGNING = "signing"  # Ed25519 (per-device, not tenant)
+_VALID_INSTANCE_KEY_KINDS = frozenset(
+    {INSTANCE_KEY_KIND_ENCRYPTION, INSTANCE_KEY_KIND_SIGNING}
+)
+
+# Peer-pin status values.
+PEER_PIN_PINNED = "pinned"
+PEER_PIN_ROTATED = "rotated"
+PEER_PIN_REJECTED = "rejected"
+_VALID_PEER_PIN_STATUSES = frozenset({PEER_PIN_PINNED, PEER_PIN_ROTATED, PEER_PIN_REJECTED})
+
+# Outbox status values.
+OUTBOX_PENDING = "pending"
+OUTBOX_SENT = "sent"
+OUTBOX_FAILED = "failed"
+_VALID_OUTBOX_STATUSES = frozenset({OUTBOX_PENDING, OUTBOX_SENT, OUTBOX_FAILED})
+
+# Inbox status values.
+INBOX_NEW = "new"
+INBOX_READ = "read"
+INBOX_ARCHIVED = "archived"
+_VALID_INBOX_STATUSES = frozenset({INBOX_NEW, INBOX_READ, INBOX_ARCHIVED})
+
+# Invite status values.
+INVITE_ACTIVE = "active"
+INVITE_REDEEMED = "redeemed"
+INVITE_EXPIRED = "expired"
+INVITE_REVOKED = "revoked"
+_VALID_INVITE_STATUSES = frozenset(
+    {INVITE_ACTIVE, INVITE_REDEEMED, INVITE_EXPIRED, INVITE_REVOKED}
+)
+
+# Tenant role values.
+ROLE_OWNER = "owner"
+ROLE_MEMBER = "member"
+_VALID_ROLES = frozenset({ROLE_OWNER, ROLE_MEMBER})
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def _now() -> float:
+    return time.time()
+
+
+# -- Records ---------------------------------------------------------------
+
+
+@dataclass
+class TenantRecord:
+    """Membership in a tenant. ``signing_pk`` is the *tenant* identity public
+    key (Ed25519 raw 32 bytes); ``role`` is this instance's role in the
+    tenant (``owner`` for the issuer, ``member`` otherwise)."""
+
+    tenant_id: str = ""
+    address: str = ""
+    signing_pk: bytes = b""
+    role: str = ROLE_MEMBER
+    created_at: float = 0.0
+
+
+@dataclass
+class InstanceKeyRecord:
+    """A single per-device key with lifecycle state."""
+
+    kid: str = ""  # short stable id, e.g. first 16 hex of fingerprint
+    tenant_id: str = ""
+    kind: str = INSTANCE_KEY_KIND_ENCRYPTION
+    public_key: bytes = b""
+    encrypted_secret: bytes = b""  # opaque to this layer; key_store decrypts
+    state: str = INSTANCE_KEY_ACTIVE
+    created_at: float = 0.0
+    retired_at: float = 0.0
+
+
+@dataclass
+class PeerPinRecord:
+    """TOFU pin for a remote peer."""
+
+    peer_address: str = ""
+    sig_pk: bytes = b""
+    enc_pk: bytes = b""
+    fingerprint: bytes = b""
+    status: str = PEER_PIN_PINNED
+    first_seen: float = 0.0
+    last_seen: float = 0.0
+
+
+@dataclass
+class OutboxRecord:
+    """A queued outbound envelope."""
+
+    msg_id: str = ""
+    tenant_id: str = ""
+    recipient_address: str = ""
+    envelope_blob: bytes = b""
+    status: str = OUTBOX_PENDING
+    attempts: int = 0
+    last_error: str = ""
+    created_at: float = 0.0
+    next_retry_at: float = 0.0
+
+
+@dataclass
+class InboxRecord:
+    """A received decrypted message."""
+
+    msg_id: str = ""
+    tenant_id: str = ""
+    sender_address: str = ""
+    plaintext_blob: bytes = b""
+    status: str = INBOX_NEW
+    received_at: float = 0.0
+
+
+@dataclass
+class InviteRecord:
+    """An invite issued by this instance. We only store the *hash* of the
+    redemption token; the raw token is given out once and never persisted."""
+
+    invite_id: str = ""
+    tenant_id: str = ""
+    recipient_hint: str = ""
+    token_hash: bytes = b""
+    expires_at: float = 0.0
+    status: str = INVITE_ACTIVE
+    created_at: float = 0.0
+
+
+@dataclass
+class AttachmentRecord:
+    """Metadata pointer for an attachment blob."""
+
+    attachment_id: str = ""
+    msg_id: str = ""
+    sha256: bytes = b""
+    size: int = 0
+    mime: str = ""
+    local_path: str = ""
+    encrypted: bool = True
+    created_at: float = 0.0
+
+
+# -- Store -----------------------------------------------------------------
+
+
+class FederationStateStore:
+    """SQLite-backed federation state.
+
+    All methods are safe to call from multiple threads — the connection
+    is opened with ``check_same_thread=False`` and we serialize writes via
+    SQLite's own locking. Reads use the same connection; if write contention
+    becomes an issue we can split read/write later.
+    """
+
+    def __init__(self, db_path: str = DEFAULT_DB_PATH) -> None:
+        self.db_path = db_path
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA foreign_keys=ON")
+        self._db.row_factory = sqlite3.Row
+        self._create_schema()
+        self._ensure_columns()
+
+    # -- schema ------------------------------------------------------------
+
+    def _create_schema(self) -> None:
+        c = self._db
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tenants (
+                tenant_id TEXT PRIMARY KEY,
+                address TEXT NOT NULL,
+                signing_pk BLOB NOT NULL,
+                role TEXT NOT NULL DEFAULT 'member',
+                created_at REAL NOT NULL
+            )
+            """
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tenant_signing_keys (
+                tenant_id TEXT PRIMARY KEY,
+                encrypted_seed BLOB NOT NULL,
+                nonce BLOB NOT NULL,
+                kdf_version INTEGER NOT NULL DEFAULT 1,
+                created_at REAL NOT NULL,
+                FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE CASCADE
+            )
+            """
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS instance_keys (
+                kid TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                public_key BLOB NOT NULL,
+                encrypted_secret BLOB NOT NULL,
+                state TEXT NOT NULL DEFAULT 'active',
+                created_at REAL NOT NULL,
+                retired_at REAL NOT NULL DEFAULT 0,
+                FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE CASCADE
+            )
+            """
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_instance_keys_tenant_state "
+            "ON instance_keys(tenant_id, state)"
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS peer_pins (
+                peer_address TEXT PRIMARY KEY,
+                sig_pk BLOB NOT NULL,
+                enc_pk BLOB NOT NULL,
+                fingerprint BLOB NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pinned',
+                first_seen REAL NOT NULL,
+                last_seen REAL NOT NULL
+            )
+            """
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS outbox (
+                msg_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                recipient_address TEXT NOT NULL,
+                envelope_blob BLOB NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                attempts INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT NOT NULL DEFAULT '',
+                created_at REAL NOT NULL,
+                next_retry_at REAL NOT NULL DEFAULT 0
+            )
+            """
+        )
+        c.execute("CREATE INDEX IF NOT EXISTS idx_outbox_status ON outbox(status, next_retry_at)")
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS inbox (
+                msg_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                sender_address TEXT NOT NULL,
+                plaintext_blob BLOB NOT NULL,
+                status TEXT NOT NULL DEFAULT 'new',
+                received_at REAL NOT NULL
+            )
+            """
+        )
+        c.execute("CREATE INDEX IF NOT EXISTS idx_inbox_tenant_status ON inbox(tenant_id, status)")
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS issued_invites (
+                invite_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                recipient_hint TEXT NOT NULL DEFAULT '',
+                token_hash BLOB NOT NULL,
+                expires_at REAL NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                created_at REAL NOT NULL,
+                FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE CASCADE
+            )
+            """
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_invites_tenant_status "
+            "ON issued_invites(tenant_id, status)"
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS attachments (
+                attachment_id TEXT PRIMARY KEY,
+                msg_id TEXT NOT NULL,
+                sha256 BLOB NOT NULL,
+                size INTEGER NOT NULL,
+                mime TEXT NOT NULL DEFAULT '',
+                local_path TEXT NOT NULL,
+                encrypted INTEGER NOT NULL DEFAULT 1,
+                created_at REAL NOT NULL
+            )
+            """
+        )
+        c.execute("CREATE INDEX IF NOT EXISTS idx_attachments_msg ON attachments(msg_id)")
+        c.commit()
+
+    def _ensure_columns(self) -> None:
+        """Forward-compatible column additions following the project pattern."""
+        # No migrations yet — this is the initial schema. Future additions:
+        #   migrations: list[tuple[str, str, list[tuple[str, str]]]] = [
+        #       ("table", "column", "TYPE DEFAULT ..."),
+        #   ]
+        pass
+
+    # -- tenants -----------------------------------------------------------
+
+    def upsert_tenant(self, rec: TenantRecord) -> TenantRecord:
+        if rec.role not in _VALID_ROLES:
+            raise ValueError(f"invalid role: {rec.role!r}")
+        if not rec.tenant_id or not rec.address:
+            raise ValueError("tenant_id and address are required")
+        if not isinstance(rec.signing_pk, bytes) or len(rec.signing_pk) != 32:
+            raise ValueError("signing_pk must be 32 bytes")
+        if not rec.created_at:
+            rec.created_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO tenants (tenant_id, address, signing_pk, role, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(tenant_id) DO UPDATE SET
+                address=excluded.address,
+                signing_pk=excluded.signing_pk,
+                role=excluded.role
+            """,
+            (rec.tenant_id, rec.address, rec.signing_pk, rec.role, rec.created_at),
+        )
+        self._db.commit()
+        return rec
+
+    def get_tenant(self, tenant_id: str) -> Optional[TenantRecord]:
+        row = self._db.execute(
+            "SELECT * FROM tenants WHERE tenant_id = ?", (tenant_id,)
+        ).fetchone()
+        if not row:
+            return None
+        return TenantRecord(
+            tenant_id=row["tenant_id"],
+            address=row["address"],
+            signing_pk=bytes(row["signing_pk"]),
+            role=row["role"],
+            created_at=row["created_at"],
+        )
+
+    def list_tenants(self) -> list[TenantRecord]:
+        rows = self._db.execute("SELECT * FROM tenants ORDER BY created_at").fetchall()
+        return [
+            TenantRecord(
+                tenant_id=r["tenant_id"],
+                address=r["address"],
+                signing_pk=bytes(r["signing_pk"]),
+                role=r["role"],
+                created_at=r["created_at"],
+            )
+            for r in rows
+        ]
+
+    # -- instance keys -----------------------------------------------------
+
+    def add_instance_key(self, rec: InstanceKeyRecord) -> InstanceKeyRecord:
+        if rec.kind not in _VALID_INSTANCE_KEY_KINDS:
+            raise ValueError(f"invalid kind: {rec.kind!r}")
+        if rec.state not in _VALID_INSTANCE_KEY_STATES:
+            raise ValueError(f"invalid state: {rec.state!r}")
+        if not rec.kid or not rec.tenant_id:
+            raise ValueError("kid and tenant_id are required")
+        if not rec.created_at:
+            rec.created_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO instance_keys
+                (kid, tenant_id, kind, public_key, encrypted_secret, state,
+                 created_at, retired_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                rec.kid,
+                rec.tenant_id,
+                rec.kind,
+                rec.public_key,
+                rec.encrypted_secret,
+                rec.state,
+                rec.created_at,
+                rec.retired_at,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def get_instance_key(self, kid: str) -> Optional[InstanceKeyRecord]:
+        row = self._db.execute(
+            "SELECT * FROM instance_keys WHERE kid = ?", (kid,)
+        ).fetchone()
+        if not row:
+            return None
+        return self._row_to_instance_key(row)
+
+    def list_instance_keys(
+        self,
+        tenant_id: Optional[str] = None,
+        state: Optional[str] = None,
+        kind: Optional[str] = None,
+    ) -> list[InstanceKeyRecord]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("tenant_id = ?")
+            params.append(tenant_id)
+        if state is not None:
+            if state not in _VALID_INSTANCE_KEY_STATES:
+                raise ValueError(f"invalid state filter: {state!r}")
+            clauses.append("state = ?")
+            params.append(state)
+        if kind is not None:
+            if kind not in _VALID_INSTANCE_KEY_KINDS:
+                raise ValueError(f"invalid kind filter: {kind!r}")
+            clauses.append("kind = ?")
+            params.append(kind)
+        sql = "SELECT * FROM instance_keys"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY created_at"
+        rows = self._db.execute(sql, params).fetchall()
+        return [self._row_to_instance_key(r) for r in rows]
+
+    def transition_instance_key(self, kid: str, new_state: str) -> None:
+        """Move an instance key between lifecycle states.
+
+        Allowed transitions:
+            active        -> decrypt_only, retired
+            decrypt_only  -> retired
+            retired       -> (terminal)
+        """
+        if new_state not in _VALID_INSTANCE_KEY_STATES:
+            raise ValueError(f"invalid state: {new_state!r}")
+        current = self.get_instance_key(kid)
+        if current is None:
+            raise KeyError(f"unknown instance key: {kid!r}")
+        if current.state == new_state:
+            return
+        allowed = {
+            INSTANCE_KEY_ACTIVE: {INSTANCE_KEY_DECRYPT_ONLY, INSTANCE_KEY_RETIRED},
+            INSTANCE_KEY_DECRYPT_ONLY: {INSTANCE_KEY_RETIRED},
+            INSTANCE_KEY_RETIRED: set(),
+        }
+        if new_state not in allowed[current.state]:
+            raise ValueError(
+                f"illegal transition {current.state!r} -> {new_state!r} for kid={kid!r}"
+            )
+        retired_at = _now() if new_state == INSTANCE_KEY_RETIRED else current.retired_at
+        self._db.execute(
+            "UPDATE instance_keys SET state = ?, retired_at = ? WHERE kid = ?",
+            (new_state, retired_at, kid),
+        )
+        self._db.commit()
+
+    @staticmethod
+    def _row_to_instance_key(row: sqlite3.Row) -> InstanceKeyRecord:
+        return InstanceKeyRecord(
+            kid=row["kid"],
+            tenant_id=row["tenant_id"],
+            kind=row["kind"],
+            public_key=bytes(row["public_key"]),
+            encrypted_secret=bytes(row["encrypted_secret"]),
+            state=row["state"],
+            created_at=row["created_at"],
+            retired_at=row["retired_at"],
+        )
+
+    # -- peer pins ---------------------------------------------------------
+
+    def upsert_peer_pin(self, rec: PeerPinRecord) -> PeerPinRecord:
+        if rec.status not in _VALID_PEER_PIN_STATUSES:
+            raise ValueError(f"invalid pin status: {rec.status!r}")
+        if not rec.peer_address:
+            raise ValueError("peer_address is required")
+        if len(rec.sig_pk) != 32 or len(rec.enc_pk) != 32:
+            raise ValueError("sig_pk and enc_pk must be 32 bytes each")
+        if len(rec.fingerprint) != 16:
+            raise ValueError("fingerprint must be 16 bytes")
+        now = _now()
+        if not rec.first_seen:
+            rec.first_seen = now
+        rec.last_seen = now
+        self._db.execute(
+            """
+            INSERT INTO peer_pins
+                (peer_address, sig_pk, enc_pk, fingerprint, status, first_seen, last_seen)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(peer_address) DO UPDATE SET
+                sig_pk=excluded.sig_pk,
+                enc_pk=excluded.enc_pk,
+                fingerprint=excluded.fingerprint,
+                status=excluded.status,
+                last_seen=excluded.last_seen
+            """,
+            (
+                rec.peer_address,
+                rec.sig_pk,
+                rec.enc_pk,
+                rec.fingerprint,
+                rec.status,
+                rec.first_seen,
+                rec.last_seen,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def get_peer_pin(self, peer_address: str) -> Optional[PeerPinRecord]:
+        row = self._db.execute(
+            "SELECT * FROM peer_pins WHERE peer_address = ?", (peer_address,)
+        ).fetchone()
+        if not row:
+            return None
+        return PeerPinRecord(
+            peer_address=row["peer_address"],
+            sig_pk=bytes(row["sig_pk"]),
+            enc_pk=bytes(row["enc_pk"]),
+            fingerprint=bytes(row["fingerprint"]),
+            status=row["status"],
+            first_seen=row["first_seen"],
+            last_seen=row["last_seen"],
+        )
+
+    # -- outbox / inbox ----------------------------------------------------
+
+    def enqueue_outbound(self, rec: OutboxRecord) -> OutboxRecord:
+        if rec.status not in _VALID_OUTBOX_STATUSES:
+            raise ValueError(f"invalid outbox status: {rec.status!r}")
+        if not rec.msg_id or not rec.tenant_id or not rec.recipient_address:
+            raise ValueError("msg_id, tenant_id, recipient_address are required")
+        if not rec.created_at:
+            rec.created_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO outbox
+                (msg_id, tenant_id, recipient_address, envelope_blob, status,
+                 attempts, last_error, created_at, next_retry_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                rec.msg_id,
+                rec.tenant_id,
+                rec.recipient_address,
+                rec.envelope_blob,
+                rec.status,
+                rec.attempts,
+                rec.last_error,
+                rec.created_at,
+                rec.next_retry_at,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def mark_outbound_status(
+        self,
+        msg_id: str,
+        status: str,
+        last_error: str = "",
+        next_retry_at: float = 0.0,
+    ) -> None:
+        if status not in _VALID_OUTBOX_STATUSES:
+            raise ValueError(f"invalid outbox status: {status!r}")
+        cur = self._db.execute(
+            """
+            UPDATE outbox
+               SET status = ?,
+                   attempts = attempts + 1,
+                   last_error = ?,
+                   next_retry_at = ?
+             WHERE msg_id = ?
+            """,
+            (status, last_error, next_retry_at, msg_id),
+        )
+        self._db.commit()
+        if cur.rowcount == 0:
+            raise KeyError(f"unknown outbound msg_id: {msg_id!r}")
+
+    def list_outbound(
+        self, status: Optional[str] = None, limit: int = 100
+    ) -> list[OutboxRecord]:
+        if status is not None and status not in _VALID_OUTBOX_STATUSES:
+            raise ValueError(f"invalid status filter: {status!r}")
+        if status is None:
+            rows = self._db.execute(
+                "SELECT * FROM outbox ORDER BY created_at LIMIT ?", (limit,)
+            ).fetchall()
+        else:
+            rows = self._db.execute(
+                "SELECT * FROM outbox WHERE status = ? ORDER BY created_at LIMIT ?",
+                (status, limit),
+            ).fetchall()
+        return [
+            OutboxRecord(
+                msg_id=r["msg_id"],
+                tenant_id=r["tenant_id"],
+                recipient_address=r["recipient_address"],
+                envelope_blob=bytes(r["envelope_blob"]),
+                status=r["status"],
+                attempts=r["attempts"],
+                last_error=r["last_error"],
+                created_at=r["created_at"],
+                next_retry_at=r["next_retry_at"],
+            )
+            for r in rows
+        ]
+
+    def store_inbound(self, rec: InboxRecord) -> InboxRecord:
+        if rec.status not in _VALID_INBOX_STATUSES:
+            raise ValueError(f"invalid inbox status: {rec.status!r}")
+        if not rec.msg_id or not rec.tenant_id or not rec.sender_address:
+            raise ValueError("msg_id, tenant_id, sender_address are required")
+        if not rec.received_at:
+            rec.received_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO inbox
+                (msg_id, tenant_id, sender_address, plaintext_blob, status, received_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                rec.msg_id,
+                rec.tenant_id,
+                rec.sender_address,
+                rec.plaintext_blob,
+                rec.status,
+                rec.received_at,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def mark_inbound_status(self, msg_id: str, status: str) -> None:
+        if status not in _VALID_INBOX_STATUSES:
+            raise ValueError(f"invalid inbox status: {status!r}")
+        cur = self._db.execute(
+            "UPDATE inbox SET status = ? WHERE msg_id = ?", (status, msg_id)
+        )
+        self._db.commit()
+        if cur.rowcount == 0:
+            raise KeyError(f"unknown inbound msg_id: {msg_id!r}")
+
+    def list_inbound(
+        self,
+        tenant_id: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 100,
+    ) -> list[InboxRecord]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("tenant_id = ?")
+            params.append(tenant_id)
+        if status is not None:
+            if status not in _VALID_INBOX_STATUSES:
+                raise ValueError(f"invalid status filter: {status!r}")
+            clauses.append("status = ?")
+            params.append(status)
+        sql = "SELECT * FROM inbox"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY received_at DESC LIMIT ?"
+        params.append(limit)
+        rows = self._db.execute(sql, params).fetchall()
+        return [
+            InboxRecord(
+                msg_id=r["msg_id"],
+                tenant_id=r["tenant_id"],
+                sender_address=r["sender_address"],
+                plaintext_blob=bytes(r["plaintext_blob"]),
+                status=r["status"],
+                received_at=r["received_at"],
+            )
+            for r in rows
+        ]
+
+    # -- invites -----------------------------------------------------------
+
+    def add_invite(self, rec: InviteRecord) -> InviteRecord:
+        if rec.status not in _VALID_INVITE_STATUSES:
+            raise ValueError(f"invalid invite status: {rec.status!r}")
+        if not rec.invite_id or not rec.tenant_id:
+            raise ValueError("invite_id and tenant_id are required")
+        if not isinstance(rec.token_hash, bytes) or len(rec.token_hash) != 32:
+            raise ValueError("token_hash must be 32 bytes (SHA-256 of token)")
+        if not rec.created_at:
+            rec.created_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO issued_invites
+                (invite_id, tenant_id, recipient_hint, token_hash,
+                 expires_at, status, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                rec.invite_id,
+                rec.tenant_id,
+                rec.recipient_hint,
+                rec.token_hash,
+                rec.expires_at,
+                rec.status,
+                rec.created_at,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def mark_invite_status(self, invite_id: str, status: str) -> None:
+        if status not in _VALID_INVITE_STATUSES:
+            raise ValueError(f"invalid invite status: {status!r}")
+        cur = self._db.execute(
+            "UPDATE issued_invites SET status = ? WHERE invite_id = ?",
+            (status, invite_id),
+        )
+        self._db.commit()
+        if cur.rowcount == 0:
+            raise KeyError(f"unknown invite_id: {invite_id!r}")
+
+    def list_invites(
+        self, tenant_id: Optional[str] = None, status: Optional[str] = None
+    ) -> list[InviteRecord]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("tenant_id = ?")
+            params.append(tenant_id)
+        if status is not None:
+            if status not in _VALID_INVITE_STATUSES:
+                raise ValueError(f"invalid status filter: {status!r}")
+            clauses.append("status = ?")
+            params.append(status)
+        sql = "SELECT * FROM issued_invites"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY created_at DESC"
+        rows = self._db.execute(sql, params).fetchall()
+        return [
+            InviteRecord(
+                invite_id=r["invite_id"],
+                tenant_id=r["tenant_id"],
+                recipient_hint=r["recipient_hint"],
+                token_hash=bytes(r["token_hash"]),
+                expires_at=r["expires_at"],
+                status=r["status"],
+                created_at=r["created_at"],
+            )
+            for r in rows
+        ]
+
+    # -- attachments -------------------------------------------------------
+
+    def add_attachment(self, rec: AttachmentRecord) -> AttachmentRecord:
+        if not rec.attachment_id or not rec.msg_id:
+            raise ValueError("attachment_id and msg_id are required")
+        if not isinstance(rec.sha256, bytes) or len(rec.sha256) != 32:
+            raise ValueError("sha256 must be 32 bytes")
+        if rec.size < 0:
+            raise ValueError("size must be non-negative")
+        if not rec.created_at:
+            rec.created_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO attachments
+                (attachment_id, msg_id, sha256, size, mime, local_path,
+                 encrypted, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                rec.attachment_id,
+                rec.msg_id,
+                rec.sha256,
+                rec.size,
+                rec.mime,
+                rec.local_path,
+                int(bool(rec.encrypted)),
+                rec.created_at,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def list_attachments(self, msg_id: str) -> list[AttachmentRecord]:
+        rows = self._db.execute(
+            "SELECT * FROM attachments WHERE msg_id = ? ORDER BY created_at",
+            (msg_id,),
+        ).fetchall()
+        return [
+            AttachmentRecord(
+                attachment_id=r["attachment_id"],
+                msg_id=r["msg_id"],
+                sha256=bytes(r["sha256"]),
+                size=r["size"],
+                mime=r["mime"],
+                local_path=r["local_path"],
+                encrypted=bool(r["encrypted"]),
+                created_at=r["created_at"],
+            )
+            for r in rows
+        ]
+
+    # -- diagnostics -------------------------------------------------------
+
+    def stats(self) -> dict[str, int]:
+        """Counts only — no key material, no envelope contents."""
+        out: dict[str, int] = {}
+        for table in (
+            "tenants",
+            "tenant_signing_keys",
+            "instance_keys",
+            "peer_pins",
+            "outbox",
+            "inbox",
+            "issued_invites",
+            "attachments",
+        ):
+            out[table] = self._db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        return out
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return f"FederationStateStore(db_path={self.db_path!r})"
+
+    def close(self) -> None:
+        self._db.close()

--- a/tests/pinky_federation/test_key_store.py
+++ b/tests/pinky_federation/test_key_store.py
@@ -1,0 +1,327 @@
+"""Encrypted tenant key store tests.
+
+Focus areas:
+- Round-trip: encrypt -> persist -> decrypt yields original signing seed.
+- Repr / log discipline: seed bytes never appear in any exposed string.
+- Permissions: device key file is created 0600; loose perms are rejected.
+- Tenant binding: ciphertext for tenant A cannot be replayed under tenant B.
+- Export gate: raw seed export requires explicit operator acknowledgement.
+- Lifecycle: ``has_signing_key`` reflects state; ``get_signing_key`` raises
+  ``KeyError`` when no key is stored.
+- Wrong device key surfaces as ``DecryptionError`` (not raw libsodium type).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import secrets
+import stat
+
+import pytest
+
+from pinky_federation.errors import DecryptionError
+from pinky_federation.key_store import (
+    DEFAULT_DEVICE_KEY_PATH,
+    DEVICE_KEY_BYTES,
+    DeviceKey,
+    EncryptedTenantKeyStore,
+)
+from pinky_federation.keys import SigningKeyPair
+from pinky_federation.state import FederationStateStore, TenantRecord
+
+
+@pytest.fixture
+def state(tmp_path):
+    s = FederationStateStore(str(tmp_path / "fed.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def device_key(tmp_path):
+    return DeviceKey.load_or_create(str(tmp_path / "device.key"))
+
+
+@pytest.fixture
+def key_store(state, device_key):
+    return EncryptedTenantKeyStore(state, device_key)
+
+
+def _register_tenant(state: FederationStateStore, tenant_id: str = "t1") -> None:
+    state.upsert_tenant(
+        TenantRecord(
+            tenant_id=tenant_id,
+            address=f"{tenant_id}@example.com",
+            signing_pk=b"\x01" * 32,
+        )
+    )
+
+
+# -- DeviceKey ------------------------------------------------------------
+
+
+def test_device_key_creates_file_with_0600_perms(tmp_path) -> None:
+    path = tmp_path / "device.key"
+    dk = DeviceKey.load_or_create(str(path))
+    assert path.exists()
+    mode = stat.S_IMODE(path.stat().st_mode)
+    # On macOS / Linux this should be exactly 0o600.
+    assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+    assert len(dk.material_insecure()) == DEVICE_KEY_BYTES
+
+
+def test_device_key_is_persistent_across_loads(tmp_path) -> None:
+    path = tmp_path / "device.key"
+    dk1 = DeviceKey.load_or_create(str(path))
+    dk2 = DeviceKey.load_or_create(str(path))
+    assert dk1.material_insecure() == dk2.material_insecure()
+
+
+def test_device_key_rejects_loose_permissions(tmp_path) -> None:
+    path = tmp_path / "device.key"
+    DeviceKey.load_or_create(str(path))
+    os.chmod(str(path), 0o644)
+    with pytest.raises(PermissionError):
+        DeviceKey.load_or_create(str(path))
+
+
+def test_device_key_rejects_wrong_size_file(tmp_path) -> None:
+    path = tmp_path / "device.key"
+    path.write_bytes(b"\x00" * 31)
+    os.chmod(str(path), 0o600)
+    with pytest.raises(ValueError):
+        DeviceKey.load_or_create(str(path))
+
+
+def test_device_key_repr_does_not_expose_full_material(tmp_path) -> None:
+    dk = DeviceKey.load_or_create(str(tmp_path / "device.key"))
+    text = repr(dk)
+    assert dk.material_insecure().hex() not in text
+    # Truncated tag (4 bytes = 8 hex chars) is fine; full key is not.
+    assert "DeviceKey(" in text
+
+
+def test_device_key_validates_constructor_input() -> None:
+    with pytest.raises(ValueError):
+        DeviceKey(b"too-short")
+
+
+def test_default_device_key_path_constant() -> None:
+    # Sanity: the documented default path lives under data/federation/.
+    assert "data/federation/" in DEFAULT_DEVICE_KEY_PATH
+    assert DEFAULT_DEVICE_KEY_PATH.endswith(".device_key")
+
+
+# -- Round-trip -----------------------------------------------------------
+
+
+def test_put_then_get_round_trip(key_store, state) -> None:
+    _register_tenant(state)
+    original = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", original)
+    restored = key_store.get_signing_key("t1")
+    # Equality on Ed25519 keys: same public key implies same seed.
+    assert restored.public_key.raw == original.public_key.raw
+
+
+def test_put_overwrites_previous_key(key_store, state) -> None:
+    _register_tenant(state)
+    first = SigningKeyPair.generate()
+    second = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", first)
+    key_store.put_signing_key("t1", second)
+    restored = key_store.get_signing_key("t1")
+    assert restored.public_key.raw == second.public_key.raw
+    assert restored.public_key.raw != first.public_key.raw
+
+
+def test_has_signing_key_reflects_state(key_store, state) -> None:
+    _register_tenant(state)
+    assert key_store.has_signing_key("t1") is False
+    key_store.put_signing_key("t1", SigningKeyPair.generate())
+    assert key_store.has_signing_key("t1") is True
+
+
+def test_get_signing_key_raises_keyerror_when_missing(key_store) -> None:
+    with pytest.raises(KeyError):
+        key_store.get_signing_key("nope")
+
+
+def test_put_requires_existing_tenant(key_store) -> None:
+    with pytest.raises(ValueError):
+        key_store.put_signing_key("ghost", SigningKeyPair.generate())
+
+
+def test_put_validates_types(key_store, state) -> None:
+    _register_tenant(state)
+    with pytest.raises(TypeError):
+        key_store.put_signing_key("t1", "not-a-keypair")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        key_store.put_signing_key("", SigningKeyPair.generate())
+
+
+# -- Tenant binding (AAD) -------------------------------------------------
+
+
+def test_ciphertext_cannot_be_replayed_to_other_tenant(key_store, state) -> None:
+    _register_tenant(state, "alice")
+    _register_tenant(state, "bob")
+    key_store.put_signing_key("alice", SigningKeyPair.generate())
+    # Forge: copy alice's stored ciphertext into bob's row.
+    row = state._db.execute(  # noqa: SLF001
+        "SELECT encrypted_seed, nonce, kdf_version FROM tenant_signing_keys "
+        "WHERE tenant_id = ?",
+        ("alice",),
+    ).fetchone()
+    state._db.execute(  # noqa: SLF001
+        "INSERT INTO tenant_signing_keys (tenant_id, encrypted_seed, nonce, "
+        "kdf_version, created_at) VALUES (?, ?, ?, ?, ?)",
+        ("bob", bytes(row["encrypted_seed"]), bytes(row["nonce"]), int(row["kdf_version"]), 1.0),
+    )
+    state._db.commit()  # noqa: SLF001
+    with pytest.raises(DecryptionError):
+        key_store.get_signing_key("bob")
+
+
+# -- Wrong device key -----------------------------------------------------
+
+
+def test_wrong_device_key_raises_decryption_error(state, tmp_path) -> None:
+    real_dk = DeviceKey.load_or_create(str(tmp_path / "device.key"))
+    other_dk = DeviceKey(secrets.token_bytes(DEVICE_KEY_BYTES))
+    real_store = EncryptedTenantKeyStore(state, real_dk)
+    other_store = EncryptedTenantKeyStore(state, other_dk)
+    _register_tenant(state)
+    real_store.put_signing_key("t1", SigningKeyPair.generate())
+    with pytest.raises(DecryptionError):
+        other_store.get_signing_key("t1")
+
+
+def test_corrupt_ciphertext_raises_decryption_error(key_store, state) -> None:
+    _register_tenant(state)
+    key_store.put_signing_key("t1", SigningKeyPair.generate())
+    state._db.execute(  # noqa: SLF001
+        "UPDATE tenant_signing_keys SET encrypted_seed = ? WHERE tenant_id = ?",
+        (b"\x00" * 48, "t1"),
+    )
+    state._db.commit()  # noqa: SLF001
+    with pytest.raises(DecryptionError):
+        key_store.get_signing_key("t1")
+
+
+def test_unsupported_kdf_version_raises(key_store, state) -> None:
+    _register_tenant(state)
+    key_store.put_signing_key("t1", SigningKeyPair.generate())
+    state._db.execute(  # noqa: SLF001
+        "UPDATE tenant_signing_keys SET kdf_version = 999 WHERE tenant_id = ?", ("t1",)
+    )
+    state._db.commit()  # noqa: SLF001
+    with pytest.raises(DecryptionError):
+        key_store.get_signing_key("t1")
+
+
+# -- Export gate ----------------------------------------------------------
+
+
+def test_export_requires_explicit_acknowledgement(key_store, state) -> None:
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", kp)
+    with pytest.raises(PermissionError):
+        key_store.export_signing_seed_explicit(
+            "t1", operator_acknowledged=False, reason="reason"
+        )
+
+
+def test_export_requires_non_empty_reason(key_store, state) -> None:
+    _register_tenant(state)
+    key_store.put_signing_key("t1", SigningKeyPair.generate())
+    with pytest.raises(ValueError):
+        key_store.export_signing_seed_explicit(
+            "t1", operator_acknowledged=True, reason="   "
+        )
+
+
+def test_export_returns_seed_when_acknowledged(key_store, state) -> None:
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", kp)
+    seed = key_store.export_signing_seed_explicit(
+        "t1", operator_acknowledged=True, reason="operator initiated migration"
+    )
+    assert isinstance(seed, bytes)
+    assert len(seed) == 32
+    # The seed actually reproduces the same keypair.
+    assert SigningKeyPair.from_seed(seed).public_key.raw == kp.public_key.raw
+
+
+# -- Repr / log discipline ------------------------------------------------
+
+
+def test_repr_does_not_leak_seed(key_store, state) -> None:
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", kp)
+    seed_hex = kp.seed_bytes_insecure().hex()
+    text = repr(key_store)
+    assert seed_hex not in text
+
+
+def test_logging_module_does_not_capture_seed_via_repr(
+    key_store, state, caplog
+) -> None:
+    """Even if a careless caller logs the store object, the seed must not appear."""
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", kp)
+    seed_hex = kp.seed_bytes_insecure().hex()
+
+    log = logging.getLogger("test-fed-keystore-repr")
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    log.addHandler(handler)
+    log.setLevel(logging.DEBUG)
+    try:
+        log.debug("store snapshot: %r", key_store)
+    finally:
+        log.removeHandler(handler)
+
+    output = buf.getvalue()
+    assert seed_hex not in output
+
+
+def test_state_stats_contains_count_only_not_material(key_store, state) -> None:
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", kp)
+    stats = state.stats()
+    # stats is a dict[str, int] — there is nowhere for key bytes to hide.
+    assert isinstance(stats, dict)
+    assert stats["tenant_signing_keys"] == 1
+    for v in stats.values():
+        assert isinstance(v, int)
+
+
+def test_signing_keypair_repr_does_not_leak_seed(key_store, state) -> None:
+    """Returned SigningKeyPair must follow the same repr discipline."""
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    seed_hex = kp.seed_bytes_insecure().hex()
+    key_store.put_signing_key("t1", kp)
+    restored = key_store.get_signing_key("t1")
+    assert seed_hex not in repr(restored)
+
+
+# -- Constructor validation -----------------------------------------------
+
+
+def test_constructor_rejects_wrong_state_type(device_key) -> None:
+    with pytest.raises(TypeError):
+        EncryptedTenantKeyStore(state="not-a-store", device_key=device_key)  # type: ignore[arg-type]
+
+
+def test_constructor_rejects_wrong_device_key_type(state) -> None:
+    with pytest.raises(TypeError):
+        EncryptedTenantKeyStore(state=state, device_key=b"raw-bytes")  # type: ignore[arg-type]

--- a/tests/pinky_federation/test_state.py
+++ b/tests/pinky_federation/test_state.py
@@ -1,0 +1,487 @@
+"""Federation state store tests: schema, CRUD, lifecycle, validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_federation.state import (
+    INBOX_ARCHIVED,
+    INBOX_NEW,
+    INBOX_READ,
+    INSTANCE_KEY_ACTIVE,
+    INSTANCE_KEY_DECRYPT_ONLY,
+    INSTANCE_KEY_KIND_ENCRYPTION,
+    INSTANCE_KEY_KIND_SIGNING,
+    INSTANCE_KEY_RETIRED,
+    INVITE_ACTIVE,
+    INVITE_REDEEMED,
+    OUTBOX_FAILED,
+    OUTBOX_PENDING,
+    OUTBOX_SENT,
+    PEER_PIN_PINNED,
+    PEER_PIN_REJECTED,
+    PEER_PIN_ROTATED,
+    ROLE_MEMBER,
+    ROLE_OWNER,
+    AttachmentRecord,
+    FederationStateStore,
+    InboxRecord,
+    InstanceKeyRecord,
+    InviteRecord,
+    OutboxRecord,
+    PeerPinRecord,
+    TenantRecord,
+)
+
+
+@pytest.fixture
+def store(tmp_path):
+    db_path = tmp_path / "fed.db"
+    s = FederationStateStore(str(db_path))
+    yield s
+    s.close()
+
+
+def _tenant(tenant_id: str = "t1", role: str = ROLE_MEMBER) -> TenantRecord:
+    return TenantRecord(
+        tenant_id=tenant_id,
+        address=f"{tenant_id}@example.com",
+        signing_pk=b"\x01" * 32,
+        role=role,
+    )
+
+
+# -- schema ---------------------------------------------------------------
+
+
+def test_schema_creates_all_tables(store: FederationStateStore) -> None:
+    expected = {
+        "tenants",
+        "tenant_signing_keys",
+        "instance_keys",
+        "peer_pins",
+        "outbox",
+        "inbox",
+        "issued_invites",
+        "attachments",
+    }
+    rows = store._db.execute(  # noqa: SLF001
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()
+    names = {r[0] for r in rows}
+    assert expected <= names
+
+
+def test_init_is_idempotent(tmp_path) -> None:
+    db_path = tmp_path / "fed.db"
+    s1 = FederationStateStore(str(db_path))
+    s1.close()
+    s2 = FederationStateStore(str(db_path))
+    s2.close()  # second open does not raise
+
+
+def test_stats_counts_only(store: FederationStateStore) -> None:
+    s = store.stats()
+    assert all(v == 0 for v in s.values())
+    assert "tenants" in s and "tenant_signing_keys" in s
+
+
+# -- tenants --------------------------------------------------------------
+
+
+def test_tenant_upsert_and_get(store: FederationStateStore) -> None:
+    rec = store.upsert_tenant(_tenant("brad", ROLE_OWNER))
+    assert rec.created_at > 0
+    got = store.get_tenant("brad")
+    assert got is not None
+    assert got.address == "brad@example.com"
+    assert got.role == ROLE_OWNER
+    assert got.signing_pk == b"\x01" * 32
+
+
+def test_tenant_upsert_overwrites_address_and_role(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("brad", ROLE_MEMBER))
+    rec = TenantRecord(
+        tenant_id="brad",
+        address="brad+new@example.com",
+        signing_pk=b"\x02" * 32,
+        role=ROLE_OWNER,
+    )
+    store.upsert_tenant(rec)
+    got = store.get_tenant("brad")
+    assert got is not None
+    assert got.address == "brad+new@example.com"
+    assert got.role == ROLE_OWNER
+
+
+def test_tenant_upsert_rejects_bad_role(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.upsert_tenant(
+            TenantRecord(
+                tenant_id="x", address="x@y", signing_pk=b"\x00" * 32, role="admin"
+            )
+        )
+
+
+def test_tenant_upsert_rejects_bad_signing_pk(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.upsert_tenant(
+            TenantRecord(tenant_id="x", address="x@y", signing_pk=b"short", role=ROLE_MEMBER)
+        )
+
+
+def test_tenant_list_orders_by_created_at(store: FederationStateStore) -> None:
+    a = store.upsert_tenant(TenantRecord(
+        tenant_id="a", address="a@x", signing_pk=b"\x01" * 32, created_at=1.0))
+    b = store.upsert_tenant(TenantRecord(
+        tenant_id="b", address="b@x", signing_pk=b"\x02" * 32, created_at=2.0))
+    listed = store.list_tenants()
+    assert [t.tenant_id for t in listed] == ["a", "b"]
+    assert a.tenant_id == "a" and b.tenant_id == "b"
+
+
+# -- instance keys --------------------------------------------------------
+
+
+def _ik(kid: str, tenant_id: str = "t1", state: str = INSTANCE_KEY_ACTIVE) -> InstanceKeyRecord:
+    return InstanceKeyRecord(
+        kid=kid,
+        tenant_id=tenant_id,
+        kind=INSTANCE_KEY_KIND_ENCRYPTION,
+        public_key=b"\x10" * 32,
+        encrypted_secret=b"\x20" * 48,
+        state=state,
+    )
+
+
+def test_instance_key_add_and_get(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    rec = store.add_instance_key(_ik("k1"))
+    assert rec.created_at > 0
+    got = store.get_instance_key("k1")
+    assert got is not None
+    assert got.tenant_id == "t1"
+    assert got.state == INSTANCE_KEY_ACTIVE
+
+
+def test_instance_key_validates_kind_and_state(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    with pytest.raises(ValueError):
+        store.add_instance_key(InstanceKeyRecord(
+            kid="bad", tenant_id="t1", kind="garbage", public_key=b"\x00" * 32,
+            encrypted_secret=b"\x00", state=INSTANCE_KEY_ACTIVE))
+    with pytest.raises(ValueError):
+        store.add_instance_key(InstanceKeyRecord(
+            kid="bad2", tenant_id="t1", kind=INSTANCE_KEY_KIND_SIGNING,
+            public_key=b"\x00" * 32, encrypted_secret=b"\x00", state="weird"))
+
+
+def test_instance_key_lifecycle_active_to_decrypt_only(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_instance_key(_ik("k1"))
+    store.transition_instance_key("k1", INSTANCE_KEY_DECRYPT_ONLY)
+    assert store.get_instance_key("k1").state == INSTANCE_KEY_DECRYPT_ONLY
+    store.transition_instance_key("k1", INSTANCE_KEY_RETIRED)
+    got = store.get_instance_key("k1")
+    assert got.state == INSTANCE_KEY_RETIRED
+    assert got.retired_at > 0
+
+
+def test_instance_key_lifecycle_active_directly_to_retired(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_instance_key(_ik("k1"))
+    store.transition_instance_key("k1", INSTANCE_KEY_RETIRED)
+    assert store.get_instance_key("k1").state == INSTANCE_KEY_RETIRED
+
+
+def test_instance_key_lifecycle_rejects_decrypt_only_to_active(
+    store: FederationStateStore,
+) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_instance_key(_ik("k1", state=INSTANCE_KEY_DECRYPT_ONLY))
+    with pytest.raises(ValueError):
+        store.transition_instance_key("k1", INSTANCE_KEY_ACTIVE)
+
+
+def test_instance_key_lifecycle_rejects_retired_to_anything(
+    store: FederationStateStore,
+) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_instance_key(_ik("k1", state=INSTANCE_KEY_RETIRED))
+    for target in (INSTANCE_KEY_ACTIVE, INSTANCE_KEY_DECRYPT_ONLY):
+        with pytest.raises(ValueError):
+            store.transition_instance_key("k1", target)
+
+
+def test_instance_key_transition_no_op_same_state(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_instance_key(_ik("k1"))
+    store.transition_instance_key("k1", INSTANCE_KEY_ACTIVE)  # no error
+    assert store.get_instance_key("k1").state == INSTANCE_KEY_ACTIVE
+
+
+def test_instance_key_transition_unknown_kid(store: FederationStateStore) -> None:
+    with pytest.raises(KeyError):
+        store.transition_instance_key("nope", INSTANCE_KEY_RETIRED)
+
+
+def test_list_instance_keys_filters(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.upsert_tenant(_tenant("t2"))
+    store.add_instance_key(_ik("k1", tenant_id="t1"))
+    store.add_instance_key(_ik("k2", tenant_id="t1", state=INSTANCE_KEY_DECRYPT_ONLY))
+    store.add_instance_key(_ik("k3", tenant_id="t2"))
+    assert {k.kid for k in store.list_instance_keys(tenant_id="t1")} == {"k1", "k2"}
+    assert {k.kid for k in store.list_instance_keys(state=INSTANCE_KEY_ACTIVE)} == {"k1", "k3"}
+    assert {
+        k.kid for k in store.list_instance_keys(kind=INSTANCE_KEY_KIND_ENCRYPTION)
+    } == {"k1", "k2", "k3"}
+
+
+# -- peer pins ------------------------------------------------------------
+
+
+def _pin(addr: str = "alice@example.com", status: str = PEER_PIN_PINNED) -> PeerPinRecord:
+    return PeerPinRecord(
+        peer_address=addr,
+        sig_pk=b"\x11" * 32,
+        enc_pk=b"\x22" * 32,
+        fingerprint=b"\xaa" * 16,
+        status=status,
+    )
+
+
+def test_peer_pin_upsert_sets_first_and_last_seen(store: FederationStateStore) -> None:
+    rec = store.upsert_peer_pin(_pin())
+    assert rec.first_seen > 0
+    assert rec.last_seen >= rec.first_seen
+    got = store.get_peer_pin("alice@example.com")
+    assert got is not None
+    assert got.fingerprint == b"\xaa" * 16
+
+
+def test_peer_pin_upsert_preserves_first_seen_on_update(
+    store: FederationStateStore,
+) -> None:
+    first = store.upsert_peer_pin(_pin())
+    original_first_seen = first.first_seen
+    second = store.upsert_peer_pin(
+        PeerPinRecord(
+            peer_address="alice@example.com",
+            sig_pk=b"\x33" * 32,
+            enc_pk=b"\x44" * 32,
+            fingerprint=b"\xbb" * 16,
+            status=PEER_PIN_ROTATED,
+            first_seen=original_first_seen,
+        )
+    )
+    got = store.get_peer_pin("alice@example.com")
+    assert got.first_seen == original_first_seen
+    assert got.last_seen >= second.last_seen - 1
+    assert got.status == PEER_PIN_ROTATED
+    assert got.sig_pk == b"\x33" * 32
+
+
+def test_peer_pin_validates_lengths(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.upsert_peer_pin(
+            PeerPinRecord(
+                peer_address="x", sig_pk=b"short", enc_pk=b"\x00" * 32,
+                fingerprint=b"\x00" * 16))
+    with pytest.raises(ValueError):
+        store.upsert_peer_pin(
+            PeerPinRecord(
+                peer_address="x", sig_pk=b"\x00" * 32, enc_pk=b"\x00" * 32,
+                fingerprint=b"\x00" * 8))
+
+
+def test_peer_pin_rejects_bad_status(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.upsert_peer_pin(_pin(status="weird"))
+
+
+def test_peer_pin_status_rejected_round_trip(store: FederationStateStore) -> None:
+    store.upsert_peer_pin(_pin(status=PEER_PIN_REJECTED))
+    got = store.get_peer_pin("alice@example.com")
+    assert got.status == PEER_PIN_REJECTED
+
+
+# -- outbox ---------------------------------------------------------------
+
+
+def _ob(msg_id: str = "m1") -> OutboxRecord:
+    return OutboxRecord(
+        msg_id=msg_id,
+        tenant_id="t1",
+        recipient_address="alice@example.com",
+        envelope_blob=b"envelope-bytes",
+    )
+
+
+def test_outbox_enqueue_and_list(store: FederationStateStore) -> None:
+    store.enqueue_outbound(_ob("m1"))
+    store.enqueue_outbound(_ob("m2"))
+    pending = store.list_outbound(status=OUTBOX_PENDING)
+    assert {r.msg_id for r in pending} == {"m1", "m2"}
+
+
+def test_outbox_mark_sent_increments_attempts(store: FederationStateStore) -> None:
+    store.enqueue_outbound(_ob("m1"))
+    store.mark_outbound_status("m1", OUTBOX_SENT)
+    sent = store.list_outbound(status=OUTBOX_SENT)
+    assert len(sent) == 1
+    assert sent[0].attempts == 1
+
+
+def test_outbox_mark_failed_records_error(store: FederationStateStore) -> None:
+    store.enqueue_outbound(_ob("m1"))
+    store.mark_outbound_status("m1", OUTBOX_FAILED, last_error="relay 503", next_retry_at=42.0)
+    failed = store.list_outbound(status=OUTBOX_FAILED)
+    assert failed[0].last_error == "relay 503"
+    assert failed[0].next_retry_at == 42.0
+
+
+def test_outbox_mark_unknown_msg_raises(store: FederationStateStore) -> None:
+    with pytest.raises(KeyError):
+        store.mark_outbound_status("nope", OUTBOX_SENT)
+
+
+def test_outbox_status_filter_validation(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.list_outbound(status="weird")
+
+
+# -- inbox ----------------------------------------------------------------
+
+
+def _ib(msg_id: str = "i1", tenant_id: str = "t1") -> InboxRecord:
+    return InboxRecord(
+        msg_id=msg_id,
+        tenant_id=tenant_id,
+        sender_address="alice@example.com",
+        plaintext_blob=b"hello",
+    )
+
+
+def test_inbox_store_and_list(store: FederationStateStore) -> None:
+    store.store_inbound(_ib("i1"))
+    store.store_inbound(_ib("i2"))
+    rows = store.list_inbound(tenant_id="t1")
+    assert {r.msg_id for r in rows} == {"i1", "i2"}
+
+
+def test_inbox_mark_read_then_archived(store: FederationStateStore) -> None:
+    store.store_inbound(_ib("i1"))
+    store.mark_inbound_status("i1", INBOX_READ)
+    assert store.list_inbound(status=INBOX_READ)[0].msg_id == "i1"
+    store.mark_inbound_status("i1", INBOX_ARCHIVED)
+    assert store.list_inbound(status=INBOX_ARCHIVED)[0].status == INBOX_ARCHIVED
+
+
+def test_inbox_default_status_is_new(store: FederationStateStore) -> None:
+    store.store_inbound(_ib("i1"))
+    assert store.list_inbound(status=INBOX_NEW)[0].status == INBOX_NEW
+
+
+def test_inbox_mark_unknown_raises(store: FederationStateStore) -> None:
+    with pytest.raises(KeyError):
+        store.mark_inbound_status("nope", INBOX_READ)
+
+
+# -- invites --------------------------------------------------------------
+
+
+def _inv(invite_id: str = "v1") -> InviteRecord:
+    return InviteRecord(
+        invite_id=invite_id,
+        tenant_id="t1",
+        recipient_hint="alice@example.com",
+        token_hash=b"\xdd" * 32,
+        expires_at=999999999.0,
+    )
+
+
+def test_invite_add_and_list(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_invite(_inv("v1"))
+    store.add_invite(_inv("v2"))
+    listed = store.list_invites(tenant_id="t1")
+    assert {i.invite_id for i in listed} == {"v1", "v2"}
+
+
+def test_invite_token_hash_must_be_32_bytes(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    with pytest.raises(ValueError):
+        store.add_invite(InviteRecord(
+            invite_id="v1", tenant_id="t1", token_hash=b"short", expires_at=1.0))
+
+
+def test_invite_status_lifecycle(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_invite(_inv("v1"))
+    assert store.list_invites(status=INVITE_ACTIVE)[0].invite_id == "v1"
+    store.mark_invite_status("v1", INVITE_REDEEMED)
+    assert store.list_invites(status=INVITE_REDEEMED)[0].invite_id == "v1"
+
+
+def test_invite_mark_unknown_raises(store: FederationStateStore) -> None:
+    with pytest.raises(KeyError):
+        store.mark_invite_status("nope", INVITE_REDEEMED)
+
+
+# -- attachments ----------------------------------------------------------
+
+
+def _att(att_id: str = "a1", msg_id: str = "i1") -> AttachmentRecord:
+    return AttachmentRecord(
+        attachment_id=att_id,
+        msg_id=msg_id,
+        sha256=b"\x99" * 32,
+        size=1024,
+        mime="image/png",
+        local_path="/tmp/blob",
+        encrypted=True,
+    )
+
+
+def test_attachment_add_and_list(store: FederationStateStore) -> None:
+    store.add_attachment(_att("a1"))
+    store.add_attachment(_att("a2"))
+    rows = store.list_attachments("i1")
+    assert {a.attachment_id for a in rows} == {"a1", "a2"}
+    assert rows[0].encrypted is True
+    assert rows[0].size == 1024
+
+
+def test_attachment_validates_sha_and_size(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.add_attachment(AttachmentRecord(
+            attachment_id="a", msg_id="m", sha256=b"short", size=1, local_path="/x"))
+    with pytest.raises(ValueError):
+        store.add_attachment(AttachmentRecord(
+            attachment_id="a", msg_id="m", sha256=b"\x00" * 32, size=-1, local_path="/x"))
+
+
+# -- foreign keys ---------------------------------------------------------
+
+
+def test_tenant_signing_keys_fk_cascades_on_tenant_delete(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    # Insert a row directly via the connection (key_store does this normally).
+    store._db.execute(  # noqa: SLF001
+        "INSERT INTO tenant_signing_keys (tenant_id, encrypted_seed, nonce, "
+        "kdf_version, created_at) VALUES (?, ?, ?, ?, ?)",
+        ("t1", b"ct", b"n", 1, 1.0),
+    )
+    store._db.commit()  # noqa: SLF001
+    store._db.execute("DELETE FROM tenants WHERE tenant_id = ?", ("t1",))  # noqa: SLF001
+    store._db.commit()  # noqa: SLF001
+    rows = store._db.execute(  # noqa: SLF001
+        "SELECT * FROM tenant_signing_keys WHERE tenant_id = ?", ("t1",)
+    ).fetchall()
+    assert rows == []
+
+
+def test_db_uses_wal_mode(store: FederationStateStore) -> None:
+    mode = store._db.execute("PRAGMA journal_mode").fetchone()[0]  # noqa: SLF001
+    assert mode.lower() == "wal"


### PR DESCRIPTION
## Summary
P-02: lays the storage foundation for federation v0.2. Owns the on-disk layout under `data/federation/` that downstream TOFU (P-03), transport (P-04), invites (P-05), and attachments (P-06) all build on.

**Stacked on top of #264 (P-01 sealed_box_v1 crypto).** Once #264 lands on `beta`, I'll retarget this PR to `beta`.

## What's in the box

### `src/pinky_federation/state.py` — `FederationStateStore`
SQLite-backed store, WAL + foreign keys. Tables:
- `tenants` — membership context, role (owner/member), tenant identity Ed25519 pk
- `tenant_signing_keys` — opaque-from-this-layer encrypted seeds (key_store owns)
- `instance_keys` — per-device receive keys with lifecycle: `active` → `{decrypt_only, retired}`; `decrypt_only` → `retired`; `retired` is terminal
- `peer_pins` — TOFU pin store keyed by canonical address (sig_pk + enc_pk + 16-byte fingerprint)
- `outbox` / `inbox` — pending outbound + received plaintext slices
- `issued_invites` — token *hash* only (raw token never persisted)
- `attachments` — metadata pointer for on-disk encrypted blobs

`stats()` returns counts only — no key material, no envelope contents.

### `src/pinky_federation/key_store.py` — `EncryptedTenantKeyStore`
- **`DeviceKey`**: 32-byte device-local secret at `data/federation/.device_key` with strict `0o600` perms; loose perms rejected on load.
- **Encryption**: XChaCha20-Poly1305 with a fresh 24-byte nonce per write. AAD = `pinky-fed/v1/tenant-signing-seed | <tenant_id>` so a row from one tenant can't be replayed under another.
- **Discipline**:
  - Seed never appears in `repr()` of `DeviceKey` or `EncryptedTenantKeyStore`
  - `get_signing_key()` returns a `SigningKeyPair` (no raw bytes leak)
  - Raw seed export gated behind `export_signing_seed_explicit(tenant_id, *, operator_acknowledged=True, reason=...)` — defensive against accidental "give me the key" from generic settings/debug paths
  - Wrong device key / corrupt ciphertext / unsupported `kdf_version` → `DecryptionError` (never raw libsodium types)

## Acceptance criteria from #251
- [x] Tables for tenants, instance keys, peer pins, outbox, inbox, invites, attachments
- [x] Tenant signing key encrypted at rest with device-local key
- [x] Tenant signing key never logged / never in stats / never in repr
- [x] Tenant signing key exportable only via deliberate operator flow
- [x] Instance keys support active / decrypt_only / retired lifecycle
- [x] `federation_peers` pin-store slice present so P-03 isn't blocked

## Tests
- 65 new (39 state + 26 key_store)
- 119 federation total green
- 1591 full suite green
- `ruff check src/pinky_federation/ tests/pinky_federation/` clean

## Notes
- Schema is initial — `_ensure_columns()` stub is in place for future migrations following the project pattern.
- Device key ergonomics: writes atomically with `O_EXCL | 0o600`. If you ever need to rotate, delete the file and re-key (everything currently stored becomes unreadable, which is the intended blast radius).
- This module deliberately does not touch `instance_keys.encrypted_secret` semantics — same `DeviceKey` is reusable for that table when P-03/P-04 arrive.

🤖 Opened by Barsik