### PR TITLE
chore(deps): bump claude-agent-sdk >=0.1.77 → >=0.1.80 (#409)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "httpx>=0.28",
     "fastapi>=0.135",
     "uvicorn>=0.44",
-    "claude-agent-sdk>=0.1.77",
+    "claude-agent-sdk>=0.1.80",
     "Pillow>=10.0",
     # Federation crypto (sealed_box_v1): X25519, Ed25519, HKDF, XChaCha20-Poly1305.
     "cryptography>=41.0",


### PR DESCRIPTION
Closes #409.

## Summary

One-line version floor bump in `pyproject.toml`. No code changes.

SDK 0.1.80 (bundled CC 2.1.138) includes several fixes that directly affect PinkyBot:

- **MCP OAuth refresh-token race** — fixed in 0.1.78/CC 2.1.136. We run ~6 MCP servers concurrently (pinky-memory, pinky-messaging, pinky-self, pinky-outreach, pinky-calendar, pinky-self) — this race is firmly in scope. Prior behaviour: re-auth required daily.
- **`AskUserQuestion` multi-select silent data loss** — answers supplied as an array were silently dropped. We use `AskUserQuestion` in agent flows.
- **API 400 on redacted thinking block after tool call** — affects any flow with `thinking_blocks` + tool use.
- **`CLAUDE_ENV_FILE` env vars going stale after `/resume` or `/clear`** — fixed.
- **Login loop from concurrent credential write** — same auth shape as daemon session refresh.

0.1.79/0.1.80 are smaller (VSCode-Windows path fix + internal cleanup).

## Test plan
- [ ] CI passes (Python 3.11 / 3.12 / 3.13, ruff, CodeQL, frontend build)
- [ ] No behaviour changes expected — every fix is at the CLI layer the SDK shells out to

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzJjHgAphT4iJpYiyJoMEm)_