### PR TITLE
Fix CodexSession.send missing agent_hint kwarg

### DIFF
--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -157,8 +157,20 @@ class CodexSession:
         platform: str = "",
         chat_id: str = "",
         message_id: str = "",
+        agent_hint: str = "",
     ) -> None:
-        """Send a message to the agent. Non-blocking — queued for processing."""
+        """Send a message to the agent. Non-blocking — queued for processing.
+
+        Args:
+            prompt: The formatted message to send.
+            platform: The platform the message came from (e.g. 'telegram').
+            chat_id: The chat_id to route the response back to.
+            message_id: The source message_id to route reactions back to.
+            agent_hint: Extra context appended to the queued prompt but NOT
+                stored in conversation history (e.g. reply-platform hints).
+                Mirrors StreamingSession.send so the broker can call both
+                session types polymorphically.
+        """
         if not self._connected:
             _log(f"codex[{self.agent_name}]: not connected, dropping message")
             return
@@ -172,7 +184,10 @@ class CodexSession:
             metadata={"platform": platform, "chat_id": chat_id, "message_id": message_id},
         )
 
-        # Log to conversation store
+        # Log to conversation store BEFORE appending the hint so chat history
+        # only contains the user's actual prompt, not the agent-only routing
+        # hint. Matches StreamingSession's "stored prompt vs. queried prompt"
+        # split (see streaming_session.py: query is `prompt + agent_hint`).
         if self._conversation_store:
             try:
                 self._conversation_store.append(
@@ -182,7 +197,8 @@ class CodexSession:
             except Exception:
                 pass
 
-        await self._message_queue.put((prompt, platform, chat_id, message_id))
+        queued_prompt = prompt + agent_hint if agent_hint else prompt
+        await self._message_queue.put((queued_prompt, platform, chat_id, message_id))
         _log(f"codex[{self.agent_name}]: queued message (chat={chat_id})")
 
     async def _message_worker(self) -> None:

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -241,6 +241,69 @@ class TestCodexSessionSendDrop:
         assert s._stats["messages_sent"] == 0  # Not connected, message dropped
 
 
+class TestCodexSessionSendSignature:
+    """The broker calls .send() with `agent_hint=...` for both StreamingSession
+    and CodexSession (broker.py:804-810). CodexSession.send must accept the
+    kwarg or every inbound message to a Codex agent crashes with TypeError —
+    the regression that masked the #351 fix on production.
+    """
+
+    def _make(self, **overrides):
+        kwargs = {
+            "agent_name": "test",
+            "working_dir": "/tmp",
+            "provider_url": "codex_cli",
+        }
+        kwargs.update(overrides)
+        return CodexSession(StreamingSessionConfig(**kwargs))
+
+    @pytest.mark.asyncio
+    async def test_send_accepts_agent_hint_kwarg(self):
+        """Regression: broker passes agent_hint; signature must accept it."""
+        s = self._make()
+        # Even disconnected — the signature mismatch raised before reaching
+        # the connected check, so this would TypeError pre-fix.
+        await s.send(
+            "hello",
+            platform="telegram",
+            chat_id="123",
+            message_id="msg-1",
+            agent_hint="\n💬 reply hint",
+        )
+        # Disconnected → message dropped, but call must not raise.
+        assert s._stats["messages_sent"] == 0
+
+    @pytest.mark.asyncio
+    async def test_send_appends_agent_hint_to_queued_prompt(self):
+        """Hint should be appended to the queued prompt (matches Streaming-
+        Session.send behavior) but NOT stored in the conversation log."""
+        s = self._make()
+        s._connected = True  # bypass the dropped-when-disconnected branch
+
+        await s.send(
+            "actual user text",
+            platform="telegram",
+            chat_id="123",
+            agent_hint="\n💬 routing hint",
+        )
+
+        # Queued prompt has the hint appended
+        queued = await s._message_queue.get()
+        queued_prompt = queued[0]
+        assert queued_prompt == "actual user text\n💬 routing hint"
+
+    @pytest.mark.asyncio
+    async def test_send_without_agent_hint_unchanged(self):
+        """No-hint path is the previous behavior — prompt queued verbatim."""
+        s = self._make()
+        s._connected = True
+
+        await s.send("plain prompt", platform="telegram", chat_id="123")
+
+        queued = await s._message_queue.get()
+        assert queued[0] == "plain prompt"
+
+
 class TestCodexSessionDisconnect:
     @pytest.mark.asyncio
     async def test_disconnect_idempotent(self):


### PR DESCRIPTION
## Summary

Broker calls `.send(prompt, ..., agent_hint=hint)` polymorphically for both StreamingSession and CodexSession. `agent_hint` was added to StreamingSession.send (for the "💬 Reply on telegram..." routing footer) but never propagated to CodexSession — so every inbound DM to a Codex agent crashed at the broker call site:

```
TypeError: CodexSession.send() got an unexpected keyword argument 'agent_hint'
```

This was masking the #351 fix on production. Brad's test DM to Murzik post-deploy looked like it should have worked — broker-poller logged the inbound, no `--sandbox` errors, but no response. Logs show this TypeError firing at the broker layer instead.

Mirror StreamingSession.send behavior: accept the kwarg, append to the queued prompt, do NOT store in conversation log (agent-only routing hint, not user text).

## Test plan

- [x] `pytest tests/test_codex_session.py -v` — 22/22 pass (3 new)
  - `test_send_accepts_agent_hint_kwarg` (regression)
  - `test_send_appends_agent_hint_to_queued_prompt`
  - `test_send_without_agent_hint_unchanged`
- [x] `ruff check` clean
- [ ] Post-deploy: Brad→Murzik DM round-trip

🤖 Opened by Barsik