### PR TITLE
feat(docker): containerize PinkyBot for portable deploys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,62 @@
+# Version control / CI metadata
+.git
+.gitignore
+.github
+
+# Editor / IDE
+.vscode
+.idea
+*.swp
+*.swo
+.DS_Store
+
+# Python build artifacts
+__pycache__
+*.py[cod]
+*$py.class
+.pytest_cache
+.ruff_cache
+.mypy_cache
+.coverage
+htmlcov
+*.egg-info
+build
+dist
+
+# Virtual envs
+.venv
+venv
+env
+
+# Frontend build artifacts (the image rebuilds them in the frontend stage)
+frontend-dist
+frontend-svelte/node_modules
+frontend-svelte/dist
+
+# Per-agent runtime data — never bake into an image
+data
+logs
+*.log
+
+# Tests are not needed in the runtime image (CI runs them outside Docker)
+tests
+
+# Local secrets / config
+.env
+.env.*
+*.pem
+*.key
+secrets
+
+# Docs / dev-only artifacts
+docs
+.claude
+notes
+scratch
+*.md.bak
+
+# Skill files are user-specific and gitignored
+skills
+
+# OS / misc
+Thumbs.db

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,126 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ["26.*"]
+  pull_request:
+    branches: [main, beta]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/docker-publish.yml"
+      - "pyproject.toml"
+      - "frontend-svelte/**"
+      - "src/**"
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # ──────────────────────────────────────────────────────────────────
+  # PR validation — build single-arch (linux/amd64) without pushing.
+  # Catches Dockerfile breakage before merge without burning multi-arch
+  # build minutes.
+  # ──────────────────────────────────────────────────────────────────
+  build-pr:
+    if: github.event_name == 'pull_request'
+    name: Build (PR validation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: pinkybot:pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test the image starts
+        run: |
+          docker run --rm --name pinkybot-smoke \
+            -e PINKY_SESSION_SECRET=ci-smoke-only \
+            -e PINKY_UI_PASSWORD=ci-smoke \
+            -d -p 8888:8888 \
+            pinkybot:pr-${{ github.event.pull_request.number }}
+          # Give it up to 60s to come up
+          for i in $(seq 1 30); do
+            if curl --fail --silent http://localhost:8888/ -o /dev/null; then
+              echo "Daemon responded on / after ${i} attempts"
+              docker logs pinkybot-smoke | tail -30
+              docker stop pinkybot-smoke
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Daemon did not respond on / within 60s"
+          docker logs pinkybot-smoke | tail -50
+          docker stop pinkybot-smoke
+          exit 1
+
+  # ──────────────────────────────────────────────────────────────────
+  # Publish — multi-arch build + push to GHCR on main pushes and tags.
+  # ──────────────────────────────────────────────────────────────────
+  publish:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    name: Build + push (multi-arch)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU (for arm64 emulation on x86 runner)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Tagging strategy:
+          #   - main push  →  :main (floating)
+          #   - tag 26.*   →  :<tag-as-is>, :latest
+          #   - any        →  :sha-<short-sha> (immutable forensic tag)
+          tags: |
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=match,pattern=^26\..*,enable=${{ startsWith(github.ref, 'refs/tags/26.') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/26.') }}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build + push (linux/amd64, linux/arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,13 +25,13 @@ env:
 
 jobs:
   # ──────────────────────────────────────────────────────────────────
-  # PR validation — build single-arch (linux/amd64) without pushing.
-  # Catches Dockerfile breakage before merge without burning multi-arch
-  # build minutes.
+  # PR validation (amd64) — build native + run a 60s daemon smoke.
+  # `load: true` only supports single-platform images, so the smoke
+  # test lives on amd64. Catches most Dockerfile breakage cheaply.
   # ──────────────────────────────────────────────────────────────────
-  build-pr:
+  build-pr-amd64:
     if: github.event_name == 'pull_request'
-    name: Build (PR validation)
+    name: Build + smoke (linux/amd64)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -71,6 +71,39 @@ jobs:
           docker logs pinkybot-smoke | tail -50
           docker stop pinkybot-smoke
           exit 1
+
+  # ──────────────────────────────────────────────────────────────────
+  # PR validation (arm64) — build via QEMU emulation, no push, no
+  # smoke (multi-platform images can't be `load: true`'d, and running
+  # an emulated daemon is flaky). The build itself is the gate:
+  # it fails fast on arch-specific deps that wheel-resolve on amd64
+  # but need a source build on arm64. Without this, an arm64-only
+  # break would only surface in the post-merge multi-arch publish.
+  # ──────────────────────────────────────────────────────────────────
+  build-pr-arm64:
+    if: github.event_name == 'pull_request'
+    name: Build (linux/arm64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (arm64, no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: false
+          tags: pinkybot:pr-${{ github.event.pull_request.number }}-arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # ──────────────────────────────────────────────────────────────────
   # Publish — multi-arch build + push to GHCR on main pushes and tags.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,94 @@
+# syntax=docker/dockerfile:1.7
+
+# ─────────────────────────────────────────────────────────────────────
+# Stage 1 — Build the Svelte frontend
+# ─────────────────────────────────────────────────────────────────────
+FROM node:20-slim AS frontend
+
+WORKDIR /app/frontend-svelte
+
+# Install deps separately so this layer caches when only source changes
+COPY frontend-svelte/package.json frontend-svelte/package-lock.json ./
+RUN npm ci
+
+# Build outputs to /app/frontend-dist (per vite.config.js: outDir: '../frontend-dist')
+COPY frontend-svelte/ ./
+RUN npm run build
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Stage 2 — Install Python dependencies into an isolated venv
+# ─────────────────────────────────────────────────────────────────────
+FROM python:3.13-slim AS python-build
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# build-essential covers cffi/cryptography source builds when wheels are missing
+# (mostly relevant on linux/arm64); pruned in the runtime stage anyway.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Bring in metadata + source for an editable-style install (hatchling reads src/)
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+# Install into an isolated venv — easy to copy into the runtime stage.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --upgrade pip \
+    && pip install ".[telegram,discord,slack,google,calendar,voice,web]"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Stage 3 — Lean runtime image
+# ─────────────────────────────────────────────────────────────────────
+FROM python:3.13-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PATH="/opt/venv/bin:$PATH" \
+    PYTHONPATH=/app/src \
+    PINKYBOT_CHANNEL=stable
+
+# curl needed for HEALTHCHECK; ca-certificates for outbound TLS
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root runtime user
+RUN groupadd --system pinky \
+    && useradd --system --gid pinky --shell /bin/bash --home /home/pinky --create-home pinky
+
+WORKDIR /app
+
+# Bring in the prebuilt venv
+COPY --from=python-build --chown=pinky:pinky /opt/venv /opt/venv
+
+# Application source + built frontend assets
+COPY --chown=pinky:pinky src/ ./src/
+COPY --chown=pinky:pinky pyproject.toml README.md ./
+COPY --from=frontend --chown=pinky:pinky /app/frontend-dist ./frontend-dist
+
+# Persistent state lives at /app/data — mount a volume here.
+# The daemon's default working_dir is "." so `/app/data/agents/<name>/...`
+# matches the layout used in non-Docker deployments.
+RUN mkdir -p /app/data && chown -R pinky:pinky /app/data
+VOLUME ["/app/data"]
+
+USER pinky
+
+EXPOSE 8888
+
+# Liveness probe — the SPA root returns 200 once the API server is up.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl --fail --silent --show-error http://localhost:8888/ -o /dev/null || exit 1
+
+ENTRYPOINT ["python", "-m", "pinky_daemon"]
+CMD ["--mode", "api", "--host", "0.0.0.0", "--port", "8888"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,14 @@ COPY src/ ./src/
 # Install into an isolated venv — easy to copy into the runtime stage.
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
+# NOTE: the `web` extra (camoufox) is intentionally omitted.
+# Camoufox needs Firefox runtime libs (libgtk-3-0, libx11-xcb1, libasound2, …)
+# AND a `python -m camoufox fetch` browser download (~200MB) to actually work.
+# A future `pinkybot:web` variant can layer those in. v1 keeps the image lean
+# and assumes web scraping runs out-of-container (e.g. via the shared pinky-web
+# MCP service) when needed.
 RUN pip install --upgrade pip \
-    && pip install ".[telegram,discord,slack,google,calendar,voice,web]"
+    && pip install ".[telegram,discord,slack,google,calendar,voice]"
 
 
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile (Svelte build → Python venv → lean python:3.13-slim runtime). Non-root user, `/app/data` volume, `curl` HEALTHCHECK. Bundles `[telegram,discord,slack,google,calendar,voice]`. **`web` extra is intentionally omitted** in v1 (camoufox requires Firefox runtime libs + a 200MB browser fetch — future `pinkybot:web` variant).
- `.dockerignore` keeps git, tests, `data/`, `skills/`, secrets, frontend `node_modules` and build artifacts out of the image. Image carries `src/` + built frontend + venv only.
- New `docker-publish.yml` workflow:
  - **PR validation (amd64):** native build (`load: true`) + 60s daemon-up smoke test on `/`.
  - **PR validation (arm64):** QEMU-emulated build, no push/load (multi-platform images can't `load`, emulated daemon is flaky). Build itself is the gate against arm64-only breakage.
  - **Publish (push to `main` / tag `26.*`):** multi-arch (`linux/amd64,linux/arm64`) build + push to `ghcr.io/bradbrok/pinkybot`. Tags: `:main` (floating), `:<tag-as-is>`, `:latest` (on `26.*` tags), `:sha-<short>` always.

## Why
Right now PinkyBot only ships as a checkout-on-the-Mac-mini deploy. A container makes it portable — Pi clusters, friends' machines, on-call laptops. Same artifact everywhere, same code path as the Mac mini.

## Test plan
- [ ] CI `Build + smoke (linux/amd64)` goes green (build + 60s daemon-up smoke)
- [ ] CI `Build (linux/arm64)` goes green (catches arm64-specific dep breakage pre-merge)
- [ ] After merge: `:main` and `:sha-<short>` images appear under `ghcr.io/bradbrok/pinkybot`
- [ ] After tagging `26.05.069` (or whatever): `:26.05.069` and `:latest` published, both arches
- [ ] Manual smoke: `docker run -p 8888:8888 -e PINKY_SESSION_SECRET=test -e PINKY_UI_PASSWORD=test ghcr.io/bradbrok/pinkybot:latest` → SPA loads on `:8888`

## Run cheat sheet
```
docker run -d --name pinkybot \
  -p 8888:8888 \
  -v pinkybot-data:/app/data \
  -e PINKY_SESSION_SECRET=$(openssl rand -hex 32) \
  -e PINKY_UI_PASSWORD=changeme \
  ghcr.io/bradbrok/pinkybot:latest
```

## Known limitations (v1)
- **No `web` extra** — pinky_web (camoufox/scraping) won't work inside this image. Run pinky-web as a separate service (the existing shared MCP setup) or use a future `pinkybot:web` variant.
- **`/admin/update` is a no-op** — the immutable image has no git repo to pull. Update by pulling a newer image tag instead.

## Notes
- No behavioral code changes — purely additive packaging.
- `PINKYBOT_CHANNEL` defaults to `stable` in the runtime image; override at run time.
- Mac mini deploy stays exactly as it is. Image is an alternate distribution, not a replacement (yet).

🤖 Opened by Barsik