### PR TITLE
fix(outreach): reject failed WhatsApp media downloads (#284)

### DIFF
--- a/src/pinky_outreach/whatsapp.py
+++ b/src/pinky_outreach/whatsapp.py
@@ -246,6 +246,17 @@ class WhatsAppAdapter:
             raise WhatsAppError("No download URL for media", 0)
         # Step 2: Download the file
         resp = self._client.get(url, headers={"Authorization": f"Bearer {self._token}"})
+        if resp.status_code >= 400:
+            message = f"Media download failed with HTTP {resp.status_code}"
+            code = resp.status_code
+            try:
+                error = resp.json().get("error", {})
+            except Exception:
+                error = {}
+            if error:
+                message = error.get("message", message)
+                code = error.get("code", code)
+            raise WhatsAppError(message, code)
         ext = data.get("mime_type", "application/octet-stream").split("/")[-1].split(";")[0]
         path = os.path.join(dest_dir, f"wa_{media_id}.{ext}")
         with open(path, "wb") as f:

--- a/tests/test_whatsapp.py
+++ b/tests/test_whatsapp.py
@@ -232,6 +232,7 @@ class TestDownloadFile:
         # Step 2: download the file
         file_content = b"fake_image_bytes"
         download_resp = MagicMock()
+        download_resp.status_code = 200
         download_resp.content = file_content
 
         def fake_request(method, path, **kwargs):
@@ -254,6 +255,25 @@ class TestDownloadFile:
             with pytest.raises(WhatsAppError) as exc_info:
                 adapter.download_file("bad_id", dest_dir=str(tmp_path))
         assert "No download URL" in exc_info.value.message
+
+    def test_download_http_error_raises_without_writing_file(self, tmp_path):
+        adapter = _wa()
+        media_info = {"url": "https://example.com/file.jpg", "mime_type": "image/jpeg"}
+        error_resp = MagicMock()
+        error_resp.status_code = 401
+        error_resp.json.return_value = {
+            "error": {"message": "Expired token", "code": 190}
+        }
+        error_resp.content = b"<html>not an image</html>"
+
+        with patch.object(adapter, "_request", return_value=media_info), \
+             patch.object(adapter._client, "get", return_value=error_resp):
+            with pytest.raises(WhatsAppError) as exc_info:
+                adapter.download_file("media_id_123", dest_dir=str(tmp_path))
+
+        assert exc_info.value.error_code == 190
+        assert "Expired token" in exc_info.value.message
+        assert not (tmp_path / "wa_media_id_123.jpeg").exists()
 
 
 # ── get_me ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixes #284 — `WhatsAppAdapter.download_file()` wrote whatever bytes came back from the media URL GET, so a 401/404 HTML or Graph-API error JSON was silently persisted as `wa_<media_id>.<ext>`.
- Adds a status-code check; raises `WhatsAppError` with the Graph API `error.message`/`error.code` when present, otherwise the raw HTTP status.
- Happy-path test now asserts `status_code == 200` so the guard is exercised.
- Regression: a 401 response raises with `error_code=190`, leaves no file on disk.

**Authored by Murzik, applied + PR'd by Barsik via patch-stage workflow.**

## Test plan
- [x] `pytest tests/test_whatsapp.py` → 32 passed
- [x] `ruff check` on changed files → clean
- [x] `git apply --check` on staged patch → pass

🤖 Opened by Barsik (fix authored by Murzik)