### PR TITLE
feat(ferry): scaffold @ferry/host-pinky with substrate v0.1 ingestion (#413)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -733,6 +733,9 @@ class AgentRegistry:
             ("watchdog_config", "TEXT NOT NULL DEFAULT '{}'"),
             ("last_seen_at", "REAL NOT NULL DEFAULT 0"),
             ("runtime", "TEXT NOT NULL DEFAULT 'claude_sdk'"),
+            # Ferry peer-fleet ACL — list of AgentCardSelector dicts
+            # (separate identity primitive from approved_users; default deny-all)
+            ("peer_fleet_acl", "TEXT NOT NULL DEFAULT '[]'"),
         ]
         for col, typedef in migrations:
             if col not in existing:
@@ -2673,6 +2676,128 @@ except Exception:
         """Get total lifetime cost across all agents."""
         row = self._db.execute("SELECT SUM(cost_usd) FROM agent_costs").fetchone()
         return round(row[0] or 0, 6)
+
+    # ── Ferry peer-fleet ACL ───────────────────────────────
+    #
+    # Separate identity primitive from approved_users (humans on Telegram /
+    # Discord / etc.). Ferry inbound is *agents* addressing an agent —
+    # different identity primitive, separate list. Default-deny.
+    #
+    # Stored as JSON array of AgentCardSelector dicts on the `agents` row's
+    # `peer_fleet_acl` column. See `pinky_daemon.ferry.types.AgentCardSelector`
+    # for the selector shape.
+
+    def has_agent(self, agent_name: str) -> bool:
+        """Return True if an agent with this name is registered (any status)."""
+        row = self._db.execute(
+            "SELECT 1 FROM agents WHERE name = ? LIMIT 1", (agent_name,)
+        ).fetchone()
+        return row is not None
+
+    def get_peer_fleet_acl(self, agent_name: str) -> list[dict]:
+        """Return the list of peer-fleet ACL selector dicts for an agent.
+
+        Each dict has shape `{fleet, agent_id, pinky_type}` (any combination,
+        with at least one non-null field per AgentCardSelector contract).
+        Returns [] for unknown agents or empty/missing ACL.
+        """
+        row = self._db.execute(
+            "SELECT peer_fleet_acl FROM agents WHERE name = ?", (agent_name,)
+        ).fetchone()
+        if not row or not row[0]:
+            return []
+        try:
+            data = json.loads(row[0])
+        except (TypeError, ValueError):
+            return []
+        if not isinstance(data, list):
+            return []
+        return [d for d in data if isinstance(d, dict)]
+
+    def set_peer_fleet_acl(
+        self,
+        agent_name: str,
+        selectors: list[dict],
+    ) -> None:
+        """Replace the peer-fleet ACL for an agent (full replacement, not merge).
+
+        Each selector must have at least one of fleet/agent_id/pinky_type
+        non-empty. Selectors that don't validate are silently dropped with
+        a log line. Empty list = deny all peer-fleet inbound.
+        """
+        clean: list[dict] = []
+        for raw in selectors or []:
+            if not isinstance(raw, dict):
+                _log(f"peer_fleet_acl: skipping non-dict selector for {agent_name}: {raw!r}")
+                continue
+            fleet = (raw.get("fleet") or "").strip() or None
+            agent_id = (raw.get("agent_id") or "").strip() or None
+            pinky_type = (raw.get("pinky_type") or "").strip() or None
+            if not (fleet or agent_id or pinky_type):
+                _log(f"peer_fleet_acl: skipping empty selector for {agent_name}")
+                continue
+            clean.append({
+                "fleet": fleet,
+                "agent_id": agent_id,
+                "pinky_type": pinky_type,
+            })
+        self._db.execute(
+            "UPDATE agents SET peer_fleet_acl = ? WHERE name = ?",
+            (json.dumps(clean), agent_name),
+        )
+        self._db.commit()
+
+    def add_peer_fleet_acl(
+        self,
+        agent_name: str,
+        *,
+        fleet: str | None = None,
+        agent_id: str | None = None,
+        pinky_type: str | None = None,
+    ) -> bool:
+        """Append one selector to an agent's peer_fleet_acl.
+
+        Returns True if added, False if the selector was empty (dropped).
+        Idempotent: a selector matching an existing entry is skipped.
+        """
+        entry = {
+            "fleet": (fleet or "").strip() or None,
+            "agent_id": (agent_id or "").strip() or None,
+            "pinky_type": (pinky_type or "").strip() or None,
+        }
+        if not (entry["fleet"] or entry["agent_id"] or entry["pinky_type"]):
+            return False
+        existing = self.get_peer_fleet_acl(agent_name)
+        if entry in existing:
+            return True
+        existing.append(entry)
+        self.set_peer_fleet_acl(agent_name, existing)
+        return True
+
+    def remove_peer_fleet_acl(
+        self,
+        agent_name: str,
+        *,
+        fleet: str | None = None,
+        agent_id: str | None = None,
+        pinky_type: str | None = None,
+    ) -> int:
+        """Remove all selectors matching the given criteria. Returns count removed.
+
+        Matching is exact: a selector matches if all three fields equal
+        (with None == empty-string == "don't filter on this").
+        """
+        target = {
+            "fleet": (fleet or "").strip() or None,
+            "agent_id": (agent_id or "").strip() or None,
+            "pinky_type": (pinky_type or "").strip() or None,
+        }
+        existing = self.get_peer_fleet_acl(agent_name)
+        kept = [s for s in existing if s != target]
+        removed = len(existing) - len(kept)
+        if removed:
+            self.set_peer_fleet_acl(agent_name, kept)
+        return removed
 
     def close(self) -> None:
         self._db.close()

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -452,6 +453,13 @@ class AgentRegistry:
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         self._db.execute("PRAGMA journal_mode=WAL")
         self._db.execute("PRAGMA foreign_keys=ON")
+        # Guard read-modify-write sequences (e.g. peer_fleet_acl mutation)
+        # from concurrent admin-API requests. SQLite connection is shared
+        # across threads (check_same_thread=False) and Python's default
+        # isolation_level uses deferred BEGIN — without this lock, two
+        # admin requests can both read the same baseline ACL, append
+        # different entries, and one write loses.
+        self._rmw_lock = threading.RLock()
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -2759,6 +2767,9 @@ except Exception:
 
         Returns True if added, False if the selector was empty (dropped).
         Idempotent: a selector matching an existing entry is skipped.
+
+        Thread-safe: read-modify-write is guarded by ``_rmw_lock`` so
+        concurrent admin-API requests can't lose updates.
         """
         entry = {
             "fleet": (fleet or "").strip() or None,
@@ -2767,12 +2778,13 @@ except Exception:
         }
         if not (entry["fleet"] or entry["agent_id"] or entry["pinky_type"]):
             return False
-        existing = self.get_peer_fleet_acl(agent_name)
-        if entry in existing:
+        with self._rmw_lock:
+            existing = self.get_peer_fleet_acl(agent_name)
+            if entry in existing:
+                return True
+            existing.append(entry)
+            self.set_peer_fleet_acl(agent_name, existing)
             return True
-        existing.append(entry)
-        self.set_peer_fleet_acl(agent_name, existing)
-        return True
 
     def remove_peer_fleet_acl(
         self,
@@ -2784,20 +2796,33 @@ except Exception:
     ) -> int:
         """Remove all selectors matching the given criteria. Returns count removed.
 
-        Matching is exact: a selector matches if all three fields equal
-        (with None == empty-string == "don't filter on this").
+        Matching is **exact** on every field. A stored selector matches
+        only when all three of ``fleet`` / ``agent_id`` / ``pinky_type``
+        equal the corresponding argument (``None`` and empty string are
+        normalized to the same value, so omitting an argument is the
+        same as passing ``""``).
+
+        Wildcard caveat: a stored selector with ``agent_id="*"`` is
+        removed only by passing ``agent_id="*"`` — calling
+        ``remove_peer_fleet_acl(agent_name, fleet="sigil")`` will **not**
+        remove a stored ``{fleet:"sigil", agent_id:"*"}`` and silently
+        returns 0. Pass the exact stored selector you want to delete.
+
+        Thread-safe: read-modify-write is guarded by ``_rmw_lock`` so
+        concurrent admin-API requests can't lose updates.
         """
         target = {
             "fleet": (fleet or "").strip() or None,
             "agent_id": (agent_id or "").strip() or None,
             "pinky_type": (pinky_type or "").strip() or None,
         }
-        existing = self.get_peer_fleet_acl(agent_name)
-        kept = [s for s in existing if s != target]
-        removed = len(existing) - len(kept)
-        if removed:
-            self.set_peer_fleet_acl(agent_name, kept)
-        return removed
+        with self._rmw_lock:
+            existing = self.get_peer_fleet_acl(agent_name)
+            kept = [s for s in existing if s != target]
+            removed = len(existing) - len(kept)
+            if removed:
+                self.set_peer_fleet_acl(agent_name, kept)
+            return removed
 
     def close(self) -> None:
         self._db.close()

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -615,6 +615,25 @@ class ApproveUserRequest(BaseModel):
     approved_by: str = ""
 
 
+class PeerFleetAclEntryRequest(BaseModel):
+    """Add or remove one peer-fleet ACL selector for an agent.
+
+    Selectors are shaped after `pinky_daemon.ferry.types.AgentCardSelector` —
+    at-least-one of fleet/agent_id/pinky_type must be non-empty. Wildcards via
+    agent_id="*" or fleet="*".
+    """
+
+    fleet: str = ""
+    agent_id: str = ""
+    pinky_type: str = ""
+
+
+class PeerFleetAclSetRequest(BaseModel):
+    """Replace the full peer-fleet ACL for an agent (full replacement, not merge)."""
+
+    selectors: list[PeerFleetAclEntryRequest] = []
+
+
 class SpawnSessionRequest(BaseModel):
     """Spawn a new session from an agent's config."""
 
@@ -6339,6 +6358,94 @@ def create_api(
         if not agents.set_user_timezone(name, chat_id, timezone):
             raise HTTPException(404, "User not found")
         return {"updated": True, "chat_id": chat_id, "timezone": timezone}
+
+    # ── Ferry Peer-Fleet ACL ───────────────────────────────
+    #
+    # Separate identity primitive from approved_users. Ferry inbound is
+    # *agents* addressing an agent; approved_users is *humans*. Default-deny.
+    # See `pinky_daemon.ferry.types.AgentCardSelector` for selector shape.
+
+    @app.get("/agents/{name}/peer-fleet-acl")
+    async def get_peer_fleet_acl(name: str):
+        """List the peer-fleet ACL selectors for an agent."""
+        if not agents.has_agent(name):
+            raise HTTPException(404, f"Agent '{name}' not found")
+        return {
+            "agent": name,
+            "selectors": agents.get_peer_fleet_acl(name),
+        }
+
+    @app.post("/agents/{name}/peer-fleet-acl")
+    async def add_peer_fleet_acl(name: str, req: PeerFleetAclEntryRequest):
+        """Add one selector to an agent's peer-fleet ACL.
+
+        Empty selectors (no fleet/agent_id/pinky_type set) are rejected with 400.
+        Adds are idempotent — already-present selectors return success without
+        creating duplicates.
+        """
+        if not agents.has_agent(name):
+            raise HTTPException(404, f"Agent '{name}' not found")
+        added = agents.add_peer_fleet_acl(
+            name,
+            fleet=req.fleet or None,
+            agent_id=req.agent_id or None,
+            pinky_type=req.pinky_type or None,
+        )
+        if not added:
+            raise HTTPException(
+                400,
+                "selector requires at least one of fleet, agent_id, or pinky_type",
+            )
+        return {
+            "agent": name,
+            "added": True,
+            "selectors": agents.get_peer_fleet_acl(name),
+        }
+
+    @app.put("/agents/{name}/peer-fleet-acl")
+    async def set_peer_fleet_acl(name: str, req: PeerFleetAclSetRequest):
+        """Replace the full peer-fleet ACL for an agent (full replacement)."""
+        if not agents.has_agent(name):
+            raise HTTPException(404, f"Agent '{name}' not found")
+        selector_dicts = [
+            {
+                "fleet": s.fleet or None,
+                "agent_id": s.agent_id or None,
+                "pinky_type": s.pinky_type or None,
+            }
+            for s in req.selectors
+        ]
+        agents.set_peer_fleet_acl(name, selector_dicts)
+        return {
+            "agent": name,
+            "selectors": agents.get_peer_fleet_acl(name),
+        }
+
+    @app.delete("/agents/{name}/peer-fleet-acl")
+    async def remove_peer_fleet_acl(
+        name: str,
+        fleet: str = "",
+        agent_id: str = "",
+        pinky_type: str = "",
+    ):
+        """Remove all selectors matching the given query.
+
+        Match is exact across all three fields (None == empty == "don't filter").
+        Returns the count removed.
+        """
+        if not agents.has_agent(name):
+            raise HTTPException(404, f"Agent '{name}' not found")
+        removed = agents.remove_peer_fleet_acl(
+            name,
+            fleet=fleet or None,
+            agent_id=agent_id or None,
+            pinky_type=pinky_type or None,
+        )
+        return {
+            "agent": name,
+            "removed": removed,
+            "selectors": agents.get_peer_fleet_acl(name),
+        }
 
     # ── Pending Messages (Broker) ──────────────────────────
 

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -631,6 +631,33 @@ class MessageBroker:
             except Exception:
                 pass
 
+    async def dispatch_pre_authorized(
+        self, agent_name: str, message: BrokerMessage,
+    ) -> None:
+        """Dispatch a message whose sender is already authorized upstream.
+
+        Bypasses the human-platform onboarding flow that ``handle_inbound``
+        runs (``get_user_status`` → ``add_pending_user`` → ``/approve_…``
+        Telegram prompt to the owner). Intended for callers that enforce
+        their own identity gating before invoking the broker — currently
+        the ferry host-callback (``host_pinky``), where peer-fleet ACL has
+        already been enforced. Future pre-authorized channels (federation,
+        MCP-host inbound) should land on this same primitive rather than
+        reusing ``handle_inbound``.
+
+        Concretely: routes the message to the agent's streaming session
+        without consulting ``approved_users``. The agent will see the
+        message in its prompt feed exactly as if the broker had approved
+        it via the human-platform flow.
+
+        Activity-log emission is intentionally left to the caller — ferry
+        inbound has its own observability (host-pinky's stats counters),
+        and the broker's ``message_received`` event is shaped for human
+        platforms (sender/preview formatting). If a future caller wants
+        broker-side activity logs, expose that as a separate flag.
+        """
+        await self._route_streaming(agent_name, message)
+
     def _format_prompt(self, message: BrokerMessage) -> str:
         """Format a single message as a platform-aware prompt line."""
         from datetime import datetime

--- a/src/pinky_daemon/ferry/__init__.py
+++ b/src/pinky_daemon/ferry/__init__.py
@@ -1,0 +1,36 @@
+"""Ferry — federated agent messaging integration.
+
+`@ferry/host-pinky` Python implementation. Receives ferry envelopes addressed
+to a PinkyBot agent and routes them either as inbound platform messages
+(via broker.handle_inbound) or as substrate-spec memory imports (via
+pinky-memory + pinky-self).
+
+References:
+- ferry PROTOCOL.md v0.1 — envelope shape
+- substrate v0.1 — memory interchange spec, §12 worked example
+- packages/host-pinky/README.md — design doc
+
+See PinkyBot issue #413 for the behavior contract and acceptance test plan.
+"""
+
+from pinky_daemon.ferry.types import (
+    AgentCardSelector,
+    DeliveryResult,
+    FerryEnvelope,
+    PortHistoryEntry,
+    SubstrateEntry,
+    SubstrateLifecycle,
+    SubstrateScope,
+    SubstrateSource,
+)
+
+__all__ = [
+    "AgentCardSelector",
+    "DeliveryResult",
+    "FerryEnvelope",
+    "SubstrateEntry",
+    "SubstrateScope",
+    "SubstrateSource",
+    "SubstrateLifecycle",
+    "PortHistoryEntry",
+]

--- a/src/pinky_daemon/ferry/host_pinky.py
+++ b/src/pinky_daemon/ferry/host_pinky.py
@@ -17,7 +17,10 @@ substrate's port_history canonicality invariant on inbound (§6.4).
 
 from __future__ import annotations
 
+import json
+import sqlite3
 import sys
+from collections.abc import Callable
 from dataclasses import asdict
 from typing import Any
 
@@ -34,6 +37,14 @@ from pinky_daemon.ferry.types import (
     IngestResult,
     SubstrateEntry,
 )
+
+
+class _TransientACLLoadError(Exception):
+    """Raised by ``_load_peer_fleet_acl`` when the registry read failed for
+    operator-side reasons (DB lock, schema mismatch during rolling deploy,
+    etc.). Distinct from "ACL is empty" so the broker can replay rather
+    than treat the message as policy-denied. Internal to host_pinky.
+    """
 
 
 def _log(msg: str) -> None:
@@ -102,16 +113,26 @@ class HostPinky:
         memory_store: Any | None = None,
         task_store: Any | None = None,
         verify_signatures: bool = False,
+        reflection_factory: Callable[[dict[str, Any]], Any] | None = None,
     ) -> None:
+        """Construct a HostPinky.
+
+        ``reflection_factory`` (optional): callable that builds a Reflection
+        from a kwargs dict. Defaults to ``pinky_memory.types.Reflection`` when
+        unset. Inject in tests to avoid the pinky_memory import cost and to
+        substitute a stand-in shape; production callers leave it as ``None``.
+        """
         self._registry = registry
         self._broker = broker
         self._memory_store = memory_store
         self._task_store = task_store
         self._verify_signatures = verify_signatures
+        self._reflection_factory = reflection_factory
         self._stats: dict[str, int] = {
             "delivered": 0,
             "rejected": 0,
             "queued": 0,
+            "transient_failures": 0,
             "substrate_imports": 0,
             "messages_routed": 0,
         }
@@ -148,7 +169,17 @@ class HostPinky:
             return self._reject("unknown_agent", f"no agent named {agent_name!r}")
 
         # 3. Peer-fleet ACL check
-        if not self._acl_allows(agent_name, envelope.from_):
+        try:
+            allowed = self._acl_allows(agent_name, envelope.from_)
+        except _TransientACLLoadError as e:
+            # Operator-side hiccup (DB lock, schema mismatch during rolling
+            # deploy). Not a policy denial — the broker should retry rather
+            # than terminally drop a message that an ACL would have allowed.
+            return self._transient(
+                "acl_load_failed",
+                f"could not load peer_fleet_acl for {agent_name}: {e}",
+            )
+        if not allowed:
             return self._reject(
                 "acl_denied",
                 f"peer {envelope.from_!r} not on {agent_name}'s peer_fleet_acl",
@@ -206,14 +237,28 @@ class HostPinky:
         return False
 
     def _load_peer_fleet_acl(self, agent_name: str) -> list[AgentCardSelector]:
-        """Load the agent's peer_fleet_acl selectors. Returns [] if unset."""
+        """Load the agent's peer_fleet_acl selectors.
+
+        Returns [] when the ACL is unset (policy: empty list = deny all).
+
+        Raises ``_TransientACLLoadError`` when the registry read fails for
+        operator-side reasons (DB lock, schema mismatch). The caller in
+        ``deliver()`` translates that into a ``transient_failure`` delivery
+        result so the broker retries instead of treating the message as
+        terminally rejected.
+
+        Per-item parse errors (malformed selector dict, invalid field
+        combinations) are skipped silently — they don't taint the rest of
+        the ACL or trigger a transient.
+        """
         try:
             raw = self._registry.get_peer_fleet_acl(agent_name)
         except AttributeError:
+            # Registry implementation doesn't expose peer_fleet_acl — older
+            # registry shape. Treat as empty (deny). Not transient.
             return []
-        except Exception as e:
-            _log(f"failed to load peer_fleet_acl for {agent_name}: {e}")
-            return []
+        except sqlite3.Error as e:
+            raise _TransientACLLoadError(str(e)) from e
         if not raw:
             return []
         out: list[AgentCardSelector] = []
@@ -223,7 +268,7 @@ class HostPinky:
                     out.append(item)
                 elif isinstance(item, dict):
                     out.append(AgentCardSelector(**item))
-            except Exception as e:
+            except (TypeError, ValueError, json.JSONDecodeError) as e:
                 _log(f"skipping invalid ACL entry for {agent_name}: {item} ({e})")
         return out
 
@@ -234,13 +279,20 @@ class HostPinky:
         agent_name: str,
         envelope: FerryEnvelope,
     ) -> DeliveryResult:
-        """Route a ferry message envelope as a normal platform inbound.
+        """Route a ferry message envelope to the agent's streaming session.
 
-        Bypasses broker.handle_inbound's human-approval path: peer-fleet
-        ACL was already enforced upstream. We achieve the bypass by
-        constructing a BrokerMessage whose sender_id is treated as
-        pre-approved (we do that by injecting through a dedicated path
-        rather than triggering the human-approval flow).
+        Identity-primitive separation: peer-fleet ACL was enforced
+        upstream in this module's ``_acl_allows`` step. The peer-fleet
+        identity (``ferry:<peer_address>``) is **not** written into the
+        receiving agent's human-platform ``approved_users`` table — the
+        two identity primitives stay disjoint at the broker boundary.
+
+        Concretely: we call ``broker.dispatch_pre_authorized``, which
+        routes the message straight to the agent's streaming session,
+        bypassing ``handle_inbound``'s human-onboarding flow
+        (``get_user_status`` → ``add_pending_user`` → ``/approve_…``
+        Telegram prompt). That bypass is what makes the dedicated-path
+        claim load-bearing-true at the broker surface.
         """
         from pinky_daemon.broker import BrokerMessage  # local import to avoid cycles
 
@@ -277,9 +329,12 @@ class HostPinky:
         )
 
         try:
-            await self._broker.handle_inbound(broker_msg)
+            await self._broker.dispatch_pre_authorized(agent_name, broker_msg)
         except Exception as e:
-            _log(f"broker.handle_inbound failed for ferry envelope {envelope.id}: {e}")
+            _log(
+                f"broker.dispatch_pre_authorized failed for ferry envelope "
+                f"{envelope.id}: {e}"
+            )
             return DeliveryResult(status="rejected", reason="broker_error", detail={"error": str(e)})
 
         self._stats["delivered"] += 1
@@ -369,21 +424,32 @@ class HostPinky:
     def _insert_reflection(self, ref_kwargs: dict[str, Any]) -> str:
         """Insert into pinky-memory. Returns the inserted reflection id.
 
-        Uses the MemoryStore's standard insert path. We construct a
-        Reflection from kwargs to stay loosely coupled to the store API.
+        Uses the configured ``reflection_factory`` if provided (test-only
+        injection point), otherwise falls back to ``pinky_memory.types.Reflection``.
         """
-        from pinky_memory.types import Reflection  # local import: optional dep at call time
-
-        reflection = Reflection(**ref_kwargs)
+        if self._reflection_factory is not None:
+            reflection = self._reflection_factory(ref_kwargs)
+        else:
+            # Local import: pinky_memory is an optional dep at call time so
+            # ferry tests don't have to install it.
+            from pinky_memory.types import Reflection
+            reflection = Reflection(**ref_kwargs)
         result = self._memory_store.insert(reflection)
         return getattr(result, "id", "") or getattr(reflection, "id", "")
 
     def _insert_task(self, task_kwargs: dict[str, Any]) -> str:
-        """Insert into pinky-self task store. Returns task id (as str)."""
-        # task_store.create_task is the canonical entry; signature varies
-        # so we pass kwargs through and accept whichever id field comes back.
+        """Insert into pinky-self task store. Returns task id (as str).
+
+        ``task_store.create_task`` may return either a dict (older signature)
+        or an object with ``.id`` (newer signature). Handle both explicitly
+        rather than via a ternary that becomes ambiguous when ``.id`` is
+        empty (the prior implementation would stringify the entire object
+        as a "task id" in that case — see PR #414 round 2 finding #2).
+        """
         result = self._task_store.create_task(**task_kwargs)
-        return str(getattr(result, "id", "") or result if not isinstance(result, dict) else result.get("id", ""))
+        if isinstance(result, dict):
+            return str(result.get("id", ""))
+        return str(getattr(result, "id", "") or "")
 
     # -- substrate envelope unwrapping ----------------------------------------
 
@@ -443,6 +509,16 @@ class HostPinky:
         _log(f"reject reason={reason}: {detail_text}")
         return DeliveryResult(
             status="rejected",
+            reason=reason,
+            detail={"detail": detail_text},
+        )
+
+    def _transient(self, reason: str, detail_text: str) -> DeliveryResult:
+        """Return a ``transient_failure`` result. Broker should retry."""
+        self._stats["transient_failures"] += 1
+        _log(f"transient_failure reason={reason}: {detail_text}")
+        return DeliveryResult(
+            status="transient_failure",
             reason=reason,
             detail={"detail": detail_text},
         )

--- a/src/pinky_daemon/ferry/host_pinky.py
+++ b/src/pinky_daemon/ferry/host_pinky.py
@@ -1,0 +1,448 @@
+"""@ferry/host-pinky — PinkyBot host-callback for ferry.
+
+Receives ferry envelopes addressed to a PinkyBot agent and routes them
+either as inbound platform messages (via broker.handle_inbound) or as
+substrate-spec memory imports (via pinky-memory + pinky-self).
+
+The behavior contract is documented in PinkyBot issue #413 and mirrored
+in ferry repo's packages/host-pinky/README.md.
+
+This module is the **adapter** — it does no transport (NATS / leaf-link
+plumbing is owned by ferry-core) and does no model invocation (broker +
+streaming sessions handle that). host-pinky's job is to translate one
+identity primitive (signed ferry agent cards) into another (PinkyBot
+agent + chat_id), enforce the peer-fleet ACL on the way in, and keep
+substrate's port_history canonicality invariant on inbound (§6.4).
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import asdict
+from typing import Any
+
+from pinky_daemon.ferry.substrate import (
+    classify_entry_destination,
+    populate_port_history,
+    to_reflection_input,
+    to_task_input,
+)
+from pinky_daemon.ferry.types import (
+    AgentCardSelector,
+    DeliveryResult,
+    FerryEnvelope,
+    IngestResult,
+    SubstrateEntry,
+)
+
+
+def _log(msg: str) -> None:
+    print(f"host-pinky: {msg}", file=sys.stderr, flush=True)
+
+
+# -- Address parsing -----------------------------------------------------------
+
+_FERRY_PINKY_PREFIX = "ferry://pinkybot/"
+
+
+def parse_pinkybot_address(addr: str) -> str | None:
+    """Extract the agent name from a ferry://pinkybot/<name> address.
+
+    Returns the agent name on success, or None if the address is not
+    pointed at this fleet.
+    """
+    if not addr:
+        return None
+    if not addr.startswith(_FERRY_PINKY_PREFIX):
+        return None
+    name = addr[len(_FERRY_PINKY_PREFIX):].strip()
+    return name or None
+
+
+def parse_peer_card(addr: str) -> tuple[str, str]:
+    """Parse a peer agent's address into (fleet, agent_id).
+
+    Examples:
+      pulse@studio@sigil → ("sigil", "pulse@studio@sigil")
+      ferry://sigil/pulse → ("sigil", "ferry://sigil/pulse")
+      misha@pinky.local  → ("pinky.local", "misha@pinky.local")
+    """
+    if addr.startswith("ferry://"):
+        rest = addr[len("ferry://"):]
+        parts = rest.split("/", 1)
+        fleet = parts[0] if parts else ""
+        return (fleet, addr)
+    # at-form: name@(scope@)?fleet — rightmost segment is the fleet
+    parts = addr.split("@")
+    if len(parts) >= 2:
+        return (parts[-1], addr)
+    return ("", addr)
+
+
+# -- HostPinky -----------------------------------------------------------------
+
+
+class HostPinky:
+    """Per-daemon host-callback. Constructed once at daemon startup.
+
+    Required collaborators:
+      registry       — AgentRegistry (for agent lookup + peer_fleet_acl read)
+      broker         — MessageBroker (for handle_inbound)
+      memory_store   — pinky-memory MemoryStore (for substrate→reflection insert)
+      task_store     — pinky-self TaskStore (for substrate→pending→create_task)
+
+    The collaborators are passed by reference; HostPinky does not own them.
+    """
+
+    def __init__(
+        self,
+        *,
+        registry: Any,
+        broker: Any,
+        memory_store: Any | None = None,
+        task_store: Any | None = None,
+        verify_signatures: bool = False,
+    ) -> None:
+        self._registry = registry
+        self._broker = broker
+        self._memory_store = memory_store
+        self._task_store = task_store
+        self._verify_signatures = verify_signatures
+        self._stats: dict[str, int] = {
+            "delivered": 0,
+            "rejected": 0,
+            "queued": 0,
+            "substrate_imports": 0,
+            "messages_routed": 0,
+        }
+
+    @property
+    def stats(self) -> dict[str, int]:
+        return dict(self._stats)
+
+    # -- Main entry point ------------------------------------------------------
+
+    async def deliver(self, envelope: FerryEnvelope) -> DeliveryResult:
+        """Deliver a ferry envelope to a PinkyBot agent.
+
+        Implements the four-step contract from the host-pinky design doc:
+          1. Verify ferry envelope signatures
+          2. Resolve target agent
+          3. Peer-fleet ACL check
+          4. Dispatch by body.kind
+        """
+        # 1. Signature verification
+        if self._verify_signatures:
+            verify_err = self._verify(envelope)
+            if verify_err:
+                return self._reject("auth_failed", verify_err)
+
+        # 2. Resolve target agent
+        agent_name = parse_pinkybot_address(envelope.to)
+        if not agent_name:
+            return self._reject(
+                "unknown_agent",
+                f"address {envelope.to!r} is not a PinkyBot ferry address",
+            )
+        if not self._agent_exists(agent_name):
+            return self._reject("unknown_agent", f"no agent named {agent_name!r}")
+
+        # 3. Peer-fleet ACL check
+        if not self._acl_allows(agent_name, envelope.from_):
+            return self._reject(
+                "acl_denied",
+                f"peer {envelope.from_!r} not on {agent_name}'s peer_fleet_acl",
+            )
+
+        # 4. Dispatch by payload kind
+        kind = envelope.kind
+        if kind == "message":
+            return await self._deliver_message(agent_name, envelope)
+        if kind in ("substrate.entry", "substrate.batch"):
+            return await self._deliver_substrate(agent_name, envelope)
+
+        return self._reject("unsupported_payload_kind", f"kind={kind!r}")
+
+    # -- Signature verification (deferred for v0.1) ---------------------------
+
+    def _verify(self, envelope: FerryEnvelope) -> str | None:
+        """Verify envelope.from_ + each traversal record's signature.
+
+        Returns None on success, or a human-readable error string.
+
+        v0.1: stub — accept all. Real implementation lands with the
+        signed-agent-card subsystem in v0.2/v0.3 (per Pulse §12.3 thread).
+        """
+        # TODO(v0.2): real Ed25519 signature verification.
+        return None
+
+    # -- Agent lookup ---------------------------------------------------------
+
+    def _agent_exists(self, agent_name: str) -> bool:
+        try:
+            return self._registry.has_agent(agent_name)
+        except AttributeError:
+            # Fallback: most AgentRegistry impls expose either has_agent or list_agents.
+            try:
+                names = {a.get("name") for a in self._registry.list_agents()}
+                return agent_name in names
+            except Exception:
+                return False
+
+    # -- Peer-fleet ACL -------------------------------------------------------
+
+    def _acl_allows(self, agent_name: str, peer_address: str) -> bool:
+        """Check peer_fleet_acl for the receiving agent.
+
+        Default-deny: empty/missing ACL means no peer-fleet inbound allowed.
+        """
+        selectors = self._load_peer_fleet_acl(agent_name)
+        if not selectors:
+            return False
+        peer_fleet, peer_agent_id = parse_peer_card(peer_address)
+        for sel in selectors:
+            if sel.matches(peer_fleet, peer_agent_id, ""):
+                return True
+        return False
+
+    def _load_peer_fleet_acl(self, agent_name: str) -> list[AgentCardSelector]:
+        """Load the agent's peer_fleet_acl selectors. Returns [] if unset."""
+        try:
+            raw = self._registry.get_peer_fleet_acl(agent_name)
+        except AttributeError:
+            return []
+        except Exception as e:
+            _log(f"failed to load peer_fleet_acl for {agent_name}: {e}")
+            return []
+        if not raw:
+            return []
+        out: list[AgentCardSelector] = []
+        for item in raw:
+            try:
+                if isinstance(item, AgentCardSelector):
+                    out.append(item)
+                elif isinstance(item, dict):
+                    out.append(AgentCardSelector(**item))
+            except Exception as e:
+                _log(f"skipping invalid ACL entry for {agent_name}: {item} ({e})")
+        return out
+
+    # -- Dispatch: message → broker.handle_inbound ----------------------------
+
+    async def _deliver_message(
+        self,
+        agent_name: str,
+        envelope: FerryEnvelope,
+    ) -> DeliveryResult:
+        """Route a ferry message envelope as a normal platform inbound.
+
+        Bypasses broker.handle_inbound's human-approval path: peer-fleet
+        ACL was already enforced upstream. We achieve the bypass by
+        constructing a BrokerMessage whose sender_id is treated as
+        pre-approved (we do that by injecting through a dedicated path
+        rather than triggering the human-approval flow).
+        """
+        from pinky_daemon.broker import BrokerMessage  # local import to avoid cycles
+
+        text = str(envelope.body.get("text") or envelope.body.get("content") or "").strip()
+        if not text:
+            return self._reject("empty_message_body", "body.text was empty")
+
+        peer_address = envelope.from_
+        broker_msg = BrokerMessage(
+            platform="ferry",
+            chat_id=peer_address,
+            sender_name=peer_address,
+            sender_id=f"ferry:{peer_address}",
+            content=text,
+            agent_name=agent_name,
+            timestamp=envelope.ts / 1000.0,
+            message_id=envelope.id,
+            chat_title=envelope.subject or "",
+            is_group=False,
+            metadata={
+                "ferry": {
+                    "envelope_id": envelope.id,
+                    "from": envelope.from_,
+                    "to": envelope.to,
+                    "ts": envelope.ts,
+                    "wake": envelope.wake,
+                    "ack": envelope.ack,
+                    "correlation_id": envelope.correlation_id,
+                    "reply_to": envelope.reply_to,
+                    "headers": dict(envelope.headers),
+                    "traversal": [asdict(t) for t in envelope.traversal],
+                }
+            },
+        )
+
+        try:
+            await self._broker.handle_inbound(broker_msg)
+        except Exception as e:
+            _log(f"broker.handle_inbound failed for ferry envelope {envelope.id}: {e}")
+            return DeliveryResult(status="rejected", reason="broker_error", detail={"error": str(e)})
+
+        self._stats["delivered"] += 1
+        self._stats["messages_routed"] += 1
+        return DeliveryResult(status="delivered")
+
+    # -- Dispatch: substrate.entry / substrate.batch --------------------------
+
+    async def _deliver_substrate(
+        self,
+        agent_name: str,
+        envelope: FerryEnvelope,
+    ) -> DeliveryResult:
+        """Import substrate entries into the receiving agent's stores."""
+        entries = self._extract_substrate_entries(envelope)
+        if not entries:
+            return self._reject("empty_substrate_payload", "no entries in body")
+
+        receiving_address = f"ferry://pinkybot/{agent_name}"
+        results: list[IngestResult] = []
+        for entry in entries:
+            populated = populate_port_history(entry, envelope, receiving_address)
+            try:
+                result = self._ingest_one(agent_name, populated)
+            except Exception as e:
+                _log(f"ingest failed for substrate {entry.id}: {e}")
+                results.append(
+                    IngestResult(
+                        substrate_id=entry.id,
+                        target_store="skipped",
+                        note=f"error: {e}",
+                    )
+                )
+                continue
+            results.append(result)
+
+        self._stats["delivered"] += 1
+        self._stats["substrate_imports"] += sum(1 for r in results if r.target_store != "skipped")
+        return DeliveryResult(
+            status="delivered",
+            detail={"ingested": [asdict(r) for r in results]},
+        )
+
+    def _ingest_one(self, agent_name: str, entry: SubstrateEntry) -> IngestResult:
+        """Route a single entry to its destination store."""
+        destination = classify_entry_destination(entry)
+
+        if destination == "pinky-memory":
+            if self._memory_store is None:
+                return IngestResult(
+                    substrate_id=entry.id,
+                    target_store="skipped",
+                    note="memory_store not configured",
+                )
+            ref_kwargs = to_reflection_input(entry)
+            ref_kwargs["project"] = agent_name
+            inserted = self._insert_reflection(ref_kwargs)
+            return IngestResult(
+                substrate_id=entry.id,
+                target_store="pinky-memory",
+                target_id=str(inserted),
+            )
+
+        if destination == "pinky-self":
+            if self._task_store is None:
+                return IngestResult(
+                    substrate_id=entry.id,
+                    target_store="skipped",
+                    note="task_store not configured",
+                )
+            task_kwargs = to_task_input(entry)
+            task_kwargs["assigned_agent"] = agent_name
+            task_kwargs["created_by"] = entry.source.by
+            inserted = self._insert_task(task_kwargs)
+            return IngestResult(
+                substrate_id=entry.id,
+                target_store="pinky-self",
+                target_id=str(inserted),
+            )
+
+        return IngestResult(
+            substrate_id=entry.id,
+            target_store="skipped",
+            note=f"destination={destination}",
+        )
+
+    def _insert_reflection(self, ref_kwargs: dict[str, Any]) -> str:
+        """Insert into pinky-memory. Returns the inserted reflection id.
+
+        Uses the MemoryStore's standard insert path. We construct a
+        Reflection from kwargs to stay loosely coupled to the store API.
+        """
+        from pinky_memory.types import Reflection  # local import: optional dep at call time
+
+        reflection = Reflection(**ref_kwargs)
+        result = self._memory_store.insert(reflection)
+        return getattr(result, "id", "") or getattr(reflection, "id", "")
+
+    def _insert_task(self, task_kwargs: dict[str, Any]) -> str:
+        """Insert into pinky-self task store. Returns task id (as str)."""
+        # task_store.create_task is the canonical entry; signature varies
+        # so we pass kwargs through and accept whichever id field comes back.
+        result = self._task_store.create_task(**task_kwargs)
+        return str(getattr(result, "id", "") or result if not isinstance(result, dict) else result.get("id", ""))
+
+    # -- substrate envelope unwrapping ----------------------------------------
+
+    def _extract_substrate_entries(self, envelope: FerryEnvelope) -> list[SubstrateEntry]:
+        """Pull SubstrateEntry objects out of envelope.body.
+
+        Supports both kinds:
+          body.kind == "substrate.entry" → body.entry is one entry-shaped dict
+          body.kind == "substrate.batch" → body.entries is a list of entry-shaped dicts
+        """
+        from pinky_daemon.ferry.types import (
+            PortHistoryEntry,
+            SubstrateLifecycle,
+            SubstrateScope,
+            SubstrateSource,
+        )
+
+        kind = envelope.kind
+        raw_entries: list[dict[str, Any]] = []
+        if kind == "substrate.entry":
+            entry = envelope.body.get("entry")
+            if isinstance(entry, dict):
+                raw_entries.append(entry)
+        elif kind == "substrate.batch":
+            entries = envelope.body.get("entries")
+            if isinstance(entries, list):
+                raw_entries = [e for e in entries if isinstance(e, dict)]
+
+        out: list[SubstrateEntry] = []
+        for raw in raw_entries:
+            try:
+                out.append(
+                    SubstrateEntry(
+                        id=str(raw.get("id", "")),
+                        type=raw.get("type", "fact"),
+                        scope=SubstrateScope(**raw["scope"]),
+                        source=SubstrateSource(**raw["source"]),
+                        created_at=str(raw.get("created_at", "")),
+                        updated_at=str(raw.get("updated_at", "")),
+                        content=str(raw.get("content", "")),
+                        links=list(raw.get("links") or []),
+                        lifecycle=SubstrateLifecycle(**(raw.get("lifecycle") or {})),
+                        port_history=[
+                            PortHistoryEntry(**ph) if isinstance(ph, dict) else ph
+                            for ph in (raw.get("port_history") or [])
+                        ],
+                    )
+                )
+            except Exception as e:
+                _log(f"skipping malformed substrate entry: {e}")
+        return out
+
+    # -- Helpers --------------------------------------------------------------
+
+    def _reject(self, reason: str, detail_text: str) -> DeliveryResult:
+        self._stats["rejected"] += 1
+        _log(f"reject reason={reason}: {detail_text}")
+        return DeliveryResult(
+            status="rejected",
+            reason=reason,
+            detail={"detail": detail_text},
+        )

--- a/src/pinky_daemon/ferry/substrate.py
+++ b/src/pinky_daemon/ferry/substrate.py
@@ -95,6 +95,8 @@ def populate_port_history(
         # First port — no traversal recorded. Emit a single hop from
         # envelope.from_ → receiving agent so port_history reflects this
         # crossing even when traversal was empty (single-broker delivery).
+        # `attested_by="receiver"` because no broker stamped this hop —
+        # the receiver's clock is the only witness on `at`.
         entry.port_history.append(
             PortHistoryEntry(
                 from_=envelope.from_,
@@ -102,12 +104,14 @@ def populate_port_history(
                 at=_iso_now(),
                 via=envelope.id,
                 re_grounded=False,
+                attested_by="receiver",
             )
         )
         return entry
 
     prior_address = envelope.from_
     for hop in envelope.traversal:
+        # Broker-attested: the broker stamped `at` when receiving the hop.
         entry.port_history.append(
             PortHistoryEntry(
                 from_=prior_address,
@@ -115,10 +119,13 @@ def populate_port_history(
                 at=_ms_to_iso(hop.at),
                 via=hop.via or envelope.id,
                 re_grounded=False,
+                attested_by="broker",
             )
         )
         prior_address = hop.broker
-    # Final hop: last broker → receiving agent
+    # Final hop: last broker → receiving agent. Receiver-attested because
+    # no broker stamped this hop (last broker stamped its own arrival,
+    # not its handoff to this receiver).
     entry.port_history.append(
         PortHistoryEntry(
             from_=prior_address,
@@ -126,6 +133,7 @@ def populate_port_history(
             at=_iso_now(),
             via=envelope.id,
             re_grounded=False,
+            attested_by="receiver",
         )
     )
     return entry

--- a/src/pinky_daemon/ferry/substrate.py
+++ b/src/pinky_daemon/ferry/substrate.py
@@ -1,0 +1,262 @@
+"""substrate v0.1 → PinkyBot stores translation.
+
+Implements the five host-side unwrap steps from substrate v0.1 §12.5:
+  1. Verify ferry envelope (deferred — see host_pinky.deliver())
+  2. Populate port_history from envelope.traversal (§6.4 canonicality)
+  3. Preserve source.by verbatim (§6.1 — never overwrite with immediate sender)
+  4. Type-map per §11 reference impl notes (host-implementation-defined)
+  5. Index rebuild (handled by pinky-memory's normal insert path)
+
+Type mapping (host-pinky's choice, not the spec's):
+  fact / event / reference  → pinky-memory `fact`
+  feedback / decision       → pinky-memory `insight`
+  pattern                   → pinky-memory `interaction_pattern`
+  pending                   → pinky-self `create_task`
+
+Trust → salience: salience = 1 + round(trust * 4) clamped [1, 5]
+  (one valid mapping; not the mapping. Documented in host-pinky README.)
+
+Links: pinky-memory has no native cross-entry edge surface, so substrate
+`links` are preserved in `context` JSON sidecar. v0.2 §3.2.1 "no-link-surface
+pattern" reference recipe will formalize the recall-time fan-out helper.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Any
+
+from pinky_daemon.ferry.types import (
+    FerryEnvelope,
+    PortHistoryEntry,
+    SubstrateEntry,
+)
+
+
+def _log(msg: str) -> None:
+    print(f"host-pinky/substrate: {msg}", file=sys.stderr, flush=True)
+
+
+# -- §11 type mapping ----------------------------------------------------------
+
+# substrate.type → pinky-memory ReflectionType.value
+_PINKY_MEMORY_TYPE_MAP: dict[str, str] = {
+    "fact": "fact",
+    "event": "fact",
+    "reference": "fact",
+    "feedback": "insight",
+    "decision": "insight",
+    "pattern": "interaction_pattern",
+    # "pending" is special-cased — routes to pinky-self, not pinky-memory
+}
+
+
+def map_substrate_type_to_reflection(substrate_type: str) -> str | None:
+    """Return the pinky-memory ReflectionType.value for a substrate type, or None."""
+    return _PINKY_MEMORY_TYPE_MAP.get(substrate_type)
+
+
+def trust_to_salience(trust: float) -> int:
+    """Trust [0.0, 1.0] → pinky-memory salience [1, 5].
+
+    Formula: 1 + round(trust * 4), clamped [1, 5].
+
+    This is host-pinky's mapping, not substrate's. Substrate stays
+    trust-opaque per §6 — hosts decide how to discretize.
+    """
+    if trust <= 0:
+        return 1
+    if trust >= 1:
+        return 5
+    return max(1, min(5, 1 + round(trust * 4)))
+
+
+# -- port_history population (§6.4) -------------------------------------------
+
+
+def populate_port_history(
+    entry: SubstrateEntry,
+    envelope: FerryEnvelope,
+    receiving_agent_address: str,
+) -> SubstrateEntry:
+    """Append one port_history entry per ferry traversal hop.
+
+    Per substrate v0.1 §6.4: substrate's port_history is canonical;
+    ferry's traversal is transport metadata. The receiving host walks
+    the traversal array on inbound and writes one port_history record
+    per hop, preserving from/to/at/via.
+
+    Mutates and returns the entry.
+    """
+    if not envelope.traversal:
+        # First port — no traversal recorded. Emit a single hop from
+        # envelope.from_ → receiving agent so port_history reflects this
+        # crossing even when traversal was empty (single-broker delivery).
+        entry.port_history.append(
+            PortHistoryEntry(
+                from_=envelope.from_,
+                to=receiving_agent_address,
+                at=_iso_now(),
+                via=envelope.id,
+                re_grounded=False,
+            )
+        )
+        return entry
+
+    prior_address = envelope.from_
+    for hop in envelope.traversal:
+        entry.port_history.append(
+            PortHistoryEntry(
+                from_=prior_address,
+                to=hop.broker,
+                at=_ms_to_iso(hop.at),
+                via=hop.via or envelope.id,
+                re_grounded=False,
+            )
+        )
+        prior_address = hop.broker
+    # Final hop: last broker → receiving agent
+    entry.port_history.append(
+        PortHistoryEntry(
+            from_=prior_address,
+            to=receiving_agent_address,
+            at=_iso_now(),
+            via=envelope.id,
+            re_grounded=False,
+        )
+    )
+    return entry
+
+
+# -- pinky-memory storage shape -----------------------------------------------
+
+
+def to_reflection_input(entry: SubstrateEntry) -> dict[str, Any]:
+    """Build a pinky-memory Reflection-shaped dict for a substrate entry.
+
+    Returned dict is suitable for `MemoryStore.insert(Reflection(**d))`.
+    Caller is responsible for resolving the project (typically the agent name).
+
+    Keys produced:
+      - type: pinky-memory ReflectionType.value
+      - content: substrate entry content (markdown allowed)
+      - context: JSON-encoded substrate sidecar (provenance, links, port_history)
+      - salience: derived from trust
+      - entities: [scope.ref] when scope.kind in {user, agent}
+      - source_session_id: derived from source.by (for traceability)
+    """
+    reflection_type = map_substrate_type_to_reflection(entry.type)
+    if reflection_type is None:
+        raise ValueError(
+            f"Substrate type {entry.type!r} does not map to a pinky-memory "
+            "ReflectionType. (Did you mean to route 'pending' to pinky-self?)"
+        )
+
+    sidecar = {
+        "substrate_id": entry.id,
+        "substrate_type": entry.type,
+        "scope": asdict(entry.scope),
+        "source": asdict(entry.source),
+        "lifecycle": asdict(entry.lifecycle),
+        "links": list(entry.links),
+        "port_history": [asdict(p) for p in entry.port_history],
+        "created_at": entry.created_at,
+        "updated_at": entry.updated_at,
+    }
+
+    entities: list[str] = []
+    if entry.scope.kind in ("user", "agent") and entry.scope.ref:
+        entities.append(entry.scope.ref)
+
+    return {
+        "type": reflection_type,
+        "content": entry.content,
+        "context": json.dumps(sidecar, ensure_ascii=False, sort_keys=True),
+        "salience": trust_to_salience(entry.source.trust),
+        "entities": entities,
+        "source_channel": "ferry",
+        "source_session_id": f"ferry:{entry.source.by}",
+    }
+
+
+# -- pinky-self task shape (for `pending` entries) ----------------------------
+
+
+def to_task_input(entry: SubstrateEntry) -> dict[str, Any]:
+    """Build a pinky-self task-shaped dict for a substrate `pending` entry.
+
+    Lifecycle mapping (substrate → pinky-self task):
+      pending  + expected_resolution_by → pending (with deps if known)
+      pending  + no resolution date     → pending
+      pending  + state=active(?)        → in_progress (rare on import)
+    """
+    if entry.type != "pending":
+        raise ValueError(
+            f"to_task_input called on non-pending entry (type={entry.type!r})"
+        )
+
+    title = entry.content.split("\n", 1)[0].strip()[:120] or "(unnamed substrate pending)"
+    description_parts = [
+        entry.content,
+        "",
+        "---",
+        f"Imported from substrate (id: {entry.id})",
+        f"Author: {entry.source.by} (origin: {entry.source.origin}, trust: {entry.source.trust})",
+    ]
+    if entry.lifecycle.expected_resolution_by:
+        description_parts.append(
+            f"Expected resolution: {entry.lifecycle.expected_resolution_by}"
+        )
+    if entry.source.evidence:
+        description_parts.append(f"Evidence: {entry.source.evidence}")
+
+    return {
+        "title": title,
+        "description": "\n".join(description_parts),
+        "priority": _priority_from_trust(entry.source.trust),
+        "tags": ["substrate", "substrate-pending", f"trust:{entry.source.trust:.2f}"],
+        # Caller adds project / assigned_agent based on receiving agent.
+    }
+
+
+def _priority_from_trust(trust: float) -> str:
+    """Map trust → task priority. Higher trust = higher priority."""
+    if trust >= 0.85:
+        return "high"
+    if trust >= 0.5:
+        return "normal"
+    return "low"
+
+
+# -- Top-level ingest dispatcher ----------------------------------------------
+
+
+def classify_entry_destination(entry: SubstrateEntry) -> str:
+    """Return one of: 'pinky-memory', 'pinky-self', 'skipped'.
+
+    `pending` → pinky-self (cross-MCP integration, lifecycle-shaped).
+    `decayed` lifecycle → skipped (per §5.1, the decay event imports
+    as its own `event`-type entry, not via the decayed entry itself).
+    Everything else → pinky-memory.
+    """
+    if entry.lifecycle.state == "decayed":
+        return "skipped"
+    if entry.type == "pending":
+        return "pinky-self"
+    if map_substrate_type_to_reflection(entry.type) is not None:
+        return "pinky-memory"
+    return "skipped"
+
+
+# -- Time helpers --------------------------------------------------------------
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ms_to_iso(ms: int) -> str:
+    return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc).isoformat()

--- a/src/pinky_daemon/ferry/types.py
+++ b/src/pinky_daemon/ferry/types.py
@@ -75,10 +75,14 @@ class DeliveryResult:
     The ferry broker uses the status to decide ack semantics (PROTOCOL.md §6):
     - `delivered`: at-least-once delivery satisfied, processing started
     - `queued`: agent offline / asleep; envelope will be replayed on wake
-    - `rejected`: do not retry — auth, ACL, or unsupported payload
+    - `rejected`: do not retry — auth, ACL, or unsupported payload (terminal)
+    - `transient_failure`: retry with backoff — operational failure (DB lock,
+      schema mismatch during rolling deploy, etc.) on the host side. Distinct
+      from `rejected` so the broker doesn't swallow a real ACL-allowed message
+      because of an operator-side hiccup.
     """
 
-    status: Literal["delivered", "queued", "rejected"]
+    status: Literal["delivered", "queued", "rejected", "transient_failure"]
     reason: str | None = None
     detail: dict[str, Any] = field(default_factory=dict)
 
@@ -157,6 +161,14 @@ class PortHistoryEntry:
 
     Populated on inbound from ferry's traversal array. Substrate's
     port_history is canonical (§6.4); ferry's traversal is transport-only.
+
+    Trust boundary on `at`:
+      - `attested_by="broker"` — `at` mirrors a broker-stamped traversal
+        record's wall-clock time. Witnessed by a transport intermediary.
+      - `attested_by="receiver"` — `at` was fabricated by the receiver
+        (synthetic hop, no broker traversal record). The receiver's clock
+        is the only witness. Don't conflate with broker-attested `at`
+        when reasoning about cross-fleet timing.
     """
 
     from_: str
@@ -164,6 +176,7 @@ class PortHistoryEntry:
     at: str  # ISO datetime
     via: str = ""  # ferry msg_id (transport-stable id)
     re_grounded: bool = False  # whether receiver re-verified the claim
+    attested_by: Literal["broker", "receiver"] = "broker"
 
 
 @dataclass

--- a/src/pinky_daemon/ferry/types.py
+++ b/src/pinky_daemon/ferry/types.py
@@ -1,0 +1,201 @@
+"""Ferry envelope + substrate entry dataclasses.
+
+Mirrors:
+- ferry PROTOCOL.md v0.1 §1 envelope schema
+- substrate v0.1 §3 entry schema
+
+These are wire-shapes — they describe what crosses the boundary, not
+how PinkyBot stores things internally. Storage shapes (Reflection in
+pinky-memory, Task in pinky-self) are separate; the substrate.py module
+translates between the two.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+# -- Ferry PROTOCOL.md v0.1 §1 -------------------------------------------------
+
+
+@dataclass
+class TraversalRecord:
+    """One broker hop on a ferry envelope's traversal path.
+
+    Per PROTOCOL.md §12.3, brokers append (never modify) traversal records
+    as the envelope crosses each broker. The receiving host-callback uses
+    the array to populate substrate's port_history on inbound (§6.4).
+    """
+
+    broker: str  # broker identity (e.g. "ferry-broker:nova")
+    at: int  # broker wall-clock millis when received
+    via: str = ""  # link/transport identifier (optional)
+    signature: str = ""  # broker signature over the prior envelope state
+
+
+@dataclass
+class FerryEnvelope:
+    """A ferry envelope, per PROTOCOL.md v0.1 §1.
+
+    Top-level fields are spec-defined; `headers` is the only place
+    extension metadata may live.
+    """
+
+    v: str  # protocol version, e.g. "0.1"
+    id: str  # uuid-v7, transport-stable, broker-deduped within 24h
+    from_: str  # immediate sender address
+    to: str  # recipient address
+    ts: int  # sender wall-clock millis
+    body: dict[str, Any]  # application payload — must contain "kind"
+
+    priority: Literal["low", "normal", "high", "urgent"] = "normal"
+    wake: Literal["none", "if-idle", "when-free", "interrupt"] = "if-idle"
+    ack: Literal["none", "delivery", "processed"] = "delivery"
+
+    ttl_ms: int | None = None
+    correlation_id: str | None = None
+    reply_to: str | None = None
+    subject: str | None = None
+    traversal: list[TraversalRecord] = field(default_factory=list)
+    headers: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def kind(self) -> str:
+        """Payload kind — `body.kind` per PROTOCOL.md §1 + ferry overlay docs."""
+        return str(self.body.get("kind", "")).strip()
+
+
+# -- DeliveryResult — host-pinky's contract with the ferry broker --------------
+
+
+@dataclass
+class DeliveryResult:
+    """Result of host-pinky's `deliver(envelope)` call.
+
+    The ferry broker uses the status to decide ack semantics (PROTOCOL.md §6):
+    - `delivered`: at-least-once delivery satisfied, processing started
+    - `queued`: agent offline / asleep; envelope will be replayed on wake
+    - `rejected`: do not retry — auth, ACL, or unsupported payload
+    """
+
+    status: Literal["delivered", "queued", "rejected"]
+    reason: str | None = None
+    detail: dict[str, Any] = field(default_factory=dict)
+
+
+# -- AgentCardSelector — peer-fleet ACL primitive ------------------------------
+
+
+@dataclass(frozen=True)
+class AgentCardSelector:
+    """Selector for a peer-fleet agent card.
+
+    At-least-one field must be set. Wildcards via `agent_id="*"` (matches
+    any agent on the fleet) and `fleet="*"` (matches any fleet — use sparingly).
+
+    Examples:
+        AgentCardSelector(fleet="sigil", agent_id="pulse@studio@sigil")
+        AgentCardSelector(fleet="sigil", agent_id="*")  # fleet-wide allow
+        AgentCardSelector(pinky_type="executor")  # capability-based
+    """
+
+    fleet: str | None = None
+    agent_id: str | None = None
+    pinky_type: str | None = None
+
+    def __post_init__(self) -> None:
+        if not (self.fleet or self.agent_id or self.pinky_type):
+            raise ValueError(
+                "AgentCardSelector requires at least one of fleet, agent_id, "
+                "or pinky_type — empty selectors are not permitted."
+            )
+
+    def matches(self, card_fleet: str, card_agent_id: str, card_pinky_type: str = "") -> bool:
+        """Test whether a peer's signed card matches this selector."""
+        if self.fleet is not None and self.fleet != "*" and self.fleet != card_fleet:
+            return False
+        if self.agent_id is not None and self.agent_id != "*" and self.agent_id != card_agent_id:
+            return False
+        if self.pinky_type is not None and self.pinky_type != card_pinky_type:
+            return False
+        return True
+
+
+# -- substrate v0.1 §3 entry schema --------------------------------------------
+
+
+@dataclass
+class SubstrateScope:
+    """substrate v0.1 §3.3 scope — what the entry is *about*."""
+
+    kind: Literal["user", "agent", "project", "global"]
+    ref: str  # e.g. "brad", "misha@pinky.local", "ferry-v0.1"
+
+
+@dataclass
+class SubstrateSource:
+    """substrate v0.1 §6 provenance — where the claim came from."""
+
+    origin: Literal["user-stated", "agent-inferred", "agent-observed", "external"]
+    by: str  # original author identity (e.g. "misha@pinky.local") — §6.1 immutable on port
+    evidence: str = ""  # human-readable trace; quotes, refs, observations
+    trust: float = 0.5  # [0.0, 1.0]; opaque to spec, host decides what it means
+
+
+@dataclass
+class SubstrateLifecycle:
+    """substrate v0.1 §5 lifecycle state."""
+
+    state: Literal["active", "pending", "decayed", "superseded"] = "active"
+    expected_resolution_by: str | None = None  # ISO datetime
+    resolved_by: str | None = None  # substrate id of resolver entry
+
+
+@dataclass
+class PortHistoryEntry:
+    """substrate v0.1 §6.4 — one hop in the entry's cross-fleet history.
+
+    Populated on inbound from ferry's traversal array. Substrate's
+    port_history is canonical (§6.4); ferry's traversal is transport-only.
+    """
+
+    from_: str
+    to: str
+    at: str  # ISO datetime
+    via: str = ""  # ferry msg_id (transport-stable id)
+    re_grounded: bool = False  # whether receiver re-verified the claim
+
+
+@dataclass
+class SubstrateEntry:
+    """A substrate v0.1 §3 entry — wire shape, pre-storage.
+
+    On inbound to host-pinky, this is what we get out of `envelope.body`
+    (for `kind=substrate.entry`) or each item of `body.entries` (for
+    `kind=substrate.batch`). The substrate.py module translates this
+    into pinky-memory Reflection / pinky-self Task primitives.
+    """
+
+    id: str  # substrate-stable id (uuid) — distinct from ferry transport id
+    type: Literal["fact", "feedback", "decision", "pattern", "event", "reference", "pending"]
+    scope: SubstrateScope
+    source: SubstrateSource
+    created_at: str  # ISO datetime
+    updated_at: str  # ISO datetime
+    content: str  # free-text body (markdown allowed)
+    links: list[str] = field(default_factory=list)  # substrate ids of linked entries
+    lifecycle: SubstrateLifecycle = field(default_factory=SubstrateLifecycle)
+    port_history: list[PortHistoryEntry] = field(default_factory=list)
+
+
+# -- Ingest result -------------------------------------------------------------
+
+
+@dataclass
+class IngestResult:
+    """Outcome of a single substrate-entry import into PinkyBot stores."""
+
+    substrate_id: str
+    target_store: Literal["pinky-memory", "pinky-self", "skipped"]
+    target_id: str = ""  # reflection id / task id
+    note: str = ""

--- a/tests/test_ferry_host_pinky.py
+++ b/tests/test_ferry_host_pinky.py
@@ -165,12 +165,22 @@ class FakeRegistry:
 
 
 class FakeBroker:
-    """Records every handle_inbound call."""
+    """Records every dispatch_pre_authorized call.
+
+    Note: host-pinky calls ``broker.dispatch_pre_authorized(agent_name,
+    broker_msg)`` — NOT ``broker.handle_inbound``. The latter is the
+    human-platform onboarding path that ferry inbound MUST bypass to
+    keep peer-fleet identities out of the ``approved_users`` table.
+    See PR #414 round-2 — round-1 had this wired to ``handle_inbound``,
+    which leaked the peer-fleet identity into the human-approval flow.
+    """
 
     def __init__(self) -> None:
         self.received: list = []
+        self.dispatched_for: list[str] = []
 
-    async def handle_inbound(self, broker_msg) -> None:  # noqa: ANN001
+    async def dispatch_pre_authorized(self, agent_name, broker_msg) -> None:  # noqa: ANN001
+        self.dispatched_for.append(agent_name)
         self.received.append(broker_msg)
 
 
@@ -265,6 +275,10 @@ class TestPortHistory:
         assert entry.port_history[-1].to == "ferry://pinkybot/barsik"
         # All hops re_grounded=False on inbound (§6.4)
         assert all(p.re_grounded is False for p in entry.port_history)
+        # attested_by distinction (round-2 finding #5):
+        # broker-stamped hop gets "broker", receiver-fabricated final hop "receiver"
+        assert entry.port_history[0].attested_by == "broker"
+        assert entry.port_history[-1].attested_by == "receiver"
 
     def test_no_traversal_writes_single_synthetic_hop(self):
         entry = _entry_1_feedback()
@@ -280,6 +294,8 @@ class TestPortHistory:
         assert len(entry.port_history) == 1
         assert entry.port_history[0].from_ == "misha@pinky.local"
         assert entry.port_history[0].to == "ferry://pinkybot/barsik"
+        # No traversal records → entire hop is receiver-attested
+        assert entry.port_history[0].attested_by == "receiver"
 
 
 class TestToReflectionInput:
@@ -778,3 +794,270 @@ class TestPeerFleetAclApi:
         )
         assert r.status_code == 200
         assert r.json()["removed"] == 0
+
+
+# -- Round-2 additions: transient ACL, wildcard remove, pending substrate, broker integration --
+
+
+class _RaisingRegistry:
+    """Registry stub whose get_peer_fleet_acl raises a sqlite3.Error.
+
+    Models the "DB locked / schema mismatch during rolling deploy" scenario
+    that Misha's PR #414 review #1 flagged. See round-2 finding #1.
+    """
+
+    def __init__(self) -> None:
+        import sqlite3 as _sq3
+        self._exc = _sq3.OperationalError("database is locked")
+
+    def has_agent(self, name: str) -> bool:
+        return name == "barsik"
+
+    def get_peer_fleet_acl(self, name: str):  # noqa: ANN001
+        raise self._exc
+
+
+@pytest.mark.asyncio
+class TestTransientACLLoadFailure:
+    """A sqlite3 error during ACL load yields ``transient_failure``,
+    NOT ``rejected``/``acl_denied`` (round-2 finding #1).
+
+    Without this distinction, a brief DB lock during a rolling deploy
+    permanently drops a real ACL-allowed message because the broker
+    can't tell "operator hiccup" from "policy denial."
+    """
+
+    async def test_sqlite_error_during_acl_load_yields_transient_failure(self):
+        registry = _RaisingRegistry()
+        broker = FakeBroker()
+        host = HostPinky(registry=registry, broker=broker)
+
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="msg-transient",
+            from_="misha@pinky.local",
+            to="ferry://pinkybot/barsik",
+            ts=1,
+            body={"kind": "message", "text": "x"},
+        )
+
+        result = await host.deliver(envelope)
+
+        assert result.status == "transient_failure"
+        assert result.reason == "acl_load_failed"
+        assert "database is locked" in result.detail.get("detail", "")
+        # Critically: did NOT degrade to rejected/acl_denied
+        assert result.status != "rejected"
+        # Broker not invoked (we never got to dispatch)
+        assert broker.received == []
+        # Stats incremented on the right counter
+        assert host.stats["transient_failures"] == 1
+        assert host.stats["rejected"] == 0
+
+
+class TestACLRemoveWildcardSemantics:
+    """The exact-match contract on ``remove_peer_fleet_acl`` is documented
+    on the method (round-2 nit). This test pins the documented behavior:
+    a stored ``agent_id="*"`` is removed only by passing ``agent_id="*"``.
+    """
+
+    def test_remove_without_wildcard_does_not_match_stored_wildcard(self, real_registry):
+        # Store a fleet-wide allow
+        real_registry.add_peer_fleet_acl("barsik", fleet="sigil", agent_id="*")
+
+        # Forgetting the wildcard MUST silently zero-remove (don't surprise-delete)
+        removed = real_registry.remove_peer_fleet_acl("barsik", fleet="sigil")
+        assert removed == 0
+        assert len(real_registry.get_peer_fleet_acl("barsik")) == 1
+
+        # Passing the exact stored selector removes it
+        removed = real_registry.remove_peer_fleet_acl(
+            "barsik", fleet="sigil", agent_id="*",
+        )
+        assert removed == 1
+        assert real_registry.get_peer_fleet_acl("barsik") == []
+
+
+@pytest.mark.asyncio
+class TestDeliverPendingSubstrate:
+    """End-to-end test of the ``pending`` substrate path through ``deliver()``.
+
+    Round-2 finding #2 / test gap: round-1 only exercised entries that
+    routed to pinky-memory; the pinky-self ``_insert_task`` path was
+    untested, which kept a latent ternary bug undetectable. This fixture
+    routes a ``pending`` entry through the full deliver() flow and
+    confirms it lands in the task store.
+    """
+
+    async def test_pending_entry_routes_to_task_store(self, allow_misha_acl):
+        registry = FakeRegistry(allow_misha_acl)
+        broker = FakeBroker()
+        memory = FakeMemoryStore()
+        tasks = FakeTaskStore()
+        host = HostPinky(
+            registry=registry,
+            broker=broker,
+            memory_store=memory,
+            task_store=tasks,
+        )
+
+        pending_entry = SubstrateEntry(
+            id="pending-001",
+            type="pending",  # routes to pinky-self per classify_entry_destination
+            scope=SubstrateScope(kind="user", ref="brad"),
+            source=SubstrateSource(
+                origin="agent-inferred",
+                by="misha@pinky.local",
+                evidence="Brad mentioned needing to follow up with Matt re: NATS creds",
+                trust=0.85,
+            ),
+            created_at="2026-05-09T10:00:00-07:00",
+            updated_at="2026-05-09T10:00:00-07:00",
+            content="Follow up with Matt about NATS creds for ferry demo",
+            links=[],
+            lifecycle=SubstrateLifecycle(state="pending"),
+            port_history=[],
+        )
+
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="msg-pending",
+            from_="misha@pinky.local",
+            to="ferry://pinkybot/barsik",
+            ts=1746846000000,
+            body={
+                "kind": "substrate.entry",
+                "entry": _entry_to_dict(pending_entry),
+            },
+        )
+
+        result = await host.deliver(envelope)
+
+        assert result.status == "delivered"
+        # Pending → pinky-self, not pinky-memory
+        assert len(tasks.created) == 1
+        assert len(memory.inserted) == 0
+        # Confirm the task carries the right substrate provenance
+        task = tasks.created[0]
+        assert "Follow up with Matt" in task["title"] or "Follow up with Matt" in task.get("description", "")
+        assert task["assigned_agent"] == "barsik"
+        # IngestResult shape
+        results = result.detail["ingested"]
+        assert results[0]["target_store"] == "pinky-self"
+        assert results[0]["target_id"]  # non-empty (round-2 finding #2 — ternary returned object str before)
+
+
+@pytest.mark.asyncio
+class TestBrokerIntegrationFerryInbound:
+    """Regression guard for round-2 blocking finding (broker boundary leak).
+
+    Round-1 wired host-pinky's message dispatch through ``broker.handle_inbound``
+    — which runs the human-platform onboarding flow (``get_user_status`` →
+    ``add_pending_user`` → ``/approve_…`` Telegram prompt to the owner) and
+    writes the ferry sender_id into the human ``approved_users`` table. That
+    defeated the load-bearing identity-primitive separation claim of the PR.
+
+    Round-2 fixed it by routing through ``broker.dispatch_pre_authorized``
+    (a public broker entry point that bypasses onboarding). This test pipes
+    a ferry envelope through real Broker + real AgentRegistry and confirms:
+
+      1. ``approved_users`` does NOT contain the ferry sender_id
+      2. The owner does NOT receive an ``/approve_…`` Telegram prompt
+      3. No pending message is queued under the ferry sender_id
+
+    If a future refactor of ``handle_inbound`` re-introduces the leak, this
+    test fails. None of the FakeBroker tests above would have caught it.
+    """
+
+    async def test_ferry_inbound_does_not_touch_human_approval_path(self, real_registry):
+        # Real Broker, real Registry. send_callback records every outbound;
+        # we assert no /approve_ prompt was emitted.
+        from pinky_daemon.broker import MessageBroker
+
+        sent: list[tuple[str, str, str, str]] = []
+
+        async def record_send(agent_name, platform, chat_id, content):  # noqa: ANN001
+            sent.append((agent_name, platform, chat_id, content))
+
+        broker = MessageBroker(
+            real_registry,
+            session_manager=None,  # not exercised — _route_streaming finds no session
+            send_callback=record_send,
+        )
+
+        # Allow misha@pinky.local fleet-wide
+        real_registry.add_peer_fleet_acl(
+            "barsik", fleet="pinky.local", agent_id="*",
+        )
+
+        host = HostPinky(registry=real_registry, broker=broker)
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="msg-ferry-integration",
+            from_="misha@pinky.local",
+            to="ferry://pinkybot/barsik",
+            ts=1746846000000,
+            body={"kind": "message", "text": "hello from misha across the fleet"},
+        )
+
+        result = await host.deliver(envelope)
+        assert result.status == "delivered"
+
+        # 1. ferry sender NOT in approved_users (the human-identity table)
+        ferry_user_id = "ferry:misha@pinky.local"
+        status = real_registry.get_user_status("barsik", ferry_user_id)
+        assert status is None, (
+            f"ferry sender_id {ferry_user_id!r} leaked into approved_users "
+            f"with status={status!r} — round-1 bug regression"
+        )
+
+        # 2. no /approve_ prompt sent (would have gone to owner on round-1 bug)
+        for _, _, _, content in sent:
+            assert "/approve_" not in content, (
+                f"owner received /approve_ prompt for ferry inbound: {content!r}"
+            )
+            assert "wants to talk to" not in content, (
+                f"owner received human-onboarding prompt for ferry inbound: {content!r}"
+            )
+
+        # 3. no pending message queued under ferry sender_id
+        pending = real_registry.get_pending_messages("barsik", ferry_user_id)
+        assert pending == [], (
+            f"ferry message queued as pending under {ferry_user_id!r}: {pending}"
+        )
+
+    async def test_acl_denied_does_not_leak_either(self, real_registry):
+        """Same regression guard, denied path. ACL-deny must not fall back
+        to onboarding either — the agent should never see the message and
+        the owner should never see an /approve_ prompt."""
+        from pinky_daemon.broker import MessageBroker
+
+        sent: list[tuple[str, str, str, str]] = []
+
+        async def record_send(agent_name, platform, chat_id, content):  # noqa: ANN001
+            sent.append((agent_name, platform, chat_id, content))
+
+        broker = MessageBroker(
+            real_registry, session_manager=None, send_callback=record_send,
+        )
+        # Empty ACL — default-deny
+        host = HostPinky(registry=real_registry, broker=broker)
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="msg-ferry-deny",
+            from_="pulse@studio@sigil",  # not on barsik's empty ACL
+            to="ferry://pinkybot/barsik",
+            ts=1,
+            body={"kind": "message", "text": "x"},
+        )
+
+        result = await host.deliver(envelope)
+        assert result.status == "rejected"
+        assert result.reason == "acl_denied"
+
+        # Owner gets nothing
+        assert sent == []
+        # Registry untouched
+        assert real_registry.get_user_status(
+            "barsik", "ferry:pulse@studio@sigil",
+        ) is None

--- a/tests/test_ferry_host_pinky.py
+++ b/tests/test_ferry_host_pinky.py
@@ -11,10 +11,13 @@ See PinkyBot issue #413 and ferry packages/host-pinky/README.md.
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from dataclasses import asdict
 
 import pytest
 
+from pinky_daemon.agent_registry import AgentRegistry
 from pinky_daemon.ferry.host_pinky import (
     HostPinky,
     parse_peer_card,
@@ -507,3 +510,271 @@ class TestAgentCardSelector:
         sel = AgentCardSelector(fleet="sigil", agent_id="pulse@studio@sigil")
         assert sel.matches("sigil", "pulse@studio@sigil") is True
         assert sel.matches("sigil", "kain@ces-mini@sigil") is False
+
+
+# -- AgentRegistry peer_fleet_acl persistence ---------------------------------
+
+
+@pytest.fixture
+def real_registry():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    r = AgentRegistry(db_path=path)
+    r.register("barsik", model="opus")
+    yield r
+    r.close()
+    os.unlink(path)
+
+
+class TestPeerFleetAclPersistence:
+    def test_unset_returns_empty_list(self, real_registry):
+        assert real_registry.get_peer_fleet_acl("barsik") == []
+
+    def test_unknown_agent_returns_empty_list(self, real_registry):
+        assert real_registry.get_peer_fleet_acl("nonexistent") == []
+
+    def test_has_agent(self, real_registry):
+        assert real_registry.has_agent("barsik") is True
+        assert real_registry.has_agent("nonexistent") is False
+
+    def test_set_and_get_roundtrip(self, real_registry):
+        real_registry.set_peer_fleet_acl(
+            "barsik",
+            [
+                {"fleet": "sigil", "agent_id": "pulse@studio@sigil", "pinky_type": None},
+                {"fleet": "sigil", "agent_id": "kain@ces-mini@sigil", "pinky_type": None},
+            ],
+        )
+        loaded = real_registry.get_peer_fleet_acl("barsik")
+        assert len(loaded) == 2
+        assert loaded[0]["fleet"] == "sigil"
+        assert loaded[0]["agent_id"] == "pulse@studio@sigil"
+
+    def test_set_drops_empty_selectors(self, real_registry):
+        real_registry.set_peer_fleet_acl(
+            "barsik",
+            [
+                {"fleet": "sigil", "agent_id": "pulse@studio@sigil"},
+                {"fleet": "", "agent_id": "", "pinky_type": ""},  # empty — dropped
+                {},  # empty — dropped
+                "not-a-dict",  # type-invalid — dropped
+            ],
+        )
+        loaded = real_registry.get_peer_fleet_acl("barsik")
+        assert len(loaded) == 1
+        assert loaded[0]["agent_id"] == "pulse@studio@sigil"
+
+    def test_set_replaces_not_merges(self, real_registry):
+        real_registry.set_peer_fleet_acl(
+            "barsik", [{"fleet": "sigil", "agent_id": "*"}]
+        )
+        real_registry.set_peer_fleet_acl(
+            "barsik", [{"fleet": "pinky.local", "agent_id": "*"}]
+        )
+        loaded = real_registry.get_peer_fleet_acl("barsik")
+        assert len(loaded) == 1
+        assert loaded[0]["fleet"] == "pinky.local"
+
+    def test_add_idempotent(self, real_registry):
+        added1 = real_registry.add_peer_fleet_acl(
+            "barsik", fleet="sigil", agent_id="pulse@studio@sigil"
+        )
+        added2 = real_registry.add_peer_fleet_acl(
+            "barsik", fleet="sigil", agent_id="pulse@studio@sigil"
+        )
+        assert added1 is True
+        assert added2 is True  # idempotent — already-present is success
+        assert len(real_registry.get_peer_fleet_acl("barsik")) == 1
+
+    def test_add_rejects_empty(self, real_registry):
+        added = real_registry.add_peer_fleet_acl("barsik")
+        assert added is False
+        assert real_registry.get_peer_fleet_acl("barsik") == []
+
+    def test_remove(self, real_registry):
+        real_registry.add_peer_fleet_acl("barsik", fleet="sigil", agent_id="pulse@studio@sigil")
+        real_registry.add_peer_fleet_acl("barsik", fleet="sigil", agent_id="kain@ces-mini@sigil")
+        removed = real_registry.remove_peer_fleet_acl(
+            "barsik", fleet="sigil", agent_id="pulse@studio@sigil"
+        )
+        assert removed == 1
+        loaded = real_registry.get_peer_fleet_acl("barsik")
+        assert len(loaded) == 1
+        assert loaded[0]["agent_id"] == "kain@ces-mini@sigil"
+
+    def test_remove_no_match_returns_zero(self, real_registry):
+        real_registry.add_peer_fleet_acl("barsik", fleet="sigil", agent_id="*")
+        removed = real_registry.remove_peer_fleet_acl(
+            "barsik", fleet="other", agent_id="x"
+        )
+        assert removed == 0
+
+
+@pytest.mark.asyncio
+class TestHostPinkyAgainstRealRegistry:
+    """End-to-end: real AgentRegistry + FakeBroker confirms ACL plumbing works."""
+
+    async def test_acl_allows_then_denies_after_remove(self, real_registry):
+        broker = FakeBroker()
+        host = HostPinky(registry=real_registry, broker=broker)
+
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="msg-allow-flow",
+            from_="pulse@studio@sigil",
+            to="ferry://pinkybot/barsik",
+            ts=1,
+            body={"kind": "message", "text": "hello"},
+        )
+
+        # Default: deny-all
+        result = await host.deliver(envelope)
+        assert result.status == "rejected"
+        assert result.reason == "acl_denied"
+
+        # Allow Pulse
+        real_registry.add_peer_fleet_acl(
+            "barsik", fleet="sigil", agent_id="pulse@studio@sigil"
+        )
+        result = await host.deliver(envelope)
+        assert result.status == "delivered"
+        assert len(broker.received) == 1
+
+        # Remove Pulse — back to deny
+        real_registry.remove_peer_fleet_acl(
+            "barsik", fleet="sigil", agent_id="pulse@studio@sigil"
+        )
+        result = await host.deliver(envelope)
+        assert result.status == "rejected"
+        assert result.reason == "acl_denied"
+
+    async def test_unknown_agent_uses_real_has_agent(self, real_registry):
+        broker = FakeBroker()
+        host = HostPinky(registry=real_registry, broker=broker)
+
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="msg-unknown",
+            from_="misha@pinky.local",
+            to="ferry://pinkybot/nonexistent",
+            ts=1,
+            body={"kind": "message", "text": "hi"},
+        )
+
+        result = await host.deliver(envelope)
+        assert result.status == "rejected"
+        assert result.reason == "unknown_agent"
+
+
+# -- API: peer-fleet-acl endpoints --------------------------------------------
+
+
+@pytest.fixture
+def api_client():
+    """FastAPI TestClient with a fresh registry containing 'barsik'."""
+    from fastapi.testclient import TestClient
+
+    from pinky_daemon.api import create_api
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    app = create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
+    client = TestClient(app)
+    # Register barsik via the API
+    r = client.post("/agents", json={"name": "barsik", "model": "opus"})
+    assert r.status_code in (200, 201), f"agent register failed: {r.status_code} {r.text}"
+    yield client
+    client.close()
+    os.unlink(path)
+
+
+class TestPeerFleetAclApi:
+    def test_get_empty_for_known_agent(self, api_client):
+        r = api_client.get("/agents/barsik/peer-fleet-acl")
+        assert r.status_code == 200
+        assert r.json() == {"agent": "barsik", "selectors": []}
+
+    def test_get_404_for_unknown_agent(self, api_client):
+        r = api_client.get("/agents/nonexistent/peer-fleet-acl")
+        assert r.status_code == 404
+
+    def test_post_adds_selector(self, api_client):
+        r = api_client.post(
+            "/agents/barsik/peer-fleet-acl",
+            json={"fleet": "sigil", "agent_id": "pulse@studio@sigil"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["added"] is True
+        assert len(body["selectors"]) == 1
+        assert body["selectors"][0]["fleet"] == "sigil"
+        assert body["selectors"][0]["agent_id"] == "pulse@studio@sigil"
+
+    def test_post_rejects_empty_selector(self, api_client):
+        r = api_client.post(
+            "/agents/barsik/peer-fleet-acl",
+            json={"fleet": "", "agent_id": "", "pinky_type": ""},
+        )
+        assert r.status_code == 400
+        assert "at least one" in r.json()["detail"]
+
+    def test_post_idempotent(self, api_client):
+        for _ in range(3):
+            r = api_client.post(
+                "/agents/barsik/peer-fleet-acl",
+                json={"fleet": "sigil", "agent_id": "pulse@studio@sigil"},
+            )
+            assert r.status_code == 200
+        r = api_client.get("/agents/barsik/peer-fleet-acl")
+        assert len(r.json()["selectors"]) == 1
+
+    def test_put_replaces_full_acl(self, api_client):
+        # Add two
+        api_client.post(
+            "/agents/barsik/peer-fleet-acl",
+            json={"fleet": "sigil", "agent_id": "pulse@studio@sigil"},
+        )
+        api_client.post(
+            "/agents/barsik/peer-fleet-acl",
+            json={"fleet": "sigil", "agent_id": "kain@ces-mini@sigil"},
+        )
+        # PUT to replace with just one different selector
+        r = api_client.put(
+            "/agents/barsik/peer-fleet-acl",
+            json={"selectors": [{"fleet": "pinky.local", "agent_id": "*"}]},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["selectors"]) == 1
+        assert body["selectors"][0]["fleet"] == "pinky.local"
+
+    def test_delete_by_query_removes_matching(self, api_client):
+        api_client.post(
+            "/agents/barsik/peer-fleet-acl",
+            json={"fleet": "sigil", "agent_id": "pulse@studio@sigil"},
+        )
+        api_client.post(
+            "/agents/barsik/peer-fleet-acl",
+            json={"fleet": "sigil", "agent_id": "kain@ces-mini@sigil"},
+        )
+        r = api_client.delete(
+            "/agents/barsik/peer-fleet-acl",
+            params={"fleet": "sigil", "agent_id": "pulse@studio@sigil"},
+        )
+        assert r.status_code == 200
+        assert r.json()["removed"] == 1
+        remaining = r.json()["selectors"]
+        assert len(remaining) == 1
+        assert remaining[0]["agent_id"] == "kain@ces-mini@sigil"
+
+    def test_delete_no_match_returns_zero(self, api_client):
+        api_client.post(
+            "/agents/barsik/peer-fleet-acl",
+            json={"fleet": "sigil", "agent_id": "*"},
+        )
+        r = api_client.delete(
+            "/agents/barsik/peer-fleet-acl",
+            params={"fleet": "other", "agent_id": "pulse"},
+        )
+        assert r.status_code == 200
+        assert r.json()["removed"] == 0

--- a/tests/test_ferry_host_pinky.py
+++ b/tests/test_ferry_host_pinky.py
@@ -1,0 +1,509 @@
+"""Tests for @ferry/host-pinky — substrate ↔ pinky-memory bridge.
+
+Acceptance test uses substrate v0.1 §12 worked example as fixtures:
+  Entry 1: feedback, trust 0.95, scope user/brad ("Brad wants terse responses…")
+  Entry 2: pattern,  trust 0.7,  scope user/brad ("Brad's tolerance for response length…")
+            links → Entry 1
+
+See PinkyBot issue #413 and ferry packages/host-pinky/README.md.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+import pytest
+
+from pinky_daemon.ferry.host_pinky import (
+    HostPinky,
+    parse_peer_card,
+    parse_pinkybot_address,
+)
+from pinky_daemon.ferry.substrate import (
+    classify_entry_destination,
+    map_substrate_type_to_reflection,
+    populate_port_history,
+    to_reflection_input,
+    trust_to_salience,
+)
+from pinky_daemon.ferry.types import (
+    AgentCardSelector,
+    FerryEnvelope,
+    SubstrateEntry,
+    SubstrateLifecycle,
+    SubstrateScope,
+    SubstrateSource,
+    TraversalRecord,
+)
+
+# -- §12 worked example fixtures (substrate v0.1) ------------------------------
+
+
+def _entry_1_feedback() -> SubstrateEntry:
+    """Entry 1 from substrate v0.1 §12.2 — user-stated feedback."""
+    return SubstrateEntry(
+        id="0c7e3d12-9f8a-4f1e-b6e2-2d8a8c1f4f9a",
+        type="feedback",
+        scope=SubstrateScope(kind="user", ref="brad"),
+        source=SubstrateSource(
+            origin="user-stated",
+            by="misha@pinky.local",
+            evidence=(
+                "Brad in DM, 2026-04-12 16:23 PT: 'stop summarizing what you "
+                "just did at the end of every response, I can read the diff'"
+            ),
+            trust=0.95,
+        ),
+        created_at="2026-04-12T16:24:11-07:00",
+        updated_at="2026-04-12T16:24:11-07:00",
+        content=(
+            "Brad wants terse responses with no trailing summaries.\n"
+            "Why: he reads the diff himself; trailing summaries are noise.\n"
+            "How to apply: end responses at the last substantive sentence; "
+            "do not append a recap of what was changed."
+        ),
+        links=[],
+        lifecycle=SubstrateLifecycle(state="active"),
+        port_history=[],
+    )
+
+
+def _entry_2_pattern() -> SubstrateEntry:
+    """Entry 2 from substrate v0.1 §12.3 — agent-inferred pattern."""
+    return SubstrateEntry(
+        id="4a9b2e57-3c1d-4e8f-9a0b-7e6c5d4f3e2a",
+        type="pattern",
+        scope=SubstrateScope(kind="user", ref="brad"),
+        source=SubstrateSource(
+            origin="agent-inferred",
+            by="misha@pinky.local",
+            evidence=(
+                "Refs to 12 conversation entries: [list of 12 ids elided]; "
+                "pattern: Brad responds with curtness or 'too long' when "
+                "responses exceed ~3 sentences without functional content."
+            ),
+            trust=0.7,
+        ),
+        created_at="2026-05-02T09:11:32-07:00",
+        updated_at="2026-05-02T09:11:32-07:00",
+        content=(
+            "Brad's tolerance for response length appears bounded around 3 "
+            "sentences of non-functional prose. Beyond that, he often "
+            "pushes back ('too long', curtness, or no reply).\n"
+            "This pattern holds even when he hasn't explicitly asked for brevity.\n"
+            "Implication for response calibration: default to terse; verbose "
+            "only when Brad explicitly asks for depth or the content is "
+            "irreducibly long."
+        ),
+        links=["0c7e3d12-9f8a-4f1e-b6e2-2d8a8c1f4f9a"],
+        lifecycle=SubstrateLifecycle(state="active"),
+        port_history=[],
+    )
+
+
+def _build_envelope_substrate_batch(entries: list[SubstrateEntry]) -> FerryEnvelope:
+    """Wrap §12 entries in a ferry envelope addressed to barsik."""
+    return FerryEnvelope(
+        v="0.1",
+        id="01891e0e-7a00-7000-9000-000000000042",  # uuid-v7 placeholder
+        from_="misha@pinky.local",
+        to="ferry://pinkybot/barsik",
+        ts=1746846000000,
+        body={
+            "kind": "substrate.batch",
+            "entries": [_entry_to_dict(e) for e in entries],
+        },
+        traversal=[
+            TraversalRecord(
+                broker="ferry-broker:misha-local",
+                at=1746846000050,
+                via="leaf-link",
+                signature="<broker-sig-stub>",
+            ),
+        ],
+    )
+
+
+def _entry_to_dict(e: SubstrateEntry) -> dict:
+    """Serialize a SubstrateEntry to the wire-shape dict (handles from_ → from)."""
+    raw = {
+        "id": e.id,
+        "type": e.type,
+        "scope": asdict(e.scope),
+        "source": asdict(e.source),
+        "created_at": e.created_at,
+        "updated_at": e.updated_at,
+        "content": e.content,
+        "links": list(e.links),
+        "lifecycle": asdict(e.lifecycle),
+        "port_history": [asdict(p) for p in e.port_history],
+    }
+    return raw
+
+
+# -- Fakes ---------------------------------------------------------------------
+
+
+class FakeRegistry:
+    """Minimal AgentRegistry stand-in for host-pinky tests."""
+
+    def __init__(self, agents: dict[str, list[AgentCardSelector]]) -> None:
+        self._agents = agents
+
+    def has_agent(self, name: str) -> bool:
+        return name in self._agents
+
+    def list_agents(self) -> list[dict]:
+        return [{"name": n} for n in self._agents]
+
+    def get_peer_fleet_acl(self, name: str) -> list[AgentCardSelector]:
+        return list(self._agents.get(name, []))
+
+
+class FakeBroker:
+    """Records every handle_inbound call."""
+
+    def __init__(self) -> None:
+        self.received: list = []
+
+    async def handle_inbound(self, broker_msg) -> None:  # noqa: ANN001
+        self.received.append(broker_msg)
+
+
+class FakeReflection:
+    """Reflection stand-in for FakeMemoryStore.insert."""
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        if not getattr(self, "id", ""):
+            self.id = f"refl-{abs(hash(self.content)) % 10**8}"
+
+
+class FakeMemoryStore:
+    """Records every insert call."""
+
+    def __init__(self) -> None:
+        self.inserted: list = []
+
+    def insert(self, reflection):  # noqa: ANN001
+        # Accept both the real Reflection and our FakeReflection stand-in.
+        # Add an id if not present.
+        if not getattr(reflection, "id", ""):
+            reflection.id = f"refl-{len(self.inserted) + 1}"
+        self.inserted.append(reflection)
+        return reflection
+
+
+class FakeTaskStore:
+    """Records every create_task call."""
+
+    def __init__(self) -> None:
+        self.created: list = []
+
+    def create_task(self, **kwargs):
+        kwargs["id"] = f"task-{len(self.created) + 1}"
+        self.created.append(kwargs)
+        return kwargs
+
+
+# -- substrate.py unit tests ---------------------------------------------------
+
+
+class TestTypeMapping:
+    def test_fact_event_reference_map_to_pinky_memory_fact(self):
+        for sub in ("fact", "event", "reference"):
+            assert map_substrate_type_to_reflection(sub) == "fact"
+
+    def test_feedback_decision_map_to_insight(self):
+        for sub in ("feedback", "decision"):
+            assert map_substrate_type_to_reflection(sub) == "insight"
+
+    def test_pattern_maps_to_interaction_pattern(self):
+        assert map_substrate_type_to_reflection("pattern") == "interaction_pattern"
+
+    def test_pending_does_not_map_to_pinky_memory(self):
+        assert map_substrate_type_to_reflection("pending") is None
+
+    def test_unknown_does_not_map(self):
+        assert map_substrate_type_to_reflection("nonsense") is None
+
+
+class TestTrustToSalience:
+    @pytest.mark.parametrize(
+        "trust,expected",
+        [
+            (0.0, 1),
+            (0.1, 1),  # 1 + round(0.4) = 1 + 0 = 1
+            (0.25, 2),  # 1 + round(1.0) = 2
+            (0.5, 3),
+            (0.7, 4),  # Entry 2 from §12 — trust 0.7 → salience 4
+            (0.95, 5),  # Entry 1 from §12 — trust 0.95 → salience 5
+            (1.0, 5),
+            (-0.1, 1),  # clamped
+            (1.5, 5),  # clamped
+        ],
+    )
+    def test_formula(self, trust, expected):
+        assert trust_to_salience(trust) == expected
+
+
+class TestPortHistory:
+    def test_single_hop_with_traversal_record(self):
+        entry = _entry_1_feedback()
+        envelope = _build_envelope_substrate_batch([entry])
+        populate_port_history(entry, envelope, "ferry://pinkybot/barsik")
+
+        # One traversal hop in fixture → broker hop + final delivery hop = 2 entries
+        assert len(entry.port_history) == 2
+        assert entry.port_history[0].from_ == "misha@pinky.local"
+        assert entry.port_history[0].to == "ferry-broker:misha-local"
+        assert entry.port_history[-1].to == "ferry://pinkybot/barsik"
+        # All hops re_grounded=False on inbound (§6.4)
+        assert all(p.re_grounded is False for p in entry.port_history)
+
+    def test_no_traversal_writes_single_synthetic_hop(self):
+        entry = _entry_1_feedback()
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="abc",
+            from_="misha@pinky.local",
+            to="ferry://pinkybot/barsik",
+            ts=1,
+            body={"kind": "substrate.entry", "entry": _entry_to_dict(entry)},
+        )
+        populate_port_history(entry, envelope, "ferry://pinkybot/barsik")
+        assert len(entry.port_history) == 1
+        assert entry.port_history[0].from_ == "misha@pinky.local"
+        assert entry.port_history[0].to == "ferry://pinkybot/barsik"
+
+
+class TestToReflectionInput:
+    def test_entry_1_lands_as_insight_salience_5(self):
+        e = _entry_1_feedback()
+        ref = to_reflection_input(e)
+
+        assert ref["type"] == "insight"
+        assert ref["salience"] == 5
+        assert ref["entities"] == ["brad"]
+        assert ref["source_channel"] == "ferry"
+        assert "Brad wants terse responses" in ref["content"]
+
+        # Sidecar preserves source.by per §6.1
+        sidecar = json.loads(ref["context"])
+        assert sidecar["substrate_id"] == e.id
+        assert sidecar["substrate_type"] == "feedback"
+        assert sidecar["source"]["by"] == "misha@pinky.local"
+        assert sidecar["source"]["origin"] == "user-stated"
+        assert sidecar["scope"] == {"kind": "user", "ref": "brad"}
+
+    def test_entry_2_lands_as_interaction_pattern_salience_4_with_links(self):
+        e = _entry_2_pattern()
+        ref = to_reflection_input(e)
+
+        assert ref["type"] == "interaction_pattern"
+        assert ref["salience"] == 4
+        assert ref["entities"] == ["brad"]
+
+        sidecar = json.loads(ref["context"])
+        # links surface preserved (no native pinky-memory edge surface; v0.2 §3.2.1 recipe)
+        assert sidecar["links"] == ["0c7e3d12-9f8a-4f1e-b6e2-2d8a8c1f4f9a"]
+
+    def test_pending_entry_raises(self):
+        e = _entry_1_feedback()
+        e.type = "pending"  # type: ignore[assignment]
+        with pytest.raises(ValueError, match="pinky-self"):
+            to_reflection_input(e)
+
+
+class TestClassifyEntryDestination:
+    def test_pending_routes_to_pinky_self(self):
+        e = _entry_1_feedback()
+        e.type = "pending"  # type: ignore[assignment]
+        assert classify_entry_destination(e) == "pinky-self"
+
+    def test_decayed_lifecycle_skips(self):
+        e = _entry_1_feedback()
+        e.lifecycle = SubstrateLifecycle(state="decayed")
+        assert classify_entry_destination(e) == "skipped"
+
+    def test_active_feedback_routes_to_pinky_memory(self):
+        assert classify_entry_destination(_entry_1_feedback()) == "pinky-memory"
+
+
+# -- HostPinky.deliver() integration tests -------------------------------------
+
+
+@pytest.fixture
+def allow_misha_acl() -> dict[str, list[AgentCardSelector]]:
+    """Barsik has an ACL allowing the entire pinky.local fleet."""
+    return {
+        "barsik": [AgentCardSelector(fleet="pinky.local", agent_id="*")],
+    }
+
+
+@pytest.mark.asyncio
+class TestDeliverMessage:
+    async def test_message_routes_to_broker_with_ferry_metadata(self, allow_misha_acl):
+        registry = FakeRegistry(allow_misha_acl)
+        broker = FakeBroker()
+        host = HostPinky(registry=registry, broker=broker)
+
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="msg-001",
+            from_="misha@pinky.local",
+            to="ferry://pinkybot/barsik",
+            ts=1746846000000,
+            body={"kind": "message", "text": "ping from misha"},
+        )
+
+        result = await host.deliver(envelope)
+
+        assert result.status == "delivered"
+        assert len(broker.received) == 1
+        bm = broker.received[0]
+        assert bm.platform == "ferry"
+        assert bm.agent_name == "barsik"
+        assert bm.content == "ping from misha"
+        assert bm.message_id == "msg-001"
+        assert bm.metadata["ferry"]["from"] == "misha@pinky.local"
+
+    async def test_unknown_agent_rejected(self, allow_misha_acl):
+        registry = FakeRegistry(allow_misha_acl)
+        broker = FakeBroker()
+        host = HostPinky(registry=registry, broker=broker)
+
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="msg-002",
+            from_="misha@pinky.local",
+            to="ferry://pinkybot/nonexistent",
+            ts=1,
+            body={"kind": "message", "text": "x"},
+        )
+
+        result = await host.deliver(envelope)
+        assert result.status == "rejected"
+        assert result.reason == "unknown_agent"
+        assert broker.received == []
+
+    async def test_acl_denied_rejected(self):
+        # Empty ACL → deny all
+        registry = FakeRegistry({"barsik": []})
+        broker = FakeBroker()
+        host = HostPinky(registry=registry, broker=broker)
+
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="msg-003",
+            from_="pulse@studio@sigil",
+            to="ferry://pinkybot/barsik",
+            ts=1,
+            body={"kind": "message", "text": "x"},
+        )
+
+        result = await host.deliver(envelope)
+        assert result.status == "rejected"
+        assert result.reason == "acl_denied"
+        assert broker.received == []
+
+
+@pytest.mark.asyncio
+class TestDeliverSubstrateBatch:
+    """Acceptance test: substrate v0.1 §12 worked example, ported A → B."""
+
+    async def test_two_entries_land_in_pinky_memory_with_correct_shape(
+        self, allow_misha_acl
+    ):
+        registry = FakeRegistry(allow_misha_acl)
+        broker = FakeBroker()
+        memory = FakeMemoryStore()
+        tasks = FakeTaskStore()
+        host = HostPinky(
+            registry=registry,
+            broker=broker,
+            memory_store=memory,
+            task_store=tasks,
+        )
+
+        envelope = _build_envelope_substrate_batch(
+            [_entry_1_feedback(), _entry_2_pattern()]
+        )
+
+        # Patch out the real Reflection import inside the host_pinky module so
+        # we can run the test without the pinky_memory dependency providing a
+        # concrete model. The test substitutes our FakeReflection.
+        import pinky_daemon.ferry.host_pinky as host_pinky_mod
+
+        original_insert = host_pinky_mod.HostPinky._insert_reflection
+
+        def _fake_insert(self, ref_kwargs):  # noqa: ANN001
+            r = FakeReflection(**ref_kwargs)
+            self._memory_store.insert(r)
+            return r.id
+
+        host_pinky_mod.HostPinky._insert_reflection = _fake_insert  # type: ignore[method-assign]
+        try:
+            result = await host.deliver(envelope)
+        finally:
+            host_pinky_mod.HostPinky._insert_reflection = original_insert  # type: ignore[method-assign]
+
+        assert result.status == "delivered"
+        assert len(memory.inserted) == 2
+        assert len(tasks.created) == 0  # no `pending` entries in §12 example
+
+        # Entry 1: feedback → insight, salience 5
+        e1 = memory.inserted[0]
+        assert e1.type == "insight"
+        assert e1.salience == 5
+        assert "Brad wants terse responses" in e1.content
+        sidecar1 = json.loads(e1.context)
+        assert sidecar1["source"]["by"] == "misha@pinky.local"  # §6.1 preserved
+        assert sidecar1["substrate_type"] == "feedback"
+        assert len(sidecar1["port_history"]) >= 1
+        assert sidecar1["port_history"][-1]["to"] == "ferry://pinkybot/barsik"
+
+        # Entry 2: pattern → interaction_pattern, salience 4, links preserved
+        e2 = memory.inserted[1]
+        assert e2.type == "interaction_pattern"
+        assert e2.salience == 4
+        sidecar2 = json.loads(e2.context)
+        assert sidecar2["links"] == ["0c7e3d12-9f8a-4f1e-b6e2-2d8a8c1f4f9a"]
+
+
+# -- Address parsing -----------------------------------------------------------
+
+
+class TestAddressParsing:
+    def test_parse_pinkybot_address_extracts_agent(self):
+        assert parse_pinkybot_address("ferry://pinkybot/barsik") == "barsik"
+
+    def test_parse_pinkybot_address_rejects_other_fleets(self):
+        assert parse_pinkybot_address("ferry://sigil/pulse") is None
+        assert parse_pinkybot_address("misha@pinky.local") is None
+
+    def test_parse_peer_card_at_form(self):
+        assert parse_peer_card("pulse@studio@sigil") == ("sigil", "pulse@studio@sigil")
+        assert parse_peer_card("misha@pinky.local") == ("pinky.local", "misha@pinky.local")
+
+    def test_parse_peer_card_ferry_form(self):
+        assert parse_peer_card("ferry://sigil/pulse") == ("sigil", "ferry://sigil/pulse")
+
+
+class TestAgentCardSelector:
+    def test_empty_selector_rejected(self):
+        with pytest.raises(ValueError, match="at least one"):
+            AgentCardSelector()
+
+    def test_fleet_wildcard_matches_any_agent(self):
+        sel = AgentCardSelector(fleet="sigil", agent_id="*")
+        assert sel.matches("sigil", "pulse@studio@sigil") is True
+        assert sel.matches("sigil", "kain@ces-mini@sigil") is True
+        assert sel.matches("pinky.local", "misha@pinky.local") is False
+
+    def test_specific_match(self):
+        sel = AgentCardSelector(fleet="sigil", agent_id="pulse@studio@sigil")
+        assert sel.matches("sigil", "pulse@studio@sigil") is True
+        assert sel.matches("sigil", "kain@ces-mini@sigil") is False


### PR DESCRIPTION
## Summary

PinkyBot-side implementation of `@ferry/host-pinky` — receives ferry envelopes addressed to PinkyBot agents and translates them into either inbound platform messages (via `broker.dispatch_pre_authorized`) or substrate-spec memory imports (`pinky-memory` + `pinky-self`).

This is the Python implementation companion to choose27/ferry PR #1 (TS placeholder package + design doc at `packages/host-pinky/README.md`).

Closes #413 once acceptance criteria are met.

## Round-2 changes (broker-boundary identity-leak fix)

Round-1 docstring claimed `host_pinky._deliver_message` bypassed `broker.handle_inbound`'s human-approval flow via a "dedicated path" — but no such path existed. Misha's Class A rotation review caught it. Round-2 adds the actual primitive:

**Blocking fix:**
- New `broker.dispatch_pre_authorized(agent_name, message)` public entry — routes a pre-authorized message straight to the agent's streaming session, bypassing onboarding (`get_user_status` / `add_pending_user` / `/approve_…` Telegram prompt). Reusable for federation, MCP-host inbound, etc.
- `host_pinky._deliver_message` now calls `dispatch_pre_authorized` instead of `handle_inbound`. Docstring rewritten to describe the actual broker-boundary semantics.
- New `TestBrokerIntegrationFerryInbound` regression guard — pipes a ferry envelope through real `Broker` + `AgentRegistry` and asserts the ferry sender_id stays out of `approved_users`, no `/approve_` prompt fires, no message queues under the ferry identity. None of the FakeBroker tests would have caught the round-1 bug.

**Other findings addressed:**
- `DeliveryResult.status` gains `"transient_failure"`. `host_pinky` raises `_TransientACLLoadError` on `sqlite3.Error` from the registry read and translates to `transient_failure` so the broker retries instead of treating an operator-side hiccup (DB lock, schema mismatch during rolling deploy) as a policy denial.
- `_insert_task` ternary refactored — old form stringified the entire task object as a "task id" when `.id` was empty.
- `AgentRegistry.add/remove_peer_fleet_acl` now guarded by an `RLock` so concurrent admin-API requests can't lose updates on the read-modify-write of `peer_fleet_acl`.
- `PortHistoryEntry` gains `attested_by: "broker" | "receiver"` so receiver-fabricated synthetic-hop timestamps don't conflate with broker-stamped traversal timestamps.
- `_load_peer_fleet_acl` narrows broad `except` to `(TypeError, ValueError, json.JSONDecodeError)` for per-item parse skips; `sqlite3.Error` escapes for the transient path.
- `HostPinky` gains optional `reflection_factory` injection for tests (replaces monkey-patching).
- `remove_peer_fleet_acl` wildcard-vs-exact semantics documented + new test pins the contract.

## platform=ferry consumer audit

Downstream of `dispatch_pre_authorized` → `_route_streaming`, every consumer of `message.platform` was audited:

| Consumer | Behavior with platform="ferry" |
|---|---|
| `_format_prompt` header rendering | `[ferry \| dm \| <peer_address> \| ...]` — works, just shows ferry as the platform name |
| `_format_prompt` timezone lookup | `get_user_timezone(agent, peer_address)` falls back to default tz — fine |
| `_route_streaming` "agent not running" fallback | calls `_send_callback(..., "ferry", ...)`. No ferry sender wired yet; would log silently. Acceptable for v0.1. |
| `_typing_loop` | Early-returns when `platform != "telegram"` — no-op for ferry ✓ |
| `_no_hint_platforms` (line 828) | "ferry" not in skip-set — agent gets `💬 Reply on ferry using send_message()` hint appended. Confusing but harmless for v0.1; v0.2 will register ferry as a first-class platform with its own outbound surface. |
| Voice/photo attachment paths | Only fire when attachments present; ferry doesn't carry binary attachments yet ✓ |
| `handle_inbound` activity log | NOT in `dispatch_pre_authorized` path — ferry has its own observability via `host_pinky.stats`. Documented. |

Net: `dispatch_pre_authorized` is safe for ferry inbound. The remaining cosmetic issues (reply hint, "agent not running" fallback) move into v0.2 when ferry becomes a first-class platform with its own outbound surface.

## Files

- `src/pinky_daemon/ferry/__init__.py` — package re-exports
- `src/pinky_daemon/ferry/types.py` — wire shapes: `FerryEnvelope`, `TraversalRecord`, `DeliveryResult` (with `transient_failure`), `AgentCardSelector`, `PortHistoryEntry` (with `attested_by`), `SubstrateEntry` and friends
- `src/pinky_daemon/ferry/substrate.py` — substrate v0.1 §12.5 unwrap: type mapping, trust→salience, `populate_port_history` (now sets `attested_by` per hop), reflection-input + task-input shaping
- `src/pinky_daemon/ferry/host_pinky.py` — `HostPinky.deliver()` with peer-fleet ACL, dispatch by `body.kind`, broker injection, substrate ingestion, transient-failure path
- `src/pinky_daemon/broker.py` — `dispatch_pre_authorized` public primitive
- `src/pinky_daemon/agent_registry.py` — `peer_fleet_acl` persistence + REST methods, RLock-guarded r-m-w, documented exact-match remove semantics
- `tests/test_ferry_host_pinky.py` — **58 tests collected** including new round-2 classes: `TestTransientACLLoadFailure`, `TestACLRemoveWildcardSemantics`, `TestDeliverPendingSubstrate`, `TestBrokerIntegrationFerryInbound`

## Status

- [x] Behavior contract (issue #413)
- [x] Wire-shape dataclasses
- [x] `HostPinky.deliver()` with peer-fleet ACL + dispatch
- [x] Substrate ingestion (type mapping, port_history, sidecar metadata)
- [x] Tests against §12 worked-example fixtures
- [x] `agent_registry.py` — `peer_fleet_acl` column + persistence (round-2: + RLock)
- [x] API surface — `POST/PUT/DELETE /agents/{name}/peer-fleet-acl`
- [x] Round-2: broker-boundary identity-leak fix + integration regression guard
- [ ] Wire as a pinky-daemon long-running task (substitute for poller pattern; activates once leaf-link plumbing lands)
- [ ] Real pinky-memory integration test (replace `FakeMemoryStore` with real `MemoryStore`)
- [ ] README field-name alignment commit on choose27/ferry side (separate PR)

## Acceptance test

Uses substrate v0.1 §12 worked example verbatim:

| Entry | Type | Trust | → pinky-memory shape |
|---|---|---|---|
| 1: "stop summarizing" feedback (Brad's exact words, 2026-04-12) | `feedback` | 0.95 | `insight`, salience 5, entities=[brad] |
| 2: pattern across 12 conversations | `pattern` | 0.7 | `interaction_pattern`, salience 4, entities=[brad], context.links → Entry 1 |

The test exercises:
- §3 schema (full entry round-trip)
- §6.1 original-author preservation (`source.by` survives port)
- §6.4 port_history canonicality (populated from envelope.traversal on inbound; round-2 adds `attested_by` distinction)
- §11 type mapping (host-implementation-defined)
- §12.5 five-step unwrap

## Substrate ↔ pinky-memory mapping (host-side, not spec-side)

Per substrate v0.1 §11 reference impl notes:

```
fact / event / reference  → pinky-memory `fact`
feedback / decision       → pinky-memory `insight`
pattern                   → pinky-memory `interaction_pattern`
pending                   → pinky-self `create_task`  (cross-MCP)
```

Trust → salience: `salience = 1 + round(trust * 4)` clamped [1, 5]. Documented as "one valid mapping, not the mapping" per Pulse + Misha threads — substrate stays trust-opaque, hosts decide.

Links: pinky-memory has no native cross-entry edge surface, so substrate `links` are stored in `context` JSON sidecar. v0.2 §3.2.1 "no-link-surface pattern" reference recipe will formalize the recall-time fan-out helper.

## Out of scope (v0.1)

Tracked in #413:
- NATS leaf-link plumbing (Pulse owns)
- Outbound from PinkyBot (`mcp__pinky-self__send_to_peer_fleet`) — v0.2
- Multi-agent target routing (broadcast) — v0.2
- Real Ed25519 signature verification (accept-all + log) — v0.2/v0.3
- Twice-ported degradation (`re_grounded: true` reset) — v0.2 example
- Import-time read-quiesce protocol (write-race during demo) — v0.2
- Ferry as first-class platform in broker (cosmetic outbound surface) — v0.2

## Test plan

- [x] Unit tests for `substrate.py` (type mapping, trust→salience, port_history with `attested_by`, reflection/task shaping)
- [x] `HostPinky.deliver()` integration tests (message routing, ACL deny, unknown agent, substrate batch, **substrate pending → pinky-self**)
- [x] §12 worked-example acceptance fixture
- [x] **Round-2: Broker-integration regression guard** — real Broker + AgentRegistry, asserts no identity leak into `approved_users`
- [x] **Round-2: Transient ACL-load failure** — sqlite3 error → `transient_failure` not `rejected`
- [x] **Round-2: Wildcard remove semantics** — exact-match contract pinned
- [ ] Real `pinky-memory.MemoryStore` integration test
- [ ] End-to-end demo: Pulse → Nova broker → leaf-link → Mac Mini broker → host-pinky → barsik session (gated on plumbing thread)

## References

- ferry [PROTOCOL.md v0.1](https://github.com/choose27/ferry/blob/main/PROTOCOL.md) — envelope shape
- substrate [v0.1.md](https://github.com/choose27/ferry/blob/main/specs/substrate/v0.1.md) — entry schema + §12 worked example
- ferry [packages/host-pinky/README.md](https://github.com/choose27/ferry/blob/main/packages/host-pinky/README.md) — design doc

## Review history

- **Class A (rotation, same-substrate)** — Misha @ choose27/ferry. Pre-shaped checklist (author-assisted). Caught broker-boundary identity-leak (blocking) + 5 suggestions + 4 nits. PR #414 round-trip logged as v0.1 evidence point for rotation-within-substrate-author-assisted sub-claim. Round-2 (this push) addresses all findings.
- **Class C (heterogeneity)** — pending Brad (genuinely-different-substrate gate)

🤖 Opened by Barsik