### PR TITLE
fix(outreach): let httpx set Discord multipart content type (#283)

### DIFF
--- a/src/pinky_outreach/discord.py
+++ b/src/pinky_outreach/discord.py
@@ -37,7 +37,6 @@ class DiscordAdapter:
             base_url=self.BASE_URL,
             headers={
                 "Authorization": f"Bot {bot_token}",
-                "Content-Type": "application/json",
             },
             timeout=timeout,
         )
@@ -108,7 +107,6 @@ class DiscordAdapter:
                 f"/channels/{channel_id}/messages",
                 data={"content": content} if content else {},
                 files={"files[0]": (filename, f)},
-                headers={"Content-Type": None},  # Let httpx set multipart headers
             )
 
         if resp.status_code >= 400:

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+import httpx
 
 from pinky_outreach.discord import DiscordAdapter, DiscordError
 from pinky_outreach.types import Platform
@@ -81,6 +82,45 @@ class TestDiscordAdapter:
             adapter.send_message("99999", "Hello!")
         assert "Missing Access" in str(exc.value)
         assert exc.value.status_code == 403
+        adapter.close()
+
+    def test_send_file_success_uses_httpx_multipart_header(self, tmp_path):
+        """Regression: passing Content-Type=None makes httpx raise before sending."""
+        adapter = self._make_adapter()
+        file_path = tmp_path / "note.txt"
+        file_path.write_text("hello discord")
+        seen_requests = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_requests.append(request)
+            body = request.read()
+            assert request.method == "POST"
+            assert request.url.path.endswith("/channels/99999/messages")
+            assert request.headers["content-type"].startswith("multipart/form-data; boundary=")
+            assert b'name="files[0]"' in body
+            assert b'filename="note.txt"' in body
+            assert b"hello discord" in body
+            return httpx.Response(
+                200,
+                json={
+                    "id": "file-msg-1",
+                    "channel_id": "99999",
+                    "content": "upload caption",
+                    "timestamp": "2026-03-27T12:02:00+00:00",
+                },
+            )
+
+        adapter._client.close()
+        adapter._client = httpx.Client(
+            base_url=adapter.BASE_URL,
+            headers={"Authorization": "Bot fake-discord-token"},
+            transport=httpx.MockTransport(handler),
+        )
+
+        msg = adapter.send_file("99999", str(file_path), content="upload caption")
+        assert msg.message_id == "file-msg-1"
+        assert msg.content == "upload caption"
+        assert len(seen_requests) == 1
         adapter.close()
 
     def test_get_messages_empty(self):

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
 import httpx
+import pytest
 
 from pinky_outreach.discord import DiscordAdapter, DiscordError
 from pinky_outreach.types import Platform


### PR DESCRIPTION
## Summary
- Fixes #283 — Discord file uploads crashed before sending because the adapter set a Client-level `Content-Type: application/json` default and then tried to clear it per-request with `Content-Type: None`, which httpx rejects.
- Drops the client-level default so httpx picks the right Content-Type per request (application/json for JSON bodies, multipart/form-data with boundary for file bodies).
- Removes the invalid `Content-Type: None` override on `send_file()`.
- Adds a regression test using `httpx.MockTransport` that exercises the real `send_file()` path and asserts a proper multipart request is emitted.

**Authored by Murzik, applied + PR'd by Barsik via patch-stage workflow.**

## Test plan
- [x] `pytest tests/test_discord.py` → 18 passed
- [x] `ruff check` on changed files → clean
- [x] `git apply --check` on staged patch → pass

Review requested: self-review via GitHub diff (Murzik) + any additional eyes welcome.

🤖 Opened by Barsik (fix authored by Murzik)