### PR TITLE
fix(self): encode KB tool URL parameters (#292)

### DIFF
--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -18,6 +18,7 @@ import json
 import os
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 
@@ -2138,7 +2139,12 @@ def create_server(
         @mcp.tool()
         def kb_search(query: str, scope: str = "all") -> str:
             """Search the knowledge base. scope: all | raw | wiki."""
-            result = _api("GET", f"/kb/search?q={query}&scope={scope}&limit=15")
+            params = urllib.parse.urlencode({
+                "q": query,
+                "scope": scope,
+                "limit": 15,
+            })
+            result = _api("GET", f"/kb/search?{params}")
             if "error" in result:
                 return f"Error: {result['error']}"
 
@@ -2157,7 +2163,8 @@ def create_server(
         @mcp.tool()
         def kb_get_wiki(topic: str) -> str:
             """Get a wiki page by slug (e.g. "topics/llm-knowledge-bases")."""
-            result = _api("GET", f"/kb/wiki/{topic}?include_content=true")
+            topic_path = urllib.parse.quote(topic, safe="/")
+            result = _api("GET", f"/kb/wiki/{topic_path}?include_content=true")
             if "error" in result:
                 return f"No wiki page found for: {topic}"
 
@@ -2217,7 +2224,8 @@ def create_server(
             source_list = [s.strip() for s in sources.split(",") if s.strip()] if sources else []
             related_list = [r.strip() for r in related.split(",") if r.strip()] if related else []
 
-            result = _api("PUT", f"/kb/wiki/{slug}", body={
+            slug_path = urllib.parse.quote(slug, safe="/")
+            result = _api("PUT", f"/kb/wiki/{slug_path}", body={
                 "title": title,
                 "content": content,
                 "sources": source_list,
@@ -2230,7 +2238,8 @@ def create_server(
         @mcp.tool()
         def kb_delete_wiki(slug: str) -> str:
             """Delete a wiki page by slug."""
-            result = _api("DELETE", f"/kb/wiki/{slug}")
+            slug_path = urllib.parse.quote(slug, safe="/")
+            result = _api("DELETE", f"/kb/wiki/{slug_path}")
             if "error" in result:
                 return f"Error: {result['error']}"
             return f"🗑️ Wiki page deleted: {slug}"
@@ -2238,7 +2247,8 @@ def create_server(
         @mcp.tool()
         def kb_delete_raw(source_id: str) -> str:
             """Delete a raw KB source by ID (e.g. 'raw-2026-04-08-001')."""
-            result = _api("DELETE", f"/kb/raw/{source_id}")
+            source_path = urllib.parse.quote(source_id, safe="")
+            result = _api("DELETE", f"/kb/raw/{source_path}")
             if "error" in result:
                 return f"Error: {result['error']}"
             return f"🗑️ Raw source deleted: {source_id}"
@@ -2272,7 +2282,8 @@ def create_server(
                 body["owner_notes"] = owner_notes
             if not body:
                 return "No fields to update — provide at least one field."
-            result = _api("PUT", f"/kb/raw/{source_id}", body=body)
+            source_path = urllib.parse.quote(source_id, safe="")
+            result = _api("PUT", f"/kb/raw/{source_path}", body=body)
             if "error" in result:
                 return f"Error: {result['error']}"
             return f"✅ Raw source updated: {source_id} — {result.get('title', '')}"

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -1902,6 +1902,47 @@ EXTRAS_TOOLS = {
 }
 
 
+class TestKbUrlEncoding:
+    def _capture_urls(self, response: dict):
+        seen: list[str] = []
+
+        def _urlopen(req, timeout=30):
+            seen.append(req.full_url if hasattr(req, "full_url") else str(req))
+            body = json.dumps(response).encode()
+            resp = MagicMock()
+            resp.read.return_value = body
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        return seen, patch("urllib.request.urlopen", side_effect=_urlopen)
+
+    def test_kb_search_encodes_query_params(self, srv):
+        seen, patched = self._capture_urls({"results": []})
+        with patched:
+            _tools(srv)["kb_search"](query="alpha & scope=raw", scope="wiki")
+
+        assert "q=alpha+%26+scope%3Draw" in seen[0]
+        assert "&scope=wiki" in seen[0]
+        assert "alpha & scope=raw" not in seen[0]
+
+    def test_kb_wiki_slug_encodes_path_specials(self, srv):
+        seen, patched = self._capture_urls({"content": "ok"})
+        with patched:
+            result = _tools(srv)["kb_get_wiki"](topic="topics/foo bar?draft=1")
+
+        assert result == "ok"
+        assert "/kb/wiki/topics/foo%20bar%3Fdraft%3D1?include_content=true" in seen[0]
+
+    def test_kb_raw_source_id_encodes_path_segment(self, srv):
+        seen, patched = self._capture_urls({})
+        with patched:
+            result = _tools(srv)["kb_delete_raw"](source_id="raw/odd id")
+
+        assert "deleted" in result.lower()
+        assert "/kb/raw/raw%2Fodd%20id" in seen[0]
+
+
 class TestToolGates:
     def test_core_only_has_23_tools(self):
         """No gates → only core tools registered."""


### PR DESCRIPTION
## Summary

Closes #292.

The KB self-tools (`kb_search`, `kb_get_wiki`, `kb_save_wiki`, `kb_delete_wiki`, `kb_delete_raw`, `kb_update_raw`) were interpolating user-supplied values directly into request URIs without escaping. That meant:

- A query containing `&`, `#`, `?`, or whitespace in `kb_search` silently corrupted the querystring.
- Wiki slugs or raw source IDs containing `/`, spaces, or URL-reserved characters broke routing.

Now:

- `kb_search` builds its querystring via `urllib.parse.urlencode`.
- Wiki slug endpoints use `urllib.parse.quote(slug, safe="/")` — nested slugs like `topics/llm-knowledge-bases` still work, but `/` inside a single segment is escaped where required.
- Raw source IDs are quoted with `safe=""`, so they're treated as a single path segment.

## Test plan

- [x] `pytest tests/test_pinky_self_tools.py` — 169 passed
- [x] `ruff check` — clean
- [ ] CI

## Attribution

Patch authored by **Murzik**, applied + opened by Barsik. Cross-review requested from Murzik.

🤖 Opened by Barsik