### PR TITLE
chore(pollers): asyncio.get_event_loop() → asyncio.get_running_loop() (#74)

### DIFF
--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -80,7 +80,7 @@ class TelegramPoller:
     async def _poll_once(self) -> None:
         """Single poll iteration."""
         # Run blocking HTTP call in thread pool
-        messages = await asyncio.get_event_loop().run_in_executor(
+        messages = await asyncio.get_running_loop().run_in_executor(
             None,
             lambda: self._adapter.get_updates(timeout=self._poll_timeout),
         )
@@ -202,7 +202,7 @@ class BrokerTelegramPoller:
 
     async def _poll_once(self) -> None:
         """Single poll iteration — routes messages through broker."""
-        messages = await asyncio.get_event_loop().run_in_executor(
+        messages = await asyncio.get_running_loop().run_in_executor(
             None,
             lambda: self._adapter.get_updates(timeout=self._poll_timeout),
         )
@@ -338,7 +338,7 @@ class BrokeriMessagePoller:
         from pinky_outreach.imessage import iMessageError
 
         try:
-            messages = await asyncio.get_event_loop().run_in_executor(
+            messages = await asyncio.get_running_loop().run_in_executor(
                 None, lambda: self._adapter.get_updates(limit=20),
             )
         except iMessageError as e:


### PR DESCRIPTION
## Summary
- Closes task #74. Three sites in `src/pinky_daemon/pollers.py` still used the deprecated `asyncio.get_event_loop()` pattern from inside async methods. Replaced with `asyncio.get_running_loop()`.
- Sites: `TelegramPoller._poll_once`, `BrokerTelegramPoller._poll_once`, `BrokeriMessagePoller._poll_once`. Sibling pollers in the same file (e.g. `BrokerDiscordPoller`) already use `get_running_loop`, so this just brings the three holdouts in line.
- No behavior change at runtime — both APIs return the running loop when called from inside an `await` context — but `get_running_loop` is the fail-loudly version recommended by PEP 492 and the modern Python docs (raises `RuntimeError` instead of silently creating a new loop if no loop is running).

## Test plan
- [x] All 18 poller-related tests pass: `pytest tests/ -k "poller" --ignore=tests/pinky_federation` → 18 passed, 1 skipped.
- [x] `ruff check src/pinky_daemon/pollers.py` — clean.
- [x] Diff is exactly 3 lines (`get_event_loop` → `get_running_loop` in three method bodies); no other changes.

## Note on holding pattern
PR #397 is currently held open pending Brad's wake-up review (api.py + active rogue-CC forensics). This PR is intentionally a different file — pollers.py is unrelated to the api.py forensic window — but I'm leaving it open for Brad's review alongside #397 rather than merging unilaterally. Trivial revert if anything's off.

🤖 Opened by Barsik