### PR TITLE
fix(broker): cold-start streaming session for inbound platform messages

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2115,6 +2115,14 @@ def create_api(
         resume_id = agents.get_streaming_session_id(agent_name, label=label)
         return await _start_streaming_session(agent_name, label=label, resume_id=resume_id)
 
+    # Wire the broker's cold-wake path so inbound platform messages
+    # (Telegram, Discord, etc.) can start a fresh streaming session for a
+    # sibling agent that was never auto-started at boot. Without this,
+    # `MessageBroker._route_streaming` would only handle the "session
+    # exists but disconnected" case and fall through to "not running" for
+    # any sibling that hasn't been touched via the web admin chat path.
+    broker.set_ensure_session_callback(_ensure_streaming_session)
+
     async def _disconnect_streaming_sessions(agent_name: str) -> int:
         """Disconnect and unregister all streaming sessions for an agent."""
         persisted = agents.list_streaming_session_ids(agent_name)

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -183,6 +183,14 @@ class MessageBroker:
         self._stop_all_callback = stop_all_callback
         self._stats = {"routed": 0, "pending": 0, "denied": 0, "errors": 0}
 
+        # Optional callback to ensure (start/resume) a streaming session on
+        # demand. Wired by api.py after `_ensure_streaming_session` is
+        # defined; left None in tests that don't drive the full daemon.
+        # Signature: async fn(agent_name: str, *, label: str) -> StreamingSession | None
+        # See `set_ensure_session_callback` and `_route_streaming` for the
+        # cold-wake path that uses this.
+        self._ensure_session_callback = None
+
         # Streaming sessions — persistent ClaudeSDKClient connections per agent
         # agent_name -> {label -> StreamingSession}
         self._streaming: dict[str, dict[str, object]] = {}
@@ -199,6 +207,21 @@ class MessageBroker:
     def send_callback(self):
         """Expose the send callback for direct use by scheduler etc."""
         return self._send_callback
+
+    def set_ensure_session_callback(self, callback) -> None:
+        """Register the on-demand streaming-session ensurer.
+
+        Used by ``_route_streaming`` to cold-start a session when an
+        inbound message arrives for an agent whose session was never
+        created (sibling boot policy) or was disconnected after auto-sleep.
+
+        Wired post-construction because ``_ensure_streaming_session`` is
+        defined inside ``api.create_app`` and isn't available when the
+        broker is built (api.py:1291 vs api.py:2106).
+
+        Signature: ``async fn(agent_name, *, label) -> StreamingSession | None``.
+        """
+        self._ensure_session_callback = callback
 
     async def _typing_loop(
         self,
@@ -762,10 +785,30 @@ class MessageBroker:
         return sessions.get("main")
 
     async def _route_streaming(self, agent_name: str, message: BrokerMessage) -> None:
-        """Route a message via streaming session — non-blocking."""
+        """Route a message via streaming session — non-blocking.
+
+        Resolution order:
+
+        1. Existing session for this channel/label is connected → use it.
+        2. Existing session is disconnected with a persisted session_id →
+           reconnect in-place (idle-sleep wake).
+        3. No session object yet OR reconnect failed → cold-start a fresh
+           session via ``_ensure_session_callback`` (sibling boot policy:
+           non-main agents have no session at startup; see api.py boot
+           policy comment at the streaming-session startup loop).
+        4. Still nothing usable → notify the user that the agent isn't
+           running.
+
+        Step 3 closes the gap where inbound platform messages (Telegram,
+        Discord, etc.) used to fall straight to step 4 for any sibling
+        agent that had never been touched via the web admin, even though
+        the web admin's ``/agents/{name}/chat`` endpoint always cold-starts
+        via ``_ensure_streaming_session``. See bradbrok/PinkyBot fix branch
+        ``fix/inbound-msg-cold-wake``.
+        """
         streaming = self._get_streaming_session(agent_name, message.chat_id)
 
-        # Auto-wake: if session exists but is disconnected (idle sleep), reconnect
+        # Auto-wake: if session exists but is disconnected (idle sleep), reconnect.
         if streaming and not streaming.is_connected and streaming.session_id:
             _log(f"broker: {agent_name} is sleeping — auto-waking for inbound message")
             try:
@@ -773,6 +816,26 @@ class MessageBroker:
                 _log(f"broker: {agent_name} auto-woke successfully")
             except Exception as e:
                 _log(f"broker: {agent_name} auto-wake failed: {e}")
+                streaming = None
+
+        # Cold-start path: no session object yet, or reconnect failed.
+        # Use the on-demand ensurer if wired (api.py registers it post-init).
+        # This matches the web admin chat path so inbound platform messages
+        # don't fall through to "not running" just because the sibling
+        # auto-start was skipped at boot.
+        if (not streaming or not streaming.is_connected) and self._ensure_session_callback:
+            label = "main"
+            try:
+                if message.chat_id:
+                    mapped = self._registry.get_channel_session(agent_name, message.chat_id)
+                    if mapped:
+                        label = mapped
+                _log(f"broker: {agent_name} has no live session — cold-starting via ensurer (label={label})")
+                streaming = await self._ensure_session_callback(agent_name, label=label)
+                if streaming and streaming.is_connected:
+                    _log(f"broker: {agent_name} cold-started successfully")
+            except Exception as e:
+                _log(f"broker: {agent_name} cold-start failed: {e}")
                 streaming = None
 
         if not streaming or not streaming.is_connected:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -196,6 +196,140 @@ class TestMessageBrokerRouting:
         finally:
             tmpdir.cleanup()
 
+    @pytest.mark.asyncio
+    async def test_route_streaming_cold_starts_via_ensurer_when_no_session(self):
+        """Regression: inbound platform message must cold-start the session.
+
+        Pre-fix, ``_route_streaming`` only auto-woke a streaming session
+        if one already existed in ``broker._streaming`` with a persisted
+        ``session_id``. Sibling agents under the boot policy never have a
+        session created at boot, so inbound Telegram/Discord/etc. messages
+        for them fell straight to "not running" — even though the web
+        admin chat path always cold-started via
+        ``_ensure_streaming_session``. The ensurer callback closes that
+        gap.
+        """
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            class _FakeStreaming:
+                is_connected = True
+                session_id = "freshly-cold-started"
+                sent: list[str] = []
+
+                async def send(self, prompt, **kwargs) -> None:
+                    _FakeStreaming.sent.append(prompt)
+
+            ensure_calls: list[tuple[str, str]] = []
+
+            async def fake_ensurer(agent_name, *, label):
+                ensure_calls.append((agent_name, label))
+                return _FakeStreaming()
+
+            broker.set_ensure_session_callback(fake_ensurer)
+
+            msg = BrokerMessage(
+                platform="telegram",
+                chat_id="6770805286",
+                sender_name="Brad",
+                sender_id="u-1",
+                content="hi lera",
+                agent_name="lera",
+            )
+            await broker._route_streaming("lera", msg)
+
+            # Ensurer was called for the missing session.
+            assert ensure_calls == [("lera", "main")]
+            # "Not running" fallback did NOT fire.
+            assert not any("not running" in m[3] for m in sent_messages), (
+                f"unexpected fallback message sent: {sent_messages}"
+            )
+            # The cold-started session received the routed message.
+            assert _FakeStreaming.sent, "cold-started session received no message"
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_streaming_falls_back_when_no_ensurer_wired(self):
+        """If no ensurer is wired (e.g. in tests/embedded scenarios), the
+        broker must preserve the pre-fix behavior and surface the
+        "not running" fallback rather than crashing on a missing callback.
+        """
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            # No set_ensure_session_callback call — _ensure_session_callback is None.
+            msg = BrokerMessage(
+                platform="telegram",
+                chat_id="6770805286",
+                sender_name="Brad",
+                sender_id="u-1",
+                content="hi lera",
+                agent_name="lera",
+            )
+            await broker._route_streaming("lera", msg)
+
+            # Fallback fired exactly once with the canonical text.
+            assert sent_messages == [
+                ("lera", "telegram", "6770805286",
+                 "⚠️ lera is not running right now. Try again later."),
+            ]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_streaming_uses_existing_disconnected_session_before_ensurer(self):
+        """If a session object exists with a persisted session_id but is
+        disconnected, the existing auto-wake (reconnect) path must run
+        first — the ensurer is only for the cold-start case.
+        """
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            class _FakeStreaming:
+                session_id = "persisted-id"
+                connect_calls = 0
+                sent: list[str] = []
+
+                def __init__(self):
+                    self.is_connected = False
+
+                async def connect(self):
+                    type(self).connect_calls += 1
+                    self.is_connected = True
+
+                async def send(self, prompt, **kwargs):
+                    type(self).sent.append(prompt)
+
+            ss = _FakeStreaming()
+            broker.register_streaming("lera", ss, label="main")
+
+            ensure_calls: list[tuple[str, str]] = []
+
+            async def fake_ensurer(agent_name, *, label):
+                ensure_calls.append((agent_name, label))
+                return None  # would fail if called — we expect it NOT to be
+
+            broker.set_ensure_session_callback(fake_ensurer)
+
+            msg = BrokerMessage(
+                platform="telegram",
+                chat_id="6770805286",
+                sender_name="Brad",
+                sender_id="u-1",
+                content="hi lera",
+                agent_name="lera",
+            )
+            await broker._route_streaming("lera", msg)
+
+            # Existing session's connect() was called once.
+            assert _FakeStreaming.connect_calls == 1
+            # Ensurer was NOT called — existing session won.
+            assert ensure_calls == [], (
+                f"ensurer should not be called when an existing session is "
+                f"reconnectable, got: {ensure_calls}"
+            )
+            assert _FakeStreaming.sent, "reconnected session received no message"
+        finally:
+            tmpdir.cleanup()
+
     def test_remember_message_context_tracks_voice_and_reply_metadata(self):
         tmpdir, _, broker, _, _ = self._make_broker()
         try:


### PR DESCRIPTION
## Summary

Inbound Telegram (and Discord/etc.) messages for any **sibling agent** were falling straight to `⚠️ {agent} is not running right now. Try again later.` — even when the agent was enabled and the web admin chat path could happily start them.

Brad's report: messaging Lera or Olga on Telegram returns the "not running" reply; the same agents wake fine via the web admin chat. This PR closes the asymmetry.

## Why it broke

Under the sibling boot policy (`api.py` startup loop — only the main agent's streaming session is auto-resumed at boot, siblings are on-demand only), non-main agents have **no entry in `broker._streaming` until something explicitly starts one**.

- **Web admin** (`api.py:6097 POST /agents/{name}/chat`) → calls `_ensure_streaming_session` → reconnects existing or starts fresh from persisted resume_id ✅
- **Broker `_route_streaming`** (`broker.py:764`) → only auto-wakes if a session **already exists** with a `session_id`; no session object → straight to fallback ❌

## What this changes

| File | Change |
|---|---|
| `src/pinky_daemon/broker.py` | New `set_ensure_session_callback(callback)` on `MessageBroker`. `_route_streaming` now calls it when no session object exists (or when reconnect of an existing session failed), **before** sending the "not running" fallback. Resolves to the channel-mapped session label via `registry.get_channel_session(...)` exactly like `_get_streaming_session` does, defaulting to `"main"`. |
| `src/pinky_daemon/api.py` | Wires the callback to `_ensure_streaming_session` immediately after that function is defined. Can't be passed at broker construction because the broker is built at `api.py:1291` and the ensurer is defined at `api.py:2106`. |
| `tests/test_broker.py` | Three regression tests. |

## Resolution order in the patched `_route_streaming`

1. Existing session for this channel/label is connected → use it.
2. Existing session is disconnected with a persisted `session_id` → reconnect in-place (idle-sleep wake, unchanged).
3. No session object yet OR reconnect failed → cold-start a fresh session via `_ensure_session_callback`. **← new**
4. Still nothing usable → notify the user that the agent isn't running.

## Tests

- `test_route_streaming_cold_starts_via_ensurer_when_no_session` — ensurer is called for missing session, fallback does NOT fire, cold-started session receives the routed message.
- `test_route_streaming_falls_back_when_no_ensurer_wired` — preserves pre-fix behavior in standalone/embedded scenarios (tests, etc.).
- `test_route_streaming_uses_existing_disconnected_session_before_ensurer` — existing reconnectable session wins over the ensurer; ensurer is for cold-start only.

Targeted: `pytest tests/test_broker.py` → **12 passed** (was 9, +3 regression).
Full suite: **1993 passed, 1 skipped**.
`ruff check` clean on touched files.

## Manual verification plan (post-merge, on Pi)

1. Confirm Lera + Olga have no live streaming session: `curl localhost:8888/agents | jq '.agents[] | select(.name | IN("lera","olga")) | {name, working_status}'`
2. Send a Telegram message to Lera and Olga from Brad.
3. Daemon log should show `broker: lera has no live session — cold-starting via ensurer (label=main)` then `broker: lera cold-started successfully`.
4. Telegram receives the agent's actual reply, not the "not running" message.
5. Repeat for any other sibling agents (kuzya, ivan, daria, sasha already validated cold-start works).

## Rollback

Revert the commit. Pure-additive code path — the existing auto-wake and fallback paths are unchanged. Setting `_ensure_session_callback = None` (default) restores pre-fix behavior.

🤖 Opened by Barsik