### PR TITLE
fix(calendar): return tool error for invalid event dates (#296)

### DIFF
--- a/src/pinky_calendar/server.py
+++ b/src/pinky_calendar/server.py
@@ -91,11 +91,10 @@ def create_server(
                 "Set CALDAV_URL, CALDAV_USERNAME, CALDAV_PASSWORD."
             )
 
-        now = datetime.now(tz=timezone.utc)
-        start = _parse_dt(start_date) if start_date else now
-        end = _parse_dt(end_date) if end_date else start + timedelta(days=days)
-
         try:
+            now = datetime.now(tz=timezone.utc)
+            start = _parse_dt(start_date) if start_date else now
+            end = _parse_dt(end_date) if end_date else start + timedelta(days=days)
             events = a.get_events(start, end)
             return json.dumps([
                 {
@@ -109,6 +108,8 @@ def create_server(
                 }
                 for e in events
             ])
+        except ValueError as e:
+            return _err(f"Invalid date: {e}")
         except Exception as e:
             return _err(f"Failed to fetch events: {e}")
 

--- a/tests/test_calendar_server.py
+++ b/tests/test_calendar_server.py
@@ -1,0 +1,26 @@
+"""Tests for pinky_calendar MCP tools."""
+
+from __future__ import annotations
+
+import json
+
+from pinky_calendar.server import create_server
+
+
+def _tools(srv):
+    return {t.name: t.fn for t in srv._tool_manager.list_tools()}
+
+
+class TestCalendarDateParsing:
+    def test_get_events_invalid_start_date_returns_tool_error(self):
+        srv = create_server(
+            caldav_url="https://calendar.example.test",
+            caldav_username="user",
+            caldav_password="pass",
+        )
+
+        raw = _tools(srv)["get_events"](start_date="not-a-date")
+        result = json.loads(raw)
+
+        assert "error" in result
+        assert "Invalid date" in result["error"]


### PR DESCRIPTION
## Summary

Closes #296.

`get_events()` in `pinky_calendar` was parsing `start_date` / `end_date` outside the `try/except` block. A caller passing an invalid ISO string (e.g. `"not-a-date"`) would trigger an unhandled `ValueError` that escaped the MCP tool instead of returning a structured `{"error": "..."}` response.

Fix moves the parse inside the error boundary and adds a dedicated `except ValueError` branch that returns `{"error": "Invalid date: ..."}`, matching the tool's existing error contract.

## Changes

- `src/pinky_calendar/server.py`: moved `_parse_dt` calls inside the try/except; added `except ValueError` that returns a structured error.
- `tests/test_calendar_server.py` (new): regression for invalid `start_date`.

## Test plan

- [x] `pytest tests/test_calendar_server.py` — 1 passed
- [x] `ruff check` — clean
- [ ] CI

## Attribution

Patch authored by **Murzik**, applied + opened by Barsik. Cross-review requested from Murzik.

🤖 Opened by Barsik