### PR TITLE
Refactor Codex context estimation

### DIFF
--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -23,7 +23,8 @@ import os
 import time
 from dataclasses import dataclass, field
 
-from pinky_daemon.sessions import CHARS_PER_TOKEN, MODEL_CONTEXT_SIZES, SessionUsage
+from pinky_daemon.context_estimator import ContextTextEstimator
+from pinky_daemon.sessions import MODEL_CONTEXT_SIZES, SessionUsage
 from pinky_daemon.streaming_session import (
     StreamingSessionConfig,
     StreamingTurnResult,
@@ -96,7 +97,7 @@ class CodexSession:
         self.account_info: dict = {"apiProvider": "codex_cli"}
         self._on_session_id = None  # async fn(agent_name, session_id)
         self._pending_session_id_update = ""  # Set by sync _handle_event, consumed by async worker
-        self._internal_context_texts: list[str] = []
+        self._context_estimator = ContextTextEstimator()
         self._current_turn_seq = 0
         self._last_user_message = ""  # For analytics keyword classification
 
@@ -877,21 +878,9 @@ class CodexSession:
     @property
     def estimated_tokens(self) -> int:
         """Estimate current context size from persisted chat plus internal prompts."""
-        total = sum(
-            max(1, len(text) // CHARS_PER_TOKEN)
-            for text in self._internal_context_texts
-            if text
-        )
-        if not self._conversation_store:
-            return total
-        try:
-            history = self._conversation_store.get_history(self.id, limit=1000)
-        except Exception:
-            return total
-        return total + sum(
-            max(1, len(msg.content) // CHARS_PER_TOKEN)
-            for msg in history
-            if msg.content
+        return self._context_estimator.estimated_tokens(
+            session_id=self.id,
+            conversation_store=self._conversation_store,
         )
 
     @property
@@ -902,16 +891,11 @@ class CodexSession:
 
     def get_context_info(self) -> dict:
         """Best-effort context info for APIs that expect session context details."""
-        total = self.estimated_tokens
-        max_tokens = self.max_tokens
-        pct = round(total / max_tokens * 100, 1) if max_tokens > 0 else 0.0
-        return {
-            "total_tokens": total,
-            "max_tokens": max_tokens,
-            "percentage": pct,
-            "categories": [],
-            "mcp_tools": [],
-        }
+        return self._context_estimator.context_info(
+            session_id=self.id,
+            conversation_store=self._conversation_store,
+            max_tokens=self.max_tokens,
+        )
 
     @property
     def stats(self) -> dict:
@@ -934,8 +918,7 @@ class CodexSession:
 
     def _record_internal_context_text(self, text: str) -> None:
         """Track prompts/responses that do not appear in the conversation store."""
-        if text:
-            self._internal_context_texts.append(text)
+        self._context_estimator.record_internal_text(text)
 
     def _analytics_session_started(self) -> None:
         if not self._analytics_store:

--- a/src/pinky_daemon/context_estimator.py
+++ b/src/pinky_daemon/context_estimator.py
@@ -1,0 +1,70 @@
+"""Shared context-size estimation helpers for non-SDK runtimes."""
+
+from __future__ import annotations
+
+from pinky_daemon.sessions import CHARS_PER_TOKEN
+
+
+class ContextTextEstimator:
+    """Estimate context from internal prompts plus persisted conversation text.
+
+    Runtimes that do not expose authoritative context usage can share this
+    best-effort estimator instead of duplicating token-counting fallback code.
+    """
+
+    def __init__(self, *, chars_per_token: int = CHARS_PER_TOKEN) -> None:
+        self._chars_per_token = max(1, chars_per_token)
+        self._internal_context_texts: list[str] = []
+
+    def record_internal_text(self, text: str) -> None:
+        """Track prompt/response text that is not in ConversationStore."""
+        if text:
+            self._internal_context_texts.append(text)
+
+    def estimated_tokens(
+        self,
+        *,
+        session_id: str,
+        conversation_store=None,
+        history_limit: int = 1000,
+    ) -> int:
+        """Estimate tokens from internal text and optional conversation history."""
+        total = sum(self._estimate_text_tokens(text) for text in self._internal_context_texts)
+        if not conversation_store:
+            return total
+        try:
+            history = conversation_store.get_history(session_id, limit=history_limit)
+        except Exception:
+            return total
+        return total + sum(
+            self._estimate_text_tokens(getattr(msg, "content", ""))
+            for msg in history
+        )
+
+    def context_info(
+        self,
+        *,
+        session_id: str,
+        max_tokens: int,
+        conversation_store=None,
+        history_limit: int = 1000,
+    ) -> dict:
+        """Return the context-info shape expected by streaming status APIs."""
+        total = self.estimated_tokens(
+            session_id=session_id,
+            conversation_store=conversation_store,
+            history_limit=history_limit,
+        )
+        pct = round(total / max_tokens * 100, 1) if max_tokens > 0 else 0.0
+        return {
+            "total_tokens": total,
+            "max_tokens": max_tokens,
+            "percentage": pct,
+            "categories": [],
+            "mcp_tools": [],
+        }
+
+    def _estimate_text_tokens(self, text: str) -> int:
+        if not text:
+            return 0
+        return max(1, len(text) // self._chars_per_token)

--- a/tests/test_context_estimator.py
+++ b/tests/test_context_estimator.py
@@ -1,0 +1,72 @@
+"""Tests for shared context estimation helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pinky_daemon.context_estimator import ContextTextEstimator
+
+
+class _Store:
+    def __init__(self, *contents: str) -> None:
+        self.contents = contents
+        self.calls: list[tuple[str, int]] = []
+
+    def get_history(self, session_id: str, limit: int = 1000):
+        self.calls.append((session_id, limit))
+        return [SimpleNamespace(content=content) for content in self.contents]
+
+
+class _BrokenStore:
+    def get_history(self, session_id: str, limit: int = 1000):
+        raise RuntimeError("db unavailable")
+
+
+def test_estimates_internal_texts():
+    estimator = ContextTextEstimator(chars_per_token=4)
+
+    estimator.record_internal_text("")
+    estimator.record_internal_text("abcd")
+    estimator.record_internal_text("abcdefghi")
+
+    assert estimator.estimated_tokens(session_id="s") == 3
+
+
+def test_estimates_store_history_with_internal_texts():
+    estimator = ContextTextEstimator(chars_per_token=4)
+    estimator.record_internal_text("abcdefgh")
+    store = _Store("abcd", "", "abcdefghijkl")
+
+    total = estimator.estimated_tokens(
+        session_id="agent-main",
+        conversation_store=store,
+        history_limit=50,
+    )
+
+    assert total == 6
+    assert store.calls == [("agent-main", 50)]
+
+
+def test_returns_internal_estimate_when_store_read_fails():
+    estimator = ContextTextEstimator(chars_per_token=4)
+    estimator.record_internal_text("abcdefgh")
+
+    assert estimator.estimated_tokens(
+        session_id="agent-main",
+        conversation_store=_BrokenStore(),
+    ) == 2
+
+
+def test_context_info_shape_and_percentage():
+    estimator = ContextTextEstimator(chars_per_token=4)
+    estimator.record_internal_text("abcdefgh")
+
+    info = estimator.context_info(session_id="agent-main", max_tokens=10)
+
+    assert info == {
+        "total_tokens": 2,
+        "max_tokens": 10,
+        "percentage": 20.0,
+        "categories": [],
+        "mcp_tools": [],
+    }


### PR DESCRIPTION
## Summary

Phase 1 PR A for the opencode runtime work.

This adds a shared `ContextTextEstimator` helper for runtimes that do not expose authoritative context usage, then refactors `CodexSession` to use it instead of keeping its own private `_internal_context_texts` token-estimation implementation.

## Why

The opencode design spec calls out this refactor before adding `OpencodeSession`, so we do not copy the Codex fallback estimator into a third runtime.

This is intended as a pure extraction for Codex: same internal-text accounting, same fallback behavior when conversation history is unavailable, same token estimate rule, and same `get_context_info()` response shape. Existing `CodexSession` tests pass unchanged; the new tests cover the extracted helper directly.

The helper API is deliberately the intersection needed by both `CodexSession` and the upcoming `OpencodeSession`: record runtime-only context text, estimate against optional `ConversationStore` history by session id, tolerate store read failures, and produce the existing status API context-info shape from a supplied max context window. Runtime-specific model-window selection stays outside the helper.

## Validation

- `uv run pytest tests/test_context_estimator.py tests/test_codex_session.py`
- `uv run ruff check src/pinky_daemon/context_estimator.py src/pinky_daemon/codex_session.py tests/test_context_estimator.py tests/test_codex_session.py`
- `git diff --check`

## Notes

- No opencode runtime implementation in this PR.
- No `agents.runtime` migration in this PR.
- Codex dupe-send work remains untouched.
- Existing local `frontend-dist/index.html` change is not part of this branch/PR.

🤖 Opened by Murzik
