### PR TITLE
feat(pinky_identity): session-bound bearer tokens (PR-4b-3)

### DIFF
--- a/src/pinky_identity/__init__.py
+++ b/src/pinky_identity/__init__.py
@@ -26,6 +26,18 @@ are mesh-transport tenant identities. Per the design doc, keys must not
 be shared across purposes.
 """
 
+from pinky_identity.bearer_tokens import (
+    DEFAULT_BEARER_TOKEN_STORE_PATH,
+    DEFAULT_TOKEN_TTL,
+    TOKEN_SECRET_BYTES,
+    BearerTokenClaims,
+    BearerTokenError,
+    BearerTokenExpiredError,
+    BearerTokenNotFoundError,
+    BearerTokenRevokedError,
+    BearerTokenStore,
+    MintResult,
+)
 from pinky_identity.http_signatures import (
     CONTENT_DIGEST_ALGORITHM,
     DEFAULT_COVERED_COMPONENTS,
@@ -38,6 +50,7 @@ from pinky_identity.http_signatures import (
     VerifyResult,
     attach_content_digest,
     compute_content_digest,
+    content_digest_header_matches_body,
     sign_request,
     verify_request,
 )
@@ -92,6 +105,7 @@ from pinky_identity.signer_store import (
 
 __all__ = [
     "CONTENT_DIGEST_ALGORITHM",
+    "DEFAULT_BEARER_TOKEN_STORE_PATH",
     "DEFAULT_COVERED_COMPONENTS",
     "DEFAULT_DEVICE_KEY_PATH",
     "DEFAULT_FLEET",
@@ -100,6 +114,7 @@ __all__ = [
     "DEFAULT_REQUIRED_COMPONENTS",
     "DEFAULT_SIGNER_STORE_PATH",
     "DEFAULT_TAG",
+    "DEFAULT_TOKEN_TTL",
     "DEVICE_KEY_BYTES",
     "ED25519_PUBLIC_KEY_BYTES",
     "ED25519_SECRET_KEY_BYTES",
@@ -107,7 +122,14 @@ __all__ = [
     "KEY_ACTIVE",
     "KID_HEX_LEN",
     "PURPOSE_SERVICE_AUTH",
+    "TOKEN_SECRET_BYTES",
     "WRAP_VERSION",
+    "BearerTokenClaims",
+    "BearerTokenError",
+    "BearerTokenExpiredError",
+    "BearerTokenNotFoundError",
+    "BearerTokenRevokedError",
+    "BearerTokenStore",
     "BodyNotBoundError",
     "DaemonSigner",
     "DeviceKey",
@@ -119,6 +141,7 @@ __all__ = [
     "KeyNotRegisteredError",
     "KeystoreError",
     "KidFingerprintMismatchError",
+    "MintResult",
     "PinkyKeyResolver",
     "PublicKey",
     "RegistryLike",
@@ -133,6 +156,7 @@ __all__ = [
     "WrappedKeypair",
     "attach_content_digest",
     "compute_content_digest",
+    "content_digest_header_matches_body",
     "deserialize_wrapped",
     "fingerprint",
     "generate_keypair",

--- a/src/pinky_identity/bearer_tokens.py
+++ b/src/pinky_identity/bearer_tokens.py
@@ -1,0 +1,675 @@
+"""Session-bound bearer tokens for the daemon-local signer service.
+
+A bearer token is the capability "this streaming session may ask the
+daemon-local signer to sign HTTP requests on behalf of agent
+``(fleet, agent_name, purpose)``". The daemon mints one when a streaming
+session starts; the session presents it on every call to
+``/internal/signer/sign`` (PR-4b-4); the daemon validates the token
+before composing :class:`pinky_identity.DaemonSigner` to sign.
+
+Design rules (see ``docs/design/agent-asymmetric-identity.md`` and #461):
+
+- **Tokens are opaque secrets.** 32 cryptographically random bytes,
+  transported as base64url. The store persists only ``sha256(secret)`` —
+  the raw secret never touches the database after the mint call returns
+  it. Lookups happen by hash; a database leak doesn't yield usable
+  tokens.
+- **Bound to the identity tuple, not the kid.** Tokens authorize
+  signing as ``(fleet, agent_name, purpose)``. The kid is resolved at
+  sign time via the registry, so a key rotation doesn't invalidate
+  outstanding session tokens. Revocation of the *agent identity* is
+  separate from revocation of the *session capability*.
+- **Session-scoped.** Each token carries the ``session_id`` of the
+  streaming session it was minted for. The daemon can invalidate every
+  outstanding token for a session in one call (e.g. when the session
+  process exits or its context restart drops authority).
+- **Expiry is mandatory.** Every token has an ``expires_at`` —
+  :meth:`BearerTokenStore.mint` requires either an explicit value or a
+  ``ttl``. The verifier's ``validate()`` refuses expired tokens.
+- **Revocation is explicit.** :meth:`invalidate`, :meth:`invalidate_session`,
+  and :meth:`invalidate_identity` write a ``revoked_at`` timestamp;
+  ``validate()`` refuses any token with a non-null ``revoked_at``.
+- **No partial trust.** :meth:`validate` returns the full
+  :class:`BearerTokenClaims` or raises a :class:`BearerTokenError`
+  subclass. No "valid but not active" middle state.
+- **Stand-alone primitive.** Depends only on SQLite + the package's
+  :class:`SignatureError`. Does not import the registry, the signer,
+  the keystore, or any HTTP layer — so it can be tested without
+  standing up the rest of the stack, and PR-4b-4 composes this with
+  :class:`DaemonSigner` cleanly.
+
+Error model:
+
+- :class:`BearerTokenError` — umbrella, subclass of
+  :class:`pinky_identity.SignatureError`. One ``except`` covers every
+  failure mode.
+- :class:`BearerTokenNotFoundError` — token doesn't exist in the store
+  (unknown secret, or a partially-typed token). Indistinguishable in
+  the message from an outright fake — we don't leak whether the prefix
+  was real.
+- :class:`BearerTokenExpiredError` — past ``expires_at``.
+- :class:`BearerTokenRevokedError` — explicit ``revoked_at`` is set.
+
+Token format on the wire: base64url-encoded 32 raw bytes (43 ASCII
+chars, no padding). Callers usually wrap in ``Authorization: Bearer …``
+on the HTTP layer (PR-4b-4); this module deals in the raw token string.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import secrets
+import sqlite3
+import time
+from collections.abc import Iterable
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+
+from pinky_identity.keys import SignatureError
+
+# -- Constants ---------------------------------------------------------------
+
+#: Default on-disk path for the bearer-token store. Lives alongside the
+#: signer store under ``data/identity/`` — same trust boundary (daemon
+#: only), different concern (capabilities vs encrypted seeds), so kept
+#: in separate files.
+DEFAULT_BEARER_TOKEN_STORE_PATH = "data/identity/bearer_tokens.db"
+
+#: Bytes of cryptographic randomness in each token secret. 32 bytes →
+#: 256 bits. RFC 4648 base64url with no padding encodes that as 43
+#: characters. Don't lower this below 16 (128 bits); 32 is the modern
+#: default and matches the device-key length.
+TOKEN_SECRET_BYTES: int = 32
+
+#: Default TTL when callers don't specify one. 1 hour matches typical
+#: streaming-session lifetimes; daemons can mint longer for batch jobs
+#: by passing an explicit ``ttl=`` or ``expires_at=``.
+DEFAULT_TOKEN_TTL: timedelta = timedelta(hours=1)
+
+
+# -- Errors ------------------------------------------------------------------
+
+
+class BearerTokenError(SignatureError):
+    """Umbrella for any bearer-token failure.
+
+    Subclass of :class:`pinky_identity.SignatureError` so a generic
+    ``except SignatureError`` block covers signer, keystore, and bearer
+    failures uniformly.
+    """
+
+
+class BearerTokenNotFoundError(BearerTokenError):
+    """The presented token doesn't match any stored row.
+
+    Indistinguishable in the message from outright forgery — we don't
+    confirm whether a prefix was real, only that the full secret
+    doesn't authenticate. Callers should log generically.
+    """
+
+
+class BearerTokenExpiredError(BearerTokenError):
+    """The token's ``expires_at`` is in the past."""
+
+
+class BearerTokenRevokedError(BearerTokenError):
+    """The token was explicitly invalidated by a revoke call."""
+
+
+# -- Token primitives --------------------------------------------------------
+
+
+def _encode_token(secret_bytes: bytes) -> str:
+    """Encode raw secret bytes as base64url (RFC 4648 §5, no padding).
+
+    43 chars for 32 bytes. URL/header safe.
+    """
+    return base64.urlsafe_b64encode(secret_bytes).rstrip(b"=").decode("ascii")
+
+
+def _decode_token(token: str) -> bytes:
+    """Inverse of :func:`_encode_token`. Restores stripped padding.
+
+    Raises :class:`BearerTokenNotFoundError` for any malformed input —
+    we don't leak which kind of malformation occurred (length, charset,
+    etc.) since unknown-token and bad-token are the same threat model.
+    """
+    if not isinstance(token, str) or not token:
+        raise BearerTokenNotFoundError("empty or non-string token")
+    # base64url-no-padding length for 32 bytes is 43. We don't actually
+    # constrain length here (other lengths just won't match a real
+    # row), but we do reject obviously-malformed input before hashing
+    # so callers can't induce unbounded work with a 10 MB "token".
+    if len(token) > 4 * TOKEN_SECRET_BYTES:
+        raise BearerTokenNotFoundError("token too long")
+    padding = "=" * (-len(token) % 4)
+    try:
+        return base64.urlsafe_b64decode(token + padding)
+    except (ValueError, binascii.Error) as e:
+        raise BearerTokenNotFoundError("malformed token encoding") from e
+
+
+def _hash_secret(secret_bytes: bytes) -> str:
+    """SHA-256 the raw secret. Returns lowercase hex.
+
+    Used both at mint time (to store the verifier-side hash) and at
+    validate time (to look up by hash). The store never sees raw
+    secrets after the mint call returns.
+    """
+    return hashlib.sha256(secret_bytes).hexdigest()
+
+
+# -- Claims dataclass --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BearerTokenClaims:
+    """The validated identity behind a bearer token.
+
+    Returned by :meth:`BearerTokenStore.validate`. The caller composes
+    these claims with :class:`pinky_identity.DaemonSigner` —
+    ``(fleet, agent_name, purpose)`` resolves to the active kid via
+    :meth:`DaemonSigner.resolve_active_kid`, and the signer signs.
+
+    The raw secret is not present here on purpose. By the time
+    ``validate`` returns, the secret has done its job and the rest of
+    the request flow should reason about identity, not credentials.
+    """
+
+    token_id: str
+    session_id: str
+    fleet: str
+    agent_name: str
+    purpose: str
+    created_at: float
+    expires_at: float
+    last_used_at: float | None
+    revoked_at: float | None
+
+    @property
+    def is_expired(self) -> bool:
+        return time.time() >= self.expires_at
+
+    @property
+    def is_revoked(self) -> bool:
+        return self.revoked_at is not None
+
+
+@dataclass(frozen=True)
+class MintResult:
+    """The output of :meth:`BearerTokenStore.mint`.
+
+    ``token`` is the secret string the caller hands to the streaming
+    session — this is the **only** time the secret exists outside the
+    minting process's memory. The other fields are the bookkeeping
+    half (safe to log).
+    """
+
+    token: str
+    token_id: str
+    claims: BearerTokenClaims
+
+
+# -- Store -------------------------------------------------------------------
+
+
+class BearerTokenStore:
+    """SQLite-backed store for session-bound bearer tokens.
+
+    One row per outstanding token. The schema holds the bookkeeping
+    half — id, session, identity tuple, timestamps, revocation flag —
+    plus ``secret_hash`` (sha-256 hex). The raw secret is returned
+    once at mint time and never persisted.
+
+    Concurrency: single-process. WAL mode + autocommit with explicit
+    transactions for multi-statement writes, matching
+    :mod:`pinky_identity.signer_store`. Cross-process use isn't
+    supported; only the daemon owns this file.
+
+    Errors normalize to :class:`BearerTokenError` subclasses. Lookup
+    misses and bad encodings both surface as
+    :class:`BearerTokenNotFoundError` — callers shouldn't be able to
+    distinguish "wrong format" from "no such token" since both are
+    attacker-controlled.
+    """
+
+    __slots__ = ("_db_path", "_db")
+
+    def __init__(
+        self,
+        *,
+        db_path: str | Path = DEFAULT_BEARER_TOKEN_STORE_PATH,
+    ) -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._db = sqlite3.connect(
+            str(self._db_path), isolation_level=None, check_same_thread=False
+        )
+        self._db.row_factory = sqlite3.Row
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA foreign_keys=ON")
+        self._ensure_schema()
+
+    # -- schema --
+
+    def _ensure_schema(self) -> None:
+        # ``secret_hash`` is UNIQUE: a single secret can only correspond
+        # to one row. Lookups go through it. The composite indexes on
+        # ``session_id`` and ``(fleet, agent_name, purpose)`` make the
+        # bulk-invalidate paths O(rows-to-revoke), not full-scan.
+        self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bearer_tokens (
+                token_id      TEXT PRIMARY KEY,
+                secret_hash   TEXT UNIQUE NOT NULL,
+                session_id    TEXT NOT NULL,
+                fleet         TEXT NOT NULL,
+                agent_name    TEXT NOT NULL,
+                purpose       TEXT NOT NULL,
+                created_at    REAL NOT NULL,
+                expires_at    REAL NOT NULL,
+                last_used_at  REAL,
+                revoked_at    REAL
+            )
+            """
+        )
+        self._db.execute(
+            "CREATE INDEX IF NOT EXISTS bearer_tokens_session_idx "
+            "ON bearer_tokens (session_id)"
+        )
+        self._db.execute(
+            "CREATE INDEX IF NOT EXISTS bearer_tokens_identity_idx "
+            "ON bearer_tokens (fleet, agent_name, purpose)"
+        )
+
+    # -- mint --
+
+    def mint(
+        self,
+        *,
+        session_id: str,
+        agent_name: str,
+        fleet: str,
+        purpose: str,
+        ttl: timedelta | None = None,
+        expires_at: float | None = None,
+        now: float | None = None,
+    ) -> MintResult:
+        """Mint a new bearer token bound to a session and identity tuple.
+
+        Exactly one of ``ttl`` or ``expires_at`` may be supplied; if
+        both are ``None``, :data:`DEFAULT_TOKEN_TTL` is used. The
+        resulting ``expires_at`` is in absolute seconds since the
+        epoch.
+
+        Returns a :class:`MintResult` containing the secret token (the
+        **only** time the raw secret is exposed outside the minting
+        process) plus the verifier-side claims.
+
+        Idempotency: this method is **not** idempotent — every call
+        generates fresh randomness. Callers that want one token per
+        session per identity should track that on their side.
+        """
+        if not session_id or not agent_name or not fleet or not purpose:
+            raise ValueError(
+                "session_id, agent_name, fleet, purpose must all be non-empty"
+            )
+        if ttl is not None and expires_at is not None:
+            raise ValueError("pass at most one of ttl or expires_at")
+
+        now_val = now if now is not None else time.time()
+        if expires_at is None:
+            effective_ttl = ttl if ttl is not None else DEFAULT_TOKEN_TTL
+            expires_at = now_val + effective_ttl.total_seconds()
+        if expires_at <= now_val:
+            raise ValueError("expires_at must be in the future")
+
+        secret_bytes = secrets.token_bytes(TOKEN_SECRET_BYTES)
+        token = _encode_token(secret_bytes)
+        secret_hash = _hash_secret(secret_bytes)
+        # The token_id is a short-but-unique identifier for the row.
+        # Derive it from the hash so it's deterministic given the
+        # secret (handy for "I revoked this; here's the id"); keeping
+        # only the first 16 hex chars matches the kid format used
+        # elsewhere in this package.
+        token_id = secret_hash[:16]
+
+        with self._txn():
+            self._db.execute(
+                """
+                INSERT INTO bearer_tokens
+                    (token_id, secret_hash, session_id, fleet, agent_name,
+                     purpose, created_at, expires_at, last_used_at, revoked_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+                """,
+                (
+                    token_id,
+                    secret_hash,
+                    session_id,
+                    fleet,
+                    agent_name,
+                    purpose,
+                    now_val,
+                    float(expires_at),
+                ),
+            )
+
+        claims = BearerTokenClaims(
+            token_id=token_id,
+            session_id=session_id,
+            fleet=fleet,
+            agent_name=agent_name,
+            purpose=purpose,
+            created_at=now_val,
+            expires_at=float(expires_at),
+            last_used_at=None,
+            revoked_at=None,
+        )
+        return MintResult(token=token, token_id=token_id, claims=claims)
+
+    # -- validate --
+
+    def validate(
+        self,
+        token: str,
+        *,
+        now: float | None = None,
+        touch: bool = True,
+    ) -> BearerTokenClaims:
+        """Validate *token* and return its claims.
+
+        Steps, in order:
+
+        1. Decode the token (rejects malformed input as
+           :class:`BearerTokenNotFoundError`).
+        2. Look up by ``sha256(secret)`` in constant time relative to
+           the database key — SQLite indexes are O(log n).
+        3. Reject revoked tokens with :class:`BearerTokenRevokedError`.
+        4. Reject expired tokens with :class:`BearerTokenExpiredError`.
+        5. If ``touch`` is True (default), bump ``last_used_at`` to
+           ``now``. This is a separate UPDATE; the validation itself
+           doesn't depend on the bump succeeding.
+
+        Note on side-channels: the hash comparison happens server-side
+        inside SQLite, not in Python. A timing-oracle on bearer-token
+        validation would have to bypass SQLite's index — unlikely. For
+        completeness, the lookup uses :func:`hmac.compare_digest` on
+        the resulting ``secret_hash`` to make any application-level
+        comparison constant-time too.
+        """
+        secret_bytes = _decode_token(token)
+        if len(secret_bytes) != TOKEN_SECRET_BYTES:
+            # Wrong length is the same threat as forgery — no row
+            # could match. Use the same error.
+            raise BearerTokenNotFoundError("token length mismatch")
+        secret_hash = _hash_secret(secret_bytes)
+
+        row = self._db.execute(
+            """
+            SELECT token_id, secret_hash, session_id, fleet, agent_name,
+                   purpose, created_at, expires_at, last_used_at, revoked_at
+            FROM bearer_tokens
+            WHERE secret_hash = ?
+            """,
+            (secret_hash,),
+        ).fetchone()
+        if row is None:
+            raise BearerTokenNotFoundError("no matching token")
+
+        # Defense-in-depth: constant-time compare in Python too. A
+        # SQLite index hit already implies bytewise equality, but a
+        # future migration to a different store shouldn't quietly
+        # introduce a timing oracle.
+        if not hmac.compare_digest(row["secret_hash"], secret_hash):
+            raise BearerTokenNotFoundError("hash mismatch")  # pragma: no cover
+
+        now_val = now if now is not None else time.time()
+        revoked_at = row["revoked_at"]
+        expires_at = float(row["expires_at"])
+
+        if revoked_at is not None:
+            raise BearerTokenRevokedError(
+                f"token {row['token_id']!r} was revoked at {revoked_at}"
+            )
+        if now_val >= expires_at:
+            raise BearerTokenExpiredError(
+                f"token {row['token_id']!r} expired at {expires_at}"
+            )
+
+        if touch:
+            # Separate UPDATE. Failure here doesn't fail the validation;
+            # the claims are already authoritative.
+            with self._txn():
+                self._db.execute(
+                    "UPDATE bearer_tokens SET last_used_at = ? "
+                    "WHERE token_id = ?",
+                    (now_val, row["token_id"]),
+                )
+            last_used_at: float | None = now_val
+        else:
+            last_used_at = (
+                float(row["last_used_at"]) if row["last_used_at"] is not None else None
+            )
+
+        return BearerTokenClaims(
+            token_id=row["token_id"],
+            session_id=row["session_id"],
+            fleet=row["fleet"],
+            agent_name=row["agent_name"],
+            purpose=row["purpose"],
+            created_at=float(row["created_at"]),
+            expires_at=expires_at,
+            last_used_at=last_used_at,
+            revoked_at=None,
+        )
+
+    # -- introspection (no secret material) --
+
+    def get_claims(self, token_id: str) -> BearerTokenClaims:
+        """Return claims for *token_id* without requiring the secret.
+
+        For admin/diagnostic tooling — e.g. "what session does this
+        token belong to". Returns even revoked/expired claims so the
+        operator can see what happened. Raises
+        :class:`BearerTokenNotFoundError` if the id is unknown.
+        """
+        row = self._db.execute(
+            """
+            SELECT token_id, session_id, fleet, agent_name, purpose,
+                   created_at, expires_at, last_used_at, revoked_at
+            FROM bearer_tokens WHERE token_id = ?
+            """,
+            (token_id,),
+        ).fetchone()
+        if row is None:
+            raise BearerTokenNotFoundError(f"no token with id {token_id!r}")
+        return _row_to_claims(row)
+
+    def list_for_session(self, session_id: str) -> list[BearerTokenClaims]:
+        """All claims (active and revoked) for a session, oldest first."""
+        rows = self._db.execute(
+            """
+            SELECT token_id, session_id, fleet, agent_name, purpose,
+                   created_at, expires_at, last_used_at, revoked_at
+            FROM bearer_tokens
+            WHERE session_id = ?
+            ORDER BY created_at
+            """,
+            (session_id,),
+        ).fetchall()
+        return [_row_to_claims(r) for r in rows]
+
+    def list_for_identity(
+        self, *, fleet: str, agent_name: str, purpose: str
+    ) -> list[BearerTokenClaims]:
+        """All claims for an identity tuple, oldest first."""
+        rows = self._db.execute(
+            """
+            SELECT token_id, session_id, fleet, agent_name, purpose,
+                   created_at, expires_at, last_used_at, revoked_at
+            FROM bearer_tokens
+            WHERE fleet = ? AND agent_name = ? AND purpose = ?
+            ORDER BY created_at
+            """,
+            (fleet, agent_name, purpose),
+        ).fetchall()
+        return [_row_to_claims(r) for r in rows]
+
+    def iter_active(self, *, now: float | None = None) -> Iterable[BearerTokenClaims]:
+        """Yield every currently-valid claim (non-revoked, non-expired)."""
+        now_val = now if now is not None else time.time()
+        rows = self._db.execute(
+            """
+            SELECT token_id, session_id, fleet, agent_name, purpose,
+                   created_at, expires_at, last_used_at, revoked_at
+            FROM bearer_tokens
+            WHERE revoked_at IS NULL AND expires_at > ?
+            ORDER BY created_at
+            """,
+            (now_val,),
+        ).fetchall()
+        for r in rows:
+            yield _row_to_claims(r)
+
+    # -- invalidate --
+
+    def invalidate(self, token_id: str, *, now: float | None = None) -> bool:
+        """Mark a single token revoked. Returns True if a row was touched.
+
+        Already-revoked tokens are left alone (idempotent — return
+        False so callers can distinguish "this was the revoke that
+        landed" from "already done").
+        """
+        now_val = now if now is not None else time.time()
+        with self._txn():
+            cursor = self._db.execute(
+                "UPDATE bearer_tokens SET revoked_at = ? "
+                "WHERE token_id = ? AND revoked_at IS NULL",
+                (now_val, token_id),
+            )
+            return cursor.rowcount > 0
+
+    def invalidate_session(self, session_id: str, *, now: float | None = None) -> int:
+        """Revoke every outstanding token for a session. Returns the count.
+
+        Use when a streaming session ends or restarts — the new
+        session should re-mint, not inherit the old session's
+        capability set.
+        """
+        now_val = now if now is not None else time.time()
+        with self._txn():
+            cursor = self._db.execute(
+                "UPDATE bearer_tokens SET revoked_at = ? "
+                "WHERE session_id = ? AND revoked_at IS NULL",
+                (now_val, session_id),
+            )
+            return cursor.rowcount
+
+    def invalidate_identity(
+        self,
+        *,
+        fleet: str,
+        agent_name: str,
+        purpose: str,
+        now: float | None = None,
+    ) -> int:
+        """Revoke every outstanding token for an identity tuple.
+
+        Use when the registry retires/revokes the underlying key —
+        outstanding session capabilities for that identity should die
+        with it, even though the tokens technically refer to the tuple
+        rather than the kid. Counterpart on the public side to
+        :meth:`pinky_identity.DaemonSigner._resolve`'s KEY_ACTIVE check.
+        """
+        now_val = now if now is not None else time.time()
+        with self._txn():
+            cursor = self._db.execute(
+                "UPDATE bearer_tokens SET revoked_at = ? "
+                "WHERE fleet = ? AND agent_name = ? AND purpose = ? "
+                "AND revoked_at IS NULL",
+                (now_val, fleet, agent_name, purpose),
+            )
+            return cursor.rowcount
+
+    def purge_expired(self, *, now: float | None = None) -> int:
+        """Delete expired and revoked rows. Returns the count deleted.
+
+        Optional housekeeping; the validator already rejects expired
+        and revoked rows, so this is purely about reclaiming disk. Safe
+        to call on a timer.
+        """
+        now_val = now if now is not None else time.time()
+        with self._txn():
+            cursor = self._db.execute(
+                "DELETE FROM bearer_tokens "
+                "WHERE expires_at <= ? OR revoked_at IS NOT NULL",
+                (now_val,),
+            )
+            return cursor.rowcount
+
+    # -- bookkeeping --
+
+    def close(self) -> None:
+        self._db.close()
+
+    def __enter__(self) -> "BearerTokenStore":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    @contextmanager
+    def _txn(self):
+        # Matches signer_store: autocommit connection wrapped in
+        # explicit BEGIN/COMMIT so multi-statement writes are atomic.
+        self._db.execute("BEGIN")
+        try:
+            yield
+            self._db.execute("COMMIT")
+        except Exception:
+            self._db.execute("ROLLBACK")
+            raise
+
+    def __repr__(self) -> str:
+        return f"BearerTokenStore(db_path={str(self._db_path)!r})"
+
+
+# -- helpers ----------------------------------------------------------------
+
+
+def _row_to_claims(row: sqlite3.Row) -> BearerTokenClaims:
+    """Build a :class:`BearerTokenClaims` from a SQLite row."""
+    return BearerTokenClaims(
+        token_id=row["token_id"],
+        session_id=row["session_id"],
+        fleet=row["fleet"],
+        agent_name=row["agent_name"],
+        purpose=row["purpose"],
+        created_at=float(row["created_at"]),
+        expires_at=float(row["expires_at"]),
+        last_used_at=(
+            float(row["last_used_at"]) if row["last_used_at"] is not None else None
+        ),
+        revoked_at=(
+            float(row["revoked_at"]) if row["revoked_at"] is not None else None
+        ),
+    )
+
+
+__all__ = [
+    "DEFAULT_BEARER_TOKEN_STORE_PATH",
+    "DEFAULT_TOKEN_TTL",
+    "TOKEN_SECRET_BYTES",
+    "BearerTokenClaims",
+    "BearerTokenError",
+    "BearerTokenExpiredError",
+    "BearerTokenNotFoundError",
+    "BearerTokenRevokedError",
+    "BearerTokenStore",
+    "MintResult",
+]

--- a/src/pinky_identity/bearer_tokens.py
+++ b/src/pinky_identity/bearer_tokens.py
@@ -66,7 +66,7 @@ import sqlite3
 import time
 from collections.abc import Iterable
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
 
@@ -133,20 +133,33 @@ def _encode_token(secret_bytes: bytes) -> str:
 
 
 def _decode_token(token: str) -> bytes:
-    """Inverse of :func:`_encode_token`. Restores stripped padding.
+    """Inverse of :func:`_encode_token`.
 
-    Raises :class:`BearerTokenNotFoundError` for any malformed input —
-    we don't leak which kind of malformation occurred (length, charset,
-    etc.) since unknown-token and bad-token are the same threat model.
+    The wire format is **strict no-padding base64url**: any ``=``
+    character in the input is rejected. Two reasons:
+
+    1. The encoder never emits padding, so a legitimate caller has
+       no reason to send any. Accepting padded variants creates a
+       normalization gap — two distinct strings both decode to the
+       same secret, which complicates audit/log invariants.
+    2. Strict parsing shrinks the attacker surface (one canonical
+       form to reason about).
+
+    Raises :class:`BearerTokenNotFoundError` for any malformed input
+    — we don't leak which kind of malformation occurred (length,
+    charset, padding, etc.) since unknown-token and bad-token are the
+    same threat model.
     """
     if not isinstance(token, str) or not token:
         raise BearerTokenNotFoundError("empty or non-string token")
-    # base64url-no-padding length for 32 bytes is 43. We don't actually
-    # constrain length here (other lengths just won't match a real
-    # row), but we do reject obviously-malformed input before hashing
-    # so callers can't induce unbounded work with a 10 MB "token".
+    # Reject obviously-oversized input before hashing so callers
+    # can't induce unbounded work with a 10 MB "token".
     if len(token) > 4 * TOKEN_SECRET_BYTES:
         raise BearerTokenNotFoundError("token too long")
+    # Strict no-padding enforcement. ``=`` only appears as base64
+    # padding; the encoder strips it.
+    if "=" in token:
+        raise BearerTokenNotFoundError("token must not contain padding")
     padding = "=" * (-len(token) % 4)
     try:
         return base64.urlsafe_b64decode(token + padding)
@@ -208,11 +221,30 @@ class MintResult:
     session — this is the **only** time the secret exists outside the
     minting process's memory. The other fields are the bookkeeping
     half (safe to log).
+
+    The default :func:`repr` redacts ``token``. The credential must
+    never leak through diagnostic logging: a stray
+    ``log.debug("minted %r", result)`` would otherwise stamp the
+    full signer-authority secret into a log file. Callers that need
+    the token must read ``result.token`` explicitly.
     """
 
-    token: str
+    token: str = field(repr=False)
     token_id: str
     claims: BearerTokenClaims
+
+    def __repr__(self) -> str:
+        # Custom repr — the dataclass-generated default would have
+        # shown ``token=...`` even with ``repr=False`` on the field,
+        # since field(repr=False) merely omits a field from the
+        # auto-generated repr. Explicit is better than relying on
+        # that; this makes the redaction obvious and adds a marker
+        # so reviewers grepping for leaked tokens spot the safe form.
+        return (
+            "MintResult(token=<redacted>, "
+            f"token_id={self.token_id!r}, "
+            f"claims={self.claims!r})"
+        )
 
 
 # -- Store -------------------------------------------------------------------

--- a/tests/test_pinky_identity_bearer_tokens.py
+++ b/tests/test_pinky_identity_bearer_tokens.py
@@ -471,6 +471,77 @@ def test_claims_is_expired_property():
     assert expired.is_expired
 
 
+# -- Secret redaction in repr -----------------------------------------------
+#
+# Regression for Murzik's PR-4b-3 review: MintResult must NOT leak the
+# raw token through default dataclass repr — a stray debug log would
+# otherwise stamp the full signer-authority secret into a logfile.
+
+
+def test_mint_result_repr_does_not_leak_token(store):
+    result = _mint_default(store)
+    text = repr(result)
+    assert result.token not in text
+    # Make the redaction marker visible to reviewers grepping for
+    # leaked tokens — they'll see the safe form explicitly.
+    assert "<redacted>" in text
+    # token_id and claims are still in the repr (they're not the
+    # credential and are useful for diagnostics).
+    assert result.token_id in text
+
+
+def test_mint_result_str_does_not_leak_token(store):
+    """``str(result)`` falls back to ``__repr__`` for dataclasses;
+    verify the redaction holds through both surfaces."""
+    result = _mint_default(store)
+    assert result.token not in str(result)
+    assert "<redacted>" in str(result)
+
+
+def test_mint_result_format_does_not_leak_token(store):
+    """The most common accidental leak is ``f"{result}"`` in a log
+    statement. Lock down via the same custom repr."""
+    result = _mint_default(store)
+    formatted = f"{result}"
+    assert result.token not in formatted
+    assert "<redacted>" in formatted
+
+
+def test_mint_result_token_still_accessible_as_attribute(store):
+    """Redaction is for diagnostics, not access — callers explicitly
+    reading ``result.token`` must still get the secret."""
+    result = _mint_default(store)
+    # Validates: the attribute holds the actual base64url token.
+    claims = store.validate(result.token)
+    assert claims.token_id == result.token_id
+
+
+# -- Strict no-padding parsing ----------------------------------------------
+#
+# Murzik's non-blocking note: the encoder emits no padding, so the
+# decoder shouldn't accept padded variants either. Reduces the
+# canonical-form surface to exactly one string per secret.
+
+
+def test_validate_rejects_padded_token(store):
+    """A padded variant of a real token must be rejected even though
+    it base64-decodes to the same secret."""
+    result = _mint_default(store)
+    # Real tokens are 43 chars (32 bytes); pad up to multiple of 4.
+    padded = result.token + "="
+    with pytest.raises(BearerTokenNotFoundError, match="padding"):
+        store.validate(padded)
+    # The canonical form still validates fine.
+    store.validate(result.token)
+
+
+def test_validate_rejects_token_with_internal_equals(store):
+    """``=`` only appears as base64 padding; rejecting anywhere in the
+    string is fine and slightly cheaper than position-aware checks."""
+    with pytest.raises(BearerTokenNotFoundError, match="padding"):
+        store.validate("AAAA=AAAA")
+
+
 def test_claims_is_revoked_property():
     now = time.time()
     alive = BearerTokenClaims(

--- a/tests/test_pinky_identity_bearer_tokens.py
+++ b/tests/test_pinky_identity_bearer_tokens.py
@@ -1,0 +1,489 @@
+"""Tests for pinky_identity.bearer_tokens (BearerTokenStore + primitives)."""
+
+from __future__ import annotations
+
+import base64
+import secrets
+import time
+from datetime import timedelta
+
+import pytest
+
+from pinky_identity import (
+    DEFAULT_TOKEN_TTL,
+    TOKEN_SECRET_BYTES,
+    BearerTokenClaims,
+    BearerTokenError,
+    BearerTokenExpiredError,
+    BearerTokenNotFoundError,
+    BearerTokenRevokedError,
+    BearerTokenStore,
+    MintResult,
+    SignatureError,
+)
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = BearerTokenStore(db_path=tmp_path / "bearer.db")
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _mint_default(store: BearerTokenStore, **overrides) -> MintResult:
+    """Mint a token with sensible defaults so each test only spells the
+    fields it cares about."""
+    kwargs = dict(
+        session_id="sess-1",
+        agent_name="barsik",
+        fleet="pinky",
+        purpose="service-auth",
+    )
+    kwargs.update(overrides)
+    return store.mint(**kwargs)
+
+
+# -- Construction ------------------------------------------------------------
+
+
+def test_store_creates_db_file(tmp_path):
+    path = tmp_path / "nested" / "bearer.db"
+    assert not path.exists()
+    BearerTokenStore(db_path=path).close()
+    assert path.exists()
+
+
+def test_token_secret_constants():
+    # If TOKEN_SECRET_BYTES drops below 16 (128-bit security), tests
+    # should fail loudly — bearer tokens are the gate to the signer.
+    assert TOKEN_SECRET_BYTES >= 16
+    assert DEFAULT_TOKEN_TTL.total_seconds() > 0
+
+
+# -- Mint --------------------------------------------------------------------
+
+
+def test_mint_returns_secret_token_and_claims(store):
+    result = _mint_default(store)
+    assert isinstance(result, MintResult)
+    # base64url-no-padding of 32 bytes is 43 chars.
+    assert len(result.token) == 43
+    # token_id is the first 16 hex chars of sha256(secret).
+    assert len(result.token_id) == 16
+    # All claims fields populated, last_used_at/revoked_at clean.
+    c = result.claims
+    assert c.session_id == "sess-1"
+    assert c.agent_name == "barsik"
+    assert c.fleet == "pinky"
+    assert c.purpose == "service-auth"
+    assert c.last_used_at is None
+    assert c.revoked_at is None
+    # Expires roughly 1h out (DEFAULT_TOKEN_TTL).
+    assert c.expires_at - c.created_at == pytest.approx(
+        DEFAULT_TOKEN_TTL.total_seconds(), abs=1.0
+    )
+
+
+def test_mint_distinct_tokens_have_distinct_secrets(store):
+    """Sanity check on secrets.token_bytes — every mint produces a
+    fresh random secret."""
+    t1 = _mint_default(store).token
+    t2 = _mint_default(store).token
+    assert t1 != t2
+
+
+def test_mint_with_explicit_ttl(store):
+    result = _mint_default(store, ttl=timedelta(minutes=5))
+    delta = result.claims.expires_at - result.claims.created_at
+    assert delta == pytest.approx(300.0, abs=1.0)
+
+
+def test_mint_with_explicit_expires_at(store):
+    now = time.time()
+    explicit = now + 600.0
+    result = _mint_default(store, expires_at=explicit, now=now)
+    assert result.claims.expires_at == pytest.approx(explicit, abs=0.01)
+
+
+def test_mint_rejects_both_ttl_and_expires_at(store):
+    now = time.time()
+    with pytest.raises(ValueError, match="at most one"):
+        _mint_default(
+            store,
+            ttl=timedelta(minutes=5),
+            expires_at=now + 600,
+            now=now,
+        )
+
+
+def test_mint_rejects_past_expires_at(store):
+    now = time.time()
+    with pytest.raises(ValueError, match="must be in the future"):
+        _mint_default(store, expires_at=now - 1, now=now)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("session_id", ""),
+        ("agent_name", ""),
+        ("fleet", ""),
+        ("purpose", ""),
+    ],
+)
+def test_mint_rejects_empty_required_fields(store, field, value):
+    with pytest.raises(ValueError):
+        _mint_default(store, **{field: value})
+
+
+# -- Validate: happy path ---------------------------------------------------
+
+
+def test_validate_round_trips(store):
+    result = _mint_default(store)
+    claims = store.validate(result.token)
+    assert claims.token_id == result.token_id
+    assert claims.session_id == "sess-1"
+    assert claims.agent_name == "barsik"
+    assert claims.fleet == "pinky"
+    assert claims.purpose == "service-auth"
+    assert claims.revoked_at is None
+
+
+def test_validate_bumps_last_used_at_by_default(store):
+    result = _mint_default(store)
+    assert result.claims.last_used_at is None
+    before = time.time()
+    claims = store.validate(result.token)
+    assert claims.last_used_at is not None
+    assert claims.last_used_at >= before
+    # Persists across calls.
+    persisted = store.get_claims(result.token_id)
+    assert persisted.last_used_at == claims.last_used_at
+
+
+def test_validate_does_not_touch_when_touch_false(store):
+    result = _mint_default(store)
+    claims = store.validate(result.token, touch=False)
+    assert claims.last_used_at is None
+    persisted = store.get_claims(result.token_id)
+    assert persisted.last_used_at is None
+
+
+# -- Validate: failure modes ------------------------------------------------
+
+
+def test_validate_rejects_unknown_token(store):
+    # Mint nothing; present a syntactically valid but unknown token.
+    fake = base64.urlsafe_b64encode(secrets.token_bytes(TOKEN_SECRET_BYTES))
+    fake_str = fake.rstrip(b"=").decode("ascii")
+    with pytest.raises(BearerTokenNotFoundError):
+        store.validate(fake_str)
+
+
+def test_validate_rejects_malformed_token(store):
+    with pytest.raises(BearerTokenNotFoundError):
+        store.validate("not!valid!base64!")
+
+
+def test_validate_rejects_empty_token(store):
+    with pytest.raises(BearerTokenNotFoundError):
+        store.validate("")
+
+
+def test_validate_rejects_oversized_token(store):
+    # Don't burn CPU hashing arbitrary attacker input — the decoder
+    # bails on tokens far longer than the legitimate size.
+    big = "A" * (4 * TOKEN_SECRET_BYTES + 1)
+    with pytest.raises(BearerTokenNotFoundError):
+        store.validate(big)
+
+
+def test_validate_rejects_wrong_length_token(store):
+    # Valid base64url but decodes to wrong-length secret bytes — treat
+    # as not-found, same as forgery.
+    short = base64.urlsafe_b64encode(b"\x00" * 8).rstrip(b"=").decode("ascii")
+    with pytest.raises(BearerTokenNotFoundError):
+        store.validate(short)
+
+
+def test_validate_rejects_expired_token(store):
+    now = time.time()
+    result = _mint_default(store, ttl=timedelta(seconds=10), now=now)
+    # Validate "in the future" past expiry.
+    with pytest.raises(BearerTokenExpiredError) as exc:
+        store.validate(result.token, now=now + 11)
+    assert result.token_id in str(exc.value)
+
+
+def test_validate_rejects_revoked_token(store):
+    result = _mint_default(store)
+    store.invalidate(result.token_id)
+    with pytest.raises(BearerTokenRevokedError) as exc:
+        store.validate(result.token)
+    assert result.token_id in str(exc.value)
+
+
+def test_validate_does_not_touch_on_failure(store):
+    """An expired/revoked token's last_used_at must NOT advance — the
+    audit trail should reflect the last successful use, not failed
+    attempts."""
+    now = time.time()
+    result = _mint_default(store, ttl=timedelta(seconds=10), now=now)
+    with pytest.raises(BearerTokenExpiredError):
+        store.validate(result.token, now=now + 11)
+    persisted = store.get_claims(result.token_id)
+    assert persisted.last_used_at is None
+
+
+# -- Revocation -------------------------------------------------------------
+
+
+def test_invalidate_returns_true_on_first_call_false_on_second(store):
+    result = _mint_default(store)
+    assert store.invalidate(result.token_id) is True
+    # Idempotent: already revoked → no-op, returns False.
+    assert store.invalidate(result.token_id) is False
+
+
+def test_invalidate_unknown_token_id_returns_false(store):
+    assert store.invalidate("deadbeefdeadbeef") is False
+
+
+def test_invalidate_session_revokes_all_tokens_for_session(store):
+    a = _mint_default(store, session_id="sess-A")
+    b = _mint_default(store, session_id="sess-A", agent_name="other")
+    c = _mint_default(store, session_id="sess-B")
+
+    count = store.invalidate_session("sess-A")
+    assert count == 2
+
+    with pytest.raises(BearerTokenRevokedError):
+        store.validate(a.token)
+    with pytest.raises(BearerTokenRevokedError):
+        store.validate(b.token)
+    # Other session unaffected.
+    store.validate(c.token)
+
+
+def test_invalidate_session_unknown_id_returns_zero(store):
+    assert store.invalidate_session("does-not-exist") == 0
+
+
+def test_invalidate_identity_revokes_all_tokens_for_tuple(store):
+    # Same identity, different sessions.
+    a = _mint_default(store, session_id="sess-A")
+    b = _mint_default(store, session_id="sess-B")
+    # Different agent — should be untouched.
+    c = _mint_default(store, session_id="sess-C", agent_name="murzik")
+
+    count = store.invalidate_identity(
+        fleet="pinky", agent_name="barsik", purpose="service-auth"
+    )
+    assert count == 2
+
+    with pytest.raises(BearerTokenRevokedError):
+        store.validate(a.token)
+    with pytest.raises(BearerTokenRevokedError):
+        store.validate(b.token)
+    store.validate(c.token)
+
+
+def test_invalidate_skips_already_revoked_rows(store):
+    """Bulk revoke shouldn't double-stamp revoked_at — the timestamp
+    should reflect the original revocation, not a later sweep."""
+    result = _mint_default(store)
+    first = time.time()
+    store.invalidate(result.token_id, now=first)
+    first_persisted = store.get_claims(result.token_id)
+    assert first_persisted.revoked_at == pytest.approx(first, abs=0.01)
+
+    # Bulk revoke later — must not overwrite.
+    later = first + 100
+    count = store.invalidate_session("sess-1", now=later)
+    assert count == 0  # already revoked
+    second_persisted = store.get_claims(result.token_id)
+    assert second_persisted.revoked_at == pytest.approx(first, abs=0.01)
+
+
+# -- Introspection ----------------------------------------------------------
+
+
+def test_get_claims_returns_revoked_claims_for_audit(store):
+    """Operator tooling should see what happened to a revoked token."""
+    result = _mint_default(store)
+    store.invalidate(result.token_id)
+    claims = store.get_claims(result.token_id)
+    assert claims.revoked_at is not None
+    assert claims.token_id == result.token_id
+
+
+def test_get_claims_raises_on_unknown_id(store):
+    with pytest.raises(BearerTokenNotFoundError):
+        store.get_claims("deadbeefdeadbeef")
+
+
+def test_list_for_session_returns_in_age_order(store):
+    now = time.time()
+    a = store.mint(
+        session_id="sess-A", agent_name="x", fleet="pinky",
+        purpose="service-auth", now=now,
+    )
+    b = store.mint(
+        session_id="sess-A", agent_name="x", fleet="pinky",
+        purpose="service-auth", now=now + 1,
+    )
+    rows = store.list_for_session("sess-A")
+    assert [r.token_id for r in rows] == [a.token_id, b.token_id]
+
+
+def test_list_for_identity_filters_correctly(store):
+    a = _mint_default(store, agent_name="alpha")
+    _b = _mint_default(store, agent_name="beta")
+    rows = store.list_for_identity(
+        fleet="pinky", agent_name="alpha", purpose="service-auth"
+    )
+    assert [r.token_id for r in rows] == [a.token_id]
+
+
+def test_iter_active_excludes_revoked_and_expired(store):
+    now = time.time()
+    active = _mint_default(store, session_id="a", now=now)
+    revoked = _mint_default(store, session_id="b", now=now)
+    expired = _mint_default(
+        store, session_id="c", ttl=timedelta(seconds=1), now=now
+    )
+    store.invalidate(revoked.token_id, now=now)
+
+    # iter_active "now" is later than expired but earlier than active expiry.
+    snapshot = list(store.iter_active(now=now + 5))
+    ids = {c.token_id for c in snapshot}
+    assert active.token_id in ids
+    assert revoked.token_id not in ids
+    assert expired.token_id not in ids
+
+
+# -- Purging ----------------------------------------------------------------
+
+
+def test_purge_expired_removes_expired_and_revoked(store):
+    now = time.time()
+    active = _mint_default(store, session_id="a", now=now)
+    revoked = _mint_default(store, session_id="b", now=now)
+    expired = _mint_default(
+        store, session_id="c", ttl=timedelta(seconds=1), now=now
+    )
+    store.invalidate(revoked.token_id, now=now)
+
+    count = store.purge_expired(now=now + 5)
+    assert count == 2  # revoked + expired
+
+    # Active still there.
+    store.validate(active.token)
+    # Revoked + expired are gone — get_claims now raises.
+    with pytest.raises(BearerTokenNotFoundError):
+        store.get_claims(revoked.token_id)
+    with pytest.raises(BearerTokenNotFoundError):
+        store.get_claims(expired.token_id)
+
+
+def test_purge_expired_leaves_active_alone(store):
+    now = time.time()
+    a = _mint_default(store, now=now, ttl=timedelta(hours=1))
+    assert store.purge_expired(now=now) == 0
+    store.validate(a.token, now=now)
+
+
+# -- Error class structure --------------------------------------------------
+
+
+def test_all_bearer_errors_inherit_from_bearer_token_error():
+    for cls in [
+        BearerTokenNotFoundError,
+        BearerTokenExpiredError,
+        BearerTokenRevokedError,
+    ]:
+        assert issubclass(cls, BearerTokenError)
+
+
+def test_bearer_token_error_is_signature_error_subclass(store):
+    """Lets callers ``except SignatureError`` and catch every identity-
+    side failure in one place — including bearer-token failures."""
+    with pytest.raises(SignatureError):
+        store.validate("clearly-not-a-token")
+
+
+# -- Persistence across reopens ---------------------------------------------
+
+
+def test_token_survives_store_close_and_reopen(tmp_path):
+    """The point of a SQLite-backed store: state lives past process
+    restart. A token minted in one BearerTokenStore instance must
+    validate in a fresh instance pointing at the same file."""
+    path = tmp_path / "bearer.db"
+    s1 = BearerTokenStore(db_path=path)
+    result = s1.mint(
+        session_id="sess", agent_name="alpha", fleet="pinky",
+        purpose="service-auth",
+    )
+    s1.close()
+
+    s2 = BearerTokenStore(db_path=path)
+    try:
+        claims = s2.validate(result.token)
+        assert claims.token_id == result.token_id
+    finally:
+        s2.close()
+
+
+def test_context_manager_closes_store(tmp_path):
+    path = tmp_path / "bearer.db"
+    with BearerTokenStore(db_path=path) as s:
+        s.mint(
+            session_id="x", agent_name="x", fleet="x", purpose="x"
+        )
+    # Reopening must succeed (close released the connection).
+    BearerTokenStore(db_path=path).close()
+
+
+# -- Claims dataclass -------------------------------------------------------
+
+
+def test_claims_is_expired_property():
+    now = time.time()
+    fresh = BearerTokenClaims(
+        token_id="t", session_id="s", fleet="pinky",
+        agent_name="a", purpose="p",
+        created_at=now, expires_at=now + 100,
+        last_used_at=None, revoked_at=None,
+    )
+    expired = BearerTokenClaims(
+        token_id="t", session_id="s", fleet="pinky",
+        agent_name="a", purpose="p",
+        created_at=now - 200, expires_at=now - 1,
+        last_used_at=None, revoked_at=None,
+    )
+    assert not fresh.is_expired
+    assert expired.is_expired
+
+
+def test_claims_is_revoked_property():
+    now = time.time()
+    alive = BearerTokenClaims(
+        token_id="t", session_id="s", fleet="pinky",
+        agent_name="a", purpose="p",
+        created_at=now, expires_at=now + 100,
+        last_used_at=None, revoked_at=None,
+    )
+    dead = BearerTokenClaims(
+        token_id="t", session_id="s", fleet="pinky",
+        agent_name="a", purpose="p",
+        created_at=now, expires_at=now + 100,
+        last_used_at=None, revoked_at=now,
+    )
+    assert not alive.is_revoked
+    assert dead.is_revoked


### PR DESCRIPTION
## Summary

Adds `BearerTokenStore`: SQLite-backed mint/validate/invalidate for session-scoped capabilities that gate the daemon-local signer (PR-4b-2). A bearer token authorizes a streaming session to ask the signer to sign HTTP requests as a specific `(fleet, agent_name, purpose)` tuple. Composes with `DaemonSigner` in PR-4b-4 (`/internal/signer/sign` endpoint).

Stand-alone primitive — depends only on SQLite + `SignatureError`. No registry / signer / keystore / HTTP imports.

## Design

- **32 random bytes per token**, transported as base64url-no-padding (43 chars). Store persists only `sha256(secret)`; the raw secret never hits disk after `mint()` returns.
- **Lookup by hash**, plus `hmac.compare_digest` defense-in-depth at the Python layer (future-proofs against a non-SQLite backend).
- **Bound to the identity tuple, not the kid.** A key rotation in the registry doesn't invalidate outstanding session tokens — they still resolve through `DaemonSigner.resolve_active_kid` at sign time.
- **Three revoke paths**: by `token_id`, by `session_id`, by identity tuple. Bulk revokes skip already-revoked rows so the original `revoked_at` timestamp is preserved for audit.
- **Optional `purge_expired()`** housekeeping; validation already rejects expired/revoked rows so purge is purely about disk.
- **Mandatory expiry**: mint requires `ttl` or `expires_at` (1h default).
- **Errors**: `BearerTokenError(SignatureError)` umbrella with `NotFound` / `Expired` / `Revoked` subclasses. Bad encodings normalize to `NotFound` so callers can't tell forgery from typo (same threat model).

## Test plan

- [x] Mint returns secret + claims; secret is fresh randomness; explicit ttl/expires_at respected; rejects both-or-past
- [x] Validate round-trips; bumps `last_used_at`; `touch=False` opt-out
- [x] Validate rejects: unknown, malformed, empty, oversized, wrong-length, expired, revoked
- [x] Audit invariant: `last_used_at` does NOT advance on failed validation
- [x] Three revoke paths exercise correctly; idempotency on double-revoke; bulk revoke preserves original `revoked_at`
- [x] Introspection (`get_claims`, `list_for_session`, `list_for_identity`, `iter_active`)
- [x] `purge_expired` removes revoked+expired, leaves active alone
- [x] Persistence across store close/reopen
- [x] Claims `is_expired` / `is_revoked` helper properties
- [x] Error hierarchy: every bearer error is a `BearerTokenError` and a `SignatureError`
- [x] 42 new tests, 197/197 identity suite green, ruff clean

## Stack context

Sits on top of `main` (post #467 / 6c7cd76). Independent of #464 (registry) — bearer tokens reference the identity tuple, not the kid, so PR-3's registry isn't a dependency.

Next: PR-4b-4 (`/internal/signer/sign` FastAPI endpoint composing BearerTokenStore + DaemonSigner + streaming_session integration).

🤖 Opened by Barsik