### PR TITLE
chore: carve out docs/review/ as a tracked subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,12 @@ stitch/
 skills/.gitkeep
 skills/*
 website/
-docs/
+# Curated docs that should live in-repo carve out of the gitignore.
+# Pattern is ``docs/*`` (contents) + explicit ``!docs/<tracked>/``
+# negations — NOT ``docs/`` (directory), because git won't descend into
+# an excluded directory to honour child negations.
+docs/*
+!docs/review/
 heartbeat.log
 .coverage
 output/

--- a/docs/review/README.md
+++ b/docs/review/README.md
@@ -1,0 +1,39 @@
+# Review heuristics
+
+This directory holds shared review and authoring heuristics for the agent
+pool — frameworks that compound across PRs when every agent applies the
+same checklist at *write* time, not just at review time.
+
+## Why this directory is tracked
+
+`docs/` is gitignored by default so scratch design notes and local-only
+investigation don't accidentally get committed. `docs/review/` is carved
+out as an explicit tracked subdir because the heuristics here are
+intended to outlive any single PR and to be discoverable next to the
+source they shape.
+
+If you want to add another always-tracked docs subdirectory in the
+future, follow the same pattern: add `!docs/<name>/` to `.gitignore`
+in its own small PR, then ship the actual content separately so the
+review of the carve-out doesn't get tangled with the review of the
+content.
+
+## Current docs
+
+- _Placeholder — heuristics doc landing in a follow-up PR._
+
+## Adding a new heuristic
+
+Heuristics earn their place by surviving the same discipline they
+impose:
+
+1. **n=2 cross-domain** for case-shaped detectors (mechanical detectors
+   for bug-shape patterns).
+2. **Mechanical detector required** — broad pattern recognition without
+   a detector belongs in an open-observations appendix, not a numbered
+   case.
+3. **Self-application** — if the framework can't survive being applied
+   to itself, it's not strong enough yet.
+
+Open observations (n=1 candidates) and case candidates that lack sharp
+detectors live in appendices, not the main framework.


### PR DESCRIPTION
## Summary

Carves out ``docs/review/`` as a tracked subdirectory so curated
review/authoring heuristics can live in-repo alongside the source
they shape. Everything else under ``docs/`` stays gitignored.

The shared review heuristics doc itself (drafted by Pushok during
PR #496's iteration arc, covering matrix-delta-first / concurrency
lens / five-cases framework with composition-drift / fail-on-broken
discipline / tagged-observation pattern) lands in a **follow-up PR**
to keep the carve-out review separate from the content review.

## Why

PR #496 surfaced enough cross-agent review discipline that
externalizing it pays off. Three contributors (Pushok, Murzik, me)
each have complementary review lenses; a single canonical reference
that any agent can load on review tasks means we stop re-deriving
the same heuristics across PRs.

Minimal-scope on purpose — additional always-tracked docs subdirs
(``!docs/architecture/`` etc.) can carve out in their own small PRs
when there's actual content to land.

## Implementation note

Gitignore negations don't work when the parent directory is fully
excluded — git won't descend into ``docs/`` to honour ``!docs/review/``
if it's already pruned the directory. Widened to ``docs/*`` (contents)
+ explicit negations.

## Test plan

- [x] ``git check-ignore -v docs/scratch.md`` → ignored ✓
- [x] ``git check-ignore -v docs/review/README.md`` → tracked ✓
- [x] Local-only scratch files under ``docs/`` still don't get
      accidentally committed

🤖 Opened by Barsik