### PR TITLE
release: agent runtime column + Codex context estimation (cherry-pick of #357/#358/#360/#361)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -185,6 +185,7 @@ class Agent:
     working_status: str = "idle"  # idle, working, offline
     working_status_updated_at: float = 0.0  # When working_status last changed
     last_seen_at: float = 0.0  # Server-side presence: updated on delivery/turn completion
+    runtime: str = "claude_sdk"  # Agent runtime: claude_sdk, codex_cli, opencode
     provider_url: str = ""   # e.g. "http://localhost:11434" for Ollama, empty = Anthropic default
     provider_key: str = ""   # API key override, empty = use ANTHROPIC_API_KEY env var
     provider_model: str = ""  # model name override (e.g. "llama3.2"), empty = use agent.model
@@ -243,6 +244,7 @@ class Agent:
             "working_status": self.working_status,
             "working_status_updated_at": self.working_status_updated_at,
             "last_seen_at": self.last_seen_at,
+            "runtime": self.runtime,
             "provider_url": self.provider_url,
             "provider_key": self.provider_key,
             "provider_model": self.provider_model,
@@ -475,6 +477,7 @@ class AgentRegistry:
                 heartbeat_interval INTEGER NOT NULL DEFAULT 0,
                 plain_text_fallback INTEGER NOT NULL DEFAULT 0,
                 role TEXT NOT NULL DEFAULT '',
+                runtime TEXT NOT NULL DEFAULT 'claude_sdk',
                 created_at REAL NOT NULL,
                 updated_at REAL NOT NULL
             );
@@ -729,11 +732,14 @@ class AgentRegistry:
             ("thinking_effort", "TEXT NOT NULL DEFAULT 'medium'"),
             ("watchdog_config", "TEXT NOT NULL DEFAULT '{}'"),
             ("last_seen_at", "REAL NOT NULL DEFAULT 0"),
+            ("runtime", "TEXT NOT NULL DEFAULT 'claude_sdk'"),
         ]
         for col, typedef in migrations:
             if col not in existing:
                 self._db.execute(f"ALTER TABLE agents ADD COLUMN {col} {typedef}")
                 _log(f"agent_registry: migrated — added column {col}")
+        self._db.commit()
+        self._backfill_runtime_from_provider_url()
 
         # Migrate agent_schedules table
         sched_existing = {
@@ -803,6 +809,25 @@ class AgentRegistry:
 
         # Seed default models
         self._seed_models()
+
+    def _backfill_runtime_from_provider_url(self) -> None:
+        """One-shot migration from legacy provider_url runtime selection."""
+        marker = "migration:agents_runtime_codex_cli_backfill"
+        if self.get_setting(marker) == "1":
+            return
+
+        cursor = self._db.execute(
+            "UPDATE agents SET runtime='codex_cli' "
+            "WHERE provider_url='codex_cli' AND runtime='claude_sdk'"
+        )
+        self._db.execute(
+            "INSERT INTO system_settings (key, value) VALUES (?, '1') "
+            "ON CONFLICT(key) DO UPDATE SET value='1'",
+            (marker,),
+        )
+        self._db.commit()
+        if cursor.rowcount:
+            _log(f"agent_registry: backfilled runtime=codex_cli for {cursor.rowcount} agent(s)")
 
     # ── Workspace Init ─────────────────────────────────────
 
@@ -932,7 +957,7 @@ except Exception:
                         "clock_aligned", "auto_sleep_hours", "plain_text_fallback", "voice_config", "role",
                         "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
                         "librarian_enabled", "librarian_schedule",
-                        "provider_url", "provider_key", "provider_model", "provider_ref",
+                        "runtime", "provider_url", "provider_key", "provider_model", "provider_ref",
                         "thinking_effort"):
                 if key in kwargs:
                     updates[key] = kwargs[key]
@@ -1014,6 +1039,12 @@ except Exception:
                 dream_notify=kwargs.get("dream_notify", True),
                 librarian_enabled=kwargs.get("librarian_enabled", False),
                 librarian_schedule=kwargs.get("librarian_schedule", "0 4 * * *"),
+                runtime=kwargs.get("runtime", "claude_sdk"),
+                provider_url=kwargs.get("provider_url", ""),
+                provider_key=kwargs.get("provider_key", ""),
+                provider_model=kwargs.get("provider_model", ""),
+                provider_ref=kwargs.get("provider_ref", ""),
+                thinking_effort=kwargs.get("thinking_effort", "medium"),
                 watchdog_config=kwargs.get("watchdog_config", {}),
                 created_at=now,
                 updated_at=now,
@@ -1027,9 +1058,11 @@ except Exception:
                     max_sessions, enabled, auto_start, heartbeat_interval, plain_text_fallback,
                     wake_interval, clock_aligned, auto_sleep_hours, voice_config, role,
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
-                    librarian_enabled, librarian_schedule, watchdog_config,
+                    librarian_enabled, librarian_schedule,
+                    runtime, provider_url, provider_key, provider_model, provider_ref,
+                    thinking_effort, watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -1042,7 +1075,9 @@ except Exception:
                  json.dumps(agent.voice_config), agent.role,
                  int(agent.dream_enabled), agent.dream_schedule, agent.dream_timezone, agent.dream_model, int(agent.dream_notify),
                  int(agent.librarian_enabled), agent.librarian_schedule,
-                 json.dumps(agent.watchdog_config),
+                 agent.runtime, agent.provider_url, agent.provider_key,
+                 agent.provider_model, agent.provider_ref,
+                 agent.thinking_effort, json.dumps(agent.watchdog_config),
                  agent.created_at, agent.updated_at),
             )
             self._db.commit()
@@ -1060,7 +1095,7 @@ except Exception:
         "dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify, "
         "librarian_enabled, librarian_schedule, "
         "working_status, working_status_updated_at, "
-        "provider_url, provider_key, provider_model, provider_ref, "
+        "runtime, provider_url, provider_key, provider_model, provider_ref, "
         "disallowed_tools, thinking_effort, watchdog_config, last_seen_at"
     )
 
@@ -2584,14 +2619,15 @@ except Exception:
             librarian_schedule=row[36] if len(row) > 36 and row[36] else "0 4 * * *",
             working_status=row[37] if len(row) > 37 and row[37] else "idle",
             working_status_updated_at=row[38] if len(row) > 38 else 0.0,
-            provider_url=row[39] if len(row) > 39 and row[39] else "",
-            provider_key=row[40] if len(row) > 40 and row[40] else "",
-            provider_model=row[41] if len(row) > 41 and row[41] else "",
-            provider_ref=row[42] if len(row) > 42 and row[42] else "",
-            disallowed_tools=json.loads(row[43]) if len(row) > 43 and row[43] else [],
-            thinking_effort=row[44] if len(row) > 44 and row[44] else "medium",
-            watchdog_config=json.loads(row[45]) if len(row) > 45 and row[45] else {},
-            last_seen_at=row[46] if len(row) > 46 else 0.0,
+            runtime=row[39] if len(row) > 39 and row[39] else "claude_sdk",
+            provider_url=row[40] if len(row) > 40 and row[40] else "",
+            provider_key=row[41] if len(row) > 41 and row[41] else "",
+            provider_model=row[42] if len(row) > 42 and row[42] else "",
+            provider_ref=row[43] if len(row) > 43 and row[43] else "",
+            disallowed_tools=json.loads(row[44]) if len(row) > 44 and row[44] else [],
+            thinking_effort=row[45] if len(row) > 45 and row[45] else "medium",
+            watchdog_config=json.loads(row[46]) if len(row) > 46 and row[46] else {},
+            last_seen_at=row[47] if len(row) > 47 else 0.0,
         )
 
     # ── Cost Tracking ──────────────────────────────────────

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1745,12 +1745,47 @@ def create_api(
             # Deduplicate
             effective_disallowed = sorted(set(effective_disallowed))
 
-        resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
+        def runtime_from_legacy_provider(agent_config) -> str:
+            """Deprecated temporary shim for the runtime rollout.
+
+            Runtime selection now belongs to agents.runtime. This fallback exists
+            only for legacy rows that have not passed the one-shot codex_cli
+            provider_url backfill yet, and should be removed after rollout.
+            """
+            runtime = (getattr(agent_config, "runtime", "") or "").strip()
+            if runtime:
+                return runtime
+            if (getattr(agent_config, "provider_url", "") or "").strip() == "codex_cli":
+                return "codex_cli"
+            return "claude_sdk"
+
+        runtime = runtime_from_legacy_provider(agent)
+        if runtime == "opencode":
+            if os.environ.get("PINKY_ENABLE_OPENCODE", "0") == "1":
+                msg = "opencode runtime is enabled but OpencodeSession is not implemented yet"
+                status = 501
+            else:
+                msg = "opencode runtime is disabled; set PINKY_ENABLE_OPENCODE=1 after implementation lands"
+                status = 503
+            _log(f"api: refusing to start {agent_name}: {msg}")
+            raise HTTPException(status, msg)
+        if runtime not in {"claude_sdk", "codex_cli"}:
+            msg = f"unknown runtime '{runtime}' for agent '{agent_name}'"
+            _log(f"api: {msg}")
+            raise HTTPException(400, msg)
+
+        is_codex = runtime == "codex_cli"
+        if is_codex:
+            resolved_provider_url = "codex_cli"
+            resolved_provider_key = agent.provider_key or ""
+            resolved_provider_model = agent.provider_model or ""
+        else:
+            resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
         effective_model = resolved_provider_model or agent.model
 
         # Build MCP server config for Codex agents (injected via -c flags)
         codex_mcp_servers = {}
-        if resolved_provider_url == "codex_cli" and SHARED_MCP_ENABLED:
+        if is_codex and SHARED_MCP_ENABLED:
             shared_base = f"http://{SHARED_MCP_HOST}:{SHARED_MCP_PORT}"
             agent_headers = {"X-Agent-Name": agent_name}
             for srv_name in ("self", "memory", "messaging"):
@@ -1786,8 +1821,7 @@ def create_api(
         callback = await _make_streaming_response_callback()
         sid_callback = await _make_streaming_session_id_callback(agent_name, label)
 
-        # Select session class based on provider type
-        is_codex = resolved_provider_url == "codex_cli"
+        # Select session class based on the persisted runtime.
         SessionClass = CodexSession if is_codex else StreamingSession  # noqa: N806
 
         init_kwargs = {
@@ -1812,7 +1846,7 @@ def create_api(
                 session_id=ss.id,
                 agent_name=agent_name,
                 session_label=label,
-                provider=resolved_provider_url or "default",
+                provider=runtime if is_codex else (resolved_provider_url or "default"),
                 model=effective_model or "",
             )
             analytics.log_activity(
@@ -3699,6 +3733,11 @@ def create_api(
             auto_start=req.auto_start,
             role=req.role,
             heartbeat_interval=req.heartbeat_interval,
+            runtime=req.runtime,
+            provider_url=req.provider_url,
+            provider_key=req.provider_key,
+            provider_model=req.provider_model,
+            provider_ref=req.provider_ref,
             thinking_effort=req.thinking_effort,
             watchdog_config=req.watchdog_config or {},
         )

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1775,12 +1775,9 @@ def create_api(
             raise HTTPException(400, msg)
 
         is_codex = runtime == "codex_cli"
+        resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
         if is_codex:
             resolved_provider_url = "codex_cli"
-            resolved_provider_key = agent.provider_key or ""
-            resolved_provider_model = agent.provider_model or ""
-        else:
-            resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
         effective_model = resolved_provider_model or agent.model
 
         # Build MCP server config for Codex agents (injected via -c flags)

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -305,6 +305,11 @@ class RegisterAgentRequest(BaseModel):
     auto_start: bool = False
     role: str = ""
     heartbeat_interval: int = 0
+    runtime: str = "claude_sdk"
+    provider_url: str = ""  # ANTHROPIC_BASE_URL override (e.g. Ollama endpoint)
+    provider_key: str = ""  # ANTHROPIC_API_KEY override
+    provider_model: str = ""  # Model name override for this provider
+    provider_ref: str = ""  # ID of a global provider from the providers table
     thinking_effort: str = "medium"  # low/medium/high/xhigh/max
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
 
@@ -338,9 +343,11 @@ class UpdateAgentRequest(BaseModel):
     dream_timezone: str | None = None  # IANA timezone for dream schedule
     dream_model: str | None = None  # Model override for dream runs (empty = agent's model)
     dream_notify: bool | None = None  # Inject dream summary into morning wake context
+    runtime: str | None = None  # Runtime selector: claude_sdk, codex_cli, opencode
     provider_url: str | None = None  # ANTHROPIC_BASE_URL override (e.g. Ollama endpoint)
     provider_key: str | None = None  # ANTHROPIC_API_KEY override
     provider_model: str | None = None  # Model name override for this provider
+    provider_ref: str | None = None  # ID of a global provider from the providers table
     thinking_effort: str | None = None  # low/medium/high/xhigh/max
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
 

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -23,7 +23,8 @@ import os
 import time
 from dataclasses import dataclass, field
 
-from pinky_daemon.sessions import CHARS_PER_TOKEN, MODEL_CONTEXT_SIZES, SessionUsage
+from pinky_daemon.context_estimator import ContextTextEstimator
+from pinky_daemon.sessions import MODEL_CONTEXT_SIZES, SessionUsage
 from pinky_daemon.streaming_session import (
     StreamingSessionConfig,
     StreamingTurnResult,
@@ -96,7 +97,7 @@ class CodexSession:
         self.account_info: dict = {"apiProvider": "codex_cli"}
         self._on_session_id = None  # async fn(agent_name, session_id)
         self._pending_session_id_update = ""  # Set by sync _handle_event, consumed by async worker
-        self._internal_context_texts: list[str] = []
+        self._context_estimator = ContextTextEstimator()
         self._current_turn_seq = 0
         self._last_user_message = ""  # For analytics keyword classification
 
@@ -877,21 +878,9 @@ class CodexSession:
     @property
     def estimated_tokens(self) -> int:
         """Estimate current context size from persisted chat plus internal prompts."""
-        total = sum(
-            max(1, len(text) // CHARS_PER_TOKEN)
-            for text in self._internal_context_texts
-            if text
-        )
-        if not self._conversation_store:
-            return total
-        try:
-            history = self._conversation_store.get_history(self.id, limit=1000)
-        except Exception:
-            return total
-        return total + sum(
-            max(1, len(msg.content) // CHARS_PER_TOKEN)
-            for msg in history
-            if msg.content
+        return self._context_estimator.estimated_tokens(
+            session_id=self.id,
+            conversation_store=self._conversation_store,
         )
 
     @property
@@ -902,16 +891,11 @@ class CodexSession:
 
     def get_context_info(self) -> dict:
         """Best-effort context info for APIs that expect session context details."""
-        total = self.estimated_tokens
-        max_tokens = self.max_tokens
-        pct = round(total / max_tokens * 100, 1) if max_tokens > 0 else 0.0
-        return {
-            "total_tokens": total,
-            "max_tokens": max_tokens,
-            "percentage": pct,
-            "categories": [],
-            "mcp_tools": [],
-        }
+        return self._context_estimator.context_info(
+            session_id=self.id,
+            conversation_store=self._conversation_store,
+            max_tokens=self.max_tokens,
+        )
 
     @property
     def stats(self) -> dict:
@@ -934,8 +918,7 @@ class CodexSession:
 
     def _record_internal_context_text(self, text: str) -> None:
         """Track prompts/responses that do not appear in the conversation store."""
-        if text:
-            self._internal_context_texts.append(text)
+        self._context_estimator.record_internal_text(text)
 
     def _analytics_session_started(self) -> None:
         if not self._analytics_store:

--- a/src/pinky_daemon/context_estimator.py
+++ b/src/pinky_daemon/context_estimator.py
@@ -1,0 +1,70 @@
+"""Shared context-size estimation helpers for non-SDK runtimes."""
+
+from __future__ import annotations
+
+from pinky_daemon.sessions import CHARS_PER_TOKEN
+
+
+class ContextTextEstimator:
+    """Estimate context from internal prompts plus persisted conversation text.
+
+    Runtimes that do not expose authoritative context usage can share this
+    best-effort estimator instead of duplicating token-counting fallback code.
+    """
+
+    def __init__(self, *, chars_per_token: int = CHARS_PER_TOKEN) -> None:
+        self._chars_per_token = max(1, chars_per_token)
+        self._internal_context_texts: list[str] = []
+
+    def record_internal_text(self, text: str) -> None:
+        """Track prompt/response text that is not in ConversationStore."""
+        if text:
+            self._internal_context_texts.append(text)
+
+    def estimated_tokens(
+        self,
+        *,
+        session_id: str,
+        conversation_store=None,
+        history_limit: int = 1000,
+    ) -> int:
+        """Estimate tokens from internal text and optional conversation history."""
+        total = sum(self._estimate_text_tokens(text) for text in self._internal_context_texts)
+        if not conversation_store:
+            return total
+        try:
+            history = conversation_store.get_history(session_id, limit=history_limit)
+        except Exception:
+            return total
+        return total + sum(
+            self._estimate_text_tokens(getattr(msg, "content", ""))
+            for msg in history
+        )
+
+    def context_info(
+        self,
+        *,
+        session_id: str,
+        max_tokens: int,
+        conversation_store=None,
+        history_limit: int = 1000,
+    ) -> dict:
+        """Return the context-info shape expected by streaming status APIs."""
+        total = self.estimated_tokens(
+            session_id=session_id,
+            conversation_store=conversation_store,
+            history_limit=history_limit,
+        )
+        pct = round(total / max_tokens * 100, 1) if max_tokens > 0 else 0.0
+        return {
+            "total_tokens": total,
+            "max_tokens": max_tokens,
+            "percentage": pct,
+            "categories": [],
+            "mcp_tools": [],
+        }
+
+    def _estimate_text_tokens(self, text: str) -> int:
+        if not text:
+            return 0
+        return max(1, len(text) // self._chars_per_token)

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -35,6 +35,9 @@ _RATE_LIMIT_THRESHOLD = 80  # percent — skip heartbeats above this
 
 def _is_claude_code_agent(agent, registry: AgentRegistry) -> bool:
     """Return True if this agent runs on Claude Code (not Codex or other provider)."""
+    runtime = (getattr(agent, "runtime", "") or "").strip()
+    if runtime:
+        return runtime == "claude_sdk"
     try:
         from pinky_daemon.api import resolve_provider_config
         url, _, _ = resolve_provider_config(

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -26,6 +26,7 @@ class TestAgentCRUD:
         assert agent.name == "oleg"
         assert agent.display_name == "Oleg"
         assert agent.model == "opus"
+        assert agent.runtime == "claude_sdk"
         assert agent.enabled is True
         assert agent.created_at > 0
 
@@ -44,6 +45,7 @@ class TestAgentCRUD:
             parent="oleg",
             groups=["butter-team"],
             max_sessions=3,
+            runtime="codex_cli",
         )
         assert agent.model == "sonnet"
         assert agent.soul == "# Leo the Worker"
@@ -51,6 +53,7 @@ class TestAgentCRUD:
         assert agent.parent == "oleg"
         assert agent.groups == ["butter-team"]
         assert agent.max_sessions == 3
+        assert agent.runtime == "codex_cli"
 
     def test_register_update(self, registry):
         registry.register("oleg", model="sonnet")
@@ -126,7 +129,34 @@ class TestAgentCRUD:
         assert d["name"] == "test"
         assert d["display_name"] == "Test Agent"
         assert d["model"] == "opus"
+        assert d["runtime"] == "claude_sdk"
         assert d["enabled"] is True
+
+    def test_runtime_column_exists_with_default(self, registry):
+        columns = {
+            row[1]: row
+            for row in registry._db.execute("PRAGMA table_info(agents)").fetchall()
+        }
+        assert "runtime" in columns
+        assert columns["runtime"][4] == "'claude_sdk'"
+
+        agent = registry.register("runtime-default")
+        assert agent.runtime == "claude_sdk"
+
+    def test_runtime_codex_cli_backfill_is_one_shot_and_idempotent(self, registry):
+        registry.register("legacy-codex", provider_url="codex_cli", runtime="claude_sdk")
+        registry.register("explicit-claude", provider_url="codex_cli", runtime="claude_sdk")
+
+        marker = "migration:agents_runtime_codex_cli_backfill"
+        registry.set_setting(marker, "")
+        registry._backfill_runtime_from_provider_url()
+        assert registry.get("legacy-codex").runtime == "codex_cli"
+        assert registry.get("explicit-claude").runtime == "codex_cli"
+        assert registry.get_setting(marker) == "1"
+
+        registry.register("explicit-claude", runtime="claude_sdk")
+        registry._backfill_runtime_from_provider_url()
+        assert registry.get("explicit-claude").runtime == "claude_sdk"
 
     def test_stamp_last_seen_updates_column(self, registry):
         registry.register("seen")

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -146,13 +146,23 @@ class TestAgentCRUD:
     def test_runtime_codex_cli_backfill_is_one_shot_and_idempotent(self, registry):
         registry.register("legacy-codex", provider_url="codex_cli", runtime="claude_sdk")
         registry.register("explicit-claude", provider_url="codex_cli", runtime="claude_sdk")
+        registry.register("already-codex", provider_url="codex_cli", runtime="codex_cli")
+        registry.register("opencode-agent", provider_url="codex_cli", runtime="opencode")
 
         marker = "migration:agents_runtime_codex_cli_backfill"
         registry.set_setting(marker, "")
         registry._backfill_runtime_from_provider_url()
         assert registry.get("legacy-codex").runtime == "codex_cli"
         assert registry.get("explicit-claude").runtime == "codex_cli"
+        assert registry.get("already-codex").runtime == "codex_cli"
+        assert registry.get("opencode-agent").runtime == "opencode"
         assert registry.get_setting(marker) == "1"
+
+        registry.set_setting(marker, "")
+        registry._backfill_runtime_from_provider_url()
+        assert registry.get("legacy-codex").runtime == "codex_cli"
+        assert registry.get("already-codex").runtime == "codex_cli"
+        assert registry.get("opencode-agent").runtime == "opencode"
 
         registry.register("explicit-claude", runtime="claude_sdk")
         registry._backfill_runtime_from_provider_url()

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -143,6 +143,35 @@ class TestAgentCRUD:
         agent = registry.register("runtime-default")
         assert agent.runtime == "claude_sdk"
 
+    def test_first_register_with_all_kwargs_persists_every_field(self, registry):
+        # Regression: pre-#358 INSERT omitted provider_url/key/model/ref, thinking_effort, runtime.
+        # A single register() call (no follow-up UPDATE) must persist all of them.
+        agent = registry.register(
+            "full-kwargs-agent",
+            provider_url="https://api.openai.com/v1",
+            provider_key="sk-test-key",
+            provider_model="gpt-5",
+            provider_ref="some-provider-id",
+            thinking_effort="high",
+            runtime="codex_cli",
+        )
+        # Verify via the returned object (built from INSERT path)
+        assert agent.provider_url == "https://api.openai.com/v1"
+        assert agent.provider_key == "sk-test-key"
+        assert agent.provider_model == "gpt-5"
+        assert agent.provider_ref == "some-provider-id"
+        assert agent.thinking_effort == "high"
+        assert agent.runtime == "codex_cli"
+
+        # Verify via a fresh get() to confirm DB round-trip, not just in-memory object
+        fetched = registry.get("full-kwargs-agent")
+        assert fetched.provider_url == "https://api.openai.com/v1"
+        assert fetched.provider_key == "sk-test-key"
+        assert fetched.provider_model == "gpt-5"
+        assert fetched.provider_ref == "some-provider-id"
+        assert fetched.thinking_effort == "high"
+        assert fetched.runtime == "codex_cli"
+
     def test_runtime_codex_cli_backfill_is_one_shot_and_idempotent(self, registry):
         registry.register("legacy-codex", provider_url="codex_cli", runtime="claude_sdk")
         registry.register("explicit-claude", provider_url="codex_cli", runtime="claude_sdk")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -600,6 +600,63 @@ class TestAPI:
                 assert app.state.broker._streaming["test-agent"]["main"].is_connected is True
                 assert sent_prompts[-1][1] == "Wake up"
 
+    def test_wake_uses_streaming_session_for_claude_runtime(self):
+        async def fake_connect(self):
+            self._connected = True
+
+        async def fake_send(self, prompt: str, platform: str = "", chat_id: str = ""):
+            del prompt, platform, chat_id
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.streaming_session.StreamingSession.connect", new=fake_connect), \
+                patch("pinky_daemon.streaming_session.StreamingSession.send", new=fake_send):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "claude-agent", "model": "sonnet", "runtime": "claude_sdk"})
+
+                resp = client.post("/agents/claude-agent/wake?prompt=Wake")
+                assert resp.status_code == 200
+
+                session = app.state.broker._streaming["claude-agent"]["main"]
+                assert session.__class__.__name__ == "StreamingSession"
+
+    def test_wake_uses_codex_session_for_codex_runtime(self):
+        async def fake_connect(self):
+            self._connected = True
+            self.session_id = self.session_id or f"{self.agent_name}-codex"
+            if self._on_session_id:
+                await self._on_session_id(self.agent_name, self.session_id)
+
+        async def fake_send(self, prompt: str, platform: str = "", chat_id: str = "", message_id: str = "", agent_hint: str = ""):
+            del prompt, platform, chat_id, message_id, agent_hint
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.codex_session.CodexSession.connect", new=fake_connect), \
+                patch("pinky_daemon.codex_session.CodexSession.send", new=fake_send):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "codex-agent", "model": "gpt-5-codex", "runtime": "codex_cli"})
+
+                resp = client.post("/agents/codex-agent/wake?prompt=Wake")
+                assert resp.status_code == 200
+
+                session = app.state.broker._streaming["codex-agent"]["main"]
+                assert session.__class__.__name__ == "CodexSession"
+                assert session._config.provider_url == "codex_cli"
+
+    def test_wake_rejects_opencode_runtime_until_session_exists(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "opencode-agent", "model": "deepseek-v4", "runtime": "opencode"})
+
+                resp = client.post("/agents/opencode-agent/wake?prompt=Wake")
+                assert resp.status_code == 503
+                assert "opencode runtime is disabled" in resp.text
+
     def test_streaming_restart_requires_explicit_current_session_save(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
@@ -1382,11 +1439,28 @@ class TestAgentCRUD:
 
     def test_register_agent(self):
         client = self._make_client()
-        resp = client.post("/agents", json={"name": "alice", "model": "sonnet"})
+        resp = client.post("/agents", json={
+            "name": "alice",
+            "model": "sonnet",
+            "runtime": "codex_cli",
+            "provider_url": "codex_cli",
+            "provider_model": "gpt-5-codex",
+        })
         assert resp.status_code == 200
         data = resp.json()
         assert data["name"] == "alice"
         assert data["model"] == "sonnet"
+        assert data["runtime"] == "codex_cli"
+        assert data["provider_url"] == "codex_cli"
+        assert data["provider_model"] == "gpt-5-codex"
+
+    def test_update_agent_runtime(self):
+        client = self._make_client()
+        client.post("/agents", json={"name": "alice", "model": "sonnet"})
+
+        resp = client.put("/agents/alice", json={"runtime": "codex_cli"})
+        assert resp.status_code == 200
+        assert resp.json()["runtime"] == "codex_cli"
 
     def test_register_agent_with_soul(self):
         client = self._make_client()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -637,7 +637,29 @@ class TestAPI:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             with TestClient(app) as client:
-                client.post("/agents", json={"name": "codex-agent", "model": "gpt-5-codex", "runtime": "codex_cli"})
+                now = time.time()
+                app.state.agents._db.execute(
+                    "INSERT INTO providers "
+                    "(id, name, preset, provider_url, provider_key, provider_model, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        "codex-openai",
+                        "Codex OpenAI",
+                        "",
+                        "https://api.openai.com/v1",
+                        "global-openai-key",
+                        "gpt-5-codex",
+                        now,
+                        now,
+                    ),
+                )
+                app.state.agents._db.commit()
+                client.post("/agents", json={
+                    "name": "codex-agent",
+                    "model": "fallback-model",
+                    "runtime": "codex_cli",
+                    "provider_ref": "codex-openai",
+                })
 
                 resp = client.post("/agents/codex-agent/wake?prompt=Wake")
                 assert resp.status_code == 200
@@ -645,6 +667,8 @@ class TestAPI:
                 session = app.state.broker._streaming["codex-agent"]["main"]
                 assert session.__class__.__name__ == "CodexSession"
                 assert session._config.provider_url == "codex_cli"
+                assert session._config.provider_key == "global-openai-key"
+                assert session._config.model == "gpt-5-codex"
 
     def test_wake_rejects_opencode_runtime_until_session_exists(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_context_estimator.py
+++ b/tests/test_context_estimator.py
@@ -1,0 +1,72 @@
+"""Tests for shared context estimation helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pinky_daemon.context_estimator import ContextTextEstimator
+
+
+class _Store:
+    def __init__(self, *contents: str) -> None:
+        self.contents = contents
+        self.calls: list[tuple[str, int]] = []
+
+    def get_history(self, session_id: str, limit: int = 1000):
+        self.calls.append((session_id, limit))
+        return [SimpleNamespace(content=content) for content in self.contents]
+
+
+class _BrokenStore:
+    def get_history(self, session_id: str, limit: int = 1000):
+        raise RuntimeError("db unavailable")
+
+
+def test_estimates_internal_texts():
+    estimator = ContextTextEstimator(chars_per_token=4)
+
+    estimator.record_internal_text("")
+    estimator.record_internal_text("abcd")
+    estimator.record_internal_text("abcdefghi")
+
+    assert estimator.estimated_tokens(session_id="s") == 3
+
+
+def test_estimates_store_history_with_internal_texts():
+    estimator = ContextTextEstimator(chars_per_token=4)
+    estimator.record_internal_text("abcdefgh")
+    store = _Store("abcd", "", "abcdefghijkl")
+
+    total = estimator.estimated_tokens(
+        session_id="agent-main",
+        conversation_store=store,
+        history_limit=50,
+    )
+
+    assert total == 6
+    assert store.calls == [("agent-main", 50)]
+
+
+def test_returns_internal_estimate_when_store_read_fails():
+    estimator = ContextTextEstimator(chars_per_token=4)
+    estimator.record_internal_text("abcdefgh")
+
+    assert estimator.estimated_tokens(
+        session_id="agent-main",
+        conversation_store=_BrokenStore(),
+    ) == 2
+
+
+def test_context_info_shape_and_percentage():
+    estimator = ContextTextEstimator(chars_per_token=4)
+    estimator.record_internal_text("abcdefgh")
+
+    info = estimator.context_info(session_id="agent-main", max_tokens=10)
+
+    assert info == {
+        "total_tokens": 2,
+        "max_tokens": 10,
+        "percentage": 20.0,
+        "categories": [],
+        "mcp_tools": [],
+    }


### PR DESCRIPTION
## Summary
Lands the 4 stale Codex/runtime-column commits that were stuck on beta because they predate main's api.py route extraction (#362). Cherry-picks them onto a fresh release branch off main, with the Pydantic field additions relocated to `api_models.py` (where models now live).

## What's in
| PR | What it does |
|----|--------------|
| #357 | Refactor Codex context estimation — extracts `context_estimator.py` |
| #358 | Add `agents.runtime` column + Pydantic fields + runtime-aware session selection |
| #360 | Fix Codex runtime provider resolution — restore `_resolve_agent_provider()` for all runtimes |
| #361 | Regression test for first-register-with-all-kwargs persistence |

## Conflict resolution
Single mechanical conflict in `api.py` lines 188–598: main extracted Pydantic models into `api_models.py` (#362), beta still had them inline. Resolved by:
- Accepting main's structure (empty in api.py)
- Adding the new fields (`runtime`, `provider_url/key/model/ref` on `RegisterAgentRequest`; `runtime`, `provider_ref` on `UpdateAgentRequest`) directly to `api_models.py`

All other hunks (runtime resolution logic in `api.py`, `register_agent` route kwargs, `agent_registry.py` schema migration, `codex_session.py`, `scheduler.py`, tests) auto-merged cleanly.

## Test plan
- [x] Local: `pytest -q` — 1747 passed, 1 skipped (matches beta count)
- [x] Local: `ruff check` — clean
- [x] Targeted: `tests/test_api.py`, `tests/test_agent_registry.py`, `tests/test_context_estimator.py` — 320 passed
- [ ] CI: lint + Python 3.11/3.12/3.13 + frontend + CodeQL

## Why now
Closes the long-standing beta→main divergence so future stable promotions are clean. The 4 commits had been deferred pending a "design call" but on inspection the conflict is purely mechanical — Brad green-lit the integration.

🤖 Opened by Barsik