### PR TITLE
fix(broker): harden send-gif / send-voice / send-animation error handling (#395 follow-up)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1107,15 +1107,35 @@ def create_api(
                     except Exception:
                         pass
 
+        # Issue #395 follow-up: wrap in try/except so a failure surfaces as a
+        # structured 502 (not 500), and move _stop_typing into `finally` so a
+        # failed send doesn't leave the chat showing "typing…" forever.
         try:
             loop = asyncio.get_running_loop()
             result = await loop.run_in_executor(None, _generate_and_send)
         except HTTPException:
+            _outreach_attempt_log(
+                agent_name=agent_name, platform=platform, method="send_voice",
+                chat_id=chat_id, file_path="", caption_len=len(text),
+                outcome="error", error="HTTPException",
+            )
             raise
         except Exception as e:
-            raise HTTPException(500, f"Voice note failed: {e}")
-        # Stop the typing loop now that the voice message has landed.
-        broker._stop_typing(agent_name, chat_id)
+            error_repr = f"{type(e).__name__}: {e}"
+            _outreach_attempt_log(
+                agent_name=agent_name, platform=platform, method="send_voice",
+                chat_id=chat_id, file_path="", caption_len=len(text),
+                outcome="error", error=error_repr,
+            )
+            raise HTTPException(502, f"Failed to send_voice: {error_repr}") from e
+        finally:
+            broker._stop_typing(agent_name, chat_id)
+
+        _outreach_attempt_log(
+            agent_name=agent_name, platform=platform, method="send_voice",
+            chat_id=chat_id, file_path="", caption_len=len(text),
+            outcome="ok",
+        )
         return result
 
     activity = ActivityStore(db_path=db_path.replace(".db", "_activity.db"))
@@ -4874,6 +4894,8 @@ def create_api(
         )
         if kind == "photo":
             content_default = "[photo]"
+        elif kind == "animation":
+            content_default = f"[animation] {Path(file_path).name}"
         else:
             content_default = f"[document] {Path(file_path).name}"
         _record_outbound_message(
@@ -4981,52 +5003,54 @@ def create_api(
                 except Exception:
                     pass
 
+        # Issue #395 follow-up: wrap the download+send in try/except so a
+        # failure surfaces as a structured 502 (not 500/unhandled), and move
+        # _stop_typing into `finally` so a failed send doesn't leave the chat
+        # showing "typing…" forever.
         try:
             msg = await loop.run_in_executor(None, _download_and_send)
-            result = {"sent": True, "message_id": msg.message_id, "query": query, "platform": platform, "chat_id": chat_id}
-            broker._stop_typing(agent_name_req, chat_id)
-            _record_outbound_message(
-                agent_name_req,
-                platform=platform,
-                chat_id=chat_id,
-                content=caption or f"[gif] {query}",
-                metadata={"tool": "send_gif", "source_message_id": source_message_id, "query": query, "delivery": result},
+        except HTTPException:
+            _outreach_attempt_log(
+                agent_name=agent_name_req, platform=platform, method="send_gif",
+                chat_id=chat_id, file_path="", caption_len=len(caption),
+                outcome="error", error="HTTPException",
             )
-            return result
+            raise
         except Exception as e:
-            raise HTTPException(500, str(e))
+            error_repr = f"{type(e).__name__}: {e}"
+            _outreach_attempt_log(
+                agent_name=agent_name_req, platform=platform, method="send_gif",
+                chat_id=chat_id, file_path="", caption_len=len(caption),
+                outcome="error", error=error_repr,
+            )
+            raise HTTPException(502, f"Failed to send_gif: {error_repr}") from e
+        finally:
+            broker._stop_typing(agent_name_req, chat_id)
+
+        result = {"sent": True, "message_id": msg.message_id, "query": query, "platform": platform, "chat_id": chat_id}
+        _outreach_attempt_log(
+            agent_name=agent_name_req, platform=platform, method="send_gif",
+            chat_id=chat_id, file_path="", caption_len=len(caption),
+            outcome="ok",
+        )
+        _record_outbound_message(
+            agent_name_req,
+            platform=platform,
+            chat_id=chat_id,
+            content=caption or f"[gif] {query}",
+            metadata={"tool": "send_gif", "source_message_id": source_message_id, "query": query, "delivery": result},
+        )
+        return result
 
     @app.post("/broker/send-animation")
     async def broker_send_animation(req: dict):
-        """Send an animation (GIF) through the broker on behalf of an agent."""
-        agent_name = req.get("agent_name", "")
-        source_message_id = req.get("message_id", "")
-        platform = req.get("platform", "telegram")
-        chat_id = req.get("chat_id", "")
-        file_path = req.get("file_path", "")
-        caption = req.get("caption", "")
-        reply_to = ""
-        if source_message_id and not chat_id:
-            ctx = _resolve_message_context(agent_name, source_message_id)
-            platform = ctx.platform
-            chat_id = ctx.chat_id
-            reply_to = ctx.message_id
-        if not agent_name or not chat_id or not file_path:
-            raise HTTPException(400, "agent_name, chat_id, and file_path are required")
-        loop = asyncio.get_running_loop()
-        msg = await loop.run_in_executor(None, lambda: _send_file_message(agent_name, platform, chat_id, file_path, caption=caption, reply_to=reply_to, kind="animation"))
-        result = {"sent": True, "message_id": msg.message_id, "platform": platform, "chat_id": chat_id}
-        broker._stop_typing(agent_name, chat_id)
-        _record_outbound_message(
-            agent_name,
-            platform=platform,
-            chat_id=chat_id,
-            content=caption or f"[animation] {Path(file_path).name}",
-            # PII-safe: record argument key names only, not the raw file_path.
-            # Matches the arg_keys pattern used in codex_session.py / streaming_session.py.
-            metadata={"tool": "send_animation", "source_message_id": source_message_id, "arg_keys": ["file_path"], "delivery": result},
-        )
-        return result
+        """Send an animation (GIF) through the broker on behalf of an agent.
+
+        Issue #395 follow-up: routed through the shared _broker_send_file_route
+        helper so failures surface as structured 502 and the typing indicator
+        is always torn down in `finally`.
+        """
+        return await _broker_send_file_route(req, kind="animation", method="send_animation")
 
     @app.post("/broker/send-voice")
     async def broker_send_voice(req: dict):

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -4975,55 +4975,71 @@ def create_api(
             with urllib.request.urlopen(search_url, timeout=10) as resp:
                 return json.loads(resp.read())
 
+        # Issue #397 follow-up (Murzik P1): widen the try/finally to cover the
+        # Giphy search step AND the no-results 404 path, not just download+send.
+        # Previously, a search timeout or empty-results response would raise
+        # before reaching the cleanup block, leaving the typing indicator stuck
+        # — same class of bug as the original incident #395.
         try:
-            data = await loop.run_in_executor(None, _search_giphy)
-        except Exception as e:
-            raise HTTPException(502, f"Giphy search failed: {e}")
-
-        results = data.get("data", [])
-        if not results:
-            raise HTTPException(404, f"No GIFs found for query: {query!r}")
-
-        # Pick randomly from top 5 for variety
-        pick = random.choice(results[:min(5, len(results))])
-        gif_url = pick["images"]["original"]["url"].split("?")[0]
-
-        # Download GIF to a temp file and send via adapter (all blocking I/O)
-        def _download_and_send():
-            with tempfile.NamedTemporaryFile(suffix=".gif", delete=False) as tmp:
-                tmp_path = tmp.name
             try:
-                with urllib.request.urlopen(gif_url, timeout=30) as resp:
-                    with open(tmp_path, "wb") as f:
-                        f.write(resp.read())
-                return adapter.send_animation(chat_id, tmp_path, caption=caption, reply_to_message_id=int(reply_to) if reply_to else None)
-            finally:
-                try:
-                    os.unlink(tmp_path)
-                except Exception:
-                    pass
+                data = await loop.run_in_executor(None, _search_giphy)
+            except Exception as e:
+                error_repr = f"Giphy search failed: {e}"
+                _outreach_attempt_log(
+                    agent_name=agent_name_req, platform=platform, method="send_gif",
+                    chat_id=chat_id, file_path="", caption_len=len(caption),
+                    outcome="error", error=error_repr,
+                )
+                raise HTTPException(502, error_repr) from e
 
-        # Issue #395 follow-up: wrap the download+send in try/except so a
-        # failure surfaces as a structured 502 (not 500/unhandled), and move
-        # _stop_typing into `finally` so a failed send doesn't leave the chat
-        # showing "typing…" forever.
-        try:
-            msg = await loop.run_in_executor(None, _download_and_send)
-        except HTTPException:
-            _outreach_attempt_log(
-                agent_name=agent_name_req, platform=platform, method="send_gif",
-                chat_id=chat_id, file_path="", caption_len=len(caption),
-                outcome="error", error="HTTPException",
-            )
-            raise
-        except Exception as e:
-            error_repr = f"{type(e).__name__}: {e}"
-            _outreach_attempt_log(
-                agent_name=agent_name_req, platform=platform, method="send_gif",
-                chat_id=chat_id, file_path="", caption_len=len(caption),
-                outcome="error", error=error_repr,
-            )
-            raise HTTPException(502, f"Failed to send_gif: {error_repr}") from e
+            results = data.get("data", [])
+            if not results:
+                _outreach_attempt_log(
+                    agent_name=agent_name_req, platform=platform, method="send_gif",
+                    chat_id=chat_id, file_path="", caption_len=len(caption),
+                    outcome="error", error="no_results",
+                )
+                raise HTTPException(404, f"No GIFs found for query: {query!r}")
+
+            # Pick randomly from top 5 for variety
+            pick = random.choice(results[:min(5, len(results))])
+            gif_url = pick["images"]["original"]["url"].split("?")[0]
+
+            # Download GIF to a temp file and send via adapter (all blocking I/O)
+            def _download_and_send():
+                with tempfile.NamedTemporaryFile(suffix=".gif", delete=False) as tmp:
+                    tmp_path = tmp.name
+                try:
+                    with urllib.request.urlopen(gif_url, timeout=30) as resp:
+                        with open(tmp_path, "wb") as f:
+                            f.write(resp.read())
+                    return adapter.send_animation(chat_id, tmp_path, caption=caption, reply_to_message_id=int(reply_to) if reply_to else None)
+                finally:
+                    try:
+                        os.unlink(tmp_path)
+                    except Exception:
+                        pass
+
+            # Issue #395 follow-up: wrap the download+send in try/except so a
+            # failure surfaces as a structured 502 (not 500/unhandled). The
+            # outer finally below ensures _stop_typing fires on every exit path.
+            try:
+                msg = await loop.run_in_executor(None, _download_and_send)
+            except HTTPException:
+                _outreach_attempt_log(
+                    agent_name=agent_name_req, platform=platform, method="send_gif",
+                    chat_id=chat_id, file_path="", caption_len=len(caption),
+                    outcome="error", error="HTTPException",
+                )
+                raise
+            except Exception as e:
+                error_repr = f"{type(e).__name__}: {e}"
+                _outreach_attempt_log(
+                    agent_name=agent_name_req, platform=platform, method="send_gif",
+                    chat_id=chat_id, file_path="", caption_len=len(caption),
+                    outcome="error", error=error_repr,
+                )
+                raise HTTPException(502, f"Failed to send_gif: {error_repr}") from e
         finally:
             broker._stop_typing(agent_name_req, chat_id)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1287,13 +1287,23 @@ class TestAPI:
                 ), f"failed send leaked into conversation history: {history}"
 
     def test_broker_send_animation_filenotfound_returns_structured_502(self):
-        """Issue #395 follow-up: missing animation file must surface as 502."""
+        """Issue #395 follow-up: missing animation file must surface as 502 and
+        still tear down the typing indicator (phantom typing dots after a
+        missing file was one of the original #395 symptoms).
+        """
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             with TestClient(app) as client:
                 client.post("/agents", json={"name": "barsik", "model": "sonnet"})
                 app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                stop_typing_calls = []
+                orig_stop_typing = app.state.broker._stop_typing
+                def _spy_stop_typing(agent, chat):
+                    stop_typing_calls.append((agent, chat))
+                    return orig_stop_typing(agent, chat)
+                app.state.broker._stop_typing = _spy_stop_typing
 
                 resp = client.post(
                     "/broker/send-animation",
@@ -1307,6 +1317,9 @@ class TestAPI:
 
                 assert resp.status_code == 502, f"expected 502, got {resp.status_code}: {resp.text}"
                 assert "FileNotFoundError" in resp.json().get("detail", "")
+                assert ("barsik", "6770805286") in stop_typing_calls, (
+                    f"stop_typing not called on failure path: {stop_typing_calls}"
+                )
 
     def test_broker_send_gif_telegram_error_returns_structured_502(self):
         """Issue #395 follow-up: /broker/send-gif must translate adapter

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 import sys
@@ -1231,6 +1232,212 @@ class TestAPI:
                 # FileNotFoundError, which the route must wrap.
                 assert resp.status_code == 502, f"expected 502, got {resp.status_code}: {resp.text}"
                 assert "FileNotFoundError" in resp.json().get("detail", "")
+
+    def test_broker_send_animation_telegram_error_returns_structured_502(self):
+        """Issue #395 follow-up: /broker/send-animation must translate adapter
+        exceptions to a structured 502 and tear down the typing indicator on
+        failure (previously had no try/except — exceptions bubbled as ASGI 500
+        and typing got stuck).
+        """
+        from pinky_outreach.telegram import TelegramAdapter, TelegramError
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                stop_typing_calls = []
+                orig_stop_typing = app.state.broker._stop_typing
+                def _spy_stop_typing(agent, chat):
+                    stop_typing_calls.append((agent, chat))
+                    return orig_stop_typing(agent, chat)
+                app.state.broker._stop_typing = _spy_stop_typing
+
+                with patch.object(
+                    TelegramAdapter,
+                    "send_animation",
+                    side_effect=TelegramError("Bad Request: ANIMATION_INVALID", 400),
+                ):
+                    resp = client.post(
+                        "/broker/send-animation",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "telegram",
+                            "chat_id": "6770805286",
+                            "file_path": "/tmp/bad.gif",
+                        },
+                    )
+
+                assert resp.status_code == 502, f"expected 502, got {resp.status_code}: {resp.text}"
+                body = resp.json()
+                assert "send_animation" in body.get("detail", ""), body
+                assert "TelegramError" in body.get("detail", ""), body
+
+                # Typing indicator must be cleaned up even on failure.
+                assert ("barsik", "6770805286") in stop_typing_calls, (
+                    f"stop_typing not called on failure path: {stop_typing_calls}"
+                )
+
+                # No outbound message should be recorded for a failed send.
+                history = app.state.conversation_store.get_history("barsik-main")
+                assert not any(
+                    e.metadata.get("tool") == "send_animation" for e in history
+                ), f"failed send leaked into conversation history: {history}"
+
+    def test_broker_send_animation_filenotfound_returns_structured_502(self):
+        """Issue #395 follow-up: missing animation file must surface as 502."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                resp = client.post(
+                    "/broker/send-animation",
+                    json={
+                        "agent_name": "barsik",
+                        "platform": "telegram",
+                        "chat_id": "6770805286",
+                        "file_path": "/tmp/does-not-exist-xyz.gif",
+                    },
+                )
+
+                assert resp.status_code == 502, f"expected 502, got {resp.status_code}: {resp.text}"
+                assert "FileNotFoundError" in resp.json().get("detail", "")
+
+    def test_broker_send_gif_telegram_error_returns_structured_502(self):
+        """Issue #395 follow-up: /broker/send-gif must translate adapter
+        exceptions to a structured 502 and tear down the typing indicator on
+        failure (previously returned bare 500 and typing got stuck on failure).
+        """
+        from pinky_outreach.telegram import TelegramAdapter, TelegramError
+
+        class _GiphyResp:
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+            def read(self):
+                return json.dumps({
+                    "data": [{"images": {"original": {"url": "https://media.giphy.com/test.gif?cid=abc"}}}]
+                }).encode()
+
+        class _GifBlobResp:
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+            def read(self):
+                return b"GIF89a-bytes"
+
+        def _urlopen_side_effect(req_or_url, *args, **kwargs):
+            url = req_or_url if isinstance(req_or_url, str) else getattr(req_or_url, "full_url", "")
+            if "giphy.com/v1/gifs/search" in url:
+                return _GiphyResp()
+            return _GifBlobResp()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                stop_typing_calls = []
+                orig_stop_typing = app.state.broker._stop_typing
+                def _spy_stop_typing(agent, chat):
+                    stop_typing_calls.append((agent, chat))
+                    return orig_stop_typing(agent, chat)
+                app.state.broker._stop_typing = _spy_stop_typing
+
+                with patch("urllib.request.urlopen", side_effect=_urlopen_side_effect), \
+                        patch.object(
+                            TelegramAdapter,
+                            "send_animation",
+                            side_effect=TelegramError("Bad Request: ANIMATION_INVALID", 400),
+                        ):
+                    resp = client.post(
+                        "/broker/send-gif",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "telegram",
+                            "chat_id": "6770805286",
+                            "query": "cat typing",
+                        },
+                    )
+
+                assert resp.status_code == 502, f"expected 502, got {resp.status_code}: {resp.text}"
+                body = resp.json()
+                assert "send_gif" in body.get("detail", ""), body
+                assert "TelegramError" in body.get("detail", ""), body
+
+                assert ("barsik", "6770805286") in stop_typing_calls, (
+                    f"stop_typing not called on failure path: {stop_typing_calls}"
+                )
+
+                history = app.state.conversation_store.get_history("barsik-main")
+                assert not any(
+                    e.metadata.get("tool") == "send_gif" for e in history
+                ), f"failed send leaked into conversation history: {history}"
+
+    def test_broker_send_voice_telegram_error_returns_structured_502(self):
+        """Issue #395 follow-up: /broker/send-voice must translate adapter
+        exceptions to a structured 502 and tear down the typing indicator on
+        failure (previously returned bare 500 and typing got stuck on failure).
+        """
+        from pinky_outreach.telegram import TelegramAdapter, TelegramError
+
+        class _TtsResp:
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+            def read(self):
+                return b"opus-bytes"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_setting("OPENAI_API_KEY", "test-key")
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                stop_typing_calls = []
+                orig_stop_typing = app.state.broker._stop_typing
+                def _spy_stop_typing(agent, chat):
+                    stop_typing_calls.append((agent, chat))
+                    return orig_stop_typing(agent, chat)
+                app.state.broker._stop_typing = _spy_stop_typing
+
+                with patch("urllib.request.urlopen", return_value=_TtsResp()), \
+                        patch.object(
+                            TelegramAdapter,
+                            "send_voice",
+                            side_effect=TelegramError("Bad Request: VOICE_TOO_LONG", 400),
+                        ):
+                    resp = client.post(
+                        "/broker/send-voice",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "telegram",
+                            "chat_id": "6770805286",
+                            "text": "hello world",
+                            "provider": "openai",
+                        },
+                    )
+
+                assert resp.status_code == 502, f"expected 502, got {resp.status_code}: {resp.text}"
+                body = resp.json()
+                assert "send_voice" in body.get("detail", ""), body
+                assert "TelegramError" in body.get("detail", ""), body
+
+                assert ("barsik", "6770805286") in stop_typing_calls, (
+                    f"stop_typing not called on failure path: {stop_typing_calls}"
+                )
 
     def test_broker_thread_voice_context_auto_uses_voice_reply(self):
         class _UrlResp:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1396,6 +1396,109 @@ class TestAPI:
                     e.metadata.get("tool") == "send_gif" for e in history
                 ), f"failed send leaked into conversation history: {history}"
 
+    def test_broker_send_gif_search_failure_stops_typing(self):
+        """Issue #397 follow-up (Murzik P1): when the Giphy search call itself
+        raises (e.g. urlopen timeout/connection error), the handler must still
+        tear down the typing indicator. Previously the search HTTPException was
+        raised before the try/finally was entered, leaving typing dots stuck —
+        same bug class as the original incident #395.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                stop_typing_calls = []
+                orig_stop_typing = app.state.broker._stop_typing
+                def _spy_stop_typing(agent, chat):
+                    stop_typing_calls.append((agent, chat))
+                    return orig_stop_typing(agent, chat)
+                app.state.broker._stop_typing = _spy_stop_typing
+
+                # Patch urlopen to raise during the Giphy search call.
+                with patch(
+                    "urllib.request.urlopen",
+                    side_effect=TimeoutError("giphy timeout"),
+                ):
+                    resp = client.post(
+                        "/broker/send-gif",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "telegram",
+                            "chat_id": "6770805286",
+                            "query": "cat typing",
+                        },
+                    )
+
+                assert resp.status_code == 502, f"expected 502, got {resp.status_code}: {resp.text}"
+                body = resp.json()
+                assert "Giphy search failed" in body.get("detail", ""), body
+
+                # Typing indicator must be cleaned up even when the search
+                # itself fails before download+send is attempted.
+                assert stop_typing_calls.count(("barsik", "6770805286")) == 1, (
+                    f"stop_typing not called exactly once on search-failure path: {stop_typing_calls}"
+                )
+
+                # Failed send must not leak into history.
+                history = app.state.conversation_store.get_history("barsik-main")
+                assert not any(
+                    e.metadata.get("tool") == "send_gif" for e in history
+                ), f"failed send leaked into conversation history: {history}"
+
+    def test_broker_send_gif_no_results_stops_typing(self):
+        """Issue #397 follow-up (Murzik P1): the no-results 404 path must also
+        tear down the typing indicator. Previously this raise happened before
+        the try/finally was entered.
+        """
+        class _EmptyGiphyResp:
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+            def read(self):
+                return json.dumps({"data": []}).encode()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                stop_typing_calls = []
+                orig_stop_typing = app.state.broker._stop_typing
+                def _spy_stop_typing(agent, chat):
+                    stop_typing_calls.append((agent, chat))
+                    return orig_stop_typing(agent, chat)
+                app.state.broker._stop_typing = _spy_stop_typing
+
+                with patch(
+                    "urllib.request.urlopen",
+                    return_value=_EmptyGiphyResp(),
+                ):
+                    resp = client.post(
+                        "/broker/send-gif",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "telegram",
+                            "chat_id": "6770805286",
+                            "query": "asdfghjklqwerty-no-such-thing",
+                        },
+                    )
+
+                # Current behavior: empty results still surfaces as 404.
+                assert resp.status_code == 404, f"expected 404, got {resp.status_code}: {resp.text}"
+                body = resp.json()
+                assert "No GIFs found" in body.get("detail", ""), body
+
+                # Typing indicator must still be cleaned up.
+                assert stop_typing_calls.count(("barsik", "6770805286")) == 1, (
+                    f"stop_typing not called exactly once on no-results path: {stop_typing_calls}"
+                )
+
     def test_broker_send_voice_telegram_error_returns_structured_502(self):
         """Issue #395 follow-up: /broker/send-voice must translate adapter
         exceptions to a structured 502 and tear down the typing indicator on


### PR DESCRIPTION
## Summary
- PR #396 (issue #395) wrapped `/broker/send-photo` and `/broker/send-document` in try/except + structured 502 with `_stop_typing` in `finally`. Three sibling broker routes still had the same gap.
- This PR brings `/broker/send-gif`, `/broker/send-voice`, and `/broker/send-animation` up to the same standard so a failed media send no longer (a) leaks an unhandled ASGI 500 / bare 500, or (b) leaves the chat stuck showing "typing…".

## What was wrong
- **`/broker/send-animation`** had no `try/except` at all. A `TelegramError` from `send_animation` bubbled out as an unhandled ASGI exception → opaque 500 with no body. `_stop_typing` was on the success path only.
- **`/broker/send-gif`** wrapped the download+send block but returned bare `HTTPException(500, str(e))` (not a structured 502 with the exception type). `_stop_typing` was on the success path only.
- **`/broker/send-voice`** (via `_broker_send_voice_message`) had the same bare-500 / success-only `_stop_typing` pattern.

In all three cases, when an upstream Telegram call (or `urllib.urlopen`, or `open()`) raised, the typing indicator stayed on until the 4s loop timed out.

## What changed
- **`/broker/send-animation`** now delegates to the shared `_broker_send_file_route(kind="animation", method="send_animation")` helper that #396 introduced — eliminating ~30 lines of duplicated logic and inheriting the safe error handling for free. Added an `"animation"` branch in `_broker_send_file_route`'s `content_default` ladder so the recorded fallback content stays `"[animation] file.gif"`.
- **`/broker/send-gif`** and **`_broker_send_voice_message`** now follow the #396 pattern: `HTTPException` re-raised unchanged; any other `Exception` translated to `HTTPException(502, "Failed to {method}: {Type}: {msg}")`; `_stop_typing` in `finally`; `_outreach_attempt_log` on both success and error paths. `file_path=""` since these routes don't take a file path.

## Test plan
- [x] New: `test_broker_send_animation_telegram_error_returns_structured_502` — `TelegramError` → 502 with "send_animation" + "TelegramError" in detail; typing torn down; no leaked history entry.
- [x] New: `test_broker_send_animation_filenotfound_returns_structured_502` — non-existent file → 502 with `FileNotFoundError` detail.
- [x] New: `test_broker_send_gif_telegram_error_returns_structured_502` — `TelegramError` on `send_animation` adapter call → 502 with "send_gif" + "TelegramError" in detail; typing torn down; no leaked history. Mocks Giphy search + gif download to stay offline.
- [x] New: `test_broker_send_voice_telegram_error_returns_structured_502` — `TelegramError` on `send_voice` adapter call → 502 with "send_voice" + "TelegramError" in detail; typing torn down. Mocks the OpenAI TTS HTTP call.
- [x] Local: full `tests/test_api.py` — 279 passed.
- [x] Local: `ruff check src/pinky_daemon/api.py tests/test_api.py` — clean.

Flagged this gap in saved state after #396 merged; this is the pre-emptive cleanup before another agent (or a real failure) hits the same trap.

🤖 Opened by Barsik