### PR TITLE
Refactor api.py: extract Activity / Audit / Hook-Feed routes

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6906,45 +6906,12 @@ def create_api(
             "pending": autonomy.event_queue.pending_count(agent_name),
         }
 
-    # ── Audit & Hooks ──────────────────────────────────────
+    # ── Activity / Audit / Hook-Feed Routes ──────────────────
+    from pinky_daemon.routes.activity import router as _activity_router
+    from pinky_daemon.routes.activity import set_dependencies as _activity_set_deps
 
-    @app.get("/audit")
-    async def get_audit_log(
-        agent_name: str = "", session_id: str = "",
-        event: str = "", limit: int = 50,
-    ):
-        """Query the audit trail."""
-        entries = audit.get_log(
-            agent_name=agent_name, session_id=session_id,
-            event=event, limit=limit,
-        )
-        return {"entries": [e.to_dict() for e in entries], "count": len(entries)}
-
-    @app.get("/audit/costs")
-    async def get_audit_costs(agent_name: str = "", session_id: str = ""):
-        """Get cost summary from audit trail."""
-        return audit.get_costs(agent_name=agent_name, session_id=session_id)
-
-    @app.get("/hooks")
-    async def list_hooks():
-        """List all registered hooks."""
-        return hooks.list_hooks()
-
-    @app.get("/activity/hooks")
-    async def get_activity_feed(limit: int = 50, since: float = 0.0):
-        """Get live activity feed from hooks (in-memory, real-time).
-
-        Poll this endpoint for real-time agent activity.
-        Use 'since' param with the last timestamp to get only new events.
-        """
-        feed = hooks.get_activity_feed(limit=limit, since=since)
-        return {"events": feed, "count": len(feed)}
-
-    @app.get("/activity/active")
-    async def get_active_agents():
-        """Get currently active agents and what they're doing."""
-        active = hooks.get_active_agents()
-        return {"agents": active, "count": len(active)}
+    _activity_set_deps(audit=audit, hooks=hooks, activity=activity)
+    app.include_router(_activity_router)
 
     # ── Task/Project Management ──────────────────────────
 
@@ -7110,29 +7077,6 @@ def create_api(
 
         return StreamingResponse(event_generator(), media_type="text/event-stream")
 
-    @app.get("/activity/stream")
-    async def stream_activity():
-        """SSE endpoint for real-time activity feed.
-
-        Polls the hook manager's activity store for new events.
-        Bridge pattern — replace with proper event bus later.
-        """
-        async def event_generator():
-            last_check = time.time()
-            while True:
-                await asyncio.sleep(2)
-                now = time.time()
-                # Get new activity since last check
-                feed = hooks.get_activity_feed(limit=20, since=last_check)
-                if feed:
-                    for event in feed:
-                        yield f"data: {json.dumps(event)}\n\n"
-                else:
-                    yield f"data: {json.dumps({'type': 'ping', 'timestamp': now})}\n\n"
-                last_check = now
-
-        return StreamingResponse(event_generator(), media_type="text/event-stream")
-
     # ── Research Pipeline Endpoints ──────────────────────────
     from pinky_daemon.routes.research import router as _research_router
     from pinky_daemon.routes.research import set_dependencies as _research_set_deps
@@ -7156,23 +7100,6 @@ def create_api(
         activity=activity,
     )
     app.include_router(_pres_router)
-
-    # ── Activity Log ─────────────────────────────────────────
-
-    @app.get("/activity")
-    async def list_activity(
-        limit: int = 50, offset: int = 0, agent_name: str = "", event_type: str = ""
-    ):
-        """Return recent activity events across all agents (or filtered to one agent)."""
-        events = activity.list(
-            limit=limit, offset=offset, agent_name=agent_name, event_type=event_type
-        )
-        return {"events": events, "count": len(events)}
-
-    @app.get("/activity/stats")
-    async def activity_stats():
-        """Return summary stats for the activity log."""
-        return activity.get_stats()
 
     # ── Trigger Endpoints + Public Webhook Receiver ──────────
     from pinky_daemon.routes.triggers import router as _triggers_router

--- a/src/pinky_daemon/routes/activity.py
+++ b/src/pinky_daemon/routes/activity.py
@@ -1,0 +1,127 @@
+"""Activity log + audit + hook-feed routes.
+
+Extracted from api.py. Three small surfaces that all share `audit`,
+`hooks`, and `activity` as their only dependencies — bundled together
+because they were defined contiguously and conceptually all show
+"what's happening" in the system.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+
+router = APIRouter(tags=["activity"])
+
+
+# ── Shared dependency state ───────────────────────────────────────────────────
+
+_audit: Any = None
+_hooks: Any = None
+_activity: Any = None
+
+
+def set_dependencies(*, audit, hooks, activity) -> None:
+    """Wire shared instances for the activity router."""
+    global _audit, _hooks, _activity
+    _audit = audit
+    _hooks = hooks
+    _activity = activity
+
+
+# ── Audit & Hooks ─────────────────────────────────────────────────────────────
+
+
+@router.get("/audit")
+async def get_audit_log(
+    agent_name: str = "", session_id: str = "",
+    event: str = "", limit: int = 50,
+):
+    """Query the audit trail."""
+    entries = _audit.get_log(
+        agent_name=agent_name, session_id=session_id,
+        event=event, limit=limit,
+    )
+    return {"entries": [e.to_dict() for e in entries], "count": len(entries)}
+
+
+@router.get("/audit/costs")
+async def get_audit_costs(agent_name: str = "", session_id: str = ""):
+    """Get cost summary from audit trail."""
+    return _audit.get_costs(agent_name=agent_name, session_id=session_id)
+
+
+@router.get("/hooks")
+async def list_hooks():
+    """List all registered hooks."""
+    return _hooks.list_hooks()
+
+
+@router.get("/activity/hooks")
+async def get_activity_feed(limit: int = 50, since: float = 0.0):
+    """Get live activity feed from hooks (in-memory, real-time).
+
+    Poll this endpoint for real-time agent activity.
+    Use 'since' param with the last timestamp to get only new events.
+    """
+    feed = _hooks.get_activity_feed(limit=limit, since=since)
+    return {"events": feed, "count": len(feed)}
+
+
+@router.get("/activity/active")
+async def get_active_agents():
+    """Get currently active agents and what they're doing."""
+    active = _hooks.get_active_agents()
+    return {"agents": active, "count": len(active)}
+
+
+# ── Activity Log ──────────────────────────────────────────────────────────────
+
+
+@router.get("/activity")
+async def list_activity(
+    limit: int = 50, offset: int = 0, agent_name: str = "", event_type: str = ""
+):
+    """Return recent activity events across all agents (or filtered to one agent)."""
+    events = _activity.list(
+        limit=limit, offset=offset, agent_name=agent_name, event_type=event_type
+    )
+    return {"events": events, "count": len(events)}
+
+
+@router.get("/activity/stats")
+async def activity_stats():
+    """Return summary stats for the activity log."""
+    return _activity.get_stats()
+
+
+# ── Activity SSE stream ───────────────────────────────────────────────────────
+
+
+@router.get("/activity/stream")
+async def stream_activity():
+    """SSE endpoint for real-time activity feed.
+
+    Polls the hook manager's activity store for new events.
+    Bridge pattern — replace with proper event bus later.
+    """
+    async def event_generator():
+        last_check = time.time()
+        while True:
+            await asyncio.sleep(2)
+            now = time.time()
+            # Get new activity since last check
+            feed = _hooks.get_activity_feed(limit=20, since=last_check)
+            if feed:
+                for event in feed:
+                    yield f"data: {json.dumps(event)}\n\n"
+            else:
+                yield f"data: {json.dumps({'type': 'ping', 'timestamp': now})}\n\n"
+            last_check = now
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")


### PR DESCRIPTION
## Summary

Stacked on top of #370. Same `APIRouter` + `set_dependencies(...)` pattern.

- `/audit` + `/audit/costs` (2 endpoints)
- `/hooks` + `/activity/hooks` + `/activity/active` (3 endpoints)
- `/activity` + `/activity/stats` (2 endpoints)
- `/activity/stream` SSE feed (1 endpoint)

8 endpoints moved → `routes/activity.py`. Three small surfaces that all share `audit`, `hooks`, and `activity` — bundled because they conceptually all expose "what's happening" in the system.

**api.py: 7,235 → 7,151 lines (-84, -1.2%)**
**Cumulative since main: 11,138 → 7,151 (-3,987 lines, -35.8%)**

## Test plan

- [x] `pytest --ignore=tests/pinky_federation` — 1542 passed, 1 skipped
- [x] `ruff check src/pinky_daemon/{api.py,routes/activity.py}` clean

## Merge order

#362 → ... → #370 → this. GitHub auto-rebases as parents land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)