### PR TITLE
feat(pinky_daemon): /internal/signer/sign endpoint (PR-4b-4)

### DIFF
--- a/src/pinky_daemon/signer_routes.py
+++ b/src/pinky_daemon/signer_routes.py
@@ -1,0 +1,502 @@
+"""Signer Routes — daemon-internal FastAPI router for the service-auth signer.
+
+Exposes ``POST /internal/signer/sign``: the gate streaming sessions (and
+other in-process callers) go through to mint RFC 9421 signatures on
+outbound HTTP requests, using the daemon-local key material managed by
+:class:`pinky_identity.DaemonSigner` (PR-4b-2).
+
+Authorization model:
+
+- Every request MUST carry ``Authorization: Bearer <token>``.
+- The bearer token is minted by the daemon at session-start via
+  :meth:`pinky_identity.BearerTokenStore.mint` (PR-4b-3) and bound to
+  the streaming session and the identity tuple
+  ``(fleet, agent_name, purpose)``. The session cannot ask the signer
+  to sign as a different agent.
+- The token validates, expires, and can be revoked by session, by
+  token id, or by identity tuple. All three failure modes surface as
+  HTTP 401.
+
+Why a separate module:
+
+- ``api.py`` is large; the signer surface is tight (one endpoint plus
+  models) and isolating it keeps the unit tests fast and obvious.
+- Same pattern as ``voice_routes.py`` / ``migration/routes.py``: a
+  ``router`` plus ``set_dependencies()`` for the daemon to wire in
+  singletons. The router has zero coupling to FastAPI app state —
+  daemon wiring (api.py mount + DaemonSigner construction) is a
+  separate PR (PR-4b-5).
+
+Wire format:
+
+Request body (JSON):
+
+.. code-block:: json
+
+    {
+        "method": "POST",
+        "url": "https://api.example.com/v1/things",
+        "headers": {"Content-Type": "application/json", "Accept": "*/*"},
+        "body_b64": "<base64-of-bytes-or-empty-string>",
+        "covered_components": ["@method", "@target-uri", "@authority",
+                               "content-digest"],
+        "expires_in_seconds": null,
+        "nonce": null,
+        "require_content_digest_if_body": true,
+        "tag": "pinky-service-auth-v1",
+        "label": "pinky"
+    }
+
+Response body (JSON):
+
+.. code-block:: json
+
+    {
+        "kid": "abc123def456...",
+        "headers": {
+            "Signature": "pinky=:<sig>:",
+            "Signature-Input": "pinky=(\"@method\" \"@target-uri\" ...);created=...;keyid=\"...\";...",
+            "Content-Digest": "sha-256=:...:"
+        }
+    }
+
+Only the headers the signer actually attached are returned —
+``Content-Digest`` is present only when the signer attached it (i.e.
+``content-digest`` was covered and the body was non-empty and the
+caller didn't pre-set the header).
+
+Bodies are never returned. The caller still owns the body; this
+endpoint signs and hands the auth headers back.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import sys
+from datetime import timedelta
+from typing import Any
+
+import requests
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from pinky_identity import (
+    DEFAULT_COVERED_COMPONENTS,
+    DEFAULT_LABEL,
+    DEFAULT_TAG,
+    BearerTokenClaims,
+    BearerTokenError,
+    BearerTokenExpiredError,
+    BearerTokenNotFoundError,
+    BearerTokenRevokedError,
+    BearerTokenStore,
+    BodyNotBoundError,
+    DaemonSigner,
+    KeyNotActiveError,
+    KeyNotInStoreError,
+    KeyNotRegisteredError,
+    KidFingerprintMismatchError,
+    SignerError,
+)
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+# ── Module-level shared state (populated by set_dependencies) ────────────────
+
+_bearer_store: BearerTokenStore | None = None
+_signer: DaemonSigner | None = None
+
+
+def set_dependencies(
+    *,
+    bearer_store: BearerTokenStore,
+    signer: DaemonSigner,
+) -> None:
+    """Wire the BearerTokenStore + DaemonSigner singletons.
+
+    Called once at daemon startup, after both components have been
+    constructed. The router exposes module-level state for simplicity;
+    the daemon never swaps these out at runtime, and a fresh
+    DaemonSigner can be installed by restarting the daemon — same
+    contract as ``voice_routes``.
+    """
+    if not isinstance(bearer_store, BearerTokenStore):
+        raise TypeError("bearer_store must be a BearerTokenStore")
+    if not isinstance(signer, DaemonSigner):
+        raise TypeError("signer must be a DaemonSigner")
+    global _bearer_store, _signer
+    _bearer_store = bearer_store
+    _signer = signer
+
+
+# ── Pydantic models ──────────────────────────────────────────────────────────
+
+
+class SignRequestPayload(BaseModel):
+    """Inbound payload for ``POST /internal/signer/sign``.
+
+    Models the subset of an outbound HTTP request the signer needs to
+    compute an RFC 9421 signature. The caller (a streaming session,
+    typically) builds the request elsewhere — this endpoint signs and
+    returns the auth headers.
+    """
+
+    method: str = Field(
+        ...,
+        min_length=1,
+        max_length=16,
+        description="HTTP method, uppercased canonical form (GET/POST/PUT/...).",
+    )
+    url: str = Field(
+        ...,
+        min_length=1,
+        max_length=8192,
+        description=(
+            "Full request URL including scheme + authority. Signed as "
+            "``@target-uri`` and parsed for ``@authority``."
+        ),
+    )
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Outbound headers the caller intends to send. Headers the "
+            "signer chooses to add (Signature, Signature-Input, and "
+            "Content-Digest when applicable) are returned separately in "
+            "the response; the caller merges."
+        ),
+    )
+    body_b64: str = Field(
+        default="",
+        description=(
+            "Base64-encoded body bytes. Empty string means no body. "
+            "Bodies travel base64 because JSON can't represent "
+            "arbitrary bytes natively."
+        ),
+    )
+    covered_components: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_COVERED_COMPONENTS),
+        description=(
+            "RFC 9421 covered component IDs. Order is significant for "
+            "the signature base; keep callers consistent. Defaults to "
+            "``DEFAULT_COVERED_COMPONENTS`` from pinky_identity."
+        ),
+    )
+    expires_in_seconds: float | None = Field(
+        default=None,
+        gt=0,
+        le=86400,
+        description=(
+            "Optional ``expires`` parameter in seconds; encoded as "
+            "``created + expires_in``. Bound to 24h max to keep "
+            "outbound signatures from outliving sessions."
+        ),
+    )
+    nonce: str | None = Field(
+        default=None,
+        max_length=128,
+        description=(
+            "Optional explicit nonce. Defaults to a random 16-byte hex "
+            "value in the signer."
+        ),
+    )
+    require_content_digest_if_body: bool = Field(
+        default=True,
+        description=(
+            "Mirrors the DaemonSigner knob: when True (default), "
+            "a non-empty body without 'content-digest' in covered "
+            "components is rejected at sign time."
+        ),
+    )
+    tag: str = Field(
+        default=DEFAULT_TAG,
+        min_length=1,
+        max_length=128,
+        description="RFC 9421 ``tag`` parameter. Pinned by verifiers.",
+    )
+    label: str = Field(
+        default=DEFAULT_LABEL,
+        min_length=1,
+        max_length=64,
+        description=(
+            "Signature label written into the ``Signature`` header. "
+            "Single-label only; multi-sig is not supported here."
+        ),
+    )
+
+
+class SignResponse(BaseModel):
+    """Outbound payload from ``POST /internal/signer/sign``.
+
+    Carries the kid that was stamped into the signature plus the auth
+    headers the caller should merge into the outbound request. Body
+    bytes are never echoed back — the caller owns them.
+    """
+
+    kid: str = Field(
+        ...,
+        description=(
+            "The kid stamped into the signature. Useful for log "
+            "correlation; the receiver also reads this off "
+            "``Signature-Input`` for key lookup."
+        ),
+    )
+    headers: dict[str, str] = Field(
+        ...,
+        description=(
+            "Headers the signer attached: ``Signature``, "
+            "``Signature-Input``, and ``Content-Digest`` when "
+            "applicable. Merge into the outbound request before "
+            "sending."
+        ),
+    )
+
+
+# ── Bearer auth dependency ──────────────────────────────────────────────────
+
+
+def _require_bearer(authorization: str | None) -> BearerTokenClaims:
+    """Extract and validate the Authorization: Bearer header.
+
+    Maps every :class:`BearerTokenError` subclass to HTTP 401 with a
+    short reason. The reason does not distinguish "unknown" from
+    "revoked" from "expired" beyond a single word — the client doesn't
+    benefit from finer granularity and we don't want to leak which
+    rows exist.
+
+    Raised as :class:`HTTPException` so FastAPI surfaces them with the
+    right status + JSON shape.
+    """
+    if _bearer_store is None:
+        # 503 not 500: the dependency wiring hasn't completed yet (or
+        # the daemon was started without identity enabled). Either
+        # way, the caller can retry.
+        raise HTTPException(
+            status_code=503,
+            detail="signer service not ready: bearer_store not configured",
+        )
+    if not authorization:
+        raise HTTPException(
+            status_code=401,
+            detail="missing Authorization header",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization scheme must be 'Bearer'",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        claims = _bearer_store.validate(token)
+    except BearerTokenExpiredError:
+        raise HTTPException(
+            status_code=401,
+            detail="bearer token expired",
+            headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
+        ) from None
+    except BearerTokenRevokedError:
+        raise HTTPException(
+            status_code=401,
+            detail="bearer token revoked",
+            headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
+        ) from None
+    except BearerTokenNotFoundError:
+        raise HTTPException(
+            status_code=401,
+            detail="bearer token invalid",
+            headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
+        ) from None
+    except BearerTokenError as e:
+        # Defensive: any new BearerTokenError subclass not handled above
+        # should still 401, not 500. The umbrella catch keeps the
+        # endpoint from surfacing internal class names.
+        _log(f"signer: unexpected bearer error: {e!r}")  # pragma: no cover
+        raise HTTPException(  # pragma: no cover
+            status_code=401,
+            detail="bearer token invalid",
+            headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
+        ) from None
+    return claims
+
+
+# ── Router ──────────────────────────────────────────────────────────────────
+
+
+router = APIRouter(prefix="/internal/signer", tags=["signer"])
+
+
+def _decode_body(body_b64: str) -> bytes:
+    """Decode the base64 body field. Empty string → empty bytes.
+
+    Strict base64 (not base64url) for the wire — internal API,
+    callers control both ends. Invalid base64 surfaces as HTTP 400.
+    """
+    if not body_b64:
+        return b""
+    try:
+        return base64.b64decode(body_b64, validate=True)
+    except (ValueError, binascii.Error) as e:
+        raise HTTPException(
+            status_code=400, detail=f"body_b64 is not valid base64: {e}"
+        ) from None
+
+
+def _build_prepared(payload: SignRequestPayload, body: bytes) -> Any:
+    """Build the request object the signer accepts.
+
+    :class:`pinky_identity.DaemonSigner.sign_request_by_kid` calls into
+    :func:`pinky_identity.sign_request`, which forwards to
+    ``http_message_signatures`` — that library accepts any object with
+    ``method``, ``url``, ``headers`` (mutable dict), and ``body``
+    attributes. The simplest fit is ``requests.Request().prepare()``.
+    """
+    req = requests.Request(
+        method=payload.method.upper(),
+        url=payload.url,
+        data=body if body else None,
+        headers=dict(payload.headers),
+    ).prepare()
+    # PreparedRequest can normalize Content-Length etc.; preserve the
+    # caller's headers verbatim by reapplying after prepare(). This
+    # keeps signed component values aligned with what the caller will
+    # actually send.
+    for k, v in payload.headers.items():
+        req.headers[k] = v
+    return req
+
+
+@router.post("/sign", response_model=SignResponse)
+def sign(
+    payload: SignRequestPayload,
+    authorization: str | None = Header(default=None),
+) -> SignResponse:
+    """Sign an outbound HTTP request on behalf of a bearer-authenticated session.
+
+    Flow:
+
+    1. Validate ``Authorization: Bearer …`` → :class:`BearerTokenClaims`.
+       Failures → 401 with ``WWW-Authenticate``.
+    2. Reject the request if the signer wiring isn't ready → 503.
+    3. Build a :class:`requests.PreparedRequest` from the payload.
+    4. Resolve the active kid for the bearer's identity tuple via
+       :meth:`DaemonSigner.resolve_active_kid` and sign with
+       ``sign_request_by_kid``.
+    5. Map :class:`SignerError` failure modes to HTTP statuses:
+
+       - :class:`KeyNotRegisteredError` → 404 ("agent has no key
+         registered yet")
+       - :class:`KeyNotActiveError` → 409 ("key is pending/retired/
+         revoked"). The bearer outlived the key.
+       - :class:`KeyNotInStoreError` → 500 (provisioning bug; the
+         registry has it but the signer store doesn't)
+       - :class:`KidFingerprintMismatchError` → 500 (corruption)
+       - :class:`BodyNotBoundError` → 400 (caller foot-gun: body
+         without content-digest in covered components)
+
+    6. Return the kid + just the headers the signer attached. The
+       caller merges into the outbound request before sending.
+    """
+    claims = _require_bearer(authorization)
+    if _signer is None:
+        raise HTTPException(
+            status_code=503,
+            detail="signer service not ready: DaemonSigner not configured",
+        )
+
+    body = _decode_body(payload.body_b64)
+    req = _build_prepared(payload, body)
+
+    expires_in = (
+        timedelta(seconds=payload.expires_in_seconds)
+        if payload.expires_in_seconds is not None
+        else None
+    )
+
+    # Snapshot headers before signing so we can return only the delta
+    # — the caller already has the headers they sent us, no point in
+    # echoing them back.
+    pre_sign_keys = set(req.headers.keys())
+
+    try:
+        kid = _signer.sign_request_for_agent(
+            req,
+            agent_name=claims.agent_name,
+            fleet=claims.fleet,
+            purpose=claims.purpose,
+            covered_components=tuple(payload.covered_components),
+            expires_in=expires_in,
+            nonce=payload.nonce,
+            tag=payload.tag,
+            label=payload.label,
+            require_content_digest_if_body=payload.require_content_digest_if_body,
+        )
+    except KeyNotRegisteredError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"no active key registered for "
+                f"(fleet={claims.fleet!r}, agent_name={claims.agent_name!r}, "
+                f"purpose={claims.purpose!r})"
+            ),
+        ) from e
+    except KeyNotActiveError as e:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"key for {claims.agent_name!r} is not active "
+                f"(status={e.status!r}); the bearer token outlived the key"
+            ),
+        ) from e
+    except BodyNotBoundError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except KidFingerprintMismatchError as e:
+        # Corruption: registry and signer-store disagree. Don't leak
+        # the fingerprints; log them and surface a generic 500.
+        _log(f"signer: kid fingerprint mismatch — {e}")
+        raise HTTPException(
+            status_code=500, detail="signer state inconsistent"
+        ) from e
+    except KeyNotInStoreError as e:
+        # Provisioning bug: registry has it, store doesn't. Generic 500
+        # — the operator looks at logs.
+        _log(f"signer: key in registry but not in signer store — {e}")
+        raise HTTPException(
+            status_code=500, detail="signer state inconsistent"
+        ) from e
+    except SignerError as e:
+        # Defensive: any unmodelled SignerError subclass still surfaces
+        # as 500 rather than escaping as an unhandled exception.
+        _log(f"signer: unexpected signer error: {e!r}")  # pragma: no cover
+        raise HTTPException(  # pragma: no cover
+            status_code=500, detail="signer error"
+        ) from e
+
+    new_headers = {
+        name: value
+        for name, value in req.headers.items()
+        if name not in pre_sign_keys
+        or name in ("Signature", "Signature-Input", "Content-Digest")
+    }
+    # Trim to just the signer-attached headers so callers don't have to
+    # diff client-side. The pre_sign_keys snapshot above catches new
+    # headers; the explicit name set above keeps Signature/-Input/Content-
+    # Digest even on the off chance the caller pre-set one of them
+    # (rare for Content-Digest, never for Signature).
+    relevant = {"Signature", "Signature-Input", "Content-Digest"}
+    new_headers = {k: v for k, v in new_headers.items() if k in relevant}
+
+    return SignResponse(kid=kid, headers=new_headers)
+
+
+__all__ = [
+    "SignRequestPayload",
+    "SignResponse",
+    "router",
+    "set_dependencies",
+]

--- a/tests/test_signer_routes.py
+++ b/tests/test_signer_routes.py
@@ -1,0 +1,601 @@
+"""Tests for pinky_daemon.signer_routes (POST /internal/signer/sign).
+
+Drives the router via FastAPI TestClient with a real BearerTokenStore +
+a real DaemonSigner. The DaemonSigner is constructed against an
+in-memory _StubRegistry (same pattern as
+tests/test_pinky_identity_signer.py) plus a real EncryptedSignerStore on
+a tmp path. This exercises the full sign path end-to-end without
+needing PR-3's registry impl.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import secrets
+from dataclasses import dataclass
+from datetime import timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from pinky_identity import (
+    DEFAULT_TAG,
+    DEVICE_KEY_BYTES,
+    KEY_ACTIVE,
+    PURPOSE_SERVICE_AUTH,
+    BearerTokenStore,
+    DaemonSigner,
+    DeviceKey,
+    EncryptedSignerStore,
+    PinkyKeyResolver,
+    fingerprint,
+    generate_keypair,
+    kid_from_public_key,
+    verify_request,
+)
+from pinky_identity.signer import DEFAULT_FLEET
+
+# -- Stub registry (mirrors test_pinky_identity_signer.py) -------------------
+
+
+@dataclass
+class _StubKeyRecord:
+    kid: str
+    fingerprint: str
+    status: str
+    public_key: bytes
+
+
+class _StubRegistry:
+    def __init__(self) -> None:
+        self._rows: dict[str, _StubKeyRecord] = {}
+        self._active: dict[tuple[str, str, str], str] = {}
+
+    def add(
+        self,
+        keypair,
+        *,
+        agent_name: str,
+        fleet: str = DEFAULT_FLEET,
+        purpose: str = PURPOSE_SERVICE_AUTH,
+        status: str = KEY_ACTIVE,
+    ) -> str:
+        kid = kid_from_public_key(keypair.public)
+        row = _StubKeyRecord(
+            kid=kid,
+            fingerprint=fingerprint(keypair.public),
+            status=status,
+            public_key=keypair.public.raw,
+        )
+        self._rows[kid] = row
+        if status == KEY_ACTIVE:
+            self._active[(fleet, agent_name, purpose)] = kid
+        return kid
+
+    def set_status(self, kid: str, status: str) -> None:
+        self._rows[kid].status = status
+        if status != KEY_ACTIVE:
+            stale = [k for k, v in self._active.items() if v == kid]
+            for k in stale:
+                del self._active[k]
+
+    def get_key(self, kid: str):
+        return self._rows.get(kid)
+
+    def get_active_key(self, fleet: str, agent_name: str, purpose: str):
+        kid = self._active.get((fleet, agent_name, purpose))
+        if kid is None:
+            return None
+        return self._rows[kid]
+
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def device_key():
+    return DeviceKey.from_bytes(secrets.token_bytes(DEVICE_KEY_BYTES))
+
+
+@pytest.fixture
+def store(tmp_path, device_key):
+    s = EncryptedSignerStore(db_path=tmp_path / "signer.db", device_key=device_key)
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+@pytest.fixture
+def bearer_store(tmp_path):
+    s = BearerTokenStore(db_path=tmp_path / "bearer.db")
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+@pytest.fixture
+def registry():
+    return _StubRegistry()
+
+
+@pytest.fixture
+def signer(registry, store):
+    return DaemonSigner(registry=registry, signer_store=store)
+
+
+@pytest.fixture
+def signer_routes_module():
+    """Fresh-import the router module per test so module-level state
+    (set_dependencies) doesn't bleed between cases."""
+    import pinky_daemon.signer_routes as mod
+
+    importlib.reload(mod)
+    return mod
+
+
+@pytest.fixture
+def client(signer_routes_module, bearer_store, signer):
+    signer_routes_module.set_dependencies(
+        bearer_store=bearer_store, signer=signer
+    )
+    app = FastAPI()
+    app.include_router(signer_routes_module.router)
+    return TestClient(app)
+
+
+# -- Helpers -----------------------------------------------------------------
+
+
+def _mint_bearer(bearer_store, agent_name="alpha"):
+    """Mint a bearer for the default identity tuple."""
+    return bearer_store.mint(
+        session_id="sess-1",
+        agent_name=agent_name,
+        fleet=DEFAULT_FLEET,
+        purpose=PURPOSE_SERVICE_AUTH,
+    )
+
+
+def _enroll_agent(registry, store, *, agent_name="alpha"):
+    """Add an active key for *agent_name* to both registry and store.
+    Returns the keypair so tests can verify."""
+    kp = generate_keypair()
+    registry.add(kp, agent_name=agent_name)
+    store.put_keypair(kp)
+    return kp
+
+
+def _sign_payload(
+    *,
+    method="GET",
+    url="https://api.example.com/v1/things",
+    headers=None,
+    body=b"",
+    covered_components=None,
+):
+    payload: dict = {
+        "method": method,
+        "url": url,
+        "headers": headers or {},
+        "body_b64": base64.b64encode(body).decode("ascii") if body else "",
+    }
+    if covered_components is not None:
+        payload["covered_components"] = covered_components
+    return payload
+
+
+# -- Construction / wiring ---------------------------------------------------
+
+
+def test_set_dependencies_rejects_wrong_types(signer_routes_module, signer):
+    with pytest.raises(TypeError):
+        signer_routes_module.set_dependencies(
+            bearer_store={"not": "a store"}, signer=signer
+        )
+
+
+def test_set_dependencies_rejects_wrong_signer(
+    signer_routes_module, bearer_store
+):
+    with pytest.raises(TypeError):
+        signer_routes_module.set_dependencies(
+            bearer_store=bearer_store, signer="not-a-signer"
+        )
+
+
+def test_sign_returns_503_when_bearer_store_unconfigured(signer_routes_module):
+    # Module loaded but set_dependencies never called → 503.
+    app = FastAPI()
+    app.include_router(signer_routes_module.router)
+    c = TestClient(app)
+    r = c.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": "Bearer anything"},
+    )
+    assert r.status_code == 503
+    assert "bearer_store" in r.json()["detail"]
+
+
+def test_sign_returns_503_when_signer_unconfigured_but_bearer_present(
+    signer_routes_module, bearer_store
+):
+    """Bearer store is wired but DaemonSigner isn't — first the bearer
+    validates, then the missing signer triggers 503. Defensive: the
+    daemon may wire them in stages."""
+    # Manual half-wire: bearer set, signer left None.
+    signer_routes_module._bearer_store = bearer_store
+    signer_routes_module._signer = None
+    app = FastAPI()
+    app.include_router(signer_routes_module.router)
+    c = TestClient(app)
+    mint = _mint_bearer(bearer_store)
+    r = c.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 503
+    assert "DaemonSigner" in r.json()["detail"]
+
+
+# -- Bearer auth -------------------------------------------------------------
+
+
+def test_sign_requires_authorization_header(client):
+    r = client.post("/internal/signer/sign", json=_sign_payload())
+    assert r.status_code == 401
+    assert r.headers.get("www-authenticate", "").lower().startswith("bearer")
+
+
+def test_sign_requires_bearer_scheme(client):
+    r = client.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": "Basic abcd"},
+    )
+    assert r.status_code == 401
+    assert "Bearer" in r.json()["detail"]
+
+
+def test_sign_rejects_empty_bearer(client):
+    r = client.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": "Bearer "},
+    )
+    assert r.status_code == 401
+
+
+def test_sign_rejects_unknown_bearer(client):
+    r = client.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": "Bearer not-a-real-token-blah-blah"},
+    )
+    assert r.status_code == 401
+    assert "invalid" in r.json()["detail"]
+
+
+def test_sign_rejects_revoked_bearer(client, bearer_store, registry, store):
+    _enroll_agent(registry, store)
+    mint = _mint_bearer(bearer_store)
+    bearer_store.invalidate(mint.token_id)
+    r = client.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 401
+    assert "revoked" in r.json()["detail"]
+
+
+def test_sign_rejects_expired_bearer(
+    signer_routes_module, bearer_store, registry, store, signer
+):
+    """Mint a token that expires in 1 second, then validate the
+    endpoint refuses it. We rely on real time here rather than
+    monkeypatching now() because the FastAPI dependency chain doesn't
+    plumb time.now through."""
+    import time as _time
+
+    _enroll_agent(registry, store)
+    # Override mint to use short TTL.
+    mint = bearer_store.mint(
+        session_id="sess-1",
+        agent_name="alpha",
+        fleet=DEFAULT_FLEET,
+        purpose=PURPOSE_SERVICE_AUTH,
+        ttl=timedelta(seconds=1),
+    )
+    signer_routes_module.set_dependencies(
+        bearer_store=bearer_store, signer=signer
+    )
+    app = FastAPI()
+    app.include_router(signer_routes_module.router)
+    c = TestClient(app)
+    _time.sleep(1.1)
+    r = c.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 401
+    assert "expired" in r.json()["detail"]
+
+
+# -- Happy path --------------------------------------------------------------
+
+
+def test_sign_get_round_trips_against_verifier(
+    client, bearer_store, registry, store
+):
+    kp = _enroll_agent(registry, store)
+    mint = _mint_bearer(bearer_store)
+
+    r = client.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["kid"] == kid_from_public_key(kp.public)
+    # Default GET → no Content-Digest header.
+    assert "Signature" in body["headers"]
+    assert "Signature-Input" in body["headers"]
+    assert "Content-Digest" not in body["headers"]
+
+    # Reconstruct the would-be outbound request and verify.
+    import requests as _req
+
+    req = _req.Request("GET", "https://api.example.com/v1/things").prepare()
+    for k, v in body["headers"].items():
+        req.headers[k] = v
+    resolver = PinkyKeyResolver.from_signing_keypairs([kp])
+    result = verify_request(req, key_resolver=resolver)
+    assert result.parameters["keyid"] == body["kid"]
+    assert result.parameters["tag"] == DEFAULT_TAG
+
+
+def test_sign_post_with_content_digest_round_trips(
+    client, bearer_store, registry, store
+):
+    """POST with content-digest covered: signer auto-attaches the
+    digest header, returns it alongside Signature/-Input, and the
+    default verifier accepts the reassembled request."""
+    kp = _enroll_agent(registry, store)
+    mint = _mint_bearer(bearer_store)
+
+    payload_body = b'{"hello":"world"}'
+    payload = _sign_payload(
+        method="POST",
+        headers={"Content-Type": "application/json"},
+        body=payload_body,
+        covered_components=[
+            "@method",
+            "@target-uri",
+            "@authority",
+            "content-digest",
+        ],
+    )
+    r = client.post(
+        "/internal/signer/sign",
+        json=payload,
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "Content-Digest" in body["headers"]
+
+    # Reassemble + verify end-to-end.
+    import requests as _req
+
+    req = _req.Request(
+        "POST",
+        "https://api.example.com/v1/things",
+        data=payload_body,
+        headers={"Content-Type": "application/json"},
+    ).prepare()
+    for k, v in body["headers"].items():
+        req.headers[k] = v
+    resolver = PinkyKeyResolver.from_signing_keypairs([kp])
+    verify_request(req, key_resolver=resolver)
+
+
+def test_sign_response_only_contains_signer_attached_headers(
+    client, bearer_store, registry, store
+):
+    """The endpoint must not echo back caller-supplied headers — just
+    the signer's auth-header delta. Saves bandwidth and avoids
+    accidentally surfacing sensitive headers (Authorization, cookies)."""
+    _enroll_agent(registry, store)
+    mint = _mint_bearer(bearer_store)
+
+    payload = _sign_payload(
+        headers={
+            "Authorization": "Bearer dont-echo-me",
+            "Cookie": "session=secret",
+            "Accept": "*/*",
+        }
+    )
+    r = client.post(
+        "/internal/signer/sign",
+        json=payload,
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 200
+    keys = set(r.json()["headers"].keys())
+    assert keys <= {"Signature", "Signature-Input", "Content-Digest"}
+
+
+def test_sign_uses_bearer_identity_tuple(
+    client, bearer_store, registry, store
+):
+    """Two agents enrolled; bearer is bound to one. The endpoint must
+    sign as the bearer's agent, not the caller-supplied one (which
+    isn't in the payload at all — that's the point)."""
+    alpha = _enroll_agent(registry, store, agent_name="alpha")
+    beta = _enroll_agent(registry, store, agent_name="beta")
+    mint = bearer_store.mint(
+        session_id="sess-1",
+        agent_name="beta",
+        fleet=DEFAULT_FLEET,
+        purpose=PURPOSE_SERVICE_AUTH,
+    )
+    r = client.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["kid"] == kid_from_public_key(beta.public)
+    assert r.json()["kid"] != kid_from_public_key(alpha.public)
+
+
+# -- Signer error mapping ----------------------------------------------------
+
+
+def test_sign_returns_404_when_agent_not_enrolled(
+    client, bearer_store
+):
+    """Bearer claims an identity that's never been enrolled in the
+    registry → KeyNotRegisteredError → 404."""
+    mint = _mint_bearer(bearer_store, agent_name="ghost")
+    r = client.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 404
+    assert "ghost" in r.json()["detail"]
+
+
+def test_sign_returns_404_when_active_key_revoked_post_mint(
+    client, bearer_store, registry, store
+):
+    """Bearer outlives the key — at mint time the key was active; by
+    the time the endpoint is called it's been revoked. With
+    ``sign_request_for_agent`` the registry's ``get_active_key``
+    returns None for non-active rows, surfacing as
+    :class:`KeyNotRegisteredError` (no *active* key) → 404.
+
+    The 409/``KeyNotActiveError`` mapping in the endpoint stays as
+    defense-in-depth — it would fire if a future endpoint ever signs
+    by an explicit kid that's gone non-active. Through the
+    for-agent path, 404 is the observable outcome."""
+    kp = _enroll_agent(registry, store)
+    kid = kid_from_public_key(kp.public)
+    mint = _mint_bearer(bearer_store)
+    registry.set_status(kid, "revoked")
+    r = client.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 404
+    assert "alpha" in r.json()["detail"]
+
+
+def test_sign_returns_400_for_body_without_content_digest(
+    client, bearer_store, registry, store
+):
+    """Default covered components omit content-digest. A POST with a
+    body must be rejected (BodyNotBoundError → 400). Same secure-by-
+    default we test on the signer side, exercised through the wire."""
+    _enroll_agent(registry, store)
+    mint = _mint_bearer(bearer_store)
+    payload = _sign_payload(
+        method="POST",
+        headers={"Content-Type": "application/json"},
+        body=b'{"x":1}',
+        # Default covered_components — no content-digest.
+    )
+    r = client.post(
+        "/internal/signer/sign",
+        json=payload,
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 400
+    assert "content-digest" in r.json()["detail"].lower()
+
+
+def test_sign_400_on_malformed_body_b64(client, bearer_store, registry, store):
+    _enroll_agent(registry, store)
+    mint = _mint_bearer(bearer_store)
+    payload = _sign_payload()
+    payload["body_b64"] = "this is not base64!@#"
+    r = client.post(
+        "/internal/signer/sign",
+        json=payload,
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 400
+    assert "base64" in r.json()["detail"]
+
+
+# -- Payload validation ------------------------------------------------------
+
+
+def test_sign_rejects_empty_method(client, bearer_store, registry, store):
+    _enroll_agent(registry, store)
+    mint = _mint_bearer(bearer_store)
+    payload = _sign_payload(method="")
+    r = client.post(
+        "/internal/signer/sign",
+        json=payload,
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 422  # pydantic field validation
+
+
+def test_sign_rejects_excessive_expires_in_seconds(
+    client, bearer_store, registry, store
+):
+    _enroll_agent(registry, store)
+    mint = _mint_bearer(bearer_store)
+    payload = _sign_payload()
+    payload["expires_in_seconds"] = 999999  # exceeds 86400 cap
+    r = client.post(
+        "/internal/signer/sign",
+        json=payload,
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 422
+
+
+def test_sign_accepts_custom_tag(client, bearer_store, registry, store):
+    """The tag knob propagates so callers can mint per-purpose tags
+    that the verifier pins. Default is pinky-service-auth-v1."""
+    _enroll_agent(registry, store)
+    mint = _mint_bearer(bearer_store)
+    payload = _sign_payload()
+    payload["tag"] = "custom-tag-v2"
+    r = client.post(
+        "/internal/signer/sign",
+        json=payload,
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    assert r.status_code == 200
+    assert 'tag="custom-tag-v2"' in r.json()["headers"]["Signature-Input"]
+
+
+def test_sign_bumps_last_used_at_on_success(
+    client, bearer_store, registry, store
+):
+    """End-to-end: a successful sign should bump the bearer's
+    last_used_at via the validate() touch — useful for audit."""
+    _enroll_agent(registry, store)
+    mint = _mint_bearer(bearer_store)
+    assert mint.claims.last_used_at is None
+    client.post(
+        "/internal/signer/sign",
+        json=_sign_payload(),
+        headers={"Authorization": f"Bearer {mint.token}"},
+    )
+    after = bearer_store.get_claims(mint.token_id)
+    assert after.last_used_at is not None


### PR DESCRIPTION
## Summary

Adds `POST /internal/signer/sign` — the FastAPI surface that composes `BearerTokenStore` (#468) + `DaemonSigner` (#467) into the gate for daemon-local signing. Streaming sessions present `Authorization: Bearer <token>` minted at session start; the endpoint validates the bearer, resolves the active kid for the bearer's `(fleet, agent_name, purpose)` tuple, signs the outbound HTTP request, and returns just the auth-header delta.

## Scope

- `src/pinky_daemon/signer_routes.py` — router + `set_dependencies()`, same pattern as `voice_routes` / `migration.routes`. No daemon-state coupling.
- `tests/test_signer_routes.py` — 22 tests via FastAPI TestClient with a real BearerTokenStore + real DaemonSigner + stub registry.

**Deliberately NOT in this PR**: wiring into `api.py` (mount router + construct BearerTokenStore + construct DaemonSigner singletons) and `streaming_session` integration. Those need a real `IdentityRegistry`, which is #464 territory. Once #464 lands I'll open PR-4b-5 with the wire-up.

## Design highlights

- **Bearer-bound identity**: the endpoint NEVER reads the agent identity from the request body. It comes solely from the bearer claims — a caller can't ask the signer to sign as a different agent. Tested explicitly.
- **Body transport**: base64 in `body_b64`. Malformed base64 → 400.
- **Bounded expiry**: `expires_in_seconds` capped at 86400 so outbound signatures can't outlive sessions.
- **Response is the delta only**: just the headers the signer attached (`Signature`, `Signature-Input`, `Content-Digest` when attached). Caller-supplied headers are NOT echoed back — reduces accidental sensitive-header leakage in logs.
- **Audit**: `last_used_at` on the bearer bumps on successful sign.

## Error mapping

| Failure | Status |
|---|---|
| Missing / wrong-scheme / unknown / revoked / expired bearer | 401 + `WWW-Authenticate` |
| Bearer or signer wiring not ready | 503 |
| Body present, content-digest not covered (`BodyNotBoundError`) | 400 |
| Malformed `body_b64` | 400 |
| Agent not enrolled / no active key | 404 |
| Registry/store corruption (`KidFingerprintMismatch`, `KeyNotInStore`) | 500 (logged, no fingerprint leak) |
| Per-kid not-active (defensive — unreachable via `for_agent` path today) | 409 |

## Test plan

- [x] Bearer auth: missing / wrong-scheme / empty / unknown / revoked / expired
- [x] Happy path: GET round-trip verified via PinkyKeyResolver + verify_request
- [x] Happy path: POST with content-digest covered, default verifier accepts
- [x] Response carries ONLY signer-attached headers (Authorization/Cookie sent by caller not echoed)
- [x] Identity gate: signs as bearer's agent, not caller's choice (two enrolled, bearer for one)
- [x] Signer errors: 404 (unenrolled), 404 (active key revoked post-mint), 400 (body without content-digest), 400 (malformed body)
- [x] Payload validation: empty method (422), oversized expires (422), custom tag propagates
- [x] Audit: `last_used_at` bumps on successful sign
- [x] Wiring: 503 when bearer_store unconfigured; 503 when signer unconfigured (post-bearer-validate)
- [x] 22 new tests, 225/225 with full identity suite, ruff clean

## Stack

Builds on #467 + #468 (both in main). Independent of #464 — uses the duck-typed `RegistryLike` so the router is testable without PR-3's `IdentityRegistry` impl.

Next: PR-4b-5 (daemon wiring + streaming_session integration) once #464 lands.

🤖 Opened by Barsik