### PR TITLE
hotfix(streaming): clear codex_session_id on session restart

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6732,6 +6732,12 @@ def create_api(
         ss._config.resume_session_id = ""
         ss._config.restart_reason = "context_restart"
         ss.session_id = ""
+        # Codex sessions track the thread_id separately on the session object;
+        # clear it too or `codex exec resume <stale-id>` keeps firing next turn.
+        if hasattr(ss, "codex_session_id"):
+            if ss.codex_session_id:
+                _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
+            ss.codex_session_id = ""
         try:
             await ss.connect()
             _log(f"api: streaming session restarted for {name}")
@@ -6805,6 +6811,10 @@ def create_api(
             agents.set_streaming_session_id(name, "", label="main")
             ss._config.resume_session_id = ""
             ss.session_id = ""
+            if hasattr(ss, "codex_session_id"):
+                if ss.codex_session_id:
+                    _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
+                ss.codex_session_id = ""
             ss._config.model = req.model
             try:
                 await ss.connect()
@@ -6886,6 +6896,10 @@ def create_api(
         ss._config.wake_context = _build_streaming_wake_context(name)
         ss._config.resume_session_id = ""
         ss.session_id = ""
+        if hasattr(ss, "codex_session_id"):
+            if ss.codex_session_id:
+                _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
+            ss.codex_session_id = ""
         try:
             await ss.connect()
             _log(f"api: archived and restarted session for {name}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -391,9 +391,13 @@ class TestAPI:
         def __init__(self, total_tokens=0, max_tokens=200_000):
             self.total_tokens = total_tokens
             self.max_tokens = max_tokens
+            self.queries: list[str] = []
 
         async def get_context_usage(self):
             return {"totalTokens": self.total_tokens, "maxTokens": self.max_tokens}
+
+        async def query(self, prompt: str):
+            self.queries.append(prompt)
 
     class _FakeStreamingSession:
         def __init__(self, agent_name: str, label: str = "main", *, connected: bool = True, total_tokens: int = 0, max_tokens: int = 200_000):
@@ -660,6 +664,97 @@ class TestAPI:
                 assert resp.json()["restarted"] is True
                 assert fake.disconnect_calls == 1
                 assert fake.connect_calls == 1
+
+    def test_streaming_restart_clears_codex_session_id_on_codex_sessions(self):
+        """Codex sessions track thread_id in `codex_session_id`; restart must clear it
+        or the next turn will run `codex exec resume <stale-id>` and fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                fake = self._FakeStreamingSession("test-agent", "main")
+                # Simulate a codex-backed session with a stale thread id pinned.
+                fake.codex_session_id = "019dc43b-99cd-7b81-884d-eb09a93f9144"
+                app.state.broker.register_streaming("test-agent", fake, label="main")
+
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="Testing codex restart clears thread id",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.session_id,
+                )
+                fake.last_active = time.time()
+
+                resp = client.post("/agents/test-agent/streaming/restart")
+                assert resp.status_code == 200
+                assert resp.json()["restarted"] is True
+                assert fake.codex_session_id == "", (
+                    "codex_session_id must be cleared so next turn does not "
+                    "issue `codex exec resume <stale-id>`"
+                )
+                assert fake.session_id == ""
+
+    def test_streaming_model_change_clears_codex_session_id(self):
+        """When /streaming/model triggers a context-window restart, codex_session_id
+        must also be cleared (sibling of the /streaming/restart bug fix)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                # Default fake has max_tokens=200_000 (not a 1M model). Switching to
+                # a 1M model triggers needs_restart=True path inside set_streaming_model.
+                fake = self._FakeStreamingSession("test-agent", "main", max_tokens=200_000)
+                fake.codex_session_id = "019dc43b-99cd-7b81-884d-eb09a93f9144"
+                app.state.broker.register_streaming("test-agent", fake, label="main")
+
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="Testing /streaming/model clears codex thread",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.session_id,
+                )
+                fake.last_active = time.time()
+
+                resp = client.post(
+                    "/agents/test-agent/streaming/model",
+                    json={"model": "claude-opus-4-7"},  # in _1M_MODELS → triggers restart
+                )
+                assert resp.status_code == 200, resp.text
+                assert fake.codex_session_id == ""
+                assert fake.session_id == ""
+
+    def test_streaming_archive_clears_codex_session_id(self):
+        """/streaming/archive must clear codex_session_id alongside session_id —
+        same bug pattern as /streaming/restart."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                fake = self._FakeStreamingSession("test-agent", "main")
+                fake.codex_session_id = "019dc43b-99cd-7b81-884d-eb09a93f9144"
+                app.state.broker.register_streaming("test-agent", fake, label="main")
+
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="Testing /streaming/archive clears codex thread",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.session_id,
+                )
+                fake.last_active = time.time()
+
+                resp = client.post("/agents/test-agent/streaming/archive")
+                assert resp.status_code == 200, resp.text
+                assert resp.json()["archived"] is True
+                assert fake.codex_session_id == ""
+                assert fake.session_id == ""
+                # Sanity: archive prompted the agent to save state before resetting.
+                assert any(
+                    "archived" in q.lower() or "save" in q.lower()
+                    for q in fake._client.queries
+                )
 
     def test_wake_streaming_session_defaults_include_outreach_tools(self):
         async def fake_connect(self):


### PR DESCRIPTION
## Summary

Cherry-pick of #327 directly onto main as a focused hotfix to unwedge Murzik in production. Brad is on vacation (through 2026-05-01); rolling the full 18-commit beta→main batch right now is more blast radius than this fix justifies, so this PR isolates only the codex_session_id fix.

The full beta→main release can land on his return as the normal cadence.

## What's in this PR

Single commit: `1f6533c fix(streaming): clear codex_session_id on session restart (#327)` — same commit that landed on beta in PR #327.

- `/streaming/restart`, `/streaming/archive`, `/streaming/model` now clear `ss.codex_session_id` (defensive `hasattr` so non-codex sessions are no-ops)
- New log line `clearing stale codex thread <prefix> for <agent>` so this class of bug is visible next time
- Test coverage on all three endpoints
- 268 tests pass locally, ruff clean

## Why hotfix-only

Beta currently has 18 unreleased commits — federation work, analytics_store, voice_engine, app_store, etc. All real features, but not what Brad signed off on for "merge when ready" tonight. Promoting them in a single PR titled "fix Murzik" would be misleading and Brad can't react fast if anything regresses while he's on vacation.

This hotfix is the minimum production change to unwedge Murzik. The broader release waits.

## Test plan

- [x] PR #327 CI on the same diff: 8/8 green (lint, tests 3.11/3.12/3.13, frontend, CodeQL)
- [x] Pushok review: LGTM
- [ ] CI on this hotfix branch
- [ ] After merge: `update_and_restart` on stable → call `/streaming/restart` for murzik → verify next codex turn does NOT contain `exec resume <stale-id>` in logs

## Followups (already filed)

- #329 — refactor /streaming/* to call `prepare_restart()` + `connect_fresh()` primitives instead of inline duplication

🤖 Opened by Barsik