### PR TITLE
fix(memory): distinguish zero-norm query embedding from empty results (#285)

### DIFF
--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from mcp.server.fastmcp import FastMCP
 
+from pinky_memory.store import InvalidQueryEmbeddingError
 from pinky_memory.types import (
     PRESET_NAMES,
     IntrospectInput,
@@ -153,15 +154,25 @@ def create_server(
             # Try vector search first
             query_embedding = embedder.embed(input_data.query)
             if query_embedding:
-                results = s.search_by_embedding(
-                    query_embedding=query_embedding,
-                    limit=input_data.limit,
-                    active_only=input_data.active_only,
-                    type_filter=input_data.type,
-                    project_filter=input_data.project,
-                    min_weight=input_data.min_weight,
-                    entity_filter=input_data.entity,
-                )
+                try:
+                    results = s.search_by_embedding(
+                        query_embedding=query_embedding,
+                        limit=input_data.limit,
+                        active_only=input_data.active_only,
+                        type_filter=input_data.type,
+                        project_filter=input_data.project,
+                        min_weight=input_data.min_weight,
+                        entity_filter=input_data.entity,
+                    )
+                except InvalidQueryEmbeddingError as exc:
+                    # Broken query embedding (zero-norm/empty). Log loudly and
+                    # fall back to keyword search so the user still gets a
+                    # meaningful response instead of a silent empty result.
+                    _log(
+                        f"[recall] invalid query embedding ({exc}); "
+                        f"falling back to keyword search"
+                    )
+                    results = []
 
             # Fall back to keyword search if no vector results
             if not results:

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import sqlite3
 import struct
@@ -22,6 +23,18 @@ from pinky_memory.types import (
 
 if TYPE_CHECKING:
     pass
+
+logger = logging.getLogger(__name__)
+
+
+class InvalidQueryEmbeddingError(ValueError):
+    """Raised when a query embedding cannot be used for similarity search.
+
+    Distinguishes a broken/degenerate query (all zeros, empty, wrong shape)
+    from a legitimate 'no matches found' result. Callers should catch and
+    either log + fall back to keyword search or surface to the user.
+    """
+
 
 # ── Memory linking constants ──
 
@@ -538,7 +551,26 @@ class ReflectionStore:
             final_score = similarity * weight * (recency_factor ^ hours_since_access)
         If access_boost > 0, boosts weight on each accessed reflection.
         If entity_filter is set, only returns reflections tagged with that entity.
+
+        Raises:
+            InvalidQueryEmbeddingError: if query_embedding is empty or has zero
+                norm. Distinguishes a broken embedding from a legitimate
+                "no matches" empty result.
         """
+        if not query_embedding:
+            logger.warning("search_by_embedding_scored: empty query embedding")
+            raise InvalidQueryEmbeddingError("query embedding is empty")
+
+        query_norm = float(np.linalg.norm(np.asarray(query_embedding, dtype=np.float32)))
+        if query_norm == 0.0:
+            logger.warning(
+                "search_by_embedding_scored: zero-norm query embedding (len=%d)",
+                len(query_embedding),
+            )
+            raise InvalidQueryEmbeddingError(
+                "query embedding has zero norm; cannot compute cosine similarity"
+            )
+
         with self._lock:
             if (
                 self._vec_available
@@ -719,7 +751,14 @@ class ReflectionStore:
         query_vec = np.array(query_embedding, dtype=np.float32)
         query_norm = np.linalg.norm(query_vec)
         if query_norm == 0:
-            return []
+            logger.warning(
+                "search_by_embedding: zero-norm query embedding "
+                "(len=%d) — refusing to conflate with 'no matches'",
+                len(query_embedding),
+            )
+            raise InvalidQueryEmbeddingError(
+                "query embedding has zero norm; cannot compute cosine similarity"
+            )
 
         now_dt = datetime.now(timezone.utc)
         now = now_dt.isoformat()

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from pinky_memory.store import ReflectionStore
+import pytest
+
+from pinky_memory.store import InvalidQueryEmbeddingError, ReflectionStore
 from pinky_memory.types import MemoryQueryFilters, Reflection, ReflectionType
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -283,6 +285,25 @@ class TestEmbeddingSearch:
         store.set_no_recall(r.id, True)
         results = store.search_by_embedding(emb)
         assert all(x.id != r.id for x in results)
+
+    def test_zero_norm_query_raises(self, tmp_path):
+        """A zero-norm query embedding must raise — not silently return [].
+
+        Regression for #285: zero-norm previously returned [] which could
+        not be distinguished from a legitimate 'no matches' result.
+        """
+        store = _store(tmp_path)
+        store.insert(_fact("some content", embedding=_emb()))
+        with pytest.raises(InvalidQueryEmbeddingError):
+            store.search_by_embedding([0.0] * 8)
+        with pytest.raises(InvalidQueryEmbeddingError):
+            store.search_by_embedding_scored([0.0] * 8)
+
+    def test_empty_query_embedding_raises(self, tmp_path):
+        """An empty query embedding must raise — regression for #285."""
+        store = _store(tmp_path)
+        with pytest.raises(InvalidQueryEmbeddingError):
+            store.search_by_embedding_scored([])
 
 
 # ── Near-Duplicate Detection ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixes #285 — `search_by_embedding` silently returned `[]` on a zero-norm query, conflating a broken embedding with a legitimate "no matches" result.
- Adds `InvalidQueryEmbeddingError(ValueError)` in `pinky_memory.store`; `search_by_embedding_scored` raises on empty or zero-norm inputs; the inner `_search_by_numpy` keeps a defense-in-depth guard.
- `pinky_memory.server.recall()` catches the new exception, logs it, and falls back to keyword search — so broken embeddings surface in logs instead of vanishing.

## Test plan
- [x] New regression tests: `test_zero_norm_query_raises`, `test_empty_query_embedding_raises`
- [x] `pytest tests/test_memory_store.py` → 97 passed
- [x] `pytest tests/test_memory_server.py` → 54 passed
- [x] `ruff check` on changed files → clean

Review requested: @murzik

🤖 Opened by Barsik