### PR TITLE
fix(tmux): detect dead pane and transition to DEAD (task #90)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1338,6 +1338,14 @@ class TmuxSession:
                     # failure; defensively re-arm here in case some other
                     # path raised (e.g. tailer state corruption).
                     self._turn_done.set()
+                    # Task #90: dead-pane already scheduled disconnect from
+                    # inside _deliver_turn. Exit the worker cleanly so we
+                    # don't retry into the now-being-torn-down pane.
+                    # Mirrors the turn_done timeout path's create_task +
+                    # return pattern above (the finally block below still
+                    # runs and resets _processing).
+                    if "can't find pane" in str(e):
+                        return
                 finally:
                     self._processing = False
         except asyncio.CancelledError:
@@ -1400,6 +1408,24 @@ class TmuxSession:
             # so a stale value doesn't leak to a later (unrelated) turn.
             self._inflight_meta = {}
             self._turn_done.set()
+            # Task #90: detect dead-pane (tmux session killed externally,
+            # tmux server crashed, etc.). Without this, the worker would
+            # loop forever pasting into a non-existent pane. Schedule
+            # disconnect (NOT force_restart — that's gated by the
+            # restart_guard from #517 and may block once we've had a
+            # completed turn). The disconnect drives CONNECTED → DEAD
+            # via the default-disconnect path; the next inbound
+            # send_to_agent triggers the normal auto-wake cold-start
+            # path (validated in production by #517/#518/#519).
+            if "can't find pane" in (result.stderr or ""):
+                _log(
+                    f"tmux[{self.agent_name}]: pane vanished "
+                    f"(stderr={result.stderr.strip()!r}); scheduling disconnect"
+                )
+                # create_task — must not await disconnect from inside
+                # the worker; disconnect cancels the worker task and
+                # awaits its completion, which would deadlock here.
+                asyncio.create_task(self.disconnect())
             raise RuntimeError(
                 f"tmux paste-buffer / send-keys failed: rc={result.returncode} "
                 f"stderr={result.stderr.strip()!r}"

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1459,6 +1459,54 @@ async def test_deliver_turn_paste_text_failure_re_arms_turn_done() -> None:
 
 
 @pytest.mark.asyncio
+async def test_deliver_turn_dead_pane_schedules_disconnect_and_worker_exits() -> None:
+    """Task #90: when paste_text fails because the tmux pane is gone
+    (external kill, tmux server crash), _deliver_turn must schedule a
+    disconnect so the session transitions CONNECTED → DEAD. The worker
+    must exit cleanly on the resulting RuntimeError (rather than
+    looping forever pasting into the missing pane). After this, a
+    follow-up send() must be dropped per the not-CONNECTED contract
+    — the next inbound message will cold-start a fresh pane via the
+    auto-wake path validated in #517/#518/#519.
+    """
+    tmux = _make_mock_tmux()
+    # Mimic tmux's exact stderr shape when the target session/pane is gone.
+    tmux.paste_text = AsyncMock(
+        return_value=_fail("can't find pane: pinky-dymok")
+    )
+    ss, _ = _make_session(tmux=tmux)
+    await ss.connect()
+    assert ss.state == SessionState.CONNECTED
+    worker_task = ss._worker_task
+    assert worker_task is not None
+
+    # Queue one turn — worker will pick it up, paste_text fails with
+    # dead-pane stderr, disconnect gets scheduled, worker exits.
+    await ss.send("hi", platform="telegram", chat_id="123", message_id="m1")
+
+    # Wait for state to transition to DEAD (disconnect runs as a
+    # background task scheduled via create_task).
+    for _ in range(100):
+        await asyncio.sleep(0.01)
+        if ss.state == SessionState.DEAD and worker_task.done():
+            break
+
+    assert ss.state == SessionState.DEAD, (
+        f"expected DEAD after dead-pane detect, got {ss.state.value}"
+    )
+    assert worker_task.done(), "worker must exit cleanly on dead-pane"
+
+    # Follow-up send is dropped because state != CONNECTED (matches the
+    # existing "drop with log line" behavior at the top of send()).
+    paste_count_before = tmux.paste_text.await_count
+    await ss.send("again", platform="telegram", chat_id="123", message_id="m2")
+    assert tmux.paste_text.await_count == paste_count_before, (
+        "send() must drop while not CONNECTED — no additional paste_text "
+        "calls into the dead pane"
+    )
+
+
+@pytest.mark.asyncio
 async def test_disconnect_clears_inflight_meta() -> None:
     """Pushok's PR #496 round-1 Case 2: a stale ``_inflight_meta`` from
     a turn that was in-flight at disconnect time must not survive the


### PR DESCRIPTION
## Task #90 — dead-pane wedge

When a `pinky-{agent}` tmux pane dies unexpectedly (external kill,
tmux server crash, etc.) the daemon's `transport_state` stayed
`CONNECTED` and every subsequent message wedged:

```
tmux paste-buffer / send-keys failed: rc=1 stderr="can't find pane: pinky-{agent}"
tmux[{agent}]: turn delivery raised: tmux paste-buffer / send-keys failed: rc=1 stderr="can't find pane: pinky-{agent}"
```

The worker would loop forever pasting into a non-existent pane; the
daemon never recovered without a full restart.

## Fix

`_deliver_turn` now sniffs the `paste_text` stderr for `can't find
pane`. On match it schedules `disconnect()` (via `create_task` —
`disconnect` cancels the worker task, so awaiting it from inside the
worker would deadlock) before raising the existing `RuntimeError`.
The default-disconnect path already handles `CONNECTED → DEAD`. The
worker's generic exception handler returns cleanly on the dead-pane
`RuntimeError` so we don't retry into the now-being-torn-down pane.

After the transition to `DEAD`, the next inbound `send_to_agent`
triggers the normal auto-wake cold-start path — validated in
production by #517 / #518 / #519.

### Why `disconnect`, not `force_restart`

- `force_restart` is gated by the `restart_guard` (#517) once a turn
  has completed; on a wedged-but-completed-turn agent it would BLOCK,
  leaving us wedged in a different way.
- The natural semantics are "pane died → we're dead → wake on next
  inbound via the existing cold-start path." No need to reinvent
  auto-wake.

## Test

Added `test_deliver_turn_dead_pane_schedules_disconnect_and_worker_exits`
in `tests/test_tmux_session.py`. Connects a session, makes
`paste_text` return `rc=1, stderr="can't find pane: pinky-dymok"`,
queues one turn, then asserts: state transitions to `DEAD`, worker
task exits, follow-up `send()` is dropped per the not-`CONNECTED`
contract.

## Verification

- `pytest tests/test_tmux_session.py -q` — 77 passed
- `pytest tests/test_tmux_session.py tests/test_codex_session.py -q` — 104 passed
- `ruff check src/pinky_daemon/tmux_session.py tests/test_tmux_session.py` — clean

🤖 Opened by Barsik