### PR TITLE
feat(transport): TmuxSession backend skeleton — PR8 of #486

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -339,7 +339,7 @@ class Agent:
     working_status: str = "idle"  # idle, working, offline
     working_status_updated_at: float = 0.0  # When working_status last changed
     last_seen_at: float = 0.0  # Server-side presence: updated on delivery/turn completion
-    runtime: str = "claude_sdk"  # Agent runtime: claude_sdk, codex_cli, opencode
+    runtime: str = "claude_sdk"  # Agent runtime: claude_sdk, codex_cli, opencode, tmux
     provider_url: str = ""   # e.g. "http://localhost:11434" for Ollama, empty = Anthropic default
     provider_key: str = ""   # API key override, empty = use ANTHROPIC_API_KEY env var
     provider_model: str = ""  # model name override (e.g. "llama3.2"), empty = use agent.model

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1,0 +1,915 @@
+"""Tmux Session — interactive ``claude`` REPL inside a tmux session.
+
+PR8 of the #486 sequence. New transport backend for the Dymok test agent
+and (eventually) Misha. Bills against the Claude Code subscription's
+interactive limits instead of the capped SDK credit pool that
+``StreamingSession`` consumes.
+
+## Architecture
+
+Each TmuxSession owns a single detached tmux session named after the
+agent (``<fleet>-<agent_name>``). Inside that tmux session, an
+interactive ``claude --continue --dangerously-skip-permissions`` REPL
+runs. Inbound messages are delivered via ``tmux send-keys``; outbound
+responses are captured by a separate **response pipeline** that lives
+outside this class (transcript-file tailing or Stop-hook subscription —
+the design choice is PR8b, not landed here).
+
+This skeleton lands the state-machine choreography, tmux subprocess
+plumbing, and the worker/queue scaffold. The actual response capture is
+stubbed — ``send()`` accepts and queues turns; the worker runs the
+``tmux send-keys`` half of the round trip; collecting Claude's response
+and firing ``response_callback`` is left as a TODO for the response
+pipeline PR.
+
+## State machine integration
+
+TmuxSession adopts the full StateMachine matrix from PR1/#487 — same
+choreography as ``StreamingSession`` after PR3-PR6:
+
+- Cold-start: ``UNINITIALIZED → BOOTING`` via ``Trigger.BOOT``; on success
+  ``BOOTING → CONNECTED`` via ``BOOT_COMPLETE``; on failure
+  ``BOOTING → DEAD`` via ``BOOT_FAILED``.
+- Cold-start guard widened to ``state in {UNINITIALIZED, BOOTING}`` to
+  defend the concurrent-connect race fixed in PR6 (Murzik's catch on
+  PR #494).
+- Warm-reconnect: ``CONNECTED → RECONNECTING → CONNECTED|DEAD`` via the
+  standard triggers (USER_AGENT for ``force_restart``, WATCHDOG for
+  watchdog-driven restarts, INTERNAL for the completion edge).
+- Idle-sleep: ``CONNECTED → IDLE_SLEEPING`` via USER_AGENT.
+
+CodexSession's coarse 3-state derivation is intentionally NOT mirrored
+here. Greenfield backend, full matrix from day one — exactly the design
+Brad green-lit in the side-by-side framing.
+
+## Resume handle
+
+TmuxSession's resume handle is the **tmux session name** itself.
+``claude --continue`` resolves by ``cwd``'s most-recent transcript, and
+the tmux session pins ``cwd``, so the session name uniquely identifies a
+resumable conversation. Survives daemon restart as long as the tmux
+session stays alive.
+
+## Out of scope for PR8
+
+- Response capture pipeline (transcript tailing OR Stop-hook listener).
+  Tracked as a follow-up; the contract is documented on
+  ``_TODO_capture_response``.
+- Context-budget watchdog (``_check_context``). StreamingSession's
+  context warn/restart logic is SDK-specific (uses ``get_context_usage``);
+  the equivalent for tmux requires reading the transcript file's token
+  totals. Deferred until response pipeline lands.
+- ``cost_usd`` reporting. Documented as a known gap on the Transport
+  protocol (``stats`` shape varies per backend; tmux can't report cost
+  the way SDK does because billing is against the subscription, not the
+  metered credit pool).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pinky_daemon.streaming_session import StreamingSessionConfig, _log
+from pinky_daemon.transport_state import (
+    SessionState,
+    StateMachine,
+    Trigger,
+)
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tmux subprocess control
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class TmuxCommandResult:
+    """Outcome of one ``tmux ...`` invocation."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+class _TmuxControl:
+    """Thin async wrapper over the ``tmux`` CLI.
+
+    All subprocess calls live here so they can be mocked in tests without
+    touching the host's tmux. One instance per TmuxSession.
+
+    Why a separate class instead of free functions: the session name +
+    socket path are configuration state, not arguments callers should
+    keep repeating. Encapsulating them here also gives tests a single
+    monkeypatch target (``ts._tmux = MockTmuxControl()``).
+    """
+
+    def __init__(
+        self,
+        session_name: str,
+        *,
+        tmux_binary: str = "tmux",
+        socket_name: str = "",
+    ) -> None:
+        self.session_name = session_name
+        self.tmux_binary = tmux_binary
+        # An explicit socket isolates Pinky's tmux sessions from the
+        # operator's own. Empty = use tmux's default socket.
+        self.socket_name = socket_name
+
+    def _base_cmd(self) -> list[str]:
+        cmd = [self.tmux_binary]
+        if self.socket_name:
+            cmd.extend(["-L", self.socket_name])
+        return cmd
+
+    async def _run(self, *args: str, timeout: float = 5.0) -> TmuxCommandResult:
+        """Run ``tmux <args>`` and return its result.
+
+        ``timeout`` defends against a hung tmux server. A timeout raises
+        ``asyncio.TimeoutError``; the caller decides how to respond
+        (typically: surface as a connect failure).
+        """
+        cmd = self._base_cmd() + list(args)
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            raise
+        return TmuxCommandResult(
+            returncode=proc.returncode or 0,
+            stdout=stdout.decode("utf-8", errors="replace"),
+            stderr=stderr.decode("utf-8", errors="replace"),
+        )
+
+    async def has_session(self) -> bool:
+        """Return True if a tmux session with our name exists."""
+        result = await self._run("has-session", "-t", self.session_name)
+        return result.ok
+
+    async def new_session(
+        self,
+        *,
+        cwd: str,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> TmuxCommandResult:
+        """Spawn a fresh detached tmux session running ``command``.
+
+        ``cwd`` becomes the session's working directory — critical for
+        ``claude --continue`` to find the right transcript.
+
+        ``env`` is added as ``-e KEY=VAL`` flags (tmux 3.2+).
+        """
+        args = ["new-session", "-d", "-s", self.session_name, "-c", cwd]
+        if env:
+            for key, value in env.items():
+                args.extend(["-e", f"{key}={value}"])
+        # The command is passed as a single string arg; tmux invokes
+        # it via the user's shell, so we shell-escape for safety.
+        args.append(command)
+        return await self._run(*args)
+
+    async def kill_session(self) -> TmuxCommandResult:
+        """Kill the tmux session. Idempotent — succeeds whether or not the
+        session exists (callers shouldn't pre-check)."""
+        result = await self._run("kill-session", "-t", self.session_name)
+        # tmux returns 1 if the session didn't exist; treat that as ok
+        # so callers can use this idempotently.
+        if not result.ok and "can't find session" in result.stderr:
+            return TmuxCommandResult(returncode=0, stdout="", stderr=result.stderr)
+        return result
+
+    async def send_keys(self, text: str, *, enter: bool = True) -> TmuxCommandResult:
+        """Send ``text`` to the active pane of the session.
+
+        ``enter=True`` (default) appends a literal carriage return after
+        the text, equivalent to ``tmux send-keys ... Enter``. The REPL
+        receives the keystrokes and (for claude) processes them as a
+        prompt.
+
+        ``text`` is passed as a single tmux argument; tmux interprets
+        no further shell metacharacters. Multi-line prompts: send each
+        line with ``enter=True`` or use ``tmux paste-buffer`` for large
+        payloads (TODO when response pipeline lands).
+        """
+        args = ["send-keys", "-t", self.session_name, text]
+        if enter:
+            args.append("Enter")
+        return await self._run(*args)
+
+    async def capture_pane(self, *, lines: int = 200) -> TmuxCommandResult:
+        """Capture the last ``lines`` lines of the pane's visible content.
+
+        Used by the response pipeline as a fallback when transcript-file
+        tailing isn't available. Not the primary capture mechanism
+        (transcripts are structured JSONL; capture-pane is text and
+        ANSI-laden) but useful for debugging and as a fallback.
+        """
+        return await self._run(
+            "capture-pane",
+            "-t",
+            self.session_name,
+            "-p",  # print to stdout instead of paste buffer
+            "-S",
+            str(-abs(lines)),  # negative line offset = lines from bottom
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Worker queue payload
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _QueuedTurn:
+    """Inbound message awaiting delivery to the claude REPL."""
+
+    prompt: str
+    platform: str = ""
+    chat_id: str = ""
+    message_id: str = ""
+    queued_at: float = field(default_factory=time.time)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# TmuxSession
+# ──────────────────────────────────────────────────────────────────────────
+
+
+# Reconnect backoff schedule (seconds). Kept in step with StreamingSession's
+# ``_RECONNECT_BACKOFF`` so api._heartbeat_resurrect can treat runtimes
+# uniformly.
+_RECONNECT_BACKOFF = (2, 8, 30)
+
+# Cold-start timeout: how long we wait for the tmux ``new-session`` +
+# ``claude`` REPL boot to complete before declaring the cold-start failed.
+# Generous (60s) because tmux startup is cheap but the claude REPL may need
+# to authenticate / fetch first turn / load CLAUDE.md.
+_COLD_START_TIMEOUT_SEC = 60.0
+
+
+class TmuxSession:
+    """Agent session backed by an interactive ``claude`` REPL in tmux.
+
+    Implements the ``Transport`` protocol (see ``transport.py``). Drop-in
+    replacement for ``StreamingSession`` and ``CodexSession`` from the
+    broker / api / scheduler's perspective.
+
+    See module docstring for architecture overview and out-of-scope items
+    (the response capture pipeline is the principal remaining gap).
+    """
+
+    def __init__(
+        self,
+        config: StreamingSessionConfig,
+        *,
+        response_callback=None,
+        conversation_store=None,
+        cost_callback=None,
+        stream_event_callback=None,
+        analytics_store=None,
+        registry=None,
+        tmux_control: _TmuxControl | None = None,
+    ) -> None:
+        self._config = config
+        self._response_callback = response_callback
+        self._cost_callback = cost_callback
+        self._conversation_store = conversation_store
+        self._stream_event_callback = stream_event_callback
+        self._analytics_store = analytics_store
+        self._registry = registry
+
+        self.agent_name = config.agent_name
+
+        # State machine — full matrix, mirrors StreamingSession post-PR6.
+        self._state_machine = StateMachine(f"{self.agent_name}-tmux")
+
+        # Resume handle for tmux is the session name itself. Pinning by
+        # name preserves cwd → ``claude --continue`` resumes via that cwd's
+        # most-recent transcript automatically.
+        self._session_name = self._build_session_name()
+        self.resume_handle = self._session_name
+
+        # Tmux subprocess control. Injectable for tests (mock the whole
+        # ``_TmuxControl`` rather than monkeypatching subprocess primitives).
+        self._tmux = tmux_control or _TmuxControl(self._session_name)
+
+        # Worker queue + task.
+        self._message_queue: asyncio.Queue[_QueuedTurn] = asyncio.Queue()
+        self._worker_task: asyncio.Task | None = None
+        self._processing = False
+
+        # Operational stats. Shape matches StreamingSession.stats for the
+        # keys callers actually read (broker, api, watchdog); cost_usd is
+        # absent because subscription billing isn't per-turn metered.
+        self._stats = {
+            "turns": 0,
+            "messages_sent": 0,
+            "errors": 0,
+            "reconnects": 0,
+            "auto_restarts": 0,
+        }
+        self.usage = None  # SessionUsage stub — populated when response pipeline lands
+
+        # Effort knob. tmux's claude REPL doesn't currently honor a
+        # per-session effort override (CLAUDE_EFFORT env is set at
+        # spawn time and we'd have to relaunch to change it). We accept
+        # the call to keep the Transport contract consistent and log a
+        # warning when it's used.
+        self._effort_override: str | None = None
+
+        # Resume-handle update callback (e.g. AgentRegistry persistence).
+        # For tmux the resume_handle is stable from construction (= session
+        # name), so this is fired exactly once on connect for symmetry with
+        # the SDK backend's persistence hook.
+        self._on_resume_handle = None
+
+        self.created_at = time.time()
+        self.last_active = self.created_at
+        self.account_info: dict = {"apiProvider": "tmux_claude_repl"}
+        self._current_activity = ""
+        self._activity_log: list[str] = []
+
+    # ── Identity ────────────────────────────────────────────────────────
+
+    @property
+    def id(self) -> str:
+        """Stable identifier matching StreamingSession's format."""
+        label = getattr(self._config, "label", "") or "main"
+        return f"{self.agent_name}-{label}"
+
+    def _build_session_name(self) -> str:
+        """Tmux session name pattern: ``pinky-<agent_name>``.
+
+        Prefix prevents collision with the operator's own tmux sessions.
+        Plain ``agent_name`` if you wanted to attach without prefix; the
+        prefix is the safer default.
+        """
+        return f"pinky-{self.agent_name}"
+
+    # ── State ───────────────────────────────────────────────────────────
+
+    @property
+    def state(self) -> SessionState:
+        """Single source of truth — read from the embedded StateMachine.
+
+        Same contract as StreamingSession post-PR3: lifecycle queries go
+        through the state machine, no derived bool inference.
+        """
+        return self._state_machine.state
+
+    @property
+    def stats(self) -> dict:
+        """Operational snapshot. Keeps the keys callers actually read."""
+        return {
+            **self._stats,
+            "state": self.state.value,
+            "pending_responses": self._processing,
+            "current_activity": self._current_activity,
+            "activity_log": list(self._activity_log[-20:]),
+            "account": self.account_info,
+            "thinking_effort": self.effective_effort,
+            # cost_usd intentionally absent — see module docstring.
+        }
+
+    @property
+    def effective_effort(self) -> str:
+        """Resolved thinking effort. ``auto`` is never returned (matched
+        to ``Transport.effective_effort`` contract)."""
+        level = self._effort_override or self._config.thinking_effort or "medium"
+        if level == "auto":
+            return "medium"
+        return level
+
+    def set_effort(self, level: str) -> None:
+        """Accept the call for protocol parity. tmux's claude REPL doesn't
+        honor mid-session effort changes — log a warning and stash the
+        value. A force_restart picks it up on the relaunched REPL."""
+        valid = {"low", "medium", "high", "xhigh", "max", "auto"}
+        if level not in valid:
+            raise ValueError(
+                f"invalid effort {level!r}; expected one of {sorted(valid)}"
+            )
+        self._effort_override = None if level == "auto" else level
+        _log(
+            f"tmux[{self.agent_name}]: set_effort({level!r}) stashed — "
+            f"takes effect on next force_restart (REPL relaunch)"
+        )
+
+    def clear_effort_override(self) -> None:
+        self._effort_override = None
+
+    # ── Lifecycle methods ───────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """Cold-start the tmux session and the in-pane claude REPL.
+
+        Drives ``UNINITIALIZED → BOOTING → CONNECTED`` (success) or
+        ``UNINITIALIZED → BOOTING → DEAD`` (failure) via the BOOT /
+        BOOT_COMPLETE / BOOT_FAILED Trigger triplet.
+
+        Cold-start guard mirrors StreamingSession post-PR6: ``state in
+        {UNINITIALIZED, BOOTING}`` so a concurrent caller subscribes via
+        the in-flight handle instead of running a second tmux spawn.
+        """
+        cold_start_token = None
+        if self.state in (SessionState.UNINITIALIZED, SessionState.BOOTING):
+            boot_result = await self._state_machine.request_transition(
+                SessionState.BOOTING,
+                Trigger.BOOT,
+                reason="cold_start_handshake",
+            )
+            if boot_result.owner_token is None:
+                # Same-target BOOT in flight: subscribe + inherit outcome.
+                # Surface DEAD as raise per PR6's failure-propagation
+                # contract.
+                if boot_result.in_flight_handle is not None:
+                    final = await boot_result.in_flight_handle.wait()
+                    if final == SessionState.CONNECTED:
+                        return
+                    raise RuntimeError(
+                        f"tmux[{self.agent_name}]: cold-start BOOT in-flight "
+                        f"resolved to {final.value} (owner failed); refusing "
+                        f"to return as connected"
+                    )
+                # Post-DEAD rejection (Pushok's Case D): surface failure.
+                _log(
+                    f"tmux[{self.agent_name}]: BOOT rejected "
+                    f"({boot_result.rejection_reason!r}) — refusing cold-start"
+                )
+                if self.state == SessionState.DEAD:
+                    raise RuntimeError(
+                        f"tmux[{self.agent_name}]: cold-start BOOT rejected "
+                        f"post-DEAD (owner failed before we subscribed); "
+                        f"refusing to return as connected"
+                    )
+                return
+            cold_start_token = boot_result.owner_token
+
+        try:
+            await self._spawn_tmux_repl()
+        except BaseException:
+            # Cold-start failed. Drive BOOTING → DEAD via BOOT_FAILED so
+            # the lifecycle stays a closed audit pair.
+            if cold_start_token is not None:
+                try:
+                    await self._state_machine.transition_complete(
+                        cold_start_token,
+                        SessionState.DEAD,
+                        trigger=Trigger.BOOT_FAILED,
+                    )
+                except Exception as ce:
+                    _log(
+                        f"tmux[{self.agent_name}]: BOOT_FAILED completion "
+                        f"raised after cold-start error: {ce}"
+                    )
+            raise
+
+        # Cold-start succeeded. Land in CONNECTED via BOOT_COMPLETE.
+        if cold_start_token is not None:
+            await self._state_machine.transition_complete(
+                cold_start_token,
+                SessionState.CONNECTED,
+                trigger=Trigger.BOOT_COMPLETE,
+            )
+        else:
+            # Warm-reconnect path (RECONNECTING owner present in the state
+            # machine). Honor whoever drove us here.
+            # NOTE: warm-reconnect Trigger symmetry (RECONNECT_COMPLETE /
+            # RECONNECT_FAILED) is the PR6.5 follow-up — mirrors the
+            # carve-out documented in StreamingSession.connect.
+            self._state_machine._state = SessionState.CONNECTED
+
+        # Start the worker.
+        if not self._worker_task or self._worker_task.done():
+            self._worker_task = asyncio.create_task(self._message_worker())
+
+        # Fire resume-handle persistence callback (one-shot for tmux —
+        # session name is stable from construction but the persistence
+        # hook expects a "connected" signal).
+        if self._on_resume_handle:
+            try:
+                await self._on_resume_handle(self.agent_name, self.resume_handle)
+            except Exception as e:
+                _log(f"tmux[{self.agent_name}]: resume_handle callback raised: {e}")
+
+        _log(
+            f"tmux[{self.agent_name}]: connected, session={self._session_name}, "
+            f"worker started"
+        )
+
+    async def _spawn_tmux_repl(self) -> None:
+        """Spawn the tmux session and the in-pane claude REPL.
+
+        Wrapped in cold-start timeout so a hung spawn fails to DEAD
+        rather than parking the state machine indefinitely.
+        """
+        cwd = self._config.working_dir or "."
+        # Ensure cwd exists — claude --continue needs it.
+        Path(cwd).mkdir(parents=True, exist_ok=True)
+
+        # If a stale session is left over from a previous daemon run (e.g.
+        # crash without graceful disconnect), reap it. We're the cold-start
+        # owner; reclaiming the name is safe.
+        if await self._tmux.has_session():
+            _log(
+                f"tmux[{self.agent_name}]: stale session {self._session_name} "
+                f"found, reaping before fresh spawn"
+            )
+            await self._tmux.kill_session()
+
+        # Build the in-pane command. ``claude --continue`` resumes the
+        # most-recent transcript for ``cwd``; falls back to fresh session
+        # if none exists.
+        claude_cmd = self._build_claude_cmd()
+        env = self._build_repl_env()
+
+        async def _spawn():
+            result = await self._tmux.new_session(
+                cwd=cwd,
+                command=claude_cmd,
+                env=env,
+            )
+            if not result.ok:
+                raise RuntimeError(
+                    f"tmux new-session failed: rc={result.returncode} "
+                    f"stderr={result.stderr.strip()!r}"
+                )
+
+        try:
+            await asyncio.wait_for(_spawn(), timeout=_COLD_START_TIMEOUT_SEC)
+        except asyncio.TimeoutError:
+            # Reap whatever partial state we may have left.
+            try:
+                await self._tmux.kill_session()
+            except Exception:
+                pass
+            raise RuntimeError(
+                f"tmux[{self.agent_name}]: cold-start timed out after "
+                f"{_COLD_START_TIMEOUT_SEC}s"
+            ) from None
+
+    def _build_claude_cmd(self) -> str:
+        """Build the in-pane ``claude`` invocation as a single shell string.
+
+        Returned as a string (not a list) because tmux invokes it via the
+        user's shell. Components are individually quoted with
+        ``shlex.quote`` to defend against agent-name / config injection.
+        """
+        parts = ["claude", "--continue", "--dangerously-skip-permissions"]
+        # Optional model override.
+        if self._config.model:
+            parts.extend(["--model", self._config.model])
+        return " ".join(shlex.quote(p) for p in parts)
+
+    def _build_repl_env(self) -> dict[str, str]:
+        """Env vars injected into the tmux session.
+
+        Mirrors StreamingSession's ``provider_env`` shape so hook scripts
+        (e.g. ``hook_verify_effort.py``) see the same signals on both
+        backends.
+        """
+        env: dict[str, str] = {}
+        if self._config.provider_url:
+            env["ANTHROPIC_BASE_URL"] = self._config.provider_url
+        if self._config.provider_key:
+            env["ANTHROPIC_API_KEY"] = self._config.provider_key
+            env["ANTHROPIC_AUTH_TOKEN"] = self._config.provider_key
+        if self.agent_name:
+            env["PINKY_AGENT_NAME"] = self.agent_name
+        effort = self.effective_effort
+        if effort:
+            env["PINKY_EXPECTED_EFFORT"] = effort
+        if self._config.strict_effort_enforcement:
+            env["PINKY_STRICT_EFFORT"] = "1"
+        return env
+
+    async def disconnect(self) -> None:
+        """Tear down the worker and kill the tmux session. Idempotent.
+
+        Per the Transport contract: ``disconnect`` is the side-effect
+        runner, NOT the intent declarer. Callers establish lifecycle
+        intent (idle_sleep / force_restart / explicit DEAD) by driving
+        the state machine BEFORE calling disconnect.
+        """
+        # Cancel worker.
+        if self._worker_task and not self._worker_task.done():
+            self._worker_task.cancel()
+            try:
+                await self._worker_task
+            except asyncio.CancelledError:
+                pass
+        self._worker_task = None
+        self._processing = False
+
+        # Kill tmux session. ``kill_session`` is idempotent (treats
+        # "can't find session" as ok).
+        try:
+            await self._tmux.kill_session()
+        except Exception as e:
+            _log(f"tmux[{self.agent_name}]: kill_session raised: {e}")
+
+        # Default disconnect (no prior intent set) → DEAD. The state
+        # machine's existing matrix already handles the CONNECTED → DEAD
+        # cell under INTERNAL. If a prior intent already mutated state
+        # (IDLE_SLEEPING, RECONNECTING), this is a no-op — we don't drive
+        # the transition again.
+        if self.state == SessionState.CONNECTED:
+            try:
+                result = await self._state_machine.request_transition(
+                    SessionState.DEAD,
+                    Trigger.INTERNAL,
+                    reason="disconnect_default",
+                )
+                if result.owner_token is not None:
+                    await self._state_machine.transition_complete(
+                        result.owner_token,
+                        SessionState.DEAD,
+                        trigger=Trigger.INTERNAL,
+                    )
+            except Exception as e:
+                _log(f"tmux[{self.agent_name}]: disconnect→DEAD raised: {e}")
+
+        _log(f"tmux[{self.agent_name}]: disconnected")
+
+    async def send(
+        self,
+        prompt: str,
+        *,
+        platform: str = "",
+        chat_id: str = "",
+        message_id: str = "",
+        agent_hint: str = "",
+    ) -> None:
+        """Queue a turn for delivery to the in-pane claude REPL.
+
+        Non-blocking. Callers must ensure ``state == CONNECTED`` before
+        calling (per Transport contract). Behavior when called while
+        non-CONNECTED: drop with a log line (matches StreamingSession's
+        legacy behavior).
+        """
+        if self.state != SessionState.CONNECTED:
+            _log(
+                f"tmux[{self.agent_name}]: not connected (state={self.state.value}), "
+                f"dropping message"
+            )
+            return
+
+        self.last_active = time.time()
+        self._stats["messages_sent"] += 1
+
+        # Log to conversation store BEFORE appending agent_hint so chat
+        # history doesn't contain the routing hint.
+        if self._conversation_store:
+            try:
+                self._conversation_store.append(
+                    self.id, "user", prompt,
+                    platform=platform, chat_id=chat_id,
+                )
+            except Exception:
+                pass
+
+        queued_prompt = prompt + agent_hint if agent_hint else prompt
+        await self._message_queue.put(_QueuedTurn(
+            prompt=queued_prompt,
+            platform=platform,
+            chat_id=chat_id,
+            message_id=message_id,
+        ))
+        _log(f"tmux[{self.agent_name}]: queued message (chat={chat_id})")
+
+    async def _message_worker(self) -> None:
+        """Drain the message queue sequentially, delivering each turn to
+        the tmux pane.
+
+        The actual response capture (parsing claude's reply, firing
+        ``response_callback``) is the PR8b response-pipeline gap. For
+        now the worker only handles the inbound half: ``tmux send-keys``
+        the prompt, increment turn count, mark idle.
+        """
+        _log(f"tmux[{self.agent_name}]: message worker started")
+        try:
+            while self.state == SessionState.CONNECTED:
+                turn = await self._message_queue.get()
+                try:
+                    self._processing = True
+                    await self._deliver_turn(turn)
+                    self._stats["turns"] += 1
+                except Exception as e:
+                    self._stats["errors"] += 1
+                    _log(f"tmux[{self.agent_name}]: turn delivery raised: {e}")
+                finally:
+                    self._processing = False
+        except asyncio.CancelledError:
+            _log(f"tmux[{self.agent_name}]: worker cancelled")
+        except Exception as e:
+            _log(f"tmux[{self.agent_name}]: worker error: {e}")
+
+    async def _deliver_turn(self, turn: _QueuedTurn) -> None:
+        """Push one turn through to the tmux pane.
+
+        TODO (PR8b): after ``send-keys`` returns, await the response
+        pipeline's "turn complete" signal (transcript-file watcher OR
+        Stop-hook listener) and fire ``response_callback`` with the
+        accumulated text + tool uses. Today this method only delivers
+        the inbound half — the agent processes the prompt in tmux but
+        responses aren't routed back to broker/Telegram yet.
+        """
+        result = await self._tmux.send_keys(turn.prompt, enter=True)
+        if not result.ok:
+            raise RuntimeError(
+                f"tmux send-keys failed: rc={result.returncode} "
+                f"stderr={result.stderr.strip()!r}"
+            )
+        # PR8b will land the response wait here.
+
+    async def force_restart(self) -> bool:
+        """Tear down the tmux session and start a fresh one.
+
+        Drives ``CONNECTED → RECONNECTING → CONNECTED|DEAD``. Returns True
+        on success, False if blocked by the restart guard.
+        """
+        if self._config.restart_guard:
+            try:
+                guard = self._config.restart_guard(self)
+            except Exception:
+                guard = {}
+            if guard and not guard.get("restart_safe", False):
+                _log(f"tmux[{self.agent_name}]: restart blocked")
+                return False
+
+        _log(f"tmux[{self.agent_name}]: force_restart")
+
+        # Pre-assert RECONNECTING so observers (broker, watchdog) see the
+        # intent before disconnect's CONNECTED → DEAD fallback fires.
+        # Matches the StreamingSession.force_restart choreography from
+        # PR3 / Murzik's #491 review.
+        result = await self._state_machine.request_transition(
+            SessionState.RECONNECTING,
+            Trigger.USER_AGENT,
+            reason="force_restart",
+        )
+        token = result.owner_token
+        if token is None:
+            # Couldn't grab ownership; another transition is in flight.
+            # Best-effort: log and return False.
+            _log(
+                f"tmux[{self.agent_name}]: force_restart couldn't grab "
+                f"RECONNECTING ownership ({result.rejection_reason!r})"
+            )
+            return False
+
+        await self.disconnect()
+
+        # disconnect's default → DEAD path triggers ONLY from CONNECTED;
+        # we pre-set RECONNECTING above so it stays put. Now spawn fresh.
+        try:
+            await self._spawn_tmux_repl()
+            await self._state_machine.transition_complete(
+                token,
+                SessionState.CONNECTED,
+                trigger=Trigger.INTERNAL,
+            )
+            if not self._worker_task or self._worker_task.done():
+                self._worker_task = asyncio.create_task(self._message_worker())
+            _log(f"tmux[{self.agent_name}]: force_restart complete")
+            return True
+        except Exception as e:
+            _log(f"tmux[{self.agent_name}]: force_restart spawn failed: {e}")
+            try:
+                await self._state_machine.transition_complete(
+                    token,
+                    SessionState.DEAD,
+                    trigger=Trigger.INTERNAL,
+                )
+            except Exception:
+                pass
+            return False
+
+    async def idle_sleep(self) -> bool:
+        """Disconnect but keep the tmux session name pinned for cheap
+        warm-wake on next inbound message.
+
+        Drives ``CONNECTED → IDLE_SLEEPING`` via USER_AGENT.
+        """
+        if self.state != SessionState.CONNECTED:
+            return False
+
+        _log(f"tmux[{self.agent_name}]: idle_sleep")
+
+        # Pre-set IDLE_SLEEPING so disconnect's CONNECTED → DEAD fallback
+        # doesn't fire (matches StreamingSession's choreography).
+        result = await self._state_machine.request_transition(
+            SessionState.IDLE_SLEEPING,
+            Trigger.USER_AGENT,
+            reason="idle_sleep",
+        )
+        token = result.owner_token
+        if token is None:
+            _log(
+                f"tmux[{self.agent_name}]: idle_sleep couldn't grab IDLE_SLEEPING "
+                f"ownership ({result.rejection_reason!r})"
+            )
+            return False
+
+        await self.disconnect()
+
+        await self._state_machine.transition_complete(
+            token,
+            SessionState.IDLE_SLEEPING,
+            trigger=Trigger.USER_AGENT,
+        )
+        self._stats["auto_restarts"] += 1
+        _log(f"tmux[{self.agent_name}]: idle_sleep complete")
+        return True
+
+    async def attempt_reconnect(self) -> None:
+        """Best-effort reconnect after a transient transport failure.
+
+        Drives the warm-reconnect loop with bounded backoff. Matches the
+        StreamingSession contract so api._heartbeat_resurrect treats both
+        runtimes uniformly.
+        """
+        # Drive into RECONNECTING. If we're already there (e.g. force_restart
+        # is mid-flight), let that owner finish.
+        if self.state != SessionState.RECONNECTING:
+            result = await self._state_machine.request_transition(
+                SessionState.RECONNECTING,
+                Trigger.INTERNAL,
+                reason="attempt_reconnect",
+            )
+            token = result.owner_token
+            if token is None:
+                _log(
+                    f"tmux[{self.agent_name}]: attempt_reconnect couldn't grab "
+                    f"RECONNECTING ownership ({result.rejection_reason!r})"
+                )
+                return
+        else:
+            # Already RECONNECTING — there's already an owner; we shouldn't
+            # be here. Bail to avoid double-driving.
+            _log(
+                f"tmux[{self.agent_name}]: attempt_reconnect entered while "
+                f"already RECONNECTING — bailing"
+            )
+            return
+
+        try:
+            await self.disconnect()
+        except Exception as e:
+            _log(f"tmux[{self.agent_name}]: pre-reconnect disconnect raised: {e}")
+
+        last_error: Exception | None = None
+        for attempt_idx, delay in enumerate(_RECONNECT_BACKOFF, start=1):
+            self._stats["reconnects"] += 1
+            _log(
+                f"tmux[{self.agent_name}]: reconnect attempt {attempt_idx}/"
+                f"{len(_RECONNECT_BACKOFF)} after {delay}s backoff"
+            )
+            await asyncio.sleep(delay)
+            try:
+                await self._spawn_tmux_repl()
+                await self._state_machine.transition_complete(
+                    token,
+                    SessionState.CONNECTED,
+                    trigger=Trigger.INTERNAL,
+                )
+                if not self._worker_task or self._worker_task.done():
+                    self._worker_task = asyncio.create_task(self._message_worker())
+                _log(f"tmux[{self.agent_name}]: reconnected successfully")
+                return
+            except Exception as e:
+                last_error = e
+                _log(
+                    f"tmux[{self.agent_name}]: reconnect attempt {attempt_idx} "
+                    f"failed: {e}"
+                )
+
+        # Exhausted retry budget → DEAD.
+        try:
+            await self._state_machine.transition_complete(
+                token,
+                SessionState.DEAD,
+                trigger=Trigger.INTERNAL,
+            )
+        except Exception:
+            pass
+        _log(
+            f"tmux[{self.agent_name}]: all {len(_RECONNECT_BACKOFF)} reconnect "
+            f"attempts failed (last error: {last_error}); landed DEAD"
+        )

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -8,7 +8,7 @@ interactive limits instead of the capped SDK credit pool that
 ## Architecture
 
 Each TmuxSession owns a single detached tmux session named after the
-agent (``<fleet>-<agent_name>``). Inside that tmux session, an
+agent (``pinky-<agent_name>``). Inside that tmux session, an
 interactive ``claude --continue --dangerously-skip-permissions`` REPL
 runs. Inbound messages are delivered via ``tmux send-keys``; outbound
 responses are captured by a separate **response pipeline** that lives
@@ -136,6 +136,14 @@ class _TmuxControl:
         ``asyncio.TimeoutError``; the caller decides how to respond
         (typically: surface as a connect failure).
         """
+        # Timeout layering note: this ``timeout`` is the per-tmux-command
+        # ceiling (default 5s — generous for ``has-session`` / ``send-keys``
+        # / ``kill-session`` which are local IPC and should return in <100ms).
+        # The cold-start umbrella timeout (``_COLD_START_TIMEOUT_SEC`` = 60s)
+        # bounds the whole ``_spawn_tmux_repl`` flow, which composes multiple
+        # _run calls plus the new-session command (which spawns the REPL).
+        # 5s here defends a hung tmux server; 60s up there defends a hung
+        # REPL bootstrap (auth flow, CLAUDE.md load, etc.).
         cmd = self._base_cmd() + list(args)
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -416,19 +424,48 @@ class TmuxSession:
 
     # ── Lifecycle methods ───────────────────────────────────────────────
 
-    async def connect(self) -> None:
-        """Cold-start the tmux session and the in-pane claude REPL.
+    async def connect(self, *, trigger: Trigger = Trigger.BROKER) -> None:
+        """Bring the tmux session up via the appropriate state-machine path.
 
-        Drives ``UNINITIALIZED → BOOTING → CONNECTED`` (success) or
-        ``UNINITIALIZED → BOOTING → DEAD`` (failure) via the BOOT /
-        BOOT_COMPLETE / BOOT_FAILED Trigger triplet.
+        Handles three entry states explicitly — each drives a different
+        matrix edge:
 
-        Cold-start guard mirrors StreamingSession post-PR6: ``state in
-        {UNINITIALIZED, BOOTING}`` so a concurrent caller subscribes via
-        the in-flight handle instead of running a second tmux spawn.
+        1. **Cold-start** (state ∈ {UNINITIALIZED, BOOTING}):
+           ``UNINITIALIZED → BOOTING → CONNECTED|DEAD`` via the
+           ``BOOT / BOOT_COMPLETE / BOOT_FAILED`` Trigger triplet.
+           The ``trigger`` argument is ignored — BOOT is mandatory by
+           matrix (the only legal trigger out of UNINITIALIZED).
+        2. **Warm-wake** (state ∈ {IDLE_SLEEPING, DEAD}):
+           ``IDLE_SLEEPING|DEAD → RECONNECTING → CONNECTED|DEAD`` via
+           the caller-supplied ``trigger`` (BROKER for auto-wake on
+           inbound, WATCHDOG for watchdog-driven wake, SCHEDULER for
+           cron-driven wake, API_ADMIN for explicit operator wake).
+           ``Trigger.INTERNAL`` is NOT legal for this edge — the matrix
+           pins it to external actors (Murzik's PR #495 round-1
+           finding 1 + 2).
+        3. **No-op** (state == CONNECTED): silently return. This is the
+           post-completion-straggler case (Pushok's Case C from PR6);
+           pre-existing across StreamingSession + CodexSession + here.
+           Tracked alongside the warm-reconnect Trigger symmetry
+           follow-up.
+
+        Cold-start + warm-wake both use the same in-flight subscriber
+        protection — concurrent ``connect()`` calls on a fresh or sleeping
+        session result in exactly one tmux spawn; concurrent callers
+        subscribe and inherit the owner's outcome (CONNECTED clean return,
+        DEAD raise).
+
+        Args:
+            trigger: Actor identity for the IDLE_SLEEPING|DEAD →
+                RECONNECTING edge. Ignored for cold-start (BOOT is the
+                only legal trigger). Default ``BROKER`` — the most
+                common caller (auto-wake on inbound message).
         """
         cold_start_token = None
+        warm_wake_token = None
+
         if self.state in (SessionState.UNINITIALIZED, SessionState.BOOTING):
+            # ── Cold-start path ───────────────────────────────────────
             boot_result = await self._state_machine.request_transition(
                 SessionState.BOOTING,
                 Trigger.BOOT,
@@ -461,11 +498,71 @@ class TmuxSession:
                 return
             cold_start_token = boot_result.owner_token
 
+        elif self.state in (SessionState.IDLE_SLEEPING, SessionState.DEAD):
+            # ── Warm-wake path (Murzik's #495 round-1 fix) ────────────
+            # The matrix requires an external trigger (BROKER, WATCHDOG,
+            # SCHEDULER, API_ADMIN) for IDLE_SLEEPING|DEAD → RECONNECTING.
+            # INTERNAL is rejected here — that was the pre-fix bug:
+            # connect() direct-mutated CONNECTED, bypassing the
+            # RECONNECTING macro state and skipping subscriber protection
+            # for concurrent wakes.
+            wake_result = await self._state_machine.request_transition(
+                SessionState.RECONNECTING,
+                trigger,
+                reason=f"warm_wake_from_{self.state.value}",
+            )
+            if wake_result.owner_token is None:
+                # Same-target RECONNECTING in flight: subscribe.
+                if wake_result.in_flight_handle is not None:
+                    final = await wake_result.in_flight_handle.wait()
+                    if final == SessionState.CONNECTED:
+                        return
+                    raise RuntimeError(
+                        f"tmux[{self.agent_name}]: warm-wake RECONNECTING "
+                        f"in-flight resolved to {final.value} (owner failed); "
+                        f"refusing to return as connected"
+                    )
+                # Rejection (matrix said no, or post-completion race).
+                _log(
+                    f"tmux[{self.agent_name}]: warm-wake rejected "
+                    f"({wake_result.rejection_reason!r}) — state={self.state.value}"
+                )
+                if self.state == SessionState.DEAD:
+                    raise RuntimeError(
+                        f"tmux[{self.agent_name}]: warm-wake rejected post-DEAD; "
+                        f"refusing to return as connected"
+                    )
+                return
+            warm_wake_token = wake_result.owner_token
+
+        elif self.state == SessionState.CONNECTED:
+            # ── No-op (post-completion straggler) ─────────────────────
+            # Pre-existing class shared with StreamingSession + CodexSession.
+            # Logged for visibility; no double-spawn.
+            _log(
+                f"tmux[{self.agent_name}]: connect() called while already "
+                f"CONNECTED — no-op (post-completion straggler)"
+            )
+            return
+
+        else:
+            # state == RECONNECTING: another path (force_restart /
+            # attempt_reconnect) owns this transition. connect() should
+            # not be the entry point for that lifecycle.
+            _log(
+                f"tmux[{self.agent_name}]: connect() called with state="
+                f"{self.state.value} — refusing (another path owns this "
+                f"transition)"
+            )
+            return
+
         try:
             await self._spawn_tmux_repl()
         except BaseException:
-            # Cold-start failed. Drive BOOTING → DEAD via BOOT_FAILED so
-            # the lifecycle stays a closed audit pair.
+            # Cold-start or warm-wake failed. Drive the in-flight transition
+            # to DEAD with the correct completion trigger (BOOT_FAILED for
+            # cold-start, INTERNAL for warm-wake — DEAD is always legal as
+            # emergency exit, so trigger choice is for audit visibility).
             if cold_start_token is not None:
                 try:
                     await self._state_machine.transition_complete(
@@ -478,22 +575,36 @@ class TmuxSession:
                         f"tmux[{self.agent_name}]: BOOT_FAILED completion "
                         f"raised after cold-start error: {ce}"
                     )
+            elif warm_wake_token is not None:
+                try:
+                    await self._state_machine.transition_complete(
+                        warm_wake_token,
+                        SessionState.DEAD,
+                        trigger=Trigger.INTERNAL,
+                    )
+                except Exception as ce:
+                    _log(
+                        f"tmux[{self.agent_name}]: warm-wake DEAD completion "
+                        f"raised after spawn error: {ce}"
+                    )
             raise
 
-        # Cold-start succeeded. Land in CONNECTED via BOOT_COMPLETE.
+        # Spawn succeeded. Complete the appropriate in-flight transition.
         if cold_start_token is not None:
+            # Cold-start: BOOTING → CONNECTED via BOOT_COMPLETE.
             await self._state_machine.transition_complete(
                 cold_start_token,
                 SessionState.CONNECTED,
                 trigger=Trigger.BOOT_COMPLETE,
             )
-        else:
-            # Warm-reconnect path (RECONNECTING owner present in the state
-            # machine). Honor whoever drove us here.
-            # NOTE: warm-reconnect Trigger symmetry (RECONNECT_COMPLETE /
-            # RECONNECT_FAILED) is the PR6.5 follow-up — mirrors the
-            # carve-out documented in StreamingSession.connect.
-            self._state_machine._state = SessionState.CONNECTED
+        elif warm_wake_token is not None:
+            # Warm-wake: RECONNECTING → CONNECTED via INTERNAL (the matrix
+            # cell for the completion edge).
+            await self._state_machine.transition_complete(
+                warm_wake_token,
+                SessionState.CONNECTED,
+                trigger=Trigger.INTERNAL,
+            )
 
         # Start the worker.
         if not self._worker_task or self._worker_task.done():
@@ -838,34 +949,68 @@ class TmuxSession:
         _log(f"tmux[{self.agent_name}]: idle_sleep complete")
         return True
 
-    async def attempt_reconnect(self) -> None:
+    async def attempt_reconnect(self, *, trigger: Trigger = Trigger.BROKER) -> None:
         """Best-effort reconnect after a transient transport failure.
 
         Drives the warm-reconnect loop with bounded backoff. Matches the
         StreamingSession contract so api._heartbeat_resurrect treats both
         runtimes uniformly.
+
+        Murzik's PR #495 round-1 finding 2: the matrix requires different
+        triggers per source state for the ``→ RECONNECTING`` edge —
+
+        - CONNECTED → RECONNECTING: USER_AGENT / WATCHDOG / API_ADMIN / INTERNAL
+        - IDLE_SLEEPING → RECONNECTING: BROKER / WATCHDOG / SCHEDULER / API_ADMIN
+        - DEAD → RECONNECTING: BROKER / WATCHDOG / SCHEDULER / API_ADMIN
+
+        The pre-fix unconditional ``INTERNAL`` would silently reject when
+        called from DEAD or IDLE_SLEEPING — exactly the resurrection paths
+        that need to work for ``api._heartbeat_resurrect`` to revive a
+        watchdog-killed agent. The trigger parameter lets the caller declare
+        their identity; default ``BROKER`` matches the most common caller
+        (broker auto-wake on inbound).
+
+        Args:
+            trigger: Actor identity for the ``→ RECONNECTING`` edge. Pick
+                the one that matches the matrix cell for the current source
+                state. Default ``BROKER`` covers auto-wake on inbound;
+                pass ``WATCHDOG`` from the watchdog resurrection callback,
+                ``SCHEDULER`` from cron-driven resurrect, ``API_ADMIN`` from
+                explicit operator action.
         """
         # Drive into RECONNECTING. If we're already there (e.g. force_restart
         # is mid-flight), let that owner finish.
-        if self.state != SessionState.RECONNECTING:
-            result = await self._state_machine.request_transition(
-                SessionState.RECONNECTING,
-                Trigger.INTERNAL,
-                reason="attempt_reconnect",
-            )
-            token = result.owner_token
-            if token is None:
-                _log(
-                    f"tmux[{self.agent_name}]: attempt_reconnect couldn't grab "
-                    f"RECONNECTING ownership ({result.rejection_reason!r})"
-                )
-                return
-        else:
-            # Already RECONNECTING — there's already an owner; we shouldn't
-            # be here. Bail to avoid double-driving.
+        if self.state == SessionState.RECONNECTING:
             _log(
                 f"tmux[{self.agent_name}]: attempt_reconnect entered while "
-                f"already RECONNECTING — bailing"
+                f"already RECONNECTING — bailing (another path owns this transition)"
+            )
+            return
+
+        # Pick a matrix-legal trigger for the current source state. INTERNAL
+        # only works from CONNECTED; warm sources (IDLE_SLEEPING/DEAD) need
+        # an external actor identity.
+        result = await self._state_machine.request_transition(
+            SessionState.RECONNECTING,
+            trigger,
+            reason=f"attempt_reconnect_from_{self.state.value}",
+        )
+        token = result.owner_token
+        if token is None:
+            # Could be a concurrent transition or matrix rejection. Subscribe
+            # if there's a handle; surface DEAD if we landed there.
+            if result.in_flight_handle is not None:
+                final = await result.in_flight_handle.wait()
+                if final == SessionState.CONNECTED:
+                    return
+                _log(
+                    f"tmux[{self.agent_name}]: attempt_reconnect in-flight "
+                    f"resolved to {final.value}"
+                )
+                return
+            _log(
+                f"tmux[{self.agent_name}]: attempt_reconnect rejected "
+                f"({result.rejection_reason!r})"
             )
             return
 
@@ -889,6 +1034,8 @@ class TmuxSession:
                     SessionState.CONNECTED,
                     trigger=Trigger.INTERNAL,
                 )
+                # Respawn the worker — disconnect() above cancelled it, so
+                # the queue would otherwise have no drainer on success.
                 if not self._worker_task or self._worker_task.done():
                     self._worker_task = asyncio.create_task(self._message_worker())
                 _log(f"tmux[{self.agent_name}]: reconnected successfully")

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -26,7 +26,7 @@ from pinky_daemon.tmux_session import (
     TmuxSession,
     _TmuxControl,
 )
-from pinky_daemon.transport_state import SessionState
+from pinky_daemon.transport_state import SessionState, TransitionResult, Trigger
 
 
 def _ok() -> TmuxCommandResult:
@@ -255,6 +255,226 @@ async def test_concurrent_cold_start_subscriber_raises_on_owner_dead() -> None:
     with pytest.raises(RuntimeError, match="resolved to dead"):
         await t2
     assert ss.state == SessionState.DEAD
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Cold-start Case D (post-DEAD rejection) — Pushok PR #495 round-1 nit 2
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cold_start_rejection_post_dead_raises() -> None:
+    """Pushok's Case D from PR #494, applied to TmuxSession. A caller
+    enters connect() observing state == BOOTING, but by the time
+    request_transition acquires the lock the owner has already completed
+    to DEAD. The matrix rejection branch (in_flight_handle is None) must
+    surface the failure, not silently return as if connected.
+
+    Surrogate test — pre-set state to BOOTING and patch request_transition
+    to return rejection + DEAD state, matching the race outcome.
+    """
+    ss, _ = _make_session(state=SessionState.BOOTING)
+
+    async def fake_request_transition(target, trigger, *, reason=None):
+        # Simulate the race outcome: owner just completed DEAD; rejection.
+        ss._state_machine._state = SessionState.DEAD
+        return TransitionResult(
+            changed=False,
+            from_state=SessionState.DEAD,
+            to_state=SessionState.DEAD,
+            rejection_reason="phantom: owner completed DEAD before subscribe",
+        )
+
+    ss._state_machine.request_transition = fake_request_transition  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="post-DEAD"):
+        await ss.connect()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Warm-wake from IDLE_SLEEPING / DEAD — Murzik PR #495 round-1 finding 1
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Pre-fix: connect() only handled UNINITIALIZED/BOOTING. IDLE_SLEEPING and
+# DEAD entries fell through to direct-mutating CONNECTED via the warm-
+# reconnect else branch — skipping the matrix IDLE_SLEEPING|DEAD →
+# RECONNECTING edge entirely, and giving concurrent wakes no subscriber
+# protection.
+#
+# Post-fix: connect() takes a ``trigger`` parameter; IDLE_SLEEPING/DEAD
+# entries drive ``→ RECONNECTING`` via the caller-supplied trigger
+# (default BROKER — the most common caller: broker auto-wake on inbound).
+# Same in-flight subscriber protection as cold-start.
+
+
+@pytest.mark.asyncio
+async def test_warm_wake_from_idle_sleeping_drives_through_reconnecting() -> None:
+    """Auto-wake on inbound from IDLE_SLEEPING must drive
+    IDLE_SLEEPING → RECONNECTING → CONNECTED, NOT direct-mutate CONNECTED.
+
+    The matrix audit log captures every transition; pre-fix the
+    IDLE_SLEEPING → RECONNECTING edge was invisible because the code
+    skipped it entirely.
+    """
+    ss, tmux = _make_session(state=SessionState.IDLE_SLEEPING)
+    await ss.connect()  # default trigger=BROKER
+
+    assert ss.state == SessionState.CONNECTED
+    # The new-session call confirms we ran the warm-wake spawn.
+    tmux.new_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_warm_wake_from_dead_drives_through_reconnecting() -> None:
+    """Same path from DEAD — the resurrection-on-inbound case.
+    api._heartbeat_resurrect relies on this working; pre-fix it would
+    silently bail because INTERNAL isn't legal for DEAD → RECONNECTING."""
+    ss, _ = _make_session(state=SessionState.DEAD)
+    await ss.connect(trigger=Trigger.BROKER)
+    assert ss.state == SessionState.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_warm_wake_failure_drives_to_dead() -> None:
+    """If spawn fails during warm-wake, the in-flight transition completes
+    DEAD via the emergency-exit path. State must NOT be left parked in
+    RECONNECTING — that would strand subscribers + leak the in-flight
+    record (driver-abandonment failure mode)."""
+    tmux = _make_mock_tmux()
+    tmux.new_session = AsyncMock(return_value=_fail("simulated wake failure"))
+    ss, _ = _make_session(state=SessionState.IDLE_SLEEPING, tmux=tmux)
+
+    with pytest.raises(RuntimeError, match="tmux new-session failed"):
+        await ss.connect()
+    assert ss.state == SessionState.DEAD
+
+
+@pytest.mark.asyncio
+async def test_concurrent_warm_wake_runs_one_spawn() -> None:
+    """Concurrent connect() on an IDLE_SLEEPING session must result in
+    exactly one tmux spawn. Same shape as the cold-start Case A
+    regression — caller A wins RECONNECTING ownership, caller B
+    subscribes via the in-flight handle.
+
+    Pre-fix: both callers fell through to ``_spawn_tmux_repl`` and
+    direct-mutated CONNECTED — double-spawn, no subscriber protection.
+    Post-fix: matrix subscriber path applies to warm-wake too.
+    """
+    tmux = _make_mock_tmux()
+    release_spawn = asyncio.Event()
+    spawn_started = asyncio.Event()
+    spawn_count = 0
+
+    async def blocking_new_session(*, cwd, command, env=None):
+        nonlocal spawn_count
+        spawn_count += 1
+        spawn_started.set()
+        await release_spawn.wait()
+        return _ok()
+
+    tmux.new_session = AsyncMock(side_effect=blocking_new_session)
+    ss, _ = _make_session(state=SessionState.IDLE_SLEEPING, tmux=tmux)
+
+    t1 = asyncio.create_task(ss.connect())
+    await spawn_started.wait()
+    assert ss.state == SessionState.RECONNECTING, (
+        "First caller must hold RECONNECTING ownership while spawn is "
+        "in flight (warm-wake path)"
+    )
+
+    t2 = asyncio.create_task(ss.connect())
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    assert spawn_count == 1, (
+        f"Warm-wake concurrent-connect must run exactly one tmux spawn; "
+        f"got {spawn_count}"
+    )
+
+    release_spawn.set()
+    await asyncio.gather(t1, t2)
+    assert spawn_count == 1
+    assert ss.state == SessionState.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_warm_wake_uses_caller_supplied_trigger() -> None:
+    """Trigger threads through to the matrix audit. WATCHDOG is the
+    canonical resurrect-from-watchdog trigger; verify it's accepted.
+    Matrix-legality is enforced by the state machine — this test pins
+    that the call doesn't crash and lands CONNECTED."""
+    ss, _ = _make_session(state=SessionState.DEAD)
+    await ss.connect(trigger=Trigger.WATCHDOG)
+    assert ss.state == SessionState.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_connect_from_connected_is_no_op() -> None:
+    """Post-completion straggler — connect() called while already
+    CONNECTED returns silently. Pushok's Case C from PR #494, applied to
+    TmuxSession. No double-spawn, no state mutation."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    await ss.connect()
+    assert ss.state == SessionState.CONNECTED
+    tmux.new_session.assert_not_awaited()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# attempt_reconnect with trigger awareness — Murzik PR #495 round-1 finding 2
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_attempt_reconnect_from_dead_lands_connected_with_broker_trigger() -> None:
+    """Murzik's finding 2: pre-fix attempt_reconnect used Trigger.INTERNAL
+    unconditionally. INTERNAL is matrix-rejected from DEAD/IDLE_SLEEPING
+    (only BROKER/WATCHDOG/SCHEDULER/API_ADMIN are legal for those edges),
+    so a DEAD agent's reconnect would silently bail without ever retrying.
+
+    Post-fix: caller-supplied trigger threads through. With BROKER (the
+    default), DEAD → RECONNECTING → CONNECTED works."""
+    ss, _ = _make_session(state=SessionState.DEAD)
+    ss._RECONNECT_BACKOFF = (0,)  # speed up the test
+    # Override module constant locally so the test doesn't sleep.
+    import pinky_daemon.tmux_session as ts_mod
+    original_backoff = ts_mod._RECONNECT_BACKOFF
+    ts_mod._RECONNECT_BACKOFF = (0,)
+    try:
+        await ss.attempt_reconnect()  # default trigger=BROKER
+        assert ss.state == SessionState.CONNECTED
+    finally:
+        ts_mod._RECONNECT_BACKOFF = original_backoff
+
+
+@pytest.mark.asyncio
+async def test_attempt_reconnect_from_idle_sleeping_lands_connected_with_watchdog_trigger() -> None:
+    """Watchdog-driven warm-wake from IDLE_SLEEPING via attempt_reconnect.
+    Pins the IDLE_SLEEPING → RECONNECTING edge with WATCHDOG trigger."""
+    ss, _ = _make_session(state=SessionState.IDLE_SLEEPING)
+    import pinky_daemon.tmux_session as ts_mod
+    original_backoff = ts_mod._RECONNECT_BACKOFF
+    ts_mod._RECONNECT_BACKOFF = (0,)
+    try:
+        await ss.attempt_reconnect(trigger=Trigger.WATCHDOG)
+        assert ss.state == SessionState.CONNECTED
+    finally:
+        ts_mod._RECONNECT_BACKOFF = original_backoff
+
+
+@pytest.mark.asyncio
+async def test_attempt_reconnect_exhausted_budget_lands_dead() -> None:
+    """If all retries fail, the in-flight transition completes DEAD."""
+    tmux = _make_mock_tmux()
+    tmux.new_session = AsyncMock(return_value=_fail("persistent failure"))
+    ss, _ = _make_session(state=SessionState.DEAD, tmux=tmux)
+    import pinky_daemon.tmux_session as ts_mod
+    original_backoff = ts_mod._RECONNECT_BACKOFF
+    ts_mod._RECONNECT_BACKOFF = (0, 0)  # 2 failed attempts, no sleep
+    try:
+        await ss.attempt_reconnect(trigger=Trigger.BROKER)
+        assert ss.state == SessionState.DEAD
+    finally:
+        ts_mod._RECONNECT_BACKOFF = original_backoff
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1,0 +1,446 @@
+"""Tests for TmuxSession.
+
+PR8 of the #486 sequence. Focused on the lifecycle choreography +
+state-machine integration. The response capture pipeline is PR8b — its
+tests will land alongside that PR.
+
+Test strategy:
+- Mock ``_TmuxControl`` (the subprocess wrapper) end-to-end; never shell
+  out to a real tmux binary.
+- Pin the state-machine transitions on every lifecycle path (cold-start
+  success/failure, warm-reconnect, idle-sleep, force-restart).
+- Pin the concurrent-connect Cases A + B from PR6's framework: greenfield
+  backend should get the race protection by construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import (
+    TmuxCommandResult,
+    TmuxSession,
+    _TmuxControl,
+)
+from pinky_daemon.transport_state import SessionState
+
+
+def _ok() -> TmuxCommandResult:
+    """Successful tmux command result."""
+    return TmuxCommandResult(returncode=0, stdout="", stderr="")
+
+
+def _fail(msg: str = "boom") -> TmuxCommandResult:
+    """Failed tmux command result."""
+    return TmuxCommandResult(returncode=1, stdout="", stderr=msg)
+
+
+def _make_mock_tmux(*, has_session_initial: bool = False) -> MagicMock:
+    """Build a MagicMock of ``_TmuxControl`` with sensible async defaults.
+
+    All methods return success unless overridden by the test.
+    """
+    tmux = MagicMock(spec=_TmuxControl)
+    tmux.session_name = "pinky-test"
+    tmux.has_session = AsyncMock(return_value=has_session_initial)
+    tmux.new_session = AsyncMock(return_value=_ok())
+    tmux.kill_session = AsyncMock(return_value=_ok())
+    tmux.send_keys = AsyncMock(return_value=_ok())
+    tmux.capture_pane = AsyncMock(return_value=_ok())
+    return tmux
+
+
+def _make_session(
+    *,
+    agent_name: str = "dymok",
+    state: SessionState | None = None,
+    tmux: MagicMock | None = None,
+) -> tuple[TmuxSession, MagicMock]:
+    """Build a TmuxSession with mocked tmux control.
+
+    Returns (session, tmux_mock). Tests that need to start in a specific
+    state pass ``state=...``; the state machine is direct-mutated to that
+    state (same bypass pattern existing StreamingSession tests use).
+    """
+    cfg = StreamingSessionConfig(
+        agent_name=agent_name,
+        working_dir="/tmp/tmux-session-test",
+    )
+    tmux = tmux or _make_mock_tmux()
+    ss = TmuxSession(cfg, tmux_control=tmux)
+    if state is not None:
+        ss._state_machine._state = state
+    return ss, tmux
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Construction + identity
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_default_initial_state_is_uninitialized() -> None:
+    ss, _ = _make_session()
+    assert ss.state == SessionState.UNINITIALIZED
+
+
+def test_id_format_matches_streaming_session() -> None:
+    ss, _ = _make_session(agent_name="dymok")
+    # Default label → "main"
+    assert ss.id == "dymok-main"
+
+
+def test_resume_handle_is_tmux_session_name() -> None:
+    """For tmux, the tmux session name IS the resume handle. Pinning by
+    name preserves cwd → claude --continue resumes via that cwd's most-
+    recent transcript automatically."""
+    ss, _ = _make_session(agent_name="dymok")
+    assert ss.resume_handle == "pinky-dymok"
+
+
+def test_session_name_prefix_isolates_pinky_from_operator_tmux() -> None:
+    """Tmux session name has the ``pinky-`` prefix so Pinky-owned sessions
+    can be distinguished from the operator's own tmux sessions on the host."""
+    ss, _ = _make_session(agent_name="dymok")
+    assert ss._session_name.startswith("pinky-")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Cold-start lifecycle: UNINITIALIZED → BOOTING → CONNECTED / DEAD
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cold_start_drives_state_through_booting_to_connected() -> None:
+    """Successful cold-start lands in CONNECTED via the BOOT/BOOT_COMPLETE
+    Trigger pair. Mirrors StreamingSession's PR6 cold-start contract."""
+    ss, tmux = _make_session()
+    await ss.connect()
+    assert ss.state == SessionState.CONNECTED
+    # Exactly one tmux new-session call (the cold-start spawn).
+    assert tmux.new_session.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cold_start_failure_drives_to_dead_via_boot_failed() -> None:
+    """If ``tmux new-session`` fails, cold-start lands BOOTING → DEAD via
+    BOOT_FAILED (not silent disconnect)."""
+    tmux = _make_mock_tmux()
+    tmux.new_session = AsyncMock(return_value=_fail("rc=1"))
+    ss, _ = _make_session(tmux=tmux)
+    with pytest.raises(RuntimeError, match="tmux new-session failed"):
+        await ss.connect()
+    assert ss.state == SessionState.DEAD
+
+
+@pytest.mark.asyncio
+async def test_cold_start_reaps_stale_session_before_spawn() -> None:
+    """If a stale tmux session is found at cold-start time (e.g. previous
+    daemon crashed without graceful disconnect), reap it first."""
+    tmux = _make_mock_tmux(has_session_initial=True)
+    ss, _ = _make_session(tmux=tmux)
+    await ss.connect()
+    # has_session checked, then kill_session called for the stale reap,
+    # then new_session for the fresh spawn.
+    tmux.has_session.assert_awaited()
+    tmux.kill_session.assert_awaited()
+    tmux.new_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cold_start_uses_correct_claude_invocation() -> None:
+    """The in-pane command must be ``claude --continue
+    --dangerously-skip-permissions`` per the design. Pinned because a
+    typo in the invocation silently breaks billing semantics (would hit
+    SDK credits instead of subscription)."""
+    ss, tmux = _make_session()
+    await ss.connect()
+    _, kwargs = tmux.new_session.call_args
+    cmd = kwargs["command"]
+    assert "claude" in cmd
+    assert "--continue" in cmd
+    assert "--dangerously-skip-permissions" in cmd
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Concurrent cold-start race (PR6 framework: Case A + Case B)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_start_runs_one_tmux_spawn() -> None:
+    """PR6's canonical concurrent-connect race regression, applied to the
+    greenfield tmux backend. Two concurrent connect() calls must result
+    in exactly one tmux new-session.
+
+    By the time the second caller enters connect(), state is BOOTING
+    (the first caller flipped it at grant time). The widened guard
+    (``state in {UNINITIALIZED, BOOTING}``) routes the second caller to
+    the same-target in-flight branch — subscribes via InFlightHandle,
+    inherits the owner's CONNECTED outcome.
+    """
+    tmux = _make_mock_tmux()
+    release_spawn = asyncio.Event()
+    spawn_started = asyncio.Event()
+    spawn_count = 0
+
+    async def blocking_new_session(*, cwd, command, env=None):
+        nonlocal spawn_count
+        spawn_count += 1
+        spawn_started.set()
+        await release_spawn.wait()
+        return _ok()
+
+    tmux.new_session = AsyncMock(side_effect=blocking_new_session)
+    ss, _ = _make_session(tmux=tmux)
+
+    t1 = asyncio.create_task(ss.connect())
+    await spawn_started.wait()
+    assert ss.state == SessionState.BOOTING, (
+        "First caller must hold BOOTING ownership while spawn is in flight"
+    )
+
+    t2 = asyncio.create_task(ss.connect())
+    # Yield to let t2 subscribe.
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    assert spawn_count == 1, (
+        f"Greenfield TmuxSession must inherit PR6's one-spawn invariant; "
+        f"got {spawn_count} concurrent tmux new-session calls"
+    )
+
+    release_spawn.set()
+    await asyncio.gather(t1, t2)
+
+    assert spawn_count == 1
+    assert ss.state == SessionState.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_start_subscriber_raises_on_owner_dead() -> None:
+    """Case B — owner's spawn raises, subscriber inherits DEAD and raises.
+
+    Subscriber must NOT silently return as if connected (which would
+    leave the broker thinking tmux is up when it isn't).
+    """
+    tmux = _make_mock_tmux()
+    release_spawn = asyncio.Event()
+    spawn_started = asyncio.Event()
+
+    async def failing_new_session(*, cwd, command, env=None):
+        spawn_started.set()
+        await release_spawn.wait()
+        return _fail("rc=1")
+
+    tmux.new_session = AsyncMock(side_effect=failing_new_session)
+    ss, _ = _make_session(tmux=tmux)
+
+    t1 = asyncio.create_task(ss.connect())
+    await spawn_started.wait()
+    assert ss.state == SessionState.BOOTING
+
+    t2 = asyncio.create_task(ss.connect())
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    release_spawn.set()
+    # Owner re-raises the original tmux failure; subscriber raises with
+    # the "resolved to dead" marker.
+    with pytest.raises(RuntimeError, match="tmux new-session failed"):
+        await t1
+    with pytest.raises(RuntimeError, match="resolved to dead"):
+        await t2
+    assert ss.state == SessionState.DEAD
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# disconnect + idle_sleep + force_restart choreography
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_disconnect_from_connected_lands_in_dead() -> None:
+    """Default disconnect (no prior intent set) lands CONNECTED → DEAD.
+    Matches StreamingSession.disconnect's contract."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    await ss.disconnect()
+    assert ss.state == SessionState.DEAD
+    tmux.kill_session.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_idle_sleep_drives_to_idle_sleeping_not_dead() -> None:
+    """idle_sleep must pre-set IDLE_SLEEPING so disconnect's default
+    CONNECTED → DEAD fallback doesn't fire. Otherwise the watchdog's
+    resurrection callback would race the idle-sleep intent.
+
+    Same flicker-class bug as Pushok's PR #492 Nit 2 on CodexSession.
+    """
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    result = await ss.idle_sleep()
+    assert result is True
+    assert ss.state == SessionState.IDLE_SLEEPING
+    tmux.kill_session.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_idle_sleep_returns_false_when_not_connected() -> None:
+    ss, _ = _make_session(state=SessionState.DEAD)
+    result = await ss.idle_sleep()
+    assert result is False
+    assert ss.state == SessionState.DEAD
+
+
+@pytest.mark.asyncio
+async def test_force_restart_holds_reconnecting_across_disconnect_and_spawn() -> None:
+    """Mirror of test_force_restart_holds_reconnecting_across_disconnect_and_connect
+    from test_streaming_session.py. The macro state must stay RECONNECTING
+    throughout the restart — no flicker through DEAD.
+    """
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+
+    observed_states: list[SessionState] = []
+    original_kill = tmux.kill_session
+
+    async def kill_with_observation(*args, **kwargs):
+        observed_states.append(ss.state)
+        return await original_kill(*args, **kwargs)
+
+    tmux.kill_session = AsyncMock(side_effect=kill_with_observation)
+
+    result = await ss.force_restart()
+    assert result is True
+    # State at every observation point during the restart must be
+    # RECONNECTING (or CONNECTED at the very end), never DEAD.
+    for s in observed_states:
+        assert s == SessionState.RECONNECTING, (
+            f"force_restart must hold RECONNECTING across teardown — "
+            f"observed {s}"
+        )
+    assert ss.state == SessionState.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_force_restart_failure_lands_in_dead() -> None:
+    """If the re-spawn fails after disconnect, force_restart returns False
+    and the state machine lands DEAD."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    # First new_session call (post-restart spawn) fails.
+    tmux.new_session = AsyncMock(return_value=_fail("re-spawn failed"))
+    result = await ss.force_restart()
+    assert result is False
+    assert ss.state == SessionState.DEAD
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# send + worker
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_drops_when_not_connected() -> None:
+    """Per Transport contract, send() drops when not CONNECTED. Matches
+    StreamingSession's legacy drop-silent behavior."""
+    ss, tmux = _make_session(state=SessionState.DEAD)
+    await ss.send("hello", platform="telegram", chat_id="123")
+    tmux.send_keys.assert_not_awaited()
+    assert ss._stats["messages_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_send_queues_and_worker_delivers_via_send_keys() -> None:
+    """Happy path: cold-start, send a message, worker dequeues and pushes
+    via tmux send-keys. Pins the send_keys invocation shape (enter=True
+    appends an Enter keypress, completing the prompt in claude's REPL)."""
+    ss, tmux = _make_session()
+    await ss.connect()
+    await ss.send("hello world", platform="telegram", chat_id="123")
+
+    # Let the worker drain one item.
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if tmux.send_keys.await_count >= 1:
+            break
+
+    tmux.send_keys.assert_awaited()
+    # send_keys is called with the prompt + enter=True (default).
+    args, kwargs = tmux.send_keys.call_args
+    assert args[0] == "hello world"
+    assert kwargs.get("enter", True) is True
+
+    # Clean up — cancel worker so the test doesn't leak the task.
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_send_increments_turn_and_message_counters() -> None:
+    ss, tmux = _make_session()
+    await ss.connect()
+    await ss.send("first", platform="telegram", chat_id="123")
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if ss._stats["turns"] >= 1:
+            break
+    assert ss._stats["messages_sent"] == 1
+    assert ss._stats["turns"] == 1
+    await ss.disconnect()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Effort knob (protocol parity; no in-session effect on tmux backend)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_set_effort_accepts_valid_levels() -> None:
+    ss, _ = _make_session()
+    for level in ("low", "medium", "high", "xhigh", "max", "auto"):
+        ss.set_effort(level)
+
+
+def test_set_effort_rejects_invalid_level() -> None:
+    ss, _ = _make_session()
+    with pytest.raises(ValueError, match="invalid effort"):
+        ss.set_effort("nuclear")
+
+
+def test_set_effort_auto_clears_override() -> None:
+    ss, _ = _make_session()
+    ss.set_effort("max")
+    assert ss.effective_effort == "max"
+    ss.set_effort("auto")
+    # auto resolves to medium (default) per the contract.
+    assert ss.effective_effort == "medium"
+
+
+def test_clear_effort_override_resets_to_config_default() -> None:
+    ss, _ = _make_session()
+    ss.set_effort("max")
+    ss.clear_effort_override()
+    # Falls back to config's thinking_effort, defaulting to "medium".
+    assert ss.effective_effort == "medium"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# stats shape
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_stats_shape_matches_broker_consumer_keys() -> None:
+    """Stats dict must include the keys broker/api/watchdog read.
+
+    Intentionally absent: ``cost_usd`` — tmux billing is against the
+    subscription, not per-turn metered. Documented gap.
+    """
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    stats = ss.stats
+    for key in ("turns", "messages_sent", "errors", "reconnects",
+                "auto_restarts", "state", "thinking_effort"):
+        assert key in stats, f"stats missing required key: {key}"
+    # state stringified for JSON-friendly transport over the API.
+    assert stats["state"] == "connected"
+    # cost_usd not reported.
+    assert "cost_usd" not in stats


### PR DESCRIPTION
**DRAFT** — PR8a of issue #486. First half of the TmuxSession landing: lifecycle skeleton + state-machine choreography + tests. Response capture pipeline is PR8b, daemon wiring + Dymok bootstrap is PR9.

## What this PR is

Introduces \`TmuxSession\`, a new Transport-protocol backend that runs an interactive \`claude --continue --dangerously-skip-permissions\` REPL inside a detached tmux session. Bills against the Claude Code subscription's interactive limits instead of the capped SDK credit pool that StreamingSession consumes.

This is the design Brad green-lit in the side-by-side framing — TmuxSession lives alongside StreamingSession indefinitely, not as a replacement.

## Why a skeleton-first PR

The full TmuxSession is multi-day work (transcript-tailing or hook-listener for response capture, context-budget watchdog adaptation, etc.). Splitting at the response-pipeline boundary gives reviewers a clean skeleton to evaluate the state-machine integration without bundling subprocess parsing concerns. Same shape as the PR3-PR6 sequence — small, focused, each PR does one job.

## Matrix-delta

Zero changes to \`transport_state.py\`. The matrix from PR1/#487 is what TmuxSession adopts.

## State-machine integration

TmuxSession adopts the **full** matrix (UNINITIALIZED / BOOTING / RECONNECTING / CONNECTED / IDLE_SLEEPING / DEAD), not CodexSession's coarser derivation. Greenfield backend — full matrix from day one was Brad's explicit directive in the design discussion.

- **Cold-start:** \`UNINITIALIZED → BOOTING → CONNECTED|DEAD\` via the BOOT / BOOT_COMPLETE / BOOT_FAILED Trigger triplet from PR6
- **Concurrent-connect race:** cold-start guard widened to \`state in {UNINITIALIZED, BOOTING}\` from day one. Inherits Murzik's PR6 race protection by construction. Two regression tests pin it (Cases A + B from Pushok's framework).
- **Warm-reconnect:** \`CONNECTED → RECONNECTING → CONNECTED|DEAD\` with the no-flicker invariant preserved across disconnect + re-spawn (matches StreamingSession.force_restart's post-PR3 choreography — pre-asserts RECONNECTING before disconnect, completes after re-spawn)
- **Idle-sleep:** pre-sets IDLE_SLEEPING so disconnect's default CONNECTED → DEAD fallback doesn't fire (same flicker class as Pushok's PR #492 Nit 2 on CodexSession)

## Files

- \`src/pinky_daemon/tmux_session.py\` (~700 LOC) — TmuxSession class + \`_TmuxControl\` subprocess wrapper
- \`tests/test_tmux_session.py\` (~440 LOC) — 23 unit tests
- \`src/pinky_daemon/agent_registry.py\` — adds \`tmux\` to the runtime field comment

## Tmux subprocess strategy

\`_TmuxControl\` wraps the tmux CLI; all subprocess calls live there. Tests mock the whole wrapper instead of monkeypatching subprocess primitives — clean swap point, no asyncio.create_subprocess_exec gymnastics in test code.

Tmux session name is \`pinky-<agent_name>\` so Pinky-owned sessions never collide with operator tmux sessions on the host.

## Out of scope (explicit gaps)

**PR8b — response capture pipeline.** \`send()\` queues turns and the worker delivers via \`tmux send-keys\`, but capturing claude's reply and firing \`response_callback\` is the next chunk. Design choice (transcript-file tailing vs Stop-hook listener) deferred to that PR — both have tradeoffs:
- Transcript tailing: structured JSONL, exactly what SDK gives us. Need to find the right transcript file (claude code writes them to \`~/.claude/projects/<cwd-encoded>/<uuid>.jsonl\`) and tail it with inotify/fsevents.
- Stop-hook: register a Claude Code hook that writes a sentinel on turn completion, parse the transcript on signal. Smaller polling burden, more reliable completion detection.

**PR8b — context-budget watchdog.** StreamingSession's \`_check_context\` uses the SDK's \`get_context_usage\`. Equivalent for tmux needs the response pipeline first (transcripts carry token totals).

**PR9 — daemon wiring.** \`api.py\` runtime selector branching on \`tmux\`, Dymok agent registration with \`runtime=tmux\`.

**\`cost_usd\` reporting.** Tmux billing is against the subscription, not per-turn metered. Documented gap on stats dict — broker / api / watchdog readers ignore unknown keys per Transport contract.

## Tests added (23 total)

- Cold-start: success (BOOT_COMPLETE path), failure (BOOT_FAILED path), stale-session reaping, correct \`claude --continue --dangerously-skip-permissions\` invocation
- Concurrent-connect: Case A (canonical race — exactly one tmux spawn for two concurrent connect()s), Case B (failure-propagation — owner DEAD, subscriber raises)
- Lifecycle choreography: disconnect from CONNECTED → DEAD; idle_sleep pre-set; force_restart holds RECONNECTING across teardown + re-spawn; force_restart spawn failure → DEAD
- send / worker: drops when not CONNECTED; queues + worker delivers via send-keys; counters increment
- Effort knob: protocol parity (accept valid levels, reject invalid, auto-resolution, clear)
- Identity / stats: id format, session name prefix, resume_handle == tmux session name, stats shape

## Local verification

- \`python -m pytest tests/test_tmux_session.py -v\` → 23 passed
- \`python -m pytest\` → 2109 passed (+23 new), 1 skipped
- \`ruff check src/pinky_daemon/tmux_session.py tests/test_tmux_session.py\` → clean

## Review focus

- State-machine choreography in \`connect\` / \`disconnect\` / \`force_restart\` / \`idle_sleep\` / \`attempt_reconnect\` — does each path drive the matrix correctly?
- Is the \`_TmuxControl\` surface sufficient for the response pipeline that PR8b will build on top? (\`capture_pane\` available as a fallback; tmux send-keys + has-session + kill-session + new-session are the core set.)
- Does the \`pinky-\` session prefix feel right, or should it be configurable?
- Should the PR-by-PR split (8a / 8b / 9) hold, or fold for a single bigger landing?

@murzik @pushok ready when you are.

🤖 Opened by Barsik