### PR TITLE
fix(oauth): validate state nonce on legacy Google Calendar callback (#287)

### DIFF
--- a/src/pinky_calendar/oauth.py
+++ b/src/pinky_calendar/oauth.py
@@ -53,9 +53,14 @@ def exchange_code(
     client_id: str,
     client_secret: str,
     code: str,
-    state: str,  # noqa: ARG001 — validated by caller
+    state: str,  # noqa: ARG001 — caller is responsible for validating state first
 ) -> dict:
     """Exchange an authorisation code for access + refresh tokens.
+
+    SECURITY: Callers MUST validate `state` against a previously issued,
+    unexpired, unconsumed nonce before invoking this function. Passing an
+    attacker-controlled `state` here without prior validation re-opens the
+    CSRF / account-linking hole fixed by #287.
 
     Returns:
         dict with keys: access_token, refresh_token, expiry (datetime | None).

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -4950,6 +4950,68 @@ def create_api(
             "session": session_id,
         }
 
+    # ── Legacy direct-Google OAuth state lifecycle (#287) ─────────
+    # Keys: GOOGLE_OAUTH_STATE_{state_nonce} → ISO-8601 issued timestamp.
+    # State nonces are single-use with a 10-minute TTL; consumed by the
+    # callback handler before the code exchange is attempted.
+    _google_oauth_state_ttl_sec = 600
+    _google_oauth_state_prefix = "GOOGLE_OAUTH_STATE_"
+
+    def _issue_google_oauth_state(nonce: str) -> None:
+        from datetime import datetime, timezone
+        agents.set_setting(
+            f"{_google_oauth_state_prefix}{nonce}",
+            datetime.now(tz=timezone.utc).isoformat(),
+        )
+
+    def _consume_google_oauth_state(nonce: str) -> str:
+        """Validate + delete a state nonce. Returns '' on success, else error reason.
+
+        Callers MUST treat any non-empty return as a hard rejection — the token
+        exchange must not proceed. The nonce is deleted even on expiry so a stale
+        state can't be retried.
+        """
+        from datetime import datetime, timezone
+        if not nonce:
+            return "missing state parameter"
+        key = f"{_google_oauth_state_prefix}{nonce}"
+        issued_raw = agents.get_setting(key)
+        if not issued_raw:
+            return "unknown or replayed state"
+        # Delete immediately to enforce single-use + prevent TOCTOU reuse.
+        try:
+            agents.delete_setting(key)
+        except Exception:
+            pass
+        try:
+            issued = datetime.fromisoformat(issued_raw)
+        except ValueError:
+            return "corrupt state record"
+        age_sec = (datetime.now(tz=timezone.utc) - issued).total_seconds()
+        if age_sec > _google_oauth_state_ttl_sec:
+            return "expired state"
+        if age_sec < 0:
+            return "state issued in the future"
+        return ""
+
+    @app.get("/calendar/google/direct-auth-url")
+    async def google_direct_auth_url():
+        """Generate a direct-Google OAuth auth URL with a persisted state nonce.
+
+        Used by the backward-compat flow where a user has registered their own
+        Google Cloud client credentials and `/calendar/google/callback` as the
+        redirect URI. The state nonce is persisted here so the callback can
+        validate it (CSRF defense — see #287).
+        """
+        store = _google_token_store()
+        client_id, client_secret = store.get_client_credentials()
+        if not client_id or not client_secret:
+            raise HTTPException(400, "Google client credentials not configured")
+        from pinky_calendar.oauth import get_auth_url
+        auth_url, state = get_auth_url(client_id, client_secret)
+        _issue_google_oauth_state(state)
+        return {"auth_url": auth_url, "state": state}
+
     @app.get("/calendar/google/fetch-token")
     async def fetch_google_token(session: str):
         """Retrieve tokens from pinkybot.ai proxy after OAuth completes."""
@@ -4985,9 +5047,29 @@ def create_api(
         return {"connected": True}
 
     @app.get("/calendar/google/callback")
-    async def google_callback(code: str, state: str):
-        """Handle the OAuth2 redirect (backward-compat for users with own credentials)."""
+    async def google_callback(code: str = "", state: str = ""):
+        """Handle the OAuth2 redirect (backward-compat for users with own credentials).
+
+        Requires a previously issued + unexpired + unconsumed state nonce
+        (see `/calendar/google/direct-auth-url`). Missing / unknown / replayed /
+        expired states are rejected before any token exchange happens, which
+        closes the CSRF / account-linking hole described in #287.
+        """
         from fastapi.responses import HTMLResponse
+        state_error = _consume_google_oauth_state(state)
+        if state_error:
+            return HTMLResponse(
+                f"<html><body><h3>OAuth state validation failed: {state_error}.</h3>"
+                "<p>Please retry from Settings — do not re-use an old link.</p>"
+                "<script>window.close();</script></body></html>",
+                status_code=400,
+            )
+        if not code:
+            return HTMLResponse(
+                "<html><body><h3>OAuth error: missing authorization code.</h3>"
+                "<script>window.close();</script></body></html>",
+                status_code=400,
+            )
         store = _google_token_store()
         client_id, client_secret = store.get_client_credentials()
         if not client_id or not client_secret:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -4968,8 +4968,13 @@ def create_api(
         """Validate + delete a state nonce. Returns '' on success, else error reason.
 
         Callers MUST treat any non-empty return as a hard rejection — the token
-        exchange must not proceed. The nonce is deleted even on expiry so a stale
-        state can't be retried.
+        exchange must not proceed. Fails closed on every error path: the nonce
+        is considered consumed only if the DELETE observably removed a row.
+
+        Race semantics: if two callbacks fire concurrently with the same nonce
+        (one legitimate, one forged replay), exactly one `delete_setting()`
+        returns True and is accepted; the loser sees False and is rejected
+        as "unknown or replayed state".
         """
         from datetime import datetime, timezone
         if not nonce:
@@ -4978,14 +4983,25 @@ def create_api(
         issued_raw = agents.get_setting(key)
         if not issued_raw:
             return "unknown or replayed state"
-        # Delete immediately to enforce single-use + prevent TOCTOU reuse.
+        # DELETE is the authoritative consume step: its return value tells us
+        # whether *we* were the one to remove the row. If False, another
+        # caller beat us to it → treat as replay. If it raises, fail closed.
         try:
-            agents.delete_setting(key)
+            deleted = agents.delete_setting(key)
         except Exception:
-            pass
+            return "could not consume state"
+        if not deleted:
+            return "unknown or replayed state"
         try:
             issued = datetime.fromisoformat(issued_raw)
         except ValueError:
+            return "corrupt state record"
+        # Reject naive timestamps — `datetime.fromisoformat` happily accepts
+        # ISO strings without a tz suffix and returns a naive datetime, and
+        # subtracting a naive dt from an aware `now()` raises TypeError.
+        # We only ever *issue* aware UTC timestamps, so a naive record here
+        # implies corruption or tampering.
+        if issued.tzinfo is None:
             return "corrupt state record"
         age_sec = (datetime.now(tz=timezone.utc) - issued).total_seconds()
         if age_sec > _google_oauth_state_ttl_sec:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3022,3 +3022,154 @@ class TestProviders:
             db=db,
         )
         assert (url, key, model) == ("https://api.deepseek.com/anthropic", "", "deepseek-chat")
+
+
+# ── Google OAuth CSRF state validation (#287) ────────────────────
+
+
+class TestGoogleOAuthStateValidation:
+    """Regression for #287: the legacy /calendar/google/callback endpoint must
+    validate a previously-issued state nonce before exchanging the code."""
+
+    def _make_app(self):
+        from pinky_daemon.api import create_api
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        return create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
+
+    def _seed_credentials(self, app):
+        """Seed client credentials so the callback can't early-return on them."""
+        agents = app.state.agents
+        # TokenStore uses these exact setting keys (see pinky_calendar.store).
+        agents.set_setting("GOOGLE_CALENDAR_CLIENT_ID", "test-client-id")
+        agents.set_setting("GOOGLE_CALENDAR_CLIENT_SECRET", "test-client-secret")
+
+    def test_callback_rejects_missing_state(self):
+        app = self._make_app()
+        self._seed_credentials(app)
+        with TestClient(app) as client:
+            resp = client.get(
+                "/calendar/google/callback",
+                params={"code": "auth-code", "state": ""},
+                follow_redirects=False,
+            )
+        assert resp.status_code == 400
+        assert "missing state" in resp.text.lower()
+
+    def test_callback_rejects_unknown_state(self):
+        app = self._make_app()
+        self._seed_credentials(app)
+        with TestClient(app) as client:
+            resp = client.get(
+                "/calendar/google/callback",
+                params={"code": "auth-code", "state": "attacker-forged-nonce"},
+                follow_redirects=False,
+            )
+        assert resp.status_code == 400
+        assert "unknown or replayed" in resp.text.lower()
+
+    def test_callback_rejects_expired_state(self):
+        from datetime import datetime, timedelta, timezone
+        app = self._make_app()
+        self._seed_credentials(app)
+        # Manually insert a state key with an issued timestamp in the distant past.
+        stale = (datetime.now(tz=timezone.utc) - timedelta(hours=1)).isoformat()
+        app.state.agents.set_setting("GOOGLE_OAUTH_STATE_stale-nonce", stale)
+        with TestClient(app) as client:
+            resp = client.get(
+                "/calendar/google/callback",
+                params={"code": "auth-code", "state": "stale-nonce"},
+                follow_redirects=False,
+            )
+        assert resp.status_code == 400
+        assert "expired" in resp.text.lower()
+        # Expired state must be purged so it can't be retried.
+        assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_stale-nonce") == ""
+
+    def test_callback_rejects_replayed_state(self):
+        """A state nonce must be single-use. After one consume, a second hit
+        with the same nonce must be treated as unknown."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch as _patch
+
+        app = self._make_app()
+        self._seed_credentials(app)
+        fresh = datetime.now(tz=timezone.utc).isoformat()
+        app.state.agents.set_setting("GOOGLE_OAUTH_STATE_one-shot", fresh)
+
+        # First use consumes the nonce. We don't care about the token-exchange
+        # outcome here (which will fail because we're not mocking Google), we
+        # only need to confirm the state was accepted + deleted.
+        fake_tokens = {"access_token": "a", "refresh_token": "r", "expiry": None}
+        with _patch("pinky_calendar.oauth.exchange_code", return_value=fake_tokens):
+            with TestClient(app) as client:
+                first = client.get(
+                    "/calendar/google/callback",
+                    params={"code": "auth-code", "state": "one-shot"},
+                    follow_redirects=False,
+                )
+                assert first.status_code == 200  # happy path
+                assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_one-shot") == ""
+                # Replay with the same nonce must now be rejected.
+                replay = client.get(
+                    "/calendar/google/callback",
+                    params={"code": "auth-code", "state": "one-shot"},
+                    follow_redirects=False,
+                )
+        assert replay.status_code == 400
+        assert "unknown or replayed" in replay.text.lower()
+
+    def test_callback_deletes_state_even_on_exchange_failure(self):
+        """If exchange_code raises, the state nonce must still have been
+        consumed — otherwise an attacker could race a valid flow."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch as _patch
+
+        app = self._make_app()
+        self._seed_credentials(app)
+        fresh = datetime.now(tz=timezone.utc).isoformat()
+        app.state.agents.set_setting("GOOGLE_OAUTH_STATE_single-use", fresh)
+
+        with _patch(
+            "pinky_calendar.oauth.exchange_code",
+            side_effect=RuntimeError("invalid code"),
+        ):
+            with TestClient(app) as client:
+                resp = client.get(
+                    "/calendar/google/callback",
+                    params={"code": "bad-code", "state": "single-use"},
+                    follow_redirects=False,
+                )
+        assert resp.status_code == 400
+        assert "oauth error" in resp.text.lower()
+        assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_single-use") == ""
+
+    def test_direct_auth_url_persists_state(self):
+        """The direct-auth-url endpoint must persist a single-use state nonce
+        that the callback can later validate against."""
+        from unittest.mock import patch as _patch
+
+        app = self._make_app()
+        self._seed_credentials(app)
+        with _patch(
+            "pinky_calendar.oauth.get_auth_url",
+            return_value=("https://accounts.google.com/o/oauth2/auth?state=xyz", "xyz"),
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/calendar/google/direct-auth-url")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "xyz"
+        assert "accounts.google.com" in body["auth_url"]
+        # State key must be present and non-empty (timestamp).
+        stored = app.state.agents.get_setting("GOOGLE_OAUTH_STATE_xyz")
+        assert stored != ""
+
+    def test_direct_auth_url_requires_credentials(self):
+        """Without stored client credentials, direct-auth must 400 — there's
+        nothing to build a direct-Google auth URL for."""
+        app = self._make_app()
+        # Intentionally skip _seed_credentials().
+        with TestClient(app) as client:
+            resp = client.get("/calendar/google/direct-auth-url")
+        assert resp.status_code == 400

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3173,3 +3173,97 @@ class TestGoogleOAuthStateValidation:
         with TestClient(app) as client:
             resp = client.get("/calendar/google/direct-auth-url")
         assert resp.status_code == 400
+
+    def test_consume_fails_closed_when_delete_returns_false(self):
+        """Regression for Murzik's review: if delete_setting() returns False
+        (because a concurrent consumer already deleted the row), we must NOT
+        proceed to token exchange. Treat the loser of the race as replayed."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch as _patch
+
+        app = self._make_app()
+        self._seed_credentials(app)
+        fresh = datetime.now(tz=timezone.utc).isoformat()
+        app.state.agents.set_setting("GOOGLE_OAUTH_STATE_race-nonce", fresh)
+
+        # Simulate the race: get_setting sees the value, but by the time we
+        # try to delete it, a concurrent consumer has beaten us to it.
+        real_delete = app.state.agents.delete_setting
+
+        def fake_delete(key):
+            if key == "GOOGLE_OAUTH_STATE_race-nonce":
+                return False  # Another consumer won the race.
+            return real_delete(key)
+
+        exchange_called = {"count": 0}
+
+        def fake_exchange(*args, **kwargs):
+            exchange_called["count"] += 1
+            return {"access_token": "a", "refresh_token": "r", "expiry": None}
+
+        with _patch.object(app.state.agents, "delete_setting", fake_delete), \
+             _patch("pinky_calendar.oauth.exchange_code", fake_exchange):
+            with TestClient(app) as client:
+                resp = client.get(
+                    "/calendar/google/callback",
+                    params={"code": "auth-code", "state": "race-nonce"},
+                    follow_redirects=False,
+                )
+        assert resp.status_code == 400
+        assert "unknown or replayed" in resp.text.lower()
+        # Critical: exchange must not have been invoked.
+        assert exchange_called["count"] == 0
+
+    def test_consume_fails_closed_when_delete_raises(self):
+        """Regression for Murzik's review: if delete_setting() raises (DB
+        error, disk full, etc.), fail closed — don't exchange the code."""
+        from datetime import datetime, timezone
+        from unittest.mock import patch as _patch
+
+        app = self._make_app()
+        self._seed_credentials(app)
+        fresh = datetime.now(tz=timezone.utc).isoformat()
+        app.state.agents.set_setting("GOOGLE_OAUTH_STATE_boom", fresh)
+
+        def raising_delete(key):
+            raise sqlite3.OperationalError("database is locked")
+
+        exchange_called = {"count": 0}
+
+        def fake_exchange(*args, **kwargs):
+            exchange_called["count"] += 1
+            return {"access_token": "a", "refresh_token": "r", "expiry": None}
+
+        with _patch.object(app.state.agents, "delete_setting", raising_delete), \
+             _patch("pinky_calendar.oauth.exchange_code", fake_exchange):
+            with TestClient(app) as client:
+                resp = client.get(
+                    "/calendar/google/callback",
+                    params={"code": "auth-code", "state": "boom"},
+                    follow_redirects=False,
+                )
+        assert resp.status_code == 400
+        assert "could not consume state" in resp.text.lower()
+        assert exchange_called["count"] == 0
+
+    def test_callback_rejects_naive_timestamp_state(self):
+        """Regression for Murzik's review: datetime.fromisoformat() can return
+        a naive datetime for valid ISO strings without a tz suffix, and
+        subtracting naive from aware raises TypeError → 500. Reject naive
+        records as corrupt so the callback still returns a clean 400."""
+        app = self._make_app()
+        self._seed_credentials(app)
+        # No tz suffix — fromisoformat() will parse this as naive.
+        app.state.agents.set_setting(
+            "GOOGLE_OAUTH_STATE_naive-nonce", "2026-04-21T10:00:00",
+        )
+        with TestClient(app) as client:
+            resp = client.get(
+                "/calendar/google/callback",
+                params={"code": "auth-code", "state": "naive-nonce"},
+                follow_redirects=False,
+            )
+        assert resp.status_code == 400
+        assert "corrupt state" in resp.text.lower()
+        # Still purged, even though it was malformed — can't be retried.
+        assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_naive-nonce") == ""


### PR DESCRIPTION
## Summary

Closes #287 — **security, high severity**.

The legacy `/calendar/google/callback` endpoint accepted the `state` query parameter but never validated it before exchanging the authorization code and saving tokens. `exchange_code()` even had a `# noqa: ARG001 — validated by caller` comment marking the parameter as handled elsewhere, but no caller actually compared it against any stored nonce.

**Impact:** OAuth CSRF / account-linking risk on the backward-compat flow. A crafted callback hitting the owner's browser with an attacker-controlled authorization code could bind the wrong Google Calendar account to PinkyBot.

## Fix

1. **New `/calendar/google/direct-auth-url` endpoint** — calls the existing `pinky_calendar.oauth.get_auth_url()`, persists the returned state nonce with an ISO-8601 timestamp under `GOOGLE_OAUTH_STATE_{nonce}` (TTL 10 min), and returns `{auth_url, state}`. This is the only path that issues a state nonce.
2. **`/calendar/google/callback` now enforces state**:
   - Missing state → 400
   - Unknown / forged state → 400
   - Expired state → 400 (also purged so it can't be retried)
   - State is deleted on first consumption — **single-use**, before any client-credential lookup or code exchange
   - Replay with the same nonce is rejected as unknown
3. **`pinky_calendar.oauth.exchange_code`**: the misleading "validated by caller" marker is replaced with a real `SECURITY:` note spelling out the caller's obligation.

## Threat model coverage

| Attack | Before | After |
|---|---|---|
| Attacker sends owner a crafted `?code=X&state=Y` link | Tokens saved for attacker's Google account | 400 "unknown or replayed state" |
| Owner starts legit flow, attacker intercepts + replays the state | Replay succeeds if timed well | 400 "unknown or replayed state" (nonce deleted on first use) |
| Nonce sits around past TTL | Indefinitely valid | Rejected after 10 minutes + purged |
| Exchange succeeds but someone retries the same state | Possible double-save | Single-use; second callback fails |
| `code` is omitted | 500 from google_auth_oauthlib | 400 "missing authorization code" |

## Test plan

New `TestGoogleOAuthStateValidation` class in `tests/test_api.py`:

- [x] `test_callback_rejects_missing_state`
- [x] `test_callback_rejects_unknown_state`
- [x] `test_callback_rejects_expired_state` — also asserts the stale key is purged
- [x] `test_callback_rejects_replayed_state` — happy path consume, then replay rejected
- [x] `test_callback_deletes_state_even_on_exchange_failure` — prevents TOCTOU reuse
- [x] `test_direct_auth_url_persists_state`
- [x] `test_direct_auth_url_requires_credentials`
- [x] `pytest tests/test_api.py` — 262 passed
- [x] `ruff check` — clean
- [ ] CI

## Notes for reviewer

- I kept the backward-compat flow alive rather than ripping out the callback, because `frontend-svelte/src/pages/Settings.svelte` still documents `/calendar/google/callback` as the redirect URI users register in Google Cloud Console. The new `direct-auth-url` endpoint completes that flow with proper CSRF defense.
- The proxy session flow (`/calendar/google/auth-url` → pinkybot.ai) is untouched — it already validates sessions server-side.

🤖 Opened by Barsik