### PR TITLE
fix(broker): stop typing indicator after outreach send

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -907,6 +907,10 @@ def create_api(
                 silent=silent,
             ),
         )
+        # Once an outbound message lands, the typing indicator becomes noise —
+        # Telegram has no "stop typing" API, but cancelling our 4s sendChatAction
+        # loop prevents the indicator from popping back up after the message arrives.
+        broker._stop_typing(agent_name, chat_id)
         return {
             "sent": True,
             "agent": agent_name,
@@ -1105,11 +1109,14 @@ def create_api(
 
         try:
             loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(None, _generate_and_send)
+            result = await loop.run_in_executor(None, _generate_and_send)
         except HTTPException:
             raise
         except Exception as e:
             raise HTTPException(500, f"Voice note failed: {e}")
+        # Stop the typing loop now that the voice message has landed.
+        broker._stop_typing(agent_name, chat_id)
+        return result
 
     activity = ActivityStore(db_path=db_path.replace(".db", "_activity.db"))
 
@@ -4747,6 +4754,7 @@ def create_api(
         loop = asyncio.get_running_loop()
         msg = await loop.run_in_executor(None, lambda: _send_file_message(agent_name, platform, chat_id, file_path, caption=caption, reply_to=reply_to, kind="photo"))
         result = {"sent": True, "message_id": msg.message_id, "platform": platform, "chat_id": chat_id}
+        broker._stop_typing(agent_name, chat_id)
         _record_outbound_message(
             agent_name,
             platform=platform,
@@ -4778,6 +4786,7 @@ def create_api(
         loop = asyncio.get_running_loop()
         msg = await loop.run_in_executor(None, lambda: _send_file_message(agent_name, platform, chat_id, file_path, caption=caption, reply_to=reply_to, kind="document"))
         result = {"sent": True, "message_id": msg.message_id, "platform": platform, "chat_id": chat_id}
+        broker._stop_typing(agent_name, chat_id)
         _record_outbound_message(
             agent_name,
             platform=platform,
@@ -4876,6 +4885,7 @@ def create_api(
         try:
             msg = await loop.run_in_executor(None, _download_and_send)
             result = {"sent": True, "message_id": msg.message_id, "query": query, "platform": platform, "chat_id": chat_id}
+            broker._stop_typing(agent_name_req, chat_id)
             _record_outbound_message(
                 agent_name_req,
                 platform=platform,
@@ -4907,6 +4917,7 @@ def create_api(
         loop = asyncio.get_running_loop()
         msg = await loop.run_in_executor(None, lambda: _send_file_message(agent_name, platform, chat_id, file_path, caption=caption, reply_to=reply_to, kind="animation"))
         result = {"sent": True, "message_id": msg.message_id, "platform": platform, "chat_id": chat_id}
+        broker._stop_typing(agent_name, chat_id)
         _record_outbound_message(
             agent_name,
             platform=platform,

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -237,12 +237,15 @@ class MessageBroker:
         _log(f"broker: typing indicator started for {agent_name}/{chat_id}")
 
     def _stop_typing(self, agent_name: str, chat_id: str) -> None:
-        """Stop the native typing indicator loop."""
+        """Stop the native typing indicator loop.
+
+        Safe to call defensively — no-op (and silent) when no task is active.
+        """
         key = (agent_name, chat_id)
         task = self._typing_tasks.pop(key, None)
         if task and not task.done():
             task.cancel()
-        _log(f"broker: typing indicator stopped for {agent_name}/{chat_id}")
+            _log(f"broker: typing indicator stopped for {agent_name}/{chat_id}")
 
     def _stop_all_typing(self, agent_name: str) -> None:
         """Stop ALL typing indicator loops for an agent (used on disconnect/stop)."""

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -126,6 +126,76 @@ class TestMessageBrokerRouting:
         finally:
             tmpdir.cleanup()
 
+    @pytest.mark.asyncio
+    async def test_stop_typing_cancels_active_task(self):
+        """_stop_typing must cancel a running typing-loop task."""
+        import asyncio
+
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            async def _fake_loop():
+                await asyncio.sleep(60)
+
+            task = asyncio.create_task(_fake_loop())
+            # Yield once so the task actually starts before we cancel it.
+            await asyncio.sleep(0)
+            broker._typing_tasks[("barsik", "6770805286")] = task
+
+            broker._stop_typing("barsik", "6770805286")
+            # Yield until cancellation has propagated to the task.
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+            assert ("barsik", "6770805286") not in broker._typing_tasks
+            assert task.cancelled()
+        finally:
+            tmpdir.cleanup()
+
+    def test_stop_typing_is_silent_noop_when_no_task(self):
+        """Defensive _stop_typing calls (e.g. after every outreach send) must be no-op."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            # No task registered for this chat — should not raise, should not log.
+            broker._stop_typing("barsik", "never-typed-here")
+            assert ("barsik", "never-typed-here") not in broker._typing_tasks
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_scoped_per_chat(self):
+        """Stopping typing for one chat must not affect other chats for the same agent."""
+        import asyncio
+
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            async def _fake_loop():
+                await asyncio.sleep(60)
+
+            task_a = asyncio.create_task(_fake_loop())
+            task_b = asyncio.create_task(_fake_loop())
+            broker._typing_tasks[("barsik", "chat-A")] = task_a
+            broker._typing_tasks[("barsik", "chat-B")] = task_b
+
+            broker._stop_typing("barsik", "chat-A")
+            # Yield once so cancellation propagates.
+            await asyncio.sleep(0)
+
+            assert ("barsik", "chat-A") not in broker._typing_tasks
+            assert ("barsik", "chat-B") in broker._typing_tasks
+            assert task_a.cancelled() or task_a.done()
+            assert not task_b.done()
+
+            # Cleanup
+            task_b.cancel()
+            try:
+                await task_b
+            except asyncio.CancelledError:
+                pass
+        finally:
+            tmpdir.cleanup()
+
     def test_remember_message_context_tracks_voice_and_reply_metadata(self):
         tmpdir, _, broker, _, _ = self._make_broker()
         try:


### PR DESCRIPTION
Cherry-pick of beta c38238f onto main. (Beta has unrelated unpromoted commits — separating this fix to keep the change minimal.)

## Summary
- Cancel the broker's 4s `sendChatAction` loop the moment an outbound message lands (text, voice, photo, document, animation, gif).
- Reactions intentionally skipped — the agent may still be drafting a real reply.
- Silence the no-op log line in `_stop_typing` so defensive calls don't spam logs.

## Why
Telegram clears the typing indicator when a bot message arrives, but our loop kept firing every 4s until `route_response` ran (turn complete). The next loop tick would re-fire `sendChatAction` mid-await, popping the indicator back up *after* the message landed and lingering for the indicator's ~5s TTL. Brad observed this on the Pi — same code path runs on Mac Mini.

## Test plan
- [x] 3 new regression tests in `test_broker.py` (cancel active task, no-op silent, scoped per chat) — pass on this branch
- [x] Ruff clean on changed files
- [ ] Live-verify in Telegram once merged + Pi pulls latest: send → reply arrives → typing should NOT pop back up

🤖 Opened by Barsik