### PR TITLE
fix(broker): wait for in-flight reconnect before dropping inbound

### DIFF
--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -21,6 +21,16 @@ from dataclasses import dataclass, field
 
 from pinky_daemon.agent_registry import AgentRegistry
 
+# Bounded wait for an in-flight reconnect/restart to complete before we drop an
+# inbound message. Covers the context_restart window where the streaming session
+# object exists but ``is_connected`` is briefly False between
+# ``disconnect()`` → ``connect()``. Without this, messages arriving during a
+# restart get silently dropped and the user sees the "not running" fallback
+# even though the session is about to come back up. See issue tracker bug
+# reported 2026-05-13 by bradbrok.
+_INBOUND_RECONNECT_WAIT_SEC = 20.0
+_INBOUND_RECONNECT_POLL_SEC = 0.25
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -774,6 +784,26 @@ class MessageBroker:
             except Exception as e:
                 _log(f"broker: {agent_name} auto-wake failed: {e}")
                 streaming = None
+
+        # Wait-for-reconnect: if the session object still exists but isn't
+        # connected, an in-flight reconnect or context_restart is most likely
+        # the cause (disconnect()→connect() runs in a separate task and briefly
+        # leaves ``is_connected`` False, with ``session_id`` wiped to "" so the
+        # auto-wake branch above can't help). Poll for a bounded window before
+        # falling back to the user-visible "not running" error so the message
+        # gets delivered as soon as the new session comes up instead of being
+        # dropped. See _INBOUND_RECONNECT_WAIT_SEC.
+        if streaming is not None and not streaming.is_connected:
+            _log(
+                f"broker: {agent_name} session present but disconnected — "
+                f"waiting up to {_INBOUND_RECONNECT_WAIT_SEC:g}s for reconnect"
+            )
+            deadline = time.monotonic() + _INBOUND_RECONNECT_WAIT_SEC
+            while time.monotonic() < deadline:
+                await asyncio.sleep(_INBOUND_RECONNECT_POLL_SEC)
+                if streaming.is_connected:
+                    _log(f"broker: {agent_name} reconnect completed — resuming delivery")
+                    break
 
         if not streaming or not streaming.is_connected:
             _log(f"broker: streaming session for {agent_name} not connected, dropping message")

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -127,6 +127,115 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
+    async def test_route_streaming_waits_for_in_flight_reconnect(self, monkeypatch):
+        """Regression: messages arriving during ``context_restart`` (where the
+        streaming session object exists but ``is_connected`` is briefly False
+        and ``session_id`` is wiped to "") must be held until the reconnect
+        completes — not dropped with a "not running" fallback.
+
+        Simulates the restart window by flipping ``is_connected`` back to True
+        on a background task after a short delay, mirroring what
+        ``StreamingSession.force_restart`` does in production.
+        """
+        import asyncio
+
+        # Speed up the poll loop so the test stays fast.
+        import pinky_daemon.broker as broker_mod
+        monkeypatch.setattr(broker_mod, "_INBOUND_RECONNECT_WAIT_SEC", 2.0)
+        monkeypatch.setattr(broker_mod, "_INBOUND_RECONNECT_POLL_SEC", 0.01)
+
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            class _RestartingSession:
+                # Mirror StreamingSession state during force_restart:
+                # disconnect() has run, session_id has been wiped.
+                session_id = ""
+
+                def __init__(self):
+                    self.is_connected = False
+                    self.sent: list[str] = []
+
+                async def send(self, prompt, **kwargs):
+                    self.sent.append(prompt)
+
+            ss = _RestartingSession()
+            broker.register_streaming("barsik", ss, label="main")
+
+            # Background task to flip is_connected=True after a small delay,
+            # simulating force_restart's connect() completing.
+            async def _finish_restart():
+                await asyncio.sleep(0.1)
+                ss.is_connected = True
+
+            asyncio.create_task(_finish_restart())
+
+            msg = BrokerMessage(
+                platform="telegram",
+                chat_id="6770805286",
+                sender_name="Brad",
+                sender_id="u-1",
+                content="message during restart",
+                agent_name="barsik",
+            )
+            await broker._route_streaming("barsik", msg)
+
+            # The "not running" fallback MUST NOT fire — that's the bug.
+            assert not any(
+                "not running" in m[3] for m in sent_messages
+            ), f"unexpected fallback sent during restart window: {sent_messages}"
+            # And the message DID get delivered to the reconnected session.
+            assert ss.sent, "session reconnected but message wasn't delivered"
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_streaming_falls_back_when_reconnect_never_completes(
+        self, monkeypatch,
+    ):
+        """If the wait window elapses without reconnect, the broker must still
+        surface the "not running" fallback (preserving the previous behavior
+        for genuinely-dead sessions). The wait is bounded, not infinite.
+        """
+        import pinky_daemon.broker as broker_mod
+        monkeypatch.setattr(broker_mod, "_INBOUND_RECONNECT_WAIT_SEC", 0.2)
+        monkeypatch.setattr(broker_mod, "_INBOUND_RECONNECT_POLL_SEC", 0.01)
+
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            class _DeadSession:
+                session_id = ""
+
+                def __init__(self):
+                    self.is_connected = False
+                    self.sent: list[str] = []
+
+                async def send(self, prompt, **kwargs):  # pragma: no cover
+                    self.sent.append(prompt)
+
+            ss = _DeadSession()
+            broker.register_streaming("barsik", ss, label="main")
+
+            msg = BrokerMessage(
+                platform="telegram",
+                chat_id="6770805286",
+                sender_name="Brad",
+                sender_id="u-1",
+                content="message into the void",
+                agent_name="barsik",
+            )
+            await broker._route_streaming("barsik", msg)
+
+            # Wait elapsed without reconnect → fallback fires exactly once
+            # with the canonical text. Message was NOT delivered.
+            assert sent_messages == [
+                ("barsik", "telegram", "6770805286",
+                 "⚠️ barsik is not running right now. Try again later."),
+            ]
+            assert ss.sent == []
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
     async def test_stop_typing_cancels_active_task(self):
         """_stop_typing must cancel a running typing-loop task."""
         import asyncio


### PR DESCRIPTION
## Summary
- During a `context_restart`, the streaming session object stays in `broker._streaming` but `is_connected` is briefly False (and `session_id` is wiped to `""`) between `disconnect()` and `connect()`. Inbound messages arriving in that window fell straight through `_route_streaming`'s drop check and the user got `⚠️ <agent> is not running right now. Try again later.` — even though the session was about to come back up.
- This PR adds a bounded poll between the auto-wake branch and the drop check (default 20s, 250ms steps). If the in-flight reconnect completes, the message is delivered to the freshly-restarted session. If the window elapses, the canonical fallback still fires so genuinely-dead sessions stay surfaced.
- Two constants at module top (`_INBOUND_RECONNECT_WAIT_SEC`, `_INBOUND_RECONNECT_POLL_SEC`) make the wait window easy to tune and easy to monkeypatch in tests.

## Reproduction
1. Send a message to an agent.
2. While the daemon is still routing it, trigger `context_restart` on that agent's session (or just message during a watchdog-triggered force_restart).
3. **Before this PR:** the inbound message is silently dropped and the user sees `⚠️ … not running right now.`
4. **After this PR:** the message is held for up to 20s; as soon as the new session connects the message is replayed.

Reported by @bradbrok via Telegram (Discord screenshot of barsik's own restart-window drop, 2026-05-13 16:37 PDT).

## Test plan
- [x] `pytest tests/test_broker.py` — 11/11 pass, including two new tests:
  - `test_route_streaming_waits_for_in_flight_reconnect` — session starts disconnected with empty `session_id` (mirrors `force_restart` state), background task flips `is_connected=True` after 100ms; asserts the fallback did NOT fire and the message was delivered to the reconnected session.
  - `test_route_streaming_falls_back_when_reconnect_never_completes` — wait window elapses without reconnect; asserts the canonical fallback fires exactly once and the message wasn't delivered (preserves the previous behavior for genuinely-dead sessions).
- [x] `pytest tests/test_broker.py tests/test_daemon.py tests/test_streaming_session.py` — 58/58 pass.
- [x] `ruff check src/pinky_daemon/broker.py tests/test_broker.py` — clean.
- [ ] Pushok code review.
- [ ] Verify on Mac Mini after merge: trigger a `context_restart` mid-conversation, confirm no `not running` fallback fires and the message is delivered.

🤖 Opened by Barsik