### PR TITLE
feat(transport): add tmux transport selector

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -339,7 +339,8 @@ class Agent:
     working_status: str = "idle"  # idle, working, offline
     working_status_updated_at: float = 0.0  # When working_status last changed
     last_seen_at: float = 0.0  # Server-side presence: updated on delivery/turn completion
-    runtime: str = "claude_sdk"  # Agent runtime: claude_sdk, codex_cli, opencode, tmux
+    runtime: str = "claude_sdk"  # Agent runtime: claude_sdk, codex_cli, opencode
+    transport: str = "sdk"  # Claude runtime transport: sdk, tmux
     provider_url: str = ""   # e.g. "http://localhost:11434" for Ollama, empty = Anthropic default
     provider_key: str = ""   # API key override, empty = use ANTHROPIC_API_KEY env var
     provider_model: str = ""  # model name override (e.g. "llama3.2"), empty = use agent.model
@@ -403,6 +404,7 @@ class Agent:
             "working_status_updated_at": self.working_status_updated_at,
             "last_seen_at": self.last_seen_at,
             "runtime": self.runtime,
+            "transport": self.transport,
             "provider_url": self.provider_url,
             "provider_key": self.provider_key,
             "provider_model": self.provider_model,
@@ -758,6 +760,7 @@ class AgentRegistry:
                 plain_text_fallback INTEGER NOT NULL DEFAULT 0,
                 role TEXT NOT NULL DEFAULT '',
                 runtime TEXT NOT NULL DEFAULT 'claude_sdk',
+                transport TEXT NOT NULL DEFAULT 'sdk',
                 created_at REAL NOT NULL,
                 updated_at REAL NOT NULL
             );
@@ -1030,6 +1033,7 @@ class AgentRegistry:
             ("watchdog_config", "TEXT NOT NULL DEFAULT '{}'"),
             ("last_seen_at", "REAL NOT NULL DEFAULT 0"),
             ("runtime", "TEXT NOT NULL DEFAULT 'claude_sdk'"),
+            ("transport", "TEXT NOT NULL DEFAULT 'sdk'"),
             # Ferry peer-fleet ACL — list of AgentCardSelector dicts
             # (separate identity primitive from approved_users; default deny-all)
             ("peer_fleet_acl", "TEXT NOT NULL DEFAULT '[]'"),
@@ -1463,7 +1467,7 @@ except Exception:
                         "clock_aligned", "auto_sleep_hours", "plain_text_fallback", "voice_config", "role",
                         "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
                         "librarian_enabled", "librarian_schedule",
-                        "runtime", "provider_url", "provider_key", "provider_model", "provider_ref",
+                        "runtime", "transport", "provider_url", "provider_key", "provider_model", "provider_ref",
                         "thinking_effort", "strict_effort_enforcement"):
                 if key in kwargs:
                     updates[key] = kwargs[key]
@@ -1548,6 +1552,7 @@ except Exception:
                 librarian_enabled=kwargs.get("librarian_enabled", False),
                 librarian_schedule=kwargs.get("librarian_schedule", "0 4 * * *"),
                 runtime=kwargs.get("runtime", "claude_sdk"),
+                transport=kwargs.get("transport", "sdk"),
                 provider_url=kwargs.get("provider_url", ""),
                 provider_key=kwargs.get("provider_key", ""),
                 provider_model=kwargs.get("provider_model", ""),
@@ -1568,10 +1573,10 @@ except Exception:
                     wake_interval, clock_aligned, auto_sleep_hours, voice_config, role,
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
                     librarian_enabled, librarian_schedule,
-                    runtime, provider_url, provider_key, provider_model, provider_ref,
+                    runtime, transport, provider_url, provider_key, provider_model, provider_ref,
                     thinking_effort, strict_effort_enforcement, watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -1584,7 +1589,7 @@ except Exception:
                  json.dumps(agent.voice_config), agent.role,
                  int(agent.dream_enabled), agent.dream_schedule, agent.dream_timezone, agent.dream_model, int(agent.dream_notify),
                  int(agent.librarian_enabled), agent.librarian_schedule,
-                 agent.runtime, agent.provider_url, agent.provider_key,
+                 agent.runtime, agent.transport, agent.provider_url, agent.provider_key,
                  agent.provider_model, agent.provider_ref,
                  agent.thinking_effort, int(agent.strict_effort_enforcement),
                  json.dumps(agent.watchdog_config),
@@ -1605,7 +1610,7 @@ except Exception:
         "dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify, "
         "librarian_enabled, librarian_schedule, "
         "working_status, working_status_updated_at, "
-        "runtime, provider_url, provider_key, provider_model, provider_ref, "
+        "runtime, transport, provider_url, provider_key, provider_model, provider_ref, "
         "disallowed_tools, thinking_effort, watchdog_config, last_seen_at, "
         "strict_effort_enforcement"
     )
@@ -3227,15 +3232,16 @@ except Exception:
             working_status=row[37] if len(row) > 37 and row[37] else "idle",
             working_status_updated_at=row[38] if len(row) > 38 else 0.0,
             runtime=row[39] if len(row) > 39 and row[39] else "claude_sdk",
-            provider_url=row[40] if len(row) > 40 and row[40] else "",
-            provider_key=row[41] if len(row) > 41 and row[41] else "",
-            provider_model=row[42] if len(row) > 42 and row[42] else "",
-            provider_ref=row[43] if len(row) > 43 and row[43] else "",
-            disallowed_tools=json.loads(row[44]) if len(row) > 44 and row[44] else [],
-            thinking_effort=row[45] if len(row) > 45 and row[45] else "medium",
-            watchdog_config=json.loads(row[46]) if len(row) > 46 and row[46] else {},
-            last_seen_at=row[47] if len(row) > 47 else 0.0,
-            strict_effort_enforcement=bool(row[48]) if len(row) > 48 else False,
+            transport=row[40] if len(row) > 40 and row[40] else "sdk",
+            provider_url=row[41] if len(row) > 41 and row[41] else "",
+            provider_key=row[42] if len(row) > 42 and row[42] else "",
+            provider_model=row[43] if len(row) > 43 and row[43] else "",
+            provider_ref=row[44] if len(row) > 44 and row[44] else "",
+            disallowed_tools=json.loads(row[45]) if len(row) > 45 and row[45] else [],
+            thinking_effort=row[46] if len(row) > 46 and row[46] else "medium",
+            watchdog_config=json.loads(row[47]) if len(row) > 47 and row[47] else {},
+            last_seen_at=row[48] if len(row) > 48 else 0.0,
+            strict_effort_enforcement=bool(row[49]) if len(row) > 49 else False,
         )
 
     # ── Cost Tracking ──────────────────────────────────────

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1819,6 +1819,7 @@ def create_api(
             StreamingSession,
             StreamingSessionConfig,
         )
+        from pinky_daemon.tmux_session import TmuxSession
 
         agent = agents.get(agent_name)
         if not agent or not agent.enabled:
@@ -1880,6 +1881,7 @@ def create_api(
             return "claude_sdk"
 
         runtime = runtime_from_legacy_provider(agent)
+        transport = (getattr(agent, "transport", "") or "sdk").strip() or "sdk"
         if runtime == "opencode":
             if os.environ.get("PINKY_ENABLE_OPENCODE", "0") == "1":
                 msg = "opencode runtime is enabled but OpencodeSession is not implemented yet"
@@ -1893,8 +1895,20 @@ def create_api(
             msg = f"unknown runtime '{runtime}' for agent '{agent_name}'"
             _log(f"api: {msg}")
             raise HTTPException(400, msg)
+        if transport not in {"sdk", "tmux"}:
+            msg = f"unknown transport '{transport}' for agent '{agent_name}'"
+            _log(f"api: {msg}")
+            raise HTTPException(400, msg)
+        if runtime != "claude_sdk" and transport != "sdk":
+            msg = (
+                f"transport '{transport}' is only valid for claude_sdk runtime "
+                f"(agent '{agent_name}' has runtime '{runtime}')"
+            )
+            _log(f"api: {msg}")
+            raise HTTPException(400, msg)
 
         is_codex = runtime == "codex_cli"
+        is_tmux = runtime == "claude_sdk" and transport == "tmux"
         resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
         if is_codex:
             resolved_provider_url = "codex_cli"
@@ -1949,8 +1963,13 @@ def create_api(
         callback = await _make_streaming_response_callback()
         sid_callback = await _make_streaming_resume_handle_callback(agent_name, label)
 
-        # Select session class based on the persisted runtime.
-        SessionClass = CodexSession if is_codex else StreamingSession  # noqa: N806
+        # Select session class based on persisted runtime + Claude transport.
+        if is_tmux:
+            SessionClass = TmuxSession  # noqa: N806
+        elif is_codex:
+            SessionClass = CodexSession  # noqa: N806
+        else:
+            SessionClass = StreamingSession  # noqa: N806
 
         init_kwargs = {
             "response_callback": callback,
@@ -1961,12 +1980,12 @@ def create_api(
         }
         # Auth-failure detection is currently only wired for the SDK-based
         # StreamingSession. Codex sessions don't surface an equivalent
-        # "authentication_failed" signal — they rely on a separate provider
-        # token lifecycle — so we skip the hooks there.
-        if not is_codex:
+        # "authentication_failed" signal, and TmuxSession relies on the
+        # interactive Claude REPL + hook/tailer path, so skip the hooks there.
+        if not is_codex and not is_tmux:
             init_kwargs["auth_alert_callback"] = _on_auth_failure
             init_kwargs["auth_success_callback"] = _on_auth_success
-        if is_codex:
+        if is_codex or is_tmux:
             init_kwargs["stream_event_callback"] = await _make_streaming_event_callback(agent_name, label)
 
         ss = SessionClass(config, **init_kwargs)
@@ -1981,7 +2000,7 @@ def create_api(
                 session_id=ss.id,
                 agent_name=agent_name,
                 session_label=label,
-                provider=runtime if is_codex else (resolved_provider_url or "default"),
+                provider="tmux" if is_tmux else (runtime if is_codex else (resolved_provider_url or "default")),
                 model=effective_model or "",
             )
             analytics.log_activity(
@@ -3952,6 +3971,7 @@ def create_api(
             role=req.role,
             heartbeat_interval=req.heartbeat_interval,
             runtime=req.runtime,
+            transport=req.transport,
             provider_url=req.provider_url,
             provider_key=req.provider_key,
             provider_model=req.provider_model,

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -306,6 +306,7 @@ class RegisterAgentRequest(BaseModel):
     role: str = ""
     heartbeat_interval: int = 0
     runtime: str = "claude_sdk"
+    transport: str = "sdk"  # Claude runtime transport: sdk, tmux
     provider_url: str = ""  # ANTHROPIC_BASE_URL override (e.g. Ollama endpoint)
     provider_key: str = ""  # ANTHROPIC_API_KEY override
     provider_model: str = ""  # Model name override for this provider
@@ -345,6 +346,7 @@ class UpdateAgentRequest(BaseModel):
     dream_model: str | None = None  # Model override for dream runs (empty = agent's model)
     dream_notify: bool | None = None  # Inject dream summary into morning wake context
     runtime: str | None = None  # Runtime selector: claude_sdk, codex_cli, opencode
+    transport: str | None = None  # Claude runtime transport: sdk, tmux
     provider_url: str | None = None  # ANTHROPIC_BASE_URL override (e.g. Ollama endpoint)
     provider_key: str | None = None  # ANTHROPIC_API_KEY override
     provider_model: str | None = None  # Model name override for this provider

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -11,16 +11,8 @@ Each TmuxSession owns a single detached tmux session named after the
 agent (``pinky-<agent_name>``). Inside that tmux session, an
 interactive ``claude --continue --dangerously-skip-permissions`` REPL
 runs. Inbound messages are delivered via ``tmux send-keys``; outbound
-responses are captured by a separate **response pipeline** that lives
-outside this class (transcript-file tailing or Stop-hook subscription —
-the design choice is PR8b, not landed here).
-
-This skeleton lands the state-machine choreography, tmux subprocess
-plumbing, and the worker/queue scaffold. The actual response capture is
-stubbed — ``send()`` accepts and queues turns; the worker runs the
-``tmux send-keys`` half of the round trip; collecting Claude's response
-and firing ``response_callback`` is left as a TODO for the response
-pipeline PR.
+responses are captured by transcript-file tailing and delivered through
+the shared ``response_callback`` contract.
 
 ## State machine integration
 
@@ -52,9 +44,6 @@ session stays alive.
 
 ## Out of scope for PR8
 
-- Response capture pipeline (transcript tailing OR Stop-hook listener).
-  Tracked as a follow-up; the contract is documented on
-  ``_TODO_capture_response``.
 - Context-budget watchdog (``_check_context``). StreamingSession's
   context warn/restart logic is SDK-specific (uses ``get_context_usage``);
   the equivalent for tmux requires reading the transcript file's token
@@ -73,6 +62,7 @@ import time
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
+from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.streaming_session import (
     StreamingSessionConfig,
     _is_outreach_tool,
@@ -346,7 +336,7 @@ class TmuxSession:
             "reconnects": 0,
             "auto_restarts": 0,
         }
-        self.usage = None  # SessionUsage stub — populated when response pipeline lands
+        self.usage = SessionUsage()
 
         # Effort knob. tmux's claude REPL doesn't currently honor a
         # per-session effort override (CLAUDE_EFFORT env is set at
@@ -958,13 +948,14 @@ class TmuxSession:
             try:
                 evt = {
                     "type": "turn_complete",
+                    "agent_name": self.agent_name,
                     "stop_reason": response.stop_reason,
                     "usage": response.usage,
                     "duration_ms": response.duration_ms,
                     "assistant_entry_count": response.assistant_entry_count,
                     "tool_use_count": len(response.tool_uses),
                 }
-                result = self._stream_event_callback(self.agent_name, evt)
+                result = self._stream_event_callback(evt)
                 if asyncio.iscoroutine(result):
                     await result
             except Exception as e:

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -27,6 +27,7 @@ class TestAgentCRUD:
         assert agent.display_name == "Oleg"
         assert agent.model == "opus"
         assert agent.runtime == "claude_sdk"
+        assert agent.transport == "sdk"
         assert agent.enabled is True
         assert agent.created_at > 0
 
@@ -46,6 +47,7 @@ class TestAgentCRUD:
             groups=["butter-team"],
             max_sessions=3,
             runtime="codex_cli",
+            transport="sdk",
         )
         assert agent.model == "sonnet"
         assert agent.soul == "# Leo the Worker"
@@ -54,6 +56,7 @@ class TestAgentCRUD:
         assert agent.groups == ["butter-team"]
         assert agent.max_sessions == 3
         assert agent.runtime == "codex_cli"
+        assert agent.transport == "sdk"
 
     def test_register_update(self, registry):
         registry.register("oleg", model="sonnet")
@@ -130,6 +133,7 @@ class TestAgentCRUD:
         assert d["display_name"] == "Test Agent"
         assert d["model"] == "opus"
         assert d["runtime"] == "claude_sdk"
+        assert d["transport"] == "sdk"
         assert d["enabled"] is True
 
     def test_runtime_column_exists_with_default(self, registry):
@@ -143,8 +147,20 @@ class TestAgentCRUD:
         agent = registry.register("runtime-default")
         assert agent.runtime == "claude_sdk"
 
+    def test_transport_column_exists_with_default(self, registry):
+        columns = {
+            row[1]: row
+            for row in registry._db.execute("PRAGMA table_info(agents)").fetchall()
+        }
+        assert "transport" in columns
+        assert columns["transport"][4] == "'sdk'"
+
+        agent = registry.register("transport-default")
+        assert agent.transport == "sdk"
+
     def test_first_register_with_all_kwargs_persists_every_field(self, registry):
-        # Regression: pre-#358 INSERT omitted provider_url/key/model/ref, thinking_effort, runtime.
+        # Regression: pre-#358 INSERT omitted provider_url/key/model/ref,
+        # thinking_effort, runtime-adjacent fields.
         # A single register() call (no follow-up UPDATE) must persist all of them.
         agent = registry.register(
             "full-kwargs-agent",
@@ -153,7 +169,8 @@ class TestAgentCRUD:
             provider_model="gpt-5",
             provider_ref="some-provider-id",
             thinking_effort="high",
-            runtime="codex_cli",
+            runtime="claude_sdk",
+            transport="tmux",
         )
         # Verify via the returned object (built from INSERT path)
         assert agent.provider_url == "https://api.openai.com/v1"
@@ -161,7 +178,8 @@ class TestAgentCRUD:
         assert agent.provider_model == "gpt-5"
         assert agent.provider_ref == "some-provider-id"
         assert agent.thinking_effort == "high"
-        assert agent.runtime == "codex_cli"
+        assert agent.runtime == "claude_sdk"
+        assert agent.transport == "tmux"
 
         # Verify via a fresh get() to confirm DB round-trip, not just in-memory object
         fetched = registry.get("full-kwargs-agent")
@@ -170,7 +188,8 @@ class TestAgentCRUD:
         assert fetched.provider_model == "gpt-5"
         assert fetched.provider_ref == "some-provider-id"
         assert fetched.thinking_effort == "high"
-        assert fetched.runtime == "codex_cli"
+        assert fetched.runtime == "claude_sdk"
+        assert fetched.transport == "tmux"
 
     def test_runtime_codex_cli_backfill_is_one_shot_and_idempotent(self, registry):
         registry.register("legacy-codex", provider_url="codex_cli", runtime="claude_sdk")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -700,6 +700,61 @@ class TestAPI:
                 assert session._config.provider_key == "global-openai-key"
                 assert session._config.model == "gpt-5-codex"
 
+    def test_wake_uses_tmux_session_for_tmux_transport(self):
+        async def fake_connect(self):
+            from pinky_daemon.transport_state import SessionState
+            self._state_machine._state = SessionState.CONNECTED
+            if self._on_resume_handle:
+                await self._on_resume_handle(self.agent_name, self.resume_handle)
+
+        async def fake_send(
+            self,
+            prompt: str,
+            *,
+            platform: str = "",
+            chat_id: str = "",
+            message_id: str = "",
+            agent_hint: str = "",
+        ):
+            del prompt, platform, chat_id, message_id, agent_hint
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.tmux_session.TmuxSession.connect", new=fake_connect), \
+                patch("pinky_daemon.tmux_session.TmuxSession.send", new=fake_send):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={
+                    "name": "tmux-agent",
+                    "model": "sonnet",
+                    "runtime": "claude_sdk",
+                    "transport": "tmux",
+                })
+
+                resp = client.post("/agents/tmux-agent/wake?prompt=Wake")
+                assert resp.status_code == 200
+
+                session = app.state.broker._streaming["tmux-agent"]["main"]
+                assert session.__class__.__name__ == "TmuxSession"
+                assert session._config.model == "sonnet"
+                assert session.resume_handle == "pinky-tmux-agent"
+
+    def test_wake_rejects_tmux_transport_for_codex_runtime(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={
+                    "name": "bad-agent",
+                    "model": "gpt-5-codex",
+                    "runtime": "codex_cli",
+                    "transport": "tmux",
+                })
+
+                resp = client.post("/agents/bad-agent/wake?prompt=Wake")
+                assert resp.status_code == 400
+                assert "only valid for claude_sdk runtime" in resp.text
+
     def test_wake_rejects_opencode_runtime_until_session_exists(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
@@ -2262,6 +2317,7 @@ class TestAgentCRUD:
         assert data["name"] == "alice"
         assert data["model"] == "sonnet"
         assert data["runtime"] == "codex_cli"
+        assert data["transport"] == "sdk"
         assert data["provider_url"] == "codex_cli"
         assert data["provider_model"] == "gpt-5-codex"
 
@@ -2272,6 +2328,14 @@ class TestAgentCRUD:
         resp = client.put("/agents/alice", json={"runtime": "codex_cli"})
         assert resp.status_code == 200
         assert resp.json()["runtime"] == "codex_cli"
+
+    def test_update_agent_transport(self):
+        client = self._make_client()
+        client.post("/agents", json={"name": "alice", "model": "sonnet"})
+
+        resp = client.put("/agents/alice", json={"transport": "tmux"})
+        assert resp.status_code == 200
+        assert resp.json()["transport"] == "tmux"
 
     def test_register_agent_with_soul(self):
         client = self._make_client()

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -845,10 +845,10 @@ async def test_handle_turn_complete_writes_to_conversation_store() -> None:
 @pytest.mark.asyncio
 async def test_handle_turn_complete_fires_stream_event() -> None:
     """stream_event_callback gets a turn_complete event with usage + duration."""
-    events: list[tuple[str, dict]] = []
+    events: list[dict] = []
 
-    async def stream_cb(agent_name, evt):
-        events.append((agent_name, evt))
+    async def stream_cb(evt):
+        events.append(evt)
 
     ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
     response = TurnResponse(
@@ -860,8 +860,8 @@ async def test_handle_turn_complete_fires_stream_event() -> None:
     )
     await ss._handle_turn_complete(response)
     assert len(events) == 1
-    agent, evt = events[0]
-    assert agent == "dymok"
+    evt = events[0]
+    assert evt["agent_name"] == "dymok"
     assert evt["type"] == "turn_complete"
     assert evt["stop_reason"] == "end_turn"
     assert evt["duration_ms"] == 1500


### PR DESCRIPTION
## Summary

- Add persisted `Agent.transport` with default `sdk`, including registry migration, API create/update models, and `to_dict()` output.
- Wire `runtime=claude_sdk` + `transport=tmux` to boot `TmuxSession`; keep Codex and SDK paths unchanged.
- Reject invalid non-SDK transports on non-Claude runtimes, pass stream events through the unified one-arg callback shape, and give tmux sessions a `SessionUsage` object for existing API/cost surfaces.

## Validation

- `pytest tests/test_agent_registry.py tests/test_api.py tests/test_tmux_session.py tests/test_tmux_transcript.py tests/test_codex_session.py tests/test_streaming_session.py -q` → 479 passed
- `pytest -q --ignore=tests/pinky_federation` → 2053 passed, 1 skipped
- `ruff check src/pinky_daemon/agent_registry.py src/pinky_daemon/api_models.py src/pinky_daemon/api.py src/pinky_daemon/tmux_session.py tests/test_agent_registry.py tests/test_api.py tests/test_tmux_session.py` → clean
- `git diff --check` → clean

Note: repo-wide `ruff check` sees known untracked local `scripts/burn_*.py` files and reports issues there; those files are not staged or included in this PR.