### PR TITLE
fix(tmux): gate claude --continue on prior transcript (#511)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -763,8 +763,20 @@ class TmuxSession:
         Returned as a string (not a list) because tmux invokes it via the
         user's shell. Components are individually quoted with
         ``shlex.quote`` to defend against agent-name / config injection.
+
+        ``--continue`` is gated on a prior transcript existing for this
+        agent's cwd (issue #511). Otherwise the Claude CLI exits 1
+        ("no conversation found to continue"), the detached tmux session
+        is auto-reaped on command exit, and the Python state machine ends
+        up CONNECTED against a dead REPL. Cold-starting a fresh agent
+        must fall through to ``claude`` (no ``--continue``) so a new
+        transcript is created on the first turn; subsequent reconnects
+        will find that transcript and resume normally.
         """
-        parts = ["claude", "--continue", "--dangerously-skip-permissions"]
+        parts = ["claude"]
+        if self._has_prior_transcript():
+            parts.append("--continue")
+        parts.append("--dangerously-skip-permissions")
         # Optional model override.
         if self._config.model:
             parts.extend(["--model", self._config.model])
@@ -1083,16 +1095,50 @@ class TmuxSession:
             # Keep the instance — notify_tail() before next spawn is a no-op
             # but reusing the instance preserves stats across reconnects.
 
+    def _project_dir(self) -> Path:
+        """Return Claude Code's ``~/.claude/projects/<encoded-cwd>`` path
+        for this agent's working_dir. The directory may not exist yet —
+        callers must handle that case.
+
+        ``encoded-cwd``: the absolute cwd with the leading ``/`` consumed
+        and remaining ``/`` replaced with ``-`` (e.g.
+        ``/Users/oleg/foo`` → ``-Users-oleg-foo``). Mirrors Claude Code's
+        own encoding so the glob targets the right directory.
+        """
+        cwd = Path(self._config.working_dir or ".").resolve()
+        encoded = "-" + str(cwd).replace("/", "-")
+        return Path.home() / ".claude" / "projects" / encoded
+
+    def _has_prior_transcript(self) -> bool:
+        """True iff at least one ``*.jsonl`` transcript exists for this
+        agent's cwd. Used by ``_build_claude_cmd`` to decide whether
+        ``claude --continue`` is safe (issue #511).
+
+        ``claude --continue`` exits with code 1 when no prior transcript
+        exists for cwd. On detached tmux that exit silently reaps the
+        session (the command ran and exited, no remain-on-exit) while
+        ``tmux new-session`` itself returned 0 — leaving the Python
+        state machine in CONNECTED against a dead REPL. Gate
+        ``--continue`` on this check to avoid that wedge.
+        """
+        project_dir = self._project_dir()
+        if not project_dir.exists():
+            return False
+        try:
+            return any(project_dir.glob("*.jsonl"))
+        except OSError:
+            return False
+
     def _discover_transcript_path(self) -> Path | None:
         """Best-effort guess at the transcript path before SessionStart
         hook reports it.
 
         Claude Code stores transcripts at
-        ``~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`` where
-        ``encoded-cwd`` is the cwd with separators replaced by ``-``.
-        We glob the project dir and return the newest .jsonl. If none
-        exist yet (cold start before claude writes anything) returns
-        None; the SessionStart hook will repoint us once it fires.
+        ``~/.claude/projects/<encoded-cwd>/<session-id>.jsonl``. We glob
+        the project dir (see ``_project_dir``) and return the newest
+        .jsonl. If none exist yet (cold start before claude writes
+        anything) returns None; the SessionStart hook will repoint us
+        once it fires.
 
         Assumption: each PinkyBot agent has a unique working_dir
         (``data/agents/<name>/`` by convention). If two agents ever
@@ -1101,10 +1147,7 @@ class TmuxSession:
         SessionStart hook's path-update is the authoritative correction
         either way; this is a startup race window only.
         """
-        cwd = Path(self._config.working_dir or ".").resolve()
-        # encoded-cwd: leading slash becomes empty, other slashes become dashes
-        encoded = "-" + str(cwd).replace("/", "-")
-        project_dir = Path.home() / ".claude" / "projects" / encoded
+        project_dir = self._project_dir()
         if not project_dir.exists():
             return None
         try:

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -154,18 +154,109 @@ async def test_cold_start_reaps_stale_session_before_spawn() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cold_start_uses_correct_claude_invocation() -> None:
-    """The in-pane command must be ``claude --continue
-    --dangerously-skip-permissions`` per the design. Pinned because a
-    typo in the invocation silently breaks billing semantics (would hit
-    SDK credits instead of subscription)."""
+async def test_cold_start_uses_correct_claude_invocation(tmp_path, monkeypatch) -> None:
+    """The in-pane command must be
+    ``claude --continue --dangerously-skip-permissions`` when a prior
+    transcript exists for cwd. Pinned because a typo in the invocation
+    silently breaks billing semantics (would hit SDK credits instead of
+    subscription).
+
+    Post-#511: ``--continue`` is gated on transcript existence, so this
+    test pre-seeds a fake transcript before asserting.
+    """
+    # Point HOME at tmp so we can seed a transcript at the encoded-cwd path.
+    monkeypatch.setenv("HOME", str(tmp_path))
     ss, tmux = _make_session()
+    project_dir = ss._project_dir()
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "seed.jsonl").write_text("")
     await ss.connect()
     _, kwargs = tmux.new_session.call_args
     cmd = kwargs["command"]
     assert "claude" in cmd
     assert "--continue" in cmd
     assert "--dangerously-skip-permissions" in cmd
+
+
+@pytest.mark.asyncio
+async def test_cold_start_omits_continue_when_no_prior_transcript(
+    tmp_path, monkeypatch
+) -> None:
+    """Issue #511 regression: a freshly-registered agent has no transcript
+    at ``~/.claude/projects/<encoded-cwd>/``. ``claude --continue`` exits 1
+    in that case, tmux auto-reaps the detached session, and the Python
+    state machine ends up CONNECTED against a dead REPL.
+
+    Fix: cold-start cmd must fall through to ``claude`` (no
+    ``--continue``) when no prior transcript exists. The Claude CLI
+    then creates a fresh transcript on the first turn, and subsequent
+    reconnects find it and resume normally.
+    """
+    # Point HOME at an empty tmp dir — no project_dir, no transcripts.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, tmux = _make_session()
+    await ss.connect()
+    _, kwargs = tmux.new_session.call_args
+    cmd = kwargs["command"]
+    assert "claude" in cmd
+    assert "--dangerously-skip-permissions" in cmd
+    # The critical assertion — no --continue when no prior transcript.
+    assert "--continue" not in cmd
+
+
+def test_has_prior_transcript_false_when_project_dir_missing(
+    tmp_path, monkeypatch
+) -> None:
+    """``_has_prior_transcript`` returns False when the encoded-cwd
+    project dir doesn't exist (cold-start case)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    assert ss._has_prior_transcript() is False
+
+
+def test_has_prior_transcript_false_when_project_dir_empty(
+    tmp_path, monkeypatch
+) -> None:
+    """``_has_prior_transcript`` returns False when the project dir
+    exists but contains no ``*.jsonl`` transcripts.
+
+    Defends the race where Claude Code has created the directory
+    (e.g. via a SessionStart hook) but hasn't written a transcript yet.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    project_dir = ss._project_dir()
+    project_dir.mkdir(parents=True, exist_ok=True)
+    # Drop an unrelated file in there to confirm the glob filters by suffix.
+    (project_dir / "not-a-transcript.txt").write_text("")
+    assert ss._has_prior_transcript() is False
+
+
+def test_has_prior_transcript_true_when_jsonl_exists(tmp_path, monkeypatch) -> None:
+    """``_has_prior_transcript`` returns True when at least one .jsonl
+    transcript exists for the agent's cwd."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    project_dir = ss._project_dir()
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "abc123.jsonl").write_text("")
+    assert ss._has_prior_transcript() is True
+
+
+def test_build_claude_cmd_includes_dangerously_skip_when_no_transcript(
+    tmp_path, monkeypatch
+) -> None:
+    """Even with no prior transcript, the cold-start cmd must still
+    carry ``--dangerously-skip-permissions`` (the non-interactive
+    bootstrap flag). Pinning so the #511 fix can't accidentally regress
+    the unrelated permissions handling.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    cmd = ss._build_claude_cmd()
+    assert "claude" in cmd
+    assert "--dangerously-skip-permissions" in cmd
+    assert "--continue" not in cmd
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fixes #511. Cold-start path on `transport=tmux` no longer wedges fresh agents.
- `_build_claude_cmd` gates `--continue` on prior transcript existence; cold-start falls through to plain `claude` and the CLI creates a fresh transcript on the first turn.
- Subsequent reconnects find that transcript and resume via `--continue` normally — no behavior change on the warm path.

## Why this fixes the wedge

`claude --continue` exits with code 1 when no prior transcript exists for cwd. On detached tmux the command-exit silently reaps the session, but `tmux new-session` itself already returned 0. `_cold_start` therefore proceeds to spin up the tailer + worker against a dead REPL, and the state machine ends up CONNECTED against nothing. Inter-agent messages queue but never produce a turn.

Surfaced during Dymok bootstrap on prod (Mac Mini, main @ `075e65b`) immediately after PR #510. Full reproduction + log trace in #511.

## Implementation notes

- Factored out `_project_dir()` returning `~/.claude/projects/<encoded-cwd>` regardless of existence — shared by `_has_prior_transcript` (new) and `_discover_transcript_path` (refactored to use it). Single source of truth for the encoded-cwd mapping.
- `_has_prior_transcript()` returns True iff at least one `*.jsonl` exists under the project dir. OSError handling mirrors `_discover_transcript_path`'s defensive style.
- Did NOT add the post-spawn `tmux has_session` recheck (option B in #511) — that's a structural defense worth its own PR; the targeted fix here is enough to unblock new-agent bootstrap.

## Test plan

- [x] 5 new tests in `test_tmux_session.py`:
  - `test_cold_start_omits_continue_when_no_prior_transcript` — the cold-start regression
  - `test_has_prior_transcript_false_when_project_dir_missing` — pure helper, no project dir
  - `test_has_prior_transcript_false_when_project_dir_empty` — project dir exists but no .jsonl (mid-bootstrap race)
  - `test_has_prior_transcript_true_when_jsonl_exists` — warm-path helper
  - `test_build_claude_cmd_includes_dangerously_skip_when_no_transcript` — pins that the cold-start cmd still carries `--dangerously-skip-permissions` (defends the unrelated flag from accidental regression)
- [x] Updated existing `test_cold_start_uses_correct_claude_invocation` to pre-seed a transcript so it continues to assert `--continue` on the warm path.
- [x] `pytest -q` clean locally (2095 passed, 1 skipped). Federation/identity test modules skipped — missing `nacl` in this Python; unrelated to this change.
- [x] `ruff check` clean on both files.

## Rollout

- Once merged, `update_and_restart()` on prod pulls the fix.
- Dymok specifically: transcript was pre-seeded earlier today as a workaround, but his REPL ended up wedged downstream (force_restart guard tripped). Easiest path post-merge is to delete his transcript dir and re-trigger cold-start so we exercise this fix end-to-end on the live agent. Or just re-bootstrap him.

## Out of scope

- Option B from #511 (post-spawn `tmux has_session` recheck) — file separately if wanted; this PR is the targeted unblock.
- The downstream "force_restart guard blocked recovery" wedge that bit Dymok's second probe — needs its own investigation; left for a follow-up issue.

🤖 Opened by Barsik