### PR TITLE
fix(codex): drop --full-auto so --sandbox=danger-full-access takes effect

### DIFF
--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -308,7 +308,13 @@ class CodexSession:
         # "user cancelled MCP tool call". The workspace-write gate isn't
         # buying us safety here — codex agents already have shell + write
         # access via exec_command — so opt out explicitly.
-        cmd.extend(["--json", "--full-auto", "--sandbox=danger-full-access"])
+        #
+        # NOTE: do NOT combine with `--full-auto`. `--full-auto` is a convenience
+        # alias for `sandbox=workspace-write + approval-policy=on-failure` and
+        # overrides the explicit `--sandbox` flag (verified 2026-04-27: PR #333
+        # had both, MCP calls still cancelled in 6.7ms). Use the explicit flag
+        # alone, or `--dangerously-bypass-approvals-and-sandbox`.
+        cmd.extend(["--json", "--sandbox=danger-full-access"])
 
         if self._codex_model:
             cmd.extend(["-m", self._codex_model])


### PR DESCRIPTION
## Summary

PR #333 added \`--sandbox=danger-full-access\` to fix MCP tool cancellations, but kept \`--full-auto\` alongside it. Verified post-deploy that this didn't actually fix the bug.

## Root cause

\`--full-auto\` is a convenience alias that sets \`sandbox=workspace-write + approval-policy=on-failure\`. It silently overrides the explicit \`--sandbox\` flag.

## Verification

After PR #333 deploy on beta (commit dac29d4):
- codex process has both \`--full-auto\` AND \`--sandbox=danger-full-access\`
- Sent Murzik a test message requiring an MCP call
- \`mcp__pinky_messaging__send\` was cancelled in 6.7ms with \`[{\"type\":\"text\",\"text\":\"user cancelled MCP tool call\"}]\` — same as before

Reference: repro harness at \`/tmp/codex-mcp-repro/\` — variant 3 (\`--sandbox=danger-full-access\` alone) was the only successful MCP call.

## Fix

Drop \`--full-auto\`. The explicit \`--sandbox=danger-full-access\` is sufficient and unambiguous.

## Test plan
- [ ] Merge → \`update_and_restart()\` on beta
- [ ] Verify codex process command line no longer contains \`--full-auto\`
- [ ] Send Murzik a test message requiring an MCP call
- [ ] Confirm rollout shows the call succeeded (no \"user cancelled MCP tool call\")

🤖 Opened by Barsik