### PR TITLE
feat(ferry): mesh persistence + federation peer registry (#419) — stacked on #421

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -78,6 +78,7 @@ from pinky_daemon.hooks import (
 )
 from pinky_daemon.kb_store import KBStore
 from pinky_daemon.librarian_runner import LibrarianRunner
+from pinky_daemon.mesh_store import MeshStore
 from pinky_daemon.outreach_config import OutreachConfigStore
 from pinky_daemon.plugin_manager import PluginManager
 from pinky_daemon.presentation_store import PresentationStore
@@ -662,6 +663,19 @@ class MeshAllowlistSetRequest(BaseModel):
     """Replace the full mesh outbound allowlist for an agent."""
 
     patterns: list[str] = []
+
+
+class FederationPeerUpsertRequest(BaseModel):
+    """Insert or update a federation peer (admin / config-seeded path).
+
+    Composite key: (fleet, agent). ``seed_source='config'`` is the stronger
+    statement of intent and never gets downgraded by an observed update.
+    """
+
+    fleet: str
+    agent: str
+    display_name: str = ""
+    seed_source: str = "config"  # "config" | "observed"
 
 
 class SpawnSessionRequest(BaseModel):
@@ -2812,6 +2826,7 @@ def create_api(
     presentations = PresentationStore(db_path=db_path.replace(".db", "_presentations.db"))
     app_store = AppStore(db_path=db_path.replace(".db", "_apps.db"))
     trigger_store = TriggerStore(db_path=db_path.replace(".db", "_triggers.db"))
+    mesh_store = MeshStore(db_path=db_path.replace(".db", "_mesh.db"))
 
     # Knowledge Base — project-level, all agents share
     _data_dir = Path(db_path).parent
@@ -6592,6 +6607,26 @@ def create_api(
 
         sender = MeshSender()
         result = sender.send(envelope)
+
+        # Audit log: every send attempt, success or failure. Persistence
+        # failure must not propagate into the API response (defensive try).
+        try:
+            target_fleet, target_agent = parse_address(target) or ("", "")
+            mesh_store.log_message(
+                direction="outbound",
+                local_agent=name,
+                remote_fleet=target_fleet,
+                remote_agent=target_agent,
+                correlation_id=envelope.correlation_id or "",
+                kind=envelope.body.get("kind", "msg"),
+                body=envelope.body,
+                envelope_ts=envelope.ts,
+                reply_to=envelope.reply_to,
+                error=result.error,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _log(f"mesh outbound log failed (non-fatal): {exc}")
+
         return {
             "sent": result.sent,
             "correlation_id": result.correlation_id,
@@ -6599,6 +6634,79 @@ def create_api(
             "ts": result.ts,
             "error": result.error,
         }
+
+    @app.get("/agents/{name}/mesh/inbox")
+    async def get_mesh_inbox(
+        name: str,
+        limit: int = 50,
+        offset: int = 0,
+        kind: str = "",
+        sender: str = "",
+        direction: str = "",
+    ):
+        """List mesh messages for an agent, newest first.
+
+        Filters: ``kind`` (exact), ``sender`` (``"agent@fleet"``),
+        ``direction`` (``"inbound"`` | ``"outbound"`` | ``""``).
+        """
+        if not agents.has_agent(name):
+            raise HTTPException(404, f"Agent '{name}' not found")
+        messages = mesh_store.get_inbox(
+            name,
+            limit=limit,
+            offset=offset,
+            kind=kind,
+            sender=sender,
+            direction=direction,
+        )
+        return {
+            "agent": name,
+            "count": len(messages),
+            "messages": [m.to_dict() for m in messages],
+        }
+
+    @app.get("/federation/peers")
+    async def list_federation_peers(
+        fleet: str = "",
+        seed_source: str = "",
+        limit: int = 200,
+    ):
+        """List known federation peers, newest-seen first.
+
+        Filters: ``fleet`` (exact), ``seed_source`` (``"config"`` | ``"observed"``).
+        """
+        peers = mesh_store.list_peers(
+            fleet=fleet, seed_source=seed_source, limit=limit,
+        )
+        return {
+            "count": len(peers),
+            "peers": [p.to_dict() for p in peers],
+        }
+
+    @app.post("/federation/peers")
+    async def upsert_federation_peer(req: FederationPeerUpsertRequest):
+        """Insert or update a federation peer (admin / config-seeded path).
+
+        ``seed_source='config'`` is the stronger statement of intent — once
+        set, an observed-update doesn't downgrade it.
+        """
+        if not (req.fleet and req.agent):
+            raise HTTPException(400, "fleet and agent are required")
+        seed = req.seed_source if req.seed_source in ("config", "observed") else "config"
+        mesh_store.upsert_peer(
+            fleet=req.fleet,
+            agent=req.agent,
+            display_name=req.display_name,
+            seed_source=seed,
+        )
+        peer = mesh_store.get_peer(req.fleet, req.agent)
+        return {"upserted": True, "peer": peer.to_dict() if peer else None}
+
+    @app.delete("/federation/peers/{fleet}/{agent}")
+    async def delete_federation_peer(fleet: str, agent: str):
+        """Hard-delete a federation peer."""
+        removed = mesh_store.remove_peer(fleet, agent)
+        return {"removed": removed, "fleet": fleet, "agent": agent}
 
     # ── Pending Messages (Broker) ──────────────────────────
 

--- a/src/pinky_daemon/ferry/host_pinky.py
+++ b/src/pinky_daemon/ferry/host_pinky.py
@@ -112,6 +112,7 @@ class HostPinky:
         broker: Any,
         memory_store: Any | None = None,
         task_store: Any | None = None,
+        mesh_store: Any | None = None,
         verify_signatures: bool = False,
         reflection_factory: Callable[[dict[str, Any]], Any] | None = None,
     ) -> None:
@@ -121,11 +122,16 @@ class HostPinky:
         from a kwargs dict. Defaults to ``pinky_memory.types.Reflection`` when
         unset. Inject in tests to avoid the pinky_memory import cost and to
         substitute a stand-in shape; production callers leave it as ``None``.
+
+        ``mesh_store`` (optional): a ``MeshStore`` for inbound envelope
+        audit + federation peer auto-registration (see #419). When ``None``,
+        delivery proceeds without persistence.
         """
         self._registry = registry
         self._broker = broker
         self._memory_store = memory_store
         self._task_store = task_store
+        self._mesh_store = mesh_store
         self._verify_signatures = verify_signatures
         self._reflection_factory = reflection_factory
         self._stats: dict[str, int] = {
@@ -151,7 +157,17 @@ class HostPinky:
           2. Resolve target agent
           3. Peer-fleet ACL check
           4. Dispatch by body.kind
+
+        Side effect: if a ``mesh_store`` was passed at construction time,
+        every call here logs one ``mesh_messages`` row with the final
+        disposition (success or rejection reason).
         """
+        result = await self._deliver_core(envelope)
+        self._log_inbound_safely(envelope, result)
+        return result
+
+    async def _deliver_core(self, envelope: FerryEnvelope) -> DeliveryResult:
+        """The main deliver pipeline. ``deliver()`` wraps this with logging."""
         # 1. Signature verification
         if self._verify_signatures:
             verify_err = self._verify(envelope)
@@ -193,6 +209,36 @@ class HostPinky:
             return await self._deliver_substrate(agent_name, envelope)
 
         return self._reject("unsupported_payload_kind", f"kind={kind!r}")
+
+    def _log_inbound_safely(
+        self,
+        envelope: FerryEnvelope,
+        result: DeliveryResult,
+    ) -> None:
+        """Best-effort log + peer-touch. Never propagates persistence errors —
+        delivery semantics must not depend on whether mesh persistence is up."""
+        if self._mesh_store is None:
+            return
+        try:
+            local_agent = parse_pinkybot_address(envelope.to) or ""
+            peer_fleet, peer_agent_id = parse_peer_card(envelope.from_)
+            error: str | None = None
+            if result.status in ("rejected", "transient_failure"):
+                error = f"{result.status}:{result.reason or ''}"
+            self._mesh_store.log_message(
+                direction="inbound",
+                local_agent=local_agent,
+                remote_fleet=peer_fleet,
+                remote_agent=peer_agent_id,
+                correlation_id=envelope.correlation_id or "",
+                kind=envelope.kind,
+                body=envelope.body if isinstance(envelope.body, dict) else {"_raw": envelope.body},
+                envelope_ts=envelope.ts,
+                reply_to=envelope.reply_to,
+                error=error,
+            )
+        except Exception as e:  # noqa: BLE001 — defensive: persistence must not break delivery
+            _log(f"mesh_store inbound log failed (non-fatal): {e}")
 
     # -- Signature verification (deferred for v0.1) ---------------------------
 

--- a/src/pinky_daemon/mesh_store.py
+++ b/src/pinky_daemon/mesh_store.py
@@ -1,0 +1,416 @@
+"""Mesh persistence — ferry envelope log + federation peer registry.
+
+Two tables in SQLite (its own DB file by default, sibling to the others
+under ``data/``):
+
+- ``mesh_messages`` — every cross-fleet envelope we send or receive,
+  one row each. Direction-tagged. Indexed on (local_agent, received_at)
+  for the per-agent inbox view (#420 UI) and on correlation_id for
+  request/response pairing.
+- ``federation_peers`` — known remote agents, keyed by (fleet, agent).
+  Tracks first/last seen + ``seed_source`` (``"config"`` for
+  pre-configured peers vs ``"observed"`` for those auto-registered
+  on first inbound).
+
+Default-deny still lives in the ``mesh_outbound_allowlist`` (per-agent,
+in agent_registry); this store is the *audit log + directory*, not the
+permission boundary.
+
+PinkyBot issue: #419.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+# -- Records -------------------------------------------------------------------
+
+
+@dataclass
+class MeshMessage:
+    """One row in ``mesh_messages``."""
+
+    id: int
+    correlation_id: str
+    direction: Literal["inbound", "outbound"]
+    local_agent: str
+    remote_fleet: str
+    remote_agent: str
+    kind: str
+    body: dict  # JSON-decoded
+    envelope_ts: int  # millis from envelope.ts
+    received_at: float  # our wall clock (seconds since epoch)
+    reply_to: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "correlation_id": self.correlation_id,
+            "direction": self.direction,
+            "local_agent": self.local_agent,
+            "remote_fleet": self.remote_fleet,
+            "remote_agent": self.remote_agent,
+            "kind": self.kind,
+            "body": self.body,
+            "envelope_ts": self.envelope_ts,
+            "received_at": self.received_at,
+            "reply_to": self.reply_to,
+            "error": self.error,
+        }
+
+
+@dataclass
+class FederationPeer:
+    """One row in ``federation_peers``."""
+
+    fleet: str
+    agent: str
+    display_name: str
+    first_seen: float
+    last_seen: float
+    seed_source: Literal["config", "observed"]
+
+    def to_dict(self) -> dict:
+        return {
+            "fleet": self.fleet,
+            "agent": self.agent,
+            "display_name": self.display_name,
+            "first_seen": self.first_seen,
+            "last_seen": self.last_seen,
+            "seed_source": self.seed_source,
+            "address": f"{self.agent}@{self.fleet}",
+        }
+
+
+# -- Store ---------------------------------------------------------------------
+
+
+class MeshStore:
+    """SQLite-backed mesh log + federation peer registry.
+
+    Thread-safe via a per-instance lock around writes; reads use SQLite's
+    own concurrency story.
+    """
+
+    def __init__(self, db_path: str = "data/mesh.db") -> None:
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA foreign_keys=ON")
+        self._lock = threading.RLock()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS mesh_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                correlation_id TEXT NOT NULL DEFAULT '',
+                direction TEXT NOT NULL CHECK(direction IN ('inbound','outbound')),
+                local_agent TEXT NOT NULL,
+                remote_fleet TEXT NOT NULL,
+                remote_agent TEXT NOT NULL,
+                kind TEXT NOT NULL DEFAULT '',
+                body TEXT NOT NULL DEFAULT '{}',
+                envelope_ts INTEGER NOT NULL DEFAULT 0,
+                received_at REAL NOT NULL,
+                reply_to TEXT,
+                error TEXT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_mesh_messages_local
+                ON mesh_messages(local_agent, received_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_mesh_messages_corr
+                ON mesh_messages(correlation_id);
+            CREATE INDEX IF NOT EXISTS idx_mesh_messages_direction
+                ON mesh_messages(direction, received_at DESC);
+
+            CREATE TABLE IF NOT EXISTS federation_peers (
+                fleet TEXT NOT NULL,
+                agent TEXT NOT NULL,
+                display_name TEXT NOT NULL DEFAULT '',
+                first_seen REAL NOT NULL,
+                last_seen REAL NOT NULL,
+                seed_source TEXT NOT NULL DEFAULT 'observed',
+                PRIMARY KEY (fleet, agent)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_federation_peers_seen
+                ON federation_peers(last_seen DESC);
+        """)
+        self._db.commit()
+
+    # -- mesh_messages --------------------------------------------------------
+
+    def log_message(
+        self,
+        *,
+        direction: Literal["inbound", "outbound"],
+        local_agent: str,
+        remote_fleet: str,
+        remote_agent: str,
+        correlation_id: str = "",
+        kind: str = "",
+        body: dict | None = None,
+        envelope_ts: int = 0,
+        reply_to: str | None = None,
+        error: str | None = None,
+    ) -> int:
+        """Append a row to ``mesh_messages`` and return its id.
+
+        Side effect: also touches ``federation_peers`` — bumps last_seen
+        if known, registers as ``seed_source='observed'`` if not. For
+        outbound rows, only updates peer state when ``error is None``
+        (a failed publish doesn't prove the peer's reachable).
+        """
+        body_json = json.dumps(body or {}, separators=(",", ":"), ensure_ascii=False)
+        now = time.time()
+        with self._lock:
+            cur = self._db.execute(
+                """INSERT INTO mesh_messages
+                   (correlation_id, direction, local_agent,
+                    remote_fleet, remote_agent, kind, body,
+                    envelope_ts, received_at, reply_to, error)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (correlation_id, direction, local_agent,
+                 remote_fleet, remote_agent, kind, body_json,
+                 envelope_ts, now, reply_to, error),
+            )
+            row_id = cur.lastrowid or 0
+            # Touch peer for inbound-success and outbound-success only.
+            should_touch = direction == "inbound" or (direction == "outbound" and error is None)
+            if should_touch:
+                self._touch_peer_locked(remote_fleet, remote_agent, now)
+            self._db.commit()
+            return row_id
+
+    def get_inbox(
+        self,
+        local_agent: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        kind: str = "",
+        sender: str = "",
+        direction: str = "",
+    ) -> list[MeshMessage]:
+        """Return mesh messages for ``local_agent``, newest first.
+
+        Filters: ``kind`` exact match, ``sender`` matches against
+        ``"agent@fleet"``, ``direction`` ∈ ``{"", "inbound", "outbound"}``.
+        """
+        clauses = ["local_agent = ?"]
+        params: list[Any] = [local_agent]
+        if kind:
+            clauses.append("kind = ?")
+            params.append(kind)
+        if direction in ("inbound", "outbound"):
+            clauses.append("direction = ?")
+            params.append(direction)
+        if sender:
+            # sender is "agent@fleet"; split on rightmost @ for matching
+            if "@" in sender:
+                agent, _, fleet = sender.rpartition("@")
+                if agent and fleet:
+                    clauses.append("remote_agent = ? AND remote_fleet = ?")
+                    params.extend([agent, fleet])
+        where = " AND ".join(clauses)
+        params.extend([int(limit), int(offset)])
+        rows = self._db.execute(
+            f"""SELECT id, correlation_id, direction, local_agent,
+                       remote_fleet, remote_agent, kind, body,
+                       envelope_ts, received_at, reply_to, error
+                FROM mesh_messages
+                WHERE {where}
+                ORDER BY received_at DESC
+                LIMIT ? OFFSET ?""",
+            params,
+        ).fetchall()
+        return [self._row_to_message(r) for r in rows]
+
+    def get_message_by_correlation_id(self, correlation_id: str) -> MeshMessage | None:
+        """Fetch the most recent message with this correlation_id (any agent).
+
+        Useful for request/response pairing. Returns None if not found.
+        """
+        if not correlation_id:
+            return None
+        row = self._db.execute(
+            """SELECT id, correlation_id, direction, local_agent,
+                      remote_fleet, remote_agent, kind, body,
+                      envelope_ts, received_at, reply_to, error
+               FROM mesh_messages
+               WHERE correlation_id = ?
+               ORDER BY received_at DESC
+               LIMIT 1""",
+            (correlation_id,),
+        ).fetchone()
+        return self._row_to_message(row) if row else None
+
+    def count_messages(self, local_agent: str = "") -> int:
+        """Count messages, optionally filtered to one agent."""
+        if local_agent:
+            row = self._db.execute(
+                "SELECT COUNT(*) FROM mesh_messages WHERE local_agent = ?",
+                (local_agent,),
+            ).fetchone()
+        else:
+            row = self._db.execute("SELECT COUNT(*) FROM mesh_messages").fetchone()
+        return int(row[0]) if row else 0
+
+    def _row_to_message(self, row: tuple) -> MeshMessage:
+        try:
+            body = json.loads(row[7]) if row[7] else {}
+            if not isinstance(body, dict):
+                body = {"_raw": body}
+        except (TypeError, ValueError):
+            body = {"_raw": row[7]}
+        return MeshMessage(
+            id=row[0],
+            correlation_id=row[1],
+            direction=row[2],
+            local_agent=row[3],
+            remote_fleet=row[4],
+            remote_agent=row[5],
+            kind=row[6],
+            body=body,
+            envelope_ts=row[8],
+            received_at=row[9],
+            reply_to=row[10],
+            error=row[11],
+        )
+
+    # -- federation_peers -----------------------------------------------------
+
+    def _touch_peer_locked(self, fleet: str, agent: str, now: float) -> None:
+        """Insert-or-update peer's last_seen. Called under self._lock."""
+        existing = self._db.execute(
+            "SELECT first_seen FROM federation_peers WHERE fleet = ? AND agent = ?",
+            (fleet, agent),
+        ).fetchone()
+        if existing:
+            self._db.execute(
+                "UPDATE federation_peers SET last_seen = ? WHERE fleet = ? AND agent = ?",
+                (now, fleet, agent),
+            )
+        else:
+            self._db.execute(
+                """INSERT INTO federation_peers
+                   (fleet, agent, display_name, first_seen, last_seen, seed_source)
+                   VALUES (?, ?, '', ?, ?, 'observed')""",
+                (fleet, agent, now, now),
+            )
+
+    def upsert_peer(
+        self,
+        *,
+        fleet: str,
+        agent: str,
+        display_name: str = "",
+        seed_source: Literal["config", "observed"] = "config",
+    ) -> None:
+        """Insert or update a peer (admin / config-seeded path).
+
+        ``seed_source='config'`` does NOT downgrade an already-observed
+        peer to "observed" — config-flagged peers stay flagged. Conversely,
+        an already-config peer that becomes observed keeps the 'config'
+        flag (config wins, since it's a stronger statement of intent).
+        """
+        now = time.time()
+        with self._lock:
+            existing = self._db.execute(
+                """SELECT first_seen, seed_source FROM federation_peers
+                   WHERE fleet = ? AND agent = ?""",
+                (fleet, agent),
+            ).fetchone()
+            if existing:
+                # Keep the stronger seed_source: config beats observed.
+                final_source = (
+                    "config"
+                    if seed_source == "config" or existing[1] == "config"
+                    else "observed"
+                )
+                self._db.execute(
+                    """UPDATE federation_peers
+                       SET display_name = ?, last_seen = ?, seed_source = ?
+                       WHERE fleet = ? AND agent = ?""",
+                    (display_name, now, final_source, fleet, agent),
+                )
+            else:
+                self._db.execute(
+                    """INSERT INTO federation_peers
+                       (fleet, agent, display_name, first_seen, last_seen, seed_source)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (fleet, agent, display_name, now, now, seed_source),
+                )
+            self._db.commit()
+
+    def list_peers(
+        self,
+        *,
+        fleet: str = "",
+        seed_source: str = "",
+        limit: int = 200,
+    ) -> list[FederationPeer]:
+        """List peers, newest-seen first. Filter by fleet or seed_source."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if fleet:
+            clauses.append("fleet = ?")
+            params.append(fleet)
+        if seed_source in ("config", "observed"):
+            clauses.append("seed_source = ?")
+            params.append(seed_source)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(int(limit))
+        rows = self._db.execute(
+            f"""SELECT fleet, agent, display_name, first_seen, last_seen, seed_source
+                FROM federation_peers
+                {where}
+                ORDER BY last_seen DESC
+                LIMIT ?""",
+            params,
+        ).fetchall()
+        return [
+            FederationPeer(
+                fleet=r[0], agent=r[1], display_name=r[2],
+                first_seen=r[3], last_seen=r[4], seed_source=r[5],
+            )
+            for r in rows
+        ]
+
+    def get_peer(self, fleet: str, agent: str) -> FederationPeer | None:
+        """Look up one peer by composite key."""
+        row = self._db.execute(
+            """SELECT fleet, agent, display_name, first_seen, last_seen, seed_source
+               FROM federation_peers
+               WHERE fleet = ? AND agent = ?""",
+            (fleet, agent),
+        ).fetchone()
+        if not row:
+            return None
+        return FederationPeer(
+            fleet=row[0], agent=row[1], display_name=row[2],
+            first_seen=row[3], last_seen=row[4], seed_source=row[5],
+        )
+
+    def remove_peer(self, fleet: str, agent: str) -> bool:
+        """Hard-delete a peer. Returns True if removed."""
+        with self._lock:
+            cur = self._db.execute(
+                "DELETE FROM federation_peers WHERE fleet = ? AND agent = ?",
+                (fleet, agent),
+            )
+            self._db.commit()
+            return (cur.rowcount or 0) > 0
+
+    # -- Lifecycle ------------------------------------------------------------
+
+    def close(self) -> None:
+        self._db.close()

--- a/tests/test_mesh_store.py
+++ b/tests/test_mesh_store.py
@@ -1,0 +1,299 @@
+"""Tests for MeshStore — ferry envelope log + federation peer registry.
+
+Covers:
+- schema migration / idempotent init
+- log_message: inbound/outbound rows, side-effect peer touch, error semantics
+- get_inbox: filters (kind, sender, direction), pagination, ordering
+- get_message_by_correlation_id: most-recent on duplicate, missing returns None
+- federation_peers: upsert (config wins), list filters, get/remove
+- defensive: malformed body fields don't crash deserialization
+
+PinkyBot issue: #419.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from pinky_daemon.mesh_store import MeshStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = MeshStore(db_path=str(tmp_path / "mesh.db"))
+    yield s
+    s.close()
+
+
+# -- Schema --------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_init_idempotent(self, tmp_path):
+        path = str(tmp_path / "mesh.db")
+        s1 = MeshStore(db_path=path)
+        s1.close()
+        # Second open should not crash on existing tables.
+        s2 = MeshStore(db_path=path)
+        s2.close()
+
+
+# -- log_message ---------------------------------------------------------------
+
+
+class TestLogMessage:
+    def test_outbound_success_logs_and_touches_peer(self, store):
+        rid = store.log_message(
+            direction="outbound",
+            local_agent="barsik",
+            remote_fleet="pulse",
+            remote_agent="pulse",
+            correlation_id="cid-1",
+            kind="msg",
+            body={"text": "hi", "kind": "msg"},
+            envelope_ts=1234567890,
+        )
+        assert rid > 0
+        peer = store.get_peer("pulse", "pulse")
+        assert peer is not None
+        assert peer.seed_source == "observed"
+
+    def test_outbound_failure_does_not_touch_peer(self, store):
+        store.log_message(
+            direction="outbound",
+            local_agent="barsik",
+            remote_fleet="ghost",
+            remote_agent="ghost",
+            correlation_id="cid-fail",
+            kind="msg",
+            body={"text": "x", "kind": "msg"},
+            error="nats: error: connection refused",
+        )
+        # Failed sends shouldn't auto-register the unreachable peer.
+        assert store.get_peer("ghost", "ghost") is None
+
+    def test_inbound_always_touches_peer(self, store):
+        store.log_message(
+            direction="inbound",
+            local_agent="barsik",
+            remote_fleet="pulse",
+            remote_agent="misha",
+            correlation_id="cid-in-1",
+            kind="message",
+            body={"text": "hello", "kind": "message"},
+            error="rejected:acl_denied",  # even rejected inbound counts as "we saw them"
+        )
+        peer = store.get_peer("pulse", "misha")
+        assert peer is not None
+        assert peer.seed_source == "observed"
+
+    def test_count_messages(self, store):
+        for i in range(5):
+            store.log_message(
+                direction="outbound",
+                local_agent="barsik",
+                remote_fleet="pulse",
+                remote_agent="pulse",
+                correlation_id=f"cid-{i}",
+                kind="msg",
+                body={"kind": "msg"},
+            )
+        for _ in range(3):
+            store.log_message(
+                direction="inbound",
+                local_agent="pushok",
+                remote_fleet="pulse",
+                remote_agent="misha",
+                kind="message",
+                body={"kind": "message"},
+            )
+        assert store.count_messages() == 8
+        assert store.count_messages("barsik") == 5
+        assert store.count_messages("pushok") == 3
+        assert store.count_messages("nobody") == 0
+
+
+# -- get_inbox -----------------------------------------------------------------
+
+
+class TestGetInbox:
+    def _seed(self, store):
+        # Three messages spaced apart in time so ordering is stable.
+        for i, kind in enumerate(["msg", "smoke", "msg"]):
+            store.log_message(
+                direction="outbound" if i % 2 else "inbound",
+                local_agent="barsik",
+                remote_fleet="pulse",
+                remote_agent="pulse" if i < 2 else "misha",
+                correlation_id=f"cid-{i}",
+                kind=kind,
+                body={"kind": kind, "n": i},
+            )
+            time.sleep(0.005)
+
+    def test_newest_first(self, store):
+        self._seed(store)
+        msgs = store.get_inbox("barsik")
+        assert len(msgs) == 3
+        # received_at descends
+        assert msgs[0].received_at >= msgs[1].received_at >= msgs[2].received_at
+
+    def test_kind_filter(self, store):
+        self._seed(store)
+        smokes = store.get_inbox("barsik", kind="smoke")
+        assert len(smokes) == 1
+        assert smokes[0].kind == "smoke"
+
+    def test_direction_filter(self, store):
+        self._seed(store)
+        out = store.get_inbox("barsik", direction="outbound")
+        assert all(m.direction == "outbound" for m in out)
+
+    def test_sender_filter(self, store):
+        self._seed(store)
+        from_misha = store.get_inbox("barsik", sender="misha@pulse")
+        assert len(from_misha) == 1
+        assert from_misha[0].remote_agent == "misha"
+
+    def test_pagination(self, store):
+        self._seed(store)
+        page1 = store.get_inbox("barsik", limit=2, offset=0)
+        page2 = store.get_inbox("barsik", limit=2, offset=2)
+        assert len(page1) == 2
+        assert len(page2) == 1
+        # No overlap.
+        assert page1[1].id != page2[0].id
+
+    def test_other_agent_isolated(self, store):
+        self._seed(store)
+        store.log_message(
+            direction="inbound",
+            local_agent="pushok",
+            remote_fleet="pulse",
+            remote_agent="pulse",
+            kind="msg",
+            body={"kind": "msg"},
+        )
+        assert len(store.get_inbox("barsik")) == 3
+        assert len(store.get_inbox("pushok")) == 1
+
+
+# -- get_message_by_correlation_id --------------------------------------------
+
+
+class TestGetByCorrelationId:
+    def test_missing_returns_none(self, store):
+        assert store.get_message_by_correlation_id("nope") is None
+        assert store.get_message_by_correlation_id("") is None
+
+    def test_returns_most_recent_on_duplicate(self, store):
+        store.log_message(
+            direction="outbound", local_agent="barsik",
+            remote_fleet="p", remote_agent="p",
+            correlation_id="cid-dup", kind="msg", body={"kind": "msg", "v": 1},
+        )
+        time.sleep(0.005)
+        store.log_message(
+            direction="inbound", local_agent="barsik",
+            remote_fleet="p", remote_agent="p",
+            correlation_id="cid-dup", kind="ack", body={"kind": "ack", "v": 2},
+        )
+        latest = store.get_message_by_correlation_id("cid-dup")
+        assert latest is not None
+        assert latest.kind == "ack"
+        assert latest.body == {"kind": "ack", "v": 2}
+
+
+# -- federation_peers ----------------------------------------------------------
+
+
+class TestFederationPeers:
+    def test_upsert_inserts_then_updates(self, store):
+        store.upsert_peer(fleet="pulse", agent="pulse", display_name="Pulse")
+        p1 = store.get_peer("pulse", "pulse")
+        assert p1 is not None
+        assert p1.display_name == "Pulse"
+        assert p1.seed_source == "config"
+
+        time.sleep(0.005)
+        store.upsert_peer(fleet="pulse", agent="pulse", display_name="Pulse v2")
+        p2 = store.get_peer("pulse", "pulse")
+        assert p2 is not None
+        assert p2.display_name == "Pulse v2"
+        # first_seen preserved across update
+        assert p2.first_seen == p1.first_seen
+        assert p2.last_seen >= p1.last_seen
+
+    def test_config_beats_observed_on_promotion(self, store):
+        # Observed first.
+        store.log_message(
+            direction="inbound", local_agent="barsik",
+            remote_fleet="pulse", remote_agent="pulse",
+            kind="msg", body={"kind": "msg"},
+        )
+        assert store.get_peer("pulse", "pulse").seed_source == "observed"
+        # Then config-promoted.
+        store.upsert_peer(fleet="pulse", agent="pulse", display_name="Pulse")
+        assert store.get_peer("pulse", "pulse").seed_source == "config"
+
+    def test_observed_does_not_downgrade_config(self, store):
+        store.upsert_peer(fleet="pulse", agent="pulse", display_name="Pulse")
+        # Subsequent observed traffic shouldn't downgrade seed_source.
+        store.log_message(
+            direction="inbound", local_agent="barsik",
+            remote_fleet="pulse", remote_agent="pulse",
+            kind="msg", body={"kind": "msg"},
+        )
+        assert store.get_peer("pulse", "pulse").seed_source == "config"
+
+    def test_list_peers_filters(self, store):
+        store.upsert_peer(fleet="pulse", agent="pulse", seed_source="config")
+        store.upsert_peer(fleet="pulse", agent="misha", seed_source="config")
+        store.upsert_peer(fleet="sigil", agent="agent3", seed_source="observed")
+
+        all_peers = store.list_peers()
+        assert len(all_peers) == 3
+
+        pulse_only = store.list_peers(fleet="pulse")
+        assert len(pulse_only) == 2
+        assert {p.agent for p in pulse_only} == {"pulse", "misha"}
+
+        config_only = store.list_peers(seed_source="config")
+        assert len(config_only) == 2
+
+        observed_only = store.list_peers(seed_source="observed")
+        assert len(observed_only) == 1
+        assert observed_only[0].fleet == "sigil"
+
+    def test_remove_peer(self, store):
+        store.upsert_peer(fleet="pulse", agent="pulse")
+        assert store.remove_peer("pulse", "pulse") is True
+        assert store.remove_peer("pulse", "pulse") is False  # already gone
+        assert store.get_peer("pulse", "pulse") is None
+
+    def test_address_field_in_to_dict(self, store):
+        store.upsert_peer(fleet="pulse", agent="misha")
+        peer = store.get_peer("pulse", "misha")
+        assert peer.to_dict()["address"] == "misha@pulse"
+
+
+# -- Defensive deserialization -------------------------------------------------
+
+
+class TestDefensive:
+    def test_malformed_body_json_does_not_crash(self, store):
+        # Bypass the public API to write a row with broken JSON.
+        store._db.execute(
+            """INSERT INTO mesh_messages
+               (correlation_id, direction, local_agent, remote_fleet,
+                remote_agent, kind, body, envelope_ts, received_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("cid-x", "inbound", "barsik", "p", "p", "msg",
+             "{not valid json", 0, time.time()),
+        )
+        store._db.commit()
+        msgs = store.get_inbox("barsik")
+        assert len(msgs) == 1
+        assert "_raw" in msgs[0].body  # fell back gracefully


### PR DESCRIPTION
Closes #419. **Stacked on PR #421** which is stacked on PR #414. Cascading rebase target on each parent merge.

## Summary

Adds the audit log + directory layer to the ferry stack. Two new tables in their own SQLite file (`data/pinky_mesh.db`):

| Table | Purpose |
|-------|---------|
| `mesh_messages` | Every cross-fleet envelope we send or receive, one row each. Direction-tagged, indexed for the UI inbox view (#420) and for correlation_id pairing. |
| `federation_peers` | Known remote agents, keyed by (fleet, agent). Tracks first/last seen + `seed_source` (`"config"` for pre-configured vs `"observed"` for auto-registered). |

## What lands (4 files, +869 LOC)

| File | Adds |
|------|------|
| `src/pinky_daemon/mesh_store.py` | `MeshStore` class, `MeshMessage` + `FederationPeer` dataclasses, two tables, three indices, thread-safe writes via RLock |
| `src/pinky_daemon/api.py` | `MeshStore` instantiated alongside the other `*_store` singletons. Outbound logging wired into existing `POST /agents/{name}/mesh/send`. New endpoints: `GET /agents/{name}/mesh/inbox`, `GET/POST /federation/peers`, `DELETE /federation/peers/{fleet}/{agent}` |
| `src/pinky_daemon/ferry/host_pinky.py` | New optional `mesh_store` kwarg on `HostPinky.__init__`. Every `deliver()` call logs one `mesh_messages` row with disposition (success or rejection reason). Wrapped in try/except — persistence errors never break delivery. |
| `tests/test_mesh_store.py` | 20 new tests (new) |

## Auto-registration semantics

- Inbound + successful outbound → touch peer's `last_seen`, register as `seed_source='observed'` if new
- Failed outbound → does NOT touch peer (a failed publish doesn't prove reachability)
- Config peers are stronger than observed: `upsert_peer(seed_source='config')` promotes an observed peer; subsequent observed traffic does NOT downgrade a config peer

## Defensive boundaries

- All persistence calls wrapped in try/except in api.py and host_pinky.py — mesh persistence outages must not break ferry delivery
- Malformed body JSON in mesh_messages.body falls back to `{\"_raw\": ...}` instead of crashing the inbox query
- `mesh_store.log_message` and `upsert_peer` are RLock-guarded for concurrent writes from broker threads

## Deferred from #419

- **YAML config seeder** (`data/federation_peers.yaml` at daemon start). The new `POST /federation/peers` admin endpoint covers config-seeding for now; a startup YAML loader is a small follow-up if you want it. Punting on the n≥2 rule — let's see if we feel friction first.

## Test plan

- [x] 20 new mesh_store tests pass
- [x] 122 ferry-area tests pass (mesh_store + ferry_outbound + ferry_host_pinky)
- [x] 438 tests pass across all touched modules (api, agent_registry, ferry_*, mesh_store)
- [x] ruff clean
- [ ] CI green (will run on push)
- [ ] After PR #414 + #421 merge: end-to-end smoke via `mesh_remote_send` → confirm an outbound row lands in `mesh_messages` with peer touched in `federation_peers`

## Stack

```
beta
 ↑
 #414  feat/ferry-host-pinky          (Brad's, awaits Class C)
 ↑
 #421  feat/ferry-mesh-remote-send    (this session, draft, +999 LOC)
 ↑
 #422  feat/ferry-mesh-persistence    (this PR, draft, +869 LOC)
```

When #414 lands, rebase #421 base → `beta` is one click. When #421 lands, rebase this PR's base → `beta` is one click.

## Refs

- #419 issue with full design
- #418 / PR #421 — outbound mesh_remote_send (parent)
- #414 — host-pinky inbound (grandparent)
- #420 — Svelte Mesh tab (next, consumes the new read endpoints)

🤖 Opened by Barsik