### PR TITLE
fix(memory): validate and log embed() failures on reflect/recall (#291)

### DIFF
--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from mcp.server.fastmcp import FastMCP
 
+from pinky_memory.embeddings import NoOpEmbeddingClient
 from pinky_memory.store import InvalidQueryEmbeddingError
 from pinky_memory.types import (
     PRESET_NAMES,
@@ -19,13 +20,41 @@ from pinky_memory.types import (
 )
 
 if TYPE_CHECKING:
-    from pinky_memory.embeddings import EmbeddingClient, NoOpEmbeddingClient
+    from pinky_memory.embeddings import EmbeddingClient
     from pinky_memory.store import ReflectionStore
 
 
 def _log(msg: str) -> None:
     """Log to stderr (stdout is MCP protocol)."""
     print(msg, file=sys.stderr, flush=True)
+
+
+def _safe_embed(
+    embedder: "EmbeddingClient | NoOpEmbeddingClient",
+    text: str,
+    op: str,
+) -> list[float]:
+    """Call embedder.embed() with loud failure logging.
+
+    Returns the embedding vector, or [] on failure. Distinguishes three
+    cases for the logs:
+      - NoOp embedder (no OPENAI_API_KEY): silent, expected downgrade
+      - embed() raised: log with exception type + message
+      - embed() returned [] from a non-NoOp client: log as degraded
+    """
+    if isinstance(embedder, NoOpEmbeddingClient):
+        return []
+    try:
+        embedding = embedder.embed(text)
+    except Exception as exc:  # noqa: BLE001 — we want any embed failure visible
+        _log(f"[{op}] embedder.embed() raised {type(exc).__name__}: {exc}")
+        return []
+    if not embedding:
+        _log(
+            f"[{op}] embedder.embed() returned empty vector with non-NoOp client — "
+            f"embeddings are degraded; semantic search will miss this entry"
+        )
+    return embedding
 
 
 def create_server(
@@ -90,8 +119,9 @@ def create_server(
             source_message_ids=source_message_ids or [],
         )
 
-        # Generate embedding
-        embedding = embedder.embed(input_data.content)
+        # Generate embedding (tolerant: empty / raised embeddings downgrade
+        # to keyword-only search rather than aborting storage).
+        embedding = _safe_embed(embedder, input_data.content, "reflect")
 
         # Build reflection
         ref = Reflection(
@@ -122,6 +152,7 @@ def create_server(
             "type": ref.type.value,
             "salience": ref.salience,
             "stored": True,
+            "embedded": bool(embedding),
         })
 
     @mcp.tool()
@@ -151,8 +182,8 @@ def create_server(
 
         s = _get_store()
         if input_data.query:
-            # Try vector search first
-            query_embedding = embedder.embed(input_data.query)
+            # Try vector search first (tolerant of embedder failures / degrades).
+            query_embedding = _safe_embed(embedder, input_data.query, "recall")
             if query_embedding:
                 try:
                     results = s.search_by_embedding(

--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -36,11 +37,15 @@ def _safe_embed(
 ) -> list[float]:
     """Call embedder.embed() with loud failure logging.
 
-    Returns the embedding vector, or [] on failure. Distinguishes three
+    Returns the embedding vector, or [] on failure. Distinguishes four
     cases for the logs:
       - NoOp embedder (no OPENAI_API_KEY): silent, expected downgrade
       - embed() raised: log with exception type + message
       - embed() returned [] from a non-NoOp client: log as degraded
+      - embed() returned a zero-norm or non-finite vector: log as degraded
+        and coerce to [] so downstream search can treat it as "no embedding"
+        rather than silently storing/querying an unusable vector
+        (see #285 zero-norm query handling).
     """
     if isinstance(embedder, NoOpEmbeddingClient):
         return []
@@ -54,6 +59,29 @@ def _safe_embed(
             f"[{op}] embedder.embed() returned empty vector with non-NoOp client — "
             f"embeddings are degraded; semantic search will miss this entry"
         )
+        return []
+    # Guard against non-empty-but-unusable vectors: all zeros, NaN, or inf.
+    # These pass `if not embedding` but are semantically equivalent to a
+    # failed embed — storing them creates rows that zero-norm-skip in search
+    # (see ReflectionStore._search_by_numpy) with no signal upstream.
+    try:
+        norm_sq = 0.0
+        has_bad = False
+        for x in embedding:
+            if not math.isfinite(x):
+                has_bad = True
+                break
+            norm_sq += x * x
+        if has_bad or norm_sq == 0.0:
+            _log(
+                f"[{op}] embedder.embed() returned a degenerate vector "
+                f"(zero-norm or non-finite) — treating as degraded; "
+                f"semantic search will miss this entry"
+            )
+            return []
+    except Exception as exc:  # noqa: BLE001 — defensive
+        _log(f"[{op}] embedding validation raised {type(exc).__name__}: {exc}")
+        return []
     return embedding
 
 

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -188,6 +188,56 @@ class TestReflect:
         assert "brad" in ref.entities
         assert "oleg" in ref.entities
 
+    def test_reflect_reports_embedded_false_with_noop(self, srv):
+        """Regression for #291: response must surface whether an embedding was generated."""
+        result = json.loads(_tools(srv)["reflect"](content="fact without embedding", type="fact"))
+        assert result["stored"] is True
+        assert result["embedded"] is False
+
+    def test_reflect_reports_embedded_true_with_real_embedder(self, store, capsys):
+        """When a real embedder returns a vector, response reflects embedded=True."""
+        class FakeRealEmbedder:
+            dimensions = 8
+
+            def embed(self, text: str) -> list[float]:
+                return [0.1] * 8
+
+        srv = create_server(store, FakeRealEmbedder())
+        result = json.loads(_tools(srv)["reflect"](content="embedded fact", type="fact"))
+        assert result["stored"] is True
+        assert result["embedded"] is True
+
+    def test_reflect_logs_when_real_embedder_returns_empty(self, store, capsys):
+        """Regression for #291: real embedder returning [] must log degraded mode."""
+        class DegradedRealEmbedder:
+            dimensions = 8
+
+            def embed(self, text: str) -> list[float]:
+                return []
+
+        srv = create_server(store, DegradedRealEmbedder())
+        result = json.loads(_tools(srv)["reflect"](content="degraded", type="fact"))
+        assert result["stored"] is True
+        assert result["embedded"] is False
+        captured = capsys.readouterr()
+        assert "degraded" in captured.err.lower()
+
+    def test_reflect_survives_embedder_exception(self, store, capsys):
+        """Regression for #291: embedder raising must not abort reflect(); log instead."""
+        class RaisingEmbedder:
+            dimensions = 8
+
+            def embed(self, text: str) -> list[float]:
+                raise RuntimeError("network error")
+
+        srv = create_server(store, RaisingEmbedder())
+        result = json.loads(_tools(srv)["reflect"](content="survives", type="fact"))
+        assert result["stored"] is True
+        assert result["embedded"] is False
+        captured = capsys.readouterr()
+        assert "runtimeerror" in captured.err.lower()
+        assert "network error" in captured.err.lower()
+
 
 # ── recall tool ────────────────────────────────────────────────────────────────
 

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -238,6 +238,44 @@ class TestReflect:
         assert "runtimeerror" in captured.err.lower()
         assert "network error" in captured.err.lower()
 
+    def test_reflect_treats_zero_norm_vector_as_degraded(self, store, capsys):
+        """Regression for #291 (Murzik review): real embedder returning [0.0, ...]
+        must be treated as degraded, not stored as a usable embedding.
+
+        Without this check, reflect() would report embedded=True and store an
+        all-zero vector that search_by_embedding silently skips (zero-norm row
+        guard in _search_by_numpy), reproducing the original silent-degrade bug.
+        """
+        class ZeroVectorEmbedder:
+            dimensions = 8
+
+            def embed(self, text: str) -> list[float]:
+                return [0.0] * 8
+
+        srv = create_server(store, ZeroVectorEmbedder())
+        result = json.loads(_tools(srv)["reflect"](content="all zeros", type="fact"))
+        assert result["stored"] is True
+        assert result["embedded"] is False
+        ref = store.get(result["id"])
+        assert ref.embedding == []
+        captured = capsys.readouterr()
+        assert "degenerate" in captured.err.lower()
+
+    def test_reflect_treats_nonfinite_vector_as_degraded(self, store, capsys):
+        """Non-finite values (NaN/inf) in an embedding are also degraded."""
+        class NaNEmbedder:
+            dimensions = 8
+
+            def embed(self, text: str) -> list[float]:
+                return [float("nan")] + [0.1] * 7
+
+        srv = create_server(store, NaNEmbedder())
+        result = json.loads(_tools(srv)["reflect"](content="nan inside", type="fact"))
+        assert result["stored"] is True
+        assert result["embedded"] is False
+        captured = capsys.readouterr()
+        assert "degenerate" in captured.err.lower()
+
 
 # ── recall tool ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Fixes #291 — `embed()` failures (empty returns or raised exceptions) were silently storing memories without usable vectors and silently degrading `recall()`.
- Adds `_safe_embed()` helper that distinguishes three cases: NoOp client (silent), real client raised (log with exception info), real client returned `[]` (log 'degraded').
- `reflect()` now returns `embedded: bool` so callers can see whether the memory has a usable vector.
- `recall()` routes through the same helper; keyword fallback still works but failures are visible in logs.

## Test plan
- [x] New regression tests: NoOp reports `embedded=False`, real embedder reports `embedded=True`, degraded real embedder logs warning, raising embedder survives with log
- [x] `pytest tests/test_memory_server.py` → 58 passed
- [x] `ruff check` on changed files → clean

Review requested: @murzik

🤖 Opened by Barsik