### PR TITLE
[codex] Add pinky-zoho MCP server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,10 @@ dev = [
 
 [project.scripts]
 pinky = "pinky_cli.__main__:main"
+pinky-zoho = "pinky_zoho.__main__:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/pinky_memory", "src/pinky_outreach", "src/pinky_messaging", "src/pinky_daemon", "src/pinky_cli", "src/pinky_self", "src/pinky_calendar", "src/pinky_hub", "src/pinky_web", "src/pinky_federation"]
+packages = ["src/pinky_memory", "src/pinky_outreach", "src/pinky_messaging", "src/pinky_daemon", "src/pinky_cli", "src/pinky_self", "src/pinky_calendar", "src/pinky_hub", "src/pinky_web", "src/pinky_federation", "src/pinky_zoho"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/pinky_zoho/__init__.py
+++ b/src/pinky_zoho/__init__.py
@@ -1,0 +1,7 @@
+"""Pinky Zoho MCP server."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/pinky_zoho/__main__.py
+++ b/src/pinky_zoho/__main__.py
@@ -1,0 +1,44 @@
+"""Run pinky-zoho MCP server standalone."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from .client import resolve_secret
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Pinky Zoho MCP Server")
+    parser.add_argument(
+        "--agent",
+        default=os.environ.get("PINKY_AGENT_NAME", ""),
+        help="Agent name (or set PINKY_AGENT_NAME env var)",
+    )
+    parser.add_argument(
+        "--api-url",
+        default="",
+        help="Zoho API URL. Falls back to ZOHO_API_URL, then LAN hosts.",
+    )
+    args = parser.parse_args()
+
+    if not args.agent:
+        print("Error: --agent is required", file=sys.stderr)
+        sys.exit(1)
+
+    secret = resolve_secret()
+    if not secret:
+        print("Error: ZOHO_API_SECRET or PINKY_SESSION_SECRET is required", file=sys.stderr)
+        sys.exit(1)
+
+    from .server import create_server
+
+    server = create_server(agent_name=args.agent, api_url=args.api_url, secret=secret)
+    target = args.api_url or os.environ.get("ZOHO_API_URL") or "LAN fallback"
+    print(f"[pinky-zoho] {args.agent} -> {target}", file=sys.stderr)
+    server.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pinky_zoho/client.py
+++ b/src/pinky_zoho/client.py
@@ -1,0 +1,175 @@
+"""HTTP client for the HMAC-authenticated Zoho API server."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from typing import Any
+
+FALLBACK_API_URLS = ("http://10.0.0.32:9100", "http://10.0.0.209:9100")
+
+
+def resolve_secret() -> str:
+    """Return the Zoho API secret from the supported client-side env vars."""
+    return os.environ.get("ZOHO_API_SECRET") or os.environ.get("PINKY_SESSION_SECRET", "")
+
+
+def normalize_path(path: str) -> str:
+    """Return the path portion used by the Zoho server's HMAC verifier."""
+    return path.split("?", 1)[0]
+
+
+def sign_headers(
+    secret: str,
+    agent: str,
+    method: str,
+    path: str,
+    *,
+    timestamp: int | None = None,
+) -> dict[str, str]:
+    """Build signed request headers for the Zoho API server."""
+    ts = int(time.time()) if timestamp is None else int(timestamp)
+    payload = f"{agent}\n{method.upper()}\n{normalize_path(path)}\n{ts}".encode()
+    signature = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return {
+        "x-pinky-agent": agent,
+        "x-pinky-timestamp": str(ts),
+        "x-pinky-signature": signature,
+    }
+
+
+def _coerce_param(value: Any) -> Any:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return value
+
+
+def _clean_params(params: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not params:
+        return {}
+    return {
+        key: _coerce_param(value)
+        for key, value in params.items()
+        if value is not None and value != ""
+    }
+
+
+class ZohoClient:
+    """Small resilient client for the local Zoho API server."""
+
+    def __init__(
+        self,
+        *,
+        agent_name: str,
+        api_url: str = "",
+        secret: str = "",
+        timeout: int = 30,
+    ) -> None:
+        if not agent_name:
+            raise ValueError("agent_name is required")
+        self.agent_name = agent_name
+        self.secret = secret or resolve_secret()
+        self.timeout = timeout
+        self._api_urls = self._resolve_api_urls(api_url)
+        self._active_api_url: str | None = None
+
+    @property
+    def active_api_url(self) -> str:
+        return self._active_api_url or self._api_urls[0]
+
+    @staticmethod
+    def _resolve_api_urls(api_url: str) -> list[str]:
+        configured = api_url or os.environ.get("ZOHO_API_URL", "")
+        if configured:
+            return [configured.rstrip("/")]
+        return [url.rstrip("/") for url in FALLBACK_API_URLS]
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        body: Mapping[str, Any] | list[Any] | None = None,
+    ) -> dict[str, Any]:
+        """Call an endpoint and return a JSON-compatible response envelope."""
+        method = method.upper()
+        full_path = self._path_with_query(path, params)
+        data = json.dumps(body).encode() if body is not None else None
+        headers = sign_headers(self.secret, self.agent_name, method, full_path)
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+
+        bases = [self._active_api_url] if self._active_api_url else self._api_urls
+        last_error = ""
+        for base_url in bases:
+            if not base_url:
+                continue
+            url = f"{base_url}{full_path}"
+            req = urllib.request.Request(url, data=data, method=method, headers=headers)
+            try:
+                with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                    self._active_api_url = base_url
+                    return self._read_response(resp)
+            except urllib.error.HTTPError as exc:
+                self._active_api_url = base_url
+                return self._http_error(exc)
+            except (urllib.error.URLError, TimeoutError, OSError) as exc:
+                last_error = self._sanitize(str(exc))
+                continue
+
+        return {"error": last_error or "Zoho API unavailable", "status": 0}
+
+    def get(self, path: str, **params: Any) -> dict[str, Any]:
+        return self.request("GET", path, params=params)
+
+    def post(self, path: str, body: Mapping[str, Any] | list[Any] | None = None) -> dict[str, Any]:
+        return self.request("POST", path, body=body)
+
+    def put(self, path: str, body: Mapping[str, Any] | list[Any] | None = None) -> dict[str, Any]:
+        return self.request("PUT", path, body=body)
+
+    def patch(self, path: str, body: Mapping[str, Any] | list[Any] | None = None) -> dict[str, Any]:
+        return self.request("PATCH", path, body=body)
+
+    @staticmethod
+    def _path_with_query(path: str, params: Mapping[str, Any] | None) -> str:
+        clean = _clean_params(params)
+        if not clean:
+            return path
+        separator = "&" if "?" in path else "?"
+        return f"{path}{separator}{urllib.parse.urlencode(clean, doseq=True)}"
+
+    def _sanitize(self, value: str) -> str:
+        if self.secret:
+            value = value.replace(self.secret, "[redacted]")
+        return value
+
+    def _read_response(self, resp: Any) -> dict[str, Any]:
+        raw = resp.read()
+        if not raw:
+            return {}
+        text = raw.decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return {"text": self._sanitize(text)}
+        return parsed if isinstance(parsed, dict) else {"data": parsed}
+
+    def _http_error(self, exc: urllib.error.HTTPError) -> dict[str, Any]:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            parsed = {"error": self._sanitize(body)}
+        if isinstance(parsed, dict):
+            parsed.setdefault("status", exc.code)
+            return parsed
+        return {"error": self._sanitize(str(parsed)), "status": exc.code}

--- a/src/pinky_zoho/helpers.py
+++ b/src/pinky_zoho/helpers.py
@@ -17,6 +17,10 @@ def _records(response: dict[str, Any]) -> list[dict[str, Any]]:
     return data if isinstance(data, list) else []
 
 
+def _lookup(record_id: str) -> dict[str, str]:
+    return {"id": record_id}
+
+
 class ZohoHelpers:
     """Composite Zoho workflows built on the low-level client."""
 
@@ -46,9 +50,9 @@ class ZohoHelpers:
             "Description": description,
         }
         if contact_id or lead_id:
-            payload["Who_Id"] = contact_id or lead_id
+            payload["Who_Id"] = _lookup(contact_id or lead_id)
         if account_id:
-            payload["What_Id"] = account_id
+            payload["What_Id"] = _lookup(account_id)
             payload["se_module"] = "Accounts"
         elif lead_id:
             payload["se_module"] = "Leads"
@@ -65,7 +69,7 @@ class ZohoHelpers:
         when: str = "",
     ) -> dict[str, Any]:
         payload = {
-            "Who_Id": contact_or_lead_id,
+            "Who_Id": _lookup(contact_or_lead_id),
             "Call_Type": call_type,
             "Subject": subject or f"{call_type} call",
             "Description": description,
@@ -94,9 +98,9 @@ class ZohoHelpers:
             "Description": description,
         }
         if contact_id or lead_id:
-            payload["Who_Id"] = contact_id or lead_id
+            payload["Who_Id"] = _lookup(contact_id or lead_id)
         if account_id:
-            payload["What_Id"] = account_id
+            payload["What_Id"] = _lookup(account_id)
             payload["se_module"] = "Accounts"
         elif lead_id:
             payload["se_module"] = "Leads"

--- a/src/pinky_zoho/helpers.py
+++ b/src/pinky_zoho/helpers.py
@@ -1,0 +1,162 @@
+"""High-level Zoho helper flows exposed as MCP composite tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .client import ZohoClient
+from .schema_cache import SchemaCache
+
+
+def _drop_empty(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if value not in ("", None)}
+
+
+def _records(response: dict[str, Any]) -> list[dict[str, Any]]:
+    data = response.get("data", [])
+    return data if isinstance(data, list) else []
+
+
+class ZohoHelpers:
+    """Composite Zoho workflows built on the low-level client."""
+
+    def __init__(self, client: ZohoClient, schema_cache: SchemaCache) -> None:
+        self.client = client
+        self.schema_cache = schema_cache
+
+    def book_event(
+        self,
+        *,
+        start: str,
+        end: str,
+        title: str,
+        contact_id: str = "",
+        account_id: str = "",
+        lead_id: str = "",
+        venue: str = "",
+        meeting_venue: str = "",
+        description: str = "",
+    ) -> dict[str, Any]:
+        payload = {
+            "Event_Title": title,
+            "Start_DateTime": start,
+            "End_DateTime": end,
+            "Venue": venue,
+            "Meeting_Venue__s": meeting_venue or self._default_meeting_venue(),
+            "Description": description,
+        }
+        if contact_id or lead_id:
+            payload["Who_Id"] = contact_id or lead_id
+        if account_id:
+            payload["What_Id"] = account_id
+            payload["se_module"] = "Accounts"
+        elif lead_id:
+            payload["se_module"] = "Leads"
+        return self.client.post("/crm/Events", {"data": _drop_empty(payload)})
+
+    def log_call(
+        self,
+        *,
+        contact_or_lead_id: str,
+        call_type: str = "Outbound",
+        subject: str = "",
+        description: str = "",
+        duration_seconds: int | None = None,
+        when: str = "",
+    ) -> dict[str, Any]:
+        payload = {
+            "Who_Id": contact_or_lead_id,
+            "Call_Type": call_type,
+            "Subject": subject or f"{call_type} call",
+            "Description": description,
+            "Call_Start_Time": when,
+            "Call_Duration": duration_seconds,
+        }
+        return self.client.post("/crm/Calls", {"data": _drop_empty(payload)})
+
+    def create_task(
+        self,
+        *,
+        subject: str,
+        due_date: str = "",
+        contact_id: str = "",
+        account_id: str = "",
+        lead_id: str = "",
+        priority: str = "Normal",
+        status: str = "Not Started",
+        description: str = "",
+    ) -> dict[str, Any]:
+        payload = {
+            "Subject": subject,
+            "Due_Date": due_date,
+            "Priority": priority,
+            "Status": status,
+            "Description": description,
+        }
+        if contact_id or lead_id:
+            payload["Who_Id"] = contact_id or lead_id
+        if account_id:
+            payload["What_Id"] = account_id
+            payload["se_module"] = "Accounts"
+        elif lead_id:
+            payload["se_module"] = "Leads"
+        return self.client.post("/crm/Tasks", {"data": _drop_empty(payload)})
+
+    def find_or_create_lead(
+        self,
+        *,
+        last_name: str,
+        first_name: str = "",
+        company: str = "",
+        phone: str = "",
+        email: str = "",
+    ) -> dict[str, Any]:
+        for params in self._lead_searches(last_name, first_name, phone, email):
+            found = self.client.get("/crm/Leads/search", **params)
+            matches = _records(found)
+            if matches:
+                return {"created": False, "data": matches[0], "search": found}
+
+        payload = {
+            "Last_Name": last_name,
+            "First_Name": first_name,
+            "Company": company or "Unknown",
+            "Phone": phone,
+            "Email": email,
+        }
+        created = self.client.post("/crm/Leads", {"data": _drop_empty(payload)})
+        return {"created": True, "response": created}
+
+    def _lead_searches(
+        self,
+        last_name: str,
+        first_name: str,
+        phone: str,
+        email: str,
+    ) -> list[dict[str, str]]:
+        searches: list[dict[str, str]] = []
+        if phone:
+            searches.append({"phone": phone})
+        if email:
+            searches.append({"email": email})
+        criteria = f"(Last_Name:equals:{last_name})"
+        if first_name:
+            criteria = f"({criteria}and(First_Name:equals:{first_name}))"
+        searches.append({"criteria": criteria})
+        return searches
+
+    def _default_meeting_venue(self) -> str:
+        fields = self.schema_cache.get("Events", lambda module: self.client.get(f"/crm/{module}/fields"))
+        for field in fields.get("fields", []) or fields.get("data", []):
+            if field.get("api_name") != "Meeting_Venue__s":
+                continue
+            values = [
+                item.get("actual_value") or item.get("display_value")
+                for item in field.get("pick_list_values", [])
+                if item.get("actual_value") or item.get("display_value")
+            ]
+            for preferred in ("Phone", "In-office"):
+                if preferred in values:
+                    return preferred
+            return values[0] if values else ""
+        return ""

--- a/src/pinky_zoho/schema_cache.py
+++ b/src/pinky_zoho/schema_cache.py
@@ -1,0 +1,36 @@
+"""Small in-process schema cache for Zoho field metadata."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+
+class SchemaCache:
+    """Cache `/crm/{module}/fields` responses for a bounded TTL."""
+
+    def __init__(self, *, ttl_seconds: int = 3600, time_fn: Callable[[], float] = time.time) -> None:
+        self.ttl_seconds = ttl_seconds
+        self._time_fn = time_fn
+        self._cache: dict[str, tuple[float, dict[str, Any]]] = {}
+
+    def get(self, module: str, fetch: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+        now = self._time_fn()
+        cached = self._cache.get(module)
+        if cached and now - cached[0] < self.ttl_seconds:
+            return cached[1]
+        value = fetch(module)
+        self._cache[module] = (now, value)
+        return value
+
+    def refresh(self, module: str, fetch: Callable[[str], dict[str, Any]]) -> dict[str, Any]:
+        value = fetch(module)
+        self._cache[module] = (self._time_fn(), value)
+        return value
+
+    def clear(self, module: str | None = None) -> None:
+        if module is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(module, None)

--- a/src/pinky_zoho/server.py
+++ b/src/pinky_zoho/server.py
@@ -1,0 +1,658 @@
+"""Pinky Zoho MCP server tools."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from .client import ZohoClient
+from .helpers import ZohoHelpers
+from .schema_cache import SchemaCache
+
+
+def _json(result: dict[str, Any]) -> str:
+    return json.dumps(result)
+
+
+class ZohoToolbox:
+    """Testable implementation behind the MCP function wrappers."""
+
+    def __init__(self, client: ZohoClient, schema_cache: SchemaCache | None = None) -> None:
+        self.client = client
+        self.schema_cache = schema_cache or SchemaCache()
+        self.helpers = ZohoHelpers(client, self.schema_cache)
+
+    def health(self) -> str:
+        return _json(self.client.get("/health"))
+
+    def whoami(self) -> str:
+        return _json(self.client.get("/whoami"))
+
+    def audit(self, module: str = "", operation: str = "", since: str = "", limit: int = 50) -> str:
+        return _json(self.client.get("/audit", module=module, operation=operation, since=since, limit=limit))
+
+    def crm_modules(self) -> str:
+        return _json(self.client.get("/crm/modules"))
+
+    def crm_fields(self, module: str, refresh: bool = False) -> str:
+        def fetch(name: str) -> dict[str, Any]:
+            return self.client.get(f"/crm/{name}/fields")
+
+        result = self.schema_cache.refresh(module, fetch) if refresh else self.schema_cache.get(module, fetch)
+        return _json(result)
+
+    def crm_search(
+        self,
+        module: str,
+        criteria: str = "",
+        word: str = "",
+        email: str = "",
+        phone: str = "",
+        page: int = 1,
+        limit: int = 20,
+        page_token: str = "",
+        all: bool = False,
+        max_records: int = 5000,
+    ) -> str:
+        return _json(self.client.get(
+            f"/crm/{module}/search",
+            criteria=criteria,
+            word=word,
+            email=email,
+            phone=phone,
+            page=page,
+            limit=limit,
+            page_token=page_token,
+            all=all,
+            max_records=max_records,
+        ))
+
+    def crm_get(self, module: str, record_id: str) -> str:
+        return _json(self.client.get(f"/crm/{module}/{record_id}"))
+
+    def crm_list(
+        self,
+        module: str,
+        fields: str = "",
+        sort: str = "",
+        order: str = "desc",
+        page: int = 1,
+        limit: int = 20,
+        criteria: str = "",
+        page_token: str = "",
+        all: bool = False,
+        max_records: int = 5000,
+    ) -> str:
+        return _json(self.client.get(
+            f"/crm/{module}",
+            fields=fields,
+            sort=sort,
+            order=order,
+            page=page,
+            limit=limit,
+            criteria=criteria,
+            page_token=page_token,
+            all=all,
+            max_records=max_records,
+        ))
+
+    def crm_related(
+        self,
+        module: str,
+        record_id: str,
+        related_module: str,
+        fields: str = "",
+        page: int = 1,
+        limit: int = 20,
+    ) -> str:
+        return _json(self.client.get(
+            f"/crm/{module}/{record_id}/related/{related_module}",
+            fields=fields,
+            page=page,
+            limit=limit,
+        ))
+
+    def crm_create(self, module: str, data: dict[str, Any] | list[dict[str, Any]]) -> str:
+        return _json(self.client.post(f"/crm/{module}", {"data": data}))
+
+    def crm_update(self, module: str, record_id: str, data: dict[str, Any] | list[dict[str, Any]]) -> str:
+        return _json(self.client.put(f"/crm/{module}/{record_id}", {"data": data}))
+
+    def crm_add_note(self, module: str, record_id: str, title: str, content: str) -> str:
+        return _json(self.client.post(f"/crm/{module}/{record_id}/notes", {
+            "title": title,
+            "content": content,
+        }))
+
+    def crm_notes(self, module: str, record_id: str) -> str:
+        return _json(self.client.get(f"/crm/{module}/{record_id}/notes"))
+
+    def email_templates(self, module: str = "") -> str:
+        return _json(self.client.get("/email/templates", module=module))
+
+    def email_template(self, template_id: str) -> str:
+        return _json(self.client.get(f"/email/templates/{template_id}"))
+
+    def email_from_addresses(self) -> str:
+        return _json(self.client.get("/email/from-addresses"))
+
+    def crm_send_email(
+        self,
+        module: str,
+        record_id: str,
+        from_email: str,
+        to_email: str,
+        subject: str = "",
+        content: str = "",
+        template_id: str = "",
+    ) -> str:
+        mail: dict[str, Any] = {
+            "from": {"email": from_email},
+            "to": [{"email": to_email}],
+            "subject": subject,
+            "content": content,
+        }
+        if template_id:
+            mail["template"] = {"id": template_id}
+        return _json(self.client.post(f"/crm/{module}/{record_id}/email", {"data": [mail]}))
+
+    def email_approvals(self, state: str = "", limit: int = 20) -> str:
+        return _json(self.client.get("/email/approvals", status=state or "pending", limit=limit))
+
+    def email_approval(self, approval_id: str) -> str:
+        return _json(self.client.get(f"/email/approvals/{approval_id}"))
+
+    def email_approve(self, approval_id: str) -> str:
+        return _json(self.client.post(f"/email/approvals/{approval_id}/approve"))
+
+    def email_reject(self, approval_id: str, reason: str = "") -> str:
+        body = {"reason": reason} if reason else None
+        return _json(self.client.post(f"/email/approvals/{approval_id}/reject", body))
+
+    def desk_tickets(
+        self,
+        status: str = "",
+        sort: str = "-modifiedTime",
+        limit: int = 20,
+        from_index: int = 1,
+        assignee: str = "",
+        department_id: str = "",
+        channel: str = "",
+        priority: str = "",
+        created_time_range: str = "",
+        modified_time_range: str = "",
+        received_in_days: int | None = None,
+        view_id: str = "",
+        include: str = "",
+    ) -> str:
+        return _json(self.client.get(
+            "/desk/tickets",
+            status=status,
+            sort=sort,
+            limit=limit,
+            from_index=from_index,
+            assignee=assignee,
+            department_id=department_id,
+            channel=channel,
+            priority=priority,
+            created_time_range=created_time_range,
+            modified_time_range=modified_time_range,
+            received_in_days=received_in_days,
+            view_id=view_id,
+            include=include,
+        ))
+
+    def desk_agents(self, limit: int = 50, from_index: int = 1) -> str:
+        return _json(self.client.get("/desk/agents", limit=limit, from_index=from_index))
+
+    def desk_views(
+        self,
+        module: str = "tickets",
+        department_id: str = "",
+        limit: int = 50,
+        from_index: int = 1,
+    ) -> str:
+        return _json(self.client.get(
+            "/desk/views",
+            module=module,
+            department_id=department_id,
+            limit=limit,
+            from_index=from_index,
+        ))
+
+    def desk_ticket(self, ticket_id: str) -> str:
+        return _json(self.client.get(f"/desk/tickets/{ticket_id}"))
+
+    def desk_create_ticket(self, data: dict[str, Any]) -> str:
+        return _json(self.client.post("/desk/tickets", data))
+
+    def desk_update_ticket(self, ticket_id: str, data: dict[str, Any]) -> str:
+        return _json(self.client.patch(f"/desk/tickets/{ticket_id}", data))
+
+    def desk_ticket_comments(self, ticket_id: str) -> str:
+        return _json(self.client.get(f"/desk/tickets/{ticket_id}/comments"))
+
+    def desk_add_ticket_comment(self, ticket_id: str, content: str, is_public: bool = False) -> str:
+        return _json(self.client.post(f"/desk/tickets/{ticket_id}/comments", {
+            "content": content,
+            "is_public": is_public,
+        }))
+
+    def desk_search(self, q: str, module: str = "tickets", limit: int = 20, from_index: int = 1) -> str:
+        return _json(self.client.get(
+            "/desk/search",
+            module=module,
+            q=q,
+            limit=limit,
+            from_index=from_index,
+        ))
+
+    def projects(self, status: str = "active", page: int = 1, limit: int = 100) -> str:
+        return _json(self.client.get("/projects", status=status, page=page, limit=limit))
+
+    def project(self, project_id: str) -> str:
+        return _json(self.client.get(f"/projects/{project_id}"))
+
+    def project_tasks(self, project_id: str, page: int = 1, limit: int = 100) -> str:
+        return _json(self.client.get(f"/projects/{project_id}/tasks", page=page, limit=limit))
+
+    def project_task(self, project_id: str, task_id: str) -> str:
+        return _json(self.client.get(f"/projects/{project_id}/tasks/{task_id}"))
+
+    def project_milestones(self, project_id: str) -> str:
+        return _json(self.client.get(f"/projects/{project_id}/milestones"))
+
+    def book_event(
+        self,
+        start: str,
+        end: str,
+        title: str,
+        contact_id: str = "",
+        account_id: str = "",
+        lead_id: str = "",
+        venue: str = "",
+        meeting_venue: str = "",
+        description: str = "",
+    ) -> str:
+        return _json(self.helpers.book_event(
+            start=start,
+            end=end,
+            title=title,
+            contact_id=contact_id,
+            account_id=account_id,
+            lead_id=lead_id,
+            venue=venue,
+            meeting_venue=meeting_venue,
+            description=description,
+        ))
+
+    def log_call(
+        self,
+        contact_or_lead_id: str,
+        call_type: str = "Outbound",
+        subject: str = "",
+        description: str = "",
+        duration_seconds: int | None = None,
+        when: str = "",
+    ) -> str:
+        return _json(self.helpers.log_call(
+            contact_or_lead_id=contact_or_lead_id,
+            call_type=call_type,
+            subject=subject,
+            description=description,
+            duration_seconds=duration_seconds,
+            when=when,
+        ))
+
+    def create_task(
+        self,
+        subject: str,
+        due_date: str = "",
+        contact_id: str = "",
+        account_id: str = "",
+        lead_id: str = "",
+        priority: str = "Normal",
+        status: str = "Not Started",
+        description: str = "",
+    ) -> str:
+        return _json(self.helpers.create_task(
+            subject=subject,
+            due_date=due_date,
+            contact_id=contact_id,
+            account_id=account_id,
+            lead_id=lead_id,
+            priority=priority,
+            status=status,
+            description=description,
+        ))
+
+    def find_or_create_lead(
+        self,
+        last_name: str,
+        first_name: str = "",
+        company: str = "",
+        phone: str = "",
+        email: str = "",
+    ) -> str:
+        return _json(self.helpers.find_or_create_lead(
+            last_name=last_name,
+            first_name=first_name,
+            company=company,
+            phone=phone,
+            email=email,
+        ))
+
+
+def create_server(
+    *,
+    agent_name: str,
+    api_url: str = "",
+    secret: str = "",
+    host: str = "127.0.0.1",
+    port: int = 8108,
+    client: ZohoClient | None = None,
+) -> FastMCP:
+    """Create the pinky-zoho MCP server."""
+    mcp = FastMCP("pinky-zoho", host=host, port=port)
+    toolbox = ZohoToolbox(client or ZohoClient(agent_name=agent_name, api_url=api_url, secret=secret))
+
+    @mcp.tool()
+    def zoho_health() -> str:
+        """Check Zoho API server health."""
+        return toolbox.health()
+
+    @mcp.tool()
+    def zoho_whoami() -> str:
+        """Show the bound agent's Zoho permissions and scoping."""
+        return toolbox.whoami()
+
+    @mcp.tool()
+    def zoho_audit(module: str = "", operation: str = "", since: str = "", limit: int = 50) -> str:
+        """Read this agent's Zoho audit log."""
+        return toolbox.audit(module, operation, since, limit)
+
+    @mcp.tool()
+    def zoho_crm_modules() -> str:
+        """List accessible CRM modules."""
+        return toolbox.crm_modules()
+
+    @mcp.tool()
+    def zoho_crm_fields(module: str, refresh: bool = False) -> str:
+        """Get CRM field metadata for a module, cached in-process for one hour."""
+        return toolbox.crm_fields(module, refresh)
+
+    @mcp.tool()
+    def zoho_crm_search(
+        module: str,
+        criteria: str = "",
+        word: str = "",
+        email: str = "",
+        phone: str = "",
+        page: int = 1,
+        limit: int = 20,
+        page_token: str = "",
+        all: bool = False,
+        max_records: int = 5000,
+    ) -> str:
+        """Search CRM records by criteria, word, email, or phone."""
+        return toolbox.crm_search(module, criteria, word, email, phone, page, limit, page_token, all, max_records)
+
+    @mcp.tool()
+    def zoho_crm_get(module: str, record_id: str) -> str:
+        """Get a single CRM record."""
+        return toolbox.crm_get(module, record_id)
+
+    @mcp.tool()
+    def zoho_crm_list(
+        module: str,
+        fields: str = "",
+        sort: str = "",
+        order: str = "desc",
+        page: int = 1,
+        limit: int = 20,
+        criteria: str = "",
+        page_token: str = "",
+        all: bool = False,
+        max_records: int = 5000,
+    ) -> str:
+        """List CRM records."""
+        return toolbox.crm_list(module, fields, sort, order, page, limit, criteria, page_token, all, max_records)
+
+    @mcp.tool()
+    def zoho_crm_related(
+        module: str,
+        record_id: str,
+        related_module: str,
+        fields: str = "",
+        page: int = 1,
+        limit: int = 20,
+    ) -> str:
+        """List related CRM records."""
+        return toolbox.crm_related(module, record_id, related_module, fields, page, limit)
+
+    @mcp.tool()
+    def zoho_crm_create(module: str, data: dict[str, Any] | list[dict[str, Any]]) -> str:
+        """Create a CRM record."""
+        return toolbox.crm_create(module, data)
+
+    @mcp.tool()
+    def zoho_crm_update(module: str, record_id: str, data: dict[str, Any] | list[dict[str, Any]]) -> str:
+        """Update a CRM record."""
+        return toolbox.crm_update(module, record_id, data)
+
+    @mcp.tool()
+    def zoho_crm_add_note(module: str, record_id: str, title: str, content: str) -> str:
+        """Add a note to a CRM record."""
+        return toolbox.crm_add_note(module, record_id, title, content)
+
+    @mcp.tool()
+    def zoho_crm_notes(module: str, record_id: str) -> str:
+        """List notes on a CRM record."""
+        return toolbox.crm_notes(module, record_id)
+
+    @mcp.tool()
+    def zoho_email_templates(module: str = "") -> str:
+        """List available email templates."""
+        return toolbox.email_templates(module)
+
+    @mcp.tool()
+    def zoho_email_template(template_id: str) -> str:
+        """Get one email template."""
+        return toolbox.email_template(template_id)
+
+    @mcp.tool()
+    def zoho_email_from_addresses() -> str:
+        """List available email sender addresses."""
+        return toolbox.email_from_addresses()
+
+    @mcp.tool()
+    def zoho_crm_send_email(
+        module: str,
+        record_id: str,
+        from_email: str,
+        to_email: str,
+        subject: str = "",
+        content: str = "",
+        template_id: str = "",
+    ) -> str:
+        """Send or queue an email through the Zoho approval gate."""
+        return toolbox.crm_send_email(module, record_id, from_email, to_email, subject, content, template_id)
+
+    @mcp.tool()
+    def zoho_email_approvals(state: str = "", limit: int = 20) -> str:
+        """List email approvals for the bound agent identity."""
+        return toolbox.email_approvals(state, limit)
+
+    @mcp.tool()
+    def zoho_email_approval(approval_id: str) -> str:
+        """Get one email approval."""
+        return toolbox.email_approval(approval_id)
+
+    @mcp.tool()
+    def zoho_email_approve(approval_id: str) -> str:
+        """Approve a pending email."""
+        return toolbox.email_approve(approval_id)
+
+    @mcp.tool()
+    def zoho_email_reject(approval_id: str, reason: str = "") -> str:
+        """Reject a pending email."""
+        return toolbox.email_reject(approval_id, reason)
+
+    @mcp.tool()
+    def zoho_desk_tickets(
+        status: str = "",
+        sort: str = "-modifiedTime",
+        limit: int = 20,
+        from_index: int = 1,
+        assignee: str = "",
+        department_id: str = "",
+        channel: str = "",
+        priority: str = "",
+        created_time_range: str = "",
+        modified_time_range: str = "",
+        received_in_days: int | None = None,
+        view_id: str = "",
+        include: str = "",
+    ) -> str:
+        """List Desk tickets."""
+        return toolbox.desk_tickets(
+            status,
+            sort,
+            limit,
+            from_index,
+            assignee,
+            department_id,
+            channel,
+            priority,
+            created_time_range,
+            modified_time_range,
+            received_in_days,
+            view_id,
+            include,
+        )
+
+    @mcp.tool()
+    def zoho_desk_agents(limit: int = 50, from_index: int = 1) -> str:
+        """List Desk agents."""
+        return toolbox.desk_agents(limit, from_index)
+
+    @mcp.tool()
+    def zoho_desk_views(
+        module: str = "tickets",
+        department_id: str = "",
+        limit: int = 50,
+        from_index: int = 1,
+    ) -> str:
+        """List Desk views."""
+        return toolbox.desk_views(module, department_id, limit, from_index)
+
+    @mcp.tool()
+    def zoho_desk_ticket(ticket_id: str) -> str:
+        """Get a Desk ticket."""
+        return toolbox.desk_ticket(ticket_id)
+
+    @mcp.tool()
+    def zoho_desk_create_ticket(data: dict[str, Any]) -> str:
+        """Create a Desk ticket."""
+        return toolbox.desk_create_ticket(data)
+
+    @mcp.tool()
+    def zoho_desk_update_ticket(ticket_id: str, data: dict[str, Any]) -> str:
+        """Update a Desk ticket."""
+        return toolbox.desk_update_ticket(ticket_id, data)
+
+    @mcp.tool()
+    def zoho_desk_ticket_comments(ticket_id: str) -> str:
+        """List Desk ticket comments."""
+        return toolbox.desk_ticket_comments(ticket_id)
+
+    @mcp.tool()
+    def zoho_desk_add_ticket_comment(ticket_id: str, content: str, is_public: bool = False) -> str:
+        """Add a Desk ticket comment."""
+        return toolbox.desk_add_ticket_comment(ticket_id, content, is_public)
+
+    @mcp.tool()
+    def zoho_desk_search(q: str, module: str = "tickets", limit: int = 20, from_index: int = 1) -> str:
+        """Search Desk records."""
+        return toolbox.desk_search(q, module, limit, from_index)
+
+    @mcp.tool()
+    def zoho_projects(status: str = "active", page: int = 1, limit: int = 100) -> str:
+        """List Zoho Projects projects."""
+        return toolbox.projects(status, page, limit)
+
+    @mcp.tool()
+    def zoho_project(project_id: str) -> str:
+        """Get a Zoho Projects project."""
+        return toolbox.project(project_id)
+
+    @mcp.tool()
+    def zoho_project_tasks(project_id: str, page: int = 1, limit: int = 100) -> str:
+        """List project tasks."""
+        return toolbox.project_tasks(project_id, page, limit)
+
+    @mcp.tool()
+    def zoho_project_task(project_id: str, task_id: str) -> str:
+        """Get one project task."""
+        return toolbox.project_task(project_id, task_id)
+
+    @mcp.tool()
+    def zoho_project_milestones(project_id: str) -> str:
+        """List project milestones."""
+        return toolbox.project_milestones(project_id)
+
+    @mcp.tool()
+    def zoho_book_event(
+        start: str,
+        end: str,
+        title: str,
+        contact_id: str = "",
+        account_id: str = "",
+        lead_id: str = "",
+        venue: str = "",
+        meeting_venue: str = "",
+        description: str = "",
+    ) -> str:
+        """Create an Events record with the common relationship fields filled in."""
+        return toolbox.book_event(start, end, title, contact_id, account_id, lead_id, venue, meeting_venue, description)
+
+    @mcp.tool()
+    def zoho_log_call(
+        contact_or_lead_id: str,
+        call_type: str = "Outbound",
+        subject: str = "",
+        description: str = "",
+        duration_seconds: int | None = None,
+        when: str = "",
+    ) -> str:
+        """Create a Calls record for a contact or lead."""
+        return toolbox.log_call(contact_or_lead_id, call_type, subject, description, duration_seconds, when)
+
+    @mcp.tool()
+    def zoho_create_task(
+        subject: str,
+        due_date: str = "",
+        contact_id: str = "",
+        account_id: str = "",
+        lead_id: str = "",
+        priority: str = "Normal",
+        status: str = "Not Started",
+        description: str = "",
+    ) -> str:
+        """Create a Tasks record with common relationship fields filled in."""
+        return toolbox.create_task(subject, due_date, contact_id, account_id, lead_id, priority, status, description)
+
+    @mcp.tool()
+    def zoho_find_or_create_lead(
+        last_name: str,
+        first_name: str = "",
+        company: str = "",
+        phone: str = "",
+        email: str = "",
+    ) -> str:
+        """Find a lead by phone, email, or name criteria, creating one if no match exists."""
+        return toolbox.find_or_create_lead(last_name, first_name, company, phone, email)
+
+    return mcp

--- a/src/pinky_zoho/server.py
+++ b/src/pinky_zoho/server.py
@@ -158,7 +158,7 @@ class ZohoToolbox:
             mail["template"] = {"id": template_id}
         return _json(self.client.post(f"/crm/{module}/{record_id}/email", {"data": [mail]}))
 
-    def email_approvals(self, state: str = "", limit: int = 20) -> str:
+    def email_approvals(self, state: str = "pending", limit: int = 20) -> str:
         return _json(self.client.get("/email/approvals", status=state or "pending", limit=limit))
 
     def email_approval(self, approval_id: str) -> str:
@@ -481,8 +481,8 @@ def create_server(
         return toolbox.crm_send_email(module, record_id, from_email, to_email, subject, content, template_id)
 
     @mcp.tool()
-    def zoho_email_approvals(state: str = "", limit: int = 20) -> str:
-        """List email approvals for the bound agent identity."""
+    def zoho_email_approvals(state: str = "pending", limit: int = 20) -> str:
+        """List email approvals for the bound agent identity. Defaults to pending approvals."""
         return toolbox.email_approvals(state, limit)
 
     @mcp.tool()

--- a/tests/test_pinky_zoho_client.py
+++ b/tests/test_pinky_zoho_client.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from pinky_zoho.client import ZohoClient
+
+
+class FakeResponse:
+    def __init__(self, body: dict[str, Any] | list[Any] | str = "") -> None:
+        self.body = body
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        if isinstance(self.body, str):
+            return self.body.encode()
+        return json.dumps(self.body).encode()
+
+
+def test_client_falls_back_and_caches_first_working_host(monkeypatch) -> None:
+    seen: list[str] = []
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int) -> FakeResponse:
+        seen.append(req.full_url)
+        if req.full_url.startswith("http://10.0.0.32"):
+            raise urllib.error.URLError("down")
+        return FakeResponse({"ok": True})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client = ZohoClient(agent_name="lera", secret="secret", timeout=1)
+
+    assert client.get("/whoami") == {"ok": True}
+    assert client.get("/health") == {"ok": True}
+    assert seen == [
+        "http://10.0.0.32:9100/whoami",
+        "http://10.0.0.209:9100/whoami",
+        "http://10.0.0.209:9100/health",
+    ]
+
+
+def test_client_uses_api_url_before_env_and_fallback(monkeypatch) -> None:
+    seen: list[str] = []
+    monkeypatch.setenv("ZOHO_API_URL", "http://env-host:9100")
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int) -> FakeResponse:
+        seen.append(req.full_url)
+        return FakeResponse({"ok": True})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client = ZohoClient(agent_name="barsik", api_url="http://cli-host:9100", secret="secret")
+
+    assert client.get("/crm/Contacts", limit=5) == {"ok": True}
+    assert seen == ["http://cli-host:9100/crm/Contacts?limit=5"]
+
+
+def test_client_builds_json_body_query_and_signed_headers(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int) -> FakeResponse:
+        captured["url"] = req.full_url
+        captured["body"] = req.data
+        captured["headers"] = req.headers
+        return FakeResponse({"created": True})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client = ZohoClient(agent_name="sasha", api_url="http://zoho:9100", secret="secret")
+
+    assert client.post("/crm/Tasks", {"data": {"Subject": "Follow up"}}) == {"created": True}
+    assert captured["url"] == "http://zoho:9100/crm/Tasks"
+    assert json.loads(captured["body"]) == {"data": {"Subject": "Follow up"}}
+    headers = {key.lower(): value for key, value in captured["headers"].items()}
+    assert headers["x-pinky-agent"] == "sasha"
+    assert len(headers["x-pinky-signature"]) == 64
+    assert headers["content-type"] == "application/json"
+
+
+def test_client_returns_http_error_envelope_without_secret_leak(monkeypatch) -> None:
+    def fake_urlopen(req: urllib.request.Request, timeout: int) -> FakeResponse:
+        raise urllib.error.HTTPError(
+            req.full_url,
+            403,
+            "Forbidden",
+            {},
+            io.BytesIO(b'{"detail":"denied"}'),
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    client = ZohoClient(agent_name="daria", api_url="http://zoho:9100", secret="top-secret")
+
+    result = client.get("/crm/Deals")
+
+    assert result == {"detail": "denied", "status": 403}
+    assert "top-secret" not in json.dumps(result)
+
+
+def test_client_sanitizes_transport_errors(monkeypatch) -> None:
+    def fake_urlopen(req: urllib.request.Request, timeout: int) -> FakeResponse:
+        raise urllib.error.URLError("top-secret unavailable")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    client = ZohoClient(agent_name="olga", api_url="http://zoho:9100", secret="top-secret")
+
+    result = client.get("/whoami")
+
+    assert result["status"] == 0
+    assert "[redacted]" in result["error"]
+    assert "top-secret" not in result["error"]

--- a/tests/test_pinky_zoho_helpers.py
+++ b/tests/test_pinky_zoho_helpers.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pinky_zoho.helpers import ZohoHelpers
+from pinky_zoho.schema_cache import SchemaCache
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.search_results: list[dict[str, Any]] = []
+
+    def get(self, path: str, **params: Any) -> dict[str, Any]:
+        self.calls.append(("GET", path, params))
+        if path == "/crm/Events/fields":
+            return {
+                "fields": [{
+                    "api_name": "Meeting_Venue__s",
+                    "pick_list_values": [{"actual_value": "Phone"}, {"actual_value": "In-office"}],
+                }]
+            }
+        if path == "/crm/Leads/search":
+            return self.search_results.pop(0) if self.search_results else {"data": []}
+        return {"ok": True}
+
+    def post(self, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.calls.append(("POST", path, body or {}))
+        return {"posted": path, "body": body}
+
+
+def test_book_event_builds_related_event_payload_with_schema_default() -> None:
+    client = FakeClient()
+    helpers = ZohoHelpers(client, SchemaCache())
+
+    result = helpers.book_event(
+        start="2026-05-12T10:00:00-07:00",
+        end="2026-05-12T10:30:00-07:00",
+        title="Intro call",
+        contact_id="c1",
+        account_id="a1",
+    )
+
+    assert result["posted"] == "/crm/Events"
+    payload = result["body"]["data"]
+    assert payload["Event_Title"] == "Intro call"
+    assert payload["Who_Id"] == "c1"
+    assert payload["What_Id"] == "a1"
+    assert payload["se_module"] == "Accounts"
+    assert payload["Meeting_Venue__s"] == "Phone"
+
+
+def test_create_task_uses_lead_relationship_when_no_account() -> None:
+    client = FakeClient()
+    helpers = ZohoHelpers(client, SchemaCache())
+
+    result = helpers.create_task(subject="Follow up", lead_id="l1")
+
+    payload = result["body"]["data"]
+    assert payload["Who_Id"] == "l1"
+    assert "What_Id" not in payload
+    assert payload["se_module"] == "Leads"
+    assert payload["Priority"] == "Normal"
+    assert payload["Status"] == "Not Started"
+
+
+def test_book_event_uses_lead_without_what_id_when_no_account() -> None:
+    client = FakeClient()
+    helpers = ZohoHelpers(client, SchemaCache())
+
+    result = helpers.book_event(start="2026-05-12T10:00:00-07:00", end="2026-05-12T10:30:00-07:00", title="Lead call", lead_id="l1")
+
+    payload = result["body"]["data"]
+    assert payload["Who_Id"] == "l1"
+    assert "What_Id" not in payload
+    assert payload["se_module"] == "Leads"
+
+
+def test_find_or_create_lead_returns_existing_match_before_create() -> None:
+    client = FakeClient()
+    client.search_results = [{"data": []}, {"data": [{"id": "lead1"}]}]
+    helpers = ZohoHelpers(client, SchemaCache())
+
+    result = helpers.find_or_create_lead(last_name="Smith", phone="555", email="a@b.test")
+
+    assert result["created"] is False
+    assert result["data"] == {"id": "lead1"}
+    assert client.calls == [
+        ("GET", "/crm/Leads/search", {"phone": "555"}),
+        ("GET", "/crm/Leads/search", {"email": "a@b.test"}),
+    ]
+
+
+def test_find_or_create_lead_creates_when_searches_miss() -> None:
+    client = FakeClient()
+    helpers = ZohoHelpers(client, SchemaCache())
+
+    result = helpers.find_or_create_lead(last_name="Smith", first_name="Ava")
+
+    assert result["created"] is True
+    assert client.calls[-1] == (
+        "POST",
+        "/crm/Leads",
+        {"data": {"Last_Name": "Smith", "First_Name": "Ava", "Company": "Unknown"}},
+    )

--- a/tests/test_pinky_zoho_helpers.py
+++ b/tests/test_pinky_zoho_helpers.py
@@ -44,8 +44,8 @@ def test_book_event_builds_related_event_payload_with_schema_default() -> None:
     assert result["posted"] == "/crm/Events"
     payload = result["body"]["data"]
     assert payload["Event_Title"] == "Intro call"
-    assert payload["Who_Id"] == "c1"
-    assert payload["What_Id"] == "a1"
+    assert payload["Who_Id"] == {"id": "c1"}
+    assert payload["What_Id"] == {"id": "a1"}
     assert payload["se_module"] == "Accounts"
     assert payload["Meeting_Venue__s"] == "Phone"
 
@@ -57,7 +57,7 @@ def test_create_task_uses_lead_relationship_when_no_account() -> None:
     result = helpers.create_task(subject="Follow up", lead_id="l1")
 
     payload = result["body"]["data"]
-    assert payload["Who_Id"] == "l1"
+    assert payload["Who_Id"] == {"id": "l1"}
     assert "What_Id" not in payload
     assert payload["se_module"] == "Leads"
     assert payload["Priority"] == "Normal"
@@ -71,9 +71,20 @@ def test_book_event_uses_lead_without_what_id_when_no_account() -> None:
     result = helpers.book_event(start="2026-05-12T10:00:00-07:00", end="2026-05-12T10:30:00-07:00", title="Lead call", lead_id="l1")
 
     payload = result["body"]["data"]
-    assert payload["Who_Id"] == "l1"
+    assert payload["Who_Id"] == {"id": "l1"}
     assert "What_Id" not in payload
     assert payload["se_module"] == "Leads"
+
+
+def test_log_call_uses_lookup_object_for_who_id() -> None:
+    client = FakeClient()
+    helpers = ZohoHelpers(client, SchemaCache())
+
+    result = helpers.log_call(contact_or_lead_id="c1", subject="Call summary")
+
+    payload = result["body"]["data"]
+    assert payload["Who_Id"] == {"id": "c1"}
+    assert payload["Subject"] == "Call summary"
 
 
 def test_find_or_create_lead_returns_existing_match_before_create() -> None:

--- a/tests/test_pinky_zoho_schema_cache.py
+++ b/tests/test_pinky_zoho_schema_cache.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pinky_zoho.schema_cache import SchemaCache
+
+
+def test_schema_cache_uses_value_until_ttl_expires() -> None:
+    now = 1000.0
+    calls: list[str] = []
+
+    def time_fn() -> float:
+        return now
+
+    def fetch(module: str) -> dict:
+        calls.append(module)
+        return {"module": module, "version": len(calls)}
+
+    cache = SchemaCache(ttl_seconds=60, time_fn=time_fn)
+
+    first = cache.get("Events", fetch)
+    second = cache.get("Events", fetch)
+    now = 1061.0
+    third = cache.get("Events", fetch)
+
+    assert first == {"module": "Events", "version": 1}
+    assert second is first
+    assert third == {"module": "Events", "version": 2}
+    assert calls == ["Events", "Events"]
+
+
+def test_schema_cache_refresh_and_clear() -> None:
+    counter = 0
+
+    def fetch(module: str) -> dict:
+        nonlocal counter
+        counter += 1
+        return {"module": module, "counter": counter}
+
+    cache = SchemaCache()
+
+    assert cache.get("Tasks", fetch)["counter"] == 1
+    assert cache.refresh("Tasks", fetch)["counter"] == 2
+    cache.clear("Tasks")
+    assert cache.get("Tasks", fetch)["counter"] == 3
+    cache.clear()
+    assert cache.get("Tasks", fetch)["counter"] == 4

--- a/tests/test_pinky_zoho_signing.py
+++ b/tests/test_pinky_zoho_signing.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from pinky_zoho.client import normalize_path, resolve_secret, sign_headers
+
+
+def _verify(secret: str, agent: str, method: str, path: str, timestamp: int, signature: str) -> bool:
+    payload = f"{agent}\n{method.upper()}\n{normalize_path(path)}\n{timestamp}".encode()
+    expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+def test_sign_headers_match_server_wire_protocol() -> None:
+    headers = sign_headers(
+        "shared-secret",
+        "lera",
+        "get",
+        "/crm/Contacts/search?email=a%40b.test",
+        timestamp=1777777777,
+    )
+
+    assert headers["x-pinky-agent"] == "lera"
+    assert headers["x-pinky-timestamp"] == "1777777777"
+    assert len(headers["x-pinky-signature"]) == 64
+    assert _verify(
+        "shared-secret",
+        "lera",
+        "GET",
+        "/crm/Contacts/search?email=a%40b.test",
+        1777777777,
+        headers["x-pinky-signature"],
+    )
+    assert not _verify(
+        "shared-secret",
+        "lera",
+        "POST",
+        "/crm/Contacts/search?email=a%40b.test",
+        1777777777,
+        headers["x-pinky-signature"],
+    )
+
+
+def test_signature_normalizes_query_string_out_of_path() -> None:
+    with_query = sign_headers("s", "ivan", "GET", "/desk/search?q=billing", timestamp=1)
+    without_query = sign_headers("s", "ivan", "GET", "/desk/search", timestamp=1)
+
+    assert with_query == without_query
+
+
+def test_secret_resolution_prefers_zoho_api_secret(monkeypatch) -> None:
+    monkeypatch.setenv("ZOHO_API_SECRET", "zoho")
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "session")
+
+    assert resolve_secret() == "zoho"
+
+
+def test_secret_resolution_falls_back_to_pinky_session_secret(monkeypatch) -> None:
+    monkeypatch.delenv("ZOHO_API_SECRET", raising=False)
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "session")
+
+    assert resolve_secret() == "session"
+
+
+def test_secret_resolution_empty_when_unconfigured(monkeypatch) -> None:
+    monkeypatch.delenv("ZOHO_API_SECRET", raising=False)
+    monkeypatch.delenv("PINKY_SESSION_SECRET", raising=False)
+
+    assert resolve_secret() == ""

--- a/tests/test_pinky_zoho_tools.py
+++ b/tests/test_pinky_zoho_tools.py
@@ -46,6 +46,15 @@ def test_email_approvals_maps_state_to_live_server_status_param() -> None:
     assert client.calls == [("GET", "/email/approvals", {"status": "approved", "limit": 3})]
 
 
+def test_email_approvals_defaults_to_pending_status() -> None:
+    client = FakeClient()
+    toolbox = ZohoToolbox(client, SchemaCache())
+
+    result = json.loads(toolbox.email_approvals(limit=2))
+
+    assert result == {"path": "/email/approvals", "params": {"status": "pending", "limit": 2}}
+
+
 def test_desk_tickets_uses_live_server_pagination_params() -> None:
     client = FakeClient()
     toolbox = ZohoToolbox(client, SchemaCache())

--- a/tests/test_pinky_zoho_tools.py
+++ b/tests/test_pinky_zoho_tools.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any
+
+from pinky_zoho.schema_cache import SchemaCache
+from pinky_zoho.server import ZohoToolbox
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    def get(self, path: str, **params: Any) -> dict[str, Any]:
+        self.calls.append(("GET", path, params))
+        return {"path": path, "params": params}
+
+    def post(self, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.calls.append(("POST", path, body))
+        return {"path": path, "body": body}
+
+    def put(self, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.calls.append(("PUT", path, body))
+        return {"path": path, "body": body}
+
+    def patch(self, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.calls.append(("PATCH", path, body))
+        return {"path": path, "body": body}
+
+
+def test_toolbox_methods_do_not_accept_agent_parameter() -> None:
+    for name, method in inspect.getmembers(ZohoToolbox, predicate=inspect.isfunction):
+        if name.startswith("_"):
+            continue
+        assert "agent" not in inspect.signature(method).parameters
+
+
+def test_email_approvals_maps_state_to_live_server_status_param() -> None:
+    client = FakeClient()
+    toolbox = ZohoToolbox(client, SchemaCache())
+
+    result = json.loads(toolbox.email_approvals(state="approved", limit=3))
+
+    assert result == {"path": "/email/approvals", "params": {"status": "approved", "limit": 3}}
+    assert client.calls == [("GET", "/email/approvals", {"status": "approved", "limit": 3})]
+
+
+def test_desk_tickets_uses_live_server_pagination_params() -> None:
+    client = FakeClient()
+    toolbox = ZohoToolbox(client, SchemaCache())
+
+    result = json.loads(toolbox.desk_tickets(from_index=11, view_id="v1"))
+
+    assert result["path"] == "/desk/tickets"
+    assert result["params"]["from_index"] == 11
+    assert result["params"]["view_id"] == "v1"
+    assert "page" not in result["params"]
+    assert "all" not in result["params"]
+
+
+def test_project_task_endpoint_is_exposed() -> None:
+    client = FakeClient()
+    toolbox = ZohoToolbox(client, SchemaCache())
+
+    result = json.loads(toolbox.project_task("p1", "t1"))
+
+    assert result == {"path": "/projects/p1/tasks/t1", "params": {}}
+
+
+def test_crm_send_email_uses_server_wire_shape() -> None:
+    client = FakeClient()
+    toolbox = ZohoToolbox(client, SchemaCache())
+
+    result = json.loads(toolbox.crm_send_email(
+        "Contacts",
+        "c1",
+        "owner@example.com",
+        "client@example.com",
+        subject="Hello",
+        content="Body",
+    ))
+
+    assert result["path"] == "/crm/Contacts/c1/email"
+    assert result["body"]["data"] == [{
+        "from": {"email": "owner@example.com"},
+        "to": [{"email": "client@example.com"}],
+        "subject": "Hello",
+        "content": "Body",
+    }]


### PR DESCRIPTION
## Summary

Adds a `pinky-zoho` stdio MCP server that wraps the existing HMAC-authenticated Zoho API server instead of requiring agents to hand-roll signed curl/bash calls.

## What changed

- Added `src/pinky_zoho/` with:
  - HMAC signing using hex signatures over `agent\nMETHOD\nnormalized_path\ntimestamp`
  - `ZOHO_API_SECRET` first, `PINKY_SESSION_SECRET` fallback
  - `--agent` startup identity binding with no per-tool `agent` parameter
  - `--api-url` / `ZOHO_API_URL` / LAN fallback host resolution with per-process host caching
  - low-level tools for the live CRM, Desk, Projects, Notes, Email, and approval endpoints
  - schema cache for `/crm/{module}/fields`
  - high-level composites: `zoho_book_event`, `zoho_log_call`, `zoho_create_task`, `zoho_find_or_create_lead`
- Added `pinky-zoho` console script and wheel package registration.
- Added focused tests for signing, secret resolution, host fallback, schema cache, composite payloads, tool identity lockdown, and live endpoint parameter drift.
- Updated composite write helpers to send Zoho lookup fields as `{"id": "..."}` objects for `Who_Id` and `What_Id`.

## Notes

- This mirrors `/Users/oleg/zoho-crm-cli/zoho_crm/server.py` rather than the older sketch in the spec where they differ.
- The MCP-side identity lockdown closes the normal MCP path, but the shared-secret bash escape hatch still exists. Follow-up should move Zoho auth to per-agent secrets in `zoho-crm-cli` and daemon provisioning.
- I applied the Mac-side ignored local rollout edits for Barsik (`data/agents/barsik/.mcp.json`) and updated the ignored local `skills/zoho-crm/SKILL.md`; those paths are not tracked in this repo.
- Pi fleet `.mcp.json` rollout is intentionally deferred until merge/tag/deploy, so `alwaysLoad` does not point at a missing `pinky_zoho` module on the Pi.

## Verification

- `.venv/bin/python -m pytest tests/test_pinky_zoho_*.py -q` → 24 passed
- `.venv/bin/ruff check src/pinky_zoho tests/test_pinky_zoho_*.py` → clean
- `.venv/bin/python - <<'PY' ... create_server(...) ... PY` → FastMCP instantiated
- `.venv/bin/python -m pytest -q` → 2014 passed, 1 skipped

Closes #455.
