### PR TITLE
feat(broker): split outreach outcome into success/rejected/error_upstream/error_internal (#81)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -24,6 +24,7 @@ import urllib.request
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Literal
 
 from fastapi import (
     FastAPI,
@@ -151,6 +152,21 @@ MIN_UI_PASSWORD_LENGTH = 8
 CONTEXT_SAVE_SOURCE_SELF_TOOL = "save_my_context"
 CONTEXT_ACTIVITY_SAVE_BUFFER_SECONDS = 5 * 60
 CONTEXT_STALE_WARNING_SECONDS = 12 * 60 * 60
+
+# Outreach attempt outcome buckets (task #81 / issue #395 follow-up).
+# Splits the previous free-form "ok"/"error" outcome into 4 typed buckets so
+# dashboards can distinguish caller-side validation failures from real
+# upstream platform errors from genuinely unexpected internal exceptions.
+#   - success         — adapter call returned a message_id (the send worked)
+#   - rejected        — caller-side validation failed (HTTPException raised
+#                       by our code due to bad input: missing field, bad
+#                       platform, missing API key, no Giphy results, etc.)
+#   - error_upstream  — Telegram / OpenAI / Giphy returned a real error
+#                       (TelegramError, urlopen network failure, timeout,
+#                       upstream HTTP 4xx/5xx)
+#   - error_internal  — genuinely unexpected exception we should have caught
+#                       (bare `except Exception` paths with no upstream context)
+OutreachOutcome = Literal["success", "rejected", "error_upstream", "error_internal"]
 
 
 def resolve_provider_config(
@@ -1125,18 +1141,23 @@ def create_api(
             loop = asyncio.get_running_loop()
             result = await loop.run_in_executor(None, _generate_and_send)
         except HTTPException:
+            # All HTTPExceptions reachable here come from caller-side config
+            # validation inside _generate_and_send (e.g. missing API key,
+            # unknown TTS provider) — bucket as `rejected`.
             _outreach_attempt_log(
                 agent_name=agent_name, platform=platform, method="send_voice",
                 chat_id=chat_id, file_path="", caption_len=len(text),
-                outcome="error", error="HTTPException",
+                outcome="rejected", error="HTTPException",
             )
             raise
         except Exception as e:
+            # Bare catch-all wraps urlopen (TTS provider) + adapter.send_voice
+            # (Telegram) — both are upstream calls, so bucket as `error_upstream`.
             error_repr = f"{type(e).__name__}: {e}"
             _outreach_attempt_log(
                 agent_name=agent_name, platform=platform, method="send_voice",
                 chat_id=chat_id, file_path="", caption_len=len(text),
-                outcome="error", error=error_repr,
+                outcome="error_upstream", error=error_repr,
             )
             raise HTTPException(502, f"Failed to send_voice: {error_repr}") from e
         finally:
@@ -1145,7 +1166,7 @@ def create_api(
         _outreach_attempt_log(
             agent_name=agent_name, platform=platform, method="send_voice",
             chat_id=chat_id, file_path="", caption_len=len(text),
-            outcome="ok",
+            outcome="success",
         )
         return result
 
@@ -4896,7 +4917,7 @@ def create_api(
         chat_id: str,
         file_path: str,
         caption_len: int,
-        outcome: str,
+        outcome: OutreachOutcome,
         error: str = "",
     ) -> None:
         """Structured outreach-attempt log line (issue #395).
@@ -4965,18 +4986,26 @@ def create_api(
             )
         except HTTPException:
             # Already structured — let FastAPI render it. Still stop typing.
+            # HTTPExceptions reachable here come from _send_file_message's
+            # config-side validation (HTTPException(503, "No {platform} adapter")
+            # / HTTPException(400, "Unsupported platform")) → caller-side
+            # `rejected`.
             _outreach_attempt_log(
                 agent_name=agent_name, platform=platform, method=method,
                 chat_id=chat_id, file_path=file_path, caption_len=len(caption),
-                outcome="error", error="HTTPException",
+                outcome="rejected", error="HTTPException",
             )
             raise
         except Exception as e:
+            # Bare catch-all wraps adapter.send_{photo,document,animation},
+            # which raise TelegramError, FileNotFoundError (when adapter opens
+            # the user-supplied path), httpx errors, etc. All are produced
+            # downstream of our handler, so bucket as `error_upstream`.
             error_repr = f"{type(e).__name__}: {e}"
             _outreach_attempt_log(
                 agent_name=agent_name, platform=platform, method=method,
                 chat_id=chat_id, file_path=file_path, caption_len=len(caption),
-                outcome="error", error=error_repr,
+                outcome="error_upstream", error=error_repr,
             )
             raise HTTPException(502, f"Failed to {method}: {error_repr}") from e
         finally:
@@ -4988,7 +5017,7 @@ def create_api(
         _outreach_attempt_log(
             agent_name=agent_name, platform=platform, method=method,
             chat_id=chat_id, file_path=file_path, caption_len=len(caption),
-            outcome="ok",
+            outcome="success",
         )
         if kind == "photo":
             content_default = "[photo]"
@@ -5082,20 +5111,26 @@ def create_api(
             try:
                 data = await loop.run_in_executor(None, _search_giphy)
             except Exception as e:
+                # Giphy search failure (urlopen timeout / network / HTTP error)
+                # — purely upstream.
                 error_repr = f"Giphy search failed: {e}"
                 _outreach_attempt_log(
                     agent_name=agent_name_req, platform=platform, method="send_gif",
                     chat_id=chat_id, file_path="", caption_len=len(caption),
-                    outcome="error", error=error_repr,
+                    outcome="error_upstream", error=error_repr,
                 )
                 raise HTTPException(502, error_repr) from e
 
             results = data.get("data", [])
             if not results:
+                # Giphy returned 200 with an empty result set: not an upstream
+                # failure (the API answered correctly), but the caller's query
+                # didn't match anything. Treat as caller-side `rejected` —
+                # nothing for us to send back.
                 _outreach_attempt_log(
                     agent_name=agent_name_req, platform=platform, method="send_gif",
                     chat_id=chat_id, file_path="", caption_len=len(caption),
-                    outcome="error", error="no_results",
+                    outcome="rejected", error="no_results",
                 )
                 raise HTTPException(404, f"No GIFs found for query: {query!r}")
 
@@ -5124,18 +5159,24 @@ def create_api(
             try:
                 msg = await loop.run_in_executor(None, _download_and_send)
             except HTTPException:
+                # _download_and_send wraps urlopen + adapter.send_animation;
+                # neither raises HTTPException directly today, so this branch
+                # is defensive. If an HTTPException ever does surface here it
+                # came from a config-side check, so bucket as `rejected`.
                 _outreach_attempt_log(
                     agent_name=agent_name_req, platform=platform, method="send_gif",
                     chat_id=chat_id, file_path="", caption_len=len(caption),
-                    outcome="error", error="HTTPException",
+                    outcome="rejected", error="HTTPException",
                 )
                 raise
             except Exception as e:
+                # urlopen (download) + adapter.send_animation (Telegram) —
+                # both upstream.
                 error_repr = f"{type(e).__name__}: {e}"
                 _outreach_attempt_log(
                     agent_name=agent_name_req, platform=platform, method="send_gif",
                     chat_id=chat_id, file_path="", caption_len=len(caption),
-                    outcome="error", error=error_repr,
+                    outcome="error_upstream", error=error_repr,
                 )
                 raise HTTPException(502, f"Failed to send_gif: {error_repr}") from e
         finally:
@@ -5145,7 +5186,7 @@ def create_api(
         _outreach_attempt_log(
             agent_name=agent_name_req, platform=platform, method="send_gif",
             chat_id=chat_id, file_path="", caption_len=len(caption),
-            outcome="ok",
+            outcome="success",
         )
         _record_outbound_message(
             agent_name_req,

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -4996,11 +4996,28 @@ def create_api(
                 outcome="rejected", error="HTTPException",
             )
             raise
+        except FileNotFoundError as e:
+            # Carve-out before the generic catch-all: FileNotFoundError on the
+            # caller-supplied `file_path` happens when the adapter does
+            # `open(file_path, "rb")` and the path doesn't exist or isn't
+            # readable. Critically, NO Telegram/OpenAI/upstream call has been
+            # made yet — this is purely a caller-side validation failure
+            # (they handed us a path we can't read), so it belongs in the
+            # `rejected` bucket, not `error_upstream`. Status 400 reflects the
+            # bad-input semantics (was 502 before #408 follow-up).
+            error_repr = f"{type(e).__name__}: {e}"
+            _outreach_attempt_log(
+                agent_name=agent_name, platform=platform, method=method,
+                chat_id=chat_id, file_path=file_path, caption_len=len(caption),
+                outcome="rejected", error=error_repr,
+            )
+            raise HTTPException(400, f"Failed to {method}: {error_repr}") from e
         except Exception as e:
             # Bare catch-all wraps adapter.send_{photo,document,animation},
-            # which raise TelegramError, FileNotFoundError (when adapter opens
-            # the user-supplied path), httpx errors, etc. All are produced
-            # downstream of our handler, so bucket as `error_upstream`.
+            # which raise TelegramError, httpx errors, etc. All are produced
+            # downstream of our handler against a real network/SDK call, so
+            # bucket as `error_upstream`. (FileNotFoundError is split out
+            # above as a caller-side `rejected`.)
             error_repr = f"{type(e).__name__}: {e}"
             _outreach_attempt_log(
                 agent_name=agent_name, platform=platform, method=method,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1673,6 +1673,208 @@ class TestAPI:
                 assert resp.json()["summary"] == "No new conversation history to process."
 
 
+# ── Outreach Outcome Buckets (task #81 / issue #395 follow-up) ───────
+
+
+class TestOutreachOutcomeBuckets:
+    """Verify the 4-bucket OutreachOutcome enum is wired correctly into the
+    broker handlers and emitted on `outreach-attempt` log lines.
+
+    Buckets:
+      - success         — adapter returned a message_id
+      - rejected        — caller-side validation failed (HTTPException raised
+                          by our code due to bad input / no results / missing
+                          API key)
+      - error_upstream  — Telegram / OpenAI / Giphy returned a real error
+      - error_internal  — generic catch-all for genuinely unexpected exceptions
+                          (defined for completeness; no organic call site today)
+    """
+
+    def _make_app(self, path: str):
+        from pinky_daemon.api import create_api
+        return create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
+
+    def _capture_outreach_logs(self):
+        """Patch `pinky_daemon.api._log` to capture every log line emitted.
+
+        Returns (mock, getter) where getter() yields only the structured
+        `outreach-attempt:` lines from the captured log stream.
+        """
+        captured: list[str] = []
+
+        def _fake_log(msg: str) -> None:
+            captured.append(msg)
+
+        return captured, _fake_log
+
+    def test_outreach_outcome_logs_success_on_happy_path(self):
+        """Happy-path send_gif must log `outcome=success` and no `error=` field."""
+        from pinky_outreach.telegram import TelegramAdapter
+
+        class _GiphyResp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self):
+                return json.dumps({
+                    "data": [{"images": {"original": {"url": "https://media.giphy.com/test.gif?cid=abc"}}}]
+                }).encode()
+
+        class _GifBlobResp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b"GIF89a-bytes"
+
+        def _urlopen_side_effect(req_or_url, *args, **kwargs):
+            url = req_or_url if isinstance(req_or_url, str) else getattr(req_or_url, "full_url", "")
+            if "giphy.com/v1/gifs/search" in url:
+                return _GiphyResp()
+            return _GifBlobResp()
+
+        captured, fake_log = self._capture_outreach_logs()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                with patch("pinky_daemon.api._log", side_effect=fake_log), \
+                        patch("urllib.request.urlopen", side_effect=_urlopen_side_effect), \
+                        patch.object(
+                            TelegramAdapter,
+                            "send_animation",
+                            return_value=SimpleNamespace(message_id="msg-42"),
+                        ):
+                    resp = client.post(
+                        "/broker/send-gif",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "telegram",
+                            "chat_id": "6770805286",
+                            "query": "happy cat",
+                        },
+                    )
+
+                assert resp.status_code == 200, resp.text
+                outreach_lines = [m for m in captured if m.startswith("outreach-attempt:")]
+                assert any("outcome=success" in m and "method=send_gif" in m for m in outreach_lines), (
+                    f"expected success outcome in outreach logs, got: {outreach_lines}"
+                )
+                # Success path must not append an `error=` field.
+                success_lines = [m for m in outreach_lines if "outcome=success" in m]
+                assert all(" error=" not in m for m in success_lines), success_lines
+
+    def test_outreach_outcome_logs_rejected_on_no_giphy_results(self):
+        """Empty Giphy results → `outcome=rejected error=no_results` (treating
+        the empty-search case as caller-side: their query didn't match)."""
+        class _EmptyGiphyResp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return json.dumps({"data": []}).encode()
+
+        captured, fake_log = self._capture_outreach_logs()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                with patch("pinky_daemon.api._log", side_effect=fake_log), \
+                        patch("urllib.request.urlopen", return_value=_EmptyGiphyResp()):
+                    resp = client.post(
+                        "/broker/send-gif",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "telegram",
+                            "chat_id": "6770805286",
+                            "query": "asdfghjklqwerty-no-such-thing",
+                        },
+                    )
+
+                assert resp.status_code == 404, resp.text
+                outreach_lines = [m for m in captured if m.startswith("outreach-attempt:")]
+                assert any(
+                    "outcome=rejected" in m and "error=no_results" in m and "method=send_gif" in m
+                    for m in outreach_lines
+                ), f"expected rejected/no_results in outreach logs, got: {outreach_lines}"
+
+    def test_outreach_outcome_logs_error_upstream_on_telegram_failure(self):
+        """TelegramError from adapter.send_animation → `outcome=error_upstream`."""
+        from pinky_outreach.telegram import TelegramAdapter, TelegramError
+
+        class _GiphyResp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self):
+                return json.dumps({
+                    "data": [{"images": {"original": {"url": "https://media.giphy.com/test.gif?cid=abc"}}}]
+                }).encode()
+
+        class _GifBlobResp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b"GIF89a-bytes"
+
+        def _urlopen_side_effect(req_or_url, *args, **kwargs):
+            url = req_or_url if isinstance(req_or_url, str) else getattr(req_or_url, "full_url", "")
+            if "giphy.com/v1/gifs/search" in url:
+                return _GiphyResp()
+            return _GifBlobResp()
+
+        captured, fake_log = self._capture_outreach_logs()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                with patch("pinky_daemon.api._log", side_effect=fake_log), \
+                        patch("urllib.request.urlopen", side_effect=_urlopen_side_effect), \
+                        patch.object(
+                            TelegramAdapter,
+                            "send_animation",
+                            side_effect=TelegramError("Bad Request: ANIMATION_INVALID", 400),
+                        ):
+                    resp = client.post(
+                        "/broker/send-gif",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "telegram",
+                            "chat_id": "6770805286",
+                            "query": "cat typing",
+                        },
+                    )
+
+                assert resp.status_code == 502, resp.text
+                outreach_lines = [m for m in captured if m.startswith("outreach-attempt:")]
+                assert any(
+                    "outcome=error_upstream" in m and "TelegramError" in m and "method=send_gif" in m
+                    for m in outreach_lines
+                ), f"expected error_upstream/TelegramError in outreach logs, got: {outreach_lines}"
+
+    def test_outreach_outcome_type_alias_covers_all_four_buckets(self):
+        """Verify the OutreachOutcome Literal type alias defines exactly the
+        four expected buckets. Static-analysis tools (mypy/pyright) enforce
+        call-site correctness; this guards against accidental edits to the
+        type alias itself.
+
+        Includes `error_internal` even though no current handler emits it —
+        the bucket is reserved for future genuinely-unexpected catch-alls.
+        """
+        from pinky_daemon.api import OutreachOutcome
+        assert set(OutreachOutcome.__args__) == {
+            "success",
+            "rejected",
+            "error_upstream",
+            "error_internal",
+        }
+
+
 # ── Context Tracking ─────────────────────────────────────────
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1219,9 +1219,13 @@ class TestAPI:
                 assert resp.status_code == 502, f"expected 502, got {resp.status_code}: {resp.text}"
                 assert ("barsik", "6770805286") in stop_typing_calls
 
-    def test_broker_send_document_filenotfound_returns_structured_502(self):
-        """Issue #395 regression: missing file path raises FileNotFoundError inside the
-        Telegram adapter (`open(file_path, 'rb')`). Must surface as 502, not unhandled."""
+    def test_broker_send_document_filenotfound_returns_structured_400(self):
+        """Issue #395 regression + #408 follow-up: missing file path raises
+        FileNotFoundError inside the Telegram adapter (`open(file_path, 'rb')`).
+        Must surface as a structured response (not unhandled ASGI 500). Status
+        is 400 (bad caller input) since no upstream call has happened — this
+        was 502 before the #408 outcome-bucket split carved FileNotFoundError
+        out as `rejected`."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
@@ -1240,8 +1244,8 @@ class TestAPI:
                 )
 
                 # The adapter will try open() before any HTTP call — that's a real
-                # FileNotFoundError, which the route must wrap.
-                assert resp.status_code == 502, f"expected 502, got {resp.status_code}: {resp.text}"
+                # FileNotFoundError, which the route must wrap as a 400 (rejected).
+                assert resp.status_code == 400, f"expected 400, got {resp.status_code}: {resp.text}"
                 assert "FileNotFoundError" in resp.json().get("detail", "")
 
     def test_broker_send_animation_telegram_error_returns_structured_502(self):
@@ -1297,10 +1301,14 @@ class TestAPI:
                     e.metadata.get("tool") == "send_animation" for e in history
                 ), f"failed send leaked into conversation history: {history}"
 
-    def test_broker_send_animation_filenotfound_returns_structured_502(self):
-        """Issue #395 follow-up: missing animation file must surface as 502 and
-        still tear down the typing indicator (phantom typing dots after a
-        missing file was one of the original #395 symptoms).
+    def test_broker_send_animation_filenotfound_returns_structured_400(self):
+        """Issue #395 follow-up + #408 outcome-bucket follow-up: missing
+        animation file must surface as a structured response (not unhandled
+        ASGI 500) and still tear down the typing indicator (phantom typing
+        dots after a missing file was one of the original #395 symptoms).
+        Status is 400 (bad caller input — `rejected` bucket) since no
+        upstream call has happened yet; was 502 before the FileNotFoundError
+        carve-out in `_broker_send_file_route`.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
@@ -1326,7 +1334,7 @@ class TestAPI:
                     },
                 )
 
-                assert resp.status_code == 502, f"expected 502, got {resp.status_code}: {resp.text}"
+                assert resp.status_code == 400, f"expected 400, got {resp.status_code}: {resp.text}"
                 assert "FileNotFoundError" in resp.json().get("detail", "")
                 assert ("barsik", "6770805286") in stop_typing_calls, (
                     f"stop_typing not called on failure path: {stop_typing_calls}"
@@ -1856,6 +1864,48 @@ class TestOutreachOutcomeBuckets:
                     "outcome=error_upstream" in m and "TelegramError" in m and "method=send_gif" in m
                     for m in outreach_lines
                 ), f"expected error_upstream/TelegramError in outreach logs, got: {outreach_lines}"
+
+    def test_outreach_outcome_logs_rejected_on_send_document_filenotfound(self):
+        """PR #408 follow-up (Murzik P2): `_broker_send_file_route` previously
+        bucketed FileNotFoundError under the bare `except Exception` →
+        `error_upstream`, but the open(file_path) failure happens BEFORE any
+        Telegram/OpenAI/Giphy upstream call. Caller handed us a path we can't
+        read, so it's a caller-side validation failure → `rejected`. Status
+        code is 400 (bad input), not 502 (upstream-flavored)."""
+        captured, fake_log = self._capture_outreach_logs()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                with patch("pinky_daemon.api._log", side_effect=fake_log):
+                    resp = client.post(
+                        "/broker/send-document",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "telegram",
+                            "chat_id": "6770805286",
+                            "file_path": "/tmp/does-not-exist-xyz.pdf",
+                        },
+                    )
+
+                assert resp.status_code == 400, resp.text
+                assert "FileNotFoundError" in resp.json().get("detail", "")
+                outreach_lines = [m for m in captured if m.startswith("outreach-attempt:")]
+                assert any(
+                    "outcome=rejected" in m
+                    and "error=FileNotFoundError:" in m
+                    and "method=send_document" in m
+                    for m in outreach_lines
+                ), f"expected rejected/FileNotFoundError in outreach logs, got: {outreach_lines}"
+                # Must NOT be bucketed as error_upstream — that was the bug.
+                assert not any(
+                    "outcome=error_upstream" in m and "method=send_document" in m
+                    for m in outreach_lines
+                ), f"FileNotFoundError must not bucket as error_upstream: {outreach_lines}"
 
     def test_outreach_outcome_type_alias_covers_all_four_buckets(self):
         """Verify the OutreachOutcome Literal type alias defines exactly the


### PR DESCRIPTION
Closes task #81. Follow-up to issue #395 / PR #397.

## Summary

Replaces the free-form `outcome` string in `_outreach_attempt_log` with a typed `OutreachOutcome` Literal split into 4 buckets, so dashboards greping `outcome=error` can finally distinguish caller-side validation failures from real upstream platform errors from genuinely unexpected internal exceptions.

```python
OutreachOutcome = Literal["success", "rejected", "error_upstream", "error_internal"]
```

- **success** — adapter call returned a `message_id` (the send worked)
- **rejected** — caller-side validation failed: HTTPException raised by *our* code due to bad input (missing field, bad platform, missing API key, no Giphy results, missing/inaccessible local file path, etc.)
- **error_upstream** — Telegram / OpenAI / Giphy returned a real error (TelegramError, urlopen network failure, timeout, upstream HTTP 4xx/5xx)
- **error_internal** — genuinely unexpected exception we should have caught (bare `except Exception` paths with no upstream context)

## Wire behavior change

`/broker/send-photo`, `/broker/send-document`, and `/broker/send-animation` now return **HTTP 400** instead of HTTP 502 when the caller-supplied `file_path` raises `FileNotFoundError` (i.e. the path doesn't exist or can't be opened). The old 502 implied an upstream/gateway failure, which contradicted the new bucket taxonomy: at FileNotFoundError-time, no platform call has been made yet, so it's caller-side input validation. 400 lines up with `HTTPException(400, "Unsupported platform")` and the other `rejected`-bucket sites. Two pre-existing regression tests (`test_broker_send_document_filenotfound_returns_structured_*` + `..._send_animation_...`) updated to assert 400 with inline comments noting the #408 reclassification.

Other handlers' wire behavior is unchanged.

## Bucket-mapping decisions

Each call site now has an inline comment explaining why it's bucketed where. Highlights:

- **Voice handler `except HTTPException`** → `rejected`. Reachable HTTPExceptions come from `_generate_and_send`'s config-side validation (missing API key, unknown TTS provider).
- **Voice handler `except Exception`** → `error_upstream`. Catch-all wraps `urlopen` (TTS provider) + `adapter.send_voice`.
- **File handler `except HTTPException`** → `rejected`. `_send_file_message` raises HTTPException only for "no adapter" / "unsupported platform" — both caller-side config checks.
- **File handler `except FileNotFoundError`** → `rejected` (NEW, Murzik's P2). Caller passed a path we can't open; this fires *before* any platform call. Carved out from the generic catch-all and re-raised as `HTTPException(400, ...)`.
- **File handler `except Exception` (residual)** → `error_upstream`. Catch-all now covers only `adapter.send_{photo,document,animation}` raising TelegramError, httpx errors, etc.
- **Giphy search failure** → `error_upstream`. urlopen network/timeout — purely upstream.
- **Giphy no-results 404** → `rejected`. Slightly debatable: the Giphy API answered correctly with an empty result set, so it's not an upstream *failure*. But there's nothing to send back, so it's a caller-side outcome ("query didn't match anything").
- **`send_gif` `_download_and_send` `except HTTPException`** → `rejected`. Defensive scaffolding — `urlopen` + `adapter.send_animation` don't actually raise HTTPException today. Bucketed as `rejected` for consistency in case a future config check surfaces here.
- **`send_gif` `_download_and_send` `except Exception`** → `error_upstream`. Both calls are upstream.

`error_internal` has zero organic call sites today and is reserved for future catch-alls that genuinely can't attribute upstream-vs-caller. Documented in the type-alias comment so it doesn't look like a typo.

## Tests added

New `TestOutreachOutcomeBuckets` class in `tests/test_api.py` (5 tests):

- `test_outreach_outcome_logs_success_on_happy_path` — happy `send_gif` → `outcome=success`, no `error=` field
- `test_outreach_outcome_logs_rejected_on_no_giphy_results` — empty Giphy response → `outcome=rejected error=no_results`
- `test_outreach_outcome_logs_rejected_on_send_document_filenotfound` — missing file_path → `outcome=rejected error=FileNotFoundError:...`, status 400, AND log does NOT contain `outcome=error_upstream` for the call (regression guard for the P2 finding)
- `test_outreach_outcome_logs_error_upstream_on_telegram_failure` — `TelegramError` from `send_animation` → `outcome=error_upstream`
- `test_outreach_outcome_type_alias_covers_all_four_buckets` — verifies `OutreachOutcome.__args__` exactly matches the 4 expected values

Capture pattern: `patch("pinky_daemon.api._log", side_effect=fake_log)`. No existing log-capture harness in the file, this was the lower-touch option.

Plus updates to two pre-existing #395 regression tests for the 502→400 reclassification (see "Wire behavior change" above).

## Verification

- `pytest tests/test_api.py -q -k 'OutreachOutcomeBuckets'` → 5 passed
- `pytest tests/test_api.py -q` → 286 passed
- `ruff check src/pinky_daemon/api.py tests/test_api.py` → clean
- CI green (Murzik confirmed independently in his re-review, modulo arm64 docker build which is from #407's containerization landing today and is unrelated to this PR's scope)

## Out of scope

- Grafana / log-query updates (per task spec — clean break is fine, no backfill needed since #396 just shipped a day ago)
- The `error` field of `_outreach_attempt_log` — unchanged, still free-form string

🤖 Opened by Pushok