### PR TITLE
feat(discord): REST-polling inbound poller for per-agent Discord bots

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -5964,6 +5964,44 @@ def create_api(
             except Exception as e:
                 _log(f"api: failed to start telegram poller for {name}: {e}")
 
+        # Dynamically start/restart a broker poller for Discord tokens
+        if platform == "discord" and raw_token:
+            try:
+                from pinky_daemon.pollers import BrokerDiscordPoller
+                from pinky_outreach.discord import DiscordAdapter
+
+                # Stop any existing poller for this agent
+                for p in list(_broker_pollers):
+                    if (
+                        isinstance(p, BrokerDiscordPoller)
+                        and p._agent_name == name
+                    ):
+                        p.stop()
+                        _broker_pollers.remove(p)
+                        _log(f"api: stopped old discord poller for {name}")
+                        break
+
+                # Optional per-token overrides come through token settings.
+                settings = req.settings or {}
+                poll_interval = float(settings.get("poll_interval_sec", 1.0))
+                watched = settings.get("watched_channels") or None
+
+                adapter = DiscordAdapter(raw_token)
+                poller = BrokerDiscordPoller(
+                    adapter, name, broker, registry=agents,
+                    poll_interval=poll_interval,
+                    watched_channels=watched,
+                )
+                _broker_pollers.append(poller)
+                asyncio.create_task(poller.start())
+                _log(
+                    f"api: started discord poller for {name} "
+                    f"(poll_interval={poll_interval}s, "
+                    f"watched={'auto' if not watched else len(watched)})"
+                )
+            except Exception as e:
+                _log(f"api: failed to start discord poller for {name}: {e}")
+
         return token.to_dict()
 
     @app.get("/agents/{name}/tokens")
@@ -5991,6 +6029,19 @@ def create_api(
                     p.stop()
                     _broker_pollers.remove(p)
                     _log(f"api: stopped telegram poller for {name}")
+                    break
+
+        # Stop broker poller if removing a Discord token
+        if platform == "discord":
+            from pinky_daemon.pollers import BrokerDiscordPoller
+            for p in list(_broker_pollers):
+                if (
+                    isinstance(p, BrokerDiscordPoller)
+                    and p._agent_name == name
+                ):
+                    p.stop()
+                    _broker_pollers.remove(p)
+                    _log(f"api: stopped discord poller for {name}")
                     break
 
         return {"deleted": True, "agent": name, "platform": platform}
@@ -7896,7 +7947,12 @@ def create_api(
         auto_start_agents = agents.list_auto_start_agents()
 
         # Start broker pollers and streaming sessions for all enabled agents.
-        from pinky_daemon.pollers import BrokeriMessagePoller, BrokerTelegramPoller
+        from pinky_daemon.pollers import (
+            BrokerDiscordPoller,
+            BrokeriMessagePoller,
+            BrokerTelegramPoller,
+        )
+        from pinky_outreach.discord import DiscordAdapter
         from pinky_outreach.telegram import TelegramAdapter
         all_agents = agents.list(enabled_only=True)
         streaming_count = 0
@@ -7927,6 +7983,42 @@ def create_api(
                 _broker_pollers.append(poller)
                 asyncio.create_task(poller.start())
                 _log(f"startup: broker poller started for {agent.name}")
+
+            # Discord poller — REST polling (Gateway/WebSocket is a future v0.2)
+            discord_token = agents.get_raw_token(agent.name, "discord")
+            if discord_token:
+                existing = any(
+                    isinstance(p, BrokerDiscordPoller) and p._agent_name == agent.name
+                    for p in _broker_pollers
+                )
+                if existing:
+                    _log(f"startup: discord poller already exists for {agent.name}, skipping")
+                else:
+                    try:
+                        # Read per-token settings (poll_interval_sec, watched_channels)
+                        settings = {}
+                        for tok in agents.list_tokens(agent.name):
+                            if tok.platform == "discord":
+                                settings = tok.settings or {}
+                                break
+                        poll_interval = float(settings.get("poll_interval_sec", 1.0))
+                        watched = settings.get("watched_channels") or None
+
+                        d_adapter = DiscordAdapter(discord_token)
+                        d_poller = BrokerDiscordPoller(
+                            d_adapter, agent.name, broker, registry=agents,
+                            poll_interval=poll_interval,
+                            watched_channels=watched,
+                        )
+                        _broker_pollers.append(d_poller)
+                        asyncio.create_task(d_poller.start())
+                        _log(
+                            f"startup: discord poller started for {agent.name} "
+                            f"(interval={poll_interval}s, "
+                            f"channels={'auto' if not watched else len(watched)})"
+                        )
+                    except Exception as e:
+                        _log(f"startup: discord poller failed for {agent.name}: {e}")
 
             # iMessage poller — check if agent has imessage enabled in DB
             if agents.get_raw_token(agent.name, "imessage"):

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -11,6 +11,7 @@ import asyncio
 import sys
 
 from pinky_daemon.message_handler import InboundMessage, MessageHandler
+from pinky_outreach.discord import DiscordAdapter, DiscordError, DiscordRateLimited
 from pinky_outreach.telegram import TelegramAdapter, TelegramError
 
 
@@ -384,6 +385,280 @@ class BrokeriMessagePoller:
     @property
     def is_running(self) -> bool:
         return self._running
+
+
+class BrokerDiscordPoller:
+    """Polls Discord REST API for a specific agent's bot token, routes through MessageBroker.
+
+    This is the Discord analogue of BrokerTelegramPoller, but using REST polling
+    rather than long-polling — the Discord REST API has no equivalent to
+    Telegram's getUpdates. A future version may add a Gateway/WebSocket poller
+    for true push delivery; this class provides a working inbound channel today.
+
+    Behavior:
+      - Discovers watchable channels at startup (settings.watched_channels if set,
+        otherwise auto-discovered text channels across all the bot's guilds).
+      - Polls each channel every `poll_interval` seconds, fetching only messages
+        with id > last seen via the `?after=` parameter.
+      - On first sight of a channel, primes `last_id` from the most recent
+        message so we don't replay history.
+      - Skips messages authored by the bot itself (no self-reply loop).
+      - Honors 429 rate limits via DiscordRateLimited (sleeps retry_after).
+      - Re-discovers channels every `discovery_interval` seconds so newly-joined
+        guilds become reachable without a daemon restart.
+    """
+
+    def __init__(
+        self,
+        adapter: DiscordAdapter,
+        agent_name: str,
+        broker,  # MessageBroker
+        registry=None,  # AgentRegistry — reserved for future guild tracking
+        *,
+        poll_interval: float = 1.0,
+        discovery_interval: float = 60.0,
+        watched_channels: list[str] | None = None,
+        event_callback=None,
+    ) -> None:
+        from pinky_daemon.broker import BrokerMessage, MessageBroker
+        self._BrokerMessage = BrokerMessage
+
+        self._adapter = adapter
+        self._agent_name = agent_name
+        self._broker: MessageBroker = broker
+        self._registry = registry
+        self._poll_interval = max(0.25, float(poll_interval))
+        self._discovery_interval = max(10.0, float(discovery_interval))
+        self._configured_channels = list(watched_channels or [])
+        self._event_callback = event_callback
+        self._running = False
+        self._poll_count = 0
+        self._bot_user_id = ""
+        self._bot_username = ""
+        # Per-channel state
+        self._channels: list[str] = []
+        self._last_id: dict[str, str] = {}
+        self._last_discovery: float = 0.0
+
+    @property
+    def agent_name(self) -> str:
+        return self._agent_name
+
+    @property
+    def poll_count(self) -> int:
+        return self._poll_count
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    @property
+    def watched_channels(self) -> list[str]:
+        return list(self._channels)
+
+    async def start(self) -> None:
+        """Start the polling loop."""
+        self._running = True
+        _log(f"discord-poller[{self._agent_name}]: starting")
+
+        # Verify bot connection
+        try:
+            me = await asyncio.get_event_loop().run_in_executor(
+                None, self._adapter.get_me,
+            )
+            self._bot_user_id = me.get("id", "")
+            self._bot_username = me.get("username", "?")
+            _log(
+                f"discord-poller[{self._agent_name}]: connected as "
+                f"{self._bot_username} (id={self._bot_user_id})"
+            )
+        except DiscordError as e:
+            _log(f"discord-poller[{self._agent_name}]: failed to connect: {e}")
+            self._running = False
+            return
+
+        # Initial channel discovery + last_id priming
+        await self._refresh_channels(prime_last_ids=True)
+
+        while self._running:
+            try:
+                # Periodic re-discovery (cheap — one /users/@me/guilds + one
+                # /guilds/{id}/channels per guild per discovery_interval).
+                import time as _time
+                if _time.monotonic() - self._last_discovery >= self._discovery_interval:
+                    await self._refresh_channels(prime_last_ids=False)
+
+                await self._poll_once()
+            except DiscordRateLimited as e:
+                _log(
+                    f"discord-poller[{self._agent_name}]: rate limited, "
+                    f"sleeping {e.retry_after:.2f}s"
+                )
+                await asyncio.sleep(min(e.retry_after, 30.0))
+            except DiscordError as e:
+                _log(f"discord-poller[{self._agent_name}]: error: {e}")
+                await asyncio.sleep(5)
+            except Exception as e:
+                _log(f"discord-poller[{self._agent_name}]: unexpected error: {e}")
+                await asyncio.sleep(5)
+
+            await asyncio.sleep(self._poll_interval)
+
+    async def _refresh_channels(self, *, prime_last_ids: bool) -> None:
+        """Refresh the watched-channel set and prime last_id for newcomers."""
+        import time as _time
+        loop = asyncio.get_event_loop()
+
+        if self._configured_channels:
+            new_set = list(self._configured_channels)
+        else:
+            try:
+                new_set = await loop.run_in_executor(
+                    None, self._adapter.discover_text_channels,
+                )
+            except DiscordError as e:
+                _log(
+                    f"discord-poller[{self._agent_name}]: "
+                    f"channel discovery failed: {e}"
+                )
+                # Keep existing set on transient discovery failure.
+                self._last_discovery = _time.monotonic()
+                return
+
+        added = [c for c in new_set if c not in self._last_id]
+        removed = [c for c in self._channels if c not in new_set]
+
+        # Prime last_id for newly-discovered channels: fetch the most recent
+        # message and treat its id as the baseline so we don't replay history.
+        for ch in added:
+            try:
+                recent = await loop.run_in_executor(
+                    None,
+                    lambda c=ch: self._adapter.get_messages(c, limit=1),
+                )
+            except DiscordError:
+                # Channel might be unreadable; skip it for now, retry next discovery
+                continue
+            if recent:
+                # get_messages returns newest-first
+                self._last_id[ch] = recent[0].message_id
+            else:
+                # Empty channel — start from "0", which sorts before any real snowflake
+                self._last_id[ch] = "0"
+
+        for ch in removed:
+            self._last_id.pop(ch, None)
+
+        self._channels = new_set
+        self._last_discovery = _time.monotonic()
+
+        if added or removed or prime_last_ids:
+            _log(
+                f"discord-poller[{self._agent_name}]: watching "
+                f"{len(self._channels)} channels (+{len(added)} -{len(removed)})"
+            )
+
+    async def _poll_once(self) -> None:
+        """Single sweep across all watched channels."""
+        loop = asyncio.get_event_loop()
+        self._poll_count += 1
+
+        for channel_id in list(self._channels):
+            after = self._last_id.get(channel_id, "")
+            if after == "0":
+                # Empty-channel sentinel — drop the after filter so the first real
+                # message is picked up regardless of snowflake ordering.
+                after = ""
+
+            try:
+                messages = await loop.run_in_executor(
+                    None,
+                    lambda c=channel_id, a=after: self._adapter.get_messages(
+                        c, limit=50, after=a,
+                    ),
+                )
+            except DiscordRateLimited:
+                # Bubble up so the outer loop can sleep retry_after
+                raise
+            except DiscordError as e:
+                _log(
+                    f"discord-poller[{self._agent_name}]: "
+                    f"channel {channel_id} fetch failed: {e}"
+                )
+                continue
+
+            if not messages:
+                continue
+
+            # Discord returns newest-first; replay in chronological order so
+            # the broker sees them as they happened.
+            messages = list(reversed(messages))
+
+            for msg in messages:
+                # Track high-water mark even for skipped messages so we don't
+                # re-fetch them next tick.
+                self._last_id[channel_id] = msg.message_id
+
+                meta = msg.metadata or {}
+                if meta.get("is_bot"):
+                    continue
+                if meta.get("author_id") and meta["author_id"] == self._bot_user_id:
+                    continue
+
+                # Lookup channel/guild context lazily (only when we actually
+                # have a real inbound) to avoid wasting requests on idle polls.
+                chat_title = ""
+                is_group = False
+                try:
+                    chat_info = await loop.run_in_executor(
+                        None,
+                        lambda c=channel_id: self._adapter.get_channel(c),
+                    )
+                    chat_title = chat_info.title or ""
+                    is_group = chat_info.chat_type != "dm"
+                except DiscordError:
+                    pass
+
+                broker_msg = self._BrokerMessage(
+                    platform="discord",
+                    chat_id=channel_id,
+                    sender_name=msg.sender,
+                    sender_id=meta.get("author_id", ""),
+                    content=msg.content,
+                    agent_name=self._agent_name,
+                    message_id=msg.message_id,
+                    chat_title=chat_title,
+                    is_group=is_group,
+                    reply_to=msg.reply_to,
+                    metadata=meta,
+                    attachments=meta.get("attachments", []),
+                )
+
+                _log(
+                    f"discord-poller[{self._agent_name}]: message from "
+                    f"{msg.sender} in {channel_id}: {msg.content[:50]}..."
+                )
+
+                asyncio.create_task(self._broker.handle_inbound(broker_msg))
+
+                if self._event_callback:
+                    try:
+                        await self._event_callback(
+                            platform="discord",
+                            chat_id=str(channel_id),
+                            sender=msg.sender,
+                            content=msg.content,
+                        )
+                    except Exception as e:
+                        _log(
+                            f"discord-poller[{self._agent_name}]: "
+                            f"event callback error: {e}"
+                        )
+
+    def stop(self) -> None:
+        """Stop the polling loop."""
+        self._running = False
+        _log(f"discord-poller[{self._agent_name}]: stopping")
 
 
 def _log(msg: str) -> None:

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -9,10 +9,14 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from typing import TYPE_CHECKING
 
 from pinky_daemon.message_handler import InboundMessage, MessageHandler
 from pinky_outreach.discord import DiscordAdapter, DiscordError, DiscordRateLimited
 from pinky_outreach.telegram import TelegramAdapter, TelegramError
+
+if TYPE_CHECKING:
+    from pinky_outreach.types import Chat
 
 
 class TelegramPoller:
@@ -439,6 +443,10 @@ class BrokerDiscordPoller:
         self._channels: list[str] = []
         self._last_id: dict[str, str] = {}
         self._last_discovery: float = 0.0
+        # Channel metadata cache — invalidated each discovery cycle (~60s by
+        # default). Avoids fanning out get_channel() calls across every message
+        # in a burst on the same channel.
+        self._channel_info_cache: dict[str, Chat] = {}
 
     @property
     def agent_name(self) -> str:
@@ -463,7 +471,7 @@ class BrokerDiscordPoller:
 
         # Verify bot connection
         try:
-            me = await asyncio.get_event_loop().run_in_executor(
+            me = await asyncio.get_running_loop().run_in_executor(
                 None, self._adapter.get_me,
             )
             self._bot_user_id = me.get("id", "")
@@ -478,7 +486,7 @@ class BrokerDiscordPoller:
             return
 
         # Initial channel discovery + last_id priming
-        await self._refresh_channels(prime_last_ids=True)
+        await self._refresh_channels(verbose=True)
 
         while self._running:
             try:
@@ -486,7 +494,7 @@ class BrokerDiscordPoller:
                 # /guilds/{id}/channels per guild per discovery_interval).
                 import time as _time
                 if _time.monotonic() - self._last_discovery >= self._discovery_interval:
-                    await self._refresh_channels(prime_last_ids=False)
+                    await self._refresh_channels(verbose=False)
 
                 await self._poll_once()
             except DiscordRateLimited as e:
@@ -504,10 +512,14 @@ class BrokerDiscordPoller:
 
             await asyncio.sleep(self._poll_interval)
 
-    async def _refresh_channels(self, *, prime_last_ids: bool) -> None:
-        """Refresh the watched-channel set and prime last_id for newcomers."""
+    async def _refresh_channels(self, *, verbose: bool) -> None:
+        """Refresh the watched-channel set and prime last_id for newcomers.
+
+        `verbose=True` produces a log line on every call (used at startup);
+        otherwise we only log on add/remove changes.
+        """
         import time as _time
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         if self._configured_channels:
             new_set = list(self._configured_channels)
@@ -552,15 +564,47 @@ class BrokerDiscordPoller:
         self._channels = new_set
         self._last_discovery = _time.monotonic()
 
-        if added or removed or prime_last_ids:
+        # Drop cached channel metadata so renames / type changes get picked up
+        # on the next inbound. Cheap (≤ N discovery_interval-old entries).
+        self._channel_info_cache.clear()
+
+        if added or removed or verbose:
             _log(
                 f"discord-poller[{self._agent_name}]: watching "
                 f"{len(self._channels)} channels (+{len(added)} -{len(removed)})"
             )
 
+    async def _resolve_channel_info(self, channel_id: str):
+        """Return cached channel metadata or fetch + cache it on miss."""
+        cached = self._channel_info_cache.get(channel_id)
+        if cached is not None:
+            return cached
+        try:
+            chat_info = await asyncio.get_running_loop().run_in_executor(
+                None, lambda c=channel_id: self._adapter.get_channel(c),
+            )
+        except DiscordError:
+            return None
+        self._channel_info_cache[channel_id] = chat_info
+        return chat_info
+
+    def _attach_broker_failure_logger(self, task: "asyncio.Task") -> None:
+        """Surface unhandled broker delivery exceptions as poller log lines."""
+        def _log_failure(t: "asyncio.Task") -> None:
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is None:
+                return
+            _log(
+                f"discord-poller[{self._agent_name}]: "
+                f"broker delivery failed: {exc!r}"
+            )
+        task.add_done_callback(_log_failure)
+
     async def _poll_once(self) -> None:
         """Single sweep across all watched channels."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         self._poll_count += 1
 
         for channel_id in list(self._channels):
@@ -594,6 +638,14 @@ class BrokerDiscordPoller:
             # the broker sees them as they happened.
             messages = list(reversed(messages))
 
+            # Channel metadata is constant per channel per poll cycle (and
+            # essentially constant across the whole discovery_interval —
+            # renames are rare). Resolve once per channel per sweep instead
+            # of fanning out N get_channel calls in the per-message loop.
+            chat_info = await self._resolve_channel_info(channel_id)
+            chat_title = chat_info.title if chat_info and chat_info.title else ""
+            is_group = bool(chat_info and chat_info.chat_type != "dm")
+
             for msg in messages:
                 # Track high-water mark even for skipped messages so we don't
                 # re-fetch them next tick.
@@ -604,20 +656,6 @@ class BrokerDiscordPoller:
                     continue
                 if meta.get("author_id") and meta["author_id"] == self._bot_user_id:
                     continue
-
-                # Lookup channel/guild context lazily (only when we actually
-                # have a real inbound) to avoid wasting requests on idle polls.
-                chat_title = ""
-                is_group = False
-                try:
-                    chat_info = await loop.run_in_executor(
-                        None,
-                        lambda c=channel_id: self._adapter.get_channel(c),
-                    )
-                    chat_title = chat_info.title or ""
-                    is_group = chat_info.chat_type != "dm"
-                except DiscordError:
-                    pass
 
                 broker_msg = self._BrokerMessage(
                     platform="discord",
@@ -639,7 +677,10 @@ class BrokerDiscordPoller:
                     f"{msg.sender} in {channel_id}: {msg.content[:50]}..."
                 )
 
-                asyncio.create_task(self._broker.handle_inbound(broker_msg))
+                delivery = asyncio.create_task(
+                    self._broker.handle_inbound(broker_msg)
+                )
+                self._attach_broker_failure_logger(delivery)
 
                 if self._event_callback:
                     try:

--- a/src/pinky_outreach/discord.py
+++ b/src/pinky_outreach/discord.py
@@ -11,11 +11,17 @@ Suitable for outbound messaging and periodic message checking.
 from __future__ import annotations
 
 import os
+import time
 from datetime import datetime
 
 import httpx
 
 from pinky_outreach.types import Chat, Message, Platform
+
+# Discord requires a User-Agent that follows the convention; default urllib/httpx
+# UAs trigger Cloudflare 403s on some endpoints. See
+# https://discord.com/developers/docs/reference#user-agent
+_DEFAULT_USER_AGENT = "DiscordBot (https://github.com/olegbrok/PinkyBot, 0.1.0)"
 
 
 class DiscordError(Exception):
@@ -26,17 +32,38 @@ class DiscordError(Exception):
         super().__init__(f"Discord API error {status_code}: {message}")
 
 
+class DiscordRateLimitError(DiscordError):
+    """Discord 429 — caller may retry after `retry_after` seconds."""
+
+    def __init__(self, retry_after: float, message: str = "rate limited"):
+        self.retry_after = retry_after
+        super().__init__(message, status_code=429)
+
+
+# Backwards-compat alias (kept for existing imports / readability)
+DiscordRateLimited = DiscordRateLimitError
+
+
 class DiscordAdapter:
     """Discord REST API adapter using httpx."""
 
     BASE_URL = "https://discord.com/api/v10"
 
-    def __init__(self, bot_token: str, *, timeout: float = 30.0) -> None:
+    def __init__(
+        self,
+        bot_token: str,
+        *,
+        timeout: float = 30.0,
+        user_agent: str = _DEFAULT_USER_AGENT,
+        max_429_retries: int = 1,
+    ) -> None:
         self._token = bot_token
+        self._max_429_retries = max_429_retries
         self._client = httpx.Client(
             base_url=self.BASE_URL,
             headers={
                 "Authorization": f"Bot {bot_token}",
+                "User-Agent": user_agent,
             },
             timeout=timeout,
         )
@@ -46,19 +73,47 @@ class DiscordAdapter:
         self._client.close()
 
     def _request(self, method: str, path: str, **kwargs) -> dict | list:
-        """Make a Discord API request."""
-        resp = self._client.request(method, path, **kwargs)
+        """Make a Discord API request, with bounded 429 retry."""
+        attempts = 0
+        while True:
+            resp = self._client.request(method, path, **kwargs)
 
-        if resp.status_code == 204:
-            return {}
+            if resp.status_code == 429:
+                # Discord returns retry_after either as a JSON body field (seconds)
+                # or in the X-RateLimit-Reset-After header. Prefer the body.
+                retry_after = 1.0
+                try:
+                    body = resp.json()
+                    retry_after = float(body.get("retry_after", retry_after))
+                except Exception:
+                    header = resp.headers.get("X-RateLimit-Reset-After")
+                    if header:
+                        try:
+                            retry_after = float(header)
+                        except ValueError:
+                            pass
 
-        data = resp.json()
+                if attempts >= self._max_429_retries:
+                    raise DiscordRateLimited(retry_after)
+                attempts += 1
+                time.sleep(min(retry_after, 5.0))
+                continue
 
-        if resp.status_code >= 400:
-            msg = data.get("message", str(data))
-            raise DiscordError(msg, resp.status_code)
+            if resp.status_code == 204:
+                return {}
 
-        return data
+            try:
+                data = resp.json()
+            except Exception:
+                if resp.status_code >= 400:
+                    raise DiscordError(resp.text[:200], resp.status_code)
+                return {}
+
+            if resp.status_code >= 400:
+                msg = data.get("message", str(data)) if isinstance(data, dict) else str(data)
+                raise DiscordError(msg, resp.status_code)
+
+            return data
 
     # ── Actions ──────────────────────────────────────────────
 
@@ -248,6 +303,38 @@ class DiscordAdapter:
             )
             for ch in results
         ]
+
+    def get_my_guilds(self) -> list[dict]:
+        """List guilds (servers) the bot is currently a member of.
+
+        Returns minimal guild dicts: {id, name, owner, permissions, ...}.
+        Used by the inbound poller to auto-discover channels to watch.
+        """
+        result = self._request("GET", "/users/@me/guilds")
+        return result if isinstance(result, list) else []
+
+    def discover_text_channels(self) -> list[str]:
+        """Auto-discover all text channels (type 0) the bot can access across all guilds.
+
+        Returns a list of channel IDs. Used as a default watch-set when no
+        explicit channel list is configured in the bot token settings.
+        """
+        # Discord channel types: 0=GUILD_TEXT, 5=GUILD_ANNOUNCEMENT.
+        # We treat both as message-bearing for inbound polling purposes.
+        watchable_types = {0, 5}
+        channel_ids: list[str] = []
+        for guild in self.get_my_guilds():
+            try:
+                raw = self._request("GET", f"/guilds/{guild['id']}/channels")
+            except DiscordError:
+                # Skip guilds where listing fails (e.g., transient permission issues).
+                continue
+            if not isinstance(raw, list):
+                continue
+            for ch in raw:
+                if ch.get("type") in watchable_types:
+                    channel_ids.append(ch["id"])
+        return channel_ids
 
     # ── Reactions ────────────────────────────────────────────
 

--- a/src/pinky_outreach/discord.py
+++ b/src/pinky_outreach/discord.py
@@ -32,7 +32,7 @@ class DiscordError(Exception):
         super().__init__(f"Discord API error {status_code}: {message}")
 
 
-class DiscordRateLimitError(DiscordError):
+class DiscordRateLimited(DiscordError):  # noqa: N818 — name reads naturally at call sites
     """Discord 429 — caller may retry after `retry_after` seconds."""
 
     def __init__(self, retry_after: float, message: str = "rate limited"):
@@ -40,12 +40,15 @@ class DiscordRateLimitError(DiscordError):
         super().__init__(message, status_code=429)
 
 
-# Backwards-compat alias (kept for existing imports / readability)
-DiscordRateLimited = DiscordRateLimitError
-
-
 class DiscordAdapter:
-    """Discord REST API adapter using httpx."""
+    """Discord REST API adapter using httpx.
+
+    Synchronous: uses `httpx.Client` and `time.sleep` for 429 backoff. Callers
+    in async contexts must wrap calls in `loop.run_in_executor` to avoid
+    blocking the event loop. The bundled `BrokerDiscordPoller` does this
+    correctly; ad-hoc async callers must too. A future v0.2 may swap to
+    `httpx.AsyncClient` + `asyncio.sleep` to remove the requirement.
+    """
 
     BASE_URL = "https://discord.com/api/v10"
 
@@ -73,7 +76,11 @@ class DiscordAdapter:
         self._client.close()
 
     def _request(self, method: str, path: str, **kwargs) -> dict | list:
-        """Make a Discord API request, with bounded 429 retry."""
+        """Make a Discord API request, with bounded 429 retry.
+
+        Synchronous: blocks via `time.sleep` on 429 backoff. Async callers
+        must wrap in `run_in_executor` (see class docstring).
+        """
         attempts = 0
         while True:
             resp = self._client.request(method, path, **kwargs)

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
-from pinky_outreach.discord import DiscordAdapter, DiscordError
+from pinky_outreach.discord import DiscordAdapter, DiscordError, DiscordRateLimited
 from pinky_outreach.types import Platform
 
 
@@ -281,6 +281,122 @@ class TestDiscordAdapter:
         assert len(channels) == 3
         assert channels[0].title == "general"
         assert channels[1].title == "voice"
+        adapter.close()
+
+    def test_user_agent_header_sent(self):
+        """Discord 403s requests with the default httpx UA on some endpoints."""
+        adapter = self._make_adapter()
+        ua = adapter._client.headers["User-Agent"]
+        # Must follow Discord's "DiscordBot (..., version)" convention
+        assert ua.startswith("DiscordBot (")
+        adapter.close()
+
+    def test_429_retry_then_success(self, monkeypatch):
+        """A single 429 should sleep `retry_after` then retry transparently."""
+        adapter = self._make_adapter()
+        slept: list[float] = []
+        monkeypatch.setattr(
+            "pinky_outreach.discord.time.sleep",
+            lambda s: slept.append(s),
+        )
+
+        rate_limited = MagicMock()
+        rate_limited.status_code = 429
+        rate_limited.json.return_value = {"retry_after": 0.5, "message": "rate limited"}
+
+        success = MagicMock()
+        success.status_code = 200
+        success.json.return_value = {
+            "id": "1234567890",
+            "channel_id": "99999",
+            "content": "ok",
+            "timestamp": "2026-03-27T12:00:00+00:00",
+        }
+        adapter._client.request = MagicMock(side_effect=[rate_limited, success])
+
+        msg = adapter.send_message("99999", "ok")
+        assert msg.message_id == "1234567890"
+        assert slept and slept[0] == pytest.approx(0.5)
+        adapter.close()
+
+    def test_429_retry_exhausted_raises_rate_limited(self, monkeypatch):
+        """After `max_429_retries` attempts a 429 must surface as DiscordRateLimited."""
+        adapter = DiscordAdapter("fake-discord-token", max_429_retries=1)
+        monkeypatch.setattr("pinky_outreach.discord.time.sleep", lambda s: None)
+
+        rate_limited = MagicMock()
+        rate_limited.status_code = 429
+        rate_limited.json.return_value = {"retry_after": 2.5}
+
+        adapter._client.request = MagicMock(return_value=rate_limited)
+        with pytest.raises(DiscordRateLimited) as exc:
+            adapter.send_message("99999", "ok")
+        assert exc.value.retry_after == pytest.approx(2.5)
+        adapter.close()
+
+    def test_get_my_guilds(self):
+        adapter = self._make_adapter()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"id": "g1", "name": "Server One"},
+            {"id": "g2", "name": "Server Two"},
+        ]
+        adapter._client.request = MagicMock(return_value=mock_response)
+
+        guilds = adapter.get_my_guilds()
+        assert len(guilds) == 2
+        assert guilds[0]["id"] == "g1"
+        adapter.close()
+
+    def test_discover_text_channels_filters_voice_and_categories(self):
+        """Channel discovery should include text(0) + announcement(5), drop the rest."""
+        adapter = self._make_adapter()
+
+        guilds_resp = MagicMock()
+        guilds_resp.status_code = 200
+        guilds_resp.json.return_value = [{"id": "g1", "name": "Server One"}]
+
+        channels_resp = MagicMock()
+        channels_resp.status_code = 200
+        channels_resp.json.return_value = [
+            {"id": "ch-text", "name": "general", "type": 0},
+            {"id": "ch-voice", "name": "Lounge", "type": 2},
+            {"id": "ch-cat", "name": "Category", "type": 4},
+            {"id": "ch-announce", "name": "news", "type": 5},
+        ]
+        adapter._client.request = MagicMock(side_effect=[guilds_resp, channels_resp])
+
+        ids = adapter.discover_text_channels()
+        assert ids == ["ch-text", "ch-announce"]
+        adapter.close()
+
+    def test_discover_text_channels_skips_unreadable_guilds(self):
+        """If listing one guild's channels fails, others should still be returned."""
+        adapter = self._make_adapter()
+
+        guilds_resp = MagicMock()
+        guilds_resp.status_code = 200
+        guilds_resp.json.return_value = [
+            {"id": "g1", "name": "Server One"},
+            {"id": "g2", "name": "Server Two"},
+        ]
+
+        forbidden_resp = MagicMock()
+        forbidden_resp.status_code = 403
+        forbidden_resp.json.return_value = {"message": "Missing Access"}
+
+        ok_channels_resp = MagicMock()
+        ok_channels_resp.status_code = 200
+        ok_channels_resp.json.return_value = [
+            {"id": "ch-ok", "name": "general", "type": 0},
+        ]
+        adapter._client.request = MagicMock(
+            side_effect=[guilds_resp, forbidden_resp, ok_channels_resp],
+        )
+
+        ids = adapter.discover_text_channels()
+        assert ids == ["ch-ok"]
         adapter.close()
 
 

--- a/tests/test_discord_poller.py
+++ b/tests/test_discord_poller.py
@@ -78,7 +78,7 @@ class TestBrokerDiscordPoller:
         ]
 
         poller = self._make_poller(mock_adapter, mock_broker)
-        await poller._refresh_channels(prime_last_ids=True)
+        await poller._refresh_channels(verbose=True)
         await poller._poll_once()
 
         assert poller.watched_channels == ["chan-A"]
@@ -96,7 +96,7 @@ class TestBrokerDiscordPoller:
         ]
 
         poller = self._make_poller(mock_adapter, mock_broker)
-        await poller._refresh_channels(prime_last_ids=True)
+        await poller._refresh_channels(verbose=True)
         await poller._poll_once()
 
         # Allow the fire-and-forget task to settle
@@ -138,7 +138,7 @@ class TestBrokerDiscordPoller:
         poller = self._make_poller(mock_adapter, mock_broker)
         # Set bot id manually so we don't depend on start()
         poller._bot_user_id = "bot-001"
-        await poller._refresh_channels(prime_last_ids=True)
+        await poller._refresh_channels(verbose=True)
         await poller._poll_once()
 
         await asyncio.sleep(0)
@@ -160,7 +160,7 @@ class TestBrokerDiscordPoller:
             mock_adapter, mock_broker,
             watched_channels=["explicit-1", "explicit-2"],
         )
-        await poller._refresh_channels(prime_last_ids=True)
+        await poller._refresh_channels(verbose=True)
 
         assert sorted(poller.watched_channels) == ["explicit-1", "explicit-2"]
         mock_adapter.discover_text_channels.assert_not_called()
@@ -171,7 +171,7 @@ class TestBrokerDiscordPoller:
         mock_adapter.get_messages.return_value = []  # priming finds nothing
 
         poller = self._make_poller(mock_adapter, mock_broker)
-        await poller._refresh_channels(prime_last_ids=True)
+        await poller._refresh_channels(verbose=True)
 
         assert poller._last_id["chan-A"] == "0"
 
@@ -187,7 +187,7 @@ class TestBrokerDiscordPoller:
         ]
 
         poller = self._make_poller(mock_adapter, mock_broker)
-        await poller._refresh_channels(prime_last_ids=True)
+        await poller._refresh_channels(verbose=True)
         await poller._poll_once()
 
         await asyncio.sleep(0)
@@ -214,7 +214,7 @@ class TestBrokerDiscordPoller:
         ]
 
         poller = self._make_poller(mock_adapter, mock_broker)
-        await poller._refresh_channels(prime_last_ids=True)
+        await poller._refresh_channels(verbose=True)
         await poller._poll_once()
 
         await asyncio.sleep(0)
@@ -231,13 +231,13 @@ class TestBrokerDiscordPoller:
         mock_adapter.get_messages.return_value = []
 
         poller = self._make_poller(mock_adapter, mock_broker)
-        await poller._refresh_channels(prime_last_ids=True)
+        await poller._refresh_channels(verbose=True)
         # Now simulate failure on next discovery
         mock_adapter.discover_text_channels.side_effect = DiscordError(
             "transient", status_code=502,
         )
 
-        await poller._refresh_channels(prime_last_ids=False)
+        await poller._refresh_channels(verbose=False)
         assert poller.watched_channels == ["chan-A"]  # unchanged
 
     @pytest.mark.asyncio
@@ -250,7 +250,7 @@ class TestBrokerDiscordPoller:
         ]
 
         poller = self._make_poller(mock_adapter, mock_broker)
-        await poller._refresh_channels(prime_last_ids=True)
+        await poller._refresh_channels(verbose=True)
         with pytest.raises(DiscordRateLimited):
             await poller._poll_once()
 
@@ -266,3 +266,105 @@ class TestBrokerDiscordPoller:
         poller._running = True
         poller.stop()
         assert poller.is_running is False
+
+    @pytest.mark.asyncio
+    async def test_get_channel_cached_across_burst(self, mock_adapter, mock_broker):
+        """A burst of N messages on one channel must trigger only ONE get_channel call.
+
+        Regression for the burst pathology Pushok flagged in PR #383: prior code
+        looked up channel metadata inside the per-message loop, fanning out to N
+        round-trips for a chatty channel. Now hoisted to once per channel per poll
+        sweep with a discovery-cycle cache.
+        """
+        baseline = _msg(msg_id="100", content="baseline")
+        burst = [
+            _msg(msg_id=f"{200 + i}", content=f"msg-{i}", author_id="user-9")
+            for i in range(5)
+        ]
+        # Discord returns newest-first
+        mock_adapter.get_messages.side_effect = [
+            [baseline],          # priming
+            list(reversed(burst)),  # poll: newest-first
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(verbose=True)
+        await poller._poll_once()
+
+        await asyncio.sleep(0)
+
+        assert mock_broker.handle_inbound.await_count == 5
+        # Hoisted lookup: one call per channel per poll, not per message
+        assert mock_adapter.get_channel.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_get_channel_cache_reused_across_polls(self, mock_adapter, mock_broker):
+        """Cache survives across polls within a discovery cycle."""
+        baseline = _msg(msg_id="100", content="baseline")
+        first = _msg(msg_id="101", content="first", author_id="user-9")
+        second = _msg(msg_id="102", content="second", author_id="user-9")
+        mock_adapter.get_messages.side_effect = [
+            [baseline],     # priming
+            [first],        # poll 1
+            [second],       # poll 2
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(verbose=True)
+        await poller._poll_once()
+        await poller._poll_once()
+
+        await asyncio.sleep(0)
+
+        # Still one get_channel call total — cached after first miss
+        assert mock_adapter.get_channel.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_get_channel_cache_invalidated_on_rediscovery(
+        self, mock_adapter, mock_broker,
+    ):
+        """A discovery refresh drops the cache so renames/type-changes are picked up."""
+        baseline = _msg(msg_id="100", content="baseline")
+        first = _msg(msg_id="101", content="first", author_id="user-9")
+        second = _msg(msg_id="102", content="second", author_id="user-9")
+        mock_adapter.get_messages.side_effect = [
+            [baseline],   # priming (during first refresh)
+            [first],      # poll 1
+            [second],     # poll 2 (after rediscovery)
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(verbose=True)
+        await poller._poll_once()
+        # Force a rediscovery — should invalidate the cache
+        await poller._refresh_channels(verbose=False)
+        await poller._poll_once()
+
+        await asyncio.sleep(0)
+
+        # First poll → 1 lookup, rediscovery clears cache, second poll → 1 more lookup
+        assert mock_adapter.get_channel.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_broker_delivery_failure_logged(self, mock_adapter, mock_broker, capsys):
+        """If broker.handle_inbound raises, the failure must be visible in poller logs."""
+        baseline = _msg(msg_id="100", content="baseline")
+        new_msg = _msg(msg_id="101", content="boom", author_id="user-9")
+        mock_adapter.get_messages.side_effect = [[baseline], [new_msg]]
+
+        async def _raise(*_args, **_kwargs):
+            raise RuntimeError("broker exploded")
+
+        mock_broker.handle_inbound = AsyncMock(side_effect=_raise)
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(verbose=True)
+        await poller._poll_once()
+
+        # Let the fire-and-forget task settle and the done_callback fire.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        captured = capsys.readouterr()
+        assert "broker delivery failed" in captured.err
+        assert "broker exploded" in captured.err

--- a/tests/test_discord_poller.py
+++ b/tests/test_discord_poller.py
@@ -1,0 +1,268 @@
+"""Tests for BrokerDiscordPoller (REST-polling Discord inbound)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_outreach.discord import DiscordError, DiscordRateLimited
+from pinky_outreach.types import Chat, Message, Platform
+
+
+@pytest.fixture
+def mock_adapter():
+    """A mock DiscordAdapter with sensible defaults."""
+    adapter = MagicMock()
+    adapter.get_me.return_value = {"id": "bot-001", "username": "TestBot"}
+    adapter.discover_text_channels.return_value = ["chan-A"]
+    adapter.get_messages.return_value = []
+    adapter.get_channel.return_value = Chat(
+        platform=Platform.discord,
+        chat_id="chan-A",
+        title="general",
+        chat_type="text",
+    )
+    return adapter
+
+
+@pytest.fixture
+def mock_broker():
+    broker = MagicMock()
+    broker.handle_inbound = AsyncMock()
+    return broker
+
+
+def _msg(
+    *,
+    msg_id: str,
+    content: str,
+    author_id: str = "user-1",
+    sender: str = "brad",
+    is_bot: bool = False,
+    reply_to: str = "",
+) -> Message:
+    return Message(
+        platform=Platform.discord,
+        chat_id="chan-A",
+        sender=sender,
+        content=content,
+        timestamp=datetime.fromisoformat("2026-05-05T12:00:00+00:00"),
+        message_id=msg_id,
+        reply_to=reply_to,
+        is_outbound=is_bot,
+        metadata={"author_id": author_id, "is_bot": is_bot},
+    )
+
+
+class TestBrokerDiscordPoller:
+    """Mocked-adapter tests for the inbound Discord poller."""
+
+    def _make_poller(self, mock_adapter, mock_broker, **kwargs):
+        from pinky_daemon.pollers import BrokerDiscordPoller
+        return BrokerDiscordPoller(
+            mock_adapter, "barsik", mock_broker, registry=None,
+            **kwargs,
+        )
+
+    @pytest.mark.asyncio
+    async def test_priming_skips_history_replay(self, mock_adapter, mock_broker):
+        """First sweep should treat existing latest message as the baseline (no replay)."""
+        existing = _msg(msg_id="100", content="ancient")
+        # Adapter returns the most recent message during priming, then nothing on poll
+        mock_adapter.get_messages.side_effect = [
+            [existing],  # priming call (limit=1)
+            [],          # _poll_once call
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(prime_last_ids=True)
+        await poller._poll_once()
+
+        assert poller.watched_channels == ["chan-A"]
+        assert poller._last_id["chan-A"] == "100"
+        mock_broker.handle_inbound.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_new_message_routed_through_broker(self, mock_adapter, mock_broker):
+        """Real inbound user message should produce a BrokerMessage with platform=discord."""
+        baseline = _msg(msg_id="100", content="baseline")
+        new_msg = _msg(msg_id="101", content="hello", author_id="user-9", sender="ryan")
+        mock_adapter.get_messages.side_effect = [
+            [baseline],     # priming
+            [new_msg],      # poll
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(prime_last_ids=True)
+        await poller._poll_once()
+
+        # Allow the fire-and-forget task to settle
+        await asyncio.sleep(0)
+
+        assert mock_broker.handle_inbound.await_count == 1
+        delivered = mock_broker.handle_inbound.await_args.args[0]
+        assert delivered.platform == "discord"
+        assert delivered.chat_id == "chan-A"
+        assert delivered.message_id == "101"
+        assert delivered.content == "hello"
+        assert delivered.sender_name == "ryan"
+        assert delivered.sender_id == "user-9"
+        assert delivered.agent_name == "barsik"
+        assert poller._last_id["chan-A"] == "101"
+
+    @pytest.mark.asyncio
+    async def test_bot_messages_skipped(self, mock_adapter, mock_broker):
+        """is_bot=True or author_id matching the bot's own id must be filtered out."""
+        baseline = _msg(msg_id="100", content="baseline")
+        bot_self = _msg(
+            msg_id="101", content="self echo",
+            author_id="bot-001", sender="TestBot", is_bot=False,
+        )
+        bot_other = _msg(
+            msg_id="102", content="other bot",
+            author_id="bot-other", sender="OtherBot", is_bot=True,
+        )
+        real_user = _msg(
+            msg_id="103", content="real",
+            author_id="user-9", sender="ryan",
+        )
+        # Discord returns newest-first; poller reverses to chronological for delivery.
+        mock_adapter.get_messages.side_effect = [
+            [baseline],
+            [real_user, bot_other, bot_self],
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        # Set bot id manually so we don't depend on start()
+        poller._bot_user_id = "bot-001"
+        await poller._refresh_channels(prime_last_ids=True)
+        await poller._poll_once()
+
+        await asyncio.sleep(0)
+
+        # Only the real-user message should be delivered
+        assert mock_broker.handle_inbound.await_count == 1
+        delivered = mock_broker.handle_inbound.await_args.args[0]
+        assert delivered.message_id == "103"
+        # last_id advances past all of them so we don't refetch
+        assert poller._last_id["chan-A"] == "103"
+
+    @pytest.mark.asyncio
+    async def test_explicit_watched_channels_override_discovery(self, mock_adapter, mock_broker):
+        """If settings.watched_channels is set, discover_text_channels must NOT be called."""
+        # Empty channel = "0" sentinel
+        mock_adapter.get_messages.return_value = []
+
+        poller = self._make_poller(
+            mock_adapter, mock_broker,
+            watched_channels=["explicit-1", "explicit-2"],
+        )
+        await poller._refresh_channels(prime_last_ids=True)
+
+        assert sorted(poller.watched_channels) == ["explicit-1", "explicit-2"]
+        mock_adapter.discover_text_channels.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_channel_primes_with_zero_sentinel(self, mock_adapter, mock_broker):
+        """A channel with no messages at priming time should record last_id='0'."""
+        mock_adapter.get_messages.return_value = []  # priming finds nothing
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(prime_last_ids=True)
+
+        assert poller._last_id["chan-A"] == "0"
+
+    @pytest.mark.asyncio
+    async def test_poll_drops_after_filter_for_zero_sentinel(self, mock_adapter, mock_broker):
+        """When last_id='0' (empty channel), the poll must NOT pass after=0 to the adapter."""
+        # Priming: empty
+        # Poll: a real first message arrives
+        first = _msg(msg_id="500", content="first ever", author_id="user-9")
+        mock_adapter.get_messages.side_effect = [
+            [],          # priming
+            [first],     # poll
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(prime_last_ids=True)
+        await poller._poll_once()
+
+        await asyncio.sleep(0)
+
+        # Inspect the second call (the actual poll)
+        poll_call = mock_adapter.get_messages.call_args_list[1]
+        kwargs = poll_call.kwargs
+        # `after` should be empty (sentinel dropped), not "0"
+        assert kwargs.get("after", "") == ""
+        # And the first message did get delivered
+        assert mock_broker.handle_inbound.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_messages_routed_in_chronological_order(self, mock_adapter, mock_broker):
+        """Discord returns newest-first; poller must reverse so broker sees chronological order."""
+        baseline = _msg(msg_id="100", content="baseline")
+        # Discord returns newest-first
+        newer = _msg(msg_id="103", content="third")
+        middle = _msg(msg_id="102", content="second")
+        older = _msg(msg_id="101", content="first")
+        mock_adapter.get_messages.side_effect = [
+            [baseline],
+            [newer, middle, older],
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(prime_last_ids=True)
+        await poller._poll_once()
+
+        await asyncio.sleep(0)
+
+        delivered_ids = [
+            call.args[0].message_id
+            for call in mock_broker.handle_inbound.await_args_list
+        ]
+        assert delivered_ids == ["101", "102", "103"]
+
+    @pytest.mark.asyncio
+    async def test_discovery_failure_keeps_existing_set(self, mock_adapter, mock_broker):
+        """A transient discovery failure must not blank the watch list."""
+        mock_adapter.get_messages.return_value = []
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(prime_last_ids=True)
+        # Now simulate failure on next discovery
+        mock_adapter.discover_text_channels.side_effect = DiscordError(
+            "transient", status_code=502,
+        )
+
+        await poller._refresh_channels(prime_last_ids=False)
+        assert poller.watched_channels == ["chan-A"]  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_propagates_for_outer_sleep(self, mock_adapter, mock_broker):
+        """A 429 mid-poll must propagate so the outer loop can sleep retry_after."""
+        baseline = _msg(msg_id="100", content="baseline")
+        mock_adapter.get_messages.side_effect = [
+            [baseline],
+            DiscordRateLimited(retry_after=0.5),
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(prime_last_ids=True)
+        with pytest.raises(DiscordRateLimited):
+            await poller._poll_once()
+
+    def test_poll_interval_floor(self, mock_adapter, mock_broker):
+        """Sub-quarter-second intervals must be clamped to keep us under budget."""
+        poller = self._make_poller(
+            mock_adapter, mock_broker, poll_interval=0.05,
+        )
+        assert poller._poll_interval == 0.25
+
+    def test_stop_clears_running_flag(self, mock_adapter, mock_broker):
+        poller = self._make_poller(mock_adapter, mock_broker)
+        poller._running = True
+        poller.stop()
+        assert poller.is_running is False


### PR DESCRIPTION
## Summary
- Adds `BrokerDiscordPoller` (REST sweep, default 1s per channel) so agents can receive Discord messages, not just send. Mirrors the `BrokerTelegramPoller` pattern.
- Patches `DiscordAdapter` to send the Discord-required User-Agent (default httpx UA gets Cloudflare-403'd) and to handle 429 rate limits via `DiscordRateLimitError.retry_after` with a bounded retry.
- Auto-discovers watched channels (text + announcement) across all the bot's guilds; overridable per-token via `settings.watched_channels`. Re-discovery every 60s so newly-joined guilds become reachable without a daemon restart.
- Wires the poller into `PUT /agents/{name}/tokens/discord`, `DELETE /agents/{name}/tokens/discord`, and `on_startup` — same pattern as Telegram.

## Why
We needed an inbound channel for per-agent Discord bots. The existing `DiscordAdapter` was REST-only with no broker integration, so messages could go out but never come back. This is the simplest delivery that works today; a Gateway/WebSocket variant remains a future v0.2.

## Behavior notes
- **No history replay:** primes `last_message_id` from the most recent message on first sight. Empty channels get a `"0"` sentinel that's transparently dropped on the next real poll.
- **No self-reply loop:** filters by `is_bot` flag and by `author_id == bot_user_id`.
- **Chronological delivery:** Discord returns newest-first; the poller reverses so the broker sees messages in the order they happened.
- **Rate-limit aware:** 429 in the adapter retries `min(retry_after, 5s)` once (configurable). Repeated 429s bubble up so the outer loop can sleep `retry_after` (capped at 30s) before resuming.
- **Discovery failure tolerant:** transient `discover_text_channels` errors keep the existing watch set instead of blanking it.

## Test plan
- [x] 11 new unit tests (35 total in `tests/test_discord*.py`): UA header, 429 retry/exhaustion, guild listing, channel-type filtering (drops voice/category, keeps text/announcement), broker routing, bot-self skip (both `is_bot` and `author_id` paths), chronological ordering, empty-channel sentinel handling, discovery-failure tolerance, rate-limit propagation, poll-interval floor (0.25s minimum).
- [x] `pytest -q tests/test_discord.py tests/test_discord_poller.py` → 35 passed.
- [x] `pytest -q` full suite → 1717 passed, 1 skipped (no regressions; the only error is an unrelated port-conflict warning from `test_shared_mcp` because the prod daemon owns :8890 on this host).
- [x] `ruff check` clean on all changed files.
- [x] **Live smoke**: real Discord API + new adapter + new poller against bot Barsik#2361 (id 1501305263351660674). Boots, identifies, discovers 0 channels (bot not yet invited to any guild), runs 2 poll sweeps cleanly, graceful stop.
- [ ] Post-deploy verification: invite bot to a Brad-owned server, send a DM/channel message, confirm it lands in the agent's session.

## Notes
- `DiscordRateLimited` kept as an alias for `DiscordRateLimitError` to avoid breaking imports outside this PR.
- `poll_interval_sec` and `watched_channels` are both readable from token settings, so the poller behavior can be tuned per agent without code changes.

🤖 Opened by Barsik