### PR TITLE
fix(transport): unify response callback payload

### DIFF
--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -27,11 +27,11 @@ from pinky_daemon.context_estimator import ContextTextEstimator
 from pinky_daemon.sessions import MODEL_CONTEXT_SIZES, SessionUsage
 from pinky_daemon.streaming_session import (
     StreamingSessionConfig,
-    StreamingTurnResult,
     _is_outreach_tool,
     _log,
 )
 from pinky_daemon.transport_state import SessionState
+from pinky_daemon.turn_response import TurnResponse
 
 
 @dataclass
@@ -59,7 +59,7 @@ class CodexSession:
         self,
         config: StreamingSessionConfig,
         *,
-        response_callback=None,     # async fn(StreamingTurnResult)
+        response_callback=None,     # async fn(TurnResponse)
         conversation_store=None,    # ConversationStore for history logging
         cost_callback=None,         # fn(agent_name, cost_usd, input_tokens, output_tokens, resume_handle)
         stream_event_callback=None,  # async fn(event: dict) for incremental UI streaming
@@ -235,18 +235,23 @@ class CodexSession:
 
                     # Build turn result
                     response_text = "\n".join(result.text_parts)
-                    turn_result = StreamingTurnResult(
+                    turn_result = TurnResponse(
                         agent_name=self.agent_name,
                         session_id=self.id,
                         platform=platform,
                         chat_id=chat_id,
                         message_id=message_id,
-                        response_text=response_text,
+                        text=response_text,
                         tool_uses=result.tool_uses,
                         used_outreach_tools=any(
                             _is_outreach_tool(tu.get("tool", ""))
                             for tu in result.tool_uses
                         ),
+                        usage={
+                            "input_tokens": result.input_tokens,
+                            "output_tokens": result.output_tokens,
+                            "cached_input_tokens": result.cached_input_tokens,
+                        },
                         total_cost_usd=0.0,  # Codex doesn't report cost in JSONL
                         num_turns=1,
                         model_usage={

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.transport_state import SessionState, StateMachine, Trigger
+from pinky_daemon.turn_response import TurnResponse
 
 # Models with native 1M context (SDK reports 200k incorrectly)
 _1M_MODELS = {"claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7"}
@@ -73,21 +74,9 @@ class StreamingSessionConfig:
     restart_reason: str = ""  # "context_restart", "auto_restart", etc. — cleared after wake prompt
 
 
-@dataclass
-class StreamingTurnResult:
-    """Completed assistant turn details for broker/API handling."""
-
-    agent_name: str
-    session_id: str
-    platform: str = ""
-    chat_id: str = ""
-    message_id: str = ""
-    response_text: str = ""
-    tool_uses: list[dict] = field(default_factory=list)
-    used_outreach_tools: bool = False
-    total_cost_usd: float = 0.0
-    num_turns: int = 0
-    model_usage: dict = field(default_factory=dict)
+# Backward-compatible import name for older callers/tests. New code should use
+# TurnResponse directly.
+StreamingTurnResult = TurnResponse
 
 
 _OUTREACH_TOOL_NAMES = {
@@ -207,7 +196,7 @@ class StreamingSession:
         self,
         config: StreamingSessionConfig,
         *,
-        response_callback=None,  # async fn(StreamingTurnResult)
+        response_callback=None,  # async fn(TurnResponse)
         conversation_store=None,  # ConversationStore for history logging
         cost_callback=None,  # fn(agent_name, cost_usd, input_tokens, output_tokens, resume_handle)
         analytics_store=None,
@@ -846,18 +835,19 @@ class StreamingSession:
                         continue
 
                     # Turn complete — fire response callback
-                    turn_result = StreamingTurnResult(
+                    turn_result = TurnResponse(
                         agent_name=self.agent_name,
                         session_id=self.id,
                         platform=resp_platform,
                         chat_id=resp_chat_id,
                         message_id=resp_message_id,
-                        response_text=self._last_response,
+                        text=self._last_response,
                         tool_uses=list(turn_tool_uses),
                         used_outreach_tools=any(
                             _is_outreach_tool(tool_use.get("tool", ""))
                             for tool_use in turn_tool_uses
                         ),
+                        usage=msg.usage or {},
                         total_cost_usd=msg.total_cost_usd or 0.0,
                         num_turns=msg.num_turns or 0,
                         model_usage=msg.model_usage or {},

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -70,10 +70,14 @@ from __future__ import annotations
 import asyncio
 import shlex
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
-from pinky_daemon.streaming_session import StreamingSessionConfig, _log
+from pinky_daemon.streaming_session import (
+    StreamingSessionConfig,
+    _is_outreach_tool,
+    _log,
+)
 from pinky_daemon.tmux_transcript import (
     TmuxTranscriptTailer,
     TurnResponse,
@@ -970,14 +974,24 @@ class TmuxSession:
 
         # Response callback — the broker-routing payload. Includes the
         # captured inbound metadata so the broker can route the reply.
-        if self._response_callback and response.text:
+        if self._response_callback and (response.text or response.tool_uses):
             try:
                 meta = dict(self._inflight_meta)
-                result = self._response_callback(
-                    self.agent_name,
-                    response.text,
-                    meta,
+                turn_result = replace(
+                    response,
+                    agent_name=self.agent_name,
+                    session_id=self.id,
+                    platform=meta.get("platform", ""),
+                    chat_id=meta.get("chat_id", ""),
+                    message_id=meta.get("message_id", ""),
+                    used_outreach_tools=any(
+                        _is_outreach_tool(
+                            tool_use.get("tool", "") or tool_use.get("name", "")
+                        )
+                        for tool_use in response.tool_uses
+                    ),
                 )
+                result = self._response_callback(turn_result)
                 if asyncio.iscoroutine(result):
                     await result
             except Exception as e:

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -48,9 +48,10 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Awaitable, Callable
+
+from pinky_daemon.turn_response import TurnResponse
 
 
 def _log(msg: str) -> None:
@@ -79,65 +80,6 @@ _ACTIVE_POLL_SEC = 0.2
 # while keeping single-read memory bounded. Excess data stays on disk and
 # is picked up by the next loop iteration.
 _MAX_READ_CHUNK_BYTES = 10 * 1024 * 1024
-
-
-# ──────────────────────────────────────────────────────────────────────────
-# TurnResponse — the payload fired through on_turn_complete
-# ──────────────────────────────────────────────────────────────────────────
-
-
-@dataclass
-class TurnResponse:
-    """One conversational turn's assembled output, as seen by the broker.
-
-    Aggregates across all ``assistant`` entries between two consecutive
-    ``stop_hook_summary`` boundaries (i.e. one user-visible turn, which
-    may have included multiple tool-use cycles).
-
-    Mirrors the response shape ``StreamingSession`` synthesizes when its
-    SDK loop completes a turn — broker code that already consumes that
-    shape works against TmuxSession unchanged.
-    """
-
-    text: str = ""
-    """Concatenation of all ``text`` content blocks across the turn,
-    joined by ``\\n``. Empty string if the turn produced no text (e.g.
-    pure tool-use turn that ended on max_tokens)."""
-
-    thinking: str = ""
-    """Concatenation of all ``thinking`` content blocks, joined by
-    ``\\n``. Usually empty unless thinking is enabled at the model level."""
-
-    tool_uses: list[dict] = field(default_factory=list)
-    """Tool-use blocks in order of emission. Each dict has the raw
-    ``{name, input, id}`` shape from the transcript — opaque to the
-    tailer, parsed by downstream consumers (analytics / conversation
-    store) if they care."""
-
-    stop_reason: str = ""
-    """Final assistant entry's ``stop_reason`` (``end_turn`` / ``max_tokens`` /
-    ``refusal`` / ``tool_use``). Empty if the last entry had no
-    stop_reason (shouldn't happen in practice)."""
-
-    usage: dict = field(default_factory=dict)
-    """Last assistant entry's ``message.usage`` dict (input/output tokens,
-    cache stats). Single point-in-time snapshot rather than a sum —
-    Claude Code's usage values are cumulative-per-turn already."""
-
-    prevented_continuation: bool = False
-    """Whether a Stop hook blocked the natural end-of-turn. Surfaced
-    from the ``stop_hook_summary`` entry. Always False in practice for
-    PinkyBot's existing hooks but worth carrying through."""
-
-    duration_ms: int = 0
-    """Wall-clock from first entry of the turn to ``stop_hook_summary``,
-    derived from the transcript timestamps. Approximate — only as
-    accurate as the timestamps Claude Code wrote."""
-
-    assistant_entry_count: int = 0
-    """How many ``assistant`` entries contributed to this turn. >1 means
-    a tool-use loop fired. Useful diagnostic — surfaced through the
-    callback so consumers can tag long-running turns."""
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/src/pinky_daemon/turn_response.py
+++ b/src/pinky_daemon/turn_response.py
@@ -1,0 +1,83 @@
+"""Unified completed-turn payload for agent transport backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(init=False)
+class TurnResponse:
+    """Completed assistant turn details for broker/API handling.
+
+    The SDK, Codex CLI, and tmux transcript backends all emit this single
+    callback shape. Transport-specific parsers may populate only the fields
+    they know; routing consumers can rely on the routing fields, text,
+    tool-use fields, and usage dictionaries being present.
+    """
+
+    agent_name: str = ""
+    session_id: str = ""
+    platform: str = ""
+    chat_id: str = ""
+    message_id: str = ""
+    text: str = ""
+    thinking: str = ""
+    tool_uses: list[dict] = field(default_factory=list)
+    used_outreach_tools: bool = False
+    stop_reason: str = ""
+    usage: dict = field(default_factory=dict)
+    model_usage: dict = field(default_factory=dict)
+    total_cost_usd: float = 0.0
+    num_turns: int = 0
+    prevented_continuation: bool = False
+    duration_ms: int = 0
+    assistant_entry_count: int = 0
+
+    def __init__(
+        self,
+        *,
+        agent_name: str = "",
+        session_id: str = "",
+        platform: str = "",
+        chat_id: str = "",
+        message_id: str = "",
+        text: str = "",
+        response_text: str | None = None,
+        thinking: str = "",
+        tool_uses: list[dict] | None = None,
+        used_outreach_tools: bool = False,
+        stop_reason: str = "",
+        usage: dict | None = None,
+        model_usage: dict | None = None,
+        total_cost_usd: float = 0.0,
+        num_turns: int = 0,
+        prevented_continuation: bool = False,
+        duration_ms: int = 0,
+        assistant_entry_count: int = 0,
+    ) -> None:
+        self.agent_name = agent_name
+        self.session_id = session_id
+        self.platform = platform
+        self.chat_id = chat_id
+        self.message_id = message_id
+        self.text = text if response_text is None else response_text
+        self.thinking = thinking
+        self.tool_uses = list(tool_uses or [])
+        self.used_outreach_tools = used_outreach_tools
+        self.stop_reason = stop_reason
+        self.usage = dict(usage or {})
+        self.model_usage = dict(model_usage or {})
+        self.total_cost_usd = total_cost_usd
+        self.num_turns = num_turns
+        self.prevented_continuation = prevented_continuation
+        self.duration_ms = duration_ms
+        self.assistant_entry_count = assistant_entry_count
+
+    @property
+    def response_text(self) -> str:
+        """Compatibility alias for the pre-#498 API callback field."""
+        return self.text
+
+    @response_text.setter
+    def response_text(self, value: str) -> None:
+        self.text = value

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -675,13 +675,13 @@ def test_stats_shape_matches_broker_consumer_keys() -> None:
 
 
 class _AsyncCollector:
-    """Drop-in async callback that records (agent_name, text, meta) calls."""
+    """Drop-in async callback that records TurnResponse calls."""
 
     def __init__(self) -> None:
-        self.calls: list[tuple[str, str, dict]] = []
+        self.calls: list[TurnResponse] = []
 
-    async def __call__(self, agent_name, text, meta):
-        self.calls.append((agent_name, text, meta))
+    async def __call__(self, response: TurnResponse):
+        self.calls.append(response)
 
 
 def _make_session_with_response_cb(
@@ -761,7 +761,7 @@ async def test_deliver_turn_clears_meta_on_send_keys_failure() -> None:
 @pytest.mark.asyncio
 async def test_handle_turn_complete_fires_response_callback() -> None:
     """End-to-end: synthetic TurnResponse → response_callback called with
-    correct (agent_name, text, meta) tuple."""
+    correct unified routing payload."""
     cb = _AsyncCollector()
     ss, _ = _make_session_with_response_cb(response_cb=cb)
     ss._state_machine._state = SessionState.CONNECTED
@@ -778,23 +778,58 @@ async def test_handle_turn_complete_fires_response_callback() -> None:
     await ss._handle_turn_complete(response)
 
     assert len(cb.calls) == 1
-    agent, text, meta = cb.calls[0]
-    assert agent == "dymok"
-    assert text == "hello back"
-    assert meta == {"platform": "telegram", "chat_id": "12345", "message_id": "m1"}
+    result = cb.calls[0]
+    assert result.agent_name == "dymok"
+    assert result.session_id == ss.id
+    assert result.response_text == "hello back"
+    assert result.platform == "telegram"
+    assert result.chat_id == "12345"
+    assert result.message_id == "m1"
+    assert result.usage == {"input_tokens": 10, "output_tokens": 5}
     # Meta cleared after firing — next turn starts clean.
     assert ss._inflight_meta == {}
 
 
 @pytest.mark.asyncio
 async def test_handle_turn_complete_skips_callback_for_empty_text() -> None:
-    """Empty response (e.g. tool-use-only turn) doesn't fire the
-    response_callback — broker has no reply to deliver."""
+    """Empty response with no tool activity doesn't fire the response_callback."""
     cb = _AsyncCollector()
     ss, _ = _make_session_with_response_cb(response_cb=cb)
     response = TurnResponse(text="", stop_reason="tool_use")
     await ss._handle_turn_complete(response)
     assert cb.calls == []
+
+
+@pytest.mark.asyncio
+async def test_handle_turn_complete_fires_callback_for_tool_only_turn() -> None:
+    """Tool-only turns still notify the broker so it can stop typing and
+    suppress plain-text fallback when an outreach tool handled delivery.
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    ss._inflight_meta = {
+        "platform": "telegram",
+        "chat_id": "12345",
+        "message_id": "m1",
+    }
+    response = TurnResponse(
+        text="",
+        stop_reason="tool_use",
+        tool_uses=[
+            {
+                "name": "mcp__pinky-messaging__send",
+                "input": {"chat_id": "12345", "text": "sent via tool"},
+                "id": "toolu_1",
+            }
+        ],
+    )
+    await ss._handle_turn_complete(response)
+
+    assert len(cb.calls) == 1
+    result = cb.calls[0]
+    assert result.response_text == ""
+    assert result.chat_id == "12345"
+    assert result.used_outreach_tools is True
 
 
 @pytest.mark.asyncio
@@ -958,12 +993,14 @@ async def test_end_to_end_tailer_to_response_callback(tmp_path) -> None:
     # Drive the tailer to read.
     await ss._tailer.read_once()
 
-    # response_callback fired with the right tuple.
+    # response_callback fired with the right unified payload.
     assert len(cb.calls) == 1
-    agent, text, meta = cb.calls[0]
-    assert agent == "dymok"
-    assert text == "hello there"
-    assert meta == {"platform": "telegram", "chat_id": "777", "message_id": "m42"}
+    result = cb.calls[0]
+    assert result.agent_name == "dymok"
+    assert result.response_text == "hello there"
+    assert result.platform == "telegram"
+    assert result.chat_id == "777"
+    assert result.message_id == "m42"
 
     await ss.disconnect()
 
@@ -1141,10 +1178,10 @@ async def test_multi_prompt_routing_no_cross_user_leak(tmp_path) -> None:
 
     # Critical: response A was routed to chat A, NOT chat B (the original bug).
     assert len(cb.calls) == 1
-    agent, text, meta = cb.calls[0]
-    assert text == "response A"
-    assert meta["chat_id"] == "A", (
-        f"response A leaked to wrong chat: {meta} — original Case 1 bug regression"
+    result = cb.calls[0]
+    assert result.response_text == "response A"
+    assert result.chat_id == "A", (
+        f"response A leaked to wrong chat: {result} — original Case 1 bug regression"
     )
 
     # Worker has now dispatched turn B (meta swapped).
@@ -1171,9 +1208,9 @@ async def test_multi_prompt_routing_no_cross_user_leak(tmp_path) -> None:
 
     # Critical: response B was routed to chat B.
     assert len(cb.calls) == 2
-    agent, text, meta = cb.calls[1]
-    assert text == "response B"
-    assert meta["chat_id"] == "B"
+    result = cb.calls[1]
+    assert result.response_text == "response B"
+    assert result.chat_id == "B"
 
     await ss.disconnect()
 
@@ -1334,10 +1371,10 @@ async def test_force_restart_resumes_tailer(tmp_path) -> None:
     assert len(cb.calls) == 1, (
         "post-restart turn should have completed end-to-end"
     )
-    agent, text, meta = cb.calls[0]
-    assert agent == "dymok"
-    assert text == "alive after restart"
-    assert meta["chat_id"] == "999"
+    result = cb.calls[0]
+    assert result.agent_name == "dymok"
+    assert result.response_text == "alive after restart"
+    assert result.chat_id == "999"
 
     await ss.disconnect()
 
@@ -1435,9 +1472,9 @@ async def test_stop_tailer_drains_buffer_for_same_path_resume(tmp_path) -> None:
 
     # Callback fires with ONLY Y's text — no "partial from X" prefix.
     assert len(cb.calls) == 1, "Y's turn should have fired exactly one callback"
-    _, text, _ = cb.calls[0]
-    assert text == "response from Y", (
-        f"expected clean Y response, got {text!r} — "
+    result = cb.calls[0]
+    assert result.response_text == "response from Y", (
+        f"expected clean Y response, got {result.response_text!r} — "
         f"if this contains 'partial from X', the same-path-resume "
         f"buffer-leak regression has reopened"
     )


### PR DESCRIPTION
## Summary

Closes #498.

This PR unifies the transport response callback contract around a single `TurnResponse` object instead of mixing backend-specific callback shapes.

Changes:
- Adds `pinky_daemon.turn_response.TurnResponse` as the shared completed-turn payload.
- Keeps `StreamingTurnResult` as a compatibility alias while moving SDK streaming onto `TurnResponse`.
- Moves Codex session response callbacks onto the same `TurnResponse` payload.
- Re-exports `TurnResponse` through `tmux_transcript` and has `TmuxSession` populate `agent_name`, `session_id`, `platform`, `chat_id`, `message_id`, `used_outreach_tools`, text, tool uses, and usage before firing the callback.
- Makes tmux fire callbacks for `text or tool_uses`, matching SDK/Codex behavior so broker typing cleanup and outreach-tool fallback suppression still run on tool-only turns.
- Updates tmux response tests to assert the unified single-argument payload.

## Validation

- `pytest tests/test_tmux_transcript.py tests/test_tmux_session.py -q` -> 92 passed
- `pytest tests/test_streaming_session.py tests/test_api.py::TestStreamingSession tests/test_codex_session.py -q` -> 56 passed
- `pytest tests/test_api.py tests/test_tmux_session.py tests/test_tmux_transcript.py tests/test_codex_session.py tests/test_streaming_session.py -q` -> 431 passed
- `pytest -q --ignore=tests/pinky_federation` -> 2049 passed, 1 skipped
- `ruff check src/pinky_daemon/turn_response.py src/pinky_daemon/streaming_session.py src/pinky_daemon/codex_session.py src/pinky_daemon/tmux_session.py src/pinky_daemon/tmux_transcript.py tests/test_tmux_session.py tests/test_api.py tests/test_codex_session.py tests/test_streaming_session.py` -> clean
- `git diff --check` -> clean

Known test noise: shared MCP port `8890` is already in use in this local environment, producing the same warning seen on the prior auth PR.