### PR TITLE
Fix outreach config handling for clearing tokens and settings

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -386,9 +386,9 @@ class InstallSkillFromGitRequest(BaseModel):
 class ConfigurePlatformRequest(BaseModel):
     """Configure a messaging platform."""
 
-    token: str = ""
+    token: str | None = None
     enabled: bool | None = None
-    settings: dict = Field(default_factory=dict)
+    settings: dict | None = None
 
 
 class UpdateHeartbeatPromptRequest(BaseModel):
@@ -4753,7 +4753,7 @@ def create_api(
                 platform,
                 token=req.token,
                 enabled=req.enabled,
-                settings=req.settings if req.settings else None,
+                settings=req.settings,
             )
             return config.to_dict()
         except ValueError as e:

--- a/src/pinky_daemon/outreach_config.py
+++ b/src/pinky_daemon/outreach_config.py
@@ -73,7 +73,7 @@ class OutreachConfigStore:
         self,
         platform: str,
         *,
-        token: str = "",
+        token: str | None = None,
         enabled: bool | None = None,
         settings: dict | None = None,
     ) -> PlatformConfig:
@@ -91,7 +91,7 @@ class OutreachConfigStore:
             updates = []
             params: list = []
 
-            if token:
+            if token is not None:
                 updates.append("token=?")
                 params.append(token)
             if enabled is not None:
@@ -114,7 +114,7 @@ class OutreachConfigStore:
             self._db.execute(
                 """INSERT INTO platforms (platform, token, enabled, settings, created_at, updated_at)
                    VALUES (?, ?, ?, ?, ?, ?)""",
-                (platform, token, int(enabled if enabled is not None else bool(token)),
+                (platform, token or "", int(enabled if enabled is not None else bool(token)),
                  json.dumps(settings or {}), now, now),
             )
             self._db.commit()

--- a/tests/test_outreach_config.py
+++ b/tests/test_outreach_config.py
@@ -64,6 +64,17 @@ class TestOutreachConfigStore:
         assert store.get_token("telegram") == "my-token"
         assert config.settings["poll_timeout"] == 60
 
+
+    def test_configure_can_clear_token(self, store):
+        store.configure("telegram", token="my-token", enabled=True)
+        config = store.configure("telegram", token="")
+        assert config.token_set is False
+        assert store.get_token("telegram") == ""
+
+    def test_configure_can_clear_settings(self, store):
+        store.configure("telegram", token="my-token", settings={"poll_timeout": 30})
+        config = store.configure("telegram", settings={})
+        assert config.settings == {}
     def test_configure_unsupported_platform(self, store):
         with pytest.raises(ValueError, match="Unsupported platform"):
             store.configure("whatsapp")
@@ -161,6 +172,20 @@ class TestOutreachConfigAPI:
         assert data["token_set"] is True
         assert data["enabled"] is True
 
+
+    def test_configure_platform_can_clear_token(self):
+        client = self._make_client()
+        client.put("/outreach/platforms/telegram", json={"token": "bot123"})
+        resp = client.put("/outreach/platforms/telegram", json={"token": ""})
+        assert resp.status_code == 200
+        assert resp.json()["token_set"] is False
+
+    def test_configure_platform_can_clear_settings(self):
+        client = self._make_client()
+        client.put("/outreach/platforms/telegram", json={"token": "bot123", "settings": {"poll_timeout": 60}})
+        resp = client.put("/outreach/platforms/telegram", json={"settings": {}})
+        assert resp.status_code == 200
+        assert resp.json()["settings"] == {}
     def test_configure_bad_platform(self):
         client = self._make_client()
         resp = client.put("/outreach/platforms/whatsapp", json={"token": "x"})


### PR DESCRIPTION
### Motivation
- Partial updates treated falsy values as "no change", making it impossible to clear an already-set token or to clear settings. 
- Inserting a `None` token into the DB caused a `NOT NULL` constraint error when callers omitted the token completely. 
- The outreach API model used truthiness checks that prevented sending explicit empty values (e.g. `""` or `{}`) from taking effect.

### Description
- Change `OutreachConfigStore.configure` signature to accept `token: str | None` and `settings: dict | None`, and only update `token` when `token is not None`, allowing `""` to clear the stored token; ensure new-row inserts use `token or ""` to satisfy the DB `NOT NULL` constraint (`src/pinky_daemon/outreach_config.py`).
- Make `ConfigurePlatformRequest` fields nullable (`token: str | None` and `settings: dict | None`) and stop dropping empty settings in the API handler by passing `settings=req.settings` through to the store (`src/pinky_daemon/api.py`).
- Add regression tests covering clearing token and clearing settings at both store and API layers (`tests/test_outreach_config.py`).
- Run `ruff` and fix lint issues where applicable; no new lint errors introduced.

### Testing
- Ran `ruff check src/pinky_daemon/outreach_config.py src/pinky_daemon/api.py tests/test_outreach_config.py` and it passed. 
- Ran `pytest -q tests/test_outreach_config.py -k 'TestOutreachConfigStore'` and the store-level tests passed (`23 passed`).
- Running the full outreach API test set in this environment initially failed due to missing runtime dependency `fastapi`, not due to logic regressions, so full API tests are dependent on environment packages (store logic and added tests validated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48fd0bc348333bfc78dcca2b67725)