### PR TITLE
chore: drop beta channel — trunk-based only (#450)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, beta]
+    branches: [main]
   pull_request:
-    branches: [main, beta]
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, beta]
+    branches: [main]
   pull_request:
-    branches: [main, beta]
+    branches: [main]
   schedule:
     # Weekly — Monday 08:00 UTC (Monday 01:00 PDT / 00:00 PST)
     - cron: "0 8 * * 1"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     tags: ["26.*"]
   pull_request:
-    branches: [main, beta]
+    branches: [main]
     paths:
       - "Dockerfile"
       - ".dockerignore"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release
+
+# Cut a tagged release. Trunk-based since #450 — production hosts pull from
+# the latest tag, not main HEAD. Manual on purpose: every prod-bound release
+# is an explicit decision (no auto-promote on green main).
+#
+# Usage: GitHub Actions → "Release" → "Run workflow" → pick branch (main only)
+# + version (e.g. 26.05.071 — calver YY.MM.NNN, sequential per month).
+#
+# The Docker workflow (docker-publish.yml) is already wired to tags matching
+# `26.*` and tags this as :latest — production update_and_restart then picks
+# up the new tag on the next call.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version tag (e.g. 26.05.071 — calver YY.MM.NNN, no v prefix)'
+        required: true
+        type: string
+      release_notes:
+        description: 'Custom release notes (optional — auto-generated from commits if empty)'
+        required: false
+        type: string
+
+permissions:
+  contents: write  # create tags + releases
+
+jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Check version format + branch
+        id: check
+        run: |
+          version="${{ inputs.version }}"
+          if [[ ! "$version" =~ ^[0-9]{2}\.[0-9]{2}\.[0-9]{2,3}$ ]]; then
+            echo "::error::Version must be calver YY.MM.NNN (e.g. 26.05.071), got: $version"
+            exit 1
+          fi
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "::error::Releases can only be cut from main (got: ${{ github.ref }})"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Tag + publish release
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history so git log can find prior tag
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Verify tag doesn't exist
+        run: |
+          if git rev-parse "${{ needs.validate.outputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ needs.validate.outputs.version }} already exists"
+            exit 1
+          fi
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          version="${{ needs.validate.outputs.version }}"
+          custom_notes="${{ inputs.release_notes }}"
+          prior_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          {
+            echo "## Release $version"
+            echo
+            if [ -n "$custom_notes" ]; then
+              echo "$custom_notes"
+              echo
+            fi
+            echo "### Changes"
+            if [ -n "$prior_tag" ]; then
+              git log "$prior_tag..HEAD" --pretty='- %s (%h)' --no-merges
+            else
+              echo "- Initial tagged release"
+            fi
+            echo
+            echo "### Deploy"
+            echo "Production hosts running \`PINKYBOT_CHANNEL=stable\` (the only channel) will pull this tag on the next \`update_and_restart\`."
+          } > /tmp/notes.md
+
+          # Multiline output via heredoc
+          {
+            echo 'body<<NOTES_EOF'
+            cat /tmp/notes.md
+            echo NOTES_EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create annotated tag
+        run: |
+          version="${{ needs.validate.outputs.version }}"
+          git tag -a "$version" -m "Release $version"
+          git push origin "$version"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.validate.outputs.version }}
+          name: ${{ needs.validate.outputs.version }}
+          body: ${{ steps.notes.outputs.body }}
+          draft: false
+          prerelease: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ pytest
 ## Deploy
 
 - Production on Mac Mini (`oleg@10.0.0.209`)
-- Self-update: agents call `update_and_restart()` (pinky-self MCP) — pulls the branch matching `PINKYBOT_CHANNEL` env (`stable`→`main`, `beta`→`beta`) and restarts the daemon
+- Self-update: agents call `update_and_restart()` (pinky-self MCP) — pulls the latest GitHub Release tag from `main` and restarts the daemon. Trunk-based since #450; only `PINKYBOT_CHANNEL=stable` is supported.
+- Releases are cut manually via the `Release` workflow (Actions → Release → Run workflow → version `YY.MM.NNN`). Production picks up new tags on the next `update_and_restart()`.
 - CI auto-runs on push (`ci.yml`); `main` is branch-protected and requires passing CI + PR review
 - Agent data in `data/agents/{name}/` (gitignored)

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7183,23 +7183,44 @@ def create_api(
         }
 
     # ── Admin: Release Channel ────────────────────────────
+    #
+    # Trunk-based since 26.05.070 (#450). The only channel is "stable" —
+    # production hosts pull the latest GitHub Release tag from main.
+    # PINKYBOT_CHANNEL is retained as an env var for back-compat, but the
+    # only accepted value is "stable"; anything else is logged and coerced.
 
     @app.get("/admin/channel")
     async def get_release_channel():
-        """Return the current release channel."""
-        channel = os.environ.get("PINKYBOT_CHANNEL", "stable")
-        branch = "beta" if channel == "beta" else "main"
-        return {"channel": channel, "branch": branch}
+        """Return the current release channel.
+
+        Always reports "stable" / "main" — there is no other channel.
+        Legacy PINKYBOT_CHANNEL=beta is silently coerced to stable.
+        """
+        raw = os.environ.get("PINKYBOT_CHANNEL", "stable")
+        if raw != "stable":
+            _log(
+                f"admin: PINKYBOT_CHANNEL={raw!r} is deprecated; "
+                "trunk-based since #450 — treating as 'stable'"
+            )
+        return {"channel": "stable", "branch": "main"}
 
     @app.post("/admin/channel")
     async def set_release_channel(channel: str = "stable"):
-        """Switch release channel (stable or beta).
+        """Set the release channel — only "stable" is accepted.
+
+        Trunk-based since #450: the beta channel was removed. This endpoint
+        is preserved so legacy clients/UIs don't 404, but anything other
+        than "stable" returns 400.
 
         Persists to .env file and updates the running env var.
-        Does NOT restart — call /admin/update after to pull the new branch.
+        Does NOT restart — call /admin/update after to refresh.
         """
-        if channel not in ("stable", "beta"):
-            raise HTTPException(400, "Channel must be 'stable' or 'beta'")
+        if channel != "stable":
+            raise HTTPException(
+                400,
+                "Only 'stable' is supported. The beta channel was removed in "
+                "the trunk-based migration (#450).",
+            )
 
         os.environ["PINKYBOT_CHANNEL"] = channel
 
@@ -7218,9 +7239,8 @@ def create_api(
             lines.append(f"PINKYBOT_CHANNEL={channel}")
         env_path.write_text("\n".join(lines) + "\n")
 
-        branch = "beta" if channel == "beta" else "main"
-        _log(f"admin: release channel set to {channel} (branch={branch})")
-        return {"channel": channel, "branch": branch}
+        _log(f"admin: release channel set to {channel} (branch=main)")
+        return {"channel": "stable", "branch": "main"}
 
     # ── Admin: Update & Restart ───────────────────────────
 
@@ -7236,10 +7256,11 @@ def create_api(
         The process manager (launchctl/systemd) must be installed for
         auto-restart. Without it, the daemon will stop and stay stopped.
 
-        Stable channel: updates to the latest GitHub Release tag.
-        Beta channel: pulls HEAD of the beta branch.
-        Branch defaults to PINKYBOT_CHANNEL env var ("stable" -> release tags,
-        "beta" -> beta branch), falling back to "stable" if unset.
+        Trunk-based since #450: production always updates to the latest
+        GitHub Release tag on main. The branch arg is preserved for
+        compatibility but only "main" (or empty, which defaults to main)
+        is accepted. branch="beta" returns 400 — the beta channel was
+        removed in the trunk-based migration.
 
         force=True discards local modifications to TRACKED files
         (`git checkout -- .`) before pulling, to recover from a dirty working
@@ -7255,11 +7276,23 @@ def create_api(
         import subprocess as sp
         import sys
 
-        if not branch:
-            channel = os.environ.get("PINKYBOT_CHANNEL", "stable")
-            branch = "beta" if channel == "beta" else "main"
+        if branch and branch != "main":
+            raise HTTPException(
+                400,
+                f"Only branch='main' is supported (got {branch!r}). The beta "
+                "channel was removed in the trunk-based migration (#450).",
+            )
 
-        use_release_tags = branch == "main"
+        # Legacy env back-compat: PINKYBOT_CHANNEL=beta → log + treat as stable.
+        raw_channel = os.environ.get("PINKYBOT_CHANNEL", "stable")
+        if raw_channel != "stable":
+            _log(
+                f"admin: PINKYBOT_CHANNEL={raw_channel!r} is deprecated; "
+                "trunk-based since #450 — treating as 'stable'"
+            )
+
+        branch = "main"
+        use_release_tags = True
         repo_dir = str(Path(__file__).resolve().parent.parent.parent)
 
         # Current state
@@ -7289,7 +7322,7 @@ def create_api(
         except sp.CalledProcessError as e:
             return {"error": f"git fetch failed: {e.output.decode()[:500]}"}
 
-        # Resolve target — latest release tag for stable, HEAD for beta
+        # Resolve target — always latest release tag on main (trunk-based).
         target_tag = None
         if use_release_tags:
             try:
@@ -7341,7 +7374,7 @@ def create_api(
                 result["latest_release"] = target_tag
             return result
 
-        # Update — always pull branch HEAD (stable=main, beta=beta).
+        # Update — always pull main HEAD; release tags are resolved separately.
         # Ensure we're on the correct branch first (shallow clones may be in detached HEAD).
         try:
             current_branch = sp.check_output(

--- a/tests/test_admin_update.py
+++ b/tests/test_admin_update.py
@@ -30,7 +30,7 @@ class _GitMock:
         dirty_files: list[str] | None = None,
         before_hash: str = "abc1234",
         after_hash: str = "def5678",
-        branch: str = "beta",
+        branch: str = "main",
     ):
         self.calls: list[list[str]] = []
         self.dirty_files = dirty_files or []
@@ -119,7 +119,7 @@ class TestAdminUpdateForce:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta")
+            r = client.post("/admin/update?branch=main")
         assert r.status_code == 200
         body = r.json()
         assert body.get("updated") is True
@@ -138,7 +138,7 @@ class TestAdminUpdateForce:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta&force=true")
+            r = client.post("/admin/update?branch=main&force=true")
         assert r.status_code == 200
         body = r.json()
         assert body.get("forced_reset") is True
@@ -163,7 +163,7 @@ class TestAdminUpdateForce:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta&force=true")
+            r = client.post("/admin/update?branch=main&force=true")
         assert r.status_code == 200
         body = r.json()
         assert body.get("forced_reset") is False
@@ -180,7 +180,7 @@ class TestAdminUpdateForce:
             patch("os.kill"),
         ):
             client = _make_client()
-            client.post("/admin/update?branch=beta&force=true")
+            client.post("/admin/update?branch=main&force=true")
         assert not gm.did_clean(), "force must not delete untracked files"
 
     def test_force_ignored_in_dry_run(self):
@@ -191,7 +191,7 @@ class TestAdminUpdateForce:
             patch("shutil.which", return_value=None),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta&force=true&dry_run=true")
+            r = client.post("/admin/update?branch=main&force=true&dry_run=true")
         assert r.status_code == 200
         body = r.json()
         assert body.get("dry_run") is True
@@ -210,11 +210,11 @@ class TestAdminUpdateBaseline:
             patch("shutil.which", return_value=None),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta&dry_run=true")
+            r = client.post("/admin/update?branch=main&dry_run=true")
         assert r.status_code == 200
         body = r.json()
         assert body.get("dry_run") is True
-        assert body.get("branch") == "beta"
+        assert body.get("branch") == "main"
         # _GitMock returns one canned "feat: example" commit for git log
         assert body.get("pending_commits") == 1
         assert body.get("up_to_date") is False
@@ -234,7 +234,7 @@ class TestAdminUpdateBaseline:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta")
+            r = client.post("/admin/update?branch=main")
         assert r.status_code == 200
         body = r.json()
         assert "error" in body
@@ -278,7 +278,7 @@ class TestAdminUpdateForceDepsIntegration:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta&force_deps=true")
+            r = client.post("/admin/update?branch=main&force_deps=true")
         assert r.status_code == 200
         body = r.json()
         assert body.get("deps_rebuilt") is True
@@ -298,7 +298,7 @@ class TestAdminUpdateForceDepsIntegration:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta&force=true&force_deps=true")
+            r = client.post("/admin/update?branch=main&force=true&force_deps=true")
         assert r.status_code == 200
         body = r.json()
         assert body.get("forced_reset") is True
@@ -324,7 +324,7 @@ class TestAdminUpdateForceDepsIntegration:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta")
+            r = client.post("/admin/update?branch=main")
         body = r.json()
         assert body.get("deps_rebuilt") is False
         assert gm.pip_calls == []
@@ -349,7 +349,7 @@ class TestAdminUpdateForceDepsIntegration:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta&force_deps=true")
+            r = client.post("/admin/update?branch=main&force_deps=true")
         body = r.json()
         assert body.get("deps_rebuilt") is False
         assert body.get("deps_error")
@@ -511,7 +511,7 @@ class TestInstalledDepsDriftDetection:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta")
+            r = client.post("/admin/update?branch=main")
         body = r.json()
         assert body.get("deps_rebuilt") is True
         assert body.get("deps_drift") == fake_drift
@@ -544,7 +544,7 @@ class TestInstalledDepsDriftDetection:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta")
+            r = client.post("/admin/update?branch=main")
         body = r.json()
         assert body.get("deps_rebuilt") is False
         assert body.get("deps_drift") == []
@@ -567,10 +567,84 @@ class TestInstalledDepsDriftDetection:
             patch("os.kill"),
         ):
             client = _make_client()
-            r = client.post("/admin/update?branch=beta")
+            r = client.post("/admin/update?branch=main")
         assert r.status_code == 200
         body = r.json()
         # No reinstall (no drift, no diff, no force), and the failure didn't
         # propagate as a 500.
         assert body.get("updated") is True
         assert body.get("deps_drift") == []
+
+
+class TestTrunkBasedChannel:
+    """The beta channel was removed in the trunk-based migration (#450).
+
+    Only branch=main / channel=stable should be accepted; everything else
+    must 400. Legacy PINKYBOT_CHANNEL=beta is coerced (logged) to stable.
+    """
+
+    def test_admin_update_rejects_beta_branch(self):
+        """branch=beta must 400 — beta channel was removed."""
+        client = _make_client()
+        r = client.post("/admin/update?branch=beta")
+        assert r.status_code == 400
+        assert "beta" in r.json()["detail"].lower() or "main" in r.json()["detail"].lower()
+
+    def test_admin_update_rejects_arbitrary_branch(self):
+        """Only 'main' or empty is accepted."""
+        client = _make_client()
+        r = client.post("/admin/update?branch=feature/foo")
+        assert r.status_code == 400
+
+    def test_admin_update_empty_branch_defaults_to_main(self):
+        """No branch arg → defaults to main (release tags)."""
+        gm = _GitMock(dirty_files=[], branch="main")
+        with (
+            patch("subprocess.check_output", side_effect=gm),
+            patch("shutil.which", return_value=None),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update")
+        assert r.status_code == 200
+        assert gm.did_pull()
+
+    def test_admin_update_coerces_legacy_beta_env(self):
+        """PINKYBOT_CHANNEL=beta env should not crash; coerced to stable."""
+        gm = _GitMock(dirty_files=[], branch="main")
+        with (
+            patch.dict(os.environ, {"PINKYBOT_CHANNEL": "beta"}),
+            patch("subprocess.check_output", side_effect=gm),
+            patch("shutil.which", return_value=None),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update")
+        assert r.status_code == 200
+        # Should still attempt to pull main, not beta
+        pull_calls = [c for c in gm.calls if c[:3] == ["git", "pull", "origin"]]
+        assert pull_calls and pull_calls[0][-1] == "main"
+
+    def test_admin_channel_get_always_returns_stable(self):
+        client = _make_client()
+        r = client.get("/admin/channel")
+        assert r.status_code == 200
+        body = r.json()
+        assert body == {"channel": "stable", "branch": "main"}
+
+    def test_admin_channel_get_coerces_legacy_beta_env(self):
+        with patch.dict(os.environ, {"PINKYBOT_CHANNEL": "beta"}):
+            client = _make_client()
+            r = client.get("/admin/channel")
+        assert r.status_code == 200
+        assert r.json() == {"channel": "stable", "branch": "main"}
+
+    def test_admin_channel_post_rejects_beta(self):
+        client = _make_client()
+        r = client.post("/admin/channel?channel=beta")
+        assert r.status_code == 400
+
+    def test_admin_channel_post_rejects_arbitrary(self):
+        client = _make_client()
+        r = client.post("/admin/channel?channel=edge")
+        assert r.status_code == 400


### PR DESCRIPTION
## Summary

Final cleanup PR for Phase 1 of the trunk-based migration (#450). With beta and main now converged and tag `26.05.070` cut, this PR removes the beta channel from the codebase.

## Changes

**`src/pinky_daemon/api.py`** — channel cleanup
- `GET /admin/channel`: always returns `{channel: "stable", branch: "main"}`. Legacy `PINKYBOT_CHANNEL=beta` env is logged + coerced to stable.
- `POST /admin/channel`: only `"stable"` accepted; other values → 400.
- `POST /admin/update`: rejects `branch=beta` (or any non-main value) with 400. Empty branch defaults to `main`. `use_release_tags` is now unconditionally True — production always pulls the latest release tag.

**`.github/workflows/release.yml`** — NEW manual release workflow
- `workflow_dispatch` with `version` input (calver `YY.MM.NNN`, e.g. `26.05.071`) + optional release notes.
- Validates format + branch (must be main).
- Creates annotated tag, auto-generates release notes from commits since prior tag, publishes GitHub Release.
- Existing `docker-publish.yml` already triggers on `26.*` tags → no change needed there for tag publishing.

**CI workflows** — drop beta branch filters
- `ci.yml`, `codeql.yml`, `docker-publish.yml`: removed `beta` from `branches:` filters (no more beta branch to test).

**`CLAUDE.md`** — Deploy section updated
- Single-channel doc + reference to the manual `Release` workflow.

## Tests

`TestTrunkBasedChannel` class added to `tests/test_admin_update.py`:
- `branch=beta` → 400
- arbitrary branch → 400
- empty branch → defaults to main (release tags)
- `PINKYBOT_CHANNEL=beta` env → coerced to stable, still pulls main
- `GET /admin/channel` always returns stable/main regardless of env
- `POST /admin/channel?channel=beta` → 400

All 28 admin-update tests pass locally (`pytest tests/test_admin_update.py`). Lint clean.

## After merge

- Tag `26.05.070` is already on main (cut earlier from #453 merge).
- Next release: trigger the `Release` workflow with version `26.05.071` (or whatever's next).
- The `beta` branch on GitHub can be archived or deleted at Brad's leisure — nothing in CI references it anymore.
- Production hosts running `PINKYBOT_CHANNEL=stable` (the only channel) keep working transparently. Any host that somehow has `PINKYBOT_CHANNEL=beta` will log a deprecation warning and behave as stable.

## Test plan
- [ ] CI green
- [ ] Verify the Release workflow appears in the Actions tab post-merge (workflow_dispatch only)
- [ ] First post-merge release dry-run: trigger Release workflow with a test version on a feature branch (will fail the "must run from main" guard — expected)

🤖 Opened by Barsik