### PR TITLE
Revert PR #331: SSE transport for codex MCP (didn't fix the bug)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2444,18 +2444,14 @@ def create_api(
         resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
         effective_model = resolved_provider_model or agent.model
 
-        # Build MCP server config for Codex agents (injected via -c flags).
-        # Use SSE transport rather than Streamable HTTP: Codex CLI 0.125.0 sends
-        # an incomplete Accept header to FastMCP's /http/mcp endpoint, which
-        # responds 406 and Codex masks it as "user cancelled MCP tool call".
-        # SSE works because FastMCP's /sse endpoint negotiates separately.
+        # Build MCP server config for Codex agents (injected via -c flags)
         codex_mcp_servers = {}
         if resolved_provider_url == "codex_cli" and SHARED_MCP_ENABLED:
             shared_base = f"http://{SHARED_MCP_HOST}:{SHARED_MCP_PORT}"
             agent_headers = {"X-Agent-Name": agent_name}
             for srv_name in ("self", "memory", "messaging"):
                 codex_mcp_servers[f"pinky-{srv_name}"] = {
-                    "url": f"{shared_base}/mcp/{srv_name}/sse",
+                    "url": f"{shared_base}/mcp/{srv_name}/http/mcp",
                     "headers": agent_headers,
                 }
 


### PR DESCRIPTION
## Summary
Revert #331. The /sse switch made things worse, not better — codex CLI 0.125.0 cannot speak FastMCP's legacy SSE handshake (rmcp transport worker dies with 405 Method Not Allowed on registration), so Murzik ended up with **zero** MCP tools registered instead of "tools registered but cancelled at call time."

## Real root cause (verified in repro harness)
Codex 0.125.0 routes every MCP `tools/call` through a network-approval gate when sandbox is `workspace-write`. `codex exec --json` has no approval channel ("X approval is not supported in exec mode"), so the gate auto-cancels every MCP call in ~8ms with `[{"type":"text","text":"user cancelled MCP tool call"}]`.

Flags tested in harness, none bypass the gate:
- `sandbox_workspace_write.network_access=true` — still cancels
- `approval_policy="never"` — still cancels
- `--sandbox=workspace-write` + both above — still cancels

Only `--sandbox=danger-full-access` produces a successful MCP call (16ms clean result).

## What this PR does
Brings main back to the `/http/mcp` baseline. Beta is already reverted (`a43f271`).

## What's NOT in this PR
The actual fix. The minimal real fix is changing the codex spawn to `--sandbox=danger-full-access` in `src/pinky_daemon/api.py` near line 2454, but that's a permissions-posture change for codex agents and needs Brad's explicit greenlight before shipping.

🤖 Opened by Barsik