### PR TITLE
fix(voice): guard finalize_call against None session (#286)

### DIFF
--- a/src/pinky_daemon/voice_engine.py
+++ b/src/pinky_daemon/voice_engine.py
@@ -366,7 +366,16 @@ async def finalize_call(
     broker_send: Callable | None = None,
     api_key: str = "",
 ) -> None:
-    """Post-call finalization: build transcript, Opus review, save artifact, notify."""
+    """Post-call finalization: build transcript, Opus review, save artifact, notify.
+
+    Callers in the WS disconnect path can hit a race where the session has
+    already been cleaned up by the time we try to finalize. We accept None
+    here as a defensive belt-and-suspenders guard so a stray call can't
+    raise AttributeError on `session.call_sid`. (#286)
+    """
+    if session is None:
+        _log("voice: finalize_call called with None session — skipping")
+        return
     _log(f"voice: finalizing call {session.call_sid}")
 
     # Get call request for goal context

--- a/src/pinky_daemon/voice_routes.py
+++ b/src/pinky_daemon/voice_routes.py
@@ -865,15 +865,27 @@ async def conversationrelay_ws(ws: WebSocket, call_session_id: str):
             session.id, status="completed", ended_at=time.time()
         )
 
-        # Finalize call in background (Opus review + artifact + notify)
+        # Finalize call in background (Opus review + artifact + notify).
+        # get_session() can return None under session-expiry races (session
+        # was cleaned up between the update above and this lookup, or it was
+        # never committed). Check explicitly — handing None to finalize_call()
+        # would raise AttributeError on session.call_sid. (#286)
         if messages:
-            asyncio.create_task(
-                finalize_call(
-                    _voice_store.get_session(call_session_id),
-                    _voice_store, _agents, _broker_send,
-                    api_key=_api_key,
+            finalize_session = _voice_store.get_session(call_session_id)
+            if finalize_session is None:
+                _log(
+                    f"voice: cannot finalize call — session {call_session_id} "
+                    f"no longer in store (likely expired or cleaned up); "
+                    f"skipping Opus review + artifact"
                 )
-            )
+            else:
+                asyncio.create_task(
+                    finalize_call(
+                        finalize_session,
+                        _voice_store, _agents, _broker_send,
+                        api_key=_api_key,
+                    )
+                )
 
         _log(f"voice: WS closed for session {call_session_id}")
 

--- a/tests/test_voice_engine.py
+++ b/tests/test_voice_engine.py
@@ -1,0 +1,94 @@
+"""Tests for pinky_daemon.voice_engine helpers.
+
+Focused on regression coverage for #286 — finalize_call() getting handed
+a None session under WS-disconnect races.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from pinky_daemon.voice_engine import finalize_call
+
+
+class TestFinalizeCallNoneGuard:
+    """Regression for #286: under session-expiry races,
+    `voice_store.get_session()` can return None. Previously this raised
+    `AttributeError: 'NoneType' object has no attribute 'call_sid'` because
+    `finalize_call()` went straight to `session.call_sid` in the first log
+    line. It now no-ops + logs instead."""
+
+    def test_finalize_call_with_none_session_noops(self):
+        voice_store = MagicMock()
+        agents = MagicMock()
+        broker_send = MagicMock()
+
+        # Must not raise AttributeError.
+        asyncio.run(
+            finalize_call(
+                None,
+                voice_store,
+                agents,
+                broker_send=broker_send,
+                api_key="test",
+            )
+        )
+
+        # No voice_store / agents / broker side effects on the None path.
+        voice_store.get_call_request.assert_not_called()
+        voice_store.get_events.assert_not_called()
+        voice_store.save_artifact.assert_not_called()
+        broker_send.assert_not_called()
+
+    def test_finalize_call_with_real_session_proceeds(self):
+        """Sanity check: a real session is not short-circuited by the guard.
+
+        Uses an empty events list so finalize returns after transcript check
+        (no Opus/network dependency)."""
+        session = MagicMock()
+        session.call_sid = "CA123"
+        session.id = "session-abc"
+        session.call_request_id = None
+
+        voice_store = MagicMock()
+        voice_store.get_events.return_value = []
+        agents = MagicMock()
+
+        asyncio.run(
+            finalize_call(
+                session,
+                voice_store,
+                agents,
+                broker_send=None,
+                api_key="test",
+            )
+        )
+
+        # We got past the None guard and the initial log line — evidenced by
+        # get_events being called (which is the step right after the goal
+        # lookup).
+        voice_store.get_events.assert_called_once_with("session-abc")
+        # Empty transcript → save_artifact should be skipped.
+        voice_store.save_artifact.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [None],
+    ids=["none"],
+)
+def test_finalize_call_parametrized_nones(bad_value):
+    """Keep the bad-input set explicit so regressions show up in the
+    parametrize ID."""
+    asyncio.run(
+        finalize_call(
+            bad_value,
+            MagicMock(),
+            MagicMock(),
+            broker_send=None,
+            api_key="",
+        )
+    )


### PR DESCRIPTION
## Summary

Closes #286.

`voice_routes.voice_websocket` was handing `_voice_store.get_session(call_session_id)` directly to `finalize_call()` in the WS-disconnect path. `get_session()` can legitimately return `None` under session-expiry races (session cleaned up between the `update_session()` call and this lookup, or never committed after an earlier failure). `finalize_call()`'s very first line accesses `session.call_sid` → `AttributeError: 'NoneType' object has no attribute 'call_sid'`, and the whole finalize path (Opus review + artifact + owner notification) breaks.

## Fix

**Belt + suspenders, two layers:**

1. **Call site** (`src/pinky_daemon/voice_routes.py`): look up the session into a local before scheduling `finalize_call`; if it's `None`, log and skip scheduling entirely. Prevents the task from being launched.
2. **Callee** (`src/pinky_daemon/voice_engine.py::finalize_call`): accept `None` defensively and early-return with a log. Any future caller that forgets the guard gets a clean no-op.

## Test plan

New `tests/test_voice_engine.py`:

- [x] `test_finalize_call_with_none_session_noops` — passing None does not raise and does not touch voice_store / agents / broker
- [x] `test_finalize_call_with_real_session_proceeds` — a real session still reaches `voice_store.get_events()` (sanity: the guard doesn't over-skip)
- [x] `test_finalize_call_parametrized_nones` — explicit bad-input set for future regression tracking
- [x] `pytest tests/test_voice_engine.py` — 3 passed
- [x] `ruff check` — clean
- [ ] CI

🤖 Opened by Barsik