### PR TITLE
fix(tmux): propagate session secret + self-heal tailer discovery (#515)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -57,6 +57,7 @@ session stays alive.
 from __future__ import annotations
 
 import asyncio
+import os
 import shlex
 import time
 from dataclasses import dataclass, field, replace
@@ -862,6 +863,22 @@ class TmuxSession:
         Mirrors StreamingSession's ``provider_env`` shape so hook scripts
         (e.g. ``hook_verify_effort.py``) see the same signals on both
         backends.
+
+        **#515 follow-up: PINKY_SESSION_SECRET propagation.** Tmux
+        ``new-session`` only propagates env vars listed via ``-e
+        KEY=VAL``; parent-process env is dropped except for the small
+        ``update-environment`` allowlist (DISPLAY, SSH_*, etc.). Without
+        explicit propagation, every PinkyBot-managed hook
+        (``hook_idle.py``, ``hook_working.py``, ``hook_verify_effort.py``,
+        ``hook_tmux_wake.py``, ``hook_tmux_session_start.py``) hits the
+        guard ``if not secret: sys.exit(0)`` and silently no-ops. That
+        broke #515 (tailer never repoints from placeholder), and also
+        breaks tmux-agent presence updates, effort-drift logging, and
+        Stop-hook wakeups across the whole hook fleet. SDK agents are
+        unaffected because claude inherits daemon env via subprocess.
+
+        Propagating the secret here re-enables the entire hook fleet
+        for tmux agents without touching any individual hook script.
         """
         env: dict[str, str] = {}
         if self._config.provider_url:
@@ -876,6 +893,14 @@ class TmuxSession:
             env["PINKY_EXPECTED_EFFORT"] = effort
         if self._config.strict_effort_enforcement:
             env["PINKY_STRICT_EFFORT"] = "1"
+        # PINKY_SESSION_SECRET — see docstring. Read from os.environ
+        # rather than a config field because it's a daemon-wide secret
+        # (the daemon's own SDK clients and FastAPI middleware read it
+        # from the same env var). Empty/missing is tolerated: hooks
+        # already handle that gracefully (silent no-op).
+        secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+        if secret:
+            env["PINKY_SESSION_SECRET"] = secret
         return env
 
     async def disconnect(self) -> None:
@@ -1111,6 +1136,12 @@ class TmuxSession:
             transcript_path=path,
             on_turn_complete=self._handle_turn_complete,
             agent_name=self.agent_name,
+            # #515 self-heal: hand the tailer our discovery callback so
+            # it can mtime-scan and rebind on its own if the SessionStart
+            # hook never fires (e.g. when tmux strips PINKY_SESSION_SECRET
+            # from the hook script's env — see ``_build_repl_env``). The
+            # tailer becomes correct independently of the hook firing.
+            path_discovery=self._discover_transcript_path,
         )
         await self._tailer.start()
         if guessed is None:

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -259,12 +259,20 @@ class TmuxTranscriptTailer:
         agent_name: str = "",
         fallback_poll_sec: float = _FALLBACK_POLL_SEC,
         active_poll_sec: float = _ACTIVE_POLL_SEC,
+        path_discovery: Callable[[], Path | None] | None = None,
     ) -> None:
         self._path = Path(transcript_path)
         self._on_turn_complete = on_turn_complete
         self._agent_name = agent_name or self._path.stem[:12]
         self._fallback_poll_sec = fallback_poll_sec
         self._active_poll_sec = active_poll_sec
+        # #515 self-heal: when ``_path`` doesn't exist on a poll (e.g.
+        # tailer still pinned to the placeholder because SessionStart
+        # hook never fired), call ``path_discovery()``. If it returns a
+        # Path, rebind via ``set_transcript_path(path, seek_to_start=True)``.
+        # This makes the tailer correct without dependence on the
+        # SessionStart hook firing at all. See ``TmuxSession._discover_transcript_path``.
+        self._path_discovery = path_discovery
 
         self._offset: int = 0
         self._buffer = _TurnBuffer()
@@ -277,6 +285,10 @@ class TmuxTranscriptTailer:
             "parse_errors": 0,
             "callback_errors": 0,
             "rotations": 0,
+            # #515 self-heal: count successful discoveries so we can
+            # surface "the tailer fell back to mtime-scan N times" in
+            # diagnostics.
+            "self_heal_repoints": 0,
         }
         # ``_active`` flips True after we see a user entry but before we see
         # the closing stop_hook_summary. Drives the tighter poll cadence so
@@ -312,10 +324,13 @@ class TmuxTranscriptTailer:
         """
         self._offset = max(0, offset)
 
-    def set_transcript_path(self, path: Path) -> None:
+    def set_transcript_path(
+        self, path: Path, *, seek_to_start: bool = False,
+    ) -> None:
         """Swap the watched file. Used by the SessionStart hook to
         repoint the tailer at the canonical transcript Claude Code is
-        writing to.
+        writing to, and by the #515 self-heal mtime-scan when the
+        SessionStart hook never fires.
 
         Seeks to end-of-file by default — Pushok's PR #496 round-1
         Case 3 fix. The previous design unconditionally reset offset to
@@ -330,10 +345,20 @@ class TmuxTranscriptTailer:
         Seek-to-EOF gives the same offset==0 for a fresh file
         (size == 0) and bounds the replay risk for non-fresh.
 
+        ``seek_to_start=True`` overrides the default and seeks to byte
+        0. The self-heal discovery path uses this when transitioning
+        from a placeholder (non-existent file) to a freshly-discovered
+        transcript: in that case the daemon has never read any bytes
+        for this session, the JSONL was created seconds ago specifically
+        for this cold-start, and we want every entry from byte 0
+        forward. The reply-spam risk applies to long-lived transcripts
+        with prior turns, not to fresh-discovery files.
+
         Callers that want backfill semantics (re-read the whole file)
         can call ``set_offset(0)`` after this method — that's what the
         backfill code path is for and it's an explicit choice rather
-        than an accidental side effect.
+        than an accidental side effect. ``seek_to_start`` is the
+        in-method shorthand for the discovery case.
 
         Pushok's PR #496 round-2 Case 2': also drain the in-memory turn
         buffer. The buffer accumulates assistant entries between
@@ -349,10 +374,13 @@ class TmuxTranscriptTailer:
         """
         if Path(path) != self._path:
             self._path = Path(path)
-            try:
-                self._offset = self._path.stat().st_size if self._path.exists() else 0
-            except OSError:
+            if seek_to_start:
                 self._offset = 0
+            else:
+                try:
+                    self._offset = self._path.stat().st_size if self._path.exists() else 0
+                except OSError:
+                    self._offset = 0
             self._buffer.drain()
             self._stats["rotations"] += 1
             self._wake_event.set()
@@ -454,6 +482,14 @@ class TmuxTranscriptTailer:
             self._wake_event.clear()
             if self._stopped:
                 return
+            # #515 self-heal: if the path doesn't exist and a discovery
+            # callback is configured, try to find the real transcript
+            # via mtime-scan and rebind. Removes the SessionStart-hook
+            # dependency from the correctness path — even if the hook
+            # never fires (e.g. PINKY_SESSION_SECRET stripped by tmux,
+            # hook script removed, claude-code internals changed), the
+            # tailer reaches the real transcript on its own.
+            self._try_self_heal_repoint()
             try:
                 await self._read_and_dispatch()
             except Exception as e:  # defensive — never crash the loop
@@ -462,6 +498,50 @@ class TmuxTranscriptTailer:
                     f"tmux_tailer[{self._agent_name}]: read loop error "
                     f"({type(e).__name__}: {e}); continuing"
                 )
+
+    def _try_self_heal_repoint(self) -> None:
+        """If the watched path doesn't exist and we have a discovery
+        callback, scan for the real transcript and rebind.
+
+        Called from ``_tail_loop`` once per poll tick. Cheap when there
+        is no discovery callback (early return) and when the path
+        exists (single stat). Discovery itself (an ``os.scandir`` over
+        the project dir) is the dominant cost, only paid when the path
+        is missing.
+
+        Errors are swallowed and logged — a transient filesystem hiccup
+        during discovery must never crash the tail loop. The next poll
+        tick retries.
+        """
+        if self._path_discovery is None:
+            return
+        if self._path.exists():
+            return
+        try:
+            discovered = self._path_discovery()
+        except Exception as e:
+            _log(
+                f"tmux_tailer[{self._agent_name}]: path_discovery raised "
+                f"({type(e).__name__}: {e}); will retry next tick"
+            )
+            return
+        if discovered is None:
+            return
+        if Path(discovered) == self._path:
+            return
+        _log(
+            f"tmux_tailer[{self._agent_name}]: self-heal repointing "
+            f"{self._path} → {discovered} (placeholder/missing path "
+            f"resolved via mtime-scan)"
+        )
+        # ``seek_to_start=True``: this is the placeholder→real
+        # transition. The discovered file was just created for this
+        # cold-start session; we want every entry from byte 0. The
+        # reply-spam risk that motivated default-seek-to-EOF applies
+        # to long-lived transcripts with prior turns, not to fresh
+        # discovery on cold-start where no bytes have been read yet.
+        self.set_transcript_path(Path(discovered), seek_to_start=True)
+        self._stats["self_heal_repoints"] += 1
 
     async def _read_and_dispatch(self) -> int:
         """Read from ``_offset`` to EOF, feed each JSONL entry, fire

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -424,6 +424,56 @@ async def test_deliver_turn_uses_paste_text_not_send_keys() -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# REPL env propagation — #515 follow-up.
+#
+# Tmux ``new-session`` only propagates env via explicit ``-e KEY=VAL``;
+# parent env is dropped (except the small ``update-environment``
+# allowlist). Without explicit propagation, every PinkyBot-managed hook
+# silently exits at ``if not secret: sys.exit(0)`` and the SessionStart
+# tailer-repoint, Stop wake, presence updates, and effort-drift logs
+# all stop working for tmux agents.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_build_repl_env_propagates_pinky_session_secret_when_set(
+    monkeypatch,
+) -> None:
+    """When the daemon env has ``PINKY_SESSION_SECRET``, it must be
+    included in the tmux env so the HMAC-signing hook scripts inside
+    the tmux session can authenticate to the daemon."""
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "test-secret-32-bytes-min-xyz")
+    ss, _ = _make_session()
+    env = ss._build_repl_env()
+    assert env.get("PINKY_SESSION_SECRET") == "test-secret-32-bytes-min-xyz"
+
+
+def test_build_repl_env_omits_pinky_session_secret_when_unset(
+    monkeypatch,
+) -> None:
+    """When the daemon env has no ``PINKY_SESSION_SECRET`` (dev-mode,
+    misconfigured deploy), the env must NOT include an empty
+    ``PINKY_SESSION_SECRET=``. Hooks already handle missing-secret
+    gracefully (silent no-op); polluting tmux with an empty value
+    risks future bugs where empty-string is treated as "present"."""
+    monkeypatch.delenv("PINKY_SESSION_SECRET", raising=False)
+    ss, _ = _make_session()
+    env = ss._build_repl_env()
+    assert "PINKY_SESSION_SECRET" not in env
+
+
+def test_build_repl_env_strips_whitespace_in_pinky_session_secret(
+    monkeypatch,
+) -> None:
+    """Whitespace-only env value is treated as unset. Defends against
+    ``PINKY_SESSION_SECRET=" "`` accidentally passing the truthy guard
+    while still failing HMAC verification on the daemon side."""
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "   ")
+    ss, _ = _make_session()
+    env = ss._build_repl_env()
+    assert "PINKY_SESSION_SECRET" not in env
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # Concurrent cold-start race (PR6 framework: Case A + Case B)
 # ──────────────────────────────────────────────────────────────────────────
 
@@ -834,6 +884,12 @@ async def test_force_restart_skips_restart_guard_before_first_completed_turn() -
 async def test_force_restart_honors_restart_guard_after_completed_turn() -> None:
     """Once any turn has completed, force_restart keeps the existing
     persistence guard behavior to avoid dropping unsaved agent state.
+
+    #518 retargeting note: assertion was ``send_keys.assert_awaited()``
+    before #518 moved per-turn dispatch to ``paste_text`` (bracketed
+    paste + delayed Enter for cold-start splash survival). Updated to
+    pin the new contract; this test slipped through #518's PR-level
+    CI as a rebase artifact and broke main, picked up here in #519.
     """
     guard = MagicMock(return_value={"restart_safe": False, "reason": "stale"})
     ss, tmux = _make_session(restart_guard=guard)
@@ -842,9 +898,9 @@ async def test_force_restart_honors_restart_guard_after_completed_turn() -> None
     await ss.send(prompt="done", platform="t", chat_id="c", message_id="m")
     for _ in range(20):
         await asyncio.sleep(0)
-        if tmux.send_keys.await_count >= 1:
+        if tmux.paste_text.await_count >= 1:
             break
-    tmux.send_keys.assert_awaited()
+    tmux.paste_text.assert_awaited()
 
     await ss._handle_turn_complete(TurnResponse(text="ok", stop_reason="end_turn"))
     for _ in range(20):

--- a/tests/test_tmux_transcript.py
+++ b/tests/test_tmux_transcript.py
@@ -819,3 +819,247 @@ class TestUtf8MultiByte:
         assert cb.responses[0].text == text
         # Offset must equal exact file byte size (not char count).
         assert tailer.offset == transcript.stat().st_size
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Self-heal discovery — #515.
+#
+# The tailer is correct without the SessionStart hook firing. On each
+# poll tick, if the configured path doesn't exist and a discovery
+# callback is set, the tailer scans for the real transcript and rebinds.
+# This removes the brittle "hook MUST fire OR the daemon never sees
+# the response" coupling that caused #515.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestSetTranscriptPathSeekToStart:
+    """The ``seek_to_start`` kwarg on ``set_transcript_path`` — supports
+    the placeholder→real transition where the discovered file was
+    created fresh and we want byte 0 onward (not EOF, which would skip
+    the response we're trying to capture)."""
+
+    @pytest.mark.asyncio
+    async def test_seek_to_start_overrides_eof_default(
+        self, transcript, tmp_path,
+    ):
+        """``seek_to_start=True`` forces offset 0 even when the new
+        file has content. Mirrors the default-EOF test
+        (``test_set_transcript_path_seeks_to_eof_by_default``) with the
+        opposite expectation."""
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+
+        new_path = tmp_path / "fresh-session.jsonl"
+        _write_jsonl(new_path, [
+            _assistant(text="cold-start response"),
+            _stop_hook_summary(),
+        ])
+        tailer.set_transcript_path(new_path, seek_to_start=True)
+        assert tailer.offset == 0, "seek_to_start must override default-EOF"
+
+        await tailer.read_once()
+        assert len(cb.responses) == 1
+        assert cb.responses[0].text == "cold-start response"
+
+    @pytest.mark.asyncio
+    async def test_default_kwarg_is_seek_to_eof(self, transcript, tmp_path):
+        """Default ``seek_to_start=False`` preserves the existing
+        EOF-seek behavior. Belt + suspenders against the new kwarg
+        accidentally flipping the default."""
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+
+        new_path = tmp_path / "session-with-history.jsonl"
+        _write_jsonl(new_path, [
+            _assistant(text="historical — must not replay"),
+            _stop_hook_summary(),
+        ])
+        tailer.set_transcript_path(new_path)
+        assert tailer.offset == new_path.stat().st_size
+
+
+class TestSelfHealDiscovery:
+    """The ``path_discovery`` callback on the tailer — mtime-scan
+    fallback when the configured path doesn't exist (e.g. SessionStart
+    hook never fired). Bug #515 root cause + structural fix."""
+
+    @pytest.mark.asyncio
+    async def test_no_discovery_callback_is_no_op(self, tmp_path):
+        """Backwards compat: tailer constructed without ``path_discovery``
+        works exactly as before. No discovery attempt, no crash, no
+        spurious rebinds."""
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "does-not-exist.jsonl", cb,
+        )
+        tailer._try_self_heal_repoint()  # explicit call (no asyncio needed)
+        assert tailer.stats["self_heal_repoints"] == 0
+        assert tailer.transcript_path == tmp_path / "does-not-exist.jsonl"
+
+    @pytest.mark.asyncio
+    async def test_discovery_called_when_path_missing(self, tmp_path):
+        """When the path doesn't exist on a poll tick, the discovery
+        callback is invoked. This is the load-bearing assertion for
+        #515 — the daemon must self-heal even when the SessionStart
+        hook never fires."""
+        cb = _Captor()
+        call_count = {"n": 0}
+
+        def discover() -> Path | None:
+            call_count["n"] += 1
+            return None  # no transcript yet — still cold-starting
+
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl", cb,
+            path_discovery=discover,
+        )
+        tailer._try_self_heal_repoint()
+        assert call_count["n"] == 1
+        # No rebind because discovery returned None.
+        assert tailer.stats["self_heal_repoints"] == 0
+        assert tailer.transcript_path == tmp_path / "placeholder.jsonl"
+
+    @pytest.mark.asyncio
+    async def test_discovery_not_called_when_path_exists(
+        self, transcript, tmp_path,
+    ):
+        """When the path DOES exist, discovery must NOT run — cheap
+        early-return. We don't want to pay the project_dir glob on
+        every tick of a healthy session."""
+        cb = _Captor()
+        call_count = {"n": 0}
+
+        def discover() -> Path | None:
+            call_count["n"] += 1
+            return tmp_path / "newer.jsonl"
+
+        tailer = TmuxTranscriptTailer(
+            transcript, cb,  # path exists (touch'd by fixture)
+            path_discovery=discover,
+        )
+        tailer._try_self_heal_repoint()
+        assert call_count["n"] == 0, (
+            "discovery must not run when the watched path exists"
+        )
+
+    @pytest.mark.asyncio
+    async def test_discovery_returning_path_rebinds_with_seek_to_start(
+        self, tmp_path,
+    ):
+        """When discovery returns a fresh transcript path, the tailer
+        rebinds and seeks to byte 0 — the response written between
+        cold-start and now must be readable from the start of the file.
+
+        Without ``seek_to_start=True``, set_transcript_path's default
+        EOF-seek would skip the in-flight response entirely."""
+        cb = _Captor()
+
+        real_path = tmp_path / "real-session-after-cold-start.jsonl"
+        _write_jsonl(real_path, [
+            _assistant(text="the response we'd lose without seek_to_start"),
+            _stop_hook_summary(),
+        ])
+
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl", cb,
+            path_discovery=lambda: real_path,
+        )
+        tailer._try_self_heal_repoint()
+        assert tailer.transcript_path == real_path
+        assert tailer.offset == 0
+        assert tailer.stats["self_heal_repoints"] == 1
+
+        await tailer.read_once()
+        assert len(cb.responses) == 1
+        assert cb.responses[0].text == (
+            "the response we'd lose without seek_to_start"
+        )
+
+    @pytest.mark.asyncio
+    async def test_discovery_returning_same_path_is_no_op(self, tmp_path):
+        """Discovery returning the path we already watch is fine — no
+        rebind, no stats bump, no log spam. Defends against an over-
+        eager mtime-scan flapping when the path exists at glob time
+        but `_path.exists()` raced False (filesystem hiccup)."""
+        cb = _Captor()
+        target = tmp_path / "same.jsonl"
+        # Note: target doesn't exist yet, so discovery fires; but it
+        # returns the same path we already watch → no rebind.
+        tailer = TmuxTranscriptTailer(
+            target, cb,
+            path_discovery=lambda: target,
+        )
+        tailer._try_self_heal_repoint()
+        assert tailer.stats["self_heal_repoints"] == 0
+        assert tailer.transcript_path == target
+
+    @pytest.mark.asyncio
+    async def test_discovery_exception_swallowed_and_logged(self, tmp_path):
+        """A raised discovery callback must NOT crash the tail loop.
+        The transient filesystem error gets logged; the next poll tick
+        retries."""
+        cb = _Captor()
+
+        def discover() -> Path | None:
+            raise OSError("simulated filesystem hiccup")
+
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl", cb,
+            path_discovery=discover,
+        )
+        # The critical assertion: no raise propagates out.
+        tailer._try_self_heal_repoint()
+        assert tailer.stats["self_heal_repoints"] == 0
+
+    @pytest.mark.asyncio
+    async def test_self_heal_integration_via_background_loop(self, tmp_path):
+        """End-to-end: start the tailer with a non-existent placeholder
+        path, then have discovery return a real path with a complete
+        turn in it. The background loop discovers the path, rebinds,
+        reads from byte 0, fires the callback.
+
+        This is the #515 fix in its entirety, exercised at the asyncio
+        layer the production tailer runs at."""
+        cb = _Captor()
+        real_path = tmp_path / "real.jsonl"
+        # File doesn't exist yet — simulate cold-start state where
+        # claude hasn't written anything.
+        discovery_state = {"file_ready": False}
+
+        def discover() -> Path | None:
+            if discovery_state["file_ready"]:
+                return real_path
+            return None  # claude still cold-starting
+
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl", cb,
+            fallback_poll_sec=0.02,
+            active_poll_sec=0.01,
+            path_discovery=discover,
+        )
+        await tailer.start()
+        try:
+            # First few ticks: discovery returns None (no file yet).
+            await asyncio.sleep(0.05)
+            assert tailer.stats["self_heal_repoints"] == 0
+            assert cb.responses == []
+
+            # Now claude finishes the splash and writes a response.
+            _write_jsonl(real_path, [
+                _assistant(text="discovered cold-start response"),
+                _stop_hook_summary(),
+            ])
+            discovery_state["file_ready"] = True
+
+            # Within a few poll ticks, discovery should fire + rebind
+            # + read the file from byte 0 + fire the callback.
+            for _ in range(50):
+                await asyncio.sleep(0.02)
+                if cb.responses:
+                    break
+            assert len(cb.responses) == 1
+            assert cb.responses[0].text == "discovered cold-start response"
+            assert tailer.stats["self_heal_repoints"] == 1
+            assert tailer.transcript_path == real_path
+        finally:
+            await tailer.stop()


### PR DESCRIPTION
## Summary

Closes #515. Two coordinated changes that remove the SessionStart-hook firing from the tmux-agent response-capture *correctness* path:

1. **Propagate `PINKY_SESSION_SECRET` into the tmux env** — root cause for #515 and a much broader blast radius.
2. **Self-heal tailer via mtime-scan when path is missing** — structural fix so hooks become an optimization, not a correctness dependency.

## Root cause discovery

`tmux new-session` only propagates env via explicit `-e KEY=VAL`; parent-process env is dropped except for the `update-environment` allowlist (`DISPLAY`, `SSH_*`, …). I verified this empirically:

```
$ PINKY_SESSION_SECRET=test tmux new-session -d -s t -e FOO=bar "env | grep -E '^(PINKY|FOO|HOME)='"
FOO=bar
HOME=/Users/oleg
# PINKY_SESSION_SECRET stripped
```

`TmuxSession._build_repl_env()` omitted `PINKY_SESSION_SECRET`, so every PinkyBot-managed hook — `hook_idle.py`, `hook_working.py`, `hook_verify_effort.py`, `hook_tmux_wake.py`, **and** `hook_tmux_session_start.py` — saw an empty secret in tmux and silently exited at:

```python
secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
if not secret:
    sys.exit(0)
```

This was the literal mechanism behind #515 (tailer never repoints from placeholder), and also explains why tmux agents had no presence updates, no effort-drift logging, and no Stop-hook wakeups. SDK agents are unaffected because claude inherits the daemon env via direct subprocess; tmux is the special case that strips it.

## Change 1 — secret propagation (`tmux_session.py`)

`_build_repl_env()` now includes `PINKY_SESSION_SECRET` from `os.environ` when set + non-whitespace. Whitespace-only is treated as unset (defends against `PINKY_SESSION_SECRET=" "` accidentally passing the truthy guard while still failing HMAC verification).

## Change 2 — tailer self-heal (`tmux_transcript.py` + `tmux_session.py`)

Even with the secret fix, relying on the SessionStart hook firing for *correctness* leaves us one env-stripping bug, hook-script removal, or upstream Claude Code change away from a #515-class failure. Inspired by Batty's `discover_claude_session_file` pattern (`https://github.com/battysh/batty`).

`TmuxTranscriptTailer.__init__` accepts an optional `path_discovery: Callable[[], Path | None] | None`. The `_tail_loop` now calls `_try_self_heal_repoint()` on each poll tick: if `self._path` doesn't exist and `path_discovery` is set, the callback fires; if it returns a Path, the tailer rebinds via `set_transcript_path(path, seek_to_start=True)`.

`TmuxSession._start_tailer` wires `self._discover_transcript_path` (already an existing mtime-scan over `~/.claude/projects/<encoded-cwd>/*.jsonl`) as the discovery callback. The tailer is now correct independently of any hook firing.

`set_transcript_path` gains `seek_to_start: bool = False`. Default seek-to-EOF behavior (Pushok's PR #496 round-1 Case 3 fix) is preserved for all existing callers; only the self-heal path opts into seek-to-0 because the discovered file was just created for this cold-start and every byte is unread.

The hook → POST path remains, but is now an optimization (faster repoint when it works), not load-bearing.

## Test plan

- [x] **3 new tests** on `_build_repl_env` propagation:
  - `test_build_repl_env_propagates_pinky_session_secret_when_set`
  - `test_build_repl_env_omits_pinky_session_secret_when_unset`
  - `test_build_repl_env_strips_whitespace_in_pinky_session_secret`
- [x] **7 new tests** on tailer self-heal (`TestSelfHealDiscovery`):
  - backwards compat with no callback (load-bearing — existing constructors stay valid)
  - discovery called when path missing
  - discovery NOT called when path exists (cheap-path invariant)
  - discovery rebind with `seek_to_start=True`
  - same-path discovery is a no-op (no rebind, no stats bump)
  - exception in discovery callback swallowed + logged (tail loop never crashes)
  - full asyncio background-loop integration (start → discovery returns None → file appears → discovery returns path → repoint → response captured)
- [x] **2 new tests** pinning `set_transcript_path(seek_to_start=...)`:
  - override-EOF when explicitly passed True
  - default behavior unchanged (seek-to-EOF)
- [x] `pytest -q` full suite: **2460 passed, 1 skipped** locally
- [x] `ruff check src/pinky_daemon/tmux_*.py tests/test_tmux_*.py` clean

## Why one PR, not two

Both changes share the same diagnosis ("tmux agents are hook-blind"). Splitting them would land the smaller fix first but leave the architectural coupling — which is the actual bug-class root cause — for a follow-up that may get deprioritized. One coherent story: "secret propagation re-enables the hook fleet for tmux agents, AND structural self-heal removes the hook as a correctness dependency for response capture."

## Relationship to other PRs

Pairs with #517 (force_restart guard, merged) and #518 (paste-buffer prompt delivery, open) to make tmux cold-start fully autonomous. None of the three touch overlapping code; they layer cleanly.

🤖 Opened by Barsik