### PR TITLE
feat(pinky_identity): Ed25519 keypair primitives for service-auth (PR-2a)

### DIFF
--- a/src/pinky_identity/__init__.py
+++ b/src/pinky_identity/__init__.py
@@ -1,0 +1,55 @@
+"""pinky_identity — per-agent asymmetric service-auth identity primitives.
+
+Implements the design captured in https://github.com/bradbrok/PinkyBot/issues/461
+(``docs/design/agent-asymmetric-identity.md``).
+
+This package provides:
+
+- Ed25519 keypair primitives for the ``service-auth`` purpose
+  (``pinky_identity.keys``)
+- (Coming in PR-2b) RFC 9421 HTTP Message Signature signer/verifier helpers
+  (``pinky_identity.http_signatures``)
+- (Coming in PR-3) Registry storage + enrollment-token issuance + admin
+  approval flow (``pinky_identity.registry``)
+- (Coming in PR-4) Daemon-local signer + session-bound bearer-token
+  capability (``pinky_identity.signer``)
+
+The package is intentionally separated from ``pinky_federation``: the
+crypto primitives are similar (both use Ed25519) but the identity
+semantics, registry, and lifecycle are distinct. ``service-auth`` keys
+authenticate an agent to external services and MCPs; ``federation`` keys
+are mesh-transport tenant identities. Per the design doc, keys must not
+be shared across purposes.
+"""
+
+from pinky_identity.keys import (
+    ED25519_PUBLIC_KEY_BYTES,
+    ED25519_SECRET_KEY_BYTES,
+    ED25519_SIGNATURE_BYTES,
+    KID_HEX_LEN,
+    PublicKey,
+    SecretKey,
+    SignatureError,
+    SigningKeypair,
+    fingerprint,
+    generate_keypair,
+    jwk_export,
+    kid_from_public_key,
+    public_key_from_bytes,
+)
+
+__all__ = [
+    "ED25519_PUBLIC_KEY_BYTES",
+    "ED25519_SECRET_KEY_BYTES",
+    "ED25519_SIGNATURE_BYTES",
+    "KID_HEX_LEN",
+    "PublicKey",
+    "SecretKey",
+    "SignatureError",
+    "SigningKeypair",
+    "fingerprint",
+    "generate_keypair",
+    "jwk_export",
+    "kid_from_public_key",
+    "public_key_from_bytes",
+]

--- a/src/pinky_identity/keys.py
+++ b/src/pinky_identity/keys.py
@@ -1,0 +1,253 @@
+"""Ed25519 keypair primitives for service-auth identity.
+
+Wraps PyNaCl's Ed25519 signing primitives in a small dataclass-based API
+designed for the per-agent identity registry and the daemon-local signer.
+
+Design rules (see docs/design/agent-asymmetric-identity.md):
+
+- One Ed25519 keypair per agent, scoped to the ``service-auth`` purpose.
+- The kid is a deterministic prefix of the SHA-256 of the public key.
+  Truncating the fingerprint to a fixed-length hex string keeps kids
+  short enough for HTTP headers and URL fragments while remaining
+  collision-resistant within a fleet.
+- The full SHA-256 hex fingerprint is the canonical identifier for
+  manual verification and for binding enrollment tokens to a specific
+  public key.
+- Private key material is held inside :class:`SecretKey` and
+  :class:`SigningKeypair`. Raw-bytes accessors are explicitly named
+  ``secret_bytes_insecure`` so grep can flag callers and reviewers can
+  catch unintended exposure.
+- ``__repr__`` on key types never includes secret material.
+- No on-disk format helpers live here; storage is the registry/signer's
+  job (PR-3 / PR-4).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from dataclasses import dataclass
+
+from nacl.exceptions import BadSignatureError as _NaclBadSignatureError
+from nacl.signing import SigningKey as _NaclSigningKey
+from nacl.signing import VerifyKey as _NaclVerifyKey
+
+# -- Constants ----------------------------------------------------------------
+
+#: Ed25519 public key length in bytes (RFC 8032 §5.1.5).
+ED25519_PUBLIC_KEY_BYTES = 32
+
+#: Ed25519 secret (seed) key length in bytes. PyNaCl's ``SigningKey`` takes a
+#: 32-byte seed; the 64-byte "secret key" used by some libraries is the seed
+#: concatenated with the derived public key — we don't use that here.
+ED25519_SECRET_KEY_BYTES = 32
+
+#: Ed25519 signature length in bytes (RFC 8032 §5.1.6).
+ED25519_SIGNATURE_BYTES = 64
+
+#: kid is a hex prefix of the SHA-256 of the public key. 16 hex chars =
+#: 64 bits of fingerprint collision resistance, ample within a fleet's
+#: registry. The full ``fingerprint(pub)`` remains available for manual
+#: verification when stronger comparison is needed.
+KID_HEX_LEN = 16
+
+
+# -- Errors -------------------------------------------------------------------
+
+
+class SignatureError(Exception):
+    """Raised when a signature fails verification."""
+
+
+# -- Public key ---------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PublicKey:
+    """Ed25519 public key (32 bytes).
+
+    Safe to share, serialize, and log. Equality and hashing are on raw
+    bytes so two ``PublicKey`` instances built from the same bytes are
+    interchangeable.
+    """
+
+    raw: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.raw, (bytes, bytearray)) or len(self.raw) != ED25519_PUBLIC_KEY_BYTES:
+            raise ValueError(
+                f"Ed25519 public key must be exactly {ED25519_PUBLIC_KEY_BYTES} bytes"
+            )
+        # Normalize bytearray → bytes so equality works as expected.
+        if isinstance(self.raw, bytearray):
+            object.__setattr__(self, "raw", bytes(self.raw))
+
+    def to_bytes(self) -> bytes:
+        return self.raw
+
+    def verify(self, message: bytes, signature: bytes) -> None:
+        """Verify ``signature`` over ``message``.
+
+        Raises :class:`SignatureError` on any failure (wrong key, tampered
+        message, wrong-length signature, malformed signature). Does not
+        leak which failure occurred — verification is binary.
+        """
+        if not isinstance(signature, (bytes, bytearray)) or len(signature) != ED25519_SIGNATURE_BYTES:
+            raise SignatureError("signature must be exactly 64 bytes")
+        try:
+            _NaclVerifyKey(self.raw).verify(bytes(message), bytes(signature))
+        except _NaclBadSignatureError as e:
+            raise SignatureError(str(e)) from e
+
+    def __repr__(self) -> str:
+        # Show kid, not raw bytes — public is safe to print but kid is more useful.
+        return f"PublicKey(kid={kid_from_public_key(self)!r})"
+
+
+# -- Secret key + keypair -----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SecretKey:
+    """Ed25519 32-byte secret seed.
+
+    Holds raw seed bytes. Use :meth:`secret_bytes_insecure` to read them
+    out; the verbose name is intentional so reviewers and grep can find
+    every place secret material is exfiltrated from this object.
+
+    ``__repr__`` never includes secret material.
+    """
+
+    _raw: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self._raw, (bytes, bytearray)) or len(self._raw) != ED25519_SECRET_KEY_BYTES:
+            raise ValueError(
+                f"Ed25519 secret seed must be exactly {ED25519_SECRET_KEY_BYTES} bytes"
+            )
+        if isinstance(self._raw, bytearray):
+            object.__setattr__(self, "_raw", bytes(self._raw))
+
+    def secret_bytes_insecure(self) -> bytes:
+        """Return raw seed bytes.
+
+        Verbose name so any caller is flagged for review. Storage and
+        signer layers are expected to be the only callers.
+        """
+        return self._raw
+
+    def __repr__(self) -> str:
+        return "SecretKey(<32 bytes redacted>)"
+
+
+@dataclass(frozen=True)
+class SigningKeypair:
+    """An Ed25519 signing keypair, public + secret bound together.
+
+    Cheap to construct and pass around. Holds secret material — same
+    care as :class:`SecretKey`. The public half is always available via
+    :attr:`public`.
+    """
+
+    secret: SecretKey
+    public: PublicKey
+
+    def sign(self, message: bytes) -> bytes:
+        """Return a detached Ed25519 signature over ``message``.
+
+        Deterministic per RFC 8032 — same input produces same signature.
+        """
+        signing = _NaclSigningKey(self.secret.secret_bytes_insecure())
+        signed = signing.sign(bytes(message))
+        return bytes(signed.signature)
+
+    def __repr__(self) -> str:
+        return f"SigningKeypair(public={self.public!r})"
+
+
+# -- Constructors -------------------------------------------------------------
+
+
+def generate_keypair() -> SigningKeypair:
+    """Generate a fresh Ed25519 keypair using OS randomness.
+
+    Uses :mod:`secrets` for the seed source so callers can rely on a
+    CSPRNG-backed key without thinking about it. Returns a
+    :class:`SigningKeypair` with bound public key.
+    """
+    seed = secrets.token_bytes(ED25519_SECRET_KEY_BYTES)
+    signing = _NaclSigningKey(seed)
+    pub_raw = bytes(signing.verify_key.encode())
+    return SigningKeypair(secret=SecretKey(seed), public=PublicKey(pub_raw))
+
+
+def public_key_from_bytes(raw: bytes) -> PublicKey:
+    """Build a :class:`PublicKey` from 32 raw bytes.
+
+    Raises :class:`ValueError` for wrong-length or non-bytes input.
+    Provided as a named constructor so callers don't directly poke at
+    the dataclass field.
+    """
+    if not isinstance(raw, (bytes, bytearray)):
+        raise ValueError("public_key_from_bytes requires bytes input")
+    return PublicKey(bytes(raw))
+
+
+# -- Fingerprints + key IDs ---------------------------------------------------
+
+
+def fingerprint(public_key: PublicKey) -> str:
+    """Return the canonical full-length SHA-256 hex fingerprint.
+
+    This is the authoritative identifier for a public key in
+    enrollment-token bindings and for manual verification. Always 64
+    lowercase hex chars.
+    """
+    return hashlib.sha256(public_key.raw).hexdigest()
+
+
+def kid_from_public_key(public_key: PublicKey) -> str:
+    """Return the short kid (key ID) for HTTP headers and registry lookup.
+
+    Defined as the first :data:`KID_HEX_LEN` hex characters of the SHA-256
+    of the raw public key. Deterministic, collision-resistant within a
+    fleet, short enough for ``Signature-Input: ...;keyid="..."`` HTTP
+    headers without bloat.
+
+    A registry MUST also store and expose the full :func:`fingerprint`
+    for manual verification and for binding enrollment tokens — kid
+    collisions are computationally unlikely but the fingerprint is the
+    cryptographic identity.
+    """
+    return fingerprint(public_key)[:KID_HEX_LEN]
+
+
+# -- JWK / OKP export ---------------------------------------------------------
+
+
+def _b64url_nopad(data: bytes) -> str:
+    """Base64url without padding, per RFC 7515 §2."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def jwk_export(public_key: PublicKey, *, kid: str | None = None) -> dict:
+    """Export a public key as a JWK in OKP/Ed25519 form.
+
+    Conforms to RFC 8037 §2 for the OKP key type. Includes ``alg=EdDSA``
+    and ``use=sig`` so JOSE consumers can pick the key for signing
+    verification without extra metadata.
+
+    The returned dict is a fresh object — callers are free to add their
+    own fields (``"use": "..."``, ``"kid": "..."``, etc.) before
+    serializing.
+    """
+    out = {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "alg": "EdDSA",
+        "use": "sig",
+        "x": _b64url_nopad(public_key.raw),
+        "kid": kid if kid is not None else kid_from_public_key(public_key),
+    }
+    return out

--- a/src/pinky_identity/keys.py
+++ b/src/pinky_identity/keys.py
@@ -148,10 +148,29 @@ class SigningKeypair:
     Cheap to construct and pass around. Holds secret material — same
     care as :class:`SecretKey`. The public half is always available via
     :attr:`public`.
+
+    The constructor enforces that ``public`` is the Ed25519 public key
+    derived from ``secret``. Mismatched pairs would produce signatures
+    that do not verify under the published public key (since kid /
+    fingerprint / JWK all come from ``public`` but the signature is made
+    with ``secret``), which is a foot-gun this class refuses to load.
+    Use :meth:`from_secret` to build a keypair from a seed alone.
     """
 
     secret: SecretKey
     public: PublicKey
+
+    def __post_init__(self) -> None:
+        derived_pub_raw = bytes(
+            _NaclSigningKey(self.secret.secret_bytes_insecure()).verify_key.encode()
+        )
+        if derived_pub_raw != self.public.raw:
+            raise ValueError(
+                "SigningKeypair public does not match the public key derived "
+                "from secret; this would produce signatures that don't verify "
+                "under the published public key. Use SigningKeypair.from_secret("
+                "secret) to build a keypair from the seed alone."
+            )
 
     def sign(self, message: bytes) -> bytes:
         """Return a detached Ed25519 signature over ``message``.
@@ -161,6 +180,21 @@ class SigningKeypair:
         signing = _NaclSigningKey(self.secret.secret_bytes_insecure())
         signed = signing.sign(bytes(message))
         return bytes(signed.signature)
+
+    @classmethod
+    def from_secret(cls, secret: SecretKey) -> "SigningKeypair":
+        """Build a keypair from a :class:`SecretKey`, deriving the public.
+
+        Convenience for the common path where the seed is the only thing
+        the caller has on hand (e.g. after decrypting a wrapped seed).
+        Always returns a self-consistent pair.
+        """
+        if not isinstance(secret, SecretKey):
+            raise TypeError("secret must be a SecretKey")
+        pub_raw = bytes(
+            _NaclSigningKey(secret.secret_bytes_insecure()).verify_key.encode()
+        )
+        return cls(secret=secret, public=PublicKey(pub_raw))
 
     def __repr__(self) -> str:
         return f"SigningKeypair(public={self.public!r})"

--- a/tests/test_pinky_identity_keys.py
+++ b/tests/test_pinky_identity_keys.py
@@ -1,0 +1,262 @@
+"""Tests for pinky_identity.keys — Ed25519 primitives for service-auth identity."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+from nacl.signing import SigningKey as _NaclSigningKey
+
+from pinky_identity import keys as ik
+
+# -- generate_keypair --------------------------------------------------------
+
+
+class TestGenerateKeypair:
+    def test_returns_signing_keypair_with_correct_lengths(self):
+        kp = ik.generate_keypair()
+        assert isinstance(kp, ik.SigningKeypair)
+        assert isinstance(kp.secret, ik.SecretKey)
+        assert isinstance(kp.public, ik.PublicKey)
+        assert len(kp.secret.secret_bytes_insecure()) == ik.ED25519_SECRET_KEY_BYTES
+        assert len(kp.public.raw) == ik.ED25519_PUBLIC_KEY_BYTES
+
+    def test_two_generations_differ(self):
+        # Vanishingly unlikely to collide. Catches a broken RNG.
+        a = ik.generate_keypair()
+        b = ik.generate_keypair()
+        assert a.secret.secret_bytes_insecure() != b.secret.secret_bytes_insecure()
+        assert a.public.raw != b.public.raw
+
+    def test_public_matches_secret_derivation(self):
+        """Public key in the keypair must be the Ed25519 derivation of the seed."""
+        kp = ik.generate_keypair()
+        derived = _NaclSigningKey(kp.secret.secret_bytes_insecure()).verify_key.encode()
+        assert kp.public.raw == bytes(derived)
+
+
+# -- public_key_from_bytes ----------------------------------------------------
+
+
+class TestPublicKeyFromBytes:
+    def test_valid_bytes_roundtrip(self):
+        kp = ik.generate_keypair()
+        loaded = ik.public_key_from_bytes(kp.public.raw)
+        assert loaded.raw == kp.public.raw
+        assert loaded == kp.public  # frozen dataclass equality on raw
+
+    def test_wrong_length_rejected(self):
+        with pytest.raises(ValueError, match="32 bytes"):
+            ik.public_key_from_bytes(b"\x00" * 31)
+        with pytest.raises(ValueError, match="32 bytes"):
+            ik.public_key_from_bytes(b"\x00" * 33)
+        with pytest.raises(ValueError, match="32 bytes"):
+            ik.public_key_from_bytes(b"")
+
+    def test_non_bytes_rejected(self):
+        with pytest.raises(ValueError):
+            ik.public_key_from_bytes("not bytes")  # type: ignore[arg-type]
+
+
+# -- SecretKey ---------------------------------------------------------------
+
+
+class TestSecretKey:
+    def test_wrong_length_rejected(self):
+        with pytest.raises(ValueError, match="32 bytes"):
+            ik.SecretKey(b"\x00" * 31)
+        with pytest.raises(ValueError, match="32 bytes"):
+            ik.SecretKey(b"\x00" * 64)
+
+    def test_repr_redacts_secret_material(self):
+        sk = ik.SecretKey(b"\xab" * 32)
+        r = repr(sk)
+        # Repr must not contain any byte of the secret in hex form.
+        assert "ab" not in r.lower()
+        assert "redacted" in r.lower()
+
+    def test_secret_bytes_insecure_returns_raw(self):
+        seed = bytes(range(32))
+        sk = ik.SecretKey(seed)
+        assert sk.secret_bytes_insecure() == seed
+
+    def test_signing_keypair_repr_does_not_leak_secret(self):
+        kp = ik.generate_keypair()
+        r = repr(kp)
+        # Should reference public via kid, not show secret hex.
+        assert "redacted" not in r.lower() or "kid" in r.lower()
+        # Secret hex should not appear in repr.
+        secret_hex = kp.secret.secret_bytes_insecure().hex()
+        assert secret_hex not in r
+
+    def test_public_key_repr_uses_kid_not_raw_bytes(self):
+        kp = ik.generate_keypair()
+        r = repr(kp.public)
+        assert "kid=" in r
+        # Public is safe to print but kid is more useful — assert raw bytes
+        # aren't included as a hex blob (>= 32 hex chars would be suspicious).
+        pub_hex = kp.public.raw.hex()
+        assert pub_hex not in r
+
+
+# -- sign + verify -----------------------------------------------------------
+
+
+class TestSignVerify:
+    def test_sign_then_verify_roundtrip(self):
+        kp = ik.generate_keypair()
+        msg = b"hello world"
+        sig = kp.sign(msg)
+        assert len(sig) == ik.ED25519_SIGNATURE_BYTES
+        # Must not raise.
+        kp.public.verify(msg, sig)
+
+    def test_signature_is_deterministic(self):
+        """RFC 8032 §5.1.6 — Ed25519 signatures are deterministic over (key, msg)."""
+        kp = ik.generate_keypair()
+        msg = b"determinism check"
+        s1 = kp.sign(msg)
+        s2 = kp.sign(msg)
+        assert s1 == s2
+
+    def test_verify_rejects_tampered_message(self):
+        kp = ik.generate_keypair()
+        sig = kp.sign(b"original")
+        with pytest.raises(ik.SignatureError):
+            kp.public.verify(b"tampered", sig)
+
+    def test_verify_rejects_wrong_key(self):
+        kp1 = ik.generate_keypair()
+        kp2 = ik.generate_keypair()
+        sig = kp1.sign(b"msg")
+        with pytest.raises(ik.SignatureError):
+            kp2.public.verify(b"msg", sig)
+
+    def test_verify_rejects_short_signature(self):
+        kp = ik.generate_keypair()
+        with pytest.raises(ik.SignatureError, match="64 bytes"):
+            kp.public.verify(b"msg", b"\x00" * 32)
+
+    def test_verify_rejects_long_signature(self):
+        kp = ik.generate_keypair()
+        with pytest.raises(ik.SignatureError, match="64 bytes"):
+            kp.public.verify(b"msg", b"\x00" * 128)
+
+    def test_verify_rejects_zero_signature(self):
+        """All-zero signature must not verify against a random key+msg."""
+        kp = ik.generate_keypair()
+        with pytest.raises(ik.SignatureError):
+            kp.public.verify(b"msg", b"\x00" * ik.ED25519_SIGNATURE_BYTES)
+
+
+# -- fingerprint + kid -------------------------------------------------------
+
+
+class TestFingerprintAndKid:
+    def test_fingerprint_is_sha256_hex_of_public(self):
+        kp = ik.generate_keypair()
+        fp = ik.fingerprint(kp.public)
+        assert fp == hashlib.sha256(kp.public.raw).hexdigest()
+        assert len(fp) == 64
+        assert all(c in "0123456789abcdef" for c in fp)
+
+    def test_kid_is_prefix_of_fingerprint(self):
+        kp = ik.generate_keypair()
+        kid = ik.kid_from_public_key(kp.public)
+        fp = ik.fingerprint(kp.public)
+        assert kid == fp[: ik.KID_HEX_LEN]
+        assert len(kid) == ik.KID_HEX_LEN
+
+    def test_kid_and_fingerprint_are_deterministic(self):
+        kp = ik.generate_keypair()
+        assert ik.kid_from_public_key(kp.public) == ik.kid_from_public_key(kp.public)
+        assert ik.fingerprint(kp.public) == ik.fingerprint(kp.public)
+
+    def test_different_keys_give_different_kids(self):
+        # Strong claim — fingerprints differ with overwhelming probability,
+        # and the kid prefix inherits that uniqueness within a fleet.
+        kids = {ik.kid_from_public_key(ik.generate_keypair().public) for _ in range(50)}
+        assert len(kids) == 50
+
+    def test_kid_format_is_hex(self):
+        kp = ik.generate_keypair()
+        kid = ik.kid_from_public_key(kp.public)
+        assert all(c in "0123456789abcdef" for c in kid)
+
+
+# -- JWK export --------------------------------------------------------------
+
+
+class TestJwkExport:
+    def test_okp_jwk_shape(self):
+        kp = ik.generate_keypair()
+        jwk = ik.jwk_export(kp.public)
+        assert jwk["kty"] == "OKP"
+        assert jwk["crv"] == "Ed25519"
+        assert jwk["alg"] == "EdDSA"
+        assert jwk["use"] == "sig"
+        assert jwk["kid"] == ik.kid_from_public_key(kp.public)
+        # x is base64url without padding.
+        assert "=" not in jwk["x"]
+        assert "+" not in jwk["x"]
+        assert "/" not in jwk["x"]
+
+    def test_jwk_x_decodes_to_public_key_bytes(self):
+        kp = ik.generate_keypair()
+        jwk = ik.jwk_export(kp.public)
+        # Re-add padding for decoding.
+        x = jwk["x"]
+        padded = x + "=" * (-len(x) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        assert decoded == kp.public.raw
+
+    def test_jwk_custom_kid(self):
+        kp = ik.generate_keypair()
+        jwk = ik.jwk_export(kp.public, kid="custom-kid")
+        assert jwk["kid"] == "custom-kid"
+
+    def test_jwk_export_returns_fresh_dict_each_call(self):
+        """Callers must be free to mutate the returned dict without sharing state."""
+        kp = ik.generate_keypair()
+        a = ik.jwk_export(kp.public)
+        b = ik.jwk_export(kp.public)
+        a["use"] = "enc"  # mutate one
+        assert b["use"] == "sig"  # other unaffected
+
+
+# -- Cross-key isolation -----------------------------------------------------
+
+
+class TestCrossKeyIsolation:
+    def test_signatures_do_not_cross_verify(self):
+        """The core cross-agent-impersonation defense at the crypto layer:
+        a signature made by key A cannot be verified by key B's public key.
+
+        Higher-level cross-agent tests live in the daemon-local signer and
+        verifier libraries — this test pins the underlying invariant so a
+        regression in the wrapper would surface here first.
+        """
+        kp_lera = ik.generate_keypair()
+        kp_olga = ik.generate_keypair()
+        msg = b"i am lera"
+        sig = kp_lera.sign(msg)
+        # Lera's pubkey verifies — that's the baseline.
+        kp_lera.public.verify(msg, sig)
+        # Olga's pubkey must NOT verify it.
+        with pytest.raises(ik.SignatureError):
+            kp_olga.public.verify(msg, sig)
+
+
+# -- Public package exports --------------------------------------------------
+
+
+class TestPackageExports:
+    def test_public_api_is_importable_from_package_root(self):
+        """Anything we promise via __all__ must import cleanly from the
+        package root. Catches typos in __init__.py + accidental moves.
+        """
+        import pinky_identity
+
+        for name in pinky_identity.__all__:
+            assert hasattr(pinky_identity, name), f"{name} missing from pinky_identity"

--- a/tests/test_pinky_identity_keys.py
+++ b/tests/test_pinky_identity_keys.py
@@ -150,6 +150,52 @@ class TestSignVerify:
             kp.public.verify(b"msg", b"\x00" * ik.ED25519_SIGNATURE_BYTES)
 
 
+# -- SigningKeypair construction discipline ---------------------------------
+
+
+class TestSigningKeypairConstruction:
+    """The ``__post_init__`` derivation check is a load-bearing safety:
+    without it, a mismatched (secret, public) pair would produce
+    signatures the verifier rejects because kid/fingerprint/JWK all come
+    from ``public`` while the math came from ``secret``. Catch this at
+    construction time, not in production at sign-time."""
+
+    def test_rejects_mismatched_public_and_secret(self):
+        kp1 = ik.generate_keypair()
+        kp2 = ik.generate_keypair()
+        with pytest.raises(ValueError, match="does not match"):
+            ik.SigningKeypair(secret=kp1.secret, public=kp2.public)
+
+    def test_rejects_swapped_pair(self):
+        # Same generator, but explicitly stitch the wrong halves together.
+        a = ik.generate_keypair()
+        b = ik.generate_keypair()
+        with pytest.raises(ValueError, match="does not match"):
+            ik.SigningKeypair(secret=b.secret, public=a.public)
+        with pytest.raises(ValueError, match="does not match"):
+            ik.SigningKeypair(secret=a.secret, public=b.public)
+
+    def test_accepts_self_consistent_pair(self):
+        kp = ik.generate_keypair()
+        # Reconstruct from the same parts — must not raise.
+        twin = ik.SigningKeypair(secret=kp.secret, public=kp.public)
+        assert twin.public == kp.public
+        assert (
+            twin.secret.secret_bytes_insecure()
+            == kp.secret.secret_bytes_insecure()
+        )
+
+    def test_from_secret_derives_public(self):
+        seed = ik.generate_keypair().secret
+        kp = ik.SigningKeypair.from_secret(seed)
+        derived = _NaclSigningKey(seed.secret_bytes_insecure()).verify_key.encode()
+        assert kp.public.raw == bytes(derived)
+
+    def test_from_secret_rejects_non_secret(self):
+        with pytest.raises(TypeError):
+            ik.SigningKeypair.from_secret(b"\x00" * 32)  # type: ignore[arg-type]
+
+
 # -- fingerprint + kid -------------------------------------------------------
 
 


### PR DESCRIPTION
First implementation slice of the per-agent asymmetric identity work tracked in #461. Pure library, no daemon integration — lands a stable public API so PR-3 (registry) and PR-4 (daemon-local signer) can develop in parallel.

## What's in

`src/pinky_identity/keys.py`:

| Surface | Notes |
|---|---|
| `SigningKeypair`, `SecretKey`, `PublicKey` | Frozen dataclasses. ``__repr__`` redacts secret material. Verbose ``secret_bytes_insecure()`` accessor so grep + review can flag every secret extraction. |
| `generate_keypair()` | CSPRNG seed via ``secrets.token_bytes``. Binds public on construction. |
| `public_key_from_bytes(raw)` | Named constructor, explicit type + length validation. |
| `fingerprint(pub)` | Canonical full SHA-256 hex (64 chars). Authoritative identifier for enrollment-token bindings + manual verification. |
| `kid_from_public_key(pub)` | First 16 hex chars of the fingerprint — short enough for ``Signature-Input: ...;keyid=...`` HTTP headers, collision-resistant within a fleet. Full fingerprint stays available when stronger comparison is needed. |
| `jwk_export(pub, *, kid=None)` | OKP/Ed25519 JWK per RFC 8037 §2 with ``alg=EdDSA``, ``use=sig``, base64url-unpadded ``x``, and ``kid`` defaulting to ``kid_from_public_key()``. Returns a fresh dict each call. |
| `SignatureError` | Raised on any verify failure — uniform interface, no side-channel leakage. |

PyNaCl backs the Ed25519 primitive (already a dep via ``pinky_federation``). Keeps the dependency footprint small. RFC 9421 HTTP message signature wrappers land separately as **PR-2b**.

## Intentionally separate from ``pinky_federation.keys``

Shared crypto primitive, distinct identity semantics + lifecycle. Federation tenant identity must NOT be reused as service-auth identity per the design doc (#461). Code may share Ed25519 wrappers, but registry / lifecycle / storage stay separate.

## Tests

``tests/test_pinky_identity_keys.py`` — **29 passing**.

Covers:
- Keypair generation + RNG sanity (two generations differ).
- Public/secret length + type validation, including non-bytes rejection on the named constructor.
- ``repr`` does not leak secret material (no secret-byte hex in any repr; ``SigningKeypair`` repr shows kid-only).
- Sign + verify roundtrip, deterministic signatures (RFC 8032 §5.1.6).
- Verify rejects tampered messages, wrong keys, short/long/all-zero signatures.
- Fingerprint determinism + format (lowercase hex, 64 chars).
- Kid is prefix of fingerprint, deterministic, hex format, no collisions in a sample of 50 fresh keys.
- JWK shape, base64url-unpadded ``x`` decodes back to the public key bytes, custom kid override, fresh-dict-per-call.
- **Cross-key isolation** — the underlying crypto invariant for the cross-agent-impersonation defense. Pins the property at the wrapper level so a regression here surfaces before the daemon-local signer + verifier in later PRs.
- Public ``__all__`` exports are importable from ``pinky_identity``.

Targeted: 29 passed.
Full suite: **2022 passed**, 1 skipped (was 1993 + 29 new).
``ruff check``: clean.

## What's intentionally out of scope here

- RFC 9421 HTTP message signature canonicalization + signer/verifier wrappers → **PR-2b**.
- On-disk PEM / PKCS#8 / encrypted-at-rest storage → **PR-3** (registry) + **PR-4** (daemon signer).
- Registry tables, enrollment tokens, admin endpoints → **PR-3**.
- Session-bound bearer-token issuance + ``POST /internal/signer/sign`` endpoint → **PR-4**.

Refs #461.

🤖 Opened by Barsik