### PR TITLE
refactor(transport): rename in-memory session_id → resume_handle (#486 PR5)

### DIFF
--- a/specs/opencode-session-integration.md
+++ b/specs/opencode-session-integration.md
@@ -85,7 +85,7 @@ class OpencodeSession:
 Public fields/properties:
 
 - `agent_name`
-- `session_id`: opencode session id persisted via the existing `_on_session_id` callback.
+- `resume_handle`: opencode resume handle persisted via the existing `_on_resume_handle` callback.
 - `created_at`
 - `last_active`
 - `usage: SessionUsage`
@@ -102,8 +102,8 @@ Public methods:
 - `send(prompt, platform="", chat_id="", message_id="", agent_hint="")`: same semantics as `CodexSession.send()`. It must accept `agent_hint`, append it only to the runtime prompt, and store the raw prompt in conversation history.
 - `disconnect()`: stop local worker/subscriptions. It should not stop the shared opencode server unless this is daemon shutdown and the manager owns the process.
 - `attempt_reconnect()`: reconnect to the server and event stream with the existing bounded backoff shape from `StreamingSession`.
-- `force_restart()`: apply the restart guard, clear `session_id`, clear persisted session id via `_on_session_id`, create a fresh opencode session, and enqueue wake context.
-- `idle_sleep()`: ask the agent to persist state, disconnect this session, preserve `session_id`, and mark idle sleeping.
+- `force_restart()`: apply the restart guard, clear `resume_handle`, clear persisted handle via `_on_resume_handle`, create a fresh opencode session, and enqueue wake context.
+- `idle_sleep()`: ask the agent to persist state, disconnect this session, preserve `resume_handle`, and mark idle sleeping.
 
 Internal structure:
 
@@ -257,7 +257,7 @@ Event categories to normalize:
 - command/file activity -> current activity/status labels
 - usage/cost if available -> `StreamingTurnResult.model_usage`
 - errors -> `turn_error` or `turn_failed`
-- session created/resumed -> `_on_session_id(agent_name, session_id)`
+- session created/resumed -> `_on_resume_handle(agent_name, resume_handle)`
 
 For broker responses, `OpencodeSession` should produce the same final `StreamingTurnResult` used by the current response callback. If opencode's `POST /session/:id/message` returns the completed assistant message, use that as the authoritative final response and use SSE for incremental UI only. If the message endpoint is fire-and-stream, accumulate final text from events and resolve the queued turn on the matching completion event.
 
@@ -506,7 +506,7 @@ Unit tests:
 
 - REST client builds Basic auth headers.
 - REST client handles `/global/health` healthy/unhealthy.
-- Session creation persists returned `session_id` through `_on_session_id`.
+- Session creation persists returned `resume_handle` through `_on_resume_handle`.
 - `send()` accepts `agent_hint` and appends it only to the runtime prompt.
 - `send()` uses the wait-for-completion message endpoint for MVP.
 - `send()` stores raw prompt in `ConversationStore`.

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1437,7 +1437,7 @@ def create_api(
         """Build a restart guard for a live streaming session."""
         guard = _build_restart_guard(
             agent_name,
-            current_session_id=ss.session_id or "",
+            current_session_id=ss.resume_handle or "",
             activity_ts=getattr(ss, "last_active", 0.0) or time.time(),
         )
         guard["message"] = _guard_message("restart", guard)
@@ -1684,17 +1684,22 @@ def create_api(
         except Exception as e:
             _log(f"auth_alerts: tracker.record_success raised: {e}")
 
-    async def _make_streaming_session_id_callback(agent_name: str, label: str):
-        """Persist a streaming session ID when captured from the SDK.
+    async def _make_streaming_resume_handle_callback(agent_name: str, label: str):
+        """Persist a streaming session's SDK resume handle when captured.
 
-        Also logs auto context-restart events: an empty session_id means
-        force_restart() cleared the session internally.
+        Also logs auto context-restart events: an empty handle means
+        force_restart() cleared the resume handle internally.
+
+        Persistence layer (``agents.set_streaming_session_id`` / DB column
+        ``streaming_session_id``) keeps its name for now; PR5 renamed only
+        the in-memory surface. A DB-column / AgentRegistry rename is a
+        deliberate follow-up to avoid bundling a migration into this PR.
         """
-        async def _on_session_id(_agent_name: str, session_id: str):
-            agents.set_streaming_session_id(agent_name, session_id, label=label)
-            short_id = session_id[:12] if session_id else ""
-            _log(f"streaming[{agent_name}/{label}]: persisted session_id {short_id}")
-            if not session_id:
+        async def _on_resume_handle(_agent_name: str, resume_handle: str):
+            agents.set_streaming_session_id(agent_name, resume_handle, label=label)
+            short_id = resume_handle[:12] if resume_handle else ""
+            _log(f"streaming[{agent_name}/{label}]: persisted resume_handle {short_id}")
+            if not resume_handle:
                 # Empty = auto context restart triggered internally by the session
                 try:
                     session_event_store.log(
@@ -1711,7 +1716,7 @@ def create_api(
                     )
                 except Exception:
                     pass
-        return _on_session_id
+        return _on_resume_handle
 
     # Cache context usage per session to avoid blocking health checks
     _context_cache: dict[str, tuple[float, dict]] = {}  # session_id -> (timestamp, info)
@@ -1727,7 +1732,7 @@ def create_api(
         if not ss or ss.state != TransportSessionState.CONNECTED:
             return {}
 
-        sid = ss.session_id or getattr(ss, "id", "")
+        sid = ss.resume_handle or getattr(ss, "id", "")
         now = time.time()
 
         get_context_info = getattr(ss, "get_context_info", None)
@@ -1796,7 +1801,7 @@ def create_api(
             "streaming": True,
             "label": label,
             "connected": ss.state == TransportSessionState.CONNECTED,
-            "sdk_session_id": ss.session_id[:12] if ss.session_id else "",
+            "sdk_session_id": ss.resume_handle[:12] if ss.resume_handle else "",
         }
 
     async def _start_streaming_session(
@@ -1923,7 +1928,7 @@ def create_api(
             permission_mode=agent.permission_mode or "bypassPermissions",
             max_turns=agent.max_turns,
             system_prompt=agents.build_system_prompt(agent_name, skill_store=skills),
-            resume_session_id=resume_id,
+            resume_handle=resume_id,
             wake_context=_build_streaming_wake_context(agent_name),
             wake_context_builder=_build_streaming_wake_context,
             restart_guard=lambda session, _agent_name=agent_name: _get_streaming_restart_guard(_agent_name, session),
@@ -1940,7 +1945,7 @@ def create_api(
         )
 
         callback = await _make_streaming_response_callback()
-        sid_callback = await _make_streaming_session_id_callback(agent_name, label)
+        sid_callback = await _make_streaming_resume_handle_callback(agent_name, label)
 
         # Select session class based on the persisted runtime.
         SessionClass = CodexSession if is_codex else StreamingSession  # noqa: N806
@@ -1963,7 +1968,7 @@ def create_api(
             init_kwargs["stream_event_callback"] = await _make_streaming_event_callback(agent_name, label)
 
         ss = SessionClass(config, **init_kwargs)
-        ss._on_session_id = sid_callback
+        ss._on_resume_handle = sid_callback
         await ss.connect()
         broker.register_streaming(agent_name, ss, label=label)
 
@@ -5692,18 +5697,18 @@ def create_api(
         if not guard["restart_safe"]:
             raise HTTPException(409, guard["message"])
 
-        old_session_id = ss.session_id
+        old_resume_handle = ss.resume_handle
         old_turns = ss._stats["turns"]
 
-        # Disconnect and clear persisted session ID
+        # Disconnect and clear persisted resume handle
         await ss.disconnect()
         agents.set_streaming_session_id(name, "", label="main")
 
         # Refresh wake context and reconnect fresh
         ss._config.wake_context = _build_streaming_wake_context(name)
-        ss._config.resume_session_id = ""
+        ss._config.resume_handle = ""
         ss._config.restart_reason = "context_restart"
-        ss.session_id = ""
+        ss.resume_handle = ""
         # Codex sessions track the thread_id separately on the session object;
         # clear it too or `codex exec resume <stale-id>` keeps firing next turn.
         if hasattr(ss, "codex_session_id"):
@@ -5718,7 +5723,7 @@ def create_api(
                 session_id=ss.id,
                 agent_name=name,
                 event_type="context_restart",
-                metadata={"label": "main", "old_session_id": old_session_id[:12] if old_session_id else ""},
+                metadata={"label": "main", "old_session_id": old_resume_handle[:12] if old_resume_handle else ""},
             )
         except Exception as e:
             broker.unregister_streaming(name)
@@ -5727,7 +5732,7 @@ def create_api(
         return {
             "restarted": True,
             "agent": name,
-            "old_session_id": old_session_id[:12] if old_session_id else "",
+            "old_session_id": old_resume_handle[:12] if old_resume_handle else "",
             "old_turns": old_turns,
         }
 
@@ -5777,12 +5782,12 @@ def create_api(
                 pass
 
             # Restart streaming session
-            old_session_id = ss.session_id
+            old_resume_handle = ss.resume_handle
             old_turns = ss._stats["turns"]
             await ss.disconnect()
             agents.set_streaming_session_id(name, "", label="main")
-            ss._config.resume_session_id = ""
-            ss.session_id = ""
+            ss._config.resume_handle = ""
+            ss.resume_handle = ""
             if hasattr(ss, "codex_session_id"):
                 if ss.codex_session_id:
                     _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
@@ -5800,7 +5805,7 @@ def create_api(
                 "agent": name,
                 "model": req.model,
                 "restarted": True,
-                "old_session_id": old_session_id[:12] if old_session_id else "",
+                "old_session_id": old_resume_handle[:12] if old_resume_handle else "",
                 "old_turns": old_turns,
             }
         else:
@@ -5859,15 +5864,15 @@ def create_api(
             _log(f"api: archive memory save failed for {name}: {e}")
 
         # Step 2: Restart with fresh context
-        old_session_id = ss.session_id
+        old_resume_handle = ss.resume_handle
         old_turns = ss._stats["turns"]
 
         await ss.disconnect()
         agents.set_streaming_session_id(name, "", label="main")
 
         ss._config.wake_context = _build_streaming_wake_context(name)
-        ss._config.resume_session_id = ""
-        ss.session_id = ""
+        ss._config.resume_handle = ""
+        ss.resume_handle = ""
         if hasattr(ss, "codex_session_id"):
             if ss.codex_session_id:
                 _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
@@ -5882,7 +5887,7 @@ def create_api(
         return {
             "archived": True,
             "agent": name,
-            "old_session_id": old_session_id[:12] if old_session_id else "",
+            "old_session_id": old_resume_handle[:12] if old_resume_handle else "",
             "old_turns": old_turns,
         }
 
@@ -5912,7 +5917,7 @@ def create_api(
 
         return {
             "agent": name,
-            "session_id": ss.session_id[:12] if ss.session_id else "",
+            "session_id": ss.resume_handle[:12] if ss.resume_handle else "",
             "connected": ss.state == TransportSessionState.CONNECTED,
             "stats": ss.stats,
             "context": context_info,
@@ -5963,9 +5968,9 @@ def create_api(
 
         return {
             "agent": name,
-            "session_id": ss.session_id or "",
+            "session_id": ss.resume_handle or "",
             "context_pct": context_pct,
-            "resume_id": ss.session_id or "",
+            "resume_id": ss.resume_handle or "",
             "model": ss._config.model or agent.model or "",
             "cost_usd": round(ss.usage.total_cost_usd, 4),
             "turns": ss._stats.get("turns", 0),
@@ -6428,8 +6433,8 @@ def create_api(
         # Find which session is saving (for updated_by)
         session_id = ""
         streaming_main = broker._streaming.get(agent_name, {}).get("main")
-        if streaming_main and streaming_main.session_id:
-            session_id = streaming_main.session_id
+        if streaming_main and streaming_main.resume_handle:
+            session_id = streaming_main.resume_handle
         for s in manager.list():
             if not session_id and s.agent_name == agent_name and s.session_type == "main":
                 session_id = s.id

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -786,7 +786,7 @@ class MessageBroker:
         if (
             streaming
             and streaming.state == SessionState.IDLE_SLEEPING
-            and streaming.session_id
+            and streaming.resume_handle
         ):
             _log(f"broker: {agent_name} is idle-sleeping — auto-waking for inbound message")
             try:
@@ -1331,7 +1331,7 @@ class MessageBroker:
                 "label": label,
                 "connected": s.state == SessionState.CONNECTED,
                 "stats": s.stats,
-                "session_id": s.session_id[:12] if s.session_id else "",
+                "session_id": s.resume_handle[:12] if s.resume_handle else "",
             }
             for label, s in sessions.items()
         ]

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -61,7 +61,7 @@ class CodexSession:
         *,
         response_callback=None,     # async fn(StreamingTurnResult)
         conversation_store=None,    # ConversationStore for history logging
-        cost_callback=None,         # fn(agent_name, cost_usd, input_tokens, output_tokens, session_id)
+        cost_callback=None,         # fn(agent_name, cost_usd, input_tokens, output_tokens, resume_handle)
         stream_event_callback=None,  # async fn(event: dict) for incremental UI streaming
         analytics_store=None,
         registry=None,  # AgentRegistry — for server-side presence stamping
@@ -82,8 +82,8 @@ class CodexSession:
         self._current_proc: asyncio.subprocess.Process | None = None  # For cleanup on disconnect
 
         self.agent_name = config.agent_name
-        self.session_id = ""  # Codex thread_id for session resume
-        self.codex_session_id = ""  # Same, kept for internal tracking
+        self.resume_handle = ""  # Codex thread_id used to resume (opaque resume token)
+        self.codex_session_id = ""  # Last-seen thread_id, dedupe state for the resume-handle callback
         self.created_at = time.time()
         self.last_active = self.created_at
         self.usage = SessionUsage()
@@ -98,8 +98,8 @@ class CodexSession:
         self._activity_log: list[str] = []
         self._current_thinking = ""
         self.account_info: dict = {"apiProvider": "codex_cli"}
-        self._on_session_id = None  # async fn(agent_name, session_id)
-        self._pending_session_id_update = ""  # Set by sync _handle_event, consumed by async worker
+        self._on_resume_handle = None  # async fn(agent_name, resume_handle)
+        self._pending_resume_handle_update = ""  # Set by sync _handle_event, consumed by async worker
         self._context_estimator = ContextTextEstimator()
         self._current_turn_seq = 0
         self._last_user_message = ""  # For analytics keyword classification
@@ -223,15 +223,15 @@ class CodexSession:
                     self._current_turn_seq = self._stats["turns"] + 1
                     result = await self._exec_codex(prompt)
 
-                    # Fire async session_id callback (set by sync _handle_event)
-                    if self._pending_session_id_update and self._on_session_id:
+                    # Fire async resume-handle callback (set by sync _handle_event)
+                    if self._pending_resume_handle_update and self._on_resume_handle:
                         try:
-                            await self._on_session_id(
-                                self.agent_name, self._pending_session_id_update
+                            await self._on_resume_handle(
+                                self.agent_name, self._pending_resume_handle_update
                             )
                         except Exception:
                             pass
-                        self._pending_session_id_update = ""
+                        self._pending_resume_handle_update = ""
 
                     # Build turn result
                     response_text = "\n".join(result.text_parts)
@@ -520,11 +520,11 @@ class CodexSession:
             thread_id = event.get("thread_id", "")
             if thread_id and thread_id != self.codex_session_id:
                 self.codex_session_id = thread_id
-                self.session_id = thread_id
+                self.resume_handle = thread_id
                 result.thread_id = thread_id
                 _log(f"codex[{self.agent_name}]: thread_id={thread_id[:12]}")
-                # _on_session_id callback is fired by the worker after _exec_codex returns.
-                self._pending_session_id_update = thread_id
+                # _on_resume_handle callback is fired by the worker after _exec_codex returns.
+                self._pending_resume_handle_update = thread_id
                 self._analytics_session_started()
 
         elif event_type == "item.completed":
@@ -794,10 +794,10 @@ class CodexSession:
 
         _log(f"codex[{self.agent_name}]: force restarting")
 
-        # Clear session ID
-        if self._on_session_id:
+        # Clear the resume handle
+        if self._on_resume_handle:
             try:
-                await self._on_session_id(self.agent_name, "")
+                await self._on_resume_handle(self.agent_name, "")
             except Exception:
                 pass
 
@@ -811,7 +811,7 @@ class CodexSession:
                 _log(f"codex[{self.agent_name}]: failed to refresh wake context: {e}")
 
         self.codex_session_id = ""
-        self.session_id = ""
+        self.resume_handle = ""
 
         try:
             await self.connect()

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -54,7 +54,7 @@ class StreamingSessionConfig:
     permission_mode: str = "bypassPermissions"
     max_turns: int = 0
     system_prompt: str = ""
-    resume_session_id: str = ""  # SDK session ID to resume from previous run
+    resume_handle: str = ""  # SDK resume token (opaque session-continuation handle) from previous run
     wake_context: str = ""  # Saved continuation context to inject on wake
     wake_context_builder: object = None  # Callable(agent_name) -> str; refreshes wake_context on restart
     restart_guard: object = None  # Callable(session) -> dict; blocks restart if persistence is stale
@@ -209,7 +209,7 @@ class StreamingSession:
         *,
         response_callback=None,  # async fn(StreamingTurnResult)
         conversation_store=None,  # ConversationStore for history logging
-        cost_callback=None,  # fn(agent_name, cost_usd, input_tokens, output_tokens, session_id)
+        cost_callback=None,  # fn(agent_name, cost_usd, input_tokens, output_tokens, resume_handle)
         analytics_store=None,
         registry=None,  # AgentRegistry — for server-side presence stamping
         auth_alert_callback=None,  # async fn(agent_name, error_str) — fires on auth_failed
@@ -253,7 +253,7 @@ class StreamingSession:
         self._pending_chats: list[tuple[str, str, str]] = []  # Queue of (platform, chat_id, message_id)
 
         self.agent_name = config.agent_name
-        self.session_id = config.resume_session_id  # CC session ID (persisted across restarts)
+        self.resume_handle = config.resume_handle  # SDK resume token (persisted across restarts)
         self.created_at = time.time()
         self.last_active = self.created_at
         self.usage = SessionUsage()
@@ -262,7 +262,7 @@ class StreamingSession:
         self._activity_log: list[str] = []  # All tool activities this turn
         self._current_thinking = ""  # Latest thinking block (for UI streaming)
         self.account_info: dict = {}  # Populated from SDK init: email, subscriptionType, apiProvider
-        self._on_session_id = None  # async fn(agent_name, session_id) — called when session_id is captured
+        self._on_resume_handle = None  # async fn(agent_name, resume_handle) — called when SDK resume token is captured
         self._context_warned = False  # Track if we've already warned this session
         self._last_restart_block_notice_at = 0.0
         self._effort_override: str | None = None  # Session-level thinking effort override
@@ -336,10 +336,10 @@ class StreamingSession:
             provider_env.setdefault("API_TIMEOUT_MS", "1800000")
             options.env = provider_env
 
-        # Resume previous session if we have a session ID
-        if self.session_id:
-            options.resume = self.session_id
-            _log(f"streaming[{self.agent_name}]: resuming session {self.session_id[:12]}...")
+        # Resume previous session if we have a resume handle
+        if self.resume_handle:
+            options.resume = self.resume_handle
+            _log(f"streaming[{self.agent_name}]: resuming via handle {self.resume_handle[:12]}...")
 
         self._client = ClaudeSDKClient(options)
         await self._client.connect()
@@ -357,8 +357,8 @@ class StreamingSession:
         # the matrix invariant should hold. Fix: brief intermediate hop to
         # RECONNECTING (declared via a new BOOT trigger) before settling
         # here via INTERNAL. Deferred to PR6 in the #486 sequence (PR4 was
-        # bool-shim deletion + reader migration; PR5 is session_id rename;
-        # PR6 is cold-start wire-up; PR7 is CodexSession matrix adoption).
+        # bool-shim deletion + reader migration; PR5 was the resume_handle
+        # rename; PR6 is cold-start wire-up; PR7 is CodexSession matrix adoption).
         self._state_machine._state = SessionState.CONNECTED
 
         # Capture account info from SDK init result
@@ -379,7 +379,7 @@ class StreamingSession:
         _log(f"streaming[{self.agent_name}]: connected, reader loop started")
 
         # Auto-send wake prompt with saved context injected
-        is_resume = bool(self.session_id)
+        is_resume = bool(self.resume_handle)
         ctx_block = ""
         if self._config.wake_context:
             ctx_block = f"\n\n── Saved State ──\n{self._config.wake_context}\n──────────────────"
@@ -568,7 +568,7 @@ class StreamingSession:
                                     f"streaming[{self.agent_name}]: "
                                     f"auth_alert_callback raised: {exc}"
                                 )
-                        # Don't touch _last_response; fall through to usage/session_id capture.
+                        # Don't touch _last_response; fall through to usage/resume_handle capture.
                     else:
                         # Extract text and tool uses from content blocks
                         text_parts = []
@@ -635,13 +635,13 @@ class StreamingSession:
                         self.usage.input_tokens += msg.usage.get("input_tokens", 0)
                         self.usage.output_tokens += msg.usage.get("output_tokens", 0)
 
-                    # Capture session ID for persistence
-                    if msg.session_id and msg.session_id != self.session_id:
-                        self.session_id = msg.session_id
-                        _log(f"streaming[{self.agent_name}]: captured session_id {self.session_id[:12]}")
-                        if self._on_session_id:
+                    # Capture SDK resume handle for persistence
+                    if msg.session_id and msg.session_id != self.resume_handle:
+                        self.resume_handle = msg.session_id
+                        _log(f"streaming[{self.agent_name}]: captured resume_handle {self.resume_handle[:12]}")
+                        if self._on_resume_handle:
                             try:
-                                await self._on_session_id(self.agent_name, self.session_id)
+                                await self._on_resume_handle(self.agent_name, self.resume_handle)
                             except Exception:
                                 pass
 
@@ -780,7 +780,7 @@ class StreamingSession:
                                     self.agent_name, msg.total_cost_usd,
                                     msg.usage.get("input_tokens", 0) if msg.usage else 0,
                                     msg.usage.get("output_tokens", 0) if msg.usage else 0,
-                                    self.session_id or "",
+                                    self.resume_handle or "",
                                 )
                             except Exception as e:
                                 _log(f"streaming[{self.agent_name}]: cost callback error: {e}")
@@ -1005,10 +1005,10 @@ class StreamingSession:
         # force_restart. Per @murzik on PR #491 review.
         self._state_machine._state = SessionState.RECONNECTING
 
-        # Notify the persistence callback to clear session ID
-        if self._on_session_id:
+        # Notify the persistence callback to clear the resume handle
+        if self._on_resume_handle:
             try:
-                await self._on_session_id(self.agent_name, "")
+                await self._on_resume_handle(self.agent_name, "")
             except Exception:
                 pass
 
@@ -1029,10 +1029,10 @@ class StreamingSession:
                 _log(f"streaming[{self.agent_name}]: failed to refresh wake context: {e}")
 
         # Reconnect fresh with wake context
-        self._config.resume_session_id = ""
+        self._config.resume_handle = ""
         if not self._config.restart_reason:
             self._config.restart_reason = "auto_restart"
-        self.session_id = ""
+        self.resume_handle = ""
         self._context_warned = False
 
         try:

--- a/src/pinky_daemon/transport.py
+++ b/src/pinky_daemon/transport.py
@@ -42,12 +42,15 @@ Brad's Dymok test agent).
   through the same Transport surface.
 - PR4 — cleanup (LANDED): deleted ``is_connected`` / ``is_idle_sleeping`` shims and
   consume state directly via ``state == SessionState.X`` at the four caller
-  files identified during pre-PR scoping. **Also in PR4:** rename
-  ``session_id: str`` to ``resume_handle`` (or similar) and consider
-  re-typing as a backend-specific opaque object (per @murzik on PR #488
-  review; reaffirmed by @pushok in the same round). The migration window
-  keeps ``str`` so PR3 doesn't have to churn StreamingSession's existing
-  empty-string-as-empty pattern (see ``streaming_session.py:239,988``).
+  files identified during pre-PR scoping.
+- PR5 — rename (LANDED): renamed in-memory ``session_id`` to ``resume_handle``
+  (per @murzik on PR #488 review; reaffirmed by @pushok in the same round).
+  Scoped to the in-memory surface (Transport property, StreamingSession /
+  CodexSession instance attrs, ``StreamingSessionConfig`` field, callback
+  hooks). The persistence layer (``AgentRegistry.{get,set,list}_streaming_session_id``
+  + DB column ``streaming_session_id``) deliberately keeps its old name to
+  avoid bundling a migration into the rename PR. Re-typing as a
+  backend-specific opaque object is still open as a separate concern.
 
 ## What's intentionally NOT in this Protocol
 
@@ -142,7 +145,7 @@ class Transport(Protocol):
         ...
 
     @property
-    def session_id(self) -> str:
+    def resume_handle(self) -> str:
         """Resume handle, opaque shape per backend.
 
         For ``StreamingSession``: the Claude Code SDK session ID, persisted
@@ -152,19 +155,18 @@ class Transport(Protocol):
         ``claude --continue`` resolves by cwd's most-recent transcript and
         the tmux session pins the cwd).
 
-        **Migration-window contract.** Consumers must treat this as opaque
+        **Opacity contract.** Consumers must treat this as opaque
         compatibility data — never derive lifecycle state from it. The
-        state machine does NOT consult ``session_id`` for lifecycle
-        decisions per issue #486 invariant 7 (session_id is data, not
+        state machine does NOT consult ``resume_handle`` for lifecycle
+        decisions per issue #486 invariant 7 (resume_handle is data, not
         state). The pre-state-machine bug (#484, #486) was downstream of
-        callers inferring "is_connected ∨ session_id ≠ ''" as state; PR3
-        cuts that inference at the source.
+        callers inferring "is_connected ∨ resume_handle ≠ ''" as state; PR3
+        cut that inference at the source. PR5 renamed the property from
+        ``session_id`` to ``resume_handle`` to clarify the intent (an opaque
+        continuation token) and disambiguate from PinkyBot's own session UUID.
 
-        **Post-migration consideration.** Once all callers consume
-        ``state`` instead of inferring from ``session_id``, this property
-        is a candidate for renaming to ``resume_handle`` and possibly
-        re-typing as a backend-specific opaque object (per @murzik on PR
-        #488 review). Out of scope for the current PR sequence.
+        Re-typing as a backend-specific opaque object (per @murzik on PR
+        #488 review) is still open as a follow-up.
         """
         ...
 

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -54,7 +54,7 @@ class FakeStreamingSession:
         self._TS = SessionState
         self.agent_name = agent_name
         self.label = label
-        self.session_id = f"{agent_name}-{label}-sdk-abc123"
+        self.resume_handle = f"{agent_name}-{label}-sdk-abc123"
         self.created_at = time.time() - 120  # 2 minutes old
         self.last_active = self.created_at
         self._state = SessionState.CONNECTED if connected else SessionState.DEAD

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -421,7 +421,7 @@ class TestAPI:
             self._TS = SessionState
             self.agent_name = agent_name
             self.label = label
-            self.session_id = f"{agent_name}-{label}-sdk"
+            self.resume_handle = f"{agent_name}-{label}-sdk"
             self.created_at = time.time()
             self.last_active = self.created_at
             self._state = SessionState.CONNECTED if connected else SessionState.DEAD
@@ -550,7 +550,7 @@ class TestAPI:
                     "test-agent",
                     task="Ready for sleep",
                     metadata={"source": "save_my_context"},
-                    updated_by=fake.session_id,
+                    updated_by=fake.resume_handle,
                 )
 
                 resp = client.post("/agents/test-agent/sleep")
@@ -599,10 +599,10 @@ class TestAPI:
             # Drive state machine to CONNECTED to mimic real connect() landing.
             from pinky_daemon.transport_state import SessionState
             self._state_machine._state = SessionState.CONNECTED
-            if not self.session_id:
-                self.session_id = f"{self.agent_name}-sdk"
-            if self._on_session_id:
-                await self._on_session_id(self.agent_name, self.session_id)
+            if not self.resume_handle:
+                self.resume_handle = f"{self.agent_name}-sdk"
+            if self._on_resume_handle:
+                await self._on_resume_handle(self.agent_name, self.resume_handle)
 
         async def fake_send(self, prompt: str, platform: str = "", chat_id: str = ""):
             sent_prompts.append((self.agent_name, prompt, platform, chat_id))
@@ -654,9 +654,9 @@ class TestAPI:
             # _connected bool. PR3's state-machine routing is scoped to
             # StreamingSession; CodexSession adoption is a separate PR.
             self._connected = True
-            self.session_id = self.session_id or f"{self.agent_name}-codex"
-            if self._on_session_id:
-                await self._on_session_id(self.agent_name, self.session_id)
+            self.resume_handle = self.resume_handle or f"{self.agent_name}-codex"
+            if self._on_resume_handle:
+                await self._on_resume_handle(self.agent_name, self.resume_handle)
 
         async def fake_send(self, prompt: str, platform: str = "", chat_id: str = "", message_id: str = "", agent_hint: str = ""):
             del prompt, platform, chat_id, message_id, agent_hint
@@ -738,7 +738,7 @@ class TestAPI:
                     "test-agent",
                     task="Testing restart guard",
                     metadata={"source": "save_my_context"},
-                    updated_by=fake.session_id,
+                    updated_by=fake.resume_handle,
                 )
                 stale_ts = time.time() - 601
                 app.state.agents._db.execute(
@@ -766,7 +766,7 @@ class TestAPI:
                     "test-agent",
                     task="Testing restart guard",
                     metadata={"source": "save_my_context"},
-                    updated_by=fake.session_id,
+                    updated_by=fake.resume_handle,
                 )
                 fake.last_active = time.time()
 
@@ -793,7 +793,7 @@ class TestAPI:
                     "test-agent",
                     task="Testing codex restart clears thread id",
                     metadata={"source": "save_my_context"},
-                    updated_by=fake.session_id,
+                    updated_by=fake.resume_handle,
                 )
                 fake.last_active = time.time()
 
@@ -804,7 +804,7 @@ class TestAPI:
                     "codex_session_id must be cleared so next turn does not "
                     "issue `codex exec resume <stale-id>`"
                 )
-                assert fake.session_id == ""
+                assert fake.resume_handle == ""
 
     def test_streaming_model_change_clears_codex_session_id(self):
         """When /streaming/model triggers a context-window restart, codex_session_id
@@ -824,7 +824,7 @@ class TestAPI:
                     "test-agent",
                     task="Testing /streaming/model clears codex thread",
                     metadata={"source": "save_my_context"},
-                    updated_by=fake.session_id,
+                    updated_by=fake.resume_handle,
                 )
                 fake.last_active = time.time()
 
@@ -834,7 +834,7 @@ class TestAPI:
                 )
                 assert resp.status_code == 200, resp.text
                 assert fake.codex_session_id == ""
-                assert fake.session_id == ""
+                assert fake.resume_handle == ""
 
     def test_streaming_archive_clears_codex_session_id(self):
         """/streaming/archive must clear codex_session_id alongside session_id —
@@ -852,7 +852,7 @@ class TestAPI:
                     "test-agent",
                     task="Testing /streaming/archive clears codex thread",
                     metadata={"source": "save_my_context"},
-                    updated_by=fake.session_id,
+                    updated_by=fake.resume_handle,
                 )
                 fake.last_active = time.time()
 
@@ -860,7 +860,7 @@ class TestAPI:
                 assert resp.status_code == 200, resp.text
                 assert resp.json()["archived"] is True
                 assert fake.codex_session_id == ""
-                assert fake.session_id == ""
+                assert fake.resume_handle == ""
                 # Sanity: archive prompted the agent to save state before resetting.
                 assert any(
                     "archived" in q.lower() or "save" in q.lower()
@@ -976,10 +976,10 @@ class TestAPI:
             # Drive state machine to CONNECTED to mimic real connect() landing.
             from pinky_daemon.transport_state import SessionState
             self._state_machine._state = SessionState.CONNECTED
-            if not self.session_id:
-                self.session_id = f"{self.agent_name}-sdk"
-            if self._on_session_id:
-                await self._on_session_id(self.agent_name, self.session_id)
+            if not self.resume_handle:
+                self.resume_handle = f"{self.agent_name}-sdk"
+            if self._on_resume_handle:
+                await self._on_resume_handle(self.agent_name, self.resume_handle)
 
         with tempfile.TemporaryDirectory() as tmpdir, \
                 patch("pinky_daemon.streaming_session.StreamingSession.connect", new=fake_connect):

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -132,7 +132,7 @@ class TestMessageBrokerRouting:
     async def test_route_streaming_waits_for_in_flight_reconnect(self, monkeypatch):
         """Regression: messages arriving during ``context_restart`` (where the
         streaming session object exists but ``state`` is briefly != CONNECTED
-        and ``session_id`` is wiped to "") must be held until the reconnect
+        and ``resume_handle`` is wiped to "") must be held until the reconnect
         completes — not dropped with a "not running" fallback.
 
         Simulates the restart window by flipping ``state`` back to CONNECTED
@@ -152,8 +152,8 @@ class TestMessageBrokerRouting:
         try:
             class _RestartingSession:
                 # Mirror StreamingSession state during force_restart:
-                # disconnect() has run, session_id has been wiped.
-                session_id = ""
+                # disconnect() has run, resume_handle has been wiped.
+                resume_handle = ""
 
                 def __init__(self):
                     self.state = SessionState.RECONNECTING
@@ -209,7 +209,7 @@ class TestMessageBrokerRouting:
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
             class _DeadSession:
-                session_id = ""
+                resume_handle = ""
 
                 def __init__(self):
                     self.state = SessionState.DEAD
@@ -248,8 +248,8 @@ class TestMessageBrokerRouting:
         """Regression for @murzik PR #492 blocker 1.
 
         Pre-fix the auto-wake branch fired for ANY non-CONNECTED state
-        as long as session_id was non-empty. During force_restart /
-        attempt_reconnect, state is RECONNECTING and session_id may
+        as long as resume_handle was non-empty. During force_restart /
+        attempt_reconnect, state is RECONNECTING and resume_handle may
         still be set, so an inbound message racing the in-flight reconnect
         would call ss.connect() a SECOND time — concurrent with the
         in-flight one. Post-fix the auto-wake only fires for
@@ -265,10 +265,10 @@ class TestMessageBrokerRouting:
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
             class _ReconnectingSession:
-                # Mid-reconnect: state RECONNECTING, session_id non-empty
+                # Mid-reconnect: state RECONNECTING, resume_handle non-empty
                 # (the bug-triggering combo — pre-fix this combo would
                 # cause the broker to call connect() again).
-                session_id = "sdk-abc123"
+                resume_handle = "sdk-abc123"
 
                 def __init__(self):
                     self.state = SessionState.RECONNECTING
@@ -317,7 +317,7 @@ class TestMessageBrokerRouting:
     @pytest.mark.asyncio
     async def test_route_streaming_auto_wakes_idle_sleeping(self, monkeypatch):
         """Companion to the no-double-connect test: IDLE_SLEEPING with a
-        retained session_id IS the intended auto-wake path. Pre-fix this
+        retained resume_handle IS the intended auto-wake path. Pre-fix this
         worked via the broader `not is_connected` check; post-fix it
         works via the explicit `state == IDLE_SLEEPING` check.
         """
@@ -326,7 +326,7 @@ class TestMessageBrokerRouting:
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
             class _SleepingSession:
-                session_id = "sdk-resume"
+                resume_handle = "sdk-resume"
 
                 def __init__(self):
                     self.state = SessionState.IDLE_SLEEPING

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -60,9 +60,9 @@ class TestCodexSessionInterface:
                      "current_activity", "activity_log", "cost_usd", "account"):
             assert key in stats, f"missing key: {key}"
 
-    def test_session_id_defaults_empty(self):
+    def test_resume_handle_defaults_empty(self):
         s = self._make_session()
-        assert s.session_id == ""
+        assert s.resume_handle == ""
         assert s.codex_session_id == ""
 
     def test_context_info_estimates_from_store_and_internal_prompts(self):
@@ -449,7 +449,7 @@ class TestCodexSessionDisconnect:
         )
         s = CodexSession(config)
         s.codex_session_id = "thread-123"
-        s.session_id = "thread-123"
+        s.resume_handle = "thread-123"
         s._RECONNECT_BACKOFF = (0,)
         calls = []
 
@@ -471,7 +471,7 @@ class TestCodexSessionDisconnect:
         assert calls == ["disconnect", "connect"]
         assert s.state == SessionState.CONNECTED
         assert s.codex_session_id == "thread-123"
-        assert s.session_id == "thread-123"
+        assert s.resume_handle == "thread-123"
         assert s.stats["reconnects"] == 1
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -40,7 +40,7 @@ class _StubTransport:
         return SessionState.UNINITIALIZED
 
     @property
-    def session_id(self) -> str:
+    def resume_handle(self) -> str:
         return ""
 
     @property
@@ -117,7 +117,7 @@ class TestRuntimeCheckable:
             def id(self) -> str:
                 return ""
 
-            # Missing: state, session_id, stats, connect, disconnect, send,
+            # Missing: state, resume_handle, stats, connect, disconnect, send,
             # force_restart, idle_sleep, attempt_reconnect, effective_effort,
             # set_effort, clear_effort_override.
 
@@ -137,7 +137,7 @@ class TestSurfaceShape:
     REQUIRED_PROPERTIES = {
         "id",
         "state",
-        "session_id",
+        "resume_handle",
         "stats",
         "effective_effort",
     }


### PR DESCRIPTION
## Summary

Renames the SDK-style opaque continuation token from `session_id` to `resume_handle` across the in-memory surface. The old name was overloaded — PinkyBot also uses `session_id` for its own session UUID (`StreamingSession.id`, `ChatMessage.session_id`, `req.session_id`, etc.) — which made code reading ambiguous about which "session id" was meant in any given line.

Per @murzik on PR #488 review; reaffirmed by @pushok in the same round. Anchor TODOs in `transport.py:46,165` are now resolved.

## Renamed (in-memory only)

- `Transport.session_id` (Protocol property) → `Transport.resume_handle`
- `StreamingSession.session_id` → `StreamingSession.resume_handle`
- `CodexSession.session_id` → `CodexSession.resume_handle`
- `StreamingSessionConfig.resume_session_id` → `resume_handle`
- `StreamingSession._on_session_id` callback → `_on_resume_handle`
- `CodexSession._on_session_id` callback → `_on_resume_handle`
- `CodexSession._pending_session_id_update` → `_pending_resume_handle_update`
- `api._make_streaming_session_id_callback` → `_make_streaming_resume_handle_callback`

## NOT renamed (deliberately scoped out)

| Surface | Why not |
|---|---|
| Public API response fields (`"sdk_session_id"`, `"session_id"`, `"old_session_id"`, `"resume_id"`) | Preserves the existing wire contract. Reads from `ss.resume_handle` internally, emits the same field names. A future PR can rename the wire schema if desired (consumers: frontend, pinky_self tools). |
| `AgentRegistry.{get,set,list}_streaming_session_id` + DB column `streaming_session_id` | Bundling a DB migration into a rename PR is the wrong shape — that's a follow-up. |
| `StreamingTurnResult.session_id` | Carries `self.id` (the StreamingSession instance UUID), not the SDK token. Different concept. |
| `CodexSession.codex_session_id` | Internal dedupe state for the resume-handle callback. Different concept. |
| `SDKRunner.run(session_id=)` + `daemon.session_sender` callback param (per @pushok review) | Same concept (SDK resume token), different abstraction — SDKRunner sits alongside Transport, not under it. Renaming would expand scope beyond the Transport surface this PR is centered on; clean follow-up if we want SDKRunner aligned. |
| `Session.session_id`, `ConversationMessage.session_id`, `Inbox.session_id`, `req.session_id`, `hb.session_id` | PinkyBot's own session UUID — not the SDK resume token. |

## What's NOT in this PR

- **PR6** (next): cold-start RECONNECTING wire-up via BOOT trigger (Pushok Bug 3 from #491). Design locked with @pushok in pre-PR discussion: BOOTING state + BOOT/BOOT_COMPLETE/BOOT_FAILED Trigger triplet, UNINITIALIZED-has-zero-incoming invariant, cold-start is one-shot (retries reduce to warm-reconnect via DEAD→RECONNECTING resurrection).
- **PR7** (deferred per @bradbrok): CodexSession adopts full StateMachine matrix. The asymmetry call from @murzik on #491 review still stands; deferred from this session's shipping pass.

## Tests

- 2072 pass, 1 skipped (same as PR4 baseline).
- Updated mocks: `FakeStreamingSession`, `_FakeStreamingSession`, `_StubTransport`, `_RestartingSession`, `_DeadSession`, `_ReconnectingSession`, `_SleepingSession` — all now expose `resume_handle` matching the renamed Transport property.
- `test_transport.py::TestSurfaceShape::REQUIRED_PROPERTIES` now asserts `resume_handle` instead of `session_id`, locking in the rename at the Protocol level.

## Test plan

- [x] ruff check passes (touched files)
- [x] `pytest` full suite: 2072 pass, 1 skipped
- [ ] CI green

cc @pushok @murzik — light review pass; pure rename, no behavior change. Watching for: stale doc/log/comment references, any mock or fake I missed.

🤖 Opened by Barsik