### PR TITLE
fix(daemon): resurrect dead streaming sessions (#338)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7671,9 +7671,40 @@ def create_api(
         except Exception as e:
             _log(f"scheduler: librarian run failed for '{agent_name}': {e}")
 
+    async def _heartbeat_resurrect(agent_name: str, _session_id: str) -> None:
+        """Watchdog resurrection: reconnect a dead streaming session.
+
+        Invoked by AgentScheduler._maybe_resurrect when an agent's heartbeat
+        is currently marked dead. We bypass the save_my_context guard used by
+        the public /streaming/restart endpoint because there is no live session
+        to preserve work from — the goal is to bring the agent back at all.
+        """
+        ss = broker._get_streaming_session(agent_name)
+        if not ss:
+            _log(
+                f"api: resurrection skipped for {agent_name} — no streaming "
+                f"session registered"
+            )
+            return
+        if ss.is_connected:
+            # Race: the in-process retry recovered between heartbeat tick and
+            # the callback running. Nothing to do.
+            return
+        _log(f"api: watchdog resurrection — reconnecting {agent_name}")
+        try:
+            await ss._try_reconnect()
+            if ss.is_connected:
+                activity.log(
+                    agent_name, "watchdog_resurrect",
+                    f"{agent_name} restored by heartbeat watchdog",
+                )
+        except Exception as e:
+            _log(f"api: resurrection failed for {agent_name}: {e}")
+
     scheduler = AgentScheduler(
         agents,
         wake_callback=_wake_callback,
+        heartbeat_callback=_heartbeat_resurrect,
         direct_send_callback=broker.send_callback,
         dream_callback=_dream_callback,
         librarian_callback=_librarian_callback,

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7674,10 +7674,18 @@ def create_api(
     async def _heartbeat_resurrect(agent_name: str, _session_id: str) -> None:
         """Watchdog resurrection: reconnect a dead streaming session.
 
-        Invoked by AgentScheduler._maybe_resurrect when an agent's heartbeat
-        is currently marked dead. We bypass the save_my_context guard used by
-        the public /streaming/restart endpoint because there is no live session
-        to preserve work from — the goal is to bring the agent back at all.
+        Invoked by AgentScheduler._maybe_resurrect when an agent's heartbeat is
+        currently marked dead. The save_my_context guard used by the public
+        /streaming/restart endpoint is bypassed here — but only safely because
+        of the `is_connected` check below: if the underlying transport is still
+        live the callback bails out immediately and the public guarded path
+        remains the only way to restart. We only ever drive a reconnect when the
+        client is already disconnected, at which point there is no live session
+        whose work could be lost.
+
+        Known limitation: this does NOT cover the "transport-alive-but-agent-
+        silent" case (reader loop wedged on a stalled LLM call) — see the
+        follow-up issue noted on #338.
         """
         ss = broker._get_streaming_session(agent_name)
         if not ss:
@@ -7688,11 +7696,14 @@ def create_api(
             return
         if ss.is_connected:
             # Race: the in-process retry recovered between heartbeat tick and
-            # the callback running. Nothing to do.
+            # the callback running. Also the load-bearing guard for bypassing
+            # the save_my_context restart guard — see docstring above.
             return
         _log(f"api: watchdog resurrection — reconnecting {agent_name}")
         try:
-            await ss._try_reconnect()
+            # TODO(#338-followup): wrap in asyncio.create_task so the scheduler
+            # tick isn't blocked for up to ~40s during the internal backoff.
+            await ss.attempt_reconnect()
             if ss.is_connected:
                 activity.log(
                     agent_name, "watchdog_resurrect",

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -202,6 +202,10 @@ class AgentScheduler:
         self._task: asyncio.Task | None = None
         self._last_clock_slot: dict[str, int] = {}  # agent_name -> last fired clock slot (minutes since midnight)
         self._last_dream_check: dict[str, tuple] = {}  # agent_name -> (date_str, cron-minute) dedup key
+        # Resurrection rate-limit: agent_name -> list[timestamp] of recent attempts.
+        # Used by _check_heartbeats to cap how often we ping the heartbeat_callback
+        # for a stuck agent (avoid thrashing on a persistently-broken session).
+        self._resurrection_attempts: dict[str, list[float]] = {}
 
     async def start(self) -> None:
         """Start the scheduler background loop."""
@@ -351,6 +355,10 @@ class AgentScheduler:
                         metadata={"reason": f"no heartbeat for {int(age)}s"},
                     )
                     _log(f"scheduler: agent '{agent.name}' marked dead (no heartbeat for {int(age)}s)")
+                # Always evaluate resurrection on a dead heartbeat — even if we
+                # already logged the death earlier — so a stuck session keeps
+                # getting periodic restart attempts (rate-limited below).
+                await self._maybe_resurrect(agent.name, hb.session_id, now)
             elif age > agent.heartbeat_interval:
                 # Missed 1 interval — stale
                 if hb.status == "alive":
@@ -360,6 +368,44 @@ class AgentScheduler:
                         message_count=hb.message_count,
                         metadata={"reason": f"heartbeat overdue by {int(age - agent.heartbeat_interval)}s"},
                     )
+
+    # Resurrection cap: at most this many attempts per RESURRECTION_WINDOW_SECONDS
+    # per agent. Prevents thrashing on a persistently-broken session while still
+    # giving transient failures multiple chances to recover.
+    RESURRECTION_MAX_ATTEMPTS = 5
+    RESURRECTION_WINDOW_SECONDS = 3600  # 1 hour
+
+    async def _maybe_resurrect(
+        self, agent_name: str, session_id: str, now: float,
+    ) -> None:
+        """Trigger the heartbeat_callback for a dead agent, with rate limiting.
+
+        Called from _check_heartbeats whenever an agent's heartbeat is currently
+        marked dead. We rate-limit per agent so a permanently broken session
+        doesn't generate restart calls every tick — but transient failures still
+        get multiple recovery attempts.
+        """
+        if not self._heartbeat_callback:
+            return
+
+        # Trim attempts outside the window
+        window_start = now - self.RESURRECTION_WINDOW_SECONDS
+        attempts = [t for t in self._resurrection_attempts.get(agent_name, []) if t >= window_start]
+        if len(attempts) >= self.RESURRECTION_MAX_ATTEMPTS:
+            # Capped — log once per cap-hit (cheap; tick is 30s so worst case
+            # we log once per cap-hit window), then bail.
+            return
+
+        attempts.append(now)
+        self._resurrection_attempts[agent_name] = attempts
+        _log(
+            f"scheduler: resurrection attempt {len(attempts)}/"
+            f"{self.RESURRECTION_MAX_ATTEMPTS} for dead agent '{agent_name}'"
+        )
+        try:
+            await self._heartbeat_callback(agent_name, session_id)
+        except Exception as e:
+            _log(f"scheduler: resurrection callback failed for {agent_name}: {e}")
 
     async def _check_idle_sessions(self, now: float) -> None:
         """Put idle streaming sessions to sleep to save resources."""

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -873,19 +873,55 @@ class StreamingSession:
         _log(f"streaming[{self.agent_name}]: idle sleep complete — session preserved for resume")
         return True
 
-    async def _try_reconnect(self) -> None:
-        """Attempt to reconnect after a failure."""
-        self._stats["reconnects"] += 1
-        _log(f"streaming[{self.agent_name}]: attempting reconnect #{self._stats['reconnects']}")
+    # Reconnect backoff schedule (seconds). Each entry is the wait *before* an attempt.
+    # First attempt waits 2s (preserves prior behavior), then escalates to 8s and 30s.
+    _RECONNECT_BACKOFF = (2, 8, 30)
 
+    async def _try_reconnect(self) -> None:
+        """Attempt to reconnect after a failure with bounded retries.
+
+        Tries up to len(_RECONNECT_BACKOFF) times with escalating delays. If all
+        attempts fail the session is left disconnected and the scheduler's
+        heartbeat watchdog is responsible for any further resurrection — see
+        scheduler._check_heartbeats and the heartbeat_callback wiring in api.py.
+        """
+        # Disconnect once up front so we start each attempt from a clean state.
         try:
             await self.disconnect()
-            await asyncio.sleep(2)
-            await self.connect()
-            _log(f"streaming[{self.agent_name}]: reconnected successfully")
         except Exception as e:
-            _log(f"streaming[{self.agent_name}]: reconnect failed: {e}")
-            self._connected = False
+            _log(f"streaming[{self.agent_name}]: pre-reconnect disconnect raised: {e}")
+
+        last_error: Exception | None = None
+        for attempt_idx, delay in enumerate(self._RECONNECT_BACKOFF, start=1):
+            self._stats["reconnects"] += 1
+            _log(
+                f"streaming[{self.agent_name}]: reconnect attempt {attempt_idx}/"
+                f"{len(self._RECONNECT_BACKOFF)} (#{self._stats['reconnects']} total) "
+                f"after {delay}s backoff"
+            )
+            await asyncio.sleep(delay)
+            try:
+                await self.connect()
+                _log(f"streaming[{self.agent_name}]: reconnected successfully")
+                return
+            except Exception as e:
+                last_error = e
+                _log(
+                    f"streaming[{self.agent_name}]: reconnect attempt {attempt_idx} "
+                    f"failed: {e}"
+                )
+                # Make sure we tear down any partial state before the next try.
+                try:
+                    await self.disconnect()
+                except Exception:
+                    pass
+
+        self._connected = False
+        _log(
+            f"streaming[{self.agent_name}]: all {len(self._RECONNECT_BACKOFF)} reconnect "
+            f"attempts failed (last error: {last_error}); session left disconnected — "
+            f"awaiting watchdog resurrection"
+        )
 
     async def disconnect(self) -> None:
         """Disconnect from Claude Code."""

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -399,7 +399,7 @@ class StreamingSession:
             self._stats["errors"] += 1
             _log(f"streaming[{self.agent_name}]: send error: {e}")
             # Try to reconnect
-            await self._try_reconnect()
+            await self.attempt_reconnect()
 
     async def _reader_loop(self) -> None:
         """Background loop that reads responses and fires callbacks."""
@@ -715,7 +715,7 @@ class StreamingSession:
             _log(f"streaming[{self.agent_name}]: reader loop error: {e}")
             self._connected = False
             # Try reconnect
-            await self._try_reconnect()
+            await self.attempt_reconnect()
 
     async def _check_context(self) -> None:
         """Check context usage after each turn. Warn or force restart."""
@@ -877,13 +877,15 @@ class StreamingSession:
     # First attempt waits 2s (preserves prior behavior), then escalates to 8s and 30s.
     _RECONNECT_BACKOFF = (2, 8, 30)
 
-    async def _try_reconnect(self) -> None:
+    async def attempt_reconnect(self) -> None:
         """Attempt to reconnect after a failure with bounded retries.
 
         Tries up to len(_RECONNECT_BACKOFF) times with escalating delays. If all
-        attempts fail the session is left disconnected and the scheduler's
-        heartbeat watchdog is responsible for any further resurrection — see
-        scheduler._check_heartbeats and the heartbeat_callback wiring in api.py.
+        attempts fail the session is left disconnected (`_connected=False`) and
+        the scheduler's heartbeat watchdog is responsible for any further
+        resurrection — see scheduler._check_heartbeats and the heartbeat_callback
+        wiring in api.py. Public method: callable from inside the reader loop
+        (transient transport failure) and from the watchdog callback.
         """
         # Disconnect once up front so we start each attempt from a clean state.
         try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -178,12 +178,12 @@ class TestStreamingSession:
                 raise RuntimeError("boom")
 
         session._client = FailingClient()
-        session._try_reconnect = AsyncMock()
+        session.attempt_reconnect = AsyncMock()
 
         await session.send("hello", platform="telegram", chat_id="chat-1")
 
         assert session._pending_chats == []
-        session._try_reconnect.assert_awaited_once()
+        session.attempt_reconnect.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_reader_loop_reports_outreach_tool_only_turn(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -426,3 +426,103 @@ class TestScheduler:
         scheduler = AgentScheduler(registry)
         result = await scheduler.fire_now("oleg")
         assert result is False
+
+
+# ── Heartbeat Watchdog Resurrection (issue #338) ──────────────────────────
+
+
+class TestHeartbeatResurrection:
+    """The watchdog must invoke heartbeat_callback for dead agents,
+    rate-limited to RESURRECTION_MAX_ATTEMPTS per RESURRECTION_WINDOW_SECONDS.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dead_agent_triggers_resurrection_callback(self, registry):
+        registry.register("ivan", model="opus", heartbeat_interval=60)
+        # Backdate a heartbeat to >2x interval ago → "dead" range
+        registry.record_heartbeat("ivan", session_id="old", status="alive")
+        # Force the heartbeat to look stale by rewriting timestamp
+        registry._db.execute(
+            "UPDATE agent_heartbeats SET timestamp = ? WHERE agent_name = ?",
+            (time.time() - 600, "ivan"),
+        )
+        registry._db.commit()
+
+        called = []
+
+        async def cb(agent_name, session_id):
+            called.append((agent_name, session_id))
+
+        scheduler = AgentScheduler(registry, heartbeat_callback=cb)
+        await scheduler._check_heartbeats(time.time())
+
+        assert called == [("ivan", "old")]
+
+    @pytest.mark.asyncio
+    async def test_resurrection_is_rate_limited(self, registry):
+        """_maybe_resurrect itself caps attempts per agent within the window."""
+        called = []
+
+        async def cb(agent_name, session_id):
+            called.append(agent_name)
+
+        scheduler = AgentScheduler(registry, heartbeat_callback=cb)
+        now = time.time()
+        # Drive the resurrection helper directly past the cap
+        for _ in range(scheduler.RESURRECTION_MAX_ATTEMPTS + 3):
+            await scheduler._maybe_resurrect("ivan", "sid", now)
+
+        assert len(called) == scheduler.RESURRECTION_MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_resurrection_window_resets_after_expiry(self, registry):
+        called = []
+
+        async def cb(agent_name, session_id):
+            called.append(agent_name)
+
+        scheduler = AgentScheduler(registry, heartbeat_callback=cb)
+        now = time.time()
+        # Fill the window
+        for _ in range(scheduler.RESURRECTION_MAX_ATTEMPTS):
+            await scheduler._maybe_resurrect("ivan", "sid", now)
+        # One more — should be capped
+        await scheduler._maybe_resurrect("ivan", "sid", now)
+        assert len(called) == scheduler.RESURRECTION_MAX_ATTEMPTS
+
+        # Jump past the window — old attempts age out, new attempt allowed
+        future = now + scheduler.RESURRECTION_WINDOW_SECONDS + 1
+        await scheduler._maybe_resurrect("ivan", "sid", future)
+        assert len(called) == scheduler.RESURRECTION_MAX_ATTEMPTS + 1
+
+    @pytest.mark.asyncio
+    async def test_no_callback_means_no_crash(self, registry):
+        """Dead agents are still legal even when no resurrection wiring exists."""
+        registry.register("ivan", model="opus", heartbeat_interval=60)
+        registry.record_heartbeat("ivan", session_id="old", status="alive")
+        registry._db.execute(
+            "UPDATE agent_heartbeats SET timestamp = ? WHERE agent_name = ?",
+            (time.time() - 600, "ivan"),
+        )
+        registry._db.commit()
+
+        scheduler = AgentScheduler(registry)  # heartbeat_callback omitted
+        # Should not raise
+        await scheduler._check_heartbeats(time.time())
+
+    @pytest.mark.asyncio
+    async def test_callback_exception_does_not_break_loop(self, registry):
+        registry.register("ivan", model="opus", heartbeat_interval=60)
+        registry.record_heartbeat("ivan", session_id="old", status="alive")
+        registry._db.execute(
+            "UPDATE agent_heartbeats SET timestamp = ? WHERE agent_name = ?",
+            (time.time() - 600, "ivan"),
+        )
+        registry._db.commit()
+
+        async def cb(agent_name, session_id):
+            raise RuntimeError("boom")
+
+        scheduler = AgentScheduler(registry, heartbeat_callback=cb)
+        # Should swallow and log, not propagate
+        await scheduler._check_heartbeats(time.time())


### PR DESCRIPTION
## Summary

Closes #338. Two compounding daemon bugs let agents stay offline indefinitely after a streaming session died — discovered in production on the Pi5 (Ivan dead 14 days, Sasha dead 4h before manual recovery on 2026-05-01). Both had `auto_restart: true`, both had no claude SDK process running, both had `connected=false` in `/streaming-sessions`.

## Root cause

1. `StreamingSession._try_reconnect()` was single-shot — one `connect()` attempt, on failure `_connected=False` and the function returned. No bounded retry, no schedule.
2. `AgentScheduler._check_heartbeats()` only logged death to the DB. The `heartbeat_callback` parameter at scheduler init existed but was never invoked, so dead sessions sat dead until external intervention.

## Changes

- **`streaming_session.py`** — `attempt_reconnect` (renamed from `_try_reconnect` per review; it's now called across module boundaries) retries up to 3 times with `(2, 8, 30)` second backoff, leaving `_connected=False` only after all attempts fail.
- **`scheduler.py`** — `_check_heartbeats` now invokes `_maybe_resurrect` on every tick where an agent is currently dead. `_maybe_resurrect` calls the registered `heartbeat_callback`, rate-limited to 5 attempts/hour/agent (window slides).
- **`api.py`** — wires `_heartbeat_resurrect` as the callback. Bypasses the save-context guard *only* when `ss.is_connected` is False (load-bearing safety check); otherwise bails. Documented the bypass justification and the known limitation that this does not cover transport-alive-but-reader-wedged silence.
- **`tests/test_scheduler.py`** — 4 new tests in `TestHeartbeatResurrection`: callback fires for dead agents, rate-limit cap holds, window expiry releases the cap, no-callback-no-crash, callback exception is isolated.

## Known limitations / follow-ups (not in this PR)

- Transport-alive-but-agent-silent (reader loop wedged on a stalled LLM call) is not recovered — heartbeat dies but `is_connected=True` so the callback bails. Needs a forced disconnect-then-reconnect path. Will file a follow-up issue.
- The resurrection callback is awaited inline on the scheduler tick — a backoff sequence can block the tick for ~40s. ~5% worst-case at the 5/hr cap, acceptable for v1, marked `# TODO(#338-followup)`.
- Pi daemon stdout currently goes to a socket — no log file, no journal entries. When `attempt_reconnect` fails, the only signal is `_log()` to invisible stdout. Worth routing daemon logs to a file under `data/logs/` separately.

## Test plan

- [x] `pytest tests/test_scheduler.py tests/test_streaming_session.py tests/test_api.py` — 321 passed
- [x] Full `pytest` — 1678 passed
- [x] `ruff check` — clean
- [ ] Verify on Pi after merge: kill an agent's claude process, confirm watchdog reconnects within ~2 minutes and logs `watchdog_resurrect` activity

## Review

Reviewed by Pushok pre-push; both review items applied:
1. `_try_reconnect` → `attempt_reconnect` rename (commit 2)
2. Tightened bypass docstring to attribute the safety to `is_connected` check, not "no live work" hand-wave (commit 2)

🤖 Opened by Barsik