### PR TITLE
feat(hooks): effort.level verification hook (#429)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -63,6 +63,21 @@ import json
 import os
 import sys
 
+# Tools the hook MUST NOT block even in strict mode — these are how the
+# agent self-remediates drift. Blocking set_thinking_effort would trap
+# the agent: the only fix becomes unavailable. Match is substring against
+# the tool name, so it covers raw `set_thinking_effort` and any MCP-qualified
+# variant (e.g. `mcp__pinky-self__set_thinking_effort`).
+REMEDIATION_TOOLS = (
+    "set_thinking_effort",
+)
+
+# Set_thinking_effort MCP tool accepts these levels. If the configured
+# expected is outside this set (e.g. "xhigh" — registry-valid but the MCP
+# tool may not accept it), suggest the closest acceptable value in the
+# block reason so the agent's self-remediation actually works.
+SET_EFFORT_ACCEPTED = ("low", "medium", "high", "max", "auto")
+
 
 def _post_drift(agent: str, expected: str, actual: str, tool_name: str,
                 strict: bool, daemon_url: str) -> None:
@@ -84,6 +99,28 @@ def _post_drift(agent: str, expected: str, actual: str, tool_name: str,
         urllib.request.urlopen(req, timeout=2)
     except Exception:
         pass
+
+
+def _is_remediation_tool(tool_name: str) -> bool:
+    """True if tool_name is on the strict-mode allowlist."""
+    if not tool_name:
+        return False
+    needle = tool_name.lower()
+    return any(t in needle for t in REMEDIATION_TOOLS)
+
+
+def _remediation_suggestion(expected: str) -> str:
+    """Suggest a remediation call the agent can actually make."""
+    if expected in SET_EFFORT_ACCEPTED:
+        return f"set_thinking_effort({expected!r})"
+    # expected outside the MCP tool's accepted set (e.g. xhigh). Suggest
+    # the closest accepted neighbor + a note.
+    closest = "high" if expected == "xhigh" else "auto"
+    return (
+        f"set_thinking_effort({closest!r}) "
+        f"(note: expected={expected!r} not directly settable via the MCP "
+        "tool; ask your owner to widen the allow-list or relax strict mode)"
+    )
 
 
 def main() -> None:
@@ -120,15 +157,18 @@ def main() -> None:
     except Exception:
         pass
 
+    # Always record the drift — even when we're about to let it through.
     _post_drift(agent, expected, actual, tool_name, strict, daemon_url)
 
-    if strict:
-        # Claude Code hook protocol: emit a JSON decision to stdout to block.
+    # Strict path: emit a block decision EXCEPT when the tool being called
+    # is the very thing that can fix the drift. Blocking the remediation
+    # tool would trap the agent in an unbreakable strict-mode loop.
+    if strict and not _is_remediation_tool(tool_name):
         print(json.dumps({
             "decision": "block",
             "reason": (
                 f"Effort drift detected: expected={expected} actual={actual}. "
-                f"Call set_thinking_effort({expected!r}) and retry the tool, "
+                f"Call {_remediation_suggestion(expected)} and retry the tool, "
                 "or contact your owner to relax strict_effort_enforcement."
             ),
         }))
@@ -1080,9 +1120,19 @@ except Exception:
         # PINKY_EXPECTED_EFFORT (set by daemon at session start). On drift,
         # posts to /agents/{name}/effort-drift; under strict mode also emits
         # a block decision so Claude Code refuses the tool call.
-        if not verify_effort_path.exists():
-            verify_effort_path.write_text(_verify_effort_hook_source())
-            _log(f"agent_registry: created hook_verify_effort.py for {agent_name}")
+        #
+        # We ALWAYS rewrite this script (unlike hook_working / hook_idle
+        # which are left alone if present) — it's fully PinkyBot-managed
+        # and getting the latest semantics on disk matters: e.g. the
+        # remediation-tool allowlist fix shipped after the initial cut.
+        existing_source = (
+            verify_effort_path.read_text() if verify_effort_path.exists() else ""
+        )
+        new_source = _verify_effort_hook_source()
+        if existing_source != new_source:
+            verify_effort_path.write_text(new_source)
+            verb = "updated" if existing_source else "created"
+            _log(f"agent_registry: {verb} hook_verify_effort.py for {agent_name}")
 
         AgentRegistry._sync_hooks_settings(
             claude_dir / "settings.json",

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -72,11 +72,12 @@ REMEDIATION_TOOLS = (
     "set_thinking_effort",
 )
 
-# Set_thinking_effort MCP tool accepts these levels. If the configured
-# expected is outside this set (e.g. "xhigh" — registry-valid but the MCP
-# tool may not accept it), suggest the closest acceptable value in the
-# block reason so the agent's self-remediation actually works.
-SET_EFFORT_ACCEPTED = ("low", "medium", "high", "max", "auto")
+# Levels set_thinking_effort MCP tool accepts. Kept in sync with the tool's
+# validator (pinky_self/server.py). If a future registry adds a level
+# outside this set, suggesting `set_thinking_effort(expected)` would fail
+# at the MCP layer — surface a clear "not self-remediable" reason instead
+# of an unreachable suggestion.
+SET_EFFORT_ACCEPTED = ("low", "medium", "high", "xhigh", "max", "auto")
 
 
 def _post_drift(agent: str, expected: str, actual: str, tool_name: str,
@@ -110,16 +111,20 @@ def _is_remediation_tool(tool_name: str) -> bool:
 
 
 def _remediation_suggestion(expected: str) -> str:
-    """Suggest a remediation call the agent can actually make."""
+    """Return a remediation call the agent can actually make.
+
+    When expected is in the MCP tool's accepted set (the common case),
+    suggest the direct call. Otherwise be honest: tell the agent the
+    expected level isn't reachable from inside the session, so it knows
+    to escalate to the owner rather than spinning on a suggestion that
+    won't resolve the drift.
+    """
     if expected in SET_EFFORT_ACCEPTED:
         return f"set_thinking_effort({expected!r})"
-    # expected outside the MCP tool's accepted set (e.g. xhigh). Suggest
-    # the closest accepted neighbor + a note.
-    closest = "high" if expected == "xhigh" else "auto"
     return (
-        f"set_thinking_effort({closest!r}) "
-        f"(note: expected={expected!r} not directly settable via the MCP "
-        "tool; ask your owner to widen the allow-list or relax strict mode)"
+        f"<no self-remediation path: expected={expected!r} is not in the "
+        "set_thinking_effort tool's accepted levels; ask your owner to "
+        "either widen the tool's allow-list or relax strict_effort_enforcement>"
     )
 
 

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -35,6 +35,114 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+def _verify_effort_hook_source() -> str:
+    """Return the source for ``.claude/hook_verify_effort.py``.
+
+    The hook compares the runtime ``$CLAUDE_EFFORT`` (Claude Code v2.1.133+)
+    against ``$PINKY_EXPECTED_EFFORT`` (injected by the daemon at session
+    start). On drift, it POSTs to ``/agents/{name}/effort-drift`` and, in
+    strict mode (``$PINKY_STRICT_EFFORT=1``), emits a block decision so
+    Claude Code refuses the tool call.
+
+    No-ops silently when expected is empty/auto, when actual is unset (older
+    CLI), or when ``$PINKY_AGENT_NAME`` is missing.
+    """
+    return '''\
+#!/usr/bin/env python3
+"""PinkyBot effort-drift verification hook (#429).
+
+Compares the runtime thinking effort surfaced by Claude Code (v2.1.133+) to
+the expected value injected by the daemon. On mismatch, reports drift and
+optionally blocks the tool call.
+
+Hooks must never crash the tool call — failures are swallowed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _post_drift(agent: str, expected: str, actual: str, tool_name: str,
+                strict: bool, daemon_url: str) -> None:
+    import urllib.request
+
+    path = f"/agents/{agent}/effort-drift"
+    body = json.dumps({
+        "expected": expected,
+        "actual": actual,
+        "tool_name": tool_name,
+        "strict": bool(strict),
+    }).encode()
+    req = urllib.request.Request(
+        f"{daemon_url}{path}", data=body, method="POST",
+    )
+    req.add_header("Content-Type", "application/json")
+    req.add_header("x-pinky-agent", agent)
+    try:
+        urllib.request.urlopen(req, timeout=2)
+    except Exception:
+        pass
+
+
+def main() -> None:
+    actual = os.environ.get("CLAUDE_EFFORT", "").strip().lower()
+    expected = os.environ.get("PINKY_EXPECTED_EFFORT", "").strip().lower()
+    agent = os.environ.get("PINKY_AGENT_NAME", "").strip()
+    strict = os.environ.get("PINKY_STRICT_EFFORT", "").strip() == "1"
+    daemon_url = os.environ.get(
+        "PINKY_DAEMON_URL", "http://localhost:8888"
+    ).rstrip("/")
+
+    # No-op cases — these are not drift events:
+    #   - no expected configured
+    #   - expected is "auto" (effort is intentionally adaptive)
+    #   - actual is unset (older Claude Code without v2.1.133 effort.level)
+    #   - no agent name (hook misconfigured)
+    if not expected or expected == "auto" or not actual or not agent:
+        return
+
+    if actual == expected:
+        return  # match — no action
+
+    # Try to read the tool name from the JSON event piped to stdin, if any.
+    tool_name = ""
+    try:
+        stdin_data = sys.stdin.read() if not sys.stdin.isatty() else ""
+        if stdin_data:
+            payload = json.loads(stdin_data)
+            tool_name = (
+                payload.get("tool_name")
+                or (payload.get("tool") or {}).get("name")
+                or ""
+            )
+    except Exception:
+        pass
+
+    _post_drift(agent, expected, actual, tool_name, strict, daemon_url)
+
+    if strict:
+        # Claude Code hook protocol: emit a JSON decision to stdout to block.
+        print(json.dumps({
+            "decision": "block",
+            "reason": (
+                f"Effort drift detected: expected={expected} actual={actual}. "
+                f"Call set_thinking_effort({expected!r}) and retry the tool, "
+                "or contact your owner to relax strict_effort_enforcement."
+            ),
+        }))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # Hooks must never crash the tool call.
+        pass
+'''
+
+
 def _cron_next_run(cron: str, timezone: str = "UTC") -> float | None:
     """Compute the next run timestamp for a cron expression using stdlib only.
 
@@ -192,6 +300,10 @@ class Agent:
     provider_model: str = ""  # model name override (e.g. "llama3.2"), empty = use agent.model
     provider_ref: str = ""   # ID of a global provider from the providers table
     thinking_effort: str = "medium"  # low, medium, high, xhigh, max — default thinking depth
+    # When True, the verify_effort CLI hook blocks tool calls if the runtime
+    # effort drifts from thinking_effort. Default False (warn-only): drift is
+    # surfaced to /agents/{name}/effort-drift + heartbeat but does not block.
+    strict_effort_enforcement: bool = False
     watchdog_config: dict = field(default_factory=dict)  # Per-agent watchdog overrides (JSON blob)
     # watchdog_config schema: {
     #   "enabled": true,              # Enable/disable watchdog for this agent
@@ -251,6 +363,7 @@ class Agent:
             "provider_model": self.provider_model,
             "provider_ref": self.provider_ref,
             "thinking_effort": self.thinking_effort,
+            "strict_effort_enforcement": self.strict_effort_enforcement,
             "watchdog_config": self.watchdog_config,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
@@ -681,6 +794,20 @@ class AgentRegistry:
                 updated_at REAL NOT NULL DEFAULT 0
             );
 
+            CREATE TABLE IF NOT EXISTS effort_drift_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_name TEXT NOT NULL,
+                session_id TEXT NOT NULL DEFAULT '',
+                expected TEXT NOT NULL,
+                actual TEXT NOT NULL,
+                tool_name TEXT NOT NULL DEFAULT '',
+                strict INTEGER NOT NULL DEFAULT 0,
+                timestamp REAL NOT NULL,
+                FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_effort_drift_agent ON effort_drift_events(agent_name, timestamp DESC);
+
             CREATE TABLE IF NOT EXISTS models (
                 id TEXT PRIMARY KEY,
                 provider TEXT NOT NULL DEFAULT 'anthropic',
@@ -738,6 +865,9 @@ class AgentRegistry:
             ("provider_ref", "TEXT NOT NULL DEFAULT ''"),
             ("disallowed_tools", "TEXT NOT NULL DEFAULT '[]'"),
             ("thinking_effort", "TEXT NOT NULL DEFAULT 'medium'"),
+            # When 1, verify_effort CLI hook blocks tool calls on effort drift
+            # (vs. warn-only default of 0). See #429.
+            ("strict_effort_enforcement", "INTEGER NOT NULL DEFAULT 0"),
             ("watchdog_config", "TEXT NOT NULL DEFAULT '{}'"),
             ("last_seen_at", "REAL NOT NULL DEFAULT 0"),
             ("runtime", "TEXT NOT NULL DEFAULT 'claude_sdk'"),
@@ -846,6 +976,24 @@ class AgentRegistry:
 
     # ── Workspace Init ─────────────────────────────────────
 
+    def ensure_workspace_hooks(self, agent_name: str) -> None:
+        """Re-run hook setup for an existing agent's workspace.
+
+        Idempotent. Use to install new hooks (e.g. ``hook_verify_effort.py``
+        from #429) on agents whose workspace pre-dates them, without nuking
+        any user customizations to existing scripts.
+        """
+        agent = self.get(agent_name)
+        if not agent or not agent.working_dir:
+            return
+        work_dir = Path(agent.working_dir)
+        if not work_dir.exists():
+            return
+        try:
+            self._setup_hooks(work_dir, agent_name)
+        except Exception as e:  # pragma: no cover — defensive
+            _log(f"agent_registry: ensure_workspace_hooks({agent_name}) failed: {e}")
+
     @staticmethod
     def _init_workspace(work_dir: Path, agent_name: str = "") -> None:
         """Create an agent workspace with default directory structure.
@@ -872,10 +1020,13 @@ class AgentRegistry:
 
     @staticmethod
     def _setup_hooks(work_dir: Path, agent_name: str) -> None:
-        """Generate Claude Code hooks for agent working/idle status reporting.
+        """Generate Claude Code hooks for agent working/idle status reporting
+        and (since #429) effort-drift verification.
 
-        Creates .claude/ directory with hook_working.py, hook_idle.py, and
-        settings.json if they don't already exist. Won't overwrite custom configs.
+        Creates ``.claude/`` directory with hook scripts and settings.json.
+        Existing scripts are not overwritten; settings.json is idempotently
+        merged so the verify_effort hook can be added to agents whose
+        settings predate #429 without nuking their existing hooks.
         """
         claude_dir = work_dir / ".claude"
         claude_dir.mkdir(exist_ok=True)
@@ -911,6 +1062,7 @@ except Exception:
 '''
         working_path = claude_dir / "hook_working.py"
         idle_path = claude_dir / "hook_idle.py"
+        verify_effort_path = claude_dir / "hook_verify_effort.py"
 
         if not working_path.exists():
             working_path.write_text(
@@ -924,35 +1076,120 @@ except Exception:
             )
             _log(f"agent_registry: created hook_idle.py for {agent_name}")
 
-        settings_path = claude_dir / "settings.json"
+        # #429: verify_effort hook — compares $CLAUDE_EFFORT (v2.1.133+) to
+        # PINKY_EXPECTED_EFFORT (set by daemon at session start). On drift,
+        # posts to /agents/{name}/effort-drift; under strict mode also emits
+        # a block decision so Claude Code refuses the tool call.
+        if not verify_effort_path.exists():
+            verify_effort_path.write_text(_verify_effort_hook_source())
+            _log(f"agent_registry: created hook_verify_effort.py for {agent_name}")
+
+        AgentRegistry._sync_hooks_settings(
+            claude_dir / "settings.json",
+            working_path=working_path.resolve(),
+            idle_path=idle_path.resolve(),
+            verify_effort_path=verify_effort_path.resolve(),
+            agent_name=agent_name,
+        )
+
+    @staticmethod
+    def _sync_hooks_settings(
+        settings_path: Path,
+        *,
+        working_path: Path,
+        idle_path: Path,
+        verify_effort_path: Path,
+        agent_name: str,
+    ) -> None:
+        """Idempotently ensure settings.json has all PinkyBot hooks wired up.
+
+        - Creates settings.json with the full hook set if missing.
+        - If present, adds any missing PinkyBot-managed hook entries to
+          PreToolUse / Stop, preserving user-added entries.
+        - Identifies PinkyBot-managed entries by the absolute script path
+          appearing in the command string.
+        """
+        import json as _json
+
+        verify_cmd = (
+            f"python3 {verify_effort_path}"
+            f' "$CLAUDE_PROJECT_DIR" 2>/dev/null || true'
+        )
+        working_cmd = f"python3 {working_path} 2>/dev/null || true"
+        idle_cmd = f"python3 {idle_path} 2>/dev/null || true"
+
         if not settings_path.exists():
-            abs_working = str(working_path.resolve())
-            abs_idle = str(idle_path.resolve())
             settings = {
                 "hooks": {
-                    "PreToolUse": [{
-                        "matcher": ".*",
-                        "hooks": [{
-                            "type": "command",
-                            "command": (
-                                f"python3 {abs_working} 2>/dev/null || true"
-                            ),
-                        }],
-                    }],
-                    "Stop": [{
-                        "matcher": ".*",
-                        "hooks": [{
-                            "type": "command",
-                            "command": (
-                                f"python3 {abs_idle} 2>/dev/null || true"
-                            ),
-                        }],
-                    }],
+                    "PreToolUse": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [
+                                {"type": "command", "command": working_cmd},
+                                {"type": "command", "command": verify_cmd},
+                            ],
+                        }
+                    ],
+                    "Stop": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [
+                                {"type": "command", "command": idle_cmd},
+                            ],
+                        }
+                    ],
                 }
             }
-            import json as _json
             settings_path.write_text(_json.dumps(settings, indent=2) + "\n")
             _log(f"agent_registry: created settings.json for {agent_name}")
+            return
+
+        # Merge path — only add the verify_effort hook if it's not already
+        # present. Match on the absolute script path so we don't dup if the
+        # user re-pathed it manually.
+        try:
+            data = _json.loads(settings_path.read_text())
+        except Exception as e:
+            _log(
+                f"agent_registry: settings.json parse failed for {agent_name}: {e}; "
+                "skipping verify_effort merge"
+            )
+            return
+
+        hooks = data.setdefault("hooks", {})
+        pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+        needle = str(verify_effort_path)
+        already_installed = False
+        for entry in pre_tool_use:
+            for h in entry.get("hooks", []):
+                if needle in (h.get("command") or ""):
+                    already_installed = True
+                    break
+            if already_installed:
+                break
+
+        if already_installed:
+            return
+
+        # Append to the first matcher=".*" bucket if one exists, else create.
+        target_bucket = None
+        for entry in pre_tool_use:
+            if entry.get("matcher") == ".*":
+                target_bucket = entry
+                break
+        if target_bucket is None:
+            target_bucket = {"matcher": ".*", "hooks": []}
+            pre_tool_use.append(target_bucket)
+
+        target_bucket.setdefault("hooks", []).append(
+            {"type": "command", "command": verify_cmd}
+        )
+        settings_path.write_text(_json.dumps(data, indent=2) + "\n")
+        _log(
+            f"agent_registry: merged hook_verify_effort into settings.json "
+            f"for {agent_name}"
+        )
 
     # ── Agent CRUD ──────────────────────────────────────────
 
@@ -973,7 +1210,7 @@ except Exception:
                         "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
                         "librarian_enabled", "librarian_schedule",
                         "runtime", "provider_url", "provider_key", "provider_model", "provider_ref",
-                        "thinking_effort"):
+                        "thinking_effort", "strict_effort_enforcement"):
                 if key in kwargs:
                     updates[key] = kwargs[key]
 
@@ -1003,6 +1240,8 @@ except Exception:
                 updates["dream_notify"] = int(updates["dream_notify"])
             if "librarian_enabled" in updates:
                 updates["librarian_enabled"] = int(updates["librarian_enabled"])
+            if "strict_effort_enforcement" in updates:
+                updates["strict_effort_enforcement"] = int(updates["strict_effort_enforcement"])
 
             if updates:
                 updates["updated_at"] = now
@@ -1060,6 +1299,7 @@ except Exception:
                 provider_model=kwargs.get("provider_model", ""),
                 provider_ref=kwargs.get("provider_ref", ""),
                 thinking_effort=kwargs.get("thinking_effort", "medium"),
+                strict_effort_enforcement=kwargs.get("strict_effort_enforcement", False),
                 watchdog_config=kwargs.get("watchdog_config", {}),
                 created_at=now,
                 updated_at=now,
@@ -1075,9 +1315,9 @@ except Exception:
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
                     librarian_enabled, librarian_schedule,
                     runtime, provider_url, provider_key, provider_model, provider_ref,
-                    thinking_effort, watchdog_config,
+                    thinking_effort, strict_effort_enforcement, watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -1092,7 +1332,8 @@ except Exception:
                  int(agent.librarian_enabled), agent.librarian_schedule,
                  agent.runtime, agent.provider_url, agent.provider_key,
                  agent.provider_model, agent.provider_ref,
-                 agent.thinking_effort, json.dumps(agent.watchdog_config),
+                 agent.thinking_effort, int(agent.strict_effort_enforcement),
+                 json.dumps(agent.watchdog_config),
                  agent.created_at, agent.updated_at),
             )
             self._db.commit()
@@ -1111,7 +1352,8 @@ except Exception:
         "librarian_enabled, librarian_schedule, "
         "working_status, working_status_updated_at, "
         "runtime, provider_url, provider_key, provider_model, provider_ref, "
-        "disallowed_tools, thinking_effort, watchdog_config, last_seen_at"
+        "disallowed_tools, thinking_effort, watchdog_config, last_seen_at, "
+        "strict_effort_enforcement"
     )
 
     def get(self, name: str) -> Agent | None:
@@ -1661,6 +1903,102 @@ except Exception:
             message_count=message_count, metadata=metadata or {},
             notes=notes, latency_ms=latency_ms,
         )
+
+    # ── Effort Drift Events (#429) ───────────────────────
+
+    def record_effort_drift(
+        self,
+        agent_name: str,
+        *,
+        expected: str,
+        actual: str,
+        session_id: str = "",
+        tool_name: str = "",
+        strict: bool = False,
+    ) -> int:
+        """Record a thinking-effort drift event from the verify_effort CLI hook.
+
+        Emitted when ``$CLAUDE_EFFORT`` (runtime) diverges from the agent's
+        configured ``thinking_effort``. See #429 / verify_effort hook.
+
+        Also writes a structured note to the heartbeat stream so drift is
+        visible alongside normal liveness telemetry without a separate
+        query.
+
+        Returns the inserted event row id.
+        """
+        now = time.time()
+        cursor = self._db.execute(
+            """INSERT INTO effort_drift_events
+               (agent_name, session_id, expected, actual, tool_name, strict, timestamp)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (agent_name, session_id, expected, actual, tool_name,
+             int(bool(strict)), now),
+        )
+        self._db.commit()
+
+        # Mirror to heartbeat notes so it shows up in normal observability.
+        # Don't let heartbeat failure break the drift recording.
+        try:
+            label = "blocked" if strict else "warn"
+            note = (
+                f"[effort drift / {label}] expected={expected} actual={actual}"
+            )
+            if tool_name:
+                note += f" tool={tool_name}"
+            self.record_heartbeat(
+                agent_name,
+                session_id=session_id,
+                status="alive",
+                notes=note,
+            )
+        except Exception as e:  # pragma: no cover — defensive
+            _log(f"agent_registry: effort-drift heartbeat note failed: {e}")
+
+        return int(cursor.lastrowid or 0)
+
+    def get_effort_drift_events(
+        self,
+        agent_name: str = "",
+        *,
+        limit: int = 50,
+        since: float = 0.0,
+    ) -> list[dict]:
+        """Query recent effort-drift events.
+
+        Pass ``agent_name=""`` to get fleet-wide events. ``since`` is a unix
+        timestamp; only events after it are returned.
+        """
+        conditions: list[str] = []
+        params: list = []
+        if agent_name:
+            conditions.append("agent_name=?")
+            params.append(agent_name)
+        if since:
+            conditions.append("timestamp>?")
+            params.append(since)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        params.append(limit)
+        rows = self._db.execute(
+            f"""SELECT id, agent_name, session_id, expected, actual,
+                       tool_name, strict, timestamp
+                FROM effort_drift_events {where}
+                ORDER BY timestamp DESC LIMIT ?""",
+            params,
+        ).fetchall()
+        return [
+            {
+                "id": r[0],
+                "agent_name": r[1],
+                "session_id": r[2],
+                "expected": r[3],
+                "actual": r[4],
+                "tool_name": r[5],
+                "strict": bool(r[6]),
+                "timestamp": r[7],
+            }
+            for r in rows
+        ]
 
     def get_latest_heartbeat(self, agent_name: str) -> AgentHeartbeat | None:
         """Get the most recent heartbeat for an agent."""
@@ -2643,6 +2981,7 @@ except Exception:
             thinking_effort=row[45] if len(row) > 45 and row[45] else "medium",
             watchdog_config=json.loads(row[46]) if len(row) > 46 and row[46] else {},
             last_seen_at=row[47] if len(row) > 47 else 0.0,
+            strict_effort_enforcement=bool(row[48]) if len(row) > 48 else False,
         )
 
     # ── Cost Tracking ──────────────────────────────────────

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -864,6 +864,20 @@ class AgentStatusRequest(BaseModel):
     detail: str = ""
 
 
+class EffortDriftRequest(BaseModel):
+    """Effort-drift event — POSTed by hook_verify_effort.py (#429).
+
+    Emitted when the runtime ``$CLAUDE_EFFORT`` (Claude Code v2.1.133+)
+    diverges from the daemon-injected ``PINKY_EXPECTED_EFFORT``.
+    """
+
+    expected: str
+    actual: str
+    tool_name: str = ""
+    strict: bool = False
+    session_id: str = ""
+
+
 # ── Research Pipeline Models ──────────────────────────────────
 
 
@@ -2661,6 +2675,14 @@ def create_api(
                     "headers": agent_headers,
                 }
 
+        # #429: ensure verify_effort hook is installed in the agent's
+        # .claude/settings.json before we spin up the session. No-op for
+        # agents whose workspace already has it.
+        try:
+            agents.ensure_workspace_hooks(agent_name)
+        except Exception as e:
+            _log(f"streaming-start: ensure_workspace_hooks({agent_name}) — {e}")
+
         config = StreamingSessionConfig(
             agent_name=agent_name,
             label=label,
@@ -2683,6 +2705,9 @@ def create_api(
             provider_url=resolved_provider_url,
             provider_key=resolved_provider_key,
             thinking_effort=agent.thinking_effort or "medium",
+            strict_effort_enforcement=bool(
+                getattr(agent, "strict_effort_enforcement", False)
+            ),
         )
 
         callback = await _make_streaming_response_callback()
@@ -5588,6 +5613,63 @@ def create_api(
             "working_status": db_status,
             "ok": True,
         }
+
+    @app.post("/agents/{name}/effort-drift")
+    async def report_effort_drift(name: str, req: EffortDriftRequest):
+        """Record a thinking-effort drift event from hook_verify_effort.py (#429).
+
+        Called when ``$CLAUDE_EFFORT`` (runtime) diverges from
+        ``$PINKY_EXPECTED_EFFORT`` (agent's configured ``thinking_effort``).
+        The hook is fire-and-forget — we return quickly and never fail the
+        tool call.
+        """
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+        event_id = agents.record_effort_drift(
+            name,
+            expected=req.expected,
+            actual=req.actual,
+            session_id=req.session_id,
+            tool_name=req.tool_name,
+            strict=req.strict,
+        )
+        activity.log(
+            agent_name=name,
+            event_type="effort_drift",
+            title=(
+                f"effort drift — expected={req.expected} actual={req.actual}"
+                + (" (blocked)" if req.strict else "")
+            ),
+            metadata={
+                "agent": name,
+                "expected": req.expected,
+                "actual": req.actual,
+                "tool_name": req.tool_name,
+                "strict": req.strict,
+            },
+        )
+        return {
+            "ok": True,
+            "agent": name,
+            "event_id": event_id,
+            "expected": req.expected,
+            "actual": req.actual,
+            "strict": req.strict,
+        }
+
+    @app.get("/agents/{name}/effort-drift")
+    async def list_effort_drift_events(
+        name: str, limit: int = 50, since: float = 0.0,
+    ):
+        """List recent effort-drift events for an agent (#429)."""
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+        events = agents.get_effort_drift_events(
+            agent_name=name, limit=limit, since=since,
+        )
+        return {"agent": name, "events": events, "count": len(events)}
 
     @app.get("/agents/{name}/status")
     async def get_agent_working_status(name: str):

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -454,6 +454,9 @@ class RegisterAgentRequest(BaseModel):
     provider_model: str = ""  # Model name override for this provider
     provider_ref: str = ""  # ID of a global provider from the providers table
     thinking_effort: str = "medium"  # low/medium/high/xhigh/max
+    # When True, the verify_effort CLI hook blocks tool calls if the runtime
+    # effort drifts from thinking_effort. Default False (warn-only). See #429.
+    strict_effort_enforcement: bool = False
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
 
 
@@ -492,6 +495,8 @@ class UpdateAgentRequest(BaseModel):
     provider_model: str | None = None  # Model name override for this provider
     provider_ref: str | None = None  # ID of a global provider from the providers table
     thinking_effort: str | None = None  # low/medium/high/xhigh/max
+    # When True, verify_effort CLI hook blocks tool calls on effort drift. See #429.
+    strict_effort_enforcement: bool | None = None
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
 
 
@@ -5482,6 +5487,7 @@ def create_api(
             provider_model=req.provider_model,
             provider_ref=req.provider_ref,
             thinking_effort=req.thinking_effort,
+            strict_effort_enforcement=req.strict_effort_enforcement,
             watchdog_config=req.watchdog_config or {},
         )
         # Write .mcp.json so the agent gets default MCP servers (memory, self, messaging)

--- a/src/pinky_daemon/sdk_runner.py
+++ b/src/pinky_daemon/sdk_runner.py
@@ -62,6 +62,10 @@ class SDKRunnerConfig:
     # Thinking effort: low, medium, high, max
     thinking_effort: str = "medium"
 
+    # When True, the verify_effort CLI hook blocks tool calls if the runtime
+    # effort drifts from thinking_effort. Default False (warn-only). See #429.
+    strict_effort_enforcement: bool = False
+
     # Provider overrides — set these to use Ollama or other compatible endpoints
     provider_url: str = ""   # ANTHROPIC_BASE_URL override
     provider_key: str = ""   # ANTHROPIC_API_KEY override
@@ -158,6 +162,16 @@ class SDKRunner:
             env_overrides["ANTHROPIC_BASE_URL"] = self._config.provider_url
         if self._config.provider_key:
             env_overrides["ANTHROPIC_API_KEY"] = self._config.provider_key
+        # #429: surface configured effort + agent identity to CLI hooks so
+        # verify_effort.py can detect drift from PINKY_EXPECTED_EFFORT vs
+        # $CLAUDE_EFFORT at PreToolUse time. The hook no-ops on "auto" /
+        # empty (intentionally adaptive).
+        if self._agent_name:
+            env_overrides["PINKY_AGENT_NAME"] = self._agent_name
+        if effort:
+            env_overrides["PINKY_EXPECTED_EFFORT"] = effort
+        if self._config.strict_effort_enforcement:
+            env_overrides["PINKY_STRICT_EFFORT"] = "1"
         options.env = env_overrides
 
         # Session management

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -66,6 +66,9 @@ class StreamingSessionConfig:
     provider_url: str = ""   # ANTHROPIC_BASE_URL override (e.g. "http://localhost:11434" for Ollama)
     provider_key: str = ""   # ANTHROPIC_API_KEY override (empty = use env var)
     thinking_effort: str = "medium"  # low, medium, high, xhigh, max — default thinking depth
+    # When True, the verify_effort CLI hook blocks tool calls if the runtime
+    # effort drifts from thinking_effort. Default False (warn-only). See #429.
+    strict_effort_enforcement: bool = False
     restart_reason: str = ""  # "context_restart", "auto_restart", etc. — cleared after wake prompt
 
 
@@ -293,12 +296,24 @@ class StreamingSession:
             options.effort = effort
 
         # Build provider env overrides (Ollama / custom compatible endpoints)
-        provider_env = {}
+        provider_env: dict[str, str] = {}
         if self._config.provider_url:
             provider_env["ANTHROPIC_BASE_URL"] = self._config.provider_url
         if self._config.provider_key:
             provider_env["ANTHROPIC_API_KEY"] = self._config.provider_key
             provider_env["ANTHROPIC_AUTH_TOKEN"] = self._config.provider_key
+
+        # #429: surface configured effort + agent identity to CLI hooks so
+        # hook_verify_effort.py can detect drift from PINKY_EXPECTED_EFFORT
+        # vs $CLAUDE_EFFORT at PreToolUse time. The hook no-ops on "auto" /
+        # empty (intentionally adaptive).
+        if self.agent_name:
+            provider_env["PINKY_AGENT_NAME"] = self.agent_name
+        if effort:
+            provider_env["PINKY_EXPECTED_EFFORT"] = effort
+        if self._config.strict_effort_enforcement:
+            provider_env["PINKY_STRICT_EFFORT"] = "1"
+
         if provider_env:
             # Generous timeout for slow local/third-party models (30 min)
             provider_env.setdefault("API_TIMEOUT_MS", "1800000")

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -1143,10 +1143,13 @@ def create_server(
     @mcp.tool()
     def set_thinking_effort(level: str) -> str:
         """Set thinking effort for this session. Match depth to task complexity.
-        level: low | medium | high | max | auto (clears override).
+        level: low | medium | high | xhigh | max | auto (clears override).
         """
-        if level not in ("low", "medium", "high", "max", "auto"):
-            return f"Invalid level: {level}. Use low, medium, high, max, or auto."
+        if level not in ("low", "medium", "high", "xhigh", "max", "auto"):
+            return (
+                f"Invalid level: {level}. "
+                "Use low, medium, high, xhigh, max, or auto."
+            )
         result = _api("POST", f"/agents/{agent_name}/sessions/main/effort", {
             "effort": level,
         })

--- a/tests/test_effort_verification.py
+++ b/tests/test_effort_verification.py
@@ -455,12 +455,13 @@ class TestVerifyEffortHookBehavior:
         decision = json.loads(proc.stdout)
         assert decision["decision"] == "block"
 
-    def test_strict_xhigh_remediation_suggests_fallback(
+    def test_strict_xhigh_remediation_suggests_xhigh(
         self, hook_script, fake_daemon,
     ):
-        """When expected=xhigh (not directly settable via set_thinking_effort
-        MCP tool, depending on agent generation), the block reason must
-        suggest a fallback the agent can actually call.
+        """When expected=xhigh, the remediation suggestion must be
+        ``set_thinking_effort('xhigh')`` — not a closer-but-wrong level.
+        Anything else leaves the agent stuck: calling set_thinking_effort
+        with the wrong level just produces another drift event.
         """
         port, _captured = fake_daemon
         proc = _run_hook(
@@ -471,10 +472,34 @@ class TestVerifyEffortHookBehavior:
         assert proc.returncode == 0
         decision = json.loads(proc.stdout)
         reason = decision["reason"]
-        # Suggest the closest accepted level ("high"), not "xhigh"
-        assert "'high'" in reason or '"high"' in reason
-        # And flag that xhigh isn't directly settable
-        assert "xhigh" in reason
+        # Must suggest set_thinking_effort('xhigh') — matches the tool's
+        # accepted levels after #429 widened it.
+        assert "set_thinking_effort('xhigh')" in reason, reason
+        # Must NOT suggest a wrong-level call.
+        assert "set_thinking_effort('high')" not in reason, reason
+        assert "set_thinking_effort('max')" not in reason, reason
+
+    def test_strict_unreachable_level_says_so(
+        self, hook_script, fake_daemon,
+    ):
+        """If expected is somehow outside the MCP tool's accepted set
+        (configuration mismatch — shouldn't happen in normal use), the
+        reason must be honest: tell the agent there's no self-remediation
+        path so it escalates to the owner instead of spinning.
+        """
+        port, _captured = fake_daemon
+        proc = _run_hook(
+            hook_script,
+            # Synthetic invalid level — hypothetical future registry value
+            expected="ultra", actual="medium", agent="alpha", strict=True,
+            daemon_url=f"http://127.0.0.1:{port}",
+        )
+        assert proc.returncode == 0
+        decision = json.loads(proc.stdout)
+        reason = decision["reason"]
+        assert "no self-remediation path" in reason
+        # And don't suggest a tool call that won't fix the drift.
+        assert "set_thinking_effort(" not in reason
 
 
 class TestVerifyEffortScriptOnDisk:

--- a/tests/test_effort_verification.py
+++ b/tests/test_effort_verification.py
@@ -1,0 +1,440 @@
+"""Tests for the effort-drift verification hook (#429).
+
+Covers:
+- ``Agent.strict_effort_enforcement`` column round-trip
+- ``AgentRegistry.record_effort_drift`` + ``get_effort_drift_events``
+- ``ensure_workspace_hooks`` idempotently installs the verify_effort hook
+- ``_setup_hooks`` writes valid settings.json with both working + verify hooks
+- ``_setup_hooks`` merges verify_effort into pre-existing settings.json
+  without clobbering user-added hooks
+- Subprocess-level behavior of ``hook_verify_effort.py``:
+    - match → silent no-op
+    - mismatch + warn mode → POSTs to ``/agents/{name}/effort-drift``
+    - mismatch + strict mode → emits a block decision on stdout
+    - no expected / actual / agent → silent no-op
+    - ``expected=auto`` → silent no-op (intentionally adaptive)
+- ``SDKRunnerConfig`` + ``StreamingSessionConfig`` carry the strict flag
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from pinky_daemon.agent_registry import (
+    AgentRegistry,
+    _verify_effort_hook_source,
+)
+
+
+@pytest.fixture
+def registry():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    r = AgentRegistry(db_path=path)
+    yield r
+    r.close()
+    os.unlink(path)
+
+
+@pytest.fixture
+def hook_script(tmp_path):
+    """Write the hook source to a temp file we can invoke as a subprocess."""
+    p = tmp_path / "hook_verify_effort.py"
+    p.write_text(_verify_effort_hook_source())
+    return p
+
+
+class _CaptureHandler(BaseHTTPRequestHandler):
+    """Tiny test HTTP server that records POST bodies for assertion."""
+
+    captured: list = []
+
+    def do_POST(self):  # noqa: N802 — http.server interface
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length).decode() if length else ""
+        try:
+            data = json.loads(body)
+        except Exception:
+            data = {"raw": body}
+        type(self).captured.append({
+            "path": self.path,
+            "body": data,
+            "headers": dict(self.headers),
+        })
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok": true}')
+
+    def log_message(self, *_args, **_kwargs):  # silence test noise
+        pass
+
+
+@pytest.fixture
+def fake_daemon():
+    """Spin up an in-process HTTP server that captures hook POSTs."""
+
+    class _Handler(_CaptureHandler):
+        captured: list = []
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_port
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield port, _Handler.captured
+    server.shutdown()
+    server.server_close()
+
+
+def _run_hook(
+    hook_path: Path,
+    *,
+    expected: str = "",
+    actual: str = "",
+    agent: str = "",
+    strict: bool = False,
+    daemon_url: str = "",
+    stdin: str = "",
+) -> subprocess.CompletedProcess:
+    env = {**os.environ}
+    # Wipe any inherited CLAUDE_EFFORT so test env is hermetic
+    env.pop("CLAUDE_EFFORT", None)
+    env.pop("PINKY_EXPECTED_EFFORT", None)
+    env.pop("PINKY_AGENT_NAME", None)
+    env.pop("PINKY_STRICT_EFFORT", None)
+    env.pop("PINKY_DAEMON_URL", None)
+    if actual:
+        env["CLAUDE_EFFORT"] = actual
+    if expected:
+        env["PINKY_EXPECTED_EFFORT"] = expected
+    if agent:
+        env["PINKY_AGENT_NAME"] = agent
+    if strict:
+        env["PINKY_STRICT_EFFORT"] = "1"
+    if daemon_url:
+        env["PINKY_DAEMON_URL"] = daemon_url
+    return subprocess.run(
+        [sys.executable, str(hook_path)],
+        env=env,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+# ── Schema / dataclass ─────────────────────────────────────
+
+
+class TestStrictEffortColumn:
+    def test_default_false(self, registry):
+        agent = registry.register("alpha", model="opus")
+        assert agent.strict_effort_enforcement is False
+
+    def test_set_via_register(self, registry):
+        agent = registry.register("alpha", strict_effort_enforcement=True)
+        assert agent.strict_effort_enforcement is True
+
+    def test_update_round_trip(self, registry):
+        registry.register("alpha")
+        registry.register("alpha", strict_effort_enforcement=True)
+        got = registry.get("alpha")
+        assert got is not None
+        assert got.strict_effort_enforcement is True
+        # And back to off
+        registry.register("alpha", strict_effort_enforcement=False)
+        got2 = registry.get("alpha")
+        assert got2 is not None
+        assert got2.strict_effort_enforcement is False
+
+    def test_to_dict_includes_field(self, registry):
+        agent = registry.register("alpha", strict_effort_enforcement=True)
+        d = agent.to_dict()
+        assert d["strict_effort_enforcement"] is True
+
+
+# ── record_effort_drift + get_effort_drift_events ──────────
+
+
+class TestEffortDriftRecording:
+    def test_record_writes_row(self, registry):
+        registry.register("alpha")
+        event_id = registry.record_effort_drift(
+            "alpha", expected="high", actual="medium",
+            session_id="sess-1", tool_name="Bash", strict=False,
+        )
+        assert event_id > 0
+        events = registry.get_effort_drift_events("alpha")
+        assert len(events) == 1
+        e = events[0]
+        assert e["expected"] == "high"
+        assert e["actual"] == "medium"
+        assert e["tool_name"] == "Bash"
+        assert e["strict"] is False
+        assert e["agent_name"] == "alpha"
+
+    def test_record_writes_heartbeat_note(self, registry):
+        registry.register("alpha")
+        registry.record_effort_drift(
+            "alpha", expected="max", actual="low", strict=True,
+        )
+        hb = registry.get_latest_heartbeat("alpha")
+        assert hb is not None
+        assert "effort drift" in hb.notes
+        assert "blocked" in hb.notes  # strict label
+        assert "expected=max" in hb.notes
+        assert "actual=low" in hb.notes
+
+    def test_record_warn_label_in_note(self, registry):
+        registry.register("alpha")
+        registry.record_effort_drift(
+            "alpha", expected="high", actual="medium", strict=False,
+        )
+        hb = registry.get_latest_heartbeat("alpha")
+        assert hb is not None
+        assert "warn" in hb.notes
+
+    def test_get_filters_by_agent(self, registry):
+        registry.register("alpha")
+        registry.register("beta")
+        registry.record_effort_drift("alpha", expected="high", actual="low")
+        registry.record_effort_drift("beta", expected="high", actual="medium")
+        a_events = registry.get_effort_drift_events("alpha")
+        b_events = registry.get_effort_drift_events("beta")
+        assert len(a_events) == 1
+        assert len(b_events) == 1
+        assert a_events[0]["actual"] == "low"
+        assert b_events[0]["actual"] == "medium"
+
+    def test_get_filters_by_since(self, registry):
+        import time
+
+        registry.register("alpha")
+        registry.record_effort_drift("alpha", expected="high", actual="low")
+        cutoff = time.time() + 0.01
+        time.sleep(0.05)
+        registry.record_effort_drift("alpha", expected="high", actual="medium")
+        events = registry.get_effort_drift_events("alpha", since=cutoff)
+        # Only the second event should be returned
+        assert len(events) == 1
+        assert events[0]["actual"] == "medium"
+
+    def test_get_fleet_wide(self, registry):
+        registry.register("alpha")
+        registry.register("beta")
+        registry.record_effort_drift("alpha", expected="high", actual="low")
+        registry.record_effort_drift("beta", expected="high", actual="medium")
+        all_events = registry.get_effort_drift_events("")
+        assert len(all_events) == 2
+
+
+# ── settings.json installer ────────────────────────────────
+
+
+class TestHookInstaller:
+    def test_setup_creates_verify_effort_script(self, tmp_path):
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        assert (tmp_path / ".claude" / "hook_verify_effort.py").exists()
+
+    def test_setup_settings_has_verify_hook(self, tmp_path):
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        settings = json.loads(
+            (tmp_path / ".claude" / "settings.json").read_text()
+        )
+        commands = [
+            h["command"]
+            for entry in settings["hooks"]["PreToolUse"]
+            for h in entry["hooks"]
+        ]
+        assert any("hook_verify_effort.py" in c for c in commands), commands
+        # And working/idle still present
+        assert any("hook_working.py" in c for c in commands), commands
+
+    def test_setup_idempotent_double_call(self, tmp_path):
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        first = (tmp_path / ".claude" / "settings.json").read_text()
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        second = (tmp_path / ".claude" / "settings.json").read_text()
+        # The file should be unchanged on second call (no duplicate hooks)
+        # Count verify_effort references — must be exactly 1
+        assert second.count("hook_verify_effort.py") == 1
+        # And working count is also 1
+        assert second.count("hook_working.py") == first.count("hook_working.py")
+
+    def test_setup_merges_into_legacy_settings(self, tmp_path):
+        # Simulate an old agent: settings.json exists with only working hook.
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        legacy = {
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": ".*",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "python3 /custom/user-hook.py || true",
+                    }],
+                }],
+            }
+        }
+        (claude_dir / "settings.json").write_text(json.dumps(legacy))
+
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        merged = json.loads((claude_dir / "settings.json").read_text())
+        commands = [
+            h["command"]
+            for entry in merged["hooks"]["PreToolUse"]
+            for h in entry["hooks"]
+        ]
+        # User's custom hook preserved
+        assert any("user-hook.py" in c for c in commands), commands
+        # Verify hook added
+        assert any("hook_verify_effort.py" in c for c in commands), commands
+
+    def test_ensure_workspace_hooks_no_agent(self, registry):
+        # Calling on a non-existent agent must not raise.
+        registry.ensure_workspace_hooks("nonexistent")  # should no-op
+
+    def test_ensure_workspace_hooks_installs(self, registry, tmp_path):
+        registry.register(
+            "alpha",
+            working_dir=str(tmp_path / "agent"),
+        )
+        # Initial register already runs _setup_hooks; remove the
+        # verify_effort entry to simulate pre-#429 state.
+        settings_path = tmp_path / "agent" / ".claude" / "settings.json"
+        settings = json.loads(settings_path.read_text())
+        for entry in settings["hooks"]["PreToolUse"]:
+            entry["hooks"] = [
+                h for h in entry["hooks"]
+                if "hook_verify_effort" not in (h.get("command") or "")
+            ]
+        settings_path.write_text(json.dumps(settings))
+        assert "hook_verify_effort" not in settings_path.read_text()
+
+        # Now re-ensure — hook should be re-added.
+        registry.ensure_workspace_hooks("alpha")
+        assert "hook_verify_effort" in settings_path.read_text()
+
+
+# ── Hook subprocess behavior ───────────────────────────────
+
+
+class TestVerifyEffortHookBehavior:
+    def test_match_silent(self, hook_script):
+        proc = _run_hook(
+            hook_script, expected="high", actual="high", agent="alpha",
+        )
+        assert proc.returncode == 0
+        assert proc.stdout == ""
+
+    def test_no_expected_silent(self, hook_script):
+        proc = _run_hook(hook_script, actual="high", agent="alpha")
+        assert proc.returncode == 0
+        assert proc.stdout == ""
+
+    def test_no_actual_silent(self, hook_script):
+        # Older Claude Code without v2.1.133 effort.level
+        proc = _run_hook(hook_script, expected="high", agent="alpha")
+        assert proc.returncode == 0
+        assert proc.stdout == ""
+
+    def test_auto_expected_silent(self, hook_script):
+        proc = _run_hook(
+            hook_script, expected="auto", actual="low", agent="alpha",
+        )
+        assert proc.returncode == 0
+        assert proc.stdout == ""
+
+    def test_no_agent_silent(self, hook_script):
+        # Hook misconfigured — no agent name — must not crash + no output
+        proc = _run_hook(
+            hook_script, expected="high", actual="low",
+        )
+        assert proc.returncode == 0
+        assert proc.stdout == ""
+
+    def test_mismatch_warn_posts(self, hook_script, fake_daemon):
+        port, captured = fake_daemon
+        proc = _run_hook(
+            hook_script,
+            expected="high", actual="medium", agent="alpha",
+            daemon_url=f"http://127.0.0.1:{port}",
+        )
+        assert proc.returncode == 0
+        # Warn mode → no block decision printed
+        assert proc.stdout == ""
+        assert len(captured) == 1, captured
+        msg = captured[0]
+        assert msg["path"] == "/agents/alpha/effort-drift"
+        assert msg["body"]["expected"] == "high"
+        assert msg["body"]["actual"] == "medium"
+        assert msg["body"]["strict"] is False
+
+    def test_mismatch_strict_emits_block(self, hook_script, fake_daemon):
+        port, captured = fake_daemon
+        proc = _run_hook(
+            hook_script,
+            expected="high", actual="low", agent="alpha", strict=True,
+            daemon_url=f"http://127.0.0.1:{port}",
+        )
+        assert proc.returncode == 0
+        # Strict mode → block decision on stdout
+        decision = json.loads(proc.stdout)
+        assert decision["decision"] == "block"
+        assert "high" in decision["reason"]
+        assert "low" in decision["reason"]
+        # Plus the drift POST still happens
+        assert len(captured) == 1
+        assert captured[0]["body"]["strict"] is True
+
+    def test_mismatch_with_tool_name_from_stdin(self, hook_script, fake_daemon):
+        port, captured = fake_daemon
+        stdin_payload = json.dumps({"tool_name": "Bash", "session_id": "s1"})
+        proc = _run_hook(
+            hook_script,
+            expected="high", actual="medium", agent="alpha",
+            daemon_url=f"http://127.0.0.1:{port}",
+            stdin=stdin_payload,
+        )
+        assert proc.returncode == 0
+        assert len(captured) == 1
+        assert captured[0]["body"]["tool_name"] == "Bash"
+
+
+# ── Config plumbing ────────────────────────────────────────
+
+
+class TestSDKRunnerConfigField:
+    def test_default(self):
+        from pinky_daemon.sdk_runner import SDKRunnerConfig
+        cfg = SDKRunnerConfig()
+        assert cfg.strict_effort_enforcement is False
+
+    def test_set_true(self):
+        from pinky_daemon.sdk_runner import SDKRunnerConfig
+        cfg = SDKRunnerConfig(strict_effort_enforcement=True)
+        assert cfg.strict_effort_enforcement is True
+
+
+class TestStreamingSessionConfigField:
+    def test_default(self):
+        from pinky_daemon.streaming_session import StreamingSessionConfig
+        cfg = StreamingSessionConfig(agent_name="x", working_dir="/tmp")
+        assert cfg.strict_effort_enforcement is False
+
+    def test_set_true(self):
+        from pinky_daemon.streaming_session import StreamingSessionConfig
+        cfg = StreamingSessionConfig(
+            agent_name="x", working_dir="/tmp",
+            strict_effort_enforcement=True,
+        )
+        assert cfg.strict_effort_enforcement is True

--- a/tests/test_effort_verification.py
+++ b/tests/test_effort_verification.py
@@ -409,6 +409,99 @@ class TestVerifyEffortHookBehavior:
         assert len(captured) == 1
         assert captured[0]["body"]["tool_name"] == "Bash"
 
+    # ── Strict-mode remediation allowlist (Murzik review catch) ──
+
+    @pytest.mark.parametrize("tool_name", [
+        "set_thinking_effort",
+        "mcp__pinky-self__set_thinking_effort",
+        "SET_THINKING_EFFORT",  # case-insensitive
+    ])
+    def test_strict_allows_remediation_tool(
+        self, hook_script, fake_daemon, tool_name,
+    ):
+        """Strict mode must NOT block set_thinking_effort — that's the only
+        way the agent can self-correct drift. Otherwise strict is a trap.
+        """
+        port, captured = fake_daemon
+        stdin_payload = json.dumps({"tool_name": tool_name})
+        proc = _run_hook(
+            hook_script,
+            expected="high", actual="medium", agent="alpha", strict=True,
+            daemon_url=f"http://127.0.0.1:{port}",
+            stdin=stdin_payload,
+        )
+        assert proc.returncode == 0
+        # Drift still recorded
+        assert len(captured) == 1
+        assert captured[0]["body"]["tool_name"] == tool_name
+        assert captured[0]["body"]["strict"] is True
+        # But NO block decision on stdout
+        assert proc.stdout == "", (
+            f"Strict mode must not block remediation tool {tool_name!r}; "
+            f"got stdout: {proc.stdout!r}"
+        )
+
+    def test_strict_still_blocks_other_tools(self, hook_script, fake_daemon):
+        """Sanity: strict mode still blocks non-remediation tools."""
+        port, captured = fake_daemon
+        stdin_payload = json.dumps({"tool_name": "Bash"})
+        proc = _run_hook(
+            hook_script,
+            expected="high", actual="medium", agent="alpha", strict=True,
+            daemon_url=f"http://127.0.0.1:{port}",
+            stdin=stdin_payload,
+        )
+        assert proc.returncode == 0
+        decision = json.loads(proc.stdout)
+        assert decision["decision"] == "block"
+
+    def test_strict_xhigh_remediation_suggests_fallback(
+        self, hook_script, fake_daemon,
+    ):
+        """When expected=xhigh (not directly settable via set_thinking_effort
+        MCP tool, depending on agent generation), the block reason must
+        suggest a fallback the agent can actually call.
+        """
+        port, _captured = fake_daemon
+        proc = _run_hook(
+            hook_script,
+            expected="xhigh", actual="medium", agent="alpha", strict=True,
+            daemon_url=f"http://127.0.0.1:{port}",
+        )
+        assert proc.returncode == 0
+        decision = json.loads(proc.stdout)
+        reason = decision["reason"]
+        # Suggest the closest accepted level ("high"), not "xhigh"
+        assert "'high'" in reason or '"high"' in reason
+        # And flag that xhigh isn't directly settable
+        assert "xhigh" in reason
+
+
+class TestVerifyEffortScriptOnDisk:
+    """Ensure stale on-disk verify_effort scripts get refreshed."""
+
+    def test_setup_overwrites_stale_script(self, tmp_path):
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        script_path = tmp_path / ".claude" / "hook_verify_effort.py"
+        # Simulate a stale older version on disk.
+        script_path.write_text("# stale version\nprint('old')\n")
+        # Second run should refresh.
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        content = script_path.read_text()
+        assert "stale version" not in content
+        assert "PinkyBot effort-drift verification hook" in content
+
+    def test_setup_keeps_fresh_script_unchanged(self, tmp_path):
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        script_path = tmp_path / ".claude" / "hook_verify_effort.py"
+        mtime_first = script_path.stat().st_mtime
+        # Same content → should not be rewritten (mtime preserved).
+        import time
+        time.sleep(0.05)
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        mtime_second = script_path.stat().st_mtime
+        assert mtime_first == mtime_second
+
 
 # ── Config plumbing ────────────────────────────────────────
 
@@ -438,3 +531,137 @@ class TestStreamingSessionConfigField:
             strict_effort_enforcement=True,
         )
         assert cfg.strict_effort_enforcement is True
+
+
+class TestAPIRoundTrip:
+    """strict_effort_enforcement must round-trip through the public agent API
+    (Murzik review catch #2). Without this, the per-agent strict opt-in
+    promised by the design is unreachable except via direct DB writes.
+    """
+
+    def _make_client(self):
+        from fastapi.testclient import TestClient
+
+        from pinky_daemon.api import create_api
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        app = create_api(
+            max_sessions=10, default_working_dir="/tmp", db_path=path,
+        )
+        return TestClient(app), path
+
+    def test_register_with_strict_effort(self):
+        client, db_path = self._make_client()
+        try:
+            resp = client.post("/agents", json={
+                "name": "alpha",
+                "model": "opus",
+                "strict_effort_enforcement": True,
+            })
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["strict_effort_enforcement"] is True
+
+            # And it persists on GET.
+            got = client.get("/agents/alpha").json()
+            assert got["strict_effort_enforcement"] is True
+        finally:
+            client.close()
+            os.unlink(db_path)
+
+    def test_register_default_strict_effort_false(self):
+        client, db_path = self._make_client()
+        try:
+            resp = client.post("/agents", json={
+                "name": "alpha",
+                "model": "opus",
+            })
+            assert resp.status_code == 200
+            assert resp.json()["strict_effort_enforcement"] is False
+        finally:
+            client.close()
+            os.unlink(db_path)
+
+    def test_update_toggles_strict_effort(self):
+        client, db_path = self._make_client()
+        try:
+            client.post("/agents", json={"name": "alpha", "model": "opus"})
+            # Turn it on
+            resp = client.put("/agents/alpha", json={
+                "strict_effort_enforcement": True,
+            })
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["strict_effort_enforcement"] is True
+            # Turn it back off
+            resp = client.put("/agents/alpha", json={
+                "strict_effort_enforcement": False,
+            })
+            assert resp.status_code == 200
+            assert resp.json()["strict_effort_enforcement"] is False
+        finally:
+            client.close()
+            os.unlink(db_path)
+
+
+class TestEffortDriftEndpoint:
+    """Smoke-test the POST/GET /agents/{name}/effort-drift endpoints."""
+
+    def _make_client(self):
+        from fastapi.testclient import TestClient
+
+        from pinky_daemon.api import create_api
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        app = create_api(
+            max_sessions=10, default_working_dir="/tmp", db_path=path,
+        )
+        return TestClient(app), path
+
+    def test_post_records_event(self):
+        client, db_path = self._make_client()
+        try:
+            client.post("/agents", json={"name": "alpha", "model": "opus"})
+            resp = client.post("/agents/alpha/effort-drift", json={
+                "expected": "high",
+                "actual": "medium",
+                "tool_name": "Bash",
+                "strict": False,
+            })
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["ok"] is True
+            assert body["expected"] == "high"
+            assert body["actual"] == "medium"
+            assert body["event_id"] > 0
+        finally:
+            client.close()
+            os.unlink(db_path)
+
+    def test_get_lists_events(self):
+        client, db_path = self._make_client()
+        try:
+            client.post("/agents", json={"name": "alpha", "model": "opus"})
+            client.post("/agents/alpha/effort-drift", json={
+                "expected": "high", "actual": "low",
+            })
+            client.post("/agents/alpha/effort-drift", json={
+                "expected": "high", "actual": "medium",
+            })
+            resp = client.get("/agents/alpha/effort-drift")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["count"] == 2
+            assert len(body["events"]) == 2
+        finally:
+            client.close()
+            os.unlink(db_path)
+
+    def test_post_for_unknown_agent_404s(self):
+        client, db_path = self._make_client()
+        try:
+            resp = client.post("/agents/ghost/effort-drift", json={
+                "expected": "high", "actual": "low",
+            })
+            assert resp.status_code == 404
+        finally:
+            client.close()
+            os.unlink(db_path)


### PR DESCRIPTION
## Summary

Closes #429.

Adds a `PreToolUse` CLI hook that compares the runtime `\$CLAUDE_EFFORT` (Claude Code v2.1.133+) against the agent's configured `thinking_effort`. On drift, the hook fire-and-forget POSTs to `/agents/{name}/effort-drift`; in strict mode it also emits a `decision: block` so Claude Code refuses the tool call.

Closes the observability gap where an agent silently drifts off its configured effort (e.g. Pushok review downshifting to medium) with no signal — drift now surfaces in heartbeat notes + the activity feed and is queryable via the new endpoint.

## What's in

- **`agent_registry`**:
  - `Agent.strict_effort_enforcement: bool` column (default `False`) with full migration + round-trip.
  - `effort_drift_events` table + `record_effort_drift()` / `get_effort_drift_events()`.
  - `hook_verify_effort.py` source as a module-level function; `_setup_hooks` writes it next to the existing working/idle hooks.
  - `_sync_hooks_settings()`: idempotent settings.json merge — adds the verify hook to pre-existing configs **without** nuking user-added hooks. Detects already-installed by matching the script path in the command string.
  - `ensure_workspace_hooks()` public method for retrofitting existing agents.
- **`sdk_runner` + `streaming_session`**: surface `PINKY_AGENT_NAME`, `PINKY_EXPECTED_EFFORT`, `PINKY_STRICT_EFFORT` through `options.env`.
- **`api.py`**: `POST /agents/{name}/effort-drift` records the event, emits a heartbeat note (`[effort drift / warn|blocked] expected=X actual=Y tool=T`), and an activity entry. `GET /agents/{name}/effort-drift` lists recent events. Streaming-start path now calls `ensure_workspace_hooks()` so existing agents pick up the verify hook on next session connect.

## Defaults (as discussed)

- **Warn-only fleet-wide** — no agent breaks at startup.
- **Strict path is per-agent opt-in** via `strict_effort_enforcement: True`.
- **No Telegram nag in v1** — drift surfaces via heartbeat + activity feed. We can add nag later once we see drift patterns.

The hook also no-ops silently when:
- `PINKY_EXPECTED_EFFORT` is empty or `auto` (intentionally adaptive)
- `\$CLAUDE_EFFORT` is unset (older Claude Code without v2.1.133)
- `PINKY_AGENT_NAME` is missing (hook misconfigured)

## Tests

28 new tests in `tests/test_effort_verification.py`:
- `Agent.strict_effort_enforcement` column round-trip (default / register / update / `to_dict`)
- `record_effort_drift` row write + heartbeat note (warn vs blocked label) + filters (`agent_name`, `since`, fleet-wide)
- `_setup_hooks` writes valid settings.json with both working + verify hooks
- `_setup_hooks` idempotent across double-calls (no dup hooks)
- `_setup_hooks` merges into legacy settings.json **without** clobbering user-added hooks
- `ensure_workspace_hooks` retrofits agents whose workspace pre-dates this change
- Subprocess-level hook behavior via an in-process HTTP capture server:
  - match → silent no-op
  - no expected / no actual / no agent → silent no-op
  - `expected=auto` → silent no-op
  - mismatch + warn → POST to `/agents/{name}/effort-drift` with correct body
  - mismatch + strict → POST + JSON `decision: block` on stdout
  - stdin payload → `tool_name` extracted and posted
- `SDKRunnerConfig` + `StreamingSessionConfig` carry the strict flag

## Test plan

- [x] New file passes: `pytest tests/test_effort_verification.py -v` → **28 passed**
- [x] Touched files pass: `pytest tests/test_agent_registry.py tests/test_sdk_runner.py` → **54 passed**
- [x] Full suite (sans federation pre-existing `nacl` env issue): **1442 passed**, 1 pre-existing failure (`test_core_only_has_23_tools`, fails on beta too — `mesh_remote_send` unexpectedly in core; not touched by this PR)
- [x] Ruff clean on all edited files
- [ ] Murzik review (this PR)
- [ ] Live verify in staging once #416 daemon restart lands

## Unlocks with #416

The hook surfaces nothing until the daemon picks up claude-agent-sdk 0.1.80 (bundles Claude Code v2.1.138), which is where `\$CLAUDE_EFFORT` was added. #416 is merged to main awaiting your daemon restart.

## Follow-ups (deliberately not in this PR)

- Telegram nag for repeat offenders (per-agent threshold)
- Frontend drift dashboard surface (`GET /agents/{name}/effort-drift` exists now; UI consumer is separate)
- `include_hook_events=True` integration (SDK v0.1.74) — alternative path that streams hook events back through the SDK rather than via HTTP POST. Worth evaluating after we see real drift signal.

🤖 Opened by Barsik