### PR TITLE
fix(memory): handle corrupt embedding JSON in dim detection + backfill (#289)

### DIFF
--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -294,12 +294,29 @@ class ReflectionStore:
             pass
 
     def _detect_embedding_dimensions(self) -> int:
-        """Detect embedding dimensions from the first non-empty embedding in the DB."""
-        row = self._conn.execute(
-            "SELECT embedding FROM reflections WHERE embedding != '[]' LIMIT 1"
-        ).fetchone()
-        if row:
-            emb = json.loads(row[0])
+        """Detect embedding dimensions from the first valid embedding in the DB.
+
+        Scans until a parseable embedding is found; a single corrupt row no
+        longer aborts startup. Malformed rows are logged with their id so
+        they can be reviewed or GC'd manually.
+        """
+        rows = self._conn.execute(
+            "SELECT id, embedding FROM reflections WHERE embedding != '[]' "
+            "ORDER BY created_at DESC LIMIT 50"
+        ).fetchall()
+        for row in rows:
+            rid = row[0] if not isinstance(row, sqlite3.Row) else row["id"]
+            raw = row[1] if not isinstance(row, sqlite3.Row) else row["embedding"]
+            try:
+                emb = json.loads(raw)
+            except (ValueError, TypeError) as exc:
+                logger.warning(
+                    "reflection %s has malformed embedding JSON (%s); skipping "
+                    "during dimension detection",
+                    rid,
+                    exc,
+                )
+                continue
             if emb:
                 return len(emb)
         return 0
@@ -310,15 +327,26 @@ class ReflectionStore:
             return
         # Find reflections with embeddings that are NOT yet in the vec table
         rows = self._conn.execute(
-            "SELECT r.rowid, r.embedding FROM reflections r "
+            "SELECT r.rowid, r.id, r.embedding FROM reflections r "
             "WHERE r.embedding != '[]' AND r.rowid NOT IN "
             "(SELECT rowid FROM reflections_vec)"
         ).fetchall()
         if not rows:
             return
         inserted = 0
+        corrupt = 0
         for row in rows:
-            emb = json.loads(row[1])
+            try:
+                emb = json.loads(row[2])
+            except (ValueError, TypeError) as exc:
+                logger.warning(
+                    "reflection %s has malformed embedding JSON (%s); "
+                    "skipping during vec backfill",
+                    row[1],
+                    exc,
+                )
+                corrupt += 1
+                continue
             if len(emb) != self._vec_dimensions:
                 continue  # skip mismatched dimensions
             blob = struct.pack(f"{len(emb)}f", *emb)
@@ -328,11 +356,17 @@ class ReflectionStore:
                     (row[0], blob),
                 )
                 inserted += 1
-            except Exception:
-                pass  # rowid conflict or other issue — skip
+            except sqlite3.Error as exc:
+                logger.debug(
+                    "vec backfill skipped rowid=%s id=%s: %s",
+                    row[0], row[1], exc,
+                )
         if inserted:
             self._conn.commit()
-            print(f"[memory] vec_backfill_complete inserted={inserted} skipped={len(rows) - inserted}")
+            print(
+                f"[memory] vec_backfill_complete inserted={inserted} "
+                f"skipped={len(rows) - inserted} corrupt={corrupt}"
+            )
 
     @staticmethod
     def _embedding_to_blob(embedding: list[float]) -> bytes:

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -395,6 +395,37 @@ class TestEmbeddingSearch:
         )
         assert fact.id in returned_ids
 
+    def test_detect_dims_skips_corrupt_embedding_json(self, tmp_path, caplog):
+        """Regression for #289: a single corrupt embedding row must not abort
+        dimension detection / startup."""
+        import logging as _logging
+
+        store = _store(tmp_path)
+        good_emb = _emb(8, 0.2)
+        good = store.insert(_fact("good row", embedding=good_emb))
+        # Corrupt the embedding of one other row directly via SQL so the
+        # created_at ordering still lets the detector walk past it.
+        bad = store.insert(_fact("bad row", embedding=_emb(8, 0.3)))
+        store._conn.execute(
+            "UPDATE reflections SET embedding = ? WHERE id = ?",
+            ("{not json", bad.id),
+        )
+        # Make the corrupt row newer so DESC ordering hits it first.
+        store._conn.execute(
+            "UPDATE reflections SET created_at = '2099-01-01T00:00:00+00:00' "
+            "WHERE id = ?",
+            (bad.id,),
+        )
+        store._conn.commit()
+        with caplog.at_level(_logging.WARNING, logger="pinky_memory.store"):
+            dims = store._detect_embedding_dimensions()
+        assert dims == 8  # recovered from the good row
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert bad.id in messages
+        assert "malformed" in messages
+        # Good row is untouched
+        assert store.get(good.id) is not None
+
 
 # ── Near-Duplicate Detection ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Fixes #289 — a single corrupted embedding row could crash `_detect_embedding_dimensions()` (blocking startup) and was silently swallowed in `_backfill_vec()`.
- Dimension detection now scans newest-first, logs malformed rows with their id, and returns the first valid embedding length.
- Backfill catches `ValueError`/`TypeError` on `json.loads`, logs the reflection id, counts corrupt rows, and reports them in the completion message.
- Swaps the bare `except Exception: pass` in backfill's insert path for a targeted `sqlite3.Error` + debug log (partial progress on #295 — bare excepts cluster).

## Test plan
- [x] New regression: corrupts one row, makes it newest, asserts detection still returns 8 and the bad id is logged
- [x] `pytest tests/test_memory_store.py` → 96 passed
- [x] `ruff check` on changed files → clean

Review requested: @murzik

🤖 Opened by Barsik