### PR TITLE
feat(pinky_identity): encrypted-at-rest keystore (PR-4a)

### DIFF
--- a/src/pinky_identity/__init__.py
+++ b/src/pinky_identity/__init__.py
@@ -7,11 +7,12 @@ This package provides:
 
 - Ed25519 keypair primitives for the ``service-auth`` purpose
   (``pinky_identity.keys``)
+- Encrypted-at-rest wrapping for signing seeds (``pinky_identity.keystore``)
 - RFC 9421 HTTP Message Signature signer/verifier helpers
   (``pinky_identity.http_signatures``)
 - (Coming in PR-3) Registry storage + enrollment-token issuance + admin
   approval flow (``pinky_identity.registry``)
-- (Coming in PR-4) Daemon-local signer + session-bound bearer-token
+- (Coming in PR-4b) Daemon-local signer + session-bound bearer-token
   capability (``pinky_identity.signer``)
 
 The package is intentionally separated from ``pinky_federation``: the
@@ -52,32 +53,56 @@ from pinky_identity.keys import (
     kid_from_public_key,
     public_key_from_bytes,
 )
+from pinky_identity.keystore import (
+    DEFAULT_DEVICE_KEY_PATH,
+    DEVICE_KEY_BYTES,
+    WRAP_VERSION,
+    DeviceKey,
+    KeystoreError,
+    WrappedKeypair,
+    WrapVersionError,
+    deserialize_wrapped,
+    serialize_wrapped,
+    unwrap_keypair,
+    wrap_keypair,
+)
 
 __all__ = [
     "CONTENT_DIGEST_ALGORITHM",
     "DEFAULT_COVERED_COMPONENTS",
+    "DEFAULT_DEVICE_KEY_PATH",
     "DEFAULT_LABEL",
     "DEFAULT_MAX_AGE",
     "DEFAULT_REQUIRED_COMPONENTS",
     "DEFAULT_TAG",
+    "DEVICE_KEY_BYTES",
     "ED25519_PUBLIC_KEY_BYTES",
     "ED25519_SECRET_KEY_BYTES",
     "ED25519_SIGNATURE_BYTES",
-    "HttpSignatureVerificationError",
     "KID_HEX_LEN",
+    "WRAP_VERSION",
+    "DeviceKey",
+    "HttpSignatureVerificationError",
+    "KeystoreError",
     "PinkyKeyResolver",
     "PublicKey",
     "SecretKey",
     "SignatureError",
     "SigningKeypair",
     "VerifyResult",
+    "WrapVersionError",
+    "WrappedKeypair",
     "attach_content_digest",
     "compute_content_digest",
+    "deserialize_wrapped",
     "fingerprint",
     "generate_keypair",
     "jwk_export",
     "kid_from_public_key",
     "public_key_from_bytes",
+    "serialize_wrapped",
     "sign_request",
+    "unwrap_keypair",
     "verify_request",
+    "wrap_keypair",
 ]

--- a/src/pinky_identity/keystore.py
+++ b/src/pinky_identity/keystore.py
@@ -1,0 +1,412 @@
+"""Encrypted-at-rest wrapping for service-auth signing keys.
+
+This module is the crypto primitive layer the registry (PR-3) and the
+daemon-local signer (PR-4b) use to persist Ed25519 signing seeds without
+leaving plaintext key material on disk.
+
+Design rules (see ``docs/design/agent-asymmetric-identity.md`` and #461):
+
+- **One device key per host.** A 32-byte symmetric secret persisted at
+  ``data/identity/.device_key`` with mode ``0600``. Generated lazily on
+  first use. Never copied off the host. Intentionally distinct from the
+  :mod:`pinky_federation` device key — different purpose, different blast
+  radius, no cross-purpose reuse.
+- **AEAD: XChaCha20-Poly1305.** Same primitive as federation; PyNaCl
+  bindings (the :mod:`cryptography` package doesn't expose XChaCha
+  directly). 24-byte random nonce.
+- **AAD binds (purpose, version, kid, fingerprint).** A wrapped blob from
+  one agent can't be replayed under a different identity — the registry
+  unwraps with the kid/fingerprint it stored alongside, and a tampered
+  metadata column will fail the AEAD tag.
+- **Wrapped blob carries only the 32-byte seed.** The public half is
+  derivable from the seed and is stored unencrypted in the registry for
+  fast lookups (no need to unwrap just to list keys).
+- **No logging of secret material.** ``__repr__`` never shows ciphertext or
+  device-key bytes beyond a 4-byte hex tag for debugging.
+- **Discipline-aware exports.** Raw-seed exit points are explicitly named
+  (``_seed_insecure``) so reviewers and grep can find every place plaintext
+  leaves the wrapper.
+
+This module is storage-agnostic. It returns :class:`WrappedKeypair`
+dataclasses; the registry (PR-3) is responsible for persisting them into
+SQLite or wherever else.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from nacl.bindings import (
+    crypto_aead_xchacha20poly1305_ietf_decrypt,
+    crypto_aead_xchacha20poly1305_ietf_encrypt,
+    crypto_aead_xchacha20poly1305_ietf_NPUBBYTES,
+)
+from nacl.signing import SigningKey as _NaclSigningKey
+
+from pinky_identity.keys import (
+    ED25519_SECRET_KEY_BYTES,
+    PublicKey,
+    SecretKey,
+    SignatureError,
+    SigningKeypair,
+    fingerprint,
+    kid_from_public_key,
+    public_key_from_bytes,
+)
+
+# -- Constants ---------------------------------------------------------------
+
+#: Length of the device key (a 256-bit symmetric secret).
+DEVICE_KEY_BYTES = 32
+
+#: Default on-disk path for the device key. Operators can override via
+#: :meth:`DeviceKey.load_or_create`. Distinct from ``data/federation/...``
+#: so the two systems' KEKs rotate independently.
+DEFAULT_DEVICE_KEY_PATH = "data/identity/.device_key"
+
+#: Current wrap envelope version. Bump if AAD layout or cipher changes —
+#: :func:`unwrap_keypair` will refuse to decrypt unknown versions.
+WRAP_VERSION = 1
+
+#: AAD prefix pins the purpose. A blob from a different system that
+#: happens to share the device key (it shouldn't) still fails the AEAD tag.
+_WRAP_AAD_PREFIX = b"pinky-identity/v1/service-auth-seed"
+
+
+# -- Errors ------------------------------------------------------------------
+
+
+class KeystoreError(SignatureError):
+    """Raised for wrap/unwrap failures. Subclass of SignatureError so a
+    single ``except SignatureError`` clause covers identity-layer errors.
+    """
+
+
+class WrapVersionError(KeystoreError):
+    """Raised when a wrapped blob's version is unknown to this build."""
+
+
+# -- Helpers -----------------------------------------------------------------
+
+
+def _xchacha_nonce() -> bytes:
+    """Return a fresh 24-byte XChaCha20-Poly1305 nonce."""
+    return secrets.token_bytes(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES)
+
+
+def _seed_from_keypair(keypair: SigningKeypair) -> bytes:
+    """Return the 32-byte seed for *keypair*.
+
+    Verbose internal helper rather than poking ``keypair.secret`` directly
+    so grep finds all secret extraction sites.
+    """
+    return keypair.secret.secret_bytes_insecure()
+
+
+def _aad_for(*, version: int, kid: str, fingerprint_hex: str) -> bytes:
+    """Build the AAD for a wrap envelope.
+
+    Binds the ciphertext to (purpose, version, kid, fingerprint). A wrap
+    minted for one identity cannot be replayed under another — even if an
+    attacker substitutes the ciphertext blob, the AAD mismatch will fail
+    the AEAD tag.
+    """
+    return (
+        _WRAP_AAD_PREFIX
+        + b"|v="
+        + str(version).encode("ascii")
+        + b"|kid="
+        + kid.encode("ascii")
+        + b"|fp="
+        + fingerprint_hex.encode("ascii")
+    )
+
+
+# -- Device key --------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeviceKey:
+    """Device-local 32-byte symmetric KEK for wrapping signing seeds.
+
+    The bytes are accessible to the wrap/unwrap layer via
+    :meth:`material_insecure`. ``__repr__`` never reveals them in full.
+    """
+
+    _material: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self._material, bytes) or len(self._material) != DEVICE_KEY_BYTES:
+            raise ValueError(f"device key must be {DEVICE_KEY_BYTES} bytes")
+
+    def material_insecure(self) -> bytes:
+        """Raw 32-byte device key. Never log this value."""
+        return self._material
+
+    def __repr__(self) -> str:
+        return f"DeviceKey(<{self._material[:4].hex()}…>)"
+
+    @classmethod
+    def load_or_create(cls, path: str = DEFAULT_DEVICE_KEY_PATH) -> "DeviceKey":
+        """Load the device key from *path*, generating it on first use.
+
+        File is created with mode ``0600`` (owner read/write only). On
+        existing files we sanity-check size and refuse if permissions are
+        looser than 0600 — we do NOT silently tighten, because that may
+        mask a real security problem (e.g. a backup script that copied the
+        file world-readable).
+        """
+        p = Path(path)
+        if p.exists():
+            data = p.read_bytes()
+            if len(data) != DEVICE_KEY_BYTES:
+                raise ValueError(
+                    f"device key at {path!r} is {len(data)} bytes, "
+                    f"expected {DEVICE_KEY_BYTES}"
+                )
+            mode = stat.S_IMODE(p.stat().st_mode)
+            if mode & 0o077:
+                raise PermissionError(
+                    f"device key {path!r} has loose permissions {oct(mode)}; "
+                    "expected 0o600"
+                )
+            return cls(data)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        material = secrets.token_bytes(DEVICE_KEY_BYTES)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        fd = os.open(str(p), flags, 0o600)
+        try:
+            os.write(fd, material)
+        finally:
+            os.close(fd)
+        return cls(material)
+
+    @classmethod
+    def from_bytes(cls, material: bytes) -> "DeviceKey":
+        """Construct a DeviceKey from raw bytes.
+
+        Useful for tests and for callers who manage the KEK out-of-band
+        (e.g. operator-provided env var). Production deploys should
+        prefer :meth:`load_or_create`.
+        """
+        return cls(bytes(material))
+
+
+# -- Wrapped keypair ---------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WrappedKeypair:
+    """An encrypted-at-rest envelope for a service-auth signing keypair.
+
+    Carries everything needed to recover the keypair given the device
+    key, plus the public-key metadata that storage layers want to expose
+    without decrypting (kid, fingerprint, raw public bytes).
+
+    Fields:
+
+    - ``version``: wrap envelope version. Currently 1.
+    - ``kid``: short key id (deterministic from the public key).
+    - ``fingerprint``: full SHA-256 hex fingerprint of the public key.
+    - ``public_key_raw``: raw 32 bytes of the public key. Stored
+      unencrypted because (a) the public half is, by definition, public,
+      and (b) the registry needs to list/lookup without unwrapping.
+    - ``nonce``: 24-byte XChaCha20-Poly1305 nonce.
+    - ``ciphertext``: AEAD-encrypted 32-byte seed (16-byte tag appended,
+      so total length is 48 bytes).
+
+    The dataclass is frozen and never logs secret material in ``__repr__``.
+    """
+
+    version: int
+    kid: str
+    fingerprint: str
+    public_key_raw: bytes
+    nonce: bytes
+    ciphertext: bytes
+
+    def __repr__(self) -> str:
+        return (
+            f"WrappedKeypair(version={self.version}, kid={self.kid!r}, "
+            f"fingerprint={self.fingerprint[:12]!r}…, "
+            f"ciphertext=<{len(self.ciphertext)} bytes redacted>)"
+        )
+
+    def public(self) -> PublicKey:
+        """Return the public half without unwrapping."""
+        return public_key_from_bytes(self.public_key_raw)
+
+
+# -- Wrap / unwrap -----------------------------------------------------------
+
+
+def wrap_keypair(
+    keypair: SigningKeypair,
+    *,
+    device_key: DeviceKey,
+) -> WrappedKeypair:
+    """Encrypt *keypair*'s secret seed under *device_key*.
+
+    The returned :class:`WrappedKeypair` carries the public-key metadata
+    in cleartext (kid, fingerprint, raw public bytes) and the encrypted
+    seed in :attr:`WrappedKeypair.ciphertext`. AAD binds (purpose,
+    version, kid, fingerprint) so the blob cannot be replayed under a
+    different identity.
+    """
+    if not isinstance(keypair, SigningKeypair):
+        raise TypeError("keypair must be a SigningKeypair")
+    if not isinstance(device_key, DeviceKey):
+        raise TypeError("device_key must be a DeviceKey")
+
+    kid = kid_from_public_key(keypair.public)
+    fp = fingerprint(keypair.public)
+    nonce = _xchacha_nonce()
+    aad = _aad_for(version=WRAP_VERSION, kid=kid, fingerprint_hex=fp)
+    seed = _seed_from_keypair(keypair)
+    try:
+        ct = crypto_aead_xchacha20poly1305_ietf_encrypt(
+            seed, aad, nonce, device_key.material_insecure()
+        )
+    finally:
+        # Drop our binding to the seed copy as soon as the AEAD is done.
+        # Python doesn't let us truly zero memory; this is the best we can
+        # do without going through ctypes.
+        del seed
+
+    return WrappedKeypair(
+        version=WRAP_VERSION,
+        kid=kid,
+        fingerprint=fp,
+        public_key_raw=keypair.public.raw,
+        nonce=nonce,
+        ciphertext=ct,
+    )
+
+
+def unwrap_keypair(
+    wrapped: WrappedKeypair,
+    *,
+    device_key: DeviceKey,
+) -> SigningKeypair:
+    """Decrypt *wrapped* into a :class:`SigningKeypair`.
+
+    Raises
+    ------
+    WrapVersionError
+        If :attr:`WrappedKeypair.version` is not understood by this build.
+    KeystoreError
+        On any AEAD failure: corrupt ciphertext, wrong device key,
+        tampered AAD (kid/fingerprint substitution), wrong-length
+        plaintext.
+    """
+    if not isinstance(wrapped, WrappedKeypair):
+        raise TypeError("wrapped must be a WrappedKeypair")
+    if not isinstance(device_key, DeviceKey):
+        raise TypeError("device_key must be a DeviceKey")
+    if wrapped.version != WRAP_VERSION:
+        raise WrapVersionError(
+            f"unsupported wrap version {wrapped.version} "
+            f"(this build supports {WRAP_VERSION})"
+        )
+
+    aad = _aad_for(
+        version=wrapped.version,
+        kid=wrapped.kid,
+        fingerprint_hex=wrapped.fingerprint,
+    )
+    try:
+        seed = crypto_aead_xchacha20poly1305_ietf_decrypt(
+            wrapped.ciphertext,
+            aad,
+            wrapped.nonce,
+            device_key.material_insecure(),
+        )
+    except Exception as exc:  # noqa: BLE001 — normalize to our error type
+        raise KeystoreError(
+            f"failed to decrypt wrapped keypair for kid {wrapped.kid!r}"
+        ) from exc
+
+    if len(seed) != ED25519_SECRET_KEY_BYTES:
+        raise KeystoreError(
+            f"decrypted seed has wrong length {len(seed)} "
+            f"(expected {ED25519_SECRET_KEY_BYTES})"
+        )
+
+    # Reconstruct the public half from the seed and cross-check against
+    # the cleartext metadata. If the registry's public_key_raw was
+    # swapped for another key, the AAD check above would have failed —
+    # but belt and suspenders.
+    pub_bytes = bytes(_NaclSigningKey(seed).verify_key.encode())
+    if pub_bytes != wrapped.public_key_raw:
+        # Should never happen if AAD was honest. Treat as corruption.
+        raise KeystoreError(
+            "public key in wrapper does not match the key derived from "
+            "the decrypted seed"
+        )
+
+    return SigningKeypair(
+        secret=SecretKey(seed),
+        public=PublicKey(pub_bytes),
+    )
+
+
+# -- Serialization ----------------------------------------------------------
+
+
+def serialize_wrapped(wrapped: WrappedKeypair) -> dict:
+    """Return a JSON-serializable dict for a :class:`WrappedKeypair`.
+
+    Binary fields (``nonce``, ``ciphertext``, ``public_key_raw``) are
+    hex-encoded so the result survives JSON / SQLite TEXT columns. The
+    registry is free to store the binary fields as BLOB instead — this
+    helper is for transport (e.g. enrollment-response payloads) and
+    debugging.
+    """
+    return {
+        "version": wrapped.version,
+        "kid": wrapped.kid,
+        "fingerprint": wrapped.fingerprint,
+        "public_key_hex": wrapped.public_key_raw.hex(),
+        "nonce_hex": wrapped.nonce.hex(),
+        "ciphertext_hex": wrapped.ciphertext.hex(),
+    }
+
+
+def deserialize_wrapped(blob: dict) -> WrappedKeypair:
+    """Inverse of :func:`serialize_wrapped`.
+
+    Raises ``ValueError`` if required fields are missing or malformed.
+    Does not perform any crypto — that's :func:`unwrap_keypair`'s job.
+    """
+    try:
+        return WrappedKeypair(
+            version=int(blob["version"]),
+            kid=str(blob["kid"]),
+            fingerprint=str(blob["fingerprint"]),
+            public_key_raw=bytes.fromhex(blob["public_key_hex"]),
+            nonce=bytes.fromhex(blob["nonce_hex"]),
+            ciphertext=bytes.fromhex(blob["ciphertext_hex"]),
+        )
+    except KeyError as e:
+        raise ValueError(f"wrapped blob missing required field: {e}") from e
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"wrapped blob is malformed: {e}") from e
+
+
+__all__ = [
+    "DEFAULT_DEVICE_KEY_PATH",
+    "DEVICE_KEY_BYTES",
+    "DeviceKey",
+    "KeystoreError",
+    "WRAP_VERSION",
+    "WrapVersionError",
+    "WrappedKeypair",
+    "deserialize_wrapped",
+    "serialize_wrapped",
+    "unwrap_keypair",
+    "wrap_keypair",
+]

--- a/tests/test_pinky_identity_keystore.py
+++ b/tests/test_pinky_identity_keystore.py
@@ -1,0 +1,305 @@
+"""Tests for pinky_identity.keystore (encrypted-at-rest wrap/unwrap)."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+from dataclasses import replace
+
+import pytest
+
+from pinky_identity import (
+    SignatureError,
+    fingerprint,
+    generate_keypair,
+    kid_from_public_key,
+)
+from pinky_identity.keystore import (
+    DEVICE_KEY_BYTES,
+    WRAP_VERSION,
+    DeviceKey,
+    KeystoreError,
+    WrapVersionError,
+    deserialize_wrapped,
+    serialize_wrapped,
+    unwrap_keypair,
+    wrap_keypair,
+)
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def device_key():
+    return DeviceKey.from_bytes(secrets.token_bytes(DEVICE_KEY_BYTES))
+
+
+@pytest.fixture
+def keypair():
+    return generate_keypair()
+
+
+# -- DeviceKey: construction -------------------------------------------------
+
+
+def test_device_key_from_bytes_round_trip():
+    raw = secrets.token_bytes(DEVICE_KEY_BYTES)
+    dk = DeviceKey.from_bytes(raw)
+    assert dk.material_insecure() == raw
+
+
+def test_device_key_rejects_wrong_length():
+    with pytest.raises(ValueError, match="32 bytes"):
+        DeviceKey.from_bytes(b"\x00" * 16)
+
+
+def test_device_key_repr_redacts_material():
+    dk = DeviceKey.from_bytes(b"\xaa" * 32)
+    text = repr(dk)
+    # Should reveal the 4-byte tag for debugging but not the full key.
+    assert "aaaaaaaa" in text
+    assert "aaaaaaaaaaaaaaaaaaaaaaaa" not in text  # not the full 32 bytes
+
+
+# -- DeviceKey: file-backed --------------------------------------------------
+
+
+def test_device_key_load_or_create_generates_on_first_use(tmp_path):
+    path = tmp_path / "subdir" / ".device_key"
+    dk = DeviceKey.load_or_create(str(path))
+    assert path.exists()
+    assert len(path.read_bytes()) == DEVICE_KEY_BYTES
+    mode = stat.S_IMODE(path.stat().st_mode)
+    assert mode == 0o600
+    assert dk.material_insecure() == path.read_bytes()
+
+
+def test_device_key_load_or_create_returns_existing(tmp_path):
+    path = tmp_path / ".device_key"
+    material = secrets.token_bytes(DEVICE_KEY_BYTES)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, material)
+    finally:
+        os.close(fd)
+    dk = DeviceKey.load_or_create(str(path))
+    assert dk.material_insecure() == material
+
+
+def test_device_key_load_or_create_rejects_wrong_length(tmp_path):
+    path = tmp_path / ".device_key"
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, b"too-short")
+    finally:
+        os.close(fd)
+    with pytest.raises(ValueError, match="expected 32"):
+        DeviceKey.load_or_create(str(path))
+
+
+def test_device_key_load_or_create_rejects_loose_permissions(tmp_path):
+    path = tmp_path / ".device_key"
+    path.write_bytes(secrets.token_bytes(DEVICE_KEY_BYTES))
+    os.chmod(path, 0o644)
+    with pytest.raises(PermissionError, match="loose permissions"):
+        DeviceKey.load_or_create(str(path))
+
+
+# -- wrap / unwrap roundtrip -------------------------------------------------
+
+
+def test_wrap_unwrap_round_trips(keypair, device_key):
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    assert wrapped.version == WRAP_VERSION
+    assert wrapped.kid == kid_from_public_key(keypair.public)
+    assert wrapped.fingerprint == fingerprint(keypair.public)
+    assert wrapped.public_key_raw == keypair.public.raw
+
+    unwrapped = unwrap_keypair(wrapped, device_key=device_key)
+    assert unwrapped.public == keypair.public
+    assert (
+        unwrapped.secret.secret_bytes_insecure()
+        == keypair.secret.secret_bytes_insecure()
+    )
+
+
+def test_wrap_produces_distinct_ciphertexts_for_same_keypair(keypair, device_key):
+    # Random nonce → distinct ciphertexts per wrap, even for the same key.
+    w1 = wrap_keypair(keypair, device_key=device_key)
+    w2 = wrap_keypair(keypair, device_key=device_key)
+    assert w1.nonce != w2.nonce
+    assert w1.ciphertext != w2.ciphertext
+    # But both unwrap to the same keypair.
+    assert unwrap_keypair(w1, device_key=device_key).public == keypair.public
+    assert unwrap_keypair(w2, device_key=device_key).public == keypair.public
+
+
+def test_wrap_ciphertext_is_seed_length_plus_tag(keypair, device_key):
+    # Poly1305 tag = 16 bytes; seed = 32 bytes; total = 48.
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    assert len(wrapped.ciphertext) == 48
+
+
+# -- unwrap: failure modes ---------------------------------------------------
+
+
+def test_unwrap_rejects_wrong_device_key(keypair, device_key):
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    other_dk = DeviceKey.from_bytes(secrets.token_bytes(DEVICE_KEY_BYTES))
+    with pytest.raises(KeystoreError):
+        unwrap_keypair(wrapped, device_key=other_dk)
+
+
+def test_unwrap_rejects_tampered_ciphertext(keypair, device_key):
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    bad = bytearray(wrapped.ciphertext)
+    bad[0] ^= 0x01
+    tampered = replace(wrapped, ciphertext=bytes(bad))
+    with pytest.raises(KeystoreError):
+        unwrap_keypair(tampered, device_key=device_key)
+
+
+def test_unwrap_rejects_tampered_nonce(keypair, device_key):
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    bad_nonce = bytearray(wrapped.nonce)
+    bad_nonce[0] ^= 0x01
+    tampered = replace(wrapped, nonce=bytes(bad_nonce))
+    with pytest.raises(KeystoreError):
+        unwrap_keypair(tampered, device_key=device_key)
+
+
+def test_unwrap_rejects_swapped_kid(keypair, device_key):
+    # AAD pins kid; swapping kid to a different value breaks the AEAD tag.
+    other_kp = generate_keypair()
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    tampered = replace(wrapped, kid=kid_from_public_key(other_kp.public))
+    with pytest.raises(KeystoreError):
+        unwrap_keypair(tampered, device_key=device_key)
+
+
+def test_unwrap_rejects_swapped_fingerprint(keypair, device_key):
+    other_kp = generate_keypair()
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    tampered = replace(wrapped, fingerprint=fingerprint(other_kp.public))
+    with pytest.raises(KeystoreError):
+        unwrap_keypair(tampered, device_key=device_key)
+
+
+def test_unwrap_rejects_swapped_public_key_raw(keypair, device_key):
+    # Even if AAD (kid/fingerprint) is unchanged, swapping the cleartext
+    # public_key_raw should be caught by the post-decrypt cross-check.
+    # In practice, kid and fingerprint are derived from public_key_raw, so
+    # tampering only the raw bytes leaves the AAD honest — the post-decrypt
+    # check is the safety net.
+    other_kp = generate_keypair()
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    tampered = replace(wrapped, public_key_raw=other_kp.public.raw)
+    with pytest.raises(KeystoreError, match="public key in wrapper"):
+        unwrap_keypair(tampered, device_key=device_key)
+
+
+def test_unwrap_rejects_unsupported_version(keypair, device_key):
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    future = replace(wrapped, version=WRAP_VERSION + 99)
+    with pytest.raises(WrapVersionError):
+        unwrap_keypair(future, device_key=device_key)
+
+
+def test_keystore_error_is_signature_error_subclass(keypair, device_key):
+    # Callers should be able to catch identity-layer failures with the
+    # umbrella SignatureError.
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    other_dk = DeviceKey.from_bytes(secrets.token_bytes(DEVICE_KEY_BYTES))
+    with pytest.raises(SignatureError):
+        unwrap_keypair(wrapped, device_key=other_dk)
+
+
+# -- Type guards -------------------------------------------------------------
+
+
+def test_wrap_rejects_non_keypair(device_key):
+    with pytest.raises(TypeError):
+        wrap_keypair("not a keypair", device_key=device_key)  # type: ignore[arg-type]
+
+
+def test_wrap_rejects_non_device_key(keypair):
+    with pytest.raises(TypeError):
+        wrap_keypair(keypair, device_key=b"\x00" * 32)  # type: ignore[arg-type]
+
+
+def test_unwrap_rejects_non_wrapped(device_key):
+    with pytest.raises(TypeError):
+        unwrap_keypair({"not": "a wrapped keypair"}, device_key=device_key)  # type: ignore[arg-type]
+
+
+# -- Public-key accessor -----------------------------------------------------
+
+
+def test_wrapped_public_returns_public_key(keypair, device_key):
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    pk = wrapped.public()
+    assert pk == keypair.public
+
+
+# -- Repr does not leak secret material --------------------------------------
+
+
+def test_wrapped_repr_redacts_ciphertext(keypair, device_key):
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    text = repr(wrapped)
+    assert "redacted" in text
+    assert wrapped.ciphertext.hex() not in text
+
+
+# -- Serialization round-trip ------------------------------------------------
+
+
+def test_serialize_deserialize_round_trips(keypair, device_key):
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    blob = serialize_wrapped(wrapped)
+    # All values are JSON-friendly types.
+    import json
+
+    rehydrated = deserialize_wrapped(json.loads(json.dumps(blob)))
+    assert rehydrated == wrapped
+    assert unwrap_keypair(rehydrated, device_key=device_key).public == keypair.public
+
+
+def test_deserialize_rejects_missing_field():
+    with pytest.raises(ValueError, match="missing"):
+        deserialize_wrapped({"version": 1, "kid": "abc"})
+
+
+def test_deserialize_rejects_malformed_hex():
+    blob = {
+        "version": 1,
+        "kid": "abc",
+        "fingerprint": "deadbeef",
+        "public_key_hex": "not-hex!!",
+        "nonce_hex": "00",
+        "ciphertext_hex": "00",
+    }
+    with pytest.raises(ValueError, match="malformed"):
+        deserialize_wrapped(blob)
+
+
+# -- AAD purpose isolation ---------------------------------------------------
+
+
+def test_aad_purpose_pin_blocks_cross_system_replay(keypair, device_key):
+    # Construct a "wrap-like" ciphertext under the same device key but
+    # with a different AAD purpose; it must NOT decrypt with our unwrap.
+    from nacl.bindings import crypto_aead_xchacha20poly1305_ietf_encrypt
+
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    foreign_aad = b"some-other-system|v=1|kid=" + wrapped.kid.encode()
+    ct = crypto_aead_xchacha20poly1305_ietf_encrypt(
+        keypair.secret.secret_bytes_insecure(),
+        foreign_aad,
+        wrapped.nonce,
+        device_key.material_insecure(),
+    )
+    foreign = replace(wrapped, ciphertext=ct)
+    with pytest.raises(KeystoreError):
+        unwrap_keypair(foreign, device_key=device_key)


### PR DESCRIPTION
## Summary

PR-4a of the per-agent service-auth identity rollout (tracking issue #461). Pure crypto-primitive layer for wrapping Ed25519 signing seeds at rest. The registry (PR-3, #464) will use this to persist seeds in SQLite; the daemon-local signer (PR-4b, upcoming) will use it to unwrap on demand.

**Stack:** branches off `feat/pinky-identity-keys` (PR-2a / #462). **Independent of PR-2b (#463) and PR-3 (#464)** — pure crypto, no SQLite, no HTTP.

## Module — `src/pinky_identity/keystore.py`

- **`DeviceKey`** — 32-byte symmetric KEK at `data/identity/.device_key` (0o600). Generated lazily on first use. `load_or_create` refuses to load on wrong size or loose permissions — does NOT silently fix, because that may mask a real security problem (backup script, world-readable cp, etc.). Distinct file from `pinky_federation`'s device key — different purpose, different blast radius, no cross-purpose KEK reuse.
- **`WrappedKeypair`** — dataclass envelope: `version + kid + fingerprint + public_key_raw + 24-byte nonce + 48-byte ciphertext` (32-byte seed + 16-byte Poly1305 tag).
- **`wrap_keypair` / `unwrap_keypair`** — AEAD: XChaCha20-Poly1305 (PyNaCl bindings; `cryptography` doesn't expose XChaCha directly). Same primitive as `pinky_federation/key_store.py`.
- **AAD pins `(purpose, version, kid, fingerprint)`.** A wrap minted for one identity cannot be replayed under another — tampering kid or fingerprint in cleartext breaks the AEAD tag. Tampering `public_key_raw` alone (AAD untouched) is caught by the post-decrypt cross-check that re-derives the public key from the seed.
- **Versioned envelope.** `WRAP_VERSION=1` today; `unwrap_keypair` raises `WrapVersionError` for unknown versions. Future cipher/AAD changes bump version and keep old blobs readable through a registry-owned migration path.
- **Public-key cleartext fields** (`kid`, `fingerprint`, `public_key_raw`). The public half is, by definition, public. Registry can list/index without unwrapping.
- **`serialize_wrapped` / `deserialize_wrapped`** — hex-encoded JSON-friendly representation for transport (e.g. enrollment-response payloads).
- **Errors** — `KeystoreError` (subclass of `SignatureError`) + `WrapVersionError`. A single `except SignatureError` covers identity-layer failures.
- **Discipline.** `__repr__` never logs ciphertext or device-key bytes beyond a 4-byte hex tag. `_seed_from_keypair` internal helper is verbosely named so grep catches plaintext extraction sites.

## Tests — `tests/test_pinky_identity_keystore.py` (27 cases)

- DeviceKey: construction, length validation, repr redaction
- DeviceKey file: generate on first use, return existing, reject wrong size, reject loose permissions, 0o600 enforced
- wrap/unwrap roundtrip: distinct ciphertexts (random nonce); 48-byte tagged ciphertext length
- Tamper rejection: wrong device key, byte-flipped ciphertext, byte-flipped nonce, swapped kid, swapped fingerprint, swapped `public_key_raw` (caught by post-decrypt check)
- `WrapVersionError` on unknown version
- `KeystoreError` is a `SignatureError` subclass
- Type guards (wrap/unwrap reject wrong-type args)
- Serialize/deserialize round-trip, missing-field / malformed-hex rejection
- AAD purpose isolation: foreign-AAD ciphertext under the same device key does NOT decrypt with our unwrap

**Suite:** 2049 passed, 1 skipped (was 2022 + 27 new). ruff clean.

## Side fix

`src/pinky_identity` added to `[tool.hatch.build.targets.wheel] packages`. Same one-line fix shipped in PR-2b (#463) — included here so PR-4a is independently mergeable; whichever lands first wins, the other rebases as a no-op.

## Test plan

- [ ] CI green (lint + Python 3.11/3.12/3.13/3.14 + Docker)
- [ ] Murzik LGTM
- [ ] Brad final per standing policy

Refs #461.

🤖 Opened by Barsik