### PR TITLE
feat(tmux): idle-prompt gate + context-lock check before paste

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import shlex
 import time
 from dataclasses import dataclass, field, replace
@@ -82,6 +83,32 @@ from pinky_daemon.transport_state import (
 # ──────────────────────────────────────────────────────────────────────────
 # Tmux subprocess control
 # ──────────────────────────────────────────────────────────────────────────
+
+
+# Idle-prompt gate (pulse-v2 port, queue-drain.ts:229-250). Polls the
+# pane's last 5 lines for claude's idle-prompt signature (``❯`` or ``>``
+# on a line by itself) before a first-turn paste, so the prompt can't
+# land while MCP servers are still booting / splash UI is still up. The
+# regex matches a line of only ``❯`` or ``>`` with optional trailing
+# whitespace, multiline mode so any of the last few lines can match.
+_IDLE_PROMPT_RE = re.compile(r"^[❯>]\s*$", re.MULTILINE)
+
+# Idle-prompt poll cadence + cap. 2s matches pulse-v2's polling interval;
+# 90s the default timeout (generous enough for slow MCP init + first-time
+# auth, tight enough that a wedged REPL surfaces rather than parking the
+# worker for 10 minutes).
+_IDLE_PROMPT_POLL_INTERVAL_SEC = 2.0
+_IDLE_PROMPT_TIMEOUT_SEC = 90.0
+
+# Context-lock check (pulse-v2 port, queue-drain.ts:252-263). When the
+# daemon-level context manager is mid-rewrite of an agent's CLAUDE.md /
+# transcript files, it touches ``data/transport-locks/<agent>.lock`` to
+# tell the worker to skip pasting for now. Directory is the repo-root
+# ``data/transport-locks/`` — consistent with other runtime-state dirs
+# under ``data/`` (``data/agents/``, ``data/transfers/``, ``data/kb/``)
+# and not per-agent because the lock signals daemon-wide intent, not
+# agent-internal state.
+_TRANSPORT_LOCK_DIR = Path("data/transport-locks")
 
 
 @dataclass
@@ -305,6 +332,68 @@ class _TmuxControl:
             "-S",
             str(-abs(lines)),  # negative line offset = lines from bottom
         )
+
+    async def wait_for_idle_prompt(
+        self,
+        *,
+        agent_name: str = "",
+        timeout_s: float = _IDLE_PROMPT_TIMEOUT_SEC,
+        poll_interval_s: float = _IDLE_PROMPT_POLL_INTERVAL_SEC,
+    ) -> bool:
+        """Poll the pane until claude's REPL shows an idle input prompt.
+
+        Ported from pulse-v2's ``waitForIdlePrompt`` (Misha's
+        ``src/daemon/queue-drain.ts`` lines 229-250). Defends against the
+        race where ``_deliver_turn`` pastes a prompt while the REPL is
+        still booting — MCP servers initializing, splash UI still up —
+        which causes data loss or corrupted input.
+
+        Captures the last 5 lines of pane content every ``poll_interval_s``
+        (default 2s, matching pulse-v2). Examines the last 3 non-empty
+        lines for a line containing only ``❯`` or ``>`` with optional
+        trailing whitespace — claude's idle-prompt signature.
+
+        On tmux capture failure, keeps polling rather than failing early;
+        the pane may simply not be ready yet.
+
+        Returns True if the idle prompt is seen within ``timeout_s``,
+        False on timeout.
+
+        ``agent_name`` is for log lines only.
+        """
+        start = time.monotonic()
+        deadline = start + timeout_s
+        label = agent_name or self.session_name
+        while time.monotonic() < deadline:
+            try:
+                result = await self._run(
+                    "capture-pane",
+                    "-t",
+                    self.session_name,
+                    "-p",
+                    "-S",
+                    "-5",
+                )
+                if result.ok:
+                    lines = [
+                        line.rstrip()
+                        for line in result.stdout.split("\n")
+                        if line.strip()
+                    ]
+                    last_few = "\n".join(lines[-3:])
+                    if _IDLE_PROMPT_RE.search(last_few):
+                        elapsed_ms = int((time.monotonic() - start) * 1000)
+                        _log(
+                            f"tmux[{label}]: idle prompt detected after "
+                            f"{elapsed_ms}ms"
+                        )
+                        return True
+            except Exception:
+                # tmux read failed (server hiccup, transient lock); keep
+                # polling — the pane may just not be ready yet.
+                pass
+            await asyncio.sleep(poll_interval_s)
+        return False
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -759,6 +848,14 @@ class TmuxSession:
         cwd = self._config.working_dir or "."
         # Ensure cwd exists — claude --continue needs it.
         Path(cwd).mkdir(parents=True, exist_ok=True)
+
+        # Pulse-v2 idle-prompt gate (task #92) re-arms on every fresh
+        # spawn. The new REPL hasn't responded to anything yet, so the
+        # next ``_deliver_turn`` must wait for its idle prompt before
+        # pasting — even if a prior REPL on this session object had
+        # ``_has_completed_turn = True``. force_restart / attempt_reconnect
+        # both flow through here, so this is the structural reset point.
+        self._has_completed_turn = False
 
         # If a stale session is left over from a previous daemon run (e.g.
         # crash without graceful disconnect), reap it. We're the cold-start
@@ -1353,6 +1450,15 @@ class TmuxSession:
         except Exception as e:
             _log(f"tmux[{self.agent_name}]: worker error: {e}")
 
+    def _context_lock_path(self) -> Path:
+        """Path of this agent's daemon-level context lock file.
+
+        See ``_TRANSPORT_LOCK_DIR`` for the directory rationale. Returns
+        a path without creating it — the file's existence (not contents)
+        is the signal, and creation/removal is the context manager's job.
+        """
+        return _TRANSPORT_LOCK_DIR / f"{self.agent_name}.lock"
+
     async def _deliver_turn(self, turn: _QueuedTurn) -> None:
         """Push one turn through to the tmux pane.
 
@@ -1371,7 +1477,53 @@ class TmuxSession:
         pump, not a request/response broker, so a fast second prompt
         would overwrite meta before the first turn's stop_hook_summary
         landed.
+
+        Pulse-v2 port (task #92): two safety primitives gate the paste:
+
+        1. **Context-lock check.** If the daemon-level context manager
+           has touched ``data/transport-locks/<agent>.lock``, it's mid-
+           rewrite of files this REPL depends on — paste would land on
+           an inconsistent state. Raise so this turn fails this
+           iteration; the worker's existing exception handler logs it
+           and the message stays queued for the next iteration when the
+           lock is released. Crucially, we do NOT schedule disconnect
+           (this is transient, not a dead-pane), so the worker keeps
+           pulling from the queue normally.
+
+        2. **Idle-prompt gate (first turn only).** If we haven't yet
+           seen a successful turn from this REPL, poll the pane for the
+           ``❯``/``>`` idle prompt before pasting. Defends against the
+           race where the prompt lands while MCP servers are still
+           booting (data loss / corrupted input). Skipped after
+           ``_has_completed_turn`` flips to True — once we've seen the
+           REPL respond, subsequent turns can paste immediately.
         """
+        # Pulse-v2 safety primitive 1: context-lock check. Cheap fs stat;
+        # do this first so we bail before mutating any state. The lock
+        # being held is transient — let the worker retry the next
+        # iteration without escalating to disconnect/restart.
+        if self._context_lock_path().exists():
+            raise RuntimeError(
+                f"context lock present at {self._context_lock_path()} — "
+                f"deferring paste; worker will retry on next iteration"
+            )
+
+        # Pulse-v2 safety primitive 2: wait for the REPL's idle prompt
+        # before the first paste. After ``_has_completed_turn`` is True
+        # we've seen the REPL respond to at least one turn, so the gate
+        # has served its purpose; skip the (up to 90s) poll on every
+        # subsequent dispatch.
+        if not self._has_completed_turn:
+            saw_idle = await self._tmux.wait_for_idle_prompt(
+                agent_name=self.agent_name,
+            )
+            if not saw_idle:
+                raise RuntimeError(
+                    f"idle prompt not seen within "
+                    f"{_IDLE_PROMPT_TIMEOUT_SEC:.0f}s — REPL not ready "
+                    f"for paste"
+                )
+
         # Capture routing metadata BEFORE send-keys so the tailer's callback
         # has access to it even if the tailer fires unusually quickly.
         self._inflight_meta = {

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -110,6 +110,44 @@ _IDLE_PROMPT_TIMEOUT_SEC = 90.0
 # agent-internal state.
 _TRANSPORT_LOCK_DIR = Path("data/transport-locks")
 
+# Transient-failure retry cadence for the worker loop. Fixed (not
+# exponential) — mirrors pulse-v2's poll cadence and keeps the
+# semantics simple: "park, sleep, retry the same turn". The worker
+# does not move on to the next queue item until the inflight turn
+# either succeeds or hits a permanent failure.
+_TRANSIENT_RETRY_BACKOFF_SEC = 2.0
+
+# How many idle-prompt timeouts the worker tolerates against the same
+# REPL before escalating to ``force_restart``. With the 90s idle-prompt
+# wait, the limit of 2 means initial wait + one retry ≈ 180s wall clock
+# before the worker concludes the REPL is wedged enough to need a fresh
+# spawn rather than just more patience.
+_IDLE_PROMPT_RETRY_LIMIT = 2
+
+
+class _ContextLockDeferral(Exception):  # noqa: N818
+    """Transient: context-lock file present at paste time.
+
+    Murzik #522 round-1: ``_deliver_turn`` previously raised a bare
+    ``RuntimeError`` here, which the worker's catch-all dropped (turn
+    was consumed from the queue with ``get()`` BEFORE ``_deliver_turn``
+    ran, so an exception lost the message). The fix: raise a typed
+    exception that the worker recognises as "transient, keep the
+    inflight turn, sleep + retry without re-fetching from the queue".
+    """
+
+
+class _IdlePromptTimeout(Exception):  # noqa: N818
+    """Transient: REPL idle prompt not observed within the gate timeout.
+
+    Murzik #522 round-1: same root cause as ``_ContextLockDeferral``.
+    The worker treats this as retryable; after
+    ``_IDLE_PROMPT_RETRY_LIMIT`` consecutive timeouts against the same
+    REPL it escalates to ``force_restart`` while preserving the
+    inflight turn (instance state survives the worker-task cancel /
+    re-spawn that ``force_restart`` performs).
+    """
+
 
 @dataclass
 class TmuxCommandResult:
@@ -545,6 +583,21 @@ class TmuxSession:
         # Before that, restart cannot discard completed agent work, so
         # watchdog recovery may bypass the persistence guard.
         self._has_completed_turn = False
+
+        # Murzik #522 round-1: the worker keeps the current turn IN-HAND
+        # across transient failures instead of ``get()``-ing a new one
+        # every iteration. ``_inflight_turn`` is None when the worker is
+        # idle / between turns; populated by the worker as soon as it
+        # pulls from the queue, and cleared only on success or permanent
+        # failure. Survives ``force_restart`` (instance state on self
+        # outlives worker-task cancellation + re-spawn), which is what
+        # lets the new REPL pick the same turn back up after a stuck-
+        # REPL escalation.
+        self._inflight_turn: _QueuedTurn | None = None
+        # Consecutive idle-prompt timeouts against the current REPL.
+        # Reset on success or after force_restart escalation. Bounded
+        # by ``_IDLE_PROMPT_RETRY_LIMIT`` before escalating.
+        self._idle_prompt_retry_count: int = 0
 
     # ── Identity ────────────────────────────────────────────────────────
 
@@ -1366,18 +1419,47 @@ class TmuxSession:
         """Drain the message queue sequentially, delivering each turn to
         the tmux pane and waiting for it to complete before the next.
 
-        PR8b round-2 (Pushok's Case 1 fix): the worker now gates dispatch
+        PR8b round-2 (Pushok's Case 1 fix): the worker gates dispatch
         on ``_turn_done``, which ``_handle_turn_complete`` sets at the
         end of every turn (including empty-text / tool-use-only turns).
         This ensures ``_inflight_meta`` is never overwritten while the
         tailer still has work to fire for the in-flight turn, AND bounds
         the prompts that get stacked into Claude Code's input queue
         (UX win — CC's queued-prompt indicator is non-obvious).
+
+        Murzik #522 round-1 (data-loss fix): the worker now keeps the
+        current turn IN-HAND across transient failures via
+        ``self._inflight_turn``. The previous shape — ``get()`` a turn,
+        run ``_deliver_turn``, let any exception fall through the
+        catch-all — silently dropped messages when the new context-lock
+        and idle-prompt gates raised: the queue had already coughed up
+        the message, and the except handler logged-but-didn't-requeue.
+        The new shape:
+
+        - Only ``get()`` from the queue when ``_inflight_turn is None``.
+        - ``_ContextLockDeferral`` / ``_IdlePromptTimeout`` are TRANSIENT
+          — sleep ``_TRANSIENT_RETRY_BACKOFF_SEC`` and loop without
+          touching ``_inflight_turn``, so the next iteration retries
+          the SAME turn against the SAME REPL.
+        - After ``_IDLE_PROMPT_RETRY_LIMIT`` consecutive idle-prompt
+          timeouts, escalate to ``force_restart`` while PRESERVING
+          ``_inflight_turn`` — instance state on ``self`` outlives the
+          worker-task cancellation and re-spawn that ``force_restart``
+          performs, so the fresh REPL's worker picks up the same turn.
+        - Any other exception (paste-fail, dead-pane, etc.) is treated
+          as PERMANENT — clear ``_inflight_turn`` and follow the
+          existing handler semantics (disconnect on dead-pane).
         """
         _log(f"tmux[{self.agent_name}]: message worker started")
         try:
             while self.state == SessionState.CONNECTED:
-                turn = await self._message_queue.get()
+                # Only pull a new turn when nothing is inflight. After
+                # a transient failure or a force_restart, ``_inflight_turn``
+                # carries the previous turn so it gets retried instead of
+                # silently dropped (Murzik #522 round-1).
+                if self._inflight_turn is None:
+                    self._inflight_turn = await self._message_queue.get()
+                turn = self._inflight_turn
                 try:
                     self._processing = True
                     await self._deliver_turn(turn)
@@ -1396,6 +1478,10 @@ class TmuxSession:
                             timeout=_TURN_DONE_TIMEOUT_SEC,
                         )
                         self._has_completed_turn = True
+                        # Success — clear inflight + retry counter so the
+                        # next iteration pulls a fresh turn.
+                        self._inflight_turn = None
+                        self._idle_prompt_retry_count = 0
                     except asyncio.TimeoutError:
                         # The REPL is stuck. Pushok's PR #496 round-2
                         # follow-up: just "continue" leaves the stuck
@@ -1421,6 +1507,13 @@ class TmuxSession:
                         self._stats["turn_timeouts"] = (
                             self._stats.get("turn_timeouts", 0) + 1
                         )
+                        # Turn-done timeout means the prompt DID land in
+                        # the REPL but the response never completed.
+                        # Treat as permanent for this turn — clear
+                        # inflight so a stale prompt doesn't get re-
+                        # pasted into the fresh REPL after force_restart.
+                        self._inflight_turn = None
+                        self._idle_prompt_retry_count = 0
                         # Schedule force_restart in the background so this
                         # worker can exit cleanly without awaiting its own
                         # cancellation (force_restart calls disconnect →
@@ -1428,13 +1521,75 @@ class TmuxSession:
                         # if invoked synchronously from inside the worker).
                         asyncio.create_task(self.force_restart())
                         return
+                except _ContextLockDeferral as e:
+                    # Transient: lock file present. Don't touch
+                    # _inflight_turn or _turn_done — _deliver_turn raised
+                    # BEFORE clearing turn_done or mutating meta, so the
+                    # signal/meta from any prior turn is still consistent.
+                    _log(
+                        f"tmux[{self.agent_name}]: turn deferred "
+                        f"(context lock); retrying in "
+                        f"{_TRANSIENT_RETRY_BACKOFF_SEC}s ({e})"
+                    )
+                    await asyncio.sleep(_TRANSIENT_RETRY_BACKOFF_SEC)
+                    continue
+                except _IdlePromptTimeout as e:
+                    # Transient: REPL hasn't reached idle prompt. Same
+                    # invariants as _ContextLockDeferral above — raised
+                    # before any state mutation.
+                    self._idle_prompt_retry_count += 1
+                    if (
+                        self._idle_prompt_retry_count
+                        >= _IDLE_PROMPT_RETRY_LIMIT
+                    ):
+                        _log(
+                            f"tmux[{self.agent_name}]: idle prompt "
+                            f"persistent timeout "
+                            f"({self._idle_prompt_retry_count}/"
+                            f"{_IDLE_PROMPT_RETRY_LIMIT}) — escalating to "
+                            f"force_restart, preserving inflight turn"
+                        )
+                        # PRESERVE _inflight_turn across force_restart —
+                        # instance state on self survives worker
+                        # cancellation + re-spawn, so the new worker
+                        # will retry the same turn against the fresh
+                        # REPL. Reset the retry counter so the new REPL
+                        # gets a clean budget.
+                        self._idle_prompt_retry_count = 0
+                        self._stats["errors"] += 1
+                        # Background create_task: see turn_done-timeout
+                        # path above for the same deadlock-avoidance
+                        # rationale.
+                        asyncio.create_task(self.force_restart())
+                        # Brief sleep so force_restart can begin tearing
+                        # down before this worker's next loop iteration
+                        # tries to re-deliver against a dying pane. The
+                        # while-loop's CONNECTED guard + worker-task
+                        # cancellation will end this loop naturally
+                        # once disconnect runs.
+                        await asyncio.sleep(_TRANSIENT_RETRY_BACKOFF_SEC)
+                        continue
+                    _log(
+                        f"tmux[{self.agent_name}]: idle prompt timeout "
+                        f"(attempt {self._idle_prompt_retry_count}/"
+                        f"{_IDLE_PROMPT_RETRY_LIMIT}) — retrying in "
+                        f"{_TRANSIENT_RETRY_BACKOFF_SEC}s ({e})"
+                    )
+                    await asyncio.sleep(_TRANSIENT_RETRY_BACKOFF_SEC)
+                    continue
                 except Exception as e:
+                    # Permanent failure (paste-buffer/send-keys failed,
+                    # dead-pane, tailer-state corruption, etc.). Drop
+                    # the inflight turn so we don't redeliver into a
+                    # broken pane on the next iteration.
                     self._stats["errors"] += 1
                     _log(f"tmux[{self.agent_name}]: turn delivery raised: {e}")
                     # _deliver_turn already re-armed turn_done on send-keys
                     # failure; defensively re-arm here in case some other
                     # path raised (e.g. tailer state corruption).
                     self._turn_done.set()
+                    self._inflight_turn = None
+                    self._idle_prompt_retry_count = 0
                     # Task #90: dead-pane already scheduled disconnect from
                     # inside _deliver_turn. Exit the worker cleanly so we
                     # don't retry into the now-being-torn-down pane.
@@ -1500,10 +1655,14 @@ class TmuxSession:
         """
         # Pulse-v2 safety primitive 1: context-lock check. Cheap fs stat;
         # do this first so we bail before mutating any state. The lock
-        # being held is transient — let the worker retry the next
-        # iteration without escalating to disconnect/restart.
+        # being held is transient — Murzik #522 round-1: raise a typed
+        # ``_ContextLockDeferral`` so the worker knows to PRESERVE the
+        # inflight turn, sleep, and retry on the next iteration. Bare
+        # ``RuntimeError`` here was being eaten by the worker's catch-
+        # all + ``get()``-before-deliver pattern, silently dropping the
+        # message.
         if self._context_lock_path().exists():
-            raise RuntimeError(
+            raise _ContextLockDeferral(
                 f"context lock present at {self._context_lock_path()} — "
                 f"deferring paste; worker will retry on next iteration"
             )
@@ -1518,7 +1677,12 @@ class TmuxSession:
                 agent_name=self.agent_name,
             )
             if not saw_idle:
-                raise RuntimeError(
+                # Murzik #522 round-1: typed exception so the worker
+                # preserves the inflight turn, increments its retry
+                # counter, and escalates to force_restart after
+                # _IDLE_PROMPT_RETRY_LIMIT consecutive failures rather
+                # than dropping the message.
+                raise _IdlePromptTimeout(
                     f"idle prompt not seen within "
                     f"{_IDLE_PROMPT_TIMEOUT_SEC:.0f}s — REPL not ready "
                     f"for paste"

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1633,23 +1633,32 @@ class TmuxSession:
         would overwrite meta before the first turn's stop_hook_summary
         landed.
 
-        Pulse-v2 port (task #92): two safety primitives gate the paste:
+        Pulse-v2 port (task #92): two safety primitives gate the paste,
+        each raising a **typed transient exception** the worker catches
+        in its retry loop (Murzik #522 round-1). Because the worker pops
+        the turn from the queue before calling ``_deliver_turn``, a bare
+        exception would silently drop the message; the worker keeps the
+        turn in ``_inflight_turn`` and re-paste the same prompt on the
+        next iteration. Neither path schedules disconnect — this is
+        transient state, not a dead-pane.
 
         1. **Context-lock check.** If the daemon-level context manager
            has touched ``data/transport-locks/<agent>.lock``, it's mid-
            rewrite of files this REPL depends on — paste would land on
-           an inconsistent state. Raise so this turn fails this
-           iteration; the worker's existing exception handler logs it
-           and the message stays queued for the next iteration when the
-           lock is released. Crucially, we do NOT schedule disconnect
-           (this is transient, not a dead-pane), so the worker keeps
-           pulling from the queue normally.
+           an inconsistent state. Raise ``_ContextLockDeferral`` so the
+           worker preserves the inflight turn, sleeps, and retries when
+           the lock is released.
 
         2. **Idle-prompt gate (first turn only).** If we haven't yet
            seen a successful turn from this REPL, poll the pane for the
            ``❯``/``>`` idle prompt before pasting. Defends against the
            race where the prompt lands while MCP servers are still
-           booting (data loss / corrupted input). Skipped after
+           booting (data loss / corrupted input). On timeout, raise
+           ``_IdlePromptTimeout`` so the worker increments
+           ``_idle_prompt_retry_count`` and either retries the same turn
+           or escalates to ``force_restart`` after
+           ``_IDLE_PROMPT_RETRY_LIMIT`` consecutive failures — turn
+           preserved across the restart. Skipped after
            ``_has_completed_turn`` flips to True — once we've seen the
            REPL respond, subsequent turns can paste immediately.
         """

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -56,6 +56,10 @@ def _make_mock_tmux(*, has_session_initial: bool = False) -> MagicMock:
     tmux.send_keys = AsyncMock(return_value=_ok())
     tmux.paste_text = AsyncMock(return_value=_ok())
     tmux.capture_pane = AsyncMock(return_value=_ok())
+    # Pulse-v2 idle-prompt gate (task #92). Default to "seen immediately"
+    # so tests focused on other lifecycle paths aren't paying a 90s timeout
+    # nor having to opt into the gate explicitly.
+    tmux.wait_for_idle_prompt = AsyncMock(return_value=True)
     return tmux
 
 
@@ -1504,6 +1508,183 @@ async def test_deliver_turn_dead_pane_schedules_disconnect_and_worker_exits() ->
         "send() must drop while not CONNECTED — no additional paste_text "
         "calls into the dead pane"
     )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pulse-v2 safety primitives (task #92): idle-prompt gate + context lock
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_waits_for_idle_prompt_on_first_turn() -> None:
+    """Pulse-v2 port: the first ``_deliver_turn`` after spawn must wait
+    for the REPL's idle prompt before pasting — defends against the
+    race where MCP servers are still booting. Subsequent turns
+    (``_has_completed_turn = True``) skip the gate since the REPL has
+    already been observed responding.
+    """
+    tmux = _make_mock_tmux()
+    tmux.wait_for_idle_prompt = AsyncMock(return_value=True)
+    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+    assert ss._has_completed_turn is False
+
+    turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m1")
+    await ss._deliver_turn(turn)
+
+    # First turn: gate is consulted exactly once, then paste happens.
+    tmux.wait_for_idle_prompt.assert_awaited_once()
+    tmux.paste_text.assert_awaited_once()
+
+    # Flip the flag (the worker does this after observing turn_done).
+    ss._has_completed_turn = True
+    turn2 = _QueuedTurn(prompt="hi2", platform="t", chat_id="c", message_id="m2")
+    await ss._deliver_turn(turn2)
+
+    # Second turn: gate is NOT consulted again (still 1 await total),
+    # paste fires again.
+    assert tmux.wait_for_idle_prompt.await_count == 1
+    assert tmux.paste_text.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_skips_paste_when_context_locked(
+    monkeypatch, tmp_path
+) -> None:
+    """Pulse-v2 port: if the daemon-level context manager has touched
+    the agent's transport-lock file, ``_deliver_turn`` must raise
+    BEFORE paste_text so the worker drops this iteration without
+    corrupting the REPL's input buffer. The worker stays alive and
+    will pick the next inbound on its next loop iteration (when the
+    lock is released — not part of this test).
+    """
+    # Point the lock dir at a tmp path so the test can't escape the
+    # sandbox or collide with a real lock.
+    monkeypatch.setattr(tmux_session, "_TRANSPORT_LOCK_DIR", tmp_path)
+    tmux = _make_mock_tmux()
+    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+
+    # Touch the lock for this agent.
+    lock_path = tmp_path / f"{ss.agent_name}.lock"
+    lock_path.write_text("")
+
+    turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m1")
+    with pytest.raises(RuntimeError, match="context lock present"):
+        await ss._deliver_turn(turn)
+
+    # Paste must not have been called, and the idle-prompt gate also
+    # not consulted (lock check is the first thing _deliver_turn does).
+    tmux.paste_text.assert_not_awaited()
+    tmux.wait_for_idle_prompt.assert_not_awaited()
+
+    # Once the lock is released, the next dispatch proceeds normally.
+    lock_path.unlink()
+    await ss._deliver_turn(turn)
+    tmux.paste_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_raises_when_idle_prompt_times_out() -> None:
+    """Pulse-v2 port: if the REPL never reaches an idle prompt within
+    the timeout, ``_deliver_turn`` must raise so the worker's existing
+    exception handler can log + re-arm. paste_text must not have been
+    called against a non-ready REPL.
+    """
+    tmux = _make_mock_tmux()
+    tmux.wait_for_idle_prompt = AsyncMock(return_value=False)
+    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+
+    turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m1")
+    with pytest.raises(RuntimeError, match="idle prompt not seen"):
+        await ss._deliver_turn(turn)
+
+    tmux.wait_for_idle_prompt.assert_awaited_once()
+    tmux.paste_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_idle_prompt_detects_signature() -> None:
+    """The real ``_TmuxControl.wait_for_idle_prompt`` returns True when
+    capture-pane stdout ends with a line containing only ``❯`` (or
+    ``>``) and optional trailing whitespace.
+    """
+    tmux = _TmuxControl("pinky-test")
+
+    async def fake_run(*args, **kwargs):
+        # Simulated claude REPL idle-prompt capture: blank, splash bits,
+        # then the ❯ prompt on its own line.
+        return TmuxCommandResult(
+            returncode=0,
+            stdout="some splash text\n\n❯ \n",
+            stderr="",
+        )
+
+    tmux._run = fake_run  # type: ignore[assignment]
+    # Tiny poll cadence + tight timeout — happy path should return in
+    # under one poll cycle.
+    saw = await tmux.wait_for_idle_prompt(
+        agent_name="dymok", timeout_s=1.0, poll_interval_s=0.01
+    )
+    assert saw is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_idle_prompt_times_out_on_non_idle_output() -> None:
+    """If capture-pane never produces an idle prompt, the helper returns
+    False after ``timeout_s``. Keep timeout small so the test is fast.
+    """
+    tmux = _TmuxControl("pinky-test")
+
+    async def fake_run(*args, **kwargs):
+        # Pane is mid-spinner / mid-bootstrap — no idle signature.
+        return TmuxCommandResult(
+            returncode=0,
+            stdout="Loading MCP servers...\n[*] thinking\n",
+            stderr="",
+        )
+
+    tmux._run = fake_run  # type: ignore[assignment]
+    saw = await tmux.wait_for_idle_prompt(
+        agent_name="dymok", timeout_s=0.1, poll_interval_s=0.02
+    )
+    assert saw is False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_idle_prompt_survives_tmux_read_failures() -> None:
+    """Pulse-v2 port: a transient tmux failure must not abort the gate —
+    keep polling. Verified by alternating failure + success: helper
+    returns True once the success lands.
+    """
+    tmux = _TmuxControl("pinky-test")
+    call_count = {"n": 0}
+
+    async def fake_run(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("synthetic tmux read failure")
+        return TmuxCommandResult(returncode=0, stdout="❯\n", stderr="")
+
+    tmux._run = fake_run  # type: ignore[assignment]
+    saw = await tmux.wait_for_idle_prompt(
+        agent_name="dymok", timeout_s=1.0, poll_interval_s=0.01
+    )
+    assert saw is True
+    assert call_count["n"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_spawn_tmux_repl_resets_completed_turn_flag() -> None:
+    """The idle-prompt gate's discriminator is ``_has_completed_turn``.
+    Every fresh spawn must reset it to False so the gate fires for the
+    first paste against the new REPL — even after a prior REPL on this
+    session object had completed turns.
+    """
+    ss, _ = _make_session()
+    # Simulate a prior REPL having completed turns.
+    ss._has_completed_turn = True
+    await ss._spawn_tmux_repl()
+    assert ss._has_completed_turn is False
+    await ss.disconnect()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1568,7 +1568,12 @@ async def test_deliver_turn_skips_paste_when_context_locked(
     lock_path.write_text("")
 
     turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m1")
-    with pytest.raises(RuntimeError, match="context lock present"):
+    # Murzik #522 round-1: typed transient exception (was bare
+    # RuntimeError) — the worker recognises it as "preserve inflight,
+    # sleep + retry the same turn".
+    with pytest.raises(
+        tmux_session._ContextLockDeferral, match="context lock present"
+    ):
         await ss._deliver_turn(turn)
 
     # Paste must not have been called, and the idle-prompt gate also
@@ -1594,7 +1599,12 @@ async def test_deliver_turn_raises_when_idle_prompt_times_out() -> None:
     ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
 
     turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m1")
-    with pytest.raises(RuntimeError, match="idle prompt not seen"):
+    # Murzik #522 round-1: typed transient exception (was bare
+    # RuntimeError) — the worker recognises it for retry + escalate-to-
+    # force_restart with inflight preservation.
+    with pytest.raises(
+        tmux_session._IdlePromptTimeout, match="idle prompt not seen"
+    ):
         await ss._deliver_turn(turn)
 
     tmux.wait_for_idle_prompt.assert_awaited_once()
@@ -2127,3 +2137,219 @@ async def test_spawn_tmux_repl_rollback_clears_partial_tailer() -> None:
     assert tmux.kill_session.await_count >= 1, (
         "rollback must call tmux.kill_session"
     )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Murzik #522 round-1 — worker-level inflight-preservation for transient
+# failures (context-lock + idle-prompt timeout). The PR-1 shape ``get()``-d
+# the turn from the queue BEFORE _deliver_turn, then let any exception fall
+# through the catch-all, silently dropping the message. These tests pin the
+# fix at the worker level (not just _deliver_turn unit) — Murzik
+# specifically called this out as required.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_context_lock_preserves_turn_until_released(
+    monkeypatch, tmp_path
+) -> None:
+    """Murzik #522 round-1 (the actual bug): the worker must keep the
+    inflight turn in-hand while the context lock is held and re-paste
+    after the lock is released, not silently drop the message.
+
+    Pre-fix shape: ``_message_queue.get()`` happened BEFORE
+    ``_deliver_turn``; the gate's ``RuntimeError`` fell through the
+    worker's catch-all log-only handler. qsize went to 0 and paste_text
+    was never called — for that turn or any successor.
+    """
+    # Speed up the worker's transient-failure backoff so the test
+    # doesn't sit on a 2s sleep per retry.
+    monkeypatch.setattr(tmux_session, "_TRANSIENT_RETRY_BACKOFF_SEC", 0.01)
+    # Sandbox the lock dir to tmp_path.
+    monkeypatch.setattr(tmux_session, "_TRANSPORT_LOCK_DIR", tmp_path)
+
+    ss, tmux = _make_session()
+    # Touch lock BEFORE connect/send so the very first delivery attempt
+    # hits the deferral.
+    lock_path = tmp_path / f"{ss.agent_name}.lock"
+    lock_path.write_text("")
+
+    await ss.connect()
+    await ss.send("hi", platform="t", chat_id="c", message_id="m1")
+
+    # Give the worker several scheduler ticks to (a) get() the turn,
+    # (b) hit the deferral, (c) loop a few times still seeing the lock.
+    for _ in range(20):
+        await asyncio.sleep(0.005)
+    # Pre-unlock invariants: paste must NOT have fired, queue is empty
+    # (turn is held in _inflight_turn, not in the queue), and the
+    # inflight slot holds the turn.
+    assert tmux.paste_text.await_count == 0, (
+        "Murzik #522 round-1: paste must not fire while context lock "
+        "is held — pre-fix this was the silent-drop window"
+    )
+    assert ss._message_queue.qsize() == 0
+    assert ss._inflight_turn is not None
+    assert ss._inflight_turn.prompt == "hi"
+
+    # Release the lock. Within a handful of backoff cycles the worker
+    # should re-attempt _deliver_turn and paste the SAME turn.
+    lock_path.unlink()
+    for _ in range(50):
+        await asyncio.sleep(0.005)
+        if tmux.paste_text.await_count >= 1:
+            break
+
+    assert tmux.paste_text.await_count == 1, (
+        "Murzik #522 round-1 fix: same turn must re-paste once the lock "
+        "is released (pre-fix paste_count stayed at 0 forever)"
+    )
+    args, _ = tmux.paste_text.call_args
+    assert args[0] == "hi"
+
+    # Drive the turn to completion so the worker clears _inflight_turn.
+    await ss._handle_turn_complete(TurnResponse(text="ok", stop_reason="end_turn"))
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if ss._inflight_turn is None:
+            break
+    assert ss._inflight_turn is None
+    assert ss._idle_prompt_retry_count == 0
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_idle_prompt_timeout_retries_then_force_restarts(
+    monkeypatch,
+) -> None:
+    """After ``_IDLE_PROMPT_RETRY_LIMIT`` consecutive idle-prompt
+    timeouts against the same REPL, the worker must escalate to
+    ``force_restart`` instead of silently dropping the turn or looping
+    forever. Pin the relationship between retry-limit and
+    force_restart invocations.
+    """
+    monkeypatch.setattr(tmux_session, "_TRANSIENT_RETRY_BACKOFF_SEC", 0.01)
+    # Keep the limit at its default of 2 but pin it explicitly so the
+    # test doesn't drift if the constant is retuned later.
+    monkeypatch.setattr(tmux_session, "_IDLE_PROMPT_RETRY_LIMIT", 2)
+
+    tmux = _make_mock_tmux()
+    # Idle prompt never observed — every attempt times out.
+    tmux.wait_for_idle_prompt = AsyncMock(return_value=False)
+    ss, _ = _make_session(tmux=tmux)
+
+    # Stub force_restart so we don't actually tear down inside the test
+    # — count invocations, return True so the worker keeps going.
+    force_restart_calls: list[int] = []
+
+    async def stub_force_restart():
+        force_restart_calls.append(1)
+        return True
+
+    ss.force_restart = stub_force_restart  # type: ignore[assignment]
+
+    await ss.connect()
+    await ss.send("hi", platform="t", chat_id="c", message_id="m1")
+
+    # Let the worker run enough cycles for retry-limit + escalation.
+    # Each cycle: deliver_turn → _IdlePromptTimeout → sleep(0.01) → loop.
+    for _ in range(200):
+        await asyncio.sleep(0.005)
+        if force_restart_calls:
+            break
+
+    assert len(force_restart_calls) >= 1, (
+        "worker must escalate to force_restart after "
+        "_IDLE_PROMPT_RETRY_LIMIT consecutive idle-prompt timeouts"
+    )
+    # wait_for_idle_prompt was called once per retry attempt; the
+    # escalation fires on the Nth attempt, so we expect at least
+    # _IDLE_PROMPT_RETRY_LIMIT calls.
+    assert tmux.wait_for_idle_prompt.await_count >= 2, (
+        f"expected ≥2 idle-prompt poll attempts before escalation, "
+        f"got {tmux.wait_for_idle_prompt.await_count}"
+    )
+    # paste_text must NEVER have fired — the gate kept it out.
+    assert tmux.paste_text.await_count == 0, (
+        "paste must not fire while idle-prompt gate is failing — "
+        "Murzik #522 round-1: this is the data-loss window"
+    )
+    # Retry counter is reset on escalation so the post-restart REPL
+    # gets a fresh budget.
+    assert ss._idle_prompt_retry_count == 0
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_idle_prompt_preserves_turn_across_force_restart(
+    monkeypatch,
+) -> None:
+    """The trickiest invariant Murzik flagged: when the worker escalates
+    an idle-prompt timeout to ``force_restart``, the inflight turn
+    survives the worker-task cancel + re-spawn and is delivered against
+    the fresh REPL.
+
+    Mocking strategy: stub ``force_restart`` to flip ``wait_for_idle_prompt``
+    from fail-mode to success-mode, mimicking the new REPL becoming
+    healthy. Worker keeps the same TmuxSession instance, so
+    ``self._inflight_turn`` persists.
+    """
+    monkeypatch.setattr(tmux_session, "_TRANSIENT_RETRY_BACKOFF_SEC", 0.01)
+    monkeypatch.setattr(tmux_session, "_IDLE_PROMPT_RETRY_LIMIT", 2)
+
+    tmux = _make_mock_tmux()
+    # Start in fail-mode; the stub flips this to success on first
+    # force_restart call.
+    tmux.wait_for_idle_prompt = AsyncMock(return_value=False)
+    ss, _ = _make_session(tmux=tmux)
+
+    # Force-restart stub: simulate the fresh-REPL semantics by flipping
+    # idle-prompt detection to success. Don't actually tear down — the
+    # real force_restart cancels the worker, which would break the test
+    # harness. The contract under test is "_inflight_turn survives the
+    # escalation"; verifying that the SAME instance still carries the
+    # turn after force_restart fires is the proof.
+    inflight_at_escalation: list = []
+
+    async def stub_force_restart():
+        # Snapshot what the worker considers inflight at the moment of
+        # escalation — must be the original turn, not None.
+        inflight_at_escalation.append(ss._inflight_turn)
+        # Flip the gate to healthy so the next deliver attempt succeeds.
+        tmux.wait_for_idle_prompt.return_value = True
+        return True
+
+    ss.force_restart = stub_force_restart  # type: ignore[assignment]
+
+    await ss.connect()
+    await ss.send("hi", platform="t", chat_id="c", message_id="m1")
+
+    # Wait for the worker to: hit two timeouts, escalate, then re-deliver
+    # the same turn against the "fresh" REPL once force_restart flipped
+    # idle-prompt to True.
+    for _ in range(200):
+        await asyncio.sleep(0.005)
+        if tmux.paste_text.await_count >= 1:
+            break
+
+    assert len(inflight_at_escalation) >= 1, (
+        "force_restart must have been invoked at least once"
+    )
+    # The inflight slot at escalation must hold the original turn,
+    # not be None — this is the Murzik-invariant that pre-fix was
+    # violated.
+    assert inflight_at_escalation[0] is not None
+    assert inflight_at_escalation[0].prompt == "hi"
+
+    # And the post-restart REPL must have received the SAME prompt.
+    assert tmux.paste_text.await_count == 1
+    args, _ = tmux.paste_text.call_args
+    assert args[0] == "hi", (
+        "post-force_restart paste must re-deliver the same turn that "
+        "triggered the escalation (Murzik #522 round-1 preservation "
+        "invariant)"
+    )
+
+    await ss.disconnect()

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1551,11 +1551,14 @@ async def test_deliver_turn_skips_paste_when_context_locked(
     monkeypatch, tmp_path
 ) -> None:
     """Pulse-v2 port: if the daemon-level context manager has touched
-    the agent's transport-lock file, ``_deliver_turn`` must raise
-    BEFORE paste_text so the worker drops this iteration without
-    corrupting the REPL's input buffer. The worker stays alive and
-    will pick the next inbound on its next loop iteration (when the
-    lock is released — not part of this test).
+    the agent's transport-lock file, ``_deliver_turn`` must raise a
+    typed ``_ContextLockDeferral`` BEFORE paste_text so the worker
+    preserves the inflight turn and re-pastes the SAME prompt on the
+    next iteration once the lock is released (worker-level retry
+    behavior pinned separately in
+    ``test_context_lock_preserves_turn_until_released``). Idle-prompt
+    gate must not even be consulted — lock check is the first thing
+    ``_deliver_turn`` does.
     """
     # Point the lock dir at a tmp path so the test can't escape the
     # sandbox or collide with a real lock.
@@ -1590,9 +1593,14 @@ async def test_deliver_turn_skips_paste_when_context_locked(
 @pytest.mark.asyncio
 async def test_deliver_turn_raises_when_idle_prompt_times_out() -> None:
     """Pulse-v2 port: if the REPL never reaches an idle prompt within
-    the timeout, ``_deliver_turn`` must raise so the worker's existing
-    exception handler can log + re-arm. paste_text must not have been
-    called against a non-ready REPL.
+    the timeout, ``_deliver_turn`` must raise a typed
+    ``_IdlePromptTimeout`` so the worker preserves the inflight turn,
+    increments ``_idle_prompt_retry_count``, and either retries or
+    escalates to ``force_restart`` (worker-level behavior pinned
+    separately in
+    ``test_idle_prompt_timeout_retries_then_force_restarts`` and
+    ``test_idle_prompt_preserves_turn_across_force_restart``).
+    paste_text must not have been called against a non-ready REPL.
     """
     tmux = _make_mock_tmux()
     tmux.wait_for_idle_prompt = AsyncMock(return_value=False)


### PR DESCRIPTION
## Summary

Port two safety primitives (idle-prompt gate + context-lock check) into `TmuxSession._deliver_turn` to prevent the data-loss / wedged-input failure mode where prompts get pasted into a freshly spawned claude REPL before it's ready to receive them.

References:
- Task #92 (green-lit by Brad in msg #7860, scope re-confirmed in msg #7861).
- Pattern adapted from Misha's reference implementation in a sibling agent codebase (`queue-drain.ts:229-263`).

## What

1. **Idle-prompt gate** (port of `waitForIdlePrompt`). Before the first paste against a freshly spawned REPL, `_TmuxControl.wait_for_idle_prompt` polls the pane's last 5 lines every 2s for the claude idle-prompt signature (a line containing only the marker char with optional trailing whitespace). Default 90s timeout. On tmux read failure: keep polling. Logs the elapsed-ms on detection.

2. **Context-lock check** (port of `isContextLocked`). Before each paste, check `data/transport-locks/<agent>.lock`. If present, `_deliver_turn` raises a typed `_ContextLockDeferral` so the worker preserves the inflight turn and re-pastes the same prompt on the next iteration once the lock is released. **Crucially does NOT schedule disconnect**: this is transient (context manager is mid-rewrite), not a dead-pane situation.

3. **Discriminator**: `_has_completed_turn`. The idle-prompt gate only fires when False (we've never seen this REPL respond). `_spawn_tmux_repl` now resets it so the gate fires again on every fresh spawn (connect / force_restart / attempt_reconnect — all flow through `_spawn_tmux_repl`). Existing restart_guard semantics preserved.

## Round-2 fix (commit b1afe19)

Murzik's round-1 review caught a real blocker: `_message_worker` consumes the turn from `asyncio.Queue.get()` BEFORE `_deliver_turn` runs, so any exception in the gates silently lost the message. The sibling codebase doesn't hit this because their queue is file-based. Repro: paste count 0 even after the context lock cleared.

Fix:
- `_inflight_turn` + `_idle_prompt_retry_count` instance state on `TmuxSession` (survives `force_restart()`).
- Typed `_ContextLockDeferral` / `_IdlePromptTimeout` exceptions caught at the worker level — turn preserved, not silently dropped.
- Fixed 2s backoff (not exponential).
- Idle-retry-limit = 2 (initial + 1 retry → `force_restart`, turn preserved across the restart).
- Turn-done timeout (pre-existing 10-min REPL-stuck path) explicitly CLEARS `_inflight_turn` before `force_restart` — paste already landed, so preserving it would risk duplicate delivery. Different semantics from idle-prompt timeout (paste never happened).

## Round-2 cleanup (commit 6b4cdab)

Refresh 3 stale docstrings whose old wording ("stays queued / worker keeps pulling normally / log + re-arm") was exactly what masked the round-1 miss. No runtime change.

## Failure mode prevented

`_deliver_turn` pastes immediately after spawning or waking a session. If the REPL hasn't reached an idle prompt yet — MCP servers still initializing, splash UI still up — the bracketed paste lands in a bad state. Result: data loss or corrupted input, and a worker that thinks it dispatched a turn but never gets a response.

## Test coverage

10 new tests in `tests/test_tmux_session.py` (77 → 87):
- Unit tests for both gates against the `_deliver_turn` entry point.
- Worker-level tests pinning the inflight-preservation behavior (context-lock retry-until-released, idle-prompt timeout → retry → force_restart, turn preserved across the restart).
- Idle-prompt detection happy path + timeout + transient-failure tolerance.
- `_spawn_tmux_repl_resets_completed_turn_flag` — every fresh spawn re-arms the gate.

`pytest tests/test_tmux_session.py -q` → **87 passed**. Full suite previously **2474 passed, 1 skipped** (no regressions). `ruff check` → clean.

## Test plan

- [x] `pytest tests/test_tmux_session.py -q` — 87 passed
- [x] `pytest tests/ -q` — 2474 passed, 1 skipped
- [x] `ruff check` — clean
- [x] CI green before merge

🤖 Opened by Barsik