### PR TITLE
fix(streaming): clear codex_session_id on session restart

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6732,6 +6732,10 @@ def create_api(
         ss._config.resume_session_id = ""
         ss._config.restart_reason = "context_restart"
         ss.session_id = ""
+        # Codex sessions track the thread_id separately on the session object;
+        # clear it too or `codex exec resume <stale-id>` keeps firing next turn.
+        if hasattr(ss, "codex_session_id"):
+            ss.codex_session_id = ""
         try:
             await ss.connect()
             _log(f"api: streaming session restarted for {name}")
@@ -6805,6 +6809,8 @@ def create_api(
             agents.set_streaming_session_id(name, "", label="main")
             ss._config.resume_session_id = ""
             ss.session_id = ""
+            if hasattr(ss, "codex_session_id"):
+                ss.codex_session_id = ""
             ss._config.model = req.model
             try:
                 await ss.connect()
@@ -6886,6 +6892,8 @@ def create_api(
         ss._config.wake_context = _build_streaming_wake_context(name)
         ss._config.resume_session_id = ""
         ss.session_id = ""
+        if hasattr(ss, "codex_session_id"):
+            ss.codex_session_id = ""
         try:
             await ss.connect()
             _log(f"api: archived and restarted session for {name}")

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6735,6 +6735,8 @@ def create_api(
         # Codex sessions track the thread_id separately on the session object;
         # clear it too or `codex exec resume <stale-id>` keeps firing next turn.
         if hasattr(ss, "codex_session_id"):
+            if ss.codex_session_id:
+                _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
             ss.codex_session_id = ""
         try:
             await ss.connect()
@@ -6810,6 +6812,8 @@ def create_api(
             ss._config.resume_session_id = ""
             ss.session_id = ""
             if hasattr(ss, "codex_session_id"):
+                if ss.codex_session_id:
+                    _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
                 ss.codex_session_id = ""
             ss._config.model = req.model
             try:
@@ -6893,6 +6897,8 @@ def create_api(
         ss._config.resume_session_id = ""
         ss.session_id = ""
         if hasattr(ss, "codex_session_id"):
+            if ss.codex_session_id:
+                _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
             ss.codex_session_id = ""
         try:
             await ss.connect()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -661,6 +661,36 @@ class TestAPI:
                 assert fake.disconnect_calls == 1
                 assert fake.connect_calls == 1
 
+    def test_streaming_restart_clears_codex_session_id_on_codex_sessions(self):
+        """Codex sessions track thread_id in `codex_session_id`; restart must clear it
+        or the next turn will run `codex exec resume <stale-id>` and fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                fake = self._FakeStreamingSession("test-agent", "main")
+                # Simulate a codex-backed session with a stale thread id pinned.
+                fake.codex_session_id = "019dc43b-99cd-7b81-884d-eb09a93f9144"
+                app.state.broker.register_streaming("test-agent", fake, label="main")
+
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="Testing codex restart clears thread id",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.session_id,
+                )
+                fake.last_active = time.time()
+
+                resp = client.post("/agents/test-agent/streaming/restart")
+                assert resp.status_code == 200
+                assert resp.json()["restarted"] is True
+                assert fake.codex_session_id == "", (
+                    "codex_session_id must be cleared so next turn does not "
+                    "issue `codex exec resume <stale-id>`"
+                )
+                assert fake.session_id == ""
+
     def test_wake_streaming_session_defaults_include_outreach_tools(self):
         async def fake_connect(self):
             self._connected = True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -391,9 +391,13 @@ class TestAPI:
         def __init__(self, total_tokens=0, max_tokens=200_000):
             self.total_tokens = total_tokens
             self.max_tokens = max_tokens
+            self.queries: list[str] = []
 
         async def get_context_usage(self):
             return {"totalTokens": self.total_tokens, "maxTokens": self.max_tokens}
+
+        async def query(self, prompt: str):
+            self.queries.append(prompt)
 
     class _FakeStreamingSession:
         def __init__(self, agent_name: str, label: str = "main", *, connected: bool = True, total_tokens: int = 0, max_tokens: int = 200_000):
@@ -690,6 +694,67 @@ class TestAPI:
                     "issue `codex exec resume <stale-id>`"
                 )
                 assert fake.session_id == ""
+
+    def test_streaming_model_change_clears_codex_session_id(self):
+        """When /streaming/model triggers a context-window restart, codex_session_id
+        must also be cleared (sibling of the /streaming/restart bug fix)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                # Default fake has max_tokens=200_000 (not a 1M model). Switching to
+                # a 1M model triggers needs_restart=True path inside set_streaming_model.
+                fake = self._FakeStreamingSession("test-agent", "main", max_tokens=200_000)
+                fake.codex_session_id = "019dc43b-99cd-7b81-884d-eb09a93f9144"
+                app.state.broker.register_streaming("test-agent", fake, label="main")
+
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="Testing /streaming/model clears codex thread",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.session_id,
+                )
+                fake.last_active = time.time()
+
+                resp = client.post(
+                    "/agents/test-agent/streaming/model",
+                    json={"model": "claude-opus-4-7"},  # in _1M_MODELS → triggers restart
+                )
+                assert resp.status_code == 200, resp.text
+                assert fake.codex_session_id == ""
+                assert fake.session_id == ""
+
+    def test_streaming_archive_clears_codex_session_id(self):
+        """/streaming/archive must clear codex_session_id alongside session_id —
+        same bug pattern as /streaming/restart."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                fake = self._FakeStreamingSession("test-agent", "main")
+                fake.codex_session_id = "019dc43b-99cd-7b81-884d-eb09a93f9144"
+                app.state.broker.register_streaming("test-agent", fake, label="main")
+
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="Testing /streaming/archive clears codex thread",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.session_id,
+                )
+                fake.last_active = time.time()
+
+                resp = client.post("/agents/test-agent/streaming/archive")
+                assert resp.status_code == 200, resp.text
+                assert resp.json()["archived"] is True
+                assert fake.codex_session_id == ""
+                assert fake.session_id == ""
+                # Sanity: archive prompted the agent to save state before resetting.
+                assert any(
+                    "archived" in q.lower() or "save" in q.lower()
+                    for q in fake._client.queries
+                )
 
     def test_wake_streaming_session_defaults_include_outreach_tools(self):
         async def fake_connect(self):


### PR DESCRIPTION
## Summary

- `/streaming/restart`, `/streaming/archive`, and `/streaming/model` clear `ss.session_id` but never touched `ss.codex_session_id` — so a "successful" restart of a codex-backed agent still ran `codex exec resume <stale-thread-id>` on the next turn and failed.
- Defensive `if hasattr(ss, "codex_session_id"): ss.codex_session_id = ""` added to all three sites. No-op for CC StreamingSession (the attribute is codex-only).
- New test `test_streaming_restart_clears_codex_session_id_on_codex_sessions` exercises the codex path.

## How it surfaced

Murzik (codex-backed) wedged on a dead thread after his codex CLI got bumped 0.116 → 0.125 (gpt-5.5 model needs ≥0.121). `/streaming/restart` returned 200 but the very next message ran `codex exec resume 019dc43b-99c…` and bailed with `thread not found`. Saved-context restart-guard had to be bypassed via DB stub before the bug was even visible.

`CodexSession.force_restart()` already clears both fields correctly (codex_session.py:752), but no API endpoint calls it — the endpoints implement their own restart logic and miss the codex-specific cleanup.

## Test plan

- [x] `pytest tests/test_api.py` — 266 passing locally (existing 265 + new 1)
- [x] `ruff check src/pinky_daemon/api.py` — clean
- [ ] CI: lint + test (3.11/3.12/3.13) + frontend + CodeQL
- [ ] After merge to beta and beta→main: `update_and_restart` on the production daemon → call `/streaming/restart` for murzik → verify next turn does NOT contain `exec resume <stale-id>` in `logs/api.log`

🤖 Opened by Barsik