### PR TITLE
fix(tmux): pre-seed transcript at cold-start to skip splash UI (#514)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -209,14 +209,84 @@ class _TmuxControl:
         prompt.
 
         ``text`` is passed as a single tmux argument; tmux interprets
-        no further shell metacharacters. Multi-line prompts: send each
-        line with ``enter=True`` or use ``tmux paste-buffer`` for large
-        payloads (TODO when response pipeline lands).
+        no further shell metacharacters.
+
+        Use ``paste_text`` instead for prompts that need to survive the
+        claude cold-start splash UI (issue #514) — bracketed-paste plus
+        a short delay is more reliable than raw keystrokes during the
+        splash-to-chat transition.
         """
         args = ["send-keys", "-t", self.session_name, text]
         if enter:
             args.append("Enter")
         return await self._run(*args)
+
+    async def paste_text(
+        self,
+        text: str,
+        *,
+        enter: bool = True,
+        enter_delay_ms: int = 300,
+    ) -> TmuxCommandResult:
+        """Deliver ``text`` to the pane via tmux paste-buffer with
+        bracketed paste mode, then (optionally) send Enter after a
+        short delay.
+
+        Adopted from Pulse v2's session manager (issue #514). Bracketed
+        paste sequences are buffered atomically by the terminal —
+        claude receives the full payload as a single block rather than
+        as a stream of keystrokes. The ``enter_delay_ms`` window gives
+        claude's post-login splash UI time to dismiss itself (which it
+        does on input focus) before the submit Enter arrives.
+
+        Compared to raw ``send-keys text Enter``: the keystroke-based
+        path delivers text and Enter back-to-back, and claude's splash
+        absorbs the Enter during its rendering transition. The result
+        is text buffered in claude's input area with no submission —
+        a permanently wedged session.
+
+        Args:
+            text: Prompt payload. Passed as a single tmux arg via
+                ``set-buffer``, so no shell-metachar interpretation.
+            enter: If True (default), send a submit Enter after
+                ``enter_delay_ms`` ms. If False, leaves the pasted text
+                in the input buffer unsubmitted.
+            enter_delay_ms: Sleep between paste and Enter. Defaults to
+                300 — the value Pulse v2's session manager uses for the
+                claude backend (it uses 4000 for codex, which renders
+                its prompt more slowly).
+
+        Returns the last tmux command's result (either the Enter send
+        or the paste, depending on ``enter``). On any intermediate
+        failure, returns that failure result immediately.
+        """
+        # Per-session buffer name so concurrent paste_text on different
+        # sessions don't race on a shared buffer.
+        buf_name = f"pinky-{self.session_name}"
+
+        set_result = await self._run("set-buffer", "-b", buf_name, text)
+        if not set_result.ok:
+            return set_result
+
+        # ``-p`` enables bracketed paste mode (atomic, single block).
+        # ``-d`` deletes the buffer after paste (saves memory on long
+        # prompts; the buffer name is reusable for the next call).
+        paste_result = await self._run(
+            "paste-buffer",
+            "-b",
+            buf_name,
+            "-d",
+            "-t",
+            self.session_name,
+            "-p",
+        )
+        if not paste_result.ok or not enter:
+            return paste_result
+
+        if enter_delay_ms > 0:
+            await asyncio.sleep(enter_delay_ms / 1000.0)
+
+        return await self._run("send-keys", "-t", self.session_name, "Enter")
 
     async def capture_pane(self, *, lines: int = 200) -> TmuxCommandResult:
         """Capture the last ``lines`` lines of the pane's visible content.
@@ -1282,7 +1352,12 @@ class TmuxSession:
         # iteration's await, so wiping it is a no-op.
         self._turn_done.clear()
 
-        result = await self._tmux.send_keys(turn.prompt, enter=True)
+        # Use paste_text (bracketed paste + delayed Enter) instead of raw
+        # send-keys (issue #514, Misha/Pulse v2 pattern). The delayed
+        # Enter gives claude's cold-start splash UI time to dismiss
+        # before the submit Enter arrives, so the first prompt of a
+        # fresh session doesn't get wedged in claude's input buffer.
+        result = await self._tmux.paste_text(turn.prompt, enter=True)
         if not result.ok:
             # Send failed — no response will arrive. Re-arm turn_done so
             # the worker's next iteration doesn't deadlock; clear meta
@@ -1290,7 +1365,7 @@ class TmuxSession:
             self._inflight_meta = {}
             self._turn_done.set()
             raise RuntimeError(
-                f"tmux send-keys failed: rc={result.returncode} "
+                f"tmux paste-buffer / send-keys failed: rc={result.returncode} "
                 f"stderr={result.stderr.strip()!r}"
             )
 

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from pinky_daemon import tmux_session
 from pinky_daemon.streaming_session import StreamingSessionConfig
 from pinky_daemon.tmux_session import (
     TmuxCommandResult,
@@ -53,6 +54,7 @@ def _make_mock_tmux(*, has_session_initial: bool = False) -> MagicMock:
     tmux.new_session = AsyncMock(return_value=_ok())
     tmux.kill_session = AsyncMock(return_value=_ok())
     tmux.send_keys = AsyncMock(return_value=_ok())
+    tmux.paste_text = AsyncMock(return_value=_ok())
     tmux.capture_pane = AsyncMock(return_value=_ok())
     return tmux
 
@@ -187,7 +189,7 @@ async def test_cold_start_omits_continue_when_no_prior_transcript(
     in that case, tmux auto-reaps the detached session, and the Python
     state machine ends up CONNECTED against a dead REPL.
 
-    Fix: cold-start cmd must fall through to ``claude`` (no
+    Fix (#512): cold-start cmd must fall through to ``claude`` (no
     ``--continue``) when no prior transcript exists. The Claude CLI
     then creates a fresh transcript on the first turn, and subsequent
     reconnects find it and resume normally.
@@ -257,6 +259,161 @@ def test_build_claude_cmd_includes_dangerously_skip_when_no_transcript(
     assert "claude" in cmd
     assert "--dangerously-skip-permissions" in cmd
     assert "--continue" not in cmd
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #514 — paste-buffer + delayed Enter for prompt delivery
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_paste_text_sets_buffer_pastes_and_sends_enter() -> None:
+    """``_TmuxControl.paste_text`` must invoke three tmux subcommands
+    in order: ``set-buffer``, ``paste-buffer -p`` (bracketed paste),
+    then ``send-keys Enter``. The bracketed-paste mode is what makes
+    this reliable across the claude cold-start splash UI (#514).
+    """
+    tmux = _TmuxControl("pinky-test")
+
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        return _ok()
+
+    tmux._run = fake_run
+    result = await tmux.paste_text("hello world", enter_delay_ms=0)
+
+    # Expect three commands in order.
+    assert len(calls) == 3
+    assert calls[0][:3] == ("set-buffer", "-b", "pinky-pinky-test")
+    assert calls[0][3] == "hello world"
+    assert "paste-buffer" in calls[1][0]
+    assert "-p" in calls[1]  # bracketed paste mode
+    assert "-d" in calls[1]  # delete buffer after paste
+    assert calls[2] == ("send-keys", "-t", "pinky-test", "Enter")
+    assert result.ok
+
+
+@pytest.mark.asyncio
+async def test_paste_text_skips_enter_when_enter_false() -> None:
+    """``enter=False`` leaves the pasted text in claude's input buffer
+    unsubmitted. Used by callers who want to stage a prompt without
+    triggering a turn (e.g. internal setup, debugging)."""
+    tmux = _TmuxControl("pinky-test")
+
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        return _ok()
+
+    tmux._run = fake_run
+    await tmux.paste_text("hello", enter=False, enter_delay_ms=0)
+
+    assert len(calls) == 2  # set-buffer + paste-buffer only
+    assert not any("send-keys" in c[0] for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_paste_text_short_circuits_on_set_buffer_failure() -> None:
+    """If ``set-buffer`` fails (tmux server down, bad session name),
+    paste_text returns the failure immediately without trying paste
+    or Enter."""
+    tmux = _TmuxControl("pinky-test")
+
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        return _fail("set-buffer broke")
+
+    tmux._run = fake_run
+    result = await tmux.paste_text("hello", enter_delay_ms=0)
+
+    assert len(calls) == 1
+    assert not result.ok
+
+
+@pytest.mark.asyncio
+async def test_paste_text_short_circuits_on_paste_failure() -> None:
+    """If ``paste-buffer`` fails after a successful ``set-buffer``,
+    paste_text returns the failure without trying Enter. Skipping the
+    Enter avoids submitting stale buffer content from a previous turn.
+    """
+    tmux = _TmuxControl("pinky-test")
+
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        if args[0] == "paste-buffer":
+            return _fail("paste broke")
+        return _ok()
+
+    tmux._run = fake_run
+    result = await tmux.paste_text("hello", enter_delay_ms=0)
+
+    assert len(calls) == 2  # set-buffer + paste-buffer; no send-keys
+    assert not result.ok
+
+
+@pytest.mark.asyncio
+async def test_paste_text_waits_enter_delay_between_paste_and_enter() -> None:
+    """The Enter delay between paste and Enter is the mechanism that
+    lets claude's cold-start splash UI dismiss itself before the
+    submit Enter arrives. Pinning so the sleep can't be accidentally
+    removed during refactor.
+    """
+    tmux = _TmuxControl("pinky-test")
+    sleep_durations: list[float] = []
+
+    original_sleep = asyncio.sleep
+
+    async def tracked_sleep(seconds):
+        sleep_durations.append(seconds)
+        # No-op the actual sleep so the test runs fast.
+        await original_sleep(0)
+
+    async def fake_run(*args, timeout=5.0):
+        return _ok()
+
+    tmux._run = fake_run
+    # Patch asyncio.sleep IN the module under test, not globally.
+    original = tmux_session.asyncio.sleep
+    tmux_session.asyncio.sleep = tracked_sleep
+    try:
+        await tmux.paste_text("hello", enter_delay_ms=250)
+    finally:
+        tmux_session.asyncio.sleep = original
+
+    assert 0.25 in sleep_durations
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_uses_paste_text_not_send_keys() -> None:
+    """The worker's per-turn delivery must go through paste_text (not
+    raw send-keys) so cold-start splash absorption (#514) is avoided.
+    Pinning so a future refactor can't silently revert the delivery
+    path."""
+    tmux = _make_mock_tmux()
+    tmux.paste_text = AsyncMock(return_value=_ok())
+    ss, _ = _make_session(tmux=tmux)
+    ss._state_machine._state = SessionState.CONNECTED
+
+    turn = _QueuedTurn(
+        prompt="hello dymok",
+        platform="telegram",
+        chat_id="123",
+        message_id="m1",
+    )
+    await ss._deliver_turn(turn)
+
+    tmux.paste_text.assert_awaited_once()
+    args, kwargs = tmux.paste_text.call_args
+    assert args[0] == "hello dymok" or kwargs.get("text") == "hello dymok"
+    # And raw send_keys must NOT have been used for dispatch.
+    tmux.send_keys.assert_not_awaited()
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -661,15 +818,16 @@ async def test_send_drops_when_not_connected() -> None:
     StreamingSession's legacy drop-silent behavior."""
     ss, tmux = _make_session(state=SessionState.DEAD)
     await ss.send("hello", platform="telegram", chat_id="123")
-    tmux.send_keys.assert_not_awaited()
+    tmux.paste_text.assert_not_awaited()
     assert ss._stats["messages_sent"] == 0
 
 
 @pytest.mark.asyncio
-async def test_send_queues_and_worker_delivers_via_send_keys() -> None:
-    """Happy path: cold-start, send a message, worker dequeues and pushes
-    via tmux send-keys. Pins the send_keys invocation shape (enter=True
-    appends an Enter keypress, completing the prompt in claude's REPL)."""
+async def test_send_queues_and_worker_delivers_via_paste_text() -> None:
+    """Happy path: cold-start, send a message, worker dequeues and
+    pushes via tmux paste_text (bracketed paste + delayed Enter, the
+    #514 fix). Pins the paste_text invocation shape (enter=True
+    submits the prompt after the cold-start splash dismisses)."""
     ss, tmux = _make_session()
     await ss.connect()
     await ss.send("hello world", platform="telegram", chat_id="123")
@@ -677,12 +835,12 @@ async def test_send_queues_and_worker_delivers_via_send_keys() -> None:
     # Let the worker drain one item.
     for _ in range(20):
         await asyncio.sleep(0)
-        if tmux.send_keys.await_count >= 1:
+        if tmux.paste_text.await_count >= 1:
             break
 
-    tmux.send_keys.assert_awaited()
-    # send_keys is called with the prompt + enter=True (default).
-    args, kwargs = tmux.send_keys.call_args
+    tmux.paste_text.assert_awaited()
+    # paste_text is called with the prompt + enter=True (default).
+    args, kwargs = tmux.paste_text.call_args
     assert args[0] == "hello world"
     assert kwargs.get("enter", True) is True
 
@@ -837,14 +995,14 @@ async def test_deliver_turn_captures_inflight_meta() -> None:
 
 
 @pytest.mark.asyncio
-async def test_deliver_turn_clears_meta_on_send_keys_failure() -> None:
-    """If tmux send-keys fails, in-flight meta is cleared so a stale tail
-    doesn't fire response_callback with bogus routing data."""
+async def test_deliver_turn_clears_meta_on_paste_text_failure() -> None:
+    """If tmux paste_text fails, in-flight meta is cleared so a stale
+    tail doesn't fire response_callback with bogus routing data."""
     tmux = _make_mock_tmux()
-    tmux.send_keys = AsyncMock(return_value=_fail("rc=1"))
+    tmux.paste_text = AsyncMock(return_value=_fail("rc=1"))
     ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
     turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m")
-    with pytest.raises(RuntimeError, match="tmux send-keys failed"):
+    with pytest.raises(RuntimeError, match="tmux paste-buffer"):
         await ss._deliver_turn(turn)
     assert ss._inflight_meta == {}
 
@@ -1142,20 +1300,20 @@ async def test_turn_done_set_unconditionally_for_empty_text_turn() -> None:
 
 
 @pytest.mark.asyncio
-async def test_deliver_turn_clears_turn_done_before_send_keys() -> None:
-    """The clear must happen BEFORE send-keys so that any subsequent
+async def test_deliver_turn_clears_turn_done_before_paste_text() -> None:
+    """The clear must happen BEFORE paste_text so that any subsequent
     stop_hook_summary unambiguously belongs to THIS turn (not a stale
     pre-arm from a prior callback). Pinned via call-order observation.
     """
     tmux = _make_mock_tmux()
     cleared_at: list[bool] = []
 
-    async def observing_send_keys(*args, **kwargs):
-        # Snapshot turn_done state at the moment send_keys is called.
+    async def observing_paste(*args, **kwargs):
+        # Snapshot turn_done state at the moment paste_text is called.
         cleared_at.append(not ss._turn_done.is_set())
         return _ok()
 
-    tmux.send_keys = AsyncMock(side_effect=observing_send_keys)
+    tmux.paste_text = AsyncMock(side_effect=observing_paste)
     ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
     # Pre-arm turn_done to a SET state to prove the clear() actually fires.
     ss._turn_done.set()
@@ -1164,19 +1322,19 @@ async def test_deliver_turn_clears_turn_done_before_send_keys() -> None:
     await ss._deliver_turn(turn)
 
     assert cleared_at == [True], (
-        "turn_done must be CLEARED at the moment send_keys is invoked"
+        "turn_done must be CLEARED at the moment paste_text is invoked"
     )
 
 
 @pytest.mark.asyncio
-async def test_deliver_turn_send_keys_failure_re_arms_turn_done() -> None:
-    """If send-keys fails, the worker would otherwise block forever on
+async def test_deliver_turn_paste_text_failure_re_arms_turn_done() -> None:
+    """If paste_text fails, the worker would otherwise block forever on
     turn_done.wait() because no callback will ever fire for the failed
     dispatch. _deliver_turn must re-arm turn_done as part of its failure
     cleanup so the worker's next iteration starts in a clean state.
     """
     tmux = _make_mock_tmux()
-    tmux.send_keys = AsyncMock(return_value=_fail("rc=1"))
+    tmux.paste_text = AsyncMock(return_value=_fail("rc=1"))
     ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
     ss._turn_done.clear()
 


### PR DESCRIPTION
## Summary

- Fixes #514. New tmux-transport agents no longer need a manual Enter to unstick their first turn.
- Adopts Misha/Pulse v2's prompt-delivery pattern: bracketed paste + 300ms delay + Enter. The splash dismisses itself during the delay window, no special handling needed.
- No API credits consumed (the earlier `--print` seed approach was rejected by Brad for billing reasons — `-p` mode hits the metered credit pool, defeating the whole point of tmux transport).
- Pairs with Murzik's #517 (force_restart guard bypass pre-first-turn) to make tmux cold-start fully autonomous.

## Why this works

`tmux send-keys text Enter` delivers text + Enter as a tight keystroke sequence. When claude is mid-splash-render on cold-start, the splash transition consumes the Enter, leaving the text buffered without submission.

`tmux set-buffer + paste-buffer -p + sleep + send-keys Enter`:
- Bracketed-paste (`-p`) sequences are buffered atomically by the terminal — they don't compete with claude's splash render
- The 300ms sleep gives claude time to transition past the splash (which auto-dismisses on input focus)
- The Enter arrives after claude is chat-ready, so the prompt submits cleanly

Reference: `pulse-v2/src/daemon/session-manager.ts` (Brad pointed me at this). Misha uses the same pattern with the same 300ms delay for claude.

## Implementation

- New method: `_TmuxControl.paste_text(text, enter=True, enter_delay_ms=300)` — three-step delivery (set-buffer → paste-buffer with `-p` → optional delayed Enter)
- Changed: `_deliver_turn` now uses `paste_text` instead of `send_keys`
- `send_keys` stays in the API for utility callers
- Per-session buffer name (`pinky-<session>`) so concurrent paste_text on different sessions don't race

## Test plan

- [x] 6 new tests:
  - `test_paste_text_sets_buffer_pastes_and_sends_enter` — verifies three-call sequence + flags (-p, -d)
  - `test_paste_text_skips_enter_when_enter_false` — staging mode (no submit)
  - `test_paste_text_short_circuits_on_set_buffer_failure` — failure handling
  - `test_paste_text_short_circuits_on_paste_failure` — failure handling
  - `test_paste_text_waits_enter_delay_between_paste_and_enter` — pins the sleep that makes the splash dismiss work
  - `test_deliver_turn_uses_paste_text_not_send_keys` — integration: worker uses new path
- [x] 3 existing tests renamed + retargeted from send_keys → paste_text (clears_meta, clears_turn_done, re_arms_turn_done failure paths)
- [x] `pytest -q tests/test_tmux_session.py` → 70 passed (was 64, 6 net new)
- [x] Full suite `pytest -q` → 2101 passed
- [x] `ruff check` clean
- [ ] Post-merge: re-run Dymok cold-start validation. Expected: net-new agent bootstrap completes end-to-end with no manual Enter.

## Coordination note

PR #517 (Murzik, #516 fix) modifies non-overlapping sections of the same file (`__init__`, `_handle_turn_complete`, `force_restart`). No merge conflict expected. Recommend merging both before validating live.

## What changed from the initial draft of this PR

Initial approach was to pre-seed a transcript via `claude --print "_"` so claude resumes a (trivial) prior conversation instead of showing the splash. Brad pointed out that `-p` mode bills the API credit pool — defeats the whole subscription-billing purpose of tmux transport. Pivoted to the Pulse v2 paste-buffer pattern at his suggestion.

## Out of scope

- #513: post-spawn tmux liveness recheck — still useful as broader structural defense.
- #515: tailer never repoints from placeholder path on cold-start. Independent of this fix; needs its own investigation.
- Channel protocol via `--dangerously-load-development-channels server:outreach` (Pulse v2's primary delivery path; tmux paste-buffer is their fallback). Bigger change; this PR's scope is parity with the fallback only.

🤖 Opened by Barsik