### PR TITLE
fix(datetime): replace deprecated utcnow() + naive now() with tz-aware (#294)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2943,7 +2943,9 @@ def create_api(
     except Exception:
         _git_branch = "unknown"
     import datetime as _dt
-    _now = _dt.datetime.now()
+    # UTC so the version string is deterministic regardless of where the
+    # daemon runs (was previously implicit local-tz). #294
+    _now = _dt.datetime.now(_dt.timezone.utc)
     _pinky_version = f"{_now.strftime('%y')}.{int(_now.strftime('%m')):02d}.{_git_hash}"
 
     if not os.environ.get("PINKY_SESSION_SECRET", "").strip():
@@ -6957,13 +6959,14 @@ def create_api(
                 raise HTTPException(503, f"Agent '{name}' session '{label}' could not be started")
 
         # Format with metadata like broker messages
-        from datetime import datetime
+        from datetime import datetime, timezone
         from zoneinfo import ZoneInfo
         tz_str = agents.get_default_timezone()
         try:
             ts = datetime.now(ZoneInfo(tz_str)).strftime(f"%Y-%m-%d %H:%M:%S {tz_str}")
         except Exception:
-            ts = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+            # datetime.utcnow() is deprecated in Python 3.12. #294
+            ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
         prompt = f"[web | dm | Admin | web | {ts}]\n{content}"
         await streaming.send(prompt, platform="web", chat_id="web")
@@ -7017,13 +7020,14 @@ def create_api(
         size = len(content_bytes)
 
         # Route to agent as a message with file attachment
-        from datetime import datetime
+        from datetime import datetime, timezone
         from zoneinfo import ZoneInfo
         tz_str = agents.get_default_timezone()
         try:
             ts = datetime.now(ZoneInfo(tz_str)).strftime(f"%Y-%m-%d %H:%M:%S {tz_str}")
         except Exception:
-            ts = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+            # datetime.utcnow() is deprecated in Python 3.12. #294
+            ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
         msg = BrokerMessage(
             platform="web",

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -16,7 +16,7 @@ import sys
 import time
 import zoneinfo
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from pinky_daemon.sessions import SessionUsage
@@ -297,7 +297,11 @@ class StreamingSession:
             _now = datetime.now(_tz)
             time_str = _now.strftime("%A, %B %-d, %Y at %-I:%M %p %Z")
         except Exception:
-            time_str = datetime.now().strftime("%A, %B %-d, %Y at %-I:%M %p UTC")
+            # Fallback labelled "UTC" was previously using implicit local-tz
+            # datetime.now() — fix to actual UTC. #294
+            time_str = datetime.now(timezone.utc).strftime(
+                "%A, %B %-d, %Y at %-I:%M %p UTC"
+            )
 
         tools_hint = (
             "You have explicit pinky-messaging outreach tools: "

--- a/src/pinky_memory/kg_extractor.py
+++ b/src/pinky_memory/kg_extractor.py
@@ -420,6 +420,10 @@ class KGExtractor:
             limit=10,
         )
 
+        # Cached once per call — previously computed per-iteration inside the
+        # loop even though the value never changes within one call. #294
+        _now_ymd = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
         for old in existing:
             # Only consider triples where subject matches exactly and object differs
             if not (
@@ -446,9 +450,7 @@ class KGExtractor:
                 })
                 return False  # Don't insert this triple
 
-            valid_to = new_valid_from or datetime.now(
-                timezone.utc
-            ).strftime("%Y-%m-%d")
+            valid_to = new_valid_from or _now_ymd
             self._store.kg_invalidate(
                 old["subject"], old["predicate"], old["object"],
                 valid_to=valid_to,


### PR DESCRIPTION
## Summary

Closes #294.

`datetime.utcnow()` is deprecated as of Python 3.12 (emits `DeprecationWarning`, will be removed in a future version). Naive `datetime.now()` silently picks up local tz, which breaks cross-tz serialization or comparison — and in `streaming_session.py:300` was labelling a local-time string as "UTC".

## Changes

| File | Line | Before | After |
|---|---|---|---|
| `pinky_daemon/api.py` | 2946 | `datetime.now()` | `datetime.now(timezone.utc)` — version string is now deterministic regardless of host tz |
| `pinky_daemon/api.py` | 6966 | `datetime.utcnow()` | `datetime.now(timezone.utc)` |
| `pinky_daemon/api.py` | 7026 | `datetime.utcnow()` | `datetime.now(timezone.utc)` |
| `pinky_daemon/streaming_session.py` | 300 | `datetime.now()` labelled "UTC" | `datetime.now(timezone.utc)` — actually UTC now |
| `pinky_memory/kg_extractor.py` | 449 | Per-triple `datetime.now(tz=utc).strftime(...)` inside `for old in existing:` loop | Hoisted out, cached once per `_resolve_functional_conflict` call |

## Test plan

- [x] `grep -n 'datetime\.utcnow\|datetime\.now()'` returns only comments
- [x] `pytest tests/test_api.py tests/test_kg_extractor.py tests/test_streaming_session.py` — 305 passed
- [x] `ruff check` — clean
- [ ] CI

🤖 Opened by Barsik