### PR TITLE
feat(transport): Transport protocol — codifies backend surface (#486 PR2)

### DIFF
--- a/src/pinky_daemon/transport.py
+++ b/src/pinky_daemon/transport.py
@@ -1,0 +1,290 @@
+"""Transport protocol — the contract that every agent transport backend honors.
+
+PR2 of the #486 sequence. Typing-only PR: this module defines a
+``runtime_checkable`` ``typing.Protocol`` that codifies the public surface
+``streaming_session.py``'s ``StreamingSession`` already implements, with the
+``SessionState`` / ``Trigger`` enums from PR1 substituted for the implicit
+``is_connected + session_id`` bool inference.
+
+This PR doesn't enforce that ``StreamingSession`` satisfies the protocol —
+PR3 makes it formally adopt. Duck-typed Protocol means landing this PR
+alone has no behavior change: the Protocol exists as documentation +
+type-check target for new code (e.g. the upcoming ``TmuxSession`` for
+Brad's Dymok test agent).
+
+## Why a Protocol instead of an abstract base class
+
+- Side-by-side architecture (Brad's directive on the tmux work): both
+  ``StreamingSession`` (SDK) and ``TmuxSession`` (tmux REPL) live in tree
+  indefinitely. A Protocol covers both backends without forcing inheritance
+  from a shared base, which would couple the two implementations.
+
+- StreamingSession exists today with a stable consumer surface (broker.py,
+  api.py, watchdog, scheduler). Migrating it to inherit from an ABC requires
+  changing its method signatures; Protocol just documents the surface
+  consumers already rely on.
+
+- Future backends (a Codex transport, a remote agent transport via the
+  ferry, etc.) compose against this Protocol without circular import
+  weirdness or shared-base lifecycle issues.
+
+## Migration plan
+
+- PR2 (this) — ``Transport`` Protocol + the state-machine-aware
+  ``is_connected`` / ``is_idle_sleeping`` shim helpers. Nothing changes.
+- PR3 — ``StreamingSession`` adopts (formally implements) ``Transport``
+  by routing ``is_connected`` through its embedded ``StateMachine``.
+  ``broker.py`` / ``api.py`` / ``scheduler.py`` / ``calendar.py`` type their
+  StreamingSession parameters as ``Transport``.
+- TmuxSession PR sequence — drafted in parallel against this Protocol.
+  Dymok agent boots with ``PINKYBOT_TRANSPORT=tmux``; everything routes
+  through the same Transport surface.
+- PR4 — cleanup: delete ``is_connected`` / ``is_idle_sleeping`` shims and
+  consume state directly via ``state == SessionState.X`` at the four caller
+  files identified during pre-PR scoping.
+
+## What's intentionally NOT in this Protocol
+
+- Constructor / config. Each backend has its own config dataclass
+  (``StreamingSessionConfig`` for SDK; ``TmuxSessionConfig`` for tmux).
+  Construction signature varies; runtime surface doesn't.
+
+- Internal helpers (``_check_context``, ``_reader_loop``, ``_analytics_*``,
+  ``_strip_prompt_headers``, etc.). Implementation detail.
+
+- Resume handle data. ``session_id`` (SDK) and tmux session name +
+  transcript path (tmux) are kept private to each backend. Consumers don't
+  need them today (the state machine carries the lifecycle signal); when
+  the broker eventually needs to query "what's the resume handle for this
+  session," that's a separate method that each backend implements
+  differently. Out of scope for PR2.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from pinky_daemon.transport_state import SessionState
+
+
+@runtime_checkable
+class Transport(Protocol):
+    """Public surface of an agent transport backend.
+
+    Two backends are planned:
+
+    1. ``StreamingSession`` — persistent Claude Agent SDK ``ClaudeSDKClient``
+       per agent. The hot path for the existing SDK-backed fleet (barsik,
+       pushok, ryzhik, persik, murzik, etc.).
+    2. ``TmuxSession`` — interactive ``claude`` REPL inside a tmux session.
+       The new backend for the Dymok test agent. Drives billing against the
+       subscription's interactive limits instead of the capped SDK credit
+       pool.
+
+    Both implement this Protocol; consumers (broker, api, scheduler,
+    watchdog) interact with whichever backend an agent is configured for
+    without caring which one it is.
+
+    ``runtime_checkable`` allows ``isinstance(obj, Transport)`` checks
+    (structural; checks attribute names, not types). Useful for diagnostic
+    code; the Protocol is otherwise enforced at type-check time only.
+    """
+
+    # ── Identity ─────────────────────────────────────────────────────────
+
+    agent_name: str
+    """Agent this transport is bound to. One transport per agent."""
+
+    @property
+    def id(self) -> str:
+        """Stable identifier for this transport instance.
+
+        For ``StreamingSession``: ``f"{agent_name}-{label or 'main'}"``.
+        For ``TmuxSession``: same shape, label captures the tmux session
+        name suffix when an agent runs multiple channels.
+
+        Used by analytics, the conversation store, and admin dashboards.
+        """
+        ...
+
+    # ── Lifecycle state ─────────────────────────────────────────────────
+
+    @property
+    def state(self) -> SessionState:
+        """Current lifecycle state. Backed by the embedded
+        ``StateMachine`` once PR3 lands.
+
+        New code should branch on this, not on the legacy
+        ``is_connected`` / ``is_idle_sleeping`` shims below.
+        """
+        ...
+
+    @property
+    def is_connected(self) -> bool:
+        """Legacy shim: ``state == SessionState.CONNECTED``.
+
+        Preserved during the PR3 migration so the four existing readers
+        (``broker.py``, ``api.py``, ``scheduler.py``,
+        ``routes/calendar.py``) don't need to be touched in the same PR
+        that adopts the protocol. PR4 deletes the shim and migrates those
+        readers to consult ``state`` directly.
+        """
+        ...
+
+    @property
+    def is_idle_sleeping(self) -> bool:
+        """Legacy shim: ``state == SessionState.IDLE_SLEEPING``.
+
+        Same deprecation timeline as ``is_connected``. Originally added to
+        let the watchdog resurrection callback skip sessions that were
+        deliberately put to sleep (issue #348); with the state machine
+        that's just a ``state == IDLE_SLEEPING`` check on the resurrection
+        path.
+        """
+        ...
+
+    @property
+    def session_id(self) -> str:
+        """Resume handle, opaque shape per backend.
+
+        For ``StreamingSession``: the Claude Code SDK session ID, persisted
+        in the agent DB and used to drive ``--resume`` on cold-start.
+
+        For ``TmuxSession``: TBD. Likely the tmux session name (since
+        ``claude --continue`` resolves by cwd's most-recent transcript and
+        the tmux session pins the cwd).
+
+        Consumers should treat this as an opaque string. The state machine
+        does NOT consult it for lifecycle decisions — that's intentional
+        per issue #486 (session_id is data, not state).
+        """
+        ...
+
+    @property
+    def stats(self) -> dict[str, Any]:
+        """Snapshot of operational metrics: turn count, message count,
+        error count, auto-restart count, current cost, current thinking
+        effort, etc. Consumed by the admin dashboard and ``/agents`` API.
+
+        Shape varies per backend (e.g. TmuxSession can't report
+        ``cost_usd`` per the migration plan's accepted-loss list); callers
+        should treat unknown keys defensively.
+        """
+        ...
+
+    # ── Lifecycle methods ───────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Bring the transport from a non-CONNECTED state into CONNECTED.
+
+        For ``StreamingSession``: instantiate ``ClaudeSDKClient``, start
+        the reader loop, register MCP servers, refresh wake context.
+
+        For ``TmuxSession``: ``tmux new-session`` (or attach to existing
+        on resume), launch ``claude --continue --dangerously-skip-
+        permissions``, register hook event subscriptions.
+
+        Drives ``RECONNECTING → CONNECTED`` via the state machine's
+        INTERNAL trigger. Raises on irrecoverable connect failure (auth,
+        config error); the StateMachine completes to DEAD via the
+        emergency-exit path.
+        """
+        ...
+
+    async def disconnect(self) -> None:
+        """Bring the transport down. Idempotent.
+
+        Drives the appropriate ``→ DEAD`` or ``→ IDLE_SLEEPING`` transition
+        depending on the caller's intent (see ``idle_sleep`` for the
+        deliberate-sleep path).
+        """
+        ...
+
+    async def send(
+        self,
+        prompt: str,
+        *,
+        platform: str = "",
+        chat_id: str = "",
+        message_id: str = "",
+        agent_hint: str = "",
+    ) -> None:
+        """Send a message to the agent. Non-blocking.
+
+        Args:
+            prompt: The formatted message to send.
+            platform: Platform the message came from (telegram, discord,
+                slack, web, etc.). Used for routing the agent's response.
+            chat_id: Chat / DM identifier on the platform.
+            message_id: Source message_id for reaction routing.
+            agent_hint: Reply-platform context appended to the query but
+                NOT stored in conversation history. Lets the agent know
+                where to reply without polluting the persistent record.
+
+        Drops silently if not connected (broker.py's wait-for-reconnect
+        plus the state machine's same-target-subscribe semantics handle
+        the in-flight reconnect case).
+        """
+        ...
+
+    async def force_restart(self) -> bool:
+        """Tear down the current session and start a fresh one.
+
+        Used by the agent's ``context_restart`` MCP tool when the agent
+        decides to clear its working context, and by the watchdog for
+        unrecoverable session failures.
+
+        Returns ``True`` if the restart completed successfully, ``False``
+        if blocked (e.g. restart guard rejecting because save_my_context
+        wasn't called from the current session).
+
+        Drives ``CONNECTED → RECONNECTING → CONNECTED|DEAD``.
+        """
+        ...
+
+    async def idle_sleep(self) -> bool:
+        """Disconnect the transport but preserve resume info so it can be
+        cheaply re-woken on the next inbound message.
+
+        Used by the agent's ``request_sleep`` MCP tool and by the watchdog
+        when an agent exceeds its idle threshold.
+
+        Returns ``True`` if the sleep completed successfully.
+
+        Drives ``CONNECTED → IDLE_SLEEPING``.
+        """
+        ...
+
+    async def attempt_reconnect(self) -> None:
+        """Best-effort reconnect after a transient transport failure.
+
+        Called from ``send()``'s exception handler and from the watchdog's
+        resurrection path. Internally drives ``CONNECTED → RECONNECTING``
+        followed by either ``→ CONNECTED`` or ``→ DEAD`` after the retry
+        budget (lives inside the Transport's RECONNECTING macro state per
+        #486 invariant).
+        """
+        ...
+
+    # ── Effort overrides (thinking-effort knob) ──────────────────────────
+
+    @property
+    def effective_effort(self) -> str:
+        """Currently-applied thinking effort: ``"low"`` / ``"medium"`` /
+        ``"high"`` / ``"xhigh"`` / ``"max"``. Reflects any session-level
+        override on top of the agent's configured default."""
+        ...
+
+    def set_effort(self, level: str) -> None:
+        """Override the thinking effort for this session.
+
+        Backends that don't honor effort (e.g. TmuxSession may not, TBD)
+        accept the call but log a warning and ignore. Consumers shouldn't
+        rely on backend-specific honoring.
+        """
+        ...
+
+    def clear_effort_override(self) -> None:
+        """Drop any session-level effort override; revert to the agent's
+        configured default on the next turn."""
+        ...

--- a/src/pinky_daemon/transport.py
+++ b/src/pinky_daemon/transport.py
@@ -154,9 +154,19 @@ class Transport(Protocol):
         ``claude --continue`` resolves by cwd's most-recent transcript and
         the tmux session pins the cwd).
 
-        Consumers should treat this as an opaque string. The state machine
-        does NOT consult it for lifecycle decisions — that's intentional
-        per issue #486 (session_id is data, not state).
+        **Migration-window contract.** Consumers must treat this as opaque
+        compatibility data — never derive lifecycle state from it. The
+        state machine does NOT consult ``session_id`` for lifecycle
+        decisions per issue #486 invariant 7 (session_id is data, not
+        state). The pre-state-machine bug (#484, #486) was downstream of
+        callers inferring "is_connected ∨ session_id ≠ ''" as state; PR3
+        cuts that inference at the source.
+
+        **Post-migration consideration.** Once all callers consume
+        ``state`` instead of inferring from ``session_id``, this property
+        is a candidate for renaming to ``resume_handle`` and possibly
+        re-typing as a backend-specific opaque object (per @murzik on PR
+        #488 review). Out of scope for the current PR sequence.
         """
         ...
 
@@ -194,9 +204,19 @@ class Transport(Protocol):
     async def disconnect(self) -> None:
         """Bring the transport down. Idempotent.
 
-        Drives the appropriate ``→ DEAD`` or ``→ IDLE_SLEEPING`` transition
-        depending on the caller's intent (see ``idle_sleep`` for the
-        deliberate-sleep path).
+        ``disconnect`` takes no intent parameter — lifecycle intent must be
+        established by the caller through a higher-level method before
+        invoking the raw disconnect:
+
+        - ``idle_sleep`` drives ``CONNECTED → IDLE_SLEEPING`` via the state
+          machine and then performs the disconnect.
+        - Default (direct caller, no preceding intent set): drives
+          ``→ DEAD``. Used for terminal shutdown paths.
+
+        PR3 enforces this by routing the state-machine transitions through
+        ``force_restart`` / ``idle_sleep`` / explicit shutdown paths;
+        ``disconnect`` itself becomes the side-effect runner, not the
+        intent declarer.
         """
         ...
 
@@ -262,7 +282,16 @@ class Transport(Protocol):
         resurrection path. Internally drives ``CONNECTED → RECONNECTING``
         followed by either ``→ CONNECTED`` or ``→ DEAD`` after the retry
         budget (lives inside the Transport's RECONNECTING macro state per
-        #486 invariant).
+        #486 invariant 5).
+
+        **Migration-public, PR4 cleanup candidate.** Kept on the Protocol
+        for now because ``send()``'s exception handler + ``scheduler.py``
+        currently call it as a public method. Once PR3 / PR4 land,
+        consumers should drive reconnects through ``request_transition``
+        on the state machine (or the equivalent dedicated transition
+        method) instead of calling ``attempt_reconnect`` directly. At that
+        point this becomes a transport-internal helper and drops off the
+        Protocol. Per @murzik on PR #488 review.
         """
         ...
 

--- a/src/pinky_daemon/transport.py
+++ b/src/pinky_daemon/transport.py
@@ -41,7 +41,12 @@ Brad's Dymok test agent).
   through the same Transport surface.
 - PR4 — cleanup: delete ``is_connected`` / ``is_idle_sleeping`` shims and
   consume state directly via ``state == SessionState.X`` at the four caller
-  files identified during pre-PR scoping.
+  files identified during pre-PR scoping. **Also in PR4:** rename
+  ``session_id: str`` to ``resume_handle`` (or similar) and consider
+  re-typing as a backend-specific opaque object (per @murzik on PR #488
+  review; reaffirmed by @pushok in the same round). The migration window
+  keeps ``str`` so PR3 doesn't have to churn StreamingSession's existing
+  empty-string-as-empty pattern (see ``streaming_session.py:239,988``).
 
 ## What's intentionally NOT in this Protocol
 
@@ -91,6 +96,11 @@ class Transport(Protocol):
     """
 
     # ── Identity ─────────────────────────────────────────────────────────
+
+    # Style note: ``agent_name`` is a plain attribute set at construction
+    # time and not derived; ``id`` is a property because it combines
+    # ``agent_name`` with the per-channel label. The mixed style is
+    # intentional (data vs derived) — not an oversight.
 
     agent_name: str
     """Agent this transport is bound to. One transport per agent."""
@@ -241,9 +251,27 @@ class Transport(Protocol):
                 NOT stored in conversation history. Lets the agent know
                 where to reply without polluting the persistent record.
 
-        Drops silently if not connected (broker.py's wait-for-reconnect
-        plus the state machine's same-target-subscribe semantics handle
-        the in-flight reconnect case).
+        **Caller contract.** Callers must ensure the transport is in
+        ``SessionState.CONNECTED`` before invoking ``send``. ``send`` itself
+        does **not** wait for in-flight transitions or trigger a reconnect
+        — its only job is to push a turn at the underlying client when one
+        is ready.
+
+        The canonical safe-call pattern is in ``broker._route_streaming``
+        (the wait-for-reconnect loop from PR #484): observe state +
+        in-flight handle, hold the inbound message until the transport
+        is either CONNECTED or terminally DEAD, then call ``send``.
+
+        Behavior when called while NOT CONNECTED is **unspecified by this
+        Protocol**:
+
+        - Current ``StreamingSession`` drops silently (legacy; see
+          ``streaming_session.py:send``).
+        - Future backends MAY raise instead.
+
+        Callers must not depend on the drop-vs-raise behavior; if you need
+        delivery guarantees during non-CONNECTED windows, drive the
+        wait/queue logic at the caller (broker's pattern).
         """
         ...
 
@@ -300,8 +328,13 @@ class Transport(Protocol):
     @property
     def effective_effort(self) -> str:
         """Currently-applied thinking effort: ``"low"`` / ``"medium"`` /
-        ``"high"`` / ``"xhigh"`` / ``"max"``. Reflects any session-level
-        override on top of the agent's configured default."""
+        ``"high"`` / ``"xhigh"`` / ``"max"``.
+
+        Reflects the *applied* effort post-resolution; the ``"auto"``
+        sentinel accepted by ``set_effort`` (and the ``set_thinking_effort``
+        MCP tool) is never returned here — it's resolved to one of the
+        five concrete levels before the next turn runs.
+        """
         ...
 
     def set_effort(self, level: str) -> None:

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,249 @@
+"""Tests for the Transport protocol.
+
+PR2 is typing-only; this test module verifies:
+
+1. The Protocol imports cleanly.
+2. A minimal hand-rolled class satisfies `isinstance(obj, Transport)`
+   structurally (since the Protocol is ``runtime_checkable``).
+3. A class missing required attributes does NOT satisfy isinstance.
+4. The Protocol surface matches what we documented — attribute / method
+   names won't silently drift without a test failure.
+
+PR3 (StreamingSession adopts) carries the behavior tests; this module
+just locks in the contract shape.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from pinky_daemon.transport import Transport
+from pinky_daemon.transport_state import SessionState
+
+
+# Hand-rolled stub that intentionally implements the full Transport
+# surface with no-op bodies. Used to verify the Protocol's structural
+# isinstance behavior and to lock in the surface shape.
+class _StubTransport:
+    """Stub satisfying Transport. Not a real backend; just structural."""
+
+    agent_name = "stub"
+
+    @property
+    def id(self) -> str:
+        return "stub-main"
+
+    @property
+    def state(self) -> SessionState:
+        return SessionState.UNINITIALIZED
+
+    @property
+    def is_connected(self) -> bool:
+        return False
+
+    @property
+    def is_idle_sleeping(self) -> bool:
+        return False
+
+    @property
+    def session_id(self) -> str:
+        return ""
+
+    @property
+    def stats(self) -> dict:
+        return {}
+
+    async def connect(self) -> None: ...
+    async def disconnect(self) -> None: ...
+
+    async def send(
+        self,
+        prompt: str,
+        *,
+        platform: str = "",
+        chat_id: str = "",
+        message_id: str = "",
+        agent_hint: str = "",
+    ) -> None: ...
+
+    async def force_restart(self) -> bool:
+        return True
+
+    async def idle_sleep(self) -> bool:
+        return True
+
+    async def attempt_reconnect(self) -> None: ...
+
+    @property
+    def effective_effort(self) -> str:
+        return "medium"
+
+    def set_effort(self, level: str) -> None: ...
+    def clear_effort_override(self) -> None: ...
+
+
+class TestProtocolImport:
+    def test_protocol_imports(self):
+        """Sanity: the Protocol module imports without errors."""
+        assert Transport is not None
+        assert hasattr(Transport, "__protocol_attrs__") or hasattr(
+            Transport, "_is_protocol"
+        )
+
+    def test_protocol_uses_session_state_enum(self):
+        """The ``state`` property's annotation refers to ``SessionState``
+        from ``transport_state``. PR1's enum is the source of truth; this
+        test fails loudly if someone defines a parallel enum in transport.py."""
+        # Inspect the Protocol's class body for the SessionState symbol.
+        # If the import was removed or shadowed, the import would fail at
+        # module load; this is just a belt-and-suspenders.
+        from pinky_daemon import transport as transport_mod
+        assert transport_mod.SessionState is SessionState
+
+
+class TestRuntimeCheckable:
+    def test_stub_satisfies_transport_protocol(self):
+        """The structural ``isinstance`` check passes for a class that
+        implements the documented surface."""
+        stub = _StubTransport()
+        assert isinstance(stub, Transport)
+
+    def test_incomplete_class_does_not_satisfy_protocol(self):
+        """A class missing required attributes fails isinstance.
+
+        ``runtime_checkable`` checks attribute names exist, not their
+        types or signatures — so this test only catches structural gaps,
+        not signature drift. Signature contracts are enforced at type-
+        check time (mypy / pyright); see PR3 for adoption tests.
+        """
+        class _MissingState:
+            agent_name = "missing"
+
+            @property
+            def id(self) -> str:
+                return ""
+
+            # Missing: state, is_connected, is_idle_sleeping, session_id,
+            # stats, connect, disconnect, send, force_restart,
+            # idle_sleep, attempt_reconnect, effective_effort,
+            # set_effort, clear_effort_override.
+
+        assert not isinstance(_MissingState(), Transport)
+
+
+class TestSurfaceShape:
+    """Lock in the public surface so silent name drift fails a test.
+
+    These tests are intentionally redundant with the Protocol definition
+    itself — the point is that renaming a method or removing a property
+    requires explicit acknowledgment in this test file rather than slipping
+    through.
+    """
+
+    REQUIRED_ATTRIBUTES = {"agent_name"}
+    REQUIRED_PROPERTIES = {
+        "id",
+        "state",
+        "is_connected",
+        "is_idle_sleeping",
+        "session_id",
+        "stats",
+        "effective_effort",
+    }
+    REQUIRED_ASYNC_METHODS = {
+        "connect",
+        "disconnect",
+        "send",
+        "force_restart",
+        "idle_sleep",
+        "attempt_reconnect",
+    }
+    REQUIRED_SYNC_METHODS = {"set_effort", "clear_effort_override"}
+
+    @pytest.mark.parametrize("name", sorted(REQUIRED_PROPERTIES))
+    def test_protocol_declares_property(self, name):
+        """Each documented property must appear on the Protocol class."""
+        assert hasattr(Transport, name), (
+            f"Transport Protocol missing property {name!r}"
+        )
+
+    @pytest.mark.parametrize("name", sorted(REQUIRED_ASYNC_METHODS))
+    def test_protocol_declares_async_method(self, name):
+        """Each documented async method must appear on the Protocol class
+        AND be detectable as a coroutine on a stub implementation."""
+        assert hasattr(Transport, name), (
+            f"Transport Protocol missing async method {name!r}"
+        )
+        # Verify the stub's implementation is actually async — catches
+        # accidental sync/async mismatch when we add new methods.
+        method = getattr(_StubTransport, name)
+        assert inspect.iscoroutinefunction(method), (
+            f"Stub {name!r} is not async — Protocol contract drift"
+        )
+
+    @pytest.mark.parametrize("name", sorted(REQUIRED_SYNC_METHODS))
+    def test_protocol_declares_sync_method(self, name):
+        """Each documented sync method must appear on the Protocol class."""
+        assert hasattr(Transport, name), (
+            f"Transport Protocol missing sync method {name!r}"
+        )
+
+    def test_send_signature_keyword_only(self):
+        """``send`` takes ``prompt`` positionally then keyword-only args.
+
+        Locks in the calling convention used across the daemon
+        (``broker.py`` calls ``streaming.send(prompt, platform=..., ...)``).
+        Catches accidental signature changes during PR3.
+        """
+        sig = inspect.signature(_StubTransport.send)
+        params = list(sig.parameters.values())
+        # self, prompt (positional), then keyword-only.
+        assert params[0].name == "self"
+        assert params[1].name == "prompt"
+        assert params[1].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+        for p in params[2:]:
+            assert p.kind == inspect.Parameter.KEYWORD_ONLY, (
+                f"send() arg {p.name!r} should be keyword-only "
+                f"(got {p.kind})"
+            )
+
+
+class TestProtocolDoesNotImportStreamingSession:
+    """Side-by-side architecture: the Transport Protocol must NOT import
+    or reference StreamingSession directly. The Protocol is the contract
+    each backend honors; concrete backends import the Protocol, not the
+    other way around. Otherwise we get an import cycle and StreamingSession
+    becomes load-bearing for TmuxSession's type definitions.
+    """
+
+    def test_transport_module_does_not_import_streaming_session(self):
+        from pinky_daemon import transport as transport_mod
+        src = inspect.getsource(transport_mod)
+        # The Protocol may MENTION StreamingSession in docstrings (it does)
+        # — but it must not IMPORT the class. Distinguish via import lines.
+        import_lines = [
+            ln for ln in src.splitlines()
+            if ln.lstrip().startswith(("import ", "from "))
+        ]
+        for ln in import_lines:
+            assert "streaming_session" not in ln.lower(), (
+                f"transport.py imports streaming_session — breaks the "
+                f"side-by-side contract. Offending line: {ln!r}"
+            )
+
+    def test_transport_module_does_not_import_tmux(self):
+        """Mirror constraint: tmux backend doesn't get import precedence
+        either. Protocol is the abstraction; both backends import it."""
+        from pinky_daemon import transport as transport_mod
+        src = inspect.getsource(transport_mod)
+        import_lines = [
+            ln for ln in src.splitlines()
+            if ln.lstrip().startswith(("import ", "from "))
+        ]
+        for ln in import_lines:
+            assert "tmux" not in ln.lower(), (
+                f"transport.py imports tmux backend — breaks the "
+                f"side-by-side contract. Offending line: {ln!r}"
+            )


### PR DESCRIPTION
## Summary
- PR2 of the #486 sequence. Defines a ``runtime_checkable`` Python Protocol in ``src/pinky_daemon/transport.py`` that codifies StreamingSession's public consumer surface, with ``SessionState`` (PR1) substituted for the ``is_connected + session_id`` bool inference.
- Typing-only. StreamingSession isn't forced to satisfy the protocol yet — duck-typed Protocol means landing this alone has zero behavior change. PR3 makes adoption formal.
- Built for the **side-by-side architecture** Brad called: both SDK-backed StreamingSession and tmux-backed TmuxSession (for the upcoming Dymok test agent) honor the same Transport contract without forcing shared inheritance.

## What's codified

- Identity: ``agent_name``, ``id``
- Lifecycle state: ``state: SessionState`` (new — backed by ``StateMachine`` from PR1), plus ``is_connected`` / ``is_idle_sleeping`` shims for the PR3 migration window (deleted in PR4)
- Resume handle: ``session_id`` (opaque per backend; treated as data, not state, per #486 invariant 7)
- Operational metrics: ``stats: dict[str, Any]``
- Lifecycle methods: ``connect``, ``disconnect``, ``send``, ``force_restart``, ``idle_sleep``, ``attempt_reconnect``
- Effort knob: ``effective_effort``, ``set_effort``, ``clear_effort_override``

## What's intentionally NOT codified

- Constructor / config (each backend has its own config dataclass)
- Internal helpers (``_check_context``, ``_reader_loop``, ``_analytics_*``)
- Resume handle data structure (private to each backend)

## Test plan

- [x] 22 tests pass in 0.01s.
- [x] Protocol imports cleanly + references SessionState from transport_state.
- [x] Stub implementing full surface satisfies ``isinstance(obj, Transport)``.
- [x] Class missing required attributes does NOT satisfy isinstance.
- [x] **Surface shape lock-in**: every documented property / method must appear on the Protocol class (catches silent name drift during the migration).
- [x] ``send`` signature is keyword-only after ``prompt`` — locks the calling convention ``broker.py`` and others already use.
- [x] ``transport.py`` does NOT import streaming_session or tmux backend — enforces the side-by-side abstraction direction (concrete backends import the Protocol, not the reverse).
- [x] Broader sweep (transport + transport_state + broker + streaming_session): 78/78 pass.
- [x] ruff clean.
- [ ] @pushok review pass.
- [ ] @murzik review pass.

## Reviewer notes

What I'd appreciate eyes on:

1. **The shape of ``state`` on the Protocol.** Currently a read-only property returning ``SessionState``. In PR3, StreamingSession's implementation will route through its embedded ``StateMachine.state`` property. Question: should the Protocol expose the StateMachine itself (so consumers can call ``request_transition`` directly) or stay narrow at just ``state``? My read: narrow Protocol with ``state`` only; transitions are driven through dedicated methods (``connect``, ``disconnect``, ``force_restart``, etc.) so consumers don't reach into the state machine. Flag if you'd prefer broader exposure.

2. **``session_id`` is intentionally typed as ``str`` — empty-string when unknown.** Tmux's resume handle could be a more structured type. Keeping ``str`` for the migration window so PR3 doesn't have to change StreamingSession; TmuxSession will return a stringified key (e.g. ``"tmux:<session-name>"``) and parse it back internally. Acceptable, or worth introducing an ``Optional[ResumeHandle]`` typed protocol now?

3. **``attempt_reconnect`` on the Protocol vs internal-only.** Currently exposed because broker.py / scheduler.py call it. Could be moved to internal-only post-PR3 if the state machine's transition methods make external reconnect calls unnecessary. Out of scope for PR2 — flag if the documentation should mark it as "deprecated, candidate for PR4 cleanup."

🤖 Opened by Barsik