### PR TITLE
feat(boot): main-agent-only boot + auto-deps drift detection

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1312,6 +1312,66 @@ def _write_mcp_json(
     mcp_json.write_text(json.dumps(mcp_config, indent=2))
 
 
+def _check_installed_deps_drift(repo_dir: str) -> list[dict]:
+    """Compare installed package versions to pyproject.toml pins.
+
+    Returns a list of drift entries — one per dependency whose installed
+    version doesn't satisfy the pin (including missing packages). Each entry
+    is ``{"package": str, "specifier": str, "installed": str | None}``.
+
+    Used by ``admin_update`` to decide whether ``pip install`` is needed even
+    when ``pyproject.toml`` didn't change in the current pull. Catches the
+    common failure mode where an earlier pull bumped a pin but its routine
+    restart skipped the reinstall step, leaving installed packages stale.
+
+    Failures (missing pyproject, unparseable deps) are surfaced via raised
+    exceptions and treated as non-fatal by callers — drift can't be assessed
+    so reinstall stays gated on the other triggers.
+    """
+    import tomllib
+    from importlib.metadata import PackageNotFoundError, version
+
+    from packaging.requirements import Requirement
+
+    pyproject_path = Path(repo_dir) / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        meta = tomllib.load(f)
+
+    project = meta.get("project", {}) or {}
+    deps: list[str] = list(project.get("dependencies", []) or [])
+    optional = project.get("optional-dependencies", {}) or {}
+    for group_deps in optional.values():
+        if group_deps:
+            deps.extend(group_deps)
+
+    drifts: list[dict] = []
+    for dep_str in deps:
+        try:
+            req = Requirement(dep_str)
+        except Exception:
+            # Unparseable entry — skip rather than fail the whole check.
+            continue
+        # Skip markers that don't apply to the current env (e.g. python_version<"3.10")
+        if req.marker is not None and not req.marker.evaluate():
+            continue
+        try:
+            installed = version(req.name)
+        except PackageNotFoundError:
+            drifts.append({
+                "package": req.name,
+                "specifier": str(req.specifier),
+                "installed": None,
+            })
+            continue
+        if req.specifier and not req.specifier.contains(installed, prereleases=True):
+            drifts.append({
+                "package": req.name,
+                "specifier": str(req.specifier),
+                "installed": installed,
+            })
+    return drifts
+
+
 # ── API Server ───────────────────────────────────────────────
 
 
@@ -8509,7 +8569,16 @@ def create_api(
             await shared_mcp_manager.start()
             _log(f"startup: shared MCP server started on {shared_mcp_manager.url}")
 
-        auto_start_agents = agents.list_auto_start_agents()
+        # Boot policy (2026-05-11): only the **main agent** auto-resumes at boot.
+        # Sibling agents stay dormant until something triggers them — an inbound
+        # message, an agent-to-agent message, or a scheduled wake firing. Their
+        # autonomy loop + streaming session are created lazily on first dispatch
+        # (see `_ensure_streaming_session` and `autonomy.push_event`).
+        #
+        # `auto_start_agents` is no longer used to gate boot startup. The
+        # `agent.auto_start` flag is preserved for compat (`/admin/auto-start`
+        # endpoint still reports it) but does not control which agents come up.
+        main_name_for_boot = agents.get_main_agent()
 
         # Start broker pollers and streaming sessions for all enabled agents.
         from pinky_daemon.pollers import (
@@ -8599,54 +8668,39 @@ def create_api(
                 except Exception as e:
                     _log(f"startup: iMessage poller failed for {agent.name}: {e}")
 
-            # Decide which agents get streaming sessions on boot:
-            # - Agents with auto_start, heartbeat, or main agent: always start (create main if needed)
-            # - Agents with persisted sessions from before: restore those sessions
-            # - Other agents: skip (sessions created on-demand via _ensure_streaming_session)
-            should_auto_start = (
-                agent.auto_start
-                or agent.heartbeat_interval > 0
-                or agent.name == agents.get_main_agent()
-            )
-            persisted = agents.list_streaming_session_ids(agent.name)
-            has_persisted = any(entry["session_id"] for entry in persisted)
+            # Boot policy: only the main agent auto-resumes its streaming session.
+            # Sibling sessions are created on-demand via `_ensure_streaming_session`
+            # when an inbound message / agent-to-agent message / scheduled wake
+            # routes through the autonomy event queue. Persisted session IDs are
+            # kept in the DB so resume-by-id still works when siblings later wake.
+            if agent.name != main_name_for_boot:
+                _log(f"startup: skipping streaming session for {agent.name} (on-demand only)")
+                continue
 
             # Validate working_dir exists — stale paths from a different machine
             # (e.g. migrating from Mac Mini to RPi) would cause Fatal errors.
             if work_dir and not work_dir.is_dir():
                 _log(f"startup: working_dir missing for {agent.name}: {work_dir} — skipping session")
                 # Clear stale session IDs so we don't retry on next boot
-                for entry in persisted:
+                for entry in agents.list_streaming_session_ids(agent.name):
                     if entry["session_id"]:
                         agents.set_streaming_session_id(agent.name, "", label=entry["label"])
                 continue
 
-            if should_auto_start:
-                # Only start main session on boot — sub-sessions are on-demand
-                main_resume = agents.get_streaming_session_id(agent.name, label="main")
-                labels_to_start = {"main": main_resume}
-            elif has_persisted:
-                # Agent had sessions before — just restore main
-                main_resume = agents.get_streaming_session_id(agent.name, label="main")
-                labels_to_start = {"main": main_resume}
-            else:
-                _log(f"startup: skipping streaming session for {agent.name} (on-demand only)")
-                continue
-
-            for label, resume_id in labels_to_start.items():
-                try:
-                    await _start_streaming_session(agent.name, label=label, resume_id=resume_id)
-                    streaming_count += 1
-                    if resume_id:
-                        _log(f"startup: streaming session resumed for {agent.name}/{label} (session {resume_id[:12]})")
-                    else:
-                        _log(f"startup: streaming session connected for {agent.name}/{label} (new)")
-                except Exception as e:
-                    _log(f"startup: streaming session failed for {agent.name}/{label}: {e}")
-                    # If resume failed, clear the stale session ID and try fresh on next boot
-                    if resume_id:
-                        _log(f"startup: clearing stale session ID for {agent.name}/{label}")
-                        agents.set_streaming_session_id(agent.name, "", label=label)
+            main_resume = agents.get_streaming_session_id(agent.name, label="main")
+            try:
+                await _start_streaming_session(agent.name, label="main", resume_id=main_resume)
+                streaming_count += 1
+                if main_resume:
+                    _log(f"startup: streaming session resumed for {agent.name}/main (session {main_resume[:12]})")
+                else:
+                    _log(f"startup: streaming session connected for {agent.name}/main (new)")
+            except Exception as e:
+                _log(f"startup: streaming session failed for {agent.name}/main: {e}")
+                # If resume failed, clear the stale session ID and try fresh on next boot
+                if main_resume:
+                    _log(f"startup: clearing stale session ID for {agent.name}/main")
+                    agents.set_streaming_session_id(agent.name, "", label="main")
 
         # Clean up legacy sessions for agents that now have streaming sessions.
         # These ghost sessions were restored by SessionManager._restore_sessions()
@@ -8664,19 +8718,29 @@ def create_api(
         await autonomy.start()
         await watchdog.start()
 
-        for agent in auto_start_agents:
-            await autonomy.start_agent_loop(agent.name)
-
-        # Main agent always gets an autonomy loop, even without auto_start
+        # Boot policy: only the main agent's autonomy loop starts at boot.
+        # Sibling loops start lazily via `autonomy.push_event` when an event
+        # arrives for them (inbound message, agent-to-agent message, scheduled
+        # wake). See `autonomy.push_event` — it ungates the wake on `enabled`
+        # rather than `auto_start` so any enabled agent can be woken on demand.
+        main_started = False
         main_name = agents.get_main_agent()
-        auto_started_names = {a.name for a in auto_start_agents}
-        if main_name and main_name not in auto_started_names:
+        if main_name:
             main_agent = agents.get(main_name)
             if main_agent and main_agent.enabled:
                 await autonomy.start_agent_loop(main_name)
-                _log(f"startup: main agent '{main_name}' auto-started")
+                main_started = True
+                _log(f"startup: main agent '{main_name}' autonomy loop started")
+            else:
+                _log(f"startup: warn — main agent '{main_name}' missing or disabled")
+        else:
+            _log("startup: warn — no main agent configured; no autonomy loop started")
 
-        _log(f"startup: scheduler + autonomy + watchdog running, {len(auto_start_agents)} agent(s) auto-started, {len(_broker_pollers)} broker poller(s), {streaming_count} streaming")
+        _log(
+            f"startup: scheduler + autonomy + watchdog running, "
+            f"main={'on' if main_started else 'off'}, "
+            f"{len(_broker_pollers)} broker poller(s), {streaming_count} streaming"
+        )
 
     @app.on_event("shutdown")
     async def on_shutdown():
@@ -8988,10 +9052,12 @@ def create_api(
             summary = ""
 
         # Detect dependency changes — rebuild whenever pyproject.toml or uv.lock
-        # changed in the pull, or when force_deps=True is passed (escape hatch
-        # for installed-vs-pinned drift that git diff can't see).
+        # changed in the pull, when force_deps=True is passed, or when the
+        # installed package versions have drifted from the pyproject pins
+        # (e.g., pyproject was bumped on an earlier pull that skipped reinstall).
         deps_rebuilt = False
         deps_error = ""
+        deps_drift: list[dict] = []
         try:
             if before_hash != after_hash:
                 changed = sp.check_output(
@@ -9002,7 +9068,17 @@ def create_api(
             else:
                 changed = ""
 
-            if changed or force_deps:
+            # Auto-deps drift check: compare installed versions to pyproject pins
+            # independently of git diff. Catches the "pyproject bumped earlier,
+            # routine restart skipped reinstall" case that force_deps used to
+            # paper over manually.
+            try:
+                deps_drift = _check_installed_deps_drift(repo_dir)
+            except Exception as drift_exc:
+                _log(f"admin: deps drift check failed (non-fatal): {drift_exc}")
+                deps_drift = []
+
+            if changed or force_deps or deps_drift:
                 # Prefer project venv pip if present, else use the running daemon's
                 # interpreter (sys.executable). This works for both venv and
                 # system-python deployments — the prior `.venv/bin/pip`-only path
@@ -9057,6 +9133,7 @@ def create_api(
             "commits": summary.splitlines() if summary else [],
             "deps_rebuilt": deps_rebuilt,
             "deps_error": deps_error or None,
+            "deps_drift": deps_drift,
             "frontend_rebuilt": frontend_rebuilt,
             "frontend_error": frontend_error or None,
             "forced_reset": forced_reset,

--- a/src/pinky_daemon/autonomy.py
+++ b/src/pinky_daemon/autonomy.py
@@ -272,14 +272,23 @@ class AutonomyEngine:
             _log(f"autonomy: stopped work loop for {agent_name}")
 
     async def push_event(self, event: AgentEvent) -> None:
-        """Push an event to an agent's queue. Starts loop if not running."""
+        """Push an event to an agent's queue. Starts loop if not running.
+
+        Boot policy (2026-05-11): only the main agent's autonomy loop is started
+        at daemon boot. Sibling agents start their loop here on demand, the
+        first time any event (inbound message, agent-to-agent message, or
+        scheduled wake) arrives. The gate is `enabled` only — the older
+        `agent.auto_start` flag is no longer consulted at wake time, since
+        gating wake on `auto_start` would strand siblings unable to receive
+        messages after the boot-policy change.
+        """
         await self._event_queue.push(event)
         _log(f"autonomy: event {event.type.value} for {event.agent_name}")
 
-        # Auto-start loop if agent has auto_start and loop isn't running
+        # Wake the loop on first event for any enabled agent.
         if event.agent_name not in self._running_loops:
             agent = self._registry.get(event.agent_name)
-            if agent and agent.auto_start and agent.enabled:
+            if agent and agent.enabled:
                 await self.start_agent_loop(event.agent_name)
 
     async def _agent_loop(self, agent_name: str) -> None:

--- a/src/pinky_daemon/daemon.py
+++ b/src/pinky_daemon/daemon.py
@@ -255,12 +255,20 @@ class Daemon:
         await self._autonomy.start()
         _log("daemon: autonomy engine started")
 
-        # Start work loops for auto-start agents
-        auto_start_agents = self._registry.list_auto_start_agents()
-        for agent in auto_start_agents:
-            await self._autonomy.start_agent_loop(agent.name)
-        if auto_start_agents:
-            _log(f"daemon: started autonomy loops for {len(auto_start_agents)} agent(s)")
+        # Boot policy (2026-05-11): only the main agent's autonomy loop starts
+        # at boot. Sibling loops start lazily via `autonomy.push_event` when an
+        # event arrives for them (inbound message, agent-to-agent message, or
+        # scheduled wake).
+        main_name = self._registry.get_main_agent()
+        if main_name:
+            main_agent = self._registry.get(main_name)
+            if main_agent and main_agent.enabled:
+                await self._autonomy.start_agent_loop(main_name)
+                _log(f"daemon: started main agent autonomy loop ({main_name})")
+            else:
+                _log(f"daemon: warn — main agent '{main_name}' missing or disabled")
+        else:
+            _log("daemon: warn — no main agent configured; no autonomy loop started")
 
         # Start platform pollers
         if self._config.telegram_token:

--- a/tests/test_admin_update.py
+++ b/tests/test_admin_update.py
@@ -308,11 +308,18 @@ class TestAdminUpdateForceDepsIntegration:
         assert len(gm.pip_calls) == 1
 
     def test_no_force_deps_skips_pip_when_pyproject_unchanged(self):
-        """Default behavior: don't reinstall when pyproject.toml didn't change."""
+        """Default behavior: don't reinstall when pyproject.toml didn't change.
+
+        The drift detector is also a reinstall trigger (see
+        TestInstalledDepsDriftDetection) so we patch it to report no drift —
+        this test pins the pyproject-diff axis specifically.
+        """
         gm = _GitMock(dirty_files=[])
         wrapped = self._track_pip_calls(gm)
         with (
             patch("subprocess.check_output", side_effect=wrapped),
+            patch("pinky_daemon.api._check_installed_deps_drift",
+                  return_value=[]),
             patch("shutil.which", return_value=None),
             patch("os.kill"),
         ):
@@ -347,3 +354,223 @@ class TestAdminUpdateForceDepsIntegration:
         assert body.get("deps_rebuilt") is False
         assert body.get("deps_error")
         assert "pip install failed" in body["deps_error"]
+
+
+class TestInstalledDepsDriftDetection:
+    """Direct unit tests for `_check_installed_deps_drift`.
+
+    The helper compares installed package versions to pyproject.toml pins to
+    catch the "pyproject bumped earlier, routine restart skipped reinstall"
+    case that previously needed manual force_deps=True.
+    """
+
+    def _write_pyproject(self, tmp_dir: str, deps: list[str],
+                        optional: dict | None = None) -> None:
+        from pathlib import Path
+        # TOML literal strings (single-quoted) — no escape processing,
+        # so embedded double quotes (env markers like `platform_system == "x"`)
+        # don't need escaping.
+        content = "[project]\nname = 'test'\nversion = '0.0.0'\ndependencies = [\n"
+        for d in deps:
+            content += f"  '{d}',\n"
+        content += "]\n"
+        if optional:
+            content += "\n[project.optional-dependencies]\n"
+            for group, group_deps in optional.items():
+                content += f"{group} = [\n"
+                for d in group_deps:
+                    content += f"  '{d}',\n"
+                content += "]\n"
+        (Path(tmp_dir) / "pyproject.toml").write_text(content)
+
+    def test_empty_drift_when_all_pins_satisfied(self):
+        """A pyproject that depends only on packages whose installed versions
+        satisfy the pins returns an empty list."""
+        from pinky_daemon.api import _check_installed_deps_drift
+
+        # `pytest` must be installed (we're literally running under it),
+        # so any-version pin should be satisfied.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_pyproject(tmp, ["pytest"])
+            drifts = _check_installed_deps_drift(tmp)
+        assert drifts == []
+
+    def test_pin_higher_than_installed_yields_drift_entry(self):
+        """When pyproject pins a version above what's installed, that package
+        shows up in the drift list with the installed version recorded."""
+        from importlib.metadata import version as _v
+
+        from pinky_daemon.api import _check_installed_deps_drift
+
+        installed = _v("pytest")
+        # Construct a pin that the installed version cannot satisfy.
+        # Bump major+1 to keep things robust against future pytest releases.
+        major = int(installed.split(".")[0]) + 1
+        unsatisfiable_pin = f"pytest>={major}.0.0"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_pyproject(tmp, [unsatisfiable_pin])
+            drifts = _check_installed_deps_drift(tmp)
+
+        assert len(drifts) == 1
+        entry = drifts[0]
+        assert entry["package"] == "pytest"
+        assert entry["installed"] == installed
+        assert str(major) in entry["specifier"]
+
+    def test_missing_package_records_installed_none(self):
+        """A pyproject dep that isn't installed at all shows up with
+        installed=None — distinct from a version mismatch."""
+        from pinky_daemon.api import _check_installed_deps_drift
+
+        ghost_pkg = "definitely-not-a-real-package-9b3c"
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_pyproject(tmp, [ghost_pkg])
+            drifts = _check_installed_deps_drift(tmp)
+
+        assert len(drifts) == 1
+        assert drifts[0]["package"] == ghost_pkg
+        assert drifts[0]["installed"] is None
+
+    def test_optional_dependencies_are_inspected(self):
+        """Drift in `project.optional-dependencies` groups is reported just
+        like core dependencies — keeps `pip install -e .[all]` honest."""
+        from pinky_daemon.api import _check_installed_deps_drift
+
+        ghost_pkg = "definitely-not-a-real-package-opt-7a2d"
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_pyproject(
+                tmp, deps=["pytest"], optional={"extra": [ghost_pkg]}
+            )
+            drifts = _check_installed_deps_drift(tmp)
+
+        ghost_entries = [d for d in drifts if d["package"] == ghost_pkg]
+        assert len(ghost_entries) == 1
+        assert ghost_entries[0]["installed"] is None
+
+    def test_markers_excluding_current_env_are_skipped(self):
+        """Deps with environment markers that don't match the current
+        interpreter must be skipped — otherwise a Windows-only pin would
+        spuriously fire on macOS."""
+        from pinky_daemon.api import _check_installed_deps_drift
+
+        # platform_system="DefinitelyNotARealOS" never matches — package
+        # should be skipped, not reported as missing.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_pyproject(
+                tmp,
+                ['ghost-pkg-marker-3f01 ; platform_system == "DefinitelyNotARealOS"'],
+            )
+            drifts = _check_installed_deps_drift(tmp)
+
+        assert drifts == []
+
+    def test_unparseable_dependency_is_skipped_silently(self):
+        """A malformed line in pyproject must not crash the whole check;
+        unparseable entries are silently skipped so well-formed deps still
+        get inspected."""
+        from pinky_daemon.api import _check_installed_deps_drift
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # First line is junk, second is a real (satisfied) pin.
+            self._write_pyproject(tmp, ["===not a requirement===", "pytest"])
+            drifts = _check_installed_deps_drift(tmp)
+        assert drifts == []
+
+    def test_drift_triggers_reinstall_in_admin_update(self):
+        """When the drift check reports any entry, admin_update kicks off
+        pip install even if pyproject.toml didn't change in this pull and
+        force_deps=False."""
+        gm = _GitMock(dirty_files=[], before_hash="same1", after_hash="same1")
+
+        fake_drift = [{
+            "package": "claude-agent-sdk",
+            "specifier": ">=0.1.77",
+            "installed": "0.1.68",
+        }]
+
+        pip_calls: list[list[str]] = []
+
+        def record_subprocess(cmd, **kwargs):
+            cmd_list = list(cmd)
+            is_pip = (
+                "install" in cmd_list
+                and (cmd_list[0].endswith("/pip") or cmd_list[0] == "pip"
+                     or "pip" in cmd_list)
+            )
+            if is_pip:
+                pip_calls.append(cmd_list)
+                return b""
+            return gm(cmd, **kwargs)
+
+        with (
+            patch("subprocess.check_output", side_effect=record_subprocess),
+            patch("pinky_daemon.api._check_installed_deps_drift",
+                  return_value=fake_drift),
+            patch("shutil.which", return_value=None),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=beta")
+        body = r.json()
+        assert body.get("deps_rebuilt") is True
+        assert body.get("deps_drift") == fake_drift
+        assert pip_calls, "drift should have triggered pip install"
+
+    def test_no_drift_no_diff_no_force_means_no_reinstall(self):
+        """The drift signal is additive — when there's no drift AND no
+        pyproject change AND no force_deps, pip is not invoked."""
+        gm = _GitMock(dirty_files=[], before_hash="same1", after_hash="same1")
+
+        pip_calls: list[list[str]] = []
+
+        def record_subprocess(cmd, **kwargs):
+            cmd_list = list(cmd)
+            is_pip = (
+                "install" in cmd_list
+                and (cmd_list[0].endswith("/pip") or cmd_list[0] == "pip"
+                     or "pip" in cmd_list)
+            )
+            if is_pip:
+                pip_calls.append(cmd_list)
+                return b""
+            return gm(cmd, **kwargs)
+
+        with (
+            patch("subprocess.check_output", side_effect=record_subprocess),
+            patch("pinky_daemon.api._check_installed_deps_drift",
+                  return_value=[]),
+            patch("shutil.which", return_value=None),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=beta")
+        body = r.json()
+        assert body.get("deps_rebuilt") is False
+        assert body.get("deps_drift") == []
+        assert pip_calls == []
+
+    def test_drift_check_failure_is_non_fatal(self):
+        """If the drift check itself raises (e.g. pyproject parse fails),
+        admin_update keeps going — drift just can't contribute to the
+        reinstall decision."""
+        gm = _GitMock(dirty_files=[], before_hash="same1", after_hash="same1")
+
+        def boom(_repo_dir):
+            raise RuntimeError("simulated drift-check failure")
+
+        with (
+            patch("subprocess.check_output", side_effect=gm),
+            patch("pinky_daemon.api._check_installed_deps_drift",
+                  side_effect=boom),
+            patch("shutil.which", return_value=None),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=beta")
+        assert r.status_code == 200
+        body = r.json()
+        # No reinstall (no drift, no diff, no force), and the failure didn't
+        # propagate as a 500.
+        assert body.get("updated") is True
+        assert body.get("deps_drift") == []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -905,6 +905,10 @@ class TestAPI:
             app1 = self._make_app(db_path)
             with TestClient(app1) as client1:
                 client1.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                # Boot policy (2026-05-11): only the main agent auto-resumes
+                # its streaming session on restart. Mark this agent as main so
+                # the cross-boot restore behavior under test still applies.
+                app1.state.agents.set_main_agent("test-agent")
                 resp = client1.post("/agents/test-agent/streaming-sessions?label=worker")
                 assert resp.status_code == 200
                 assert app1.state.agents.get_streaming_session_id("test-agent", label="worker") == "test-agent-sdk"

--- a/tests/test_autonomy.py
+++ b/tests/test_autonomy.py
@@ -1,0 +1,156 @@
+"""Tests for AutonomyEngine push_event wake gating.
+
+Boot policy (2026-05-11): only the main agent's autonomy loop starts at boot.
+Sibling agents wake on demand the first time `push_event` routes an event to
+them. These tests pin the wake gate — it must depend only on `enabled`, not
+the legacy `auto_start` flag (which used to gate wake too and would strand
+siblings under the new boot policy).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.autonomy import AgentEvent, AutonomyEngine, EventType
+from pinky_daemon.conversation_store import ConversationStore
+from pinky_daemon.task_store import TaskStore
+
+
+@pytest.fixture
+def stores():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    reg = AgentRegistry(db_path=path)
+    tasks = TaskStore(db_path=path)
+    convos = ConversationStore(db_path=path)
+    yield reg, tasks, convos
+    reg.close()
+    os.unlink(path)
+
+
+def _build_engine(registry, tasks, convos):
+    # session_sender is unused for push_event wake tests; the loop, once
+    # started, will block on its event queue waiting for more work.
+    return AutonomyEngine(
+        registry,
+        tasks,
+        convos,
+        session_sender=None,
+        idle_check_interval=3600,  # don't fire idle exit during the test
+    )
+
+
+class TestPushEventWakeGate:
+    """The wake gate in `push_event` decides whether an inbound event should
+    spin up an agent's autonomy loop. Under the post-2026-05-11 boot policy
+    siblings start out without a loop, so this gate is the on-demand wake
+    path. It must remain permissive for enabled agents and refuse disabled ones.
+    """
+
+    @pytest.mark.asyncio
+    async def test_enabled_non_auto_start_agent_wakes_on_event(self, stores):
+        registry, tasks, convos = stores
+        # Critical: auto_start=False (sibling default under the new policy)
+        registry.register("murzik", model="opus", auto_start=False, enabled=True)
+        engine = _build_engine(registry, tasks, convos)
+        await engine.start()
+        try:
+            assert "murzik" not in engine._running_loops
+
+            await engine.push_event(AgentEvent(
+                type=EventType.message_received,
+                agent_name="murzik",
+            ))
+
+            # Loop should be started despite auto_start=False
+            assert "murzik" in engine._running_loops
+        finally:
+            await engine.stop()
+
+    @pytest.mark.asyncio
+    async def test_disabled_agent_does_not_wake_on_event(self, stores):
+        registry, tasks, convos = stores
+        registry.register("retired", model="opus", auto_start=True, enabled=False)
+        engine = _build_engine(registry, tasks, convos)
+        await engine.start()
+        try:
+            await engine.push_event(AgentEvent(
+                type=EventType.manual_wake,
+                agent_name="retired",
+            ))
+
+            # Disabled agent must NOT have its loop started, even with auto_start=True
+            assert "retired" not in engine._running_loops
+        finally:
+            await engine.stop()
+
+    @pytest.mark.asyncio
+    async def test_event_for_unknown_agent_does_not_wake(self, stores):
+        registry, tasks, convos = stores
+        engine = _build_engine(registry, tasks, convos)
+        await engine.start()
+        try:
+            await engine.push_event(AgentEvent(
+                type=EventType.schedule_wake,
+                agent_name="ghost",
+            ))
+
+            assert "ghost" not in engine._running_loops
+        finally:
+            await engine.stop()
+
+    @pytest.mark.asyncio
+    async def test_running_loop_is_not_double_started(self, stores):
+        registry, tasks, convos = stores
+        registry.register("barsik", model="opus", auto_start=True, enabled=True)
+        engine = _build_engine(registry, tasks, convos)
+        await engine.start()
+        try:
+            await engine.start_agent_loop("barsik")
+            first_task = engine._running_loops["barsik"]
+
+            await engine.push_event(AgentEvent(
+                type=EventType.message_received,
+                agent_name="barsik",
+            ))
+
+            # Same task object — no replacement
+            assert engine._running_loops["barsik"] is first_task
+        finally:
+            await engine.stop()
+
+    @pytest.mark.asyncio
+    async def test_event_is_queued_even_when_wake_blocked(self, stores):
+        """A disabled agent shouldn't have its loop started, but events still
+        land on the queue. If the agent is later re-enabled and its loop is
+        started manually, the queued event is available — push_event never
+        drops the message itself.
+        """
+        registry, tasks, convos = stores
+        registry.register("retired", model="opus", auto_start=False, enabled=False)
+        engine = _build_engine(registry, tasks, convos)
+        await engine.start()
+        try:
+            ev = AgentEvent(
+                type=EventType.message_received,
+                agent_name="retired",
+                data={"text": "hello"},
+            )
+            await engine.push_event(ev)
+
+            assert "retired" not in engine._running_loops
+            # Queue exists and has the event ready to pop
+            engine._event_queue.ensure_queue("retired")
+            popped = await asyncio.wait_for(
+                engine._event_queue.pop("retired", timeout=0.5),
+                timeout=1.0,
+            )
+            assert popped is not None
+            assert popped.data == {"text": "hello"}
+        finally:
+            await engine.stop()

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -1987,7 +1987,7 @@ CORE_TOOLS = {
     "claim_task", "complete_task", "context_restart", "context_status",
     "create_task", "get_next_task", "get_owner_profile",
     "list_agents", "list_my_skills", "load_my_context",
-    "load_skill", "request_sleep", "save_my_context",
+    "load_skill", "mesh_remote_send", "request_sleep", "save_my_context",
     "search_history", "send_file_to_agent", "send_heartbeat",
     "send_to_agent", "set_thinking_effort", "who_am_i",
 }
@@ -2040,13 +2040,13 @@ class TestKbUrlEncoding:
 
 
 class TestToolGates:
-    def test_core_only_has_23_tools(self):
+    def test_core_only_has_24_tools(self):
         """No gates → only core tools registered."""
         srv = create_server(agent_name="test", tool_gates=[])
         tools = {t.name for t in srv._tool_manager.list_tools()}
         assert tools == CORE_TOOLS
 
-    def test_all_gates_has_68_tools(self):
+    def test_all_gates_has_69_tools(self):
         """All gates → full tool set."""
         all_gates = [
             "extras", "kb", "research", "presentations", "triggers",
@@ -2054,7 +2054,7 @@ class TestToolGates:
         ]
         srv = create_server(agent_name="test", tool_gates=all_gates)
         tools = srv._tool_manager.list_tools()
-        assert len(tools) == 68
+        assert len(tools) == 69
 
     def test_extras_gate_adds_extras_tools(self):
         """Enabling 'extras' gate adds get_attribution, render_pdf, etc."""


### PR DESCRIPTION
## Summary

Two related changes from today's restart cycle pain (see also PR #431):

1. **Boot policy** — only the main agent's streaming session and autonomy loop start at daemon boot. Sibling agents stay dormant until something triggers them: inbound message, agent-to-agent message, or a scheduled wake. Resources spent on demand. Main agent decides when siblings are needed.

2. **Auto-deps drift detection** — `admin_update` now compares installed package versions to `pyproject.toml` pins independently of `git diff`, so the "pyproject bumped on an earlier pull whose routine restart skipped reinstall" case self-heals on the next routine restart. The manual `force_deps=True` escape hatch remains for cases drift can't see (corrupt install, etc.).

## Why

Today's `force_deps=True` incident exposed how much state gets restored on every restart cycle. Multiple agents resurrecting in parallel can interact in pathological ways (cf. murzik resurrection loop in PR #431). Brad's call after the incident: *"only main agent on start; you decide the rest."* Cleaner failure mode, less resource churn, simpler debugging.

The deps-drift problem was even more concrete: `claude-agent-sdk` pin was bumped to `>=0.1.77` days ago but the installed venv stayed at `0.1.68` because no subsequent routine restart's pyproject diff touched that pin. `force_deps=True` was the manual fix. Drift detection makes that automatic.

## Changes

**`src/pinky_daemon/api.py`**
- Startup: only the main agent gets a streaming session resumed AND an autonomy loop started. Drop the `auto_start_agents` loop, `agent.heartbeat_interval > 0` trigger, and `has_persisted` branch for sibling sessions. Sibling sessions are created lazily via `_ensure_streaming_session` on first dispatch.
- `admin_update`: new `_check_installed_deps_drift()` helper parses `pyproject.toml` and reports packages whose installed version fails the pin (or are missing). Drift entries become a third trigger for `pip install`, alongside the pyproject diff and `force_deps=True`. Response now includes `deps_drift` field. Drift-check failures are non-fatal — other reinstall triggers still work.

**`src/pinky_daemon/daemon.py`**
- Mirror the startup policy: only start the main agent's autonomy loop. Sibling loops start lazily via `autonomy.push_event`.

**`src/pinky_daemon/autonomy.py`**
- `push_event` wake gate now checks `agent.enabled` only, not `agent.auto_start`. Gating wake on `auto_start` would have stranded siblings unable to receive messages under the new boot policy.

## Test plan

- [x] `pytest tests/test_admin_update.py tests/test_autonomy.py -q` → **25 passed** (new tests)
- [x] `pytest tests/test_admin_update.py tests/test_autonomy.py tests/test_scheduler.py tests/test_api.py tests/test_codex_session.py -q` → **367 passed**
- [x] `ruff check` on all touched files → clean

**New tests (`tests/test_autonomy.py`):**
- enabled non-auto-start agent wakes on event
- disabled agent does NOT wake even with `auto_start=True`
- event for unknown agent is no-op
- already-running loop is not double-started
- events for blocked-wake agents are still queued (no message drops)

**New tests (`tests/test_admin_update.py` — `TestInstalledDepsDriftDetection`):**
- empty drift when all pyproject pins satisfied
- pin higher than installed → drift entry with installed version
- missing package → drift entry with `installed=None`
- optional-dependencies inspected (not just core deps)
- environment markers respected (Windows-only deps skipped on macOS)
- unparseable deps skipped silently (no crash)
- drift entry triggers `pip install` in `admin_update`
- empty drift + clean diff + no force = no reinstall
- drift-check raise is non-fatal (admin_update keeps going)

**Updated test:** `test_manual_streaming_session_persists_and_restores_labels` — marks its test agent as the main agent so the boot-time restore behavior under test still applies.

## Notes

- The legacy `agent.auto_start` flag is preserved for compatibility (`/admin/auto-start` endpoint still reports it) but no longer gates anything. Removing it entirely is a future cleanup.
- This is PR A of a two-part series. PR B (status stream for `update_and_restart` visibility) follows; design doc at `docs/plans/task-84-update-and-restart-improvements.md` (gitignored, kept locally).

🤖 Opened by Barsik