### PR TITLE
refactor(auth-detect): structured AssistantMessage.error + ResultMessage.api_error_status (#403)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "httpx>=0.28",
     "fastapi>=0.135",
     "uvicorn>=0.44",
-    "claude-agent-sdk>=0.1.76",
+    "claude-agent-sdk>=0.1.77",
     "Pillow>=10.0",
     # Federation crypto (sealed_box_v1): X25519, Ed25519, HKDF, XChaCha20-Poly1305.
     "cryptography>=41.0",

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2302,10 +2302,13 @@ def create_api(
         """Streaming-session hook: record an auth failure and alert the operator.
 
         Called from StreamingSession's reader loop whenever the SDK reports
-        an authentication-class error (see auth_alerts._is_auth_error). The
-        AuthFailureTracker decides whether this failure crosses the alert
-        threshold and whether the cooldown has elapsed; if both, we DM the
-        operator via _broker_send using the affected agent's own bot.
+        an authentication-class error — either AssistantMessage.error ==
+        "authentication_failed" (see streaming_session._is_auth_error_assistant)
+        or ResultMessage.api_error_status in {401, 403} (see
+        streaming_session._is_auth_error_result). The AuthFailureTracker
+        decides whether this failure crosses the alert threshold and whether
+        the cooldown has elapsed; if both, we DM the operator via
+        _broker_send using the affected agent's own bot.
         """
         try:
             decision = auth_tracker.record_failure(agent_name, error)

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -112,25 +112,38 @@ def _is_outreach_tool(tool_name: str) -> bool:
     return _tool_basename(tool_name) in _OUTREACH_TOOL_NAMES
 
 
-# Auth-failure heuristics. The Claude Agent SDK normalises most credential
-# problems to error='authentication_failed'; older SDK versions used
-# 'invalid_api_key' / 'permission_error'. Pattern-match instead of a strict
-# equality check so a future SDK rename doesn't silently break the alerting.
-_AUTH_ERROR_TOKENS = (
-    "authentication_failed",
-    "invalid_api_key",
-    "unauthorized",
-    "auth_error",
-    "permission_error",
-)
+# Auth-failure detection — uses native SDK types (claude-agent-sdk >= 0.1.76).
+#
+# Two paths surface credential failures, and we check both:
+#
+# 1. ``AssistantMessage.error`` is an ``AssistantMessageError`` Literal whose
+#    only credential-failure value is "authentication_failed". The other
+#    Literal members (billing_error, rate_limit, invalid_request,
+#    server_error, unknown) are NOT auth issues and must NOT trip the
+#    operator alert — billing errors and rate limits in particular would
+#    spam the operator on perfectly authenticated sessions.
+#
+# 2. ``ResultMessage.api_error_status`` is the raw HTTP status of a failing
+#    API call (added in SDK 0.1.76, emitted by CLI >= 2.1.110). 401 and 403
+#    are credential failures; 429 and 5xx are transient/operational and
+#    handled separately.
+#
+# This replaces an older substring-tuple match against ``msg.error`` that
+# pre-dated the Literal type and over-matched (e.g. "permission_error" is
+# never a value the SDK can produce).
+_AUTH_ASSISTANT_ERROR = "authentication_failed"
+_AUTH_HTTP_STATUSES = frozenset({401, 403})
 
 
-def _is_auth_error(err) -> bool:
-    """True if the SDK error string looks like a credential failure."""
-    if not err:
-        return False
-    s = str(err).lower()
-    return any(token in s for token in _AUTH_ERROR_TOKENS)
+def _is_auth_error_assistant(msg) -> bool:
+    """True if an ``AssistantMessage`` indicates a credential failure."""
+    return getattr(msg, "error", None) == _AUTH_ASSISTANT_ERROR
+
+
+def _is_auth_error_result(result) -> bool:
+    """True if a ``ResultMessage``'s HTTP status indicates a credential failure."""
+    status = getattr(result, "api_error_status", None)
+    return status in _AUTH_HTTP_STATUSES
 
 
 def _describe_tool_use(tool_name: str, tool_input: dict) -> str:
@@ -468,10 +481,12 @@ class StreamingSession:
                             f" stop_reason={msg.stop_reason!r} — suppressing content"
                         )
                         # Detect auth failures and notify the operator. The SDK
-                        # surfaces these as msg.error == 'authentication_failed'
-                        # (and historically 'invalid_api_key' on some versions);
-                        # match defensively so any future variants still alert.
-                        if _is_auth_error(msg.error) and self._auth_alert_callback:
+                        # types ``msg.error`` as the AssistantMessageError
+                        # Literal; only "authentication_failed" is a credential
+                        # issue. Other Literal values (billing_error, rate_limit,
+                        # invalid_request, server_error, unknown) are NOT auth
+                        # failures and must not trip the operator alert.
+                        if _is_auth_error_assistant(msg) and self._auth_alert_callback:
                             try:
                                 await self._auth_alert_callback(
                                     self.agent_name, str(msg.error)
@@ -576,8 +591,26 @@ class StreamingSession:
                         _log(
                             f"streaming[{self.agent_name}]: error result"
                             f" stop_reason={msg.stop_reason!r}"
+                            f" api_error_status={getattr(msg, 'api_error_status', None)!r}"
                             f" errors={msg.errors!r} — suppressing forwarded response"
                         )
+                        # Detect credential failures on the result path too. The
+                        # AssistantMessage path catches errors the SDK surfaces
+                        # mid-turn; this path catches errors that only land at
+                        # turn completion (api_error_status added in 0.1.76:
+                        # 401/403 = bad creds; 429/5xx = transient, handled
+                        # below as a generic error result).
+                        if _is_auth_error_result(msg) and self._auth_alert_callback:
+                            try:
+                                await self._auth_alert_callback(
+                                    self.agent_name,
+                                    f"api_error_status={msg.api_error_status}",
+                                )
+                            except Exception as exc:
+                                _log(
+                                    f"streaming[{self.agent_name}]: "
+                                    f"auth_alert_callback (result) raised: {exc}"
+                                )
                         # Analytics: still record errored turns
                         _u = msg.usage or {}
                         self._analytics_log_turn_usage(

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -453,6 +453,7 @@ class StreamingSession:
         """Background loop that reads responses and fires callbacks."""
         from claude_agent_sdk.types import (
             AssistantMessage,
+            AssistantMessageError,
             ResultMessage,
             TextBlock,
             ThinkingBlock,
@@ -460,9 +461,30 @@ class StreamingSession:
             ToolUseBlock,
         )
 
+        # Defensive invariant: ``_is_auth_error_assistant`` does an exact
+        # match against ``AssistantMessageError`` for "authentication_failed".
+        # If a future SDK release renames that Literal value, exact-match
+        # silently stops detecting credential failures — re-creating the
+        # exact regression mode #400 was built to catch. Fail loud at session
+        # start instead. (CI also asserts this in test_auth_alerts.py, so
+        # bumps caught in PR; this guard catches local-dev SDK upgrades.)
+        assert _AUTH_ASSISTANT_ERROR in AssistantMessageError.__args__, (
+            f"claude-agent-sdk renamed AssistantMessageError Literal — "
+            f"_AUTH_ASSISTANT_ERROR={_AUTH_ASSISTANT_ERROR!r} no longer in "
+            f"{AssistantMessageError.__args__}. Update the constant and tests."
+        )
+
         _log(f"streaming[{self.agent_name}]: reader loop running")
         turn_tool_uses = []  # Track tool uses per turn
         turn_thinking: list[str] = []  # Track thinking blocks per turn
+        # Per-turn dedupe for auth-failure callbacks. A single failed turn can
+        # surface auth errors on BOTH paths: an AssistantMessage with
+        # error="authentication_failed", followed by the terminal ResultMessage
+        # with api_error_status=401. Without dedupe, AuthFailureTracker would
+        # increment twice for one real failure — tripping the operator-alert
+        # threshold early and skewing the multi-agent baseline. Reset at the
+        # end of ResultMessage handling (turn boundary).
+        auth_reported_this_turn = False
 
         try:
             async for msg in self._client.receive_messages():
@@ -487,6 +509,11 @@ class StreamingSession:
                         # invalid_request, server_error, unknown) are NOT auth
                         # failures and must not trip the operator alert.
                         if _is_auth_error_assistant(msg) and self._auth_alert_callback:
+                            # Set the dedupe flag BEFORE invoking the callback
+                            # so a callback exception can't cause the
+                            # ResultMessage path to double-fire for the same
+                            # turn.
+                            auth_reported_this_turn = True
                             try:
                                 await self._auth_alert_callback(
                                     self.agent_name, str(msg.error)
@@ -600,11 +627,27 @@ class StreamingSession:
                         # turn completion (api_error_status added in 0.1.76:
                         # 401/403 = bad creds; 429/5xx = transient, handled
                         # below as a generic error result).
-                        if _is_auth_error_result(msg) and self._auth_alert_callback:
+                        #
+                        # Skip if the AssistantMessage path already reported
+                        # auth for this turn — both paths firing for one real
+                        # failure double-counts in AuthFailureTracker.
+                        if (
+                            _is_auth_error_result(msg)
+                            and self._auth_alert_callback
+                            and not auth_reported_this_turn
+                        ):
+                            auth_reported_this_turn = True
+                            # Surface msg.errors into the callback string when
+                            # present — operators get richer triage context
+                            # than the raw status code alone (the SDK started
+                            # returning actionable messages in 0.1.77).
+                            err_detail = f"api_error_status={msg.api_error_status}"
+                            if msg.errors:
+                                err_detail += f" errors={msg.errors!r}"
                             try:
                                 await self._auth_alert_callback(
                                     self.agent_name,
-                                    f"api_error_status={msg.api_error_status}",
+                                    err_detail,
                                 )
                             except Exception as exc:
                                 _log(
@@ -645,6 +688,8 @@ class StreamingSession:
                         turn_thinking = []
                         self._stats["turns"] += 1
                         self.last_active = time.time()
+                        # Reset per-turn auth dedupe — turn boundary
+                        auth_reported_this_turn = False
                         continue
 
                     # Turn complete — fire response callback
@@ -796,6 +841,10 @@ class StreamingSession:
                     turn_thinking = []  # Reset for next turn
                     self._stats["turns"] += 1
                     self.last_active = time.time()
+                    # Reset per-turn auth dedupe — turn boundary. Successful
+                    # turns rarely set this flag (no auth error fired), but
+                    # reset unconditionally to keep the invariant simple.
+                    auth_reported_this_turn = False
 
                     _log(f"streaming[{self.agent_name}]: turn complete (total: {self._stats['turns']})")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -233,6 +233,17 @@ class TestStreamingSession:
         fake_types.ToolResultBlock = ToolResultBlock
         fake_types.AssistantMessage = AssistantMessage
         fake_types.ResultMessage = ResultMessage
+        # Stub for the SDK Literal — reader_loop's import-time invariant
+        # check (PR #404) reads __args__ to defend against SDK rename.
+        from typing import Literal as _Literal
+        fake_types.AssistantMessageError = _Literal[
+            "authentication_failed",
+            "billing_error",
+            "rate_limit",
+            "invalid_request",
+            "server_error",
+            "unknown",
+        ]
 
         old_sdk_types = sys.modules.get("claude_agent_sdk.types")
         sys.modules["claude_agent_sdk.types"] = fake_types

--- a/tests/test_auth_alerts.py
+++ b/tests/test_auth_alerts.py
@@ -9,9 +9,32 @@ from pinky_daemon.auth_alerts import (
     resolve_operator_chat,
 )
 from pinky_daemon.streaming_session import (
+    _AUTH_ASSISTANT_ERROR,
     _is_auth_error_assistant,
     _is_auth_error_result,
 )
+
+# ── SDK Literal invariant ────────────────────────────────────────
+#
+# ``_is_auth_error_assistant`` does an exact string match against
+# AssistantMessageError. If a future SDK rename of the Literal value
+# happens unnoticed, exact-match silently stops detecting credential
+# failures — re-creating the exact regression mode #400 was built to
+# catch. This test fails loud at CI time on any SDK bump that drops
+# or renames "authentication_failed".
+
+
+def test_auth_assistant_error_literal_present_in_sdk_type():
+    """``_AUTH_ASSISTANT_ERROR`` must remain a member of
+    ``AssistantMessageError.__args__``. If the SDK renames the Literal,
+    update both the constant and ``_is_auth_error_assistant``."""
+    from claude_agent_sdk.types import AssistantMessageError
+
+    assert _AUTH_ASSISTANT_ERROR in AssistantMessageError.__args__, (
+        f"claude-agent-sdk renamed the AssistantMessageError Literal — "
+        f"{_AUTH_ASSISTANT_ERROR!r} no longer in {AssistantMessageError.__args__}. "
+        f"Update _AUTH_ASSISTANT_ERROR in streaming_session.py."
+    )
 
 # ── _is_auth_error_assistant ──────────────────────────────────────
 #

--- a/tests/test_auth_alerts.py
+++ b/tests/test_auth_alerts.py
@@ -1,29 +1,84 @@
 """Tests for the auth-failure tracker and operator-alert wiring."""
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from pinky_daemon.auth_alerts import (
     AuthFailureTracker,
     format_alert_message,
     resolve_operator_chat,
 )
-from pinky_daemon.streaming_session import _is_auth_error
+from pinky_daemon.streaming_session import (
+    _is_auth_error_assistant,
+    _is_auth_error_result,
+)
 
-# ── _is_auth_error ────────────────────────────────────────────────
+# ── _is_auth_error_assistant ──────────────────────────────────────
+#
+# AssistantMessage.error is the AssistantMessageError Literal:
+#   authentication_failed, billing_error, rate_limit, invalid_request,
+#   server_error, unknown
+# Only "authentication_failed" should trip the operator alert.
 
 
-def test_is_auth_error_matches_known_tokens():
-    assert _is_auth_error("authentication_failed") is True
-    assert _is_auth_error("invalid_api_key") is True
-    assert _is_auth_error("Unauthorized") is True  # case-insensitive
-    assert _is_auth_error("auth_error: token expired") is True
-    assert _is_auth_error("permission_error") is True
+def _msg(error=None):
+    """Lightweight AssistantMessage stand-in (only the .error attr matters)."""
+    return SimpleNamespace(error=error)
 
 
-def test_is_auth_error_skips_other_failures():
-    assert _is_auth_error("rate_limit_exceeded") is False
-    assert _is_auth_error("content_filter") is False
-    assert _is_auth_error("") is False
-    assert _is_auth_error(None) is False
+def test_is_auth_error_assistant_true_only_for_authentication_failed():
+    assert _is_auth_error_assistant(_msg("authentication_failed")) is True
+
+
+def test_is_auth_error_assistant_false_for_other_literal_values():
+    # Other AssistantMessageError values are real errors but NOT credential
+    # failures. Alerting the operator on these would be noise (or actively
+    # wrong, in the case of billing/rate_limit issues that have nothing to
+    # do with credentials).
+    for not_auth in (
+        "billing_error",
+        "rate_limit",
+        "invalid_request",
+        "server_error",
+        "unknown",
+    ):
+        assert _is_auth_error_assistant(_msg(not_auth)) is False, not_auth
+
+
+def test_is_auth_error_assistant_false_for_none_and_missing():
+    assert _is_auth_error_assistant(_msg(None)) is False
+    # Missing attribute (e.g. unrelated message type) must not raise.
+    assert _is_auth_error_assistant(SimpleNamespace()) is False
+
+
+# ── _is_auth_error_result ─────────────────────────────────────────
+#
+# ResultMessage.api_error_status is int|None — raw HTTP status from a
+# failing API call. 401/403 are credential failures; 429 and 5xx are
+# transient/operational and must not trip the auth alert.
+
+
+def _result(api_error_status=None):
+    """Lightweight ResultMessage stand-in."""
+    return SimpleNamespace(api_error_status=api_error_status)
+
+
+def test_is_auth_error_result_true_for_401_and_403():
+    assert _is_auth_error_result(_result(401)) is True
+    assert _is_auth_error_result(_result(403)) is True
+
+
+def test_is_auth_error_result_false_for_transient_statuses():
+    # Rate limit (429) and any 5xx must NOT alert as a credential failure.
+    for not_auth_status in (429, 500, 502, 503, 504, 529):
+        assert _is_auth_error_result(_result(not_auth_status)) is False, not_auth_status
+
+
+def test_is_auth_error_result_false_for_none_and_success():
+    assert _is_auth_error_result(_result(None)) is False
+    assert _is_auth_error_result(_result(200)) is False
+    # Missing attribute (older SDK / non-result objects) must not raise.
+    assert _is_auth_error_result(SimpleNamespace()) is False
 
 
 # ── AuthFailureTracker ────────────────────────────────────────────

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -202,3 +202,177 @@ async def test_idle_sleep_returns_false_when_already_disconnected() -> None:
 
     assert result is False
     assert ss.is_idle_sleeping is False
+
+
+# -- Auth-failure dedupe across AssistantMessage + ResultMessage paths --------
+#
+# A single failed turn can surface auth errors on BOTH paths the reader_loop
+# watches: an AssistantMessage with error="authentication_failed", followed
+# by the terminal ResultMessage with api_error_status=401. Without dedupe,
+# AuthFailureTracker.record_failure() would increment twice for one real
+# failure — tripping the operator-alert threshold early and skewing the
+# host-wide multi-agent baseline. Reader_loop must collapse the two-path
+# emission into a single auth-alert-callback invocation per turn.
+#
+# Per Murzik's PR #404 review: "I verified locally with a synthetic reader
+# stream: callback fired as [('agent', 'authentication_failed'), ('agent',
+# 'api_error_status=401')]." This test pins down the fix.
+
+
+def _make_assistant_message(*, error: str | None = None):
+    """Build an AssistantMessage with the minimum fields the reader_loop reads."""
+    from claude_agent_sdk.types import AssistantMessage
+
+    return AssistantMessage(
+        content=[],
+        model="claude-opus-4-7",
+        error=error,
+        usage={"input_tokens": 0, "output_tokens": 0},
+        stop_reason="error" if error else "end_turn",
+    )
+
+
+def _make_result_message(
+    *,
+    is_error: bool = False,
+    api_error_status: int | None = None,
+    errors: list[str] | None = None,
+):
+    """Build a ResultMessage with the minimum fields the reader_loop reads."""
+    from claude_agent_sdk.types import ResultMessage
+
+    return ResultMessage(
+        subtype="success" if not is_error else "error",
+        duration_ms=10,
+        duration_api_ms=5,
+        is_error=is_error,
+        num_turns=1,
+        session_id="test-session",
+        stop_reason="end_turn" if not is_error else "error",
+        api_error_status=api_error_status,
+        errors=errors,
+    )
+
+
+async def _run_reader_against_stream(ss: StreamingSession, messages: list) -> None:
+    """Wire up a fake client whose receive_messages() yields the given list,
+    then run the reader_loop until the iterator drains."""
+
+    async def _receive_messages():
+        for msg in messages:
+            yield msg
+
+    ss._client.receive_messages = _receive_messages
+    await ss._reader_loop()
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_fires_once_when_both_paths_signal_for_same_turn() -> None:
+    """Regression for PR #404 / Murzik's review.
+
+    SDK emits AssistantMessage(error="authentication_failed") followed by
+    ResultMessage(is_error=True, api_error_status=401) for a single failed
+    turn. The auth-alert callback must fire exactly once — not once per path."""
+    ss = _make_session()
+    callback = AsyncMock()
+    ss._auth_alert_callback = callback
+
+    await _run_reader_against_stream(
+        ss,
+        [
+            _make_assistant_message(error="authentication_failed"),
+            _make_result_message(
+                is_error=True,
+                api_error_status=401,
+                errors=["Invalid API key"],
+            ),
+        ],
+    )
+
+    assert callback.await_count == 1, (
+        f"Expected one callback per failed turn (dedupe across "
+        f"AssistantMessage + ResultMessage paths); got {callback.await_count}: "
+        f"{callback.await_args_list}"
+    )
+    # The AssistantMessage path should win (it fires first in the stream).
+    args, _ = callback.await_args
+    assert args == (ss.agent_name, "authentication_failed")
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_fires_on_result_path_when_assistant_path_silent() -> None:
+    """If the failed turn surfaces only at the ResultMessage (no
+    AssistantMessage error mid-turn), the result-path detection must still
+    fire the alert. Dedupe must not break this case."""
+    ss = _make_session()
+    callback = AsyncMock()
+    ss._auth_alert_callback = callback
+
+    await _run_reader_against_stream(
+        ss,
+        [
+            _make_result_message(
+                is_error=True,
+                api_error_status=403,
+                errors=["Forbidden"],
+            ),
+        ],
+    )
+
+    assert callback.await_count == 1
+    args, _ = callback.await_args
+    assert args[0] == ss.agent_name
+    assert "api_error_status=403" in args[1]
+    # Enriched detail string should include msg.errors for triage context.
+    assert "Forbidden" in args[1]
+
+
+@pytest.mark.asyncio
+async def test_auth_dedupe_resets_between_turns() -> None:
+    """Two separate failed turns in one session must produce two callback
+    invocations — dedupe is per-turn, not per-session."""
+    ss = _make_session()
+    callback = AsyncMock()
+    ss._auth_alert_callback = callback
+
+    await _run_reader_against_stream(
+        ss,
+        [
+            # Turn 1: AssistantMessage auth + ResultMessage 401 — one alert
+            _make_assistant_message(error="authentication_failed"),
+            _make_result_message(is_error=True, api_error_status=401),
+            # Turn 2: ResultMessage 401 only — one more alert
+            _make_result_message(is_error=True, api_error_status=401),
+        ],
+    )
+
+    assert callback.await_count == 2, (
+        f"Expected two callbacks (one per failed turn); got {callback.await_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_billing_error_assistant_does_not_block_subsequent_auth_alert() -> None:
+    """Edge case: AssistantMessage with error="billing_error" (NOT auth) on
+    one turn must not set the dedupe flag, so a real auth failure on the
+    NEXT turn still alerts."""
+    ss = _make_session()
+    callback = AsyncMock()
+    ss._auth_alert_callback = callback
+
+    await _run_reader_against_stream(
+        ss,
+        [
+            # Turn 1: billing error — must not fire auth alert, must not
+            # set the dedupe flag (it's not an auth error).
+            _make_assistant_message(error="billing_error"),
+            _make_result_message(is_error=True, api_error_status=402),
+            # Turn 2: real auth failure — must alert.
+            _make_assistant_message(error="authentication_failed"),
+            _make_result_message(is_error=True, api_error_status=401),
+        ],
+    )
+
+    assert callback.await_count == 1
+    args, _ = callback.await_args
+    assert args == (ss.agent_name, "authentication_failed")

--- a/uv.lock
+++ b/uv.lock
@@ -508,20 +508,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.73"
+version = "0.1.77"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/d7/5207b9428813918532d52fbcc8342aa105e04cb50afb94118228a322af39/claude_agent_sdk-0.1.73.tar.gz", hash = "sha256:7dbb1e885abac558e39374da632c52e87a931861e20c67e1f36c86e7e3be7f19", size = 242906, upload-time = "2026-05-04T23:14:12.366Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/d4/7e3ca29d1b6f76639b4bd4becb796ef68a492be3a561c6cd19abe5fe903a/claude_agent_sdk-0.1.77.tar.gz", hash = "sha256:cb292268ecab294047f02365298ecbf8cc17146c4c86fda54b068a1d38e1ebbb", size = 250297, upload-time = "2026-05-08T00:03:03.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/9d/37bac90d86f50642ba1e9b70b558cdd643da8bb1109c584ce32ad0b1fc6f/claude_agent_sdk-0.1.73-py3-none-macosx_11_0_arm64.whl", hash = "sha256:62171e16840a8d00681207f6ea133736082b5df701a87548a84ec5ab00cdf5ca", size = 63885588, upload-time = "2026-05-04T23:14:16.457Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/e2/81212e886a9bc34a14b8d3588aafd3460bb37328edc4793b10e7df205e05/claude_agent_sdk-0.1.73-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:a702aecfdd1d9ad7dd9fcf19aa9ebde41ffc426e28a4125b3ab2e88b49a89c47", size = 65744104, upload-time = "2026-05-04T23:14:20.345Z" },
-    { url = "https://files.pythonhosted.org/packages/80/81/2ecea14eb376d2eaf7f121fdc6ee4b00071b9b1b859ff7251d84fe0e4686/claude_agent_sdk-0.1.73-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:6cb2c38fbfd3d6be7edfc41ce342635569403a8b41f77ded07c328f20b6138cf", size = 77049373, upload-time = "2026-05-04T23:14:24.595Z" },
-    { url = "https://files.pythonhosted.org/packages/89/16/a02de4e05bd522beddf2aa02351fc670222929e9e25fff2e23add7937df6/claude_agent_sdk-0.1.73-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:938b2f1adf10e92d4e14c0b16d61f8e616171e98cdc7c3cbcd197dd857fdbc22", size = 77225319, upload-time = "2026-05-04T23:14:28.843Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/6a/cb0b8b9a9110ca46e5fb2de7c4e4224e0b18ca8fd50430ca0ea4118608cd/claude_agent_sdk-0.1.73-py3-none-win_amd64.whl", hash = "sha256:85454108785058bab796e9de2d654ce5570c2d9f8de9a9889e02a751d4a43158", size = 78636611, upload-time = "2026-05-04T23:14:33.165Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fc/dbb90aff01fe7bdd7708077aaff4b36d5be48a38318fd4ca2216aa64ed87/claude_agent_sdk-0.1.77-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a5697c838cb3a0c78f73698933cd2eea98e8baea99be0740e314fc9e1f69fd4c", size = 60659903, upload-time = "2026-05-08T00:03:06.461Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6e/c984d60f4b3cbbf7d84157283338493d11a2b557a2f6389118b5a7f8adc2/claude_agent_sdk-0.1.77-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:a85e3a8cf5d521116d964d28939f25e367d18e5bdb2232cae260b8e8bd9d946f", size = 62721493, upload-time = "2026-05-08T00:03:09.808Z" },
+    { url = "https://files.pythonhosted.org/packages/00/83/575e798ce53b58e14d775db104cdb2558706e7f8d22dc647752208fa853f/claude_agent_sdk-0.1.77-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:16864b91bf369e99590e3ffba82e2d711807caaa4329b11462212779224cd355", size = 70393564, upload-time = "2026-05-08T00:03:13.383Z" },
+    { url = "https://files.pythonhosted.org/packages/00/67/50aed27534a9183e204cca33fbef36d0fe5f5145ebf4061c01f2edeaf6db/claude_agent_sdk-0.1.77-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:7db011c9c8ca4168249f1ce90d4372e13ebab2b122498167e6fb2a5c9c1bd427", size = 70582992, upload-time = "2026-05-08T00:03:16.997Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3f/a9d396c46e40d025d4209cf0f6f01a62c70c33b70efceb2d2e991e8ed08c/claude_agent_sdk-0.1.77-py3-none-win_amd64.whl", hash = "sha256:fe7dd006a15a85c1d9a2698d6fffd58e0ce689db1f0040f5b5e4c06d51ce2505", size = 71224295, upload-time = "2026-05-08T00:03:20.695Z" },
 ]
 
 [[package]]
@@ -2258,7 +2258,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'web'", specifier = ">=4.12" },
     { name = "caldav", marker = "extra == 'calendar'", specifier = ">=1.3" },
     { name = "camoufox", marker = "extra == 'web'", specifier = ">=0.4" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.73" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.77" },
     { name = "cryptography", specifier = ">=41.0" },
     { name = "cryptography", marker = "extra == 'calendar'", specifier = ">=41.0" },
     { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.3" },


### PR DESCRIPTION
Closes #403. Follow-up to #402 (which bumped 0.1.73→0.1.76); this PR bumps to **0.1.77** and lands the structured auth-detection refactor sketched in #401's recipe.

## Summary

- Drop the legacy substring-tuple auth detection in `streaming_session.py`.
- Add structured detectors using the SDK's typed fields:
  - `_is_auth_error_assistant(msg)` — exact match against the `AssistantMessageError` Literal `"authentication_failed"`. Other Literal values (billing_error, rate_limit, invalid_request, server_error, unknown) are NOT credential failures.
  - `_is_auth_error_result(result)` — `api_error_status in {401, 403}`. The `api_error_status` field was added in SDK 0.1.76.
- Wire both detectors into the reader loop. The ResultMessage error path previously had no auth detection at all — closes that gap.
- Bump `claude-agent-sdk` floor 0.1.76 → 0.1.77 (also brings bundled CLI 2.1.133 — subagent skill discovery fix, parallel-session refresh-token race fix, hooks effort context).
- Replace the old `_is_auth_error(str)` tests with structured tests for both detectors using `SimpleNamespace` stand-ins. 27 tests in `test_auth_alerts.py`, full suite green.

## Why this matters

Pre-refactor, `_AUTH_ERROR_TOKENS` carried entries (`invalid_api_key`, `unauthorized`, `auth_error`, `permission_error`) that the `AssistantMessageError` Literal cannot produce — pure cargo from before the type became strict. Worse, the `ResultMessage` error path had no auth detection at all, so credential failures that landed only at turn completion were silently swallowed (no operator alert).

After this refactor:
- Both message paths detect auth failures with exact-match semantics over typed values.
- Operator-alert wiring fires from either path.
- An `AssistantMessageError` variant rename becomes a test failure instead of a silent regression.

## Diff scope

```
 pyproject.toml                        |  2 +-
 src/pinky_daemon/api.py               | 11 +++--
 src/pinky_daemon/streaming_session.py | 79 +++++++++++++++++++++++----------
 tests/test_auth_alerts.py             | 81 +++++++++++++++++++++++++++++------
 4 files changed, 132 insertions(+), 41 deletions(-)
```

Pure semantics change in `api.py` — only the `_on_auth_failure` docstring was updated to point at the new detectors (the old comment referenced `auth_alerts._is_auth_error` which never existed in `auth_alerts.py`).

## Test plan

- [x] `pytest tests/test_auth_alerts.py -x` — 27 passed
- [x] `pytest tests/ -x` (full suite) — 1774 passed, 1 skipped
- [x] `ruff check` on modified files — clean
- [ ] Live verification on Pi after merge: trigger an auth failure, confirm operator alert fires from both AssistantMessage and ResultMessage paths

🤖 Opened by Barsik