### PR TITLE
feat(federation): TOFU pinning + fingerprint mismatch state machine (#252)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
     "uvicorn>=0.44",
     "claude-agent-sdk>=0.1.58",
     "Pillow>=10.0",
+    # Federation crypto (sealed_box_v1): X25519, Ed25519, HKDF, XChaCha20-Poly1305.
+    "cryptography>=41.0",
+    "pynacl>=1.5",
 ]
 
 [project.optional-dependencies]
@@ -66,7 +69,7 @@ dev = [
 pinky = "pinky_cli.__main__:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/pinky_memory", "src/pinky_outreach", "src/pinky_messaging", "src/pinky_daemon", "src/pinky_cli", "src/pinky_self", "src/pinky_calendar", "src/pinky_hub", "src/pinky_web"]
+packages = ["src/pinky_memory", "src/pinky_outreach", "src/pinky_messaging", "src/pinky_daemon", "src/pinky_cli", "src/pinky_self", "src/pinky_calendar", "src/pinky_hub", "src/pinky_web", "src/pinky_federation"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/pinky_federation/__init__.py
+++ b/src/pinky_federation/__init__.py
@@ -1,0 +1,61 @@
+"""PinkyBot federation — sealed-box-v1 crypto and envelope primitives.
+
+This package implements the reference crypto layer for PinkyBot federation v0.2:
+
+- X25519 encryption keypairs (per-tenant, per-device)
+- Ed25519 signing keypairs (per-tenant, client-owned)
+- `sealed_box_v1`: authenticated ephemeral-X25519 + XChaCha20-Poly1305 + Ed25519 sender signature
+- Versioned envelope serialization suitable for relay transport
+- Deterministic fingerprints for TOFU pinning and UX display
+
+Nothing in this package talks to a network. Higher layers (transport, invite,
+attachments) consume these primitives.
+"""
+
+from pinky_federation.envelope import (
+    Envelope,
+    EnvelopeError,
+    EnvelopeVersion,
+)
+from pinky_federation.errors import (
+    CryptoError,
+    DecryptionError,
+    SignatureError,
+)
+from pinky_federation.fingerprint import (
+    FINGERPRINT_BYTES,
+    canonical_address,
+    fingerprint,
+    format_fingerprint,
+)
+from pinky_federation.keys import (
+    EncryptionKeyPair,
+    EncryptionPublicKey,
+    SigningKeyPair,
+    SigningPublicKey,
+)
+from pinky_federation.sealed_box import (
+    SEALED_BOX_VERSION,
+    seal,
+    unseal,
+)
+
+__all__ = [
+    "CryptoError",
+    "DecryptionError",
+    "Envelope",
+    "EnvelopeError",
+    "EnvelopeVersion",
+    "EncryptionKeyPair",
+    "EncryptionPublicKey",
+    "FINGERPRINT_BYTES",
+    "SEALED_BOX_VERSION",
+    "SignatureError",
+    "SigningKeyPair",
+    "SigningPublicKey",
+    "canonical_address",
+    "fingerprint",
+    "format_fingerprint",
+    "seal",
+    "unseal",
+]

--- a/src/pinky_federation/__init__.py
+++ b/src/pinky_federation/__init__.py
@@ -1,4 +1,4 @@
-"""PinkyBot federation — sealed-box-v1 crypto and envelope primitives.
+"""PinkyBot federation — sealed-box-v1 crypto, envelope, and local state.
 
 This package implements the reference crypto layer for PinkyBot federation v0.2:
 
@@ -7,6 +7,8 @@ This package implements the reference crypto layer for PinkyBot federation v0.2:
 - `sealed_box_v1`: authenticated ephemeral-X25519 + XChaCha20-Poly1305 + Ed25519 sender signature
 - Versioned envelope serialization suitable for relay transport
 - Deterministic fingerprints for TOFU pinning and UX display
+- Local SQLite state store under ``data/federation/`` (P-02)
+- Encrypted-at-rest tenant signing key persistence with device-local key (P-02)
 
 Nothing in this package talks to a network. Higher layers (transport, invite,
 attachments) consume these primitives.
@@ -28,6 +30,12 @@ from pinky_federation.fingerprint import (
     fingerprint,
     format_fingerprint,
 )
+from pinky_federation.key_store import (
+    DEFAULT_DEVICE_KEY_PATH,
+    DEVICE_KEY_BYTES,
+    DeviceKey,
+    EncryptedTenantKeyStore,
+)
 from pinky_federation.keys import (
     EncryptionKeyPair,
     EncryptionPublicKey,
@@ -39,23 +47,95 @@ from pinky_federation.sealed_box import (
     seal,
     unseal,
 )
+from pinky_federation.state import (
+    DEFAULT_DB_PATH,
+    INBOX_ARCHIVED,
+    INBOX_NEW,
+    INBOX_READ,
+    INSTANCE_KEY_ACTIVE,
+    INSTANCE_KEY_DECRYPT_ONLY,
+    INSTANCE_KEY_KIND_ENCRYPTION,
+    INSTANCE_KEY_KIND_SIGNING,
+    INSTANCE_KEY_RETIRED,
+    INVITE_ACTIVE,
+    INVITE_EXPIRED,
+    INVITE_REDEEMED,
+    INVITE_REVOKED,
+    OUTBOX_FAILED,
+    OUTBOX_PENDING,
+    OUTBOX_SENT,
+    PEER_PIN_PINNED,
+    PEER_PIN_REJECTED,
+    PEER_PIN_ROTATED,
+    ROLE_MEMBER,
+    ROLE_OWNER,
+    AttachmentRecord,
+    FederationStateStore,
+    InboxRecord,
+    InstanceKeyRecord,
+    InviteRecord,
+    OutboxRecord,
+    PeerPinRecord,
+    TenantRecord,
+)
 
 __all__ = [
+    # Errors
     "CryptoError",
     "DecryptionError",
+    "SignatureError",
+    # Envelope
     "Envelope",
     "EnvelopeError",
     "EnvelopeVersion",
-    "EncryptionKeyPair",
-    "EncryptionPublicKey",
+    # Fingerprint
     "FINGERPRINT_BYTES",
-    "SEALED_BOX_VERSION",
-    "SignatureError",
-    "SigningKeyPair",
-    "SigningPublicKey",
     "canonical_address",
     "fingerprint",
     "format_fingerprint",
+    # Keys
+    "EncryptionKeyPair",
+    "EncryptionPublicKey",
+    "SigningKeyPair",
+    "SigningPublicKey",
+    # Sealed box
+    "SEALED_BOX_VERSION",
     "seal",
     "unseal",
+    # State store
+    "DEFAULT_DB_PATH",
+    "FederationStateStore",
+    "TenantRecord",
+    "InstanceKeyRecord",
+    "PeerPinRecord",
+    "OutboxRecord",
+    "InboxRecord",
+    "InviteRecord",
+    "AttachmentRecord",
+    # State constants
+    "INSTANCE_KEY_ACTIVE",
+    "INSTANCE_KEY_DECRYPT_ONLY",
+    "INSTANCE_KEY_RETIRED",
+    "INSTANCE_KEY_KIND_ENCRYPTION",
+    "INSTANCE_KEY_KIND_SIGNING",
+    "PEER_PIN_PINNED",
+    "PEER_PIN_ROTATED",
+    "PEER_PIN_REJECTED",
+    "OUTBOX_PENDING",
+    "OUTBOX_SENT",
+    "OUTBOX_FAILED",
+    "INBOX_NEW",
+    "INBOX_READ",
+    "INBOX_ARCHIVED",
+    "INVITE_ACTIVE",
+    "INVITE_REDEEMED",
+    "INVITE_EXPIRED",
+    "INVITE_REVOKED",
+    "ROLE_OWNER",
+    "ROLE_MEMBER",
+    # Encrypted key store
+    "DEFAULT_DEVICE_KEY_PATH",
+    "DEVICE_KEY_BYTES",
+    "DeviceKey",
+    "EncryptedTenantKeyStore",
 ]

--- a/src/pinky_federation/__init__.py
+++ b/src/pinky_federation/__init__.py
@@ -64,9 +64,12 @@ from pinky_federation.state import (
     OUTBOX_FAILED,
     OUTBOX_PENDING,
     OUTBOX_SENT,
+    PEER_PIN_CHANGED,
+    PEER_PIN_FIRST_SEEN,
     PEER_PIN_PINNED,
     PEER_PIN_REJECTED,
     PEER_PIN_ROTATED,
+    PEER_PIN_VERIFIED,
     ROLE_MEMBER,
     ROLE_OWNER,
     AttachmentRecord,
@@ -77,6 +80,14 @@ from pinky_federation.state import (
     OutboxRecord,
     PeerPinRecord,
     TenantRecord,
+)
+from pinky_federation.tofu import (
+    NoPendingRotationError,
+    TofuError,
+    TrustDecision,
+    TrustPolicy,
+    TrustResult,
+    UnknownPeerError,
 )
 
 __all__ = [
@@ -118,7 +129,10 @@ __all__ = [
     "INSTANCE_KEY_RETIRED",
     "INSTANCE_KEY_KIND_ENCRYPTION",
     "INSTANCE_KEY_KIND_SIGNING",
+    "PEER_PIN_FIRST_SEEN",
     "PEER_PIN_PINNED",
+    "PEER_PIN_CHANGED",
+    "PEER_PIN_VERIFIED",
     "PEER_PIN_ROTATED",
     "PEER_PIN_REJECTED",
     "OUTBOX_PENDING",
@@ -138,4 +152,11 @@ __all__ = [
     "DEVICE_KEY_BYTES",
     "DeviceKey",
     "EncryptedTenantKeyStore",
+    # TOFU
+    "TrustPolicy",
+    "TrustDecision",
+    "TrustResult",
+    "TofuError",
+    "NoPendingRotationError",
+    "UnknownPeerError",
 ]

--- a/src/pinky_federation/envelope.py
+++ b/src/pinky_federation/envelope.py
@@ -1,0 +1,156 @@
+"""Envelope wire format for federation v0.2.
+
+An envelope is the single unit that moves through the relay. It contains
+everything a recipient needs to authenticate and decrypt a sealed-box-v1
+message, *given* their own private key and a trust-store entry for the
+sender fingerprint.
+
+Wire format (v1), all integers big-endian:
+
+    magic        4   b"PFv1"
+    version      1   == 1
+    flags        1   reserved, must be 0
+    sender_fp    16  fingerprint bytes
+    recipient_fp 16  fingerprint bytes
+    eph_pk       32  ephemeral X25519 public key
+    nonce        24  XChaCha20-Poly1305 nonce
+    sig          64  Ed25519 signature
+    ct_len       4   length of ciphertext in bytes
+    ciphertext   ct_len
+
+Fixed-length fields simplify parsing and test-vector generation; the only
+variable-length piece is the AEAD ciphertext, length-prefixed with a 32-bit
+big-endian integer (max 4 GiB — more than enough for in-relay messages).
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+from pinky_federation.errors import EnvelopeError
+from pinky_federation.fingerprint import FINGERPRINT_BYTES
+from pinky_federation.keys import ED25519_SIG_BYTES, X25519_KEY_BYTES
+
+_MAGIC = b"PFv1"
+_NONCE_BYTES = 24
+_CT_LEN_FIELD_BYTES = 4
+#: Hard cap on ciphertext size (16 MiB). Larger blobs belong in the attachment
+#: pipeline, not the main envelope.
+MAX_CIPHERTEXT_BYTES = 16 * 1024 * 1024
+
+# Offsets within the fixed-size header.
+_HDR_MAGIC_END = len(_MAGIC)
+_HDR_VERSION = _HDR_MAGIC_END
+_HDR_FLAGS = _HDR_VERSION + 1
+_HDR_SENDER_FP = _HDR_FLAGS + 1
+_HDR_RECIPIENT_FP = _HDR_SENDER_FP + FINGERPRINT_BYTES
+_HDR_EPH_PK = _HDR_RECIPIENT_FP + FINGERPRINT_BYTES
+_HDR_NONCE = _HDR_EPH_PK + X25519_KEY_BYTES
+_HDR_SIG = _HDR_NONCE + _NONCE_BYTES
+_HDR_CT_LEN = _HDR_SIG + ED25519_SIG_BYTES
+_HDR_FIXED = _HDR_CT_LEN + _CT_LEN_FIELD_BYTES  # 142 bytes
+
+
+class EnvelopeVersion(enum.IntEnum):
+    """Wire-protocol version for sealed-box envelopes."""
+
+    V1 = 1
+
+
+@dataclass(frozen=True)
+class Envelope:
+    """Parsed sealed-box envelope.
+
+    Field sizes are validated in ``__post_init__``; instances constructed via
+    :meth:`from_bytes` are guaranteed well-shaped.
+    """
+
+    version: EnvelopeVersion
+    sender_fingerprint: bytes
+    recipient_fingerprint: bytes
+    ephemeral_public: bytes
+    nonce: bytes
+    signature: bytes
+    ciphertext: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.version, EnvelopeVersion):
+            raise ValueError("version must be EnvelopeVersion")
+        self._check_len("sender_fingerprint", self.sender_fingerprint, FINGERPRINT_BYTES)
+        self._check_len("recipient_fingerprint", self.recipient_fingerprint, FINGERPRINT_BYTES)
+        self._check_len("ephemeral_public", self.ephemeral_public, X25519_KEY_BYTES)
+        self._check_len("nonce", self.nonce, _NONCE_BYTES)
+        self._check_len("signature", self.signature, ED25519_SIG_BYTES)
+        if not isinstance(self.ciphertext, (bytes, bytearray)):
+            raise ValueError("ciphertext must be bytes")
+        if len(self.ciphertext) > MAX_CIPHERTEXT_BYTES:
+            raise ValueError("ciphertext exceeds MAX_CIPHERTEXT_BYTES")
+
+    @staticmethod
+    def _check_len(name: str, val: bytes, expected: int) -> None:
+        if not isinstance(val, (bytes, bytearray)) or len(val) != expected:
+            raise ValueError(f"{name} must be {expected} bytes")
+
+    # -- Serialization --------------------------------------------------------
+
+    def to_bytes(self) -> bytes:
+        parts = [
+            _MAGIC,
+            bytes([self.version.value]),
+            bytes([0]),  # flags reserved
+            bytes(self.sender_fingerprint),
+            bytes(self.recipient_fingerprint),
+            bytes(self.ephemeral_public),
+            bytes(self.nonce),
+            bytes(self.signature),
+            len(self.ciphertext).to_bytes(_CT_LEN_FIELD_BYTES, "big"),
+            bytes(self.ciphertext),
+        ]
+        return b"".join(parts)
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> Envelope:
+        if not isinstance(data, (bytes, bytearray)):
+            raise EnvelopeError("envelope must be bytes")
+        if len(data) < _HDR_FIXED:
+            raise EnvelopeError("envelope shorter than fixed header")
+        if data[: _HDR_MAGIC_END] != _MAGIC:
+            raise EnvelopeError("envelope magic mismatch")
+
+        version_byte = data[_HDR_VERSION]
+        try:
+            version = EnvelopeVersion(version_byte)
+        except ValueError as exc:
+            raise EnvelopeError(f"unsupported envelope version: {version_byte}") from exc
+
+        flags = data[_HDR_FLAGS]
+        if flags != 0:
+            raise EnvelopeError(f"unsupported envelope flags: 0x{flags:02x}")
+
+        sender_fp = bytes(data[_HDR_SENDER_FP:_HDR_RECIPIENT_FP])
+        recipient_fp = bytes(data[_HDR_RECIPIENT_FP:_HDR_EPH_PK])
+        eph_pk = bytes(data[_HDR_EPH_PK:_HDR_NONCE])
+        nonce = bytes(data[_HDR_NONCE:_HDR_SIG])
+        signature = bytes(data[_HDR_SIG:_HDR_CT_LEN])
+
+        ct_len = int.from_bytes(data[_HDR_CT_LEN:_HDR_FIXED], "big")
+        if ct_len > MAX_CIPHERTEXT_BYTES:
+            raise EnvelopeError("ciphertext length exceeds MAX_CIPHERTEXT_BYTES")
+        expected_end = _HDR_FIXED + ct_len
+        if len(data) != expected_end:
+            raise EnvelopeError(
+                f"envelope length mismatch: header says ct_len={ct_len}, "
+                f"total_expected={expected_end}, got={len(data)}"
+            )
+        ciphertext = bytes(data[_HDR_FIXED:expected_end])
+
+        return cls(
+            version=version,
+            sender_fingerprint=sender_fp,
+            recipient_fingerprint=recipient_fp,
+            ephemeral_public=eph_pk,
+            nonce=nonce,
+            signature=signature,
+            ciphertext=ciphertext,
+        )

--- a/src/pinky_federation/errors.py
+++ b/src/pinky_federation/errors.py
@@ -1,0 +1,25 @@
+"""Exceptions raised by the federation crypto layer.
+
+Rules:
+- Never include private key material in exception messages.
+- Keep error types narrow so higher layers can handle them distinctly
+  (e.g. TOFU mismatch vs tampered ciphertext vs unknown version).
+"""
+
+from __future__ import annotations
+
+
+class CryptoError(Exception):
+    """Base class for all federation crypto failures."""
+
+
+class DecryptionError(CryptoError):
+    """Ciphertext could not be decrypted (tamper, wrong key, or corruption)."""
+
+
+class SignatureError(CryptoError):
+    """Ed25519 sender signature did not verify."""
+
+
+class EnvelopeError(CryptoError):
+    """Envelope bytes failed structural parsing or version check."""

--- a/src/pinky_federation/fingerprint.py
+++ b/src/pinky_federation/fingerprint.py
@@ -1,0 +1,107 @@
+"""Deterministic fingerprints for federation identities.
+
+A fingerprint uniquely identifies the tuple *(canonical address, signing pubkey,
+encryption pubkey)*. It is used for:
+
+- TOFU pinning (stored on first receive, verified on subsequent receives)
+- Short UX display strings ("Verify: `a1b2 c3d4 … f7e8`")
+- Addressing senders in the wire envelope (so receivers can look up trust)
+
+Design:
+
+- Input canonicalization is strict — the same tenant address must produce
+  identical bytes regardless of case, whitespace, or surrounding noise.
+- The hash is domain-separated with a version string, so we can rotate the
+  scheme without fingerprint collisions across versions.
+- We use SHA-256 truncated to 16 bytes (128 bits). That is comfortably above
+  the preimage/collision bar for TOFU and short enough for display.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from pinky_federation.keys import (
+    EncryptionPublicKey,
+    SigningPublicKey,
+)
+
+#: Fingerprint length in bytes. 16 bytes = 128 bits.
+FINGERPRINT_BYTES = 16
+
+_FP_DOMAIN = b"pinky-federation/fingerprint/v1"
+
+
+def canonical_address(address: str) -> str:
+    """Canonicalize a federation address (``user@host`` style).
+
+    Rules:
+
+    - Strip surrounding whitespace.
+    - Lowercase the entire string (federation addresses are case-insensitive
+      in both the local part and host, per our spec; real email is
+      case-sensitive in the local part, but we want TOFU to be forgiving).
+    - Reject empty strings and strings containing control bytes or whitespace
+      after stripping.
+    """
+    if not isinstance(address, str):
+        raise TypeError("address must be str")
+    cleaned = address.strip().lower()
+    if not cleaned:
+        raise ValueError("address must not be empty")
+    for ch in cleaned:
+        if ch.isspace() or ord(ch) < 0x20:
+            raise ValueError("address must not contain whitespace or control chars")
+    return cleaned
+
+
+def fingerprint(
+    address: str,
+    signing_key: SigningPublicKey,
+    encryption_key: EncryptionPublicKey,
+) -> bytes:
+    """Compute the 16-byte fingerprint for a federation identity.
+
+    The hash input is:
+
+        FP_DOMAIN || u16(len(addr)) || utf8(addr) ||
+        u8(len(sig_pk)) || sig_pk || u8(len(enc_pk)) || enc_pk
+
+    Length-prefixing prevents cross-field ambiguity (otherwise concatenation
+    would let two different identities produce the same hash input).
+    """
+    addr = canonical_address(address).encode("utf-8")
+    sig_pk = signing_key.to_bytes()
+    enc_pk = encryption_key.to_bytes()
+
+    h = hashlib.sha256()
+    h.update(_FP_DOMAIN)
+    h.update(len(addr).to_bytes(2, "big"))
+    h.update(addr)
+    h.update(len(sig_pk).to_bytes(1, "big"))
+    h.update(sig_pk)
+    h.update(len(enc_pk).to_bytes(1, "big"))
+    h.update(enc_pk)
+    return h.digest()[:FINGERPRINT_BYTES]
+
+
+def format_fingerprint(fp: bytes, *, groups: int = 4, group_size: int = 4) -> str:
+    """Format *fp* as a human-readable grouped hex string.
+
+    Default layout: ``"a1b2 c3d4 e5f6 …"`` with 4-char groups separated by
+    spaces. Accepts any fingerprint length that is a multiple of ``group_size``.
+    """
+    if not isinstance(fp, (bytes, bytearray)):
+        raise TypeError("fp must be bytes")
+    if groups <= 0 or group_size <= 0:
+        raise ValueError("groups and group_size must be positive")
+    hex_str = fp.hex()
+    # Break into group_size-char chunks, then join the requested number of
+    # groups with spaces. Any remainder past `groups * group_size` chars is
+    # dropped — callers wanting the full hex should use fp.hex() directly.
+    chunks: list[str] = []
+    for i in range(0, len(hex_str), group_size):
+        chunks.append(hex_str[i : i + group_size])
+        if len(chunks) == groups:
+            break
+    return " ".join(chunks)

--- a/src/pinky_federation/key_store.py
+++ b/src/pinky_federation/key_store.py
@@ -1,0 +1,298 @@
+"""Encrypted at-rest persistence for tenant signing keys.
+
+The tenant signing key (Ed25519) is the *identity* of a tenant. If it leaks,
+an attacker can impersonate the tenant indefinitely (federation v0.2 has no
+escrow, no recovery — by Brad's design decision Q3, key loss means starting
+over). This module exists so that key never sits on disk in plaintext.
+
+Layered design:
+
+- :class:`DeviceKey` — a 32-byte symmetric secret persisted at
+  ``data/federation/.device_key`` with mode ``0600``. Generated on first use
+  on this device; never copied off. This is the encryption key for tenant
+  signing seeds.
+- :class:`EncryptedTenantKeyStore` — uses a :class:`DeviceKey` to write
+  tenant signing seeds (32 bytes) into the ``tenant_signing_keys`` table
+  created by :mod:`pinky_federation.state`, encrypted with
+  XChaCha20-Poly1305. Reads decrypt only on explicit request.
+
+Discipline:
+
+- The seed is **never** logged. ``__repr__`` on this class never shows seed
+  bytes. Errors talk about "decrypt failure" without exposing material.
+- The seed is **never** included in :meth:`FederationStateStore.stats` or
+  any diagnostics; that table contributes a row count only.
+- Export of the raw seed is gated behind
+  :meth:`export_signing_seed_explicit` which requires a positional
+  acknowledgement flag — defensive against accidental "give me the key"
+  flows from generic settings/debug APIs.
+
+This layer does **not** touch ``instance_keys.encrypted_secret`` — those
+per-device receive keys have their own lifecycle and rotate freely. The
+device key here is also reusable for that table if a caller wants to
+encrypt instance secrets the same way (recommended).
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from nacl.bindings import (
+    crypto_aead_xchacha20poly1305_ietf_decrypt,
+    crypto_aead_xchacha20poly1305_ietf_encrypt,
+    crypto_aead_xchacha20poly1305_ietf_NPUBBYTES,
+)
+
+from pinky_federation.errors import DecryptionError
+from pinky_federation.keys import ED25519_KEY_BYTES, SigningKeyPair
+from pinky_federation.state import FederationStateStore
+
+DEVICE_KEY_BYTES = 32
+DEFAULT_DEVICE_KEY_PATH = "data/federation/.device_key"
+
+# AAD prefix binds ciphertext to its purpose so a raw blob from one
+# table can't be replayed against another decrypt path.
+_TENANT_SIGNING_AAD_PREFIX = b"pinky-fed/v1/tenant-signing-seed"
+_KDF_VERSION = 1  # bumped if we change AAD layout / cipher choice
+
+
+def _xchacha_nonce() -> bytes:
+    """Return a fresh 24-byte XChaCha20-Poly1305 nonce."""
+    return secrets.token_bytes(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES)
+
+
+# -- Device key ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeviceKey:
+    """A device-local 32-byte symmetric secret.
+
+    This wrapper never serializes its bytes via ``repr``. The bytes are
+    accessible via :meth:`material_insecure` for the encryption layer.
+    """
+
+    _material: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self._material, bytes) or len(self._material) != DEVICE_KEY_BYTES:
+            raise ValueError(f"device key must be {DEVICE_KEY_BYTES} bytes")
+
+    def material_insecure(self) -> bytes:
+        """Raw 32-byte device key. Never log this value."""
+        return self._material
+
+    def __repr__(self) -> str:
+        # Show a 4-byte tag for log debugging; never the full key.
+        return f"DeviceKey(<{self._material[:4].hex()}…>)"
+
+    @classmethod
+    def load_or_create(cls, path: str = DEFAULT_DEVICE_KEY_PATH) -> DeviceKey:
+        """Load the device key from *path*, generating it on first use.
+
+        The file is created with mode ``0600`` (owner read/write only). On
+        existing files we sanity-check size and warn (via raised error) if
+        permissions are looser than ``0600`` — we do NOT silently tighten,
+        because that may mask a real security problem.
+        """
+        p = Path(path)
+        if p.exists():
+            data = p.read_bytes()
+            if len(data) != DEVICE_KEY_BYTES:
+                raise ValueError(
+                    f"device key at {path!r} is {len(data)} bytes, expected {DEVICE_KEY_BYTES}"
+                )
+            mode = stat.S_IMODE(p.stat().st_mode)
+            # Owner-only; reject if group/other can read or write.
+            if mode & 0o077:
+                raise PermissionError(
+                    f"device key {path!r} has loose permissions {oct(mode)}; expected 0o600"
+                )
+            return cls(data)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        material = secrets.token_bytes(DEVICE_KEY_BYTES)
+        # Write with restrictive permissions atomically.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        fd = os.open(str(p), flags, 0o600)
+        try:
+            os.write(fd, material)
+        finally:
+            os.close(fd)
+        return cls(material)
+
+
+# -- Encrypted tenant key store --------------------------------------------
+
+
+@dataclass(frozen=True)
+class _StoredSeed:
+    encrypted_seed: bytes
+    nonce: bytes
+    kdf_version: int
+
+
+class EncryptedTenantKeyStore:
+    """Persists tenant signing seeds encrypted with the device key."""
+
+    __slots__ = ("_state", "_device_key")
+
+    def __init__(self, state: FederationStateStore, device_key: DeviceKey) -> None:
+        if not isinstance(state, FederationStateStore):
+            raise TypeError("state must be a FederationStateStore")
+        if not isinstance(device_key, DeviceKey):
+            raise TypeError("device_key must be a DeviceKey")
+        self._state = state
+        self._device_key = device_key
+
+    # -- writes --------------------------------------------------------
+
+    def put_signing_key(self, tenant_id: str, signing_keypair: SigningKeyPair) -> None:
+        """Encrypt and persist the seed for *signing_keypair* under *tenant_id*.
+
+        Raises ``ValueError`` if the tenant row does not yet exist — the
+        caller must have inserted into :meth:`FederationStateStore.upsert_tenant`
+        first so foreign keys hold.
+        """
+        if not isinstance(tenant_id, str) or not tenant_id:
+            raise ValueError("tenant_id must be a non-empty string")
+        if not isinstance(signing_keypair, SigningKeyPair):
+            raise TypeError("signing_keypair must be a SigningKeyPair")
+        if self._state.get_tenant(tenant_id) is None:
+            raise ValueError(
+                f"tenant {tenant_id!r} not registered; insert into tenants first"
+            )
+        seed = signing_keypair.seed_bytes_insecure()
+        try:
+            stored = self._encrypt_seed(tenant_id, seed)
+            self._state._db.execute(  # noqa: SLF001 — intentional cross-module write
+                """
+                INSERT INTO tenant_signing_keys
+                    (tenant_id, encrypted_seed, nonce, kdf_version, created_at)
+                VALUES (?, ?, ?, ?, strftime('%s','now'))
+                ON CONFLICT(tenant_id) DO UPDATE SET
+                    encrypted_seed=excluded.encrypted_seed,
+                    nonce=excluded.nonce,
+                    kdf_version=excluded.kdf_version
+                """,
+                (tenant_id, stored.encrypted_seed, stored.nonce, stored.kdf_version),
+            )
+            self._state._db.commit()  # noqa: SLF001
+        finally:
+            # Best-effort wipe of the seed copy we just used. Python doesn't
+            # let us truly zero memory but we drop the binding immediately.
+            del seed
+
+    # -- reads ---------------------------------------------------------
+
+    def has_signing_key(self, tenant_id: str) -> bool:
+        row = self._state._db.execute(  # noqa: SLF001
+            "SELECT 1 FROM tenant_signing_keys WHERE tenant_id = ?", (tenant_id,)
+        ).fetchone()
+        return row is not None
+
+    def get_signing_key(self, tenant_id: str) -> SigningKeyPair:
+        """Decrypt and return the signing keypair for *tenant_id*.
+
+        Raises :class:`KeyError` if no key is stored, and
+        :class:`pinky_federation.errors.DecryptionError` if the on-disk
+        ciphertext is corrupt or was encrypted under a different device key.
+        """
+        stored = self._load_stored_seed(tenant_id)
+        seed = self._decrypt_seed(tenant_id, stored)
+        try:
+            return SigningKeyPair.from_seed(seed)
+        finally:
+            del seed
+
+    def export_signing_seed_explicit(
+        self,
+        tenant_id: str,
+        *,
+        operator_acknowledged: bool,
+        reason: str,
+    ) -> bytes:
+        """Return the raw 32-byte seed.
+
+        This is the only path that yields raw key material outside the
+        :class:`SigningKeyPair` wrapper. It is intentionally awkward:
+
+        - ``operator_acknowledged`` must be passed positionally as a
+          keyword arg (``True``).
+        - ``reason`` must be a non-empty string and is logged via the audit
+          channel by callers (this layer does not log).
+
+        Generic settings/debug APIs that just want "give me everything"
+        should never call this — they should call :meth:`get_signing_key`
+        and never expose seed bytes.
+        """
+        if operator_acknowledged is not True:
+            raise PermissionError(
+                "export_signing_seed_explicit requires operator_acknowledged=True"
+            )
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("export_signing_seed_explicit requires a non-empty reason")
+        stored = self._load_stored_seed(tenant_id)
+        return self._decrypt_seed(tenant_id, stored)
+
+    # -- crypto internals ---------------------------------------------
+
+    def _encrypt_seed(self, tenant_id: str, seed: bytes) -> _StoredSeed:
+        if not isinstance(seed, bytes) or len(seed) != ED25519_KEY_BYTES:
+            raise ValueError(f"signing seed must be {ED25519_KEY_BYTES} bytes")
+        nonce = _xchacha_nonce()
+        aad = self._aad_for(tenant_id)
+        ct = crypto_aead_xchacha20poly1305_ietf_encrypt(
+            seed, aad, nonce, self._device_key.material_insecure()
+        )
+        return _StoredSeed(encrypted_seed=ct, nonce=nonce, kdf_version=_KDF_VERSION)
+
+    def _decrypt_seed(self, tenant_id: str, stored: _StoredSeed) -> bytes:
+        if stored.kdf_version != _KDF_VERSION:
+            raise DecryptionError(
+                f"unsupported kdf_version {stored.kdf_version} (this build supports {_KDF_VERSION})"
+            )
+        aad = self._aad_for(tenant_id)
+        try:
+            pt = crypto_aead_xchacha20poly1305_ietf_decrypt(
+                stored.encrypted_seed, aad, stored.nonce, self._device_key.material_insecure()
+            )
+        except Exception as exc:  # noqa: BLE001 — normalize to our error type
+            raise DecryptionError(
+                f"failed to decrypt signing seed for tenant {tenant_id!r}"
+            ) from exc
+        if len(pt) != ED25519_KEY_BYTES:
+            raise DecryptionError(
+                f"decrypted seed has wrong length: {len(pt)} != {ED25519_KEY_BYTES}"
+            )
+        return pt
+
+    def _load_stored_seed(self, tenant_id: str) -> _StoredSeed:
+        row = self._state._db.execute(  # noqa: SLF001
+            "SELECT encrypted_seed, nonce, kdf_version FROM tenant_signing_keys "
+            "WHERE tenant_id = ?",
+            (tenant_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"no signing key stored for tenant {tenant_id!r}")
+        return _StoredSeed(
+            encrypted_seed=bytes(row["encrypted_seed"]),
+            nonce=bytes(row["nonce"]),
+            kdf_version=int(row["kdf_version"]),
+        )
+
+    @staticmethod
+    def _aad_for(tenant_id: str) -> bytes:
+        # Bind ciphertext to (purpose, tenant_id) so a row from one tenant
+        # cannot be replayed under a different tenant_id.
+        return _TENANT_SIGNING_AAD_PREFIX + b"|" + tenant_id.encode("utf-8")
+
+    # -- discipline ---------------------------------------------------
+
+    def __repr__(self) -> str:
+        return (
+            f"EncryptedTenantKeyStore(state={self._state!r}, device_key={self._device_key!r})"
+        )

--- a/src/pinky_federation/keys.py
+++ b/src/pinky_federation/keys.py
@@ -1,0 +1,186 @@
+"""Federation keypair types.
+
+We use:
+- **X25519** for encryption keypairs (Diffie-Hellman with ephemeral sender keys).
+- **Ed25519** for signing keypairs (tenant identity + per-message sender auth).
+
+All private key bytes stay inside their keypair objects. Raw-bytes accessors
+(`.private_bytes_insecure()`) are intentionally verbose so grep can flag callers.
+
+No key material is written to `repr()` or logs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nacl.bindings import (
+    crypto_scalarmult,
+    crypto_scalarmult_base,
+)
+from nacl.public import PrivateKey as _NaclX25519Private
+from nacl.signing import SigningKey as _NaclEd25519Signing
+from nacl.signing import VerifyKey as _NaclEd25519Verify
+
+from pinky_federation.errors import SignatureError
+
+X25519_KEY_BYTES = 32
+ED25519_KEY_BYTES = 32
+ED25519_SIG_BYTES = 64
+
+
+# -- Encryption (X25519) ------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EncryptionPublicKey:
+    """X25519 public key (32 bytes).
+
+    Safe to share, serialize, and log. Equality + hashing are on raw bytes.
+    """
+
+    raw: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.raw, bytes) or len(self.raw) != X25519_KEY_BYTES:
+            raise ValueError(f"X25519 public key must be {X25519_KEY_BYTES} bytes")
+
+    def to_bytes(self) -> bytes:
+        return self.raw
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> EncryptionPublicKey:
+        return cls(bytes(data))
+
+    def __repr__(self) -> str:
+        return f"EncryptionPublicKey(<{self.raw[:4].hex()}…>)"
+
+
+class EncryptionKeyPair:
+    """X25519 private + public pair.
+
+    The private half never appears in `repr()` and never round-trips through
+    serialization unless a caller explicitly asks via
+    :meth:`private_bytes_insecure`.
+    """
+
+    __slots__ = ("_sk",)
+
+    def __init__(self, sk: _NaclX25519Private) -> None:
+        self._sk = sk
+
+    @classmethod
+    def generate(cls) -> EncryptionKeyPair:
+        return cls(_NaclX25519Private.generate())
+
+    @classmethod
+    def from_private_bytes(cls, data: bytes) -> EncryptionKeyPair:
+        if not isinstance(data, (bytes, bytearray)) or len(data) != X25519_KEY_BYTES:
+            raise ValueError(f"X25519 private key must be {X25519_KEY_BYTES} bytes")
+        return cls(_NaclX25519Private(bytes(data)))
+
+    @property
+    def public_key(self) -> EncryptionPublicKey:
+        return EncryptionPublicKey(bytes(self._sk.public_key))
+
+    def private_bytes_insecure(self) -> bytes:
+        """Return raw 32-byte private scalar. Use only for at-rest persistence."""
+        return bytes(self._sk)
+
+    def dh(self, peer_public: EncryptionPublicKey) -> bytes:
+        """Compute X25519 ECDH shared secret with *peer_public*.
+
+        Returns the raw 32-byte shared point. Callers MUST feed this through
+        an HKDF step before using it as a symmetric key.
+        """
+        if not isinstance(peer_public, EncryptionPublicKey):
+            raise TypeError("peer_public must be EncryptionPublicKey")
+        return crypto_scalarmult(self.private_bytes_insecure(), peer_public.raw)
+
+    def __repr__(self) -> str:
+        return f"EncryptionKeyPair(public={self.public_key!r})"
+
+
+def x25519_public_from_private(sk_bytes: bytes) -> bytes:
+    """Derive X25519 public from a raw private scalar (32 bytes)."""
+    if len(sk_bytes) != X25519_KEY_BYTES:
+        raise ValueError(f"X25519 private must be {X25519_KEY_BYTES} bytes")
+    return crypto_scalarmult_base(sk_bytes)
+
+
+# -- Signing (Ed25519) --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SigningPublicKey:
+    """Ed25519 verify key (32 bytes)."""
+
+    raw: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.raw, bytes) or len(self.raw) != ED25519_KEY_BYTES:
+            raise ValueError(f"Ed25519 public key must be {ED25519_KEY_BYTES} bytes")
+
+    def to_bytes(self) -> bytes:
+        return self.raw
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> SigningPublicKey:
+        return cls(bytes(data))
+
+    def verify(self, message: bytes, signature: bytes) -> None:
+        """Raise :class:`SignatureError` if *signature* is not valid for *message*.
+
+        The underlying library raises its own exception type; we normalize so
+        higher layers only catch our own exception hierarchy.
+        """
+        if len(signature) != ED25519_SIG_BYTES:
+            raise SignatureError("signature must be 64 bytes")
+        try:
+            _NaclEd25519Verify(self.raw).verify(message, signature)
+        except Exception as exc:  # noqa: BLE001 — normalize third-party types
+            raise SignatureError("Ed25519 signature did not verify") from exc
+
+    def __repr__(self) -> str:
+        return f"SigningPublicKey(<{self.raw[:4].hex()}…>)"
+
+
+class SigningKeyPair:
+    """Ed25519 signing + verify pair (tenant identity key)."""
+
+    __slots__ = ("_sk",)
+
+    def __init__(self, sk: _NaclEd25519Signing) -> None:
+        self._sk = sk
+
+    @classmethod
+    def generate(cls) -> SigningKeyPair:
+        return cls(_NaclEd25519Signing.generate())
+
+    @classmethod
+    def from_seed(cls, seed: bytes) -> SigningKeyPair:
+        """Construct from a 32-byte seed.
+
+        Only use this for persistence/recovery — never derive a seed from a
+        low-entropy source.
+        """
+        if not isinstance(seed, (bytes, bytearray)) or len(seed) != ED25519_KEY_BYTES:
+            raise ValueError(f"Ed25519 seed must be {ED25519_KEY_BYTES} bytes")
+        return cls(_NaclEd25519Signing(bytes(seed)))
+
+    @property
+    def public_key(self) -> SigningPublicKey:
+        return SigningPublicKey(bytes(self._sk.verify_key))
+
+    def seed_bytes_insecure(self) -> bytes:
+        """Return the raw 32-byte Ed25519 seed. Use only for at-rest persistence."""
+        return bytes(self._sk)
+
+    def sign(self, message: bytes) -> bytes:
+        """Sign *message* with Ed25519. Returns raw 64-byte signature."""
+        if not isinstance(message, (bytes, bytearray)):
+            raise TypeError("message must be bytes")
+        return bytes(self._sk.sign(bytes(message)).signature)
+
+    def __repr__(self) -> str:
+        return f"SigningKeyPair(public={self.public_key!r})"

--- a/src/pinky_federation/sealed_box.py
+++ b/src/pinky_federation/sealed_box.py
@@ -1,0 +1,257 @@
+"""``sealed_box_v1`` — authenticated per-message envelope crypto.
+
+Protocol (v1):
+
+1. Sender generates an ephemeral X25519 keypair ``(eph_sk, eph_pk)``.
+2. Computes ``shared = X25519(eph_sk, recipient_enc_pk)``.
+3. Derives ``key = HKDF-SHA256(shared, salt=eph_pk||recipient_enc_pk, info="…/key")``.
+4. Picks a fresh 24-byte random nonce.
+5. Encrypts plaintext with XChaCha20-Poly1305 under (key, nonce), with AAD
+   covering protocol domain, version, both fingerprints, and ``eph_pk``.
+6. Signs a canonical "to-be-signed" byte string with the sender's Ed25519 key.
+   The signed bytes include the ciphertext, so tamper detection is
+   end-to-end even if the AEAD tag alone were somehow stripped.
+
+Properties:
+
+- **Forward secrecy** (for a given message) — the ephemeral private key is
+  discarded after use, so compromise of a long-term encryption key does not
+  retroactively decrypt past messages.
+- **Sender authenticity** — the Ed25519 signature binds a specific sender
+  identity to the envelope; the recipient's trust store resolves
+  ``sender_fingerprint`` → signing public key.
+- **Replay/cross-recipient resistance** — the AAD and signed bytes include
+  the recipient fingerprint, so an envelope can't be rebound to a different
+  recipient without invalidating the MAC and the signature.
+
+No state is kept in this module. Higher layers handle persistence and
+ratcheting (planned for v2).
+"""
+
+from __future__ import annotations
+
+import os
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from nacl.bindings import (
+    crypto_aead_xchacha20poly1305_ietf_decrypt,
+    crypto_aead_xchacha20poly1305_ietf_encrypt,
+    crypto_aead_xchacha20poly1305_ietf_KEYBYTES,
+    crypto_aead_xchacha20poly1305_ietf_NPUBBYTES,
+)
+
+from pinky_federation.envelope import (
+    Envelope,
+    EnvelopeVersion,
+)
+from pinky_federation.errors import (
+    DecryptionError,
+)
+from pinky_federation.fingerprint import (
+    FINGERPRINT_BYTES,
+)
+from pinky_federation.keys import (
+    EncryptionKeyPair,
+    EncryptionPublicKey,
+    SigningKeyPair,
+    SigningPublicKey,
+)
+
+#: Current sealed-box protocol version. Bumped only on breaking wire changes.
+SEALED_BOX_VERSION = EnvelopeVersion.V1
+
+_KEY_BYTES = crypto_aead_xchacha20poly1305_ietf_KEYBYTES  # 32
+_NONCE_BYTES = crypto_aead_xchacha20poly1305_ietf_NPUBBYTES  # 24
+
+_HKDF_INFO = b"pinky-federation/sealed_box_v1/key"
+_AAD_DOMAIN = b"pinky-federation/sealed_box_v1/aad"
+_SIG_DOMAIN = b"pinky-federation/sealed_box_v1/sig"
+
+
+def _derive_key(shared: bytes, eph_pk: bytes, recipient_enc_pk: bytes) -> bytes:
+    return HKDF(
+        algorithm=hashes.SHA256(),
+        length=_KEY_BYTES,
+        salt=eph_pk + recipient_enc_pk,
+        info=_HKDF_INFO,
+    ).derive(shared)
+
+
+def _build_aad(
+    version: int,
+    sender_fp: bytes,
+    recipient_fp: bytes,
+    eph_pk: bytes,
+) -> bytes:
+    if len(sender_fp) != FINGERPRINT_BYTES or len(recipient_fp) != FINGERPRINT_BYTES:
+        raise ValueError("fingerprints must be FINGERPRINT_BYTES bytes")
+    if len(eph_pk) != 32:
+        raise ValueError("eph_pk must be 32 bytes")
+    return b"".join(
+        [
+            _AAD_DOMAIN,
+            bytes([version]),
+            sender_fp,
+            recipient_fp,
+            eph_pk,
+        ]
+    )
+
+
+def _build_sig_tbs(
+    version: int,
+    sender_fp: bytes,
+    recipient_fp: bytes,
+    eph_pk: bytes,
+    nonce: bytes,
+    ciphertext: bytes,
+) -> bytes:
+    return b"".join(
+        [
+            _SIG_DOMAIN,
+            bytes([version]),
+            sender_fp,
+            recipient_fp,
+            eph_pk,
+            nonce,
+            len(ciphertext).to_bytes(4, "big"),
+            ciphertext,
+        ]
+    )
+
+
+def seal(
+    plaintext: bytes,
+    *,
+    sender_signing: SigningKeyPair,
+    sender_fingerprint: bytes,
+    recipient_encryption: EncryptionPublicKey,
+    recipient_fingerprint: bytes,
+    nonce: bytes | None = None,
+    ephemeral: EncryptionKeyPair | None = None,
+) -> Envelope:
+    """Encrypt + sign *plaintext* into a v1 envelope addressed to the recipient.
+
+    Arguments:
+        plaintext: Bytes to seal. May be empty.
+        sender_signing: Sender's long-term Ed25519 signing keypair.
+        sender_fingerprint: Sender identity fingerprint to embed in the envelope.
+        recipient_encryption: Recipient's long-term X25519 public key.
+        recipient_fingerprint: Recipient identity fingerprint.
+        nonce: Optional 24-byte override. ``None`` means generate fresh randomness.
+            **Only supply this for deterministic test vectors** — reusing a
+            nonce with the same key is catastrophic.
+        ephemeral: Optional ephemeral X25519 keypair override (same caveat).
+
+    The returned envelope is safe to serialize via ``envelope.to_bytes()``.
+    """
+    if not isinstance(plaintext, (bytes, bytearray)):
+        raise TypeError("plaintext must be bytes")
+    if not isinstance(sender_fingerprint, (bytes, bytearray)) or len(sender_fingerprint) != FINGERPRINT_BYTES:
+        raise ValueError(f"sender_fingerprint must be {FINGERPRINT_BYTES} bytes")
+    if not isinstance(recipient_fingerprint, (bytes, bytearray)) or len(recipient_fingerprint) != FINGERPRINT_BYTES:
+        raise ValueError(f"recipient_fingerprint must be {FINGERPRINT_BYTES} bytes")
+
+    eph = ephemeral if ephemeral is not None else EncryptionKeyPair.generate()
+    eph_pk = eph.public_key.to_bytes()
+
+    shared = eph.dh(recipient_encryption)
+    key = _derive_key(shared, eph_pk, recipient_encryption.to_bytes())
+
+    if nonce is None:
+        nonce_bytes = os.urandom(_NONCE_BYTES)
+    else:
+        if len(nonce) != _NONCE_BYTES:
+            raise ValueError(f"nonce must be {_NONCE_BYTES} bytes")
+        nonce_bytes = bytes(nonce)
+
+    aad = _build_aad(
+        SEALED_BOX_VERSION.value,
+        bytes(sender_fingerprint),
+        bytes(recipient_fingerprint),
+        eph_pk,
+    )
+    ciphertext = crypto_aead_xchacha20poly1305_ietf_encrypt(
+        bytes(plaintext), aad, nonce_bytes, key
+    )
+
+    sig_tbs = _build_sig_tbs(
+        SEALED_BOX_VERSION.value,
+        bytes(sender_fingerprint),
+        bytes(recipient_fingerprint),
+        eph_pk,
+        nonce_bytes,
+        ciphertext,
+    )
+    signature = sender_signing.sign(sig_tbs)
+
+    return Envelope(
+        version=SEALED_BOX_VERSION,
+        sender_fingerprint=bytes(sender_fingerprint),
+        recipient_fingerprint=bytes(recipient_fingerprint),
+        ephemeral_public=eph_pk,
+        nonce=nonce_bytes,
+        signature=signature,
+        ciphertext=ciphertext,
+    )
+
+
+def unseal(
+    envelope: Envelope,
+    *,
+    recipient_encryption: EncryptionKeyPair,
+    sender_signing_public: SigningPublicKey,
+) -> bytes:
+    """Verify + decrypt *envelope* using the recipient's private key.
+
+    ``sender_signing_public`` must be resolved by the caller from their local
+    trust store keyed on ``envelope.sender_fingerprint``. This function does
+    not talk to storage.
+
+    Raises:
+        SignatureError: Sender signature failed verification.
+        DecryptionError: AEAD tag did not match (tamper / wrong key / wrong version).
+    """
+    if envelope.version is not SEALED_BOX_VERSION:
+        raise DecryptionError(f"unsupported envelope version: {envelope.version}")
+
+    sig_tbs = _build_sig_tbs(
+        envelope.version.value,
+        envelope.sender_fingerprint,
+        envelope.recipient_fingerprint,
+        envelope.ephemeral_public,
+        envelope.nonce,
+        envelope.ciphertext,
+    )
+    # Raises SignatureError on failure (normalized inside SigningPublicKey).
+    sender_signing_public.verify(sig_tbs, envelope.signature)
+
+    shared = recipient_encryption.dh(EncryptionPublicKey(envelope.ephemeral_public))
+    key = _derive_key(
+        shared,
+        envelope.ephemeral_public,
+        recipient_encryption.public_key.to_bytes(),
+    )
+
+    aad = _build_aad(
+        envelope.version.value,
+        envelope.sender_fingerprint,
+        envelope.recipient_fingerprint,
+        envelope.ephemeral_public,
+    )
+    try:
+        plaintext = crypto_aead_xchacha20poly1305_ietf_decrypt(
+            envelope.ciphertext, aad, envelope.nonce, key
+        )
+    except Exception as exc:  # noqa: BLE001 — libsodium raises CryptoError
+        raise DecryptionError("AEAD decryption failed") from exc
+    return plaintext
+
+
+# Re-export for unit-test access. Not part of the public API.
+__test__ = {
+    "_derive_key": _derive_key,
+    "_build_aad": _build_aad,
+    "_build_sig_tbs": _build_sig_tbs,
+}

--- a/src/pinky_federation/state.py
+++ b/src/pinky_federation/state.py
@@ -1,0 +1,874 @@
+"""Federation state store — SQLite-backed local persistence.
+
+Owns the on-disk layout under ``data/federation/`` for the federation v0.2
+implementation. This module is the root storage dependency for TOFU peer
+pinning (P-03), transport (P-04), invite redemption (P-05), and attachment
+metadata (P-06).
+
+Tables:
+
+- ``tenants`` — tenant membership context (which tenants this instance belongs
+  to, role within each, public signing key for verification).
+- ``instance_keys`` — per-device receive keys (X25519 encryption + Ed25519
+  device signing) with lifecycle states ``active`` / ``decrypt_only`` /
+  ``retired``. Multiple keys may coexist during rotation; ``decrypt_only`` keys
+  cannot encrypt new outbound traffic but still decrypt inbound for in-flight
+  messages.
+- ``peer_pins`` — TOFU pin store keyed by canonical peer address. Stores both
+  long-term keys plus the 128-bit fingerprint for display/comparison.
+- ``outbox`` — pending outbound envelopes waiting for relay delivery.
+- ``inbox`` — received plaintext messages awaiting consumption by higher
+  layers (e.g. the messaging UI).
+- ``issued_invites`` — invite cache (token hash only — raw token never
+  persisted).
+- ``attachments`` — attachment metadata pointing at on-disk encrypted blobs.
+
+This module owns *only* the structure and CRUD. Encryption of tenant
+signing seeds is the job of ``key_store.py`` (which writes into the
+``tenant_signing_keys`` table that this module also creates).
+
+Nothing in this module talks to the network; nothing logs key material;
+nothing returns plaintext private keys. The signing-seed table is created
+here for schema cohesion, but its contents are opaque BLOBs from this
+layer's perspective — only ``key_store.EncryptedTenantKeyStore`` ever
+encrypts/decrypts them.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_DB_PATH = "data/federation/state.db"
+
+# Instance-key lifecycle states.
+INSTANCE_KEY_ACTIVE = "active"
+INSTANCE_KEY_DECRYPT_ONLY = "decrypt_only"
+INSTANCE_KEY_RETIRED = "retired"
+_VALID_INSTANCE_KEY_STATES = frozenset(
+    {INSTANCE_KEY_ACTIVE, INSTANCE_KEY_DECRYPT_ONLY, INSTANCE_KEY_RETIRED}
+)
+
+# Instance-key kinds.
+INSTANCE_KEY_KIND_ENCRYPTION = "encryption"  # X25519
+INSTANCE_KEY_KIND_SIGNING = "signing"  # Ed25519 (per-device, not tenant)
+_VALID_INSTANCE_KEY_KINDS = frozenset(
+    {INSTANCE_KEY_KIND_ENCRYPTION, INSTANCE_KEY_KIND_SIGNING}
+)
+
+# Peer-pin status values.
+PEER_PIN_PINNED = "pinned"
+PEER_PIN_ROTATED = "rotated"
+PEER_PIN_REJECTED = "rejected"
+_VALID_PEER_PIN_STATUSES = frozenset({PEER_PIN_PINNED, PEER_PIN_ROTATED, PEER_PIN_REJECTED})
+
+# Outbox status values.
+OUTBOX_PENDING = "pending"
+OUTBOX_SENT = "sent"
+OUTBOX_FAILED = "failed"
+_VALID_OUTBOX_STATUSES = frozenset({OUTBOX_PENDING, OUTBOX_SENT, OUTBOX_FAILED})
+
+# Inbox status values.
+INBOX_NEW = "new"
+INBOX_READ = "read"
+INBOX_ARCHIVED = "archived"
+_VALID_INBOX_STATUSES = frozenset({INBOX_NEW, INBOX_READ, INBOX_ARCHIVED})
+
+# Invite status values.
+INVITE_ACTIVE = "active"
+INVITE_REDEEMED = "redeemed"
+INVITE_EXPIRED = "expired"
+INVITE_REVOKED = "revoked"
+_VALID_INVITE_STATUSES = frozenset(
+    {INVITE_ACTIVE, INVITE_REDEEMED, INVITE_EXPIRED, INVITE_REVOKED}
+)
+
+# Tenant role values.
+ROLE_OWNER = "owner"
+ROLE_MEMBER = "member"
+_VALID_ROLES = frozenset({ROLE_OWNER, ROLE_MEMBER})
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def _now() -> float:
+    return time.time()
+
+
+# -- Records ---------------------------------------------------------------
+
+
+@dataclass
+class TenantRecord:
+    """Membership in a tenant. ``signing_pk`` is the *tenant* identity public
+    key (Ed25519 raw 32 bytes); ``role`` is this instance's role in the
+    tenant (``owner`` for the issuer, ``member`` otherwise)."""
+
+    tenant_id: str = ""
+    address: str = ""
+    signing_pk: bytes = b""
+    role: str = ROLE_MEMBER
+    created_at: float = 0.0
+
+
+@dataclass
+class InstanceKeyRecord:
+    """A single per-device key with lifecycle state."""
+
+    kid: str = ""  # short stable id, e.g. first 16 hex of fingerprint
+    tenant_id: str = ""
+    kind: str = INSTANCE_KEY_KIND_ENCRYPTION
+    public_key: bytes = b""
+    encrypted_secret: bytes = b""  # opaque to this layer; key_store decrypts
+    state: str = INSTANCE_KEY_ACTIVE
+    created_at: float = 0.0
+    retired_at: float = 0.0
+
+
+@dataclass
+class PeerPinRecord:
+    """TOFU pin for a remote peer."""
+
+    peer_address: str = ""
+    sig_pk: bytes = b""
+    enc_pk: bytes = b""
+    fingerprint: bytes = b""
+    status: str = PEER_PIN_PINNED
+    first_seen: float = 0.0
+    last_seen: float = 0.0
+
+
+@dataclass
+class OutboxRecord:
+    """A queued outbound envelope."""
+
+    msg_id: str = ""
+    tenant_id: str = ""
+    recipient_address: str = ""
+    envelope_blob: bytes = b""
+    status: str = OUTBOX_PENDING
+    attempts: int = 0
+    last_error: str = ""
+    created_at: float = 0.0
+    next_retry_at: float = 0.0
+
+
+@dataclass
+class InboxRecord:
+    """A received decrypted message."""
+
+    msg_id: str = ""
+    tenant_id: str = ""
+    sender_address: str = ""
+    plaintext_blob: bytes = b""
+    status: str = INBOX_NEW
+    received_at: float = 0.0
+
+
+@dataclass
+class InviteRecord:
+    """An invite issued by this instance. We only store the *hash* of the
+    redemption token; the raw token is given out once and never persisted."""
+
+    invite_id: str = ""
+    tenant_id: str = ""
+    recipient_hint: str = ""
+    token_hash: bytes = b""
+    expires_at: float = 0.0
+    status: str = INVITE_ACTIVE
+    created_at: float = 0.0
+
+
+@dataclass
+class AttachmentRecord:
+    """Metadata pointer for an attachment blob."""
+
+    attachment_id: str = ""
+    msg_id: str = ""
+    sha256: bytes = b""
+    size: int = 0
+    mime: str = ""
+    local_path: str = ""
+    encrypted: bool = True
+    created_at: float = 0.0
+
+
+# -- Store -----------------------------------------------------------------
+
+
+class FederationStateStore:
+    """SQLite-backed federation state.
+
+    All methods are safe to call from multiple threads — the connection
+    is opened with ``check_same_thread=False`` and we serialize writes via
+    SQLite's own locking. Reads use the same connection; if write contention
+    becomes an issue we can split read/write later.
+    """
+
+    def __init__(self, db_path: str = DEFAULT_DB_PATH) -> None:
+        self.db_path = db_path
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA foreign_keys=ON")
+        self._db.row_factory = sqlite3.Row
+        self._create_schema()
+        self._ensure_columns()
+
+    # -- schema ------------------------------------------------------------
+
+    def _create_schema(self) -> None:
+        c = self._db
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tenants (
+                tenant_id TEXT PRIMARY KEY,
+                address TEXT NOT NULL,
+                signing_pk BLOB NOT NULL,
+                role TEXT NOT NULL DEFAULT 'member',
+                created_at REAL NOT NULL
+            )
+            """
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tenant_signing_keys (
+                tenant_id TEXT PRIMARY KEY,
+                encrypted_seed BLOB NOT NULL,
+                nonce BLOB NOT NULL,
+                kdf_version INTEGER NOT NULL DEFAULT 1,
+                created_at REAL NOT NULL,
+                FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE CASCADE
+            )
+            """
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS instance_keys (
+                kid TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                public_key BLOB NOT NULL,
+                encrypted_secret BLOB NOT NULL,
+                state TEXT NOT NULL DEFAULT 'active',
+                created_at REAL NOT NULL,
+                retired_at REAL NOT NULL DEFAULT 0,
+                FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE CASCADE
+            )
+            """
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_instance_keys_tenant_state "
+            "ON instance_keys(tenant_id, state)"
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS peer_pins (
+                peer_address TEXT PRIMARY KEY,
+                sig_pk BLOB NOT NULL,
+                enc_pk BLOB NOT NULL,
+                fingerprint BLOB NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pinned',
+                first_seen REAL NOT NULL,
+                last_seen REAL NOT NULL
+            )
+            """
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS outbox (
+                msg_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                recipient_address TEXT NOT NULL,
+                envelope_blob BLOB NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                attempts INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT NOT NULL DEFAULT '',
+                created_at REAL NOT NULL,
+                next_retry_at REAL NOT NULL DEFAULT 0
+            )
+            """
+        )
+        c.execute("CREATE INDEX IF NOT EXISTS idx_outbox_status ON outbox(status, next_retry_at)")
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS inbox (
+                msg_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                sender_address TEXT NOT NULL,
+                plaintext_blob BLOB NOT NULL,
+                status TEXT NOT NULL DEFAULT 'new',
+                received_at REAL NOT NULL
+            )
+            """
+        )
+        c.execute("CREATE INDEX IF NOT EXISTS idx_inbox_tenant_status ON inbox(tenant_id, status)")
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS issued_invites (
+                invite_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                recipient_hint TEXT NOT NULL DEFAULT '',
+                token_hash BLOB NOT NULL,
+                expires_at REAL NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                created_at REAL NOT NULL,
+                FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE CASCADE
+            )
+            """
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_invites_tenant_status "
+            "ON issued_invites(tenant_id, status)"
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS attachments (
+                attachment_id TEXT PRIMARY KEY,
+                msg_id TEXT NOT NULL,
+                sha256 BLOB NOT NULL,
+                size INTEGER NOT NULL,
+                mime TEXT NOT NULL DEFAULT '',
+                local_path TEXT NOT NULL,
+                encrypted INTEGER NOT NULL DEFAULT 1,
+                created_at REAL NOT NULL
+            )
+            """
+        )
+        c.execute("CREATE INDEX IF NOT EXISTS idx_attachments_msg ON attachments(msg_id)")
+        c.commit()
+
+    def _ensure_columns(self) -> None:
+        """Forward-compatible column additions following the project pattern."""
+        # No migrations yet — this is the initial schema. Future additions:
+        #   migrations: list[tuple[str, str, list[tuple[str, str]]]] = [
+        #       ("table", "column", "TYPE DEFAULT ..."),
+        #   ]
+        pass
+
+    # -- tenants -----------------------------------------------------------
+
+    def upsert_tenant(self, rec: TenantRecord) -> TenantRecord:
+        if rec.role not in _VALID_ROLES:
+            raise ValueError(f"invalid role: {rec.role!r}")
+        if not rec.tenant_id or not rec.address:
+            raise ValueError("tenant_id and address are required")
+        if not isinstance(rec.signing_pk, bytes) or len(rec.signing_pk) != 32:
+            raise ValueError("signing_pk must be 32 bytes")
+        if not rec.created_at:
+            rec.created_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO tenants (tenant_id, address, signing_pk, role, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(tenant_id) DO UPDATE SET
+                address=excluded.address,
+                signing_pk=excluded.signing_pk,
+                role=excluded.role
+            """,
+            (rec.tenant_id, rec.address, rec.signing_pk, rec.role, rec.created_at),
+        )
+        self._db.commit()
+        return rec
+
+    def get_tenant(self, tenant_id: str) -> Optional[TenantRecord]:
+        row = self._db.execute(
+            "SELECT * FROM tenants WHERE tenant_id = ?", (tenant_id,)
+        ).fetchone()
+        if not row:
+            return None
+        return TenantRecord(
+            tenant_id=row["tenant_id"],
+            address=row["address"],
+            signing_pk=bytes(row["signing_pk"]),
+            role=row["role"],
+            created_at=row["created_at"],
+        )
+
+    def list_tenants(self) -> list[TenantRecord]:
+        rows = self._db.execute("SELECT * FROM tenants ORDER BY created_at").fetchall()
+        return [
+            TenantRecord(
+                tenant_id=r["tenant_id"],
+                address=r["address"],
+                signing_pk=bytes(r["signing_pk"]),
+                role=r["role"],
+                created_at=r["created_at"],
+            )
+            for r in rows
+        ]
+
+    # -- instance keys -----------------------------------------------------
+
+    def add_instance_key(self, rec: InstanceKeyRecord) -> InstanceKeyRecord:
+        if rec.kind not in _VALID_INSTANCE_KEY_KINDS:
+            raise ValueError(f"invalid kind: {rec.kind!r}")
+        if rec.state not in _VALID_INSTANCE_KEY_STATES:
+            raise ValueError(f"invalid state: {rec.state!r}")
+        if not rec.kid or not rec.tenant_id:
+            raise ValueError("kid and tenant_id are required")
+        if not rec.created_at:
+            rec.created_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO instance_keys
+                (kid, tenant_id, kind, public_key, encrypted_secret, state,
+                 created_at, retired_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                rec.kid,
+                rec.tenant_id,
+                rec.kind,
+                rec.public_key,
+                rec.encrypted_secret,
+                rec.state,
+                rec.created_at,
+                rec.retired_at,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def get_instance_key(self, kid: str) -> Optional[InstanceKeyRecord]:
+        row = self._db.execute(
+            "SELECT * FROM instance_keys WHERE kid = ?", (kid,)
+        ).fetchone()
+        if not row:
+            return None
+        return self._row_to_instance_key(row)
+
+    def list_instance_keys(
+        self,
+        tenant_id: Optional[str] = None,
+        state: Optional[str] = None,
+        kind: Optional[str] = None,
+    ) -> list[InstanceKeyRecord]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("tenant_id = ?")
+            params.append(tenant_id)
+        if state is not None:
+            if state not in _VALID_INSTANCE_KEY_STATES:
+                raise ValueError(f"invalid state filter: {state!r}")
+            clauses.append("state = ?")
+            params.append(state)
+        if kind is not None:
+            if kind not in _VALID_INSTANCE_KEY_KINDS:
+                raise ValueError(f"invalid kind filter: {kind!r}")
+            clauses.append("kind = ?")
+            params.append(kind)
+        sql = "SELECT * FROM instance_keys"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY created_at"
+        rows = self._db.execute(sql, params).fetchall()
+        return [self._row_to_instance_key(r) for r in rows]
+
+    def transition_instance_key(self, kid: str, new_state: str) -> None:
+        """Move an instance key between lifecycle states.
+
+        Allowed transitions:
+            active        -> decrypt_only, retired
+            decrypt_only  -> retired
+            retired       -> (terminal)
+        """
+        if new_state not in _VALID_INSTANCE_KEY_STATES:
+            raise ValueError(f"invalid state: {new_state!r}")
+        current = self.get_instance_key(kid)
+        if current is None:
+            raise KeyError(f"unknown instance key: {kid!r}")
+        if current.state == new_state:
+            return
+        allowed = {
+            INSTANCE_KEY_ACTIVE: {INSTANCE_KEY_DECRYPT_ONLY, INSTANCE_KEY_RETIRED},
+            INSTANCE_KEY_DECRYPT_ONLY: {INSTANCE_KEY_RETIRED},
+            INSTANCE_KEY_RETIRED: set(),
+        }
+        if new_state not in allowed[current.state]:
+            raise ValueError(
+                f"illegal transition {current.state!r} -> {new_state!r} for kid={kid!r}"
+            )
+        retired_at = _now() if new_state == INSTANCE_KEY_RETIRED else current.retired_at
+        self._db.execute(
+            "UPDATE instance_keys SET state = ?, retired_at = ? WHERE kid = ?",
+            (new_state, retired_at, kid),
+        )
+        self._db.commit()
+
+    @staticmethod
+    def _row_to_instance_key(row: sqlite3.Row) -> InstanceKeyRecord:
+        return InstanceKeyRecord(
+            kid=row["kid"],
+            tenant_id=row["tenant_id"],
+            kind=row["kind"],
+            public_key=bytes(row["public_key"]),
+            encrypted_secret=bytes(row["encrypted_secret"]),
+            state=row["state"],
+            created_at=row["created_at"],
+            retired_at=row["retired_at"],
+        )
+
+    # -- peer pins ---------------------------------------------------------
+
+    def upsert_peer_pin(self, rec: PeerPinRecord) -> PeerPinRecord:
+        if rec.status not in _VALID_PEER_PIN_STATUSES:
+            raise ValueError(f"invalid pin status: {rec.status!r}")
+        if not rec.peer_address:
+            raise ValueError("peer_address is required")
+        if len(rec.sig_pk) != 32 or len(rec.enc_pk) != 32:
+            raise ValueError("sig_pk and enc_pk must be 32 bytes each")
+        if len(rec.fingerprint) != 16:
+            raise ValueError("fingerprint must be 16 bytes")
+        now = _now()
+        if not rec.first_seen:
+            rec.first_seen = now
+        rec.last_seen = now
+        self._db.execute(
+            """
+            INSERT INTO peer_pins
+                (peer_address, sig_pk, enc_pk, fingerprint, status, first_seen, last_seen)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(peer_address) DO UPDATE SET
+                sig_pk=excluded.sig_pk,
+                enc_pk=excluded.enc_pk,
+                fingerprint=excluded.fingerprint,
+                status=excluded.status,
+                last_seen=excluded.last_seen
+            """,
+            (
+                rec.peer_address,
+                rec.sig_pk,
+                rec.enc_pk,
+                rec.fingerprint,
+                rec.status,
+                rec.first_seen,
+                rec.last_seen,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def get_peer_pin(self, peer_address: str) -> Optional[PeerPinRecord]:
+        row = self._db.execute(
+            "SELECT * FROM peer_pins WHERE peer_address = ?", (peer_address,)
+        ).fetchone()
+        if not row:
+            return None
+        return PeerPinRecord(
+            peer_address=row["peer_address"],
+            sig_pk=bytes(row["sig_pk"]),
+            enc_pk=bytes(row["enc_pk"]),
+            fingerprint=bytes(row["fingerprint"]),
+            status=row["status"],
+            first_seen=row["first_seen"],
+            last_seen=row["last_seen"],
+        )
+
+    # -- outbox / inbox ----------------------------------------------------
+
+    def enqueue_outbound(self, rec: OutboxRecord) -> OutboxRecord:
+        if rec.status not in _VALID_OUTBOX_STATUSES:
+            raise ValueError(f"invalid outbox status: {rec.status!r}")
+        if not rec.msg_id or not rec.tenant_id or not rec.recipient_address:
+            raise ValueError("msg_id, tenant_id, recipient_address are required")
+        if not rec.created_at:
+            rec.created_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO outbox
+                (msg_id, tenant_id, recipient_address, envelope_blob, status,
+                 attempts, last_error, created_at, next_retry_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                rec.msg_id,
+                rec.tenant_id,
+                rec.recipient_address,
+                rec.envelope_blob,
+                rec.status,
+                rec.attempts,
+                rec.last_error,
+                rec.created_at,
+                rec.next_retry_at,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def mark_outbound_status(
+        self,
+        msg_id: str,
+        status: str,
+        last_error: str = "",
+        next_retry_at: float = 0.0,
+    ) -> None:
+        if status not in _VALID_OUTBOX_STATUSES:
+            raise ValueError(f"invalid outbox status: {status!r}")
+        cur = self._db.execute(
+            """
+            UPDATE outbox
+               SET status = ?,
+                   attempts = attempts + 1,
+                   last_error = ?,
+                   next_retry_at = ?
+             WHERE msg_id = ?
+            """,
+            (status, last_error, next_retry_at, msg_id),
+        )
+        self._db.commit()
+        if cur.rowcount == 0:
+            raise KeyError(f"unknown outbound msg_id: {msg_id!r}")
+
+    def list_outbound(
+        self, status: Optional[str] = None, limit: int = 100
+    ) -> list[OutboxRecord]:
+        if status is not None and status not in _VALID_OUTBOX_STATUSES:
+            raise ValueError(f"invalid status filter: {status!r}")
+        if status is None:
+            rows = self._db.execute(
+                "SELECT * FROM outbox ORDER BY created_at LIMIT ?", (limit,)
+            ).fetchall()
+        else:
+            rows = self._db.execute(
+                "SELECT * FROM outbox WHERE status = ? ORDER BY created_at LIMIT ?",
+                (status, limit),
+            ).fetchall()
+        return [
+            OutboxRecord(
+                msg_id=r["msg_id"],
+                tenant_id=r["tenant_id"],
+                recipient_address=r["recipient_address"],
+                envelope_blob=bytes(r["envelope_blob"]),
+                status=r["status"],
+                attempts=r["attempts"],
+                last_error=r["last_error"],
+                created_at=r["created_at"],
+                next_retry_at=r["next_retry_at"],
+            )
+            for r in rows
+        ]
+
+    def store_inbound(self, rec: InboxRecord) -> InboxRecord:
+        if rec.status not in _VALID_INBOX_STATUSES:
+            raise ValueError(f"invalid inbox status: {rec.status!r}")
+        if not rec.msg_id or not rec.tenant_id or not rec.sender_address:
+            raise ValueError("msg_id, tenant_id, sender_address are required")
+        if not rec.received_at:
+            rec.received_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO inbox
+                (msg_id, tenant_id, sender_address, plaintext_blob, status, received_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                rec.msg_id,
+                rec.tenant_id,
+                rec.sender_address,
+                rec.plaintext_blob,
+                rec.status,
+                rec.received_at,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def mark_inbound_status(self, msg_id: str, status: str) -> None:
+        if status not in _VALID_INBOX_STATUSES:
+            raise ValueError(f"invalid inbox status: {status!r}")
+        cur = self._db.execute(
+            "UPDATE inbox SET status = ? WHERE msg_id = ?", (status, msg_id)
+        )
+        self._db.commit()
+        if cur.rowcount == 0:
+            raise KeyError(f"unknown inbound msg_id: {msg_id!r}")
+
+    def list_inbound(
+        self,
+        tenant_id: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 100,
+    ) -> list[InboxRecord]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("tenant_id = ?")
+            params.append(tenant_id)
+        if status is not None:
+            if status not in _VALID_INBOX_STATUSES:
+                raise ValueError(f"invalid status filter: {status!r}")
+            clauses.append("status = ?")
+            params.append(status)
+        sql = "SELECT * FROM inbox"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY received_at DESC LIMIT ?"
+        params.append(limit)
+        rows = self._db.execute(sql, params).fetchall()
+        return [
+            InboxRecord(
+                msg_id=r["msg_id"],
+                tenant_id=r["tenant_id"],
+                sender_address=r["sender_address"],
+                plaintext_blob=bytes(r["plaintext_blob"]),
+                status=r["status"],
+                received_at=r["received_at"],
+            )
+            for r in rows
+        ]
+
+    # -- invites -----------------------------------------------------------
+
+    def add_invite(self, rec: InviteRecord) -> InviteRecord:
+        if rec.status not in _VALID_INVITE_STATUSES:
+            raise ValueError(f"invalid invite status: {rec.status!r}")
+        if not rec.invite_id or not rec.tenant_id:
+            raise ValueError("invite_id and tenant_id are required")
+        if not isinstance(rec.token_hash, bytes) or len(rec.token_hash) != 32:
+            raise ValueError("token_hash must be 32 bytes (SHA-256 of token)")
+        if not rec.created_at:
+            rec.created_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO issued_invites
+                (invite_id, tenant_id, recipient_hint, token_hash,
+                 expires_at, status, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                rec.invite_id,
+                rec.tenant_id,
+                rec.recipient_hint,
+                rec.token_hash,
+                rec.expires_at,
+                rec.status,
+                rec.created_at,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def mark_invite_status(self, invite_id: str, status: str) -> None:
+        if status not in _VALID_INVITE_STATUSES:
+            raise ValueError(f"invalid invite status: {status!r}")
+        cur = self._db.execute(
+            "UPDATE issued_invites SET status = ? WHERE invite_id = ?",
+            (status, invite_id),
+        )
+        self._db.commit()
+        if cur.rowcount == 0:
+            raise KeyError(f"unknown invite_id: {invite_id!r}")
+
+    def list_invites(
+        self, tenant_id: Optional[str] = None, status: Optional[str] = None
+    ) -> list[InviteRecord]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("tenant_id = ?")
+            params.append(tenant_id)
+        if status is not None:
+            if status not in _VALID_INVITE_STATUSES:
+                raise ValueError(f"invalid status filter: {status!r}")
+            clauses.append("status = ?")
+            params.append(status)
+        sql = "SELECT * FROM issued_invites"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY created_at DESC"
+        rows = self._db.execute(sql, params).fetchall()
+        return [
+            InviteRecord(
+                invite_id=r["invite_id"],
+                tenant_id=r["tenant_id"],
+                recipient_hint=r["recipient_hint"],
+                token_hash=bytes(r["token_hash"]),
+                expires_at=r["expires_at"],
+                status=r["status"],
+                created_at=r["created_at"],
+            )
+            for r in rows
+        ]
+
+    # -- attachments -------------------------------------------------------
+
+    def add_attachment(self, rec: AttachmentRecord) -> AttachmentRecord:
+        if not rec.attachment_id or not rec.msg_id:
+            raise ValueError("attachment_id and msg_id are required")
+        if not isinstance(rec.sha256, bytes) or len(rec.sha256) != 32:
+            raise ValueError("sha256 must be 32 bytes")
+        if rec.size < 0:
+            raise ValueError("size must be non-negative")
+        if not rec.created_at:
+            rec.created_at = _now()
+        self._db.execute(
+            """
+            INSERT INTO attachments
+                (attachment_id, msg_id, sha256, size, mime, local_path,
+                 encrypted, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                rec.attachment_id,
+                rec.msg_id,
+                rec.sha256,
+                rec.size,
+                rec.mime,
+                rec.local_path,
+                int(bool(rec.encrypted)),
+                rec.created_at,
+            ),
+        )
+        self._db.commit()
+        return rec
+
+    def list_attachments(self, msg_id: str) -> list[AttachmentRecord]:
+        rows = self._db.execute(
+            "SELECT * FROM attachments WHERE msg_id = ? ORDER BY created_at",
+            (msg_id,),
+        ).fetchall()
+        return [
+            AttachmentRecord(
+                attachment_id=r["attachment_id"],
+                msg_id=r["msg_id"],
+                sha256=bytes(r["sha256"]),
+                size=r["size"],
+                mime=r["mime"],
+                local_path=r["local_path"],
+                encrypted=bool(r["encrypted"]),
+                created_at=r["created_at"],
+            )
+            for r in rows
+        ]
+
+    # -- diagnostics -------------------------------------------------------
+
+    def stats(self) -> dict[str, int]:
+        """Counts only — no key material, no envelope contents."""
+        out: dict[str, int] = {}
+        for table in (
+            "tenants",
+            "tenant_signing_keys",
+            "instance_keys",
+            "peer_pins",
+            "outbox",
+            "inbox",
+            "issued_invites",
+            "attachments",
+        ):
+            out[table] = self._db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        return out
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return f"FederationStateStore(db_path={self.db_path!r})"
+
+    def close(self) -> None:
+        self._db.close()

--- a/src/pinky_federation/state.py
+++ b/src/pinky_federation/state.py
@@ -61,10 +61,36 @@ _VALID_INSTANCE_KEY_KINDS = frozenset(
 )
 
 # Peer-pin status values.
+#
+# State machine (P-03, TOFU):
+#
+#     (none) --lookup first time--> first_seen
+#     first_seen --lookup same fp--> pinned
+#     pinned     --lookup diff fp--> changed         (quarantined, operator must decide)
+#     changed    --accept_rotation--> pinned         (operator re-pins new fp)
+#     changed    --reject_rotation--> rejected       (operator refuses new fp)
+#     rejected   --accept_rotation--> pinned         (operator changes mind later)
+#     any        --verify()---------> verified       (operator explicitly blesses current pin)
+#
+# ``rotated`` is retained for backward-compat (P-02 writes) and treated as
+# an alias of ``pinned`` by the trust policy, since P-02 never actually
+# transitioned anything into that state before P-03 landed.
+PEER_PIN_FIRST_SEEN = "first_seen"
 PEER_PIN_PINNED = "pinned"
-PEER_PIN_ROTATED = "rotated"
+PEER_PIN_CHANGED = "changed"
+PEER_PIN_VERIFIED = "verified"
+PEER_PIN_ROTATED = "rotated"  # deprecated: P-02 alias of ``pinned``
 PEER_PIN_REJECTED = "rejected"
-_VALID_PEER_PIN_STATUSES = frozenset({PEER_PIN_PINNED, PEER_PIN_ROTATED, PEER_PIN_REJECTED})
+_VALID_PEER_PIN_STATUSES = frozenset(
+    {
+        PEER_PIN_FIRST_SEEN,
+        PEER_PIN_PINNED,
+        PEER_PIN_CHANGED,
+        PEER_PIN_VERIFIED,
+        PEER_PIN_ROTATED,
+        PEER_PIN_REJECTED,
+    }
+)
 
 # Outbox status values.
 OUTBOX_PENDING = "pending"
@@ -101,6 +127,25 @@ def _now() -> float:
     return time.time()
 
 
+def _row_to_peer_pin(row) -> "PeerPinRecord":
+    return PeerPinRecord(
+        peer_address=row["peer_address"],
+        sig_pk=bytes(row["sig_pk"]),
+        enc_pk=bytes(row["enc_pk"]),
+        fingerprint=bytes(row["fingerprint"]),
+        status=row["status"],
+        first_seen=row["first_seen"],
+        last_seen=row["last_seen"],
+        pending_sig_pk=bytes(row["pending_sig_pk"]) if row["pending_sig_pk"] else b"",
+        pending_enc_pk=bytes(row["pending_enc_pk"]) if row["pending_enc_pk"] else b"",
+        pending_fingerprint=(
+            bytes(row["pending_fingerprint"]) if row["pending_fingerprint"] else b""
+        ),
+        pending_first_seen=row["pending_first_seen"],
+        verified_at=row["verified_at"],
+    )
+
+
 # -- Records ---------------------------------------------------------------
 
 
@@ -133,15 +178,28 @@ class InstanceKeyRecord:
 
 @dataclass
 class PeerPinRecord:
-    """TOFU pin for a remote peer."""
+    """TOFU pin for a remote peer.
+
+    The primary slot (``sig_pk``/``enc_pk``/``fingerprint``) holds the current
+    trusted keys. When a lookup sees a fingerprint that doesn't match, the new
+    keys are *not* overwritten — they're captured in the ``pending_*`` slot and
+    ``status`` moves to ``changed``. The operator then explicitly accepts (the
+    pending slot is promoted to the primary slot) or rejects (the pending slot
+    is cleared and ``status`` moves to ``rejected``).
+    """
 
     peer_address: str = ""
     sig_pk: bytes = b""
     enc_pk: bytes = b""
     fingerprint: bytes = b""
-    status: str = PEER_PIN_PINNED
+    status: str = PEER_PIN_FIRST_SEEN
     first_seen: float = 0.0
     last_seen: float = 0.0
+    pending_sig_pk: bytes = b""
+    pending_enc_pk: bytes = b""
+    pending_fingerprint: bytes = b""
+    pending_first_seen: float = 0.0
+    verified_at: float = 0.0
 
 
 @dataclass
@@ -346,11 +404,24 @@ class FederationStateStore:
 
     def _ensure_columns(self) -> None:
         """Forward-compatible column additions following the project pattern."""
-        # No migrations yet — this is the initial schema. Future additions:
-        #   migrations: list[tuple[str, str, list[tuple[str, str]]]] = [
-        #       ("table", "column", "TYPE DEFAULT ..."),
-        #   ]
-        pass
+        migrations: list[tuple[str, str, str]] = [
+            # P-03 TOFU: carry a proposed new pin alongside the current one
+            # when a fingerprint change is detected, so the operator can
+            # compare before accepting or rejecting.
+            ("peer_pins", "pending_sig_pk", "BLOB"),
+            ("peer_pins", "pending_enc_pk", "BLOB"),
+            ("peer_pins", "pending_fingerprint", "BLOB"),
+            ("peer_pins", "pending_first_seen", "REAL NOT NULL DEFAULT 0"),
+            ("peer_pins", "verified_at", "REAL NOT NULL DEFAULT 0"),
+        ]
+        for table, column, coltype in migrations:
+            cols = {
+                r["name"]
+                for r in self._db.execute(f"PRAGMA table_info({table})").fetchall()
+            }
+            if column not in cols:
+                self._db.execute(f"ALTER TABLE {table} ADD COLUMN {column} {coltype}")
+        self._db.commit()
 
     # -- tenants -----------------------------------------------------------
 
@@ -527,6 +598,13 @@ class FederationStateStore:
             raise ValueError("sig_pk and enc_pk must be 32 bytes each")
         if len(rec.fingerprint) != 16:
             raise ValueError("fingerprint must be 16 bytes")
+        # pending_* are optional but, if set, must have the right shape
+        if rec.pending_sig_pk and len(rec.pending_sig_pk) != 32:
+            raise ValueError("pending_sig_pk must be 32 bytes")
+        if rec.pending_enc_pk and len(rec.pending_enc_pk) != 32:
+            raise ValueError("pending_enc_pk must be 32 bytes")
+        if rec.pending_fingerprint and len(rec.pending_fingerprint) != 16:
+            raise ValueError("pending_fingerprint must be 16 bytes")
         now = _now()
         if not rec.first_seen:
             rec.first_seen = now
@@ -534,14 +612,22 @@ class FederationStateStore:
         self._db.execute(
             """
             INSERT INTO peer_pins
-                (peer_address, sig_pk, enc_pk, fingerprint, status, first_seen, last_seen)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (peer_address, sig_pk, enc_pk, fingerprint, status,
+                 first_seen, last_seen,
+                 pending_sig_pk, pending_enc_pk, pending_fingerprint,
+                 pending_first_seen, verified_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(peer_address) DO UPDATE SET
                 sig_pk=excluded.sig_pk,
                 enc_pk=excluded.enc_pk,
                 fingerprint=excluded.fingerprint,
                 status=excluded.status,
-                last_seen=excluded.last_seen
+                last_seen=excluded.last_seen,
+                pending_sig_pk=excluded.pending_sig_pk,
+                pending_enc_pk=excluded.pending_enc_pk,
+                pending_fingerprint=excluded.pending_fingerprint,
+                pending_first_seen=excluded.pending_first_seen,
+                verified_at=excluded.verified_at
             """,
             (
                 rec.peer_address,
@@ -551,6 +637,11 @@ class FederationStateStore:
                 rec.status,
                 rec.first_seen,
                 rec.last_seen,
+                rec.pending_sig_pk or None,
+                rec.pending_enc_pk or None,
+                rec.pending_fingerprint or None,
+                rec.pending_first_seen,
+                rec.verified_at,
             ),
         )
         self._db.commit()
@@ -562,15 +653,30 @@ class FederationStateStore:
         ).fetchone()
         if not row:
             return None
-        return PeerPinRecord(
-            peer_address=row["peer_address"],
-            sig_pk=bytes(row["sig_pk"]),
-            enc_pk=bytes(row["enc_pk"]),
-            fingerprint=bytes(row["fingerprint"]),
-            status=row["status"],
-            first_seen=row["first_seen"],
-            last_seen=row["last_seen"],
+        return _row_to_peer_pin(row)
+
+    def list_peer_pins(
+        self, status: Optional[str] = None
+    ) -> list[PeerPinRecord]:
+        if status is not None:
+            if status not in _VALID_PEER_PIN_STATUSES:
+                raise ValueError(f"invalid pin status: {status!r}")
+            rows = self._db.execute(
+                "SELECT * FROM peer_pins WHERE status = ? ORDER BY peer_address",
+                (status,),
+            ).fetchall()
+        else:
+            rows = self._db.execute(
+                "SELECT * FROM peer_pins ORDER BY peer_address"
+            ).fetchall()
+        return [_row_to_peer_pin(r) for r in rows]
+
+    def delete_peer_pin(self, peer_address: str) -> bool:
+        cur = self._db.execute(
+            "DELETE FROM peer_pins WHERE peer_address = ?", (peer_address,)
         )
+        self._db.commit()
+        return cur.rowcount > 0
 
     # -- outbox / inbox ----------------------------------------------------
 

--- a/src/pinky_federation/tofu.py
+++ b/src/pinky_federation/tofu.py
@@ -1,0 +1,352 @@
+"""Trust-on-first-use (TOFU) pinning policy for federation peers.
+
+This module is the **local trust root** for federation v0.2. The relay
+directory is treated as a lookup service, not an authority: the first time
+we see a peer's public keys we pin them locally, and every subsequent
+lookup is compared against the pinned fingerprint. A mismatch stops
+silent key substitution attacks — the relay can't swap in attacker keys
+without the operator noticing.
+
+State machine
+-------------
+
+Statuses live on :class:`~pinky_federation.state.PeerPinRecord`::
+
+    (none)
+      │   observe(new keys)
+      ▼
+    first_seen  ── observe(same fp) ──────────────▶ pinned
+        │                                            │
+        │   observe(different fp)                    │ observe(different fp)
+        ▼                                            ▼
+    changed  ◀─ observe(yet another fp, pending updated) ─┐
+      │                                                    │
+      ├── accept_rotation() ───────▶ pinned ──── verify() ──▶ verified
+      │                                   │
+      └── reject_rotation() ───▶ rejected ┘
+           │
+           └── accept_rotation(new_keys) ──▶ pinned   (operator overrides earlier no)
+
+Guarantees
+----------
+
+- **Never silently accept a new fingerprint for an existing peer.** A diff
+  always produces a ``changed`` status and requires an explicit operator
+  decision.
+- **The old pin is preserved.** When we detect a mismatch, the new proposal
+  is captured in the ``pending_*`` slot, not written over the trusted slot.
+  The operator can compare old and new side-by-side.
+- **Rejected peers stay rejected.** A peer in the ``rejected`` state always
+  returns :class:`TrustDecision.REJECTED` regardless of what keys they
+  present, until the operator explicitly accepts a rotation.
+- **Idempotent.** Calling :meth:`TrustPolicy.observe` repeatedly with the
+  same trusted keys is safe — it just bumps ``last_seen``.
+
+This module does no network I/O and no logging of secret material.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from pinky_federation.fingerprint import fingerprint as compute_fingerprint
+from pinky_federation.keys import EncryptionPublicKey, SigningPublicKey
+from pinky_federation.state import (
+    PEER_PIN_CHANGED,
+    PEER_PIN_FIRST_SEEN,
+    PEER_PIN_PINNED,
+    PEER_PIN_REJECTED,
+    PEER_PIN_ROTATED,
+    PEER_PIN_VERIFIED,
+    FederationStateStore,
+    PeerPinRecord,
+    _now,
+)
+
+# Statuses that mean "primary slot keys are currently trusted for encrypting".
+# ``rotated`` is a legacy P-02 alias kept here for backward-compat — anything
+# written in that state is treated as ``pinned``.
+_TRUSTED_STATUSES = frozenset(
+    {PEER_PIN_PINNED, PEER_PIN_VERIFIED, PEER_PIN_ROTATED}
+)
+
+
+class TrustDecision(str, Enum):
+    """Outcome of a trust lookup.
+
+    String-valued so it serialises cleanly for UI / log lines.
+    """
+
+    FIRST_SEEN = "first_seen"
+    """Brand-new peer. The keys were just auto-pinned via TOFU. Callers may
+    proceed to encrypt, but should surface this as a soft warning in the UI
+    ("new contact — verify fingerprint out-of-band")."""
+
+    TRUSTED = "trusted"
+    """Keys match the existing pin. Safe to encrypt."""
+
+    MISMATCH = "mismatch"
+    """The presented fingerprint does NOT match the pinned fingerprint. Do
+    NOT encrypt to these keys. The operator must accept or reject. The new
+    proposal has been captured in the peer's ``pending_*`` slot."""
+
+    REJECTED = "rejected"
+    """Peer is in the rejected state — a prior rotation was denied. Refuse
+    to encrypt until the operator explicitly accepts."""
+
+
+class TofuError(Exception):
+    """Base class for TOFU policy errors."""
+
+
+class NoPendingRotationError(TofuError):
+    """Raised when :meth:`TrustPolicy.accept_rotation` is called with no
+    pending proposal and no explicit new keys provided."""
+
+
+class UnknownPeerError(TofuError):
+    """Raised when operating on a peer that has never been observed."""
+
+
+@dataclass(frozen=True)
+class TrustResult:
+    """Result of :meth:`TrustPolicy.observe`.
+
+    ``decision`` is the headline outcome; ``record`` is the updated
+    :class:`PeerPinRecord` after the observation.
+    """
+
+    decision: TrustDecision
+    record: PeerPinRecord
+
+    @property
+    def trusted(self) -> bool:
+        """True iff the caller can safely encrypt to the primary slot keys.
+
+        ``FIRST_SEEN`` is considered trusted-but-unverified — we auto-pin
+        on TOFU so first messages work. Callers that want a stricter
+        posture (e.g. require operator verification before sending) should
+        gate on ``record.status == PEER_PIN_VERIFIED`` instead.
+        """
+        return self.decision in (TrustDecision.FIRST_SEEN, TrustDecision.TRUSTED)
+
+
+class TrustPolicy:
+    """Pinning + rotation policy on top of :class:`FederationStateStore`.
+
+    A thin stateless wrapper around the state store that enforces the TOFU
+    state machine. Construct once per store and share freely — it holds no
+    caches of its own.
+    """
+
+    def __init__(self, store: FederationStateStore) -> None:
+        self._store = store
+
+    # -- public API --------------------------------------------------------
+
+    def observe(
+        self,
+        address: str,
+        sig_pk: SigningPublicKey,
+        enc_pk: EncryptionPublicKey,
+    ) -> TrustResult:
+        """Observe a peer's presented keys and update the pin accordingly.
+
+        This is the hot path for every outbound send and inbound verify.
+
+        Semantics:
+
+        - No existing pin → auto-pin as ``first_seen``, return FIRST_SEEN.
+        - Existing pin, same fingerprint, status in trusted set → bump
+          ``last_seen``, return TRUSTED.
+        - Existing pin, same fingerprint, status=first_seen → promote to
+          ``pinned`` (second successful sighting confirms the pin), return
+          TRUSTED.
+        - Existing pin, different fingerprint → capture proposal in
+          ``pending_*`` slot, set status=changed, return MISMATCH.
+        - Existing pin, status=rejected → always return REJECTED regardless
+          of keys (do NOT update last_seen; a rejected peer contacting us
+          with new keys is suspicious, we don't want the mere lookup to
+          update their record).
+        - Existing pin, status=changed, mismatch against pending → update
+          pending slot to the latest proposal, remain in changed, return
+          MISMATCH. (Either the peer is rotating again, or an attacker is
+          trying keys; either way, the operator still needs to decide.)
+        - Existing pin, status=changed, match against *primary* (original
+          pinned) fingerprint → the proposal was a blip / replay; return to
+          pinned, clear pending, return TRUSTED.
+        """
+        sig_bytes = sig_pk.to_bytes()
+        enc_bytes = enc_pk.to_bytes()
+        fp = compute_fingerprint(address, sig_pk, enc_pk)
+        now = _now()
+
+        existing = self._store.get_peer_pin(address)
+
+        if existing is None:
+            rec = PeerPinRecord(
+                peer_address=address,
+                sig_pk=sig_bytes,
+                enc_pk=enc_bytes,
+                fingerprint=fp,
+                status=PEER_PIN_FIRST_SEEN,
+                first_seen=now,
+                last_seen=now,
+            )
+            rec = self._store.upsert_peer_pin(rec)
+            return TrustResult(TrustDecision.FIRST_SEEN, rec)
+
+        if existing.status == PEER_PIN_REJECTED:
+            # Do not update last_seen or capture the keys — a rejected peer
+            # stays rejected and we don't want the rejection record mutated
+            # by further probing.
+            return TrustResult(TrustDecision.REJECTED, existing)
+
+        if fp == existing.fingerprint:
+            # Match against the trusted slot.
+            existing.last_seen = now
+            if existing.status == PEER_PIN_FIRST_SEEN:
+                existing.status = PEER_PIN_PINNED
+            elif existing.status == PEER_PIN_CHANGED:
+                # Proposal was a blip — the real peer is back on their
+                # original keys. Clear the pending slot and return to
+                # pinned.
+                existing.status = PEER_PIN_PINNED
+                existing.pending_sig_pk = b""
+                existing.pending_enc_pk = b""
+                existing.pending_fingerprint = b""
+                existing.pending_first_seen = 0.0
+            # else: already pinned/verified/rotated — just a heartbeat.
+            rec = self._store.upsert_peer_pin(existing)
+            return TrustResult(TrustDecision.TRUSTED, rec)
+
+        # Fingerprint mismatch — capture in pending slot, mark changed.
+        existing.pending_sig_pk = sig_bytes
+        existing.pending_enc_pk = enc_bytes
+        existing.pending_fingerprint = fp
+        if not existing.pending_first_seen or existing.status != PEER_PIN_CHANGED:
+            existing.pending_first_seen = now
+        existing.status = PEER_PIN_CHANGED
+        existing.last_seen = now
+        rec = self._store.upsert_peer_pin(existing)
+        return TrustResult(TrustDecision.MISMATCH, rec)
+
+    def accept_rotation(
+        self,
+        address: str,
+        sig_pk: Optional[SigningPublicKey] = None,
+        enc_pk: Optional[EncryptionPublicKey] = None,
+    ) -> PeerPinRecord:
+        """Operator explicitly accepts a key rotation for *address*.
+
+        Two forms:
+
+        - ``accept_rotation(address)`` — promote the pending slot (captured
+          by the last MISMATCH observation) to the primary slot. Requires
+          a pending proposal.
+        - ``accept_rotation(address, sig_pk, enc_pk)`` — operator provides
+          the new keys directly (e.g. out-of-band verification). Overrides
+          whatever was in the pending slot.
+
+        The peer's status moves to ``pinned`` (not ``verified`` — use
+        :meth:`verify` for that) and ``first_seen`` is reset to "now" since
+        this is effectively a new trust anchor.
+        """
+        existing = self._store.get_peer_pin(address)
+        if existing is None:
+            raise UnknownPeerError(f"no pin for peer: {address!r}")
+
+        now = _now()
+
+        if sig_pk is not None and enc_pk is not None:
+            new_sig = sig_pk.to_bytes()
+            new_enc = enc_pk.to_bytes()
+            new_fp = compute_fingerprint(address, sig_pk, enc_pk)
+        elif sig_pk is None and enc_pk is None:
+            if not existing.pending_fingerprint:
+                raise NoPendingRotationError(
+                    f"no pending rotation for peer: {address!r}"
+                )
+            new_sig = existing.pending_sig_pk
+            new_enc = existing.pending_enc_pk
+            new_fp = existing.pending_fingerprint
+        else:
+            raise ValueError("provide both sig_pk and enc_pk, or neither")
+
+        existing.sig_pk = new_sig
+        existing.enc_pk = new_enc
+        existing.fingerprint = new_fp
+        existing.status = PEER_PIN_PINNED
+        # The rotation is effectively a new trust anchor — reset first_seen.
+        existing.first_seen = now
+        existing.last_seen = now
+        existing.pending_sig_pk = b""
+        existing.pending_enc_pk = b""
+        existing.pending_fingerprint = b""
+        existing.pending_first_seen = 0.0
+        # Clear any prior verification — the operator must re-verify.
+        existing.verified_at = 0.0
+        return self._store.upsert_peer_pin(existing)
+
+    def reject_rotation(self, address: str) -> PeerPinRecord:
+        """Operator rejects the pending rotation for *address*.
+
+        Clears the pending slot and sets status to ``rejected``. The
+        primary slot is left intact but is no longer considered trusted
+        (rejected peers return REJECTED from :meth:`observe`).
+        """
+        existing = self._store.get_peer_pin(address)
+        if existing is None:
+            raise UnknownPeerError(f"no pin for peer: {address!r}")
+        existing.pending_sig_pk = b""
+        existing.pending_enc_pk = b""
+        existing.pending_fingerprint = b""
+        existing.pending_first_seen = 0.0
+        existing.status = PEER_PIN_REJECTED
+        existing.last_seen = _now()
+        return self._store.upsert_peer_pin(existing)
+
+    def verify(self, address: str) -> PeerPinRecord:
+        """Mark the currently-pinned keys for *address* as operator-verified.
+
+        This represents an out-of-band confirmation (fingerprint read aloud,
+        QR code scanned, etc.) and is a stronger trust signal than TOFU.
+        Only valid for peers currently in ``first_seen`` or ``pinned`` state;
+        ``changed`` / ``rejected`` peers must be resolved via
+        :meth:`accept_rotation` or :meth:`reject_rotation` first.
+        """
+        existing = self._store.get_peer_pin(address)
+        if existing is None:
+            raise UnknownPeerError(f"no pin for peer: {address!r}")
+        if existing.status not in (PEER_PIN_FIRST_SEEN, PEER_PIN_PINNED, PEER_PIN_ROTATED):
+            raise TofuError(
+                f"cannot verify peer in status {existing.status!r}; "
+                "resolve pending rotation first"
+            )
+        existing.status = PEER_PIN_VERIFIED
+        existing.verified_at = _now()
+        existing.last_seen = existing.verified_at
+        return self._store.upsert_peer_pin(existing)
+
+    def get(self, address: str) -> Optional[PeerPinRecord]:
+        """Return the current pin record for *address*, or None."""
+        return self._store.get_peer_pin(address)
+
+    def list_changed(self) -> list[PeerPinRecord]:
+        """Return all peers in the ``changed`` state awaiting operator action.
+
+        UI surfaces (pending-rotations panel) use this to drive an inbox.
+        """
+        return self._store.list_peer_pins(status=PEER_PIN_CHANGED)
+
+
+__all__ = [
+    "TrustPolicy",
+    "TrustDecision",
+    "TrustResult",
+    "TofuError",
+    "NoPendingRotationError",
+    "UnknownPeerError",
+]

--- a/tests/pinky_federation/test_envelope.py
+++ b/tests/pinky_federation/test_envelope.py
@@ -1,0 +1,126 @@
+"""Envelope serialization tests: round-trip, header parsing, malformed inputs."""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_federation.envelope import (
+    MAX_CIPHERTEXT_BYTES,
+    Envelope,
+    EnvelopeVersion,
+)
+from pinky_federation.errors import EnvelopeError
+
+
+def _sample_envelope(ct: bytes = b"ciphertext-goes-here") -> Envelope:
+    return Envelope(
+        version=EnvelopeVersion.V1,
+        sender_fingerprint=b"\x01" * 16,
+        recipient_fingerprint=b"\x02" * 16,
+        ephemeral_public=b"\x03" * 32,
+        nonce=b"\x04" * 24,
+        signature=b"\x05" * 64,
+        ciphertext=ct,
+    )
+
+
+def test_envelope_round_trip() -> None:
+    env = _sample_envelope()
+    data = env.to_bytes()
+    restored = Envelope.from_bytes(data)
+    assert restored == env
+
+
+def test_envelope_serialized_length_matches_spec() -> None:
+    env = _sample_envelope(ct=b"")
+    data = env.to_bytes()
+    # 4 magic + 1 ver + 1 flags + 16 + 16 + 32 + 24 + 64 + 4 = 162 fixed header.
+    assert len(data) == 162
+    env2 = _sample_envelope(ct=b"x" * 100)
+    assert len(env2.to_bytes()) == 162 + 100
+
+
+def test_envelope_magic_check() -> None:
+    env = _sample_envelope()
+    data = bytearray(env.to_bytes())
+    data[0] = ord("Q")
+    with pytest.raises(EnvelopeError, match="magic"):
+        Envelope.from_bytes(bytes(data))
+
+
+def test_envelope_version_check() -> None:
+    env = _sample_envelope()
+    data = bytearray(env.to_bytes())
+    data[4] = 99  # version byte
+    with pytest.raises(EnvelopeError, match="unsupported envelope version"):
+        Envelope.from_bytes(bytes(data))
+
+
+def test_envelope_flags_must_be_zero() -> None:
+    env = _sample_envelope()
+    data = bytearray(env.to_bytes())
+    data[5] = 0x80  # flags byte
+    with pytest.raises(EnvelopeError, match="flags"):
+        Envelope.from_bytes(bytes(data))
+
+
+def test_envelope_short_header_rejected() -> None:
+    with pytest.raises(EnvelopeError, match="shorter than fixed header"):
+        Envelope.from_bytes(b"PFv1")
+
+
+def test_envelope_ct_length_mismatch_rejected() -> None:
+    env = _sample_envelope(ct=b"hello")
+    data = env.to_bytes()
+    # Truncate ciphertext but leave header ct_len untouched.
+    with pytest.raises(EnvelopeError, match="length mismatch"):
+        Envelope.from_bytes(data[:-1])
+
+
+def test_envelope_ct_length_too_large_rejected() -> None:
+    env = _sample_envelope(ct=b"hello")
+    data = bytearray(env.to_bytes())
+    # Rewrite ct_len field (last 4 bytes of the 162-byte fixed header) to overflow.
+    huge = (MAX_CIPHERTEXT_BYTES + 1).to_bytes(4, "big")
+    data[158:162] = huge
+    with pytest.raises(EnvelopeError, match="exceeds MAX_CIPHERTEXT_BYTES"):
+        Envelope.from_bytes(bytes(data))
+
+
+def test_envelope_construct_rejects_wrong_field_sizes() -> None:
+    with pytest.raises(ValueError):
+        Envelope(
+            version=EnvelopeVersion.V1,
+            sender_fingerprint=b"\x01" * 8,  # wrong size
+            recipient_fingerprint=b"\x02" * 16,
+            ephemeral_public=b"\x03" * 32,
+            nonce=b"\x04" * 24,
+            signature=b"\x05" * 64,
+            ciphertext=b"",
+        )
+
+
+def test_envelope_rejects_non_bytes_input() -> None:
+    with pytest.raises(EnvelopeError, match="must be bytes"):
+        Envelope.from_bytes("not bytes")  # type: ignore[arg-type]
+
+
+def test_envelope_deterministic_wire_vector() -> None:
+    """Lock the wire format for a fixed envelope.
+
+    If this hex changes, the wire protocol has changed — bump the version.
+    """
+    env = _sample_envelope(ct=b"hello")
+    expected = (
+        "50467631"  # magic "PFv1"
+        "01"  # version
+        "00"  # flags
+        + ("01" * 16)  # sender_fp
+        + ("02" * 16)  # recipient_fp
+        + ("03" * 32)  # eph_pk
+        + ("04" * 24)  # nonce
+        + ("05" * 64)  # signature
+        + "00000005"  # ct_len = 5
+        + "68656c6c6f"  # "hello"
+    )
+    assert env.to_bytes().hex() == expected

--- a/tests/pinky_federation/test_fingerprint.py
+++ b/tests/pinky_federation/test_fingerprint.py
@@ -1,0 +1,137 @@
+"""Fingerprint tests: canonicalization, determinism, collision resistance, display."""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_federation.fingerprint import (
+    FINGERPRINT_BYTES,
+    canonical_address,
+    fingerprint,
+    format_fingerprint,
+)
+from pinky_federation.keys import (
+    EncryptionKeyPair,
+    SigningKeyPair,
+)
+
+# -- canonical_address --------------------------------------------------------
+
+
+def test_canonical_address_strips_and_lowercases() -> None:
+    assert canonical_address("  Alice@Example.COM  ") == "alice@example.com"
+
+
+def test_canonical_address_rejects_empty() -> None:
+    with pytest.raises(ValueError):
+        canonical_address("")
+    with pytest.raises(ValueError):
+        canonical_address("   ")
+
+
+def test_canonical_address_rejects_whitespace_inside() -> None:
+    with pytest.raises(ValueError):
+        canonical_address("alice @example.com")
+
+
+def test_canonical_address_rejects_control_chars() -> None:
+    with pytest.raises(ValueError):
+        canonical_address("alice\x07@example.com")
+
+
+def test_canonical_address_rejects_non_string() -> None:
+    with pytest.raises(TypeError):
+        canonical_address(b"alice@example.com")  # type: ignore[arg-type]
+
+
+# -- fingerprint --------------------------------------------------------------
+
+
+def _sample_identity():
+    sig = SigningKeyPair.from_seed(b"\x01" * 32)
+    enc = EncryptionKeyPair.from_private_bytes(b"\x02" * 32)
+    return sig.public_key, enc.public_key
+
+
+def test_fingerprint_is_deterministic_for_same_inputs() -> None:
+    sig_pk, enc_pk = _sample_identity()
+    fp1 = fingerprint("alice@example.com", sig_pk, enc_pk)
+    fp2 = fingerprint("alice@example.com", sig_pk, enc_pk)
+    assert fp1 == fp2
+    assert len(fp1) == FINGERPRINT_BYTES
+
+
+def test_fingerprint_invariant_across_address_case_and_whitespace() -> None:
+    sig_pk, enc_pk = _sample_identity()
+    fp_lower = fingerprint("alice@example.com", sig_pk, enc_pk)
+    fp_upper = fingerprint("  ALICE@EXAMPLE.COM  ", sig_pk, enc_pk)
+    assert fp_lower == fp_upper
+
+
+def test_fingerprint_changes_with_address() -> None:
+    sig_pk, enc_pk = _sample_identity()
+    assert fingerprint("alice@example.com", sig_pk, enc_pk) != fingerprint(
+        "bob@example.com", sig_pk, enc_pk
+    )
+
+
+def test_fingerprint_changes_with_signing_key() -> None:
+    _, enc_pk = _sample_identity()
+    sig_a = SigningKeyPair.from_seed(b"\xaa" * 32).public_key
+    sig_b = SigningKeyPair.from_seed(b"\xbb" * 32).public_key
+    assert fingerprint("alice@example.com", sig_a, enc_pk) != fingerprint(
+        "alice@example.com", sig_b, enc_pk
+    )
+
+
+def test_fingerprint_changes_with_encryption_key() -> None:
+    sig_pk, _ = _sample_identity()
+    enc_a = EncryptionKeyPair.from_private_bytes(b"\xaa" * 32).public_key
+    enc_b = EncryptionKeyPair.from_private_bytes(b"\xbb" * 32).public_key
+    assert fingerprint("alice@example.com", sig_pk, enc_a) != fingerprint(
+        "alice@example.com", sig_pk, enc_b
+    )
+
+
+def test_fingerprint_known_vector_stable() -> None:
+    """Lock the fingerprint for a known (address, sig_pk, enc_pk) tuple.
+
+    If this test fails we have accidentally changed the fingerprint scheme —
+    which would invalidate every stored TOFU pin. Update this value only when
+    bumping the fingerprint domain string intentionally.
+    """
+    sig_pk, enc_pk = _sample_identity()
+    fp = fingerprint("alice@example.com", sig_pk, enc_pk)
+    assert fp.hex() == KNOWN_ALICE_FP_HEX
+
+
+# Expected fingerprint for:
+#   address       = "alice@example.com"
+#   signing seed  = b"\x01" * 32
+#   encryption sk = b"\x02" * 32
+# Pinned by test_fingerprint_known_vector_stable.
+KNOWN_ALICE_FP_HEX = "cdc6e694d8699f0fc18657242abade83"
+
+
+# -- format_fingerprint -------------------------------------------------------
+
+
+def test_format_fingerprint_groups_default() -> None:
+    fp = bytes.fromhex("a1b2c3d4e5f607080910111213141516")
+    out = format_fingerprint(fp)
+    # Default: 4 groups of 4 hex chars.
+    assert out == "a1b2 c3d4 e5f6 0708"
+
+
+def test_format_fingerprint_custom_groups() -> None:
+    fp = bytes.fromhex("a1b2c3d4e5f607080910111213141516")
+    assert format_fingerprint(fp, groups=2, group_size=8) == "a1b2c3d4 e5f60708"
+
+
+def test_format_fingerprint_rejects_invalid_params() -> None:
+    with pytest.raises(TypeError):
+        format_fingerprint("not bytes")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        format_fingerprint(b"\x00" * 16, groups=0)
+    with pytest.raises(ValueError):
+        format_fingerprint(b"\x00" * 16, group_size=0)

--- a/tests/pinky_federation/test_key_store.py
+++ b/tests/pinky_federation/test_key_store.py
@@ -1,0 +1,327 @@
+"""Encrypted tenant key store tests.
+
+Focus areas:
+- Round-trip: encrypt -> persist -> decrypt yields original signing seed.
+- Repr / log discipline: seed bytes never appear in any exposed string.
+- Permissions: device key file is created 0600; loose perms are rejected.
+- Tenant binding: ciphertext for tenant A cannot be replayed under tenant B.
+- Export gate: raw seed export requires explicit operator acknowledgement.
+- Lifecycle: ``has_signing_key`` reflects state; ``get_signing_key`` raises
+  ``KeyError`` when no key is stored.
+- Wrong device key surfaces as ``DecryptionError`` (not raw libsodium type).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import secrets
+import stat
+
+import pytest
+
+from pinky_federation.errors import DecryptionError
+from pinky_federation.key_store import (
+    DEFAULT_DEVICE_KEY_PATH,
+    DEVICE_KEY_BYTES,
+    DeviceKey,
+    EncryptedTenantKeyStore,
+)
+from pinky_federation.keys import SigningKeyPair
+from pinky_federation.state import FederationStateStore, TenantRecord
+
+
+@pytest.fixture
+def state(tmp_path):
+    s = FederationStateStore(str(tmp_path / "fed.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def device_key(tmp_path):
+    return DeviceKey.load_or_create(str(tmp_path / "device.key"))
+
+
+@pytest.fixture
+def key_store(state, device_key):
+    return EncryptedTenantKeyStore(state, device_key)
+
+
+def _register_tenant(state: FederationStateStore, tenant_id: str = "t1") -> None:
+    state.upsert_tenant(
+        TenantRecord(
+            tenant_id=tenant_id,
+            address=f"{tenant_id}@example.com",
+            signing_pk=b"\x01" * 32,
+        )
+    )
+
+
+# -- DeviceKey ------------------------------------------------------------
+
+
+def test_device_key_creates_file_with_0600_perms(tmp_path) -> None:
+    path = tmp_path / "device.key"
+    dk = DeviceKey.load_or_create(str(path))
+    assert path.exists()
+    mode = stat.S_IMODE(path.stat().st_mode)
+    # On macOS / Linux this should be exactly 0o600.
+    assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+    assert len(dk.material_insecure()) == DEVICE_KEY_BYTES
+
+
+def test_device_key_is_persistent_across_loads(tmp_path) -> None:
+    path = tmp_path / "device.key"
+    dk1 = DeviceKey.load_or_create(str(path))
+    dk2 = DeviceKey.load_or_create(str(path))
+    assert dk1.material_insecure() == dk2.material_insecure()
+
+
+def test_device_key_rejects_loose_permissions(tmp_path) -> None:
+    path = tmp_path / "device.key"
+    DeviceKey.load_or_create(str(path))
+    os.chmod(str(path), 0o644)
+    with pytest.raises(PermissionError):
+        DeviceKey.load_or_create(str(path))
+
+
+def test_device_key_rejects_wrong_size_file(tmp_path) -> None:
+    path = tmp_path / "device.key"
+    path.write_bytes(b"\x00" * 31)
+    os.chmod(str(path), 0o600)
+    with pytest.raises(ValueError):
+        DeviceKey.load_or_create(str(path))
+
+
+def test_device_key_repr_does_not_expose_full_material(tmp_path) -> None:
+    dk = DeviceKey.load_or_create(str(tmp_path / "device.key"))
+    text = repr(dk)
+    assert dk.material_insecure().hex() not in text
+    # Truncated tag (4 bytes = 8 hex chars) is fine; full key is not.
+    assert "DeviceKey(" in text
+
+
+def test_device_key_validates_constructor_input() -> None:
+    with pytest.raises(ValueError):
+        DeviceKey(b"too-short")
+
+
+def test_default_device_key_path_constant() -> None:
+    # Sanity: the documented default path lives under data/federation/.
+    assert "data/federation/" in DEFAULT_DEVICE_KEY_PATH
+    assert DEFAULT_DEVICE_KEY_PATH.endswith(".device_key")
+
+
+# -- Round-trip -----------------------------------------------------------
+
+
+def test_put_then_get_round_trip(key_store, state) -> None:
+    _register_tenant(state)
+    original = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", original)
+    restored = key_store.get_signing_key("t1")
+    # Equality on Ed25519 keys: same public key implies same seed.
+    assert restored.public_key.raw == original.public_key.raw
+
+
+def test_put_overwrites_previous_key(key_store, state) -> None:
+    _register_tenant(state)
+    first = SigningKeyPair.generate()
+    second = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", first)
+    key_store.put_signing_key("t1", second)
+    restored = key_store.get_signing_key("t1")
+    assert restored.public_key.raw == second.public_key.raw
+    assert restored.public_key.raw != first.public_key.raw
+
+
+def test_has_signing_key_reflects_state(key_store, state) -> None:
+    _register_tenant(state)
+    assert key_store.has_signing_key("t1") is False
+    key_store.put_signing_key("t1", SigningKeyPair.generate())
+    assert key_store.has_signing_key("t1") is True
+
+
+def test_get_signing_key_raises_keyerror_when_missing(key_store) -> None:
+    with pytest.raises(KeyError):
+        key_store.get_signing_key("nope")
+
+
+def test_put_requires_existing_tenant(key_store) -> None:
+    with pytest.raises(ValueError):
+        key_store.put_signing_key("ghost", SigningKeyPair.generate())
+
+
+def test_put_validates_types(key_store, state) -> None:
+    _register_tenant(state)
+    with pytest.raises(TypeError):
+        key_store.put_signing_key("t1", "not-a-keypair")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        key_store.put_signing_key("", SigningKeyPair.generate())
+
+
+# -- Tenant binding (AAD) -------------------------------------------------
+
+
+def test_ciphertext_cannot_be_replayed_to_other_tenant(key_store, state) -> None:
+    _register_tenant(state, "alice")
+    _register_tenant(state, "bob")
+    key_store.put_signing_key("alice", SigningKeyPair.generate())
+    # Forge: copy alice's stored ciphertext into bob's row.
+    row = state._db.execute(  # noqa: SLF001
+        "SELECT encrypted_seed, nonce, kdf_version FROM tenant_signing_keys "
+        "WHERE tenant_id = ?",
+        ("alice",),
+    ).fetchone()
+    state._db.execute(  # noqa: SLF001
+        "INSERT INTO tenant_signing_keys (tenant_id, encrypted_seed, nonce, "
+        "kdf_version, created_at) VALUES (?, ?, ?, ?, ?)",
+        ("bob", bytes(row["encrypted_seed"]), bytes(row["nonce"]), int(row["kdf_version"]), 1.0),
+    )
+    state._db.commit()  # noqa: SLF001
+    with pytest.raises(DecryptionError):
+        key_store.get_signing_key("bob")
+
+
+# -- Wrong device key -----------------------------------------------------
+
+
+def test_wrong_device_key_raises_decryption_error(state, tmp_path) -> None:
+    real_dk = DeviceKey.load_or_create(str(tmp_path / "device.key"))
+    other_dk = DeviceKey(secrets.token_bytes(DEVICE_KEY_BYTES))
+    real_store = EncryptedTenantKeyStore(state, real_dk)
+    other_store = EncryptedTenantKeyStore(state, other_dk)
+    _register_tenant(state)
+    real_store.put_signing_key("t1", SigningKeyPair.generate())
+    with pytest.raises(DecryptionError):
+        other_store.get_signing_key("t1")
+
+
+def test_corrupt_ciphertext_raises_decryption_error(key_store, state) -> None:
+    _register_tenant(state)
+    key_store.put_signing_key("t1", SigningKeyPair.generate())
+    state._db.execute(  # noqa: SLF001
+        "UPDATE tenant_signing_keys SET encrypted_seed = ? WHERE tenant_id = ?",
+        (b"\x00" * 48, "t1"),
+    )
+    state._db.commit()  # noqa: SLF001
+    with pytest.raises(DecryptionError):
+        key_store.get_signing_key("t1")
+
+
+def test_unsupported_kdf_version_raises(key_store, state) -> None:
+    _register_tenant(state)
+    key_store.put_signing_key("t1", SigningKeyPair.generate())
+    state._db.execute(  # noqa: SLF001
+        "UPDATE tenant_signing_keys SET kdf_version = 999 WHERE tenant_id = ?", ("t1",)
+    )
+    state._db.commit()  # noqa: SLF001
+    with pytest.raises(DecryptionError):
+        key_store.get_signing_key("t1")
+
+
+# -- Export gate ----------------------------------------------------------
+
+
+def test_export_requires_explicit_acknowledgement(key_store, state) -> None:
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", kp)
+    with pytest.raises(PermissionError):
+        key_store.export_signing_seed_explicit(
+            "t1", operator_acknowledged=False, reason="reason"
+        )
+
+
+def test_export_requires_non_empty_reason(key_store, state) -> None:
+    _register_tenant(state)
+    key_store.put_signing_key("t1", SigningKeyPair.generate())
+    with pytest.raises(ValueError):
+        key_store.export_signing_seed_explicit(
+            "t1", operator_acknowledged=True, reason="   "
+        )
+
+
+def test_export_returns_seed_when_acknowledged(key_store, state) -> None:
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", kp)
+    seed = key_store.export_signing_seed_explicit(
+        "t1", operator_acknowledged=True, reason="operator initiated migration"
+    )
+    assert isinstance(seed, bytes)
+    assert len(seed) == 32
+    # The seed actually reproduces the same keypair.
+    assert SigningKeyPair.from_seed(seed).public_key.raw == kp.public_key.raw
+
+
+# -- Repr / log discipline ------------------------------------------------
+
+
+def test_repr_does_not_leak_seed(key_store, state) -> None:
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", kp)
+    seed_hex = kp.seed_bytes_insecure().hex()
+    text = repr(key_store)
+    assert seed_hex not in text
+
+
+def test_logging_module_does_not_capture_seed_via_repr(
+    key_store, state, caplog
+) -> None:
+    """Even if a careless caller logs the store object, the seed must not appear."""
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", kp)
+    seed_hex = kp.seed_bytes_insecure().hex()
+
+    log = logging.getLogger("test-fed-keystore-repr")
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    log.addHandler(handler)
+    log.setLevel(logging.DEBUG)
+    try:
+        log.debug("store snapshot: %r", key_store)
+    finally:
+        log.removeHandler(handler)
+
+    output = buf.getvalue()
+    assert seed_hex not in output
+
+
+def test_state_stats_contains_count_only_not_material(key_store, state) -> None:
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    key_store.put_signing_key("t1", kp)
+    stats = state.stats()
+    # stats is a dict[str, int] — there is nowhere for key bytes to hide.
+    assert isinstance(stats, dict)
+    assert stats["tenant_signing_keys"] == 1
+    for v in stats.values():
+        assert isinstance(v, int)
+
+
+def test_signing_keypair_repr_does_not_leak_seed(key_store, state) -> None:
+    """Returned SigningKeyPair must follow the same repr discipline."""
+    _register_tenant(state)
+    kp = SigningKeyPair.generate()
+    seed_hex = kp.seed_bytes_insecure().hex()
+    key_store.put_signing_key("t1", kp)
+    restored = key_store.get_signing_key("t1")
+    assert seed_hex not in repr(restored)
+
+
+# -- Constructor validation -----------------------------------------------
+
+
+def test_constructor_rejects_wrong_state_type(device_key) -> None:
+    with pytest.raises(TypeError):
+        EncryptedTenantKeyStore(state="not-a-store", device_key=device_key)  # type: ignore[arg-type]
+
+
+def test_constructor_rejects_wrong_device_key_type(state) -> None:
+    with pytest.raises(TypeError):
+        EncryptedTenantKeyStore(state=state, device_key=b"raw-bytes")  # type: ignore[arg-type]

--- a/tests/pinky_federation/test_keys.py
+++ b/tests/pinky_federation/test_keys.py
@@ -1,0 +1,132 @@
+"""Key primitive tests: generation, serialization, DH correctness, repr safety."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pinky_federation.errors import SignatureError
+from pinky_federation.keys import (
+    ED25519_KEY_BYTES,
+    ED25519_SIG_BYTES,
+    X25519_KEY_BYTES,
+    EncryptionKeyPair,
+    EncryptionPublicKey,
+    SigningKeyPair,
+    SigningPublicKey,
+    x25519_public_from_private,
+)
+
+# -- Encryption keys ----------------------------------------------------------
+
+
+def test_encryption_keypair_generate_produces_unique_keys() -> None:
+    a = EncryptionKeyPair.generate()
+    b = EncryptionKeyPair.generate()
+    assert a.public_key.raw != b.public_key.raw
+    assert a.private_bytes_insecure() != b.private_bytes_insecure()
+
+
+def test_encryption_public_key_length_validation() -> None:
+    with pytest.raises(ValueError):
+        EncryptionPublicKey(b"\x00" * 31)
+    with pytest.raises(ValueError):
+        EncryptionPublicKey(b"\x00" * 33)
+
+
+def test_encryption_keypair_round_trip_private_bytes() -> None:
+    original = EncryptionKeyPair.generate()
+    restored = EncryptionKeyPair.from_private_bytes(original.private_bytes_insecure())
+    # Public keys must match exactly after reconstruction from private bytes.
+    assert restored.public_key.raw == original.public_key.raw
+
+
+def test_encryption_repr_hides_private_material() -> None:
+    kp = EncryptionKeyPair.generate()
+    text = repr(kp)
+    # Private scalar never appears in repr; only a short public prefix does.
+    assert kp.private_bytes_insecure().hex() not in text
+    assert kp.public_key.raw.hex() not in text  # only a prefix shown
+
+
+def test_dh_produces_symmetric_shared_secret() -> None:
+    alice = EncryptionKeyPair.generate()
+    bob = EncryptionKeyPair.generate()
+    s1 = alice.dh(bob.public_key)
+    s2 = bob.dh(alice.public_key)
+    assert s1 == s2
+    assert len(s1) == X25519_KEY_BYTES
+
+
+def test_dh_rejects_wrong_type() -> None:
+    alice = EncryptionKeyPair.generate()
+    with pytest.raises(TypeError):
+        alice.dh(b"\x00" * 32)  # type: ignore[arg-type]
+
+
+def test_x25519_public_from_private_matches_keypair() -> None:
+    sk_bytes = os.urandom(32)
+    derived = x25519_public_from_private(sk_bytes)
+    kp = EncryptionKeyPair.from_private_bytes(sk_bytes)
+    assert derived == kp.public_key.raw
+
+
+# -- Signing keys -------------------------------------------------------------
+
+
+def test_signing_keypair_sign_verify_round_trip() -> None:
+    kp = SigningKeyPair.generate()
+    msg = b"hello federation"
+    sig = kp.sign(msg)
+    assert len(sig) == ED25519_SIG_BYTES
+    # Should not raise.
+    kp.public_key.verify(msg, sig)
+
+
+def test_signing_verify_rejects_tampered_message() -> None:
+    kp = SigningKeyPair.generate()
+    sig = kp.sign(b"original")
+    with pytest.raises(SignatureError):
+        kp.public_key.verify(b"tampered", sig)
+
+
+def test_signing_verify_rejects_wrong_key() -> None:
+    kp = SigningKeyPair.generate()
+    other = SigningKeyPair.generate()
+    sig = kp.sign(b"hi")
+    with pytest.raises(SignatureError):
+        other.public_key.verify(b"hi", sig)
+
+
+def test_signing_verify_rejects_wrong_sig_length() -> None:
+    kp = SigningKeyPair.generate()
+    with pytest.raises(SignatureError):
+        kp.public_key.verify(b"hi", b"\x00" * 63)
+
+
+def test_signing_from_seed_is_deterministic() -> None:
+    seed = b"\x42" * ED25519_KEY_BYTES
+    a = SigningKeyPair.from_seed(seed)
+    b = SigningKeyPair.from_seed(seed)
+    assert a.public_key.raw == b.public_key.raw
+    # Signatures over the same message must match byte-for-byte (Ed25519 is deterministic).
+    assert a.sign(b"msg") == b.sign(b"msg")
+
+
+def test_signing_repr_hides_seed() -> None:
+    kp = SigningKeyPair.generate()
+    assert kp.seed_bytes_insecure().hex() not in repr(kp)
+
+
+def test_signing_public_round_trip() -> None:
+    kp = SigningKeyPair.generate()
+    raw = kp.public_key.to_bytes()
+    restored = SigningPublicKey.from_bytes(raw)
+    assert restored.raw == raw
+
+
+def test_signing_sign_rejects_non_bytes() -> None:
+    kp = SigningKeyPair.generate()
+    with pytest.raises(TypeError):
+        kp.sign("not bytes")  # type: ignore[arg-type]

--- a/tests/pinky_federation/test_sealed_box.py
+++ b/tests/pinky_federation/test_sealed_box.py
@@ -1,0 +1,414 @@
+"""Sealed-box-v1 end-to-end tests: round-trip, tamper detection, test vectors."""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_federation.envelope import Envelope
+from pinky_federation.errors import DecryptionError, SignatureError
+from pinky_federation.keys import (
+    EncryptionKeyPair,
+    SigningKeyPair,
+    SigningPublicKey,
+)
+from pinky_federation.sealed_box import (
+    SEALED_BOX_VERSION,
+    seal,
+    unseal,
+)
+
+# -- Fixtures -----------------------------------------------------------------
+
+
+@pytest.fixture
+def alice_signing() -> SigningKeyPair:
+    return SigningKeyPair.from_seed(b"\x11" * 32)
+
+
+@pytest.fixture
+def bob_encryption() -> EncryptionKeyPair:
+    return EncryptionKeyPair.from_private_bytes(b"\x22" * 32)
+
+
+@pytest.fixture
+def alice_fp() -> bytes:
+    return b"\xa1" * 16
+
+
+@pytest.fixture
+def bob_fp() -> bytes:
+    return b"\xb0" * 16
+
+
+# -- Round-trip ---------------------------------------------------------------
+
+
+def test_seal_unseal_round_trip(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    plaintext = b"hello bob, this is alice"
+    env = seal(
+        plaintext,
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    assert isinstance(env, Envelope)
+    assert env.version is SEALED_BOX_VERSION
+    assert env.sender_fingerprint == alice_fp
+    assert env.recipient_fingerprint == bob_fp
+
+    out = unseal(
+        env,
+        recipient_encryption=bob_encryption,
+        sender_signing_public=alice_signing.public_key,
+    )
+    assert out == plaintext
+
+
+def test_seal_empty_plaintext_round_trip(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    out = unseal(
+        env,
+        recipient_encryption=bob_encryption,
+        sender_signing_public=alice_signing.public_key,
+    )
+    assert out == b""
+
+
+def test_envelope_wire_round_trip_after_seal(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"across the wire",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    restored = Envelope.from_bytes(env.to_bytes())
+    out = unseal(
+        restored,
+        recipient_encryption=bob_encryption,
+        sender_signing_public=alice_signing.public_key,
+    )
+    assert out == b"across the wire"
+
+
+# -- Tamper detection ---------------------------------------------------------
+
+
+def test_unseal_rejects_tampered_ciphertext(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    # Flip a ciphertext bit — AEAD should reject.
+    tampered_ct = bytearray(env.ciphertext)
+    tampered_ct[0] ^= 0x01
+    tampered = Envelope(
+        version=env.version,
+        sender_fingerprint=env.sender_fingerprint,
+        recipient_fingerprint=env.recipient_fingerprint,
+        ephemeral_public=env.ephemeral_public,
+        nonce=env.nonce,
+        signature=env.signature,
+        ciphertext=bytes(tampered_ct),
+    )
+    # Signature covers ciphertext, so the first failure is actually SignatureError.
+    with pytest.raises(SignatureError):
+        unseal(
+            tampered,
+            recipient_encryption=bob_encryption,
+            sender_signing_public=alice_signing.public_key,
+        )
+
+
+def test_unseal_rejects_wrong_sender_pubkey(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    impostor = SigningKeyPair.generate().public_key
+    with pytest.raises(SignatureError):
+        unseal(
+            env,
+            recipient_encryption=bob_encryption,
+            sender_signing_public=impostor,
+        )
+
+
+def test_unseal_rejects_wrong_recipient_key(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    mallory = EncryptionKeyPair.generate()
+    # Wrong recipient → AEAD key mismatch → DecryptionError (signature still valid).
+    with pytest.raises(DecryptionError):
+        unseal(
+            env,
+            recipient_encryption=mallory,
+            sender_signing_public=alice_signing.public_key,
+        )
+
+
+def test_unseal_rejects_rebound_recipient_fingerprint(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    # Attacker swaps recipient_fingerprint without re-signing → sig fails.
+    rebound = Envelope(
+        version=env.version,
+        sender_fingerprint=env.sender_fingerprint,
+        recipient_fingerprint=b"\xcc" * 16,
+        ephemeral_public=env.ephemeral_public,
+        nonce=env.nonce,
+        signature=env.signature,
+        ciphertext=env.ciphertext,
+    )
+    with pytest.raises(SignatureError):
+        unseal(
+            rebound,
+            recipient_encryption=bob_encryption,
+            sender_signing_public=alice_signing.public_key,
+        )
+
+
+def test_unseal_rejects_replayed_sender_fingerprint(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    rebound = Envelope(
+        version=env.version,
+        sender_fingerprint=b"\xee" * 16,
+        recipient_fingerprint=env.recipient_fingerprint,
+        ephemeral_public=env.ephemeral_public,
+        nonce=env.nonce,
+        signature=env.signature,
+        ciphertext=env.ciphertext,
+    )
+    with pytest.raises(SignatureError):
+        unseal(
+            rebound,
+            recipient_encryption=bob_encryption,
+            sender_signing_public=alice_signing.public_key,
+        )
+
+
+def test_unseal_rejects_unsupported_version(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    env = seal(
+        b"secret",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+    )
+    # Force an unknown version number past IntEnum validation.
+    bogus = object.__new__(Envelope)
+    object.__setattr__(bogus, "version", object())  # not EnvelopeVersion
+    object.__setattr__(bogus, "sender_fingerprint", env.sender_fingerprint)
+    object.__setattr__(bogus, "recipient_fingerprint", env.recipient_fingerprint)
+    object.__setattr__(bogus, "ephemeral_public", env.ephemeral_public)
+    object.__setattr__(bogus, "nonce", env.nonce)
+    object.__setattr__(bogus, "signature", env.signature)
+    object.__setattr__(bogus, "ciphertext", env.ciphertext)
+    with pytest.raises(DecryptionError, match="unsupported envelope version"):
+        unseal(
+            bogus,  # type: ignore[arg-type]
+            recipient_encryption=bob_encryption,
+            sender_signing_public=alice_signing.public_key,
+        )
+
+
+# -- Input validation --------------------------------------------------------
+
+
+def test_seal_rejects_wrong_fingerprint_sizes(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    bob_fp: bytes,
+) -> None:
+    with pytest.raises(ValueError, match="sender_fingerprint"):
+        seal(
+            b"x",
+            sender_signing=alice_signing,
+            sender_fingerprint=b"\x00" * 8,
+            recipient_encryption=bob_encryption.public_key,
+            recipient_fingerprint=bob_fp,
+        )
+    with pytest.raises(ValueError, match="recipient_fingerprint"):
+        seal(
+            b"x",
+            sender_signing=alice_signing,
+            sender_fingerprint=b"\x00" * 16,
+            recipient_encryption=bob_encryption.public_key,
+            recipient_fingerprint=b"\x00" * 8,
+        )
+
+
+def test_seal_rejects_non_bytes_plaintext(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    with pytest.raises(TypeError):
+        seal(
+            "not bytes",  # type: ignore[arg-type]
+            sender_signing=alice_signing,
+            sender_fingerprint=alice_fp,
+            recipient_encryption=bob_encryption.public_key,
+            recipient_fingerprint=bob_fp,
+        )
+
+
+def test_seal_nonce_override_requires_correct_size(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    with pytest.raises(ValueError, match="nonce"):
+        seal(
+            b"x",
+            sender_signing=alice_signing,
+            sender_fingerprint=alice_fp,
+            recipient_encryption=bob_encryption.public_key,
+            recipient_fingerprint=bob_fp,
+            nonce=b"\x00" * 8,
+        )
+
+
+# -- Deterministic test vector (for relay compat tests) -----------------------
+
+
+def test_deterministic_vector_stable(
+    alice_signing: SigningKeyPair,
+    bob_encryption: EncryptionKeyPair,
+    alice_fp: bytes,
+    bob_fp: bytes,
+) -> None:
+    """Fully deterministic seal() output.
+
+    Purpose: lock the exact wire bytes so the Python relay and any future
+    clients can cross-verify. If this hex changes, the protocol has changed.
+
+    Inputs:
+        sender signing seed    = 0x11 * 32
+        recipient encryption sk = 0x22 * 32
+        ephemeral encryption sk = 0x33 * 32
+        sender_fp              = 0xa1 * 16
+        recipient_fp           = 0xb0 * 16
+        nonce                  = 0x44 * 24
+        plaintext              = b"hello bob"
+    """
+    ephemeral = EncryptionKeyPair.from_private_bytes(b"\x33" * 32)
+    env = seal(
+        b"hello bob",
+        sender_signing=alice_signing,
+        sender_fingerprint=alice_fp,
+        recipient_encryption=bob_encryption.public_key,
+        recipient_fingerprint=bob_fp,
+        nonce=b"\x44" * 24,
+        ephemeral=ephemeral,
+    )
+    wire = env.to_bytes()
+    assert wire.hex() == KNOWN_VECTOR_HEX
+
+    # And it must round-trip.
+    out = unseal(
+        env,
+        recipient_encryption=bob_encryption,
+        sender_signing_public=alice_signing.public_key,
+    )
+    assert out == b"hello bob"
+
+
+# Expected wire bytes for the deterministic vector above. Pinned by
+# test_deterministic_vector_stable. Update only on intentional protocol bumps.
+KNOWN_VECTOR_HEX = (
+    "504676310100"
+    + ("a1" * 16)  # sender_fp
+    + ("b0" * 16)  # recipient_fp
+    + "7b0d47d93427f8311160781c7c733fd89f88970aef490d8aa0ee19a4cb8a1b14"  # eph_pk
+    + ("44" * 24)  # nonce
+    + "65b3193d2dbf9fbee57daecda9bfbdd2b030835b13b42e6d7994747e1f6436c4"
+    + "c2c17ad573b2e788a03c6f647d2210d4df354a58c4bd4d4d52aac152933b0c05"  # sig
+    + "00000019"  # ct_len = 25
+    + "30065ea9d478499236d899a67f530cb513b720dfcc3704f4b2"  # ciphertext
+)
+
+
+def test_deterministic_vector_sender_pubkey_matches_seed(
+    alice_signing: SigningKeyPair,
+) -> None:
+    """Sanity check so the vector above is easy to reconstruct in other languages."""
+    expected = SigningKeyPair.from_seed(b"\x11" * 32).public_key.to_bytes()
+    assert alice_signing.public_key.to_bytes() == expected
+    assert isinstance(alice_signing.public_key, SigningPublicKey)

--- a/tests/pinky_federation/test_state.py
+++ b/tests/pinky_federation/test_state.py
@@ -1,0 +1,487 @@
+"""Federation state store tests: schema, CRUD, lifecycle, validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_federation.state import (
+    INBOX_ARCHIVED,
+    INBOX_NEW,
+    INBOX_READ,
+    INSTANCE_KEY_ACTIVE,
+    INSTANCE_KEY_DECRYPT_ONLY,
+    INSTANCE_KEY_KIND_ENCRYPTION,
+    INSTANCE_KEY_KIND_SIGNING,
+    INSTANCE_KEY_RETIRED,
+    INVITE_ACTIVE,
+    INVITE_REDEEMED,
+    OUTBOX_FAILED,
+    OUTBOX_PENDING,
+    OUTBOX_SENT,
+    PEER_PIN_PINNED,
+    PEER_PIN_REJECTED,
+    PEER_PIN_ROTATED,
+    ROLE_MEMBER,
+    ROLE_OWNER,
+    AttachmentRecord,
+    FederationStateStore,
+    InboxRecord,
+    InstanceKeyRecord,
+    InviteRecord,
+    OutboxRecord,
+    PeerPinRecord,
+    TenantRecord,
+)
+
+
+@pytest.fixture
+def store(tmp_path):
+    db_path = tmp_path / "fed.db"
+    s = FederationStateStore(str(db_path))
+    yield s
+    s.close()
+
+
+def _tenant(tenant_id: str = "t1", role: str = ROLE_MEMBER) -> TenantRecord:
+    return TenantRecord(
+        tenant_id=tenant_id,
+        address=f"{tenant_id}@example.com",
+        signing_pk=b"\x01" * 32,
+        role=role,
+    )
+
+
+# -- schema ---------------------------------------------------------------
+
+
+def test_schema_creates_all_tables(store: FederationStateStore) -> None:
+    expected = {
+        "tenants",
+        "tenant_signing_keys",
+        "instance_keys",
+        "peer_pins",
+        "outbox",
+        "inbox",
+        "issued_invites",
+        "attachments",
+    }
+    rows = store._db.execute(  # noqa: SLF001
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()
+    names = {r[0] for r in rows}
+    assert expected <= names
+
+
+def test_init_is_idempotent(tmp_path) -> None:
+    db_path = tmp_path / "fed.db"
+    s1 = FederationStateStore(str(db_path))
+    s1.close()
+    s2 = FederationStateStore(str(db_path))
+    s2.close()  # second open does not raise
+
+
+def test_stats_counts_only(store: FederationStateStore) -> None:
+    s = store.stats()
+    assert all(v == 0 for v in s.values())
+    assert "tenants" in s and "tenant_signing_keys" in s
+
+
+# -- tenants --------------------------------------------------------------
+
+
+def test_tenant_upsert_and_get(store: FederationStateStore) -> None:
+    rec = store.upsert_tenant(_tenant("brad", ROLE_OWNER))
+    assert rec.created_at > 0
+    got = store.get_tenant("brad")
+    assert got is not None
+    assert got.address == "brad@example.com"
+    assert got.role == ROLE_OWNER
+    assert got.signing_pk == b"\x01" * 32
+
+
+def test_tenant_upsert_overwrites_address_and_role(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("brad", ROLE_MEMBER))
+    rec = TenantRecord(
+        tenant_id="brad",
+        address="brad+new@example.com",
+        signing_pk=b"\x02" * 32,
+        role=ROLE_OWNER,
+    )
+    store.upsert_tenant(rec)
+    got = store.get_tenant("brad")
+    assert got is not None
+    assert got.address == "brad+new@example.com"
+    assert got.role == ROLE_OWNER
+
+
+def test_tenant_upsert_rejects_bad_role(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.upsert_tenant(
+            TenantRecord(
+                tenant_id="x", address="x@y", signing_pk=b"\x00" * 32, role="admin"
+            )
+        )
+
+
+def test_tenant_upsert_rejects_bad_signing_pk(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.upsert_tenant(
+            TenantRecord(tenant_id="x", address="x@y", signing_pk=b"short", role=ROLE_MEMBER)
+        )
+
+
+def test_tenant_list_orders_by_created_at(store: FederationStateStore) -> None:
+    a = store.upsert_tenant(TenantRecord(
+        tenant_id="a", address="a@x", signing_pk=b"\x01" * 32, created_at=1.0))
+    b = store.upsert_tenant(TenantRecord(
+        tenant_id="b", address="b@x", signing_pk=b"\x02" * 32, created_at=2.0))
+    listed = store.list_tenants()
+    assert [t.tenant_id for t in listed] == ["a", "b"]
+    assert a.tenant_id == "a" and b.tenant_id == "b"
+
+
+# -- instance keys --------------------------------------------------------
+
+
+def _ik(kid: str, tenant_id: str = "t1", state: str = INSTANCE_KEY_ACTIVE) -> InstanceKeyRecord:
+    return InstanceKeyRecord(
+        kid=kid,
+        tenant_id=tenant_id,
+        kind=INSTANCE_KEY_KIND_ENCRYPTION,
+        public_key=b"\x10" * 32,
+        encrypted_secret=b"\x20" * 48,
+        state=state,
+    )
+
+
+def test_instance_key_add_and_get(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    rec = store.add_instance_key(_ik("k1"))
+    assert rec.created_at > 0
+    got = store.get_instance_key("k1")
+    assert got is not None
+    assert got.tenant_id == "t1"
+    assert got.state == INSTANCE_KEY_ACTIVE
+
+
+def test_instance_key_validates_kind_and_state(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    with pytest.raises(ValueError):
+        store.add_instance_key(InstanceKeyRecord(
+            kid="bad", tenant_id="t1", kind="garbage", public_key=b"\x00" * 32,
+            encrypted_secret=b"\x00", state=INSTANCE_KEY_ACTIVE))
+    with pytest.raises(ValueError):
+        store.add_instance_key(InstanceKeyRecord(
+            kid="bad2", tenant_id="t1", kind=INSTANCE_KEY_KIND_SIGNING,
+            public_key=b"\x00" * 32, encrypted_secret=b"\x00", state="weird"))
+
+
+def test_instance_key_lifecycle_active_to_decrypt_only(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_instance_key(_ik("k1"))
+    store.transition_instance_key("k1", INSTANCE_KEY_DECRYPT_ONLY)
+    assert store.get_instance_key("k1").state == INSTANCE_KEY_DECRYPT_ONLY
+    store.transition_instance_key("k1", INSTANCE_KEY_RETIRED)
+    got = store.get_instance_key("k1")
+    assert got.state == INSTANCE_KEY_RETIRED
+    assert got.retired_at > 0
+
+
+def test_instance_key_lifecycle_active_directly_to_retired(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_instance_key(_ik("k1"))
+    store.transition_instance_key("k1", INSTANCE_KEY_RETIRED)
+    assert store.get_instance_key("k1").state == INSTANCE_KEY_RETIRED
+
+
+def test_instance_key_lifecycle_rejects_decrypt_only_to_active(
+    store: FederationStateStore,
+) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_instance_key(_ik("k1", state=INSTANCE_KEY_DECRYPT_ONLY))
+    with pytest.raises(ValueError):
+        store.transition_instance_key("k1", INSTANCE_KEY_ACTIVE)
+
+
+def test_instance_key_lifecycle_rejects_retired_to_anything(
+    store: FederationStateStore,
+) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_instance_key(_ik("k1", state=INSTANCE_KEY_RETIRED))
+    for target in (INSTANCE_KEY_ACTIVE, INSTANCE_KEY_DECRYPT_ONLY):
+        with pytest.raises(ValueError):
+            store.transition_instance_key("k1", target)
+
+
+def test_instance_key_transition_no_op_same_state(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_instance_key(_ik("k1"))
+    store.transition_instance_key("k1", INSTANCE_KEY_ACTIVE)  # no error
+    assert store.get_instance_key("k1").state == INSTANCE_KEY_ACTIVE
+
+
+def test_instance_key_transition_unknown_kid(store: FederationStateStore) -> None:
+    with pytest.raises(KeyError):
+        store.transition_instance_key("nope", INSTANCE_KEY_RETIRED)
+
+
+def test_list_instance_keys_filters(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.upsert_tenant(_tenant("t2"))
+    store.add_instance_key(_ik("k1", tenant_id="t1"))
+    store.add_instance_key(_ik("k2", tenant_id="t1", state=INSTANCE_KEY_DECRYPT_ONLY))
+    store.add_instance_key(_ik("k3", tenant_id="t2"))
+    assert {k.kid for k in store.list_instance_keys(tenant_id="t1")} == {"k1", "k2"}
+    assert {k.kid for k in store.list_instance_keys(state=INSTANCE_KEY_ACTIVE)} == {"k1", "k3"}
+    assert {
+        k.kid for k in store.list_instance_keys(kind=INSTANCE_KEY_KIND_ENCRYPTION)
+    } == {"k1", "k2", "k3"}
+
+
+# -- peer pins ------------------------------------------------------------
+
+
+def _pin(addr: str = "alice@example.com", status: str = PEER_PIN_PINNED) -> PeerPinRecord:
+    return PeerPinRecord(
+        peer_address=addr,
+        sig_pk=b"\x11" * 32,
+        enc_pk=b"\x22" * 32,
+        fingerprint=b"\xaa" * 16,
+        status=status,
+    )
+
+
+def test_peer_pin_upsert_sets_first_and_last_seen(store: FederationStateStore) -> None:
+    rec = store.upsert_peer_pin(_pin())
+    assert rec.first_seen > 0
+    assert rec.last_seen >= rec.first_seen
+    got = store.get_peer_pin("alice@example.com")
+    assert got is not None
+    assert got.fingerprint == b"\xaa" * 16
+
+
+def test_peer_pin_upsert_preserves_first_seen_on_update(
+    store: FederationStateStore,
+) -> None:
+    first = store.upsert_peer_pin(_pin())
+    original_first_seen = first.first_seen
+    second = store.upsert_peer_pin(
+        PeerPinRecord(
+            peer_address="alice@example.com",
+            sig_pk=b"\x33" * 32,
+            enc_pk=b"\x44" * 32,
+            fingerprint=b"\xbb" * 16,
+            status=PEER_PIN_ROTATED,
+            first_seen=original_first_seen,
+        )
+    )
+    got = store.get_peer_pin("alice@example.com")
+    assert got.first_seen == original_first_seen
+    assert got.last_seen >= second.last_seen - 1
+    assert got.status == PEER_PIN_ROTATED
+    assert got.sig_pk == b"\x33" * 32
+
+
+def test_peer_pin_validates_lengths(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.upsert_peer_pin(
+            PeerPinRecord(
+                peer_address="x", sig_pk=b"short", enc_pk=b"\x00" * 32,
+                fingerprint=b"\x00" * 16))
+    with pytest.raises(ValueError):
+        store.upsert_peer_pin(
+            PeerPinRecord(
+                peer_address="x", sig_pk=b"\x00" * 32, enc_pk=b"\x00" * 32,
+                fingerprint=b"\x00" * 8))
+
+
+def test_peer_pin_rejects_bad_status(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.upsert_peer_pin(_pin(status="weird"))
+
+
+def test_peer_pin_status_rejected_round_trip(store: FederationStateStore) -> None:
+    store.upsert_peer_pin(_pin(status=PEER_PIN_REJECTED))
+    got = store.get_peer_pin("alice@example.com")
+    assert got.status == PEER_PIN_REJECTED
+
+
+# -- outbox ---------------------------------------------------------------
+
+
+def _ob(msg_id: str = "m1") -> OutboxRecord:
+    return OutboxRecord(
+        msg_id=msg_id,
+        tenant_id="t1",
+        recipient_address="alice@example.com",
+        envelope_blob=b"envelope-bytes",
+    )
+
+
+def test_outbox_enqueue_and_list(store: FederationStateStore) -> None:
+    store.enqueue_outbound(_ob("m1"))
+    store.enqueue_outbound(_ob("m2"))
+    pending = store.list_outbound(status=OUTBOX_PENDING)
+    assert {r.msg_id for r in pending} == {"m1", "m2"}
+
+
+def test_outbox_mark_sent_increments_attempts(store: FederationStateStore) -> None:
+    store.enqueue_outbound(_ob("m1"))
+    store.mark_outbound_status("m1", OUTBOX_SENT)
+    sent = store.list_outbound(status=OUTBOX_SENT)
+    assert len(sent) == 1
+    assert sent[0].attempts == 1
+
+
+def test_outbox_mark_failed_records_error(store: FederationStateStore) -> None:
+    store.enqueue_outbound(_ob("m1"))
+    store.mark_outbound_status("m1", OUTBOX_FAILED, last_error="relay 503", next_retry_at=42.0)
+    failed = store.list_outbound(status=OUTBOX_FAILED)
+    assert failed[0].last_error == "relay 503"
+    assert failed[0].next_retry_at == 42.0
+
+
+def test_outbox_mark_unknown_msg_raises(store: FederationStateStore) -> None:
+    with pytest.raises(KeyError):
+        store.mark_outbound_status("nope", OUTBOX_SENT)
+
+
+def test_outbox_status_filter_validation(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.list_outbound(status="weird")
+
+
+# -- inbox ----------------------------------------------------------------
+
+
+def _ib(msg_id: str = "i1", tenant_id: str = "t1") -> InboxRecord:
+    return InboxRecord(
+        msg_id=msg_id,
+        tenant_id=tenant_id,
+        sender_address="alice@example.com",
+        plaintext_blob=b"hello",
+    )
+
+
+def test_inbox_store_and_list(store: FederationStateStore) -> None:
+    store.store_inbound(_ib("i1"))
+    store.store_inbound(_ib("i2"))
+    rows = store.list_inbound(tenant_id="t1")
+    assert {r.msg_id for r in rows} == {"i1", "i2"}
+
+
+def test_inbox_mark_read_then_archived(store: FederationStateStore) -> None:
+    store.store_inbound(_ib("i1"))
+    store.mark_inbound_status("i1", INBOX_READ)
+    assert store.list_inbound(status=INBOX_READ)[0].msg_id == "i1"
+    store.mark_inbound_status("i1", INBOX_ARCHIVED)
+    assert store.list_inbound(status=INBOX_ARCHIVED)[0].status == INBOX_ARCHIVED
+
+
+def test_inbox_default_status_is_new(store: FederationStateStore) -> None:
+    store.store_inbound(_ib("i1"))
+    assert store.list_inbound(status=INBOX_NEW)[0].status == INBOX_NEW
+
+
+def test_inbox_mark_unknown_raises(store: FederationStateStore) -> None:
+    with pytest.raises(KeyError):
+        store.mark_inbound_status("nope", INBOX_READ)
+
+
+# -- invites --------------------------------------------------------------
+
+
+def _inv(invite_id: str = "v1") -> InviteRecord:
+    return InviteRecord(
+        invite_id=invite_id,
+        tenant_id="t1",
+        recipient_hint="alice@example.com",
+        token_hash=b"\xdd" * 32,
+        expires_at=999999999.0,
+    )
+
+
+def test_invite_add_and_list(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_invite(_inv("v1"))
+    store.add_invite(_inv("v2"))
+    listed = store.list_invites(tenant_id="t1")
+    assert {i.invite_id for i in listed} == {"v1", "v2"}
+
+
+def test_invite_token_hash_must_be_32_bytes(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    with pytest.raises(ValueError):
+        store.add_invite(InviteRecord(
+            invite_id="v1", tenant_id="t1", token_hash=b"short", expires_at=1.0))
+
+
+def test_invite_status_lifecycle(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    store.add_invite(_inv("v1"))
+    assert store.list_invites(status=INVITE_ACTIVE)[0].invite_id == "v1"
+    store.mark_invite_status("v1", INVITE_REDEEMED)
+    assert store.list_invites(status=INVITE_REDEEMED)[0].invite_id == "v1"
+
+
+def test_invite_mark_unknown_raises(store: FederationStateStore) -> None:
+    with pytest.raises(KeyError):
+        store.mark_invite_status("nope", INVITE_REDEEMED)
+
+
+# -- attachments ----------------------------------------------------------
+
+
+def _att(att_id: str = "a1", msg_id: str = "i1") -> AttachmentRecord:
+    return AttachmentRecord(
+        attachment_id=att_id,
+        msg_id=msg_id,
+        sha256=b"\x99" * 32,
+        size=1024,
+        mime="image/png",
+        local_path="/tmp/blob",
+        encrypted=True,
+    )
+
+
+def test_attachment_add_and_list(store: FederationStateStore) -> None:
+    store.add_attachment(_att("a1"))
+    store.add_attachment(_att("a2"))
+    rows = store.list_attachments("i1")
+    assert {a.attachment_id for a in rows} == {"a1", "a2"}
+    assert rows[0].encrypted is True
+    assert rows[0].size == 1024
+
+
+def test_attachment_validates_sha_and_size(store: FederationStateStore) -> None:
+    with pytest.raises(ValueError):
+        store.add_attachment(AttachmentRecord(
+            attachment_id="a", msg_id="m", sha256=b"short", size=1, local_path="/x"))
+    with pytest.raises(ValueError):
+        store.add_attachment(AttachmentRecord(
+            attachment_id="a", msg_id="m", sha256=b"\x00" * 32, size=-1, local_path="/x"))
+
+
+# -- foreign keys ---------------------------------------------------------
+
+
+def test_tenant_signing_keys_fk_cascades_on_tenant_delete(store: FederationStateStore) -> None:
+    store.upsert_tenant(_tenant("t1"))
+    # Insert a row directly via the connection (key_store does this normally).
+    store._db.execute(  # noqa: SLF001
+        "INSERT INTO tenant_signing_keys (tenant_id, encrypted_seed, nonce, "
+        "kdf_version, created_at) VALUES (?, ?, ?, ?, ?)",
+        ("t1", b"ct", b"n", 1, 1.0),
+    )
+    store._db.commit()  # noqa: SLF001
+    store._db.execute("DELETE FROM tenants WHERE tenant_id = ?", ("t1",))  # noqa: SLF001
+    store._db.commit()  # noqa: SLF001
+    rows = store._db.execute(  # noqa: SLF001
+        "SELECT * FROM tenant_signing_keys WHERE tenant_id = ?", ("t1",)
+    ).fetchall()
+    assert rows == []
+
+
+def test_db_uses_wal_mode(store: FederationStateStore) -> None:
+    mode = store._db.execute("PRAGMA journal_mode").fetchone()[0]  # noqa: SLF001
+    assert mode.lower() == "wal"

--- a/tests/pinky_federation/test_tofu.py
+++ b/tests/pinky_federation/test_tofu.py
@@ -1,0 +1,435 @@
+"""TOFU trust policy tests.
+
+Exercises the state machine end-to-end:
+
+    (none) → first_seen → pinned → changed → pinned   (accept_rotation)
+                                  → rejected          (reject_rotation)
+                       → verified                     (verify)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_federation.keys import EncryptionKeyPair, SigningKeyPair
+from pinky_federation.state import (
+    PEER_PIN_CHANGED,
+    PEER_PIN_FIRST_SEEN,
+    PEER_PIN_PINNED,
+    PEER_PIN_REJECTED,
+    PEER_PIN_VERIFIED,
+    FederationStateStore,
+)
+from pinky_federation.tofu import (
+    NoPendingRotationError,
+    TofuError,
+    TrustDecision,
+    TrustPolicy,
+    UnknownPeerError,
+)
+
+ADDR = "alice@example.com"
+
+
+@pytest.fixture
+def store(tmp_path):
+    db_path = tmp_path / "fed.db"
+    s = FederationStateStore(str(db_path))
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def policy(store: FederationStateStore) -> TrustPolicy:
+    return TrustPolicy(store)
+
+
+def _new_keys() -> tuple[SigningKeyPair, EncryptionKeyPair]:
+    """Fresh random signing + encryption keypairs."""
+    return SigningKeyPair.generate(), EncryptionKeyPair.generate()
+
+
+# -- first observation (TOFU auto-pin) -----------------------------------
+
+
+def test_first_observation_auto_pins(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    result = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert result.decision == TrustDecision.FIRST_SEEN
+    assert result.record.status == PEER_PIN_FIRST_SEEN
+    assert result.record.sig_pk == sig.public_key.to_bytes()
+    assert result.record.enc_pk == enc.public_key.to_bytes()
+    assert result.record.fingerprint  # non-empty, 16 bytes
+    assert len(result.record.fingerprint) == 16
+    assert result.record.first_seen > 0
+    # first_seen and last_seen are both set to ~now (within the same call);
+    # we tolerate tiny clock drift between the two timestamp captures.
+    assert abs(result.record.first_seen - result.record.last_seen) < 0.1
+    assert result.trusted
+
+
+def test_first_seen_is_trusted_but_unverified(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    result = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert result.trusted is True
+    assert result.record.status != PEER_PIN_VERIFIED
+
+
+# -- repeat observation with same keys -----------------------------------
+
+
+def test_second_observation_matching_promotes_to_pinned(
+    policy: TrustPolicy,
+) -> None:
+    sig, enc = _new_keys()
+    first = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert first.record.status == PEER_PIN_FIRST_SEEN
+
+    second = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert second.decision == TrustDecision.TRUSTED
+    assert second.record.status == PEER_PIN_PINNED
+    assert second.record.last_seen >= first.record.last_seen
+
+
+def test_repeat_observation_pinned_is_idempotent(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    policy.observe(ADDR, sig.public_key, enc.public_key)  # → pinned
+    third = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert third.decision == TrustDecision.TRUSTED
+    assert third.record.status == PEER_PIN_PINNED
+
+
+# -- mismatch detection --------------------------------------------------
+
+
+def test_different_fingerprint_triggers_mismatch(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # → pinned
+
+    sig2, enc2 = _new_keys()
+    result = policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    assert result.decision == TrustDecision.MISMATCH
+    assert result.record.status == PEER_PIN_CHANGED
+    # Primary slot still holds the ORIGINAL pin — we don't silently overwrite.
+    assert result.record.sig_pk == sig1.public_key.to_bytes()
+    assert result.record.enc_pk == enc1.public_key.to_bytes()
+    # Pending slot captured the new proposal.
+    assert result.record.pending_sig_pk == sig2.public_key.to_bytes()
+    assert result.record.pending_enc_pk == enc2.public_key.to_bytes()
+    assert result.record.pending_fingerprint != result.record.fingerprint
+    assert result.record.pending_first_seen > 0
+    assert not result.trusted
+
+
+def test_mismatch_from_first_seen_state(policy: TrustPolicy) -> None:
+    """Mismatch should also trigger if we only have a first_seen pin, not
+    a fully promoted pinned one."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # first_seen
+
+    sig2, enc2 = _new_keys()
+    result = policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    assert result.decision == TrustDecision.MISMATCH
+    assert result.record.status == PEER_PIN_CHANGED
+
+
+def test_mismatch_is_not_silently_accepted_on_repeat(policy: TrustPolicy) -> None:
+    """A second observation with the same mismatched keys does NOT promote
+    the proposal — it stays in changed state."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # mismatch
+    result = policy.observe(ADDR, sig2.public_key, enc2.public_key)  # again
+    assert result.decision == TrustDecision.MISMATCH
+    assert result.record.status == PEER_PIN_CHANGED
+    # Primary pin was NOT overwritten by the repeat.
+    assert result.record.sig_pk == sig1.public_key.to_bytes()
+
+
+def test_mismatch_pending_updates_with_yet_another_fp(policy: TrustPolicy) -> None:
+    """If, while in changed state, a third distinct fingerprint arrives,
+    the pending slot is updated to the latest — the operator sees the
+    freshest attacker/rotating-peer keys."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # mismatch → changed
+
+    sig3, enc3 = _new_keys()
+    result = policy.observe(ADDR, sig3.public_key, enc3.public_key)
+    assert result.decision == TrustDecision.MISMATCH
+    assert result.record.status == PEER_PIN_CHANGED
+    assert result.record.pending_sig_pk == sig3.public_key.to_bytes()
+
+
+def test_pinned_peer_returning_to_original_fp_from_changed_clears_pending(
+    policy: TrustPolicy,
+) -> None:
+    """If we're in changed state and the peer shows up with the ORIGINAL
+    pinned fingerprint again, the proposal was a blip — clear pending,
+    back to pinned."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # changed
+
+    result = policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    assert result.decision == TrustDecision.TRUSTED
+    assert result.record.status == PEER_PIN_PINNED
+    assert result.record.pending_fingerprint == b""
+    assert result.record.pending_sig_pk == b""
+
+
+# -- accept_rotation -----------------------------------------------------
+
+
+def test_accept_rotation_promotes_pending(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # mismatch
+
+    record = policy.accept_rotation(ADDR)
+    assert record.status == PEER_PIN_PINNED
+    assert record.sig_pk == sig2.public_key.to_bytes()
+    assert record.enc_pk == enc2.public_key.to_bytes()
+    assert record.pending_fingerprint == b""
+    assert record.pending_sig_pk == b""
+    # Subsequent lookups with new keys are now TRUSTED.
+    result = policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    assert result.decision == TrustDecision.TRUSTED
+
+
+def test_accept_rotation_with_explicit_keys_overrides_pending(
+    policy: TrustPolicy,
+) -> None:
+    """Operator provides out-of-band verified keys — those win over whatever
+    was in the pending slot."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    # attacker-style pending proposal
+    sig_bad, enc_bad = _new_keys()
+    policy.observe(ADDR, sig_bad.public_key, enc_bad.public_key)
+
+    # operator verifies a different set of keys out-of-band
+    sig_good, enc_good = _new_keys()
+    record = policy.accept_rotation(ADDR, sig_good.public_key, enc_good.public_key)
+    assert record.sig_pk == sig_good.public_key.to_bytes()
+    assert record.enc_pk == enc_good.public_key.to_bytes()
+    assert record.status == PEER_PIN_PINNED
+    assert record.pending_fingerprint == b""
+
+
+def test_accept_rotation_without_pending_or_keys_raises(
+    policy: TrustPolicy,
+) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # first_seen, no pending
+
+    with pytest.raises(NoPendingRotationError):
+        policy.accept_rotation(ADDR)
+
+
+def test_accept_rotation_partial_keys_raises(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+
+    sig2, _enc2 = _new_keys()
+    with pytest.raises(ValueError):
+        policy.accept_rotation(ADDR, sig_pk=sig2.public_key)
+
+
+def test_accept_rotation_unknown_peer_raises(policy: TrustPolicy) -> None:
+    with pytest.raises(UnknownPeerError):
+        policy.accept_rotation("nobody@example.com")
+
+
+# -- reject_rotation -----------------------------------------------------
+
+
+def test_reject_rotation_sets_status_and_clears_pending(
+    policy: TrustPolicy,
+) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # mismatch
+
+    record = policy.reject_rotation(ADDR)
+    assert record.status == PEER_PIN_REJECTED
+    assert record.pending_fingerprint == b""
+    assert record.pending_sig_pk == b""
+
+
+def test_rejected_peer_observe_returns_rejected_regardless(
+    policy: TrustPolicy,
+) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    policy.reject_rotation(ADDR)
+
+    # Even the "original" keys should now return REJECTED.
+    r1 = policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    assert r1.decision == TrustDecision.REJECTED
+    # And any new keys.
+    sig3, enc3 = _new_keys()
+    r2 = policy.observe(ADDR, sig3.public_key, enc3.public_key)
+    assert r2.decision == TrustDecision.REJECTED
+
+
+def test_rejected_peer_can_be_re_accepted_by_operator(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    policy.reject_rotation(ADDR)
+
+    # Operator changes mind.
+    sig3, enc3 = _new_keys()
+    record = policy.accept_rotation(ADDR, sig3.public_key, enc3.public_key)
+    assert record.status == PEER_PIN_PINNED
+
+    result = policy.observe(ADDR, sig3.public_key, enc3.public_key)
+    assert result.decision == TrustDecision.TRUSTED
+
+
+def test_reject_rotation_unknown_peer_raises(policy: TrustPolicy) -> None:
+    with pytest.raises(UnknownPeerError):
+        policy.reject_rotation("nobody@example.com")
+
+
+# -- verify --------------------------------------------------------------
+
+
+def test_verify_promotes_pinned_to_verified(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    policy.observe(ADDR, sig.public_key, enc.public_key)  # pinned
+
+    record = policy.verify(ADDR)
+    assert record.status == PEER_PIN_VERIFIED
+    assert record.verified_at > 0
+
+
+def test_verify_on_first_seen_is_allowed(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+
+    record = policy.verify(ADDR)
+    assert record.status == PEER_PIN_VERIFIED
+
+
+def test_verify_refuses_changed_state(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)
+
+    with pytest.raises(TofuError):
+        policy.verify(ADDR)
+
+
+def test_verify_refuses_rejected_state(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    policy.reject_rotation(ADDR)
+
+    with pytest.raises(TofuError):
+        policy.verify(ADDR)
+
+
+def test_verify_unknown_peer_raises(policy: TrustPolicy) -> None:
+    with pytest.raises(UnknownPeerError):
+        policy.verify("nobody@example.com")
+
+
+def test_verified_peer_observation_still_trusted(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    policy.verify(ADDR)
+
+    result = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert result.decision == TrustDecision.TRUSTED
+    # verify() state persists across subsequent identical observations.
+    assert result.record.status == PEER_PIN_VERIFIED
+
+
+def test_accept_rotation_clears_verified_flag(policy: TrustPolicy) -> None:
+    """A rotation invalidates prior verification — operator must re-verify."""
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    policy.verify(ADDR)
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    record = policy.accept_rotation(ADDR)
+    assert record.status == PEER_PIN_PINNED
+    assert record.verified_at == 0
+
+
+# -- list_changed --------------------------------------------------------
+
+
+def test_list_changed_returns_only_changed_peers(policy: TrustPolicy) -> None:
+    # Peer with no mismatch.
+    sig_a, enc_a = _new_keys()
+    policy.observe("a@example.com", sig_a.public_key, enc_a.public_key)
+    policy.observe("a@example.com", sig_a.public_key, enc_a.public_key)
+
+    # Peer in changed state.
+    sig_b1, enc_b1 = _new_keys()
+    policy.observe("b@example.com", sig_b1.public_key, enc_b1.public_key)
+    policy.observe("b@example.com", sig_b1.public_key, enc_b1.public_key)
+    sig_b2, enc_b2 = _new_keys()
+    policy.observe("b@example.com", sig_b2.public_key, enc_b2.public_key)
+
+    # Peer that was rejected.
+    sig_c1, enc_c1 = _new_keys()
+    policy.observe("c@example.com", sig_c1.public_key, enc_c1.public_key)
+    policy.observe("c@example.com", sig_c1.public_key, enc_c1.public_key)
+    sig_c2, enc_c2 = _new_keys()
+    policy.observe("c@example.com", sig_c2.public_key, enc_c2.public_key)
+    policy.reject_rotation("c@example.com")
+
+    changed = policy.list_changed()
+    addrs = {r.peer_address for r in changed}
+    assert addrs == {"b@example.com"}
+
+
+# -- get -----------------------------------------------------------------
+
+
+def test_get_returns_none_for_unknown(policy: TrustPolicy) -> None:
+    assert policy.get("nobody@example.com") is None
+
+
+def test_get_returns_record_for_known(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    record = policy.get(ADDR)
+    assert record is not None
+    assert record.peer_address == ADDR


### PR DESCRIPTION
## Summary

Implements **P-03** ([#252](https://github.com/bradbrok/PinkyBot/issues/252)) — trust-on-first-use pinning against the relay key directory, with a proper state machine for fingerprint mismatches. Stacked on top of P-02 (#265, `feat/federation-state`) which shipped the `peer_pins` slice of the schema.

This is the local trust policy that stops the relay directory from silently becoming the cryptographic trust root.

### State machine

```
(none) → first_seen → pinned → changed → pinned   (accept_rotation)
                                       → rejected (reject_rotation)
                   → verified                     (verify)
```

- **First sighting** auto-pins the fingerprint (TOFU).
- **Subsequent lookups** compare presented keys against the pinned slot.
- **Mismatch is never silently accepted** — the new proposal is captured in a separate ``pending_*`` slot on ``peer_pins`` and the peer enters ``changed`` state. The operator must explicitly accept or reject.
- **Rejected peers** return REJECTED from ``observe()`` regardless of keys, until the operator explicitly accepts a rotation.
- **Verified** (operator-blessed out-of-band) is a distinct, stronger state than TOFU-pinned. Rotation clears verification and requires re-verify.

### Acceptance criteria (from #252)

- [x] First lookup of a peer pins the fingerprint locally.
- [x] Subsequent lookups compare against the pinned fingerprint before encrypting.
- [x] Unexpected fingerprint changes produce a warning state, not silent acceptance.
- [x] Expected rotations can be explicitly accepted and repinned by the operator.
- [x] The state machine distinguishes first-seen, pinned, changed, and verified states.

### Schema changes

Forward-compatible, migrated via ``_ensure_columns``:

- ``peer_pins`` gains ``pending_sig_pk`` / ``pending_enc_pk`` / ``pending_fingerprint`` / ``pending_first_seen`` / ``verified_at`` columns (nullable).
- New status constants: ``PEER_PIN_FIRST_SEEN``, ``PEER_PIN_CHANGED``, ``PEER_PIN_VERIFIED``. ``PEER_PIN_ROTATED`` retained as a P-02 backward-compat alias (treated as pinned by the policy).

### Public API

```python
from pinky_federation import TrustPolicy, TrustDecision, FederationStateStore

store = FederationStateStore()
policy = TrustPolicy(store)

result = policy.observe(addr, sig_pk, enc_pk)
if result.trusted:
    # safe to encrypt
    ...
elif result.decision == TrustDecision.MISMATCH:
    # surface to operator; policy.accept_rotation(addr) or .reject_rotation(addr)
    ...

# Operator actions:
policy.accept_rotation(addr)                       # promote pending → primary
policy.accept_rotation(addr, sig_pk, enc_pk)       # out-of-band verified keys
policy.reject_rotation(addr)                       # clear pending, mark rejected
policy.verify(addr)                                # promote pinned → verified
policy.list_changed()                              # operator inbox
```

## Test plan

- [x] Federation suite: 147/147 passing
- [x] Full suite: 1619/1619 passing (+28 new TOFU tests)
- [x] Ruff clean on ``src/pinky_federation/`` and ``tests/pinky_federation/``
- [x] All state transitions covered, including:
  - first_seen → pinned → changed → pinned (via accept_rotation with pending)
  - first_seen → pinned → changed → pinned (via accept_rotation with out-of-band keys)
  - pinned → changed → rejected → pinned (re-accept after operator changes mind)
  - Mismatch during mismatch (third distinct fingerprint updates pending slot)
  - Back-to-original blip recovery (changed → pinned when original keys reappear)
  - verify() refuses changed / rejected states
  - accept_rotation clears prior verification flag

## Stack

- Base branch: ``feat/federation-state`` (#265, draft)
- Will retarget to ``beta`` once #264 and #265 land.

## Non-goals

- UI surfacing of the pending-rotations inbox — that lives with the frontend work, not this slice.
- Transport-layer integration (hook ``observe()`` into the outbound encrypt path) — deferred to P-04.

🤖 Opened by Barsik