### PR TITLE
feat(transport): PR4 cleanup — delete bool shims, migrate readers to state

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -135,6 +135,12 @@ from pinky_daemon.shared_mcp import SHARED_MCP_HOST, SHARED_MCP_PORT, SharedMcpM
 from pinky_daemon.skill_loader import discover_all_skills, register_discovered_skills
 from pinky_daemon.skill_store import SkillStore
 from pinky_daemon.task_store import TaskStore
+
+# Alias: pinky_daemon.sessions.SessionState (imported above) is the
+# harness/agent-SDK lifecycle enum (running/closed); the import below is the
+# transport-layer lifecycle (CONNECTED/RECONNECTING/IDLE_SLEEPING/DEAD/
+# UNINITIALIZED) from transport_state.py. The alias avoids the name collision
+# while keeping both enums accessible.
 from pinky_daemon.transport_state import SessionState as TransportSessionState
 from pinky_daemon.trigger_store import TriggerStore
 
@@ -1995,12 +2001,42 @@ def create_api(
         return ss
 
     async def _ensure_streaming_session(agent_name: str, *, label: str = "main"):
-        """Return a connected streaming session for an agent label."""
+        """Return a connected streaming session for an agent label.
+
+        State-aware so RECONNECTING doesn't race an in-flight reconnect
+        with a second connect() (per @murzik PR #492 review). Branches:
+          - CONNECTED       → return as-is
+          - IDLE_SLEEPING   → connect() to wake
+          - RECONNECTING    → wait bounded for the in-flight reconnect to
+                              settle to CONNECTED; if it doesn't, return
+                              the session anyway and let the caller's own
+                              error handling kick in (matches the existing
+                              "not running" fallback shape downstream)
+          - DEAD / UNINITIALIZED → connect() (this is the auto-start /
+                              resurrection path; explicit and intentional)
+        """
         sessions = broker._streaming.get(agent_name, {})
         ss = sessions.get(label)
         if ss:
-            if ss.state != TransportSessionState.CONNECTED:
-                await ss.connect()
+            state = ss.state
+            if state == TransportSessionState.CONNECTED:
+                return ss
+            if state == TransportSessionState.RECONNECTING:
+                # Wait for the in-flight reconnect to land. Use the same
+                # bounded poll the broker uses on the inbound path so the
+                # waits stay consistent.
+                from pinky_daemon.broker import (
+                    _INBOUND_RECONNECT_POLL_SEC,
+                    _INBOUND_RECONNECT_WAIT_SEC,
+                )
+                deadline = time.monotonic() + _INBOUND_RECONNECT_WAIT_SEC
+                while time.monotonic() < deadline:
+                    await asyncio.sleep(_INBOUND_RECONNECT_POLL_SEC)
+                    if ss.state == TransportSessionState.CONNECTED:
+                        break
+                return ss
+            # IDLE_SLEEPING / DEAD / UNINITIALIZED → explicit connect()
+            await ss.connect()
             return ss
 
         resume_id = agents.get_streaming_session_id(agent_name, label=label)

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -135,6 +135,7 @@ from pinky_daemon.shared_mcp import SHARED_MCP_HOST, SHARED_MCP_PORT, SharedMcpM
 from pinky_daemon.skill_loader import discover_all_skills, register_discovered_skills
 from pinky_daemon.skill_store import SkillStore
 from pinky_daemon.task_store import TaskStore
+from pinky_daemon.transport_state import SessionState as TransportSessionState
 from pinky_daemon.trigger_store import TriggerStore
 
 # Feature flag: shared MCP mode uses a single HTTP/SSE server instead of per-agent stdio
@@ -1717,7 +1718,7 @@ def create_api(
         Uses a cache to avoid blocking callers when the SDK is busy.
         Returns cached data if a fresh fetch times out.
         """
-        if not ss or not ss.is_connected:
+        if not ss or ss.state != TransportSessionState.CONNECTED:
             return {}
 
         sid = ss.session_id or getattr(ss, "id", "")
@@ -1782,13 +1783,13 @@ def create_api(
         pct = ctx.get("percentage", 0.0)
         return {
             "id": f"{agent_name}-{label}",
-            "state": "connected" if ss.is_connected else "idle",
+            "state": "connected" if ss.state == TransportSessionState.CONNECTED else "idle",
             "context_used_pct": pct,
             "message_count": ss._stats.get("messages_sent", 0) + ss._stats.get("turns", 0),
             "needs_restart": bool(ctx) and pct >= ss._config.context_restart_pct,
             "streaming": True,
             "label": label,
-            "connected": ss.is_connected,
+            "connected": ss.state == TransportSessionState.CONNECTED,
             "sdk_session_id": ss.session_id[:12] if ss.session_id else "",
         }
 
@@ -1998,7 +1999,7 @@ def create_api(
         sessions = broker._streaming.get(agent_name, {})
         ss = sessions.get(label)
         if ss:
-            if not ss.is_connected:
+            if ss.state != TransportSessionState.CONNECTED:
                 await ss.connect()
             return ss
 
@@ -5704,7 +5705,7 @@ def create_api(
         ss = broker._get_streaming_session(name)
         if not ss:
             raise HTTPException(404, f"No streaming session for '{name}'")
-        if not ss.is_connected or not ss._client:
+        if ss.state != TransportSessionState.CONNECTED or not ss._client:
             raise HTTPException(409, f"Streaming session for '{name}' not connected")
 
         # Check if context window would change
@@ -5782,7 +5783,7 @@ def create_api(
         ss = broker._get_streaming_session(name)
         if not ss:
             raise HTTPException(404, f"No streaming session for '{name}'")
-        if not ss.is_connected:
+        if ss.state != TransportSessionState.CONNECTED:
             raise HTTPException(409, f"Streaming session for '{name}' not connected")
 
         try:
@@ -5802,7 +5803,7 @@ def create_api(
         ss = broker._get_streaming_session(name)
         if not ss:
             raise HTTPException(404, f"No streaming session for '{name}'")
-        if not ss.is_connected:
+        if ss.state != TransportSessionState.CONNECTED:
             raise HTTPException(409, f"Streaming session for '{name}' not connected")
 
         guard = _get_streaming_restart_guard(name, ss)
@@ -5876,7 +5877,7 @@ def create_api(
         return {
             "agent": name,
             "session_id": ss.session_id[:12] if ss.session_id else "",
-            "connected": ss.is_connected,
+            "connected": ss.state == TransportSessionState.CONNECTED,
             "stats": ss.stats,
             "context": context_info,
             "saved_context": guard,
@@ -5934,7 +5935,7 @@ def create_api(
             "turns": ss._stats.get("turns", 0),
             "uptime_seconds": round(time.time() - ss.created_at),
             "provider": provider,
-            "connected": ss.is_connected,
+            "connected": ss.state == TransportSessionState.CONNECTED,
             "default_effort": default_effort,
             "session_effort": session_effort,
             "effective_effort": effective_effort,
@@ -5965,7 +5966,7 @@ def create_api(
             _log(f"api: agent message {req.from_agent} -> {name} — target offline, auto-waking")
             try:
                 streaming = await _ensure_streaming_session(name, label="main")
-                if streaming and streaming.is_connected:
+                if streaming and streaming.state == TransportSessionState.CONNECTED:
                     delivered = await broker.inject_agent_message(
                         req.from_agent, name, req.message,
                     )
@@ -6004,7 +6005,7 @@ def create_api(
         # Get streaming session by label — auto-wake if not connected
         sessions = broker._streaming.get(name, {})
         streaming = sessions.get(label)
-        if not streaming or not streaming.is_connected:
+        if not streaming or streaming.state != TransportSessionState.CONNECTED:
             _log(f"api: chat to '{name}' session '{label}' — not connected, auto-waking")
             streaming = await _ensure_streaming_session(name, label=label)
             if not streaming:
@@ -6553,7 +6554,7 @@ def create_api(
             "agent": agent_name,
             "session_id": ss.id,
             "sent": True,
-            "connected": ss.is_connected,
+            "connected": ss.state == TransportSessionState.CONNECTED,
         }
 
     async def _wake_callback(agent_name: str, session_id: str, prompt: str) -> None:
@@ -6585,7 +6586,7 @@ def create_api(
             main_name = agents.get_main_agent()
             if main_name and main_name != agent_name:
                 main_ss = broker._streaming.get(main_name, {}).get("main")
-                if main_ss and main_ss.is_connected:
+                if main_ss and main_ss.state == TransportSessionState.CONNECTED:
                     try:
                         await main_ss.send(
                             f"[SYSTEM ALERT] Dream run failed for agent '{agent_name}': {e}"
@@ -6612,7 +6613,7 @@ def create_api(
         Invoked by AgentScheduler._maybe_resurrect when an agent's heartbeat is
         currently marked dead. The save_my_context guard used by the public
         /streaming/restart endpoint is bypassed here — but only safely because
-        of the `is_connected` check below: if the underlying transport is still
+        of the `state == CONNECTED` check below: if the underlying transport is still
         live the callback bails out immediately and the public guarded path
         remains the only way to restart. We only ever drive a reconnect when the
         client is already disconnected, at which point there is no live session
@@ -6629,12 +6630,12 @@ def create_api(
                 f"session registered"
             )
             return
-        if getattr(ss, "is_connected", False):
+        if getattr(ss, "state", None) == TransportSessionState.CONNECTED:
             # Race: the in-process retry recovered between heartbeat tick and
             # the callback running. Also the load-bearing guard for bypassing
             # the save_my_context restart guard — see docstring above.
             return
-        if getattr(ss, "is_idle_sleeping", False):
+        if getattr(ss, "state", None) == TransportSessionState.IDLE_SLEEPING:
             # Session was deliberately disconnected by idle_sleep(). Resurrecting
             # it here would fight the idle-sleep state and cause an immediate
             # reconnect/sleep churn cycle. The next genuine wake (scheduler or
@@ -6667,7 +6668,7 @@ def create_api(
                         f"{ss.__class__.__name__} has no attempt_reconnect or connect"
                     )
                 await connect()
-            if getattr(ss, "is_connected", False):
+            if getattr(ss, "state", None) == TransportSessionState.CONNECTED:
                 activity.log(
                     agent_name, "watchdog_resurrect",
                     f"{agent_name} restored by heartbeat watchdog",
@@ -6686,7 +6687,7 @@ def create_api(
         ss = broker._get_streaming_session(agent_name)
         if not ss:
             return False  # nothing to resurrect
-        if getattr(ss, "is_idle_sleeping", False):
+        if getattr(ss, "state", None) == TransportSessionState.IDLE_SLEEPING:
             return False  # deliberately disconnected — leave it alone
         return True
 

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -776,13 +776,19 @@ class MessageBroker:
         """Route a message via streaming session — non-blocking."""
         streaming = self._get_streaming_session(agent_name, message.chat_id)
 
-        # Auto-wake: if session exists but is disconnected (idle sleep), reconnect
+        # Auto-wake: deliberate idle-sleep with a retained session_id can be
+        # woken in-line by calling connect(). Per @murzik on PR #492 review,
+        # we must NOT route RECONNECTING through connect() here — that would
+        # race the in-flight reconnect (force_restart or attempt_reconnect)
+        # and produce a double-connect. RECONNECTING falls through to the
+        # wait-for-reconnect block below instead. DEAD also falls through:
+        # resurrection is the scheduler/watchdog's job, not the broker's.
         if (
             streaming
-            and streaming.state != SessionState.CONNECTED
+            and streaming.state == SessionState.IDLE_SLEEPING
             and streaming.session_id
         ):
-            _log(f"broker: {agent_name} is sleeping — auto-waking for inbound message")
+            _log(f"broker: {agent_name} is idle-sleeping — auto-waking for inbound message")
             try:
                 await streaming.connect()
                 _log(f"broker: {agent_name} auto-woke successfully")
@@ -791,13 +797,14 @@ class MessageBroker:
                 streaming = None
 
         # Wait-for-reconnect: if the session object still exists but isn't
-        # connected, an in-flight reconnect or context_restart is most likely
-        # the cause (disconnect()→connect() runs in a separate task and briefly
-        # leaves state != CONNECTED, with ``session_id`` wiped to "" so the
-        # auto-wake branch above can't help). Poll for a bounded window before
-        # falling back to the user-visible "not running" error so the message
-        # gets delivered as soon as the new session comes up instead of being
-        # dropped. See _INBOUND_RECONNECT_WAIT_SEC.
+        # CONNECTED, an in-flight reconnect or context_restart is most likely
+        # the cause (RECONNECTING state). disconnect()→connect() runs in a
+        # separate task and briefly leaves state != CONNECTED, with
+        # ``session_id`` possibly wiped to "" so the auto-wake branch above
+        # cannot help. Poll for a bounded window before falling back to the
+        # user-visible "not running" error so the message gets delivered as
+        # soon as the new session comes up instead of being dropped.
+        # See _INBOUND_RECONNECT_WAIT_SEC.
         if streaming is not None and streaming.state != SessionState.CONNECTED:
             _log(
                 f"broker: {agent_name} session present but disconnected — "

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -20,10 +20,11 @@ import urllib.request
 from dataclasses import dataclass, field
 
 from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.transport_state import SessionState
 
 # Bounded wait for an in-flight reconnect/restart to complete before we drop an
 # inbound message. Covers the context_restart window where the streaming session
-# object exists but ``is_connected`` is briefly False between
+# object exists but ``state`` is briefly != CONNECTED between
 # ``disconnect()`` → ``connect()``. Without this, messages arriving during a
 # restart get silently dropped and the user sees the "not running" fallback
 # even though the session is about to come back up. See issue tracker bug
@@ -766,7 +767,7 @@ class MessageBroker:
         if chat_id:
             label = self._registry.get_channel_session(agent_name, chat_id)
             session = sessions.get(label)
-            if session and session.is_connected:
+            if session and session.state == SessionState.CONNECTED:
                 return session
         # Fall back to main
         return sessions.get("main")
@@ -776,7 +777,11 @@ class MessageBroker:
         streaming = self._get_streaming_session(agent_name, message.chat_id)
 
         # Auto-wake: if session exists but is disconnected (idle sleep), reconnect
-        if streaming and not streaming.is_connected and streaming.session_id:
+        if (
+            streaming
+            and streaming.state != SessionState.CONNECTED
+            and streaming.session_id
+        ):
             _log(f"broker: {agent_name} is sleeping — auto-waking for inbound message")
             try:
                 await streaming.connect()
@@ -788,12 +793,12 @@ class MessageBroker:
         # Wait-for-reconnect: if the session object still exists but isn't
         # connected, an in-flight reconnect or context_restart is most likely
         # the cause (disconnect()→connect() runs in a separate task and briefly
-        # leaves ``is_connected`` False, with ``session_id`` wiped to "" so the
+        # leaves state != CONNECTED, with ``session_id`` wiped to "" so the
         # auto-wake branch above can't help). Poll for a bounded window before
         # falling back to the user-visible "not running" error so the message
         # gets delivered as soon as the new session comes up instead of being
         # dropped. See _INBOUND_RECONNECT_WAIT_SEC.
-        if streaming is not None and not streaming.is_connected:
+        if streaming is not None and streaming.state != SessionState.CONNECTED:
             _log(
                 f"broker: {agent_name} session present but disconnected — "
                 f"waiting up to {_INBOUND_RECONNECT_WAIT_SEC:g}s for reconnect"
@@ -801,11 +806,11 @@ class MessageBroker:
             deadline = time.monotonic() + _INBOUND_RECONNECT_WAIT_SEC
             while time.monotonic() < deadline:
                 await asyncio.sleep(_INBOUND_RECONNECT_POLL_SEC)
-                if streaming.is_connected:
+                if streaming.state == SessionState.CONNECTED:
                     _log(f"broker: {agent_name} reconnect completed — resuming delivery")
                     break
 
-        if not streaming or not streaming.is_connected:
+        if not streaming or streaming.state != SessionState.CONNECTED:
             _log(f"broker: streaming session for {agent_name} not connected, dropping message")
             self._stats["errors"] += 1
             await self._send_message(
@@ -884,7 +889,7 @@ class MessageBroker:
     ) -> bool:
         """Inject a message from one agent into another's streaming session."""
         streaming = self._get_streaming_session(to_agent)
-        if not streaming or not streaming.is_connected:
+        if not streaming or streaming.state != SessionState.CONNECTED:
             _log(f"broker: can't deliver agent message to {to_agent} — not connected")
             return False
 
@@ -1285,7 +1290,7 @@ class MessageBroker:
         """Return names of agents with connected streaming sessions."""
         return [
             name for name, sessions in self._streaming.items()
-            if any(s.is_connected for s in sessions.values())
+            if any(s.state == SessionState.CONNECTED for s in sessions.values())
         ]
 
     def register_streaming(self, agent_name: str, session, label: str = "main") -> None:
@@ -1317,7 +1322,7 @@ class MessageBroker:
         return [
             {
                 "label": label,
-                "connected": s.is_connected,
+                "connected": s.state == SessionState.CONNECTED,
                 "stats": s.stats,
                 "session_id": s.session_id[:12] if s.session_id else "",
             }

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -31,6 +31,7 @@ from pinky_daemon.streaming_session import (
     _is_outreach_tool,
     _log,
 )
+from pinky_daemon.transport_state import SessionState
 
 
 @dataclass
@@ -909,13 +910,30 @@ class CodexSession:
         _log(f"codex[{self.agent_name}]: disconnected")
 
     @property
-    def is_connected(self) -> bool:
-        return self._connected
+    def state(self) -> SessionState:
+        """Lifecycle state derived from internal ``_connected`` and
+        ``_idle_sleeping`` bools.
 
-    @property
-    def is_idle_sleeping(self) -> bool:
-        """True when disconnected deliberately by idle_sleep()."""
-        return self._idle_sleeping
+        CodexSession does not (yet) embed the full ``StateMachine`` that
+        StreamingSession adopted in PR3 of #486 — the codex backend's
+        lifecycle is simpler (no reconnect retry loop, no resume handle
+        capture race). Until/unless it adopts the matrix, the state
+        property is a derived view over the legacy two-bool model:
+
+        - ``_idle_sleeping=True``  → ``IDLE_SLEEPING`` (set by ``idle_sleep()``)
+        - ``_connected=True``      → ``CONNECTED``
+        - otherwise                → ``DEAD``
+
+        UNINITIALIZED / RECONNECTING are not modeled by CodexSession; the
+        external readers (broker, api, scheduler) only branch on
+        ``CONNECTED`` / ``IDLE_SLEEPING`` so the coarser mapping is
+        sufficient for the Transport protocol's polymorphic contract.
+        """
+        if self._idle_sleeping:
+            return SessionState.IDLE_SLEEPING
+        if self._connected:
+            return SessionState.CONNECTED
+        return SessionState.DEAD
 
     @property
     def max_tokens(self) -> int:

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -75,6 +75,7 @@ class CodexSession:
         self._registry = registry
         self._connected = False
         self._idle_sleeping = False
+        self._connect_attempted = False  # distinguishes UNINITIALIZED from DEAD
         self._processing = False  # True while a codex exec is running
         self._message_queue: asyncio.Queue[tuple[str, str, str, str]] = asyncio.Queue()
         self._worker_task: asyncio.Task | None = None
@@ -116,6 +117,7 @@ class CodexSession:
 
     async def connect(self) -> None:
         """Start the session. Sends wake prompt via codex exec."""
+        self._connect_attempted = True  # tracks state ≠ UNINITIALIZED
         if self._connected:
             self._idle_sleeping = False
             return
@@ -840,8 +842,18 @@ class CodexSession:
         except Exception as e:
             _log(f"codex[{self.agent_name}]: memory save failed before idle sleep: {e}")
 
-        await self.disconnect()
+        # Set the idle-sleeping flag BEFORE disconnect() so the derived
+        # ``state`` property reports IDLE_SLEEPING throughout the teardown
+        # window. Otherwise a concurrent heartbeat-watchdog tick between
+        # disconnect() landing _connected=False and this line setting
+        # _idle_sleeping=True would observe state == DEAD and call
+        # _heartbeat_resurrect on a session that's about to be IDLE_SLEEPING.
+        # Same class as PR3 Bug 1 on StreamingSession.force_restart, just
+        # on the codex backend (per @pushok PR #492 Nit 2). Echoes the
+        # "no flicker DEAD ↔ IDLE_SLEEPING/RECONNECTING" invariant from
+        # transport_state.py §5.
         self._idle_sleeping = True
+        await self.disconnect()
         self._stats["auto_restarts"] += 1
         _log(f"codex[{self.agent_name}]: idle sleep complete")
         return True
@@ -911,28 +923,33 @@ class CodexSession:
 
     @property
     def state(self) -> SessionState:
-        """Lifecycle state derived from internal ``_connected`` and
-        ``_idle_sleeping`` bools.
+        """Lifecycle state derived from internal ``_connected``,
+        ``_idle_sleeping``, and ``_connect_attempted`` bools.
 
         CodexSession does not (yet) embed the full ``StateMachine`` that
         StreamingSession adopted in PR3 of #486 — the codex backend's
         lifecycle is simpler (no reconnect retry loop, no resume handle
         capture race). Until/unless it adopts the matrix, the state
-        property is a derived view over the legacy two-bool model:
+        property is a derived view over the legacy bools:
 
-        - ``_idle_sleeping=True``  → ``IDLE_SLEEPING`` (set by ``idle_sleep()``)
-        - ``_connected=True``      → ``CONNECTED``
-        - otherwise                → ``DEAD``
+        - ``_idle_sleeping=True``                       → ``IDLE_SLEEPING``
+        - ``_connected=True``                           → ``CONNECTED``
+        - ``_connect_attempted=False`` (never tried)    → ``UNINITIALIZED``
+        - otherwise (tried and currently disconnected)  → ``DEAD``
 
-        UNINITIALIZED / RECONNECTING are not modeled by CodexSession; the
-        external readers (broker, api, scheduler) only branch on
-        ``CONNECTED`` / ``IDLE_SLEEPING`` so the coarser mapping is
-        sufficient for the Transport protocol's polymorphic contract.
+        RECONNECTING is not modeled; the external readers (broker, api,
+        scheduler) only branch on ``CONNECTED`` / ``IDLE_SLEEPING`` /
+        ``DEAD`` / ``UNINITIALIZED`` so the coarser mapping is sufficient
+        for the Transport protocol's polymorphic contract. Distinguishing
+        UNINITIALIZED from DEAD on a never-connected fresh session
+        (@pushok PR #492 Nit 1) preserves the "never tried" semantic.
         """
         if self._idle_sleeping:
             return SessionState.IDLE_SLEEPING
         if self._connected:
             return SessionState.CONNECTED
+        if not getattr(self, "_connect_attempted", False):
+            return SessionState.UNINITIALIZED
         return SessionState.DEAD
 
     @property

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -21,6 +21,7 @@ from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
 from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.transport_state import SessionState
 
 
 def _log(msg: str) -> None:
@@ -457,12 +458,15 @@ class AgentScheduler:
         connected_label = ""
         connected_session = None
         main_session = sessions.get("main")
-        if main_session is not None and getattr(main_session, "is_connected", False):
+        if (
+            main_session is not None
+            and getattr(main_session, "state", None) == SessionState.CONNECTED
+        ):
             connected_label = "main"
             connected_session = main_session
         else:
             for label, session in sessions.items():
-                if getattr(session, "is_connected", False):
+                if getattr(session, "state", None) == SessionState.CONNECTED:
                     connected_label = label
                     connected_session = session
                     break
@@ -531,7 +535,7 @@ class AgentScheduler:
 
         for name, session_dict in sessions.items():
             for label, ss in session_dict.items():
-                if not ss.is_connected:
+                if ss.state != SessionState.CONNECTED:
                     continue
 
                 idle_timeout = ss._config.idle_timeout
@@ -652,7 +656,7 @@ class AgentScheduler:
                 continue
 
             for label, ss in agent_sessions.items():
-                if not ss.is_connected:
+                if ss.state != SessionState.CONNECTED:
                     continue
 
                 idle_seconds = now - ss.last_active

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -229,25 +229,22 @@ class StreamingSession:
         self._client = None
         self._reader_task: asyncio.Task | None = None
         # PR3 (#486 sequence): formal adoption of the Transport protocol.
-        # The pre-PR3 ``is_connected`` + ``is_idle_sleeping`` two-bool inference
-        # is replaced by a five-state machine; the bool properties below now
-        # derive from ``self._state_machine.state``.
+        # The pre-PR3 ``_connected`` + ``_idle_sleeping`` two-bool inference
+        # was replaced by a five-state machine. PR4 deleted the legacy
+        # ``is_connected`` / ``is_idle_sleeping`` shim properties and
+        # migrated all external readers (broker, api, scheduler, watchdog)
+        # to consult ``state`` directly.
         #
-        # PR3 scope is the read-path refactor: state-machine state is the source
-        # of truth for ``is_connected`` / ``is_idle_sleeping`` / the new ``state``
-        # property, but state-write paths still mutate ``_state`` directly at
-        # the same code points where ``_connected`` / ``_idle_sleeping`` were
+        # State-write paths still mutate ``_state`` directly at the same
+        # code points where ``_connected`` / ``_idle_sleeping`` were
         # mutated before. The formal ``request_transition`` /
-        # ``transition_complete`` orchestration (with proper ``Trigger``
-        # declaration and matrix-rejection handling) is PR4 work — it requires
-        # threading ``Trigger`` awareness through the four external readers
-        # (broker, api, scheduler, watchdog) and is out of scope here to keep
-        # PR3 "parallel with current agent config" (Brad, 2026-05-13 18:21 PDT).
+        # ``transition_complete`` orchestration with full Trigger
+        # awareness (cold-start RECONNECTING wire-up etc.) is the next
+        # PR in the sequence — anchor TODO in ``connect()``.
         #
-        # Watchdog resurrection (api._heartbeat_resurrect) still inspects
-        # ``is_idle_sleeping`` to avoid fighting the idle-sleep state — see
-        # issue #348. With derivation through the state machine the contract
-        # is unchanged from the caller's perspective.
+        # Watchdog resurrection (api._heartbeat_resurrect) inspects
+        # ``state == IDLE_SLEEPING`` to avoid fighting the idle-sleep
+        # state — see issue #348.
         self._state_machine = StateMachine(
             owner_label=f"{config.agent_name}-{config.label or 'main'}",
             initial_state=SessionState.UNINITIALIZED,
@@ -346,12 +343,12 @@ class StreamingSession:
 
         self._client = ClaudeSDKClient(options)
         await self._client.connect()
-        # Drive state machine to CONNECTED. ``is_connected`` and
-        # ``is_idle_sleeping`` derive from this; settling here covers the
-        # cold-start (UNINITIALIZED → CONNECTED), the genuine wake from
-        # IDLE_SLEEPING, and the post-disconnect reconnect paths. Direct
-        # mutation is the staged-migration shape per PR3 scope; see __init__
-        # docstring for the PR4 follow-up.
+        # Drive state machine to CONNECTED. The ``state`` property reads
+        # from here; this settle covers the cold-start (UNINITIALIZED →
+        # CONNECTED — see TODO below), genuine wake from IDLE_SLEEPING,
+        # and the post-disconnect reconnect paths. Direct mutation is
+        # the staged-migration shape; full request_transition /
+        # transition_complete orchestration is the next PR.
         #
         # TODO(PR4 — @pushok on #491 review, Bug 3): The cold-start path
         # currently goes UNINITIALIZED → CONNECTED, which the matrix forbids
@@ -1081,8 +1078,8 @@ class StreamingSession:
         # This matches the state machine's grant-time-mutation invariant
         # (transport_state.py §6): observers see "we're idle-sleeping" as
         # soon as the intent is declared, not after disconnect completes.
-        # The watchdog's #348 resurrection-skip check reads ``is_idle_sleeping``
-        # which derives from this state.
+        # The watchdog's #348 resurrection-skip check reads
+        # ``state == IDLE_SLEEPING`` directly off this mutation.
         self._state_machine._state = SessionState.IDLE_SLEEPING
         # Disconnect but preserve session ID for resume
         await self.disconnect()

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -350,13 +350,15 @@ class StreamingSession:
         # the staged-migration shape; full request_transition /
         # transition_complete orchestration is the next PR.
         #
-        # TODO(PR4 — @pushok on #491 review, Bug 3): The cold-start path
+        # TODO(PR6 — @pushok on #491 review, Bug 3): The cold-start path
         # currently goes UNINITIALIZED → CONNECTED, which the matrix forbids
         # (illegal pair, must go through RECONNECTING). Direct ``_state =``
-        # bypasses the matrix check, so this isn't user-visible in PR3, but
-        # once PR4 wires ``request_transition`` through the four reader files
-        # the cold-start path needs a brief intermediate hop to RECONNECTING
-        # (declared via BOOT trigger) before settling here via INTERNAL.
+        # bypasses the matrix check, so this isn't user-visible today, but
+        # the matrix invariant should hold. Fix: brief intermediate hop to
+        # RECONNECTING (declared via a new BOOT trigger) before settling
+        # here via INTERNAL. Deferred to PR6 in the #486 sequence (PR4 was
+        # bool-shim deletion + reader migration; PR5 is session_id rename;
+        # PR6 is cold-start wire-up; PR7 is CodexSession matrix adoption).
         self._state_machine._state = SessionState.CONNECTED
 
         # Capture account info from SDK init result

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -461,7 +461,7 @@ class StreamingSession:
             agent_hint: Extra context appended to the query but NOT stored in
                 conversation history (e.g. reply-platform hints).
         """
-        if not self.is_connected or not self._client:
+        if self.state != SessionState.CONNECTED or not self._client:
             _log(f"streaming[{self.agent_name}]: not connected, dropping message")
             return
 
@@ -908,7 +908,7 @@ class StreamingSession:
 
     async def _check_context(self) -> None:
         """Check context usage after each turn. Warn or force restart."""
-        if not self._client or not self.is_connected:
+        if not self._client or self.state != SessionState.CONNECTED:
             return
 
         try:
@@ -1057,7 +1057,7 @@ class StreamingSession:
         preserved so the next wake can resume.
         Returns True if successfully slept.
         """
-        if not self.is_connected or not self._client:
+        if self.state != SessionState.CONNECTED or not self._client:
             return False
 
         _log(f"streaming[{self.agent_name}]: idle sleep triggered ({self._config.idle_timeout}s idle)")
@@ -1383,33 +1383,12 @@ class StreamingSession:
 
     @property
     def state(self) -> SessionState:
-        """Current lifecycle state. Source of truth for ``is_connected`` and
-        ``is_idle_sleeping`` below.
-
-        New code (post-PR4) should branch on this directly; the bool shims
-        are kept for the migration window so the four existing readers
-        (broker, api, scheduler, watchdog) don't need to be touched in the
-        same PR that adopts the protocol.
+        """Current lifecycle state. Single source of truth for the four
+        external readers (broker, api, scheduler, watchdog) post-PR4. The
+        legacy ``is_connected`` / ``is_idle_sleeping`` shim properties were
+        deleted in PR4 of #486 — readers branch on this directly now.
         """
         return self._state_machine.state
-
-    @property
-    def is_connected(self) -> bool:
-        """Legacy shim: ``state == SessionState.CONNECTED``. Preserved during
-        the PR3 migration window so external readers see unchanged semantics.
-        PR4 deletes this and migrates readers to consult ``state`` directly.
-        """
-        return self._state_machine.state == SessionState.CONNECTED
-
-    @property
-    def is_idle_sleeping(self) -> bool:
-        """Legacy shim: ``state == SessionState.IDLE_SLEEPING``. The watchdog
-        resurrection callback (api._heartbeat_resurrect) uses this to avoid
-        reconnecting a session that was deliberately put to sleep — see
-        issue #348. Derivation through the state machine preserves the
-        original contract.
-        """
-        return self._state_machine.state == SessionState.IDLE_SLEEPING
 
     @property
     def stats(self) -> dict:

--- a/src/pinky_daemon/transport.py
+++ b/src/pinky_daemon/transport.py
@@ -31,7 +31,8 @@ Brad's Dymok test agent).
 ## Migration plan
 
 - PR2 (this) — ``Transport`` Protocol + the state-machine-aware
-  ``is_connected`` / ``is_idle_sleeping`` shim helpers. Nothing changes.
+  ``state`` property via the embedded ``StateMachine``. Shim helpers
+  ``is_connected`` / ``is_idle_sleeping`` were deleted in PR4.
 - PR3 — ``StreamingSession`` adopts (formally implements) ``Transport``
   by routing ``is_connected`` through its embedded ``StateMachine``.
   ``broker.py`` / ``api.py`` / ``scheduler.py`` / ``calendar.py`` type their
@@ -39,7 +40,7 @@ Brad's Dymok test agent).
 - TmuxSession PR sequence — drafted in parallel against this Protocol.
   Dymok agent boots with ``PINKYBOT_TRANSPORT=tmux``; everything routes
   through the same Transport surface.
-- PR4 — cleanup: delete ``is_connected`` / ``is_idle_sleeping`` shims and
+- PR4 — cleanup (LANDED): deleted ``is_connected`` / ``is_idle_sleeping`` shims and
   consume state directly via ``state == SessionState.X`` at the four caller
   files identified during pre-PR scoping. **Also in PR4:** rename
   ``session_id: str`` to ``resume_handle`` (or similar) and consider
@@ -121,35 +122,22 @@ class Transport(Protocol):
 
     @property
     def state(self) -> SessionState:
-        """Current lifecycle state. Backed by the embedded
-        ``StateMachine`` once PR3 lands.
+        """Current lifecycle state. Single source of truth for connection
+        liveness, idle-sleep skip, and reconnect-in-flight signalling. The
+        legacy ``is_connected`` / ``is_idle_sleeping`` shim properties
+        were removed in PR4 of #486 — all readers branch on ``state``
+        directly.
 
-        New code should branch on this, not on the legacy
-        ``is_connected`` / ``is_idle_sleeping`` shims below.
-        """
-        ...
+        Backends implement this in one of two ways:
 
-    @property
-    def is_connected(self) -> bool:
-        """Legacy shim: ``state == SessionState.CONNECTED``.
-
-        Preserved during the PR3 migration so the four existing readers
-        (``broker.py``, ``api.py``, ``scheduler.py``,
-        ``routes/calendar.py``) don't need to be touched in the same PR
-        that adopts the protocol. PR4 deletes the shim and migrates those
-        readers to consult ``state`` directly.
-        """
-        ...
-
-    @property
-    def is_idle_sleeping(self) -> bool:
-        """Legacy shim: ``state == SessionState.IDLE_SLEEPING``.
-
-        Same deprecation timeline as ``is_connected``. Originally added to
-        let the watchdog resurrection callback skip sessions that were
-        deliberately put to sleep (issue #348); with the state machine
-        that's just a ``state == IDLE_SLEEPING`` check on the resurrection
-        path.
+        - ``StreamingSession`` — the full ``StateMachine`` matrix from
+          ``transport_state.py``. Tracks UNINITIALIZED, RECONNECTING,
+          CONNECTED, IDLE_SLEEPING, DEAD with explicit transitions and
+          the no-flicker invariant.
+        - ``CodexSession`` — a coarser derivation from internal
+          ``_connected`` / ``_idle_sleeping`` bools. UNINITIALIZED and
+          RECONNECTING are not modeled; CONNECTED / IDLE_SLEEPING / DEAD
+          are sufficient for the polymorphic reader contract.
         """
         ...
 

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -50,12 +50,14 @@ class FakeStreamingSession:
         cost_usd: float = 0.0,
         model: str = "claude-sonnet-4-6",
     ):
+        from pinky_daemon.transport_state import SessionState
+        self._TS = SessionState
         self.agent_name = agent_name
         self.label = label
         self.session_id = f"{agent_name}-{label}-sdk-abc123"
         self.created_at = time.time() - 120  # 2 minutes old
         self.last_active = self.created_at
-        self.is_connected = connected
+        self._state = SessionState.CONNECTED if connected else SessionState.DEAD
         self._stats = {
             "messages_sent": 4,
             "turns": 7,
@@ -83,10 +85,14 @@ class FakeStreamingSession:
         return f"{self.agent_name}-{self.label}"
 
     @property
+    def state(self):
+        return self._state
+
+    @property
     def stats(self) -> dict:
         return {
             **self._stats,
-            "connected": self.is_connected,
+            "connected": self._state == self._TS.CONNECTED,
             "pending_responses": 0,
             "current_activity": "",
             "current_thinking": "",
@@ -97,10 +103,10 @@ class FakeStreamingSession:
 
     async def disconnect(self):
         self.disconnect_calls += 1
-        self.is_connected = False
+        self._state = self._TS.DEAD
 
     async def connect(self):
-        self.is_connected = True
+        self._state = self._TS.CONNECTED
 
 
 class FakeCodexStreamingSession(FakeStreamingSession):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -417,12 +417,14 @@ class TestAPI:
 
     class _FakeStreamingSession:
         def __init__(self, agent_name: str, label: str = "main", *, connected: bool = True, total_tokens: int = 0, max_tokens: int = 200_000):
+            from pinky_daemon.transport_state import SessionState
+            self._TS = SessionState
             self.agent_name = agent_name
             self.label = label
             self.session_id = f"{agent_name}-{label}-sdk"
             self.created_at = time.time()
             self.last_active = self.created_at
-            self.is_connected = connected
+            self._state = SessionState.CONNECTED if connected else SessionState.DEAD
             self._stats = {"messages_sent": 2, "turns": 3, "errors": 0, "reconnects": 0, "auto_restarts": 0}
             self._config = SimpleNamespace(model="sonnet", context_restart_pct=80, permission_mode="bypassPermissions")
             self.usage = SimpleNamespace(total_cost_usd=0.0, input_tokens=0, output_tokens=0)
@@ -432,23 +434,27 @@ class TestAPI:
             self.connect_calls = 0
 
         @property
+        def state(self):
+            return self._state
+
+        @property
         def id(self) -> str:
             return f"{self.agent_name}-{self.label}"
 
         @property
         def stats(self) -> dict:
-            return {**self._stats, "connected": self.is_connected, "pending_responses": 0, "cost_usd": 0.0, "account": {}}
+            return {**self._stats, "connected": self._state == self._TS.CONNECTED, "pending_responses": 0, "cost_usd": 0.0, "account": {}}
 
         async def send(self, prompt: str, platform: str = "", chat_id: str = ""):
             self.sent.append((prompt, platform, chat_id))
 
         async def disconnect(self):
             self.disconnect_calls += 1
-            self.is_connected = False
+            self._state = self._TS.DEAD
 
         async def connect(self):
             self.connect_calls += 1
-            self.is_connected = True
+            self._state = self._TS.CONNECTED
 
     def test_root(self):
         client = self._make_client()
@@ -615,7 +621,8 @@ class TestAPI:
                 assert data["sent"] is True
                 assert data["connected"] is True
                 assert "test-agent" in app.state.broker._streaming
-                assert app.state.broker._streaming["test-agent"]["main"].is_connected is True
+                from pinky_daemon.transport_state import SessionState
+                assert app.state.broker._streaming["test-agent"]["main"].state == SessionState.CONNECTED
                 assert sent_prompts[-1][1] == "Wake up"
 
     def test_wake_uses_streaming_session_for_claude_runtime(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -173,7 +173,7 @@ class TestStreamingSession:
         from pinky_daemon.transport_state import SessionState
 
         session = StreamingSession(StreamingSessionConfig(agent_name="test-agent"))
-        # PR3 (#486): is_connected derives from state machine state.
+        # Drive state machine to CONNECTED to mimic real connect() landing.
         session._state_machine._state = SessionState.CONNECTED
 
         class FailingClient:
@@ -596,7 +596,7 @@ class TestAPI:
         sent_prompts = []
 
         async def fake_connect(self):
-            # PR3 (#486): is_connected derives from state machine state.
+            # Drive state machine to CONNECTED to mimic real connect() landing.
             from pinky_daemon.transport_state import SessionState
             self._state_machine._state = SessionState.CONNECTED
             if not self.session_id:
@@ -627,7 +627,7 @@ class TestAPI:
 
     def test_wake_uses_streaming_session_for_claude_runtime(self):
         async def fake_connect(self):
-            # PR3 (#486): is_connected derives from state machine state.
+            # Drive state machine to CONNECTED to mimic real connect() landing.
             from pinky_daemon.transport_state import SessionState
             self._state_machine._state = SessionState.CONNECTED
 
@@ -867,9 +867,66 @@ class TestAPI:
                     for q in fake._client.queries
                 )
 
+    def test_chat_does_not_double_connect_during_reconnecting(self):
+        """Regression for @murzik PR #492 blocker 2.
+
+        Pre-fix _ensure_streaming_session called ss.connect() for ANY
+        non-CONNECTED state, including RECONNECTING. The chat endpoint
+        delegates to _ensure_streaming_session when the session isn't
+        already connected, so an inbound web/admin message during an
+        in-flight reconnect would race the existing reconnect with a
+        second connect() call. Post-fix _ensure_streaming_session
+        branches by explicit state: RECONNECTING waits bounded for the
+        in-flight to land instead of calling connect().
+        """
+        from pinky_daemon.transport_state import SessionState
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
+                fake = self._FakeStreamingSession("test-agent", "main")
+                # Drop into RECONNECTING mid-flight.
+                fake._state = SessionState.RECONNECTING
+                app.state.broker.register_streaming("test-agent", fake, label="main")
+
+                # Settle the in-flight reconnect on a background thread so the
+                # bounded wait inside _ensure_streaming_session sees CONNECTED.
+                import threading
+                def _settle():
+                    time.sleep(0.05)
+                    fake._state = SessionState.CONNECTED
+                threading.Thread(target=_settle, daemon=True).start()
+
+                # Patch _INBOUND_RECONNECT_WAIT_SEC for fast test execution.
+                import pinky_daemon.broker as broker_mod
+                old_wait = broker_mod._INBOUND_RECONNECT_WAIT_SEC
+                old_poll = broker_mod._INBOUND_RECONNECT_POLL_SEC
+                broker_mod._INBOUND_RECONNECT_WAIT_SEC = 1.0
+                broker_mod._INBOUND_RECONNECT_POLL_SEC = 0.01
+                try:
+                    resp = client.post(
+                        "/agents/test-agent/chat?session=main",
+                        json={"content": "hello during reconnect"},
+                    )
+                finally:
+                    broker_mod._INBOUND_RECONNECT_WAIT_SEC = old_wait
+                    broker_mod._INBOUND_RECONNECT_POLL_SEC = old_poll
+
+                assert resp.status_code in (200, 202), resp.text
+                # The load-bearing assertion: _ensure_streaming_session
+                # MUST NOT have called connect() — the in-flight reconnect
+                # (the _settle thread) is what lands the session in CONNECTED.
+                assert fake.connect_calls == 0, (
+                    f"chat endpoint called connect() {fake.connect_calls}x during "
+                    f"RECONNECTING — _ensure_streaming_session must not race the "
+                    f"in-flight reconnect. Pre-fix this was the double-connect."
+                )
+
     def test_wake_streaming_session_defaults_include_outreach_tools(self):
         async def fake_connect(self):
-            # PR3 (#486): is_connected derives from state machine state.
+            # Drive state machine to CONNECTED to mimic real connect() landing.
             from pinky_daemon.transport_state import SessionState
             self._state_machine._state = SessionState.CONNECTED
 
@@ -890,7 +947,7 @@ class TestAPI:
 
     def test_wake_streaming_session_preserves_agent_allowed_tools(self):
         async def fake_connect(self):
-            # PR3 (#486): is_connected derives from state machine state.
+            # Drive state machine to CONNECTED to mimic real connect() landing.
             from pinky_daemon.transport_state import SessionState
             self._state_machine._state = SessionState.CONNECTED
 
@@ -916,7 +973,7 @@ class TestAPI:
 
     def test_manual_streaming_session_persists_and_restores_labels(self):
         async def fake_connect(self):
-            # PR3 (#486): is_connected derives from state machine state.
+            # Drive state machine to CONNECTED to mimic real connect() landing.
             from pinky_daemon.transport_state import SessionState
             self._state_machine._state = SessionState.CONNECTED
             if not self.session_id:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -242,6 +242,123 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
+    async def test_route_streaming_does_not_double_connect_during_reconnecting(
+        self, monkeypatch,
+    ):
+        """Regression for @murzik PR #492 blocker 1.
+
+        Pre-fix the auto-wake branch fired for ANY non-CONNECTED state
+        as long as session_id was non-empty. During force_restart /
+        attempt_reconnect, state is RECONNECTING and session_id may
+        still be set, so an inbound message racing the in-flight reconnect
+        would call ss.connect() a SECOND time — concurrent with the
+        in-flight one. Post-fix the auto-wake only fires for
+        IDLE_SLEEPING; RECONNECTING falls through to the wait-for-reconnect
+        poll loop and waits for the in-flight to land naturally.
+        """
+        import pinky_daemon.broker as broker_mod
+        monkeypatch.setattr(broker_mod, "_INBOUND_RECONNECT_WAIT_SEC", 0.3)
+        monkeypatch.setattr(broker_mod, "_INBOUND_RECONNECT_POLL_SEC", 0.01)
+
+        from pinky_daemon.transport_state import SessionState
+
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            class _ReconnectingSession:
+                # Mid-reconnect: state RECONNECTING, session_id non-empty
+                # (the bug-triggering combo — pre-fix this combo would
+                # cause the broker to call connect() again).
+                session_id = "sdk-abc123"
+
+                def __init__(self):
+                    self.state = SessionState.RECONNECTING
+                    self.connect_calls = 0
+                    self.sent: list[str] = []
+
+                async def connect(self):
+                    self.connect_calls += 1
+                    self.state = SessionState.CONNECTED
+
+                async def send(self, prompt, **kwargs):
+                    self.sent.append(prompt)
+
+            ss = _ReconnectingSession()
+            broker.register_streaming("barsik", ss, label="main")
+
+            # Simulate in-flight reconnect completing mid-wait.
+            import asyncio as _a
+            async def _settle():
+                await _a.sleep(0.05)
+                ss.state = SessionState.CONNECTED
+
+            _a.create_task(_settle())
+
+            msg = BrokerMessage(
+                platform="telegram", chat_id="6770805286",
+                sender_name="Brad", sender_id="u-1",
+                content="msg during reconnect", agent_name="barsik",
+            )
+            await broker._route_streaming("barsik", msg)
+
+            # The load-bearing assertion: the broker MUST NOT have called
+            # connect() — that's the bug. The in-flight reconnect (the
+            # _settle task) is what lands the session in CONNECTED.
+            assert ss.connect_calls == 0, (
+                f"broker called connect() {ss.connect_calls}x during RECONNECTING — "
+                f"the auto-wake branch must only fire for IDLE_SLEEPING. "
+                f"Pre-fix this was the double-connect race."
+            )
+            # Delivery still happens because the wait-for-reconnect block
+            # picked up the settle.
+            assert ss.sent, "message should deliver once reconnect settles"
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_streaming_auto_wakes_idle_sleeping(self, monkeypatch):
+        """Companion to the no-double-connect test: IDLE_SLEEPING with a
+        retained session_id IS the intended auto-wake path. Pre-fix this
+        worked via the broader `not is_connected` check; post-fix it
+        works via the explicit `state == IDLE_SLEEPING` check.
+        """
+        from pinky_daemon.transport_state import SessionState
+
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            class _SleepingSession:
+                session_id = "sdk-resume"
+
+                def __init__(self):
+                    self.state = SessionState.IDLE_SLEEPING
+                    self.connect_calls = 0
+                    self.sent: list[str] = []
+
+                async def connect(self):
+                    self.connect_calls += 1
+                    self.state = SessionState.CONNECTED
+
+                async def send(self, prompt, **kwargs):
+                    self.sent.append(prompt)
+
+            ss = _SleepingSession()
+            broker.register_streaming("barsik", ss, label="main")
+
+            msg = BrokerMessage(
+                platform="telegram", chat_id="6770805286",
+                sender_name="Brad", sender_id="u-1",
+                content="ping while asleep", agent_name="barsik",
+            )
+            await broker._route_streaming("barsik", msg)
+
+            assert ss.connect_calls == 1, (
+                f"IDLE_SLEEPING auto-wake must call connect() exactly once; "
+                f"got {ss.connect_calls}"
+            )
+            assert ss.sent, "message should deliver after auto-wake"
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
     async def test_stop_typing_cancels_active_task(self):
         """_stop_typing must cancel a running typing-loop task."""
         import asyncio

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -98,8 +98,10 @@ class TestMessageBrokerRouting:
     async def test_inject_agent_message_stamps_last_seen_on_success(self):
         tmpdir, registry, broker, _, _ = self._make_broker()
         try:
+            from pinky_daemon.transport_state import SessionState
+
             class _FakeStreaming:
-                is_connected = True
+                state = SessionState.CONNECTED
                 sent: list[str] = []
 
                 async def send(self, prompt: str) -> None:
@@ -129,11 +131,11 @@ class TestMessageBrokerRouting:
     @pytest.mark.asyncio
     async def test_route_streaming_waits_for_in_flight_reconnect(self, monkeypatch):
         """Regression: messages arriving during ``context_restart`` (where the
-        streaming session object exists but ``is_connected`` is briefly False
+        streaming session object exists but ``state`` is briefly != CONNECTED
         and ``session_id`` is wiped to "") must be held until the reconnect
         completes — not dropped with a "not running" fallback.
 
-        Simulates the restart window by flipping ``is_connected`` back to True
+        Simulates the restart window by flipping ``state`` back to CONNECTED
         on a background task after a short delay, mirroring what
         ``StreamingSession.force_restart`` does in production.
         """
@@ -144,6 +146,8 @@ class TestMessageBrokerRouting:
         monkeypatch.setattr(broker_mod, "_INBOUND_RECONNECT_WAIT_SEC", 2.0)
         monkeypatch.setattr(broker_mod, "_INBOUND_RECONNECT_POLL_SEC", 0.01)
 
+        from pinky_daemon.transport_state import SessionState
+
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
             class _RestartingSession:
@@ -152,7 +156,7 @@ class TestMessageBrokerRouting:
                 session_id = ""
 
                 def __init__(self):
-                    self.is_connected = False
+                    self.state = SessionState.RECONNECTING
                     self.sent: list[str] = []
 
                 async def send(self, prompt, **kwargs):
@@ -161,11 +165,11 @@ class TestMessageBrokerRouting:
             ss = _RestartingSession()
             broker.register_streaming("barsik", ss, label="main")
 
-            # Background task to flip is_connected=True after a small delay,
+            # Background task to flip state=CONNECTED after a small delay,
             # simulating force_restart's connect() completing.
             async def _finish_restart():
                 await asyncio.sleep(0.1)
-                ss.is_connected = True
+                ss.state = SessionState.CONNECTED
 
             asyncio.create_task(_finish_restart())
 
@@ -200,13 +204,15 @@ class TestMessageBrokerRouting:
         monkeypatch.setattr(broker_mod, "_INBOUND_RECONNECT_WAIT_SEC", 0.2)
         monkeypatch.setattr(broker_mod, "_INBOUND_RECONNECT_POLL_SEC", 0.01)
 
+        from pinky_daemon.transport_state import SessionState
+
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
             class _DeadSession:
                 session_id = ""
 
                 def __init__(self):
-                    self.is_connected = False
+                    self.state = SessionState.DEAD
                     self.sent: list[str] = []
 
                 async def send(self, prompt, **kwargs):  # pragma: no cover

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -40,11 +40,11 @@ class TestCodexSessionInterface:
         return CodexSession(config)
 
     def test_properties(self):
+        from pinky_daemon.transport_state import SessionState
         s = self._make_session()
         assert s.agent_name == "test-agent"
         assert s.id == "test-agent-main"
-        assert s.is_connected is False
-        assert s.is_idle_sleeping is False
+        assert s.state == SessionState.DEAD
         assert isinstance(s.stats, dict)
         assert s.stats["connected"] is False
         assert s.stats["idle_sleeping"] is False
@@ -315,14 +315,16 @@ class TestCodexSessionDisconnect:
             working_dir="/tmp",
             provider_url="codex_cli",
         )
+        from pinky_daemon.transport_state import SessionState
         s = CodexSession(config)
         # Should be safe to call multiple times
         await s.disconnect()
         await s.disconnect()
-        assert not s.is_connected
+        assert s.state != SessionState.CONNECTED
 
     @pytest.mark.asyncio
     async def test_disconnect_alone_does_not_set_idle_sleeping(self):
+        from pinky_daemon.transport_state import SessionState
         config = StreamingSessionConfig(
             agent_name="test",
             working_dir="/tmp",
@@ -332,8 +334,8 @@ class TestCodexSessionDisconnect:
 
         await s.disconnect()
 
-        assert s.is_connected is False
-        assert s.is_idle_sleeping is False
+        assert s.state != SessionState.CONNECTED
+        assert s.state != SessionState.IDLE_SLEEPING
 
     @pytest.mark.asyncio
     async def test_idle_sleep_sets_idle_sleeping(self):
@@ -352,9 +354,9 @@ class TestCodexSessionDisconnect:
 
         slept = await s.idle_sleep()
 
+        from pinky_daemon.transport_state import SessionState
         assert slept is True
-        assert s.is_connected is False
-        assert s.is_idle_sleeping is True
+        assert s.state == SessionState.IDLE_SLEEPING
         assert s.stats["idle_sleeping"] is True
 
     @pytest.mark.asyncio
@@ -374,8 +376,8 @@ class TestCodexSessionDisconnect:
 
         await s.connect()
 
-        assert s.is_connected is True
-        assert s.is_idle_sleeping is False
+        from pinky_daemon.transport_state import SessionState
+        assert s.state == SessionState.CONNECTED
         await s.disconnect()
 
     @pytest.mark.asyncio
@@ -405,8 +407,9 @@ class TestCodexSessionDisconnect:
 
         await s.attempt_reconnect()
 
+        from pinky_daemon.transport_state import SessionState
         assert calls == ["disconnect", "connect"]
-        assert s.is_connected is True
+        assert s.state == SessionState.CONNECTED
         assert s.codex_session_id == "thread-123"
         assert s.session_id == "thread-123"
         assert s.stats["reconnects"] == 1

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -44,7 +44,10 @@ class TestCodexSessionInterface:
         s = self._make_session()
         assert s.agent_name == "test-agent"
         assert s.id == "test-agent-main"
-        assert s.state == SessionState.DEAD
+        # Fresh session never tried to connect → UNINITIALIZED, not DEAD.
+        # Per @pushok PR #492 Nit 1: distinguishes "never tried" from
+        # "tried and disconnected".
+        assert s.state == SessionState.UNINITIALIZED
         assert isinstance(s.stats, dict)
         assert s.stats["connected"] is False
         assert s.stats["idle_sleeping"] is False
@@ -358,6 +361,63 @@ class TestCodexSessionDisconnect:
         assert slept is True
         assert s.state == SessionState.IDLE_SLEEPING
         assert s.stats["idle_sleeping"] is True
+
+    @pytest.mark.asyncio
+    async def test_idle_sleep_does_not_flicker_through_dead(self):
+        """Regression for @pushok PR #492 Nit 2.
+
+        Pre-fix idle_sleep() called disconnect() BEFORE setting
+        _idle_sleeping=True, so the derived state property reported DEAD
+        for the entire teardown window between disconnect() landing
+        _connected=False and the next line setting _idle_sleeping=True.
+        A concurrent heartbeat-watchdog tick observing state during that
+        window would call _heartbeat_resurrect on a session about to be
+        IDLE_SLEEPING — same bug class as PR3 Bug 1 on StreamingSession.
+
+        Post-fix _idle_sleeping=True is set BEFORE disconnect() so the
+        derived state never visits DEAD. We pin the contract by
+        instrumenting disconnect() to capture state at entry — must
+        already be IDLE_SLEEPING.
+        """
+        from pinky_daemon.transport_state import SessionState
+
+        config = StreamingSessionConfig(
+            agent_name="test",
+            working_dir="/tmp",
+            provider_url="codex_cli",
+        )
+        s = CodexSession(config)
+        s._connected = True
+        s._connect_attempted = True  # mirror post-connect()
+
+        async def fake_exec(prompt: str) -> CodexTurnResult:
+            return CodexTurnResult()
+
+        s._exec_codex = fake_exec  # type: ignore[assignment]
+
+        states_at_disconnect_entry: list = []
+
+        original_disconnect = s.disconnect
+
+        async def instrumented_disconnect():
+            states_at_disconnect_entry.append(s.state)
+            await original_disconnect()
+
+        s.disconnect = instrumented_disconnect  # type: ignore[method-assign]
+
+        await s.idle_sleep()
+
+        # The load-bearing assertion: when disconnect() is invoked from
+        # idle_sleep(), the macro state must already be IDLE_SLEEPING.
+        # Pre-fix this would be CONNECTED (so disconnect()'s side effect
+        # would land us in DEAD until _idle_sleeping=True was set after).
+        assert states_at_disconnect_entry == [SessionState.IDLE_SLEEPING], (
+            f"idle_sleep() must declare IDLE_SLEEPING intent before "
+            f"calling disconnect(); observed states at disconnect entry: "
+            f"{states_at_disconnect_entry}. Pre-fix this would be "
+            f"[CONNECTED], producing a DEAD-flicker window."
+        )
+        assert s.state == SessionState.IDLE_SLEEPING
 
     @pytest.mark.asyncio
     async def test_connect_clears_idle_sleeping(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -437,7 +437,8 @@ class TestHeartbeatResurrection:
     """
 
     class _FakeStreamingSession:
-        is_connected = True
+        from pinky_daemon.transport_state import SessionState
+        state = SessionState.CONNECTED
         id = "ivan-main"
         context_used_pct = 12.5
         stats = {"messages_sent": 2, "turns": 3}

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -124,41 +124,38 @@ async def test_restart_alone_when_already_warned() -> None:
     ss.force_restart.assert_awaited_once()
 
 
-# -- idle_sleep / is_idle_sleeping flag (#348) --------------------------------
+# -- idle_sleep / IDLE_SLEEPING state (#348) ----------------------------------
 #
 # The watchdog resurrection path (api._heartbeat_resurrect) used to fight
 # idle_sleep() because there was no way to distinguish a deliberate sleep from
-# an error disconnect. These tests pin down the new contract:
-#   - idle_sleep() sets is_idle_sleeping=True
-#   - successful connect() clears it (genuine wake)
-#   - plain disconnect() does NOT set the flag (only idle_sleep does)
+# an error disconnect. These tests pin down the contract via state:
+#   - idle_sleep() drives state → IDLE_SLEEPING
+#   - successful connect() drives state → CONNECTED (genuine wake)
+#   - plain disconnect() does NOT land in IDLE_SLEEPING (only idle_sleep does)
 
 
 @pytest.mark.asyncio
-async def test_idle_sleep_sets_is_idle_sleeping_flag() -> None:
-    """After idle_sleep(), is_idle_sleeping must be True so the watchdog
+async def test_idle_sleep_lands_in_idle_sleeping() -> None:
+    """After idle_sleep(), state must be IDLE_SLEEPING so the watchdog
     resurrection callback knows to leave the session alone."""
     ss = _make_session()
     # Replace force_restart stub — we need disconnect() to actually run, which
     # _make_session leaves intact. idle_sleep() doesn't call force_restart.
-    assert ss.is_idle_sleeping is False, "Default state must be False"
+    assert ss.state != SessionState.IDLE_SLEEPING, "Default state must not be IDLE_SLEEPING"
 
     result = await ss.idle_sleep()
 
     assert result is True
-    assert ss.is_idle_sleeping is True
-    assert ss.is_connected is False
+    assert ss.state == SessionState.IDLE_SLEEPING
     assert ss.stats["idle_sleeping"] is True
 
 
 @pytest.mark.asyncio
-async def test_connect_clears_is_idle_sleeping_flag() -> None:
-    """A successful connect() (genuine wake) must drive state CONNECTED,
-    which by derivation flips is_connected=True and is_idle_sleeping=False
-    in a single state-machine settle."""
+async def test_connect_drives_idle_sleeping_to_connected() -> None:
+    """A successful connect() from IDLE_SLEEPING (genuine wake) must drive
+    state to CONNECTED in a single state-machine settle."""
     ss = _make_session(state=SessionState.IDLE_SLEEPING)
-    assert ss.is_idle_sleeping is True
-    assert ss.is_connected is False
+    assert ss.state == SessionState.IDLE_SLEEPING
 
     # Patch SDK connect path: stub the line where connect() drives state to
     # CONNECTED. Tests don't run the real SDK.
@@ -168,24 +165,22 @@ async def test_connect_clears_is_idle_sleeping_flag() -> None:
     ss.connect = fake_connect  # type: ignore[assignment]
     await ss.connect()
 
-    assert ss.is_connected is True
-    assert ss.is_idle_sleeping is False
     assert ss.state == SessionState.CONNECTED
 
 
 @pytest.mark.asyncio
-async def test_disconnect_alone_does_not_set_idle_sleeping() -> None:
-    """Plain disconnect() (e.g. error path, force_restart) must NOT set the
-    idle-sleeping flag — only idle_sleep() owns that state. This is what
+async def test_disconnect_alone_does_not_land_in_idle_sleeping() -> None:
+    """Plain disconnect() (e.g. error path, force_restart) must NOT land in
+    IDLE_SLEEPING — only idle_sleep() drives that state. This is what
     keeps the watchdog resurrection working for genuine failures."""
     ss = _make_session()
-    assert ss.is_idle_sleeping is False
+    assert ss.state != SessionState.IDLE_SLEEPING
 
     await ss.disconnect()
 
-    assert ss.is_connected is False
-    assert ss.is_idle_sleeping is False, (
-        "disconnect() must not set the idle-sleep flag — only idle_sleep() does"
+    assert ss.state != SessionState.CONNECTED
+    assert ss.state != SessionState.IDLE_SLEEPING, (
+        "disconnect() must not land in IDLE_SLEEPING — only idle_sleep() does"
     )
 
 
@@ -199,7 +194,6 @@ async def test_idle_sleep_returns_false_when_already_disconnected() -> None:
     result = await ss.idle_sleep()
 
     assert result is False
-    assert ss.is_idle_sleeping is False
     assert ss.state == SessionState.DEAD
 
 
@@ -350,18 +344,16 @@ async def test_auth_dedupe_resets_between_turns() -> None:
     )
 
 
-# -- Transport protocol adoption (#486 PR3) -----------------------------------
+# -- Transport protocol adoption (#486 PR3+PR4) -------------------------------
 #
-# PR3 replaces the implicit (is_connected, is_idle_sleeping) two-bool inference
-# with a SessionState enum routed through an embedded StateMachine. The shims
-# below pin down:
+# PR3 replaced the implicit (is_connected, is_idle_sleeping) two-bool inference
+# with a SessionState enum routed through an embedded StateMachine. PR4 deleted
+# the bool shims and migrated all external readers to consult ``state``
+# directly. The tests below pin down:
 #   - StreamingSession structurally satisfies the Transport Protocol
 #   - state starts UNINITIALIZED
-#   - is_connected and is_idle_sleeping derive from state, not from removed
-#     `_connected` / `_idle_sleeping` attributes
 #   - lifecycle methods leave the state machine in the expected SessionState
-#   - the stats dict exposes the explicit `state` value alongside the legacy
-#     bool shims
+#   - the stats dict exposes the explicit `state` value
 
 
 def test_streaming_session_satisfies_transport_protocol() -> None:
@@ -384,40 +376,6 @@ def test_state_starts_uninitialized() -> None:
     cfg = StreamingSessionConfig(agent_name="test")
     ss = StreamingSession(cfg)
     assert ss.state == SessionState.UNINITIALIZED
-    assert ss.is_connected is False
-    assert ss.is_idle_sleeping is False
-
-
-def test_is_connected_derives_from_state() -> None:
-    """The is_connected shim is True iff state == CONNECTED."""
-    ss = _make_session(state=SessionState.CONNECTED)
-    assert ss.is_connected is True
-
-    for other in (
-        SessionState.UNINITIALIZED,
-        SessionState.RECONNECTING,
-        SessionState.IDLE_SLEEPING,
-        SessionState.DEAD,
-    ):
-        ss._state_machine._state = other
-        assert ss.is_connected is False, f"is_connected wrong for state={other}"
-
-
-def test_is_idle_sleeping_derives_from_state() -> None:
-    """The is_idle_sleeping shim is True iff state == IDLE_SLEEPING."""
-    ss = _make_session(state=SessionState.IDLE_SLEEPING)
-    assert ss.is_idle_sleeping is True
-
-    for other in (
-        SessionState.UNINITIALIZED,
-        SessionState.RECONNECTING,
-        SessionState.CONNECTED,
-        SessionState.DEAD,
-    ):
-        ss._state_machine._state = other
-        assert ss.is_idle_sleeping is False, (
-            f"is_idle_sleeping wrong for state={other}"
-        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -40,14 +40,6 @@ class _StubTransport:
         return SessionState.UNINITIALIZED
 
     @property
-    def is_connected(self) -> bool:
-        return False
-
-    @property
-    def is_idle_sleeping(self) -> bool:
-        return False
-
-    @property
     def session_id(self) -> str:
         return ""
 
@@ -125,9 +117,8 @@ class TestRuntimeCheckable:
             def id(self) -> str:
                 return ""
 
-            # Missing: state, is_connected, is_idle_sleeping, session_id,
-            # stats, connect, disconnect, send, force_restart,
-            # idle_sleep, attempt_reconnect, effective_effort,
+            # Missing: state, session_id, stats, connect, disconnect, send,
+            # force_restart, idle_sleep, attempt_reconnect, effective_effort,
             # set_effort, clear_effort_override.
 
         assert not isinstance(_MissingState(), Transport)
@@ -146,8 +137,6 @@ class TestSurfaceShape:
     REQUIRED_PROPERTIES = {
         "id",
         "state",
-        "is_connected",
-        "is_idle_sleeping",
         "session_id",
         "stats",
         "effective_effort",


### PR DESCRIPTION
## Summary

Continues #486 PR3 (StreamingSession adopts Transport, merged at 51dba18). PR4 deletes the legacy ``is_connected`` / ``is_idle_sleeping`` shim properties and migrates all external readers to consult ``state`` directly. The state machine is now the single source of truth for lifecycle queries across both backends.

**Scope choice:** I split out two follow-up PRs:
- **PR5 — session_id → resume_handle rename** (per @murzik's PR3 suggestion). Orthogonal to the state-migration; clearer review surface as its own change.
- **PR6 — cold-start RECONNECTING wire-up** (per @pushok's Bug 3 TODO from PR3 review). Touches state-machine semantics (new BOOT trigger) and merits a focused review.

Each does one job. Holler if you'd rather see them landed together.

## What changed

**Source migrations (28 reader sites total):**
- `broker.py` — 8 sites
- `api.py` — 15 sites (incl. 2 watchdog ``is_idle_sleeping`` checks). Aliased the transport-state ``SessionState`` as ``TransportSessionState`` to avoid colliding with the already-imported ``pinky_daemon.sessions.SessionState``.
- `scheduler.py` — 4 sites (idle-disconnect loop + heartbeat-watchdog liveness reconciliation)
- `streaming_session.py` — 3 internal sites

**Backends:**
- `CodexSession` gains a derived ``state`` property (IDLE_SLEEPING / CONNECTED / DEAD from its ``_idle_sleeping`` / ``_connected`` bools). CodexSession does not yet embed the full StateMachine matrix StreamingSession adopted in PR3; the coarser two-state derivation is sufficient for the polymorphic reader contract.
- `StreamingSession` — deleted ``is_connected`` and ``is_idle_sleeping`` shim properties.
- `transport.py` Protocol — removed the two shim members from the surface. Docstrings updated.

**Tests:**
- Migrated mocks/fakes in test_api.py, test_broker.py, test_agent_status.py, test_codex_session.py, test_scheduler.py to expose ``state`` via an internal SessionState reference.
- Updated test_transport.py ``REQUIRED_PROPERTIES``, ``_StubTransport``, and ``_MissingState`` fixtures.
- test_streaming_session.py: bool-shim assertions rewritten as state-based; removed ``test_is_connected_derives_from_state`` and ``test_is_idle_sleeping_derives_from_state`` (the properties don't exist anymore — the underlying state contract is still covered by the idle_sleep/connect/disconnect tests).

## Verification

- 2068 tests pass, 1 skipped (full suite)
- ruff clean across src/ and tests/
- Smoke-import of api/broker/scheduler/streaming_session/codex_session/transport modules: clean
- Visual inspection: ``grep -rn "is_connected\|is_idle_sleeping" src/pinky_daemon/`` returns only historical comments (no live calls)

## Reviewer notes

@olegbrok (Pushok) — your Bug 3 TODO from PR3 review (cold-start UNINITIALIZED→CONNECTED bypasses the matrix) is intentionally deferred to PR6. The TODO comment remains in ``streaming_session.connect()`` as the anchor.

@olegbrok (Murzik) — your ``session_id → resume_handle`` rename is intentionally deferred to PR5. Wanted to keep this PR's diff readable; rename is mechanical but touches a lot of surface.

## Test plan

- [x] Full pytest suite green (2068 passed, 1 skipped)
- [x] ruff clean
- [x] Smoke imports clean
- [x] No remaining ``is_connected`` / ``is_idle_sleeping`` calls in src/
- [ ] CI green
- [ ] Reviewer re-pass

🤖 Opened by Barsik