### PR TITLE
Release: today's two fixes (admin force + discord prime/DM)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6420,7 +6420,7 @@ def create_api(
     # ── Admin: Update & Restart ───────────────────────────
 
     @app.post("/admin/update")
-    async def admin_update(branch: str = "", dry_run: bool = False):
+    async def admin_update(branch: str = "", dry_run: bool = False, force: bool = False):
         """Pull latest code, rebuild if needed, and restart the daemon.
 
         The process manager (launchctl/systemd) must be installed for
@@ -6430,6 +6430,11 @@ def create_api(
         Beta channel: pulls HEAD of the beta branch.
         Branch defaults to PINKYBOT_CHANNEL env var ("stable" -> release tags,
         "beta" -> beta branch), falling back to "stable" if unset.
+
+        force=True discards local modifications to TRACKED files
+        (`git checkout -- .`) before pulling, to recover from a dirty working
+        tree (e.g. stale build artifacts blocking the update). Untracked files
+        are preserved — no `git clean`. Ignored when dry_run=True.
         """
         import shutil
         import subprocess as sp
@@ -6536,6 +6541,29 @@ def create_api(
         except Exception as e:
             _log(f"admin: branch checkout warning: {e}")
 
+        # Force mode: discard local mods to TRACKED files before pulling.
+        # Untracked files (e.g. .env, local notes) are NOT touched.
+        forced_reset = False
+        forced_files: list[str] = []
+        if force:
+            try:
+                dirty = sp.check_output(
+                    ["git", "diff", "--name-only", "HEAD"],
+                    cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
+                ).decode().strip()
+                if dirty:
+                    forced_files = [f for f in dirty.splitlines() if f.strip()]
+                    sp.check_output(
+                        ["git", "checkout", "--", "."],
+                        cwd=repo_dir, stderr=sp.STDOUT, timeout=30,
+                    )
+                    forced_reset = True
+                    _log(f"admin: force=True reset {len(forced_files)} tracked file(s): {forced_files[:10]}")
+            except sp.CalledProcessError as e:
+                return {"error": f"force reset failed: {e.output.decode()[:500]}"}
+            except Exception as e:
+                _log(f"admin: force reset warning: {e}")
+
         try:
             sp.check_output(
                 ["git", "pull", "origin", branch],
@@ -6610,6 +6638,8 @@ def create_api(
             "deps_rebuilt": deps_rebuilt,
             "frontend_rebuilt": frontend_rebuilt,
             "frontend_error": frontend_error or None,
+            "forced_reset": forced_reset,
+            "forced_files": forced_files,
             "restarting": before_hash != after_hash or deps_rebuilt,
         }
 

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -9,11 +9,18 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from pinky_daemon.message_handler import InboundMessage, MessageHandler
 from pinky_outreach.discord import DiscordAdapter, DiscordError, DiscordRateLimited
 from pinky_outreach.telegram import TelegramAdapter, TelegramError
+
+# Threshold below which a "most recent message" found during channel-priming
+# is treated as a real first-test inbound rather than as a replay-prevention
+# floor. Discord first-contact UX: if a user sends a test message within this
+# window before discovery sweeps, we still want to deliver it.
+_PRIME_FRESH_WINDOW_SECONDS = 30.0
 
 if TYPE_CHECKING:
     from pinky_outreach.types import Chat
@@ -542,6 +549,13 @@ class BrokerDiscordPoller:
 
         # Prime last_id for newly-discovered channels: fetch the most recent
         # message and treat its id as the baseline so we don't replay history.
+        # Exception: if that message is a fresh (< _PRIME_FRESH_WINDOW_SECONDS)
+        # non-bot message, treat it as a real first-test inbound — back the
+        # floor up by 1 snowflake so the next poll picks it up and delivers it.
+        # This avoids the "user sends test, discovery silently swallows it"
+        # first-contact UX trap. (Discord IDs are monotonic snowflakes;
+        # `?after=<id-1>` resolves to "messages with id > id-1", i.e. this
+        # message itself.)
         for ch in added:
             try:
                 recent = await loop.run_in_executor(
@@ -551,12 +565,47 @@ class BrokerDiscordPoller:
             except DiscordError:
                 # Channel might be unreadable; skip it for now, retry next discovery
                 continue
-            if recent:
-                # get_messages returns newest-first
-                self._last_id[ch] = recent[0].message_id
-            else:
+            if not recent:
                 # Empty channel — start from "0", which sorts before any real snowflake
                 self._last_id[ch] = "0"
+                _log(
+                    f"discord-poller[{self._agent_name}]: primed channel {ch} "
+                    f"(empty — first message will be delivered)"
+                )
+                continue
+
+            # get_messages returns newest-first
+            msg = recent[0]
+            now = datetime.now(timezone.utc)
+            try:
+                age_sec = (now - msg.timestamp).total_seconds()
+            except (TypeError, ValueError):
+                age_sec = float("inf")
+            is_bot = bool((msg.metadata or {}).get("is_bot", False))
+
+            if age_sec < _PRIME_FRESH_WINDOW_SECONDS and not is_bot:
+                # Fresh first-contact message — back the floor up by 1 so
+                # the next poll fetches and delivers it.
+                try:
+                    backed_off = str(int(msg.message_id) - 1)
+                except (TypeError, ValueError):
+                    # Non-numeric id (shouldn't happen on Discord) — fall back
+                    # to using the message itself as the floor.
+                    backed_off = msg.message_id
+                self._last_id[ch] = backed_off
+                _log(
+                    f"discord-poller[{self._agent_name}]: primed channel {ch} "
+                    f"with floor {backed_off} (fresh msg {msg.message_id} from "
+                    f"{msg.sender}, age {age_sec:.0f}s — will deliver on next poll)"
+                )
+            else:
+                self._last_id[ch] = msg.message_id
+                _log(
+                    f"discord-poller[{self._agent_name}]: primed channel {ch} "
+                    f"with floor {msg.message_id} (most-recent msg age "
+                    f"{age_sec:.0f}s, is_bot={is_bot} — first message AFTER "
+                    f"this will be delivered)"
+                )
 
         for ch in removed:
             self._last_id.pop(ch, None)

--- a/src/pinky_outreach/discord.py
+++ b/src/pinky_outreach/discord.py
@@ -71,6 +71,9 @@ class DiscordAdapter:
             timeout=timeout,
         )
         self._bot_user: dict | None = None
+        # Cache user_id → DM channel_id resolutions so we only call
+        # POST /users/@me/channels once per recipient.
+        self._dm_channel_cache: dict[str, str] = {}
 
     def close(self) -> None:
         self._client.close()
@@ -130,6 +133,24 @@ class DiscordAdapter:
 
     # ── Sending ──────────────────────────────────────────────
 
+    def open_dm_channel(self, user_id: str) -> str:
+        """Open (or look up cached) a DM channel with a user. Returns channel_id.
+
+        Discord requires explicitly opening a DM via POST /users/@me/channels
+        with `{recipient_id: user_id}`. The result is a channel_id that can
+        then be used with send_message / etc. The mapping is stable per bot,
+        so we cache it.
+        """
+        cached = self._dm_channel_cache.get(user_id)
+        if cached:
+            return cached
+        result = self._request(
+            "POST", "/users/@me/channels", json={"recipient_id": user_id},
+        )
+        channel_id = result["id"]
+        self._dm_channel_cache[user_id] = channel_id
+        return channel_id
+
     def send_message(
         self,
         channel_id: str,
@@ -137,12 +158,33 @@ class DiscordAdapter:
         *,
         reply_to: str = "",
     ) -> Message:
-        """Send a message to a Discord channel."""
+        """Send a message to a Discord channel.
+
+        If `channel_id` looks like a user_id (Discord returns 404 Unknown
+        Channel), transparently opens a DM channel with that user and
+        retries — this lets callers pass user_ids for owner-notify flows
+        where they only know the recipient's user_id.
+        """
         payload: dict = {"content": content}
         if reply_to:
             payload["message_reference"] = {"message_id": reply_to}
 
-        result = self._request("POST", f"/channels/{channel_id}/messages", json=payload)
+        try:
+            result = self._request(
+                "POST", f"/channels/{channel_id}/messages", json=payload,
+            )
+        except DiscordError as e:
+            if e.status_code == 404 and "Unknown Channel" in str(e):
+                # Treat channel_id as a user_id and try DMing them.
+                # Bounded — open_dm_channel will surface its own error
+                # if user_id is also invalid; we don't loop again.
+                dm_channel_id = self.open_dm_channel(channel_id)
+                result = self._request(
+                    "POST", f"/channels/{dm_channel_id}/messages", json=payload,
+                )
+                channel_id = dm_channel_id
+            else:
+                raise
 
         return Message(
             platform=Platform.discord,

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -1933,11 +1933,21 @@ def create_server(
             return "\n".join(parts)
 
         @mcp.tool()
-        def update_and_restart(branch: str = "") -> str:
-            """Pull latest code, rebuild if needed, and restart the daemon."""
+        def update_and_restart(branch: str = "", force: bool = False) -> str:
+            """Pull latest code, rebuild if needed, and restart the daemon.
+
+            force=True discards local mods to TRACKED files before pulling.
+            Use to recover from a dirty working tree (e.g. stale build artifacts).
+            Untracked files are preserved.
+            """
             url = "/admin/update"
+            params = []
             if branch:
-                url += f"?branch={branch}"
+                params.append(f"branch={branch}")
+            if force:
+                params.append("force=true")
+            if params:
+                url += "?" + "&".join(params)
             result = _api("POST", url)
             if "error" in result:
                 return f"Update failed: {result['error']}"
@@ -1950,6 +1960,14 @@ def create_server(
                 parts = [f"Updated to release {release} ({result.get('before_hash', '?')} -> {result.get('after_hash', '?')})"]
             else:
                 parts = [f"Update applied: {result.get('before_hash', '?')} -> {result.get('after_hash', '?')}"]
+
+            if result.get("forced_reset"):
+                forced_files = result.get("forced_files", [])
+                parts.append(f"\nForce reset: discarded local mods to {len(forced_files)} tracked file(s).")
+                for f in forced_files[:5]:
+                    parts.append(f"  - {f}")
+                if len(forced_files) > 5:
+                    parts.append(f"  ... and {len(forced_files) - 5} more")
 
             commits = result.get("commits", [])
             if commits:

--- a/tests/test_admin_update.py
+++ b/tests/test_admin_update.py
@@ -1,0 +1,241 @@
+"""Tests for POST /admin/update — covers force flag behavior."""
+
+from __future__ import annotations
+
+import os
+import subprocess as sp
+import tempfile
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+def _make_client():
+    from pinky_daemon.api import create_api
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    app = create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
+    return TestClient(app)
+
+
+class _GitMock:
+    """Programmable subprocess.check_output side_effect for git commands.
+
+    Records every call so tests can assert on order/presence.
+    """
+
+    def __init__(
+        self,
+        *,
+        dirty_files: list[str] | None = None,
+        before_hash: str = "abc1234",
+        after_hash: str = "def5678",
+        branch: str = "beta",
+    ):
+        self.calls: list[list[str]] = []
+        self.dirty_files = dirty_files or []
+        self.before_hash = before_hash
+        self.after_hash = after_hash
+        self.branch = branch
+        self._hash_call = 0
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+
+        # git rev-parse --short HEAD — first call returns before, second returns after
+        if cmd[:3] == ["git", "rev-parse", "--short"]:
+            self._hash_call += 1
+            val = self.before_hash if self._hash_call == 1 else self.after_hash
+            return (val + "\n").encode()
+
+        # git describe --tags --exact-match HEAD — pretend untagged
+        if cmd[:2] == ["git", "describe"]:
+            raise sp.CalledProcessError(128, cmd, output=b"")
+
+        # git fetch origin --tags <branch>
+        if cmd[:3] == ["git", "fetch", "origin"]:
+            return b""
+
+        # git tag --sort=... -l ... (only for main / use_release_tags)
+        if cmd[:2] == ["git", "tag"]:
+            return b""
+
+        # git rev-parse --is-shallow-repository
+        if cmd[:3] == ["git", "rev-parse", "--is-shallow-repository"]:
+            return b"false\n"
+
+        # git rev-parse --abbrev-ref HEAD
+        if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return (self.branch + "\n").encode()
+
+        # git diff --name-only HEAD  (used by force-mode dirty check)
+        if cmd[:4] == ["git", "diff", "--name-only", "HEAD"]:
+            joined = "\n".join(self.dirty_files)
+            if joined:
+                joined += "\n"
+            return joined.encode()
+
+        # git checkout -- .  (force reset of tracked files)
+        if cmd[:3] == ["git", "checkout", "--"]:
+            return b""
+
+        # git checkout <branch>  (used when on detached HEAD / wrong branch)
+        if cmd[:2] == ["git", "checkout"]:
+            return b""
+
+        # git pull origin <branch>
+        if cmd[:3] == ["git", "pull", "origin"]:
+            return b""
+
+        # git log --oneline ...  (commit summary or dry-run pending list)
+        if cmd[:3] == ["git", "log", "--oneline"]:
+            return b"abc1234 feat: example\n"
+
+        # git diff --name-only <before> <after> -- pyproject.toml
+        if cmd[:3] == ["git", "diff", "--name-only"]:
+            return b""
+
+        return b""
+
+    def did_force_reset(self) -> bool:
+        return any(c[:4] == ["git", "checkout", "--", "."] for c in self.calls)
+
+    def did_pull(self) -> bool:
+        return any(c[:3] == ["git", "pull", "origin"] for c in self.calls)
+
+    def did_clean(self) -> bool:
+        return any(c[:2] == ["git", "clean"] for c in self.calls)
+
+
+class TestAdminUpdateForce:
+    """Verify the force=True flag from task #77."""
+
+    def test_force_false_is_default(self):
+        """No force param → no `git checkout -- .` is invoked."""
+        gm = _GitMock(dirty_files=["frontend-dist/index.html"])
+        with (
+            patch("subprocess.check_output", side_effect=gm),
+            patch("shutil.which", return_value=None),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=beta")
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("updated") is True
+        assert body.get("forced_reset") is False
+        assert body.get("forced_files") == []
+        assert not gm.did_force_reset()
+        assert gm.did_pull()
+
+    def test_force_true_resets_dirty_tracked_files(self):
+        """force=True with a dirty tree → checkout -- . runs before pull."""
+        dirty = ["frontend-dist/index.html", "frontend-dist/assets/app.js"]
+        gm = _GitMock(dirty_files=dirty)
+        with (
+            patch("subprocess.check_output", side_effect=gm),
+            patch("shutil.which", return_value=None),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=beta&force=true")
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("forced_reset") is True
+        assert body.get("forced_files") == dirty
+        assert gm.did_force_reset()
+
+        # Critical ordering: reset must happen BEFORE the pull
+        checkout_idx = next(
+            i for i, c in enumerate(gm.calls) if c[:4] == ["git", "checkout", "--", "."]
+        )
+        pull_idx = next(
+            i for i, c in enumerate(gm.calls) if c[:3] == ["git", "pull", "origin"]
+        )
+        assert checkout_idx < pull_idx, "force reset must precede git pull"
+
+    def test_force_true_clean_tree_no_reset(self):
+        """force=True but tree is clean → no checkout invoked, forced_reset=False."""
+        gm = _GitMock(dirty_files=[])
+        with (
+            patch("subprocess.check_output", side_effect=gm),
+            patch("shutil.which", return_value=None),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=beta&force=true")
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("forced_reset") is False
+        assert body.get("forced_files") == []
+        assert not gm.did_force_reset()
+        assert gm.did_pull()
+
+    def test_force_never_runs_git_clean(self):
+        """Untracked files must be preserved — never invoke `git clean`."""
+        gm = _GitMock(dirty_files=["some/file.py"])
+        with (
+            patch("subprocess.check_output", side_effect=gm),
+            patch("shutil.which", return_value=None),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            client.post("/admin/update?branch=beta&force=true")
+        assert not gm.did_clean(), "force must not delete untracked files"
+
+    def test_force_ignored_in_dry_run(self):
+        """dry_run=True returns before the destructive force block runs."""
+        gm = _GitMock(dirty_files=["frontend-dist/index.html"])
+        with (
+            patch("subprocess.check_output", side_effect=gm),
+            patch("shutil.which", return_value=None),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=beta&force=true&dry_run=true")
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("dry_run") is True
+        # No destructive ops in dry_run, regardless of force
+        assert not gm.did_force_reset()
+        assert not gm.did_pull()
+
+
+class TestAdminUpdateBaseline:
+    """Sanity coverage for the existing endpoint paths."""
+
+    def test_dry_run_reports_pending_commits(self):
+        gm = _GitMock(dirty_files=[])
+        with (
+            patch("subprocess.check_output", side_effect=gm),
+            patch("shutil.which", return_value=None),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=beta&dry_run=true")
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("dry_run") is True
+        assert body.get("branch") == "beta"
+        # _GitMock returns one canned "feat: example" commit for git log
+        assert body.get("pending_commits") == 1
+        assert body.get("up_to_date") is False
+
+    def test_pull_failure_returns_error(self):
+        """If git pull errors, endpoint returns {'error': ...}."""
+
+        def fail_on_pull(cmd, **kwargs):
+            if cmd[:3] == ["git", "pull", "origin"]:
+                raise sp.CalledProcessError(1, cmd, output=b"merge conflict in foo")
+            # Delegate everything else to a clean mock
+            return _GitMock(dirty_files=[])(cmd, **kwargs)
+
+        with (
+            patch("subprocess.check_output", side_effect=fail_on_pull),
+            patch("shutil.which", return_value=None),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=beta")
+        assert r.status_code == 200
+        body = r.json()
+        assert "error" in body
+        assert "git pull failed" in body["error"]

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -84,6 +84,114 @@ class TestDiscordAdapter:
         assert exc.value.status_code == 403
         adapter.close()
 
+    def test_open_dm_channel_caches(self):
+        """open_dm_channel calls /users/@me/channels once per recipient and caches."""
+        adapter = self._make_adapter()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"id": "dm-channel-abc", "type": 1}
+        adapter._client.request = MagicMock(return_value=resp)
+
+        ch1 = adapter.open_dm_channel("user-754")
+        ch2 = adapter.open_dm_channel("user-754")
+
+        assert ch1 == "dm-channel-abc"
+        assert ch2 == "dm-channel-abc"
+        # Only one HTTP call thanks to the cache
+        assert adapter._client.request.call_count == 1
+        # Verify it hit the right endpoint with the right body
+        call = adapter._client.request.call_args
+        assert call.args[0] == "POST"
+        assert call.args[1] == "/users/@me/channels"
+        assert call.kwargs["json"] == {"recipient_id": "user-754"}
+        adapter.close()
+
+    def test_send_message_falls_back_to_dm_on_404_unknown_channel(self):
+        """If channel_id is actually a user_id, send_message opens a DM and retries."""
+        adapter = self._make_adapter()
+
+        send_404 = MagicMock()
+        send_404.status_code = 404
+        send_404.json.return_value = {"message": "Unknown Channel", "code": 10003}
+
+        open_dm_ok = MagicMock()
+        open_dm_ok.status_code = 200
+        open_dm_ok.json.return_value = {"id": "dm-channel-xyz", "type": 1}
+
+        send_ok = MagicMock()
+        send_ok.status_code = 200
+        send_ok.json.return_value = {
+            "id": "msg-9999",
+            "channel_id": "dm-channel-xyz",
+            "content": "hi owner",
+            "timestamp": "2026-05-05T19:00:00+00:00",
+        }
+
+        adapter._client.request = MagicMock(side_effect=[send_404, open_dm_ok, send_ok])
+
+        msg = adapter.send_message("754027672526389310", "hi owner")
+        assert msg.message_id == "msg-9999"
+        # chat_id should reflect the resolved DM channel, not the user_id
+        assert msg.chat_id == "dm-channel-xyz"
+
+        # Three calls: failed POST → open DM → retry POST
+        assert adapter._client.request.call_count == 3
+        calls = adapter._client.request.call_args_list
+        assert calls[0].args == ("POST", "/channels/754027672526389310/messages")
+        assert calls[1].args == ("POST", "/users/@me/channels")
+        assert calls[1].kwargs["json"] == {"recipient_id": "754027672526389310"}
+        assert calls[2].args == ("POST", "/channels/dm-channel-xyz/messages")
+
+        # Cache populated for next time
+        assert adapter._dm_channel_cache["754027672526389310"] == "dm-channel-xyz"
+        adapter.close()
+
+    def test_send_message_404_other_message_does_not_fallback(self):
+        """404 with a different message (e.g. Unknown Message) should NOT trigger DM open."""
+        adapter = self._make_adapter()
+
+        resp = MagicMock()
+        resp.status_code = 404
+        resp.json.return_value = {"message": "Unknown Message", "code": 10008}
+        adapter._client.request = MagicMock(return_value=resp)
+
+        with pytest.raises(DiscordError) as exc:
+            adapter.send_message("99999", "hi", reply_to="missing-msg-id")
+        assert exc.value.status_code == 404
+        assert "Unknown Message" in str(exc.value)
+        # No DM resolution attempted
+        assert adapter._client.request.call_count == 1
+        adapter.close()
+
+    def test_send_message_dm_fallback_uses_cached_channel(self):
+        """Second send to the same user_id reuses the cached DM channel — no /users/@me/channels call."""
+        adapter = self._make_adapter()
+        # Pre-populate the cache as if a previous send had resolved the DM
+        adapter._dm_channel_cache["user-754"] = "dm-channel-abc"
+
+        send_404 = MagicMock()
+        send_404.status_code = 404
+        send_404.json.return_value = {"message": "Unknown Channel", "code": 10003}
+
+        send_ok = MagicMock()
+        send_ok.status_code = 200
+        send_ok.json.return_value = {
+            "id": "msg-2",
+            "channel_id": "dm-channel-abc",
+            "content": "second msg",
+            "timestamp": "2026-05-05T19:01:00+00:00",
+        }
+
+        adapter._client.request = MagicMock(side_effect=[send_404, send_ok])
+
+        msg = adapter.send_message("user-754", "second msg")
+        assert msg.message_id == "msg-2"
+        # Only the failed initial POST + the retry — no /users/@me/channels lookup
+        assert adapter._client.request.call_count == 2
+        calls = adapter._client.request.call_args_list
+        assert "/users/@me/channels" not in (calls[0].args[1], calls[1].args[1])
+        adapter.close()
+
     def test_send_file_success_uses_httpx_multipart_header(self, tmp_path):
         """Regression: passing Content-Type=None makes httpx raise before sending."""
         adapter = self._make_adapter()

--- a/tests/test_discord_poller.py
+++ b/tests/test_discord_poller.py
@@ -176,6 +176,105 @@ class TestBrokerDiscordPoller:
         assert poller._last_id["chan-A"] == "0"
 
     @pytest.mark.asyncio
+    async def test_priming_delivers_fresh_first_test_message(
+        self, mock_adapter, mock_broker,
+    ):
+        """Fresh (<30s) non-bot message at prime time → backed-off floor so it gets delivered.
+
+        Scenario: bot joins server, user sends test message, then discovery
+        sweep runs ~seconds later. Without this fix, the test message becomes
+        the floor and is silently dropped.
+        """
+        from datetime import datetime, timezone
+        fresh_msg = Message(
+            platform=Platform.discord,
+            chat_id="chan-A",
+            sender="brad",
+            content="hi bot",
+            # Brand new — well within the 30s freshness window
+            timestamp=datetime.now(timezone.utc),
+            message_id="200",
+            metadata={"author_id": "user-1", "is_bot": False},
+        )
+        mock_adapter.get_messages.side_effect = [
+            [fresh_msg],  # priming
+            [fresh_msg],  # poll picks it up because floor was backed off to "199"
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(verbose=True)
+
+        # Floor must be id-1 so the next poll fetches this message
+        assert poller._last_id["chan-A"] == "199"
+
+        await poller._poll_once()
+        await asyncio.sleep(0)
+
+        # The fresh test message should have been delivered through the broker
+        assert mock_broker.handle_inbound.await_count == 1
+        delivered = mock_broker.handle_inbound.await_args.args[0]
+        assert delivered.message_id == "200"
+        assert delivered.content == "hi bot"
+
+    @pytest.mark.asyncio
+    async def test_priming_old_message_uses_message_as_floor(
+        self, mock_adapter, mock_broker,
+    ):
+        """Stale (>30s) most-recent message → use it as floor, NOT delivered."""
+        from datetime import datetime, timezone
+        old_msg = Message(
+            platform=Platform.discord,
+            chat_id="chan-A",
+            sender="brad",
+            content="ancient",
+            timestamp=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            message_id="100",
+            metadata={"author_id": "user-1", "is_bot": False},
+        )
+        mock_adapter.get_messages.side_effect = [
+            [old_msg],  # priming
+            [],         # poll finds nothing new
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(verbose=True)
+        await poller._poll_once()
+        await asyncio.sleep(0)
+
+        # Floor is the message id itself — replay-prevention behavior preserved
+        assert poller._last_id["chan-A"] == "100"
+        mock_broker.handle_inbound.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_priming_fresh_bot_message_does_not_back_off(
+        self, mock_adapter, mock_broker,
+    ):
+        """Fresh-but-bot message → use as floor (don't loop on bot self-reply)."""
+        from datetime import datetime, timezone
+        fresh_bot = Message(
+            platform=Platform.discord,
+            chat_id="chan-A",
+            sender="OtherBot",
+            content="bot chatter",
+            timestamp=datetime.now(timezone.utc),
+            message_id="300",
+            metadata={"author_id": "bot-other", "is_bot": True},
+        )
+        mock_adapter.get_messages.side_effect = [
+            [fresh_bot],  # priming
+            [],           # poll
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(verbose=True)
+        await poller._poll_once()
+        await asyncio.sleep(0)
+
+        # Bot message is the floor as-is — not backed off, not delivered
+        assert poller._last_id["chan-A"] == "300"
+        mock_broker.handle_inbound.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_poll_drops_after_filter_for_zero_sentinel(self, mock_adapter, mock_broker):
         """When last_id='0' (empty channel), the poll must NOT pass after=0 to the adapter."""
         # Priming: empty

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -1473,6 +1473,46 @@ class TestUpdateAndRestart:
             result = _tools(srv)["update_and_restart"]()
         assert "failed" in result.lower()
 
+    def test_force_reset_in_output(self, srv):
+        """force=True → response shows discarded files in human output."""
+        resp = {
+            "updated": True,
+            "before_hash": "abc123",
+            "after_hash": "def456",
+            "commits": [],
+            "deps_rebuilt": False,
+            "frontend_rebuilt": False,
+            "forced_reset": True,
+            "forced_files": ["frontend-dist/index.html", "frontend-dist/assets/app.js"],
+            "restarting": True,
+        }
+        with _ok(resp):
+            result = _tools(srv)["update_and_restart"](force=True)
+        assert "Force reset" in result
+        assert "2 tracked file" in result
+        assert "frontend-dist/index.html" in result
+
+    def test_force_url_includes_param(self, srv):
+        """force=True → request URL includes force=true query param."""
+        captured: dict = {}
+
+        def _urlopen(req, timeout=30):
+            captured["url"] = req.full_url if hasattr(req, "full_url") else str(req)
+            body = json.dumps({"updated": True, "before_hash": "a", "after_hash": "b",
+                               "commits": [], "deps_rebuilt": False, "frontend_rebuilt": False,
+                               "restarting": False}).encode()
+            resp = MagicMock()
+            resp.read.return_value = body
+            resp.__enter__ = MagicMock(return_value=resp)
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=_urlopen):
+            _tools(srv)["update_and_restart"](branch="beta", force=True)
+
+        assert "force=true" in captured["url"]
+        assert "branch=beta" in captured["url"]
+
 
 # ── restart_daemon ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Cherry-picked from beta — only today's two clean fixes. Skips the older 5 beta carryover commits (#356-#361 era) that conflict with main's intervening api.py refactors and need separate review/rework.

**This PR (2 commits):**
- \`4305eaa\` — \`feat(admin)\`: \`/admin/update\` accepts \`force=true\` to bypass dirty tree (tracked files only, never \`git clean\`). Closes pinkybot task #77.
- \`de6ea9c\` — \`fix(discord)\`: prime-on-discover delivers fresh first-test message (snowflake back-off) + DM owner-notify resolves user_id → DM channel via /users/@me/channels. Closes pinkybot task #75.

**Skipped (still on beta, needs separate PR after rework):**
- #356 OpencodeSession spec (markdown only — could be cherry-picked clean)
- #357 Codex context estimation refactor
- #358 agent runtime column (conflicts heavily with extracted route modules)
- #360 Codex runtime provider resolution fix
- #361 registry regression test

## Test plan
- [x] Cherry-picks applied cleanly with no conflicts
- [x] Full pytest suite green on release branch (1729 pass, 1 skip, 0 fail)
- [x] ruff clean
- [x] Both commits already passed CI on beta (\`bb956be\`)
- [ ] CI on this PR passes before merge

## Background
Original PR #389 was closed because beta had 3 commits (#386, #388, #378) already on main as different commits, plus 5 older commits with hard conflicts against main's refactors — total 410-line conflict in api.py. This branch sidesteps both issues.

🤖 Opened by Barsik