### PR TITLE
feat(identity): add registry enrollment flow

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -136,6 +136,7 @@ from pinky_daemon.skill_loader import discover_all_skills, register_discovered_s
 from pinky_daemon.skill_store import SkillStore
 from pinky_daemon.task_store import TaskStore
 from pinky_daemon.trigger_store import TriggerStore
+from pinky_identity.registry import IdentityRegistry
 
 # Feature flag: shared MCP mode uses a single HTTP/SSE server instead of per-agent stdio
 SHARED_MCP_ENABLED = os.environ.get("PINKY_SHARED_MCP", "0") == "1"
@@ -668,6 +669,14 @@ def create_api(
     store = ConversationStore(db_path=db_path)
     analytics = AnalyticsStore(db_path=db_path.replace(".db", "_analytics.db"))
     agents = AgentRegistry(db_path=db_path.replace(".db", "_agents.db"))
+    identity_db_path = (
+        "data/pinky_identity_registry.db"
+        if db_path == "data/conversations.db"
+        else db_path.replace(".db", "_pinky_identity_registry.db")
+    )
+    identity_registry = IdentityRegistry(
+        db_path=identity_db_path
+    )
     _refresh_1m_models(agents)
     audit = AuditStore(db_path=db_path.replace(".db", "_audit.db"))
     hooks = HookManager(audit_store=audit)
@@ -2683,6 +2692,11 @@ def create_api(
         if not secret:
             return False
         return bool(verify_session_cookie(secret, request.cookies.get(SESSION_COOKIE_NAME, "")))
+
+    def _require_identity_admin(request: Request) -> None:
+        """Explicit guard for identity registry admin routes."""
+        if not _has_valid_session(request):
+            raise HTTPException(401, "Authentication required")
 
     def _needs_browser_api_auth(request: Request) -> bool:
         path = request.url.path
@@ -7878,6 +7892,16 @@ def create_api(
 
     _activity_set_deps(audit=audit, hooks=hooks, activity=activity)
     app.include_router(_activity_router)
+
+    # ── Identity Registry Routes ─────────────────────────────
+    from pinky_daemon.routes.identity import router as _identity_router
+    from pinky_daemon.routes.identity import set_dependencies as _identity_set_deps
+
+    _identity_set_deps(
+        registry=identity_registry,
+        require_admin=_require_identity_admin,
+    )
+    app.include_router(_identity_router)
 
     # ── Task/Project Management ──────────────────────────
 

--- a/src/pinky_daemon/routes/identity.py
+++ b/src/pinky_daemon/routes/identity.py
@@ -1,0 +1,282 @@
+"""Agent service-auth identity registry routes.
+
+Admin routes are explicitly guarded by a dependency supplied from
+``create_api``. The read-only verifier lookup and enrollment redemption paths
+are intentionally narrow and do not grant admin power.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any, Callable
+
+from fastapi import APIRouter, HTTPException, Request
+
+from pinky_identity import (
+    DEFAULT_FLEET,
+    DEFAULT_TOKEN_TTL_SECONDS,
+    PURPOSE_SERVICE_AUTH,
+    IdentityRegistry,
+    IdentityRegistryError,
+    public_key_from_bytes,
+)
+
+router = APIRouter(tags=["identity"])
+
+_registry: IdentityRegistry | None = None
+_require_admin: Callable[[Request], None] | None = None
+
+
+def set_dependencies(
+    *, registry: IdentityRegistry, require_admin: Callable[[Request], None]
+) -> None:
+    """Wire the identity registry and explicit admin guard."""
+    global _registry, _require_admin
+    _registry = registry
+    _require_admin = require_admin
+
+
+def _store() -> IdentityRegistry:
+    if _registry is None:
+        raise HTTPException(503, "identity registry is not configured")
+    return _registry
+
+
+def _admin(request: Request) -> None:
+    if _require_admin is None:
+        raise HTTPException(503, "identity admin guard is not configured")
+    _require_admin(request)
+
+
+def _b64url_decode(value: str) -> bytes:
+    cleaned = (value or "").strip()
+    if not cleaned:
+        raise ValueError("empty base64 value")
+    padded = cleaned + "=" * (-len(cleaned) % 4)
+    return base64.urlsafe_b64decode(padded.encode("ascii"))
+
+
+def _public_key_from_request(req: dict[str, Any]):
+    raw = req.get("public_key_b64") or req.get("public_key")
+    if raw:
+        try:
+            return public_key_from_bytes(_b64url_decode(str(raw)))
+        except Exception as exc:
+            raise HTTPException(400, f"invalid public_key_b64: {exc}") from exc
+    jwk = req.get("public_jwk") or req.get("jwk")
+    if isinstance(jwk, dict) and jwk.get("x"):
+        if jwk.get("kty") not in (None, "OKP"):
+            raise HTTPException(400, "public_jwk.kty must be OKP")
+        if jwk.get("crv") not in (None, "Ed25519"):
+            raise HTTPException(400, "public_jwk.crv must be Ed25519")
+        try:
+            return public_key_from_bytes(_b64url_decode(str(jwk["x"])))
+        except Exception as exc:
+            raise HTTPException(400, f"invalid public_jwk.x: {exc}") from exc
+    raise HTTPException(400, "public_key_b64 or public_jwk.x is required")
+
+
+def _actor(req: dict[str, Any], default: str = "admin") -> str:
+    return (
+        req.get("actor")
+        or req.get("issued_by")
+        or req.get("approved_by")
+        or default
+    ).strip()
+
+
+def _error(exc: Exception) -> HTTPException:
+    if isinstance(exc, KeyError):
+        return HTTPException(404, str(exc))
+    if isinstance(exc, IdentityRegistryError):
+        return HTTPException(400, str(exc))
+    return HTTPException(500, str(exc))
+
+
+# -- Read-only verifier path --------------------------------------------------
+
+
+@router.get("/identity/keys/{kid}")
+async def get_identity_key(kid: str):
+    """Read-only, kid-narrow public key lookup for service verifiers."""
+    key = _store().get_key(kid)
+    if key is None:
+        raise HTTPException(404, f"identity key not found: {kid}")
+    return key.to_dict()
+
+
+# -- Enrollment redemption ----------------------------------------------------
+
+
+@router.post("/identity/enroll/redeem")
+async def redeem_enrollment_token(req: dict[str, Any]):
+    """Redeem a one-time enrollment token and activate the submitted key."""
+    pub = _public_key_from_request(req)
+    try:
+        key = _store().redeem_enrollment_token(
+            token=str(req.get("token") or ""),
+            public_key=pub,
+            fleet=(req.get("fleet") or DEFAULT_FLEET),
+            agent_name=str(req.get("agent_name") or ""),
+            purpose=(req.get("purpose") or PURPOSE_SERVICE_AUTH),
+            actor=str(req.get("actor") or req.get("agent_name") or ""),
+            metadata=req.get("metadata") if isinstance(req.get("metadata"), dict) else None,
+        )
+    except Exception as exc:
+        raise _error(exc) from exc
+    return key.to_dict()
+
+
+# -- Explicitly guarded admin paths ------------------------------------------
+
+
+@router.post("/identity/admin/enrollment-tokens")
+async def issue_enrollment_token(req: dict[str, Any], request: Request):
+    _admin(request)
+    ttl = int(req.get("ttl_seconds") or DEFAULT_TOKEN_TTL_SECONDS)
+    try:
+        token = _store().issue_enrollment_token(
+            fleet=(req.get("fleet") or DEFAULT_FLEET),
+            agent_name=str(req.get("agent_name") or ""),
+            purpose=(req.get("purpose") or PURPOSE_SERVICE_AUTH),
+            public_key_fingerprint=str(req.get("public_key_fingerprint") or ""),
+            issued_by=_actor(req),
+            ttl_seconds=ttl,
+            reason=str(req.get("reason") or ""),
+            metadata=req.get("metadata") if isinstance(req.get("metadata"), dict) else None,
+        )
+    except Exception as exc:
+        raise _error(exc) from exc
+    return token.to_dict(include_token=True)
+
+
+@router.get("/identity/admin/enrollment-tokens")
+async def list_enrollment_tokens(
+    request: Request,
+    fleet: str = "",
+    agent_name: str = "",
+    purpose: str = "",
+    status: str = "",
+    limit: int = 100,
+):
+    _admin(request)
+    tokens = _store().list_enrollment_tokens(
+        fleet=fleet,
+        agent_name=agent_name,
+        purpose=purpose,
+        status=status,
+        limit=limit,
+    )
+    return {"tokens": [t.to_dict() for t in tokens], "count": len(tokens)}
+
+
+@router.post("/identity/admin/enrollment-tokens/{token_id}/revoke")
+async def revoke_enrollment_token(token_id: str, req: dict[str, Any], request: Request):
+    _admin(request)
+    try:
+        token = _store().revoke_enrollment_token(
+            token_id,
+            revoked_by=_actor(req),
+            reason=str(req.get("reason") or ""),
+        )
+    except Exception as exc:
+        raise _error(exc) from exc
+    return token.to_dict()
+
+
+@router.post("/identity/admin/keys/pending")
+async def submit_pending_key(req: dict[str, Any], request: Request):
+    _admin(request)
+    pub = _public_key_from_request(req)
+    try:
+        key = _store().submit_pending_key(
+            public_key=pub,
+            fleet=(req.get("fleet") or DEFAULT_FLEET),
+            agent_name=str(req.get("agent_name") or ""),
+            purpose=(req.get("purpose") or PURPOSE_SERVICE_AUTH),
+            actor=_actor(req),
+            metadata=req.get("metadata") if isinstance(req.get("metadata"), dict) else None,
+        )
+    except Exception as exc:
+        raise _error(exc) from exc
+    return key.to_dict()
+
+
+@router.get("/identity/admin/keys")
+async def list_identity_keys(
+    request: Request,
+    fleet: str = "",
+    agent_name: str = "",
+    purpose: str = "",
+    status: str = "",
+    limit: int = 100,
+):
+    _admin(request)
+    keys = _store().list_keys(
+        fleet=fleet,
+        agent_name=agent_name,
+        purpose=purpose,
+        status=status,
+        limit=limit,
+    )
+    return {"keys": [k.to_dict() for k in keys], "count": len(keys)}
+
+
+@router.post("/identity/admin/keys/{kid}/approve")
+async def approve_identity_key(kid: str, req: dict[str, Any], request: Request):
+    _admin(request)
+    try:
+        key = _store().approve_key(
+            kid,
+            approved_by=_actor(req),
+            reason=str(req.get("reason") or ""),
+        )
+    except Exception as exc:
+        raise _error(exc) from exc
+    return key.to_dict()
+
+
+@router.post("/identity/admin/keys/{kid}/revoke")
+async def revoke_identity_key(kid: str, req: dict[str, Any], request: Request):
+    _admin(request)
+    try:
+        key = _store().revoke_key(
+            kid,
+            revoked_by=_actor(req),
+            reason=str(req.get("reason") or ""),
+        )
+    except Exception as exc:
+        raise _error(exc) from exc
+    return key.to_dict()
+
+
+@router.post("/identity/admin/keys/{kid}/retire")
+async def retire_identity_key(kid: str, req: dict[str, Any], request: Request):
+    _admin(request)
+    try:
+        key = _store().retire_key(
+            kid,
+            retired_by=_actor(req),
+            reason=str(req.get("reason") or ""),
+        )
+    except Exception as exc:
+        raise _error(exc) from exc
+    return key.to_dict()
+
+
+@router.get("/identity/admin/audit")
+async def list_identity_audit(
+    request: Request,
+    fleet: str = "",
+    agent_name: str = "",
+    event_type: str = "",
+    limit: int = 100,
+):
+    _admin(request)
+    entries = _store().list_audit(
+        fleet=fleet,
+        agent_name=agent_name,
+        event_type=event_type,
+        limit=limit,
+    )
+    return {"entries": [e.to_dict() for e in entries], "count": len(entries)}

--- a/src/pinky_identity/__init__.py
+++ b/src/pinky_identity/__init__.py
@@ -12,8 +12,8 @@ This package provides:
   (``pinky_identity.signer_store``)
 - RFC 9421 HTTP Message Signature signer/verifier helpers
   (``pinky_identity.http_signatures``)
-- (Coming in PR-3) Registry storage + enrollment-token issuance + admin
-  approval flow (``pinky_identity.registry``)
+- Registry storage + enrollment-token issuance + admin approval flow
+  (``pinky_identity.registry``)
 - (Coming in PR-4b-2) Daemon-local signer + session-bound bearer-token
   capability (``pinky_identity.signer``)
 
@@ -68,6 +68,24 @@ from pinky_identity.keystore import (
     unwrap_keypair,
     wrap_keypair,
 )
+from pinky_identity.registry import (
+    DEFAULT_DB_PATH,
+    DEFAULT_FLEET,
+    DEFAULT_TOKEN_TTL_SECONDS,
+    KEY_ACTIVE,
+    KEY_PENDING,
+    KEY_RETIRED,
+    KEY_REVOKED,
+    PURPOSE_SERVICE_AUTH,
+    TOKEN_ACTIVE,
+    TOKEN_REVOKED,
+    TOKEN_USED,
+    EnrollmentTokenRecord,
+    IdentityAuditRecord,
+    IdentityKeyRecord,
+    IdentityRegistry,
+    IdentityRegistryError,
+)
 from pinky_identity.signer_store import (
     DEFAULT_SIGNER_STORE_PATH,
     EncryptedSignerStore,
@@ -78,21 +96,37 @@ from pinky_identity.signer_store import (
 __all__ = [
     "CONTENT_DIGEST_ALGORITHM",
     "DEFAULT_COVERED_COMPONENTS",
+    "DEFAULT_DB_PATH",
     "DEFAULT_DEVICE_KEY_PATH",
+    "DEFAULT_FLEET",
     "DEFAULT_LABEL",
     "DEFAULT_MAX_AGE",
     "DEFAULT_REQUIRED_COMPONENTS",
     "DEFAULT_SIGNER_STORE_PATH",
     "DEFAULT_TAG",
+    "DEFAULT_TOKEN_TTL_SECONDS",
     "DEVICE_KEY_BYTES",
     "ED25519_PUBLIC_KEY_BYTES",
     "ED25519_SECRET_KEY_BYTES",
     "ED25519_SIGNATURE_BYTES",
+    "KEY_ACTIVE",
+    "KEY_PENDING",
+    "KEY_RETIRED",
+    "KEY_REVOKED",
     "KID_HEX_LEN",
+    "PURPOSE_SERVICE_AUTH",
+    "TOKEN_ACTIVE",
+    "TOKEN_REVOKED",
+    "TOKEN_USED",
     "WRAP_VERSION",
     "DeviceKey",
     "EncryptedSignerStore",
+    "EnrollmentTokenRecord",
     "HttpSignatureVerificationError",
+    "IdentityAuditRecord",
+    "IdentityKeyRecord",
+    "IdentityRegistry",
+    "IdentityRegistryError",
     "KeystoreError",
     "PinkyKeyResolver",
     "PublicKey",

--- a/src/pinky_identity/registry.py
+++ b/src/pinky_identity/registry.py
@@ -1,0 +1,989 @@
+"""SQLite registry for service-auth public keys and enrollment tokens.
+
+This is the registry/admin half of the per-agent asymmetric identity design.
+It stores public service-auth keys, one-time enrollment tokens, lifecycle state,
+and an audit trail. Private key storage belongs to the daemon-local signer
+(PR-4), not this module.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pinky_identity.keys import (
+    PublicKey,
+    jwk_export,
+    kid_from_public_key,
+)
+from pinky_identity.keys import (
+    fingerprint as public_key_fingerprint,
+)
+
+DEFAULT_DB_PATH = "data/pinky_identity_registry.db"
+DEFAULT_FLEET = "pos"
+PURPOSE_SERVICE_AUTH = "service-auth"
+
+KEY_PENDING = "pending"
+KEY_ACTIVE = "active"
+KEY_RETIRED = "retired"
+KEY_REVOKED = "revoked"
+KEY_STATUSES = frozenset({KEY_PENDING, KEY_ACTIVE, KEY_RETIRED, KEY_REVOKED})
+
+TOKEN_ACTIVE = "active"
+TOKEN_USED = "used"
+TOKEN_REVOKED = "revoked"
+TOKEN_STATUSES = frozenset({TOKEN_ACTIVE, TOKEN_USED, TOKEN_REVOKED})
+
+DEFAULT_TOKEN_TTL_SECONDS = 15 * 60
+
+
+class IdentityRegistryError(ValueError):
+    """Raised when a registry operation is invalid."""
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _json_dumps(data: dict[str, Any] | None) -> str:
+    return json.dumps(data or {}, sort_keys=True, separators=(",", ":"))
+
+
+def _json_loads(raw: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(raw or "{}")
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _b64url_nopad(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:20]}"
+
+
+def _clean_nonempty(value: str, field: str) -> str:
+    cleaned = (value or "").strip()
+    if not cleaned:
+        raise IdentityRegistryError(f"{field} is required")
+    return cleaned
+
+
+def _clean_fleet_agent_purpose(
+    *, fleet: str, agent_name: str, purpose: str
+) -> tuple[str, str, str]:
+    return (
+        _clean_nonempty(fleet, "fleet"),
+        _clean_nonempty(agent_name, "agent_name"),
+        _clean_nonempty(purpose, "purpose"),
+    )
+
+
+def _clean_fingerprint(value: str) -> str:
+    fp = _clean_nonempty(value, "public_key_fingerprint").lower()
+    if len(fp) != 64 or any(c not in "0123456789abcdef" for c in fp):
+        raise IdentityRegistryError("public_key_fingerprint must be 64 hex chars")
+    return fp
+
+
+@dataclass(frozen=True)
+class IdentityKeyRecord:
+    """A service-auth public key registered for one agent."""
+
+    kid: str
+    fleet: str
+    agent_name: str
+    purpose: str
+    public_key: bytes
+    public_jwk: dict[str, Any]
+    fingerprint: str
+    status: str
+    created_at: float
+    approved_at: float = 0.0
+    approved_by: str = ""
+    retired_at: float = 0.0
+    revoked_at: float = 0.0
+    revoked_by: str = ""
+    revoke_reason: str = ""
+    replaced_by_kid: str = ""
+    not_before: float = 0.0
+    not_after: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kid": self.kid,
+            "fleet": self.fleet,
+            "agent_name": self.agent_name,
+            "purpose": self.purpose,
+            "public_key_b64": _b64url_nopad(self.public_key),
+            "public_jwk": dict(self.public_jwk),
+            "fingerprint": self.fingerprint,
+            "status": self.status,
+            "created_at": self.created_at,
+            "approved_at": self.approved_at or None,
+            "approved_by": self.approved_by,
+            "retired_at": self.retired_at or None,
+            "revoked_at": self.revoked_at or None,
+            "revoked_by": self.revoked_by,
+            "revoke_reason": self.revoke_reason,
+            "replaced_by_kid": self.replaced_by_kid,
+            "not_before": self.not_before or None,
+            "not_after": self.not_after or None,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class EnrollmentTokenRecord:
+    """One-time token binding a future public key to an agent identity."""
+
+    token_id: str
+    token_hash: str
+    fleet: str
+    agent_name: str
+    purpose: str
+    public_key_fingerprint: str
+    status: str
+    issued_by: str
+    created_at: float
+    expires_at: float
+    used_at: float = 0.0
+    revoked_at: float = 0.0
+    reason: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    token: str = ""
+
+    def to_dict(self, *, include_token: bool = False) -> dict[str, Any]:
+        out = {
+            "token_id": self.token_id,
+            "fleet": self.fleet,
+            "agent_name": self.agent_name,
+            "purpose": self.purpose,
+            "public_key_fingerprint": self.public_key_fingerprint,
+            "status": self.status,
+            "issued_by": self.issued_by,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "used_at": self.used_at or None,
+            "revoked_at": self.revoked_at or None,
+            "reason": self.reason,
+            "metadata": dict(self.metadata),
+        }
+        if include_token:
+            out["token"] = self.token
+        return out
+
+
+@dataclass(frozen=True)
+class IdentityAuditRecord:
+    """Registry audit event."""
+
+    id: int
+    event_type: str
+    fleet: str
+    agent_name: str
+    purpose: str
+    kid: str
+    fingerprint: str
+    actor: str
+    outcome: str
+    reason: str
+    metadata: dict[str, Any]
+    created_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "event_type": self.event_type,
+            "fleet": self.fleet,
+            "agent_name": self.agent_name,
+            "purpose": self.purpose,
+            "kid": self.kid,
+            "fingerprint": self.fingerprint,
+            "actor": self.actor,
+            "outcome": self.outcome,
+            "reason": self.reason,
+            "metadata": dict(self.metadata),
+            "created_at": self.created_at,
+        }
+
+
+class IdentityRegistry:
+    """SQLite-backed service-auth identity registry."""
+
+    def __init__(self, db_path: str = DEFAULT_DB_PATH) -> None:
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._db_path = db_path
+        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db.row_factory = sqlite3.Row
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA foreign_keys=ON")
+        self._lock = threading.RLock()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS identity_keys (
+                kid          TEXT PRIMARY KEY,
+                fleet        TEXT NOT NULL,
+                agent_name   TEXT NOT NULL,
+                purpose      TEXT NOT NULL,
+                public_key   BLOB NOT NULL,
+                public_jwk   TEXT NOT NULL DEFAULT '{}',
+                fingerprint  TEXT NOT NULL UNIQUE,
+                status       TEXT NOT NULL,
+                created_at   REAL NOT NULL,
+                approved_at  REAL NOT NULL DEFAULT 0,
+                approved_by  TEXT NOT NULL DEFAULT '',
+                retired_at   REAL NOT NULL DEFAULT 0,
+                revoked_at   REAL NOT NULL DEFAULT 0,
+                revoked_by   TEXT NOT NULL DEFAULT '',
+                revoke_reason TEXT NOT NULL DEFAULT '',
+                replaced_by_kid TEXT NOT NULL DEFAULT '',
+                not_before   REAL NOT NULL DEFAULT 0,
+                not_after    REAL NOT NULL DEFAULT 0,
+                metadata     TEXT NOT NULL DEFAULT '{}'
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_identity_keys_agent
+                ON identity_keys(fleet, agent_name, purpose, status);
+            CREATE INDEX IF NOT EXISTS idx_identity_keys_fingerprint
+                ON identity_keys(fingerprint);
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_identity_keys_one_active
+                ON identity_keys(fleet, agent_name, purpose)
+                WHERE status = 'active';
+
+            CREATE TABLE IF NOT EXISTS enrollment_tokens (
+                token_id     TEXT PRIMARY KEY,
+                token_hash   TEXT NOT NULL UNIQUE,
+                fleet        TEXT NOT NULL,
+                agent_name   TEXT NOT NULL,
+                purpose      TEXT NOT NULL,
+                public_key_fingerprint TEXT NOT NULL,
+                status       TEXT NOT NULL,
+                issued_by    TEXT NOT NULL,
+                created_at   REAL NOT NULL,
+                expires_at   REAL NOT NULL,
+                used_at      REAL NOT NULL DEFAULT 0,
+                revoked_at   REAL NOT NULL DEFAULT 0,
+                reason       TEXT NOT NULL DEFAULT '',
+                metadata     TEXT NOT NULL DEFAULT '{}'
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_enrollment_tokens_agent
+                ON enrollment_tokens(fleet, agent_name, purpose, status);
+            CREATE INDEX IF NOT EXISTS idx_enrollment_tokens_fingerprint
+                ON enrollment_tokens(public_key_fingerprint);
+
+            CREATE TABLE IF NOT EXISTS identity_audit (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type  TEXT NOT NULL,
+                fleet       TEXT NOT NULL DEFAULT '',
+                agent_name  TEXT NOT NULL DEFAULT '',
+                purpose     TEXT NOT NULL DEFAULT '',
+                kid         TEXT NOT NULL DEFAULT '',
+                fingerprint TEXT NOT NULL DEFAULT '',
+                actor       TEXT NOT NULL DEFAULT '',
+                outcome     TEXT NOT NULL DEFAULT 'success',
+                reason      TEXT NOT NULL DEFAULT '',
+                metadata    TEXT NOT NULL DEFAULT '{}',
+                created_at  REAL NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_identity_audit_created
+                ON identity_audit(created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_identity_audit_agent
+                ON identity_audit(fleet, agent_name, purpose, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_identity_audit_event
+                ON identity_audit(event_type);
+        """)
+        self._db.commit()
+
+    # -- enrollment tokens -------------------------------------------------
+
+    def issue_enrollment_token(
+        self,
+        *,
+        fleet: str,
+        agent_name: str,
+        public_key_fingerprint: str,
+        issued_by: str,
+        purpose: str = PURPOSE_SERVICE_AUTH,
+        ttl_seconds: int = DEFAULT_TOKEN_TTL_SECONDS,
+        reason: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> EnrollmentTokenRecord:
+        """Mint a one-time enrollment token bound to a public-key fingerprint."""
+        fleet, agent_name, purpose = _clean_fleet_agent_purpose(
+            fleet=fleet, agent_name=agent_name, purpose=purpose
+        )
+        public_key_fingerprint = _clean_fingerprint(public_key_fingerprint)
+        issued_by = _clean_nonempty(issued_by, "issued_by")
+        if ttl_seconds <= 0:
+            raise IdentityRegistryError("ttl_seconds must be positive")
+        now = _now()
+        token = secrets.token_urlsafe(32)
+        rec = EnrollmentTokenRecord(
+            token_id=_new_id("enr"),
+            token_hash=_token_hash(token),
+            fleet=fleet,
+            agent_name=agent_name,
+            purpose=purpose,
+            public_key_fingerprint=public_key_fingerprint,
+            status=TOKEN_ACTIVE,
+            issued_by=issued_by,
+            created_at=now,
+            expires_at=now + ttl_seconds,
+            reason=reason.strip(),
+            metadata=metadata or {},
+            token=token,
+        )
+        with self._lock:
+            self._db.execute(
+                """
+                INSERT INTO enrollment_tokens
+                    (token_id, token_hash, fleet, agent_name, purpose,
+                     public_key_fingerprint, status, issued_by, created_at,
+                     expires_at, reason, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    rec.token_id,
+                    rec.token_hash,
+                    rec.fleet,
+                    rec.agent_name,
+                    rec.purpose,
+                    rec.public_key_fingerprint,
+                    rec.status,
+                    rec.issued_by,
+                    rec.created_at,
+                    rec.expires_at,
+                    rec.reason,
+                    _json_dumps(rec.metadata),
+                ),
+            )
+            self._audit(
+                "enrollment_token.issued",
+                fleet=fleet,
+                agent_name=agent_name,
+                purpose=purpose,
+                fingerprint=public_key_fingerprint,
+                actor=issued_by,
+                reason=reason,
+                metadata={"token_id": rec.token_id, "ttl_seconds": ttl_seconds},
+            )
+            self._db.commit()
+        return rec
+
+    def get_enrollment_token(self, token_id: str) -> EnrollmentTokenRecord | None:
+        row = self._db.execute(
+            "SELECT * FROM enrollment_tokens WHERE token_id = ?", (token_id,)
+        ).fetchone()
+        return self._row_to_token(row) if row else None
+
+    def list_enrollment_tokens(
+        self,
+        *,
+        fleet: str = "",
+        agent_name: str = "",
+        purpose: str = "",
+        status: str = "",
+        limit: int = 100,
+    ) -> list[EnrollmentTokenRecord]:
+        conditions = []
+        params: list[Any] = []
+        for col, val in (
+            ("fleet", fleet),
+            ("agent_name", agent_name),
+            ("purpose", purpose),
+            ("status", status),
+        ):
+            if val:
+                conditions.append(f"{col} = ?")
+                params.append(val)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        params.append(max(1, min(int(limit), 500)))
+        rows = self._db.execute(
+            f"SELECT * FROM enrollment_tokens {where} ORDER BY created_at DESC LIMIT ?",
+            params,
+        ).fetchall()
+        return [self._row_to_token(row) for row in rows]
+
+    def revoke_enrollment_token(
+        self, token_id: str, *, revoked_by: str, reason: str = ""
+    ) -> EnrollmentTokenRecord:
+        revoked_by = _clean_nonempty(revoked_by, "revoked_by")
+        now = _now()
+        with self._lock:
+            rec = self.get_enrollment_token(token_id)
+            if rec is None:
+                raise KeyError(f"unknown enrollment token: {token_id}")
+            if rec.status != TOKEN_ACTIVE:
+                raise IdentityRegistryError(
+                    f"only active tokens can be revoked (got {rec.status})"
+                )
+            self._db.execute(
+                """
+                UPDATE enrollment_tokens
+                SET status = ?, revoked_at = ?, reason = ?
+                WHERE token_id = ?
+                """,
+                (TOKEN_REVOKED, now, reason.strip(), token_id),
+            )
+            self._audit(
+                "enrollment_token.revoked",
+                fleet=rec.fleet,
+                agent_name=rec.agent_name,
+                purpose=rec.purpose,
+                fingerprint=rec.public_key_fingerprint,
+                actor=revoked_by,
+                reason=reason,
+                metadata={"token_id": rec.token_id},
+            )
+            self._db.commit()
+        updated = self.get_enrollment_token(token_id)
+        assert updated is not None
+        return updated
+
+    def redeem_enrollment_token(
+        self,
+        *,
+        token: str,
+        public_key: PublicKey,
+        fleet: str,
+        agent_name: str,
+        purpose: str = PURPOSE_SERVICE_AUTH,
+        actor: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> IdentityKeyRecord:
+        """Redeem a one-time token and activate the matching public key."""
+        token = _clean_nonempty(token, "token")
+        fleet, agent_name, purpose = _clean_fleet_agent_purpose(
+            fleet=fleet, agent_name=agent_name, purpose=purpose
+        )
+        fp = public_key_fingerprint(public_key)
+        kid = kid_from_public_key(public_key)
+        now = _now()
+        with self._lock:
+            row = self._db.execute(
+                "SELECT * FROM enrollment_tokens WHERE token_hash = ?",
+                (_token_hash(token),),
+            ).fetchone()
+            if row is None:
+                self._audit(
+                    "enrollment_token.redeem_failed",
+                    fleet=fleet,
+                    agent_name=agent_name,
+                    purpose=purpose,
+                    fingerprint=fp,
+                    actor=actor,
+                    outcome="failure",
+                    reason="unknown token",
+                )
+                self._db.commit()
+                raise IdentityRegistryError("invalid enrollment token")
+            token_rec = self._row_to_token(row)
+            if token_rec.status != TOKEN_ACTIVE:
+                self._audit(
+                    "enrollment_token.redeem_failed",
+                    fleet=fleet,
+                    agent_name=agent_name,
+                    purpose=purpose,
+                    fingerprint=fp,
+                    actor=actor,
+                    outcome="failure",
+                    reason=f"token status {token_rec.status}",
+                    metadata={"token_id": token_rec.token_id},
+                )
+                self._db.commit()
+                raise IdentityRegistryError(
+                    f"enrollment token is not active (got {token_rec.status})"
+                )
+            if token_rec.expires_at < now:
+                self._audit(
+                    "enrollment_token.redeem_failed",
+                    fleet=fleet,
+                    agent_name=agent_name,
+                    purpose=purpose,
+                    fingerprint=fp,
+                    actor=actor,
+                    outcome="failure",
+                    reason="token expired",
+                    metadata={"token_id": token_rec.token_id},
+                )
+                self._db.commit()
+                raise IdentityRegistryError("enrollment token expired")
+            if (
+                token_rec.fleet != fleet
+                or token_rec.agent_name != agent_name
+                or token_rec.purpose != purpose
+                or token_rec.public_key_fingerprint != fp
+            ):
+                self._audit(
+                    "enrollment_token.redeem_failed",
+                    fleet=fleet,
+                    agent_name=agent_name,
+                    purpose=purpose,
+                    fingerprint=fp,
+                    actor=actor,
+                    outcome="failure",
+                    reason="binding mismatch",
+                    metadata={"token_id": token_rec.token_id},
+                )
+                self._db.commit()
+                raise IdentityRegistryError(
+                    "enrollment token binding does not match submitted key"
+                )
+            if self.get_key(kid) is not None:
+                raise IdentityRegistryError(f"key already registered: {kid}")
+            active = self.get_active_key(
+                fleet=fleet, agent_name=agent_name, purpose=purpose
+            )
+            if active is not None:
+                raise IdentityRegistryError(
+                    "active key already exists; use rotation or admin approval"
+                )
+            key = self._insert_key(
+                public_key=public_key,
+                fleet=fleet,
+                agent_name=agent_name,
+                purpose=purpose,
+                status=KEY_ACTIVE,
+                created_at=now,
+                approved_at=now,
+                approved_by=f"enrollment:{token_rec.token_id}",
+                metadata=metadata or {},
+            )
+            self._db.execute(
+                """
+                UPDATE enrollment_tokens
+                SET status = ?, used_at = ?
+                WHERE token_id = ?
+                """,
+                (TOKEN_USED, now, token_rec.token_id),
+            )
+            self._audit(
+                "identity_key.enrolled",
+                fleet=fleet,
+                agent_name=agent_name,
+                purpose=purpose,
+                kid=key.kid,
+                fingerprint=key.fingerprint,
+                actor=actor or agent_name,
+                metadata={"token_id": token_rec.token_id},
+            )
+            self._db.commit()
+            return key
+
+    # -- key lifecycle -----------------------------------------------------
+
+    def submit_pending_key(
+        self,
+        *,
+        public_key: PublicKey,
+        fleet: str,
+        agent_name: str,
+        purpose: str = PURPOSE_SERVICE_AUTH,
+        actor: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> IdentityKeyRecord:
+        """Store a key as pending for manual break-glass approval."""
+        fleet, agent_name, purpose = _clean_fleet_agent_purpose(
+            fleet=fleet, agent_name=agent_name, purpose=purpose
+        )
+        actor = actor.strip()
+        now = _now()
+        with self._lock:
+            kid = kid_from_public_key(public_key)
+            if self.get_key(kid) is not None:
+                raise IdentityRegistryError(f"key already registered: {kid}")
+            key = self._insert_key(
+                public_key=public_key,
+                fleet=fleet,
+                agent_name=agent_name,
+                purpose=purpose,
+                status=KEY_PENDING,
+                created_at=now,
+                metadata=metadata or {},
+            )
+            self._audit(
+                "identity_key.submitted",
+                fleet=fleet,
+                agent_name=agent_name,
+                purpose=purpose,
+                kid=key.kid,
+                fingerprint=key.fingerprint,
+                actor=actor,
+            )
+            self._db.commit()
+            return key
+
+    def approve_key(
+        self, kid: str, *, approved_by: str, reason: str = ""
+    ) -> IdentityKeyRecord:
+        """Activate a pending key, retiring any currently active key."""
+        approved_by = _clean_nonempty(approved_by, "approved_by")
+        now = _now()
+        with self._lock:
+            key = self.get_key(kid)
+            if key is None:
+                raise KeyError(f"unknown key: {kid}")
+            if key.status == KEY_REVOKED:
+                raise IdentityRegistryError("revoked keys cannot be approved")
+            active = self.get_active_key(
+                fleet=key.fleet, agent_name=key.agent_name, purpose=key.purpose
+            )
+            if active and active.kid != kid:
+                self._db.execute(
+                    """
+                    UPDATE identity_keys
+                    SET status = ?, retired_at = ?, replaced_by_kid = ?
+                    WHERE kid = ?
+                    """,
+                    (KEY_RETIRED, now, kid, active.kid),
+                )
+                self._audit(
+                    "identity_key.retired",
+                    fleet=active.fleet,
+                    agent_name=active.agent_name,
+                    purpose=active.purpose,
+                    kid=active.kid,
+                    fingerprint=active.fingerprint,
+                    actor=approved_by,
+                    reason=f"replaced by {kid}",
+                )
+            self._db.execute(
+                """
+                UPDATE identity_keys
+                SET status = ?, approved_at = ?, approved_by = ?
+                WHERE kid = ?
+                """,
+                (KEY_ACTIVE, now, approved_by, kid),
+            )
+            self._audit(
+                "identity_key.approved",
+                fleet=key.fleet,
+                agent_name=key.agent_name,
+                purpose=key.purpose,
+                kid=kid,
+                fingerprint=key.fingerprint,
+                actor=approved_by,
+                reason=reason,
+            )
+            self._db.commit()
+        updated = self.get_key(kid)
+        assert updated is not None
+        return updated
+
+    def revoke_key(self, kid: str, *, revoked_by: str, reason: str) -> IdentityKeyRecord:
+        """Revoke a key so services reject it even if signatures verify."""
+        revoked_by = _clean_nonempty(revoked_by, "revoked_by")
+        reason = _clean_nonempty(reason, "reason")
+        now = _now()
+        with self._lock:
+            key = self.get_key(kid)
+            if key is None:
+                raise KeyError(f"unknown key: {kid}")
+            if key.status == KEY_REVOKED:
+                return key
+            self._db.execute(
+                """
+                UPDATE identity_keys
+                SET status = ?, revoked_at = ?, revoked_by = ?, revoke_reason = ?
+                WHERE kid = ?
+                """,
+                (KEY_REVOKED, now, revoked_by, reason, kid),
+            )
+            self._audit(
+                "identity_key.revoked",
+                fleet=key.fleet,
+                agent_name=key.agent_name,
+                purpose=key.purpose,
+                kid=kid,
+                fingerprint=key.fingerprint,
+                actor=revoked_by,
+                reason=reason,
+            )
+            self._db.commit()
+        updated = self.get_key(kid)
+        assert updated is not None
+        return updated
+
+    def retire_key(
+        self, kid: str, *, retired_by: str, reason: str = ""
+    ) -> IdentityKeyRecord:
+        retired_by = _clean_nonempty(retired_by, "retired_by")
+        now = _now()
+        with self._lock:
+            key = self.get_key(kid)
+            if key is None:
+                raise KeyError(f"unknown key: {kid}")
+            if key.status == KEY_REVOKED:
+                raise IdentityRegistryError("revoked keys cannot be retired")
+            self._db.execute(
+                "UPDATE identity_keys SET status = ?, retired_at = ? WHERE kid = ?",
+                (KEY_RETIRED, now, kid),
+            )
+            self._audit(
+                "identity_key.retired",
+                fleet=key.fleet,
+                agent_name=key.agent_name,
+                purpose=key.purpose,
+                kid=kid,
+                fingerprint=key.fingerprint,
+                actor=retired_by,
+                reason=reason,
+            )
+            self._db.commit()
+        updated = self.get_key(kid)
+        assert updated is not None
+        return updated
+
+    def get_key(self, kid: str) -> IdentityKeyRecord | None:
+        row = self._db.execute(
+            "SELECT * FROM identity_keys WHERE kid = ?", (kid,)
+        ).fetchone()
+        return self._row_to_key(row) if row else None
+
+    def get_active_key(
+        self, *, fleet: str, agent_name: str, purpose: str = PURPOSE_SERVICE_AUTH
+    ) -> IdentityKeyRecord | None:
+        row = self._db.execute(
+            """
+            SELECT * FROM identity_keys
+            WHERE fleet = ? AND agent_name = ? AND purpose = ? AND status = ?
+            """,
+            (fleet, agent_name, purpose, KEY_ACTIVE),
+        ).fetchone()
+        return self._row_to_key(row) if row else None
+
+    def list_keys(
+        self,
+        *,
+        fleet: str = "",
+        agent_name: str = "",
+        purpose: str = "",
+        status: str = "",
+        limit: int = 100,
+    ) -> list[IdentityKeyRecord]:
+        conditions = []
+        params: list[Any] = []
+        for col, val in (
+            ("fleet", fleet),
+            ("agent_name", agent_name),
+            ("purpose", purpose),
+            ("status", status),
+        ):
+            if val:
+                conditions.append(f"{col} = ?")
+                params.append(val)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        params.append(max(1, min(int(limit), 500)))
+        rows = self._db.execute(
+            f"SELECT * FROM identity_keys {where} ORDER BY created_at DESC LIMIT ?",
+            params,
+        ).fetchall()
+        return [self._row_to_key(row) for row in rows]
+
+    # -- audit --------------------------------------------------------------
+
+    def list_audit(
+        self,
+        *,
+        fleet: str = "",
+        agent_name: str = "",
+        event_type: str = "",
+        limit: int = 100,
+    ) -> list[IdentityAuditRecord]:
+        conditions = []
+        params: list[Any] = []
+        for col, val in (
+            ("fleet", fleet),
+            ("agent_name", agent_name),
+            ("event_type", event_type),
+        ):
+            if val:
+                conditions.append(f"{col} = ?")
+                params.append(val)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        params.append(max(1, min(int(limit), 500)))
+        rows = self._db.execute(
+            f"SELECT * FROM identity_audit {where} ORDER BY created_at DESC LIMIT ?",
+            params,
+        ).fetchall()
+        return [self._row_to_audit(row) for row in rows]
+
+    def close(self) -> None:
+        self._db.close()
+
+    # -- internals ---------------------------------------------------------
+
+    def _insert_key(
+        self,
+        *,
+        public_key: PublicKey,
+        fleet: str,
+        agent_name: str,
+        purpose: str,
+        status: str,
+        created_at: float,
+        approved_at: float = 0.0,
+        approved_by: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> IdentityKeyRecord:
+        if status not in KEY_STATUSES:
+            raise IdentityRegistryError(f"invalid key status: {status}")
+        kid = kid_from_public_key(public_key)
+        fp = public_key_fingerprint(public_key)
+        jwk = jwk_export(public_key, kid=kid)
+        self._db.execute(
+            """
+            INSERT INTO identity_keys
+                (kid, fleet, agent_name, purpose, public_key, public_jwk,
+                 fingerprint, status, created_at, approved_at, approved_by,
+                 metadata)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                kid,
+                fleet,
+                agent_name,
+                purpose,
+                public_key.raw,
+                _json_dumps(jwk),
+                fp,
+                status,
+                created_at,
+                approved_at,
+                approved_by,
+                _json_dumps(metadata),
+            ),
+        )
+        return IdentityKeyRecord(
+            kid=kid,
+            fleet=fleet,
+            agent_name=agent_name,
+            purpose=purpose,
+            public_key=public_key.raw,
+            public_jwk=jwk,
+            fingerprint=fp,
+            status=status,
+            created_at=created_at,
+            approved_at=approved_at,
+            approved_by=approved_by,
+            metadata=metadata or {},
+        )
+
+    def _audit(
+        self,
+        event_type: str,
+        *,
+        fleet: str = "",
+        agent_name: str = "",
+        purpose: str = "",
+        kid: str = "",
+        fingerprint: str = "",
+        actor: str = "",
+        outcome: str = "success",
+        reason: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self._db.execute(
+            """
+            INSERT INTO identity_audit
+                (event_type, fleet, agent_name, purpose, kid, fingerprint,
+                 actor, outcome, reason, metadata, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_type,
+                fleet,
+                agent_name,
+                purpose,
+                kid,
+                fingerprint,
+                actor,
+                outcome,
+                reason.strip(),
+                _json_dumps(metadata),
+                _now(),
+            ),
+        )
+
+    @staticmethod
+    def _row_to_key(row: sqlite3.Row) -> IdentityKeyRecord:
+        return IdentityKeyRecord(
+            kid=row["kid"],
+            fleet=row["fleet"],
+            agent_name=row["agent_name"],
+            purpose=row["purpose"],
+            public_key=bytes(row["public_key"]),
+            public_jwk=_json_loads(row["public_jwk"]),
+            fingerprint=row["fingerprint"],
+            status=row["status"],
+            created_at=row["created_at"],
+            approved_at=row["approved_at"],
+            approved_by=row["approved_by"],
+            retired_at=row["retired_at"],
+            revoked_at=row["revoked_at"],
+            revoked_by=row["revoked_by"],
+            revoke_reason=row["revoke_reason"],
+            replaced_by_kid=row["replaced_by_kid"],
+            not_before=row["not_before"],
+            not_after=row["not_after"],
+            metadata=_json_loads(row["metadata"]),
+        )
+
+    @staticmethod
+    def _row_to_token(row: sqlite3.Row) -> EnrollmentTokenRecord:
+        return EnrollmentTokenRecord(
+            token_id=row["token_id"],
+            token_hash=row["token_hash"],
+            fleet=row["fleet"],
+            agent_name=row["agent_name"],
+            purpose=row["purpose"],
+            public_key_fingerprint=row["public_key_fingerprint"],
+            status=row["status"],
+            issued_by=row["issued_by"],
+            created_at=row["created_at"],
+            expires_at=row["expires_at"],
+            used_at=row["used_at"],
+            revoked_at=row["revoked_at"],
+            reason=row["reason"],
+            metadata=_json_loads(row["metadata"]),
+        )
+
+    @staticmethod
+    def _row_to_audit(row: sqlite3.Row) -> IdentityAuditRecord:
+        return IdentityAuditRecord(
+            id=row["id"],
+            event_type=row["event_type"],
+            fleet=row["fleet"],
+            agent_name=row["agent_name"],
+            purpose=row["purpose"],
+            kid=row["kid"],
+            fingerprint=row["fingerprint"],
+            actor=row["actor"],
+            outcome=row["outcome"],
+            reason=row["reason"],
+            metadata=_json_loads(row["metadata"]),
+            created_at=row["created_at"],
+        )

--- a/src/pinky_identity/registry.py
+++ b/src/pinky_identity/registry.py
@@ -30,7 +30,7 @@ from pinky_identity.keys import (
 )
 
 DEFAULT_DB_PATH = "data/pinky_identity_registry.db"
-DEFAULT_FLEET = "pos"
+DEFAULT_FLEET = "pinky"
 PURPOSE_SERVICE_AUTH = "service-auth"
 
 KEY_PENDING = "pending"

--- a/tests/test_pinky_identity_registry.py
+++ b/tests/test_pinky_identity_registry.py
@@ -1,0 +1,326 @@
+"""Tests for the service-auth identity registry and enrollment routes."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pinky_daemon.api import create_api
+from pinky_daemon.auth import SESSION_COOKIE_NAME, create_session_cookie
+from pinky_identity import (
+    KEY_ACTIVE,
+    KEY_PENDING,
+    KEY_RETIRED,
+    KEY_REVOKED,
+    TOKEN_USED,
+    IdentityRegistry,
+    IdentityRegistryError,
+    fingerprint,
+    generate_keypair,
+    kid_from_public_key,
+)
+
+
+def _b64url_nopad(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+@pytest.fixture
+def registry(tmp_path):
+    store = IdentityRegistry(db_path=str(tmp_path / "identity.db"))
+    yield store
+    store.close()
+
+
+class TestIdentityRegistryStore:
+    def test_issue_token_returns_raw_once_and_stores_hash_only(self, registry):
+        kp = generate_keypair()
+        fp = fingerprint(kp.public)
+
+        token = registry.issue_enrollment_token(
+            fleet="pos",
+            agent_name="lera",
+            public_key_fingerprint=fp,
+            issued_by="brad",
+            ttl_seconds=60,
+            reason="new agent",
+        )
+
+        assert token.token
+        assert token.public_key_fingerprint == fp
+        assert "token" not in token.to_dict()
+        assert token.to_dict(include_token=True)["token"] == token.token
+
+        stored = registry.get_enrollment_token(token.token_id)
+        assert stored is not None
+        assert stored.token == ""
+        assert stored.token_hash
+        assert token.token not in stored.token_hash
+
+    def test_redeem_matching_token_activates_key_and_marks_token_used(self, registry):
+        kp = generate_keypair()
+        token = registry.issue_enrollment_token(
+            fleet="pos",
+            agent_name="lera",
+            public_key_fingerprint=fingerprint(kp.public),
+            issued_by="brad",
+        )
+
+        key = registry.redeem_enrollment_token(
+            token=token.token,
+            public_key=kp.public,
+            fleet="pos",
+            agent_name="lera",
+            actor="lera",
+        )
+
+        assert key.status == KEY_ACTIVE
+        assert key.kid == kid_from_public_key(kp.public)
+        assert key.public_jwk["kty"] == "OKP"
+        assert registry.get_active_key(fleet="pos", agent_name="lera") == key
+
+        stored_token = registry.get_enrollment_token(token.token_id)
+        assert stored_token is not None
+        assert stored_token.status == TOKEN_USED
+        assert stored_token.used_at > 0
+
+        events = registry.list_audit(agent_name="lera")
+        assert {e.event_type for e in events} >= {
+            "enrollment_token.issued",
+            "identity_key.enrolled",
+        }
+
+    def test_redeem_rejects_binding_mismatch(self, registry):
+        token_key = generate_keypair()
+        submitted_key = generate_keypair()
+        token = registry.issue_enrollment_token(
+            fleet="pos",
+            agent_name="lera",
+            public_key_fingerprint=fingerprint(token_key.public),
+            issued_by="brad",
+        )
+
+        with pytest.raises(IdentityRegistryError, match="binding"):
+            registry.redeem_enrollment_token(
+                token=token.token,
+                public_key=submitted_key.public,
+                fleet="pos",
+                agent_name="lera",
+            )
+
+        assert registry.get_key(kid_from_public_key(submitted_key.public)) is None
+        failures = registry.list_audit(event_type="enrollment_token.redeem_failed")
+        assert failures
+        assert failures[0].outcome == "failure"
+
+    def test_redeem_rejects_replay(self, registry):
+        kp = generate_keypair()
+        token = registry.issue_enrollment_token(
+            fleet="pos",
+            agent_name="lera",
+            public_key_fingerprint=fingerprint(kp.public),
+            issued_by="brad",
+        )
+        registry.redeem_enrollment_token(
+            token=token.token,
+            public_key=kp.public,
+            fleet="pos",
+            agent_name="lera",
+        )
+
+        with pytest.raises(IdentityRegistryError, match="not active"):
+            registry.redeem_enrollment_token(
+                token=token.token,
+                public_key=kp.public,
+                fleet="pos",
+                agent_name="lera",
+            )
+
+    def test_redeem_rejects_expired_token(self, registry, monkeypatch):
+        kp = generate_keypair()
+        token = registry.issue_enrollment_token(
+            fleet="pos",
+            agent_name="lera",
+            public_key_fingerprint=fingerprint(kp.public),
+            issued_by="brad",
+            ttl_seconds=1,
+        )
+
+        monkeypatch.setattr("pinky_identity.registry._now", lambda: token.expires_at + 1)
+        with pytest.raises(IdentityRegistryError, match="expired"):
+            registry.redeem_enrollment_token(
+                token=token.token,
+                public_key=kp.public,
+                fleet="pos",
+                agent_name="lera",
+            )
+
+    def test_approve_pending_key_retires_existing_active_key(self, registry):
+        first = generate_keypair()
+        first_token = registry.issue_enrollment_token(
+            fleet="pos",
+            agent_name="lera",
+            public_key_fingerprint=fingerprint(first.public),
+            issued_by="brad",
+        )
+        active = registry.redeem_enrollment_token(
+            token=first_token.token,
+            public_key=first.public,
+            fleet="pos",
+            agent_name="lera",
+        )
+
+        replacement = generate_keypair()
+        pending = registry.submit_pending_key(
+            public_key=replacement.public,
+            fleet="pos",
+            agent_name="lera",
+            actor="brad",
+        )
+        assert pending.status == KEY_PENDING
+
+        approved = registry.approve_key(
+            pending.kid, approved_by="brad", reason="break-glass rotate"
+        )
+        assert approved.status == KEY_ACTIVE
+        old = registry.get_key(active.kid)
+        assert old is not None
+        assert old.status == KEY_RETIRED
+        assert old.replaced_by_kid == pending.kid
+
+    def test_revoke_key_marks_revoked_and_audits_reason(self, registry):
+        kp = generate_keypair()
+        pending = registry.submit_pending_key(
+            public_key=kp.public,
+            fleet="pos",
+            agent_name="olga",
+            actor="brad",
+        )
+
+        revoked = registry.revoke_key(
+            pending.kid,
+            revoked_by="brad",
+            reason="compromised",
+        )
+
+        assert revoked.status == KEY_REVOKED
+        assert revoked.revoked_by == "brad"
+        assert revoked.revoke_reason == "compromised"
+        events = registry.list_audit(event_type="identity_key.revoked")
+        assert events[0].reason == "compromised"
+
+
+class TestIdentityRegistryRoutes:
+    def _client(self, tmp_path, monkeypatch):
+        db_path = str(tmp_path / "pinky.db")
+        monkeypatch.setenv("PINKY_SESSION_SECRET", "test-session-secret")
+        monkeypatch.delenv("PINKY_UI_PASSWORD", raising=False)
+        app = create_api(max_sessions=10, default_working_dir="/tmp", db_path=db_path)
+        return TestClient(app)
+
+    def _admin_client(self, tmp_path, monkeypatch):
+        client = self._client(tmp_path, monkeypatch)
+        client.cookies.set(
+            SESSION_COOKIE_NAME,
+            create_session_cookie("test-session-secret"),
+            domain="testserver.local",
+        )
+        return client
+
+    def test_admin_token_issue_requires_session_even_for_non_browser_call(
+        self, tmp_path, monkeypatch
+    ):
+        client = self._client(tmp_path, monkeypatch)
+        kp = generate_keypair()
+
+        resp = client.post(
+            "/identity/admin/enrollment-tokens",
+            json={
+                "fleet": "pos",
+                "agent_name": "lera",
+                "public_key_fingerprint": fingerprint(kp.public),
+                "issued_by": "brad",
+            },
+        )
+
+        assert resp.status_code == 401
+
+    def test_token_issue_redeem_and_public_lookup_route(self, tmp_path, monkeypatch):
+        client = self._admin_client(tmp_path, monkeypatch)
+        kp = generate_keypair()
+        fp = fingerprint(kp.public)
+
+        issued = client.post(
+            "/identity/admin/enrollment-tokens",
+            json={
+                "fleet": "pos",
+                "agent_name": "lera",
+                "public_key_fingerprint": fp,
+                "issued_by": "brad",
+                "ttl_seconds": 60,
+            },
+        )
+        assert issued.status_code == 200
+        token = issued.json()["token"]
+        assert token
+        assert "token_hash" not in issued.json()
+
+        redeem = client.post(
+            "/identity/enroll/redeem",
+            json={
+                "token": token,
+                "fleet": "pos",
+                "agent_name": "lera",
+                "public_key_b64": _b64url_nopad(kp.public.raw),
+            },
+        )
+        assert redeem.status_code == 200
+        key = redeem.json()
+        assert key["status"] == KEY_ACTIVE
+        assert key["fingerprint"] == fp
+
+        lookup = client.get(f"/identity/keys/{key['kid']}")
+        assert lookup.status_code == 200
+        assert lookup.json()["public_jwk"]["kid"] == key["kid"]
+
+    def test_admin_pending_approve_revoke_and_audit_routes(self, tmp_path, monkeypatch):
+        client = self._admin_client(tmp_path, monkeypatch)
+        kp = generate_keypair()
+
+        pending = client.post(
+            "/identity/admin/keys/pending",
+            json={
+                "fleet": "pos",
+                "agent_name": "olga",
+                "public_jwk": {"x": _b64url_nopad(kp.public.raw)},
+                "actor": "brad",
+            },
+        )
+        assert pending.status_code == 200
+        kid = pending.json()["kid"]
+        assert pending.json()["status"] == KEY_PENDING
+
+        approved = client.post(
+            f"/identity/admin/keys/{kid}/approve",
+            json={"approved_by": "brad", "reason": "manual break-glass"},
+        )
+        assert approved.status_code == 200
+        assert approved.json()["status"] == KEY_ACTIVE
+
+        revoked = client.post(
+            f"/identity/admin/keys/{kid}/revoke",
+            json={"revoked_by": "brad", "reason": "test revoke"},
+        )
+        assert revoked.status_code == 200
+        assert revoked.json()["status"] == KEY_REVOKED
+
+        audit = client.get("/identity/admin/audit?agent_name=olga")
+        assert audit.status_code == 200
+        event_types = {e["event_type"] for e in audit.json()["entries"]}
+        assert {
+            "identity_key.submitted",
+            "identity_key.approved",
+            "identity_key.revoked",
+        }.issubset(event_types)


### PR DESCRIPTION
## Summary

Implements PR-3 from #461: the service-auth identity registry and enrollment-token flow, stacked on PR-2a's `pinky_identity.keys` primitives.

Adds:
- `pinky_identity.registry.IdentityRegistry` with SQLite-backed `identity_keys`, `enrollment_tokens`, and `identity_audit` tables
- one-time enrollment tokens bound to `(fleet, agent_name, purpose, public_key_fingerprint)` with hash-only token storage
- token redemption that activates the matching public key and marks the token used
- pending-key submission plus admin approve, revoke, retire, and break-glass replacement behavior
- read-only kid-narrow verifier lookup at `/identity/keys/{kid}`
- explicitly guarded admin routes under `/identity/admin/...`
- focused store and route tests

## Security notes

- Enrollment tokens are returned only at issuance; stored records expose token metadata but not token hashes or raw tokens.
- Admin routes use an explicit session guard and do not rely on broad browser middleware behavior.
- The verifier lookup path is read-only and narrowed to a single `kid`.
- Approving a replacement key retires the prior active key for the same `(fleet, agent_name, purpose)`.

## Validation

- `/Users/oleg/PinkyBot/.venv/bin/python -m pytest tests/test_pinky_identity_keys.py tests/test_pinky_identity_registry.py tests/test_auth.py -q` -> 53 passed
- `/Users/oleg/PinkyBot/.venv/bin/python -m pytest tests/test_api.py tests/test_auth.py tests/test_pinky_identity_keys.py tests/test_pinky_identity_registry.py -q` -> 339 passed
- `/Users/oleg/PinkyBot/.venv/bin/ruff check src/pinky_identity src/pinky_daemon/routes/identity.py src/pinky_daemon/api.py tests/test_pinky_identity_registry.py` -> clean

## Stacking

Base is `feat/pinky-identity-keys` until PR #462 lands. After PR #462 merges, this PR can be retargeted/rebased onto `main`.

🤖 Implemented by Murzik
