### PR TITLE
feat(transport): TmuxSession response capture pipeline — PR8b of #486

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -603,6 +603,120 @@ class AgentContext:
         return "\n\n".join(parts) if parts else ""
 
 
+def _tmux_wake_hook_source(agent_name: str) -> str:
+    """Return the source for ``.claude/hook_tmux_wake.py``.
+
+    Fires on ``Stop`` (and ``PostCompact``, if wired). POSTs to
+    ``/agents/{name}/transport/wake`` so the TmuxSession's transcript
+    tailer wakes immediately rather than waiting for the next poll tick.
+    HMAC-signed identically to ``hook_idle.py``. No-op for non-tmux
+    agents — the daemon endpoint returns 200 with session: None.
+
+    Idempotent + fire-and-forget. Failures are swallowed so a daemon
+    outage doesn't block the model turn.
+    """
+    return f'''\
+#!/usr/bin/env python3
+"""PinkyBot transport wake hook (PR8b).
+
+Notifies the daemon that the model turn has ended so the response
+tailer can read up-to-EOF on the transcript file without waiting for
+the fallback poll. No-op for non-tmux runtimes (daemon returns 200
+session: None).
+"""
+import hashlib, hmac, base64, time, urllib.request, json, os, sys
+
+secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+if not secret:
+    sys.exit(0)
+
+agent = "{agent_name}"
+path = "/agents/{agent_name}/transport/wake"
+ts = int(time.time())
+payload = f"{{agent}}\\nPOST\\n{{path}}\\n{{ts}}".encode()
+digest = hmac.new(secret.encode(), payload, hashlib.sha256).digest()
+sig = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+req = urllib.request.Request(
+    f"http://localhost:8888{{path}}",
+    data=json.dumps({{"event": "stop_hook_summary"}}).encode(),
+    method="POST",
+)
+req.add_header("Content-Type", "application/json")
+req.add_header("x-pinky-agent", agent)
+req.add_header("x-pinky-timestamp", str(ts))
+req.add_header("x-pinky-signature", sig)
+try:
+    urllib.request.urlopen(req, timeout=2)
+except Exception:
+    pass
+'''
+
+
+def _tmux_session_start_hook_source(agent_name: str) -> str:
+    """Return the source for ``.claude/hook_tmux_session_start.py``.
+
+    Fires on ``SessionStart``. Reads the JSON payload from stdin
+    (``session_id``, ``transcript_path``, ``cwd``) and POSTs the
+    transcript path to ``/agents/{name}/transport/transcript-path``
+    so the tailer can repoint at the canonical file instead of relying
+    on the daemon's mtime-glob guess.
+
+    No-op for non-tmux runtimes (daemon returns 200 session: None).
+    """
+    return f'''\
+#!/usr/bin/env python3
+"""PinkyBot transport SessionStart hook (PR8b).
+
+Reports the actual transcript path Claude Code is writing to so the
+TmuxSession tailer doesn't have to guess via mtime-glob. Reads the
+SessionStart hook payload from stdin (per Claude Code hook spec) and
+forwards transcript_path to the daemon.
+"""
+import hashlib, hmac, base64, time, urllib.request, json, os, sys
+
+secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+if not secret:
+    sys.exit(0)
+
+# SessionStart payload arrives on stdin per Claude Code hook spec.
+try:
+    raw = sys.stdin.read()
+    payload_in = json.loads(raw) if raw else {{}}
+except Exception:
+    sys.exit(0)
+
+transcript_path = payload_in.get("transcript_path", "")
+if not transcript_path:
+    sys.exit(0)
+session_id = payload_in.get("session_id", "")
+
+agent = "{agent_name}"
+path = "/agents/{agent_name}/transport/transcript-path"
+ts = int(time.time())
+payload_sig = f"{{agent}}\\nPOST\\n{{path}}\\n{{ts}}".encode()
+digest = hmac.new(secret.encode(), payload_sig, hashlib.sha256).digest()
+sig = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+req = urllib.request.Request(
+    f"http://localhost:8888{{path}}",
+    data=json.dumps({{
+        "transcript_path": transcript_path,
+        "session_id": session_id,
+    }}).encode(),
+    method="POST",
+)
+req.add_header("Content-Type", "application/json")
+req.add_header("x-pinky-agent", agent)
+req.add_header("x-pinky-timestamp", str(ts))
+req.add_header("x-pinky-signature", sig)
+try:
+    urllib.request.urlopen(req, timeout=2)
+except Exception:
+    pass
+'''
+
+
 class AgentRegistry:
     """SQLite-backed agent registry."""
 
@@ -1108,6 +1222,8 @@ except Exception:
         working_path = claude_dir / "hook_working.py"
         idle_path = claude_dir / "hook_idle.py"
         verify_effort_path = claude_dir / "hook_verify_effort.py"
+        tmux_wake_path = claude_dir / "hook_tmux_wake.py"
+        tmux_session_start_path = claude_dir / "hook_tmux_session_start.py"
 
         if not working_path.exists():
             working_path.write_text(
@@ -1139,11 +1255,44 @@ except Exception:
             verb = "updated" if existing_source else "created"
             _log(f"agent_registry: {verb} hook_verify_effort.py for {agent_name}")
 
+        # PR8b: TmuxSession response capture pipeline. Two new hook scripts:
+        #   - hook_tmux_wake.py: fires on Stop, POSTs /transport/wake
+        #   - hook_tmux_session_start.py: fires on SessionStart, POSTs the
+        #     transcript_path so the tailer watches the right file.
+        # Installed unconditionally; the daemon endpoint returns ``ok: True,
+        # session: None`` for non-tmux runtimes, so the hook is a cheap no-op
+        # for SDK / codex agents (one extra POST per turn). Daemon-side
+        # cost is negligible (HMAC verify + dict lookup). Worth the
+        # simplicity of not threading runtime through _setup_hooks.
+        existing_wake = (
+            tmux_wake_path.read_text() if tmux_wake_path.exists() else ""
+        )
+        new_wake = _tmux_wake_hook_source(agent_name)
+        if existing_wake != new_wake:
+            tmux_wake_path.write_text(new_wake)
+            verb = "updated" if existing_wake else "created"
+            _log(f"agent_registry: {verb} hook_tmux_wake.py for {agent_name}")
+
+        existing_ss = (
+            tmux_session_start_path.read_text()
+            if tmux_session_start_path.exists() else ""
+        )
+        new_ss = _tmux_session_start_hook_source(agent_name)
+        if existing_ss != new_ss:
+            tmux_session_start_path.write_text(new_ss)
+            verb = "updated" if existing_ss else "created"
+            _log(
+                f"agent_registry: {verb} hook_tmux_session_start.py "
+                f"for {agent_name}"
+            )
+
         AgentRegistry._sync_hooks_settings(
             claude_dir / "settings.json",
             working_path=working_path.resolve(),
             idle_path=idle_path.resolve(),
             verify_effort_path=verify_effort_path.resolve(),
+            tmux_wake_path=tmux_wake_path.resolve(),
+            tmux_session_start_path=tmux_session_start_path.resolve(),
             agent_name=agent_name,
         )
 
@@ -1154,13 +1303,15 @@ except Exception:
         working_path: Path,
         idle_path: Path,
         verify_effort_path: Path,
+        tmux_wake_path: Path,
+        tmux_session_start_path: Path,
         agent_name: str,
     ) -> None:
         """Idempotently ensure settings.json has all PinkyBot hooks wired up.
 
         - Creates settings.json with the full hook set if missing.
         - If present, adds any missing PinkyBot-managed hook entries to
-          PreToolUse / Stop, preserving user-added entries.
+          PreToolUse / Stop / SessionStart, preserving user-added entries.
         - Identifies PinkyBot-managed entries by the absolute script path
           appearing in the command string.
         """
@@ -1172,6 +1323,10 @@ except Exception:
         )
         working_cmd = f"python3 {working_path} 2>/dev/null || true"
         idle_cmd = f"python3 {idle_path} 2>/dev/null || true"
+        tmux_wake_cmd = f"python3 {tmux_wake_path} 2>/dev/null || true"
+        tmux_session_start_cmd = (
+            f"python3 {tmux_session_start_path} 2>/dev/null || true"
+        )
 
         if not settings_path.exists():
             settings = {
@@ -1190,6 +1345,24 @@ except Exception:
                             "matcher": ".*",
                             "hooks": [
                                 {"type": "command", "command": idle_cmd},
+                                # PR8b: wake the tmux response tailer on Stop.
+                                # No-op for non-tmux agents (daemon returns
+                                # 200 session: None).
+                                {"type": "command", "command": tmux_wake_cmd},
+                            ],
+                        }
+                    ],
+                    "SessionStart": [
+                        {
+                            # SessionStart fires on startup/resume/clear/compact.
+                            # Match all so the tailer is repointed any time the
+                            # transcript file might have changed.
+                            "matcher": ".*",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": tmux_session_start_cmd,
+                                },
                             ],
                         }
                     ],
@@ -1199,52 +1372,78 @@ except Exception:
             _log(f"agent_registry: created settings.json for {agent_name}")
             return
 
-        # Merge path — only add the verify_effort hook if it's not already
-        # present. Match on the absolute script path so we don't dup if the
-        # user re-pathed it manually.
+        # Merge path — add any missing PinkyBot-managed entries. We use
+        # absolute script paths as needles so user-renamed copies aren't
+        # mistaken for already-installed hooks.
         try:
             data = _json.loads(settings_path.read_text())
         except Exception as e:
             _log(
                 f"agent_registry: settings.json parse failed for {agent_name}: {e}; "
-                "skipping verify_effort merge"
+                "skipping merge"
             )
             return
 
+        changed = False
         hooks = data.setdefault("hooks", {})
-        pre_tool_use = hooks.setdefault("PreToolUse", [])
 
-        needle = str(verify_effort_path)
-        already_installed = False
-        for entry in pre_tool_use:
+        # verify_effort hook → PreToolUse bucket
+        changed |= AgentRegistry._merge_hook_into_event(
+            hooks, "PreToolUse",
+            needle=str(verify_effort_path),
+            command=verify_cmd,
+        )
+
+        # tmux_wake hook → Stop bucket
+        changed |= AgentRegistry._merge_hook_into_event(
+            hooks, "Stop",
+            needle=str(tmux_wake_path),
+            command=tmux_wake_cmd,
+        )
+
+        # tmux_session_start hook → SessionStart bucket
+        changed |= AgentRegistry._merge_hook_into_event(
+            hooks, "SessionStart",
+            needle=str(tmux_session_start_path),
+            command=tmux_session_start_cmd,
+        )
+
+        if changed:
+            settings_path.write_text(_json.dumps(data, indent=2) + "\n")
+            _log(
+                f"agent_registry: merged PinkyBot hooks into settings.json "
+                f"for {agent_name}"
+            )
+
+    @staticmethod
+    def _merge_hook_into_event(
+        hooks: dict, event: str, *, needle: str, command: str,
+    ) -> bool:
+        """Insert ``command`` into ``hooks[event]`` if no entry containing
+        ``needle`` exists. Returns True iff the structure was modified.
+
+        Targets (or creates) the matcher=``.*`` bucket within the event.
+        Idempotent — re-running this with the same args does nothing.
+        """
+        event_list = hooks.setdefault(event, [])
+        for entry in event_list:
             for h in entry.get("hooks", []):
                 if needle in (h.get("command") or ""):
-                    already_installed = True
-                    break
-            if already_installed:
-                break
+                    return False
 
-        if already_installed:
-            return
-
-        # Append to the first matcher=".*" bucket if one exists, else create.
         target_bucket = None
-        for entry in pre_tool_use:
+        for entry in event_list:
             if entry.get("matcher") == ".*":
                 target_bucket = entry
                 break
         if target_bucket is None:
             target_bucket = {"matcher": ".*", "hooks": []}
-            pre_tool_use.append(target_bucket)
+            event_list.append(target_bucket)
 
         target_bucket.setdefault("hooks", []).append(
-            {"type": "command", "command": verify_cmd}
+            {"type": "command", "command": command}
         )
-        settings_path.write_text(_json.dumps(data, indent=2) + "\n")
-        _log(
-            f"agent_registry: merged hook_verify_effort into settings.json "
-            f"for {agent_name}"
-        )
+        return True
 
     # ── Agent CRUD ──────────────────────────────────────────
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -88,6 +88,8 @@ from pinky_daemon.api_models import (
     SetMainAgentRequest,
     SetModelRequest,
     SpawnSessionRequest,
+    TransportTranscriptPathRequest,
+    TransportWakeRequest,
     UpdateAgentRequest,
     UpdateHeartbeatPromptRequest,
     UpdateMcpServerRequest,
@@ -4079,6 +4081,79 @@ def create_api(
             "actual": req.actual,
             "strict": req.strict,
         }
+
+    @app.post("/agents/{name}/transport/wake")
+    async def transport_wake(name: str, req: TransportWakeRequest):
+        """Wake the Transport's response pipeline — called by Stop /
+        PostCompact hooks (PR8b).
+
+        Generic across runtimes: ``TmuxSession`` uses this to wake its
+        transcript tailer; future backends (e.g. a wire-protocol REPL)
+        could reuse the same endpoint. ``StreamingSession`` ignores the
+        wake — its response is in-band via the SDK callback.
+
+        Fire-and-forget: returns 200 immediately. Hook scripts wrap the
+        request in ``|| true`` so a 404/500 here doesn't fail the model
+        turn.
+        """
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+
+        session = broker.get_streaming_session(name, label=req.label)
+        if session is None:
+            # Hook fired before the daemon registered the session, or
+            # after a graceful disconnect. Not an error — the next
+            # tailer start picks up where we left off.
+            return {"ok": True, "agent": name, "session": None}
+
+        # Duck-typed dispatch: only tmux currently exposes notify_tail.
+        notify = getattr(session, "notify_tail", None)
+        if callable(notify):
+            try:
+                notify()
+            except Exception as e:
+                _log(f"api: transport_wake notify_tail raised for {name}: {e}")
+        return {"ok": True, "agent": name, "event": req.event}
+
+    @app.post("/agents/{name}/transport/transcript-path")
+    async def transport_transcript_path(
+        name: str, req: TransportTranscriptPathRequest,
+    ):
+        """Update the Transport's watched transcript path — called by
+        the SessionStart hook (PR8b).
+
+        The SessionStart hook reports the file Claude Code is actually
+        writing to, replacing the daemon's mtime-glob guess. Validated:
+        path must be absolute and exist. Symlink resolution is left to
+        the caller — we don't normalise here to avoid surprising rewrites.
+        """
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+
+        path = Path(req.transcript_path)
+        if not path.is_absolute():
+            raise HTTPException(400, "transcript_path must be absolute")
+        # File may not exist yet on a fresh session (Claude Code creates
+        # it on first append); we accept that and let the tailer's
+        # read_once handle the missing-file path gracefully.
+
+        session = broker.get_streaming_session(name, label=req.label)
+        if session is None:
+            return {"ok": True, "agent": name, "session": None}
+
+        update = getattr(session, "set_transcript_path", None)
+        if callable(update):
+            try:
+                update(path)
+            except Exception as e:
+                _log(
+                    f"api: transport_transcript_path set_transcript_path "
+                    f"raised for {name}: {e}"
+                )
+                raise HTTPException(500, str(e))
+        return {"ok": True, "agent": name, "transcript_path": str(path)}
 
     @app.get("/agents/{name}/effort-drift")
     async def list_effort_drift_events(

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -4153,7 +4153,11 @@ def create_api(
             normalised = path.resolve(strict=False)
         except (OSError, RuntimeError) as e:
             raise HTTPException(400, f"transcript_path could not be resolved: {e}")
-        if projects_root not in normalised.parents and normalised != projects_root:
+        # ``is_relative_to`` (Py 3.9+) is the idiomatic sanitizer here and
+        # is recognized by CodeQL's path-traversal taint analysis — the
+        # equivalent ``parents``-membership check tripped a false-positive
+        # CodeQL alert in round-2 even though it had the same semantics.
+        if not normalised.is_relative_to(projects_root):
             raise HTTPException(
                 403,
                 f"transcript_path must be under {projects_root}",

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -4124,9 +4124,20 @@ def create_api(
         the SessionStart hook (PR8b).
 
         The SessionStart hook reports the file Claude Code is actually
-        writing to, replacing the daemon's mtime-glob guess. Validated:
-        path must be absolute and exist. Symlink resolution is left to
-        the caller — we don't normalise here to avoid surprising rewrites.
+        writing to, replacing the daemon's mtime-glob guess.
+
+        Validation (Pushok's PR #496 round-1 Case 4a):
+          - Must be absolute.
+          - Must be under ``~/.claude/projects/`` — defends against a
+            caller with a valid HMAC pointing the tailer at an arbitrary
+            file (e.g. ``/var/log/system.log``) and forcing the daemon
+            to read large chunks of it. The size cap inside the tailer
+            (``_MAX_READ_CHUNK_BYTES``) is the defense-in-depth; this
+            prefix check is the perimeter.
+
+        File may not exist yet on a fresh session (Claude Code creates
+        it on first append); the tailer's ``read_once`` handles the
+        missing-file path gracefully, so we don't insist on existence.
         """
         agent = agents.get(name)
         if not agent:
@@ -4135,9 +4146,18 @@ def create_api(
         path = Path(req.transcript_path)
         if not path.is_absolute():
             raise HTTPException(400, "transcript_path must be absolute")
-        # File may not exist yet on a fresh session (Claude Code creates
-        # it on first append); we accept that and let the tailer's
-        # read_once handle the missing-file path gracefully.
+        # Restrict to ``~/.claude/projects/``. Resolve symlinks before
+        # the prefix check so a symlinked attack path is normalised.
+        projects_root = (Path.home() / ".claude" / "projects").resolve()
+        try:
+            normalised = path.resolve(strict=False)
+        except (OSError, RuntimeError) as e:
+            raise HTTPException(400, f"transcript_path could not be resolved: {e}")
+        if projects_root not in normalised.parents and normalised != projects_root:
+            raise HTTPException(
+                403,
+                f"transcript_path must be under {projects_root}",
+            )
 
         session = broker.get_streaming_session(name, label=req.label)
         if session is None:
@@ -4146,14 +4166,14 @@ def create_api(
         update = getattr(session, "set_transcript_path", None)
         if callable(update):
             try:
-                update(path)
+                update(normalised)
             except Exception as e:
                 _log(
                     f"api: transport_transcript_path set_transcript_path "
                     f"raised for {name}: {e}"
                 )
                 raise HTTPException(500, str(e))
-        return {"ok": True, "agent": name, "transcript_path": str(path)}
+        return {"ok": True, "agent": name, "transcript_path": str(normalised)}
 
     @app.get("/agents/{name}/effort-drift")
     async def list_effort_drift_events(

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -793,6 +793,35 @@ class EffortDriftRequest(BaseModel):
     session_id: str = ""
 
 
+class TransportWakeRequest(BaseModel):
+    """Backend-agnostic wake signal — POSTed by Stop / PostCompact hooks (PR8b).
+
+    The ``event`` tag tells the Transport why it was woken; backends
+    interpret it. For ``TmuxSession`` the tailer's ``wake()`` is
+    idempotent and the event is informational — ``stop_hook_summary``
+    expects new data in the transcript; ``compact`` should force a
+    re-stat in case the file rotated.
+    """
+
+    event: Literal["stop_hook_summary", "compact", "manual"] = "stop_hook_summary"
+    label: str = "main"
+
+
+class TransportTranscriptPathRequest(BaseModel):
+    """Report the canonical transcript path — POSTed by the SessionStart
+    hook (PR8b).
+
+    Lets the daemon repoint the tailer at the actual file Claude Code
+    is writing to, instead of relying on the mtime-glob guess. Path is
+    absolute; the daemon validates it's under the configured Claude
+    projects dir and that the file exists before swapping.
+    """
+
+    transcript_path: str
+    session_id: str = ""
+    label: str = "main"
+
+
 class FederationPeerUpsertRequest(BaseModel):
     """Insert or update a federation peer (admin / config-seeded path).
 

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1336,6 +1336,19 @@ class MessageBroker:
             for label, s in sessions.items()
         ]
 
+    def get_streaming_session(self, agent_name: str, label: str = "main"):
+        """Return the registered session instance for ``agent_name/label``.
+
+        Returns ``None`` if no session is registered. Used by hook-driven
+        endpoints (e.g. ``/agents/<name>/transport/wake``) to reach into
+        the Transport-typed session and call backend-specific surfaces
+        (``notify_tail``, ``set_transcript_path``). The returned object's
+        type is implementation-defined (``StreamingSession`` for SDK,
+        ``TmuxSession`` for tmux, ``CodexSession`` for codex) — callers
+        must duck-type the method they need and tolerate its absence.
+        """
+        return self._streaming.get(agent_name, {}).get(label)
+
     @property
     def stats(self) -> dict:
         stats = dict(self._stats)

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -274,6 +274,12 @@ _RECONNECT_BACKOFF = (2, 8, 30)
 # to authenticate / fetch first turn / load CLAUDE.md.
 _COLD_START_TIMEOUT_SEC = 60.0
 
+# Per-turn timeout: how long the worker waits for ``_turn_done`` between
+# dispatching a prompt and the tailer firing ``_handle_turn_complete``.
+# Generous (10 min) to cover tool-use loops + slow models + cold-model
+# dispatch. Anything longer is "stuck" — caller / watchdog retries.
+_TURN_DONE_TIMEOUT_SEC = 600.0
+
 
 class TmuxSession:
     """Agent session backed by an interactive ``claude`` REPL in tmux.
@@ -367,9 +373,20 @@ class TmuxSession:
         # Last user-message metadata (platform / chat_id / message_id),
         # captured at send() time. Forwarded to ``_response_callback``
         # so the broker can route the reply back to the right channel.
-        # Tmux's worker is strictly sequential — exactly one turn is in
-        # flight at any time, so a single field is correct (no queue).
+        # Worker awaits ``_turn_done`` between turns so exactly one turn
+        # is in flight at any time — meta is set in ``_deliver_turn`` and
+        # cleared in ``_handle_turn_complete``, with the turn-done gate
+        # preventing the worker from overwriting it before the tailer
+        # consumes it. Pushok's PR #496 round-1 critical finding (Case 1).
         self._inflight_meta: dict = {}
+        # Set by ``_handle_turn_complete`` at the end of every turn;
+        # awaited by ``_message_worker`` after ``_deliver_turn`` so the
+        # next dispatch can't clobber ``_inflight_meta`` mid-flight.
+        # Invariant: between dispatches, turn_done is CLEARED; it's set
+        # only after a callback fires. The first ``_deliver_turn`` clears
+        # it (no-op on a fresh Event) before send-keys; the worker only
+        # awaits on subsequent iterations.
+        self._turn_done: asyncio.Event = asyncio.Event()
 
     # ── Identity ────────────────────────────────────────────────────────
 
@@ -629,6 +646,13 @@ class TmuxSession:
         # later repoint it at the actual file once Claude Code reports it.
         await self._start_tailer()
 
+        # Ensure turn_done invariant: between dispatches, the event is
+        # cleared. After a force_restart, the previous worker may have
+        # set it just before dying; reset to the invariant baseline so
+        # the first new dispatch's await blocks on THIS session's turns,
+        # not a stale signal from the killed session.
+        self._turn_done.clear()
+
         # Start the worker.
         if not self._worker_task or self._worker_task.done():
             self._worker_task = asyncio.create_task(self._message_worker())
@@ -750,6 +774,11 @@ class TmuxSession:
                 pass
         self._worker_task = None
         self._processing = False
+
+        # Clear in-flight routing metadata so a straggler stop_hook_summary
+        # (e.g. read from a stale transcript on reconnect) can't route a
+        # late response to a stale chat. Pushok's PR #496 round-1 Case 2.
+        self._inflight_meta = {}
 
         # Stop the response tailer (PR8b). Tailer instance is retained
         # so stats/path persist; only the background task is cancelled.
@@ -918,6 +947,14 @@ class TmuxSession:
         # Clear in-flight metadata — next send() will populate it.
         self._inflight_meta = {}
 
+        # Signal turn-complete to the worker UNCONDITIONALLY. Must be
+        # outside any ``if response.text`` gate (Pushok's PR #496 round-1
+        # Case 1 follow-up): empty-text turns (e.g. pure tool-use that
+        # hit max_tokens) still complete a turn, and the worker is
+        # awaiting this event regardless. Gating on text would deadlock
+        # the worker forever on a tool-use-only turn.
+        self._turn_done.set()
+
     async def _start_tailer(self) -> None:
         """Construct + start the transcript tailer.
 
@@ -982,6 +1019,13 @@ class TmuxSession:
         We glob the project dir and return the newest .jsonl. If none
         exist yet (cold start before claude writes anything) returns
         None; the SessionStart hook will repoint us once it fires.
+
+        Assumption: each PinkyBot agent has a unique working_dir
+        (``data/agents/<name>/`` by convention). If two agents ever
+        share a cwd, this mtime-glob would cross-talk and the wrong
+        agent's tailer might be repointed at another's transcript. The
+        SessionStart hook's path-update is the authoritative correction
+        either way; this is a startup race window only.
         """
         cwd = Path(self._config.working_dir or ".").resolve()
         # encoded-cwd: leading slash becomes empty, other slashes become dashes
@@ -1001,12 +1045,15 @@ class TmuxSession:
 
     async def _message_worker(self) -> None:
         """Drain the message queue sequentially, delivering each turn to
-        the tmux pane.
+        the tmux pane and waiting for it to complete before the next.
 
-        The actual response capture (parsing claude's reply, firing
-        ``response_callback``) is the PR8b response-pipeline gap. For
-        now the worker only handles the inbound half: ``tmux send-keys``
-        the prompt, increment turn count, mark idle.
+        PR8b round-2 (Pushok's Case 1 fix): the worker now gates dispatch
+        on ``_turn_done``, which ``_handle_turn_complete`` sets at the
+        end of every turn (including empty-text / tool-use-only turns).
+        This ensures ``_inflight_meta`` is never overwritten while the
+        tailer still has work to fire for the in-flight turn, AND bounds
+        the prompts that get stacked into Claude Code's input queue
+        (UX win — CC's queued-prompt indicator is non-obvious).
         """
         _log(f"tmux[{self.agent_name}]: message worker started")
         try:
@@ -1016,9 +1063,58 @@ class TmuxSession:
                     self._processing = True
                     await self._deliver_turn(turn)
                     self._stats["turns"] += 1
+
+                    # Wait for THIS turn's stop_hook_summary to fire
+                    # _handle_turn_complete, which sets _turn_done.
+                    # Bounded so a missed Stop hook (e.g. transcript path
+                    # never reported, hook script removed) doesn't strand
+                    # the worker forever — 10 minutes is generous enough
+                    # for long tool-use loops + slow models, tight enough
+                    # that a real wedge surfaces in operations.
+                    try:
+                        await asyncio.wait_for(
+                            self._turn_done.wait(),
+                            timeout=_TURN_DONE_TIMEOUT_SEC,
+                        )
+                    except asyncio.TimeoutError:
+                        # The REPL is stuck. Pushok's PR #496 round-2
+                        # follow-up: just "continue" leaves the stuck
+                        # turn's stop_hook_summary free to land later
+                        # and route to the *next* dispatch's meta —
+                        # exactly the original Case 1 bug, slow-motion.
+                        # Solution: force_restart the tmux pane. The
+                        # orphaned turn dies with the REPL; SessionStart
+                        # hook repoints the tailer at the new transcript
+                        # file, so any late stop_hook_summary from the
+                        # dead session can't poison the new one. The
+                        # cancelled worker exits; ``_spawn_tmux_repl``
+                        # spawns a fresh worker that resumes the queue
+                        # in a clean state.
+                        _log(
+                            f"tmux[{self.agent_name}]: turn_done timeout "
+                            f"after {_TURN_DONE_TIMEOUT_SEC}s — REPL stuck; "
+                            f"scheduling force_restart and exiting worker"
+                        )
+                        self._inflight_meta = {}
+                        self._turn_done.set()
+                        self._stats["errors"] += 1
+                        self._stats["turn_timeouts"] = (
+                            self._stats.get("turn_timeouts", 0) + 1
+                        )
+                        # Schedule force_restart in the background so this
+                        # worker can exit cleanly without awaiting its own
+                        # cancellation (force_restart calls disconnect →
+                        # worker_task.cancel + await, which would deadlock
+                        # if invoked synchronously from inside the worker).
+                        asyncio.create_task(self.force_restart())
+                        return
                 except Exception as e:
                     self._stats["errors"] += 1
                     _log(f"tmux[{self.agent_name}]: turn delivery raised: {e}")
+                    # _deliver_turn already re-armed turn_done on send-keys
+                    # failure; defensively re-arm here in case some other
+                    # path raised (e.g. tailer state corruption).
+                    self._turn_done.set()
                 finally:
                     self._processing = False
         except asyncio.CancelledError:
@@ -1031,25 +1127,51 @@ class TmuxSession:
 
         PR8b: the response side is handled asynchronously by the
         transcript tailer (set up in ``_spawn_tmux_repl``). This method
-        only handles the inbound half — push the prompt, capture the
-        routing metadata for the tailer to use when it fires the
-        response_callback, and signal the tailer to switch to the
-        tighter active-poll cadence so latency is minimal.
+        handles the inbound half — push the prompt, capture the routing
+        metadata for the tailer to use when it fires the response_callback,
+        clear the turn-done gate so the worker waits for THIS turn's
+        completion before dispatching the next prompt, and signal the
+        tailer to switch to the tighter active-poll cadence.
+
+        Pushok's PR #496 round-1 Case 1 fix: the turn_done gate is what
+        prevents ``_inflight_meta`` from being clobbered between back-to-
+        back ``send()`` calls. The previous design assumed worker
+        sequentiality alone was enough — but the worker is a dispatch
+        pump, not a request/response broker, so a fast second prompt
+        would overwrite meta before the first turn's stop_hook_summary
+        landed.
         """
         # Capture routing metadata BEFORE send-keys so the tailer's callback
-        # has access to it even if the tailer fires unusually quickly
-        # (active-poll cadence is 200ms; should never beat send-keys, but
-        # ordering is a free win).
+        # has access to it even if the tailer fires unusually quickly.
         self._inflight_meta = {
             "platform": turn.platform,
             "chat_id": turn.chat_id,
             "message_id": turn.message_id,
         }
 
+        # Clear the turn-done gate BEFORE send-keys. Two reasons for
+        # ordering this here (vs. after mark_active, the other reasonable
+        # spot):
+        #   1. ANY stop_hook_summary that arrives after this clear must
+        #      come from THIS turn (we haven't yet delivered the prompt,
+        #      let alone produced a response). So waiting on the next set
+        #      is unambiguous.
+        #   2. If we cleared after mark_active, a degenerate-fast tailer
+        #      (test fixture, or a claude refusal turn) could conceivably
+        #      set turn_done between mark_active and clear, then we'd
+        #      wipe the signal and the worker would block forever.
+        # Cost is one extra .clear() call that wipes a stale signal from
+        # the previous turn — already-consumed by the previous worker
+        # iteration's await, so wiping it is a no-op.
+        self._turn_done.clear()
+
         result = await self._tmux.send_keys(turn.prompt, enter=True)
         if not result.ok:
-            # Clear in-flight meta — no response will arrive.
+            # Send failed — no response will arrive. Re-arm turn_done so
+            # the worker's next iteration doesn't deadlock; clear meta
+            # so a stale value doesn't leak to a later (unrelated) turn.
             self._inflight_meta = {}
+            self._turn_done.set()
             raise RuntimeError(
                 f"tmux send-keys failed: rc={result.returncode} "
                 f"stderr={result.stderr.strip()!r}"

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -74,6 +74,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from pinky_daemon.streaming_session import StreamingSessionConfig, _log
+from pinky_daemon.tmux_transcript import (
+    TmuxTranscriptTailer,
+    TurnResponse,
+)
 from pinky_daemon.transport_state import (
     SessionState,
     StateMachine,
@@ -353,6 +357,20 @@ class TmuxSession:
         self._current_activity = ""
         self._activity_log: list[str] = []
 
+        # Response capture pipeline (PR8b). Lazily constructed in
+        # ``_spawn_tmux_repl`` after we know the transcript path. The
+        # tailer reads Claude Code's JSONL transcript, accumulates each
+        # turn's assistant content, and fires ``_handle_turn_complete``
+        # on every ``stop_hook_summary`` entry — which routes to
+        # ``_response_callback`` to deliver the response upstream.
+        self._tailer: TmuxTranscriptTailer | None = None
+        # Last user-message metadata (platform / chat_id / message_id),
+        # captured at send() time. Forwarded to ``_response_callback``
+        # so the broker can route the reply back to the right channel.
+        # Tmux's worker is strictly sequential — exactly one turn is in
+        # flight at any time, so a single field is correct (no queue).
+        self._inflight_meta: dict = {}
+
     # ── Identity ────────────────────────────────────────────────────────
 
     @property
@@ -606,6 +624,11 @@ class TmuxSession:
                 trigger=Trigger.INTERNAL,
             )
 
+        # Start the response capture pipeline (PR8b). Tailer wraps the
+        # JSONL transcript Claude Code writes; SessionStart hook will
+        # later repoint it at the actual file once Claude Code reports it.
+        await self._start_tailer()
+
         # Start the worker.
         if not self._worker_task or self._worker_task.done():
             self._worker_task = asyncio.create_task(self._message_worker())
@@ -728,6 +751,10 @@ class TmuxSession:
         self._worker_task = None
         self._processing = False
 
+        # Stop the response tailer (PR8b). Tailer instance is retained
+        # so stats/path persist; only the background task is cancelled.
+        await self._stop_tailer()
+
         # Kill tmux session. ``kill_session`` is idempotent (treats
         # "can't find session" as ok).
         try:
@@ -804,6 +831,174 @@ class TmuxSession:
         ))
         _log(f"tmux[{self.agent_name}]: queued message (chat={chat_id})")
 
+    # ── Response capture pipeline (PR8b) ────────────────────────────────
+
+    def notify_tail(self) -> None:
+        """Wake the transcript tailer — called from the Stop hook handler.
+
+        Idempotent + no-op if the tailer hasn't started yet (e.g. wake
+        arrives during cold-start before the spawn completes). The
+        tailer's own ``wake()`` is safe before ``start()``.
+        """
+        if self._tailer is not None:
+            self._tailer.wake()
+
+    def set_transcript_path(self, path: Path | str) -> None:
+        """Update the watched transcript path — called when SessionStart
+        hook reports the actual path Claude Code is writing to.
+
+        Cleaner than guessing the path via mtime glob: the SessionStart
+        hook fires before the first model call, so the tailer is
+        repointed at the right file before any response data arrives.
+        """
+        if self._tailer is not None:
+            self._tailer.set_transcript_path(Path(path))
+            _log(
+                f"tmux[{self.agent_name}]: transcript path updated to "
+                f"{path}"
+            )
+
+    async def _handle_turn_complete(self, response: TurnResponse) -> None:
+        """Tailer callback — fired once per ``stop_hook_summary`` entry.
+
+        Mirrors StreamingSession's per-turn dispatch: feed the
+        conversation store, fire response_callback, fire stream_event
+        for analytics. cost_callback is a no-op for tmux (subscription
+        billing, no per-turn cost) but we still fire stream_event so
+        usage telemetry is visible.
+        """
+        # Log to conversation store. role=assistant.
+        if self._conversation_store and response.text:
+            try:
+                self._conversation_store.append(
+                    self.id, "assistant", response.text,
+                )
+            except Exception as e:
+                _log(
+                    f"tmux[{self.agent_name}]: conversation_store.append "
+                    f"raised: {e}"
+                )
+
+        # Stream event for analytics (usage / duration).
+        if self._stream_event_callback:
+            try:
+                evt = {
+                    "type": "turn_complete",
+                    "stop_reason": response.stop_reason,
+                    "usage": response.usage,
+                    "duration_ms": response.duration_ms,
+                    "assistant_entry_count": response.assistant_entry_count,
+                    "tool_use_count": len(response.tool_uses),
+                }
+                result = self._stream_event_callback(self.agent_name, evt)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as e:
+                _log(
+                    f"tmux[{self.agent_name}]: stream_event_callback raised: {e}"
+                )
+
+        # Response callback — the broker-routing payload. Includes the
+        # captured inbound metadata so the broker can route the reply.
+        if self._response_callback and response.text:
+            try:
+                meta = dict(self._inflight_meta)
+                result = self._response_callback(
+                    self.agent_name,
+                    response.text,
+                    meta,
+                )
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as e:
+                _log(
+                    f"tmux[{self.agent_name}]: response_callback raised: {e}"
+                )
+
+        # Clear in-flight metadata — next send() will populate it.
+        self._inflight_meta = {}
+
+    async def _start_tailer(self) -> None:
+        """Construct + start the transcript tailer.
+
+        Called from ``_spawn_tmux_repl`` after the REPL boots. Uses the
+        best-effort path guess (newest .jsonl in the project dir);
+        SessionStart hook later repoints us at the canonical path.
+
+        Idempotent — calling twice is a no-op.
+        """
+        if self._tailer is not None:
+            await self._tailer.start()  # idempotent
+            return
+
+        guessed = self._discover_transcript_path()
+        # Even if guessed is None (cold start, no transcript yet) we still
+        # construct the tailer so notify_tail() works as soon as the
+        # SessionStart hook reports a path. Use a placeholder path that
+        # .exists() returns False for — the tailer's read_once handles
+        # that gracefully.
+        path = guessed or Path("/dev/null/no-transcript-yet")
+        self._tailer = TmuxTranscriptTailer(
+            transcript_path=path,
+            on_turn_complete=self._handle_turn_complete,
+            agent_name=self.agent_name,
+        )
+        await self._tailer.start()
+        if guessed is None:
+            _log(
+                f"tmux[{self.agent_name}]: tailer started with placeholder "
+                f"path — awaiting SessionStart hook to report actual transcript"
+            )
+        else:
+            # Seek to EOF on the existing file so we don't replay historical
+            # turns on a warm-wake / resume. The SessionStart hook can
+            # set_offset(0) if a fresh backfill is wanted.
+            try:
+                self._tailer.set_offset(guessed.stat().st_size)
+            except OSError:
+                pass
+            _log(
+                f"tmux[{self.agent_name}]: tailer started at {guessed} "
+                f"(offset={self._tailer.offset})"
+            )
+
+    async def _stop_tailer(self) -> None:
+        """Stop the tailer if running. Idempotent."""
+        if self._tailer is not None:
+            try:
+                await self._tailer.stop()
+            except Exception as e:
+                _log(f"tmux[{self.agent_name}]: tailer.stop raised: {e}")
+            # Keep the instance — notify_tail() before next spawn is a no-op
+            # but reusing the instance preserves stats across reconnects.
+
+    def _discover_transcript_path(self) -> Path | None:
+        """Best-effort guess at the transcript path before SessionStart
+        hook reports it.
+
+        Claude Code stores transcripts at
+        ``~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`` where
+        ``encoded-cwd`` is the cwd with separators replaced by ``-``.
+        We glob the project dir and return the newest .jsonl. If none
+        exist yet (cold start before claude writes anything) returns
+        None; the SessionStart hook will repoint us once it fires.
+        """
+        cwd = Path(self._config.working_dir or ".").resolve()
+        # encoded-cwd: leading slash becomes empty, other slashes become dashes
+        encoded = "-" + str(cwd).replace("/", "-")
+        project_dir = Path.home() / ".claude" / "projects" / encoded
+        if not project_dir.exists():
+            return None
+        try:
+            jsonls = sorted(
+                project_dir.glob("*.jsonl"),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+        except OSError:
+            return None
+        return jsonls[0] if jsonls else None
+
     async def _message_worker(self) -> None:
         """Drain the message queue sequentially, delivering each turn to
         the tmux pane.
@@ -834,20 +1029,38 @@ class TmuxSession:
     async def _deliver_turn(self, turn: _QueuedTurn) -> None:
         """Push one turn through to the tmux pane.
 
-        TODO (PR8b): after ``send-keys`` returns, await the response
-        pipeline's "turn complete" signal (transcript-file watcher OR
-        Stop-hook listener) and fire ``response_callback`` with the
-        accumulated text + tool uses. Today this method only delivers
-        the inbound half — the agent processes the prompt in tmux but
-        responses aren't routed back to broker/Telegram yet.
+        PR8b: the response side is handled asynchronously by the
+        transcript tailer (set up in ``_spawn_tmux_repl``). This method
+        only handles the inbound half — push the prompt, capture the
+        routing metadata for the tailer to use when it fires the
+        response_callback, and signal the tailer to switch to the
+        tighter active-poll cadence so latency is minimal.
         """
+        # Capture routing metadata BEFORE send-keys so the tailer's callback
+        # has access to it even if the tailer fires unusually quickly
+        # (active-poll cadence is 200ms; should never beat send-keys, but
+        # ordering is a free win).
+        self._inflight_meta = {
+            "platform": turn.platform,
+            "chat_id": turn.chat_id,
+            "message_id": turn.message_id,
+        }
+
         result = await self._tmux.send_keys(turn.prompt, enter=True)
         if not result.ok:
+            # Clear in-flight meta — no response will arrive.
+            self._inflight_meta = {}
             raise RuntimeError(
                 f"tmux send-keys failed: rc={result.returncode} "
                 f"stderr={result.stderr.strip()!r}"
             )
-        # PR8b will land the response wait here.
+
+        # Hint to the tailer that a turn is in flight — switches to the
+        # active-poll cadence (200ms vs 2s) for low-latency response
+        # capture. Stop hook will short-circuit this further by wake()ing
+        # the tailer the moment the turn completes.
+        if self._tailer is not None:
+            self._tailer.mark_active()
 
     async def force_restart(self) -> bool:
         """Tear down the tmux session and start a fresh one.

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -641,10 +641,10 @@ class TmuxSession:
                 trigger=Trigger.INTERNAL,
             )
 
-        # Start the response capture pipeline (PR8b). Tailer wraps the
-        # JSONL transcript Claude Code writes; SessionStart hook will
-        # later repoint it at the actual file once Claude Code reports it.
-        await self._start_tailer()
+        # NOTE: tailer startup moved into ``_spawn_tmux_repl`` (Pushok's
+        # PR #496 round-2 Case 1' fix) so ``force_restart`` and
+        # ``attempt_reconnect`` get the same composition. The REPL + tailer
+        # come up as a unit; do not start the tailer here.
 
         # Ensure turn_done invariant: between dispatches, the event is
         # cleared. After a force_restart, the previous worker may have
@@ -672,10 +672,20 @@ class TmuxSession:
         )
 
     async def _spawn_tmux_repl(self) -> None:
-        """Spawn the tmux session and the in-pane claude REPL.
+        """Spawn the tmux session and the in-pane claude REPL, then start
+        the response tailer.
 
         Wrapped in cold-start timeout so a hung spawn fails to DEAD
         rather than parking the state machine indefinitely.
+
+        Invariant (Pushok's PR #496 round-2 Case 1'): REPL + tailer come
+        up as a unit — single source of truth for all callers (``connect``,
+        ``force_restart``, ``attempt_reconnect``). Previously the tailer
+        was started only by ``connect``, which left ``force_restart`` and
+        ``attempt_reconnect`` with a dead tailer task → ``turn_done`` could
+        never fire → worker timed out → another ``force_restart`` →
+        death loop. Bundling here makes the contract structural rather
+        than docstring-only.
         """
         cwd = self._config.working_dir or "."
         # Ensure cwd exists — claude --continue needs it.
@@ -716,11 +726,31 @@ class TmuxSession:
             try:
                 await self._tmux.kill_session()
             except Exception:
+                # Best-effort cleanup; ignore failure since we're already
+                # raising the cold-start timeout to the caller.
                 pass
             raise RuntimeError(
                 f"tmux[{self.agent_name}]: cold-start timed out after "
                 f"{_COLD_START_TIMEOUT_SEC}s"
             ) from None
+
+        # REPL is up — bring up the response capture pipeline (PR8b).
+        # Kept OUTSIDE the cold-start timeout so tailer construction
+        # (which stats the project dir to guess the transcript path)
+        # can't get killed mid-flight and leave a partial state. On
+        # tailer-start failure we roll back the spawn — the REPL is
+        # unusable without response capture, and callers expect the
+        # symmetric "spawn raised → caller transitions DEAD" semantics.
+        try:
+            await self._start_tailer()
+        except Exception:
+            try:
+                await self._tmux.kill_session()
+            except Exception:
+                # Best-effort cleanup; ignore failure since we're already
+                # re-raising the tailer-start error to the caller.
+                pass
+            raise
 
     def _build_claude_cmd(self) -> str:
         """Build the in-pane ``claude`` invocation as a single shell string.
@@ -993,6 +1023,10 @@ class TmuxSession:
             try:
                 self._tailer.set_offset(guessed.stat().st_size)
             except OSError:
+                # File disappeared between exists() check and stat() — race
+                # with Claude Code rotating/clearing the project dir. Fall
+                # through with offset=0 (the SessionStart hook will reset
+                # us to the canonical path shortly).
                 pass
             _log(
                 f"tmux[{self.agent_name}]: tailer started at {guessed} "

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -744,6 +744,17 @@ class TmuxSession:
         try:
             await self._start_tailer()
         except Exception:
+            # Murzik's PR #496 round-3 cleanup-hole fix: if _start_tailer
+            # raises AFTER constructing self._tailer but before/during
+            # the await on start(), we'd otherwise transition DEAD with
+            # a live orphan tailer instance. Stop the partial tailer +
+            # null the slot before re-raising, so the caller sees a
+            # clean state. Symmetric with the tmux kill below.
+            try:
+                await self._stop_tailer()
+            except Exception:
+                pass
+            self._tailer = None
             try:
                 await self._tmux.kill_session()
             except Exception:
@@ -1034,12 +1045,36 @@ class TmuxSession:
             )
 
     async def _stop_tailer(self) -> None:
-        """Stop the tailer if running. Idempotent."""
+        """Stop the tailer if running. Idempotent.
+
+        Murzik's PR #496 round-3 Case 2'' fix: ALSO drain the tailer's
+        in-progress turn buffer. The round-2 drain inside
+        ``set_transcript_path`` only fires when the path actually
+        changes — but ``claude --continue`` after ``force_restart``
+        resumes the same JSONL path, so the path-equality guard skips
+        the drain and partial assistant text from the killed session
+        would survive into the next session's first turn.
+
+        ``_stop_tailer`` is the single semantic "session ended"
+        boundary that covers both the new-path and same-path cases —
+        drain here unconditionally and the path-equality guard in
+        ``set_transcript_path`` becomes belt-and-suspenders rather
+        than the sole defense.
+        """
         if self._tailer is not None:
             try:
                 await self._tailer.stop()
             except Exception as e:
                 _log(f"tmux[{self.agent_name}]: tailer.stop raised: {e}")
+            # Discard any partial turn state. Doing this AFTER stop()
+            # means we don't race the tail loop's _read_and_dispatch
+            # (the loop is cancelled by stop()).
+            try:
+                self._tailer.drain_buffer()
+            except Exception as e:
+                _log(
+                    f"tmux[{self.agent_name}]: tailer.drain_buffer raised: {e}"
+                )
             # Keep the instance — notify_tail() before next spawn is a no-op
             # but reusing the instance preserves stats across reconnects.
 

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -69,6 +69,17 @@ _FALLBACK_POLL_SEC = 2.0
 # to do on a hot file.
 _ACTIVE_POLL_SEC = 0.2
 
+# Max bytes read per ``_read_and_dispatch`` invocation. Bounds memory if the
+# transcript path ever points at something pathologically large (per
+# Pushok's PR #496 round-1 Case 4a: the daemon endpoint's docstring claims
+# path validation that the code doesn't actually enforce, so an attacker
+# with a valid HMAC could point the tailer at /var/log/system.log and OOM
+# the daemon via a single uncapped fh.read()). 10 MiB is generous for one
+# turn's worth of transcript (typical turn = a few KB to a few hundred KB)
+# while keeping single-read memory bounded. Excess data stays on disk and
+# is picked up by the next loop iteration.
+_MAX_READ_CHUNK_BYTES = 10 * 1024 * 1024
+
 
 # ──────────────────────────────────────────────────────────────────────────
 # TurnResponse — the payload fired through on_turn_complete
@@ -360,15 +371,34 @@ class TmuxTranscriptTailer:
         self._offset = max(0, offset)
 
     def set_transcript_path(self, path: Path) -> None:
-        """Swap the watched file. Useful when SessionStart reports a new
-        transcript path (post-compact, post-resume).
+        """Swap the watched file. Used by the SessionStart hook to
+        repoint the tailer at the canonical transcript Claude Code is
+        writing to.
 
-        Resets offset to 0 — the new file is assumed unread. Caller can
-        call ``set_offset`` after if they want to resume mid-file.
+        Seeks to end-of-file by default — Pushok's PR #496 round-1
+        Case 3 fix. The previous design unconditionally reset offset to
+        0, which was safe ONLY under the contract that SessionStart
+        fires before any turns. If that contract is ever violated
+        (compact-resume swap, daemon-restart mid-session re-fire,
+        misconfigured test fixture, late-arriving hook on a session
+        that already produced turns), reading from 0 would re-fire
+        every historical turn's ``response_callback`` — reply-spam to
+        every chat that ever talked to this agent.
+
+        Seek-to-EOF gives the same offset==0 for a fresh file
+        (size == 0) and bounds the replay risk for non-fresh.
+
+        Callers that want backfill semantics (re-read the whole file)
+        can call ``set_offset(0)`` after this method — that's what the
+        backfill code path is for and it's an explicit choice rather
+        than an accidental side effect.
         """
         if Path(path) != self._path:
             self._path = Path(path)
-            self._offset = 0
+            try:
+                self._offset = self._path.stat().st_size if self._path.exists() else 0
+            except OSError:
+                self._offset = 0
             self._stats["rotations"] += 1
             self._wake_event.set()
 
@@ -417,6 +447,17 @@ class TmuxTranscriptTailer:
 
         TmuxSession calls this from ``_deliver_turn`` after ``send-keys``
         returns.
+
+        Note (Pushok's PR #496 round-1 Case 4b): there's a benign
+        ordering race between ``mark_active()`` (sets True, called by
+        the worker) and the False-flip inside ``_read_and_dispatch``
+        (called by the tail loop on stop_hook_summary). If the worker
+        dispatches turn N+1 before the tailer has flipped False for
+        turn N, the True-set may race a False-flip and end up at the
+        fallback cadence during an in-flight turn. Latency-only, not
+        correctness — CPython bool stores are atomic so no torn state.
+        Stop-hook wake() short-circuits the slower cadence anyway.
+        Not worth a lock.
         """
         self._active = True
         self._wake_event.set()
@@ -474,9 +515,16 @@ class TmuxTranscriptTailer:
         # Read in text mode — Claude Code transcripts are UTF-8. Buffer
         # may contain a partial trailing line if Claude Code is mid-write;
         # we only advance offset by complete lines.
+        #
+        # ``_MAX_READ_CHUNK_BYTES`` caps single-read memory so a pathological
+        # transcript path (or attacker-pointed file via the path-update
+        # endpoint) can't OOM the daemon. If more data remains after the
+        # cap, the wake_event is re-armed below so the next loop iteration
+        # picks it up — slower but bounded.
         with self._path.open("r", encoding="utf-8", errors="replace") as fh:
             fh.seek(self._offset)
-            chunk = fh.read()
+            chunk = fh.read(_MAX_READ_CHUNK_BYTES)
+            more_pending = (size - self._offset) > _MAX_READ_CHUNK_BYTES
             # Split into lines manually so we can detect a partial trailing
             # line (no trailing newline → don't consume).
             if not chunk:
@@ -539,6 +587,12 @@ class TmuxTranscriptTailer:
             self._offset += len(complete.encode("utf-8"))
             # ``partial`` is dropped intentionally — next read picks it up.
             _ = partial
+
+        # If the size cap forced us to stop short of EOF, re-arm the wake
+        # event so the next loop iteration picks up the remainder
+        # immediately rather than waiting for the poll cadence.
+        if more_pending:
+            self._wake_event.set()
 
         return bytes_read
 

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -424,6 +424,25 @@ class TmuxTranscriptTailer:
         """
         self._wake_event.set()
 
+    def drain_buffer(self) -> None:
+        """Discard any in-progress turn state.
+
+        Public counterpart of ``self._buffer.drain()`` for lifecycle
+        callers (notably ``TmuxSession._stop_tailer``). Murzik's PR #496
+        round-3 finding (Case 2''): the round-2 drain inside
+        ``set_transcript_path`` only fires when the path actually
+        changes. ``claude --continue`` after ``force_restart`` resumes
+        the same JSONL path, so the path-equality guard skips the drain
+        and partial assistant text from the killed session survives
+        across the lifecycle restart.
+
+        ``_stop_tailer`` is the single semantic "session ended"
+        boundary that handles both the new-path and same-path cases.
+        Silent drain — no callback (we're not at a turn boundary,
+        just discarding stale state).
+        """
+        self._buffer.drain()
+
     async def start(self) -> None:
         """Begin tailing in the background. Idempotent."""
         if self._task is not None and not self._task.done():

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -392,6 +392,18 @@ class TmuxTranscriptTailer:
         can call ``set_offset(0)`` after this method — that's what the
         backfill code path is for and it's an explicit choice rather
         than an accidental side effect.
+
+        Pushok's PR #496 round-2 Case 2': also drain the in-memory turn
+        buffer. The buffer accumulates assistant entries between
+        ``stop_hook_summary`` markers, so a session that was killed
+        mid-turn (e.g. force_restart) can leave partial text in the
+        buffer. If we swap to a new session's transcript without
+        draining, the next ``stop_hook_summary`` we read would surface
+        ``old_session_text + new_session_text`` as a single response,
+        leaking dead-session content into the new session's first reply.
+        Silent drain — no callback (we're not at a turn boundary, just
+        discarding partial state, symmetric with the truncation/rotation
+        path in ``_read_and_dispatch``).
         """
         if Path(path) != self._path:
             self._path = Path(path)
@@ -399,6 +411,7 @@ class TmuxTranscriptTailer:
                 self._offset = self._path.stat().st_size if self._path.exists() else 0
             except OSError:
                 self._offset = 0
+            self._buffer.drain()
             self._stats["rotations"] += 1
             self._wake_event.set()
 
@@ -429,6 +442,9 @@ class TmuxTranscriptTailer:
             try:
                 await self._task
             except (asyncio.CancelledError, Exception):
+                # Cancellation is expected and any other failure during
+                # shutdown is logged-and-swallowed — we're tearing down,
+                # not a programmable failure mode for callers to handle.
                 pass
             self._task = None
 
@@ -471,6 +487,8 @@ class TmuxTranscriptTailer:
             try:
                 await asyncio.wait_for(self._wake_event.wait(), timeout=cadence)
             except asyncio.TimeoutError:
+                # Timeout is the normal "no wake fired — proceed to poll"
+                # path; not an error. Used as control flow.
                 pass
             self._wake_event.clear()
             if self._stopped:

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -1,0 +1,566 @@
+"""Tmux transcript tailer — response capture pipeline for ``TmuxSession``.
+
+PR8b of the #486 sequence. Closes the response-capture gap left open by
+PR8a (#495). Design proposal: ``docs/design/tmux-response-pipeline.md``.
+
+## What this module does
+
+Claude Code's interactive REPL appends one JSONL entry per event to
+``~/.claude/projects/<encoded-cwd>/<session-id>.jsonl``. Inside that
+stream are:
+
+- ``{"type": "user", ...}`` — inbound prompt or tool result
+- ``{"type": "assistant", "message": {"content": [...]}, ...}`` — one
+  model API call's output. Multiple of these can appear inside a single
+  conversational turn (tool-use loops).
+- ``{"type": "system", "subtype": "stop_hook_summary", ...}`` — written
+  by Claude Code itself after the configured ``Stop`` hooks complete.
+  This is the authoritative turn-end marker.
+
+``TmuxTranscriptTailer`` watches the file from a byte offset, accumulates
+each assistant entry's text / thinking / tool_use blocks into a
+``_TurnBuffer``, and fires ``on_turn_complete(TurnResponse)`` when it
+sees a ``stop_hook_summary`` entry.
+
+## Hybrid wake model
+
+The tailer normally polls at ``_FALLBACK_POLL_SEC`` so it makes progress
+even without external signals. ``wake()`` short-circuits the poll —
+callers wire that to a ``Stop`` hook that POSTs to the daemon, giving
+near-zero latency on turn-end while keeping the file as single source of
+truth. See module docstring in ``tmux_session.py`` and the design doc
+for the full rationale.
+
+## Why this is its own module (not folded into TmuxSession)
+
+Two reasons:
+
+1. **Reuse.** Context-budget watchdog and conversation-store backfill
+   both need to read the same transcripts. A standalone tailer is the
+   shared primitive; ``TmuxSession`` is one consumer.
+2. **Testability.** The tailer is a pure function of (file content, wake
+   events) → callback invocations. Unit-testable without any tmux /
+   claude / asyncio session setup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Awaitable, Callable
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+# Fallback poll cadence when no external ``wake()`` arrives. Cheap — stat'ing
+# a file is microseconds. Bounded so a missed Stop hook doesn't strand a
+# response forever (worst case the user perceives this much latency).
+_FALLBACK_POLL_SEC = 2.0
+
+# Tight poll cadence used during an in-flight turn (between send_keys and the
+# next stop_hook_summary). We want low latency here; the Stop-hook wake
+# normally short-circuits this entirely, but if the hook is misconfigured we
+# still want sub-second response. Bounded below by what stat()/read are happy
+# to do on a hot file.
+_ACTIVE_POLL_SEC = 0.2
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# TurnResponse — the payload fired through on_turn_complete
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class TurnResponse:
+    """One conversational turn's assembled output, as seen by the broker.
+
+    Aggregates across all ``assistant`` entries between two consecutive
+    ``stop_hook_summary`` boundaries (i.e. one user-visible turn, which
+    may have included multiple tool-use cycles).
+
+    Mirrors the response shape ``StreamingSession`` synthesizes when its
+    SDK loop completes a turn — broker code that already consumes that
+    shape works against TmuxSession unchanged.
+    """
+
+    text: str = ""
+    """Concatenation of all ``text`` content blocks across the turn,
+    joined by ``\\n``. Empty string if the turn produced no text (e.g.
+    pure tool-use turn that ended on max_tokens)."""
+
+    thinking: str = ""
+    """Concatenation of all ``thinking`` content blocks, joined by
+    ``\\n``. Usually empty unless thinking is enabled at the model level."""
+
+    tool_uses: list[dict] = field(default_factory=list)
+    """Tool-use blocks in order of emission. Each dict has the raw
+    ``{name, input, id}`` shape from the transcript — opaque to the
+    tailer, parsed by downstream consumers (analytics / conversation
+    store) if they care."""
+
+    stop_reason: str = ""
+    """Final assistant entry's ``stop_reason`` (``end_turn`` / ``max_tokens`` /
+    ``refusal`` / ``tool_use``). Empty if the last entry had no
+    stop_reason (shouldn't happen in practice)."""
+
+    usage: dict = field(default_factory=dict)
+    """Last assistant entry's ``message.usage`` dict (input/output tokens,
+    cache stats). Single point-in-time snapshot rather than a sum —
+    Claude Code's usage values are cumulative-per-turn already."""
+
+    prevented_continuation: bool = False
+    """Whether a Stop hook blocked the natural end-of-turn. Surfaced
+    from the ``stop_hook_summary`` entry. Always False in practice for
+    PinkyBot's existing hooks but worth carrying through."""
+
+    duration_ms: int = 0
+    """Wall-clock from first entry of the turn to ``stop_hook_summary``,
+    derived from the transcript timestamps. Approximate — only as
+    accurate as the timestamps Claude Code wrote."""
+
+    assistant_entry_count: int = 0
+    """How many ``assistant`` entries contributed to this turn. >1 means
+    a tool-use loop fired. Useful diagnostic — surfaced through the
+    callback so consumers can tag long-running turns."""
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _TurnBuffer — accumulates assistant content between stop_hook_summary
+# boundaries
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _TurnBuffer:
+    """In-progress accumulator for one conversational turn.
+
+    Fed one transcript entry at a time. ``feed`` returns True iff the
+    entry was a ``stop_hook_summary`` (i.e. the turn is now complete and
+    the caller should ``drain()``). Otherwise the entry is either
+    accumulated (assistant) or ignored (everything else).
+
+    Drain resets the buffer for the next turn.
+    """
+
+    def __init__(self) -> None:
+        self._text_blocks: list[str] = []
+        self._thinking_blocks: list[str] = []
+        self._tool_uses: list[dict] = []
+        self._last_stop_reason: str = ""
+        self._last_usage: dict = {}
+        self._assistant_count: int = 0
+        self._turn_started_at: float | None = None  # epoch seconds
+        self._turn_ended_at: float | None = None
+
+    def feed(self, entry: dict) -> bool:
+        """Process one transcript entry. Return True iff this closes a turn."""
+        etype = entry.get("type", "")
+
+        # Track wall-clock by harvesting the first usable timestamp.
+        ts = _parse_ts(entry.get("timestamp", ""))
+        if ts is not None and self._turn_started_at is None:
+            self._turn_started_at = ts
+
+        if etype == "assistant":
+            self._consume_assistant(entry)
+            return False
+        if etype == "system" and entry.get("subtype") == "stop_hook_summary":
+            self._turn_ended_at = ts
+            return True
+        # user / attachment / queue-operation / ai-title / last-prompt — ignore.
+        # These either don't carry response data (queue-op, ai-title) or are
+        # inputs we don't echo back through the response callback.
+        return False
+
+    def _consume_assistant(self, entry: dict) -> None:
+        msg = entry.get("message") or {}
+        if not isinstance(msg, dict):
+            return
+        self._assistant_count += 1
+        for block in msg.get("content") or []:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                txt = block.get("text") or ""
+                if txt:
+                    self._text_blocks.append(txt)
+            elif btype == "thinking":
+                txt = block.get("thinking") or ""
+                if txt:
+                    self._thinking_blocks.append(txt)
+            elif btype == "tool_use":
+                self._tool_uses.append({
+                    "name": block.get("name", ""),
+                    "input": block.get("input", {}),
+                    "id": block.get("id", ""),
+                })
+            # tool_result blocks appear on user-role entries; we don't see
+            # them here. Unknown block types are silently skipped — schema
+            # drift defense per design doc Risk #1.
+        # Last assistant entry wins for stop_reason / usage. Per turn,
+        # the *final* assistant entry carries the user-visible stop_reason
+        # (the in-loop ones tend to be tool_use); usage is cumulative
+        # so the last one is the right snapshot.
+        sr = msg.get("stop_reason")
+        if sr:
+            self._last_stop_reason = sr
+        usage = msg.get("usage")
+        if isinstance(usage, dict):
+            self._last_usage = usage
+
+    def drain(self, prevented_continuation: bool = False) -> TurnResponse:
+        """Snapshot + reset for the next turn."""
+        duration_ms = 0
+        if self._turn_started_at is not None and self._turn_ended_at is not None:
+            duration_ms = max(0, int((self._turn_ended_at - self._turn_started_at) * 1000))
+
+        resp = TurnResponse(
+            text="\n".join(self._text_blocks),
+            thinking="\n".join(self._thinking_blocks),
+            tool_uses=list(self._tool_uses),
+            stop_reason=self._last_stop_reason,
+            usage=dict(self._last_usage),
+            prevented_continuation=prevented_continuation,
+            duration_ms=duration_ms,
+            assistant_entry_count=self._assistant_count,
+        )
+
+        self._text_blocks.clear()
+        self._thinking_blocks.clear()
+        self._tool_uses.clear()
+        self._last_stop_reason = ""
+        self._last_usage = {}
+        self._assistant_count = 0
+        self._turn_started_at = None
+        self._turn_ended_at = None
+
+        return resp
+
+    @property
+    def is_empty(self) -> bool:
+        """True iff nothing has been fed since the last drain.
+
+        Useful for the tailer's catch-up path: if a stop_hook_summary
+        appears and the buffer is empty (e.g. cold-start replay of an
+        already-fired turn), the tailer can skip firing the callback to
+        avoid emitting empty TurnResponses to the broker.
+        """
+        return self._assistant_count == 0 and not self._text_blocks
+
+
+def _parse_ts(raw: str) -> float | None:
+    """Parse an ISO8601 timestamp into epoch seconds. ``None`` on failure."""
+    if not raw:
+        return None
+    # Claude Code uses Z-suffixed UTC ISO8601 (e.g. "2026-05-14T05:03:16.161Z").
+    # Strip the trailing Z; the rest is fromisoformat-compatible on 3.11+.
+    s = raw[:-1] if raw.endswith("Z") else raw
+    try:
+        import datetime as _dt
+        return _dt.datetime.fromisoformat(s).replace(tzinfo=_dt.timezone.utc).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# TmuxTranscriptTailer — file watcher + parser + dispatcher
+# ──────────────────────────────────────────────────────────────────────────
+
+
+# Callback type. Async so consumers (e.g. TmuxSession._handle_turn_complete)
+# can do async work like awaiting the response_callback / cost_callback /
+# conversation_store writes without forcing a sync bridge.
+TurnCallback = Callable[[TurnResponse], Awaitable[None]]
+
+
+class TmuxTranscriptTailer:
+    """Per-session tailer for a Claude Code JSONL transcript.
+
+    Lifecycle:
+    1. Constructor: configured with path + callback. No I/O yet.
+    2. ``start()`` opens the file at the configured offset and spawns
+       the background tail task. Idempotent.
+    3. ``wake()`` is called from external Stop-hook handlers (or tests)
+       to signal "new data available, read now."
+    4. Background task loops: wait for wake_event OR poll timeout,
+       read until EOF, feed entries to the buffer, fire callback on
+       turn-complete.
+    5. ``stop()`` cancels the task and closes the file handle.
+
+    Offset can be persisted across daemon restarts to replay missed
+    turns (or skipped, if the consumer prefers to re-resume from EOF).
+    ``set_offset(0)`` re-reads the whole file from scratch — useful for
+    backfill.
+    """
+
+    def __init__(
+        self,
+        transcript_path: Path,
+        on_turn_complete: TurnCallback,
+        *,
+        agent_name: str = "",
+        fallback_poll_sec: float = _FALLBACK_POLL_SEC,
+        active_poll_sec: float = _ACTIVE_POLL_SEC,
+    ) -> None:
+        self._path = Path(transcript_path)
+        self._on_turn_complete = on_turn_complete
+        self._agent_name = agent_name or self._path.stem[:12]
+        self._fallback_poll_sec = fallback_poll_sec
+        self._active_poll_sec = active_poll_sec
+
+        self._offset: int = 0
+        self._buffer = _TurnBuffer()
+        self._wake_event = asyncio.Event()
+        self._task: asyncio.Task | None = None
+        self._stopped = False
+        self._stats = {
+            "turns_fired": 0,
+            "lines_read": 0,
+            "parse_errors": 0,
+            "callback_errors": 0,
+            "rotations": 0,
+        }
+        # ``_active`` flips True after we see a user entry but before we see
+        # the closing stop_hook_summary. Drives the tighter poll cadence so
+        # we minimise the perceived round-trip latency.
+        self._active: bool = False
+
+    # ── External API ────────────────────────────────────────────────────
+
+    @property
+    def offset(self) -> int:
+        """Current byte offset. Persist this across restarts to resume."""
+        return self._offset
+
+    @property
+    def transcript_path(self) -> Path:
+        return self._path
+
+    @property
+    def stats(self) -> dict:
+        return {
+            **self._stats,
+            "offset": self._offset,
+            "buffer_empty": self._buffer.is_empty,
+            "active": self._active,
+            "running": self._task is not None and not self._task.done(),
+        }
+
+    def set_offset(self, offset: int) -> None:
+        """Override the offset (e.g. for backfill or post-restart resume).
+
+        Safe to call before ``start()``. After start, the next read uses
+        the new offset.
+        """
+        self._offset = max(0, offset)
+
+    def set_transcript_path(self, path: Path) -> None:
+        """Swap the watched file. Useful when SessionStart reports a new
+        transcript path (post-compact, post-resume).
+
+        Resets offset to 0 — the new file is assumed unread. Caller can
+        call ``set_offset`` after if they want to resume mid-file.
+        """
+        if Path(path) != self._path:
+            self._path = Path(path)
+            self._offset = 0
+            self._stats["rotations"] += 1
+            self._wake_event.set()
+
+    def wake(self) -> None:
+        """Signal the tail loop that new data is available now.
+
+        Idempotent — multiple wakes between reads coalesce into one
+        read. Safe to call before ``start()`` (the next read will pick
+        up the latched event).
+        """
+        self._wake_event.set()
+
+    async def start(self) -> None:
+        """Begin tailing in the background. Idempotent."""
+        if self._task is not None and not self._task.done():
+            return
+        self._stopped = False
+        self._task = asyncio.create_task(
+            self._tail_loop(), name=f"tmux_tailer:{self._agent_name}"
+        )
+
+    async def stop(self) -> None:
+        """Cancel the background task. Idempotent."""
+        self._stopped = True
+        self._wake_event.set()  # wake the loop so it can see _stopped
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._task = None
+
+    async def read_once(self) -> int:
+        """Read up to EOF, feed entries, fire callbacks. Returns number
+        of new bytes consumed.
+
+        Exposed for tests and for callers that want synchronous control
+        (e.g. force a flush before recording state).
+        """
+        return await self._read_and_dispatch()
+
+    def mark_active(self) -> None:
+        """Hint to the tailer that a turn is in flight. Switches to the
+        tighter poll cadence until the next stop_hook_summary fires.
+
+        TmuxSession calls this from ``_deliver_turn`` after ``send-keys``
+        returns.
+        """
+        self._active = True
+        self._wake_event.set()
+
+    # ── Internals ───────────────────────────────────────────────────────
+
+    async def _tail_loop(self) -> None:
+        """Main loop: wait for wake OR poll timeout, then read+dispatch."""
+        while not self._stopped:
+            cadence = self._active_poll_sec if self._active else self._fallback_poll_sec
+            try:
+                await asyncio.wait_for(self._wake_event.wait(), timeout=cadence)
+            except asyncio.TimeoutError:
+                pass
+            self._wake_event.clear()
+            if self._stopped:
+                return
+            try:
+                await self._read_and_dispatch()
+            except Exception as e:  # defensive — never crash the loop
+                self._stats["parse_errors"] += 1
+                _log(
+                    f"tmux_tailer[{self._agent_name}]: read loop error "
+                    f"({type(e).__name__}: {e}); continuing"
+                )
+
+    async def _read_and_dispatch(self) -> int:
+        """Read from ``_offset`` to EOF, feed each JSONL entry, fire
+        ``on_turn_complete`` per stop_hook_summary.
+
+        Returns number of bytes consumed. Zero if file doesn't exist yet
+        (cold start before claude has written anything).
+        """
+        if not self._path.exists():
+            return 0
+
+        size = self._path.stat().st_size
+        if size < self._offset:
+            # File truncated or rotated underneath us. Reset to 0 and
+            # replay; downstream consumers should be idempotent against
+            # repeat turns, but in practice the buffer is empty on
+            # rotation so this just rebuilds state from scratch.
+            _log(
+                f"tmux_tailer[{self._agent_name}]: file shrank "
+                f"({size} < {self._offset}); resetting to 0"
+            )
+            self._offset = 0
+            self._buffer.drain()  # discard partial state
+            self._stats["rotations"] += 1
+
+        if size == self._offset:
+            return 0
+
+        bytes_read = 0
+        # Read in text mode — Claude Code transcripts are UTF-8. Buffer
+        # may contain a partial trailing line if Claude Code is mid-write;
+        # we only advance offset by complete lines.
+        with self._path.open("r", encoding="utf-8", errors="replace") as fh:
+            fh.seek(self._offset)
+            chunk = fh.read()
+            # Split into lines manually so we can detect a partial trailing
+            # line (no trailing newline → don't consume).
+            if not chunk:
+                return 0
+            if chunk.endswith("\n"):
+                complete = chunk
+                partial = ""
+            else:
+                last_nl = chunk.rfind("\n")
+                if last_nl == -1:
+                    # No complete line yet. Don't advance offset.
+                    return 0
+                complete = chunk[: last_nl + 1]
+                partial = chunk[last_nl + 1:]
+
+            for line in complete.splitlines():
+                if not line.strip():
+                    continue
+                self._stats["lines_read"] += 1
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    self._stats["parse_errors"] += 1
+                    _log(
+                        f"tmux_tailer[{self._agent_name}]: skipping malformed "
+                        f"JSON at offset {self._offset}+{bytes_read}"
+                    )
+                    bytes_read += len(line) + 1
+                    continue
+
+                closes_turn = False
+                prevented = False
+                try:
+                    closes_turn = self._buffer.feed(entry)
+                    if closes_turn:
+                        prevented = bool(entry.get("preventedContinuation", False))
+                except Exception as e:
+                    self._stats["parse_errors"] += 1
+                    _log(
+                        f"tmux_tailer[{self._agent_name}]: feed raised "
+                        f"({type(e).__name__}: {e}); skipping entry"
+                    )
+
+                bytes_read += len(line.encode("utf-8")) + 1  # +1 for the \n
+
+                if closes_turn and not self._buffer.is_empty:
+                    response = self._buffer.drain(prevented_continuation=prevented)
+                    self._active = False
+                    self._stats["turns_fired"] += 1
+                    await self._safe_callback(response)
+                elif closes_turn:
+                    # Cold-start replay: stop_hook_summary appeared but the
+                    # buffer is empty (we entered mid-transcript). Drain
+                    # silently to clear ts state; don't fire.
+                    self._buffer.drain(prevented_continuation=prevented)
+                    self._active = False
+
+            # Advance past complete lines only. Partial line stays in the
+            # file and we'll re-read it next loop.
+            self._offset += len(complete.encode("utf-8"))
+            # ``partial`` is dropped intentionally — next read picks it up.
+            _ = partial
+
+        return bytes_read
+
+    async def _safe_callback(self, response: TurnResponse) -> None:
+        """Invoke ``on_turn_complete`` swallowing any callback exception.
+
+        A misbehaving callback should not strand the tailer. We log and
+        increment a stat so behavior is visible.
+        """
+        try:
+            result = self._on_turn_complete(response)
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception as e:
+            self._stats["callback_errors"] += 1
+            _log(
+                f"tmux_tailer[{self._agent_name}]: on_turn_complete raised "
+                f"({type(e).__name__}: {e}); continuing"
+            )
+
+
+__all__ = [
+    "TmuxTranscriptTailer",
+    "TurnResponse",
+]

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -424,3 +424,100 @@ class TestActivityLogging:
             events = resp.json()["events"]
             types = [e["event_type"] for e in events]
             assert "agent_thinking" not in types
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# PR8b — Transport wake + transcript-path endpoints
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestTransportEndpoints:
+    """Tests for ``/agents/<name>/transport/wake`` and
+    ``/agents/<name>/transport/transcript-path`` (PR8b).
+
+    Path-validation hardening is from Pushok's PR #496 round-1 Case 4a
+    review — restricted to ``~/.claude/projects/`` with symlink
+    resolution to defend against a valid-HMAC caller pointing the
+    tailer at arbitrary files.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._db = os.path.join(self._tmpdir, "test.db")
+
+    def _client_with_agent(self, name: str = "dymok"):
+        app = _make_app(self._db)
+        client = TestClient(app)
+        r = client.post("/agents", json={"name": name, "model": "sonnet"})
+        assert r.status_code == 200
+        return client
+
+    def test_wake_endpoint_returns_ok_for_missing_session(self):
+        """Wake endpoint is a no-op if no streaming session is registered
+        (fires before connect / after disconnect). Returns 200 with
+        ``session: None`` so the hook script's ``|| true`` doesn't fail
+        the model turn."""
+        client = self._client_with_agent()
+        resp = client.post(
+            "/agents/dymok/transport/wake",
+            json={"event": "stop_hook_summary"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["session"] is None
+
+    def test_wake_endpoint_404_for_unknown_agent(self):
+        client = self._client_with_agent()
+        resp = client.post(
+            "/agents/nobody/transport/wake",
+            json={"event": "stop_hook_summary"},
+        )
+        assert resp.status_code == 404
+
+    def test_transcript_path_rejects_non_absolute(self):
+        """Pushok Case 4a: relative paths rejected with 400."""
+        client = self._client_with_agent()
+        resp = client.post(
+            "/agents/dymok/transport/transcript-path",
+            json={"transcript_path": "relative/path.jsonl"},
+        )
+        assert resp.status_code == 400
+        assert "absolute" in resp.json()["detail"].lower()
+
+    def test_transcript_path_rejects_outside_projects_dir(self):
+        """Pushok Case 4a: paths outside ``~/.claude/projects/`` rejected
+        with 403 — the perimeter defense against pointing the tailer at
+        ``/var/log/system.log`` etc."""
+        client = self._client_with_agent()
+        # Use a deliberately-attacker-flavored absolute path.
+        resp = client.post(
+            "/agents/dymok/transport/transcript-path",
+            json={"transcript_path": "/var/log/system.log"},
+        )
+        assert resp.status_code == 403
+        assert "projects" in resp.json()["detail"].lower()
+
+    def test_transcript_path_accepts_valid_path(self):
+        """Path under ``~/.claude/projects/`` passes validation (200).
+
+        Test agent has no streaming session registered, so response is
+        ``ok: True, session: None`` — the validation gate fired
+        successfully, which is what we're pinning."""
+        from pathlib import Path
+        client = self._client_with_agent()
+        projects = Path.home() / ".claude" / "projects" / "test-agent"
+        candidate = projects / "test-session.jsonl"
+        # Don't need to create the file — endpoint accepts missing
+        # files (Claude Code creates them on first append).
+        resp = client.post(
+            "/agents/dymok/transport/transcript-path",
+            json={"transcript_path": str(candidate)},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        # No streaming session registered → endpoint short-circuits with
+        # session: None (the path validation already succeeded, which is
+        # what this test pins).
+        assert body.get("session") is None

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -16,6 +16,7 @@ Test strategy:
 from __future__ import annotations
 
 import asyncio
+import json as _json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -24,8 +25,10 @@ from pinky_daemon.streaming_session import StreamingSessionConfig
 from pinky_daemon.tmux_session import (
     TmuxCommandResult,
     TmuxSession,
+    _QueuedTurn,
     _TmuxControl,
 )
+from pinky_daemon.tmux_transcript import TurnResponse
 from pinky_daemon.transport_state import SessionState, TransitionResult, Trigger
 
 
@@ -664,3 +667,317 @@ def test_stats_shape_matches_broker_consumer_keys() -> None:
     assert stats["state"] == "connected"
     # cost_usd not reported.
     assert "cost_usd" not in stats
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# PR8b — Response capture pipeline integration
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _AsyncCollector:
+    """Drop-in async callback that records (agent_name, text, meta) calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict]] = []
+
+    async def __call__(self, agent_name, text, meta):
+        self.calls.append((agent_name, text, meta))
+
+
+def _make_session_with_response_cb(
+    *, response_cb=None, conv_store=None, stream_evt=None,
+) -> tuple[TmuxSession, MagicMock]:
+    """TmuxSession built with the response-side callbacks wired up."""
+    cfg = StreamingSessionConfig(
+        agent_name="dymok",
+        working_dir="/tmp/tmux-session-test",
+    )
+    tmux = _make_mock_tmux()
+    ss = TmuxSession(
+        cfg,
+        tmux_control=tmux,
+        response_callback=response_cb,
+        conversation_store=conv_store,
+        stream_event_callback=stream_evt,
+    )
+    return ss, tmux
+
+
+@pytest.mark.asyncio
+async def test_connect_starts_tailer() -> None:
+    """After cold-start, the tailer is constructed and running."""
+    ss, _ = _make_session()
+    await ss.connect()
+    assert ss._tailer is not None
+    assert ss._tailer.stats["running"] is True
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_stops_tailer() -> None:
+    """disconnect() cancels the tailer's background task."""
+    ss, _ = _make_session()
+    await ss.connect()
+    tailer = ss._tailer
+    assert tailer is not None
+    await ss.disconnect()
+    # Tailer instance preserved (so stats survive); but task is stopped.
+    assert ss._tailer is tailer
+    assert ss._tailer.stats["running"] is False
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_captures_inflight_meta() -> None:
+    """_deliver_turn stashes routing metadata for the tailer's callback
+    to forward through response_callback."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    turn = _QueuedTurn(
+        prompt="hello",
+        platform="telegram",
+        chat_id="12345",
+        message_id="m1",
+    )
+    await ss._deliver_turn(turn)
+    assert ss._inflight_meta == {
+        "platform": "telegram",
+        "chat_id": "12345",
+        "message_id": "m1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_clears_meta_on_send_keys_failure() -> None:
+    """If tmux send-keys fails, in-flight meta is cleared so a stale tail
+    doesn't fire response_callback with bogus routing data."""
+    tmux = _make_mock_tmux()
+    tmux.send_keys = AsyncMock(return_value=_fail("rc=1"))
+    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+    turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m")
+    with pytest.raises(RuntimeError, match="tmux send-keys failed"):
+        await ss._deliver_turn(turn)
+    assert ss._inflight_meta == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_turn_complete_fires_response_callback() -> None:
+    """End-to-end: synthetic TurnResponse → response_callback called with
+    correct (agent_name, text, meta) tuple."""
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._inflight_meta = {
+        "platform": "telegram",
+        "chat_id": "12345",
+        "message_id": "m1",
+    }
+    response = TurnResponse(
+        text="hello back",
+        stop_reason="end_turn",
+        usage={"input_tokens": 10, "output_tokens": 5},
+    )
+    await ss._handle_turn_complete(response)
+
+    assert len(cb.calls) == 1
+    agent, text, meta = cb.calls[0]
+    assert agent == "dymok"
+    assert text == "hello back"
+    assert meta == {"platform": "telegram", "chat_id": "12345", "message_id": "m1"}
+    # Meta cleared after firing — next turn starts clean.
+    assert ss._inflight_meta == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_turn_complete_skips_callback_for_empty_text() -> None:
+    """Empty response (e.g. tool-use-only turn) doesn't fire the
+    response_callback — broker has no reply to deliver."""
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    response = TurnResponse(text="", stop_reason="tool_use")
+    await ss._handle_turn_complete(response)
+    assert cb.calls == []
+
+
+@pytest.mark.asyncio
+async def test_handle_turn_complete_writes_to_conversation_store() -> None:
+    """assistant response is appended to the conversation store."""
+    conv = MagicMock()
+    ss, _ = _make_session_with_response_cb(conv_store=conv)
+    response = TurnResponse(text="response text", stop_reason="end_turn")
+    await ss._handle_turn_complete(response)
+    conv.append.assert_called_once_with(ss.id, "assistant", "response text")
+
+
+@pytest.mark.asyncio
+async def test_handle_turn_complete_fires_stream_event() -> None:
+    """stream_event_callback gets a turn_complete event with usage + duration."""
+    events: list[tuple[str, dict]] = []
+
+    async def stream_cb(agent_name, evt):
+        events.append((agent_name, evt))
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    response = TurnResponse(
+        text="x", stop_reason="end_turn",
+        usage={"input_tokens": 100, "output_tokens": 50},
+        duration_ms=1500,
+        assistant_entry_count=2,
+        tool_uses=[{"name": "Bash", "input": {}, "id": "t1"}],
+    )
+    await ss._handle_turn_complete(response)
+    assert len(events) == 1
+    agent, evt = events[0]
+    assert agent == "dymok"
+    assert evt["type"] == "turn_complete"
+    assert evt["stop_reason"] == "end_turn"
+    assert evt["duration_ms"] == 1500
+    assert evt["assistant_entry_count"] == 2
+    assert evt["tool_use_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_turn_complete_swallows_callback_exceptions() -> None:
+    """A misbehaving response_callback must not strand the session.
+
+    Critical because the tailer awaits this method; an unhandled raise
+    would leak out and (in production) blow up the tail loop's exception
+    handler, dropping subsequent turns."""
+    async def bad_cb(*args, **kwargs):
+        raise RuntimeError("downstream broke")
+
+    bad_conv = MagicMock()
+    bad_conv.append = MagicMock(side_effect=RuntimeError("store broke"))
+
+    async def bad_stream(*args, **kwargs):
+        raise RuntimeError("stream broke")
+
+    ss, _ = _make_session_with_response_cb(
+        response_cb=bad_cb,
+        conv_store=bad_conv,
+        stream_evt=bad_stream,
+    )
+    response = TurnResponse(text="x", stop_reason="end_turn")
+    # All three callbacks raise; method must not.
+    await ss._handle_turn_complete(response)
+    # Meta still cleared (PR8b contract: clear at end regardless).
+    assert ss._inflight_meta == {}
+
+
+@pytest.mark.asyncio
+async def test_notify_tail_wakes_tailer() -> None:
+    """notify_tail() forwards to the tailer's wake() method."""
+    ss, _ = _make_session()
+    await ss.connect()
+    assert ss._tailer is not None
+    # Clear any latched wake from start().
+    ss._tailer._wake_event.clear()
+    ss.notify_tail()
+    assert ss._tailer._wake_event.is_set()
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_notify_tail_safe_before_connect() -> None:
+    """notify_tail() before tailer is constructed is a silent no-op."""
+    ss, _ = _make_session()
+    assert ss._tailer is None
+    ss.notify_tail()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_set_transcript_path_forwards_to_tailer(tmp_path) -> None:
+    """SessionStart hook reports a new path → tailer is repointed."""
+    ss, _ = _make_session()
+    await ss.connect()
+    new_path = tmp_path / "new-session.jsonl"
+    new_path.touch()
+    ss.set_transcript_path(new_path)
+    assert ss._tailer.transcript_path == new_path
+    # Offset reset on rotation (per tailer contract).
+    assert ss._tailer.offset == 0
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_set_transcript_path_safe_before_connect(tmp_path) -> None:
+    """set_transcript_path before tailer exists is a silent no-op."""
+    ss, _ = _make_session()
+    # Don't connect — tailer is None.
+    ss.set_transcript_path(tmp_path / "x.jsonl")  # must not raise
+    assert ss._tailer is None
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_tailer_to_response_callback(tmp_path) -> None:
+    """Full integration: synthetic transcript file → tailer reads → turn
+    complete → response_callback fires with full routing metadata.
+
+    This exercises the real tailer (no mocks) but feeds it a synthetic
+    transcript instead of a live claude REPL. Pins the entire PR8b
+    contract end-to-end."""
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+
+    # Replace the tailer's path with our synthetic transcript.
+    transcript = tmp_path / "synthetic.jsonl"
+    transcript.write_text("")
+    ss.set_transcript_path(transcript)
+
+    # Simulate _deliver_turn capturing routing meta.
+    ss._inflight_meta = {
+        "platform": "telegram",
+        "chat_id": "777",
+        "message_id": "m42",
+    }
+
+    # Write a synthetic turn to the transcript file.
+    entries = [
+        {
+            "type": "user",
+            "timestamp": "2026-05-14T05:00:00.000Z",
+            "message": {"role": "user", "content": "hi"},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-14T05:00:00.100Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hello there"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 5, "output_tokens": 3},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "timestamp": "2026-05-14T05:00:00.500Z",
+        },
+    ]
+    transcript.write_text("\n".join(_json.dumps(e) for e in entries) + "\n")
+
+    # Drive the tailer to read.
+    await ss._tailer.read_once()
+
+    # response_callback fired with the right tuple.
+    assert len(cb.calls) == 1
+    agent, text, meta = cb.calls[0]
+    assert agent == "dymok"
+    assert text == "hello there"
+    assert meta == {"platform": "telegram", "chat_id": "777", "message_id": "m42"}
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_discover_transcript_path_returns_none_for_empty_project_dir(tmp_path, monkeypatch) -> None:
+    """When the encoded-cwd project dir doesn't exist, return None.
+
+    This is the cold-start case — agent has never been run, so Claude
+    Code hasn't created the project dir yet. Tailer starts with a
+    placeholder path and SessionStart hook later reports the canonical one."""
+    # Point HOME at a tmp dir so the glob has nowhere to find anything.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    # working_dir is /tmp/tmux-session-test from the fixture; project dir
+    # path under our fake HOME does not exist.
+    assert ss._discover_transcript_path() is None

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1117,7 +1117,7 @@ async def test_multi_prompt_routing_no_cross_user_leak(tmp_path) -> None:
     )
 
     # Write turn A's response + stop_hook_summary to the transcript.
-    import json as _json
+    # (``_json`` is imported at file scope; no local re-import needed.)
     turn_a_entries = [
         {"type": "assistant", "timestamp": "2026-05-14T05:00:00.000Z",
          "message": {"role": "assistant",
@@ -1242,4 +1242,101 @@ async def test_spawn_clears_turn_done_after_reconnect() -> None:
     assert not ss._turn_done.is_set(), (
         "turn_done invariant violated post-spawn — should be cleared"
     )
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_force_restart_resumes_tailer(tmp_path) -> None:
+    """Pushok's PR #496 round-2 Case 1': ``force_restart`` must leave
+    the tailer running so the new session can complete a turn.
+
+    Bug shape pre-fix: ``_start_tailer`` was only called from
+    ``connect``. ``force_restart`` invoked ``_spawn_tmux_repl`` directly
+    (bypassing ``connect``), so after a restart the tailer instance
+    survived but its background task was dead. Result:
+
+    1. New worker dispatches turn → ``mark_active`` wakes a dead task.
+    2. No ``stop_hook_summary`` ever fires → ``turn_done`` never set.
+    3. Worker times out after 600s → another ``force_restart``.
+    4. Death loop. Agent silently never delivers responses.
+
+    The round-2 turn_done event gate (Case 1) made this loud — without
+    it, the failure was silently-dropped responses on a "live" agent.
+
+    Pre-fix this test fails with:
+      ``assert ss._tailer.stats["running"] is True`` → ``False``
+    and the end-to-end response_callback never fires.
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+    assert ss._tailer.stats["running"] is True, (
+        "tailer should be running after cold-start connect"
+    )
+
+    # Trigger a force_restart. This drives:
+    #   CONNECTED → RECONNECTING (via disconnect+_stop_tailer)
+    #            → CONNECTED (via _spawn_tmux_repl)
+    # The fix moves _start_tailer into _spawn_tmux_repl so the post-
+    # restart session has a live tailer task.
+    restart_ok = await ss.force_restart()
+    assert restart_ok, "force_restart should succeed"
+
+    # Critical invariant — pre-fix this is False (task killed by
+    # disconnect's _stop_tailer, never restarted).
+    assert ss._tailer is not None
+    assert ss._tailer.stats["running"] is True, (
+        "tailer task must be running after force_restart — Pushok Case 1' "
+        "regression: if this fires, force_restart skipped _start_tailer"
+    )
+
+    # End-to-end pin: drive a complete turn through the post-restart
+    # tailer and assert response_callback fires. This is the real test
+    # — even if the tailer instance is "running" by accident, can it
+    # actually deliver a response?
+    transcript = tmp_path / "post_restart.jsonl"
+    transcript.write_text("")
+    ss.set_transcript_path(transcript)
+
+    ss._inflight_meta = {
+        "platform": "telegram",
+        "chat_id": "999",
+        "message_id": "m_post_restart",
+    }
+
+    entries = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-14T06:00:00.100Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "alive after restart"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "timestamp": "2026-05-14T06:00:00.500Z",
+        },
+    ]
+    transcript.write_text("\n".join(_json.dumps(e) for e in entries) + "\n")
+
+    await ss._tailer.read_once()
+
+    # Pre-fix: this assertion fails because the tailer task is dead and
+    # ``read_once`` is the only thing keeping it limping — but the
+    # background loop that would actually drive turn completion in
+    # production never runs. We explicitly call ``read_once`` here so
+    # the assertion is robust against scheduling jitter; the real
+    # production-shape assertion is the ``stats["running"]`` one above.
+    assert len(cb.calls) == 1, (
+        "post-restart turn should have completed end-to-end"
+    )
+    agent, text, meta = cb.calls[0]
+    assert agent == "dymok"
+    assert text == "alive after restart"
+    assert meta["chat_id"] == "999"
+
     await ss.disconnect()

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -981,3 +981,265 @@ async def test_discover_transcript_path_returns_none_for_empty_project_dir(tmp_p
     # working_dir is /tmp/tmux-session-test from the fixture; project dir
     # path under our fake HOME does not exist.
     assert ss._discover_transcript_path() is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# PR8b round 2 — Pushok's review fixes
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_turn_done_set_unconditionally_for_empty_text_turn() -> None:
+    """Pushok's PR #496 round-1 Case 1 follow-up: a turn that produces
+    zero assistant text (pure tool-use that hit max_tokens, or refusal)
+    must still set ``_turn_done`` so the worker can dispatch the next
+    prompt. If turn_done were gated on ``response.text``, the worker
+    would deadlock forever on tool-use-only turns.
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    # Pre-clear turn_done to mimic what _deliver_turn does.
+    ss._turn_done.clear()
+    assert not ss._turn_done.is_set()
+
+    # Empty-text turn — pure tool-use refusal, max_tokens, etc.
+    empty_response = TurnResponse(text="", stop_reason="max_tokens")
+    await ss._handle_turn_complete(empty_response)
+
+    # response_callback NOT fired (empty text), but turn_done IS set.
+    assert cb.calls == []
+    assert ss._turn_done.is_set(), (
+        "turn_done must be set unconditionally so the worker can proceed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_clears_turn_done_before_send_keys() -> None:
+    """The clear must happen BEFORE send-keys so that any subsequent
+    stop_hook_summary unambiguously belongs to THIS turn (not a stale
+    pre-arm from a prior callback). Pinned via call-order observation.
+    """
+    tmux = _make_mock_tmux()
+    cleared_at: list[bool] = []
+
+    async def observing_send_keys(*args, **kwargs):
+        # Snapshot turn_done state at the moment send_keys is called.
+        cleared_at.append(not ss._turn_done.is_set())
+        return _ok()
+
+    tmux.send_keys = AsyncMock(side_effect=observing_send_keys)
+    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+    # Pre-arm turn_done to a SET state to prove the clear() actually fires.
+    ss._turn_done.set()
+
+    turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m")
+    await ss._deliver_turn(turn)
+
+    assert cleared_at == [True], (
+        "turn_done must be CLEARED at the moment send_keys is invoked"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_send_keys_failure_re_arms_turn_done() -> None:
+    """If send-keys fails, the worker would otherwise block forever on
+    turn_done.wait() because no callback will ever fire for the failed
+    dispatch. _deliver_turn must re-arm turn_done as part of its failure
+    cleanup so the worker's next iteration starts in a clean state.
+    """
+    tmux = _make_mock_tmux()
+    tmux.send_keys = AsyncMock(return_value=_fail("rc=1"))
+    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+    ss._turn_done.clear()
+
+    turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m")
+    with pytest.raises(RuntimeError):
+        await ss._deliver_turn(turn)
+
+    # Meta cleared AND turn_done re-armed.
+    assert ss._inflight_meta == {}
+    assert ss._turn_done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_clears_inflight_meta() -> None:
+    """Pushok's PR #496 round-1 Case 2: a stale ``_inflight_meta`` from
+    a turn that was in-flight at disconnect time must not survive the
+    disconnect — otherwise a straggler stop_hook_summary read after
+    reconnect could route a response to a stale chat."""
+    ss, _ = _make_session()
+    await ss.connect()
+    # Simulate an in-flight turn.
+    ss._inflight_meta = {"platform": "telegram", "chat_id": "999", "message_id": "m"}
+    await ss.disconnect()
+    assert ss._inflight_meta == {}
+
+
+@pytest.mark.asyncio
+async def test_multi_prompt_routing_no_cross_user_leak(tmp_path) -> None:
+    """Pushok's PR #496 round-1 critical Case 1 repro: two send() calls
+    in quick succession must route response 1 to chat A and response 2
+    to chat B. The worker's turn_done gate enforces this by blocking
+    dispatch of turn 2 until turn 1's stop_hook_summary lands.
+
+    This is the canonical regression test for the bug: pre-fix, the
+    second send() would clobber _inflight_meta before turn 1's
+    response_callback fired, routing response 1 to chat B."""
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+
+    # Repoint tailer at our synthetic transcript.
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text("")
+    ss.set_transcript_path(transcript)
+    # Use tight cadences so the test runs fast.
+    ss._tailer._fallback_poll_sec = 0.02
+    ss._tailer._active_poll_sec = 0.01
+
+    # Queue two prompts back-to-back.
+    await ss.send(prompt="from A", platform="telegram", chat_id="A", message_id="mA")
+    await ss.send(prompt="from B", platform="telegram", chat_id="B", message_id="mB")
+
+    # Worker should have dispatched turn 1 but be blocked on turn_done
+    # for turn 1's completion. Verify by checking the queue still has
+    # turn 2 (give the worker a tick to drain turn 1).
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if ss._inflight_meta.get("chat_id") == "A":
+            break
+    assert ss._inflight_meta == {
+        "platform": "telegram", "chat_id": "A", "message_id": "mA",
+    }, "worker should be holding turn A's meta while awaiting turn_done"
+    assert ss._message_queue.qsize() == 1, (
+        "turn B must still be queued — worker should not dispatch it "
+        "until turn A's stop_hook_summary lands"
+    )
+
+    # Write turn A's response + stop_hook_summary to the transcript.
+    import json as _json
+    turn_a_entries = [
+        {"type": "assistant", "timestamp": "2026-05-14T05:00:00.000Z",
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "response A"}],
+                     "stop_reason": "end_turn",
+                     "usage": {}}},
+        {"type": "system", "subtype": "stop_hook_summary",
+         "timestamp": "2026-05-14T05:00:00.500Z"},
+    ]
+    transcript.write_text(
+        "\n".join(_json.dumps(e) for e in turn_a_entries) + "\n"
+    )
+    ss._tailer.wake()
+
+    # Wait for response A to be delivered AND for the worker to dispatch
+    # turn B.
+    for _ in range(50):
+        await asyncio.sleep(0.02)
+        if cb.calls and ss._inflight_meta.get("chat_id") == "B":
+            break
+
+    # Critical: response A was routed to chat A, NOT chat B (the original bug).
+    assert len(cb.calls) == 1
+    agent, text, meta = cb.calls[0]
+    assert text == "response A"
+    assert meta["chat_id"] == "A", (
+        f"response A leaked to wrong chat: {meta} — original Case 1 bug regression"
+    )
+
+    # Worker has now dispatched turn B (meta swapped).
+    assert ss._inflight_meta["chat_id"] == "B"
+
+    # Append turn B's response + stop_hook_summary.
+    turn_b_entries = [
+        {"type": "assistant", "timestamp": "2026-05-14T05:00:01.000Z",
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "response B"}],
+                     "stop_reason": "end_turn",
+                     "usage": {}}},
+        {"type": "system", "subtype": "stop_hook_summary",
+         "timestamp": "2026-05-14T05:00:01.500Z"},
+    ]
+    with transcript.open("a", encoding="utf-8") as fh:
+        fh.write("\n".join(_json.dumps(e) for e in turn_b_entries) + "\n")
+    ss._tailer.wake()
+
+    for _ in range(50):
+        await asyncio.sleep(0.02)
+        if len(cb.calls) == 2:
+            break
+
+    # Critical: response B was routed to chat B.
+    assert len(cb.calls) == 2
+    agent, text, meta = cb.calls[1]
+    assert text == "response B"
+    assert meta["chat_id"] == "B"
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_worker_force_restarts_on_turn_done_timeout(monkeypatch) -> None:
+    """Pushok's PR #496 round-1 Case 1 follow-up: when the model gets
+    stuck and turn_done never fires, the worker times out and triggers
+    force_restart instead of just clearing meta and continuing. The
+    latter would re-introduce the original Case 1 cross-routing bug —
+    a late-arriving stop_hook_summary for the stuck turn would route
+    to the *next* turn's meta.
+    """
+    from pinky_daemon import tmux_session
+    # Shorten the timeout so the test doesn't take 10 minutes.
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.1)
+
+    ss, tmux = _make_session()
+    await ss.connect()
+
+    # Track force_restart calls — replace with a stub that signals.
+    force_restart_called = asyncio.Event()
+    original_force_restart = ss.force_restart
+
+    async def stub_force_restart():
+        force_restart_called.set()
+        # Call original to drive state machine through reconnect.
+        return await original_force_restart()
+
+    ss.force_restart = stub_force_restart
+
+    # Send one prompt — worker dispatches and waits for turn_done.
+    # No stop_hook_summary will ever be written, so timeout fires.
+    await ss.send(prompt="stuck", platform="t", chat_id="c", message_id="m")
+
+    # Wait for the timeout path to fire force_restart.
+    try:
+        await asyncio.wait_for(force_restart_called.wait(), timeout=2.0)
+    except asyncio.TimeoutError:
+        pytest.fail("force_restart should have been called after turn_done timeout")
+
+    # Turn-timeout counter incremented.
+    assert ss._stats.get("turn_timeouts", 0) == 1
+
+    # Final cleanup — force_restart may still be running, give it a moment.
+    await asyncio.sleep(0.05)
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_spawn_clears_turn_done_after_reconnect() -> None:
+    """The turn_done invariant ("cleared between dispatches") must be
+    re-established after force_restart so the first dispatch on the
+    new tmux pane doesn't see a stale set() from the killed session's
+    last callback.
+    """
+    ss, _ = _make_session()
+    # Pre-set turn_done to simulate the state at the moment a
+    # force_restart happens (last turn completed → callback set it).
+    ss._turn_done.set()
+    assert ss._turn_done.is_set()
+
+    await ss.connect()
+    # After connect (which calls _spawn_tmux_repl), the invariant is
+    # restored: turn_done is cleared.
+    assert not ss._turn_done.is_set(), (
+        "turn_done invariant violated post-spawn — should be cleared"
+    )
+    await ss.disconnect()

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1340,3 +1340,150 @@ async def test_force_restart_resumes_tailer(tmp_path) -> None:
     assert meta["chat_id"] == "999"
 
     await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_stop_tailer_drains_buffer_for_same_path_resume(tmp_path) -> None:
+    """Murzik's PR #496 round-3 Case 2'' regression: ``_stop_tailer``
+    must drain the in-progress turn buffer so a same-path lifecycle
+    restart (``claude --continue`` resume) doesn't leak dead-session
+    partial text into the next session's first turn.
+
+    The round-2 fix in ``set_transcript_path`` only drained on path
+    *change*. If ``force_restart`` is followed by Claude Code resuming
+    the same JSONL path, ``set_transcript_path`` either isn't called or
+    skips the drain due to path equality. The killed session's partial
+    assistant text would then survive into the next session, and the
+    first complete turn's callback would fire with
+    ``old_partial + new_text``.
+
+    Pre-fix this test fails with:
+      ``assert ss._tailer._buffer.is_empty`` → ``False`` after
+      ``_stop_tailer``, because round-2's drain was scoped to path
+      swaps and round-3's ``_start_tailer`` fix did not address the
+      buffer-retention angle.
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+
+    # Replace the tailer's path with a controlled synthetic transcript.
+    transcript = tmp_path / "session_x.jsonl"
+    transcript.write_text("")
+    ss.set_transcript_path(transcript)
+
+    # Feed a partial turn — assistant entry without stop_hook_summary.
+    # This simulates the in-flight state when a session is killed mid-turn.
+    partial_entries = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-14T06:00:00.100Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "partial from X"}],
+                "stop_reason": "",
+                "usage": {},
+            },
+        },
+    ]
+    transcript.write_text("\n".join(_json.dumps(e) for e in partial_entries) + "\n")
+    await ss._tailer.read_once()
+
+    # Buffer should hold "partial from X"; no callback yet (no
+    # stop_hook_summary).
+    assert len(cb.calls) == 0
+    assert not ss._tailer._buffer.is_empty, (
+        "buffer should have accumulated partial assistant text"
+    )
+
+    # Stop the tailer — the fix: this should also drain the buffer.
+    await ss._stop_tailer()
+    assert ss._tailer._buffer.is_empty, (
+        "_stop_tailer must drain the buffer (Murzik Case 2'') — "
+        "without this, a same-path resume leaks dead-session text "
+        "into the next session's first reply"
+    )
+
+    # Restart the tailer with the SAME path — simulates claude --continue
+    # resuming. The round-2 set_transcript_path drain wouldn't fire here
+    # because the path didn't change; we rely on _stop_tailer's drain.
+    await ss._start_tailer()
+
+    # Session Y produces a complete turn, appended to the same transcript.
+    with open(transcript, "a") as fh:
+        new_entries = [
+            {
+                "type": "assistant",
+                "timestamp": "2026-05-14T06:05:00.100Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "response from Y"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 5, "output_tokens": 3},
+                },
+            },
+            {
+                "type": "system",
+                "subtype": "stop_hook_summary",
+                "timestamp": "2026-05-14T06:05:00.500Z",
+            },
+        ]
+        fh.write("\n".join(_json.dumps(e) for e in new_entries) + "\n")
+
+    ss._inflight_meta = {"platform": "telegram", "chat_id": "Y", "message_id": "mY"}
+    await ss._tailer.read_once()
+
+    # Callback fires with ONLY Y's text — no "partial from X" prefix.
+    assert len(cb.calls) == 1, "Y's turn should have fired exactly one callback"
+    _, text, _ = cb.calls[0]
+    assert text == "response from Y", (
+        f"expected clean Y response, got {text!r} — "
+        f"if this contains 'partial from X', the same-path-resume "
+        f"buffer-leak regression has reopened"
+    )
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_spawn_tmux_repl_rollback_clears_partial_tailer() -> None:
+    """Murzik's PR #496 round-3 cleanup-hole regression: if
+    ``_start_tailer`` raises AFTER constructing ``self._tailer``, the
+    ``_spawn_tmux_repl`` rollback path must stop+null the partial
+    tailer instance before re-raising. Otherwise the caller transitions
+    DEAD with a live orphan tailer instance.
+
+    Pre-fix this test fails with:
+      ``assert ss._tailer is None`` → ``False``, because the round-3
+      rollback only killed tmux and left ``self._tailer`` populated.
+    """
+    ss, tmux = _make_session()
+
+    # Monkeypatch TmuxTranscriptTailer.start so it raises AFTER the
+    # tailer instance has been constructed by _start_tailer's
+    # ``self._tailer = TmuxTranscriptTailer(...)`` assignment.
+    from pinky_daemon import tmux_transcript
+
+    async def boom(self):
+        raise RuntimeError("synthetic tailer start failure")
+
+    original_start = tmux_transcript.TmuxTranscriptTailer.start
+    tmux_transcript.TmuxTranscriptTailer.start = boom
+    try:
+        with pytest.raises(RuntimeError, match="synthetic tailer start failure"):
+            await ss._spawn_tmux_repl()
+    finally:
+        tmux_transcript.TmuxTranscriptTailer.start = original_start
+
+    # Rollback assertions: tailer slot is cleared and tmux was killed.
+    assert ss._tailer is None, (
+        "rollback in _spawn_tmux_repl must reset self._tailer — "
+        "otherwise the caller transitions DEAD with a live orphan "
+        "tailer instance (Murzik round-3 cleanup-hole regression)"
+    )
+    # The tmux.kill_session call from the rollback block should have
+    # fired at least once (it may also have been called by the pre-spawn
+    # stale-session reaper; either way, count >= 1).
+    assert tmux.kill_session.await_count >= 1, (
+        "rollback must call tmux.kill_session"
+    )

--- a/tests/test_tmux_transcript.py
+++ b/tests/test_tmux_transcript.py
@@ -551,6 +551,73 @@ class TestTailerReadOnce:
         await tailer.read_once()
         assert [r.text for r in cb.responses] == ["t1", "t2"]
 
+    @pytest.mark.asyncio
+    async def test_set_transcript_path_drains_buffer_across_swap(
+        self, transcript, tmp_path,
+    ):
+        """Pushok's PR #496 round-2 Case 2': swapping the transcript
+        path must also drain the in-memory turn buffer.
+
+        Failure mode without the drain:
+        1. Session X is mid-turn — tailer has accumulated assistant text
+           in its buffer but no ``stop_hook_summary`` has landed yet.
+        2. Session X gets killed (force_restart). Session Y spawns with
+           a fresh transcript path. SessionStart hook fires
+           ``set_transcript_path(new_path)``.
+        3. Without the drain, ``_buffer`` still holds X's partial text.
+           When Y produces its first complete turn, the callback gets
+           ``X_partial + "\\n" + Y_text`` — dead-session content leaking
+           into Y's first reply.
+
+        Pre-fix: this test would fail with the callback firing on text
+        like ``"partial from X\\nresponse from Y"``. With the drain:
+        callback fires with exactly ``"response from Y"``.
+        """
+        cb = _Captor()
+
+        # File A: partial turn (assistant entry, NO stop_hook_summary).
+        # This is the in-flight state when a session dies.
+        _write_jsonl(transcript, [
+            _assistant(text="partial from X"),
+        ])
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        await tailer.read_once()
+        # Buffer should now hold "partial from X" but no callback fired
+        # (no stop_hook_summary yet — turn is incomplete).
+        assert len(cb.responses) == 0
+        assert not tailer._buffer.is_empty, (
+            "buffer should have accumulated assistant text from session X"
+        )
+
+        # File B: fresh transcript for the new (post-restart) session.
+        new_path = tmp_path / "session_y.jsonl"
+        new_path.touch()  # exists but empty
+
+        # Swap. The fix: this should drain X's partial text out of the
+        # buffer, preventing leak into Y's first turn.
+        tailer.set_transcript_path(new_path)
+        assert tailer._buffer.is_empty, (
+            "set_transcript_path must drain the buffer to prevent "
+            "cross-session text leak (Pushok Case 2')"
+        )
+
+        # Y produces a complete turn.
+        _append_jsonl(new_path, [
+            _assistant(text="response from Y"),
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()
+
+        # Callback fires with ONLY Y's text — no "partial from X" prefix.
+        assert len(cb.responses) == 1, (
+            "exactly one turn should have fired"
+        )
+        assert cb.responses[0].text == "response from Y", (
+            f"expected clean Y response, got {cb.responses[0].text!r} — "
+            f"if this contains 'partial from X', the buffer-drain "
+            f"regression has reopened"
+        )
+
 
 class TestTailerBackgroundLoop:
     """Drive the actual asyncio loop end-to-end (with shortened cadences)."""

--- a/tests/test_tmux_transcript.py
+++ b/tests/test_tmux_transcript.py
@@ -470,7 +470,17 @@ class TestTailerReadOnce:
         assert cb.responses[0].text == "good"
 
     @pytest.mark.asyncio
-    async def test_set_transcript_path_resets_offset(self, transcript, tmp_path):
+    async def test_set_transcript_path_seeks_to_eof_by_default(self, transcript, tmp_path):
+        """Pushok's PR #496 round-1 Case 3 fix: rotating to a transcript
+        that already has entries must NOT replay them. The default
+        offset on swap is EOF, not 0.
+
+        This protects against compact-resume, daemon-restart re-fire,
+        and misconfigured test fixture cases where SessionStart fires
+        with a path that already contains stop_hook_summary entries.
+        Without seek-to-EOF, those would re-fire response_callback for
+        every historical turn → reply-spam.
+        """
         cb = _Captor()
         _write_jsonl(transcript, [
             _assistant(text="old"),
@@ -480,18 +490,66 @@ class TestTailerReadOnce:
         await tailer.read_once()
         assert tailer.offset > 0
 
-        # Rotate to a new transcript file (e.g. SessionStart hook reported one).
+        # Rotate to a new transcript that already contains entries
+        # (e.g. compact-resume case where Claude Code resumed an existing
+        # session). Default offset is EOF, so existing entries are NOT
+        # re-fired.
         new_path = tmp_path / "session2.jsonl"
         _write_jsonl(new_path, [
-            _assistant(text="new"),
+            _assistant(text="historical — must not replay"),
             _stop_hook_summary(),
         ])
+        responses_before = len(cb.responses)
         tailer.set_transcript_path(new_path)
-        assert tailer.offset == 0
+        new_size = new_path.stat().st_size
+        assert tailer.offset == new_size, "swap must default to EOF, not 0"
         assert tailer.stats["rotations"] == 1
 
         await tailer.read_once()
+        # Critical assertion: existing entries in the swapped-in file are
+        # NOT re-fired. Replay would have produced a callback for "historical".
+        assert len(cb.responses) == responses_before
+
+        # New entries appended AFTER the swap fire correctly.
+        _append_jsonl(new_path, [
+            _assistant(text="new"),
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()
         assert cb.responses[-1].text == "new"
+
+    @pytest.mark.asyncio
+    async def test_set_transcript_path_fresh_file_offset_is_zero(self, transcript, tmp_path):
+        """Swap-to-fresh-file (size==0) yields offset==0 by construction —
+        no behavior change vs. pre-fix on the contract'd path."""
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+
+        fresh = tmp_path / "fresh.jsonl"
+        fresh.touch()  # exists but empty
+        tailer.set_transcript_path(fresh)
+        assert tailer.offset == 0
+
+    @pytest.mark.asyncio
+    async def test_set_offset_zero_allows_explicit_backfill(self, transcript, tmp_path):
+        """The seek-to-EOF default doesn't preclude backfill: callers
+        who want to re-read the whole file can call set_offset(0)
+        explicitly after the swap. Pinned because the contract is in
+        the docstring and the migration note depends on this path
+        working for ops use cases (re-process a session's history)."""
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+
+        target = tmp_path / "session.jsonl"
+        _write_jsonl(target, [
+            _assistant(text="t1"), _stop_hook_summary(),
+            _assistant(text="t2"), _stop_hook_summary(),
+        ])
+        tailer.set_transcript_path(target)
+        # Default would skip both; explicit backfill re-reads them.
+        tailer.set_offset(0)
+        await tailer.read_once()
+        assert [r.text for r in cb.responses] == ["t1", "t2"]
 
 
 class TestTailerBackgroundLoop:
@@ -610,3 +668,87 @@ class TestTailerStats:
         ])
         await tailer.read_once()
         assert tailer.stats["turns_fired"] == 3
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pushok's PR #496 round-1 hardening — size cap, UTF-8, defense-in-depth
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestSizeCap:
+    """Bounded single-read memory (Pushok's Case 4a defense-in-depth)."""
+
+    @pytest.mark.asyncio
+    async def test_chunk_read_is_bounded(self, transcript, monkeypatch):
+        """A single ``read_once`` should not pull more than
+        ``_MAX_READ_CHUNK_BYTES``. Remaining data is consumed by the
+        next iteration via the re-armed wake_event.
+
+        Uses many small turns so each individual line fits within the
+        shrunken test cap — verifies the cap bounds aggregate read
+        without exercising the (degenerate) single-huge-line case.
+        Production cap (10 MiB) is large enough that any realistic
+        single JSONL line fits.
+        """
+        from pinky_daemon import tmux_transcript
+
+        # Shrink cap to 2KB so multiple small turns exceed it.
+        monkeypatch.setattr(tmux_transcript, "_MAX_READ_CHUNK_BYTES", 2048)
+
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        # Write ~30 small turns. Each turn is roughly 400 bytes; 30 turns
+        # ≈ 12 KB → well over the 2 KB cap.
+        entries = []
+        for i in range(30):
+            entries.append(_assistant(text=f"turn {i}"))
+            entries.append(_stop_hook_summary(
+                ts=f"2026-05-14T05:00:{i:02d}.000Z",
+            ))
+        _write_jsonl(transcript, entries)
+        first_size = transcript.stat().st_size
+        assert first_size > 2048, "test fixture must exceed the cap"
+
+        # First read consumes at most the cap; some turns fire, more pending.
+        await tailer.read_once()
+        assert tailer.offset < first_size, "first read must be cap-bounded"
+        # wake_event is re-armed so the next loop tick picks up immediately.
+        assert tailer._wake_event.is_set()
+        turns_after_first = len(cb.responses)
+        assert 0 < turns_after_first < 30, (
+            f"first read should have fired some but not all turns: "
+            f"{turns_after_first}/30"
+        )
+
+        # Drain the rest via successive reads.
+        for _ in range(20):
+            if tailer.offset >= first_size:
+                break
+            await tailer.read_once()
+        assert tailer.offset == first_size
+        assert len(cb.responses) == 30
+        # No turn was lost or duplicated.
+        assert [r.text for r in cb.responses] == [f"turn {i}" for i in range(30)]
+
+
+class TestUtf8MultiByte:
+    """UTF-8 byte-counting correctness for non-ASCII transcript content."""
+
+    @pytest.mark.asyncio
+    async def test_offset_advances_correctly_for_multi_byte_chars(self, transcript):
+        """Cyrillic + CJK characters: bytes != chars. ``len(line.encode())``
+        is the right unit for offset accounting, not ``len(line)``. Pins
+        the existing implementation against a future regression."""
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        # Russian + Japanese + emoji — guarantees multi-byte UTF-8 sequences.
+        text = "Привет, мир! こんにちは 🐈"
+        _write_jsonl(transcript, [
+            _assistant(text=text),
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()
+        assert len(cb.responses) == 1
+        assert cb.responses[0].text == text
+        # Offset must equal exact file byte size (not char count).
+        assert tailer.offset == transcript.stat().st_size

--- a/tests/test_tmux_transcript.py
+++ b/tests/test_tmux_transcript.py
@@ -1,0 +1,612 @@
+"""Tests for ``tmux_transcript`` — the response capture pipeline.
+
+PR8b of the #486 sequence. Tests are pure-Python (no tmux, no claude,
+no asyncio scheduler tricks) — the tailer is a function of (file
+content, wake events) → callbacks, and we test exactly that.
+
+Coverage shape:
+- ``_TurnBuffer``: per-entry accumulation, drain shape, multi-block
+  turns, missing/malformed blocks.
+- ``TmuxTranscriptTailer``: read-once semantics, partial-line
+  tolerance, offset replay, file rotation/truncation, callback errors,
+  cold-start replay where stop_hook_summary has no preceding buffer.
+- Active-poll mode toggling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from pinky_daemon.tmux_transcript import (
+    TmuxTranscriptTailer,
+    TurnResponse,
+    _TurnBuffer,
+)
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fixtures + helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _assistant(
+    text: str = "",
+    *,
+    thinking: str = "",
+    tool_use: dict | None = None,
+    stop_reason: str = "end_turn",
+    usage: dict | None = None,
+    ts: str = "2026-05-14T05:00:00.000Z",
+) -> dict:
+    """Build a synthetic ``assistant`` transcript entry."""
+    content: list[dict] = []
+    if thinking:
+        content.append({"type": "thinking", "thinking": thinking})
+    if text:
+        content.append({"type": "text", "text": text})
+    if tool_use is not None:
+        content.append({
+            "type": "tool_use",
+            "name": tool_use.get("name", "Bash"),
+            "input": tool_use.get("input", {}),
+            "id": tool_use.get("id", "tool_1"),
+        })
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "message": {
+            "role": "assistant",
+            "model": "claude-opus-test",
+            "content": content,
+            "stop_reason": stop_reason,
+            "usage": usage or {"input_tokens": 100, "output_tokens": 50},
+        },
+    }
+
+
+def _user(text: str = "hi", ts: str = "2026-05-14T04:59:59.000Z") -> dict:
+    """Build a synthetic ``user`` transcript entry."""
+    return {
+        "type": "user",
+        "timestamp": ts,
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _stop_hook_summary(
+    *,
+    prevented: bool = False,
+    ts: str = "2026-05-14T05:00:01.500Z",
+) -> dict:
+    """Build a synthetic ``stop_hook_summary`` entry."""
+    return {
+        "type": "system",
+        "subtype": "stop_hook_summary",
+        "timestamp": ts,
+        "preventedContinuation": prevented,
+        "hookCount": 1,
+        "stopReason": "",
+        "hasOutput": False,
+        "level": "suggestion",
+    }
+
+
+def _write_jsonl(path: Path, entries: list[dict], *, trailing_newline: bool = True) -> int:
+    """Append entries to a JSONL file. Returns total bytes written."""
+    text = "\n".join(json.dumps(e) for e in entries)
+    if trailing_newline:
+        text += "\n"
+    path.write_text(text, encoding="utf-8")
+    return len(text.encode("utf-8"))
+
+
+def _append_jsonl(path: Path, entries: list[dict], *, trailing_newline: bool = True) -> int:
+    """Append entries to an existing JSONL file."""
+    chunk = "\n".join(json.dumps(e) for e in entries)
+    if trailing_newline:
+        chunk += "\n"
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(chunk)
+    return len(chunk.encode("utf-8"))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _TurnBuffer tests
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestTurnBuffer:
+    """Pure-data tests for the per-turn accumulator."""
+
+    def test_single_assistant_then_stop(self):
+        buf = _TurnBuffer()
+        assert buf.feed(_assistant(text="hello world")) is False
+        assert buf.feed(_stop_hook_summary()) is True
+
+        resp = buf.drain()
+        assert resp.text == "hello world"
+        assert resp.thinking == ""
+        assert resp.tool_uses == []
+        assert resp.stop_reason == "end_turn"
+        assert resp.assistant_entry_count == 1
+        assert resp.usage == {"input_tokens": 100, "output_tokens": 50}
+
+    def test_multi_block_turn(self):
+        """Tool-use loop: thinking → text → tool_use → text → end_turn."""
+        buf = _TurnBuffer()
+        buf.feed(_assistant(
+            thinking="planning the call",
+            text="let me check that",
+            tool_use={"name": "Bash", "input": {"cmd": "ls"}, "id": "tu_1"},
+            stop_reason="tool_use",
+        ))
+        # second assistant entry after tool_result comes in
+        buf.feed(_assistant(
+            text="here's the answer",
+            stop_reason="end_turn",
+        ))
+        closed = buf.feed(_stop_hook_summary())
+        assert closed is True
+
+        resp = buf.drain()
+        assert resp.text == "let me check that\nhere's the answer"
+        assert resp.thinking == "planning the call"
+        assert resp.tool_uses == [
+            {"name": "Bash", "input": {"cmd": "ls"}, "id": "tu_1"},
+        ]
+        # Last assistant entry's stop_reason wins
+        assert resp.stop_reason == "end_turn"
+        assert resp.assistant_entry_count == 2
+
+    def test_drain_resets_buffer(self):
+        """A drained buffer accepts the next turn cleanly."""
+        buf = _TurnBuffer()
+        buf.feed(_assistant(text="first"))
+        buf.feed(_stop_hook_summary())
+        buf.drain()
+        assert buf.is_empty
+
+        buf.feed(_assistant(text="second"))
+        buf.feed(_stop_hook_summary())
+        resp = buf.drain()
+        assert resp.text == "second"
+
+    def test_user_and_unknown_entries_ignored(self):
+        """user / attachment / queue-operation / unknown types don't pollute."""
+        buf = _TurnBuffer()
+        buf.feed(_user())
+        buf.feed({"type": "attachment", "attachment": {"foo": "bar"}})
+        buf.feed({"type": "queue-operation", "operation": "enqueue"})
+        buf.feed({"type": "ai-title", "aiTitle": "Test Session"})
+        buf.feed({"type": "last-prompt", "lastPrompt": "..."})
+        buf.feed({"type": "future-type-we-do-not-know-about", "foo": "bar"})
+        assert buf.is_empty
+
+        # Now a real assistant + stop closes a clean turn.
+        buf.feed(_assistant(text="real response"))
+        buf.feed(_stop_hook_summary())
+        resp = buf.drain()
+        assert resp.text == "real response"
+
+    def test_malformed_assistant_entry(self):
+        """Defensive against schema drift — bad shapes are skipped silently."""
+        buf = _TurnBuffer()
+        # message field missing
+        buf.feed({"type": "assistant", "timestamp": "2026-05-14T05:00:00Z"})
+        # message field not a dict
+        buf.feed({"type": "assistant", "message": "not a dict"})
+        # content not a list
+        buf.feed({"type": "assistant", "message": {"content": "not a list"}})
+        # content block not a dict
+        buf.feed({"type": "assistant", "message": {"content": [None, 42, "str"]}})
+        # block with unknown type
+        buf.feed({
+            "type": "assistant",
+            "message": {"content": [{"type": "future_block_type", "data": "x"}]},
+        })
+        # Buffer must not raise on any of these shapes. Count is 4 because
+        # the "message is a string" shape early-returns before incrementing
+        # (the early-return defends against AttributeError on .get); the
+        # other 4 are dict-shaped (some via the ``or {}`` fallback) and
+        # do increment. Either count is defensible; the invariant we care
+        # about is "no raise + no spurious text/tool_uses".
+        assert buf._assistant_count == 4
+        assert buf._text_blocks == []
+        assert buf._tool_uses == []
+
+        # A real assistant after malformed entries still works.
+        buf.feed(_assistant(text="recovered"))
+        buf.feed(_stop_hook_summary())
+        resp = buf.drain()
+        assert resp.text == "recovered"
+
+    def test_empty_text_blocks_skipped(self):
+        """Empty string text/thinking blocks don't pollute the output."""
+        buf = _TurnBuffer()
+        buf.feed({
+            "type": "assistant",
+            "message": {"content": [
+                {"type": "text", "text": ""},
+                {"type": "text", "text": "real"},
+                {"type": "thinking", "thinking": ""},
+            ], "stop_reason": "end_turn"},
+        })
+        buf.feed(_stop_hook_summary())
+        resp = buf.drain()
+        assert resp.text == "real"
+        assert resp.thinking == ""
+
+    def test_duration_ms_from_timestamps(self):
+        buf = _TurnBuffer()
+        buf.feed(_assistant(text="x", ts="2026-05-14T05:00:00.000Z"))
+        buf.feed(_stop_hook_summary(ts="2026-05-14T05:00:01.500Z"))
+        resp = buf.drain()
+        assert resp.duration_ms == 1500
+
+    def test_duration_ms_zero_when_timestamps_missing(self):
+        buf = _TurnBuffer()
+        buf.feed({"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "x"}], "stop_reason": "end_turn"}})
+        buf.feed({"type": "system", "subtype": "stop_hook_summary"})
+        resp = buf.drain()
+        assert resp.duration_ms == 0
+
+    def test_prevented_continuation_propagates(self):
+        buf = _TurnBuffer()
+        buf.feed(_assistant(text="x"))
+        buf.feed(_stop_hook_summary(prevented=True))
+        resp = buf.drain(prevented_continuation=True)
+        assert resp.prevented_continuation is True
+
+    def test_is_empty_after_drain(self):
+        buf = _TurnBuffer()
+        buf.feed(_assistant(text="x"))
+        assert buf.is_empty is False
+        buf.feed(_stop_hook_summary())
+        buf.drain()
+        assert buf.is_empty is True
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# TmuxTranscriptTailer tests
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def transcript(tmp_path) -> Path:
+    """A fresh empty transcript file in a tmp dir."""
+    p = tmp_path / "session.jsonl"
+    p.touch()
+    return p
+
+
+class _Captor:
+    """Captures callback invocations for assertions."""
+
+    def __init__(self) -> None:
+        self.responses: list[TurnResponse] = []
+        self.raise_on_call: Exception | None = None
+
+    async def __call__(self, response: TurnResponse) -> None:
+        if self.raise_on_call is not None:
+            raise self.raise_on_call
+        self.responses.append(response)
+
+
+class TestTailerReadOnce:
+    """Synchronous semantics — drive read_once() directly, no background task."""
+
+    @pytest.mark.asyncio
+    async def test_empty_file_no_callbacks(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        await tailer.read_once()
+        assert cb.responses == []
+        assert tailer.offset == 0
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_file_no_error(self, tmp_path):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(tmp_path / "does-not-exist.jsonl", cb)
+        consumed = await tailer.read_once()
+        assert consumed == 0
+        assert cb.responses == []
+
+    @pytest.mark.asyncio
+    async def test_single_turn_fires_callback(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        _write_jsonl(transcript, [
+            _user(text="hi"),
+            _assistant(text="hello back"),
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()
+        assert len(cb.responses) == 1
+        assert cb.responses[0].text == "hello back"
+        assert tailer.offset == transcript.stat().st_size
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_fires_callback_per_turn(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        _write_jsonl(transcript, [
+            _user(text="prompt 1"),
+            _assistant(text="reply 1"),
+            _stop_hook_summary(ts="2026-05-14T05:00:01Z"),
+            _user(text="prompt 2"),
+            _assistant(text="reply 2"),
+            _stop_hook_summary(ts="2026-05-14T05:00:03Z"),
+        ])
+        await tailer.read_once()
+        assert [r.text for r in cb.responses] == ["reply 1", "reply 2"]
+
+    @pytest.mark.asyncio
+    async def test_offset_advances_only_on_complete_lines(self, transcript):
+        """Partial trailing line (no \\n) is not consumed."""
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+
+        # First write: one complete entry + a half-written entry (no newline).
+        complete = json.dumps(_user(text="hi")) + "\n"
+        partial = json.dumps(_assistant(text="par"))[:30]  # truncated mid-write
+        transcript.write_text(complete + partial, encoding="utf-8")
+
+        await tailer.read_once()
+        assert cb.responses == []  # no stop_hook_summary yet
+        # Offset advanced past the complete line only.
+        assert tailer.offset == len(complete.encode("utf-8"))
+
+        # Now finish the assistant entry and add stop_hook_summary.
+        finish = json.dumps(_assistant(text="hello")) + "\n"
+        finish += json.dumps(_stop_hook_summary()) + "\n"
+        # Replace the partial chunk with the finished entries.
+        transcript.write_text(complete + finish, encoding="utf-8")
+
+        await tailer.read_once()
+        assert len(cb.responses) == 1
+        assert cb.responses[0].text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_replay_from_persisted_offset(self, transcript):
+        """Two turns written, tailer set to offset after turn 1 — only turn 2 fires."""
+        cb = _Captor()
+        # Pre-populate with turn 1.
+        _write_jsonl(transcript, [
+            _user(text="p1"),
+            _assistant(text="r1"),
+            _stop_hook_summary(),
+        ])
+        turn1_size = transcript.stat().st_size
+
+        # Append turn 2.
+        _append_jsonl(transcript, [
+            _user(text="p2"),
+            _assistant(text="r2"),
+            _stop_hook_summary(),
+        ])
+
+        # Construct tailer at offset = turn1_size; only turn 2 should fire.
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        tailer.set_offset(turn1_size)
+        await tailer.read_once()
+
+        assert len(cb.responses) == 1
+        assert cb.responses[0].text == "r2"
+
+    @pytest.mark.asyncio
+    async def test_truncation_resets_offset(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        _write_jsonl(transcript, [
+            _user(text="p1"),
+            _assistant(text="r1"),
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()
+        assert len(cb.responses) == 1
+        assert tailer.offset > 0
+
+        # Simulate file replacement (smaller content). Tailer should detect
+        # and reset.
+        transcript.write_text("", encoding="utf-8")
+        await tailer.read_once()
+        assert tailer.offset == 0
+
+        # New content after truncation reads cleanly.
+        _write_jsonl(transcript, [
+            _assistant(text="post-truncate"),
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()
+        assert cb.responses[-1].text == "post-truncate"
+
+    @pytest.mark.asyncio
+    async def test_cold_start_replay_skips_empty_buffer(self, transcript):
+        """Mid-file resume past previous turns: stop_hook_summary fires for
+        an empty buffer (we entered after the assistant entries). Tailer
+        should NOT fire an empty callback."""
+        cb = _Captor()
+        # File contains only a stop_hook_summary (simulating mid-file resume
+        # where we missed the earlier entries).
+        _write_jsonl(transcript, [_stop_hook_summary()])
+
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        await tailer.read_once()
+        assert cb.responses == []  # no spurious empty turn
+
+    @pytest.mark.asyncio
+    async def test_callback_exception_is_swallowed(self, transcript):
+        """A misbehaving callback doesn't strand the tailer."""
+        cb = _Captor()
+        cb.raise_on_call = RuntimeError("downstream blew up")
+
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        _write_jsonl(transcript, [
+            _assistant(text="r1"),
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()  # must not raise
+        assert tailer.stats["callback_errors"] == 1
+        assert tailer.stats["turns_fired"] == 1
+        # Offset still advanced — we don't get stuck retrying a bad callback.
+        assert tailer.offset == transcript.stat().st_size
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_line_skipped(self, transcript):
+        cb = _Captor()
+        good_line = json.dumps(_assistant(text="good")) + "\n"
+        bad_line = "{this is not valid json\n"
+        stop_line = json.dumps(_stop_hook_summary()) + "\n"
+        transcript.write_text(good_line + bad_line + stop_line, encoding="utf-8")
+
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        await tailer.read_once()
+        assert tailer.stats["parse_errors"] == 1
+        assert len(cb.responses) == 1
+        assert cb.responses[0].text == "good"
+
+    @pytest.mark.asyncio
+    async def test_set_transcript_path_resets_offset(self, transcript, tmp_path):
+        cb = _Captor()
+        _write_jsonl(transcript, [
+            _assistant(text="old"),
+            _stop_hook_summary(),
+        ])
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        await tailer.read_once()
+        assert tailer.offset > 0
+
+        # Rotate to a new transcript file (e.g. SessionStart hook reported one).
+        new_path = tmp_path / "session2.jsonl"
+        _write_jsonl(new_path, [
+            _assistant(text="new"),
+            _stop_hook_summary(),
+        ])
+        tailer.set_transcript_path(new_path)
+        assert tailer.offset == 0
+        assert tailer.stats["rotations"] == 1
+
+        await tailer.read_once()
+        assert cb.responses[-1].text == "new"
+
+
+class TestTailerBackgroundLoop:
+    """Drive the actual asyncio loop end-to-end (with shortened cadences)."""
+
+    @pytest.mark.asyncio
+    async def test_wake_picks_up_new_entries(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(
+            transcript, cb,
+            fallback_poll_sec=0.05,
+            active_poll_sec=0.01,
+        )
+        await tailer.start()
+        try:
+            _write_jsonl(transcript, [
+                _assistant(text="wake test"),
+                _stop_hook_summary(),
+            ])
+            tailer.wake()
+            # Give the loop a tick.
+            for _ in range(20):
+                await asyncio.sleep(0.02)
+                if cb.responses:
+                    break
+            assert len(cb.responses) == 1
+            assert cb.responses[0].text == "wake test"
+        finally:
+            await tailer.stop()
+
+    @pytest.mark.asyncio
+    async def test_fallback_poll_makes_progress_without_wake(self, transcript):
+        """With no wake() calls, the poll-timeout path still reads new data."""
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(
+            transcript, cb,
+            fallback_poll_sec=0.02,
+            active_poll_sec=0.01,
+        )
+        await tailer.start()
+        try:
+            _write_jsonl(transcript, [
+                _assistant(text="poll test"),
+                _stop_hook_summary(),
+            ])
+            # Wait up to ~0.5s without calling wake().
+            for _ in range(30):
+                await asyncio.sleep(0.02)
+                if cb.responses:
+                    break
+            assert len(cb.responses) == 1
+        finally:
+            await tailer.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        await tailer.start()
+        await tailer.stop()
+        await tailer.stop()  # second call must not raise
+        assert tailer.stats["running"] is False
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        await tailer.start()
+        await tailer.start()  # second call must not spawn a second task
+        await tailer.stop()
+
+    @pytest.mark.asyncio
+    async def test_mark_active_switches_cadence(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(
+            transcript, cb,
+            fallback_poll_sec=10.0,  # huge — would never fire in test window
+            active_poll_sec=0.02,
+        )
+        await tailer.start()
+        try:
+            tailer.mark_active()  # switch to active cadence
+            _write_jsonl(transcript, [
+                _assistant(text="active poll"),
+                _stop_hook_summary(),
+            ])
+            # The active cadence (20ms) should reach the file well within 0.5s.
+            for _ in range(30):
+                await asyncio.sleep(0.02)
+                if cb.responses:
+                    break
+            assert len(cb.responses) == 1
+            # And active flips back to False after the turn fires.
+            assert tailer.stats["active"] is False
+        finally:
+            await tailer.stop()
+
+
+class TestTailerStats:
+    @pytest.mark.asyncio
+    async def test_stats_shape(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        stats = tailer.stats
+        assert {"turns_fired", "lines_read", "parse_errors", "callback_errors",
+                "rotations", "offset", "buffer_empty", "active", "running"} <= set(stats)
+
+    @pytest.mark.asyncio
+    async def test_turns_fired_counter(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        _write_jsonl(transcript, [
+            _assistant(text="a"), _stop_hook_summary(),
+            _assistant(text="b"), _stop_hook_summary(),
+            _assistant(text="c"), _stop_hook_summary(),
+        ])
+        await tailer.read_once()
+        assert tailer.stats["turns_fired"] == 3


### PR DESCRIPTION
## Summary

Closes the PR8a response-capture gap. After `_deliver_turn` pushes a
prompt via tmux send-keys, capture Claude's response by tailing the
JSONL transcript and fire `response_callback` so the broker can route
the reply back to Telegram / Discord / etc.

**Hybrid design (per Brad's greenlight on the design doc):**

- **Data source = transcript JSONL** at
  `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. Turn-end is
  signalled by the `{type: "system", subtype: "stop_hook_summary"}`
  entry that Claude Code itself writes after Stop hooks complete — no
  inference from `stop_reason: end_turn` needed.
- **Latency signal = minimal Stop hook** that POSTs to
  `/agents/<name>/transport/wake`, wake()ing the tailer for sub-second
  response capture without parsing anything client-side.
- **Path discovery = SessionStart hook** that POSTs the canonical
  transcript path to `/agents/<name>/transport/transcript-path`.
  Best-effort mtime-glob is the fallback for cold-starts before the
  hook fires.

The transcript-as-SoT choice also unlocks the deferred context-budget
watchdog and conversation-store backfill (both need to read the same
file).

## What's in this PR

| Layer | File | Lines |
|---|---|---|
| Tailer module | `src/pinky_daemon/tmux_transcript.py` | +566 |
| TmuxSession wiring | `src/pinky_daemon/tmux_session.py` | +220 / -7 |
| Hook scripts + settings.json merge | `src/pinky_daemon/agent_registry.py` | +234 / -15 |
| Endpoints | `src/pinky_daemon/api.py` + `api_models.py` | +104 |
| Session lookup accessor | `src/pinky_daemon/broker.py` | +13 |
| Tailer unit tests (28) | `tests/test_tmux_transcript.py` | +612 |
| TmuxSession integration tests (15) | `tests/test_tmux_session.py` | +317 |

Highlights:

- `TmuxTranscriptTailer` is a pure (file content, wake events) →
  callback invocations function — no asyncio scheduler tricks. Handles
  partial trailing lines (mid-write tolerance), file truncation /
  rotation, malformed JSON, cold-start mid-file replay, callback
  exceptions.
- `_handle_turn_complete` routes to `response_callback` +
  `conversation_store` + `stream_event_callback`; all wrapped to
  swallow exceptions so a misbehaving consumer can't strand the tail
  loop.
- Endpoints HMAC-authenticated via the existing internal-auth
  middleware (same path used by `hook_idle.py`). Generic across
  runtimes — non-tmux agents return `ok: True, session: None` so the
  hooks are cheap no-ops on SDK / codex backends.

## Out of scope (deferred per PR8 docstring)

- **Context-budget watchdog parity.** `TurnResponse.usage` is surfaced;
  plumbing into the existing `_check_context` cadence is a follow-up.
- **`cost_usd` reporting.** Tmux billing is subscription-flat; documented
  gap.
- **Streaming partial responses to the broker.** One-shot-on-turn-complete
  matches `StreamingSession`'s contract; chunked streaming is orthogonal.

## Test plan

- [x] Unit: `TmuxTranscriptTailer` + `_TurnBuffer` (28 tests covering
  partial lines, truncation, replay, callback exceptions, multi-block
  turns, schema drift defense).
- [x] Integration: `TmuxSession` lifecycle (connect starts tailer,
  disconnect stops it, `_deliver_turn` captures meta, `notify_tail` /
  `set_transcript_path` forward correctly).
- [x] End-to-end: synthetic transcript → real tailer → real
  `_handle_turn_complete` → `response_callback` invoked with full
  routing metadata.
- [x] Full suite: 2015 passed, 1 skipped (federation env).
- [x] Ruff clean.
- [ ] Live smoke against a real Dymok agent — pending Brad's approval
  to wire one up.

## Reviewers

Requesting @murzik and @pushok for the same review framework that
caught the PR6 / PR8a issues — concurrent-access and state-machine
contract pins.

cc @bradbrok

🤖 Opened by Barsik