### PR TITLE
Refactor api.py: extract Outreach platform configuration routes

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -57,7 +57,6 @@ from pinky_daemon.api_models import (
     AuthLoginRequest,
     AuthSetupRequest,
     CloneWorkerRequest,
-    ConfigurePlatformRequest,
     ContextResponse,
     ConversationListResponse,
     CreateGroupRequest,
@@ -3655,71 +3654,12 @@ def create_api(
         """List all approved users across all agents."""
         return {"users": agents.list_all_approved_users()}
 
-    # ── Outreach Configuration Endpoints ────────────────────
+    # ── Outreach Platform Configuration Routes ──────────
+    from pinky_daemon.routes.outreach import router as _outreach_router
+    from pinky_daemon.routes.outreach import set_dependencies as _outreach_set_deps
 
-    @app.get("/outreach/platforms")
-    async def list_platforms():
-        """List all configured outreach platforms."""
-        result = outreach_config.list()
-        return {"platforms": [p.to_dict() for p in result], "count": len(result)}
-
-    @app.get("/outreach/platforms/{platform}")
-    async def get_platform(platform: str):
-        """Get platform configuration (token is never exposed)."""
-        config = outreach_config.get(platform)
-        if not config:
-            raise HTTPException(404, f"Platform '{platform}' not configured")
-        return config.to_dict()
-
-    @app.put("/outreach/platforms/{platform}")
-    async def configure_platform(platform: str, req: ConfigurePlatformRequest):
-        """Configure or update a messaging platform.
-
-        Set token, enabled state, and platform-specific settings.
-        Token is stored securely and never returned in API responses.
-        """
-        try:
-            config = outreach_config.configure(
-                platform,
-                token=req.token,
-                enabled=req.enabled,
-                settings=req.settings,
-            )
-            return config.to_dict()
-        except ValueError as e:
-            raise HTTPException(400, str(e))
-
-    @app.post("/outreach/platforms/{platform}/enable")
-    async def enable_platform(platform: str):
-        """Enable an outreach platform."""
-        if not outreach_config.enable(platform):
-            raise HTTPException(404, f"Platform '{platform}' not configured")
-        return {"enabled": True, "platform": platform}
-
-    @app.post("/outreach/platforms/{platform}/disable")
-    async def disable_platform(platform: str):
-        """Disable an outreach platform."""
-        if not outreach_config.disable(platform):
-            raise HTTPException(404, f"Platform '{platform}' not configured")
-        return {"disabled": True, "platform": platform}
-
-    @app.post("/outreach/platforms/{platform}/test")
-    async def test_platform(platform: str):
-        """Test connectivity to a platform.
-
-        Attempts to call the platform's API with the stored token
-        and returns success/error info.
-        """
-        result = outreach_config.test_connection(platform)
-        return result
-
-    @app.delete("/outreach/platforms/{platform}")
-    async def delete_platform(platform: str):
-        """Remove a platform configuration entirely."""
-        deleted = outreach_config.delete(platform)
-        if not deleted:
-            raise HTTPException(404, f"Platform '{platform}' not configured")
-        return {"deleted": True, "platform": platform}
+    _outreach_set_deps(outreach_config=outreach_config)
+    app.include_router(_outreach_router)
 
     # ── Calendar Endpoints ───────────────────────────────────
     from pinky_daemon.routes.calendar import router as _calendar_router

--- a/src/pinky_daemon/routes/outreach.py
+++ b/src/pinky_daemon/routes/outreach.py
@@ -1,0 +1,100 @@
+"""Outreach platform configuration routes.
+
+Extracted from api.py. Manages messaging-platform credentials and
+toggles (Telegram, Discord, Slack, etc.) — distinct from the broker
+*sending* endpoints (`/broker/*`) which still live in api.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from pinky_daemon.api_models import ConfigurePlatformRequest
+
+router = APIRouter(tags=["outreach"])
+
+
+# ── Shared dependency state ───────────────────────────────────────────────────
+
+_outreach_config: Any = None
+
+
+def set_dependencies(*, outreach_config) -> None:
+    """Wire shared state for the outreach router."""
+    global _outreach_config
+    _outreach_config = outreach_config
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+
+@router.get("/outreach/platforms")
+async def list_platforms():
+    """List all configured outreach platforms."""
+    result = _outreach_config.list()
+    return {"platforms": [p.to_dict() for p in result], "count": len(result)}
+
+
+@router.get("/outreach/platforms/{platform}")
+async def get_platform(platform: str):
+    """Get platform configuration (token is never exposed)."""
+    config = _outreach_config.get(platform)
+    if not config:
+        raise HTTPException(404, f"Platform '{platform}' not configured")
+    return config.to_dict()
+
+
+@router.put("/outreach/platforms/{platform}")
+async def configure_platform(platform: str, req: ConfigurePlatformRequest):
+    """Configure or update a messaging platform.
+
+    Set token, enabled state, and platform-specific settings.
+    Token is stored securely and never returned in API responses.
+    """
+    try:
+        config = _outreach_config.configure(
+            platform,
+            token=req.token,
+            enabled=req.enabled,
+            settings=req.settings,
+        )
+        return config.to_dict()
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+
+
+@router.post("/outreach/platforms/{platform}/enable")
+async def enable_platform(platform: str):
+    """Enable an outreach platform."""
+    if not _outreach_config.enable(platform):
+        raise HTTPException(404, f"Platform '{platform}' not configured")
+    return {"enabled": True, "platform": platform}
+
+
+@router.post("/outreach/platforms/{platform}/disable")
+async def disable_platform(platform: str):
+    """Disable an outreach platform."""
+    if not _outreach_config.disable(platform):
+        raise HTTPException(404, f"Platform '{platform}' not configured")
+    return {"disabled": True, "platform": platform}
+
+
+@router.post("/outreach/platforms/{platform}/test")
+async def test_platform(platform: str):
+    """Test connectivity to a platform.
+
+    Attempts to call the platform's API with the stored token
+    and returns success/error info.
+    """
+    return _outreach_config.test_connection(platform)
+
+
+@router.delete("/outreach/platforms/{platform}")
+async def delete_platform(platform: str):
+    """Remove a platform configuration entirely."""
+    deleted = _outreach_config.delete(platform)
+    if not deleted:
+        raise HTTPException(404, f"Platform '{platform}' not configured")
+    return {"deleted": True, "platform": platform}


### PR DESCRIPTION
## Summary

Stacked on top of #371. Same `APIRouter` + `set_dependencies(...)` pattern.

- `/outreach/platforms` list (1 endpoint)
- `/outreach/platforms/{platform}` CRUD (3 endpoints)
- enable / disable / test (3 endpoints)

7 endpoints moved → `routes/outreach.py`.

These manage messaging-platform credentials and toggles. They are distinct from `/broker/*` (the *send* endpoints) which still live in api.py since those tunnel through deep streaming-session machinery — those need the agents-domain extraction first.

**api.py: 7,151 → 7,092 lines (-59, -0.8%)**
**Cumulative since main: 11,138 → 7,092 (-4,046 lines, -36.3%)**

## Test plan

- [x] `pytest --ignore=tests/pinky_federation` — 1542 passed, 1 skipped
- [x] `ruff check src/pinky_daemon/{api.py,routes/outreach.py}` clean

## Merge order

#362 → ... → #371 → this. GitHub auto-rebases as parents land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)