### PR TITLE
Fix codex exec resume failing on --sandbox flag (#351)

### DIFF
--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -285,14 +285,38 @@ class CodexSession:
             _log(f"codex[{self.agent_name}]: worker error: {e}")
             self._connected = False
 
-    async def _exec_codex(self, prompt: str) -> CodexTurnResult:
-        """Run a single codex exec invocation and parse JSONL output.
+    def _build_codex_cmd(self) -> list[str]:
+        """Build the codex CLI invocation for the current session state.
 
-        Streams stdout line-by-line for real-time activity tracking.
+        Extracted from `_exec_codex` so the command construction is unit-
+        testable. Returns a list suitable for `asyncio.create_subprocess_exec`,
+        terminating with `-` to signal that the prompt comes via stdin.
+
+        Resume vs fresh:
+          - Fresh: `codex exec ...`
+          - Resume: `codex exec resume <session_id> ...`
+
+        Sandbox/approval:
+          --dangerously-bypass-approvals-and-sandbox (a.k.a. "yolo") bypasses
+          both the sandbox AND the approval channel. In `codex exec --json`
+          there is no approval channel surfaced to us, so any MCP `tools/call`
+          (and other network-touching tools) is auto-cancelled in ~8ms with
+          "user cancelled MCP tool call" unless we bypass approvals too.
+
+          We previously used `--sandbox=danger-full-access`, which works on
+          `codex exec` for fresh sessions but is rejected by `codex exec
+          resume` ("error: unexpected argument '--sandbox' found") — every
+          reply to an existing thread therefore failed silently (see #351).
+          The yolo flag is accepted on both subcommands and bypasses both
+          gates uniformly.
+
+          Safety note: codex agents already have shell + write access via
+          exec_command, so the sandbox gate isn't buying us meaningful
+          safety. The daemon is the trust boundary. Do NOT combine with
+          `--full-auto` — that's a convenience alias for `workspace-write +
+          on-failure` and overrides explicit flags (verified 2026-04-27 in
+          PR #333).
         """
-        result = CodexTurnResult()
-
-        # Build command
         cmd = ["codex", "exec"]
 
         # Resume previous session for multi-turn context
@@ -301,20 +325,7 @@ class CodexSession:
 
         is_resume = bool(self.codex_session_id)
 
-        # --sandbox=danger-full-access bypasses the network-approval gate that
-        # codex 0.125.0 enforces under workspace-write. In `codex exec --json`
-        # there is no approval channel, so any MCP `tools/call` (and other
-        # network-touching tools) is auto-cancelled in ~8ms with
-        # "user cancelled MCP tool call". The workspace-write gate isn't
-        # buying us safety here — codex agents already have shell + write
-        # access via exec_command — so opt out explicitly.
-        #
-        # NOTE: do NOT combine with `--full-auto`. `--full-auto` is a convenience
-        # alias for `sandbox=workspace-write + approval-policy=on-failure` and
-        # overrides the explicit `--sandbox` flag (verified 2026-04-27: PR #333
-        # had both, MCP calls still cancelled in 6.7ms). Use the explicit flag
-        # alone, or `--dangerously-bypass-approvals-and-sandbox`.
-        cmd.extend(["--json", "--sandbox=danger-full-access"])
+        cmd.extend(["--json", "--dangerously-bypass-approvals-and-sandbox"])
 
         if self._codex_model:
             cmd.extend(["-m", self._codex_model])
@@ -345,6 +356,16 @@ class CodexSession:
 
         # Pass prompt via stdin to avoid shell escaping issues
         cmd.append("-")
+        return cmd
+
+    async def _exec_codex(self, prompt: str) -> CodexTurnResult:
+        """Run a single codex exec invocation and parse JSONL output.
+
+        Streams stdout line-by-line for real-time activity tracking.
+        """
+        result = CodexTurnResult()
+
+        cmd = self._build_codex_cmd()
 
         # Build environment
         env = {**os.environ}

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -254,3 +254,81 @@ class TestCodexSessionDisconnect:
         await s.disconnect()
         await s.disconnect()
         assert not s.is_connected
+
+
+class TestCodexCommandConstruction:
+    """Pin down `_build_codex_cmd()` against #351 regression: `--sandbox=...`
+    is not accepted by `codex exec resume`, so the resume path used to fail
+    silently with `error: unexpected argument '--sandbox' found`. The fix
+    swaps to `--dangerously-bypass-approvals-and-sandbox`, which is accepted
+    on BOTH `codex exec` and `codex exec resume` and bypasses both gates.
+    """
+
+    def _make(self, **overrides):
+        kwargs = {
+            "agent_name": "test-agent",
+            "label": "main",
+            "working_dir": "/tmp",
+            "provider_url": "codex_cli",
+        }
+        kwargs.update(overrides)
+        return CodexSession(StreamingSessionConfig(**kwargs))
+
+    def test_fresh_session_uses_yolo_flag_not_sandbox(self):
+        """Fresh session: command must use the bypass flag, not --sandbox."""
+        s = self._make()
+        cmd = s._build_codex_cmd()
+
+        assert cmd[:2] == ["codex", "exec"]
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd
+        # The old flag must be gone — it's the very thing that broke resume
+        assert not any(
+            arg.startswith("--sandbox") or arg == "--sandbox" for arg in cmd
+        ), f"--sandbox flag must not appear in cmd: {cmd}"
+        assert "--full-auto" not in cmd, "must not combine with --full-auto"
+        assert cmd[-1] == "-", "prompt must be passed via stdin"
+
+    def test_resume_session_uses_yolo_flag_not_sandbox(self):
+        """Resume session: this is the path that #351 broke. Same flags must
+        apply, and the resume subcommand must come right after `exec`."""
+        s = self._make()
+        s.codex_session_id = "019de4d8-609a-7000-8000-000000000000"
+
+        cmd = s._build_codex_cmd()
+
+        # Subcommand layout: codex exec resume <id> ...
+        assert cmd[:3] == ["codex", "exec", "resume"]
+        assert cmd[3] == "019de4d8-609a-7000-8000-000000000000"
+        # Bypass flag works on resume; --sandbox does NOT (the bug)
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd
+        assert not any(
+            arg.startswith("--sandbox") or arg == "--sandbox" for arg in cmd
+        ), f"--sandbox is rejected by `codex exec resume`: {cmd}"
+        # -C (working dir) is only valid for new sessions, not resume
+        assert "-C" not in cmd, "-C must not be passed on resume"
+
+    def test_resume_includes_mcp_server_config(self):
+        """MCP servers must be injected on resume too — that's the whole
+        point of why bypass-on-resume matters (otherwise MCP tool calls die)."""
+        s = self._make()
+        s.codex_session_id = "session-id"
+        s._mcp_servers = {
+            "pinky-self": {
+                "url": "http://127.0.0.1:8890/mcp",
+                "headers": {"X-Agent-Name": "test-agent"},
+            }
+        }
+
+        cmd = s._build_codex_cmd()
+
+        # MCP url + header overrides should be present
+        joined = " ".join(cmd)
+        assert "mcp_servers.pinky-self.url=" in joined
+        assert "mcp_servers.pinky-self.http_headers.X-Agent-Name=" in joined
+
+    def test_fresh_session_includes_working_dir(self):
+        """Fresh session passes -C; the resume path skips it."""
+        s = self._make(working_dir="/some/cwd")
+        cmd = s._build_codex_cmd()
+        assert "-C" in cmd
+        assert cmd[cmd.index("-C") + 1] == "/some/cwd"


### PR DESCRIPTION
## Summary

Closes #351. Swaps `--sandbox=danger-full-access` → `--dangerously-bypass-approvals-and-sandbox` in `_build_codex_cmd()`. The old flag is rejected by `codex exec resume` ("unexpected argument '--sandbox'"), so every reply to an existing Codex thread was silently failing.

## Why yolo flag

- Accepted on both `codex exec` (fresh) and `codex exec resume` — uniform code path, no branching needed
- Bypasses both sandbox AND approval channel; the old flag only bypassed sandbox, but `codex exec --json` has no approval channel surfaced, so MCP `tools/call` was being auto-cancelled in ~8ms anyway
- Same effective blast radius (codex agents already have shell+write via `exec_command`); the daemon is the trust boundary

## Refactor

Pulled the cmd construction out into `_build_codex_cmd()` so it's unit-testable.

## Test plan

- [x] `pytest tests/test_codex_session.py -v` — 19/19 (4 new)
  - `test_fresh_session_uses_yolo_flag_not_sandbox`
  - `test_resume_session_uses_yolo_flag_not_sandbox` (the regression)
  - `test_resume_includes_mcp_server_config`
  - `test_fresh_session_includes_working_dir`
- [x] Full suite: 1686 passed, 1 skipped
- [x] `ruff check` clean
- [ ] Post-deploy: confirm Brad→Murzik DM round-trip works

🤖 Opened by Barsik