### PR TITLE
feat(auth-alerts): operator alert + auth_status when Claude credentials break

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2347,16 +2347,26 @@ def create_api(
 
         try:
             await _broker_send(agent_name, platform, chat_id, body)
-            _log(
-                f"auth_alerts: operator alert sent to {platform}:{chat_id} "
-                f"for {agent_name} (reason={decision.get('reason')}, "
-                f"agents_failing={decision.get('agents_failing')})"
-            )
         except Exception as e:
+            # Delivery failed — do NOT commit the alert. The next failure
+            # crossing threshold will retry instead of being silenced for
+            # the cooldown window.
             _log(
                 f"auth_alerts: failed to send operator alert via "
-                f"{agent_name} bot to {platform}:{chat_id}: {e}"
+                f"{agent_name} bot to {platform}:{chat_id}: {e} "
+                f"(cooldown not advanced — will retry on next failure)"
             )
+            return
+
+        try:
+            auth_tracker.commit_alert()
+        except Exception as e:
+            _log(f"auth_alerts: tracker.commit_alert raised: {e}")
+        _log(
+            f"auth_alerts: operator alert sent to {platform}:{chat_id} "
+            f"for {agent_name} (reason={decision.get('reason')}, "
+            f"agents_failing={decision.get('agents_failing')})"
+        )
 
     def _on_auth_success(agent_name: str) -> None:
         """Clear an agent's auth-failure record after a successful turn."""

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1310,6 +1310,17 @@ def create_api(
     _comms_db = db_path.replace(".db", "_agent_comms.db")
     comms = AgentComms(db_path=_comms_db)
 
+    # Auth-failure tracker — counts SDK auth errors across all streaming
+    # sessions on this host and decides when to alert the operator. The
+    # callback wiring is created in _build_auth_alert_callbacks() below
+    # once _broker_send is available; the tracker itself is host-global.
+    from pinky_daemon.auth_alerts import (
+        AuthFailureTracker,
+        format_alert_message,
+        resolve_operator_chat,
+    )
+    auth_tracker = AuthFailureTracker()
+
     # Message broker — routes platform messages through approval checks to agent sessions
     _platform_adapters: dict[tuple[str, str], object] = {}
 
@@ -2287,6 +2298,73 @@ def create_api(
 
         return _on_stream_event
 
+    async def _on_auth_failure(agent_name: str, error: str) -> None:
+        """Streaming-session hook: record an auth failure and alert the operator.
+
+        Called from StreamingSession's reader loop whenever the SDK reports
+        an authentication-class error (see auth_alerts._is_auth_error). The
+        AuthFailureTracker decides whether this failure crosses the alert
+        threshold and whether the cooldown has elapsed; if both, we DM the
+        operator via _broker_send using the affected agent's own bot.
+        """
+        try:
+            decision = auth_tracker.record_failure(agent_name, error)
+        except Exception as e:
+            _log(f"auth_alerts: tracker.record_failure raised: {e}")
+            return
+
+        if not decision.get("should_alert"):
+            return
+
+        try:
+            chat_id, platform = resolve_operator_chat(
+                get_setting=agents.get_setting,
+                list_all_approved_users=agents.list_all_approved_users,
+            )
+        except Exception as e:
+            _log(f"auth_alerts: resolve_operator_chat raised: {e}")
+            return
+
+        if not chat_id:
+            _log(
+                "auth_alerts: auth failure detected but no operator_chat_id "
+                "configured and no approved_users to fall back on — "
+                "alert suppressed (set system_settings.operator_chat_id)"
+            )
+            return
+
+        try:
+            host_label = agents.get_setting("host_label", "") or ""
+        except Exception:
+            host_label = ""
+
+        body = format_alert_message(
+            agent_name=agent_name,
+            decision=decision,
+            error=error,
+            host_label=host_label,
+        )
+
+        try:
+            await _broker_send(agent_name, platform, chat_id, body)
+            _log(
+                f"auth_alerts: operator alert sent to {platform}:{chat_id} "
+                f"for {agent_name} (reason={decision.get('reason')}, "
+                f"agents_failing={decision.get('agents_failing')})"
+            )
+        except Exception as e:
+            _log(
+                f"auth_alerts: failed to send operator alert via "
+                f"{agent_name} bot to {platform}:{chat_id}: {e}"
+            )
+
+    def _on_auth_success(agent_name: str) -> None:
+        """Clear an agent's auth-failure record after a successful turn."""
+        try:
+            auth_tracker.record_success(agent_name)
+        except Exception as e:
+            _log(f"auth_alerts: tracker.record_success raised: {e}")
+
     async def _make_streaming_session_id_callback(agent_name: str, label: str):
         """Persist a streaming session ID when captured from the SDK.
 
@@ -2544,6 +2622,13 @@ def create_api(
             "analytics_store": analytics,
             "registry": agents,
         }
+        # Auth-failure detection is currently only wired for the SDK-based
+        # StreamingSession. Codex sessions don't surface an equivalent
+        # "authentication_failed" signal — they rely on a separate provider
+        # token lifecycle — so we skip the hooks there.
+        if not is_codex:
+            init_kwargs["auth_alert_callback"] = _on_auth_failure
+            init_kwargs["auth_success_callback"] = _on_auth_success
         if is_codex:
             init_kwargs["stream_event_callback"] = await _make_streaming_event_callback(agent_name, label)
 
@@ -8181,8 +8266,22 @@ def create_api(
 
     @app.get("/admin/watchdog")
     async def get_watchdog_status():
-        """Return session watchdog status and tracked agents."""
-        return watchdog.status()
+        """Return session watchdog status, tracked agents, and Claude auth health.
+
+        Three top-level keys for external monitors:
+            running / check_interval / agents — session-stuck watchdog state.
+            auth_status — host-wide Claude auth health (see auth_alerts).
+
+        ``auth_status.status`` is one of ``ok | degraded | broken``; tying a
+        Prometheus alert to ``broken`` catches credential outages quickly.
+        """
+        out = watchdog.status()
+        try:
+            out["auth_status"] = auth_tracker.status()
+        except Exception as e:
+            _log(f"admin/watchdog: auth_tracker.status raised: {e}")
+            out["auth_status"] = {"status": "unknown", "error": str(e)}
+        return out
 
     # ── Admin: Shared MCP Status ─────────────────────────
 

--- a/src/pinky_daemon/auth_alerts.py
+++ b/src/pinky_daemon/auth_alerts.py
@@ -64,9 +64,18 @@ class _AgentFailures:
 class AuthFailureTracker:
     """Per-host auth failure detector with cooldown.
 
-    Thread-safety: not async-safe. Caller must invoke from the same event loop
-    (the streaming session reader loop). Methods are O(N) over recent
+    Concurrency: callers must share a single event loop (the streaming-session
+    reader loop). No internal locking is needed — every method is synchronous
+    and mutation happens before return. Methods are O(N) over recent
     timestamps which is fine — N is bounded by the threshold in practice.
+
+    Two-phase alerting: ``record_failure()`` decides whether an alert *should*
+    fire but never advances the cooldown by itself. The caller must invoke
+    ``commit_alert()`` only after the operator notification was actually
+    delivered. If delivery raises (broker down, bot token revoked, etc.), the
+    cooldown is preserved so the next failure can retry — that's the whole
+    reason this PR exists, so a single failed-send doesn't silence the alert
+    system for 30 minutes.
     """
 
     def __init__(
@@ -119,7 +128,7 @@ class AuthFailureTracker:
                 "agents_failing": agents_failing,
             }
 
-        if now - self._last_alert_at < self._cooldown:
+        if self._last_alert_at and now - self._last_alert_at < self._cooldown:
             return {
                 "should_alert": False,
                 "reason": "cooldown",
@@ -130,8 +139,10 @@ class AuthFailureTracker:
                 ),
             }
 
-        self._last_alert_at = now
-        self._alert_count += 1
+        # NOTE: do NOT advance _last_alert_at / _alert_count here. Caller must
+        # invoke commit_alert() after successful delivery; that way a broker
+        # failure preserves the cooldown so the alert can retry on the next
+        # failure instead of being silenced for the cooldown window.
         return {
             "should_alert": True,
             "reason": (
@@ -140,6 +151,17 @@ class AuthFailureTracker:
             "count": count,
             "agents_failing": agents_failing,
         }
+
+    def commit_alert(self) -> None:
+        """Mark an alert as delivered: advance cooldown and bump the counter.
+
+        Call this only after the operator notification was actually sent. If
+        delivery fails, do NOT call this — the next record_failure() that
+        crosses threshold will return should_alert=True so the alert retries
+        instead of being lost for the cooldown window.
+        """
+        self._last_alert_at = self._clock()
+        self._alert_count += 1
 
     def record_success(self, agent_name: str) -> None:
         """Clear failure tracking for an agent that successfully called Claude.
@@ -264,6 +286,10 @@ def format_alert_message(
 ) -> str:
     """Render the operator-alert message body.
 
+    Plain text — _broker_send defaults to no parse_mode, so anything wrapped
+    in ``*`` or `` ` `` would render literally on Telegram. Keep it readable
+    without markdown affordances.
+
     Kept human-readable and short; includes enough detail for the operator
     to know which host to log into and re-auth.
     """
@@ -278,13 +304,13 @@ def format_alert_message(
         )
     else:
         headline = (
-            f"🚨 Claude auth broken for *{agent_name}*: "
+            f"🚨 Claude auth broken for {agent_name}: "
             f"{count} failures in window"
         )
 
     detail = error.strip()[:200] or "no error detail"
     instructions = (
-        "Re-auth needed: SSH to the host, run `claude` to log back in, "
-        "then `sudo systemctl restart pinkybot` (or equivalent)."
+        "Re-auth needed: SSH to the host, run 'claude' to log back in, "
+        "then 'sudo systemctl restart pinkybot' (or equivalent)."
     )
-    return f"{headline}\n\nLast error: `{detail}`\n\n{instructions}"
+    return f"{headline}\n\nLast error: {detail}\n\n{instructions}"

--- a/src/pinky_daemon/auth_alerts.py
+++ b/src/pinky_daemon/auth_alerts.py
@@ -1,0 +1,290 @@
+"""Auth-failure tracking and operator alerts.
+
+When the Claude SDK returns ``error='authentication_failed'`` for an agent's
+streaming session, the user-facing chat sees nothing — the daemon suppresses
+the response so raw error JSON never reaches end users. The downside is the
+operator (the person who can re-auth) has no idea Claude credentials are
+broken until someone complains.
+
+This module provides:
+
+- ``AuthFailureTracker`` — in-memory counter that records auth failures across
+  all agents on a host, decides when an alert should fire, and enforces a
+  cooldown so we don't spam the operator.
+- ``resolve_operator_chat()`` — best-effort lookup of the operator's
+  chat_id/platform. Reads ``operator_chat_id`` / ``operator_platform`` from
+  system_settings if set; otherwise picks the chat_id appearing across the
+  most ``approved_users`` rows (heuristic: the person with broadest access
+  is the operator).
+
+The streaming session calls into the tracker on each auth failure; when the
+tracker says "alert", the daemon's alert wiring sends a Telegram DM via the
+existing broker. Both are documented inline so the next Brad wedge debug is
+faster.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from typing import Iterable
+
+_log = logging.getLogger("pinky.auth_alerts").info
+_warn = logging.getLogger("pinky.auth_alerts").warning
+
+
+# ── Defaults ────────────────────────────────────────────────────────
+
+DEFAULT_FAIL_WINDOW_SECONDS = 300        # 5 min
+DEFAULT_FAIL_THRESHOLD = 3               # within window → alert
+DEFAULT_ALERT_COOLDOWN_SECONDS = 1800    # 30 min between alerts
+
+
+@dataclass
+class _AgentFailures:
+    """Sliding-window record of recent auth failures for one agent."""
+
+    timestamps: list[float] = field(default_factory=list)
+    last_error: str = ""
+
+    def record(self, now: float, error: str, window: float) -> int:
+        """Append a failure timestamp, prune older ones, return current count."""
+        self.timestamps.append(now)
+        self.last_error = error or ""
+        cutoff = now - window
+        self.timestamps = [t for t in self.timestamps if t >= cutoff]
+        return len(self.timestamps)
+
+    def reset(self) -> None:
+        self.timestamps = []
+        self.last_error = ""
+
+
+class AuthFailureTracker:
+    """Per-host auth failure detector with cooldown.
+
+    Thread-safety: not async-safe. Caller must invoke from the same event loop
+    (the streaming session reader loop). Methods are O(N) over recent
+    timestamps which is fine — N is bounded by the threshold in practice.
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_window_seconds: int = DEFAULT_FAIL_WINDOW_SECONDS,
+        fail_threshold: int = DEFAULT_FAIL_THRESHOLD,
+        alert_cooldown_seconds: int = DEFAULT_ALERT_COOLDOWN_SECONDS,
+        clock=time.time,
+    ) -> None:
+        self._window = fail_window_seconds
+        self._threshold = fail_threshold
+        self._cooldown = alert_cooldown_seconds
+        self._clock = clock
+        self._agents: dict[str, _AgentFailures] = defaultdict(_AgentFailures)
+        self._last_alert_at: float = 0.0
+        self._first_failure_at: float = 0.0  # When current outage started
+        self._alert_count: int = 0           # Alerts fired since last clear
+
+    def record_failure(self, agent_name: str, error: str = "") -> dict:
+        """Record one auth failure. Returns a decision dict.
+
+        Returned keys:
+            should_alert (bool):  True if this failure crossed the threshold
+                                  AND cooldown has elapsed.
+            reason (str):         Short message explaining the decision.
+            count (int):          Current failures-in-window for this agent.
+            agents_failing (int): Count of distinct agents currently failing.
+        """
+        now = self._clock()
+        if self._first_failure_at == 0.0:
+            self._first_failure_at = now
+
+        record = self._agents[agent_name]
+        count = record.record(now, error, self._window)
+        agents_failing = sum(1 for r in self._agents.values() if r.timestamps)
+
+        # Multi-agent host outage: if ≥ threshold agents failing simultaneously,
+        # alert immediately on the very first qualifying failure (don't wait for
+        # any single agent to hit `threshold` failures alone).
+        threshold_hit = (
+            count >= self._threshold or agents_failing >= self._threshold
+        )
+
+        if not threshold_hit:
+            return {
+                "should_alert": False,
+                "reason": "below_threshold",
+                "count": count,
+                "agents_failing": agents_failing,
+            }
+
+        if now - self._last_alert_at < self._cooldown:
+            return {
+                "should_alert": False,
+                "reason": "cooldown",
+                "count": count,
+                "agents_failing": agents_failing,
+                "cooldown_remaining": int(
+                    self._cooldown - (now - self._last_alert_at)
+                ),
+            }
+
+        self._last_alert_at = now
+        self._alert_count += 1
+        return {
+            "should_alert": True,
+            "reason": (
+                "host_wide" if agents_failing >= self._threshold else "agent_repeated"
+            ),
+            "count": count,
+            "agents_failing": agents_failing,
+        }
+
+    def record_success(self, agent_name: str) -> None:
+        """Clear failure tracking for an agent that successfully called Claude.
+
+        If all agents are clear, reset the outage state so the next outage
+        emits a fresh "outage started" alert.
+        """
+        if agent_name in self._agents:
+            self._agents[agent_name].reset()
+        if not any(r.timestamps for r in self._agents.values()):
+            self._first_failure_at = 0.0
+            # Keep _last_alert_at in place — cooldown still respected even
+            # across a brief recovery → re-failure to avoid alert flapping.
+
+    def status(self) -> dict:
+        """Snapshot for /admin/watchdog and diagnostics.
+
+        Status semantics:
+            "ok"        — no agent has failures in window.
+            "degraded"  — some failures but below threshold.
+            "broken"    — at or above threshold (alert is or will fire).
+        """
+        now = self._clock()
+        agents_failing: list[dict] = []
+        for name, rec in self._agents.items():
+            # Prune stale timestamps lazily here too so /admin/watchdog
+            # doesn't show ghosts after the window has elapsed.
+            cutoff = now - self._window
+            rec.timestamps = [t for t in rec.timestamps if t >= cutoff]
+            if not rec.timestamps:
+                continue
+            agents_failing.append(
+                {
+                    "agent": name,
+                    "failures_in_window": len(rec.timestamps),
+                    "last_failure_age_s": int(now - rec.timestamps[-1]),
+                    "last_error": rec.last_error[:120],
+                }
+            )
+
+        if not agents_failing:
+            status = "ok"
+        elif any(
+            a["failures_in_window"] >= self._threshold for a in agents_failing
+        ) or len(agents_failing) >= self._threshold:
+            status = "broken"
+        else:
+            status = "degraded"
+
+        return {
+            "status": status,
+            "fail_window_seconds": self._window,
+            "fail_threshold": self._threshold,
+            "alert_cooldown_seconds": self._cooldown,
+            "outage_started_at": self._first_failure_at or None,
+            "outage_age_seconds": (
+                int(now - self._first_failure_at)
+                if self._first_failure_at
+                else None
+            ),
+            "alerts_sent": self._alert_count,
+            "last_alert_age_seconds": (
+                int(now - self._last_alert_at) if self._last_alert_at else None
+            ),
+            "agents_failing": agents_failing,
+        }
+
+
+# ── Operator chat resolution ────────────────────────────────────────
+
+
+def resolve_operator_chat(
+    *,
+    get_setting,
+    list_all_approved_users,
+) -> tuple[str, str]:
+    """Pick the (chat_id, platform) that should receive operator alerts.
+
+    Resolution order:
+        1. ``operator_chat_id`` + ``operator_platform`` in system_settings.
+        2. Fallback: the chat_id appearing across the most approved_users rows
+           (heuristic: the person with broadest access is the operator).
+        3. Empty strings if nothing matches — caller must handle "no operator".
+
+    Returns ("", "") when unresolved. Never raises.
+    """
+    try:
+        chat_id = (get_setting("operator_chat_id", "") or "").strip()
+        platform = (get_setting("operator_platform", "") or "").strip() or "telegram"
+        if chat_id:
+            return chat_id, platform
+    except Exception as e:
+        _warn("auth_alerts: failed to read operator_chat_id setting: %s", e)
+
+    try:
+        users: Iterable[dict] = list_all_approved_users() or []
+    except Exception as e:
+        _warn("auth_alerts: failed to list approved users: %s", e)
+        return "", ""
+
+    counter: Counter[str] = Counter()
+    for u in users:
+        cid = (u.get("chat_id") or "").strip() if isinstance(u, dict) else ""
+        if cid:
+            counter[cid] += 1
+    if not counter:
+        return "", ""
+
+    chat_id, _ = counter.most_common(1)[0]
+    return chat_id, "telegram"
+
+
+# ── Alert formatting ───────────────────────────────────────────────
+
+
+def format_alert_message(
+    *,
+    agent_name: str,
+    decision: dict,
+    error: str,
+    host_label: str = "",
+) -> str:
+    """Render the operator-alert message body.
+
+    Kept human-readable and short; includes enough detail for the operator
+    to know which host to log into and re-auth.
+    """
+    reason = decision.get("reason", "")
+    agents_failing = decision.get("agents_failing", 0)
+    count = decision.get("count", 0)
+
+    if reason == "host_wide":
+        headline = (
+            f"🚨 Claude auth broken on {host_label or 'this host'}: "
+            f"{agents_failing} agent(s) failing"
+        )
+    else:
+        headline = (
+            f"🚨 Claude auth broken for *{agent_name}*: "
+            f"{count} failures in window"
+        )
+
+    detail = error.strip()[:200] or "no error detail"
+    instructions = (
+        "Re-auth needed: SSH to the host, run `claude` to log back in, "
+        "then `sudo systemctl restart pinkybot` (or equivalent)."
+    )
+    return f"{headline}\n\nLast error: `{detail}`\n\n{instructions}"

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -112,6 +112,27 @@ def _is_outreach_tool(tool_name: str) -> bool:
     return _tool_basename(tool_name) in _OUTREACH_TOOL_NAMES
 
 
+# Auth-failure heuristics. The Claude Agent SDK normalises most credential
+# problems to error='authentication_failed'; older SDK versions used
+# 'invalid_api_key' / 'permission_error'. Pattern-match instead of a strict
+# equality check so a future SDK rename doesn't silently break the alerting.
+_AUTH_ERROR_TOKENS = (
+    "authentication_failed",
+    "invalid_api_key",
+    "unauthorized",
+    "auth_error",
+    "permission_error",
+)
+
+
+def _is_auth_error(err) -> bool:
+    """True if the SDK error string looks like a credential failure."""
+    if not err:
+        return False
+    s = str(err).lower()
+    return any(token in s for token in _AUTH_ERROR_TOKENS)
+
+
 def _describe_tool_use(tool_name: str, tool_input: dict) -> str:
     """Build a human-readable description of a tool invocation."""
     name = _tool_basename(tool_name)
@@ -174,6 +195,8 @@ class StreamingSession:
         cost_callback=None,  # fn(agent_name, cost_usd, input_tokens, output_tokens, session_id)
         analytics_store=None,
         registry=None,  # AgentRegistry — for server-side presence stamping
+        auth_alert_callback=None,  # async fn(agent_name, error_str) — fires on auth_failed
+        auth_success_callback=None,  # fn(agent_name) — fires on a successful turn (clears auth fail state)
     ) -> None:
         self._config = config
         self._response_callback = response_callback
@@ -181,6 +204,11 @@ class StreamingSession:
         self._conversation_store = conversation_store
         self._analytics_store = analytics_store
         self._registry = registry
+        # Auth-failure detection plumbing — called from the reader loop when
+        # the SDK reports an authentication error so the daemon can alert
+        # the operator. See pinky_daemon/auth_alerts.py for the tracker.
+        self._auth_alert_callback = auth_alert_callback
+        self._auth_success_callback = auth_success_callback
         self._client = None
         self._reader_task: asyncio.Task | None = None
         self._connected = False
@@ -439,6 +467,20 @@ class StreamingSession:
                             f"streaming[{self.agent_name}]: assistant error={msg.error!r}"
                             f" stop_reason={msg.stop_reason!r} — suppressing content"
                         )
+                        # Detect auth failures and notify the operator. The SDK
+                        # surfaces these as msg.error == 'authentication_failed'
+                        # (and historically 'invalid_api_key' on some versions);
+                        # match defensively so any future variants still alert.
+                        if _is_auth_error(msg.error) and self._auth_alert_callback:
+                            try:
+                                await self._auth_alert_callback(
+                                    self.agent_name, str(msg.error)
+                                )
+                            except Exception as exc:
+                                _log(
+                                    f"streaming[{self.agent_name}]: "
+                                    f"auth_alert_callback raised: {exc}"
+                                )
                         # Don't touch _last_response; fall through to usage/session_id capture.
                     else:
                         # Extract text and tool uses from content blocks
@@ -595,6 +637,15 @@ class StreamingSession:
                             await self._response_callback(turn_result)
                         except Exception as e:
                             _log(f"streaming[{self.agent_name}]: callback error: {e}")
+
+                    # A successful (non-errored) turn proves Claude auth is
+                    # working again — clear any auth-fail tracking for this
+                    # agent so the next outage emits a fresh alert.
+                    if self._auth_success_callback:
+                        try:
+                            self._auth_success_callback(self.agent_name)
+                        except Exception:
+                            pass
 
                     # Track usage from result
                     if msg.total_cost_usd:

--- a/tests/test_auth_alerts.py
+++ b/tests/test_auth_alerts.py
@@ -70,6 +70,9 @@ def test_threshold_for_single_agent_fires_alert():
     assert d["should_alert"] is True
     assert d["reason"] == "agent_repeated"
     assert d["count"] == 3
+    # Decision alone must not commit cooldown — caller hasn't delivered yet.
+    assert tracker._last_alert_at == 0.0
+    assert tracker._alert_count == 0
 
 
 def test_host_wide_outage_fires_immediately_at_threshold_agents():
@@ -86,9 +89,10 @@ def test_host_wide_outage_fires_immediately_at_threshold_agents():
 
 def test_cooldown_blocks_repeat_alerts():
     tracker, clock = _make_tracker(threshold=3, cooldown=600)
-    # Drive past threshold once.
+    # Drive past threshold once and simulate successful delivery.
     for _ in range(3):
         tracker.record_failure("sasha", "auth")
+    tracker.commit_alert()
     # Next failure within cooldown — must not realert.
     clock.tick(60)
     d = tracker.record_failure("sasha", "auth")
@@ -105,11 +109,47 @@ def test_cooldown_elapses_then_alert_fires_again():
     """
     tracker, clock = _make_tracker(threshold=3, window=3600, cooldown=600)
     for _ in range(3):
-        tracker.record_failure("sasha", "auth")  # first alert fires here
+        tracker.record_failure("sasha", "auth")  # first alert decision here
+    tracker.commit_alert()  # simulate first delivery succeeded
     clock.tick(601)  # past cooldown, still inside window
     d = tracker.record_failure("sasha", "auth")
     assert d["should_alert"] is True
     assert d["count"] >= 3
+
+
+def test_failed_delivery_preserves_cooldown_and_retries_next_failure():
+    """Regression: a broker_send raise must NOT advance the cooldown.
+
+    Pushok review on PR #400: the original code mutated _last_alert_at
+    *before* the await, so a network blip on the very first send-attempt
+    silenced the alert system for 30 minutes — the exact regression this
+    feature exists to prevent (Sasha-down-9-12h).
+    """
+    tracker, clock = _make_tracker(threshold=3, cooldown=600)
+    # First three failures cross threshold; caller "tries to deliver" but
+    # the broker raises, so commit_alert() is NEVER called.
+    for _ in range(3):
+        d = tracker.record_failure("sasha", "auth")
+    assert d["should_alert"] is True
+    # No commit_alert() — simulating broker_send failure.
+    assert tracker._last_alert_at == 0.0  # cooldown untouched
+
+    # Next failure (1 second later) must still be should_alert: True so the
+    # caller can retry delivery.
+    clock.tick(1)
+    d = tracker.record_failure("sasha", "auth")
+    assert d["should_alert"] is True
+    assert d["reason"] == "agent_repeated"
+
+
+def test_commit_alert_advances_cooldown_and_counter():
+    tracker, clock = _make_tracker(threshold=3, cooldown=600)
+    for _ in range(3):
+        tracker.record_failure("sasha", "auth")
+    assert tracker._alert_count == 0
+    tracker.commit_alert()
+    assert tracker._alert_count == 1
+    assert tracker._last_alert_at == clock.now
 
 
 def test_window_eviction_drops_old_failures():
@@ -146,6 +186,7 @@ def test_status_reports_broken_at_or_above_threshold():
     tracker, _ = _make_tracker(threshold=3)
     for _ in range(3):
         tracker.record_failure("sasha", "auth")
+    tracker.commit_alert()  # simulate delivery succeeded
     s = tracker.status()
     assert s["status"] == "broken"
     assert s["alerts_sent"] == 1
@@ -244,6 +285,24 @@ def test_format_alert_truncates_long_error_strings():
     )
     # Last error block is capped at 200 chars.
     assert "x" * 5000 not in msg
+
+
+def test_format_alert_uses_no_markdown_so_plain_text_renders_clean():
+    """Pushok review: _broker_send defaults to no parse_mode, so any markdown
+    in the message renders literally on Telegram (operator sees `*sasha*`).
+    Keep the message plain text.
+    """
+    msg = format_alert_message(
+        agent_name="sasha",
+        decision={"reason": "agent_repeated", "count": 3, "agents_failing": 1},
+        error="authentication_failed",
+        host_label="rpi5",
+    )
+    assert "*" not in msg
+    assert "`" not in msg
+    # Sanity: still actually informative.
+    assert "sasha" in msg
+    assert "authentication_failed" in msg
 
 
 # ── /admin/watchdog integration ───────────────────────────────────

--- a/tests/test_auth_alerts.py
+++ b/tests/test_auth_alerts.py
@@ -1,0 +1,269 @@
+"""Tests for the auth-failure tracker and operator-alert wiring."""
+from __future__ import annotations
+
+from pinky_daemon.auth_alerts import (
+    AuthFailureTracker,
+    format_alert_message,
+    resolve_operator_chat,
+)
+from pinky_daemon.streaming_session import _is_auth_error
+
+# ── _is_auth_error ────────────────────────────────────────────────
+
+
+def test_is_auth_error_matches_known_tokens():
+    assert _is_auth_error("authentication_failed") is True
+    assert _is_auth_error("invalid_api_key") is True
+    assert _is_auth_error("Unauthorized") is True  # case-insensitive
+    assert _is_auth_error("auth_error: token expired") is True
+    assert _is_auth_error("permission_error") is True
+
+
+def test_is_auth_error_skips_other_failures():
+    assert _is_auth_error("rate_limit_exceeded") is False
+    assert _is_auth_error("content_filter") is False
+    assert _is_auth_error("") is False
+    assert _is_auth_error(None) is False
+
+
+# ── AuthFailureTracker ────────────────────────────────────────────
+
+
+class _FakeClock:
+    def __init__(self, start: float = 1_000_000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def tick(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _make_tracker(**kw):
+    clock = _FakeClock()
+    tracker = AuthFailureTracker(
+        fail_window_seconds=kw.get("window", 300),
+        fail_threshold=kw.get("threshold", 3),
+        alert_cooldown_seconds=kw.get("cooldown", 1800),
+        clock=clock,
+    )
+    return tracker, clock
+
+
+def test_below_threshold_does_not_alert():
+    tracker, _ = _make_tracker()
+    d = tracker.record_failure("sasha", "authentication_failed")
+    assert d["should_alert"] is False
+    assert d["count"] == 1
+    assert d["reason"] == "below_threshold"
+
+
+def test_threshold_for_single_agent_fires_alert():
+    tracker, clock = _make_tracker(threshold=3)
+    for _ in range(2):
+        clock.tick(10)
+        d = tracker.record_failure("sasha", "authentication_failed")
+        assert d["should_alert"] is False
+    clock.tick(10)
+    d = tracker.record_failure("sasha", "authentication_failed")
+    assert d["should_alert"] is True
+    assert d["reason"] == "agent_repeated"
+    assert d["count"] == 3
+
+
+def test_host_wide_outage_fires_immediately_at_threshold_agents():
+    """If 3 different agents fail, alert on the 3rd — don't wait for any
+    single agent to hit the per-agent threshold."""
+    tracker, _ = _make_tracker(threshold=3)
+    assert tracker.record_failure("sasha", "auth")["should_alert"] is False
+    assert tracker.record_failure("ivan", "auth")["should_alert"] is False
+    d = tracker.record_failure("kuzya", "auth")
+    assert d["should_alert"] is True
+    assert d["reason"] == "host_wide"
+    assert d["agents_failing"] == 3
+
+
+def test_cooldown_blocks_repeat_alerts():
+    tracker, clock = _make_tracker(threshold=3, cooldown=600)
+    # Drive past threshold once.
+    for _ in range(3):
+        tracker.record_failure("sasha", "auth")
+    # Next failure within cooldown — must not realert.
+    clock.tick(60)
+    d = tracker.record_failure("sasha", "auth")
+    assert d["should_alert"] is False
+    assert d["reason"] == "cooldown"
+    assert d["cooldown_remaining"] > 0
+
+
+def test_cooldown_elapses_then_alert_fires_again():
+    """During a continuous outage we want a re-alert each cooldown period.
+
+    Use a window long enough that failures stay live across the cooldown gap
+    — that's the realistic outage shape (agent retries every minute or so).
+    """
+    tracker, clock = _make_tracker(threshold=3, window=3600, cooldown=600)
+    for _ in range(3):
+        tracker.record_failure("sasha", "auth")  # first alert fires here
+    clock.tick(601)  # past cooldown, still inside window
+    d = tracker.record_failure("sasha", "auth")
+    assert d["should_alert"] is True
+    assert d["count"] >= 3
+
+
+def test_window_eviction_drops_old_failures():
+    tracker, clock = _make_tracker(window=60, threshold=3)
+    tracker.record_failure("sasha", "auth")
+    clock.tick(61)  # first entry now stale
+    tracker.record_failure("sasha", "auth")
+    clock.tick(1)
+    d = tracker.record_failure("sasha", "auth")
+    # Only 2 fresh entries within window — below threshold.
+    assert d["should_alert"] is False
+    assert d["count"] == 2
+
+
+def test_record_success_clears_agent_failures():
+    tracker, _ = _make_tracker(threshold=3)
+    tracker.record_failure("sasha", "auth")
+    tracker.record_failure("sasha", "auth")
+    tracker.record_success("sasha")
+    d = tracker.record_failure("sasha", "auth")
+    assert d["count"] == 1
+    assert d["should_alert"] is False
+
+
+def test_status_reports_ok_when_no_failures():
+    tracker, _ = _make_tracker()
+    s = tracker.status()
+    assert s["status"] == "ok"
+    assert s["agents_failing"] == []
+    assert s["alerts_sent"] == 0
+
+
+def test_status_reports_broken_at_or_above_threshold():
+    tracker, _ = _make_tracker(threshold=3)
+    for _ in range(3):
+        tracker.record_failure("sasha", "auth")
+    s = tracker.status()
+    assert s["status"] == "broken"
+    assert s["alerts_sent"] == 1
+    assert any(a["agent"] == "sasha" for a in s["agents_failing"])
+
+
+def test_status_reports_degraded_below_threshold():
+    tracker, _ = _make_tracker(threshold=3)
+    tracker.record_failure("sasha", "auth")
+    s = tracker.status()
+    assert s["status"] == "degraded"
+
+
+# ── resolve_operator_chat ─────────────────────────────────────────
+
+
+def test_resolve_operator_chat_prefers_setting():
+    settings = {"operator_chat_id": "12345", "operator_platform": "telegram"}
+    chat_id, platform = resolve_operator_chat(
+        get_setting=lambda k, default="": settings.get(k, default),
+        list_all_approved_users=lambda: [],
+    )
+    assert chat_id == "12345"
+    assert platform == "telegram"
+
+
+def test_resolve_operator_chat_falls_back_to_most_common_approved_user():
+    users = [
+        {"chat_id": "111", "agent_name": "a"},
+        {"chat_id": "222", "agent_name": "a"},
+        {"chat_id": "111", "agent_name": "b"},
+        {"chat_id": "111", "agent_name": "c"},
+    ]
+    chat_id, platform = resolve_operator_chat(
+        get_setting=lambda k, default="": "",
+        list_all_approved_users=lambda: users,
+    )
+    assert chat_id == "111"  # appears 3× → operator
+    assert platform == "telegram"
+
+
+def test_resolve_operator_chat_returns_empty_when_nothing_known():
+    chat_id, platform = resolve_operator_chat(
+        get_setting=lambda k, default="": "",
+        list_all_approved_users=lambda: [],
+    )
+    assert chat_id == ""
+    assert platform == ""
+
+
+def test_resolve_operator_chat_tolerates_setting_errors():
+    def bad_setting(*_a, **_kw):
+        raise RuntimeError("db down")
+
+    chat_id, platform = resolve_operator_chat(
+        get_setting=bad_setting,
+        list_all_approved_users=lambda: [{"chat_id": "999"}],
+    )
+    assert chat_id == "999"  # fell through to fallback
+    assert platform == "telegram"
+
+
+# ── format_alert_message ──────────────────────────────────────────
+
+
+def test_format_alert_includes_agent_when_repeated():
+    msg = format_alert_message(
+        agent_name="sasha",
+        decision={"reason": "agent_repeated", "count": 3, "agents_failing": 1},
+        error="authentication_failed",
+        host_label="rpi5",
+    )
+    assert "sasha" in msg
+    assert "authentication_failed" in msg
+    assert "Re-auth" in msg
+
+
+def test_format_alert_says_host_wide_when_multiple_agents_fail():
+    msg = format_alert_message(
+        agent_name="sasha",
+        decision={"reason": "host_wide", "count": 1, "agents_failing": 3},
+        error="invalid_api_key",
+        host_label="rpi5",
+    )
+    assert "rpi5" in msg
+    assert "3 agent" in msg
+
+
+def test_format_alert_truncates_long_error_strings():
+    long = "x" * 5000
+    msg = format_alert_message(
+        agent_name="sasha",
+        decision={"reason": "agent_repeated", "count": 3, "agents_failing": 1},
+        error=long,
+        host_label="",
+    )
+    # Last error block is capped at 200 chars.
+    assert "x" * 5000 not in msg
+
+
+# ── /admin/watchdog integration ───────────────────────────────────
+
+
+def test_admin_watchdog_exposes_auth_status(tmp_path):
+    """End-to-end: /admin/watchdog includes auth_status with the right shape."""
+    from fastapi.testclient import TestClient
+
+    from pinky_daemon.api import create_api
+
+    api = create_api(db_path=str(tmp_path / "memory.db"))
+    with TestClient(api) as client:
+        resp = client.get("/admin/watchdog")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "auth_status" in body
+    auth = body["auth_status"]
+    assert auth["status"] == "ok"  # no failures yet
+    assert auth["fail_threshold"] >= 1
+    assert auth["agents_failing"] == []
+    assert "fail_window_seconds" in auth
+    assert "alert_cooldown_seconds" in auth


### PR DESCRIPTION
## Summary
- New `AuthFailureTracker` records SDK `authentication_failed` errors across all streaming sessions on a host, fires an alert at threshold (3 in 5 min, or 3 distinct agents at once), 30 min cooldown.
- Streaming session gains `auth_alert_callback` / `auth_success_callback` hooks; pattern-matches multiple error tokens so future SDK renames keep alerting.
- Operator gets DMed via the affected agent's own bot (no new infrastructure). Operator chat resolves from `system_settings.operator_chat_id` first, then falls back to the chat_id appearing across the most `approved_users` rows.
- `/admin/watchdog` gains `auth_status` with `status=ok|degraded|broken`, window/threshold/cooldown config, outage age, alerts sent, and a per-agent failure list. Drop-in for Prometheus/external monitors.

## Why
Hit a real outage on the Pi today: all 5 agents returning `authentication_failed` for 12+ hours. Symptom looked like a session wedge; actual cause was a bad OAuth refresh at 11:30 PDT. With this PR the operator gets a Telegram alert within minutes of the outage starting instead of finding out when a user complains.

## Notes
- Codex sessions intentionally skip the hook — they use a different provider token lifecycle.
- The `record_success()` callback clears per-agent state on the next clean turn so resolving the outage doesn't leave stale `degraded` status in the watchdog endpoint.
- 30 min cooldown is symmetric: same outage → 1 alert per 30 min; brief recovery + re-failure → respects the same cooldown to avoid flapping.

## Test plan
- [x] `pytest tests/test_auth_alerts.py` — 20 new tests pass (thresholds, cooldown, window eviction, host-wide detection, success-clears-state, operator resolution fallbacks).
- [x] Full suite `pytest tests/ --ignore=tests/pinky_federation` — 1620 passed, 0 failed.
- [x] `ruff check` clean on all changed files.
- [x] TestClient integration: `GET /admin/watchdog` returns `auth_status` with the expected shape.
- [ ] After merge to `beta` and promotion to `main`, run `update_and_restart()` on Pi and verify the next auth outage produces a telegram DM to the operator.

🤖 Opened by Barsik