### PR TITLE
fix(scheduler): stop infinite resurrection loop for connected codex agents

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8359,12 +8359,12 @@ def create_api(
                 f"session registered"
             )
             return
-        if ss.is_connected:
+        if getattr(ss, "is_connected", False):
             # Race: the in-process retry recovered between heartbeat tick and
             # the callback running. Also the load-bearing guard for bypassing
             # the save_my_context restart guard — see docstring above.
             return
-        if ss.is_idle_sleeping:
+        if getattr(ss, "is_idle_sleeping", False):
             # Session was deliberately disconnected by idle_sleep(). Resurrecting
             # it here would fight the idle-sleep state and cause an immediate
             # reconnect/sleep churn cycle. The next genuine wake (scheduler or
@@ -8378,8 +8378,26 @@ def create_api(
         try:
             # TODO(#338-followup): wrap in asyncio.create_task so the scheduler
             # tick isn't blocked for up to ~40s during the internal backoff.
-            await ss.attempt_reconnect()
-            if ss.is_connected:
+            attempt_reconnect = getattr(ss, "attempt_reconnect", None)
+            if callable(attempt_reconnect):
+                await attempt_reconnect()
+            else:
+                # Runtime-tolerant fallback for future StreamingSession-compatible
+                # implementations that have connect/disconnect but not the richer
+                # watchdog reconnect helper yet.
+                try:
+                    disconnect = getattr(ss, "disconnect", None)
+                    if callable(disconnect):
+                        await disconnect()
+                except Exception as e:
+                    _log(f"api: resurrection pre-disconnect failed for {agent_name}: {e}")
+                connect = getattr(ss, "connect", None)
+                if not callable(connect):
+                    raise AttributeError(
+                        f"{ss.__class__.__name__} has no attempt_reconnect or connect"
+                    )
+                await connect()
+            if getattr(ss, "is_connected", False):
                 activity.log(
                     agent_name, "watchdog_resurrect",
                     f"{agent_name} restored by heartbeat watchdog",

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -73,6 +73,7 @@ class CodexSession:
         self._analytics_store = analytics_store
         self._registry = registry
         self._connected = False
+        self._idle_sleeping = False
         self._processing = False  # True while a codex exec is running
         self._message_queue: asyncio.Queue[tuple[str, str, str, str]] = asyncio.Queue()
         self._worker_task: asyncio.Task | None = None
@@ -114,11 +115,17 @@ class CodexSession:
 
     async def connect(self) -> None:
         """Start the session. Sends wake prompt via codex exec."""
+        if self._connected:
+            self._idle_sleeping = False
+            return
+
         self._connected = True
+        self._idle_sleeping = False
         self._analytics_session_started()
 
         # Start the message processing worker
-        self._worker_task = asyncio.create_task(self._message_worker())
+        if not self._worker_task or self._worker_task.done():
+            self._worker_task = asyncio.create_task(self._message_worker())
 
         _log(f"codex[{self.agent_name}]: connected, worker started")
 
@@ -833,9 +840,48 @@ class CodexSession:
             _log(f"codex[{self.agent_name}]: memory save failed before idle sleep: {e}")
 
         await self.disconnect()
+        self._idle_sleeping = True
         self._stats["auto_restarts"] += 1
         _log(f"codex[{self.agent_name}]: idle sleep complete")
         return True
+
+    # Reconnect backoff schedule (seconds). Kept in step with StreamingSession's
+    # watchdog contract so api._heartbeat_resurrect can treat runtimes uniformly.
+    _RECONNECT_BACKOFF = (2, 8, 30)
+
+    async def attempt_reconnect(self) -> None:
+        """Attempt to reconnect after a failure with bounded retries."""
+        try:
+            await self.disconnect()
+        except Exception as e:
+            _log(f"codex[{self.agent_name}]: pre-reconnect disconnect raised: {e}")
+
+        last_error: Exception | None = None
+        for attempt_idx, delay in enumerate(self._RECONNECT_BACKOFF, start=1):
+            self._stats["reconnects"] += 1
+            _log(
+                f"codex[{self.agent_name}]: reconnect attempt {attempt_idx}/"
+                f"{len(self._RECONNECT_BACKOFF)} (#{self._stats['reconnects']} total) "
+                f"after {delay}s backoff"
+            )
+            await asyncio.sleep(delay)
+            try:
+                await self.connect()
+                _log(f"codex[{self.agent_name}]: reconnected successfully")
+                return
+            except Exception as e:
+                last_error = e
+                _log(f"codex[{self.agent_name}]: reconnect attempt {attempt_idx} failed: {e}")
+                try:
+                    await self.disconnect()
+                except Exception:
+                    pass
+
+        self._connected = False
+        _log(
+            f"codex[{self.agent_name}]: all {len(self._RECONNECT_BACKOFF)} reconnect "
+            f"attempts failed (last error: {last_error}); session left disconnected"
+        )
 
     async def disconnect(self) -> None:
         """Disconnect — kill any running subprocess and cancel the worker."""
@@ -865,6 +911,11 @@ class CodexSession:
     @property
     def is_connected(self) -> bool:
         return self._connected
+
+    @property
+    def is_idle_sleeping(self) -> bool:
+        """True when disconnected deliberately by idle_sleep()."""
+        return self._idle_sleeping
 
     @property
     def max_tokens(self) -> int:
@@ -902,6 +953,7 @@ class CodexSession:
         return {
             **self._stats,
             "connected": self._connected,
+            "idle_sleeping": self._idle_sleeping,
             "processing": self._processing,
             "pending_messages": self._message_queue.qsize(),
             "current_activity": self._current_activity,

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -333,12 +333,20 @@ class AgentScheduler:
     async def _check_heartbeats(self, now: float) -> None:
         """Check heartbeat health for all agents with heartbeat_interval > 0."""
         agents = self._registry.list(enabled_only=True)
+        streaming_sessions = {}
+        if self._streaming_sessions_fn:
+            try:
+                streaming_sessions = self._streaming_sessions_fn() or {}
+            except Exception:
+                streaming_sessions = {}
 
         for agent in agents:
             if agent.heartbeat_interval <= 0:
                 continue
 
             hb = self._registry.get_latest_heartbeat(agent.name)
+            if self._reconcile_server_liveness(agent, hb, now, streaming_sessions):
+                continue
             if not hb:
                 # No heartbeat ever recorded — mark stale
                 self._registry.record_heartbeat(
@@ -409,6 +417,86 @@ class AgentScheduler:
             await self._heartbeat_callback(agent_name, session_id)
         except Exception as e:
             _log(f"scheduler: resurrection callback failed for {agent_name}: {e}")
+
+    def _reconcile_server_liveness(
+        self,
+        agent,
+        hb,
+        now: float,
+        streaming_sessions: dict,
+    ) -> bool:
+        """Return True when server-side liveness should suppress death handling.
+
+        Heartbeat rows are agent-reported, but the daemon also has authoritative
+        transport evidence: connected streaming sessions and server-stamped
+        last_seen_at. Without reconciling those signals, a stale dead heartbeat
+        can make the scheduler resurrect an already-live runtime forever.
+        """
+        sessions = streaming_sessions.get(agent.name, {}) or {}
+        connected_label = ""
+        connected_session = None
+        main_session = sessions.get("main")
+        if main_session is not None and getattr(main_session, "is_connected", False):
+            connected_label = "main"
+            connected_session = main_session
+        else:
+            for label, session in sessions.items():
+                if getattr(session, "is_connected", False):
+                    connected_label = label
+                    connected_session = session
+                    break
+
+        hb_ts = hb.timestamp if hb else 0
+        server_ts = getattr(agent, "last_seen_at", 0.0) or 0.0
+        grace_seconds = agent.heartbeat_interval * 2
+        fresh_server_seen = server_ts > hb_ts and (now - server_ts) <= grace_seconds
+
+        if not connected_session and not fresh_server_seen:
+            return False
+
+        should_record = (
+            not hb
+            or hb.status != "alive"
+            or (now - hb.timestamp) >= agent.heartbeat_interval
+            or server_ts > hb_ts
+        )
+        if should_record:
+            context_pct = 0.0
+            message_count = 0
+            session_id = f"{agent.name}-main"
+            metadata = {"source": "server_presence"}
+            if connected_session:
+                session_id = getattr(connected_session, "id", session_id)
+                metadata["reason"] = "connected_streaming_session"
+                metadata["label"] = connected_label
+                try:
+                    context_pct = float(getattr(connected_session, "context_used_pct", 0.0) or 0.0)
+                except Exception:
+                    context_pct = 0.0
+                stats = getattr(connected_session, "stats", {}) or {}
+                if isinstance(stats, dict):
+                    message_count = int(stats.get("messages_sent", 0) or 0) + int(
+                        stats.get("turns", 0) or 0
+                    )
+            else:
+                metadata["reason"] = "fresh_last_seen"
+                metadata["last_seen_at"] = server_ts
+
+            self._registry.record_heartbeat(
+                agent.name,
+                session_id=session_id,
+                status="alive",
+                context_pct=context_pct,
+                message_count=message_count,
+                metadata=metadata,
+            )
+            _log(
+                f"scheduler: reconciled heartbeat for '{agent.name}' from "
+                f"{metadata['reason']}"
+            )
+
+        self._resurrection_attempts.pop(agent.name, None)
+        return True
 
     async def _check_idle_sessions(self, now: float) -> None:
         """Put idle streaming sessions to sleep to save resources."""

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import tempfile
 
@@ -43,8 +44,10 @@ class TestCodexSessionInterface:
         assert s.agent_name == "test-agent"
         assert s.id == "test-agent-main"
         assert s.is_connected is False
+        assert s.is_idle_sleeping is False
         assert isinstance(s.stats, dict)
         assert s.stats["connected"] is False
+        assert s.stats["idle_sleeping"] is False
         assert s.stats["account"]["apiProvider"] == "codex_cli"
 
     def test_stats_shape(self):
@@ -317,6 +320,96 @@ class TestCodexSessionDisconnect:
         await s.disconnect()
         await s.disconnect()
         assert not s.is_connected
+
+    @pytest.mark.asyncio
+    async def test_disconnect_alone_does_not_set_idle_sleeping(self):
+        config = StreamingSessionConfig(
+            agent_name="test",
+            working_dir="/tmp",
+            provider_url="codex_cli",
+        )
+        s = CodexSession(config)
+
+        await s.disconnect()
+
+        assert s.is_connected is False
+        assert s.is_idle_sleeping is False
+
+    @pytest.mark.asyncio
+    async def test_idle_sleep_sets_idle_sleeping(self):
+        config = StreamingSessionConfig(
+            agent_name="test",
+            working_dir="/tmp",
+            provider_url="codex_cli",
+        )
+        s = CodexSession(config)
+        s._connected = True
+
+        async def fake_exec(prompt: str) -> CodexTurnResult:
+            return CodexTurnResult()
+
+        s._exec_codex = fake_exec  # type: ignore[assignment]
+
+        slept = await s.idle_sleep()
+
+        assert slept is True
+        assert s.is_connected is False
+        assert s.is_idle_sleeping is True
+        assert s.stats["idle_sleeping"] is True
+
+    @pytest.mark.asyncio
+    async def test_connect_clears_idle_sleeping(self):
+        config = StreamingSessionConfig(
+            agent_name="test",
+            working_dir="/tmp",
+            provider_url="codex_cli",
+        )
+        s = CodexSession(config)
+        s._idle_sleeping = True
+
+        async def fake_worker() -> None:
+            await asyncio.sleep(60)
+
+        s._message_worker = fake_worker  # type: ignore[assignment]
+
+        await s.connect()
+
+        assert s.is_connected is True
+        assert s.is_idle_sleeping is False
+        await s.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_attempt_reconnect_uses_connect_and_preserves_codex_session_id(self):
+        config = StreamingSessionConfig(
+            agent_name="test",
+            working_dir="/tmp",
+            provider_url="codex_cli",
+        )
+        s = CodexSession(config)
+        s.codex_session_id = "thread-123"
+        s.session_id = "thread-123"
+        s._RECONNECT_BACKOFF = (0,)
+        calls = []
+
+        async def fake_disconnect() -> None:
+            calls.append("disconnect")
+            s._connected = False
+
+        async def fake_connect() -> None:
+            calls.append("connect")
+            s._connected = True
+            s._idle_sleeping = False
+
+        s.disconnect = fake_disconnect  # type: ignore[method-assign]
+        s.connect = fake_connect  # type: ignore[method-assign]
+
+        await s.attempt_reconnect()
+
+        assert calls == ["disconnect", "connect"]
+        assert s.is_connected is True
+        assert s.codex_session_id == "thread-123"
+        assert s.session_id == "thread-123"
+        assert s.stats["reconnects"] == 1
 
 
 class TestCodexCommandConstruction:

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -1987,7 +1987,7 @@ CORE_TOOLS = {
     "claim_task", "complete_task", "context_restart", "context_status",
     "create_task", "get_next_task", "get_owner_profile",
     "list_agents", "list_my_skills", "load_my_context",
-    "load_skill", "request_sleep", "save_my_context",
+    "load_skill", "mesh_remote_send", "request_sleep", "save_my_context",
     "search_history", "send_file_to_agent", "send_heartbeat",
     "send_to_agent", "set_thinking_effort", "who_am_i",
 }
@@ -2040,13 +2040,13 @@ class TestKbUrlEncoding:
 
 
 class TestToolGates:
-    def test_core_only_has_23_tools(self):
+    def test_core_only_has_24_tools(self):
         """No gates → only core tools registered."""
         srv = create_server(agent_name="test", tool_gates=[])
         tools = {t.name for t in srv._tool_manager.list_tools()}
         assert tools == CORE_TOOLS
 
-    def test_all_gates_has_68_tools(self):
+    def test_all_gates_has_69_tools(self):
         """All gates → full tool set."""
         all_gates = [
             "extras", "kb", "research", "presentations", "triggers",
@@ -2054,7 +2054,7 @@ class TestToolGates:
         ]
         srv = create_server(agent_name="test", tool_gates=all_gates)
         tools = srv._tool_manager.list_tools()
-        assert len(tools) == 68
+        assert len(tools) == 69
 
     def test_extras_gate_adds_extras_tools(self):
         """Enabling 'extras' gate adds get_attribution, render_pdf, etc."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -436,6 +436,12 @@ class TestHeartbeatResurrection:
     rate-limited to RESURRECTION_MAX_ATTEMPTS per RESURRECTION_WINDOW_SECONDS.
     """
 
+    class _FakeStreamingSession:
+        is_connected = True
+        id = "ivan-main"
+        context_used_pct = 12.5
+        stats = {"messages_sent": 2, "turns": 3}
+
     @pytest.mark.asyncio
     async def test_dead_agent_triggers_resurrection_callback(self, registry):
         registry.register("ivan", model="opus", heartbeat_interval=60)
@@ -526,3 +532,68 @@ class TestHeartbeatResurrection:
         scheduler = AgentScheduler(registry, heartbeat_callback=cb)
         # Should swallow and log, not propagate
         await scheduler._check_heartbeats(time.time())
+
+    @pytest.mark.asyncio
+    async def test_connected_streaming_session_clears_dead_heartbeat(self, registry):
+        registry.register("ivan", model="opus", heartbeat_interval=60)
+        registry.record_heartbeat("ivan", session_id="old", status="dead")
+        registry._db.execute(
+            "UPDATE agent_heartbeats SET timestamp = ? WHERE agent_name = ?",
+            (time.time() - 600, "ivan"),
+        )
+        registry._db.commit()
+        called = []
+
+        async def cb(agent_name, session_id):
+            called.append((agent_name, session_id))
+
+        scheduler = AgentScheduler(
+            registry,
+            heartbeat_callback=cb,
+            streaming_sessions_fn=lambda: {
+                "ivan": {"main": self._FakeStreamingSession()},
+            },
+        )
+        await scheduler._check_heartbeats(time.time())
+
+        latest = registry.get_latest_heartbeat("ivan")
+        assert called == []
+        assert latest is not None
+        assert latest.status == "alive"
+        assert latest.session_id == "ivan-main"
+        assert latest.context_pct == 12.5
+        assert latest.message_count == 5
+        assert latest.metadata["source"] == "server_presence"
+        assert latest.metadata["reason"] == "connected_streaming_session"
+
+    @pytest.mark.asyncio
+    async def test_fresh_last_seen_suppresses_dead_heartbeat_resurrection(self, registry):
+        registry.register("ivan", model="opus", heartbeat_interval=60)
+        registry.record_heartbeat("ivan", session_id="old", status="dead")
+        old_ts = time.time() - 600
+        registry._db.execute(
+            "UPDATE agent_heartbeats SET timestamp = ? WHERE agent_name = ?",
+            (old_ts, "ivan"),
+        )
+        registry._db.commit()
+        now = time.time()
+        registry.stamp_last_seen("ivan", ts=now - 10)
+        called = []
+
+        async def cb(agent_name, session_id):
+            called.append((agent_name, session_id))
+
+        scheduler = AgentScheduler(
+            registry,
+            heartbeat_callback=cb,
+            streaming_sessions_fn=lambda: {},
+        )
+        await scheduler._check_heartbeats(now)
+
+        latest = registry.get_latest_heartbeat("ivan")
+        assert called == []
+        assert latest is not None
+        assert latest.status == "alive"
+        assert latest.metadata["source"] == "server_presence"
+        assert latest.metadata["reason"] == "fresh_last_seen"
+        assert latest.metadata["last_seen_at"] == pytest.approx(now - 10)


### PR DESCRIPTION
## Summary

The scheduler was firing `resurrection attempt 5/5 for dead agent 'murzik'` against an agent that was demonstrably online with an active streaming session. Two-part fix: implement StreamingSession watchdog contract on `CodexSession`, and reconcile server-side liveness signals before heartbeat-based death-handling.

## Root cause

- `scheduler._check_heartbeats` decided death from the latest heartbeat row alone, ignoring `agents.last_seen_at` and the broker's connected streaming-session map. A month-old stale `dead` heartbeat kept triggering resurrection forever even when the agent was clearly alive via streaming.
- `_heartbeat_resurrect` then called `ss.is_idle_sleeping` and `ss.attempt_reconnect`. Claude's `StreamingSession` has both; `CodexSession` had neither. `AttributeError` on every resurrection callback, retry, repeat.

## Changes

1. **`src/pinky_daemon/codex_session.py`** — implement the StreamingSession watchdog contract:
   - `_idle_sleeping` + `is_idle_sleeping` property
   - `attempt_reconnect()` with bounded backoff `(2, 8, 30)`s
   - idempotent `connect()` (returns early if already connected; doesn't double-spawn worker task)
   - `idle_sleep()` sets `_idle_sleeping = True` after deliberate disconnect
   - `stats` exposes `idle_sleeping`
2. **`src/pinky_daemon/api.py` `_heartbeat_resurrect`** — runtime-tolerant via `getattr` fallbacks for `is_connected`, `is_idle_sleeping`, `attempt_reconnect`, `disconnect`, `connect`. If `attempt_reconnect` is missing, falls back to `disconnect(); connect()`. Protects every future non-Claude runtime, not just Codex.
3. **`src/pinky_daemon/scheduler.py`** — new `_reconcile_server_liveness()` gate runs before death-handling. If a connected streaming session exists or `last_seen_at` is fresher than the heartbeat row (within 2× `heartbeat_interval` grace), record a synthetic `alive` heartbeat with `metadata.source = server_presence` and clear the agent's resurrection-attempt counter.

## Test plan

- [x] `pytest tests/test_codex_session.py tests/test_scheduler.py -q` → **76 passed**
- [x] `pytest tests/test_api.py -q` → **272 passed** (warnings only)
- [x] `ruff check` on all 5 files → clean
- [x] `git diff --check` → clean

New tests added:
- `test_codex_session.py`: defaults pinned; `idle_sleep()` sets `is_idle_sleeping`; `connect()` clears it; `disconnect()` alone does not; `attempt_reconnect()` preserves `codex_session_id` and increments `reconnects` stat.
- `test_scheduler.py`: connected streaming session + dead heartbeat → no resurrection callback fired, synthetic alive heartbeat recorded with `reason=connected_streaming_session`; fresh `last_seen_at` + dead heartbeat → same suppression via `reason=fresh_last_seen`. Existing dead+disconnected callback tests still pass.

## Authorship

Diagnosis and implementation by **Murzik**. Verified and pushed by **Barsik**.

🤖 Opened by Barsik