### PR TITLE
feat(transport): StreamingSession formally adopts Transport — PR3 of #486

### DIFF
--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -990,6 +990,14 @@ class StreamingSession:
 
         _log(f"streaming[{self.agent_name}]: force restarting session")
 
+        # Settle macro state in RECONNECTING for the full restart window —
+        # disconnect → wake-context refresh → connect. Without this,
+        # ``disconnect()``'s no-prior-intent fallback would drive
+        # CONNECTED → DEAD and observers (broker auto-wake, watchdog
+        # resurrection) would see DEAD mid-restart and race the in-flight
+        # force_restart. Per @murzik on PR #491 review.
+        self._state_machine._state = SessionState.RECONNECTING
+
         # Notify the persistence callback to clear session ID
         if self._on_session_id:
             try:
@@ -999,6 +1007,12 @@ class StreamingSession:
 
         # Disconnect
         await self.disconnect()
+        # Re-assert RECONNECTING after the teardown. ``disconnect()``'s
+        # fallback only fires from CONNECTED, so it shouldn't trip here —
+        # but defensive: if a future change adds another path that flips
+        # state inside disconnect, we still observe RECONNECTING during
+        # wake-context refresh and at connect() entry.
+        self._state_machine._state = SessionState.RECONNECTING
 
         # Refresh wake context from DB before reconnecting
         if self._config.wake_context_builder:

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -352,6 +352,14 @@ class StreamingSession:
         # IDLE_SLEEPING, and the post-disconnect reconnect paths. Direct
         # mutation is the staged-migration shape per PR3 scope; see __init__
         # docstring for the PR4 follow-up.
+        #
+        # TODO(PR4 — @pushok on #491 review, Bug 3): The cold-start path
+        # currently goes UNINITIALIZED → CONNECTED, which the matrix forbids
+        # (illegal pair, must go through RECONNECTING). Direct ``_state =``
+        # bypasses the matrix check, so this isn't user-visible in PR3, but
+        # once PR4 wires ``request_transition`` through the four reader files
+        # the cold-start path needs a brief intermediate hop to RECONNECTING
+        # (declared via BOOT trigger) before settling here via INTERNAL.
         self._state_machine._state = SessionState.CONNECTED
 
         # Capture account info from SDK init result
@@ -1139,6 +1147,16 @@ class StreamingSession:
                     await self.disconnect()
                 except Exception:
                     pass
+                # Re-assert RECONNECTING after the inner disconnect. ``connect()``
+                # flips state to CONNECTED before its post-connect setup
+                # (analytics session-started, reader-loop spawn); a raise during
+                # setup leaves us briefly in CONNECTED, then the inner
+                # ``disconnect()`` above fires the standalone-from-CONNECTED →
+                # DEAD fallback. Without this re-assert the macro-state flickers
+                # to DEAD between retries — contradicts the "no flicker
+                # DEAD↔RECONNECTING" invariant from transport_state.py §5.
+                # Per @pushok on PR #491 review (Bug 2).
+                self._state_machine._state = SessionState.RECONNECTING
 
         # All retries exhausted — settle in DEAD. Watchdog resurrection on
         # the next inbound message can drive DEAD → RECONNECTING via BROKER

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from pinky_daemon.sessions import SessionUsage
+from pinky_daemon.transport_state import SessionState, StateMachine
 
 # Models with native 1M context (SDK reports 200k incorrectly)
 _1M_MODELS = {"claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7"}
@@ -227,11 +228,30 @@ class StreamingSession:
         self._auth_success_callback = auth_success_callback
         self._client = None
         self._reader_task: asyncio.Task | None = None
-        self._connected = False
-        # Set True when idle_sleep() deliberately disconnects the session.
-        # Watchdog resurrection (api._heartbeat_resurrect) checks this to avoid
-        # fighting the idle-sleep state — see issue #348.
-        self._idle_sleeping = False
+        # PR3 (#486 sequence): formal adoption of the Transport protocol.
+        # The pre-PR3 ``is_connected`` + ``is_idle_sleeping`` two-bool inference
+        # is replaced by a five-state machine; the bool properties below now
+        # derive from ``self._state_machine.state``.
+        #
+        # PR3 scope is the read-path refactor: state-machine state is the source
+        # of truth for ``is_connected`` / ``is_idle_sleeping`` / the new ``state``
+        # property, but state-write paths still mutate ``_state`` directly at
+        # the same code points where ``_connected`` / ``_idle_sleeping`` were
+        # mutated before. The formal ``request_transition`` /
+        # ``transition_complete`` orchestration (with proper ``Trigger``
+        # declaration and matrix-rejection handling) is PR4 work — it requires
+        # threading ``Trigger`` awareness through the four external readers
+        # (broker, api, scheduler, watchdog) and is out of scope here to keep
+        # PR3 "parallel with current agent config" (Brad, 2026-05-13 18:21 PDT).
+        #
+        # Watchdog resurrection (api._heartbeat_resurrect) still inspects
+        # ``is_idle_sleeping`` to avoid fighting the idle-sleep state — see
+        # issue #348. With derivation through the state machine the contract
+        # is unchanged from the caller's perspective.
+        self._state_machine = StateMachine(
+            owner_label=f"{config.agent_name}-{config.label or 'main'}",
+            initial_state=SessionState.UNINITIALIZED,
+        )
         self._last_response = ""
         self._pending_chats: list[tuple[str, str, str]] = []  # Queue of (platform, chat_id, message_id)
 
@@ -326,10 +346,13 @@ class StreamingSession:
 
         self._client = ClaudeSDKClient(options)
         await self._client.connect()
-        self._connected = True
-        # Clear idle-sleep flag on successful (re)connect — covers genuine wake
-        # via /streaming/restart, scheduler wake, or any explicit reconnect.
-        self._idle_sleeping = False
+        # Drive state machine to CONNECTED. ``is_connected`` and
+        # ``is_idle_sleeping`` derive from this; settling here covers the
+        # cold-start (UNINITIALIZED → CONNECTED), the genuine wake from
+        # IDLE_SLEEPING, and the post-disconnect reconnect paths. Direct
+        # mutation is the staged-migration shape per PR3 scope; see __init__
+        # docstring for the PR4 follow-up.
+        self._state_machine._state = SessionState.CONNECTED
 
         # Capture account info from SDK init result
         try:
@@ -430,7 +453,7 @@ class StreamingSession:
             agent_hint: Extra context appended to the query but NOT stored in
                 conversation history (e.g. reply-platform hints).
         """
-        if not self._connected or not self._client:
+        if not self.is_connected or not self._client:
             _log(f"streaming[{self.agent_name}]: not connected, dropping message")
             return
 
@@ -868,13 +891,16 @@ class StreamingSession:
 
         except Exception as e:
             _log(f"streaming[{self.agent_name}]: reader loop error: {e}")
-            self._connected = False
-            # Try reconnect
+            # Recoverable transport loss — drive to RECONNECTING so observers
+            # see the intent immediately (matches the broker's wait-for-reconnect
+            # pattern from PR #484). attempt_reconnect drives the retry loop and
+            # settles to CONNECTED or DEAD.
+            self._state_machine._state = SessionState.RECONNECTING
             await self.attempt_reconnect()
 
     async def _check_context(self) -> None:
         """Check context usage after each turn. Warn or force restart."""
-        if not self._client or not self._connected:
+        if not self._client or not self.is_connected:
             return
 
         try:
@@ -994,7 +1020,12 @@ class StreamingSession:
             return True
         except Exception as e:
             _log(f"streaming[{self.agent_name}]: force restart failed: {e}")
-            self._connected = False
+            # Connect raised mid-restart — terminal failure. DEAD is the
+            # universal emergency-exit sink per transport_state.py docstring.
+            # The watchdog's resurrection path (api._heartbeat_resurrect) can
+            # drive DEAD → RECONNECTING via BROKER/SCHEDULER on the next
+            # inbound message.
+            self._state_machine._state = SessionState.DEAD
             return False
 
     async def idle_sleep(self) -> bool:
@@ -1004,7 +1035,7 @@ class StreamingSession:
         preserved so the next wake can resume.
         Returns True if successfully slept.
         """
-        if not self._connected or not self._client:
+        if not self.is_connected or not self._client:
             return False
 
         _log(f"streaming[{self.agent_name}]: idle sleep triggered ({self._config.idle_timeout}s idle)")
@@ -1022,12 +1053,17 @@ class StreamingSession:
         except Exception as e:
             _log(f"streaming[{self.agent_name}]: memory save failed before idle sleep: {e}")
 
+        # Set IDLE_SLEEPING state BEFORE the disconnect side effect, so
+        # ``disconnect()``'s "from CONNECTED → DEAD" fallback (for callers
+        # that didn't declare intent) doesn't override the idle-sleep intent.
+        # This matches the state machine's grant-time-mutation invariant
+        # (transport_state.py §6): observers see "we're idle-sleeping" as
+        # soon as the intent is declared, not after disconnect completes.
+        # The watchdog's #348 resurrection-skip check reads ``is_idle_sleeping``
+        # which derives from this state.
+        self._state_machine._state = SessionState.IDLE_SLEEPING
         # Disconnect but preserve session ID for resume
         await self.disconnect()
-        # Mark as deliberately sleeping so the heartbeat watchdog won't try to
-        # resurrect us — the next genuine wake (connect()) will clear this.
-        # See issue #348.
-        self._idle_sleeping = True
         self._stats["auto_restarts"] += 1
         _log(f"streaming[{self.agent_name}]: idle sleep complete — session preserved for resume")
         return True
@@ -1039,18 +1075,31 @@ class StreamingSession:
     async def attempt_reconnect(self) -> None:
         """Attempt to reconnect after a failure with bounded retries.
 
-        Tries up to len(_RECONNECT_BACKOFF) times with escalating delays. If all
-        attempts fail the session is left disconnected (`_connected=False`) and
-        the scheduler's heartbeat watchdog is responsible for any further
-        resurrection — see scheduler._check_heartbeats and the heartbeat_callback
-        wiring in api.py. Public method: callable from inside the reader loop
-        (transient transport failure) and from the watchdog callback.
+        Tries up to len(_RECONNECT_BACKOFF) times with escalating delays. If
+        all attempts fail the session settles in DEAD (the universal emergency
+        exit per transport_state.py docstring) and the scheduler's heartbeat
+        watchdog is responsible for any further resurrection — see
+        scheduler._check_heartbeats and the heartbeat_callback wiring in
+        api.py (BROKER / SCHEDULER triggers drive DEAD → RECONNECTING).
+        Public method: callable from inside the reader loop (transient
+        transport failure) and from the watchdog callback.
         """
+        # Settle the macro state: RECONNECTING for the duration of all retry
+        # attempts (transport_state.py §5 — no flicker DEAD ↔ RECONNECTING
+        # between attempts). The reader-loop exception path already drove us
+        # here; we re-assert idempotently for callers that bypassed that path
+        # (e.g. session_watchdog calling attempt_reconnect directly).
+        self._state_machine._state = SessionState.RECONNECTING
+
         # Disconnect once up front so we start each attempt from a clean state.
         try:
             await self.disconnect()
         except Exception as e:
             _log(f"streaming[{self.agent_name}]: pre-reconnect disconnect raised: {e}")
+        # disconnect()'s no-prior-intent fallback would normally drive
+        # CONNECTED → DEAD; re-assert RECONNECTING after teardown so the
+        # state reflects the in-flight retry, not a terminal failure.
+        self._state_machine._state = SessionState.RECONNECTING
 
         last_error: Exception | None = None
         for attempt_idx, delay in enumerate(self._RECONNECT_BACKOFF, start=1):
@@ -1077,16 +1126,37 @@ class StreamingSession:
                 except Exception:
                     pass
 
-        self._connected = False
+        # All retries exhausted — settle in DEAD. Watchdog resurrection on
+        # the next inbound message can drive DEAD → RECONNECTING via BROKER
+        # (broker auto-wake) or SCHEDULER (heartbeat resurrect).
+        self._state_machine._state = SessionState.DEAD
         _log(
             f"streaming[{self.agent_name}]: all {len(self._RECONNECT_BACKOFF)} reconnect "
-            f"attempts failed (last error: {last_error}); session left disconnected — "
+            f"attempts failed (last error: {last_error}); session settled in DEAD — "
             f"awaiting watchdog resurrection"
         )
 
     async def disconnect(self) -> None:
-        """Disconnect from Claude Code."""
-        self._connected = False
+        """Tear down the SDK client. Side-effect runner per Transport docstring.
+
+        Does NOT touch the state machine UNLESS the caller has not declared
+        a higher-level intent (no in-flight transition AND state is CONNECTED).
+        In that case ``disconnect()`` drives CONNECTED → DEAD as the default
+        terminal shutdown — matches the pre-state-machine semantics for
+        external callers that just call ``disconnect()`` without setting up
+        a lifecycle intent.
+
+        Callers with intent (``idle_sleep`` driving → IDLE_SLEEPING,
+        ``force_restart`` / ``attempt_reconnect`` driving → RECONNECTING) set
+        the target state BEFORE invoking ``disconnect()``, so this
+        no-prior-intent fallback doesn't fire.
+        """
+        if (
+            self._state_machine.state == SessionState.CONNECTED
+            and self._state_machine._in_flight is None
+        ):
+            # Standalone disconnect with no caller-declared intent → terminal.
+            self._state_machine._state = SessionState.DEAD
         self._analytics_session_ended()
         if self._reader_task and not self._reader_task.done():
             self._reader_task.cancel()
@@ -1280,23 +1350,47 @@ class StreamingSession:
         _log(f"streaming[{self.agent_name}]: effort override cleared")
 
     @property
+    def state(self) -> SessionState:
+        """Current lifecycle state. Source of truth for ``is_connected`` and
+        ``is_idle_sleeping`` below.
+
+        New code (post-PR4) should branch on this directly; the bool shims
+        are kept for the migration window so the four existing readers
+        (broker, api, scheduler, watchdog) don't need to be touched in the
+        same PR that adopts the protocol.
+        """
+        return self._state_machine.state
+
+    @property
     def is_connected(self) -> bool:
-        return self._connected
+        """Legacy shim: ``state == SessionState.CONNECTED``. Preserved during
+        the PR3 migration window so external readers see unchanged semantics.
+        PR4 deletes this and migrates readers to consult ``state`` directly.
+        """
+        return self._state_machine.state == SessionState.CONNECTED
 
     @property
     def is_idle_sleeping(self) -> bool:
-        """True when the session was disconnected by idle_sleep() and not yet
-        re-woken. The watchdog resurrection callback uses this to avoid
-        reconnecting a session that was deliberately put to sleep — see #348.
+        """Legacy shim: ``state == SessionState.IDLE_SLEEPING``. The watchdog
+        resurrection callback (api._heartbeat_resurrect) uses this to avoid
+        reconnecting a session that was deliberately put to sleep — see
+        issue #348. Derivation through the state machine preserves the
+        original contract.
         """
-        return self._idle_sleeping
+        return self._state_machine.state == SessionState.IDLE_SLEEPING
 
     @property
     def stats(self) -> dict:
+        state = self._state_machine.state
         return {
             **self._stats,
-            "connected": self._connected,
-            "idle_sleeping": self._idle_sleeping,
+            "connected": state == SessionState.CONNECTED,
+            "idle_sleeping": state == SessionState.IDLE_SLEEPING,
+            # PR3 exposes the state-machine value alongside the legacy bools
+            # so dashboards / debug tools can read the explicit five-state
+            # enum without waiting for PR4's reader migration. Stringified
+            # for JSON compatibility.
+            "state": state.value,
             "pending_responses": len(self._pending_chats),
             "current_activity": self._current_activity,
             "current_thinking": self._current_thinking,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -170,9 +170,11 @@ class TestStreamingSession:
     @pytest.mark.asyncio
     async def test_failed_send_clears_pending_route(self):
         from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
+        from pinky_daemon.transport_state import SessionState
 
         session = StreamingSession(StreamingSessionConfig(agent_name="test-agent"))
-        session._connected = True
+        # PR3 (#486): is_connected derives from state machine state.
+        session._state_machine._state = SessionState.CONNECTED
 
         class FailingClient:
             async def query(self, prompt):
@@ -254,7 +256,8 @@ class TestStreamingSession:
             StreamingSessionConfig(agent_name="test-agent"),
             response_callback=callback,
         )
-        session._connected = True
+        from pinky_daemon.transport_state import SessionState
+        session._state_machine._state = SessionState.CONNECTED
         session._pending_chats.append(("telegram", "chat-1", "msg-1"))
 
         class FakeClient:
@@ -299,7 +302,8 @@ class TestStreamingSession:
                 },
             )
         )
-        session._connected = True
+        from pinky_daemon.transport_state import SessionState
+        session._state_machine._state = SessionState.CONNECTED
         session._client = client
         session.disconnect = AsyncMock()
         session.connect = AsyncMock()
@@ -586,7 +590,9 @@ class TestAPI:
         sent_prompts = []
 
         async def fake_connect(self):
-            self._connected = True
+            # PR3 (#486): is_connected derives from state machine state.
+            from pinky_daemon.transport_state import SessionState
+            self._state_machine._state = SessionState.CONNECTED
             if not self.session_id:
                 self.session_id = f"{self.agent_name}-sdk"
             if self._on_session_id:
@@ -614,7 +620,9 @@ class TestAPI:
 
     def test_wake_uses_streaming_session_for_claude_runtime(self):
         async def fake_connect(self):
-            self._connected = True
+            # PR3 (#486): is_connected derives from state machine state.
+            from pinky_daemon.transport_state import SessionState
+            self._state_machine._state = SessionState.CONNECTED
 
         async def fake_send(self, prompt: str, platform: str = "", chat_id: str = ""):
             del prompt, platform, chat_id
@@ -635,6 +643,9 @@ class TestAPI:
 
     def test_wake_uses_codex_session_for_codex_runtime(self):
         async def fake_connect(self):
+            # CodexSession (not StreamingSession) — still uses the plain
+            # _connected bool. PR3's state-machine routing is scoped to
+            # StreamingSession; CodexSession adoption is a separate PR.
             self._connected = True
             self.session_id = self.session_id or f"{self.agent_name}-codex"
             if self._on_session_id:
@@ -851,7 +862,9 @@ class TestAPI:
 
     def test_wake_streaming_session_defaults_include_outreach_tools(self):
         async def fake_connect(self):
-            self._connected = True
+            # PR3 (#486): is_connected derives from state machine state.
+            from pinky_daemon.transport_state import SessionState
+            self._state_machine._state = SessionState.CONNECTED
 
         with tempfile.TemporaryDirectory() as tmpdir, \
                 patch("pinky_daemon.streaming_session.StreamingSession.connect", new=fake_connect):
@@ -870,7 +883,9 @@ class TestAPI:
 
     def test_wake_streaming_session_preserves_agent_allowed_tools(self):
         async def fake_connect(self):
-            self._connected = True
+            # PR3 (#486): is_connected derives from state machine state.
+            from pinky_daemon.transport_state import SessionState
+            self._state_machine._state = SessionState.CONNECTED
 
         with tempfile.TemporaryDirectory() as tmpdir, \
                 patch("pinky_daemon.streaming_session.StreamingSession.connect", new=fake_connect):
@@ -894,7 +909,9 @@ class TestAPI:
 
     def test_manual_streaming_session_persists_and_restores_labels(self):
         async def fake_connect(self):
-            self._connected = True
+            # PR3 (#486): is_connected derives from state machine state.
+            from pinky_daemon.transport_state import SessionState
+            self._state_machine._state = SessionState.CONNECTED
             if not self.session_id:
                 self.session_id = f"{self.agent_name}-sdk"
             if self._on_session_id:

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -457,6 +457,98 @@ async def test_disconnect_preserves_idle_sleeping_intent() -> None:
 
 
 @pytest.mark.asyncio
+async def test_disconnect_preserves_reconnecting_intent() -> None:
+    """Symmetric to test_disconnect_preserves_idle_sleeping_intent. When
+    force_restart() / attempt_reconnect() has already set state to
+    RECONNECTING, the inner disconnect() call must NOT override it back
+    to DEAD — otherwise observers see the macro-state flicker mid-restart
+    (Bug 1 + Bug 2 from @pushok on PR #491 review).
+
+    This pins the contract that would catch a regression of either bug
+    even if force_restart() or attempt_reconnect() forgot to pre-assert
+    RECONNECTING.
+    """
+    ss = _make_session(state=SessionState.CONNECTED)
+    ss._state_machine._state = SessionState.RECONNECTING
+    await ss.disconnect()
+    assert ss.state == SessionState.RECONNECTING, (
+        "disconnect() must respect prior RECONNECTING intent — only fires "
+        "the DEAD fallback when called from CONNECTED"
+    )
+
+
+@pytest.mark.asyncio
+async def test_attempt_reconnect_holds_reconnecting_through_partial_success_retry() -> None:
+    """Regression for @pushok's PR #491 round-1 finding (Bug 2).
+
+    Before the fix, ``attempt_reconnect()``'s retry-on-failure branch flickered
+    state to DEAD between attempts. The scenario: ``connect()`` sets
+    state=CONNECTED *before* its post-connect setup (analytics, reader-loop
+    spawn); a raise during that setup leaves state=CONNECTED at the moment
+    the retry except-block calls the inner ``disconnect()``, which fires the
+    standalone-from-CONNECTED → DEAD fallback. After the inner disconnect
+    runs the macro-state is DEAD instead of RECONNECTING — contradicts the
+    "no flicker DEAD↔RECONNECTING" invariant (transport_state.py §5).
+
+    The fix re-asserts RECONNECTING after the inner disconnect. This test
+    pins it by observing state between the failed connect and the next
+    backoff sleep — must see RECONNECTING.
+    """
+    cfg = StreamingSessionConfig(
+        agent_name="test",
+        context_warn_pct=40,
+        context_restart_pct=80,
+    )
+    ss = StreamingSession(cfg)
+    ss._state_machine._state = SessionState.CONNECTED
+    # Skip the backoff sleeps entirely — we're testing state choreography.
+    ss._RECONNECT_BACKOFF = (0, 0, 0)  # type: ignore[assignment]
+
+    states_observed: list[SessionState] = []
+    connect_calls = 0
+
+    async def fake_disconnect() -> None:
+        # No teardown side effects; just observe state at the boundary.
+        pass
+
+    async def fake_connect() -> None:
+        # Simulate the Bug 2 trajectory: flip CONNECTED first, then raise.
+        # In production this is connect()'s post-handshake setup raising
+        # (analytics open, reader_loop spawn, account-info fetch, etc.).
+        nonlocal connect_calls
+        connect_calls += 1
+        ss._state_machine._state = SessionState.CONNECTED
+        # Capture state BEFORE the raise so we know we hit the partial-success
+        # window.
+        states_observed.append(("after_partial_connect", ss.state))
+        if connect_calls <= 2:
+            raise RuntimeError(f"simulated post-handshake setup failure #{connect_calls}")
+
+    ss.disconnect = fake_disconnect  # type: ignore[assignment]
+    ss.connect = fake_connect  # type: ignore[assignment]
+
+    # Pre-condition: state CONNECTED (so the initial disconnect-fallback could
+    # fire if attempt_reconnect didn't pre-assert RECONNECTING).
+    await ss.attempt_reconnect()
+
+    # 3 connect() calls: 2 raise (retries 1+2), 3rd succeeds.
+    assert connect_calls == 3
+    # Final state CONNECTED.
+    assert ss.state == SessionState.CONNECTED
+    # The partial-success observations all show CONNECTED — that's expected
+    # at that point in the trajectory (we observed BEFORE the raise).
+    # The real check: between retries, the state-machine never sat in DEAD.
+    # If Bug 2 regressed, attempt_reconnect's exception path would have
+    # left us in DEAD after the inner disconnect, the next loop iteration
+    # would try connect() from DEAD, succeed, and the final assertion
+    # above would still pass. So we need an in-loop observer too:
+    # the test_disconnect_preserves_reconnecting_intent test pins the
+    # boundary check (disconnect from RECONNECTING stays RECONNECTING),
+    # and the re-assert in attempt_reconnect's except block is what makes
+    # the retry boundary honor it.
+
+
+@pytest.mark.asyncio
 async def test_force_restart_holds_reconnecting_across_disconnect_and_connect() -> None:
     """Regression for @murzik's PR #491 round-1 finding.
 

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -12,12 +12,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
+from pinky_daemon.transport_state import SessionState
 
 
 def _make_session(
     *,
     warn_pct: int = 40,
     restart_pct: int = 80,
+    state: SessionState = SessionState.CONNECTED,
 ) -> StreamingSession:
     cfg = StreamingSessionConfig(
         agent_name="test",
@@ -25,7 +27,12 @@ def _make_session(
         context_restart_pct=restart_pct,
     )
     ss = StreamingSession(cfg)
-    ss._connected = True
+    # PR3 (#486 sequence): is_connected derives from state machine state.
+    # Tests that need a connected session bypass the lock + side effects and
+    # set ``_state`` directly — production code routes through the state
+    # machine, but unit tests of internal behavior don't need the
+    # request_transition/transition_complete dance.
+    ss._state_machine._state = state
     ss._client = MagicMock()
     ss._client.query = AsyncMock()
     # Stub force_restart so tests don't need a real connect loop
@@ -146,32 +153,24 @@ async def test_idle_sleep_sets_is_idle_sleeping_flag() -> None:
 
 @pytest.mark.asyncio
 async def test_connect_clears_is_idle_sleeping_flag() -> None:
-    """A successful connect() (genuine wake) must clear is_idle_sleeping."""
-    ss = _make_session()
-    # Simulate a session that just slept
-    ss._idle_sleeping = True
-    ss._connected = False
+    """A successful connect() (genuine wake) must drive state CONNECTED,
+    which by derivation flips is_connected=True and is_idle_sleeping=False
+    in a single state-machine settle."""
+    ss = _make_session(state=SessionState.IDLE_SLEEPING)
+    assert ss.is_idle_sleeping is True
+    assert ss.is_connected is False
 
-    # Patch the actual SDK connect path: connect() builds a ClaudeSDKClient,
-    # calls .connect(), then sets _connected=True and clears _idle_sleeping.
-    # We bypass the SDK by directly exercising the post-connect state via the
-    # public path: set the flag the way connect() does at the relevant point.
-    #
-    # Rather than monkey-patching the SDK import, we assert the contract that
-    # any code path which sets _connected=True via connect() also clears the
-    # flag. The simpler hermetic test: invoke idle_sleep then verify a manual
-    # connect-equivalent (the lines in connect() that set/clear) behaves.
-    #
-    # Direct exercise: call attempt_reconnect with a stubbed connect.
+    # Patch SDK connect path: stub the line where connect() drives state to
+    # CONNECTED. Tests don't run the real SDK.
     async def fake_connect() -> None:
-        ss._connected = True
-        ss._idle_sleeping = False
+        ss._state_machine._state = SessionState.CONNECTED
 
     ss.connect = fake_connect  # type: ignore[assignment]
     await ss.connect()
 
     assert ss.is_connected is True
     assert ss.is_idle_sleeping is False
+    assert ss.state == SessionState.CONNECTED
 
 
 @pytest.mark.asyncio
@@ -192,16 +191,16 @@ async def test_disconnect_alone_does_not_set_idle_sleeping() -> None:
 
 @pytest.mark.asyncio
 async def test_idle_sleep_returns_false_when_already_disconnected() -> None:
-    """idle_sleep() bails early if already disconnected and must not set the
-    flag in that case (no state transition occurred)."""
-    ss = _make_session()
-    ss._connected = False
+    """idle_sleep() bails early if already disconnected and must not drive
+    state into IDLE_SLEEPING in that case (no transition occurred)."""
+    ss = _make_session(state=SessionState.DEAD)
     ss._client = None
 
     result = await ss.idle_sleep()
 
     assert result is False
     assert ss.is_idle_sleeping is False
+    assert ss.state == SessionState.DEAD
 
 
 # -- Auth-failure dedupe across AssistantMessage + ResultMessage paths --------
@@ -349,6 +348,129 @@ async def test_auth_dedupe_resets_between_turns() -> None:
     assert callback.await_count == 2, (
         f"Expected two callbacks (one per failed turn); got {callback.await_count}"
     )
+
+
+# -- Transport protocol adoption (#486 PR3) -----------------------------------
+#
+# PR3 replaces the implicit (is_connected, is_idle_sleeping) two-bool inference
+# with a SessionState enum routed through an embedded StateMachine. The shims
+# below pin down:
+#   - StreamingSession structurally satisfies the Transport Protocol
+#   - state starts UNINITIALIZED
+#   - is_connected and is_idle_sleeping derive from state, not from removed
+#     `_connected` / `_idle_sleeping` attributes
+#   - lifecycle methods leave the state machine in the expected SessionState
+#   - the stats dict exposes the explicit `state` value alongside the legacy
+#     bool shims
+
+
+def test_streaming_session_satisfies_transport_protocol() -> None:
+    """StreamingSession structurally implements the Transport Protocol from
+    src/pinky_daemon/transport.py. Runtime isinstance check is a smoke test;
+    the real enforcement is type-check time via the Protocol declaration."""
+    from pinky_daemon.transport import Transport
+
+    cfg = StreamingSessionConfig(agent_name="test")
+    ss = StreamingSession(cfg)
+    assert isinstance(ss, Transport), (
+        "StreamingSession must structurally satisfy the Transport Protocol — "
+        "missing attributes or properties would surface here"
+    )
+
+
+def test_state_starts_uninitialized() -> None:
+    """Fresh StreamingSession starts UNINITIALIZED — distinguishes 'never
+    tried to connect' from 'tried and DEAD' per transport_state.py."""
+    cfg = StreamingSessionConfig(agent_name="test")
+    ss = StreamingSession(cfg)
+    assert ss.state == SessionState.UNINITIALIZED
+    assert ss.is_connected is False
+    assert ss.is_idle_sleeping is False
+
+
+def test_is_connected_derives_from_state() -> None:
+    """The is_connected shim is True iff state == CONNECTED."""
+    ss = _make_session(state=SessionState.CONNECTED)
+    assert ss.is_connected is True
+
+    for other in (
+        SessionState.UNINITIALIZED,
+        SessionState.RECONNECTING,
+        SessionState.IDLE_SLEEPING,
+        SessionState.DEAD,
+    ):
+        ss._state_machine._state = other
+        assert ss.is_connected is False, f"is_connected wrong for state={other}"
+
+
+def test_is_idle_sleeping_derives_from_state() -> None:
+    """The is_idle_sleeping shim is True iff state == IDLE_SLEEPING."""
+    ss = _make_session(state=SessionState.IDLE_SLEEPING)
+    assert ss.is_idle_sleeping is True
+
+    for other in (
+        SessionState.UNINITIALIZED,
+        SessionState.RECONNECTING,
+        SessionState.CONNECTED,
+        SessionState.DEAD,
+    ):
+        ss._state_machine._state = other
+        assert ss.is_idle_sleeping is False, (
+            f"is_idle_sleeping wrong for state={other}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_idle_sleep_drives_state_to_idle_sleeping() -> None:
+    """idle_sleep() must leave the state machine in IDLE_SLEEPING (not DEAD).
+    Critical for the #348 watchdog-resurrection-skip contract."""
+    ss = _make_session(state=SessionState.CONNECTED)
+    result = await ss.idle_sleep()
+    assert result is True
+    assert ss.state == SessionState.IDLE_SLEEPING
+
+
+@pytest.mark.asyncio
+async def test_disconnect_from_connected_drives_state_to_dead() -> None:
+    """Standalone disconnect() with no caller-declared intent drives
+    CONNECTED → DEAD as terminal shutdown (matches pre-state-machine
+    behavior for callers that just call disconnect())."""
+    ss = _make_session(state=SessionState.CONNECTED)
+    await ss.disconnect()
+    assert ss.state == SessionState.DEAD
+
+
+@pytest.mark.asyncio
+async def test_disconnect_preserves_idle_sleeping_intent() -> None:
+    """When idle_sleep() has already set state to IDLE_SLEEPING, the
+    inner disconnect() call must NOT override it back to DEAD."""
+    ss = _make_session(state=SessionState.CONNECTED)
+    # Simulate idle_sleep's pre-disconnect state mutation directly so we
+    # can isolate disconnect's behavior. (test_idle_sleep_drives_state_to_idle_sleeping
+    # covers the integrated flow.)
+    ss._state_machine._state = SessionState.IDLE_SLEEPING
+    await ss.disconnect()
+    assert ss.state == SessionState.IDLE_SLEEPING, (
+        "disconnect() must respect prior IDLE_SLEEPING intent — only fires "
+        "the DEAD fallback when called from CONNECTED"
+    )
+
+
+def test_stats_exposes_state_alongside_legacy_bools() -> None:
+    """The stats dict must include the explicit 5-state value AND the legacy
+    bool shims, so dashboards / debug tools can read either while the four
+    external readers migrate in PR4."""
+    ss = _make_session(state=SessionState.CONNECTED)
+    stats = ss.stats
+    assert stats["state"] == "connected"
+    assert stats["connected"] is True
+    assert stats["idle_sleeping"] is False
+
+    ss._state_machine._state = SessionState.IDLE_SLEEPING
+    stats = ss.stats
+    assert stats["state"] == "idle_sleeping"
+    assert stats["connected"] is False
+    assert stats["idle_sleeping"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -456,6 +456,64 @@ async def test_disconnect_preserves_idle_sleeping_intent() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_force_restart_holds_reconnecting_across_disconnect_and_connect() -> None:
+    """Regression for @murzik's PR #491 round-1 finding.
+
+    Before the fix, ``force_restart()`` called ``disconnect()`` while state was
+    still CONNECTED. ``disconnect()``'s no-prior-intent fallback then drove
+    state to DEAD, and observers (broker auto-wake, watchdog resurrect) would
+    see DEAD during the wake-context-refresh window and at ``connect()``
+    entry — racing the in-flight force_restart.
+
+    The fix sets RECONNECTING before disconnect and re-asserts after. This
+    test pins the contract by observing state at three points: after
+    ``disconnect()`` returns, inside the fake ``connect()`` (mid-restart),
+    and after ``connect()`` settles.
+    """
+    cfg = StreamingSessionConfig(
+        agent_name="test",
+        context_warn_pct=40,
+        context_restart_pct=80,
+    )
+    ss = StreamingSession(cfg)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._client = MagicMock()
+
+    observed_states: list[SessionState] = []
+
+    async def fake_disconnect() -> None:
+        # disconnect must NOT settle in DEAD when force_restart pre-set
+        # RECONNECTING. Capture state at the boundary.
+        observed_states.append(("after_intent_before_disconnect", ss.state))
+        # No-op teardown — we're testing the state choreography, not SDK.
+
+    async def fake_connect() -> None:
+        # connect must see RECONNECTING at entry, not DEAD.
+        observed_states.append(("connect_entry", ss.state))
+        ss._state_machine._state = SessionState.CONNECTED
+        observed_states.append(("connect_exit", ss.state))
+
+    ss.disconnect = fake_disconnect  # type: ignore[assignment]
+    ss.connect = fake_connect  # type: ignore[assignment]
+
+    restarted = await ss.force_restart()
+    assert restarted is True
+
+    # State must be RECONNECTING at every observation point between the
+    # intent declaration and connect() settling.
+    state_at_disconnect = dict(observed_states)["after_intent_before_disconnect"]
+    state_at_connect_entry = dict(observed_states)["connect_entry"]
+    assert state_at_disconnect == SessionState.RECONNECTING, (
+        f"state at disconnect boundary must be RECONNECTING, got {state_at_disconnect}"
+    )
+    assert state_at_connect_entry == SessionState.RECONNECTING, (
+        f"state at connect() entry must be RECONNECTING (not DEAD), "
+        f"got {state_at_connect_entry}"
+    )
+    assert ss.state == SessionState.CONNECTED
+
+
 def test_stats_exposes_state_alongside_legacy_bools() -> None:
     """The stats dict must include the explicit 5-state value AND the legacy
     bool shims, so dashboards / debug tools can read either while the four

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -504,27 +504,33 @@ async def test_attempt_reconnect_holds_reconnecting_through_partial_success_retr
     # Skip the backoff sleeps entirely — we're testing state choreography.
     ss._RECONNECT_BACKOFF = (0, 0, 0)  # type: ignore[assignment]
 
-    states_observed: list[SessionState] = []
+    # CRITICAL: do NOT stub disconnect(). The real disconnect()'s
+    # standalone-from-CONNECTED → DEAD fallback IS the bug path. We need
+    # it to fire on each retry's inner-disconnect call so the test
+    # actually exercises whether attempt_reconnect's reassert restores
+    # RECONNECTING — without using the real fallback, the test would
+    # green even with the reassert removed (per @murzik PR #491 round-2).
+    # Real disconnect() is safe on an unconfigured session: _client,
+    # _reader_task, _analytics_store all None → no-op side effects.
+    connect_call_entry_states: list[SessionState] = []
     connect_calls = 0
 
-    async def fake_disconnect() -> None:
-        # No teardown side effects; just observe state at the boundary.
-        pass
-
     async def fake_connect() -> None:
+        # Capture state AT ENTRY — this is the load-bearing observation.
+        # On retry-after-failure iterations, if attempt_reconnect's
+        # except-block reassert is missing, entry state will be DEAD
+        # (left over from the inner disconnect's CONNECTED → DEAD
+        # fallback). With the reassert, entry state stays RECONNECTING.
+        nonlocal connect_calls
+        connect_calls += 1
+        connect_call_entry_states.append(ss.state)
         # Simulate the Bug 2 trajectory: flip CONNECTED first, then raise.
         # In production this is connect()'s post-handshake setup raising
         # (analytics open, reader_loop spawn, account-info fetch, etc.).
-        nonlocal connect_calls
-        connect_calls += 1
         ss._state_machine._state = SessionState.CONNECTED
-        # Capture state BEFORE the raise so we know we hit the partial-success
-        # window.
-        states_observed.append(("after_partial_connect", ss.state))
         if connect_calls <= 2:
             raise RuntimeError(f"simulated post-handshake setup failure #{connect_calls}")
 
-    ss.disconnect = fake_disconnect  # type: ignore[assignment]
     ss.connect = fake_connect  # type: ignore[assignment]
 
     # Pre-condition: state CONNECTED (so the initial disconnect-fallback could
@@ -535,17 +541,21 @@ async def test_attempt_reconnect_holds_reconnecting_through_partial_success_retr
     assert connect_calls == 3
     # Final state CONNECTED.
     assert ss.state == SessionState.CONNECTED
-    # The partial-success observations all show CONNECTED — that's expected
-    # at that point in the trajectory (we observed BEFORE the raise).
-    # The real check: between retries, the state-machine never sat in DEAD.
-    # If Bug 2 regressed, attempt_reconnect's exception path would have
-    # left us in DEAD after the inner disconnect, the next loop iteration
-    # would try connect() from DEAD, succeed, and the final assertion
-    # above would still pass. So we need an in-loop observer too:
-    # the test_disconnect_preserves_reconnecting_intent test pins the
-    # boundary check (disconnect from RECONNECTING stays RECONNECTING),
-    # and the re-assert in attempt_reconnect's except block is what makes
-    # the retry boundary honor it.
+    # The load-bearing assertion: each connect() entry must see
+    # RECONNECTING, never DEAD. If the reassert in attempt_reconnect's
+    # except-block were removed, calls 2 and 3 would enter from DEAD
+    # (after the real disconnect()'s CONNECTED → DEAD fallback fires
+    # on the partial-success teardown). This pins the "no flicker
+    # DEAD ↔ RECONNECTING between retries" invariant structurally.
+    assert connect_call_entry_states == [
+        SessionState.RECONNECTING,
+        SessionState.RECONNECTING,
+        SessionState.RECONNECTING,
+    ], (
+        f"connect() entry states must all be RECONNECTING, got "
+        f"{connect_call_entry_states}. If DEAD appears in calls 2+, the "
+        f"attempt_reconnect except-block reassert regressed."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

PR3 of the [#486 sequence](https://github.com/bradbrok/PinkyBot/issues/486). Read-path refactor: \`is_connected\` and \`is_idle_sleeping\` now derive from an embedded \`StateMachine\`'s \`SessionState\` instead of independently-mutable bool flags. A new \`state\` property exposes the explicit 5-state enum directly for post-PR4 consumers.

After this PR, \`isinstance(ss, Transport)\` returns True — \`StreamingSession\` structurally satisfies the Protocol that landed in #488 (verified by a regression test).

## Scope: read path only — parallel with current agent config

State-write code points still mutate \`self._state_machine._state\` directly at the same places where \`_connected\` / \`_idle_sleeping\` were mutated before. This keeps PR3 **parallel with the current agent config** per Brad's directive (2026-05-13 18:21 PDT) — no breaking changes for the four external readers (broker, api, scheduler, watchdog) which continue to consume \`is_connected\` / \`is_idle_sleeping\` exactly as today. The formal \`request_transition\` / \`transition_complete\` API with proper \`Trigger\` declaration, the bool-shim deletion, and the \`session_id\` → \`resume_handle\` rename (@murzik on #488 review) are all PR4 work.

This means **no agent restart is required** for this change; an in-flight agent picks up state-machine derivation transparently when the daemon next loads streaming_session.py.

## Lifecycle method routing

| Method | Before | After |
|---|---|---|
| \`connect()\` | sets \`_connected=True\`, clears \`_idle_sleeping\` | drives state machine to \`CONNECTED\` |
| \`disconnect()\` | sets \`_connected=False\` unconditionally | side-effect runner: drives \`CONNECTED→DEAD\` only when no caller has prior intent (no in-flight + state==CONNECTED). Callers with intent set the target first. |
| \`idle_sleep()\` | post-disconnect sets \`_idle_sleeping=True\` | **pre-**disconnect drives state to \`IDLE_SLEEPING\` (matches state-machine grant-time-mutation invariant §6). Watchdog #348 resurrection-skip sees the intent immediately. |
| \`force_restart()\` | sets \`_connected=False\` on connect failure | settles in \`DEAD\` on irrecoverable failure (universal emergency exit). |
| \`attempt_reconnect()\` | bounded retries; sets \`_connected=False\` on exhaustion | asserts \`RECONNECTING\` for the duration of all retry attempts (transport_state.py §5 — no flicker DEAD↔RECONNECTING), settles in \`DEAD\` on retry exhaustion. |
| reader-loop exception | sets \`_connected=False\` | drives \`RECONNECTING\` so observers see intent immediately (matches broker's wait-for-reconnect from PR #484). |

## Stats dict

Adds an explicit \`state\` field (stringified enum value: \`\"uninitialized\"\` / \`\"reconnecting\"\` / \`\"connected\"\` / \`\"idle_sleeping\"\` / \`\"dead\"\`) alongside the legacy \`connected\` / \`idle_sleeping\` bools. Dashboards and debug tools can read either while PR4's reader migration is in flight.

## Test changes

- \`tests/test_streaming_session.py\`:
  - Existing 13 tests updated to drive state via \`ss._state_machine._state = SessionState.X\` instead of the removed \`_connected\` / \`_idle_sleeping\` attributes. The unit-test bypass of the state-machine async lock is intentional and documented.
  - 9 new tests pin:
    - Transport-Protocol \`isinstance\` regression
    - \`UNINITIALIZED\` start state
    - \`is_connected\` derivation across all 5 states (parametric)
    - \`is_idle_sleeping\` derivation across all 5 states (parametric)
    - \`idle_sleep\` drives state to \`IDLE_SLEEPING\`
    - Standalone \`disconnect\` drives state to \`DEAD\`
    - \`disconnect\` preserves prior \`IDLE_SLEEPING\` intent
    - \`stats\` exposes state alongside legacy bools
- \`tests/test_api.py\`: 3 direct-mutation sites and 5 \`fake_connect\` patches updated to use the state-machine path; the \`CodexSession\` \`fake_connect\` (separate class, not state-machine-adopted yet) is kept as-is with an explanatory comment.

## Migration plan reminder (out of scope)

- **PR4** — Bool-shim deletion + reader migration. The four external readers (broker.py, api.py, scheduler.py, routes/calendar.py) migrate to \`state == SessionState.X\` consults. \`session_id\` → \`resume_handle\` rename + possible re-typing per @murzik on #488 review.
- **TmuxSession PR sequence** — drafts in parallel against the same Transport surface.
- **Dymok agent registration** — \`PINKYBOT_TRANSPORT=tmux\`. The tmux backend goes live without touching SDK fleet behavior.

## Test plan

- [x] \`pytest tests/test_streaming_session.py -q\` → 22 passed
- [x] \`pytest tests/test_api.py -q\` → 286 passed
- [x] Full sweep: \`pytest --ignore=test_voice_call --ignore=test_calendar\` → 2069 passed, 1 skipped
- [x] \`python -c \"isinstance(StreamingSession(...), Transport)\"\` → True
- [x] Ruff clean on touched files
- [ ] CI green
- [ ] Live verify post-merge: an existing agent (this one) keeps running with no restart required

🤖 Opened by Barsik