### PR TITLE
Fix Codex runtime provider resolution

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2484,12 +2484,9 @@ def create_api(
             raise HTTPException(400, msg)
 
         is_codex = runtime == "codex_cli"
+        resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
         if is_codex:
             resolved_provider_url = "codex_cli"
-            resolved_provider_key = agent.provider_key or ""
-            resolved_provider_model = agent.provider_model or ""
-        else:
-            resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
         effective_model = resolved_provider_model or agent.model
 
         # Build MCP server config for Codex agents (injected via -c flags)

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -146,13 +146,23 @@ class TestAgentCRUD:
     def test_runtime_codex_cli_backfill_is_one_shot_and_idempotent(self, registry):
         registry.register("legacy-codex", provider_url="codex_cli", runtime="claude_sdk")
         registry.register("explicit-claude", provider_url="codex_cli", runtime="claude_sdk")
+        registry.register("already-codex", provider_url="codex_cli", runtime="codex_cli")
+        registry.register("opencode-agent", provider_url="codex_cli", runtime="opencode")
 
         marker = "migration:agents_runtime_codex_cli_backfill"
         registry.set_setting(marker, "")
         registry._backfill_runtime_from_provider_url()
         assert registry.get("legacy-codex").runtime == "codex_cli"
         assert registry.get("explicit-claude").runtime == "codex_cli"
+        assert registry.get("already-codex").runtime == "codex_cli"
+        assert registry.get("opencode-agent").runtime == "opencode"
         assert registry.get_setting(marker) == "1"
+
+        registry.set_setting(marker, "")
+        registry._backfill_runtime_from_provider_url()
+        assert registry.get("legacy-codex").runtime == "codex_cli"
+        assert registry.get("already-codex").runtime == "codex_cli"
+        assert registry.get("opencode-agent").runtime == "opencode"
 
         registry.register("explicit-claude", runtime="claude_sdk")
         registry._backfill_runtime_from_provider_url()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -637,7 +637,29 @@ class TestAPI:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             with TestClient(app) as client:
-                client.post("/agents", json={"name": "codex-agent", "model": "gpt-5-codex", "runtime": "codex_cli"})
+                now = time.time()
+                app.state.agents._db.execute(
+                    "INSERT INTO providers "
+                    "(id, name, preset, provider_url, provider_key, provider_model, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        "codex-openai",
+                        "Codex OpenAI",
+                        "",
+                        "https://api.openai.com/v1",
+                        "global-openai-key",
+                        "gpt-5-codex",
+                        now,
+                        now,
+                    ),
+                )
+                app.state.agents._db.commit()
+                client.post("/agents", json={
+                    "name": "codex-agent",
+                    "model": "fallback-model",
+                    "runtime": "codex_cli",
+                    "provider_ref": "codex-openai",
+                })
 
                 resp = client.post("/agents/codex-agent/wake?prompt=Wake")
                 assert resp.status_code == 200
@@ -645,6 +667,8 @@ class TestAPI:
                 session = app.state.broker._streaming["codex-agent"]["main"]
                 assert session.__class__.__name__ == "CodexSession"
                 assert session._config.provider_url == "codex_cli"
+                assert session._config.provider_key == "global-openai-key"
+                assert session._config.model == "gpt-5-codex"
 
     def test_wake_rejects_opencode_runtime_until_session_exists(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- Keep Codex runtime selection on `agents.runtime`, but restore `_resolve_agent_provider(agent)` so `provider_ref` and `default_provider_ref` still resolve provider key/model.
- Override only `resolved_provider_url` to the `codex_cli` sentinel after provider resolution, preserving downstream Codex/MCP behavior.
- Extend tests for Codex `provider_ref` key/model resolution and for backfill WHERE-clause defense-in-depth.

## Follow-up
- Filed #359 to remove `runtime_from_legacy_provider()` after the rollout window.

## Validation
- `uv run pytest tests/test_agent_registry.py::TestAgentCRUD::test_runtime_codex_cli_backfill_is_one_shot_and_idempotent tests/test_api.py::TestAPI::test_wake_uses_codex_session_for_codex_runtime`
- `uv run pytest tests/test_scheduler.py tests/test_agent_registry.py tests/test_api.py::TestAgentCRUD tests/test_api.py::TestAPI::test_wake_creates_streaming_session_and_sends tests/test_api.py::TestAPI::test_wake_uses_streaming_session_for_claude_runtime tests/test_api.py::TestAPI::test_wake_uses_codex_session_for_codex_runtime tests/test_api.py::TestAPI::test_wake_rejects_opencode_runtime_until_session_exists`
- `uv run ruff check src/pinky_daemon/api.py tests/test_agent_registry.py tests/test_api.py`
- `git diff --check`

Note: API tests still emit the existing shared-MCP 8890 port warning when that port is already bound; assertions pass.

🤖 Opened by Murzik