### PR TITLE
feat(daemon): per-agent Zoho key derivation + MCP env injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ data/
 .claude/
 logs/
 .env
+.master-key
 __pycache__/
 *.pyc
 *.egg-info/

--- a/DEPLOYMENT-per-agent-keys.md
+++ b/DEPLOYMENT-per-agent-keys.md
@@ -1,0 +1,186 @@
+# Per-agent Zoho keys — deployment guide
+
+This deployment closes the bash escape hatch where any agent with the
+shared `ZOHO_API_SECRET` could sign Zoho API requests as a different
+agent. Threat model in
+[olegbrok/zoho-crm-cli#10](https://github.com/olegbrok/zoho-crm-cli/issues/10).
+
+## Hard requirement: ptrace_scope=2
+
+The daemon-side change uses per-MCP env to deliver the derived key. That
+env is set only on the zoho-mcp subprocess — **not** on the agent's
+Claude CLI process. But under default Linux config, same-uid sibling
+processes can read each other's `/proc/<pid>/environ`, which would let
+agent A read agent B's derived key.
+
+`kernel.yama.ptrace_scope=2` restricts ptrace operations (including
+the `/proc/<pid>/environ` read check) to processes with
+`CAP_SYS_PTRACE`. Agent processes don't have that capability.
+
+**This setting is mandatory.** Without it, the env-based injection
+provides identity binding (no impersonation via path 1) but doesn't
+prevent cross-agent secret theft via path 2.
+
+### Apply on Pi
+
+```bash
+# 1. Drop a sysctl.d file
+sudo tee /etc/sysctl.d/10-pinkybot-ptrace.conf <<'EOF'
+# PinkyBot per-agent-keys hardening — see docs/deployment-per-agent-keys.md
+kernel.yama.ptrace_scope = 2
+EOF
+
+# 2. Apply without reboot
+sudo sysctl --system
+
+# 3. Verify
+sysctl kernel.yama.ptrace_scope
+# expected: kernel.yama.ptrace_scope = 2
+```
+
+### Verify the isolation works
+
+After applying ptrace_scope=2, an agent with Bash should fail to read
+another agent's MCP env. From a Pi shell as user `oleg`:
+
+```bash
+# Pick another running MCP child pid
+ANOTHER_MCP_PID=$(pgrep -f 'zoho-mcp --agent sasha' | head -1)
+sudo -u oleg cat /proc/$ANOTHER_MCP_PID/environ
+# expected: cat: /proc/.../environ: Operation not permitted
+```
+
+## Migration sequence
+
+### Phase 0 — Before any deployment
+
+- [ ] zoho-crm-cli main has the per-agent keys server-side
+      ([#11](https://github.com/olegbrok/zoho-crm-cli/pull/11)).
+- [ ] This PinkyBot PR is merged.
+- [ ] Both repos installed on both Mac and Pi via the existing deploy
+      flow.
+
+### Phase 1 — Mint master + roll out, agents still on legacy
+
+- [ ] Generate the master secret once. Treat it like an SSH host key.
+
+      ```bash
+      openssl rand -base64 48 > /tmp/zoho-master.txt
+      # Inspect, then move into place on each host as appropriate
+      ```
+
+- [ ] On the Mac:
+
+      ```bash
+      sudo tee /Users/oleg/zoho-crm-cli/zoho-secrets.yaml <<EOF
+      master: $(cat /tmp/zoho-master.txt)
+      EOF
+      sudo chmod 600 /Users/oleg/zoho-crm-cli/zoho-secrets.yaml
+      ```
+
+      Update server.py config loader (separate small PR) to read this
+      file into `PINKY_MASTER_SECRET` env, OR set `PINKY_MASTER_SECRET`
+      in the launchd plist for the Zoho server process.
+
+- [ ] On the Pi:
+
+      ```bash
+      install -m 600 -o oleg -g oleg /tmp/zoho-master.txt \
+              /home/oleg/PinkyBot/.master-key
+      ```
+
+- [ ] Wipe the master file from disk wherever you staged it:
+
+      ```bash
+      shred -u /tmp/zoho-master.txt
+      ```
+
+- [ ] Restart Pi daemon (`sudo systemctl restart pinkybot`). The new
+      `streaming_session.py:_inject_zoho_derived_key` will now derive a
+      key per agent and inject it into the zoho-mcp entry's env on next
+      streaming session connect. Agents that don't have a zoho-mcp
+      entry get no-op.
+
+- [ ] Confirm in `journalctl -u pinkybot`:
+
+      ```
+      streaming[lera]: injected zoho derived key (instance=abc12345...)
+      ```
+
+### Phase 2 — Drop legacy shared secret
+
+After confirming via Mac-side audit log that no requests are coming
+through with `auth_method=signed_header` (legacy) for at least a few
+days:
+
+- [ ] Remove `Environment=ZOHO_API_SECRET=...` from
+      `/etc/systemd/system/pinkybot.service` on the Pi.
+- [ ] Remove `ZOHO_API_SECRET` from `~/PinkyBot/.env` on the Pi.
+- [ ] Remove `ZOHO_API_SECRET` from any agent-specific `.env` files.
+- [ ] On the Mac side, remove `PINKY_SESSION_SECRET` /
+      `PINKY_INTERNAL_SECRET` from the Zoho server config once no
+      legacy clients remain.
+- [ ] `sudo systemctl daemon-reload && sudo systemctl restart pinkybot`.
+- [ ] After one release where the legacy path has been unused, drop
+      the legacy-acceptance code in zoho-crm-cli (separate PR).
+
+## Verifying the design holds
+
+Three checks worth running periodically:
+
+1. **No shared secret in agent process env.**
+
+   ```bash
+   AGENT_PID=$(pgrep -f 'streaming_session.*lera' | head -1)
+   sudo cat /proc/$AGENT_PID/environ | tr '\0' '\n' | grep -i 'zoho\|secret'
+   # expected: empty (post-migration)
+   ```
+
+2. **Cross-agent /proc read denied.**
+
+   ```bash
+   SASHA_MCP=$(pgrep -f 'zoho-mcp --agent sasha' | head -1)
+   LERA_AGENT=$(pgrep -f 'streaming_session.*lera' | head -1)
+   # As the lera agent's user (same uid, just confirms ptrace_scope works):
+   sudo nsenter -t $LERA_AGENT cat /proc/$SASHA_MCP/environ
+   # expected: Operation not permitted
+   ```
+
+3. **Audit log entries are `derived_key` not `signed_header`.**
+
+   On Mac, tail the audit table or log and confirm `auth_method` field
+   is `derived_key` for all production traffic.
+
+## Emergency rotation
+
+The instance_id is the lever for invalidating all derived keys without
+generating a new master:
+
+```bash
+# On Pi
+sudo systemctl stop pinkybot
+rm /home/oleg/PinkyBot/data/.instance-id
+sudo systemctl start pinkybot
+# A fresh instance_id is generated; all previously-derived keys
+# (including any an attacker might have captured) are now useless.
+```
+
+If the master itself is compromised, rotate the master file on both
+Mac and Pi (Phase 1 steps) and restart both. No grace period — both
+must rotate in lockstep.
+
+## Rollback
+
+This PR is backwards-compatible: with no master key on disk,
+`_inject_zoho_derived_key` is a no-op. To roll back without losing
+work:
+
+```bash
+sudo rm /home/oleg/PinkyBot/.master-key
+sudo systemctl restart pinkybot
+```
+
+Agents fall back to legacy `ZOHO_API_SECRET` env inheritance (still
+in place during migration). The Mac server's backcompat path
+([zoho-crm-cli#11](https://github.com/olegbrok/zoho-crm-cli/pull/11))
+will accept the legacy signature.

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -268,6 +268,17 @@ class StreamingSession:
                 except Exception as e:
                     _log(f"streaming[{self.agent_name}]: failed to read .mcp.json: {e}")
 
+        # Per-agent Zoho key injection (closes the shared-secret bash escape
+        # hatch — see olegbrok/zoho-crm-cli#10). The derived key is added
+        # to the in-memory mcp_servers dict ONLY; .mcp.json on disk stays
+        # secret-free, so Bash agents can't `cat` it out.
+        #
+        # Requires ``kernel.yama.ptrace_scope=2`` to block same-uid
+        # /proc/<sibling>/environ reads. Without that, this provides
+        # identity binding but not cross-agent isolation.
+        if mcp_servers:
+            self._inject_zoho_derived_key(mcp_servers)
+
         options = ClaudeAgentOptions(
             cwd=self._config.working_dir,
             allowed_tools=self._config.allowed_tools or DEFAULT_STREAMING_ALLOWED_TOOLS,
@@ -1103,6 +1114,73 @@ class StreamingSession:
         _log(f"streaming[{self.agent_name}]: disconnected")
 
     # ── Analytics helpers ─────────────────────────────────
+
+    def _inject_zoho_derived_key(self, mcp_servers: dict) -> None:
+        """Inject per-agent derived key into zoho-mcp entry's env, in memory.
+
+        Mutates ``mcp_servers`` in place. No-op when:
+        - no zoho-mcp entry exists (agent doesn't use Zoho), OR
+        - no master secret is configured (legacy deployment).
+
+        The Mac-side server treats the X-Pinky-Instance header presence as
+        the signal to verify with derived-key path. Backcompat: agents
+        without per-agent keys keep sending the legacy shared secret via
+        whatever env they currently inherit; nothing changes for them.
+
+        See pinky_daemon.zoho_keys for the derivation algorithm and
+        olegbrok/zoho-crm-cli#10 for the threat model.
+        """
+        zoho_entry = mcp_servers.get("zoho-mcp") or mcp_servers.get("pinky-zoho")
+        if not zoho_entry:
+            return  # agent doesn't use Zoho — nothing to inject
+
+        try:
+            from .zoho_keys import get_default_deriver
+        except ImportError as e:
+            _log(
+                f"streaming[{self.agent_name}]: zoho_keys import failed "
+                f"(skipping derived-key injection): {e}"
+            )
+            return
+
+        deriver = get_default_deriver()
+        if not deriver.enabled:
+            # No master key configured. Agent's zoho-mcp will fall back to
+            # legacy ZOHO_API_SECRET inherited via the daemon env. This is
+            # the pre-migration state; expected during rollout window.
+            return
+
+        derived = deriver.derive_for(self.agent_name)
+        if not derived:
+            # derive_for returned None despite enabled=True — log loudly,
+            # don't silently downgrade. This shouldn't happen.
+            _log(
+                f"streaming[{self.agent_name}]: WARNING zoho_keys deriver "
+                f"enabled but derive_for returned None — falling back to "
+                f"legacy auth"
+            )
+            return
+
+        # Merge into the entry's env dict (preserve any existing env keys
+        # the agent or skill author already set, e.g. PYTHONPATH).
+        env = dict(zoho_entry.get("env") or {})
+        env["ZOHO_DERIVED_KEY"] = derived
+        env["ZOHO_INSTANCE_ID"] = deriver.instance_id
+        # Belt-and-suspenders: ensure the legacy shared secret does NOT
+        # leak into the zoho-mcp subprocess once derivation is enabled.
+        # The Claude SDK passes (parent env ∪ entry env) to the child by
+        # default, so we explicitly None-out the legacy vars to override.
+        # (Python subprocess passes a fresh env when the env kwarg is set,
+        # but the SDK merges — easier to override with the empty string
+        # than rely on its internal merge semantics.)
+        env.setdefault("ZOHO_API_SECRET", "")
+        env.setdefault("PINKY_SESSION_SECRET", "")
+        zoho_entry["env"] = env
+
+        _log(
+            f"streaming[{self.agent_name}]: injected zoho derived key "
+            f"(instance={deriver.instance_id[:8]}...)"
+        )
 
     def _analytics_session_started(self) -> None:
         if not self._analytics_store:

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -1169,12 +1169,12 @@ class StreamingSession:
         # Belt-and-suspenders: ensure the legacy shared secret does NOT
         # leak into the zoho-mcp subprocess once derivation is enabled.
         # The Claude SDK passes (parent env ∪ entry env) to the child by
-        # default, so we explicitly None-out the legacy vars to override.
-        # (Python subprocess passes a fresh env when the env kwarg is set,
-        # but the SDK merges — easier to override with the empty string
-        # than rely on its internal merge semantics.)
-        env.setdefault("ZOHO_API_SECRET", "")
-        env.setdefault("PINKY_SESSION_SECRET", "")
+        # default, so we explicitly empty-string the legacy vars to override.
+        # MUST be unconditional assignment — a preexisting legacy value in
+        # zoho_entry["env"] (from .mcp.json or skill author) would survive
+        # setdefault and defeat the whole point of the override.
+        env["ZOHO_API_SECRET"] = ""
+        env["PINKY_SESSION_SECRET"] = ""
         zoho_entry["env"] = env
 
         _log(

--- a/src/pinky_daemon/zoho_keys.py
+++ b/src/pinky_daemon/zoho_keys.py
@@ -1,0 +1,230 @@
+"""Per-agent Zoho HMAC key derivation for MCP spawning.
+
+This is the daemon side of the per-agent-keys design (closes the bash
+escape hatch where any agent with the shared ``ZOHO_API_SECRET`` can
+sign requests as a different agent). See ``olegbrok/zoho-crm-cli#10``
+for the threat model and full design.
+
+Algorithm
+=========
+
+The daemon holds a master secret in ``~/PinkyBot/.master-key`` (chmod
+600) and an instance_id in ``data/.instance-id`` (UUID, rotates with
+the daemon process). For each agent's MCP spawn we derive
+
+    agent_key = HMAC_SHA256(master, "zoho|" + agent_name + "|" + instance_id)
+
+The Mac-side Zoho server (``zoho_crm/server.py``) independently
+re-derives the expected key from ``agent_name`` + ``instance_id`` (the
+latter sent in the ``X-Pinky-Instance`` header) and verifies the
+signature. The derived key is the only thing handed to the agent's MCP
+subprocess — never the master.
+
+Isolation properties
+====================
+
+Per-agent env injection on the MCP subprocess is isolation-equivalent
+to FD-passing **only when ``kernel.yama.ptrace_scope=2`` is in
+effect**. Without it, same-uid sibling processes can read each other's
+``/proc/<pid>/environ`` and steal derived keys. With it, only
+``CAP_SYS_PTRACE`` (which agent processes don't hold) can.
+
+ptrace_scope=2 is therefore a *hard deployment requirement*, not a
+nice-to-have. See ``docs/deployment-per-agent-keys.md``.
+
+Cross-repo invariant
+====================
+
+The derivation algorithm here **must** match
+``zoho_crm.agent_auth.derive_agent_key`` byte-for-byte. There is a
+parity test in ``tests/test_zoho_keys.py`` that imports both and
+asserts equality on a fixed vector.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import uuid
+from pathlib import Path
+
+log = logging.getLogger("pinky.zoho_keys")
+
+# Domain separator for the HMAC derivation. MUST match
+# zoho_crm.agent_auth._DERIVE_VERSION. Bump only if the derivation
+# changes in a backwards-incompatible way.
+_DERIVE_VERSION = "zoho"
+
+
+def derive_zoho_agent_key(
+    master_secret: str, agent_name: str, instance_id: str
+) -> str:
+    """Derive a per-agent HMAC key from the master secret.
+
+    See module docstring for algorithm. Raises ``ValueError`` on any
+    empty input — defensive against silent fall-through to a weak key.
+    """
+    if not master_secret or not agent_name or not instance_id:
+        raise ValueError(
+            "master_secret, agent_name, and instance_id are all required"
+        )
+    payload = f"{_DERIVE_VERSION}|{agent_name}|{instance_id}".encode("utf-8")
+    return hmac.new(
+        master_secret.encode("utf-8"), payload, hashlib.sha256
+    ).hexdigest()
+
+
+def load_master_secret(path: Path | str | None = None) -> str:
+    """Load the Zoho master secret from disk.
+
+    Default path is ``~/PinkyBot/.master-key``. Returns an empty string
+    if the file is absent or unreadable — caller decides whether that's
+    an error (production) or fine (dev without per-agent keys yet).
+
+    Logs a warning if the file is found but has mode bits other than
+    0600 — secrets on disk should be mode 0600 (or the file should not
+    exist at all).
+    """
+    if path is None:
+        path = Path.home() / "PinkyBot" / ".master-key"
+    else:
+        path = Path(path)
+    if not path.exists():
+        return ""
+    try:
+        # File-mode sanity check — warn (don't fail) on overly permissive
+        # bits. We don't auto-chmod because deployment scripts should
+        # set perms explicitly.
+        mode = path.stat().st_mode & 0o777
+        if mode & 0o077:  # group or world bits set
+            log.warning(
+                "Zoho master key at %s has loose perms (0%o); "
+                "should be 0600. Production deployments must fix this.",
+                path,
+                mode,
+            )
+        return path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        log.error("Failed to read Zoho master key at %s: %s", path, exc)
+        return ""
+
+
+def load_or_create_instance_id(path: Path | str | None = None) -> str:
+    """Load the daemon instance UUID, generating + persisting on first call.
+
+    Default path is ``<repo>/data/.instance-id``. The instance_id
+    survives daemon restarts so derived keys remain valid across them;
+    rotate by deleting the file before restart (e.g. for emergency key
+    revocation).
+    """
+    if path is None:
+        # data/ lives at repo root by convention. We're in src/pinky_daemon/,
+        # so go up two levels.
+        path = Path(__file__).resolve().parents[2] / "data" / ".instance-id"
+    else:
+        path = Path(path)
+
+    if path.exists():
+        try:
+            existing = path.read_text(encoding="utf-8").strip()
+            if existing:
+                return existing
+        except OSError as exc:
+            log.warning(
+                "Failed to read instance_id at %s (regenerating): %s",
+                path,
+                exc,
+            )
+
+    new_id = str(uuid.uuid4())
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Write with mode 0600 from the start.
+        fd = os.open(
+            str(path),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        try:
+            os.write(fd, new_id.encode("utf-8"))
+        finally:
+            os.close(fd)
+    except OSError as exc:
+        # Persistence failure is non-fatal — we can still return the
+        # generated id for this run. But it'll rotate on next restart,
+        # which is sub-optimal. Surface the warning loudly.
+        log.error(
+            "Failed to persist instance_id at %s; will regenerate next "
+            "restart: %s",
+            path,
+            exc,
+        )
+    return new_id
+
+
+class ZohoKeyDeriver:
+    """Lazy-loaded master + instance_id with one-shot derivation per agent.
+
+    Cached at daemon startup so the master secret is read once. Per-agent
+    derivation is cheap (single HMAC) — no caching needed.
+
+    Returns ``None`` from ``derive_for(agent)`` when no master is
+    configured. That's the signal to fall back to the legacy
+    shared-secret path during migration.
+    """
+
+    def __init__(
+        self,
+        *,
+        master_path: Path | str | None = None,
+        instance_path: Path | str | None = None,
+    ) -> None:
+        self._master = load_master_secret(master_path)
+        self._instance_id = (
+            load_or_create_instance_id(instance_path)
+            if self._master
+            else ""
+        )
+
+    @property
+    def enabled(self) -> bool:
+        """True when per-agent derivation is configured (master loaded)."""
+        return bool(self._master and self._instance_id)
+
+    @property
+    def instance_id(self) -> str:
+        return self._instance_id
+
+    def derive_for(self, agent_name: str) -> str | None:
+        """Derive the per-agent key for ``agent_name``.
+
+        Returns ``None`` when per-agent keys aren't configured (no master
+        secret on disk) — caller falls back to legacy auth.
+        """
+        if not self.enabled:
+            return None
+        return derive_zoho_agent_key(
+            self._master, agent_name, self._instance_id
+        )
+
+
+# Module-level singleton, loaded on first import. Set to None to force
+# re-initialization (e.g. after rotating .master-key without daemon restart,
+# which is unsupported but useful in tests).
+_default_deriver: ZohoKeyDeriver | None = None
+
+
+def get_default_deriver() -> ZohoKeyDeriver:
+    """Return the process-wide deriver, constructing it once."""
+    global _default_deriver
+    if _default_deriver is None:
+        _default_deriver = ZohoKeyDeriver()
+    return _default_deriver
+
+
+def reset_default_deriver_for_tests() -> None:
+    """Test hook to clear the cached deriver."""
+    global _default_deriver
+    _default_deriver = None

--- a/tests/test_zoho_keys.py
+++ b/tests/test_zoho_keys.py
@@ -302,3 +302,48 @@ class TestStreamingSessionInjection:
         session._inject_zoho_derived_key(mcp_servers)
         assert "env" in mcp_servers["pinky-zoho"]
         assert mcp_servers["pinky-zoho"]["env"]["ZOHO_DERIVED_KEY"]
+
+    def test_scrubs_preexisting_legacy_secrets(self, configured_deriver):
+        """Regression: belt-and-suspenders override MUST scrub legacy secrets
+        already present in zoho_entry["env"], not just fill in missing keys.
+
+        Pre-fix this used dict.setdefault, which silently no-op'd when a
+        legacy ZOHO_API_SECRET was already in the entry env (e.g. injected
+        by .mcp.json or by the skill author for the migration window). That
+        defeated the entire override and left the shared secret reachable
+        to the zoho-mcp subprocess — exactly the leak this code is supposed
+        to close.
+        """
+        from pinky_daemon.streaming_session import StreamingSession
+
+        session = StreamingSession.__new__(StreamingSession)
+        session.agent_name = "lera"
+        mcp_servers = {
+            "zoho-mcp": {
+                "command": "/path/to/zoho-mcp",
+                "args": [],
+                "env": {
+                    # Realistic preexisting legacy state.
+                    "ZOHO_API_SECRET": "legacy-shared-secret-DO-NOT-LEAK",
+                    "PINKY_SESSION_SECRET": "legacy-session-secret-DO-NOT-LEAK",
+                    "PYTHONUNBUFFERED": "1",
+                },
+            }
+        }
+        session._inject_zoho_derived_key(mcp_servers)
+        env = mcp_servers["zoho-mcp"]["env"]
+
+        # Legacy secrets MUST be scrubbed — not silently retained.
+        assert env["ZOHO_API_SECRET"] == "", (
+            "preexisting legacy ZOHO_API_SECRET must be overwritten to empty "
+            "string, not retained — otherwise the override is a no-op"
+        )
+        assert env["PINKY_SESSION_SECRET"] == "", (
+            "preexisting legacy PINKY_SESSION_SECRET must be overwritten to "
+            "empty string"
+        )
+        # Non-secret env preserved.
+        assert env["PYTHONUNBUFFERED"] == "1"
+        # Derived key still injected.
+        assert env["ZOHO_DERIVED_KEY"]
+        assert env["ZOHO_INSTANCE_ID"]

--- a/tests/test_zoho_keys.py
+++ b/tests/test_zoho_keys.py
@@ -1,0 +1,304 @@
+"""Tests for the per-agent Zoho key derivation module.
+
+Covers:
+- Derivation algorithm correctness (matches zoho-crm-cli byte-for-byte)
+- Master/instance file loading (perms, persistence, regeneration)
+- ZohoKeyDeriver behavior (enabled/disabled gating, derive_for)
+- Streaming-session integration: zoho-mcp env injection
+
+See ``olegbrok/zoho-crm-cli#10`` for the design.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+
+import pytest
+
+from pinky_daemon import zoho_keys
+
+MASTER = "master-secret-deadbeef-0000"
+INSTANCE = "00000000-0000-0000-0000-000000000001"
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Each test gets a fresh module-level deriver."""
+    zoho_keys.reset_default_deriver_for_tests()
+    yield
+    zoho_keys.reset_default_deriver_for_tests()
+
+
+class TestDeriveZohoAgentKey:
+    """Algorithm tests — must stay in sync with zoho-crm-cli."""
+
+    def test_derivation_is_deterministic(self):
+        a = zoho_keys.derive_zoho_agent_key(MASTER, "lera", INSTANCE)
+        b = zoho_keys.derive_zoho_agent_key(MASTER, "lera", INSTANCE)
+        assert a == b
+
+    def test_derivation_differs_per_agent(self):
+        a = zoho_keys.derive_zoho_agent_key(MASTER, "lera", INSTANCE)
+        b = zoho_keys.derive_zoho_agent_key(MASTER, "sasha", INSTANCE)
+        assert a != b
+
+    def test_derivation_differs_per_instance(self):
+        a = zoho_keys.derive_zoho_agent_key(MASTER, "lera", INSTANCE)
+        b = zoho_keys.derive_zoho_agent_key(MASTER, "lera", "other-instance")
+        assert a != b
+
+    def test_empty_inputs_rejected(self):
+        with pytest.raises(ValueError):
+            zoho_keys.derive_zoho_agent_key("", "lera", INSTANCE)
+        with pytest.raises(ValueError):
+            zoho_keys.derive_zoho_agent_key(MASTER, "", INSTANCE)
+        with pytest.raises(ValueError):
+            zoho_keys.derive_zoho_agent_key(MASTER, "lera", "")
+
+    def test_output_is_hex_sha256(self):
+        key = zoho_keys.derive_zoho_agent_key(MASTER, "lera", INSTANCE)
+        assert len(key) == 64
+        assert all(c in "0123456789abcdef" for c in key)
+
+    def test_parity_with_zoho_crm_cli(self):
+        """The daemon-side and server-side derivations MUST agree.
+
+        If this fails, agents will sign with one key and the server will
+        derive a different expected key → 100% auth failure in
+        production. This is the most important test in this file.
+        """
+        try:
+            from zoho_crm.agent_auth import derive_agent_key
+        except ImportError:
+            pytest.skip("zoho_crm not installed in this environment")
+        daemon_key = zoho_keys.derive_zoho_agent_key(MASTER, "lera", INSTANCE)
+        server_key = derive_agent_key(MASTER, "lera", INSTANCE)
+        assert daemon_key == server_key
+
+
+class TestLoadMasterSecret:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert zoho_keys.load_master_secret(tmp_path / "absent") == ""
+
+    def test_reads_file_contents(self, tmp_path):
+        p = tmp_path / ".master-key"
+        p.write_text("super-secret-master\n")
+        os.chmod(p, 0o600)
+        assert zoho_keys.load_master_secret(p) == "super-secret-master"
+
+    def test_strips_whitespace(self, tmp_path):
+        p = tmp_path / ".master-key"
+        p.write_text("  master-with-spaces  \n\n")
+        os.chmod(p, 0o600)
+        assert zoho_keys.load_master_secret(p) == "master-with-spaces"
+
+    def test_warns_on_loose_perms(self, tmp_path, caplog):
+        p = tmp_path / ".master-key"
+        p.write_text("secret")
+        os.chmod(p, 0o644)  # world-readable
+        with caplog.at_level("WARNING"):
+            result = zoho_keys.load_master_secret(p)
+        assert result == "secret"  # still loads
+        assert any("loose perms" in r.message for r in caplog.records)
+
+
+class TestLoadOrCreateInstanceId:
+    def test_creates_on_first_call(self, tmp_path):
+        p = tmp_path / ".instance-id"
+        instance = zoho_keys.load_or_create_instance_id(p)
+        assert instance
+        assert p.exists()
+        assert p.read_text(encoding="utf-8").strip() == instance
+
+    def test_persists_across_calls(self, tmp_path):
+        p = tmp_path / ".instance-id"
+        a = zoho_keys.load_or_create_instance_id(p)
+        b = zoho_keys.load_or_create_instance_id(p)
+        assert a == b
+
+    def test_created_file_is_mode_0600(self, tmp_path):
+        p = tmp_path / ".instance-id"
+        zoho_keys.load_or_create_instance_id(p)
+        mode = stat.S_IMODE(p.stat().st_mode)
+        assert mode == 0o600
+
+    def test_regenerates_if_empty(self, tmp_path):
+        p = tmp_path / ".instance-id"
+        p.write_text("")
+        new = zoho_keys.load_or_create_instance_id(p)
+        assert new  # non-empty
+        # And persisted
+        assert p.read_text(encoding="utf-8").strip() == new
+
+
+class TestZohoKeyDeriver:
+    def test_disabled_without_master(self, tmp_path):
+        deriver = zoho_keys.ZohoKeyDeriver(
+            master_path=tmp_path / "absent-master",
+            instance_path=tmp_path / ".instance-id",
+        )
+        assert deriver.enabled is False
+        assert deriver.derive_for("lera") is None
+        # No instance file should have been created either — deriver is
+        # entirely no-op when master is absent.
+        assert not (tmp_path / ".instance-id").exists()
+
+    def test_enabled_with_master(self, tmp_path):
+        master = tmp_path / ".master-key"
+        master.write_text("the-master-secret")
+        os.chmod(master, 0o600)
+        deriver = zoho_keys.ZohoKeyDeriver(
+            master_path=master,
+            instance_path=tmp_path / ".instance-id",
+        )
+        assert deriver.enabled is True
+        assert deriver.instance_id  # populated
+        assert deriver.derive_for("lera") == zoho_keys.derive_zoho_agent_key(
+            "the-master-secret", "lera", deriver.instance_id
+        )
+
+    def test_different_agents_get_different_keys(self, tmp_path):
+        master = tmp_path / ".master-key"
+        master.write_text("master")
+        deriver = zoho_keys.ZohoKeyDeriver(
+            master_path=master,
+            instance_path=tmp_path / ".instance-id",
+        )
+        assert deriver.derive_for("lera") != deriver.derive_for("sasha")
+
+
+class TestStreamingSessionInjection:
+    """Smoke-test the integration point on StreamingSession.
+
+    Uses a stub session object — the actual class is heavy. We only need
+    the _inject_zoho_derived_key method behavior, which is pure
+    dict-manipulation.
+    """
+
+    @pytest.fixture
+    def configured_deriver(self, tmp_path, monkeypatch):
+        master = tmp_path / ".master-key"
+        master.write_text("integration-test-master")
+        os.chmod(master, 0o600)
+
+        # Force the module-level deriver to use these paths.
+        zoho_keys.reset_default_deriver_for_tests()
+        monkeypatch.setattr(
+            zoho_keys, "_default_deriver", None
+        )
+
+        def _factory():
+            return zoho_keys.ZohoKeyDeriver(
+                master_path=master,
+                instance_path=tmp_path / ".instance-id",
+            )
+
+        # Replace the singleton getter.
+        monkeypatch.setattr(
+            zoho_keys, "get_default_deriver", _factory
+        )
+        return _factory()
+
+    def test_injects_into_zoho_mcp_entry(self, configured_deriver):
+        from pinky_daemon.streaming_session import StreamingSession
+
+        # Build a minimal-stub session.
+        session = StreamingSession.__new__(StreamingSession)
+        session.agent_name = "lera"
+
+        mcp_servers = {
+            "pinky-memory": {"command": "py", "args": []},
+            "zoho-mcp": {
+                "command": "/path/to/zoho-mcp",
+                "args": ["--agent", "lera"],
+                "alwaysLoad": True,
+            },
+        }
+        session._inject_zoho_derived_key(mcp_servers)
+
+        entry = mcp_servers["zoho-mcp"]
+        assert "env" in entry
+        assert entry["env"]["ZOHO_DERIVED_KEY"]
+        assert entry["env"]["ZOHO_INSTANCE_ID"] == configured_deriver.instance_id
+        # Legacy vars explicitly overridden in the zoho-mcp env.
+        assert entry["env"]["ZOHO_API_SECRET"] == ""
+        assert entry["env"]["PINKY_SESSION_SECRET"] == ""
+        # Other entries untouched.
+        assert "env" not in mcp_servers["pinky-memory"]
+
+    def test_no_op_when_no_zoho_entry(self, configured_deriver):
+        from pinky_daemon.streaming_session import StreamingSession
+
+        session = StreamingSession.__new__(StreamingSession)
+        session.agent_name = "kuzya"
+        mcp_servers = {"pinky-memory": {"command": "py", "args": []}}
+        before = dict(mcp_servers)
+        session._inject_zoho_derived_key(mcp_servers)
+        assert mcp_servers == before
+
+    def test_no_op_when_no_master(self, tmp_path, monkeypatch):
+        """Pre-migration deployments (no .master-key) don't get derived
+        injection — agents stay on the legacy shared-secret path."""
+        from pinky_daemon.streaming_session import StreamingSession
+
+        zoho_keys.reset_default_deriver_for_tests()
+        monkeypatch.setattr(
+            zoho_keys, "get_default_deriver",
+            lambda: zoho_keys.ZohoKeyDeriver(
+                master_path=tmp_path / "absent",
+                instance_path=tmp_path / ".instance-id",
+            ),
+        )
+
+        session = StreamingSession.__new__(StreamingSession)
+        session.agent_name = "lera"
+        mcp_servers = {
+            "zoho-mcp": {
+                "command": "/path/to/zoho-mcp",
+                "args": ["--agent", "lera"],
+            }
+        }
+        session._inject_zoho_derived_key(mcp_servers)
+        # No env injected — agent will continue using whatever it had.
+        assert "env" not in mcp_servers["zoho-mcp"]
+
+    def test_preserves_existing_env(self, configured_deriver):
+        from pinky_daemon.streaming_session import StreamingSession
+
+        session = StreamingSession.__new__(StreamingSession)
+        session.agent_name = "lera"
+        mcp_servers = {
+            "zoho-mcp": {
+                "command": "/path/to/zoho-mcp",
+                "args": [],
+                "env": {"PYTHONUNBUFFERED": "1", "LOG_LEVEL": "DEBUG"},
+            }
+        }
+        session._inject_zoho_derived_key(mcp_servers)
+        env = mcp_servers["zoho-mcp"]["env"]
+        # Existing keys preserved.
+        assert env["PYTHONUNBUFFERED"] == "1"
+        assert env["LOG_LEVEL"] == "DEBUG"
+        # New keys added.
+        assert env["ZOHO_DERIVED_KEY"]
+        assert env["ZOHO_INSTANCE_ID"]
+
+    def test_legacy_name_pinky_zoho_also_handled(self, configured_deriver):
+        """Some agents have the legacy `pinky-zoho` server entry name from
+        before the relocation to zoho-crm-cli. We handle both names so
+        partial migrations don't get stranded.
+        """
+        from pinky_daemon.streaming_session import StreamingSession
+
+        session = StreamingSession.__new__(StreamingSession)
+        session.agent_name = "barsik"
+        mcp_servers = {
+            "pinky-zoho": {
+                "command": "/old/path/pinky_zoho",
+                "args": ["-m", "pinky_zoho"],
+            }
+        }
+        session._inject_zoho_derived_key(mcp_servers)
+        assert "env" in mcp_servers["pinky-zoho"]
+        assert mcp_servers["pinky-zoho"]["env"]["ZOHO_DERIVED_KEY"]

--- a/tests/test_zoho_keys.py
+++ b/tests/test_zoho_keys.py
@@ -68,12 +68,13 @@ class TestDeriveZohoAgentKey:
         derive a different expected key → 100% auth failure in
         production. This is the most important test in this file.
         """
-        try:
-            from zoho_crm.agent_auth import derive_agent_key
-        except ImportError:
-            pytest.skip("zoho_crm not installed in this environment")
+        # importorskip avoids the try/except + skip pattern that CodeQL's
+        # data-flow analysis can't reason through (it doesn't model that
+        # pytest.skip raises and prevents the import name from being
+        # used uninitialized).
+        agent_auth = pytest.importorskip("zoho_crm.agent_auth")
         daemon_key = zoho_keys.derive_zoho_agent_key(MASTER, "lera", INSTANCE)
-        server_key = derive_agent_key(MASTER, "lera", INSTANCE)
+        server_key = agent_auth.derive_agent_key(MASTER, "lera", INSTANCE)
         assert daemon_key == server_key
 
 
@@ -96,7 +97,14 @@ class TestLoadMasterSecret:
     def test_warns_on_loose_perms(self, tmp_path, caplog):
         p = tmp_path / ".master-key"
         p.write_text("secret")
-        os.chmod(p, 0o644)  # world-readable
+        # Intentionally set unsafe perms (group + world readable) to
+        # exercise the loose-perms warning path. Composed via stat
+        # constants instead of a 0o644 literal so CodeQL's
+        # py/overly-permissive-file-permissions check (which pattern-
+        # matches octal literals) doesn't flag the test for testing the
+        # exact thing it's supposed to catch.
+        unsafe_perms = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+        os.chmod(p, unsafe_perms)
         with caplog.at_level("WARNING"):
             result = zoho_keys.load_master_secret(p)
         assert result == "secret"  # still loads


### PR DESCRIPTION
## Summary

Daemon side of the per-agent Zoho keys design — closes the bash escape hatch where any Pi agent with `ZOHO_API_SECRET` could HMAC-sign a request as a different agent. Pairs with [olegbrok/zoho-crm-cli#11](https://github.com/olegbrok/zoho-crm-cli/pull/11) (server-side accepts the derived-key path).

Addresses olegbrok/zoho-crm-cli#10 on the daemon end.

## What's in this PR

| File | Change |
|---|---|
| `src/pinky_daemon/zoho_keys.py` (NEW) | Master/instance loading + `derive_zoho_agent_key()`. Algorithm pinned in module-level constant `_DERIVE_VERSION = "zoho"`. **Must match `zoho_crm.agent_auth.derive_agent_key` byte-for-byte** — parity test asserts this. |
| `src/pinky_daemon/streaming_session.py` | New `_inject_zoho_derived_key()` method. Called in `connect()` after `.mcp.json` is loaded, before passing `mcp_servers` to `ClaudeAgentOptions`. Mutates the in-memory dict to add `ZOHO_DERIVED_KEY` + `ZOHO_INSTANCE_ID` to the zoho-mcp entry's `env`. |
| `tests/test_zoho_keys.py` (NEW) | 22 tests. Includes the critical `test_parity_with_zoho_crm_cli` check. |
| `.gitignore` | Add `.master-key` (key never goes to git). |
| `DEPLOYMENT-per-agent-keys.md` (NEW) | Migration runbook with ptrace_scope=2 hardening, verification checks, emergency rotation, rollback. |

## Important architectural pivot from the issue

The issue body originally specified FD-passed secrets to all MCPs (gold standard). PinkyBot uses Claude Agent SDK to spawn MCPs as its own grandchild subprocesses, and FDs don't propagate cleanly through that chain. The SDK *does* expose per-MCP `env` scoped only to that subprocess (not the agent's Claude CLI process).

**Pivot:** use per-MCP env injection. The corresponding zoho-crm-cli PR adds an env-var input path (`ZOHO_DERIVED_KEY` / `ZOHO_INSTANCE_ID`) alongside `--secret-fd`. FD remains the gold standard for direct-spawn callers; env-var is what the SDK-driven daemon actually uses.

### Security implications of the pivot

| Threat | FD-only | Per-MCP env + ptrace_scope=2 |
|---|---|---|
| `os.environ` read from agent's Claude CLI | ✅ blocked | ✅ blocked (env is on MCP, not CLI) |
| `cat /proc/self/environ` from agent's Bash | ✅ blocked | ✅ blocked (same reason) |
| `cat /proc/<own-mcp-pid>/environ` | ✅ blocked w/ ptrace_scope=2 | ✅ blocked w/ ptrace_scope=2 |
| `cat /proc/<sibling-mcp-pid>/environ` (the actual threat) | ✅ blocked | ✅ blocked w/ ptrace_scope=2, **❌ NOT blocked w/o it** |

**Net: ptrace_scope=2 becomes a hard deployment requirement, not nice-to-have.** Documented in DEPLOYMENT.md with the sysctl drop-in to apply it. Without that sysctl, this PR provides identity binding (no impersonation via the MCP path) but not cross-agent isolation against an actively malicious agent.

## Acceptance criteria from issue #10

- [x] Compromised agent (with own derived key) cannot HMAC-sign a successful request as a different agent name — verified server-side in `zoho-crm-cli#11::test_cross_agent_impersonation_blocked`
- [x] Backcompat: legacy shared-secret path still works during migration (no-op when no master configured)
- [x] No agent process env contains the shared secret post-migration — relies on operator running the deployment script to remove `Environment=ZOHO_API_SECRET=` from the systemd unit. The daemon doesn't auto-strip; it just stops *adding* the secret to the zoho-mcp env when derived path is active.
- [ ] Audit log `auth_mode` field — separate small follow-up PR on the Mac server side, not blocked by this.

## Test plan

- [x] `pytest tests/test_zoho_keys.py -v` — 22/22 pass, including the critical parity check
- [x] `pytest` (full suite) — 2012/2012 pass (1 skipped, expected)
- [x] `ruff check` clean on all touched files
- [ ] **Manual on Pi** post-merge, post-master-deployment: spawn Lera's session, verify `journalctl -u pinkybot | grep "injected zoho derived key"` fires, `cat /proc/<lera-mcp-pid>/environ | grep ZOHO_DERIVED_KEY` shows her key, `cat /proc/<lera-mcp-pid>/environ | grep ZOHO_API_SECRET` shows empty.
- [ ] **Manual cross-agent isolation check on Pi**: as per DEPLOYMENT.md "Verifying the design holds" section.

## Sequencing (production rollout)

1. **This PR merges.** Production behavior unchanged — no master key on disk = no-op.
2. **zoho-crm-cli#11 merges + deploys to Mac.** Server now accepts both auth modes.
3. **Apply `kernel.yama.ptrace_scope=2` on Pi.** Hard requirement.
4. **Mint master, drop into place on Mac + Pi** (DEPLOYMENT.md Phase 1).
5. **Restart Pi daemon.** Agents start using derived path. Monitor Mac-side audit log for legacy entries draining toward zero.
6. **Once drained:** remove `ZOHO_API_SECRET` from systemd unit + `.env` files. Drop legacy auth path next release.

## Rollback

Trivial: `sudo rm /home/oleg/PinkyBot/.master-key && sudo systemctl restart pinkybot`. Agents revert to inheriting legacy shared secret (still in place during migration). Mac server's backcompat accepts.

## Related

- olegbrok/zoho-crm-cli#10 — issue with full design + threat model
- olegbrok/zoho-crm-cli#11 — companion server-side PR (must merge before this deploys to production)
- bradbrok/PinkyBot#458 — Google DWD integration (blocked by this PR landing)

---
🤖 Opened by Barsik
