### PR TITLE
fix(codex): use SSE transport for Codex MCP servers

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2444,14 +2444,18 @@ def create_api(
         resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
         effective_model = resolved_provider_model or agent.model
 
-        # Build MCP server config for Codex agents (injected via -c flags)
+        # Build MCP server config for Codex agents (injected via -c flags).
+        # Use SSE transport rather than Streamable HTTP: Codex CLI 0.125.0 sends
+        # an incomplete Accept header to FastMCP's /http/mcp endpoint, which
+        # responds 406 and Codex masks it as "user cancelled MCP tool call".
+        # SSE works because FastMCP's /sse endpoint negotiates separately.
         codex_mcp_servers = {}
         if resolved_provider_url == "codex_cli" and SHARED_MCP_ENABLED:
             shared_base = f"http://{SHARED_MCP_HOST}:{SHARED_MCP_PORT}"
             agent_headers = {"X-Agent-Name": agent_name}
             for srv_name in ("self", "memory", "messaging"):
                 codex_mcp_servers[f"pinky-{srv_name}"] = {
-                    "url": f"{shared_base}/mcp/{srv_name}/http/mcp",
+                    "url": f"{shared_base}/mcp/{srv_name}/sse",
                     "headers": agent_headers,
                 }
 


### PR DESCRIPTION
## Summary
- Codex CLI 0.125.0 sends an incomplete Accept header to FastMCP's Streamable HTTP endpoint (`/mcp/{srv}/http/mcp`), which responds 406 and Codex masks it as "user cancelled MCP tool call" with ~8ms instant return.
- Symptom this week on Murzik: every outbound `pinky-self` / `pinky-memory` / `pinky-messaging` tool call silently cancelled.
- Fix: switch the codex MCP server URL from `/http/mcp` (Streamable HTTP) to `/sse` (SSE), which negotiates Accept separately and works correctly with Codex 0.125.0.

## Verification
- `curl /mcp/self/http/mcp` without `Accept: application/json, text/event-stream` → 406 "Not Acceptable".
- `curl /mcp/self/sse` → 200, event stream opens.
- Codex rollout from this morning showed `name: "check_inbox"` returning `[{"type":"text","text":"user cancelled MCP tool call"}]` in 8ms — confirms client-side cancel masking the 406.

## Test plan
- [ ] After deploy + restart, send Murzik a message that requires a `pinky-self` call (e.g. inbox check) and confirm it succeeds.
- [ ] Confirm no regression for `streaming_session.py` Claude agents — they're unaffected; this only touches the `codex_cli` provider branch.

🤖 Opened by Barsik