### PR TITLE
feat(pinky_identity): RFC 9421 HTTP Message Signature wrappers (PR-2b)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ dependencies = [
     # Federation crypto (sealed_box_v1): X25519, Ed25519, HKDF, XChaCha20-Poly1305.
     "cryptography>=41.0",
     "pynacl>=1.5",
+    # Per-agent service-auth identity (pinky_identity): RFC 9421 HTTP Message
+    # Signatures over Ed25519. `requests` is the canonical message type for
+    # http-message-signatures and is already a transitive dependency.
+    "http-message-signatures>=2.0",
+    "requests>=2.32",
 ]
 
 [project.optional-dependencies]
@@ -69,7 +74,7 @@ dev = [
 pinky = "pinky_cli.__main__:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/pinky_memory", "src/pinky_outreach", "src/pinky_messaging", "src/pinky_daemon", "src/pinky_cli", "src/pinky_self", "src/pinky_calendar", "src/pinky_hub", "src/pinky_web", "src/pinky_federation"]
+packages = ["src/pinky_memory", "src/pinky_outreach", "src/pinky_messaging", "src/pinky_daemon", "src/pinky_cli", "src/pinky_self", "src/pinky_calendar", "src/pinky_hub", "src/pinky_web", "src/pinky_federation", "src/pinky_identity"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/pinky_identity/__init__.py
+++ b/src/pinky_identity/__init__.py
@@ -7,7 +7,7 @@ This package provides:
 
 - Ed25519 keypair primitives for the ``service-auth`` purpose
   (``pinky_identity.keys``)
-- (Coming in PR-2b) RFC 9421 HTTP Message Signature signer/verifier helpers
+- RFC 9421 HTTP Message Signature signer/verifier helpers
   (``pinky_identity.http_signatures``)
 - (Coming in PR-3) Registry storage + enrollment-token issuance + admin
   approval flow (``pinky_identity.registry``)
@@ -22,6 +22,21 @@ are mesh-transport tenant identities. Per the design doc, keys must not
 be shared across purposes.
 """
 
+from pinky_identity.http_signatures import (
+    CONTENT_DIGEST_ALGORITHM,
+    DEFAULT_COVERED_COMPONENTS,
+    DEFAULT_LABEL,
+    DEFAULT_MAX_AGE,
+    DEFAULT_REQUIRED_COMPONENTS,
+    DEFAULT_TAG,
+    HttpSignatureVerificationError,
+    PinkyKeyResolver,
+    VerifyResult,
+    attach_content_digest,
+    compute_content_digest,
+    sign_request,
+    verify_request,
+)
 from pinky_identity.keys import (
     ED25519_PUBLIC_KEY_BYTES,
     ED25519_SECRET_KEY_BYTES,
@@ -39,17 +54,30 @@ from pinky_identity.keys import (
 )
 
 __all__ = [
+    "CONTENT_DIGEST_ALGORITHM",
+    "DEFAULT_COVERED_COMPONENTS",
+    "DEFAULT_LABEL",
+    "DEFAULT_MAX_AGE",
+    "DEFAULT_REQUIRED_COMPONENTS",
+    "DEFAULT_TAG",
     "ED25519_PUBLIC_KEY_BYTES",
     "ED25519_SECRET_KEY_BYTES",
     "ED25519_SIGNATURE_BYTES",
+    "HttpSignatureVerificationError",
     "KID_HEX_LEN",
+    "PinkyKeyResolver",
     "PublicKey",
     "SecretKey",
     "SignatureError",
     "SigningKeypair",
+    "VerifyResult",
+    "attach_content_digest",
+    "compute_content_digest",
     "fingerprint",
     "generate_keypair",
     "jwk_export",
     "kid_from_public_key",
     "public_key_from_bytes",
+    "sign_request",
+    "verify_request",
 ]

--- a/src/pinky_identity/http_signatures.py
+++ b/src/pinky_identity/http_signatures.py
@@ -1,0 +1,451 @@
+"""RFC 9421 HTTP Message Signature wrappers for pinky_identity.
+
+A thin opinionated layer over :mod:`http_message_signatures` (the canonical
+Python implementation of RFC 9421) that speaks in terms of pinky_identity's
+:class:`SigningKeypair` / :class:`PublicKey` types instead of PEM blobs.
+
+Design rules (see ``docs/design/agent-asymmetric-identity.md`` and issue #461):
+
+- Ed25519 only. Other algorithms aren't on the roadmap.
+- Every signature carries the tag ``pinky-service-auth-v1`` — verifiers MUST
+  set ``expect_tag`` so a signature minted for one purpose can't be replayed
+  against another (an attacker who steals a Zoho-bound signature shouldn't be
+  able to present it to a federation peer).
+- A minimum covered-component set is enforced at verify time. ``@method`` and
+  ``@target-uri`` are non-negotiable; without them the signature doesn't bind
+  the operation. The defaults also include ``@authority`` so a signature
+  minted for ``api.zoho.com`` can't be replayed against ``api.evil.com``.
+- ``max_age`` is enforced via the ``created`` parameter — the library checks
+  this automatically. Default 5 minutes; tune at the call site.
+- Replay protection (nonce uniqueness) is *not* enforced here. That belongs
+  in the service-verifier layer (PR-5) which has the per-service nonce store.
+  We do emit a nonce by default so the verifier has something to dedupe on.
+
+The :class:`PinkyKeyResolver` translates kid lookups into in-memory
+:mod:`cryptography` Ed25519 key objects. PyNaCl seeds are 32 raw bytes, which
+is exactly what ``Ed25519PrivateKey.from_private_bytes`` expects, so the
+conversion is zero-copy and PEM-free.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from http_message_signatures import (
+    HTTPMessageSigner,
+    HTTPMessageVerifier,
+    HTTPSignatureKeyResolver,
+    InvalidSignature,
+    VerifyResult,
+    algorithms,
+)
+
+from pinky_identity.keys import (
+    PublicKey,
+    SignatureError,
+    SigningKeypair,
+    kid_from_public_key,
+)
+
+# -- Constants ---------------------------------------------------------------
+
+#: Service-auth tag stamped into every signature. Verifiers pin this to
+#: prevent cross-purpose replay (RFC 9421 §2.3 covers the ``tag`` parameter).
+DEFAULT_TAG = "pinky-service-auth-v1"
+
+#: Default label written into ``Signature-Input``. RFC 9421 §4.1 allows any
+#: token; ``pinky`` is short and recognizable.
+DEFAULT_LABEL = "pinky"
+
+#: Default covered components. ``@method`` + ``@target-uri`` bind the
+#: operation; ``@authority`` pins the host so a signature can't be replayed
+#: against a different origin.
+DEFAULT_COVERED_COMPONENTS: tuple[str, ...] = (
+    "@method",
+    "@target-uri",
+    "@authority",
+)
+
+#: Minimum set the verifier insists on. Anything not in this set is optional
+#: from the verifier's perspective — but if the sender omits ``@target-uri``
+#: the verifier rejects the signature even if the math checks out.
+DEFAULT_REQUIRED_COMPONENTS: frozenset[str] = frozenset(
+    {"@method", "@target-uri", "@authority"}
+)
+
+#: Default freshness window. The library checks ``created`` against
+#: ``datetime.now() - max_age`` automatically.
+DEFAULT_MAX_AGE = timedelta(minutes=5)
+
+#: ``Content-Digest`` algorithm. RFC 9530 defines ``sha-256`` and ``sha-512``;
+#: we standardize on sha-256 for size and ubiquity.
+CONTENT_DIGEST_ALGORITHM = "sha-256"
+
+
+# -- Errors ------------------------------------------------------------------
+
+
+class HttpSignatureVerificationError(SignatureError):
+    """Raised when an inbound signature fails verification.
+
+    Subclass of :class:`pinky_identity.SignatureError` so callers can catch
+    the general signature-failure case without importing this module.
+    """
+
+
+# -- Key resolver ------------------------------------------------------------
+
+
+def _to_crypto_private(keypair: SigningKeypair) -> Ed25519PrivateKey:
+    """Lift a pinky_identity SigningKeypair into a cryptography private key.
+
+    PyNaCl stores the seed as 32 raw bytes; cryptography's
+    ``Ed25519PrivateKey.from_private_bytes`` takes the same shape. No PEM
+    round-trip needed.
+    """
+    return Ed25519PrivateKey.from_private_bytes(
+        keypair.secret.secret_bytes_insecure()
+    )
+
+
+def _to_crypto_public(public_key: PublicKey) -> Ed25519PublicKey:
+    """Lift a pinky_identity PublicKey into a cryptography public key."""
+    return Ed25519PublicKey.from_public_bytes(public_key.raw)
+
+
+@dataclass
+class PinkyKeyResolver(HTTPSignatureKeyResolver):
+    """In-memory key resolver backed by pinky_identity types.
+
+    Two maps:
+
+    - ``signing_keys``: kid → :class:`SigningKeypair`, queried by the signer.
+    - ``public_keys``: kid → :class:`PublicKey`, queried by the verifier.
+
+    Either map may be empty if the resolver is used for only one direction
+    (a service that only verifies inbound signatures doesn't need any
+    signing keys, and vice versa).
+
+    The resolver is intentionally simple — the registry layer (PR-3) is
+    where lifecycle, persistence, and approval state live. This is the
+    in-process adapter that sits between the registry and the signing
+    library.
+    """
+
+    signing_keys: dict[str, SigningKeypair]
+    public_keys: dict[str, PublicKey]
+
+    def __init__(
+        self,
+        *,
+        signing_keys: dict[str, SigningKeypair] | None = None,
+        public_keys: dict[str, PublicKey] | None = None,
+    ) -> None:
+        self.signing_keys = dict(signing_keys or {})
+        self.public_keys = dict(public_keys or {})
+
+    @classmethod
+    def from_signing_keypairs(
+        cls, keypairs: Iterable[SigningKeypair]
+    ) -> "PinkyKeyResolver":
+        """Build a resolver from keypairs, indexing both halves by kid."""
+        signing: dict[str, SigningKeypair] = {}
+        public: dict[str, PublicKey] = {}
+        for kp in keypairs:
+            k = kid_from_public_key(kp.public)
+            signing[k] = kp
+            public[k] = kp.public
+        return cls(signing_keys=signing, public_keys=public)
+
+    def register_keypair(self, keypair: SigningKeypair) -> str:
+        """Add a keypair (both halves) to the resolver. Returns the kid."""
+        k = kid_from_public_key(keypair.public)
+        self.signing_keys[k] = keypair
+        self.public_keys[k] = keypair.public
+        return k
+
+    def register_public_key(self, public_key: PublicKey) -> str:
+        """Add a verify-only public key. Returns the kid."""
+        k = kid_from_public_key(public_key)
+        self.public_keys[k] = public_key
+        return k
+
+    # -- HTTPSignatureKeyResolver interface --
+
+    def resolve_private_key(self, key_id: str) -> Ed25519PrivateKey:
+        try:
+            kp = self.signing_keys[key_id]
+        except KeyError as e:
+            raise HttpSignatureVerificationError(
+                f"no signing key registered for kid {key_id!r}"
+            ) from e
+        return _to_crypto_private(kp)
+
+    def resolve_public_key(self, key_id: str) -> Ed25519PublicKey:
+        try:
+            pub = self.public_keys[key_id]
+        except KeyError as e:
+            raise HttpSignatureVerificationError(
+                f"no public key registered for kid {key_id!r}"
+            ) from e
+        return _to_crypto_public(pub)
+
+
+# -- Content-digest helper ---------------------------------------------------
+
+
+def compute_content_digest(body: bytes) -> str:
+    """Return an RFC 9530 ``Content-Digest`` value for ``body``.
+
+    Format: ``sha-256=:<base64-sha256>:`` per the structured-fields
+    dictionary encoding. The library's signer will read this header
+    when ``content-digest`` is in the covered components.
+    """
+    raw = hashlib.sha256(body).digest()
+    return f"{CONTENT_DIGEST_ALGORITHM}=:{base64.b64encode(raw).decode('ascii')}:"
+
+
+def attach_content_digest(request: Any) -> str:
+    """Compute and set the ``Content-Digest`` header on a prepared request.
+
+    Reads ``request.body`` (treating ``None`` as empty bytes), computes the
+    sha-256 digest, sets ``request.headers["Content-Digest"]``, and returns
+    the header value. Idempotent — calling twice with the same body
+    produces the same header.
+    """
+    body = request.body
+    if body is None:
+        body_bytes = b""
+    elif isinstance(body, str):
+        body_bytes = body.encode("utf-8")
+    elif isinstance(body, (bytes, bytearray)):
+        body_bytes = bytes(body)
+    else:  # pragma: no cover - defensive
+        raise TypeError(
+            f"unsupported request body type for content-digest: {type(body).__name__}"
+        )
+    digest = compute_content_digest(body_bytes)
+    request.headers["Content-Digest"] = digest
+    return digest
+
+
+# -- Sign / verify -----------------------------------------------------------
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def sign_request(
+    request: Any,
+    *,
+    keypair: SigningKeypair,
+    kid: str | None = None,
+    created: datetime | None = None,
+    expires_in: timedelta | None = None,
+    nonce: str | None = None,
+    covered_components: Sequence[str] = DEFAULT_COVERED_COMPONENTS,
+    tag: str = DEFAULT_TAG,
+    label: str = DEFAULT_LABEL,
+) -> str:
+    """Sign a prepared HTTP request in place.
+
+    Adds ``Signature`` and ``Signature-Input`` headers per RFC 9421 §4.
+
+    Parameters
+    ----------
+    request:
+        A :class:`requests.PreparedRequest` (or any object with mutable
+        ``headers`` dict, ``method``, ``url``, and ``body`` attributes
+        that ``http_message_signatures`` accepts).
+    keypair:
+        The Ed25519 keypair to sign with. Its kid is computed via
+        :func:`kid_from_public_key` unless ``kid`` is given explicitly.
+    kid:
+        Optional override for the kid stamped into ``Signature-Input``.
+        Defaults to the canonical kid of ``keypair.public``.
+    created:
+        Timestamp written into the signature parameters. Defaults to
+        ``datetime.now(UTC)``. Verifiers enforce ``max_age`` against this.
+    expires_in:
+        Optional ``expires`` parameter, encoded as ``created + expires_in``.
+        Independent of ``max_age`` — this is an absolute deadline the signer
+        commits to; ``max_age`` is the verifier's freshness window.
+    nonce:
+        Optional explicit nonce string. Defaults to a 16-byte random hex
+        nonce. Replay protection (uniqueness) is the verifier's job.
+    covered_components:
+        Tuple of component IDs (RFC 9421 §2). Order is significant for the
+        signature base — keep callers consistent.
+    tag:
+        ``tag`` parameter. Verifiers MUST pin this. Defaults to
+        :data:`DEFAULT_TAG`.
+    label:
+        Signature label written into ``Signature: <label>=...``. Defaults
+        to :data:`DEFAULT_LABEL`. Multiple labels are not supported by
+        this wrapper.
+
+    Returns
+    -------
+    str
+        The kid that was stamped into the signature, for caller logging.
+    """
+    resolver = PinkyKeyResolver.from_signing_keypairs([keypair])
+    effective_kid = kid if kid is not None else kid_from_public_key(keypair.public)
+    if kid is not None and kid != kid_from_public_key(keypair.public):
+        # The library will happily sign with whatever kid you give it; but
+        # verifiers look up by kid and would fail. Resolve this by also
+        # registering the kid override.
+        resolver.signing_keys[effective_kid] = keypair
+        resolver.public_keys[effective_kid] = keypair.public
+
+    effective_created = created if created is not None else _utc_now()
+    effective_expires = (
+        effective_created + expires_in if expires_in is not None else None
+    )
+    effective_nonce = nonce if nonce is not None else secrets.token_hex(16)
+
+    signer = HTTPMessageSigner(
+        signature_algorithm=algorithms.ED25519,
+        key_resolver=resolver,
+    )
+    signer.sign(
+        request,
+        key_id=effective_kid,
+        created=effective_created,
+        expires=effective_expires,
+        nonce=effective_nonce,
+        label=label,
+        tag=tag,
+        covered_component_ids=tuple(covered_components),
+        include_alg=True,
+    )
+    return effective_kid
+
+
+def verify_request(
+    request: Any,
+    *,
+    key_resolver: PinkyKeyResolver,
+    max_age: timedelta | None = DEFAULT_MAX_AGE,
+    expect_tag: str = DEFAULT_TAG,
+    required_components: Iterable[str] = DEFAULT_REQUIRED_COMPONENTS,
+    expect_label: str | None = None,
+) -> VerifyResult:
+    """Verify a signed HTTP request.
+
+    Wraps :class:`HTTPMessageVerifier` with the policy hooks the library
+    doesn't enforce itself:
+
+    - ``required_components`` — the library verifies whatever the sender
+      claims; this wrapper additionally insists the sender claimed at
+      least the listed components. Without this, a sender could omit
+      ``@target-uri`` and the math would still check out for a different
+      URL.
+    - ``expect_tag`` — passed through to the library; verifiers MUST set
+      this to prevent cross-purpose replay.
+
+    Raises
+    ------
+    HttpSignatureVerificationError
+        On any failure: missing/extra signature, expired, tag mismatch,
+        unknown kid, missing required component, body tamper, bad math.
+        Does not leak which failure occurred beyond the message string.
+
+    Returns
+    -------
+    VerifyResult
+        The library's :class:`VerifyResult` for the verified signature.
+        Callers can inspect ``covered_components`` and ``parameters`` for
+        downstream policy (e.g. nonce-store dedupe in PR-5).
+    """
+    verifier = HTTPMessageVerifier(
+        signature_algorithm=algorithms.ED25519,
+        key_resolver=key_resolver,
+    )
+    try:
+        # Pass a very large max_age and enforce our own — the library's
+        # InvalidSignature for staleness collapses into the generic
+        # exception type, and we want a consistent error surface.
+        results = verifier.verify(
+            request,
+            max_age=max_age if max_age is not None else timedelta(days=36500),
+            expect_tag=expect_tag,
+            expect_label=expect_label,
+        )
+    except InvalidSignature as e:
+        raise HttpSignatureVerificationError(str(e)) from e
+    except HttpSignatureVerificationError:
+        raise
+    except Exception as e:
+        # The library may surface raw cryptography or http_sfv errors when
+        # the signature is malformed. Normalize them.
+        raise HttpSignatureVerificationError(
+            f"signature verification failed: {e}"
+        ) from e
+
+    if not results:
+        raise HttpSignatureVerificationError("no signature found on request")
+    if len(results) > 1:
+        # We don't support multi-sig; reject rather than silently picking one.
+        raise HttpSignatureVerificationError(
+            f"expected exactly one signature, got {len(results)}"
+        )
+    result = results[0]
+
+    # Required-components check — the library doesn't enforce a minimum
+    # set. Compare against the structured-field list parsed by http_sfv.
+    required = frozenset(required_components)
+    covered = frozenset(result.covered_components.keys())
+    # ``covered_components`` keys come back with quoted-string syntax and
+    # may include parameters (e.g. ``"@query-param";name="foo"``). We
+    # compare on the raw component id portion before the first ``;``.
+    covered_ids = frozenset(_strip_component_params(k) for k in covered)
+    missing = required - covered_ids
+    if missing:
+        raise HttpSignatureVerificationError(
+            f"signature missing required covered components: {sorted(missing)}"
+        )
+
+    return result
+
+
+def _strip_component_params(component_id: str) -> str:
+    """Return the component id with structured-field parameters stripped.
+
+    RFC 9421 component IDs are serialized as structured-field strings,
+    optionally with parameters (e.g. ``"@query-param";name="foo"``). For
+    the required-set check we only care about the bare component id.
+    """
+    # The library hands us keys in the form '"@method"', '"content-type"',
+    # or '"@query-param";name="foo"'. http_sfv knows how to parse but for
+    # the simple prefix-strip we want here, splitting is enough.
+    head, _, _ = component_id.partition(";")
+    return head.strip().strip('"')
+
+
+__all__ = [
+    "CONTENT_DIGEST_ALGORITHM",
+    "DEFAULT_COVERED_COMPONENTS",
+    "DEFAULT_LABEL",
+    "DEFAULT_MAX_AGE",
+    "DEFAULT_REQUIRED_COMPONENTS",
+    "DEFAULT_TAG",
+    "HttpSignatureVerificationError",
+    "PinkyKeyResolver",
+    "VerifyResult",
+    "attach_content_digest",
+    "compute_content_digest",
+    "sign_request",
+    "verify_request",
+]

--- a/src/pinky_identity/http_signatures.py
+++ b/src/pinky_identity/http_signatures.py
@@ -341,6 +341,7 @@ def verify_request(
     expect_tag: str = DEFAULT_TAG,
     required_components: Iterable[str] = DEFAULT_REQUIRED_COMPONENTS,
     expect_label: str | None = None,
+    require_content_digest_if_body: bool = True,
 ) -> VerifyResult:
     """Verify a signed HTTP request.
 
@@ -354,12 +355,26 @@ def verify_request(
       URL.
     - ``expect_tag`` — passed through to the library; verifiers MUST set
       this to prevent cross-purpose replay.
+    - **Content-Digest body binding** (RFC 9421 §7.5.6, RFC 9530). The
+      library authenticates the value of the ``Content-Digest`` *header*
+      but does not check that the header value matches a hash of
+      ``request.body``. If we trusted the library alone, an attacker
+      could swap the body and keep the signed digest header unchanged —
+      the math would still verify. So when ``content-digest`` is in the
+      verified covered components, this wrapper recomputes
+      :func:`compute_content_digest` over the actual body and rejects
+      any mismatch. When ``require_content_digest_if_body=True`` (the
+      default), a request with a non-empty body that did NOT include
+      ``content-digest`` in covered components is also rejected — the
+      sender is opting out of body integrity, which is virtually never
+      what production callers want.
 
     Raises
     ------
     HttpSignatureVerificationError
         On any failure: missing/extra signature, expired, tag mismatch,
-        unknown kid, missing required component, body tamper, bad math.
+        unknown kid, missing required component, body/digest mismatch,
+        body present without ``content-digest`` covered, bad math.
         Does not leak which failure occurred beyond the message string.
 
     Returns
@@ -417,7 +432,104 @@ def verify_request(
             f"signature missing required covered components: {sorted(missing)}"
         )
 
+    # Body / content-digest binding. The signature authenticates the
+    # value of the Content-Digest *header*, not the body. Without this
+    # check, a body swap that leaves the header unchanged passes
+    # verification.
+    _enforce_content_digest_body_binding(
+        request,
+        covered_ids=covered_ids,
+        require_if_body=require_content_digest_if_body,
+    )
+
     return result
+
+
+def _enforce_content_digest_body_binding(
+    request: Any,
+    *,
+    covered_ids: frozenset[str],
+    require_if_body: bool,
+) -> None:
+    """Cross-check ``Content-Digest`` header against the actual body.
+
+    Two cases:
+
+    1. ``content-digest`` is in the verified covered components —
+       recompute the digest from ``request.body`` and require
+       byte-equality with the header value the signature authenticated.
+       Tamper anywhere on that path (body or header swap) is caught.
+    2. ``content-digest`` is NOT covered, but the request has a non-empty
+       body. If ``require_if_body=True`` (default), refuse — the sender
+       opted out of body integrity, which is virtually never what
+       production callers want. To override (e.g. proxy that doesn't
+       know the body), pass ``require_content_digest_if_body=False``
+       through :func:`verify_request`.
+
+    Multiple digest algorithms in a single ``Content-Digest`` header
+    (e.g. ``sha-256=...,sha-512=...``) are permitted by RFC 9530; we
+    accept the request as long as at least one comparable algorithm
+    (sha-256 today) matches the body. Other algorithms are ignored —
+    they were authenticated by the signature too, but the policy here is
+    "at least one match against the body". Bumping
+    :data:`CONTENT_DIGEST_ALGORITHM` later is a coordinated change.
+    """
+    body = getattr(request, "body", None)
+    headers = getattr(request, "headers", {}) or {}
+
+    if body is None or body == b"" or body == "":
+        body_bytes: bytes = b""
+    elif isinstance(body, str):
+        body_bytes = body.encode("utf-8")
+    elif isinstance(body, (bytes, bytearray)):
+        body_bytes = bytes(body)
+    else:
+        body_bytes = bytes(body)
+
+    has_body = len(body_bytes) > 0
+    content_digest_covered = "content-digest" in covered_ids
+
+    if not content_digest_covered:
+        if has_body and require_if_body:
+            raise HttpSignatureVerificationError(
+                "request has a non-empty body but the signature does not cover "
+                "content-digest; the body is not bound to the signature. "
+                "Refusing for safety; set require_content_digest_if_body=False "
+                "if you really want to verify body-free."
+            )
+        return
+
+    header_value = headers.get("Content-Digest") or headers.get("content-digest")
+    if header_value is None:
+        raise HttpSignatureVerificationError(
+            "signature covers content-digest but request has no "
+            "Content-Digest header"
+        )
+
+    expected = compute_content_digest(body_bytes)
+    # RFC 9530 lets headers carry multiple algorithms. Accept as long as
+    # one entry matches our recomputed sha-256.
+    candidate_entries = [seg.strip() for seg in header_value.split(",")]
+    if not any(_content_digest_segment_matches(seg, expected) for seg in candidate_entries):
+        raise HttpSignatureVerificationError(
+            "Content-Digest header does not match SHA-256 of request body; "
+            "body has been tampered with after signing"
+        )
+
+
+def _content_digest_segment_matches(segment: str, expected_full: str) -> bool:
+    """Return True if ``segment`` is an RFC 9530 ``sha-256=:base64:`` entry
+    whose value matches the digest from :func:`compute_content_digest`.
+
+    ``expected_full`` is the full ``sha-256=:base64:`` string from
+    :func:`compute_content_digest`. We match algorithm-then-value so a
+    mismatched algorithm doesn't accidentally pass when the bytes line
+    up. Other algorithms in the header are ignored.
+    """
+    seg = segment.strip()
+    if not seg.startswith(f"{CONTENT_DIGEST_ALGORITHM}="):
+        return False
+    return seg == expected_full
 
 
 def _strip_component_params(component_id: str) -> str:

--- a/tests/test_pinky_identity_http_signatures.py
+++ b/tests/test_pinky_identity_http_signatures.py
@@ -146,8 +146,15 @@ def test_verify_rejects_wrong_authority(keypair, resolver):
         verify_request(req, key_resolver=resolver)
 
 
-def test_verify_rejects_tampered_body(keypair, resolver):
-    req = _prep_post()
+def test_verify_rejects_tampered_body_with_intact_digest_header(keypair, resolver):
+    """Realistic body-tamper: body swapped, signed Content-Digest header intact.
+
+    The library authenticates the *header value* of Content-Digest, not
+    the body. Without the wrapper's body↔digest cross-check, an attacker
+    can swap the body and the signature math still verifies. This test
+    is the regression for Murzik's PR-2b review finding.
+    """
+    req = _prep_post(json_body={"hello": "world"})
     attach_content_digest(req)
     sign_request(
         req,
@@ -160,11 +167,34 @@ def test_verify_rejects_tampered_body(keypair, resolver):
         ),
     )
 
-    # Tamper the body but keep the original content-digest header — the
-    # library doesn't recompute the digest at verify time, but the signed
-    # digest no longer matches what the verifier would compute from the
-    # new body. To exercise the spec path, we instead tamper the digest
-    # header value (simulates either body or digest substitution).
+    # Swap the body. The Content-Digest header (signed) is untouched.
+    req.body = b'{"hello":"evil"}'
+
+    with pytest.raises(HttpSignatureVerificationError, match="body"):
+        verify_request(
+            req,
+            key_resolver=resolver,
+            required_components={"@method", "@target-uri", "content-digest"},
+        )
+
+
+def test_verify_rejects_tampered_digest_header(keypair, resolver):
+    """Mutating the signed Content-Digest header invalidates the library
+    signature math directly. Belt-and-suspenders alongside the body
+    cross-check.
+    """
+    req = _prep_post()
+    attach_content_digest(req)
+    sign_request(
+        req,
+        keypair=keypair,
+        covered_components=(
+            "@method",
+            "@target-uri",
+            "@authority",
+            "content-digest",
+        ),
+    )
     req.headers["Content-Digest"] = compute_content_digest(b"tampered!")
 
     with pytest.raises(HttpSignatureVerificationError):
@@ -173,6 +203,80 @@ def test_verify_rejects_tampered_body(keypair, resolver):
             key_resolver=resolver,
             required_components={"@method", "@target-uri", "content-digest"},
         )
+
+
+def test_verify_rejects_body_when_content_digest_not_covered(keypair, resolver):
+    """If a request has a body and the signature does NOT cover
+    content-digest, the body is unbound — refuse by default."""
+    req = _prep_post()
+    # Note: no attach_content_digest, no content-digest in covered_components.
+    sign_request(req, keypair=keypair)
+    with pytest.raises(HttpSignatureVerificationError, match="content-digest"):
+        verify_request(req, key_resolver=resolver)
+
+
+def test_verify_allows_unbound_body_when_explicitly_opted_out(keypair, resolver):
+    """The strict default can be relaxed with require_content_digest_if_body=False."""
+    req = _prep_post()
+    sign_request(req, keypair=keypair)
+    # Caller explicitly accepts an unbound body (e.g. a proxy that doesn't
+    # see the body). Library math still verifies.
+    result = verify_request(
+        req, key_resolver=resolver, require_content_digest_if_body=False
+    )
+    assert result.parameters["tag"] == DEFAULT_TAG
+
+
+def test_verify_rejects_missing_content_digest_header_when_covered(keypair, resolver):
+    """If content-digest is in covered components but the header is gone
+    at verify time, refuse."""
+    req = _prep_post()
+    attach_content_digest(req)
+    sign_request(
+        req,
+        keypair=keypair,
+        covered_components=(
+            "@method",
+            "@target-uri",
+            "@authority",
+            "content-digest",
+        ),
+    )
+    # Drop the header after signing (e.g. proxy stripped it).
+    del req.headers["Content-Digest"]
+    with pytest.raises(HttpSignatureVerificationError):
+        verify_request(
+            req,
+            key_resolver=resolver,
+            required_components={"@method", "@target-uri", "content-digest"},
+        )
+
+
+def test_verify_accepts_multi_algorithm_content_digest_header(keypair, resolver):
+    """RFC 9530 allows multiple digest algorithms in one header. We accept
+    as long as the sha-256 entry matches the body."""
+    req = _prep_post()
+    sha256_digest = compute_content_digest(req.body)
+    # Append a bogus sha-512 entry; sha-256 entry is correct.
+    req.headers["Content-Digest"] = (
+        f"{sha256_digest}, sha-512=:Zm9vYmFy:"
+    )
+    sign_request(
+        req,
+        keypair=keypair,
+        covered_components=(
+            "@method",
+            "@target-uri",
+            "@authority",
+            "content-digest",
+        ),
+    )
+    # Must not raise.
+    verify_request(
+        req,
+        key_resolver=resolver,
+        required_components={"@method", "@target-uri", "content-digest"},
+    )
 
 
 # -- Policy rejections -------------------------------------------------------

--- a/tests/test_pinky_identity_http_signatures.py
+++ b/tests/test_pinky_identity_http_signatures.py
@@ -1,0 +1,326 @@
+"""Tests for pinky_identity.http_signatures (RFC 9421 wrappers)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import requests
+
+from pinky_identity import (
+    DEFAULT_TAG,
+    HttpSignatureVerificationError,
+    PinkyKeyResolver,
+    attach_content_digest,
+    compute_content_digest,
+    generate_keypair,
+    kid_from_public_key,
+    sign_request,
+    verify_request,
+)
+from pinky_identity.http_signatures import _strip_component_params
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def keypair():
+    return generate_keypair()
+
+
+@pytest.fixture
+def resolver(keypair):
+    return PinkyKeyResolver.from_signing_keypairs([keypair])
+
+
+def _prep_get(url: str = "https://api.example.com/v1/things") -> requests.PreparedRequest:
+    return requests.Request("GET", url).prepare()
+
+
+def _prep_post(
+    url: str = "https://api.example.com/v1/things",
+    json_body: dict | None = None,
+) -> requests.PreparedRequest:
+    return requests.Request("POST", url, json=json_body or {"hello": "world"}).prepare()
+
+
+# -- Roundtrip ---------------------------------------------------------------
+
+
+def test_sign_and_verify_roundtrip_get(keypair, resolver):
+    req = _prep_get()
+    kid = sign_request(req, keypair=keypair)
+
+    assert kid == kid_from_public_key(keypair.public)
+    assert "Signature" in req.headers
+    assert "Signature-Input" in req.headers
+
+    result = verify_request(req, key_resolver=resolver)
+
+    assert result.parameters["keyid"] == kid
+    assert result.parameters["alg"] == "ed25519"
+    assert result.parameters["tag"] == DEFAULT_TAG
+    assert "nonce" in result.parameters
+    assert "created" in result.parameters
+
+
+def test_sign_and_verify_roundtrip_post_with_content_digest(keypair, resolver):
+    req = _prep_post()
+    attach_content_digest(req)
+
+    sign_request(
+        req,
+        keypair=keypair,
+        covered_components=(
+            "@method",
+            "@target-uri",
+            "@authority",
+            "content-digest",
+        ),
+    )
+
+    result = verify_request(
+        req,
+        key_resolver=resolver,
+        required_components={"@method", "@target-uri", "content-digest"},
+    )
+    assert "content-digest" in {_strip_component_params(k) for k in result.covered_components}
+
+
+def test_explicit_kid_override_signs_and_verifies(keypair):
+    req = _prep_get()
+    override = "agent-vacation-01"
+    returned_kid = sign_request(req, keypair=keypair, kid=override)
+    assert returned_kid == override
+
+    # Caller has to publish the override kid the same way to the verifier.
+    resolver = PinkyKeyResolver()
+    resolver.public_keys[override] = keypair.public
+    result = verify_request(req, key_resolver=resolver)
+    assert result.parameters["keyid"] == override
+
+
+# -- Tamper detection --------------------------------------------------------
+
+
+def test_verify_rejects_tampered_signature(keypair, resolver):
+    req = _prep_get()
+    sign_request(req, keypair=keypair)
+
+    # Flip a byte in the base64-encoded signature payload.
+    sig = req.headers["Signature"]
+    label, _, sig_value = sig.partition("=:")
+    flipped = bytearray(base64.b64decode(sig_value.rstrip(":")))
+    flipped[0] ^= 0x01
+    req.headers["Signature"] = (
+        f"{label}=:{base64.b64encode(bytes(flipped)).decode('ascii')}:"
+    )
+
+    with pytest.raises(HttpSignatureVerificationError):
+        verify_request(req, key_resolver=resolver)
+
+
+def test_verify_rejects_wrong_method(keypair, resolver):
+    req = _prep_get()
+    sign_request(req, keypair=keypair)
+    req.method = "POST"
+    with pytest.raises(HttpSignatureVerificationError):
+        verify_request(req, key_resolver=resolver)
+
+
+def test_verify_rejects_wrong_target_uri(keypair, resolver):
+    req = _prep_get("https://api.example.com/v1/things")
+    sign_request(req, keypair=keypair)
+    req.url = "https://api.example.com/v1/OTHER"
+    with pytest.raises(HttpSignatureVerificationError):
+        verify_request(req, key_resolver=resolver)
+
+
+def test_verify_rejects_wrong_authority(keypair, resolver):
+    req = _prep_get("https://api.example.com/v1/things")
+    sign_request(req, keypair=keypair)
+    req.url = "https://evil.example.com/v1/things"
+    with pytest.raises(HttpSignatureVerificationError):
+        verify_request(req, key_resolver=resolver)
+
+
+def test_verify_rejects_tampered_body(keypair, resolver):
+    req = _prep_post()
+    attach_content_digest(req)
+    sign_request(
+        req,
+        keypair=keypair,
+        covered_components=(
+            "@method",
+            "@target-uri",
+            "@authority",
+            "content-digest",
+        ),
+    )
+
+    # Tamper the body but keep the original content-digest header — the
+    # library doesn't recompute the digest at verify time, but the signed
+    # digest no longer matches what the verifier would compute from the
+    # new body. To exercise the spec path, we instead tamper the digest
+    # header value (simulates either body or digest substitution).
+    req.headers["Content-Digest"] = compute_content_digest(b"tampered!")
+
+    with pytest.raises(HttpSignatureVerificationError):
+        verify_request(
+            req,
+            key_resolver=resolver,
+            required_components={"@method", "@target-uri", "content-digest"},
+        )
+
+
+# -- Policy rejections -------------------------------------------------------
+
+
+def test_verify_rejects_tag_mismatch(keypair, resolver):
+    req = _prep_get()
+    sign_request(req, keypair=keypair, tag="some-other-purpose")
+    with pytest.raises(HttpSignatureVerificationError):
+        verify_request(req, key_resolver=resolver, expect_tag=DEFAULT_TAG)
+
+
+def test_verify_rejects_unknown_kid(keypair):
+    req = _prep_get()
+    sign_request(req, keypair=keypair)
+    # Verifier has a completely different keypair registered.
+    other = generate_keypair()
+    resolver = PinkyKeyResolver.from_signing_keypairs([other])
+    with pytest.raises(HttpSignatureVerificationError):
+        verify_request(req, key_resolver=resolver)
+
+
+def test_verify_rejects_expired(keypair, resolver):
+    req = _prep_get()
+    long_ago = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    sign_request(req, keypair=keypair, created=long_ago)
+    with pytest.raises(HttpSignatureVerificationError):
+        verify_request(
+            req, key_resolver=resolver, max_age=timedelta(minutes=5)
+        )
+
+
+def test_verify_accepts_within_max_age(keypair, resolver):
+    req = _prep_get()
+    recent = datetime.now(tz=timezone.utc) - timedelta(seconds=10)
+    sign_request(req, keypair=keypair, created=recent)
+    result = verify_request(req, key_resolver=resolver, max_age=timedelta(minutes=5))
+    assert result.parameters["tag"] == DEFAULT_TAG
+
+
+def test_verify_rejects_missing_required_component(keypair, resolver):
+    req = _prep_get()
+    # Sender only covers @method — verifier insists on @target-uri.
+    sign_request(req, keypair=keypair, covered_components=("@method",))
+    with pytest.raises(HttpSignatureVerificationError) as exc:
+        verify_request(
+            req,
+            key_resolver=resolver,
+            required_components={"@method", "@target-uri"},
+        )
+    assert "@target-uri" in str(exc.value)
+
+
+def test_verify_rejects_when_no_signature(resolver):
+    req = _prep_get()
+    with pytest.raises(HttpSignatureVerificationError):
+        verify_request(req, key_resolver=resolver)
+
+
+# -- Content-digest helpers --------------------------------------------------
+
+
+def test_compute_content_digest_matches_rfc9530_format():
+    body = b'{"hello":"world"}'
+    digest = compute_content_digest(body)
+    raw = hashlib.sha256(body).digest()
+    expected = f"sha-256=:{base64.b64encode(raw).decode('ascii')}:"
+    assert digest == expected
+
+
+def test_attach_content_digest_sets_header_for_bytes_body():
+    req = _prep_post()
+    expected = compute_content_digest(req.body)  # bytes
+    digest = attach_content_digest(req)
+    assert digest == expected
+    assert req.headers["Content-Digest"] == expected
+
+
+def test_attach_content_digest_handles_str_body():
+    req = requests.Request("POST", "https://api.example.com/", data="hello").prepare()
+    digest = attach_content_digest(req)
+    assert digest == compute_content_digest(b"hello")
+
+
+def test_attach_content_digest_handles_none_body():
+    req = _prep_get()
+    digest = attach_content_digest(req)
+    assert digest == compute_content_digest(b"")
+
+
+def test_attach_content_digest_is_idempotent():
+    req = _prep_post()
+    first = attach_content_digest(req)
+    second = attach_content_digest(req)
+    assert first == second
+
+
+# -- Resolver ----------------------------------------------------------------
+
+
+def test_resolver_round_trips_register_keypair():
+    kp = generate_keypair()
+    resolver = PinkyKeyResolver()
+    kid = resolver.register_keypair(kp)
+    assert resolver.signing_keys[kid] is kp
+    assert resolver.public_keys[kid] == kp.public
+
+
+def test_resolver_register_public_key_only():
+    kp = generate_keypair()
+    resolver = PinkyKeyResolver()
+    kid = resolver.register_public_key(kp.public)
+    assert kid in resolver.public_keys
+    assert kid not in resolver.signing_keys
+
+
+def test_resolver_unknown_kid_raises_clean_error():
+    resolver = PinkyKeyResolver()
+    with pytest.raises(HttpSignatureVerificationError):
+        resolver.resolve_public_key("unknown")
+    with pytest.raises(HttpSignatureVerificationError):
+        resolver.resolve_private_key("unknown")
+
+
+# -- Signature-Input shape ---------------------------------------------------
+
+
+def test_signature_input_includes_keyid_alg_created_nonce_tag(keypair, resolver):
+    req = _prep_get()
+    sign_request(req, keypair=keypair)
+    sig_input = req.headers["Signature-Input"]
+    assert "keyid=" in sig_input
+    assert 'alg="ed25519"' in sig_input
+    assert "created=" in sig_input
+    assert "nonce=" in sig_input
+    assert f'tag="{DEFAULT_TAG}"' in sig_input
+
+
+def test_explicit_expires_appears_in_signature_input(keypair, resolver):
+    req = _prep_get()
+    sign_request(req, keypair=keypair, expires_in=timedelta(seconds=120))
+    sig_input = req.headers["Signature-Input"]
+    assert "expires=" in sig_input
+    result = verify_request(req, key_resolver=resolver)
+    assert "expires" in result.parameters
+
+
+def test_strip_component_params_helper():
+    assert _strip_component_params('"@method"') == "@method"
+    assert _strip_component_params('"content-type"') == "content-type"
+    assert _strip_component_params('"@query-param";name="foo"') == "@query-param"

--- a/uv.lock
+++ b/uv.lock
@@ -508,20 +508,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.77"
+version = "0.1.81"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/d4/7e3ca29d1b6f76639b4bd4becb796ef68a492be3a561c6cd19abe5fe903a/claude_agent_sdk-0.1.77.tar.gz", hash = "sha256:cb292268ecab294047f02365298ecbf8cc17146c4c86fda54b068a1d38e1ebbb", size = 250297, upload-time = "2026-05-08T00:03:03.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ce/e7a02076df66dd7dd48764321a7b103fe13a2bdabd48e2eb25f45e6d1f9e/claude_agent_sdk-0.1.81.tar.gz", hash = "sha256:9a3e873c99cd98b2e11ae5e65fd250f38ea192c3a8ddd117ed69a10bbf2b913b", size = 250295, upload-time = "2026-05-11T18:56:44.76Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/fc/dbb90aff01fe7bdd7708077aaff4b36d5be48a38318fd4ca2216aa64ed87/claude_agent_sdk-0.1.77-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a5697c838cb3a0c78f73698933cd2eea98e8baea99be0740e314fc9e1f69fd4c", size = 60659903, upload-time = "2026-05-08T00:03:06.461Z" },
-    { url = "https://files.pythonhosted.org/packages/37/6e/c984d60f4b3cbbf7d84157283338493d11a2b557a2f6389118b5a7f8adc2/claude_agent_sdk-0.1.77-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:a85e3a8cf5d521116d964d28939f25e367d18e5bdb2232cae260b8e8bd9d946f", size = 62721493, upload-time = "2026-05-08T00:03:09.808Z" },
-    { url = "https://files.pythonhosted.org/packages/00/83/575e798ce53b58e14d775db104cdb2558706e7f8d22dc647752208fa853f/claude_agent_sdk-0.1.77-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:16864b91bf369e99590e3ffba82e2d711807caaa4329b11462212779224cd355", size = 70393564, upload-time = "2026-05-08T00:03:13.383Z" },
-    { url = "https://files.pythonhosted.org/packages/00/67/50aed27534a9183e204cca33fbef36d0fe5f5145ebf4061c01f2edeaf6db/claude_agent_sdk-0.1.77-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:7db011c9c8ca4168249f1ce90d4372e13ebab2b122498167e6fb2a5c9c1bd427", size = 70582992, upload-time = "2026-05-08T00:03:16.997Z" },
-    { url = "https://files.pythonhosted.org/packages/83/3f/a9d396c46e40d025d4209cf0f6f01a62c70c33b70efceb2d2e991e8ed08c/claude_agent_sdk-0.1.77-py3-none-win_amd64.whl", hash = "sha256:fe7dd006a15a85c1d9a2698d6fffd58e0ce689db1f0040f5b5e4c06d51ce2505", size = 71224295, upload-time = "2026-05-08T00:03:20.695Z" },
+    { url = "https://files.pythonhosted.org/packages/81/89/454cb0c45baf0776cc3f61d10d4bafdd55a7a56963266c3a843882ba2a64/claude_agent_sdk-0.1.81-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e4bc8797cc2bc882031cf6b287a550ae2bb38a3822aa081e9ffc81bb4bed51da", size = 61076865, upload-time = "2026-05-11T18:56:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/1d895e20cae4cd767a714622825e2752257cdd3887586dea966afbb65aaf/claude_agent_sdk-0.1.81-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:a3cdbc00e18ed6b0f11387833bf2d4b7779e0f5f3a9ea63f27b6d6e62f304256", size = 63129573, upload-time = "2026-05-11T18:56:52.059Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/09/4ea3baf9deaa098dd5bc5fc4aeb93a116ab879f0d63992a8ffa000b61afe/claude_agent_sdk-0.1.81-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:e08a03b414af5814573cf89646653c1398193557f536914103f8f0708068ed27", size = 70801456, upload-time = "2026-05-11T18:56:56.356Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/0a/2d5325d3961b0896f41bcf74136350a2a54b3e4b9c3bd35f006b0adeb7b4/claude_agent_sdk-0.1.81-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:a75b3421eeabc57c31ee2515a7c58ddf17886a3166ee9481f0750ddb27eba8d8", size = 70988920, upload-time = "2026-05-11T18:57:01.024Z" },
+    { url = "https://files.pythonhosted.org/packages/30/dc/b925ae2f0bbd4783ef28f72871a9e59248f9df2f3ecb8ac6a937ad4b01f9/claude_agent_sdk-0.1.81-py3-none-win_amd64.whl", hash = "sha256:4214cef9c4fb4f6b850d23f5f931e0e556803f4c32c1ae9f87206d2327b4a1a8", size = 71616000, upload-time = "2026-05-11T18:57:05.723Z" },
 ]
 
 [[package]]
@@ -1042,6 +1042,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
     { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
     { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
+name = "http-message-signatures"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/95/083707b15af3bdbb6c9e54ae7f448046f7ab55f9eaa5cccdc5dd23791d15/http_message_signatures-2.0.1.tar.gz", hash = "sha256:394545b0cc296a4fd45166f57056e7e029dcd5b91d9bf549e108c96c23aa1cba", size = 30517, upload-time = "2026-01-19T04:01:07.277Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/4a/c778016e3a9c18f283b401319346a980f3ff9556c674afa89a22b9e756bb/http_message_signatures-2.0.1-py3-none-any.whl", hash = "sha256:2b2c463f5d077d3081f27770e8017762d5969a1f17e1dc89e8b96a57c44e8a5e", size = 28204, upload-time = "2026-01-19T04:01:05.738Z" },
 ]
 
 [[package]]
@@ -2179,6 +2191,7 @@ dependencies = [
     { name = "claude-agent-sdk" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "http-message-signatures" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "numpy" },
@@ -2187,6 +2200,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pynacl" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "uvicorn" },
 ]
 
@@ -2258,7 +2272,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'web'", specifier = ">=4.12" },
     { name = "caldav", marker = "extra == 'calendar'", specifier = ">=1.3" },
     { name = "camoufox", marker = "extra == 'web'", specifier = ">=0.4" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.77" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.80" },
     { name = "cryptography", specifier = ">=41.0" },
     { name = "cryptography", marker = "extra == 'calendar'", specifier = ">=41.0" },
     { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.3" },
@@ -2269,6 +2283,7 @@ requires-dist = [
     { name = "google-auth", marker = "extra == 'google'", specifier = ">=2.0" },
     { name = "google-auth-httplib2", marker = "extra == 'calendar'", specifier = ">=0.2" },
     { name = "google-auth-oauthlib", marker = "extra == 'calendar'", specifier = ">=1.0" },
+    { name = "http-message-signatures", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "icalendar", marker = "extra == 'calendar'", specifier = ">=5.0" },
     { name = "markdownify", marker = "extra == 'web'", specifier = ">=1.0" },
@@ -2283,6 +2298,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'telegram'", specifier = ">=21.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "requests", specifier = ">=2.32" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11" },
     { name = "sentence-transformers", marker = "extra == 'local-embeddings'", specifier = ">=2.0" },
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.0" },


### PR DESCRIPTION
## Summary

PR-2b of the per-agent service-auth identity rollout (tracking issue #461). Thin opinionated layer over [`http-message-signatures`](https://github.com/pyauth/http-message-signatures) (v2.0.1) that speaks in pinky_identity `SigningKeypair`/`PublicKey` types and pins the policy hooks the library doesn't enforce itself.

**Stacks on #462 (PR-2a).** Base set to `feat/pinky-identity-keys`; will rebase to `main` once PR-2a lands. PR-3 (registry) is parallel via Murzik.

## What's in the module

`src/pinky_identity/http_signatures.py`:
- **`PinkyKeyResolver`** — in-memory kid → keypair/public adapter. PyNaCl seed flows straight into `Ed25519PrivateKey.from_private_bytes` so keys stay PEM-free in-process.
- **`sign_request(request, *, keypair, ...)`** — mutates a `requests.PreparedRequest` in place. Defaults: `@method + @target-uri + @authority` covered, `tag="pinky-service-auth-v1"`, 16-byte random nonce, `alg=ed25519`, kid derived from public key.
- **`verify_request(request, *, key_resolver, ...)`** — wraps `HTTPMessageVerifier` with the bits the lib leaves to the caller:
  - `required_components`: rejects signatures that don't cover `@method + @target-uri + @authority` (otherwise a sender could omit `@target-uri` and the math would still pass for a different URL).
  - `expect_tag`: passed through; verifiers MUST pin to block cross-purpose replay (Zoho-bound sig replayed against federation, etc.).
  - Normalizes failure modes to a single `HttpSignatureVerificationError` (subclass of `SignatureError`).
  - Rejects multi-sig requests rather than silently picking one.
- **`compute_content_digest` / `attach_content_digest`** — RFC 9530 sha-256 helpers. Handles bytes/str/None bodies; idempotent.

## Design notes documented inline

- **Replay/nonce uniqueness is NOT enforced here.** That's the service-verifier's job (PR-5) where the per-service nonce store lives. We emit a nonce by default so the verifier has something to dedupe on.
- **PEM bypass:** PyNaCl seeds and cryptography's `from_private_bytes` use the same 32-byte raw shape, so we skip the PEM detour the library docs assume. Documented as the intentional bridge.
- **Ed25519-only.** Other algs aren't on the roadmap. Single-algorithm wrapper keeps the policy surface small.

## Side fix

`src/pinky_identity` added to `[tool.hatch.build.targets.wheel] packages`. Was missing in PR-2a — module was only visible via `pythonpath="src"` in tests, would not have shipped in wheels. Caught while wiring deps for this PR.

## Tests

`tests/test_pinky_identity_http_signatures.py` — 25 cases:

- Roundtrip: GET, POST+content-digest, explicit-kid override
- Tamper rejection: signature byte-flip, wrong method, wrong target-uri, wrong authority, tampered content-digest
- Policy rejection: expired (`max_age`), tag mismatch, unknown kid, missing required component, no signature on request
- Content-digest helpers: bytes/str/None bodies, format matches RFC 9530, idempotence
- Resolver: register keypair round-trip, public-only registration, unknown-kid clean error
- `Signature-Input` shape: keyid + alg + created + nonce + tag (+ expires when set)

**Suite:** 2047 passed, 1 skipped (was 2022 + 25 new). ruff clean.

## Deps

- `http-message-signatures>=2.0` (new direct, v2.0.1 in lock)
- `requests>=2.32` (was transitive — promoted; canonical message type for the library)

Lockfile updated.

## Test plan

- [ ] CI green (lint + Python 3.11/3.12/3.13/3.14 + Docker)
- [ ] Murzik LGTM
- [ ] Brad final sign-off (or punt to Murzik per standing review policy)

Refs #461.

🤖 Opened by Barsik