### PR TITLE
feat(federation): TOFU pinning + fingerprint mismatch state machine (#252)

### DIFF
--- a/src/pinky_federation/__init__.py
+++ b/src/pinky_federation/__init__.py
@@ -64,9 +64,12 @@ from pinky_federation.state import (
     OUTBOX_FAILED,
     OUTBOX_PENDING,
     OUTBOX_SENT,
+    PEER_PIN_CHANGED,
+    PEER_PIN_FIRST_SEEN,
     PEER_PIN_PINNED,
     PEER_PIN_REJECTED,
     PEER_PIN_ROTATED,
+    PEER_PIN_VERIFIED,
     ROLE_MEMBER,
     ROLE_OWNER,
     AttachmentRecord,
@@ -77,6 +80,14 @@ from pinky_federation.state import (
     OutboxRecord,
     PeerPinRecord,
     TenantRecord,
+)
+from pinky_federation.tofu import (
+    NoPendingRotationError,
+    TofuError,
+    TrustDecision,
+    TrustPolicy,
+    TrustResult,
+    UnknownPeerError,
 )
 
 __all__ = [
@@ -118,7 +129,10 @@ __all__ = [
     "INSTANCE_KEY_RETIRED",
     "INSTANCE_KEY_KIND_ENCRYPTION",
     "INSTANCE_KEY_KIND_SIGNING",
+    "PEER_PIN_FIRST_SEEN",
     "PEER_PIN_PINNED",
+    "PEER_PIN_CHANGED",
+    "PEER_PIN_VERIFIED",
     "PEER_PIN_ROTATED",
     "PEER_PIN_REJECTED",
     "OUTBOX_PENDING",
@@ -138,4 +152,11 @@ __all__ = [
     "DEVICE_KEY_BYTES",
     "DeviceKey",
     "EncryptedTenantKeyStore",
+    # TOFU
+    "TrustPolicy",
+    "TrustDecision",
+    "TrustResult",
+    "TofuError",
+    "NoPendingRotationError",
+    "UnknownPeerError",
 ]

--- a/src/pinky_federation/state.py
+++ b/src/pinky_federation/state.py
@@ -61,10 +61,36 @@ _VALID_INSTANCE_KEY_KINDS = frozenset(
 )
 
 # Peer-pin status values.
+#
+# State machine (P-03, TOFU):
+#
+#     (none) --lookup first time--> first_seen
+#     first_seen --lookup same fp--> pinned
+#     pinned     --lookup diff fp--> changed         (quarantined, operator must decide)
+#     changed    --accept_rotation--> pinned         (operator re-pins new fp)
+#     changed    --reject_rotation--> rejected       (operator refuses new fp)
+#     rejected   --accept_rotation--> pinned         (operator changes mind later)
+#     any        --verify()---------> verified       (operator explicitly blesses current pin)
+#
+# ``rotated`` is retained for backward-compat (P-02 writes) and treated as
+# an alias of ``pinned`` by the trust policy, since P-02 never actually
+# transitioned anything into that state before P-03 landed.
+PEER_PIN_FIRST_SEEN = "first_seen"
 PEER_PIN_PINNED = "pinned"
-PEER_PIN_ROTATED = "rotated"
+PEER_PIN_CHANGED = "changed"
+PEER_PIN_VERIFIED = "verified"
+PEER_PIN_ROTATED = "rotated"  # deprecated: P-02 alias of ``pinned``
 PEER_PIN_REJECTED = "rejected"
-_VALID_PEER_PIN_STATUSES = frozenset({PEER_PIN_PINNED, PEER_PIN_ROTATED, PEER_PIN_REJECTED})
+_VALID_PEER_PIN_STATUSES = frozenset(
+    {
+        PEER_PIN_FIRST_SEEN,
+        PEER_PIN_PINNED,
+        PEER_PIN_CHANGED,
+        PEER_PIN_VERIFIED,
+        PEER_PIN_ROTATED,
+        PEER_PIN_REJECTED,
+    }
+)
 
 # Outbox status values.
 OUTBOX_PENDING = "pending"
@@ -101,6 +127,25 @@ def _now() -> float:
     return time.time()
 
 
+def _row_to_peer_pin(row) -> "PeerPinRecord":
+    return PeerPinRecord(
+        peer_address=row["peer_address"],
+        sig_pk=bytes(row["sig_pk"]),
+        enc_pk=bytes(row["enc_pk"]),
+        fingerprint=bytes(row["fingerprint"]),
+        status=row["status"],
+        first_seen=row["first_seen"],
+        last_seen=row["last_seen"],
+        pending_sig_pk=bytes(row["pending_sig_pk"]) if row["pending_sig_pk"] else b"",
+        pending_enc_pk=bytes(row["pending_enc_pk"]) if row["pending_enc_pk"] else b"",
+        pending_fingerprint=(
+            bytes(row["pending_fingerprint"]) if row["pending_fingerprint"] else b""
+        ),
+        pending_first_seen=row["pending_first_seen"],
+        verified_at=row["verified_at"],
+    )
+
+
 # -- Records ---------------------------------------------------------------
 
 
@@ -133,15 +178,28 @@ class InstanceKeyRecord:
 
 @dataclass
 class PeerPinRecord:
-    """TOFU pin for a remote peer."""
+    """TOFU pin for a remote peer.
+
+    The primary slot (``sig_pk``/``enc_pk``/``fingerprint``) holds the current
+    trusted keys. When a lookup sees a fingerprint that doesn't match, the new
+    keys are *not* overwritten — they're captured in the ``pending_*`` slot and
+    ``status`` moves to ``changed``. The operator then explicitly accepts (the
+    pending slot is promoted to the primary slot) or rejects (the pending slot
+    is cleared and ``status`` moves to ``rejected``).
+    """
 
     peer_address: str = ""
     sig_pk: bytes = b""
     enc_pk: bytes = b""
     fingerprint: bytes = b""
-    status: str = PEER_PIN_PINNED
+    status: str = PEER_PIN_FIRST_SEEN
     first_seen: float = 0.0
     last_seen: float = 0.0
+    pending_sig_pk: bytes = b""
+    pending_enc_pk: bytes = b""
+    pending_fingerprint: bytes = b""
+    pending_first_seen: float = 0.0
+    verified_at: float = 0.0
 
 
 @dataclass
@@ -346,11 +404,24 @@ class FederationStateStore:
 
     def _ensure_columns(self) -> None:
         """Forward-compatible column additions following the project pattern."""
-        # No migrations yet — this is the initial schema. Future additions:
-        #   migrations: list[tuple[str, str, list[tuple[str, str]]]] = [
-        #       ("table", "column", "TYPE DEFAULT ..."),
-        #   ]
-        pass
+        migrations: list[tuple[str, str, str]] = [
+            # P-03 TOFU: carry a proposed new pin alongside the current one
+            # when a fingerprint change is detected, so the operator can
+            # compare before accepting or rejecting.
+            ("peer_pins", "pending_sig_pk", "BLOB"),
+            ("peer_pins", "pending_enc_pk", "BLOB"),
+            ("peer_pins", "pending_fingerprint", "BLOB"),
+            ("peer_pins", "pending_first_seen", "REAL NOT NULL DEFAULT 0"),
+            ("peer_pins", "verified_at", "REAL NOT NULL DEFAULT 0"),
+        ]
+        for table, column, coltype in migrations:
+            cols = {
+                r["name"]
+                for r in self._db.execute(f"PRAGMA table_info({table})").fetchall()
+            }
+            if column not in cols:
+                self._db.execute(f"ALTER TABLE {table} ADD COLUMN {column} {coltype}")
+        self._db.commit()
 
     # -- tenants -----------------------------------------------------------
 
@@ -527,6 +598,13 @@ class FederationStateStore:
             raise ValueError("sig_pk and enc_pk must be 32 bytes each")
         if len(rec.fingerprint) != 16:
             raise ValueError("fingerprint must be 16 bytes")
+        # pending_* are optional but, if set, must have the right shape
+        if rec.pending_sig_pk and len(rec.pending_sig_pk) != 32:
+            raise ValueError("pending_sig_pk must be 32 bytes")
+        if rec.pending_enc_pk and len(rec.pending_enc_pk) != 32:
+            raise ValueError("pending_enc_pk must be 32 bytes")
+        if rec.pending_fingerprint and len(rec.pending_fingerprint) != 16:
+            raise ValueError("pending_fingerprint must be 16 bytes")
         now = _now()
         if not rec.first_seen:
             rec.first_seen = now
@@ -534,14 +612,22 @@ class FederationStateStore:
         self._db.execute(
             """
             INSERT INTO peer_pins
-                (peer_address, sig_pk, enc_pk, fingerprint, status, first_seen, last_seen)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (peer_address, sig_pk, enc_pk, fingerprint, status,
+                 first_seen, last_seen,
+                 pending_sig_pk, pending_enc_pk, pending_fingerprint,
+                 pending_first_seen, verified_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(peer_address) DO UPDATE SET
                 sig_pk=excluded.sig_pk,
                 enc_pk=excluded.enc_pk,
                 fingerprint=excluded.fingerprint,
                 status=excluded.status,
-                last_seen=excluded.last_seen
+                last_seen=excluded.last_seen,
+                pending_sig_pk=excluded.pending_sig_pk,
+                pending_enc_pk=excluded.pending_enc_pk,
+                pending_fingerprint=excluded.pending_fingerprint,
+                pending_first_seen=excluded.pending_first_seen,
+                verified_at=excluded.verified_at
             """,
             (
                 rec.peer_address,
@@ -551,6 +637,11 @@ class FederationStateStore:
                 rec.status,
                 rec.first_seen,
                 rec.last_seen,
+                rec.pending_sig_pk or None,
+                rec.pending_enc_pk or None,
+                rec.pending_fingerprint or None,
+                rec.pending_first_seen,
+                rec.verified_at,
             ),
         )
         self._db.commit()
@@ -562,15 +653,30 @@ class FederationStateStore:
         ).fetchone()
         if not row:
             return None
-        return PeerPinRecord(
-            peer_address=row["peer_address"],
-            sig_pk=bytes(row["sig_pk"]),
-            enc_pk=bytes(row["enc_pk"]),
-            fingerprint=bytes(row["fingerprint"]),
-            status=row["status"],
-            first_seen=row["first_seen"],
-            last_seen=row["last_seen"],
+        return _row_to_peer_pin(row)
+
+    def list_peer_pins(
+        self, status: Optional[str] = None
+    ) -> list[PeerPinRecord]:
+        if status is not None:
+            if status not in _VALID_PEER_PIN_STATUSES:
+                raise ValueError(f"invalid pin status: {status!r}")
+            rows = self._db.execute(
+                "SELECT * FROM peer_pins WHERE status = ? ORDER BY peer_address",
+                (status,),
+            ).fetchall()
+        else:
+            rows = self._db.execute(
+                "SELECT * FROM peer_pins ORDER BY peer_address"
+            ).fetchall()
+        return [_row_to_peer_pin(r) for r in rows]
+
+    def delete_peer_pin(self, peer_address: str) -> bool:
+        cur = self._db.execute(
+            "DELETE FROM peer_pins WHERE peer_address = ?", (peer_address,)
         )
+        self._db.commit()
+        return cur.rowcount > 0
 
     # -- outbox / inbox ----------------------------------------------------
 

--- a/src/pinky_federation/tofu.py
+++ b/src/pinky_federation/tofu.py
@@ -1,0 +1,352 @@
+"""Trust-on-first-use (TOFU) pinning policy for federation peers.
+
+This module is the **local trust root** for federation v0.2. The relay
+directory is treated as a lookup service, not an authority: the first time
+we see a peer's public keys we pin them locally, and every subsequent
+lookup is compared against the pinned fingerprint. A mismatch stops
+silent key substitution attacks — the relay can't swap in attacker keys
+without the operator noticing.
+
+State machine
+-------------
+
+Statuses live on :class:`~pinky_federation.state.PeerPinRecord`::
+
+    (none)
+      │   observe(new keys)
+      ▼
+    first_seen  ── observe(same fp) ──────────────▶ pinned
+        │                                            │
+        │   observe(different fp)                    │ observe(different fp)
+        ▼                                            ▼
+    changed  ◀─ observe(yet another fp, pending updated) ─┐
+      │                                                    │
+      ├── accept_rotation() ───────▶ pinned ──── verify() ──▶ verified
+      │                                   │
+      └── reject_rotation() ───▶ rejected ┘
+           │
+           └── accept_rotation(new_keys) ──▶ pinned   (operator overrides earlier no)
+
+Guarantees
+----------
+
+- **Never silently accept a new fingerprint for an existing peer.** A diff
+  always produces a ``changed`` status and requires an explicit operator
+  decision.
+- **The old pin is preserved.** When we detect a mismatch, the new proposal
+  is captured in the ``pending_*`` slot, not written over the trusted slot.
+  The operator can compare old and new side-by-side.
+- **Rejected peers stay rejected.** A peer in the ``rejected`` state always
+  returns :class:`TrustDecision.REJECTED` regardless of what keys they
+  present, until the operator explicitly accepts a rotation.
+- **Idempotent.** Calling :meth:`TrustPolicy.observe` repeatedly with the
+  same trusted keys is safe — it just bumps ``last_seen``.
+
+This module does no network I/O and no logging of secret material.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from pinky_federation.fingerprint import fingerprint as compute_fingerprint
+from pinky_federation.keys import EncryptionPublicKey, SigningPublicKey
+from pinky_federation.state import (
+    PEER_PIN_CHANGED,
+    PEER_PIN_FIRST_SEEN,
+    PEER_PIN_PINNED,
+    PEER_PIN_REJECTED,
+    PEER_PIN_ROTATED,
+    PEER_PIN_VERIFIED,
+    FederationStateStore,
+    PeerPinRecord,
+    _now,
+)
+
+# Statuses that mean "primary slot keys are currently trusted for encrypting".
+# ``rotated`` is a legacy P-02 alias kept here for backward-compat — anything
+# written in that state is treated as ``pinned``.
+_TRUSTED_STATUSES = frozenset(
+    {PEER_PIN_PINNED, PEER_PIN_VERIFIED, PEER_PIN_ROTATED}
+)
+
+
+class TrustDecision(str, Enum):
+    """Outcome of a trust lookup.
+
+    String-valued so it serialises cleanly for UI / log lines.
+    """
+
+    FIRST_SEEN = "first_seen"
+    """Brand-new peer. The keys were just auto-pinned via TOFU. Callers may
+    proceed to encrypt, but should surface this as a soft warning in the UI
+    ("new contact — verify fingerprint out-of-band")."""
+
+    TRUSTED = "trusted"
+    """Keys match the existing pin. Safe to encrypt."""
+
+    MISMATCH = "mismatch"
+    """The presented fingerprint does NOT match the pinned fingerprint. Do
+    NOT encrypt to these keys. The operator must accept or reject. The new
+    proposal has been captured in the peer's ``pending_*`` slot."""
+
+    REJECTED = "rejected"
+    """Peer is in the rejected state — a prior rotation was denied. Refuse
+    to encrypt until the operator explicitly accepts."""
+
+
+class TofuError(Exception):
+    """Base class for TOFU policy errors."""
+
+
+class NoPendingRotationError(TofuError):
+    """Raised when :meth:`TrustPolicy.accept_rotation` is called with no
+    pending proposal and no explicit new keys provided."""
+
+
+class UnknownPeerError(TofuError):
+    """Raised when operating on a peer that has never been observed."""
+
+
+@dataclass(frozen=True)
+class TrustResult:
+    """Result of :meth:`TrustPolicy.observe`.
+
+    ``decision`` is the headline outcome; ``record`` is the updated
+    :class:`PeerPinRecord` after the observation.
+    """
+
+    decision: TrustDecision
+    record: PeerPinRecord
+
+    @property
+    def trusted(self) -> bool:
+        """True iff the caller can safely encrypt to the primary slot keys.
+
+        ``FIRST_SEEN`` is considered trusted-but-unverified — we auto-pin
+        on TOFU so first messages work. Callers that want a stricter
+        posture (e.g. require operator verification before sending) should
+        gate on ``record.status == PEER_PIN_VERIFIED`` instead.
+        """
+        return self.decision in (TrustDecision.FIRST_SEEN, TrustDecision.TRUSTED)
+
+
+class TrustPolicy:
+    """Pinning + rotation policy on top of :class:`FederationStateStore`.
+
+    A thin stateless wrapper around the state store that enforces the TOFU
+    state machine. Construct once per store and share freely — it holds no
+    caches of its own.
+    """
+
+    def __init__(self, store: FederationStateStore) -> None:
+        self._store = store
+
+    # -- public API --------------------------------------------------------
+
+    def observe(
+        self,
+        address: str,
+        sig_pk: SigningPublicKey,
+        enc_pk: EncryptionPublicKey,
+    ) -> TrustResult:
+        """Observe a peer's presented keys and update the pin accordingly.
+
+        This is the hot path for every outbound send and inbound verify.
+
+        Semantics:
+
+        - No existing pin → auto-pin as ``first_seen``, return FIRST_SEEN.
+        - Existing pin, same fingerprint, status in trusted set → bump
+          ``last_seen``, return TRUSTED.
+        - Existing pin, same fingerprint, status=first_seen → promote to
+          ``pinned`` (second successful sighting confirms the pin), return
+          TRUSTED.
+        - Existing pin, different fingerprint → capture proposal in
+          ``pending_*`` slot, set status=changed, return MISMATCH.
+        - Existing pin, status=rejected → always return REJECTED regardless
+          of keys (do NOT update last_seen; a rejected peer contacting us
+          with new keys is suspicious, we don't want the mere lookup to
+          update their record).
+        - Existing pin, status=changed, mismatch against pending → update
+          pending slot to the latest proposal, remain in changed, return
+          MISMATCH. (Either the peer is rotating again, or an attacker is
+          trying keys; either way, the operator still needs to decide.)
+        - Existing pin, status=changed, match against *primary* (original
+          pinned) fingerprint → the proposal was a blip / replay; return to
+          pinned, clear pending, return TRUSTED.
+        """
+        sig_bytes = sig_pk.to_bytes()
+        enc_bytes = enc_pk.to_bytes()
+        fp = compute_fingerprint(address, sig_pk, enc_pk)
+        now = _now()
+
+        existing = self._store.get_peer_pin(address)
+
+        if existing is None:
+            rec = PeerPinRecord(
+                peer_address=address,
+                sig_pk=sig_bytes,
+                enc_pk=enc_bytes,
+                fingerprint=fp,
+                status=PEER_PIN_FIRST_SEEN,
+                first_seen=now,
+                last_seen=now,
+            )
+            rec = self._store.upsert_peer_pin(rec)
+            return TrustResult(TrustDecision.FIRST_SEEN, rec)
+
+        if existing.status == PEER_PIN_REJECTED:
+            # Do not update last_seen or capture the keys — a rejected peer
+            # stays rejected and we don't want the rejection record mutated
+            # by further probing.
+            return TrustResult(TrustDecision.REJECTED, existing)
+
+        if fp == existing.fingerprint:
+            # Match against the trusted slot.
+            existing.last_seen = now
+            if existing.status == PEER_PIN_FIRST_SEEN:
+                existing.status = PEER_PIN_PINNED
+            elif existing.status == PEER_PIN_CHANGED:
+                # Proposal was a blip — the real peer is back on their
+                # original keys. Clear the pending slot and return to
+                # pinned.
+                existing.status = PEER_PIN_PINNED
+                existing.pending_sig_pk = b""
+                existing.pending_enc_pk = b""
+                existing.pending_fingerprint = b""
+                existing.pending_first_seen = 0.0
+            # else: already pinned/verified/rotated — just a heartbeat.
+            rec = self._store.upsert_peer_pin(existing)
+            return TrustResult(TrustDecision.TRUSTED, rec)
+
+        # Fingerprint mismatch — capture in pending slot, mark changed.
+        existing.pending_sig_pk = sig_bytes
+        existing.pending_enc_pk = enc_bytes
+        existing.pending_fingerprint = fp
+        if not existing.pending_first_seen or existing.status != PEER_PIN_CHANGED:
+            existing.pending_first_seen = now
+        existing.status = PEER_PIN_CHANGED
+        existing.last_seen = now
+        rec = self._store.upsert_peer_pin(existing)
+        return TrustResult(TrustDecision.MISMATCH, rec)
+
+    def accept_rotation(
+        self,
+        address: str,
+        sig_pk: Optional[SigningPublicKey] = None,
+        enc_pk: Optional[EncryptionPublicKey] = None,
+    ) -> PeerPinRecord:
+        """Operator explicitly accepts a key rotation for *address*.
+
+        Two forms:
+
+        - ``accept_rotation(address)`` — promote the pending slot (captured
+          by the last MISMATCH observation) to the primary slot. Requires
+          a pending proposal.
+        - ``accept_rotation(address, sig_pk, enc_pk)`` — operator provides
+          the new keys directly (e.g. out-of-band verification). Overrides
+          whatever was in the pending slot.
+
+        The peer's status moves to ``pinned`` (not ``verified`` — use
+        :meth:`verify` for that) and ``first_seen`` is reset to "now" since
+        this is effectively a new trust anchor.
+        """
+        existing = self._store.get_peer_pin(address)
+        if existing is None:
+            raise UnknownPeerError(f"no pin for peer: {address!r}")
+
+        now = _now()
+
+        if sig_pk is not None and enc_pk is not None:
+            new_sig = sig_pk.to_bytes()
+            new_enc = enc_pk.to_bytes()
+            new_fp = compute_fingerprint(address, sig_pk, enc_pk)
+        elif sig_pk is None and enc_pk is None:
+            if not existing.pending_fingerprint:
+                raise NoPendingRotationError(
+                    f"no pending rotation for peer: {address!r}"
+                )
+            new_sig = existing.pending_sig_pk
+            new_enc = existing.pending_enc_pk
+            new_fp = existing.pending_fingerprint
+        else:
+            raise ValueError("provide both sig_pk and enc_pk, or neither")
+
+        existing.sig_pk = new_sig
+        existing.enc_pk = new_enc
+        existing.fingerprint = new_fp
+        existing.status = PEER_PIN_PINNED
+        # The rotation is effectively a new trust anchor — reset first_seen.
+        existing.first_seen = now
+        existing.last_seen = now
+        existing.pending_sig_pk = b""
+        existing.pending_enc_pk = b""
+        existing.pending_fingerprint = b""
+        existing.pending_first_seen = 0.0
+        # Clear any prior verification — the operator must re-verify.
+        existing.verified_at = 0.0
+        return self._store.upsert_peer_pin(existing)
+
+    def reject_rotation(self, address: str) -> PeerPinRecord:
+        """Operator rejects the pending rotation for *address*.
+
+        Clears the pending slot and sets status to ``rejected``. The
+        primary slot is left intact but is no longer considered trusted
+        (rejected peers return REJECTED from :meth:`observe`).
+        """
+        existing = self._store.get_peer_pin(address)
+        if existing is None:
+            raise UnknownPeerError(f"no pin for peer: {address!r}")
+        existing.pending_sig_pk = b""
+        existing.pending_enc_pk = b""
+        existing.pending_fingerprint = b""
+        existing.pending_first_seen = 0.0
+        existing.status = PEER_PIN_REJECTED
+        existing.last_seen = _now()
+        return self._store.upsert_peer_pin(existing)
+
+    def verify(self, address: str) -> PeerPinRecord:
+        """Mark the currently-pinned keys for *address* as operator-verified.
+
+        This represents an out-of-band confirmation (fingerprint read aloud,
+        QR code scanned, etc.) and is a stronger trust signal than TOFU.
+        Only valid for peers currently in ``first_seen`` or ``pinned`` state;
+        ``changed`` / ``rejected`` peers must be resolved via
+        :meth:`accept_rotation` or :meth:`reject_rotation` first.
+        """
+        existing = self._store.get_peer_pin(address)
+        if existing is None:
+            raise UnknownPeerError(f"no pin for peer: {address!r}")
+        if existing.status not in (PEER_PIN_FIRST_SEEN, PEER_PIN_PINNED, PEER_PIN_ROTATED):
+            raise TofuError(
+                f"cannot verify peer in status {existing.status!r}; "
+                "resolve pending rotation first"
+            )
+        existing.status = PEER_PIN_VERIFIED
+        existing.verified_at = _now()
+        existing.last_seen = existing.verified_at
+        return self._store.upsert_peer_pin(existing)
+
+    def get(self, address: str) -> Optional[PeerPinRecord]:
+        """Return the current pin record for *address*, or None."""
+        return self._store.get_peer_pin(address)
+
+    def list_changed(self) -> list[PeerPinRecord]:
+        """Return all peers in the ``changed`` state awaiting operator action.
+
+        UI surfaces (pending-rotations panel) use this to drive an inbox.
+        """
+        return self._store.list_peer_pins(status=PEER_PIN_CHANGED)
+
+
+__all__ = [
+    "TrustPolicy",
+    "TrustDecision",
+    "TrustResult",
+    "TofuError",
+    "NoPendingRotationError",
+    "UnknownPeerError",
+]

--- a/tests/pinky_federation/test_tofu.py
+++ b/tests/pinky_federation/test_tofu.py
@@ -1,0 +1,435 @@
+"""TOFU trust policy tests.
+
+Exercises the state machine end-to-end:
+
+    (none) → first_seen → pinned → changed → pinned   (accept_rotation)
+                                  → rejected          (reject_rotation)
+                       → verified                     (verify)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_federation.keys import EncryptionKeyPair, SigningKeyPair
+from pinky_federation.state import (
+    PEER_PIN_CHANGED,
+    PEER_PIN_FIRST_SEEN,
+    PEER_PIN_PINNED,
+    PEER_PIN_REJECTED,
+    PEER_PIN_VERIFIED,
+    FederationStateStore,
+)
+from pinky_federation.tofu import (
+    NoPendingRotationError,
+    TofuError,
+    TrustDecision,
+    TrustPolicy,
+    UnknownPeerError,
+)
+
+ADDR = "alice@example.com"
+
+
+@pytest.fixture
+def store(tmp_path):
+    db_path = tmp_path / "fed.db"
+    s = FederationStateStore(str(db_path))
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def policy(store: FederationStateStore) -> TrustPolicy:
+    return TrustPolicy(store)
+
+
+def _new_keys() -> tuple[SigningKeyPair, EncryptionKeyPair]:
+    """Fresh random signing + encryption keypairs."""
+    return SigningKeyPair.generate(), EncryptionKeyPair.generate()
+
+
+# -- first observation (TOFU auto-pin) -----------------------------------
+
+
+def test_first_observation_auto_pins(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    result = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert result.decision == TrustDecision.FIRST_SEEN
+    assert result.record.status == PEER_PIN_FIRST_SEEN
+    assert result.record.sig_pk == sig.public_key.to_bytes()
+    assert result.record.enc_pk == enc.public_key.to_bytes()
+    assert result.record.fingerprint  # non-empty, 16 bytes
+    assert len(result.record.fingerprint) == 16
+    assert result.record.first_seen > 0
+    # first_seen and last_seen are both set to ~now (within the same call);
+    # we tolerate tiny clock drift between the two timestamp captures.
+    assert abs(result.record.first_seen - result.record.last_seen) < 0.1
+    assert result.trusted
+
+
+def test_first_seen_is_trusted_but_unverified(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    result = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert result.trusted is True
+    assert result.record.status != PEER_PIN_VERIFIED
+
+
+# -- repeat observation with same keys -----------------------------------
+
+
+def test_second_observation_matching_promotes_to_pinned(
+    policy: TrustPolicy,
+) -> None:
+    sig, enc = _new_keys()
+    first = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert first.record.status == PEER_PIN_FIRST_SEEN
+
+    second = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert second.decision == TrustDecision.TRUSTED
+    assert second.record.status == PEER_PIN_PINNED
+    assert second.record.last_seen >= first.record.last_seen
+
+
+def test_repeat_observation_pinned_is_idempotent(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    policy.observe(ADDR, sig.public_key, enc.public_key)  # → pinned
+    third = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert third.decision == TrustDecision.TRUSTED
+    assert third.record.status == PEER_PIN_PINNED
+
+
+# -- mismatch detection --------------------------------------------------
+
+
+def test_different_fingerprint_triggers_mismatch(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # → pinned
+
+    sig2, enc2 = _new_keys()
+    result = policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    assert result.decision == TrustDecision.MISMATCH
+    assert result.record.status == PEER_PIN_CHANGED
+    # Primary slot still holds the ORIGINAL pin — we don't silently overwrite.
+    assert result.record.sig_pk == sig1.public_key.to_bytes()
+    assert result.record.enc_pk == enc1.public_key.to_bytes()
+    # Pending slot captured the new proposal.
+    assert result.record.pending_sig_pk == sig2.public_key.to_bytes()
+    assert result.record.pending_enc_pk == enc2.public_key.to_bytes()
+    assert result.record.pending_fingerprint != result.record.fingerprint
+    assert result.record.pending_first_seen > 0
+    assert not result.trusted
+
+
+def test_mismatch_from_first_seen_state(policy: TrustPolicy) -> None:
+    """Mismatch should also trigger if we only have a first_seen pin, not
+    a fully promoted pinned one."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # first_seen
+
+    sig2, enc2 = _new_keys()
+    result = policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    assert result.decision == TrustDecision.MISMATCH
+    assert result.record.status == PEER_PIN_CHANGED
+
+
+def test_mismatch_is_not_silently_accepted_on_repeat(policy: TrustPolicy) -> None:
+    """A second observation with the same mismatched keys does NOT promote
+    the proposal — it stays in changed state."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # mismatch
+    result = policy.observe(ADDR, sig2.public_key, enc2.public_key)  # again
+    assert result.decision == TrustDecision.MISMATCH
+    assert result.record.status == PEER_PIN_CHANGED
+    # Primary pin was NOT overwritten by the repeat.
+    assert result.record.sig_pk == sig1.public_key.to_bytes()
+
+
+def test_mismatch_pending_updates_with_yet_another_fp(policy: TrustPolicy) -> None:
+    """If, while in changed state, a third distinct fingerprint arrives,
+    the pending slot is updated to the latest — the operator sees the
+    freshest attacker/rotating-peer keys."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # mismatch → changed
+
+    sig3, enc3 = _new_keys()
+    result = policy.observe(ADDR, sig3.public_key, enc3.public_key)
+    assert result.decision == TrustDecision.MISMATCH
+    assert result.record.status == PEER_PIN_CHANGED
+    assert result.record.pending_sig_pk == sig3.public_key.to_bytes()
+
+
+def test_pinned_peer_returning_to_original_fp_from_changed_clears_pending(
+    policy: TrustPolicy,
+) -> None:
+    """If we're in changed state and the peer shows up with the ORIGINAL
+    pinned fingerprint again, the proposal was a blip — clear pending,
+    back to pinned."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # changed
+
+    result = policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    assert result.decision == TrustDecision.TRUSTED
+    assert result.record.status == PEER_PIN_PINNED
+    assert result.record.pending_fingerprint == b""
+    assert result.record.pending_sig_pk == b""
+
+
+# -- accept_rotation -----------------------------------------------------
+
+
+def test_accept_rotation_promotes_pending(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # mismatch
+
+    record = policy.accept_rotation(ADDR)
+    assert record.status == PEER_PIN_PINNED
+    assert record.sig_pk == sig2.public_key.to_bytes()
+    assert record.enc_pk == enc2.public_key.to_bytes()
+    assert record.pending_fingerprint == b""
+    assert record.pending_sig_pk == b""
+    # Subsequent lookups with new keys are now TRUSTED.
+    result = policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    assert result.decision == TrustDecision.TRUSTED
+
+
+def test_accept_rotation_with_explicit_keys_overrides_pending(
+    policy: TrustPolicy,
+) -> None:
+    """Operator provides out-of-band verified keys — those win over whatever
+    was in the pending slot."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    # attacker-style pending proposal
+    sig_bad, enc_bad = _new_keys()
+    policy.observe(ADDR, sig_bad.public_key, enc_bad.public_key)
+
+    # operator verifies a different set of keys out-of-band
+    sig_good, enc_good = _new_keys()
+    record = policy.accept_rotation(ADDR, sig_good.public_key, enc_good.public_key)
+    assert record.sig_pk == sig_good.public_key.to_bytes()
+    assert record.enc_pk == enc_good.public_key.to_bytes()
+    assert record.status == PEER_PIN_PINNED
+    assert record.pending_fingerprint == b""
+
+
+def test_accept_rotation_without_pending_or_keys_raises(
+    policy: TrustPolicy,
+) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # first_seen, no pending
+
+    with pytest.raises(NoPendingRotationError):
+        policy.accept_rotation(ADDR)
+
+
+def test_accept_rotation_partial_keys_raises(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+
+    sig2, _enc2 = _new_keys()
+    with pytest.raises(ValueError):
+        policy.accept_rotation(ADDR, sig_pk=sig2.public_key)
+
+
+def test_accept_rotation_unknown_peer_raises(policy: TrustPolicy) -> None:
+    with pytest.raises(UnknownPeerError):
+        policy.accept_rotation("nobody@example.com")
+
+
+# -- reject_rotation -----------------------------------------------------
+
+
+def test_reject_rotation_sets_status_and_clears_pending(
+    policy: TrustPolicy,
+) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # mismatch
+
+    record = policy.reject_rotation(ADDR)
+    assert record.status == PEER_PIN_REJECTED
+    assert record.pending_fingerprint == b""
+    assert record.pending_sig_pk == b""
+
+
+def test_rejected_peer_observe_returns_rejected_regardless(
+    policy: TrustPolicy,
+) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    policy.reject_rotation(ADDR)
+
+    # Even the "original" keys should now return REJECTED.
+    r1 = policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    assert r1.decision == TrustDecision.REJECTED
+    # And any new keys.
+    sig3, enc3 = _new_keys()
+    r2 = policy.observe(ADDR, sig3.public_key, enc3.public_key)
+    assert r2.decision == TrustDecision.REJECTED
+
+
+def test_rejected_peer_can_be_re_accepted_by_operator(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    policy.reject_rotation(ADDR)
+
+    # Operator changes mind.
+    sig3, enc3 = _new_keys()
+    record = policy.accept_rotation(ADDR, sig3.public_key, enc3.public_key)
+    assert record.status == PEER_PIN_PINNED
+
+    result = policy.observe(ADDR, sig3.public_key, enc3.public_key)
+    assert result.decision == TrustDecision.TRUSTED
+
+
+def test_reject_rotation_unknown_peer_raises(policy: TrustPolicy) -> None:
+    with pytest.raises(UnknownPeerError):
+        policy.reject_rotation("nobody@example.com")
+
+
+# -- verify --------------------------------------------------------------
+
+
+def test_verify_promotes_pinned_to_verified(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    policy.observe(ADDR, sig.public_key, enc.public_key)  # pinned
+
+    record = policy.verify(ADDR)
+    assert record.status == PEER_PIN_VERIFIED
+    assert record.verified_at > 0
+
+
+def test_verify_on_first_seen_is_allowed(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+
+    record = policy.verify(ADDR)
+    assert record.status == PEER_PIN_VERIFIED
+
+
+def test_verify_refuses_changed_state(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)
+
+    with pytest.raises(TofuError):
+        policy.verify(ADDR)
+
+
+def test_verify_refuses_rejected_state(policy: TrustPolicy) -> None:
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    policy.reject_rotation(ADDR)
+
+    with pytest.raises(TofuError):
+        policy.verify(ADDR)
+
+
+def test_verify_unknown_peer_raises(policy: TrustPolicy) -> None:
+    with pytest.raises(UnknownPeerError):
+        policy.verify("nobody@example.com")
+
+
+def test_verified_peer_observation_still_trusted(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    policy.verify(ADDR)
+
+    result = policy.observe(ADDR, sig.public_key, enc.public_key)
+    assert result.decision == TrustDecision.TRUSTED
+    # verify() state persists across subsequent identical observations.
+    assert result.record.status == PEER_PIN_VERIFIED
+
+
+def test_accept_rotation_clears_verified_flag(policy: TrustPolicy) -> None:
+    """A rotation invalidates prior verification — operator must re-verify."""
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    policy.verify(ADDR)
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)
+    record = policy.accept_rotation(ADDR)
+    assert record.status == PEER_PIN_PINNED
+    assert record.verified_at == 0
+
+
+# -- list_changed --------------------------------------------------------
+
+
+def test_list_changed_returns_only_changed_peers(policy: TrustPolicy) -> None:
+    # Peer with no mismatch.
+    sig_a, enc_a = _new_keys()
+    policy.observe("a@example.com", sig_a.public_key, enc_a.public_key)
+    policy.observe("a@example.com", sig_a.public_key, enc_a.public_key)
+
+    # Peer in changed state.
+    sig_b1, enc_b1 = _new_keys()
+    policy.observe("b@example.com", sig_b1.public_key, enc_b1.public_key)
+    policy.observe("b@example.com", sig_b1.public_key, enc_b1.public_key)
+    sig_b2, enc_b2 = _new_keys()
+    policy.observe("b@example.com", sig_b2.public_key, enc_b2.public_key)
+
+    # Peer that was rejected.
+    sig_c1, enc_c1 = _new_keys()
+    policy.observe("c@example.com", sig_c1.public_key, enc_c1.public_key)
+    policy.observe("c@example.com", sig_c1.public_key, enc_c1.public_key)
+    sig_c2, enc_c2 = _new_keys()
+    policy.observe("c@example.com", sig_c2.public_key, enc_c2.public_key)
+    policy.reject_rotation("c@example.com")
+
+    changed = policy.list_changed()
+    addrs = {r.peer_address for r in changed}
+    assert addrs == {"b@example.com"}
+
+
+# -- get -----------------------------------------------------------------
+
+
+def test_get_returns_none_for_unknown(policy: TrustPolicy) -> None:
+    assert policy.get("nobody@example.com") is None
+
+
+def test_get_returns_record_for_known(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    record = policy.get(ADDR)
+    assert record is not None
+    assert record.peer_address == ADDR


### PR DESCRIPTION
## Summary

Implements **P-03** ([#252](https://github.com/bradbrok/PinkyBot/issues/252)) — trust-on-first-use pinning against the relay key directory, with a proper state machine for fingerprint mismatches. Stacked on top of P-02 (#265, `feat/federation-state`) which shipped the `peer_pins` slice of the schema.

This is the local trust policy that stops the relay directory from silently becoming the cryptographic trust root.

### State machine

```
(none) → first_seen → pinned → changed → pinned   (accept_rotation)
                                       → rejected (reject_rotation)
                   → verified                     (verify)
```

- **First sighting** auto-pins the fingerprint (TOFU).
- **Subsequent lookups** compare presented keys against the pinned slot.
- **Mismatch is never silently accepted** — the new proposal is captured in a separate ``pending_*`` slot on ``peer_pins`` and the peer enters ``changed`` state. The operator must explicitly accept or reject.
- **Rejected peers** return REJECTED from ``observe()`` regardless of keys, until the operator explicitly accepts a rotation.
- **Verified** (operator-blessed out-of-band) is a distinct, stronger state than TOFU-pinned. Rotation clears verification and requires re-verify.

### Acceptance criteria (from #252)

- [x] First lookup of a peer pins the fingerprint locally.
- [x] Subsequent lookups compare against the pinned fingerprint before encrypting.
- [x] Unexpected fingerprint changes produce a warning state, not silent acceptance.
- [x] Expected rotations can be explicitly accepted and repinned by the operator.
- [x] The state machine distinguishes first-seen, pinned, changed, and verified states.

### Schema changes

Forward-compatible, migrated via ``_ensure_columns``:

- ``peer_pins`` gains ``pending_sig_pk`` / ``pending_enc_pk`` / ``pending_fingerprint`` / ``pending_first_seen`` / ``verified_at`` columns (nullable).
- New status constants: ``PEER_PIN_FIRST_SEEN``, ``PEER_PIN_CHANGED``, ``PEER_PIN_VERIFIED``. ``PEER_PIN_ROTATED`` retained as a P-02 backward-compat alias (treated as pinned by the policy).

### Public API

```python
from pinky_federation import TrustPolicy, TrustDecision, FederationStateStore

store = FederationStateStore()
policy = TrustPolicy(store)

result = policy.observe(addr, sig_pk, enc_pk)
if result.trusted:
    # safe to encrypt
    ...
elif result.decision == TrustDecision.MISMATCH:
    # surface to operator; policy.accept_rotation(addr) or .reject_rotation(addr)
    ...

# Operator actions:
policy.accept_rotation(addr)                       # promote pending → primary
policy.accept_rotation(addr, sig_pk, enc_pk)       # out-of-band verified keys
policy.reject_rotation(addr)                       # clear pending, mark rejected
policy.verify(addr)                                # promote pinned → verified
policy.list_changed()                              # operator inbox
```

## Test plan

- [x] Federation suite: 147/147 passing
- [x] Full suite: 1619/1619 passing (+28 new TOFU tests)
- [x] Ruff clean on ``src/pinky_federation/`` and ``tests/pinky_federation/``
- [x] All state transitions covered, including:
  - first_seen → pinned → changed → pinned (via accept_rotation with pending)
  - first_seen → pinned → changed → pinned (via accept_rotation with out-of-band keys)
  - pinned → changed → rejected → pinned (re-accept after operator changes mind)
  - Mismatch during mismatch (third distinct fingerprint updates pending slot)
  - Back-to-original blip recovery (changed → pinned when original keys reappear)
  - verify() refuses changed / rejected states
  - accept_rotation clears prior verification flag

## Stack

- Base branch: ``feat/federation-state`` (#265, draft)
- Will retarget to ``beta`` once #264 and #265 land.

## Non-goals

- UI surfacing of the pending-rotations inbox — that lives with the frontend work, not this slice.
- Transport-layer integration (hook ``observe()`` into the outbound encrypt path) — deferred to P-04.

🤖 Opened by Barsik
