### PR TITLE
feat(transport): explicit session state machine (#486 PR1)

### DIFF
--- a/src/pinky_daemon/transport_state.py
+++ b/src/pinky_daemon/transport_state.py
@@ -45,6 +45,33 @@ Design contract (matrix v2 on issue #486):
 5. **RECONNECTING is the macro state across all backoff attempts.** Internal
    retry sub-states stay private to the Transport; the state machine doesn't
    flicker DEAD ↔ RECONNECTING between attempts.
+
+6. **State mutates at grant time, not at completion.** When
+   ``request_transition`` grants ownership, ``self._state`` flips to the
+   target **before** the owner's side effect runs. This is intentional and
+   has direct consequences for observers:
+
+   - Broker, watchdog, and dashboard see "we are RECONNECTING" as soon as
+     a reconnect is intended, not after it completes. This is what makes
+     "RECONNECTING-as-intent" observable and what lets the broker hold
+     inbound messages instead of dropping them during a force_restart
+     (see PR #484).
+   - The in-flight registration is the source of truth for "a transition
+     is in progress" — readers should consult both ``state`` and
+     ``in_flight`` if they need to distinguish "settled in RECONNECTING"
+     from "transitioning to RECONNECTING right now."
+   - A "state-only-changes-on-commit" alternative would defer the observable
+     flip to ``transition_complete``. That's a valid design but it requires
+     a separate "intended state" field to make in-flight observable, which
+     is just the singleton in-flight by another name. We picked the
+     simpler shape: state mutates eagerly, completion releases subscribers.
+
+   The original double-connect race (issue #486) was downstream of this
+   choice: pre-state-machine, the two bools ``is_connected`` and ``session_id``
+   were mutated independently around the side effect, so observers saw
+   intermediate combinations the code didn't expect. With the singleton
+   in-flight and grant-time mutation, observers see a single consistent
+   transition state.
 """
 
 from __future__ import annotations
@@ -52,10 +79,8 @@ from __future__ import annotations
 import asyncio
 import secrets
 import sys
-import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
 
 
 def _log(msg: str) -> None:
@@ -108,11 +133,36 @@ class Trigger(Enum):
 class OwnerToken:
     """Granted to the caller that drove a state change.
 
-    Possession of an ``OwnerToken`` confers the right (and the obligation) to
-    run the side effect bound to the transition. After completing, the owner
-    calls ``StateMachine.transition_complete(token, final_state)`` to release
-    waiting subscribers. Tokens are single-use; passing the same token twice
-    is a programming error.
+    Possession of an ``OwnerToken`` confers the right (and the **obligation**)
+    to run the side effect bound to the transition. After completing, the
+    owner calls ``StateMachine.transition_complete(token, final_state)`` to
+    release waiting subscribers. Tokens are single-use; passing the same
+    token twice is a programming error.
+
+    **Driver abandonment contract.** Owners MUST call ``transition_complete``
+    on every code path that exits ownership — success, failure, exception, or
+    ``asyncio.CancelledError``. If the owner task dies without completing, the
+    ``_in_flight`` registration is never cleared and ``InFlightHandle.wait()``
+    subscribers block forever. The canonical pattern is::
+
+        result = await sm.request_transition(target, trigger)
+        if result.owner_token is not None:
+            try:
+                await side_effect()
+                await sm.transition_complete(result.owner_token, final_state)
+            except BaseException:
+                # Universal emergency exit — DEAD is always legal here.
+                await sm.transition_complete(result.owner_token, SessionState.DEAD)
+                raise
+
+    ``transition_complete(token, SessionState.DEAD)`` is allowed from any
+    state regardless of matrix rules (see ``StateMachine.transition_complete``).
+    This is the catch-fire path for owners whose side effect failed
+    catastrophically; the state machine accepts DEAD as the terminal sink
+    so the driver-abandonment failure mode is avoidable in practice.
+
+    Auto-cleanup on owner-task cancellation is a future enhancement; for now
+    the contract is enforced by convention + the emergency-exit escape hatch.
     """
 
     token: str
@@ -173,9 +223,9 @@ class TransitionResult:
     changed: bool
     from_state: SessionState
     to_state: SessionState
-    owner_token: Optional[OwnerToken] = None
-    in_flight_handle: Optional[InFlightHandle] = None
-    rejection_reason: Optional[str] = None
+    owner_token: OwnerToken | None = None
+    in_flight_handle: InFlightHandle | None = None
+    rejection_reason: str | None = None
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -440,7 +490,6 @@ class StateMachine:
                 trigger=trigger,
                 owner_token=token,
                 subscribers=[],
-                started_at=time.monotonic(),
             )
             self._audit(
                 from_state, target, trigger, "owned", reason=reason
@@ -489,20 +538,41 @@ class StateMachine:
             # normal handshake-success path; final_state=DEAD is the retry-
             # exhausted path. Both are legal INTERNAL transitions per the matrix.
             if final_state != self._state:
-                # Internal completion is implicitly trigger=INTERNAL.
-                legal = LEGAL_TRANSITIONS.get((self._state, final_state))
-                if legal is None or Trigger.INTERNAL not in legal:
-                    raise TransitionError(
-                        f"illegal completion: {self._state.value} → "
-                        f"{final_state.value} not INTERNAL-legal"
+                # ── DEAD as universal emergency exit ─────────────────────────
+                # DEAD is the terminal sink; it's never illegal to fall to it.
+                # This is the catch-fire path for owners whose side effect
+                # failed catastrophically (e.g. CONNECTED → IDLE_SLEEPING
+                # whose disconnect crashed mid-way — the matrix doesn't give
+                # INTERNAL on IDLE_SLEEPING → DEAD, but we still need an
+                # escape so the driver-abandonment failure mode is avoidable.
+                # Bypasses the INTERNAL-legality gate; everything else still
+                # respects the matrix.
+                if final_state == SessionState.DEAD:
+                    from_state = self._state
+                    self._state = SessionState.DEAD
+                    self._audit(
+                        from_state, SessionState.DEAD, Trigger.INTERNAL,
+                        "emergency_completed",
+                        reason=f"in-flight {in_flight.from_state.value} → "
+                               f"{in_flight.target.value} failed to DEAD",
                     )
-                from_state = self._state
-                self._state = final_state
-                self._audit(
-                    from_state, final_state, Trigger.INTERNAL, "completed",
-                    reason=f"in-flight {in_flight.from_state.value} → "
-                           f"{in_flight.target.value} resolved",
-                )
+                else:
+                    # Internal completion is implicitly trigger=INTERNAL for
+                    # non-DEAD targets.
+                    legal = LEGAL_TRANSITIONS.get((self._state, final_state))
+                    if legal is None or Trigger.INTERNAL not in legal:
+                        raise TransitionError(
+                            f"illegal completion: {self._state.value} → "
+                            f"{final_state.value} not INTERNAL-legal "
+                            f"(DEAD is always legal as emergency exit)"
+                        )
+                    from_state = self._state
+                    self._state = final_state
+                    self._audit(
+                        from_state, final_state, Trigger.INTERNAL, "completed",
+                        reason=f"in-flight {in_flight.from_state.value} → "
+                               f"{in_flight.target.value} resolved",
+                    )
             else:
                 # final_state == current; owner ended exactly where the matrix
                 # parked us. Treat as completion of the in-flight transition.
@@ -552,4 +622,3 @@ class _InFlight:
     trigger: Trigger
     owner_token: OwnerToken
     subscribers: list[InFlightHandle]
-    started_at: float

--- a/src/pinky_daemon/transport_state.py
+++ b/src/pinky_daemon/transport_state.py
@@ -1,0 +1,527 @@
+"""Transport session state machine.
+
+Replaces the implicit ``is_connected + session_id`` two-bool state inference in
+``streaming_session.py`` + ``broker.py`` with an explicit five-state enum and a
+lock-guarded transition primitive that **grants ownership** of any side effect
+bound to a transition.
+
+The two-bool inference had four observable states (CONNECTED, RECONNECTING,
+IDLE_SLEEPING, DEAD) encoded across two independently-mutable booleans, plus
+an implicit fifth state ("never tried") that nothing distinguished from DEAD.
+During ``force_restart``'s ``disconnect()`` → ``connect()`` window the bools
+disagreed with each other, the broker raced the restart, and inbound messages
+got silently dropped (see PR #484 + issue #486). The fix was a bounded poll;
+the underlying race is still there.
+
+This module is the state portion of the upcoming ``Transport`` protocol.
+Backends (``StreamingSession`` for the SDK, ``TmuxSession`` for the tmux
+transport) compose this state machine; callers (broker, watchdog, API) read
+state through it instead of reverse-engineering it from per-backend bools.
+
+Design contract (matrix v2 on issue #486):
+
+1. **State transitions are ownership grants, not just mutations.** Concurrent
+   callers requesting the same target transition race for ownership exactly
+   once. The winner gets an ``OwnerToken`` and runs the side effect (e.g.
+   ``connect()``). Losers get an ``InFlightHandle`` and subscribe via
+   ``await_transition_complete``. Same-state requests are observational —
+   ``changed=False``, no token granted, no side effect implied.
+
+2. **Every transition declares a trigger.** ``request_transition(target,
+   trigger)`` carries the actor identity (BOOT / BROKER / WATCHDOG /
+   INTERNAL / USER_AGENT / API_ADMIN). The matrix defends cells per
+   ``(from, to, trigger)`` triple — most notably ``RECONNECTING → CONNECTED``
+   is INTERNAL-only, so no external caller can flip a session into CONNECTED.
+
+3. **Resume handles (``session_id`` for SDK, tmux session name + transcript
+   path for tmux) are Transport implementation detail.** The state machine
+   doesn't see them. ``IDLE_SLEEPING`` means "deliberately disconnected with
+   private wake semantics," not "has a non-empty SDK session_id."
+
+4. **Audit log per transition.** Every ``request_transition`` call writes a
+   log line — including identity / observational reads and rejected
+   transitions with reason. Free-for-future telemetry.
+
+5. **RECONNECTING is the macro state across all backoff attempts.** Internal
+   retry sub-states stay private to the Transport; the state machine doesn't
+   flicker DEAD ↔ RECONNECTING between attempts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import sys
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+class SessionState(Enum):
+    """Lifecycle state of a Transport session.
+
+    See the matrix on issue #486 for the legal/illegal transition table and the
+    rationale per cell. Summary:
+
+    - ``UNINITIALIZED`` — birth state. Constructed but never tried to connect.
+      Distinguishes "never tried" from "tried and failed."
+    - ``RECONNECTING`` — macro state for "currently trying to be CONNECTED."
+      Internal retry attempts stay inside this state; no flicker.
+    - ``CONNECTED`` — happy path. Can send/receive.
+    - ``IDLE_SLEEPING`` — deliberately disconnected with wake semantics.
+      Distinct from DEAD because the Transport retains private resume info.
+    - ``DEAD`` — unrecoverable without explicit resurrection. Auth failure,
+      retry budget exhausted, watchdog give-up, explicit shutdown.
+    """
+
+    UNINITIALIZED = "uninitialized"
+    RECONNECTING = "reconnecting"
+    CONNECTED = "connected"
+    IDLE_SLEEPING = "idle_sleeping"
+    DEAD = "dead"
+
+
+class Trigger(Enum):
+    """Actor that initiated a transition.
+
+    Carried on every ``request_transition`` call so the matrix can defend
+    cells per ``(from, to, trigger)``. ``RECONNECTING → CONNECTED`` is
+    INTERNAL-only: only the Transport's own connect coroutine can drive the
+    final flip into CONNECTED after a successful handshake.
+    """
+
+    BOOT = "boot"  # daemon startup / boot policy
+    BROKER = "broker"  # _route_streaming auto-wake / resurrection on inbound
+    WATCHDOG = "watchdog"  # session_watchdog lifecycle decisions
+    INTERNAL = "internal"  # Transport's own connect/disconnect machinery
+    USER_AGENT = "user_agent"  # agent's own MCP tools (context_restart, idle_sleep)
+    API_ADMIN = "api_admin"  # explicit operator action via HTTP
+
+
+@dataclass(frozen=True)
+class OwnerToken:
+    """Granted to the caller that drove a state change.
+
+    Possession of an ``OwnerToken`` confers the right (and the obligation) to
+    run the side effect bound to the transition. After completing, the owner
+    calls ``StateMachine.transition_complete(token, final_state)`` to release
+    waiting subscribers. Tokens are single-use; passing the same token twice
+    is a programming error.
+    """
+
+    token: str
+    target: SessionState
+
+    @classmethod
+    def _new(cls, target: SessionState) -> "OwnerToken":
+        return cls(token=secrets.token_hex(8), target=target)
+
+
+@dataclass
+class InFlightHandle:
+    """Subscriber handle for an in-flight transition.
+
+    Returned to ``request_transition`` callers that found an existing
+    transition to the same target already in flight. ``await_transition_complete``
+    blocks on the underlying event until the owning caller calls
+    ``transition_complete``; subscribers then read the final state.
+
+    Why not a busy poll: subscribers may be in the broker hot path, and a busy
+    poll would burn the event loop while the owner does I/O. ``asyncio.Event``
+    is the natural primitive — wait is parked, owner signals once.
+    """
+
+    target: SessionState
+    _event: asyncio.Event = field(default_factory=asyncio.Event)
+    _final_state: SessionState | None = None
+
+    async def wait(self) -> SessionState:
+        """Block until the owner releases the transition. Returns the final state."""
+        await self._event.wait()
+        assert self._final_state is not None, "owner released without setting final state"
+        return self._final_state
+
+    def _resolve(self, final_state: SessionState) -> None:
+        self._final_state = final_state
+        self._event.set()
+
+
+@dataclass(frozen=True)
+class TransitionResult:
+    """Outcome of a ``request_transition`` call.
+
+    Three possible shapes:
+
+    1. **Caller drove the change.** ``changed=True``, ``owner_token`` set,
+       ``in_flight_handle=None``. Caller MUST call ``transition_complete``
+       once the side effect resolves.
+    2. **Same target already in flight.** ``changed=False``,
+       ``owner_token=None``, ``in_flight_handle`` set. Caller subscribes via
+       ``in_flight_handle.wait()`` to learn the final state.
+    3. **Same-state observational read.** ``changed=False``, both tokens
+       ``None``. ``from_state == to_state``; no side effect implied.
+    4. **Rejected.** ``changed=False``, both tokens ``None``,
+       ``rejection_reason`` set. The matrix rejected this triple.
+    """
+
+    changed: bool
+    from_state: SessionState
+    to_state: SessionState
+    owner_token: Optional[OwnerToken] = None
+    in_flight_handle: Optional[InFlightHandle] = None
+    rejection_reason: Optional[str] = None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Transition matrix
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Cell key: (from_state, to_state, trigger) → legal? + reason.
+# Identity transitions (from == to) are observational reads — always allowed,
+# but ``changed=False`` and no token granted. They are not stored here; the
+# state machine handles them in ``request_transition`` before matrix lookup.
+#
+# Each illegal entry carries a reason string. "Illegal" means "intentionally
+# disallowed" — if a future case demands a new transition, add it explicitly
+# with a defense, not by accident.
+
+# Cells where the (from, to) pair is legal, listing the set of triggers that
+# may drive it. Any (from, to, trigger) outside this map is REJECTED.
+LEGAL_TRANSITIONS: dict[tuple[SessionState, SessionState], frozenset[Trigger]] = {
+    # FROM UNINITIALIZED
+    (SessionState.UNINITIALIZED, SessionState.RECONNECTING): frozenset({Trigger.BOOT}),
+    # Boot policy decline OR shutdown-before-start.
+    (SessionState.UNINITIALIZED, SessionState.DEAD): frozenset(
+        {Trigger.BOOT, Trigger.API_ADMIN}
+    ),
+
+    # FROM RECONNECTING
+    # Only the Transport's own connect handshake can drive CONNECTED.
+    (SessionState.RECONNECTING, SessionState.CONNECTED): frozenset({Trigger.INTERNAL}),
+    # Retry budget exhausted / connect() raised; also admin force-kill mid-reconnect.
+    (SessionState.RECONNECTING, SessionState.DEAD): frozenset(
+        {Trigger.INTERNAL, Trigger.API_ADMIN}
+    ),
+
+    # FROM CONNECTED
+    # context_restart (USER_AGENT) / forced reconnect (WATCHDOG) / admin restart
+    # (API_ADMIN) / recoverable transport loss (INTERNAL: EOF, reader-loop crash).
+    (SessionState.CONNECTED, SessionState.RECONNECTING): frozenset(
+        {Trigger.USER_AGENT, Trigger.WATCHDOG, Trigger.API_ADMIN, Trigger.INTERNAL}
+    ),
+    # idle_sleep MCP / watchdog idle-threshold.
+    (SessionState.CONNECTED, SessionState.IDLE_SLEEPING): frozenset(
+        {Trigger.USER_AGENT, Trigger.WATCHDOG}
+    ),
+    # Terminal: auth_failed (INTERNAL) or admin shutdown (API_ADMIN). Recoverable
+    # failures go via RECONNECTING in the cell above.
+    (SessionState.CONNECTED, SessionState.DEAD): frozenset(
+        {Trigger.INTERNAL, Trigger.API_ADMIN}
+    ),
+
+    # FROM IDLE_SLEEPING
+    # Auto-wake on inbound / scheduled wake / admin wake.
+    (SessionState.IDLE_SLEEPING, SessionState.RECONNECTING): frozenset(
+        {Trigger.BROKER, Trigger.WATCHDOG, Trigger.API_ADMIN}
+    ),
+    # Watchdog give-up / admin shutdown. Direct (no fake RECONNECTING when
+    # nothing is trying to wake).
+    (SessionState.IDLE_SLEEPING, SessionState.DEAD): frozenset(
+        {Trigger.WATCHDOG, Trigger.API_ADMIN}
+    ),
+
+    # FROM DEAD
+    # Resurrection on inbound / admin resurrect / watchdog post-backoff.
+    (SessionState.DEAD, SessionState.RECONNECTING): frozenset(
+        {Trigger.BROKER, Trigger.API_ADMIN, Trigger.WATCHDOG}
+    ),
+}
+
+
+# Illegal (from, to) pairs with the rationale. Used to produce useful rejection
+# messages when a caller requests a structurally-disallowed transition.
+ILLEGAL_PAIR_REASONS: dict[tuple[SessionState, SessionState], str] = {
+    (SessionState.UNINITIALIZED, SessionState.CONNECTED):
+        "no shortcut to CONNECTED — must go through RECONNECTING",
+    (SessionState.UNINITIALIZED, SessionState.IDLE_SLEEPING):
+        "can't sleep something that never connected",
+    (SessionState.RECONNECTING, SessionState.UNINITIALIZED):
+        "UNINITIALIZED is birth state, no return path",
+    (SessionState.RECONNECTING, SessionState.IDLE_SLEEPING):
+        "can't sleep mid-connect; finish reconnecting or fail to DEAD first",
+    (SessionState.CONNECTED, SessionState.UNINITIALIZED):
+        "UNINITIALIZED is birth state, no return path",
+    (SessionState.IDLE_SLEEPING, SessionState.UNINITIALIZED):
+        "UNINITIALIZED is birth state, no return path",
+    (SessionState.IDLE_SLEEPING, SessionState.CONNECTED):
+        "wake goes through RECONNECTING for observability — no direct CONNECTED",
+    (SessionState.DEAD, SessionState.UNINITIALIZED):
+        "UNINITIALIZED is birth state, no return path",
+    (SessionState.DEAD, SessionState.CONNECTED):
+        "resurrection goes through RECONNECTING — no direct CONNECTED",
+    (SessionState.DEAD, SessionState.IDLE_SLEEPING):
+        "sleeping a dead session has no meaning; resurrect to RECONNECTING first",
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# State machine
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TransitionError(RuntimeError):
+    """Raised when a transition primitive is misused (not when a transition
+    is structurally rejected — that returns a ``TransitionResult`` with
+    ``rejection_reason`` set)."""
+
+
+class StateMachine:
+    """Lock-guarded state machine for a single Transport session.
+
+    One instance per Transport. Not safe to share across sessions.
+
+    The state machine owns:
+    - Current ``SessionState``.
+    - A single ``asyncio.Lock`` serializing state mutations.
+    - At most one in-flight transition per target state (the ``OwnerToken``
+      holder, plus any subscribed ``InFlightHandle``s).
+    - An audit log emitter.
+
+    The state machine does NOT own:
+    - Resume handles (SDK session_id, tmux session name, transcript paths).
+      Each Transport implementation holds these privately.
+    - Retry policy. Backoff lives inside the Transport's RECONNECTING side
+      effect; the state machine stays in RECONNECTING for the duration.
+    """
+
+    def __init__(
+        self,
+        owner_label: str,
+        *,
+        initial_state: SessionState = SessionState.UNINITIALIZED,
+    ) -> None:
+        self._label = owner_label
+        self._state = initial_state
+        self._lock = asyncio.Lock()
+        # At most one in-flight transition per target state. Multiple targets
+        # can be in flight only if they come from different from-states, which
+        # is structurally impossible given the lock — so in practice the dict
+        # holds 0 or 1 entries. Keyed by target for symmetry with the public API.
+        self._in_flight: dict[SessionState, _InFlight] = {}
+
+    @property
+    def state(self) -> SessionState:
+        """Current state. Safe to read without the lock (atomic in CPython for
+        enum reads); callers wanting consistency with a transition should use
+        the ``TransitionResult`` returned from ``request_transition``."""
+        return self._state
+
+    async def request_transition(
+        self,
+        target: SessionState,
+        trigger: Trigger,
+        *,
+        reason: str | None = None,
+    ) -> TransitionResult:
+        """Request a transition to ``target`` on behalf of ``trigger``.
+
+        Returns a ``TransitionResult`` describing the outcome — see the
+        ``TransitionResult`` docstring for the four possible shapes.
+
+        ``reason`` is an optional free-form string carried in the audit log
+        (e.g. ``"boot_declined"`` for ``UNINITIALIZED → DEAD`` driven by the
+        boot policy). The state machine doesn't interpret it.
+        """
+        async with self._lock:
+            from_state = self._state
+            in_flight = self._in_flight.get(target)
+
+            # Case 1: caller arrives while a transition targeting this state is
+            # already in flight. This covers BOTH the "same as current state"
+            # case (in-flight owner already mutated state) AND the rare case
+            # where someone requests a target the in-flight is also targeting.
+            # Subscribe in either case — the caller gets the final state when
+            # the owner completes, and does NOT run a duplicate side effect.
+            # This is the bug-killer: without this branch, two callers can
+            # both think they got to the target state on their own and both
+            # run the side effect.
+            if in_flight is not None:
+                handle = InFlightHandle(target=target)
+                in_flight.subscribers.append(handle)
+                self._audit(
+                    from_state, target, trigger, "subscribed", reason=reason
+                )
+                return TransitionResult(
+                    changed=False,
+                    from_state=from_state,
+                    to_state=target,
+                    in_flight_handle=handle,
+                )
+
+            # Case 2: identity / observational read (no in-flight transition).
+            if from_state == target:
+                self._audit(
+                    from_state, target, trigger, "observational", reason=reason
+                )
+                return TransitionResult(
+                    changed=False,
+                    from_state=from_state,
+                    to_state=target,
+                )
+
+            # Case 3: matrix rejection.
+            legal_triggers = LEGAL_TRANSITIONS.get((from_state, target))
+            if legal_triggers is None:
+                rej = ILLEGAL_PAIR_REASONS.get(
+                    (from_state, target),
+                    "transition not in matrix",
+                )
+                self._audit(
+                    from_state, target, trigger, "rejected", reason=rej
+                )
+                return TransitionResult(
+                    changed=False,
+                    from_state=from_state,
+                    to_state=from_state,
+                    rejection_reason=rej,
+                )
+            if trigger not in legal_triggers:
+                rej = (
+                    f"trigger {trigger.value} not authorized for "
+                    f"{from_state.value} → {target.value} "
+                    f"(legal: {sorted(t.value for t in legal_triggers)})"
+                )
+                self._audit(
+                    from_state, target, trigger, "rejected", reason=rej
+                )
+                return TransitionResult(
+                    changed=False,
+                    from_state=from_state,
+                    to_state=from_state,
+                    rejection_reason=rej,
+                )
+
+            # Case 4: caller drives the change. Mint owner token, mutate state,
+            # register the in-flight transition.
+            token = OwnerToken._new(target)
+            self._state = target
+            self._in_flight[target] = _InFlight(
+                from_state=from_state,
+                target=target,
+                trigger=trigger,
+                owner_token=token,
+                subscribers=[],
+                started_at=time.monotonic(),
+            )
+            self._audit(
+                from_state, target, trigger, "owned", reason=reason
+            )
+            return TransitionResult(
+                changed=True,
+                from_state=from_state,
+                to_state=target,
+                owner_token=token,
+            )
+
+    async def transition_complete(
+        self,
+        token: OwnerToken,
+        final_state: SessionState,
+    ) -> None:
+        """Owner reports the transition's side effect has resolved.
+
+        ``final_state`` is what the owner's side effect ended at — for a
+        successful ``connect()`` from RECONNECTING, ``final_state=CONNECTED``;
+        for an exhausted retry budget, ``final_state=DEAD``. The state machine
+        applies ``final_state`` as a new transition (subject to matrix rules,
+        but driven by an implicit INTERNAL trigger since this is the
+        Transport's own machinery completing).
+
+        Subscribers waiting on the in-flight handle are released with the
+        final state.
+
+        Raises ``TransitionError`` if the token is unknown (already completed
+        or never issued).
+        """
+        async with self._lock:
+            in_flight = self._in_flight.get(token.target)
+            if in_flight is None or in_flight.owner_token.token != token.token:
+                raise TransitionError(
+                    f"unknown or already-completed owner token for target "
+                    f"{token.target.value}"
+                )
+
+            # Apply final_state if different from the current in-flight target.
+            # E.g. RECONNECTING in-flight with final_state=CONNECTED is the
+            # normal handshake-success path; final_state=DEAD is the retry-
+            # exhausted path. Both are legal INTERNAL transitions per the matrix.
+            if final_state != self._state:
+                # Internal completion is implicitly trigger=INTERNAL.
+                legal = LEGAL_TRANSITIONS.get((self._state, final_state))
+                if legal is None or Trigger.INTERNAL not in legal:
+                    raise TransitionError(
+                        f"illegal completion: {self._state.value} → "
+                        f"{final_state.value} not INTERNAL-legal"
+                    )
+                from_state = self._state
+                self._state = final_state
+                self._audit(
+                    from_state, final_state, Trigger.INTERNAL, "completed",
+                    reason=f"in-flight {in_flight.from_state.value} → "
+                           f"{in_flight.target.value} resolved",
+                )
+            else:
+                # final_state == current; owner ended exactly where the matrix
+                # parked us. Treat as completion of the in-flight transition.
+                self._audit(
+                    self._state, self._state, Trigger.INTERNAL, "completed",
+                    reason=f"in-flight {in_flight.from_state.value} → "
+                           f"{in_flight.target.value} resolved at target",
+                )
+
+            # Release subscribers.
+            for handle in in_flight.subscribers:
+                handle._resolve(final_state)
+            # Clear in-flight entry.
+            del self._in_flight[token.target]
+
+    def _audit(
+        self,
+        from_state: SessionState,
+        to_state: SessionState,
+        trigger: Trigger,
+        result: str,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        """Emit a single audit line per transition request.
+
+        Format: ``transport_state[<label>]: <from> → <to> via <trigger> [result=<r>]``
+        plus optional ``reason=<r>`` suffix. Easy to grep for state lifecycle
+        debugging; structured enough to feed into analytics later if we want
+        state-distribution metrics.
+        """
+        line = (
+            f"transport_state[{self._label}]: {from_state.value} → "
+            f"{to_state.value} via {trigger.value} [result={result}]"
+        )
+        if reason:
+            line += f" reason={reason!r}"
+        _log(line)
+
+
+@dataclass
+class _InFlight:
+    """Internal record of an in-flight transition. Not exposed to callers."""
+
+    from_state: SessionState
+    target: SessionState
+    trigger: Trigger
+    owner_token: OwnerToken
+    subscribers: list[InFlightHandle]
+    started_at: float

--- a/src/pinky_daemon/transport_state.py
+++ b/src/pinky_daemon/transport_state.py
@@ -340,8 +340,10 @@ class StateMachine:
     The state machine owns:
     - Current ``SessionState``.
     - A single ``asyncio.Lock`` serializing state mutations.
-    - At most one in-flight transition per target state (the ``OwnerToken``
-      holder, plus any subscribed ``InFlightHandle``s).
+    - At most one in-flight transition per state machine (singleton — same
+      target subscribes, different target rejects). The ``OwnerToken`` holder
+      runs the side effect; any number of subscribed ``InFlightHandle``s
+      observe the same outcome.
     - An audit log emitter.
 
     The state machine does NOT own:

--- a/src/pinky_daemon/transport_state.py
+++ b/src/pinky_daemon/transport_state.py
@@ -97,7 +97,8 @@ class Trigger(Enum):
 
     BOOT = "boot"  # daemon startup / boot policy
     BROKER = "broker"  # _route_streaming auto-wake / resurrection on inbound
-    WATCHDOG = "watchdog"  # session_watchdog lifecycle decisions
+    WATCHDOG = "watchdog"  # session_watchdog lifecycle decisions (idle, resurrect)
+    SCHEDULER = "scheduler"  # scheduler.py cron-driven wakes + heartbeat resurrect
     INTERNAL = "internal"  # Transport's own connect/disconnect machinery
     USER_AGENT = "user_agent"  # agent's own MCP tools (context_restart, idle_sleep)
     API_ADMIN = "api_admin"  # explicit operator action via HTTP
@@ -227,7 +228,7 @@ LEGAL_TRANSITIONS: dict[tuple[SessionState, SessionState], frozenset[Trigger]] =
     # FROM IDLE_SLEEPING
     # Auto-wake on inbound / scheduled wake / admin wake.
     (SessionState.IDLE_SLEEPING, SessionState.RECONNECTING): frozenset(
-        {Trigger.BROKER, Trigger.WATCHDOG, Trigger.API_ADMIN}
+        {Trigger.BROKER, Trigger.WATCHDOG, Trigger.SCHEDULER, Trigger.API_ADMIN}
     ),
     # Watchdog give-up / admin shutdown. Direct (no fake RECONNECTING when
     # nothing is trying to wake).
@@ -236,9 +237,10 @@ LEGAL_TRANSITIONS: dict[tuple[SessionState, SessionState], frozenset[Trigger]] =
     ),
 
     # FROM DEAD
-    # Resurrection on inbound / admin resurrect / watchdog post-backoff.
+    # Resurrection on inbound / admin resurrect / watchdog post-backoff /
+    # scheduler heartbeat resurrect.
     (SessionState.DEAD, SessionState.RECONNECTING): frozenset(
-        {Trigger.BROKER, Trigger.API_ADMIN, Trigger.WATCHDOG}
+        {Trigger.BROKER, Trigger.API_ADMIN, Trigger.WATCHDOG, Trigger.SCHEDULER}
     ),
 }
 
@@ -308,11 +310,14 @@ class StateMachine:
         self._label = owner_label
         self._state = initial_state
         self._lock = asyncio.Lock()
-        # At most one in-flight transition per target state. Multiple targets
-        # can be in flight only if they come from different from-states, which
-        # is structurally impossible given the lock — so in practice the dict
-        # holds 0 or 1 entries. Keyed by target for symmetry with the public API.
-        self._in_flight: dict[SessionState, _InFlight] = {}
+        # At most one in-flight transition per state machine (singleton, not
+        # keyed by target). Same-target requests subscribe; different-target
+        # requests reject until the owner completes. Without this, two
+        # competing in-flight transitions can coexist for different targets
+        # and the first transition's subscribers get stranded. Repro: see
+        # ``test_cross_target_rejected_while_in_flight`` and Murzik's review
+        # of PR #487 (https://github.com/bradbrok/PinkyBot/issues/486).
+        self._in_flight: _InFlight | None = None
 
     @property
     def state(self) -> SessionState:
@@ -339,28 +344,47 @@ class StateMachine:
         """
         async with self._lock:
             from_state = self._state
-            in_flight = self._in_flight.get(target)
+            in_flight = self._in_flight
 
-            # Case 1: caller arrives while a transition targeting this state is
-            # already in flight. This covers BOTH the "same as current state"
-            # case (in-flight owner already mutated state) AND the rare case
-            # where someone requests a target the in-flight is also targeting.
-            # Subscribe in either case — the caller gets the final state when
-            # the owner completes, and does NOT run a duplicate side effect.
-            # This is the bug-killer: without this branch, two callers can
-            # both think they got to the target state on their own and both
-            # run the side effect.
+            # Case 1: a transition is in flight.
             if in_flight is not None:
-                handle = InFlightHandle(target=target)
-                in_flight.subscribers.append(handle)
+                # Same target → subscribe. Caller gets the final state when
+                # the owner completes; no duplicate side effect runs.
+                if in_flight.target == target:
+                    handle = InFlightHandle(target=target)
+                    in_flight.subscribers.append(handle)
+                    self._audit(
+                        from_state, target, trigger, "subscribed", reason=reason
+                    )
+                    return TransitionResult(
+                        changed=False,
+                        from_state=from_state,
+                        to_state=target,
+                        in_flight_handle=handle,
+                    )
+
+                # Different target → reject. The state machine is committed to
+                # an in-flight transition; cross-target requests must wait for
+                # it to complete (or, in a future PR, use an explicit cancel/
+                # override path that resolves the old subscribers and
+                # invalidates the old token). Without this rejection, two
+                # owners can coexist for different targets and the first
+                # transition's subscribers get stranded — see the regression
+                # test for the exact sequence (Murzik's PR #487 review).
+                rej = (
+                    f"transition already in flight for "
+                    f"{in_flight.target.value} (started via "
+                    f"{in_flight.trigger.value}); cannot request "
+                    f"{target.value} until the owner completes"
+                )
                 self._audit(
-                    from_state, target, trigger, "subscribed", reason=reason
+                    from_state, target, trigger, "rejected", reason=rej
                 )
                 return TransitionResult(
                     changed=False,
                     from_state=from_state,
-                    to_state=target,
-                    in_flight_handle=handle,
+                    to_state=from_state,
+                    rejection_reason=rej,
                 )
 
             # Case 2: identity / observational read (no in-flight transition).
@@ -410,7 +434,7 @@ class StateMachine:
             # register the in-flight transition.
             token = OwnerToken._new(target)
             self._state = target
-            self._in_flight[target] = _InFlight(
+            self._in_flight = _InFlight(
                 from_state=from_state,
                 target=target,
                 trigger=trigger,
@@ -449,8 +473,12 @@ class StateMachine:
         or never issued).
         """
         async with self._lock:
-            in_flight = self._in_flight.get(token.target)
-            if in_flight is None or in_flight.owner_token.token != token.token:
+            in_flight = self._in_flight
+            if (
+                in_flight is None
+                or in_flight.target != token.target
+                or in_flight.owner_token.token != token.token
+            ):
                 raise TransitionError(
                     f"unknown or already-completed owner token for target "
                     f"{token.target.value}"
@@ -488,7 +516,7 @@ class StateMachine:
             for handle in in_flight.subscribers:
                 handle._resolve(final_state)
             # Clear in-flight entry.
-            del self._in_flight[token.target]
+            self._in_flight = None
 
     def _audit(
         self,

--- a/tests/test_transport_state.py
+++ b/tests/test_transport_state.py
@@ -355,6 +355,112 @@ class TestOwnership:
         assert results[1] == SessionState.CONNECTED
 
     @pytest.mark.asyncio
+    async def test_dead_is_universal_emergency_exit_from_any_in_flight(self):
+        """Regression for Pushok's #487 finding: an owner whose side effect
+        fails catastrophically must always be able to complete to DEAD,
+        regardless of whether the matrix has INTERNAL on the
+        ``current_state → DEAD`` cell. DEAD is the terminal sink; falling to
+        it is never illegal at completion time.
+
+        Pre-fix repro: ``CONNECTED → IDLE_SLEEPING`` owner whose
+        ``idle_sleep`` crashes mid-disconnect tries to mark DEAD. The matrix
+        gives ``(IDLE_SLEEPING, DEAD)`` legal triggers ``{WATCHDOG, API_ADMIN}``
+        — no INTERNAL — so ``transition_complete`` raises and the in-flight
+        registration is never cleared. Subscribers stranded.
+        """
+        # CONNECTED → IDLE_SLEEPING owner crashes mid-disconnect, falls to DEAD.
+        sm = StateMachine("agent", initial_state=SessionState.CONNECTED)
+        sleeper = await sm.request_transition(
+            SessionState.IDLE_SLEEPING, Trigger.USER_AGENT
+        )
+        assert sleeper.owner_token is not None
+        # Side effect crashes; owner reports DEAD as the emergency exit.
+        # Pre-fix: TransitionError because (IDLE_SLEEPING, DEAD) doesn't have
+        # INTERNAL in its legal set. Post-fix: accepted, state moves to DEAD.
+        await sm.transition_complete(sleeper.owner_token, SessionState.DEAD)
+        assert sm.state == SessionState.DEAD
+
+    @pytest.mark.asyncio
+    async def test_dead_emergency_exit_releases_subscribers_with_dead(self):
+        """Subscribers waiting on an in-flight transition learn the final
+        state is DEAD when the owner takes the emergency exit, not the
+        original target."""
+        sm = StateMachine("agent", initial_state=SessionState.CONNECTED)
+        sleeper = await sm.request_transition(
+            SessionState.IDLE_SLEEPING, Trigger.USER_AGENT
+        )
+        subscriber = await sm.request_transition(
+            SessionState.IDLE_SLEEPING, Trigger.WATCHDOG
+        )
+        assert subscriber.in_flight_handle is not None
+
+        async def owner_fails_to_dead():
+            await asyncio.sleep(0.01)
+            await sm.transition_complete(sleeper.owner_token, SessionState.DEAD)
+
+        owner_task = asyncio.create_task(owner_fails_to_dead())
+        final = await subscriber.in_flight_handle.wait()
+        await owner_task
+
+        assert final == SessionState.DEAD
+        assert sm.state == SessionState.DEAD
+
+    @pytest.mark.asyncio
+    async def test_non_dead_completion_still_respects_matrix(self):
+        """The DEAD emergency exit is specifically DEAD-only. Non-DEAD
+        completion still goes through the INTERNAL-legality gate so callers
+        can't quietly land in arbitrary states by claiming "complete."
+        """
+        sm = StateMachine("agent", initial_state=SessionState.CONNECTED)
+        sleeper = await sm.request_transition(
+            SessionState.IDLE_SLEEPING, Trigger.USER_AGENT
+        )
+
+        # RECONNECTING is not INTERNAL-legal from IDLE_SLEEPING (legal triggers:
+        # {BROKER, WATCHDOG, SCHEDULER, API_ADMIN}). Owner can't unilaterally
+        # land in RECONNECTING via completion.
+        with pytest.raises(TransitionError) as exc:
+            await sm.transition_complete(
+                sleeper.owner_token, SessionState.RECONNECTING
+            )
+        assert "DEAD is always legal" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_owner_can_emergency_exit_to_dead_on_cancellation_via_finally(self):
+        """Demonstrates the documented try/finally contract: owners that
+        catch ``asyncio.CancelledError`` and use the DEAD emergency exit
+        do not strand subscribers."""
+        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        owner = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.BROKER
+        )
+        subscriber = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.WATCHDOG
+        )
+
+        # Simulate the owner's side-effect task getting cancelled. The owner
+        # follows the documented contract: catch the cancellation, emergency-
+        # exit to DEAD via transition_complete, re-raise.
+        async def owner_workflow():
+            try:
+                await asyncio.sleep(10)  # would block forever
+            except asyncio.CancelledError:
+                await sm.transition_complete(owner.owner_token, SessionState.DEAD)
+                raise
+
+        task = asyncio.create_task(owner_workflow())
+        # Yield so the owner starts the sleep.
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Subscriber resolves with DEAD, not stranded.
+        final = await subscriber.in_flight_handle.wait()
+        assert final == SessionState.DEAD
+        assert sm.state == SessionState.DEAD
+
+    @pytest.mark.asyncio
     async def test_in_flight_clears_after_completion_so_new_transition_can_start(self):
         """After an in-flight transition completes, the state machine must
         accept a new transition request — the singleton guard releases."""

--- a/tests/test_transport_state.py
+++ b/tests/test_transport_state.py
@@ -261,6 +261,118 @@ class TestOwnership:
             await sm.transition_complete(result.owner_token, SessionState.CONNECTED)
 
     @pytest.mark.asyncio
+    async def test_cross_target_rejected_while_in_flight(self):
+        """Regression for Murzik's #487 finding: while a transition is in
+        flight, a different-target request from any caller must be rejected.
+
+        Repro sequence (the bug, pre-fix):
+        1. IDLE_SLEEPING → RECONNECTING via BROKER grants owner A.
+        2. Another caller subscribes to RECONNECTING and waits on its handle.
+        3. Before A completes, API_ADMIN requests DEAD. Pre-fix, this minted
+           a second owner B because ``_in_flight.get(DEAD)`` returned None.
+           State flipped to DEAD; subscriber stranded.
+        4. Owner A later tried to complete CONNECTED from DEAD → TransitionError.
+
+        Post-fix: API_ADMIN's DEAD request is rejected with a clear reason.
+        Owner A can still complete the original transition. Subscriber is
+        released with whatever final state A reports.
+        """
+        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+
+        # Step 1: owner A starts IDLE_SLEEPING → RECONNECTING.
+        owner_a = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.BROKER
+        )
+        assert owner_a.owner_token is not None
+        assert sm.state == SessionState.RECONNECTING
+
+        # Step 2: subscriber B joins.
+        subscriber_b = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.WATCHDOG
+        )
+        assert subscriber_b.in_flight_handle is not None
+
+        # Step 3: API_ADMIN requests DEAD while A is still in flight.
+        # Must be rejected, not granted a second owner.
+        cross_target = await sm.request_transition(
+            SessionState.DEAD, Trigger.API_ADMIN
+        )
+        assert cross_target.changed is False, (
+            "cross-target request granted ownership while another transition "
+            "was in flight — strands subscribers and creates competing owners"
+        )
+        assert cross_target.owner_token is None
+        assert cross_target.in_flight_handle is None
+        assert cross_target.rejection_reason is not None
+        assert "already in flight" in cross_target.rejection_reason
+        # State must NOT have moved.
+        assert sm.state == SessionState.RECONNECTING
+
+        # Step 4: owner A completes successfully — subscriber B is released
+        # with the final state, no errors thrown.
+        async def owner_workflow():
+            await asyncio.sleep(0.01)
+            await sm.transition_complete(
+                owner_a.owner_token, SessionState.CONNECTED
+            )
+
+        owner_task = asyncio.create_task(owner_workflow())
+        final = await subscriber_b.in_flight_handle.wait()
+        await owner_task
+
+        assert final == SessionState.CONNECTED
+        assert sm.state == SessionState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_cross_target_rejection_does_not_strand_subscriber(self):
+        """Tighter variant of the regression: after a cross-target request
+        is rejected, the original subscriber's ``wait()`` must still resolve
+        when the original owner completes — proving the rejection didn't
+        corrupt the in-flight registration."""
+        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+
+        owner = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.BROKER
+        )
+        subscriber = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.WATCHDOG
+        )
+
+        # Multiple cross-target rejections.
+        for trigger in (Trigger.API_ADMIN, Trigger.WATCHDOG):
+            rejected = await sm.request_transition(SessionState.DEAD, trigger)
+            assert rejected.rejection_reason is not None
+
+        # Subscriber is still in the in-flight registration and resolves
+        # cleanly when the owner completes.
+        async def owner_completes():
+            await sm.transition_complete(owner.owner_token, SessionState.CONNECTED)
+
+        results = await asyncio.gather(
+            owner_completes(),
+            subscriber.in_flight_handle.wait(),
+        )
+        assert results[1] == SessionState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_in_flight_clears_after_completion_so_new_transition_can_start(self):
+        """After an in-flight transition completes, the state machine must
+        accept a new transition request — the singleton guard releases."""
+        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+
+        owner_1 = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.BROKER
+        )
+        await sm.transition_complete(owner_1.owner_token, SessionState.CONNECTED)
+
+        # Now request a fresh transition — must succeed (CONNECTED → IDLE_SLEEPING).
+        owner_2 = await sm.request_transition(
+            SessionState.IDLE_SLEEPING, Trigger.WATCHDOG
+        )
+        assert owner_2.changed is True
+        assert owner_2.owner_token is not None
+
+    @pytest.mark.asyncio
     async def test_completion_rejects_illegal_final_state(self):
         """If an owner reports a final state that isn't an INTERNAL-legal
         transition from the current state, completion raises rather than

--- a/tests/test_transport_state.py
+++ b/tests/test_transport_state.py
@@ -1,0 +1,432 @@
+"""Tests for the Transport session state machine.
+
+PR1 of the #486 sequence: pure data-structure tests. No streaming-session
+involvement. If these pass, the state machine is correct as a standalone
+primitive; PR2 (Transport protocol) and PR3 (StreamingSession adopts) build
+on top.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pinky_daemon.transport_state import (
+    ILLEGAL_PAIR_REASONS,
+    LEGAL_TRANSITIONS,
+    InFlightHandle,
+    SessionState,
+    StateMachine,
+    TransitionError,
+    Trigger,
+)
+
+# ──────────────────────────────────────────────────────────────────────────
+# Construction & basic state reads
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestConstruction:
+    def test_default_initial_state_is_uninitialized(self):
+        sm = StateMachine("agent")
+        assert sm.state == SessionState.UNINITIALIZED
+
+    def test_explicit_initial_state_honored(self):
+        sm = StateMachine("agent", initial_state=SessionState.CONNECTED)
+        assert sm.state == SessionState.CONNECTED
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Identity / observational reads
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestIdentity:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("state", list(SessionState))
+    async def test_same_state_is_observational(self, state):
+        """``request_transition(current_state)`` returns ``changed=False`` and
+        confers no ownership, regardless of trigger."""
+        sm = StateMachine("agent", initial_state=state)
+        # Trigger is irrelevant for identity reads — pick BROKER as a placeholder.
+        result = await sm.request_transition(state, Trigger.BROKER)
+        assert result.changed is False
+        assert result.from_state == state
+        assert result.to_state == state
+        assert result.owner_token is None
+        assert result.in_flight_handle is None
+        assert result.rejection_reason is None
+        # State unchanged.
+        assert sm.state == state
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Matrix coverage: every legal cell admits exactly its declared triggers
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestMatrixLegalCells:
+    @pytest.mark.asyncio
+    async def test_every_legal_cell_accepts_each_declared_trigger(self):
+        """For each (from, to) in LEGAL_TRANSITIONS, every declared trigger
+        must produce ``changed=True`` and grant an OwnerToken."""
+        for (from_state, to_state), triggers in LEGAL_TRANSITIONS.items():
+            for trigger in triggers:
+                sm = StateMachine("agent", initial_state=from_state)
+                result = await sm.request_transition(to_state, trigger)
+                assert result.changed is True, (
+                    f"legal cell ({from_state.value} → {to_state.value}, "
+                    f"trigger={trigger.value}) did not change"
+                )
+                assert result.owner_token is not None, (
+                    f"legal cell ({from_state.value} → {to_state.value}, "
+                    f"trigger={trigger.value}) did not grant ownership"
+                )
+                assert result.from_state == from_state
+                assert result.to_state == to_state
+                assert sm.state == to_state
+
+    @pytest.mark.asyncio
+    async def test_legal_cell_rejects_unauthorized_triggers(self):
+        """Triggers NOT in the legal set for a cell must be rejected with a
+        reason. Tests the trigger enforcement column of the matrix."""
+        for (from_state, to_state), triggers in LEGAL_TRANSITIONS.items():
+            unauthorized = set(Trigger) - triggers
+            for trigger in unauthorized:
+                sm = StateMachine("agent", initial_state=from_state)
+                result = await sm.request_transition(to_state, trigger)
+                assert result.changed is False, (
+                    f"unauthorized trigger {trigger.value} drove "
+                    f"{from_state.value} → {to_state.value}"
+                )
+                assert result.rejection_reason is not None
+                assert "not authorized" in result.rejection_reason
+                # State unchanged.
+                assert sm.state == from_state
+
+
+class TestMatrixIllegalCells:
+    @pytest.mark.asyncio
+    async def test_every_illegal_pair_rejects_with_reason(self):
+        """For each illegal (from, to) pair, every trigger must reject with
+        the matrix's documented reason."""
+        for (from_state, to_state), expected_reason in ILLEGAL_PAIR_REASONS.items():
+            # Sanity: illegal pairs must not appear in LEGAL_TRANSITIONS.
+            assert (from_state, to_state) not in LEGAL_TRANSITIONS, (
+                f"({from_state.value}, {to_state.value}) is in both legal "
+                f"and illegal maps"
+            )
+            for trigger in Trigger:
+                sm = StateMachine("agent", initial_state=from_state)
+                result = await sm.request_transition(to_state, trigger)
+                assert result.changed is False
+                assert result.rejection_reason == expected_reason, (
+                    f"illegal cell ({from_state.value} → {to_state.value}, "
+                    f"trigger={trigger.value}) rejected with wrong reason"
+                )
+                assert sm.state == from_state
+
+    def test_matrix_is_exhaustive(self):
+        """Every off-diagonal (from, to) pair must be either in LEGAL_TRANSITIONS
+        or in ILLEGAL_PAIR_REASONS — no cell silently missing."""
+        for from_state in SessionState:
+            for to_state in SessionState:
+                if from_state == to_state:
+                    continue  # diagonal = identity, handled in request_transition
+                in_legal = (from_state, to_state) in LEGAL_TRANSITIONS
+                in_illegal = (from_state, to_state) in ILLEGAL_PAIR_REASONS
+                assert in_legal or in_illegal, (
+                    f"cell ({from_state.value} → {to_state.value}) is missing "
+                    f"from both LEGAL_TRANSITIONS and ILLEGAL_PAIR_REASONS — "
+                    f"every cell must be defended"
+                )
+                assert not (in_legal and in_illegal), (
+                    f"cell ({from_state.value} → {to_state.value}) appears in "
+                    f"both legal and illegal maps"
+                )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Ownership semantics: the bug-killer
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestOwnership:
+    @pytest.mark.asyncio
+    async def test_concurrent_same_target_yields_exactly_one_owner(self):
+        """Murzik's gating test: two coroutines call
+        ``request_transition(RECONNECTING)`` simultaneously from IDLE_SLEEPING.
+        Exactly one gets an OwnerToken; the other gets an InFlightHandle.
+
+        IDLE_SLEEPING → RECONNECTING accepts both BROKER (auto-wake on inbound)
+        and WATCHDOG (scheduled wake) triggers — the canonical production race.
+        """
+        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+
+        # Both callers race for ownership of IDLE_SLEEPING → RECONNECTING.
+        results = await asyncio.gather(
+            sm.request_transition(SessionState.RECONNECTING, Trigger.BROKER),
+            sm.request_transition(SessionState.RECONNECTING, Trigger.WATCHDOG),
+        )
+
+        owners = [r for r in results if r.owner_token is not None]
+        subscribers = [r for r in results if r.in_flight_handle is not None]
+
+        assert len(owners) == 1, (
+            f"expected exactly one owner; got {len(owners)}: {results}"
+        )
+        assert len(subscribers) == 1, (
+            f"expected exactly one subscriber; got {len(subscribers)}: {results}"
+        )
+        # The owner observed the change; the subscriber did not.
+        assert owners[0].changed is True
+        assert subscribers[0].changed is False
+        assert subscribers[0].in_flight_handle.target == SessionState.RECONNECTING
+
+    @pytest.mark.asyncio
+    async def test_subscriber_receives_final_state_when_owner_completes(self):
+        """Subscribers ``await`` their in-flight handle and read the final
+        state set by the owner."""
+        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+
+        owner_result = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.BROKER
+        )
+        subscriber_result = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.WATCHDOG
+        )
+        assert owner_result.owner_token is not None
+        assert subscriber_result.in_flight_handle is not None
+
+        # Owner does its side effect, then completes with the final state.
+        async def owner_workflow():
+            await asyncio.sleep(0.01)  # simulate connect() I/O
+            await sm.transition_complete(
+                owner_result.owner_token, SessionState.CONNECTED
+            )
+
+        async def subscriber_workflow():
+            return await subscriber_result.in_flight_handle.wait()
+
+        owner_task = asyncio.create_task(owner_workflow())
+        subscriber_task = asyncio.create_task(subscriber_workflow())
+
+        final_state = await subscriber_task
+        await owner_task
+
+        assert final_state == SessionState.CONNECTED
+        assert sm.state == SessionState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_subscriber_receives_dead_when_owner_fails(self):
+        """If the owner's side effect fails (retry budget exhausted), the
+        subscriber learns the final state is DEAD, not CONNECTED."""
+        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+
+        owner_result = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.BROKER
+        )
+        subscriber_result = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.WATCHDOG
+        )
+
+        async def owner_fails():
+            await asyncio.sleep(0.01)
+            # Connect failed; retry budget exhausted; state machine flips to DEAD.
+            await sm.transition_complete(
+                owner_result.owner_token, SessionState.DEAD
+            )
+
+        await asyncio.gather(
+            owner_fails(),
+            asyncio.create_task(
+                _assert_subscriber_sees(subscriber_result.in_flight_handle, SessionState.DEAD)
+            ),
+        )
+        assert sm.state == SessionState.DEAD
+
+    @pytest.mark.asyncio
+    async def test_owner_token_cannot_be_reused(self):
+        """Completing the same token twice is a programming error."""
+        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        result = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.BROKER
+        )
+        assert result.owner_token is not None
+
+        await sm.transition_complete(result.owner_token, SessionState.CONNECTED)
+
+        with pytest.raises(TransitionError):
+            await sm.transition_complete(result.owner_token, SessionState.CONNECTED)
+
+    @pytest.mark.asyncio
+    async def test_completion_rejects_illegal_final_state(self):
+        """If an owner reports a final state that isn't an INTERNAL-legal
+        transition from the current state, completion raises rather than
+        silently parking the state machine in an invalid state."""
+        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        result = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.BROKER
+        )
+        assert result.owner_token is not None
+
+        # RECONNECTING → UNINITIALIZED is not INTERNAL-legal (UNINITIALIZED
+        # has no return path).
+        with pytest.raises(TransitionError):
+            await sm.transition_complete(
+                result.owner_token, SessionState.UNINITIALIZED
+            )
+
+
+async def _assert_subscriber_sees(handle: InFlightHandle, expected: SessionState):
+    """Helper: subscriber waits and asserts the final state matches."""
+    final = await handle.wait()
+    assert final == expected
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Specific matrix invariants worth their own tests
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestMatrixInvariants:
+    @pytest.mark.asyncio
+    async def test_reconnecting_to_connected_is_internal_only(self):
+        """Invariant 2: only the Transport's own connect coroutine can flip
+        a session into CONNECTED. External triggers must be rejected."""
+        for trigger in Trigger:
+            if trigger == Trigger.INTERNAL:
+                continue  # The legal one — tested in TestMatrixLegalCells.
+            sm = StateMachine("agent", initial_state=SessionState.RECONNECTING)
+            # Inject an in-flight transition via completion, since we can't
+            # request the same transition from outside INTERNAL: just check
+            # that an external trigger requesting CONNECTED is rejected.
+            result = await sm.request_transition(
+                SessionState.CONNECTED, trigger
+            )
+            assert result.changed is False, (
+                f"external trigger {trigger.value} flipped session into CONNECTED"
+            )
+            assert result.rejection_reason is not None
+            assert "not authorized" in result.rejection_reason
+
+    @pytest.mark.asyncio
+    async def test_uninitialized_is_one_way(self):
+        """Invariant 3: once a Transport leaves UNINITIALIZED, no transition
+        returns to it."""
+        for state in SessionState:
+            if state == SessionState.UNINITIALIZED:
+                continue
+            sm = StateMachine("agent", initial_state=state)
+            for trigger in Trigger:
+                result = await sm.request_transition(
+                    SessionState.UNINITIALIZED, trigger
+                )
+                assert result.changed is False, (
+                    f"{state.value} → UNINITIALIZED accepted via {trigger.value}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_reconnecting_to_idle_sleeping_is_illegal(self):
+        """Can't sleep mid-connect."""
+        sm = StateMachine("agent", initial_state=SessionState.RECONNECTING)
+        for trigger in Trigger:
+            result = await sm.request_transition(
+                SessionState.IDLE_SLEEPING, trigger
+            )
+            assert result.changed is False
+            assert result.rejection_reason is not None
+
+    @pytest.mark.asyncio
+    async def test_idle_sleeping_to_connected_must_go_through_reconnecting(self):
+        """Invariant 1: every successful connect is observable as RECONNECTING
+        first. No direct IDLE_SLEEPING → CONNECTED."""
+        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        for trigger in Trigger:
+            result = await sm.request_transition(
+                SessionState.CONNECTED, trigger
+            )
+            assert result.changed is False
+            assert result.rejection_reason is not None
+
+    @pytest.mark.asyncio
+    async def test_dead_to_idle_sleeping_is_illegal(self):
+        """Sleeping a dead session has no meaning."""
+        sm = StateMachine("agent", initial_state=SessionState.DEAD)
+        for trigger in Trigger:
+            result = await sm.request_transition(
+                SessionState.IDLE_SLEEPING, trigger
+            )
+            assert result.changed is False
+            assert result.rejection_reason is not None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Audit log emission
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestAuditLog:
+    @pytest.mark.asyncio
+    async def test_every_request_emits_one_audit_line(self, capsys):
+        """One audit line per request_transition call, regardless of outcome
+        (changed / observational / subscribed / rejected)."""
+        sm = StateMachine("test", initial_state=SessionState.IDLE_SLEEPING)
+
+        # Identity (observational) — IDLE_SLEEPING → IDLE_SLEEPING is an
+        # observational read regardless of trigger (no in-flight transition).
+        await sm.request_transition(SessionState.IDLE_SLEEPING, Trigger.BROKER)
+        # Legal transition (owned) — IDLE_SLEEPING → RECONNECTING accepts BROKER.
+        await sm.request_transition(SessionState.RECONNECTING, Trigger.BROKER)
+        # Subscribed (in-flight) — a second caller targeting RECONNECTING
+        # while the first is still in flight subscribes instead of racing.
+        await sm.request_transition(SessionState.RECONNECTING, Trigger.WATCHDOG)
+
+        captured = capsys.readouterr().err
+        lines = [ln for ln in captured.splitlines() if "transport_state[test]" in ln]
+        assert len(lines) == 3, f"expected 3 audit lines, got {len(lines)}: {lines}"
+        assert "result=observational" in lines[0]
+        assert "result=owned" in lines[1]
+        assert "result=subscribed" in lines[2]
+
+    @pytest.mark.asyncio
+    async def test_rejection_emits_audit_with_reason(self, capsys):
+        sm = StateMachine("test", initial_state=SessionState.DEAD)
+        await sm.request_transition(SessionState.CONNECTED, Trigger.BROKER)
+        err = capsys.readouterr().err
+        assert "transport_state[test]" in err
+        assert "result=rejected" in err
+        assert "reason=" in err
+
+    @pytest.mark.asyncio
+    async def test_caller_supplied_reason_in_audit(self, capsys):
+        """Caller-supplied ``reason`` (e.g. ``boot_declined``) shows up in
+        the audit line."""
+        sm = StateMachine("test")
+        await sm.request_transition(
+            SessionState.DEAD, Trigger.BOOT, reason="boot_declined"
+        )
+        err = capsys.readouterr().err
+        assert "reason='boot_declined'" in err
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# OwnerToken uniqueness
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestOwnerToken:
+    @pytest.mark.asyncio
+    async def test_each_ownership_grant_yields_unique_token(self):
+        """OwnerTokens are minted per transition; reusing a closed transition's
+        token in transition_complete is rejected (see test_owner_token_cannot_be_reused)."""
+        tokens = set()
+        for _ in range(20):
+            sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+            result = await sm.request_transition(
+                SessionState.RECONNECTING, Trigger.BROKER
+            )
+            assert result.owner_token is not None
+            tokens.add(result.owner_token.token)
+        assert len(tokens) == 20, "OwnerToken hash collision or non-uniqueness"


### PR DESCRIPTION
## Summary
- Standalone module + tests for the Transport session state machine that replaces the implicit `is_connected + session_id` bool inference in `streaming_session.py` + `broker.py` with a five-state enum and a lock-guarded transition primitive that **grants ownership** of side effects.
- This is PR1 of the #486 sequence — pure data structure + correctness tests. No streaming-session involvement; PR2 (Transport protocol) and PR3 (StreamingSession adopts) build on top.

## Why this PR is the bug-killer

`is_connected` + `session_id` encoded four observable states across two independently-mutable booleans, plus an implicit fifth state (\"never tried\") that nothing distinguished from DEAD. During `force_restart`'s `disconnect()` → `connect()` window the bools disagreed with each other, broker raced the restart, and inbound messages got silently dropped (PR #484 patched the symptom with a bounded poll; this PR closes the underlying race).

Two design moves close the race rather than just naming it:

1. **Ownership semantics, not just lock-guarded mutation.** `request_transition(target, trigger)` returns `{changed, owner_token, in_flight_handle, rejection_reason}`. Concurrent same-target callers race for ownership *exactly once*; the rest subscribe via `InFlightHandle.wait()` and learn the final state when the owner completes. Lock-serialized state mutation alone recreates the double-connect race in prettier shape — Murzik's gating point.
2. **Trigger column enforced.** `RECONNECTING → CONNECTED` is INTERNAL-only. Each legal cell carries its set of allowed triggers; unauthorized triggers reject with the legal set in the rejection reason.

## Design captured in #486 matrix v2

See [issue #486](https://github.com/bradbrok/PinkyBot/issues/486) for the full transition matrix, invariants, and the iterative review thread that produced this contract.

States: `UNINITIALIZED`, `RECONNECTING`, `CONNECTED`, `IDLE_SLEEPING`, `DEAD`.
Triggers: `BOOT`, `BROKER`, `WATCHDOG`, `INTERNAL`, `USER_AGENT`, `API_ADMIN`.

Three substantive contracts:

- **Resume handles are Transport implementation detail.** State machine doesn't see `session_id` (SDK) or tmux session names. Generalizes cleanly to the upcoming TmuxSession (Dymok test agent).
- **RECONNECTING is a macro state across backoff attempts.** Internal retry sub-states stay private to the Transport; observers see uniform "still trying" → "ready"|"dead".
- **Audit log on every transition request,** including identity and rejected. Format: `transport_state[<label>]: <from> → <to> via <trigger> [result=<owned|subscribed|observational|rejected>] reason=<...>`.

## Test plan

- [x] 25 tests pass in 0.06s.
- [x] Identity reads parametrized over every `SessionState`.
- [x] Every legal cell accepts each declared trigger and grants ownership.
- [x] Every legal cell rejects unauthorized triggers with `not authorized` in the reason.
- [x] Every illegal `(from, to)` pair rejects with the documented matrix reason.
- [x] **Matrix exhaustiveness:** every off-diagonal cell is in exactly one of the two maps.
- [x] **Concurrent ownership** (Murzik's gating test): two simultaneous requests yield exactly one owner + one subscriber; subscriber receives final state via `await handle.wait()`.
- [x] Subscriber receives `DEAD` when owner fails (retry budget exhausted).
- [x] Owner token cannot be reused after `transition_complete`.
- [x] Completion rejects illegal final states.
- [x] Invariants: external triggers can't flip into CONNECTED; UNINITIALIZED is one-way; can't sleep mid-reconnect; can't sleep DEAD.
- [x] Audit log emits one line per call with correct result tag.
- [x] Caller-supplied `reason` (e.g. `boot_declined`) appears in audit.
- [x] OwnerTokens are unique across 20 transitions.
- [x] `ruff check` clean.
- [ ] @pushok review pass.
- [ ] @murzik review pass.

## Reviewer notes

Two real bugs caught while writing tests:

1. **v1 ownership check ran identity branch before in-flight check** — exactly the race @murzik flagged in matrix v2's gating concern, in prettier shape. Fixed in `request_transition`: in-flight check runs first; identity is only reported when no transition is in flight for the target state.
2. **Initial concurrent-ownership test used `CONNECTED → RECONNECTING` with `BROKER` trigger** — `BROKER` is not legal for that cell (legal set: `USER_AGENT`, `WATCHDOG`, `API_ADMIN`, `INTERNAL`). Corrected to `IDLE_SLEEPING → RECONNECTING` with `BROKER`+`WATCHDOG` — the canonical production race (auto-wake on inbound vs scheduled wake).

What I'd appreciate sharp eyes on:
- The `InFlightHandle.wait()` mechanic — `asyncio.Event` per handle, owner releases via `transition_complete`. Simpler than a condition variable + condition check; correct?
- The `transition_complete` semantics on \"final state == current state\" (owner ended exactly at the in-flight target) vs \"final state != current state\" (owner overrode, e.g. RECONNECTING in-flight, owner reports DEAD because connect failed). Both paths exist, both write audit lines, both release subscribers. Reviewing for edge cases.
- Whether the `Trigger` enum is missing an actor. Six covers what I've inventoried in the daemon today; flag if there's a seventh I've missed.

🤖 Opened by Barsik