### PR TITLE
feat(pinky_identity): SQLite signer store for wrapped keypairs (PR-4b-1)

### DIFF
--- a/src/pinky_identity/__init__.py
+++ b/src/pinky_identity/__init__.py
@@ -8,11 +8,13 @@ This package provides:
 - Ed25519 keypair primitives for the ``service-auth`` purpose
   (``pinky_identity.keys``)
 - Encrypted-at-rest wrapping for signing seeds (``pinky_identity.keystore``)
+- SQLite-backed persistence for wrapped signing keys
+  (``pinky_identity.signer_store``)
 - RFC 9421 HTTP Message Signature signer/verifier helpers
   (``pinky_identity.http_signatures``)
 - (Coming in PR-3) Registry storage + enrollment-token issuance + admin
   approval flow (``pinky_identity.registry``)
-- (Coming in PR-4b) Daemon-local signer + session-bound bearer-token
+- (Coming in PR-4b-2) Daemon-local signer + session-bound bearer-token
   capability (``pinky_identity.signer``)
 
 The package is intentionally separated from ``pinky_federation``: the
@@ -66,6 +68,12 @@ from pinky_identity.keystore import (
     unwrap_keypair,
     wrap_keypair,
 )
+from pinky_identity.signer_store import (
+    DEFAULT_SIGNER_STORE_PATH,
+    EncryptedSignerStore,
+    SignerStoreError,
+    SignerStoreRow,
+)
 
 __all__ = [
     "CONTENT_DIGEST_ALGORITHM",
@@ -74,6 +82,7 @@ __all__ = [
     "DEFAULT_LABEL",
     "DEFAULT_MAX_AGE",
     "DEFAULT_REQUIRED_COMPONENTS",
+    "DEFAULT_SIGNER_STORE_PATH",
     "DEFAULT_TAG",
     "DEVICE_KEY_BYTES",
     "ED25519_PUBLIC_KEY_BYTES",
@@ -82,12 +91,15 @@ __all__ = [
     "KID_HEX_LEN",
     "WRAP_VERSION",
     "DeviceKey",
+    "EncryptedSignerStore",
     "HttpSignatureVerificationError",
     "KeystoreError",
     "PinkyKeyResolver",
     "PublicKey",
     "SecretKey",
     "SignatureError",
+    "SignerStoreError",
+    "SignerStoreRow",
     "SigningKeypair",
     "VerifyResult",
     "WrapVersionError",

--- a/src/pinky_identity/signer_store.py
+++ b/src/pinky_identity/signer_store.py
@@ -1,0 +1,377 @@
+"""SQLite-backed persistence for wrapped service-auth signing keys.
+
+The :class:`EncryptedSignerStore` is the concrete on-disk backend for the
+keystore primitives in :mod:`pinky_identity.keystore`. It holds
+:class:`pinky_identity.WrappedKeypair` rows keyed by kid, decrypting on
+demand under a :class:`DeviceKey`.
+
+Design rules (see ``docs/design/agent-asymmetric-identity.md`` and #461):
+
+- **Storage is daemon-local.** One SQLite file per host
+  (``data/identity/signer_store.db`` by default). Agents do not have
+  direct access; they go through the daemon-local signer service
+  (:mod:`pinky_identity.signer`, PR-4b-2) which holds the
+  :class:`DeviceKey` and unwraps in-process.
+- **Schema mirrors :class:`WrappedKeypair`** plus a ``created_at``
+  timestamp. No metadata — the registry (:mod:`pinky_identity.registry`)
+  is the source of truth for lifecycle, status, fleet/agent/purpose
+  tuples, etc. This store is the *secret-half mirror*.
+- **Storage decouples from lifecycle.** Revocation/retirement happens in
+  the registry; the corresponding ``delete()`` here is best-effort
+  cleanup so an attacker who somehow obtains a stale row plus the device
+  key still can't impersonate a retired agent (the registry won't return
+  the kid as active).
+- **WAL mode + journal_mode=WAL**, same as other PinkyBot SQLite stores.
+- **No SQL injection surface.** All writes use parameterized queries; no
+  string concatenation into SQL.
+- **Errors normalize to** :class:`pinky_identity.keystore.KeystoreError`
+  (subclass of :class:`SignatureError`) on decrypt failures and
+  :class:`KeyError` on lookup miss.
+
+Stand-alone primitive — does not import the registry, daemon, or HTTP
+layers. PR-4b-2 (signer service) composes registry + this store.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from collections.abc import Iterable
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from pinky_identity.keys import SigningKeypair
+from pinky_identity.keystore import (
+    DeviceKey,
+    WrappedKeypair,
+    unwrap_keypair,
+    wrap_keypair,
+)
+
+# -- Constants ---------------------------------------------------------------
+
+#: Default on-disk path for the signer store. Distinct from the registry's
+#: ``data/pinky_identity_registry.db`` — the registry holds public-half
+#: lifecycle state; this file holds the encrypted secret seeds. Co-locating
+#: them in the same DB would make a single read-only file leak both.
+DEFAULT_SIGNER_STORE_PATH = "data/identity/signer_store.db"
+
+
+# -- Errors ------------------------------------------------------------------
+
+
+class SignerStoreError(KeyError):
+    """Raised on lookup misses or persistence failures.
+
+    Subclass of :class:`KeyError` so generic ``except KeyError`` clauses
+    catch the common "no key for this kid" case. Decryption failures
+    bubble up as :class:`pinky_identity.keystore.KeystoreError` from
+    :func:`unwrap_keypair` — the caller can catch
+    :class:`pinky_identity.SignatureError` for both.
+    """
+
+
+# -- Row dataclass -----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SignerStoreRow:
+    """A persisted row in the signer store.
+
+    Fields mirror :class:`WrappedKeypair` plus ``created_at``. The dataclass
+    is exposed for diagnostics / admin tooling; routine signing paths
+    should go through :meth:`EncryptedSignerStore.get_signing_keypair`
+    which returns a fully unwrapped :class:`SigningKeypair`.
+    """
+
+    kid: str
+    fingerprint: str
+    public_key_raw: bytes
+    wrap_version: int
+    nonce: bytes
+    ciphertext: bytes
+    created_at: float
+
+    def to_wrapped(self) -> WrappedKeypair:
+        return WrappedKeypair(
+            version=self.wrap_version,
+            kid=self.kid,
+            fingerprint=self.fingerprint,
+            public_key_raw=self.public_key_raw,
+            nonce=self.nonce,
+            ciphertext=self.ciphertext,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"SignerStoreRow(kid={self.kid!r}, "
+            f"fingerprint={self.fingerprint[:12]!r}…, "
+            f"wrap_version={self.wrap_version}, "
+            f"ciphertext=<{len(self.ciphertext)} bytes redacted>, "
+            f"created_at={self.created_at})"
+        )
+
+
+# -- Store -------------------------------------------------------------------
+
+
+class EncryptedSignerStore:
+    """Persists :class:`WrappedKeypair` rows in SQLite, indexed by kid.
+
+    Construction creates the schema if needed. The :class:`DeviceKey` is
+    held for the lifetime of the store — wraps and unwraps go through it.
+
+    Concurrency: single-process. SQLite is opened with WAL mode for
+    crash-consistency and to allow concurrent readers (e.g. a debug query
+    while signing). Cross-process use is not supported — only one daemon
+    should own this file.
+    """
+
+    __slots__ = ("_db_path", "_db", "_device_key")
+
+    def __init__(
+        self,
+        *,
+        db_path: str | Path = DEFAULT_SIGNER_STORE_PATH,
+        device_key: DeviceKey,
+    ) -> None:
+        if not isinstance(device_key, DeviceKey):
+            raise TypeError("device_key must be a DeviceKey")
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._device_key = device_key
+        self._db = sqlite3.connect(
+            str(self._db_path), isolation_level=None, check_same_thread=False
+        )
+        self._db.row_factory = sqlite3.Row
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA foreign_keys=ON")
+        self._ensure_schema()
+
+    # -- schema --
+
+    def _ensure_schema(self) -> None:
+        # CREATE TABLE IF NOT EXISTS — idempotent across daemon restarts.
+        self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS signing_keystore (
+                kid           TEXT PRIMARY KEY,
+                fingerprint   TEXT UNIQUE NOT NULL,
+                public_key    BLOB NOT NULL,
+                wrap_version  INTEGER NOT NULL,
+                nonce         BLOB NOT NULL,
+                ciphertext    BLOB NOT NULL,
+                created_at    REAL NOT NULL
+            )
+            """
+        )
+        self._db.execute(
+            "CREATE INDEX IF NOT EXISTS signing_keystore_fingerprint_idx "
+            "ON signing_keystore (fingerprint)"
+        )
+
+    # -- writes --
+
+    def put_wrapped(self, wrapped: WrappedKeypair) -> SignerStoreRow:
+        """Persist a pre-wrapped :class:`WrappedKeypair`.
+
+        Idempotent on ``kid``: re-puts overwrite the existing row. Useful
+        for key-rotation flows that re-wrap with a new device key.
+        """
+        if not isinstance(wrapped, WrappedKeypair):
+            raise TypeError("wrapped must be a WrappedKeypair")
+        now = time.time()
+        with self._txn():
+            self._db.execute(
+                """
+                INSERT INTO signing_keystore
+                    (kid, fingerprint, public_key, wrap_version, nonce,
+                     ciphertext, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(kid) DO UPDATE SET
+                    fingerprint=excluded.fingerprint,
+                    public_key=excluded.public_key,
+                    wrap_version=excluded.wrap_version,
+                    nonce=excluded.nonce,
+                    ciphertext=excluded.ciphertext
+                """,
+                (
+                    wrapped.kid,
+                    wrapped.fingerprint,
+                    wrapped.public_key_raw,
+                    wrapped.version,
+                    wrapped.nonce,
+                    wrapped.ciphertext,
+                    now,
+                ),
+            )
+        return SignerStoreRow(
+            kid=wrapped.kid,
+            fingerprint=wrapped.fingerprint,
+            public_key_raw=wrapped.public_key_raw,
+            wrap_version=wrapped.version,
+            nonce=wrapped.nonce,
+            ciphertext=wrapped.ciphertext,
+            created_at=now,
+        )
+
+    def put_keypair(self, keypair: SigningKeypair) -> SignerStoreRow:
+        """Wrap *keypair* under the store's device key and persist.
+
+        Convenience wrapper around :func:`wrap_keypair` + :meth:`put_wrapped`
+        for the common "fresh keypair" path.
+        """
+        if not isinstance(keypair, SigningKeypair):
+            raise TypeError("keypair must be a SigningKeypair")
+        wrapped = wrap_keypair(keypair, device_key=self._device_key)
+        return self.put_wrapped(wrapped)
+
+    # -- reads --
+
+    def has(self, kid: str) -> bool:
+        row = self._db.execute(
+            "SELECT 1 FROM signing_keystore WHERE kid = ?", (kid,)
+        ).fetchone()
+        return row is not None
+
+    def get_row(self, kid: str) -> SignerStoreRow:
+        """Return the raw stored row for *kid* without decrypting.
+
+        Raises :class:`SignerStoreError` if no row exists. Useful for
+        admin tooling that wants to inspect storage state without
+        triggering an unwrap.
+        """
+        row = self._db.execute(
+            "SELECT kid, fingerprint, public_key, wrap_version, nonce, "
+            "ciphertext, created_at FROM signing_keystore WHERE kid = ?",
+            (kid,),
+        ).fetchone()
+        if row is None:
+            raise SignerStoreError(f"no signing key stored for kid {kid!r}")
+        return SignerStoreRow(
+            kid=row["kid"],
+            fingerprint=row["fingerprint"],
+            public_key_raw=bytes(row["public_key"]),
+            wrap_version=int(row["wrap_version"]),
+            nonce=bytes(row["nonce"]),
+            ciphertext=bytes(row["ciphertext"]),
+            created_at=float(row["created_at"]),
+        )
+
+    def get_signing_keypair(self, kid: str) -> SigningKeypair:
+        """Decrypt and return the :class:`SigningKeypair` for *kid*.
+
+        Raises
+        ------
+        SignerStoreError
+            If no row is stored under *kid*.
+        pinky_identity.keystore.KeystoreError
+            If the stored row fails to decrypt under the store's device
+            key (wrong device key, corrupt blob, version mismatch).
+        """
+        row = self.get_row(kid)
+        return unwrap_keypair(row.to_wrapped(), device_key=self._device_key)
+
+    def get_row_by_fingerprint(self, fingerprint_hex: str) -> SignerStoreRow:
+        """Return the row whose full SHA-256 fingerprint matches.
+
+        kid is short (16 hex) and a registry collision check uses the full
+        fingerprint. Lookup-by-fingerprint is provided for admin tooling
+        that wants the cryptographic identifier rather than the short id.
+        """
+        row = self._db.execute(
+            "SELECT kid, fingerprint, public_key, wrap_version, nonce, "
+            "ciphertext, created_at FROM signing_keystore WHERE fingerprint = ?",
+            (fingerprint_hex,),
+        ).fetchone()
+        if row is None:
+            raise SignerStoreError(
+                f"no signing key stored for fingerprint {fingerprint_hex!r}"
+            )
+        return SignerStoreRow(
+            kid=row["kid"],
+            fingerprint=row["fingerprint"],
+            public_key_raw=bytes(row["public_key"]),
+            wrap_version=int(row["wrap_version"]),
+            nonce=bytes(row["nonce"]),
+            ciphertext=bytes(row["ciphertext"]),
+            created_at=float(row["created_at"]),
+        )
+
+    def list_kids(self) -> list[str]:
+        """Return all stored kids, sorted lexicographically."""
+        rows = self._db.execute(
+            "SELECT kid FROM signing_keystore ORDER BY kid"
+        ).fetchall()
+        return [r["kid"] for r in rows]
+
+    def iter_rows(self) -> Iterable[SignerStoreRow]:
+        """Iterate over all rows. Caller-friendly — yields one row at a time."""
+        cursor = self._db.execute(
+            "SELECT kid, fingerprint, public_key, wrap_version, nonce, "
+            "ciphertext, created_at FROM signing_keystore ORDER BY kid"
+        )
+        for row in cursor:
+            yield SignerStoreRow(
+                kid=row["kid"],
+                fingerprint=row["fingerprint"],
+                public_key_raw=bytes(row["public_key"]),
+                wrap_version=int(row["wrap_version"]),
+                nonce=bytes(row["nonce"]),
+                ciphertext=bytes(row["ciphertext"]),
+                created_at=float(row["created_at"]),
+            )
+
+    # -- deletes --
+
+    def delete(self, kid: str) -> bool:
+        """Remove the row for *kid*. Returns True if a row was deleted.
+
+        Best-effort cleanup. The registry's revoke/retire is the
+        authoritative lifecycle event; this method just clears the
+        encrypted seed so even a device-key compromise can't reanimate
+        the agent.
+        """
+        with self._txn():
+            cursor = self._db.execute(
+                "DELETE FROM signing_keystore WHERE kid = ?", (kid,)
+            )
+            return cursor.rowcount > 0
+
+    # -- bookkeeping --
+
+    def close(self) -> None:
+        self._db.close()
+
+    def __enter__(self) -> "EncryptedSignerStore":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    @contextmanager
+    def _txn(self):
+        # isolation_level=None means autocommit; we wrap explicit BEGIN/COMMIT
+        # so multi-statement writes are atomic on this connection.
+        self._db.execute("BEGIN")
+        try:
+            yield
+            self._db.execute("COMMIT")
+        except Exception:
+            self._db.execute("ROLLBACK")
+            raise
+
+    def __repr__(self) -> str:
+        return (
+            f"EncryptedSignerStore(db_path={str(self._db_path)!r}, "
+            f"device_key={self._device_key!r})"
+        )
+
+
+__all__ = [
+    "DEFAULT_SIGNER_STORE_PATH",
+    "EncryptedSignerStore",
+    "SignerStoreError",
+    "SignerStoreRow",
+]

--- a/tests/test_pinky_identity_signer_store.py
+++ b/tests/test_pinky_identity_signer_store.py
@@ -1,0 +1,325 @@
+"""Tests for pinky_identity.signer_store (SQLite-backed wrapped keypair store)."""
+
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+
+import pytest
+
+from pinky_identity import (
+    SignatureError,
+    fingerprint,
+    generate_keypair,
+)
+from pinky_identity.keystore import (
+    DEVICE_KEY_BYTES,
+    DeviceKey,
+    KeystoreError,
+    wrap_keypair,
+)
+from pinky_identity.signer_store import (
+    DEFAULT_SIGNER_STORE_PATH,
+    EncryptedSignerStore,
+    SignerStoreError,
+)
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def device_key():
+    return DeviceKey.from_bytes(secrets.token_bytes(DEVICE_KEY_BYTES))
+
+
+@pytest.fixture
+def store(tmp_path, device_key):
+    s = EncryptedSignerStore(db_path=tmp_path / "ss.db", device_key=device_key)
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+@pytest.fixture
+def keypair():
+    return generate_keypair()
+
+
+# -- Construction ------------------------------------------------------------
+
+
+def test_construct_creates_parent_directory(tmp_path, device_key):
+    nested = tmp_path / "a" / "b" / "ss.db"
+    assert not nested.exists()
+    s = EncryptedSignerStore(db_path=nested, device_key=device_key)
+    try:
+        assert nested.exists()
+    finally:
+        s.close()
+
+
+def test_construct_rejects_non_device_key(tmp_path):
+    with pytest.raises(TypeError):
+        EncryptedSignerStore(db_path=tmp_path / "ss.db", device_key=b"\x00" * 32)  # type: ignore[arg-type]
+
+
+def test_default_path_constant_is_under_data_identity():
+    assert DEFAULT_SIGNER_STORE_PATH.startswith("data/identity/")
+
+
+# -- put_keypair / get_signing_keypair ---------------------------------------
+
+
+def test_put_keypair_round_trips(store, keypair):
+    row = store.put_keypair(keypair)
+    assert row.kid
+    assert row.fingerprint == fingerprint(keypair.public)
+    assert row.public_key_raw == keypair.public.raw
+    assert len(row.ciphertext) == 48  # 32 seed + 16 Poly1305 tag
+
+    recovered = store.get_signing_keypair(row.kid)
+    assert recovered.public == keypair.public
+    assert (
+        recovered.secret.secret_bytes_insecure()
+        == keypair.secret.secret_bytes_insecure()
+    )
+
+
+def test_put_keypair_rejects_non_keypair(store):
+    with pytest.raises(TypeError):
+        store.put_keypair("not a keypair")  # type: ignore[arg-type]
+
+
+def test_put_wrapped_round_trips(store, keypair, device_key):
+    wrapped = wrap_keypair(keypair, device_key=device_key)
+    row = store.put_wrapped(wrapped)
+    assert row.kid == wrapped.kid
+
+    out = store.get_signing_keypair(wrapped.kid)
+    assert out.public == keypair.public
+
+
+def test_put_wrapped_rejects_non_wrapped(store):
+    with pytest.raises(TypeError):
+        store.put_wrapped({"kid": "abc"})  # type: ignore[arg-type]
+
+
+def test_put_is_idempotent_on_kid(store, keypair):
+    row1 = store.put_keypair(keypair)
+    row2 = store.put_keypair(keypair)
+    # Same kid, but ciphertexts differ (random nonce).
+    assert row1.kid == row2.kid
+    assert row1.ciphertext != row2.ciphertext
+    # Only one row total.
+    assert store.list_kids() == [row1.kid]
+    # Still recoverable.
+    assert store.get_signing_keypair(row1.kid).public == keypair.public
+
+
+# -- has / list / iter -------------------------------------------------------
+
+
+def test_has_returns_false_for_unknown(store):
+    assert store.has("does-not-exist") is False
+
+
+def test_has_returns_true_after_put(store, keypair):
+    row = store.put_keypair(keypair)
+    assert store.has(row.kid) is True
+
+
+def test_list_kids_orders_lexicographically(store):
+    from pinky_identity import kid_from_public_key
+
+    kps = [generate_keypair() for _ in range(3)]
+    expected = {kid_from_public_key(kp.public) for kp in kps}
+    for kp in kps:
+        store.put_keypair(kp)
+    listed = store.list_kids()
+    assert listed == sorted(listed)
+    assert set(listed) == expected
+
+
+def test_iter_rows_yields_one_per_stored_keypair(store):
+    from pinky_identity import kid_from_public_key
+
+    kps = [generate_keypair() for _ in range(5)]
+    expected = {kid_from_public_key(kp.public) for kp in kps}
+    for kp in kps:
+        store.put_keypair(kp)
+    rows = list(store.iter_rows())
+    assert len(rows) == 5
+    assert {r.kid for r in rows} == expected
+
+
+# -- get_row / get_row_by_fingerprint ----------------------------------------
+
+
+def test_get_row_returns_full_row(store, keypair):
+    inserted = store.put_keypair(keypair)
+    row = store.get_row(inserted.kid)
+    assert row.kid == inserted.kid
+    assert row.fingerprint == inserted.fingerprint
+    assert row.public_key_raw == inserted.public_key_raw
+    assert row.wrap_version == inserted.wrap_version
+    assert row.nonce == inserted.nonce
+    assert row.ciphertext == inserted.ciphertext
+    assert row.created_at == pytest.approx(inserted.created_at)
+
+
+def test_get_row_raises_signer_store_error_on_miss(store):
+    with pytest.raises(SignerStoreError):
+        store.get_row("does-not-exist")
+
+
+def test_signer_store_error_is_key_error(store):
+    # generic except KeyError clauses should still catch SignerStoreError.
+    with pytest.raises(KeyError):
+        store.get_row("does-not-exist")
+
+
+def test_get_signing_keypair_raises_on_miss(store):
+    with pytest.raises(SignerStoreError):
+        store.get_signing_keypair("does-not-exist")
+
+
+def test_get_row_by_fingerprint_round_trips(store, keypair):
+    row = store.put_keypair(keypair)
+    found = store.get_row_by_fingerprint(row.fingerprint)
+    assert found.kid == row.kid
+
+
+def test_get_row_by_fingerprint_raises_on_miss(store):
+    with pytest.raises(SignerStoreError):
+        store.get_row_by_fingerprint("0" * 64)
+
+
+# -- delete ------------------------------------------------------------------
+
+
+def test_delete_removes_row(store, keypair):
+    row = store.put_keypair(keypair)
+    assert store.has(row.kid)
+    deleted = store.delete(row.kid)
+    assert deleted is True
+    assert not store.has(row.kid)
+
+
+def test_delete_returns_false_when_missing(store):
+    assert store.delete("does-not-exist") is False
+
+
+def test_delete_after_get_signing_keypair_makes_kid_unsignable(store, keypair):
+    row = store.put_keypair(keypair)
+    store.get_signing_keypair(row.kid)  # warm-up
+    store.delete(row.kid)
+    with pytest.raises(SignerStoreError):
+        store.get_signing_keypair(row.kid)
+
+
+# -- Decrypt failures --------------------------------------------------------
+
+
+def test_get_signing_keypair_fails_with_wrong_device_key(tmp_path, keypair):
+    dk1 = DeviceKey.from_bytes(secrets.token_bytes(DEVICE_KEY_BYTES))
+    dk2 = DeviceKey.from_bytes(secrets.token_bytes(DEVICE_KEY_BYTES))
+    path = tmp_path / "ss.db"
+    s1 = EncryptedSignerStore(db_path=path, device_key=dk1)
+    try:
+        row = s1.put_keypair(keypair)
+    finally:
+        s1.close()
+    s2 = EncryptedSignerStore(db_path=path, device_key=dk2)
+    try:
+        with pytest.raises(KeystoreError):
+            s2.get_signing_keypair(row.kid)
+        # SignatureError catches both KeystoreError and SignerStoreError.
+        with pytest.raises(SignatureError):
+            s2.get_signing_keypair(row.kid)
+    finally:
+        s2.close()
+
+
+def test_persistence_across_reopen(tmp_path, device_key, keypair):
+    path = tmp_path / "ss.db"
+    s1 = EncryptedSignerStore(db_path=path, device_key=device_key)
+    try:
+        row = s1.put_keypair(keypair)
+    finally:
+        s1.close()
+
+    s2 = EncryptedSignerStore(db_path=path, device_key=device_key)
+    try:
+        assert s2.has(row.kid)
+        recovered = s2.get_signing_keypair(row.kid)
+        assert recovered.public == keypair.public
+    finally:
+        s2.close()
+
+
+# -- Context manager ---------------------------------------------------------
+
+
+def test_context_manager_closes_db(tmp_path, device_key, keypair):
+    path = tmp_path / "ss.db"
+    with EncryptedSignerStore(db_path=path, device_key=device_key) as s:
+        s.put_keypair(keypair)
+    # After exit, attempting another op via the same connection raises.
+    with pytest.raises(Exception):  # noqa: BLE001 — sqlite3.ProgrammingError
+        s.get_row("anything")
+
+
+# -- Row repr does not leak --------------------------------------------------
+
+
+def test_signer_store_row_repr_redacts_ciphertext(store, keypair):
+    row = store.put_keypair(keypair)
+    text = repr(row)
+    assert "redacted" in text
+    assert row.ciphertext.hex() not in text
+
+
+def test_signer_store_row_to_wrapped_round_trips(store, keypair):
+    row = store.put_keypair(keypair)
+    wrapped = row.to_wrapped()
+    assert wrapped.kid == row.kid
+    assert wrapped.ciphertext == row.ciphertext
+    assert wrapped.public_key_raw == row.public_key_raw
+
+
+# -- Two stores with same path see each other -------------------------------
+
+
+def test_two_stores_same_path_share_rows(tmp_path, device_key, keypair):
+    path = tmp_path / "ss.db"
+    s1 = EncryptedSignerStore(db_path=path, device_key=device_key)
+    s2 = EncryptedSignerStore(db_path=path, device_key=device_key)
+    try:
+        row = s1.put_keypair(keypair)
+        # s2 sees the row immediately (WAL mode, single host).
+        assert s2.has(row.kid)
+    finally:
+        s1.close()
+        s2.close()
+
+
+def test_path_via_string_or_path(tmp_path, device_key):
+    s_str = EncryptedSignerStore(db_path=str(tmp_path / "a.db"), device_key=device_key)
+    s_path = EncryptedSignerStore(db_path=tmp_path / "b.db", device_key=device_key)
+    try:
+        assert isinstance(s_str.list_kids(), list)
+        assert isinstance(s_path.list_kids(), list)
+    finally:
+        s_str.close()
+        s_path.close()
+
+
+def test_path_is_resolved_to_absolute(tmp_path, device_key):
+    # Ensure the parent-dir-mkdir works with absolute paths.
+    abs_path = (tmp_path / "subdir" / "ss.db").resolve()
+    s = EncryptedSignerStore(db_path=abs_path, device_key=device_key)
+    try:
+        assert Path(abs_path).exists()
+    finally:
+        s.close()


### PR DESCRIPTION
## Summary

PR-4b-1 of the per-agent service-auth identity rollout (tracking issue #461). Concrete on-disk backend for the keystore primitives in PR-4a (#465). `EncryptedSignerStore` persists `WrappedKeypair` rows keyed by `kid`, decrypting on demand under the daemon-local `DeviceKey`.

This is the **signer-side secret-half mirror** to Murzik's PR-3 registry (#464) — the registry is the public-side verifier/admin view, this store holds the encrypted seeds. The two are deliberately separate files so a single read-only filesystem leak does not give an attacker both halves.

**Stack:** branches off `feat/pinky-identity-keystore` (PR-4a / #465). Will rebase forward when PR-4a lands. Independent of PR-3 (#464) and PR-2b (#463) — no registry / HTTP coupling.

## Module — `src/pinky_identity/signer_store.py`

- **`EncryptedSignerStore`** — SQLite store at `data/identity/signer_store.db` (distinct from `data/pinky_identity_registry.db`).
- **Schema** (`signing_keystore` table):
  ```
  kid TEXT PRIMARY KEY
  fingerprint TEXT UNIQUE NOT NULL
  public_key BLOB NOT NULL
  wrap_version INTEGER NOT NULL
  nonce BLOB NOT NULL
  ciphertext BLOB NOT NULL
  created_at REAL NOT NULL
  ```
  Index on `fingerprint` for admin lookup by full SHA-256.
- **WAL mode** + `foreign_keys=ON`. `isolation_level=None` with explicit `BEGIN`/`COMMIT` txns for atomic multi-statement writes.
- **`put_keypair(keypair)`** — wrap + persist in one call (the common "fresh keypair" path).
- **`put_wrapped(wrapped)`** — persist a pre-wrapped blob. **Idempotent on `kid`** — re-puts overwrite, supporting key-rotation flows that re-wrap with a new device key.
- **`get_signing_keypair(kid)`** — load + unwrap.
- **`get_row(kid)` / `get_row_by_fingerprint(fp)`** — raw inspect, no decrypt (admin tooling).
- **`has(kid)`, `list_kids()`, `iter_rows()`**.
- **`delete(kid)`** — best-effort secret-half cleanup. The registry's revoke/retire is authoritative for lifecycle; this clears the encrypted seed so even a device-key compromise can't reanimate a retired agent.
- Context-manager interface (`close` on exit).
- **`SignerStoreError(KeyError)`** for misses. Decrypt failures bubble up as `KeystoreError` from `unwrap_keypair` — both caught by `except SignatureError`.

## Discipline

- All writes are parameterized; no SQL string concat.
- `SignerStoreRow.__repr__` never shows ciphertext beyond a length tag.
- No registry / daemon / HTTP imports — pure storage primitive. PR-4b-2 (signer service) composes registry + this store.

## Tests — `tests/test_pinky_identity_signer_store.py` (29 cases)

- Construction: parent-dir mkdir, non-`DeviceKey` rejection, default path location, str/Path acceptance
- put/get roundtrip (keypair + pre-wrapped paths)
- put idempotence on kid (same input, distinct ciphertexts via random nonce, only one row, still recoverable)
- has / list_kids (lexicographic order) / iter_rows
- get_row / get_row_by_fingerprint round-trip
- `SignerStoreError` on miss; is a `KeyError` subclass
- delete: removes row, returns False on miss, makes kid unsignable
- Wrong-device-key fails with `KeystoreError` (caught by `SignatureError`)
- Persistence across reopen
- Context-manager closes connection
- `SignerStoreRow.to_wrapped` round-trip and repr redaction
- Two stores on the same path (WAL mode) see each other's writes

**Suite:** 2078 passed, 1 skipped (was 2049 + 29 new). ruff clean.

## Up next

- PR-4b-2: `DaemonSigner` service composing this store + Murzik's registry (#464), session-bound bearer tokens, `/internal/signer/sign` endpoint
- PR-4b-3: `streaming_session` integration (session-start token mint + MCP env injection)

## Test plan

- [ ] CI green (lint + Python 3.11/3.12/3.13/3.14 + Docker)
- [ ] Murzik LGTM
- [ ] Brad final per standing policy

Refs #461.

🤖 Opened by Barsik