### PR TITLE
docs: update Deploy section in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ pytest
 
 ## Deploy
 
-- Production on Mac Mini (`oleg@10.0.0.32`)
-- `sync.sh` sources `.env`, SSH deploys, `status.sh` to verify
+- Production on Mac Mini (`oleg@10.0.0.209`)
+- Self-update: agents call `update_and_restart()` (pinky-self MCP) — pulls the branch matching `PINKYBOT_CHANNEL` env (`stable`→`main`, `beta`→`beta`) and restarts the daemon
+- CI auto-runs on push (`ci.yml`); `main` is branch-protected and requires passing CI + PR review
 - Agent data in `data/agents/{name}/` (gitignored)


### PR DESCRIPTION
## Summary
- `sync.sh` / `status.sh` no longer exist in the repo — replace with current self-update path via `update_and_restart()` (pinky-self MCP), which respects `PINKYBOT_CHANNEL`
- Refresh Mac Mini LAN IP `.32` → `.209` after the 2026-04-17 DHCP lease change
- Add a note that `main` is branch-protected and CI runs on every push

## Test plan
- [x] Docs-only change — no code affected
- [x] CI will validate nothing regresses

🤖 Opened by Barsik