### PR TITLE
feat(transport): cold-start RECONNECTING wire-up via BOOT trigger (#486 PR6)

### DIFF
--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -283,35 +283,88 @@ class StreamingSession:
         """
         from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 
-        # PR6: cold-start wire-up. If we entered connect() in UNINITIALIZED,
-        # drive through BOOT into BOOTING for the duration of the handshake.
+        # PR6: cold-start wire-up. If we entered connect() in UNINITIALIZED
+        # OR a BOOT is already in flight (state == BOOTING with our state
+        # machine mid-handshake from a concurrent caller), request BOOT
+        # ownership through the state machine. The widened guard is the
+        # load-bearing fix for the concurrent-connect race Murzik flagged
+        # on PR #494: request_transition mutates state at grant time, so a
+        # narrow ``state == UNINITIALIZED`` guard lets caller B enter
+        # connect() during caller A's handshake, see state == BOOTING, skip
+        # the ownership/subscriber path entirely, and run a second SDK
+        # handshake (then direct-mutate CONNECTED via the warm-reconnect
+        # else branch). With BOOTING in the guard, the state machine routes
+        # caller B to the same-target in-flight branch — caller B subscribes
+        # via InFlightHandle and inherits caller A's CONNECTED-or-DEAD
+        # outcome, guaranteeing exactly one SDK construction per cold start.
+        #
         # The matrix invariant pins the only legal exits from BOOTING as
         # CONNECTED (BOOT_COMPLETE) or DEAD (BOOT_FAILED). The token returned
         # here keeps us responsible for completing the in-flight transition on
         # every exit path — success, failure, or exception.
         cold_start_token = None
-        if self.state == SessionState.UNINITIALIZED:
+        if self.state in (SessionState.UNINITIALIZED, SessionState.BOOTING):
             boot_result = await self._state_machine.request_transition(
                 SessionState.BOOTING,
                 Trigger.BOOT,
                 reason="cold_start_handshake",
             )
             if boot_result.owner_token is None:
-                # Either a same-target BOOT is already in flight (subscribe
-                # and bail — the in-flight owner will land us in CONNECTED
-                # or DEAD) or a different-target transition is in flight
-                # (matrix rejected). For cold-start this should be vanishingly
-                # rare in practice — connect() is called once on a fresh
-                # session — but handle it defensively rather than crashing.
+                # Either a same-target BOOT is already in flight (we
+                # subscribe and inherit the owner's outcome) or a different-
+                # target transition is in flight (matrix rejected). The
+                # subscriber path is the hot path for the concurrent-connect
+                # race; the rejection path is rare in practice but handled
+                # defensively rather than crashing.
                 if boot_result.in_flight_handle is not None:
-                    await boot_result.in_flight_handle.wait()
-                    return
+                    final = await boot_result.in_flight_handle.wait()
+                    if final == SessionState.CONNECTED:
+                        # Owner completed the handshake; we're done.
+                        return
+                    # Owner landed DEAD (cold-start failed) or some other
+                    # non-CONNECTED state. Surface the failure — don't let
+                    # the subscriber silently return as if connected, which
+                    # would leave the caller proceeding against a session
+                    # that has no client. The DEAD → RECONNECTING
+                    # resurrection path remains available to upstream
+                    # callers via the existing warm-reconnect machinery.
+                    raise RuntimeError(
+                        f"streaming[{self.agent_name}]: cold-start BOOT "
+                        f"in-flight resolved to {final.value} (owner failed); "
+                        f"refusing to return as connected"
+                    )
+                # No in-flight handle: rejection (matrix said no), or an
+                # observational identity read that snuck through under a
+                # post-completion race window. Case D from Pushok's #494
+                # review: D enters with state == BOOTING but, by the time
+                # request_transition acquires the lock, A has already
+                # completed — state has moved to CONNECTED (happy) or DEAD
+                # (failed). For CONNECTED, returning silently is fine —
+                # the caller will see is_connected. For DEAD, returning
+                # silently would let the caller think cold-start succeeded
+                # against a dead transport; surface the failure instead.
                 _log(
                     f"streaming[{self.agent_name}]: BOOT rejected "
                     f"({boot_result.rejection_reason!r}) — refusing cold-start"
                 )
+                if self.state == SessionState.DEAD:
+                    raise RuntimeError(
+                        f"streaming[{self.agent_name}]: cold-start BOOT "
+                        f"rejected post-DEAD (owner failed before we "
+                        f"subscribed); refusing to return as connected"
+                    )
                 return
             cold_start_token = boot_result.owner_token
+
+        # PR6.5 follow-up (Pushok's #494 review, Case C): post-completion
+        # straggler. A caller entering connect() with state already CONNECTED
+        # skips the guard above, falls through to the SDK construction below,
+        # and runs a redundant handshake — then direct-mutates CONNECTED via
+        # the warm-reconnect else branch. This is the same double-connect
+        # class as the BOOTING race but driven from CONNECTED, and predates
+        # PR6 (the warm-reconnect path has always done this). Out of scope
+        # for the BOOT lifecycle; tracked alongside RECONNECT_COMPLETE /
+        # RECONNECT_FAILED Trigger symmetry as PR6.5.
 
         # Load MCP servers from .mcp.json
         mcp_servers = self._config.mcp_servers

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from pinky_daemon.sessions import SessionUsage
-from pinky_daemon.transport_state import SessionState, StateMachine
+from pinky_daemon.transport_state import SessionState, StateMachine, Trigger
 
 # Models with native 1M context (SDK reports 200k incorrectly)
 _1M_MODELS = {"claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7"}
@@ -230,17 +230,20 @@ class StreamingSession:
         self._reader_task: asyncio.Task | None = None
         # PR3 (#486 sequence): formal adoption of the Transport protocol.
         # The pre-PR3 ``_connected`` + ``_idle_sleeping`` two-bool inference
-        # was replaced by a five-state machine. PR4 deleted the legacy
+        # was replaced by an explicit state machine. PR4 deleted the legacy
         # ``is_connected`` / ``is_idle_sleeping`` shim properties and
         # migrated all external readers (broker, api, scheduler, watchdog)
-        # to consult ``state`` directly.
+        # to consult ``state`` directly. PR5 renamed the in-memory SDK
+        # resume token from ``session_id`` to ``resume_handle``. PR6 wired
+        # the cold-start UNINITIALIZED → BOOTING → CONNECTED lifecycle
+        # through the matrix via the BOOT / BOOT_COMPLETE / BOOT_FAILED
+        # Trigger triplet (see ``connect()`` for the BOOT lifecycle).
         #
-        # State-write paths still mutate ``_state`` directly at the same
-        # code points where ``_connected`` / ``_idle_sleeping`` were
-        # mutated before. The formal ``request_transition`` /
-        # ``transition_complete`` orchestration with full Trigger
-        # awareness (cold-start RECONNECTING wire-up etc.) is the next
-        # PR in the sequence — anchor TODO in ``connect()``.
+        # Warm-reconnect state writes (force_restart, idle_sleep, etc.)
+        # still mutate ``_state`` directly at the same code points as the
+        # pre-state-machine code. Adding RECONNECT_BEGIN / RECONNECT_COMPLETE /
+        # RECONNECT_FAILED Trigger symmetry to the warm path is the
+        # post-PR6 follow-up.
         #
         # Watchdog resurrection (api._heartbeat_resurrect) inspects
         # ``state == IDLE_SLEEPING`` to avoid fighting the idle-sleep
@@ -270,8 +273,45 @@ class StreamingSession:
         self._last_user_message = ""  # For analytics keyword classification
 
     async def connect(self) -> None:
-        """Connect to Claude Code. Starts the reader loop."""
+        """Connect to Claude Code. Starts the reader loop.
+
+        PR6 (Pushok): cold-start now drives the matrix-correct
+        UNINITIALIZED → BOOTING → CONNECTED (or → DEAD on failure) lifecycle
+        explicitly via the BOOT / BOOT_COMPLETE / BOOT_FAILED Trigger triplet.
+        Warm-reconnect (RECONNECTING → CONNECTED) still direct-mutates pending
+        the broader warm-reconnect-Trigger-symmetry follow-up (PR6.5/PR7).
+        """
         from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+        # PR6: cold-start wire-up. If we entered connect() in UNINITIALIZED,
+        # drive through BOOT into BOOTING for the duration of the handshake.
+        # The matrix invariant pins the only legal exits from BOOTING as
+        # CONNECTED (BOOT_COMPLETE) or DEAD (BOOT_FAILED). The token returned
+        # here keeps us responsible for completing the in-flight transition on
+        # every exit path — success, failure, or exception.
+        cold_start_token = None
+        if self.state == SessionState.UNINITIALIZED:
+            boot_result = await self._state_machine.request_transition(
+                SessionState.BOOTING,
+                Trigger.BOOT,
+                reason="cold_start_handshake",
+            )
+            if boot_result.owner_token is None:
+                # Either a same-target BOOT is already in flight (subscribe
+                # and bail — the in-flight owner will land us in CONNECTED
+                # or DEAD) or a different-target transition is in flight
+                # (matrix rejected). For cold-start this should be vanishingly
+                # rare in practice — connect() is called once on a fresh
+                # session — but handle it defensively rather than crashing.
+                if boot_result.in_flight_handle is not None:
+                    await boot_result.in_flight_handle.wait()
+                    return
+                _log(
+                    f"streaming[{self.agent_name}]: BOOT rejected "
+                    f"({boot_result.rejection_reason!r}) — refusing cold-start"
+                )
+                return
+            cold_start_token = boot_result.owner_token
 
         # Load MCP servers from .mcp.json
         mcp_servers = self._config.mcp_servers
@@ -341,25 +381,40 @@ class StreamingSession:
             options.resume = self.resume_handle
             _log(f"streaming[{self.agent_name}]: resuming via handle {self.resume_handle[:12]}...")
 
-        self._client = ClaudeSDKClient(options)
-        await self._client.connect()
-        # Drive state machine to CONNECTED. The ``state`` property reads
-        # from here; this settle covers the cold-start (UNINITIALIZED →
-        # CONNECTED — see TODO below), genuine wake from IDLE_SLEEPING,
-        # and the post-disconnect reconnect paths. Direct mutation is
-        # the staged-migration shape; full request_transition /
-        # transition_complete orchestration is the next PR.
-        #
-        # TODO(PR6 — @pushok on #491 review, Bug 3): The cold-start path
-        # currently goes UNINITIALIZED → CONNECTED, which the matrix forbids
-        # (illegal pair, must go through RECONNECTING). Direct ``_state =``
-        # bypasses the matrix check, so this isn't user-visible today, but
-        # the matrix invariant should hold. Fix: brief intermediate hop to
-        # RECONNECTING (declared via a new BOOT trigger) before settling
-        # here via INTERNAL. Deferred to PR6 in the #486 sequence (PR4 was
-        # bool-shim deletion + reader migration; PR5 was the resume_handle
-        # rename; PR6 is cold-start wire-up; PR7 is CodexSession matrix adoption).
-        self._state_machine._state = SessionState.CONNECTED
+        try:
+            self._client = ClaudeSDKClient(options)
+            await self._client.connect()
+        except BaseException:
+            # On cold-start failure, drive the BOOTING → DEAD transition via
+            # BOOT_FAILED so the lifecycle is auditable in logs. Warm-reconnect
+            # callers (force_restart etc.) don't enter this branch — their
+            # state was RECONNECTING at entry, not UNINITIALIZED.
+            if cold_start_token is not None:
+                try:
+                    await self._state_machine.transition_complete(
+                        cold_start_token, SessionState.DEAD,
+                        trigger=Trigger.BOOT_FAILED,
+                    )
+                except Exception as ce:
+                    _log(
+                        f"streaming[{self.agent_name}]: BOOT_FAILED completion "
+                        f"raised after cold-start error: {ce}"
+                    )
+            raise
+
+        # Land in CONNECTED. Cold-start goes through the matrix
+        # (BOOTING → CONNECTED via BOOT_COMPLETE), keeping the cold-start
+        # lifecycle a closed BOOT / BOOT_COMPLETE pair in audit logs.
+        # Warm-reconnect (force_restart, idle-wake, etc.) still direct-mutates;
+        # adding RECONNECT_COMPLETE / RECONNECT_FAILED Trigger symmetry is the
+        # PR6.5 follow-up (warm-path Trigger-symmetry; out of scope for PR6).
+        if cold_start_token is not None:
+            await self._state_machine.transition_complete(
+                cold_start_token, SessionState.CONNECTED,
+                trigger=Trigger.BOOT_COMPLETE,
+            )
+        else:
+            self._state_machine._state = SessionState.CONNECTED
 
         # Capture account info from SDK init result
         try:

--- a/src/pinky_daemon/transport_state.py
+++ b/src/pinky_daemon/transport_state.py
@@ -94,7 +94,14 @@ class SessionState(Enum):
     rationale per cell. Summary:
 
     - ``UNINITIALIZED`` — birth state. Constructed but never tried to connect.
-      Distinguishes "never tried" from "tried and failed."
+      Distinguishes "never tried" from "tried and failed." **Invariant:**
+      UNINITIALIZED has zero incoming edges in the matrix; once a session
+      leaves it (via BOOT or API_ADMIN), it never returns.
+    - ``BOOTING`` — one-shot cold-start in flight. Distinct from RECONNECTING:
+      RECONNECTING means "we believe a session exists and are re-establishing,"
+      BOOTING means "no prior session, first attempt." Cold-start is one-shot —
+      no BOOTING self-edge — and retries reduce to warm-reconnect through the
+      DEAD → RECONNECTING resurrection path (see Pushok's PR6 design pin).
     - ``RECONNECTING`` — macro state for "currently trying to be CONNECTED."
       Internal retry attempts stay inside this state; no flicker.
     - ``CONNECTED`` — happy path. Can send/receive.
@@ -105,6 +112,7 @@ class SessionState(Enum):
     """
 
     UNINITIALIZED = "uninitialized"
+    BOOTING = "booting"
     RECONNECTING = "reconnecting"
     CONNECTED = "connected"
     IDLE_SLEEPING = "idle_sleeping"
@@ -120,7 +128,9 @@ class Trigger(Enum):
     final flip into CONNECTED after a successful handshake.
     """
 
-    BOOT = "boot"  # daemon startup / boot policy
+    BOOT = "boot"  # cold-start initiation: UNINITIALIZED → BOOTING (PR6)
+    BOOT_COMPLETE = "boot_complete"  # cold-start success: BOOTING → CONNECTED (PR6)
+    BOOT_FAILED = "boot_failed"  # cold-start failure: BOOTING → DEAD (PR6)
     BROKER = "broker"  # _route_streaming auto-wake / resurrection on inbound
     WATCHDOG = "watchdog"  # session_watchdog lifecycle decisions (idle, resurrect)
     SCHEDULER = "scheduler"  # scheduler.py cron-driven wakes + heartbeat resurrect
@@ -245,14 +255,32 @@ class TransitionResult:
 # may drive it. Any (from, to, trigger) outside this map is REJECTED.
 LEGAL_TRANSITIONS: dict[tuple[SessionState, SessionState], frozenset[Trigger]] = {
     # FROM UNINITIALIZED
-    (SessionState.UNINITIALIZED, SessionState.RECONNECTING): frozenset({Trigger.BOOT}),
-    # Boot policy decline OR shutdown-before-start.
+    # PR6 (Pushok): cold-start goes UNINITIALIZED → BOOTING via BOOT.
+    # No direct UNINITIALIZED → RECONNECTING — that would conflate
+    # "first attempt" with "re-establishing a known session." Retries on
+    # cold-start failure reduce to warm-reconnect via DEAD → RECONNECTING.
+    (SessionState.UNINITIALIZED, SessionState.BOOTING): frozenset({Trigger.BOOT}),
+    # Boot policy decline OR shutdown-before-start. Still BOOT (policy-driven
+    # refusal to start) or API_ADMIN (operator kill before connect).
     (SessionState.UNINITIALIZED, SessionState.DEAD): frozenset(
         {Trigger.BOOT, Trigger.API_ADMIN}
     ),
 
+    # FROM BOOTING
+    # PR6 (Pushok): one-shot cold-start.
+    # - BOOT_COMPLETE: the SDK handshake succeeded.
+    # - BOOT_FAILED: cold-start raised / handshake refused.
+    # - API_ADMIN: admin kill mid-boot (rare, but symmetric with other states).
+    # No BOOTING self-edge — retries reduce to warm-reconnect through DEAD.
+    (SessionState.BOOTING, SessionState.CONNECTED): frozenset({Trigger.BOOT_COMPLETE}),
+    (SessionState.BOOTING, SessionState.DEAD): frozenset(
+        {Trigger.BOOT_FAILED, Trigger.API_ADMIN}
+    ),
+
     # FROM RECONNECTING
     # Only the Transport's own connect handshake can drive CONNECTED.
+    # See PR6.5/PR7 follow-up: consider renaming this completion to
+    # RECONNECT_COMPLETE for trigger symmetry with the cold-start lifecycle.
     (SessionState.RECONNECTING, SessionState.CONNECTED): frozenset({Trigger.INTERNAL}),
     # Retry budget exhausted / connect() raised; also admin force-kill mid-reconnect.
     (SessionState.RECONNECTING, SessionState.DEAD): frozenset(
@@ -299,21 +327,38 @@ LEGAL_TRANSITIONS: dict[tuple[SessionState, SessionState], frozenset[Trigger]] =
 # messages when a caller requests a structurally-disallowed transition.
 ILLEGAL_PAIR_REASONS: dict[tuple[SessionState, SessionState], str] = {
     (SessionState.UNINITIALIZED, SessionState.CONNECTED):
-        "no shortcut to CONNECTED — must go through RECONNECTING",
+        "no shortcut to CONNECTED — cold-start must go through BOOTING",
+    (SessionState.UNINITIALIZED, SessionState.RECONNECTING):
+        "cold-start goes through BOOTING — RECONNECTING is for re-establishing a known session",
     (SessionState.UNINITIALIZED, SessionState.IDLE_SLEEPING):
         "can't sleep something that never connected",
+    # PR6: BOOTING is one-shot. No self-edge, no sideways exits.
+    (SessionState.BOOTING, SessionState.UNINITIALIZED):
+        "UNINITIALIZED is birth state, no return path",
+    (SessionState.BOOTING, SessionState.RECONNECTING):
+        "cold-start is one-shot — retries reduce to warm-reconnect via DEAD → RECONNECTING",
+    (SessionState.BOOTING, SessionState.IDLE_SLEEPING):
+        "can't sleep mid-boot; finish via BOOT_COMPLETE or BOOT_FAILED first",
     (SessionState.RECONNECTING, SessionState.UNINITIALIZED):
         "UNINITIALIZED is birth state, no return path",
+    (SessionState.RECONNECTING, SessionState.BOOTING):
+        "BOOTING is cold-start only — RECONNECTING is the warm-reconnect macro state",
     (SessionState.RECONNECTING, SessionState.IDLE_SLEEPING):
         "can't sleep mid-connect; finish reconnecting or fail to DEAD first",
     (SessionState.CONNECTED, SessionState.UNINITIALIZED):
         "UNINITIALIZED is birth state, no return path",
+    (SessionState.CONNECTED, SessionState.BOOTING):
+        "BOOTING is cold-start only — already-connected sessions reset via RECONNECTING",
     (SessionState.IDLE_SLEEPING, SessionState.UNINITIALIZED):
         "UNINITIALIZED is birth state, no return path",
+    (SessionState.IDLE_SLEEPING, SessionState.BOOTING):
+        "BOOTING is cold-start only — wake from sleep uses RECONNECTING",
     (SessionState.IDLE_SLEEPING, SessionState.CONNECTED):
         "wake goes through RECONNECTING for observability — no direct CONNECTED",
     (SessionState.DEAD, SessionState.UNINITIALIZED):
         "UNINITIALIZED is birth state, no return path",
+    (SessionState.DEAD, SessionState.BOOTING):
+        "BOOTING is cold-start only — resurrection uses RECONNECTING",
     (SessionState.DEAD, SessionState.CONNECTED):
         "resurrection goes through RECONNECTING — no direct CONNECTED",
     (SessionState.DEAD, SessionState.IDLE_SLEEPING):
@@ -359,6 +404,18 @@ class StateMachine:
         *,
         initial_state: SessionState = SessionState.UNINITIALIZED,
     ) -> None:
+        # PR6 (Pushok): the state machine can only be constructed in
+        # UNINITIALIZED (cold-start) or DEAD (rehydrating a persisted
+        # "session died" snapshot). Constructing in any other state would
+        # bypass the matrix invariants — particularly UNINITIALIZED-has-zero-
+        # incoming and BOOT-only-from-UNINITIALIZED — and let future
+        # maintainers reach for "let me construct one in RECONNECTING for
+        # testing convenience" which silently breaks the cold-start lifecycle.
+        if initial_state not in (SessionState.UNINITIALIZED, SessionState.DEAD):
+            raise ValueError(
+                f"StateMachine initial_state must be UNINITIALIZED (cold-start) "
+                f"or DEAD (rehydrated); got {initial_state.value}"
+            )
         self._label = owner_label
         self._state = initial_state
         self._lock = asyncio.Lock()
@@ -507,15 +564,24 @@ class StateMachine:
         self,
         token: OwnerToken,
         final_state: SessionState,
+        *,
+        trigger: Trigger = Trigger.INTERNAL,
     ) -> None:
         """Owner reports the transition's side effect has resolved.
 
         ``final_state`` is what the owner's side effect ended at — for a
         successful ``connect()`` from RECONNECTING, ``final_state=CONNECTED``;
         for an exhausted retry budget, ``final_state=DEAD``. The state machine
-        applies ``final_state`` as a new transition (subject to matrix rules,
-        but driven by an implicit INTERNAL trigger since this is the
-        Transport's own machinery completing).
+        applies ``final_state`` as a new transition (subject to matrix rules).
+
+        ``trigger`` controls which Trigger drives the completion. Defaults to
+        ``Trigger.INTERNAL`` — appropriate for the warm-reconnect handshake
+        (RECONNECTING → CONNECTED) and the existing retry-exhaustion path
+        (RECONNECTING → DEAD). PR6 introduced explicit completion triggers
+        for the cold-start lifecycle: pass ``Trigger.BOOT_COMPLETE`` to close
+        BOOTING → CONNECTED and ``Trigger.BOOT_FAILED`` to close BOOTING → DEAD.
+        These keep the cold-start lifecycle a closed triplet
+        (BOOT / BOOT_COMPLETE / BOOT_FAILED) in audit logs.
 
         Subscribers waiting on the in-flight handle are released with the
         final state.
@@ -538,40 +604,47 @@ class StateMachine:
             # Apply final_state if different from the current in-flight target.
             # E.g. RECONNECTING in-flight with final_state=CONNECTED is the
             # normal handshake-success path; final_state=DEAD is the retry-
-            # exhausted path. Both are legal INTERNAL transitions per the matrix.
+            # exhausted path. Both are legal under the relevant trigger.
             if final_state != self._state:
                 # ── DEAD as universal emergency exit ─────────────────────────
                 # DEAD is the terminal sink; it's never illegal to fall to it.
                 # This is the catch-fire path for owners whose side effect
                 # failed catastrophically (e.g. CONNECTED → IDLE_SLEEPING
                 # whose disconnect crashed mid-way — the matrix doesn't give
-                # INTERNAL on IDLE_SLEEPING → DEAD, but we still need an
-                # escape so the driver-abandonment failure mode is avoidable.
-                # Bypasses the INTERNAL-legality gate; everything else still
-                # respects the matrix.
+                # the caller-supplied trigger on IDLE_SLEEPING → DEAD, but we
+                # still need an escape so the driver-abandonment failure mode
+                # is avoidable. Bypasses the trigger-legality gate;
+                # everything else still respects the matrix. The audit log
+                # carries the original caller-supplied trigger so debugging
+                # can distinguish "INTERNAL emergency" from
+                # "BOOT_FAILED emergency" etc.
                 if final_state == SessionState.DEAD:
                     from_state = self._state
                     self._state = SessionState.DEAD
                     self._audit(
-                        from_state, SessionState.DEAD, Trigger.INTERNAL,
+                        from_state, SessionState.DEAD, trigger,
                         "emergency_completed",
                         reason=f"in-flight {in_flight.from_state.value} → "
                                f"{in_flight.target.value} failed to DEAD",
                     )
                 else:
-                    # Internal completion is implicitly trigger=INTERNAL for
-                    # non-DEAD targets.
+                    # Completion uses the caller-supplied trigger; the matrix
+                    # cell must allow that trigger explicitly.
                     legal = LEGAL_TRANSITIONS.get((self._state, final_state))
-                    if legal is None or Trigger.INTERNAL not in legal:
+                    if legal is None or trigger not in legal:
+                        legal_str = (
+                            sorted(t.value for t in legal) if legal else []
+                        )
                         raise TransitionError(
                             f"illegal completion: {self._state.value} → "
-                            f"{final_state.value} not INTERNAL-legal "
-                            f"(DEAD is always legal as emergency exit)"
+                            f"{final_state.value} not legal via "
+                            f"{trigger.value} (legal triggers: {legal_str}; "
+                            f"DEAD is always legal as emergency exit)"
                         )
                     from_state = self._state
                     self._state = final_state
                     self._audit(
-                        from_state, final_state, Trigger.INTERNAL, "completed",
+                        from_state, final_state, trigger, "completed",
                         reason=f"in-flight {in_flight.from_state.value} → "
                                f"{in_flight.target.value} resolved",
                     )
@@ -579,7 +652,7 @@ class StateMachine:
                 # final_state == current; owner ended exactly where the matrix
                 # parked us. Treat as completion of the in-flight transition.
                 self._audit(
-                    self._state, self._state, Trigger.INTERNAL, "completed",
+                    self._state, self._state, trigger, "completed",
                     reason=f"in-flight {in_flight.from_state.value} → "
                            f"{in_flight.target.value} resolved at target",
                 )

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -7,6 +7,7 @@ Focuses on _check_context() — the warn/restart logic that was buggy pre-fix:
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -589,6 +590,224 @@ def test_stats_exposes_state_alongside_legacy_bools() -> None:
     assert stats["state"] == "idle_sleeping"
     assert stats["connected"] is False
     assert stats["idle_sleeping"] is True
+
+
+# -- PR6 round-2: concurrent cold-start race (Murzik's blocker on #494) ------
+#
+# Repro shape: caller A enters connect() on an UNINITIALIZED session, wins
+# BOOT ownership, state flips UNINITIALIZED → BOOTING at grant time, A's SDK
+# handshake is still awaiting. Caller B enters connect() during A's handshake.
+#
+# Pre-fix: the cold-start guard was ``if self.state == UNINITIALIZED:``. B
+# saw state == BOOTING, skipped the entire ownership/subscriber block,
+# constructed a second ClaudeSDKClient, ran a second await connect(), and
+# direct-mutated _state = CONNECTED at the warm-reconnect else branch. Two
+# concurrent SDK handshakes for one logical cold start — same double-connect
+# class PR1 was meant to prevent, just for the new BOOTING state.
+#
+# Post-fix: guard widened to ``state in {UNINITIALIZED, BOOTING}``. The state
+# machine's same-target in-flight branch routes B to an InFlightHandle; B
+# subscribes via wait() and inherits A's outcome. Subscriber surfaces failure
+# (DEAD resolution) as a raise so the second caller never silently looks
+# connected.
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_start_runs_one_sdk_handshake(monkeypatch) -> None:
+    """Two concurrent connect() calls on an UNINITIALIZED StreamingSession
+    must result in exactly one SDK construction + handshake. Caller A wins
+    BOOT ownership; caller B subscribes via the in-flight handle.
+
+    Pre-fix (Murzik's #494 blocker): B saw state == BOOTING, bypassed the
+    ownership path, and built a second SDK client. Post-fix: B subscribes
+    and returns only when A lands CONNECTED.
+    """
+    import claude_agent_sdk
+
+    cfg = StreamingSessionConfig(agent_name="test-concurrent-boot")
+    ss = StreamingSession(cfg)
+
+    construction_count = 0
+    release_handshake = asyncio.Event()
+    handshake_entered = asyncio.Event()
+
+    class FakeClient:
+        def __init__(self, options):
+            nonlocal construction_count
+            construction_count += 1
+            self._options = options
+
+        async def connect(self):
+            handshake_entered.set()
+            await release_handshake.wait()
+
+        async def get_server_info(self):
+            return None
+
+        async def disconnect(self):
+            pass
+
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeSDKClient", FakeClient)
+    # Strip the post-connect side effects we don't care about for this test.
+    ss._analytics_session_started = MagicMock()
+
+    async def _noop_reader_loop():
+        pass
+
+    ss._reader_loop = _noop_reader_loop  # type: ignore[assignment]
+    # Skip the wake-prompt auto-send (no client.query needed).
+    ss._config.wake_context = ""
+
+    t1 = asyncio.create_task(ss.connect())
+    # Yield until A is parked inside the fake SDK handshake, so B enters
+    # connect() while state is BOOTING (the load-bearing race window).
+    await handshake_entered.wait()
+    assert ss.state == SessionState.BOOTING, (
+        "After A wins BOOT ownership but before completion, state must be "
+        "BOOTING — the race window B must defend against"
+    )
+
+    t2 = asyncio.create_task(ss.connect())
+    # Yield to let B subscribe (request_transition acquires the lock briefly).
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    # B must NOT have constructed a second SDK client.
+    assert construction_count == 1, (
+        f"Concurrent connect() must run exactly one SDK handshake; "
+        f"got {construction_count}. If >1, B bypassed the in-flight "
+        f"subscriber path — Murzik's #494 race regressed."
+    )
+
+    # Release A's handshake. Both tasks must complete cleanly.
+    release_handshake.set()
+    await asyncio.gather(t1, t2)
+
+    assert construction_count == 1
+    assert ss.state == SessionState.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_start_subscriber_raises_on_owner_dead(monkeypatch) -> None:
+    """If the BOOT owner's handshake fails (lands DEAD), the concurrent
+    subscriber must raise — not silently return as if connected. Otherwise
+    caller B would proceed to use a non-existent client.
+    """
+    import claude_agent_sdk
+
+    cfg = StreamingSessionConfig(agent_name="test-concurrent-boot-fail")
+    ss = StreamingSession(cfg)
+
+    handshake_entered = asyncio.Event()
+    release_handshake = asyncio.Event()
+    construction_count = 0
+
+    class FailingClient:
+        def __init__(self, options):
+            nonlocal construction_count
+            construction_count += 1
+
+        async def connect(self):
+            handshake_entered.set()
+            await release_handshake.wait()
+            raise RuntimeError("simulated cold-start handshake failure")
+
+        async def disconnect(self):
+            pass
+
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeSDKClient", FailingClient)
+
+    t1 = asyncio.create_task(ss.connect())
+    await handshake_entered.wait()
+    assert ss.state == SessionState.BOOTING
+
+    t2 = asyncio.create_task(ss.connect())
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    # Release — A's handshake raises, drives BOOTING → DEAD via BOOT_FAILED.
+    release_handshake.set()
+
+    # A propagates the original RuntimeError; B raises because final state DEAD.
+    with pytest.raises(RuntimeError, match="simulated cold-start handshake"):
+        await t1
+    with pytest.raises(RuntimeError, match="resolved to dead"):
+        await t2
+
+    # Still exactly one SDK construction — B never built a second client.
+    assert construction_count == 1
+    assert ss.state == SessionState.DEAD
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_start_rejection_post_dead_raises(monkeypatch) -> None:
+    """Pushok's Case D from #494: caller D enters connect() with state ==
+    BOOTING but, by the time request_transition acquires the lock, the
+    owner has already completed to DEAD. request_transition returns a
+    matrix rejection (BOOTING is illegal from DEAD), in_flight_handle is
+    None. Pre-Case-D fix: silently returned, caller thought cold-start
+    succeeded against a dead transport. Post-fix: raises so the caller
+    sees the failure.
+    """
+    cfg = StreamingSessionConfig(agent_name="test-case-d-rejection")
+    ss = StreamingSession(cfg)
+    # Place the session in DEAD (owner already failed). connect() guard
+    # widening doesn't catch this — DEAD isn't in {UNINITIALIZED, BOOTING}.
+    # To trip Case D specifically we need to enter the guard with BOOTING
+    # but observe DEAD by lock time. Simulate by direct-setting state to
+    # BOOTING with no in-flight, then connect()'s request_transition will
+    # see no in-flight + identity check (BOOTING == BOOTING) and return
+    # observational. To get the DEAD-rejection branch we set the state to
+    # something else after the guard but before the lock — but since
+    # connect() doesn't yield between those, we can't easily simulate the
+    # exact race. Instead, place state in BOOTING with no in-flight; the
+    # observational read returns (owner_token=None, handle=None,
+    # rejection_reason=None). Then the post-log check inspects self.state;
+    # mutate to DEAD just before by setting both.
+    #
+    # Practical surrogate: trip the same code path by placing the state
+    # machine in a configuration where request_transition will return
+    # (owner_token=None, handle=None) AND self.state == DEAD when the
+    # check runs. Place state in BOOTING (so the guard matches), then
+    # after request_transition's identity-observational return we want
+    # self.state == DEAD. Since the test doesn't have a real concurrent
+    # owner, set the state machine directly to DEAD after the guard
+    # decision — but connect() reads self.state synchronously. The
+    # cleanest surrogate: pre-set _state to DEAD; the guard skips entirely
+    # (DEAD not in {UNINITIALIZED, BOOTING}) and we fall through. That
+    # tests Case C path, not Case D.
+    #
+    # The truly-realistic Case D test would require a concurrent owner
+    # whose completion lands DEAD between D's guard and D's lock
+    # acquisition. That's a narrow race window. We approximate by
+    # patching request_transition to return a synthetic rejection while
+    # the state machine reports DEAD — verifying connect() raises.
+    from pinky_daemon.transport_state import TransitionResult
+
+    ss._state_machine._state = SessionState.BOOTING
+    # After this synthetic transition_complete from a phantom owner,
+    # the state machine reports DEAD.
+    real_request_transition = ss._state_machine.request_transition
+
+    async def fake_request_transition(target, trigger, *, reason=None):
+        # Simulate the race: owner just completed to DEAD; rejection.
+        ss._state_machine._state = SessionState.DEAD
+        return TransitionResult(
+            changed=False,
+            from_state=SessionState.DEAD,
+            to_state=SessionState.DEAD,
+            rejection_reason="phantom: owner completed DEAD before subscribe",
+        )
+
+    ss._state_machine.request_transition = fake_request_transition  # type: ignore[assignment]
+    # Restore state to BOOTING so the guard matches at entry.
+    ss._state_machine._state = SessionState.BOOTING
+
+    with pytest.raises(RuntimeError, match="post-DEAD"):
+        await ss.connect()
+
+    # Cleanup
+    ss._state_machine.request_transition = real_request_transition  # type: ignore[assignment]
 
 
 @pytest.mark.asyncio

--- a/tests/test_transport_state.py
+++ b/tests/test_transport_state.py
@@ -22,6 +22,25 @@ from pinky_daemon.transport_state import (
     Trigger,
 )
 
+
+def _sm_in(label: str, state: SessionState) -> StateMachine:
+    """Construct a StateMachine and place it in ``state`` directly.
+
+    PR6 (Pushok) added a production guard requiring ``initial_state`` to be
+    one of ``{UNINITIALIZED, DEAD}`` — the two states a fresh state machine
+    can legitimately be constructed in. Tests need to start in arbitrary
+    states without driving through a real handshake; this helper bypasses
+    the guard by direct ``_state =`` mutation (same pattern existing tests
+    already use for inline state changes elsewhere).
+
+    Use this in tests that need a specific starting state for matrix-cell
+    coverage, ownership semantics, identity reads, etc. Production code
+    must NOT do this.
+    """
+    sm = StateMachine(label)
+    sm._state = state
+    return sm
+
 # ──────────────────────────────────────────────────────────────────────────
 # Construction & basic state reads
 # ──────────────────────────────────────────────────────────────────────────
@@ -33,8 +52,25 @@ class TestConstruction:
         assert sm.state == SessionState.UNINITIALIZED
 
     def test_explicit_initial_state_honored(self):
-        sm = StateMachine("agent", initial_state=SessionState.CONNECTED)
-        assert sm.state == SessionState.CONNECTED
+        # PR6: production guard restricts initial_state to UNINITIALIZED
+        # or DEAD; both are honored. Other states must raise.
+        sm = _sm_in("agent", SessionState.DEAD)
+        assert sm.state == SessionState.DEAD
+
+    def test_initial_state_guard_rejects_non_birth_states(self):
+        # PR6 invariant: ``StateMachine.__init__`` only accepts
+        # UNINITIALIZED (cold-start) or DEAD (rehydrated from persisted
+        # "session died" snapshot). Any other state would let callers
+        # bypass the cold-start lifecycle invariants (UNINITIALIZED-has-
+        # zero-incoming, BOOT-only-from-UNINITIALIZED). Hard guard rail.
+        for invalid in (
+            SessionState.BOOTING,
+            SessionState.RECONNECTING,
+            SessionState.CONNECTED,
+            SessionState.IDLE_SLEEPING,
+        ):
+            with pytest.raises(ValueError, match="UNINITIALIZED.*DEAD"):
+                StateMachine("agent", initial_state=invalid)
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -48,7 +84,7 @@ class TestIdentity:
     async def test_same_state_is_observational(self, state):
         """``request_transition(current_state)`` returns ``changed=False`` and
         confers no ownership, regardless of trigger."""
-        sm = StateMachine("agent", initial_state=state)
+        sm = _sm_in("agent", state)
         # Trigger is irrelevant for identity reads — pick BROKER as a placeholder.
         result = await sm.request_transition(state, Trigger.BROKER)
         assert result.changed is False
@@ -73,7 +109,7 @@ class TestMatrixLegalCells:
         must produce ``changed=True`` and grant an OwnerToken."""
         for (from_state, to_state), triggers in LEGAL_TRANSITIONS.items():
             for trigger in triggers:
-                sm = StateMachine("agent", initial_state=from_state)
+                sm = _sm_in("agent", from_state)
                 result = await sm.request_transition(to_state, trigger)
                 assert result.changed is True, (
                     f"legal cell ({from_state.value} → {to_state.value}, "
@@ -94,7 +130,7 @@ class TestMatrixLegalCells:
         for (from_state, to_state), triggers in LEGAL_TRANSITIONS.items():
             unauthorized = set(Trigger) - triggers
             for trigger in unauthorized:
-                sm = StateMachine("agent", initial_state=from_state)
+                sm = _sm_in("agent", from_state)
                 result = await sm.request_transition(to_state, trigger)
                 assert result.changed is False, (
                     f"unauthorized trigger {trigger.value} drove "
@@ -118,7 +154,7 @@ class TestMatrixIllegalCells:
                 f"and illegal maps"
             )
             for trigger in Trigger:
-                sm = StateMachine("agent", initial_state=from_state)
+                sm = _sm_in("agent", from_state)
                 result = await sm.request_transition(to_state, trigger)
                 assert result.changed is False
                 assert result.rejection_reason == expected_reason, (
@@ -162,7 +198,7 @@ class TestOwnership:
         IDLE_SLEEPING → RECONNECTING accepts both BROKER (auto-wake on inbound)
         and WATCHDOG (scheduled wake) triggers — the canonical production race.
         """
-        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
 
         # Both callers race for ownership of IDLE_SLEEPING → RECONNECTING.
         results = await asyncio.gather(
@@ -188,7 +224,7 @@ class TestOwnership:
     async def test_subscriber_receives_final_state_when_owner_completes(self):
         """Subscribers ``await`` their in-flight handle and read the final
         state set by the owner."""
-        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
 
         owner_result = await sm.request_transition(
             SessionState.RECONNECTING, Trigger.BROKER
@@ -222,7 +258,7 @@ class TestOwnership:
     async def test_subscriber_receives_dead_when_owner_fails(self):
         """If the owner's side effect fails (retry budget exhausted), the
         subscriber learns the final state is DEAD, not CONNECTED."""
-        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
 
         owner_result = await sm.request_transition(
             SessionState.RECONNECTING, Trigger.BROKER
@@ -249,7 +285,7 @@ class TestOwnership:
     @pytest.mark.asyncio
     async def test_owner_token_cannot_be_reused(self):
         """Completing the same token twice is a programming error."""
-        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
         result = await sm.request_transition(
             SessionState.RECONNECTING, Trigger.BROKER
         )
@@ -277,7 +313,7 @@ class TestOwnership:
         Owner A can still complete the original transition. Subscriber is
         released with whatever final state A reports.
         """
-        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
 
         # Step 1: owner A starts IDLE_SLEEPING → RECONNECTING.
         owner_a = await sm.request_transition(
@@ -329,7 +365,7 @@ class TestOwnership:
         is rejected, the original subscriber's ``wait()`` must still resolve
         when the original owner completes — proving the rejection didn't
         corrupt the in-flight registration."""
-        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
 
         owner = await sm.request_transition(
             SessionState.RECONNECTING, Trigger.BROKER
@@ -369,7 +405,7 @@ class TestOwnership:
         registration is never cleared. Subscribers stranded.
         """
         # CONNECTED → IDLE_SLEEPING owner crashes mid-disconnect, falls to DEAD.
-        sm = StateMachine("agent", initial_state=SessionState.CONNECTED)
+        sm = _sm_in("agent", SessionState.CONNECTED)
         sleeper = await sm.request_transition(
             SessionState.IDLE_SLEEPING, Trigger.USER_AGENT
         )
@@ -385,7 +421,7 @@ class TestOwnership:
         """Subscribers waiting on an in-flight transition learn the final
         state is DEAD when the owner takes the emergency exit, not the
         original target."""
-        sm = StateMachine("agent", initial_state=SessionState.CONNECTED)
+        sm = _sm_in("agent", SessionState.CONNECTED)
         sleeper = await sm.request_transition(
             SessionState.IDLE_SLEEPING, Trigger.USER_AGENT
         )
@@ -411,7 +447,7 @@ class TestOwnership:
         completion still goes through the INTERNAL-legality gate so callers
         can't quietly land in arbitrary states by claiming "complete."
         """
-        sm = StateMachine("agent", initial_state=SessionState.CONNECTED)
+        sm = _sm_in("agent", SessionState.CONNECTED)
         sleeper = await sm.request_transition(
             SessionState.IDLE_SLEEPING, Trigger.USER_AGENT
         )
@@ -430,7 +466,7 @@ class TestOwnership:
         """Demonstrates the documented try/finally contract: owners that
         catch ``asyncio.CancelledError`` and use the DEAD emergency exit
         do not strand subscribers."""
-        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
         owner = await sm.request_transition(
             SessionState.RECONNECTING, Trigger.BROKER
         )
@@ -464,7 +500,7 @@ class TestOwnership:
     async def test_in_flight_clears_after_completion_so_new_transition_can_start(self):
         """After an in-flight transition completes, the state machine must
         accept a new transition request — the singleton guard releases."""
-        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
 
         owner_1 = await sm.request_transition(
             SessionState.RECONNECTING, Trigger.BROKER
@@ -483,7 +519,7 @@ class TestOwnership:
         """If an owner reports a final state that isn't an INTERNAL-legal
         transition from the current state, completion raises rather than
         silently parking the state machine in an invalid state."""
-        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
         result = await sm.request_transition(
             SessionState.RECONNECTING, Trigger.BROKER
         )
@@ -516,7 +552,7 @@ class TestMatrixInvariants:
         for trigger in Trigger:
             if trigger == Trigger.INTERNAL:
                 continue  # The legal one — tested in TestMatrixLegalCells.
-            sm = StateMachine("agent", initial_state=SessionState.RECONNECTING)
+            sm = _sm_in("agent", SessionState.RECONNECTING)
             # Inject an in-flight transition via completion, since we can't
             # request the same transition from outside INTERNAL: just check
             # that an external trigger requesting CONNECTED is rejected.
@@ -536,7 +572,7 @@ class TestMatrixInvariants:
         for state in SessionState:
             if state == SessionState.UNINITIALIZED:
                 continue
-            sm = StateMachine("agent", initial_state=state)
+            sm = _sm_in("agent", state)
             for trigger in Trigger:
                 result = await sm.request_transition(
                     SessionState.UNINITIALIZED, trigger
@@ -548,7 +584,7 @@ class TestMatrixInvariants:
     @pytest.mark.asyncio
     async def test_reconnecting_to_idle_sleeping_is_illegal(self):
         """Can't sleep mid-connect."""
-        sm = StateMachine("agent", initial_state=SessionState.RECONNECTING)
+        sm = _sm_in("agent", SessionState.RECONNECTING)
         for trigger in Trigger:
             result = await sm.request_transition(
                 SessionState.IDLE_SLEEPING, trigger
@@ -560,7 +596,7 @@ class TestMatrixInvariants:
     async def test_idle_sleeping_to_connected_must_go_through_reconnecting(self):
         """Invariant 1: every successful connect is observable as RECONNECTING
         first. No direct IDLE_SLEEPING → CONNECTED."""
-        sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
         for trigger in Trigger:
             result = await sm.request_transition(
                 SessionState.CONNECTED, trigger
@@ -571,13 +607,176 @@ class TestMatrixInvariants:
     @pytest.mark.asyncio
     async def test_dead_to_idle_sleeping_is_illegal(self):
         """Sleeping a dead session has no meaning."""
-        sm = StateMachine("agent", initial_state=SessionState.DEAD)
+        sm = _sm_in("agent", SessionState.DEAD)
         for trigger in Trigger:
             result = await sm.request_transition(
                 SessionState.IDLE_SLEEPING, trigger
             )
             assert result.changed is False
             assert result.rejection_reason is not None
+
+    # ── PR6 invariants (Pushok): cold-start lifecycle ───────────────────────
+
+    def test_uninitialized_has_zero_incoming_edges(self):
+        """PR6 (Pushok dual-frame invariant): UNINITIALIZED is the birth state
+        and has zero incoming edges in the matrix. Combined with the test
+        ``test_uninitialized_is_one_way`` (which proves no trigger lands a
+        non-UNINITIALIZED session there) this is the strongest version of
+        "never reachable" — a future maintainer adding a row whose to_state
+        is UNINITIALIZED will fail this structural check immediately,
+        independent of any trigger.
+
+        This is the dual of DEAD's pattern: DEAD has many incoming edges
+        (universal sink) and limited outgoing edges (resurrection only);
+        UNINITIALIZED has zero incoming edges and many legal outgoing edges.
+        """
+        for (from_state, to_state), _triggers in LEGAL_TRANSITIONS.items():
+            assert to_state != SessionState.UNINITIALIZED, (
+                f"matrix violates UNINITIALIZED-zero-incoming invariant: "
+                f"({from_state.value} → {to_state.value}) lands in UNINITIALIZED"
+            )
+
+    def test_boot_only_drives_from_uninitialized(self):
+        """PR6 (Pushok): the BOOT trigger only fires when from_state is
+        UNINITIALIZED. Pairs with ``test_uninitialized_has_zero_incoming_edges``
+        as the structural bypass for the singleton-in-flight guard:
+        UNINITIALIZED is provably never reachable while another transition
+        is in flight (because nothing transitions TO UNINITIALIZED), and
+        BOOT only fires from UNINITIALIZED, so a BOOT request cannot race
+        an in-flight transition by construction.
+        """
+        for (from_state, to_state), triggers in LEGAL_TRANSITIONS.items():
+            if Trigger.BOOT not in triggers:
+                continue
+            assert from_state == SessionState.UNINITIALIZED, (
+                f"BOOT trigger drives non-cold-start cell "
+                f"({from_state.value} → {to_state.value}); BOOT must only "
+                f"fire from UNINITIALIZED"
+            )
+
+    def test_boot_complete_only_drives_from_booting(self):
+        """PR6 (Pushok): BOOT_COMPLETE closes the cold-start lifecycle. It
+        must only ever drive BOOTING → CONNECTED — any other cell would
+        decouple the trigger from the cold-start lifecycle it's named for.
+        """
+        for (from_state, to_state), triggers in LEGAL_TRANSITIONS.items():
+            if Trigger.BOOT_COMPLETE not in triggers:
+                continue
+            assert (from_state, to_state) == (
+                SessionState.BOOTING, SessionState.CONNECTED
+            ), (
+                f"BOOT_COMPLETE drives unexpected cell "
+                f"({from_state.value} → {to_state.value}); must only close "
+                f"BOOTING → CONNECTED"
+            )
+
+    def test_boot_failed_only_drives_from_booting(self):
+        """PR6 (Pushok): BOOT_FAILED closes the cold-start lifecycle on
+        failure. It must only ever drive BOOTING → DEAD.
+        """
+        for (from_state, to_state), triggers in LEGAL_TRANSITIONS.items():
+            if Trigger.BOOT_FAILED not in triggers:
+                continue
+            assert (from_state, to_state) == (
+                SessionState.BOOTING, SessionState.DEAD
+            ), (
+                f"BOOT_FAILED drives unexpected cell "
+                f"({from_state.value} → {to_state.value}); must only close "
+                f"BOOTING → DEAD"
+            )
+
+    def test_booting_is_one_shot(self):
+        """PR6 (Pushok): cold-start is one-shot. BOOTING has no self-edge
+        and no exit to RECONNECTING — failed cold-starts go to DEAD and
+        reduce to warm-reconnect through the DEAD → RECONNECTING
+        resurrection path.
+        """
+        # No self-edge.
+        assert (SessionState.BOOTING, SessionState.BOOTING) not in LEGAL_TRANSITIONS
+        # No direct hop to RECONNECTING; that conflation is exactly what
+        # introducing BOOTING avoids.
+        assert (SessionState.BOOTING, SessionState.RECONNECTING) in ILLEGAL_PAIR_REASONS
+        # The legal exits from BOOTING are exactly {CONNECTED, DEAD}.
+        booting_exits = {
+            to_state
+            for (from_state, to_state) in LEGAL_TRANSITIONS
+            if from_state == SessionState.BOOTING
+        }
+        assert booting_exits == {SessionState.CONNECTED, SessionState.DEAD}, (
+            f"BOOTING legal exits drifted: got {booting_exits}, "
+            f"expected {{CONNECTED, DEAD}}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_boot_completion_uses_boot_complete_trigger(self):
+        """End-to-end: cold-start lifecycle goes UNINITIALIZED → BOOTING via
+        BOOT, then BOOTING → CONNECTED via BOOT_COMPLETE (not INTERNAL).
+        Audit logs gain a distinct cold-start completion signal vs the warm
+        RECONNECTING → CONNECTED INTERNAL completion.
+        """
+        sm = StateMachine("agent")
+        boot = await sm.request_transition(SessionState.BOOTING, Trigger.BOOT)
+        assert boot.owner_token is not None
+        assert sm.state == SessionState.BOOTING
+        # Complete with BOOT_COMPLETE explicitly.
+        await sm.transition_complete(
+            boot.owner_token, SessionState.CONNECTED,
+            trigger=Trigger.BOOT_COMPLETE,
+        )
+        assert sm.state == SessionState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_boot_completion_with_internal_trigger_rejected(self):
+        """The matrix authorizes BOOTING → CONNECTED ONLY via BOOT_COMPLETE.
+        A completion that tries to use INTERNAL — the warm-reconnect
+        completion trigger — must be rejected. Without this guard, callers
+        could silently complete cold-start through the warm-path code path
+        and lose the audit-log distinction.
+        """
+        sm = StateMachine("agent")
+        boot = await sm.request_transition(SessionState.BOOTING, Trigger.BOOT)
+        assert boot.owner_token is not None
+        with pytest.raises(TransitionError, match="not legal via internal"):
+            await sm.transition_complete(
+                boot.owner_token, SessionState.CONNECTED,
+                trigger=Trigger.INTERNAL,
+            )
+
+    @pytest.mark.asyncio
+    async def test_boot_failure_uses_boot_failed_trigger(self):
+        """Cold-start failure: BOOTING → DEAD via BOOT_FAILED."""
+        sm = StateMachine("agent")
+        boot = await sm.request_transition(SessionState.BOOTING, Trigger.BOOT)
+        assert boot.owner_token is not None
+        await sm.transition_complete(
+            boot.owner_token, SessionState.DEAD,
+            trigger=Trigger.BOOT_FAILED,
+        )
+        assert sm.state == SessionState.DEAD
+
+    @pytest.mark.asyncio
+    async def test_cold_start_failure_reduces_to_warm_reconnect(self):
+        """PR6 (Pushok one-shot semantic): after BOOTING → DEAD, the only
+        recovery path is the warm-reconnect resurrection DEAD → RECONNECTING.
+        There is no BOOTING → BOOTING self-edge and no BOOTING → RECONNECTING
+        hop; retries reduce to warm-reconnect through the existing
+        resurrection machinery.
+        """
+        sm = StateMachine("agent")
+        boot = await sm.request_transition(SessionState.BOOTING, Trigger.BOOT)
+        await sm.transition_complete(
+            boot.owner_token, SessionState.DEAD, trigger=Trigger.BOOT_FAILED,
+        )
+        # No retry within BOOTING — a BOOT trigger from DEAD must reject
+        # (UNINITIALIZED is never reachable, so BOOT has nothing to drive).
+        reject = await sm.request_transition(SessionState.BOOTING, Trigger.BOOT)
+        assert reject.changed is False
+        # Warm-reconnect resurrection IS legal — that's the retry path.
+        reconnect = await sm.request_transition(
+            SessionState.RECONNECTING, Trigger.WATCHDOG,
+        )
+        assert reconnect.changed is True
+        assert sm.state == SessionState.RECONNECTING
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -590,7 +789,7 @@ class TestAuditLog:
     async def test_every_request_emits_one_audit_line(self, capsys):
         """One audit line per request_transition call, regardless of outcome
         (changed / observational / subscribed / rejected)."""
-        sm = StateMachine("test", initial_state=SessionState.IDLE_SLEEPING)
+        sm = _sm_in("test", SessionState.IDLE_SLEEPING)
 
         # Identity (observational) — IDLE_SLEEPING → IDLE_SLEEPING is an
         # observational read regardless of trigger (no in-flight transition).
@@ -610,7 +809,7 @@ class TestAuditLog:
 
     @pytest.mark.asyncio
     async def test_rejection_emits_audit_with_reason(self, capsys):
-        sm = StateMachine("test", initial_state=SessionState.DEAD)
+        sm = _sm_in("test", SessionState.DEAD)
         await sm.request_transition(SessionState.CONNECTED, Trigger.BROKER)
         err = capsys.readouterr().err
         assert "transport_state[test]" in err
@@ -641,7 +840,7 @@ class TestOwnerToken:
         token in transition_complete is rejected (see test_owner_token_cannot_be_reused)."""
         tokens = set()
         for _ in range(20):
-            sm = StateMachine("agent", initial_state=SessionState.IDLE_SLEEPING)
+            sm = _sm_in("agent", SessionState.IDLE_SLEEPING)
             result = await sm.request_transition(
                 SessionState.RECONNECTING, Trigger.BROKER
             )


### PR DESCRIPTION
## Summary

Closes @pushok's Bug 3 from PR #491 review: the cold-start path currently goes `UNINITIALIZED → CONNECTED` via direct `_state =` mutation, which the matrix would forbid if asked. The bypass isn't user-visible today but the matrix invariant should hold. This PR wires the cold-start lifecycle through the matrix as a closed BOOT / BOOT_COMPLETE / BOOT_FAILED Trigger triplet landing in a new `BOOTING` state.

Design pinned with @pushok in pre-PR discussion (matrix delta first, code second).

## Matrix delta

### New state

| State | Semantics |
|---|---|
| `BOOTING` | One-shot cold-start in flight. Semantically distinct from `RECONNECTING`: `RECONNECTING` means "we believe a session exists and are re-establishing," `BOOTING` means "no prior session, first attempt." Adding `BOOTING` rather than reusing `RECONNECTING` bakes the distinction into the matrix where PR7 can inherit it. |

### New / repurposed Triggers

| Trigger | Drives | Notes |
|---|---|---|
| `BOOT` | `UNINITIALIZED → BOOTING` only | already existed; cell repurposed |
| `BOOT_COMPLETE` | `BOOTING → CONNECTED` only | success-path completion |
| `BOOT_FAILED` | `BOOTING → DEAD` only | failure-path completion |

### Cells added

| (from, to, trigger) |
|---|
| `(UNINITIALIZED, BOOTING, BOOT)` |
| `(BOOTING, CONNECTED, BOOT_COMPLETE)` |
| `(BOOTING, DEAD, {BOOT_FAILED, API_ADMIN})` |

### Cell removed

- `(UNINITIALIZED, RECONNECTING, BOOT)` — listed in `ILLEGAL_PAIR_REASONS` with the rationale "cold-start goes through BOOTING — RECONNECTING is for re-establishing a known session".

### One-shot semantic

Cold-start is one-shot. No `BOOTING → BOOTING` self-edge, no `BOOTING → RECONNECTING`. Failed cold-starts go to `DEAD` and retries reduce to warm-reconnect through the existing `DEAD → RECONNECTING` resurrection path (BROKER/WATCHDOG/SCHEDULER/API_ADMIN). Threads cleanly through the existing watchdog/broker resurrection machinery; no new code paths required for retries.

## Invariants pinned

| Invariant | Test |
|---|---|
| UNINITIALIZED has zero incoming edges | `test_uninitialized_has_zero_incoming_edges` |
| BOOT only fires from UNINITIALIZED | `test_boot_only_drives_from_uninitialized` |
| BOOT_COMPLETE only drives BOOTING → CONNECTED | `test_boot_complete_only_drives_from_booting` |
| BOOT_FAILED only drives BOOTING → DEAD | `test_boot_failed_only_drives_from_booting` |
| BOOTING is one-shot (no self-edge, no RECONNECTING exit) | `test_booting_is_one_shot` |
| `StateMachine.__init__` rejects non-birth initial states | `test_initial_state_guard_rejects_non_birth_states` |

The first two together are the structural bypass for the singleton-in-flight guard: UNINITIALIZED is provably never reachable while another transition is in flight (because nothing transitions TO it), and BOOT only fires FROM UNINITIALIZED — so a BOOT request cannot race an in-flight transition by construction.

## `transition_complete` change

`StateMachine.transition_complete(token, final_state, *, trigger=INTERNAL)` now accepts an explicit `trigger` kwarg.

- Default `INTERNAL` preserves the existing warm-reconnect contract — no caller change needed for `force_restart`, `attempt_reconnect`, etc.
- Cold-start callers pass `BOOT_COMPLETE` / `BOOT_FAILED` so audit logs distinguish cold-start completion from warm-reconnect INTERNAL completion.
- The universal `DEAD` emergency-exit still bypasses the matrix check; the caller-supplied trigger is preserved in the audit log so debugging can distinguish "INTERNAL emergency" from "BOOT_FAILED emergency".

## `StreamingSession.connect()` wiring

Cold-start (`state == UNINITIALIZED` at entry):

1. `request_transition(BOOTING, BOOT)` — owner token captured; defensively handles the rare in-flight/rejected paths.
2. SDK handshake inside `try`.
3. On failure: `transition_complete(DEAD, trigger=BOOT_FAILED)`, then re-raise.
4. On success: `transition_complete(CONNECTED, trigger=BOOT_COMPLETE)`.

Warm-reconnect paths (`force_restart`, `idle_sleep` wake, etc.) still direct-mutate `_state`. See out-of-scope section.

## Out of scope (deliberately deferred)

- **Warm-reconnect Trigger symmetry** (`RECONNECT_BEGIN` / `RECONNECT_COMPLETE` / `RECONNECT_FAILED`). Calling it now would expand scope past a reviewable size and re-litigate the warm path. Deferred to PR6.5 or PR7 — leaving the choice open whether PR7 inherits symmetric vocabulary or picks a different asymmetry deliberately.
- **CodexSession adoption of the matrix** (per @murzik's asymmetry observation on PR #491 review). Deferred to PR7 per @bradbrok's call this session.

## Tests

- 2083 pass, 1 skipped (PR5 baseline 2072; +11 new PR6 invariant tests).
- Existing matrix tests adapted around the new `initial_state` guard via a `_sm_in("label", state)` helper that bypasses the guard with direct `_state =` mutation. Test-only; documented; the guard stays strict in production.

## Test plan

- [x] ruff check passes (`streaming_session.py`, `transport_state.py`, `tests/test_transport_state.py`)
- [x] `pytest tests/test_transport_state.py tests/test_streaming_session.py tests/test_broker.py tests/test_transport.py tests/test_codex_session.py`: 125 passed
- [x] full `pytest`: 2083 passed, 1 skipped
- [ ] CI green

cc @pushok — full design review; matrix cells, invariants, and the one-shot claim are the load-bearing items. cc @murzik for awareness; warm-reconnect Trigger symmetry will be PR6.5/PR7 conversation.

🤖 Opened by Barsik