### PR TITLE
chore(deps): bump claude-agent-sdk floor 0.1.73 → 0.1.76

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "httpx>=0.28",
     "fastapi>=0.135",
     "uvicorn>=0.44",
-    "claude-agent-sdk>=0.1.73",
+    "claude-agent-sdk>=0.1.76",
     "Pillow>=10.0",
     # Federation crypto (sealed_box_v1): X25519, Ed25519, HKDF, XChaCha20-Poly1305.
     "cryptography>=41.0",


### PR DESCRIPTION
## Summary

Bumps the `claude-agent-sdk` floor pin in `pyproject.toml` from `>=0.1.73` to `>=0.1.76`. Closes the floor-bump action item from #401.

Picks up the cumulative 0.1.74–0.1.76 changes:

- **0.1.76**: API error status on result messages, permission-suggestions deserialization fix
- **0.1.75**: bundled CC 2.1.128 (MCP reconnect-flood fix, image-paste hangs)
- **0.1.74**: hook event streaming + deferred decisions, strict MCP config validation, permission context enrichment, **subprocess cleanup on parent exit**
- Bundled CLI now `2.1.132` (verified via `claude_agent_sdk._cli_version.__cli_version__`) — adds `CLAUDE_CODE_SESSION_ID` env in subprocesses, external SIGINT graceful shutdown, `--resume` emoji-truncation crash fix.

## What this PR does NOT do

The other action items from #401 are intentionally out of scope here — they need their own diffs and tests:

3. Native API-error-status refactor of `pinky_daemon/streaming_session._is_auth_error()` + `auth_alerts.py` (today's regex-based detection still works as fallback).
4. `/admin/restart` orphaned-subprocess verification.
5. PR #400 auth-alert flow re-validation against the bumped SDK.

I'll open follow-ups for those once this lands.

## Verification

- `pip install -e .` resolves to `claude-agent-sdk 0.1.76`, bundled CC 2.1.132.
- `pytest`: **1770 passed, 1 skipped** — parity with pre-bump (the 1 skip is unrelated and pre-existing).
- No source changes besides the version pin.

## Test plan

- [ ] CI green on this branch
- [ ] Beta daemon picks up the bump on next `update_and_restart()` (channel = beta)
- [ ] Watch for any session-store / MCP-config behavior changes after the daemon restarts on beta
- [ ] Re-validate PR #400's auth-alert flow under bumped SDK before promoting beta → main

🤖 Opened by Barsik