### PR TITLE
fix(tmux): rip pane-scraping readiness gate; trust paste-buffer (#525)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -58,7 +58,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import re
 import shlex
 import time
 from dataclasses import dataclass, field, replace

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -85,45 +85,6 @@ from pinky_daemon.transport_state import (
 # ──────────────────────────────────────────────────────────────────────────
 
 
-# Idle-prompt gate (pulse-v2 port, queue-drain.ts:229-250). Polls the
-# pane's last 5 lines for claude's idle-prompt signature (``❯`` or ``>``
-# on a line by itself) before a first-turn paste, so the prompt can't
-# land while MCP servers are still booting / splash UI is still up. The
-# regex matches a line of only ``❯`` or ``>`` with optional trailing
-# whitespace, multiline mode so any of the last few lines can match.
-_IDLE_PROMPT_RE = re.compile(r"^[❯>]\s*$", re.MULTILINE)
-_RATE_LIMIT_WAIT_RE = re.compile(
-    r"Rate limits:\s*waiting for data\.*", re.IGNORECASE
-)
-_SPLASH_TRY_RE = re.compile(r"^[❯>]\s+Try\b.*$", re.MULTILINE)
-
-
-class _PaneReadiness:
-    READY = "ready"
-    RATE_LIMIT_WAIT = "rate_limit_wait"
-    SPLASH_NOT_READY = "splash_not_ready"
-    NOT_READY = "not_ready"
-    UNKNOWN = "unknown"
-
-
-@dataclass(frozen=True)
-class _IdlePromptWaitResult:
-    ready: bool
-    state: str
-    elapsed_ms: int = 0
-    matched_line: str = ""
-
-    def __bool__(self) -> bool:
-        return self.ready
-
-# Idle-prompt poll cadence + cap. 2s matches pulse-v2's polling interval;
-# 90s the default timeout (generous enough for slow MCP init + first-time
-# auth, tight enough that a wedged REPL surfaces rather than parking the
-# worker for 10 minutes).
-_IDLE_PROMPT_POLL_INTERVAL_SEC = 2.0
-_IDLE_PROMPT_TIMEOUT_SEC = 90.0
-_IDLE_PROMPT_CAPTURE_LINES = 10
-
 # Context-lock check (pulse-v2 port, queue-drain.ts:252-263). When the
 # daemon-level context manager is mid-rewrite of an agent's CLAUDE.md /
 # transcript files, it touches ``data/transport-locks/<agent>.lock`` to
@@ -141,23 +102,6 @@ _TRANSPORT_LOCK_DIR = Path("data/transport-locks")
 # either succeeds or hits a permanent failure.
 _TRANSIENT_RETRY_BACKOFF_SEC = 2.0
 
-# How many idle-prompt timeouts the worker tolerates against the same
-# REPL before escalating to ``force_restart``. With the 90s idle-prompt
-# wait, the limit of 2 means initial wait + one retry ≈ 180s wall clock
-# before the worker concludes the REPL is wedged enough to need a fresh
-# spawn rather than just more patience.
-_IDLE_PROMPT_RETRY_LIMIT = 2
-
-# How long to tolerate Claude Code's explicit rate-limit preflight wait
-# before marking the tmux transport unhealthy. Restarting usually recreates
-# the same upstream block, so this is wall-clock budget, not restart count.
-_RATE_LIMIT_WAIT_MAX_SEC = 600.0
-
-# Circuit breaker for first-turn startup gates across force_restart cycles.
-# Reset after the first successful turn_done. If every fresh REPL still fails
-# the gate, stop the restart loop and surface the transport as DEAD.
-_PRE_FIRST_TURN_RESTART_LIMIT = 2
-
 
 class _ContextLockDeferral(Exception):  # noqa: N818
     """Transient: context-lock file present at paste time.
@@ -169,31 +113,6 @@ class _ContextLockDeferral(Exception):  # noqa: N818
     exception that the worker recognises as "transient, keep the
     inflight turn, sleep + retry without re-fetching from the queue".
     """
-
-
-class _IdlePromptTimeout(Exception):  # noqa: N818
-    """Transient: REPL idle prompt not observed within the gate timeout.
-
-    Murzik #522 round-1: same root cause as ``_ContextLockDeferral``.
-    The worker treats this as retryable; after
-    ``_IDLE_PROMPT_RETRY_LIMIT`` consecutive timeouts against the same
-    REPL it escalates to ``force_restart`` while preserving the
-    inflight turn (instance state survives the worker-task cancel /
-    re-spawn that ``force_restart`` performs).
-    """
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        state: str = _PaneReadiness.NOT_READY,
-        elapsed_ms: int = 0,
-        matched_line: str = "",
-    ) -> None:
-        super().__init__(message)
-        self.state = state
-        self.elapsed_ms = elapsed_ms
-        self.matched_line = matched_line
 
 
 @dataclass
@@ -418,114 +337,6 @@ class _TmuxControl:
             str(-abs(lines)),  # negative line offset = lines from bottom
         )
 
-    async def wait_for_idle_prompt(
-        self,
-        *,
-        agent_name: str = "",
-        timeout_s: float = _IDLE_PROMPT_TIMEOUT_SEC,
-        poll_interval_s: float = _IDLE_PROMPT_POLL_INTERVAL_SEC,
-    ) -> _IdlePromptWaitResult:
-        """Poll the pane until claude's REPL shows an idle input prompt.
-
-        Ported from pulse-v2's ``waitForIdlePrompt`` (Misha's
-        ``src/daemon/queue-drain.ts`` lines 229-250). Defends against the
-        race where ``_deliver_turn`` pastes a prompt while the REPL is
-        still booting — MCP servers initializing, splash UI still up —
-        which causes data loss or corrupted input.
-
-        Captures the last few lines of pane content every
-        ``poll_interval_s`` (default 2s, matching pulse-v2). Examines the
-        non-empty tail for a line containing only ``❯`` or ``>`` with
-        optional trailing whitespace — claude's idle-prompt signature.
-
-        Some Claude startup screens also begin with ``❯`` but are not
-        ready for input, notably the rotating ``❯ Try "..."`` splash
-        suggestion. Those are classified explicitly so the caller can
-        avoid broad prompt regexes that would paste into the splash. The
-        ``Rate limits: waiting for data...`` preflight is also classified
-        separately because restarting generally recreates the same upstream
-        stall.
-
-        On tmux capture failure, keeps polling rather than failing early;
-        the pane may simply not be ready yet.
-
-        Returns a structured result. ``bool(result)`` is true only when
-        the idle prompt was seen.
-
-        ``agent_name`` is for log lines only.
-        """
-        start = time.monotonic()
-        deadline = start + timeout_s
-        label = agent_name or self.session_name
-        last_state = _PaneReadiness.UNKNOWN
-        last_match = ""
-        while time.monotonic() < deadline:
-            try:
-                result = await self._run(
-                    "capture-pane",
-                    "-t",
-                    self.session_name,
-                    "-p",
-                    "-S",
-                    str(-_IDLE_PROMPT_CAPTURE_LINES),
-                )
-                if result.ok:
-                    classified = self._classify_prompt_readiness(result.stdout)
-                    last_state = classified.state
-                    last_match = classified.matched_line
-                    if classified.ready:
-                        elapsed_ms = int((time.monotonic() - start) * 1000)
-                        _log(
-                            f"tmux[{label}]: idle prompt detected after "
-                            f"{elapsed_ms}ms"
-                        )
-                        return replace(classified, elapsed_ms=elapsed_ms)
-            except Exception:
-                # tmux read failed (server hiccup, transient lock); keep
-                # polling — the pane may just not be ready yet.
-                pass
-            await asyncio.sleep(poll_interval_s)
-        return _IdlePromptWaitResult(
-            ready=False,
-            state=last_state,
-            elapsed_ms=int((time.monotonic() - start) * 1000),
-            matched_line=last_match,
-        )
-
-    @staticmethod
-    def _classify_prompt_readiness(stdout: str) -> _IdlePromptWaitResult:
-        lines = [
-            line.rstrip()
-            for line in (stdout or "").split("\n")
-            if line.strip()
-        ]
-        tail = "\n".join(lines[-_IDLE_PROMPT_CAPTURE_LINES:])
-        idle_match = _IDLE_PROMPT_RE.search(tail)
-        if idle_match:
-            return _IdlePromptWaitResult(
-                ready=True,
-                state=_PaneReadiness.READY,
-                matched_line=idle_match.group(0).strip(),
-            )
-        rate_match = _RATE_LIMIT_WAIT_RE.search(tail)
-        if rate_match:
-            return _IdlePromptWaitResult(
-                ready=False,
-                state=_PaneReadiness.RATE_LIMIT_WAIT,
-                matched_line=rate_match.group(0).strip(),
-            )
-        splash_match = _SPLASH_TRY_RE.search(tail)
-        if splash_match:
-            return _IdlePromptWaitResult(
-                ready=False,
-                state=_PaneReadiness.SPLASH_NOT_READY,
-                matched_line=splash_match.group(0).strip(),
-            )
-        return _IdlePromptWaitResult(
-            ready=False,
-            state=_PaneReadiness.NOT_READY,
-        )
-
 
 # ──────────────────────────────────────────────────────────────────────────
 # Worker queue payload
@@ -687,18 +498,6 @@ class TmuxSession:
         # lets the new REPL pick the same turn back up after a stuck-
         # REPL escalation.
         self._inflight_turn: _QueuedTurn | None = None
-        # Consecutive idle-prompt timeouts against the current REPL.
-        # Reset on success or after force_restart escalation. Bounded
-        # by ``_IDLE_PROMPT_RETRY_LIMIT`` before escalating.
-        self._idle_prompt_retry_count: int = 0
-        # Pre-first-turn startup recovery budget. Unlike
-        # _idle_prompt_retry_count, this survives force_restart so a
-        # Claude startup state that reproduces after every fresh spawn
-        # cannot restart-loop forever. Reset after the first successful
-        # turn_done.
-        self._pre_first_turn_restart_count: int = 0
-        self._startup_gate_wait_started_at: float | None = None
-        self._startup_gate_alerted: bool = False
 
     # ── Identity ────────────────────────────────────────────────────────
 
@@ -760,50 +559,6 @@ class TmuxSession:
                 await result
         except Exception as e:
             _log(f"tmux[{self.agent_name}]: stream_event_callback raised: {e}")
-
-    async def _trip_startup_gate_circuit(
-        self,
-        *,
-        reason: str,
-        state: str,
-        matched_line: str = "",
-    ) -> None:
-        """Stop pre-first-turn restart loops while preserving the turn.
-
-        Called from the worker before any paste has succeeded. The current
-        turn remains in ``_inflight_turn`` so a future explicit reconnect can
-        retry it instead of silently dropping Brad's inbound message.
-        """
-        self._stats["errors"] += 1
-        self._stats["startup_gate_circuit_breakers"] = (
-            self._stats.get("startup_gate_circuit_breakers", 0) + 1
-        )
-        self._stats["last_startup_gate_state"] = state
-        self._stats["last_startup_gate_reason"] = reason
-        if matched_line:
-            self._stats["last_startup_gate_match"] = matched_line
-
-        alert = (
-            f"tmux[{self.agent_name}]: startup gate circuit breaker tripped "
-            f"({state}; {reason}); preserving inflight turn and marking DEAD"
-        )
-        _log(alert)
-        if not self._startup_gate_alerted:
-            self._startup_gate_alerted = True
-            await self._emit_stream_event(
-                {
-                    "type": "transport_alert",
-                    "severity": "error",
-                    "agent_name": self.agent_name,
-                    "state": state,
-                    "reason": reason,
-                    "matched_line": matched_line,
-                    "pre_first_turn_restarts": (
-                        self._pre_first_turn_restart_count
-                    ),
-                    "inflight_turn_preserved": self._inflight_turn is not None,
-                }
-            )
 
     def set_effort(self, level: str) -> None:
         """Accept the call for protocol parity. tmux's claude REPL doesn't
@@ -1579,24 +1334,26 @@ class TmuxSession:
         current turn IN-HAND across transient failures via
         ``self._inflight_turn``. The previous shape — ``get()`` a turn,
         run ``_deliver_turn``, let any exception fall through the
-        catch-all — silently dropped messages when the new context-lock
-        and idle-prompt gates raised: the queue had already coughed up
-        the message, and the except handler logged-but-didn't-requeue.
-        The new shape:
+        catch-all — silently dropped messages when the context-lock
+        gate raised: the queue had already coughed up the message,
+        and the except handler logged-but-didn't-requeue. The new
+        shape:
 
         - Only ``get()`` from the queue when ``_inflight_turn is None``.
-        - ``_ContextLockDeferral`` / ``_IdlePromptTimeout`` are TRANSIENT
-          — sleep ``_TRANSIENT_RETRY_BACKOFF_SEC`` and loop without
-          touching ``_inflight_turn``, so the next iteration retries
-          the SAME turn against the SAME REPL.
-        - After ``_IDLE_PROMPT_RETRY_LIMIT`` consecutive idle-prompt
-          timeouts, escalate to ``force_restart`` while PRESERVING
-          ``_inflight_turn`` — instance state on ``self`` outlives the
-          worker-task cancellation and re-spawn that ``force_restart``
-          performs, so the fresh REPL's worker picks up the same turn.
+        - ``_ContextLockDeferral`` is TRANSIENT — sleep
+          ``_TRANSIENT_RETRY_BACKOFF_SEC`` and loop without touching
+          ``_inflight_turn``, so the next iteration retries the SAME
+          turn against the SAME REPL.
         - Any other exception (paste-fail, dead-pane, etc.) is treated
           as PERMANENT — clear ``_inflight_turn`` and follow the
           existing handler semantics (disconnect on dead-pane).
+
+        Note: prior to #525, there was a pre-paste idle-prompt readiness
+        gate (#522) and a rate-limit-wait band-aid (#524). Both were
+        removed: the gate waited for a pane signal (bare ``❯``) that
+        Claude Code's splash never produces, so it killed every cold-
+        start. ``paste_text`` is designed to handle splash-state paste
+        (splash dismisses on input focus); we trust that path.
         """
         _log(f"tmux[{self.agent_name}]: message worker started")
         try:
@@ -1626,13 +1383,9 @@ class TmuxSession:
                             timeout=_TURN_DONE_TIMEOUT_SEC,
                         )
                         self._has_completed_turn = True
-                        # Success — clear inflight + retry counter so the
-                        # next iteration pulls a fresh turn.
+                        # Success — clear inflight so the next
+                        # iteration pulls a fresh turn.
                         self._inflight_turn = None
-                        self._idle_prompt_retry_count = 0
-                        self._pre_first_turn_restart_count = 0
-                        self._startup_gate_wait_started_at = None
-                        self._startup_gate_alerted = False
                     except asyncio.TimeoutError:
                         # The REPL is stuck. Pushok's PR #496 round-2
                         # follow-up: just "continue" leaves the stuck
@@ -1664,7 +1417,6 @@ class TmuxSession:
                         # inflight so a stale prompt doesn't get re-
                         # pasted into the fresh REPL after force_restart.
                         self._inflight_turn = None
-                        self._idle_prompt_retry_count = 0
                         # Schedule force_restart in the background so this
                         # worker can exit cleanly without awaiting its own
                         # cancellation (force_restart calls disconnect →
@@ -1684,97 +1436,6 @@ class TmuxSession:
                     )
                     await asyncio.sleep(_TRANSIENT_RETRY_BACKOFF_SEC)
                     continue
-                except _IdlePromptTimeout as e:
-                    # Transient: REPL hasn't reached idle prompt. Same
-                    # invariants as _ContextLockDeferral above — raised
-                    # before any state mutation.
-                    if self._startup_gate_wait_started_at is None:
-                        self._startup_gate_wait_started_at = time.monotonic()
-                    wait_elapsed = (
-                        time.monotonic() - self._startup_gate_wait_started_at
-                    )
-                    if e.state == _PaneReadiness.RATE_LIMIT_WAIT:
-                        if wait_elapsed >= _RATE_LIMIT_WAIT_MAX_SEC:
-                            await self._trip_startup_gate_circuit(
-                                reason=(
-                                    "rate-limit preflight did not clear within "
-                                    f"{_RATE_LIMIT_WAIT_MAX_SEC:.0f}s"
-                                ),
-                                state=e.state,
-                                matched_line=e.matched_line,
-                            )
-                            asyncio.create_task(self.disconnect())
-                            return
-                        _log(
-                            f"tmux[{self.agent_name}]: rate-limit preflight "
-                            f"wait persists ({wait_elapsed:.0f}/"
-                            f"{_RATE_LIMIT_WAIT_MAX_SEC:.0f}s); preserving "
-                            f"inflight turn and retrying in "
-                            f"{_TRANSIENT_RETRY_BACKOFF_SEC}s"
-                        )
-                        await asyncio.sleep(_TRANSIENT_RETRY_BACKOFF_SEC)
-                        continue
-
-                    self._idle_prompt_retry_count += 1
-                    if (
-                        self._idle_prompt_retry_count
-                        >= _IDLE_PROMPT_RETRY_LIMIT
-                    ):
-                        if (
-                            self._pre_first_turn_restart_count
-                            >= _PRE_FIRST_TURN_RESTART_LIMIT
-                        ):
-                            await self._trip_startup_gate_circuit(
-                                reason=(
-                                    "idle prompt gate failed after "
-                                    f"{self._pre_first_turn_restart_count} "
-                                    "pre-first-turn force restarts"
-                                ),
-                                state=e.state,
-                                matched_line=e.matched_line,
-                            )
-                            asyncio.create_task(self.disconnect())
-                            return
-                        _log(
-                            f"tmux[{self.agent_name}]: idle prompt "
-                            f"persistent timeout "
-                            f"({self._idle_prompt_retry_count}/"
-                            f"{_IDLE_PROMPT_RETRY_LIMIT}) — escalating to "
-                            f"force_restart, preserving inflight turn"
-                        )
-                        # PRESERVE _inflight_turn across force_restart —
-                        # instance state on self survives worker
-                        # cancellation + re-spawn, so the new worker
-                        # will retry the same turn against the fresh
-                        # REPL. Reset the retry counter so the new REPL
-                        # gets a clean budget.
-                        self._idle_prompt_retry_count = 0
-                        self._pre_first_turn_restart_count += 1
-                        self._stats["errors"] += 1
-                        self._stats["startup_gate_restarts"] = (
-                            self._stats.get("startup_gate_restarts", 0) + 1
-                        )
-                        # Background create_task: see turn_done-timeout
-                        # path above for the same deadlock-avoidance
-                        # rationale.
-                        asyncio.create_task(self.force_restart())
-                        # Brief sleep so force_restart can begin tearing
-                        # down before this worker's next loop iteration
-                        # tries to re-deliver against a dying pane. The
-                        # while-loop's CONNECTED guard + worker-task
-                        # cancellation will end this loop naturally
-                        # once disconnect runs.
-                        await asyncio.sleep(_TRANSIENT_RETRY_BACKOFF_SEC)
-                        continue
-                    _log(
-                        f"tmux[{self.agent_name}]: idle prompt timeout "
-                        f"(attempt {self._idle_prompt_retry_count}/"
-                        f"{_IDLE_PROMPT_RETRY_LIMIT}) — retrying in "
-                        f"{_TRANSIENT_RETRY_BACKOFF_SEC}s ({e}; "
-                        f"state={e.state})"
-                    )
-                    await asyncio.sleep(_TRANSIENT_RETRY_BACKOFF_SEC)
-                    continue
                 except Exception as e:
                     # Permanent failure (paste-buffer/send-keys failed,
                     # dead-pane, tailer-state corruption, etc.). Drop
@@ -1787,7 +1448,6 @@ class TmuxSession:
                     # path raised (e.g. tailer state corruption).
                     self._turn_done.set()
                     self._inflight_turn = None
-                    self._idle_prompt_retry_count = 0
                     # Task #90: dead-pane already scheduled disconnect from
                     # inside _deliver_turn. Exit the worker cleanly so we
                     # don't retry into the now-being-torn-down pane.
@@ -1831,36 +1491,32 @@ class TmuxSession:
         would overwrite meta before the first turn's stop_hook_summary
         landed.
 
-        Pulse-v2 port (task #92): two safety primitives gate the paste,
-        each raising a **typed transient exception** the worker catches
-        in its retry loop (Murzik #522 round-1). Because the worker pops
-        the turn from the queue before calling ``_deliver_turn``, a bare
-        exception would silently drop the message; the worker keeps the
-        turn in ``_inflight_turn`` and re-paste the same prompt on the
-        next iteration. Neither path schedules disconnect — this is
-        transient state, not a dead-pane.
+        Pulse-v2 port (task #92): one safety primitive gates the paste —
+        the context-lock check — raising a **typed transient exception**
+        the worker catches in its retry loop (Murzik #522 round-1).
+        Because the worker pops the turn from the queue before calling
+        ``_deliver_turn``, a bare exception would silently drop the
+        message; the worker keeps the turn in ``_inflight_turn`` and
+        re-pastes the same prompt on the next iteration. The deferral
+        path does not schedule disconnect — this is transient state,
+        not a dead-pane.
 
-        1. **Context-lock check.** If the daemon-level context manager
-           has touched ``data/transport-locks/<agent>.lock``, it's mid-
-           rewrite of files this REPL depends on — paste would land on
-           an inconsistent state. Raise ``_ContextLockDeferral`` so the
-           worker preserves the inflight turn, sleeps, and retries when
-           the lock is released.
+        **Context-lock check.** If the daemon-level context manager has
+        touched ``data/transport-locks/<agent>.lock``, it's mid-rewrite
+        of files this REPL depends on — paste would land on an
+        inconsistent state. Raise ``_ContextLockDeferral`` so the worker
+        preserves the inflight turn, sleeps, and retries when the lock
+        is released.
 
-        2. **Idle-prompt gate (first turn only).** If we haven't yet
-           seen a successful turn from this REPL, poll the pane for the
-           ``❯``/``>`` idle prompt before pasting. Defends against the
-           race where the prompt lands while MCP servers are still
-           booting (data loss / corrupted input). On timeout, raise
-           ``_IdlePromptTimeout`` so the worker increments
-           ``_idle_prompt_retry_count`` and either retries the same turn
-           or escalates to ``force_restart`` after
-           ``_IDLE_PROMPT_RETRY_LIMIT`` consecutive failures — turn
-           preserved across the restart. Skipped after
-           ``_has_completed_turn`` flips to True — once we've seen the
-           REPL respond, subsequent turns can paste immediately.
+        Splash-state paste handling lives in ``_TmuxControl.paste_text``
+        (bracketed-paste + delayed-Enter, commit 0864f4e / issue #514).
+        Claude Code's splash dismisses on input focus, so pasting into
+        the splash works correctly; no readiness gate is needed. (Prior
+        to #525, a pane-scraping idle-prompt gate from #522 / #524 sat
+        here; it waited for a bare ``❯`` signal that the splash never
+        produces, killing every cold start.)
         """
-        # Pulse-v2 safety primitive 1: context-lock check. Cheap fs stat;
+        # Pulse-v2 safety primitive: context-lock check. Cheap fs stat;
         # do this first so we bail before mutating any state. The lock
         # being held is transient — Murzik #522 round-1: raise a typed
         # ``_ContextLockDeferral`` so the worker knows to PRESERVE the
@@ -1873,36 +1529,6 @@ class TmuxSession:
                 f"context lock present at {self._context_lock_path()} — "
                 f"deferring paste; worker will retry on next iteration"
             )
-
-        # Pulse-v2 safety primitive 2: wait for the REPL's idle prompt
-        # before the first paste. After ``_has_completed_turn`` is True
-        # we've seen the REPL respond to at least one turn, so the gate
-        # has served its purpose; skip the (up to 90s) poll on every
-        # subsequent dispatch.
-        if not self._has_completed_turn:
-            idle_result = await self._tmux.wait_for_idle_prompt(
-                agent_name=self.agent_name,
-            )
-            saw_idle = bool(idle_result)
-            if not saw_idle:
-                state = getattr(
-                    idle_result, "state", _PaneReadiness.NOT_READY
-                )
-                elapsed_ms = int(getattr(idle_result, "elapsed_ms", 0) or 0)
-                matched_line = getattr(idle_result, "matched_line", "")
-                # Murzik #522 round-1: typed exception so the worker
-                # preserves the inflight turn, increments its retry
-                # counter, and escalates to force_restart after
-                # _IDLE_PROMPT_RETRY_LIMIT consecutive failures rather
-                # than dropping the message.
-                raise _IdlePromptTimeout(
-                    f"idle prompt not seen within "
-                    f"{_IDLE_PROMPT_TIMEOUT_SEC:.0f}s — REPL not ready "
-                    f"for paste (state={state})",
-                    state=state,
-                    elapsed_ms=elapsed_ms,
-                    matched_line=matched_line,
-                )
 
         # Capture routing metadata BEFORE send-keys so the tailer's callback
         # has access to it even if the tailer fires unusually quickly.

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -56,10 +56,6 @@ def _make_mock_tmux(*, has_session_initial: bool = False) -> MagicMock:
     tmux.send_keys = AsyncMock(return_value=_ok())
     tmux.paste_text = AsyncMock(return_value=_ok())
     tmux.capture_pane = AsyncMock(return_value=_ok())
-    # Pulse-v2 idle-prompt gate (task #92). Default to "seen immediately"
-    # so tests focused on other lifecycle paths aren't paying a 90s timeout
-    # nor having to opt into the gate explicitly.
-    tmux.wait_for_idle_prompt = AsyncMock(return_value=True)
     return tmux
 
 
@@ -1511,39 +1507,35 @@ async def test_deliver_turn_dead_pane_schedules_disconnect_and_worker_exits() ->
 
 
 # ──────────────────────────────────────────────────────────────────────────
-# Pulse-v2 safety primitives (task #92): idle-prompt gate + context lock
+# Paste-time safety: context-lock check (#522 + #525)
 # ──────────────────────────────────────────────────────────────────────────
+# Issue #525 removed the pane-scraping idle-prompt readiness gate (#522 +
+# #524). It waited for a pane signal (bare ``❯``) that Claude Code's splash
+# never produces and killed every cold start. Splash-state paste is
+# handled by ``_TmuxControl.paste_text`` (bracketed-paste + delayed Enter,
+# commit 0864f4e / issue #514): the splash dismisses on input focus.
+# Context-lock check is the only remaining paste-time gate.
 
 
 @pytest.mark.asyncio
-async def test_deliver_turn_waits_for_idle_prompt_on_first_turn() -> None:
-    """Pulse-v2 port: the first ``_deliver_turn`` after spawn must wait
-    for the REPL's idle prompt before pasting — defends against the
-    race where MCP servers are still booting. Subsequent turns
-    (``_has_completed_turn = True``) skip the gate since the REPL has
-    already been observed responding.
+async def test_deliver_turn_pastes_immediately_on_cold_repl() -> None:
+    """Issue #525: cold-start paste must NOT block on any pane-state
+    readiness check. The original gate (#522) waited for a bare ``❯``
+    that Claude Code's splash never produces, deadlocking cold starts.
+    First turn after spawn pastes directly — splash-state paste is
+    handled by ``paste_text`` (splash dismisses on input focus).
     """
     tmux = _make_mock_tmux()
-    tmux.wait_for_idle_prompt = AsyncMock(return_value=True)
     ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
     assert ss._has_completed_turn is False
 
     turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m1")
     await ss._deliver_turn(turn)
 
-    # First turn: gate is consulted exactly once, then paste happens.
-    tmux.wait_for_idle_prompt.assert_awaited_once()
+    # Paste must fire immediately, no readiness polling involved.
     tmux.paste_text.assert_awaited_once()
-
-    # Flip the flag (the worker does this after observing turn_done).
-    ss._has_completed_turn = True
-    turn2 = _QueuedTurn(prompt="hi2", platform="t", chat_id="c", message_id="m2")
-    await ss._deliver_turn(turn2)
-
-    # Second turn: gate is NOT consulted again (still 1 await total),
-    # paste fires again.
-    assert tmux.wait_for_idle_prompt.await_count == 1
-    assert tmux.paste_text.await_count == 2
+    assert not hasattr(tmux, "wait_for_idle_prompt") or \
+        not tmux.wait_for_idle_prompt.await_count
 
 
 @pytest.mark.asyncio
@@ -1556,9 +1548,7 @@ async def test_deliver_turn_skips_paste_when_context_locked(
     preserves the inflight turn and re-pastes the SAME prompt on the
     next iteration once the lock is released (worker-level retry
     behavior pinned separately in
-    ``test_context_lock_preserves_turn_until_released``). Idle-prompt
-    gate must not even be consulted — lock check is the first thing
-    ``_deliver_turn`` does.
+    ``test_context_lock_preserves_turn_until_released``).
     """
     # Point the lock dir at a tmp path so the test can't escape the
     # sandbox or collide with a real lock.
@@ -1579,172 +1569,14 @@ async def test_deliver_turn_skips_paste_when_context_locked(
     ):
         await ss._deliver_turn(turn)
 
-    # Paste must not have been called, and the idle-prompt gate also
-    # not consulted (lock check is the first thing _deliver_turn does).
+    # Paste must not have been called — lock check is the first thing
+    # _deliver_turn does.
     tmux.paste_text.assert_not_awaited()
-    tmux.wait_for_idle_prompt.assert_not_awaited()
 
     # Once the lock is released, the next dispatch proceeds normally.
     lock_path.unlink()
     await ss._deliver_turn(turn)
     tmux.paste_text.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_deliver_turn_raises_when_idle_prompt_times_out() -> None:
-    """Pulse-v2 port: if the REPL never reaches an idle prompt within
-    the timeout, ``_deliver_turn`` must raise a typed
-    ``_IdlePromptTimeout`` so the worker preserves the inflight turn,
-    increments ``_idle_prompt_retry_count``, and either retries or
-    escalates to ``force_restart`` (worker-level behavior pinned
-    separately in
-    ``test_idle_prompt_timeout_retries_then_force_restarts`` and
-    ``test_idle_prompt_preserves_turn_across_force_restart``).
-    paste_text must not have been called against a non-ready REPL.
-    """
-    tmux = _make_mock_tmux()
-    tmux.wait_for_idle_prompt = AsyncMock(return_value=False)
-    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
-
-    turn = _QueuedTurn(prompt="hi", platform="t", chat_id="c", message_id="m1")
-    # Murzik #522 round-1: typed transient exception (was bare
-    # RuntimeError) — the worker recognises it for retry + escalate-to-
-    # force_restart with inflight preservation.
-    with pytest.raises(
-        tmux_session._IdlePromptTimeout, match="idle prompt not seen"
-    ):
-        await ss._deliver_turn(turn)
-
-    tmux.wait_for_idle_prompt.assert_awaited_once()
-    tmux.paste_text.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_wait_for_idle_prompt_detects_signature() -> None:
-    """The real ``_TmuxControl.wait_for_idle_prompt`` returns True when
-    capture-pane stdout ends with a line containing only ``❯`` (or
-    ``>``) and optional trailing whitespace.
-    """
-    tmux = _TmuxControl("pinky-test")
-
-    async def fake_run(*args, **kwargs):
-        # Simulated claude REPL idle-prompt capture: blank, splash bits,
-        # then the ❯ prompt on its own line.
-        return TmuxCommandResult(
-            returncode=0,
-            stdout="some splash text\n\n❯ \n",
-            stderr="",
-        )
-
-    tmux._run = fake_run  # type: ignore[assignment]
-    # Tiny poll cadence + tight timeout — happy path should return in
-    # under one poll cycle.
-    saw = await tmux.wait_for_idle_prompt(
-        agent_name="dymok", timeout_s=1.0, poll_interval_s=0.01
-    )
-    assert saw.ready is True
-    assert saw.state == tmux_session._PaneReadiness.READY
-
-
-@pytest.mark.asyncio
-async def test_wait_for_idle_prompt_times_out_on_non_idle_output() -> None:
-    """If capture-pane never produces an idle prompt, the helper returns
-    False after ``timeout_s``. Keep timeout small so the test is fast.
-    """
-    tmux = _TmuxControl("pinky-test")
-
-    async def fake_run(*args, **kwargs):
-        # Pane is mid-spinner / mid-bootstrap — no idle signature.
-        return TmuxCommandResult(
-            returncode=0,
-            stdout="Loading MCP servers...\n[*] thinking\n",
-            stderr="",
-        )
-
-    tmux._run = fake_run  # type: ignore[assignment]
-    saw = await tmux.wait_for_idle_prompt(
-        agent_name="dymok", timeout_s=0.1, poll_interval_s=0.02
-    )
-    assert saw.ready is False
-    assert saw.state == tmux_session._PaneReadiness.NOT_READY
-
-
-@pytest.mark.asyncio
-async def test_wait_for_idle_prompt_classifies_splash_try_as_not_ready() -> None:
-    """The Claude splash suggestion starts with ``❯`` but is not an
-    idle prompt. This pins the live Dymok failure mode Brad saw: a
-    broader ``^❯ `` matcher would paste into the splash and reintroduce
-    the first-turn data-loss bug PR #522 prevented.
-    """
-    tmux = _TmuxControl("pinky-test")
-
-    async def fake_run(*args, **kwargs):
-        return TmuxCommandResult(
-            returncode=0,
-            stdout='❯ Try "refactor Agents.svelte"\n'
-                   "─────────────\n"
-                   "⏵⏵ bypass permissions on (shift+tab to cycle)\n",
-            stderr="",
-        )
-
-    tmux._run = fake_run  # type: ignore[assignment]
-    saw = await tmux.wait_for_idle_prompt(
-        agent_name="dymok", timeout_s=0.1, poll_interval_s=0.02
-    )
-    assert saw.ready is False
-    assert saw.state == tmux_session._PaneReadiness.SPLASH_NOT_READY
-    assert saw.matched_line == '❯ Try "refactor Agents.svelte"'
-
-
-@pytest.mark.asyncio
-async def test_wait_for_idle_prompt_classifies_rate_limit_wait() -> None:
-    """Claude's rate-limit preflight can wedge before the idle prompt.
-    Classify it explicitly so the worker can apply a wall-clock budget
-    instead of treating it like an ordinary no-idle timeout.
-    """
-    tmux = _TmuxControl("pinky-test")
-
-    async def fake_run(*args, **kwargs):
-        return TmuxCommandResult(
-            returncode=0,
-            stdout='❯ Try "refactor Agents.svelte"\n'
-                   "─────────────\n"
-                   "Rate limits: waiting for data...\n"
-                   "⏵⏵ bypass permissions on (shift+tab to cycle)\n",
-            stderr="",
-        )
-
-    tmux._run = fake_run  # type: ignore[assignment]
-    saw = await tmux.wait_for_idle_prompt(
-        agent_name="dymok", timeout_s=0.1, poll_interval_s=0.02
-    )
-    assert saw.ready is False
-    assert saw.state == tmux_session._PaneReadiness.RATE_LIMIT_WAIT
-    assert saw.matched_line == "Rate limits: waiting for data..."
-
-
-@pytest.mark.asyncio
-async def test_wait_for_idle_prompt_survives_tmux_read_failures() -> None:
-    """Pulse-v2 port: a transient tmux failure must not abort the gate —
-    keep polling. Verified by alternating failure + success: helper
-    returns True once the success lands.
-    """
-    tmux = _TmuxControl("pinky-test")
-    call_count = {"n": 0}
-
-    async def fake_run(*args, **kwargs):
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            raise RuntimeError("synthetic tmux read failure")
-        return TmuxCommandResult(returncode=0, stdout="❯\n", stderr="")
-
-    tmux._run = fake_run  # type: ignore[assignment]
-    saw = await tmux.wait_for_idle_prompt(
-        agent_name="dymok", timeout_s=1.0, poll_interval_s=0.01
-    )
-    assert saw.ready is True
-    assert saw.state == tmux_session._PaneReadiness.READY
-    assert call_count["n"] >= 2
 
 
 @pytest.mark.asyncio
@@ -2279,293 +2111,16 @@ async def test_context_lock_preserves_turn_until_released(
         if ss._inflight_turn is None:
             break
     assert ss._inflight_turn is None
-    assert ss._idle_prompt_retry_count == 0
 
     await ss.disconnect()
 
 
-@pytest.mark.asyncio
-async def test_idle_prompt_timeout_retries_then_force_restarts(
-    monkeypatch,
-) -> None:
-    """After ``_IDLE_PROMPT_RETRY_LIMIT`` consecutive idle-prompt
-    timeouts against the same REPL, the worker must escalate to
-    ``force_restart`` instead of silently dropping the turn or looping
-    forever. Pin the relationship between retry-limit and
-    force_restart invocations.
-    """
-    monkeypatch.setattr(tmux_session, "_TRANSIENT_RETRY_BACKOFF_SEC", 0.01)
-    # Keep the limit at its default of 2 but pin it explicitly so the
-    # test doesn't drift if the constant is retuned later.
-    monkeypatch.setattr(tmux_session, "_IDLE_PROMPT_RETRY_LIMIT", 2)
-
-    tmux = _make_mock_tmux()
-    # Idle prompt never observed — every attempt times out.
-    tmux.wait_for_idle_prompt = AsyncMock(return_value=False)
-    ss, _ = _make_session(tmux=tmux)
-
-    # Stub force_restart so we don't actually tear down inside the test
-    # — count invocations, return True so the worker keeps going.
-    force_restart_calls: list[int] = []
-
-    async def stub_force_restart():
-        force_restart_calls.append(1)
-        return True
-
-    ss.force_restart = stub_force_restart  # type: ignore[assignment]
-
-    await ss.connect()
-    await ss.send("hi", platform="t", chat_id="c", message_id="m1")
-
-    # Let the worker run enough cycles for retry-limit + escalation.
-    # Each cycle: deliver_turn → _IdlePromptTimeout → sleep(0.01) → loop.
-    for _ in range(200):
-        await asyncio.sleep(0.005)
-        if force_restart_calls:
-            break
-
-    assert len(force_restart_calls) >= 1, (
-        "worker must escalate to force_restart after "
-        "_IDLE_PROMPT_RETRY_LIMIT consecutive idle-prompt timeouts"
-    )
-    # wait_for_idle_prompt was called once per retry attempt; the
-    # escalation fires on the Nth attempt, so we expect at least
-    # _IDLE_PROMPT_RETRY_LIMIT calls.
-    assert tmux.wait_for_idle_prompt.await_count >= 2, (
-        f"expected ≥2 idle-prompt poll attempts before escalation, "
-        f"got {tmux.wait_for_idle_prompt.await_count}"
-    )
-    # paste_text must NEVER have fired — the gate kept it out.
-    assert tmux.paste_text.await_count == 0, (
-        "paste must not fire while idle-prompt gate is failing — "
-        "Murzik #522 round-1: this is the data-loss window"
-    )
-    # Retry counter is reset on escalation so the post-restart REPL
-    # gets a fresh budget.
-    assert ss._idle_prompt_retry_count == 0
-
-    await ss.disconnect()
-
-
-@pytest.mark.asyncio
-async def test_rate_limit_wait_preserves_turn_without_force_restart(
-    monkeypatch,
-) -> None:
-    """Rate-limit preflight is a distinct startup state. Restarting the
-    REPL usually recreates the same upstream wait, so the worker should
-    preserve the inflight turn and retry on a wall-clock budget rather
-    than consuming the ordinary idle-timeout force_restart counter.
-    """
-    monkeypatch.setattr(tmux_session, "_TRANSIENT_RETRY_BACKOFF_SEC", 0.01)
-    monkeypatch.setattr(tmux_session, "_RATE_LIMIT_WAIT_MAX_SEC", 60.0)
-
-    tmux = _make_mock_tmux()
-    tmux.wait_for_idle_prompt = AsyncMock(
-        return_value=tmux_session._IdlePromptWaitResult(
-            ready=False,
-            state=tmux_session._PaneReadiness.RATE_LIMIT_WAIT,
-            elapsed_ms=90_000,
-            matched_line="Rate limits: waiting for data...",
-        )
-    )
-    ss, _ = _make_session(tmux=tmux)
-
-    force_restart_calls: list[int] = []
-
-    async def stub_force_restart():
-        force_restart_calls.append(1)
-        return True
-
-    ss.force_restart = stub_force_restart  # type: ignore[assignment]
-
-    await ss.connect()
-    await ss.send("hi", platform="t", chat_id="c", message_id="m1")
-
-    for _ in range(50):
-        await asyncio.sleep(0.005)
-        if tmux.wait_for_idle_prompt.await_count >= 3:
-            break
-
-    assert force_restart_calls == []
-    assert tmux.paste_text.await_count == 0
-    assert ss._inflight_turn is not None
-    assert ss._inflight_turn.prompt == "hi"
-    assert ss._idle_prompt_retry_count == 0
-    assert ss._pre_first_turn_restart_count == 0
-
-    await ss.disconnect()
-
-
-@pytest.mark.asyncio
-async def test_rate_limit_wait_budget_trips_dead_with_turn_preserved(
-    monkeypatch,
-) -> None:
-    """If Claude's rate-limit preflight never clears, stop looping and
-    surface the tmux transport as DEAD. The queued turn stays in
-    _inflight_turn so an explicit later reconnect can retry it.
-    """
-    monkeypatch.setattr(tmux_session, "_TRANSIENT_RETRY_BACKOFF_SEC", 0.01)
-    monkeypatch.setattr(tmux_session, "_RATE_LIMIT_WAIT_MAX_SEC", 0.0)
-
-    events: list[dict] = []
-
-    async def stream_evt(event: dict) -> None:
-        events.append(event)
-
-    tmux = _make_mock_tmux()
-    tmux.wait_for_idle_prompt = AsyncMock(
-        return_value=tmux_session._IdlePromptWaitResult(
-            ready=False,
-            state=tmux_session._PaneReadiness.RATE_LIMIT_WAIT,
-            elapsed_ms=90_000,
-            matched_line="Rate limits: waiting for data...",
-        )
-    )
-    ss, _ = _make_session(tmux=tmux)
-    ss._stream_event_callback = stream_evt
-
-    await ss.connect()
-    await ss.send("hi", platform="t", chat_id="c", message_id="m1")
-
-    for _ in range(100):
-        await asyncio.sleep(0.005)
-        if ss.state == SessionState.DEAD:
-            break
-
-    assert ss.state == SessionState.DEAD
-    assert ss._inflight_turn is not None
-    assert ss._inflight_turn.prompt == "hi"
-    assert tmux.paste_text.await_count == 0
-    assert tmux.kill_session.await_count >= 1
-    assert events
-    assert events[0]["type"] == "transport_alert"
-    assert events[0]["state"] == tmux_session._PaneReadiness.RATE_LIMIT_WAIT
-    assert events[0]["inflight_turn_preserved"] is True
-
-
-@pytest.mark.asyncio
-async def test_idle_prompt_preserves_turn_across_force_restart(
-    monkeypatch,
-) -> None:
-    """The trickiest invariant Murzik flagged: when the worker escalates
-    an idle-prompt timeout to ``force_restart``, the inflight turn
-    survives the worker-task cancel + re-spawn and is delivered against
-    the fresh REPL.
-
-    Mocking strategy: stub ``force_restart`` to flip ``wait_for_idle_prompt``
-    from fail-mode to success-mode, mimicking the new REPL becoming
-    healthy. Worker keeps the same TmuxSession instance, so
-    ``self._inflight_turn`` persists.
-    """
-    monkeypatch.setattr(tmux_session, "_TRANSIENT_RETRY_BACKOFF_SEC", 0.01)
-    monkeypatch.setattr(tmux_session, "_IDLE_PROMPT_RETRY_LIMIT", 2)
-
-    tmux = _make_mock_tmux()
-    # Start in fail-mode; the stub flips this to success on first
-    # force_restart call.
-    tmux.wait_for_idle_prompt = AsyncMock(return_value=False)
-    ss, _ = _make_session(tmux=tmux)
-
-    # Force-restart stub: simulate the fresh-REPL semantics by flipping
-    # idle-prompt detection to success. Don't actually tear down — the
-    # real force_restart cancels the worker, which would break the test
-    # harness. The contract under test is "_inflight_turn survives the
-    # escalation"; verifying that the SAME instance still carries the
-    # turn after force_restart fires is the proof.
-    inflight_at_escalation: list = []
-
-    async def stub_force_restart():
-        # Snapshot what the worker considers inflight at the moment of
-        # escalation — must be the original turn, not None.
-        inflight_at_escalation.append(ss._inflight_turn)
-        # Flip the gate to healthy so the next deliver attempt succeeds.
-        tmux.wait_for_idle_prompt.return_value = True
-        return True
-
-    ss.force_restart = stub_force_restart  # type: ignore[assignment]
-
-    await ss.connect()
-    await ss.send("hi", platform="t", chat_id="c", message_id="m1")
-
-    # Wait for the worker to: hit two timeouts, escalate, then re-deliver
-    # the same turn against the "fresh" REPL once force_restart flipped
-    # idle-prompt to True.
-    for _ in range(200):
-        await asyncio.sleep(0.005)
-        if tmux.paste_text.await_count >= 1:
-            break
-
-    assert len(inflight_at_escalation) >= 1, (
-        "force_restart must have been invoked at least once"
-    )
-    # The inflight slot at escalation must hold the original turn,
-    # not be None — this is the Murzik-invariant that pre-fix was
-    # violated.
-    assert inflight_at_escalation[0] is not None
-    assert inflight_at_escalation[0].prompt == "hi"
-
-    # And the post-restart REPL must have received the SAME prompt.
-    assert tmux.paste_text.await_count == 1
-    args, _ = tmux.paste_text.call_args
-    assert args[0] == "hi", (
-        "post-force_restart paste must re-deliver the same turn that "
-        "triggered the escalation (Murzik #522 round-1 preservation "
-        "invariant)"
-    )
-
-    await ss.disconnect()
-
-
-@pytest.mark.asyncio
-async def test_pre_first_turn_restart_circuit_breaker_marks_dead(
-    monkeypatch,
-) -> None:
-    """A first-turn gate failure that reproduces after force_restart must
-    not restart-loop forever. The counter survives restart attempts and
-    trips DEAD while preserving the inflight turn.
-    """
-    monkeypatch.setattr(tmux_session, "_TRANSIENT_RETRY_BACKOFF_SEC", 0.01)
-    monkeypatch.setattr(tmux_session, "_IDLE_PROMPT_RETRY_LIMIT", 2)
-    monkeypatch.setattr(tmux_session, "_PRE_FIRST_TURN_RESTART_LIMIT", 1)
-
-    events: list[dict] = []
-
-    async def stream_evt(event: dict) -> None:
-        events.append(event)
-
-    tmux = _make_mock_tmux()
-    tmux.wait_for_idle_prompt = AsyncMock(
-        return_value=tmux_session._IdlePromptWaitResult(
-            ready=False,
-            state=tmux_session._PaneReadiness.SPLASH_NOT_READY,
-            elapsed_ms=90_000,
-            matched_line='❯ Try "refactor Agents.svelte"',
-        )
-    )
-    ss, _ = _make_session(tmux=tmux)
-    ss._stream_event_callback = stream_evt
-
-    force_restart_calls: list[int] = []
-
-    async def stub_force_restart():
-        force_restart_calls.append(1)
-        return True
-
-    ss.force_restart = stub_force_restart  # type: ignore[assignment]
-
-    await ss.connect()
-    await ss.send("hi", platform="t", chat_id="c", message_id="m1")
-
-    for _ in range(200):
-        await asyncio.sleep(0.005)
-        if ss.state == SessionState.DEAD:
-            break
-
-    assert ss.state == SessionState.DEAD
-    assert force_restart_calls == [1]
-    assert ss._inflight_turn is not None
-    assert ss._inflight_turn.prompt == "hi"
-    assert ss._pre_first_turn_restart_count == 1
-    assert tmux.paste_text.await_count == 0
-    assert len([e for e in events if e["type"] == "transport_alert"]) == 1
-    assert events[0]["state"] == tmux_session._PaneReadiness.SPLASH_NOT_READY
+# Issue #525 removed the idle-prompt readiness gate (#522 + #524) along
+# with its worker-loop escalation paths. The deleted tests covered:
+# - test_idle_prompt_timeout_retries_then_force_restarts
+# - test_rate_limit_wait_preserves_turn_without_force_restart
+# - test_rate_limit_wait_budget_trips_dead_with_turn_preserved
+# - test_idle_prompt_preserves_turn_across_force_restart
+# - test_pre_first_turn_restart_circuit_breaker_marks_dead
+# Splash-state paste is handled by `paste_text` (splash dismisses on
+# input focus); no readiness gate is needed.


### PR DESCRIPTION
Closes #525.

## Summary

PR #522 added a pre-paste idle-prompt readiness gate; #524 band-aided it with a 600s rate-limit budget. Both miss the underlying mistake: Claude Code's splash always renders `❯ Try "<filepath>..."`, so the gate's `^[❯>]\s*$` regex never matches a fresh REPL. Every cold-start session deadlocks at the gate — without #524: ~3 min restart-loop death; with #524: ~10 min budget death.

Splash-state paste is already handled by `_TmuxControl.paste_text` (bracketed-paste + delayed-Enter, commit 0864f4e / issue #514). Its own docstring:

> "The `enter_delay_ms` window gives claude's post-login splash UI time to dismiss itself **(which it does on input focus)** before the submit Enter arrives."

The splash is dismissed *as a side effect of typing.* The gate was waiting for something that only happens after the paste it refused to perform.

## Evidence

1. **Footer is cosmetic.** Four idle Claude REPLs on the prod Mac Mini (kai/leo/oleg/rex sessions) created 2026-05-16 16:33 PDT are still alive **22 hours later**, all showing `Rate limits: waiting for data...`. Three are actively processing channel messages via `--dangerously-load-development-channels server:outreach`. Unambiguously operational while the footer never resolves.
2. **Splash never produces bare `❯`.** Code comment on `paste_text` confirms the splash dismisses on input focus — the gate's target state only appears after the paste it refuses to perform.
3. **Empirical verification on production.** With this branch loaded:
   - Dymok was cold (offline, transport DEAD).
   - Sent him a test message via `send_to_agent`.
   - Cold-start completed in seconds. First paste landed. He responded `⏺ ack` in the pane.
   - **No** `rate-limit preflight wait persists` log line. **No** `idle prompt timeout`. **No** restart loop.

Pre-fix, the same sequence took 10 minutes to die without delivering the message.

## Changes

- Remove `_IDLE_PROMPT_RE`, `_RATE_LIMIT_WAIT_RE`, `_SPLASH_TRY_RE`
- Remove `_PaneReadiness`, `_IdlePromptWaitResult`, `_IdlePromptTimeout`
- Remove `_RATE_LIMIT_WAIT_MAX_SEC`, `_IDLE_PROMPT_*`, `_PRE_FIRST_TURN_RESTART_LIMIT`
- Remove `_TmuxControl.wait_for_idle_prompt` + `_classify_prompt_readiness`
- Remove `_trip_startup_gate_circuit` and the gate's instance state (`_idle_prompt_retry_count`, `_pre_first_turn_restart_count`, `_startup_gate_wait_started_at`, `_startup_gate_alerted`)
- Remove the idle-prompt branch from `_deliver_turn` and the `_IdlePromptTimeout` handler from the worker loop
- **Keep `_ContextLockDeferral` + the context-lock path** (real signal — daemon-level coordination from #522 that's unrelated to the gate)
- Delete the gate's unit + worker-level tests
- Add a positive cold-paste test pinning the new behavior

Net: -889 +70.

## Test plan

- [x] `pytest tests/test_tmux_session.py` — 81 passed
- [x] `pytest` (full suite) — 2471 passed / 1 skipped
- [x] Live: cold-start Dymok on production with this branch loaded; first paste lands and gets a response
- [ ] Brad's review

🤖 Opened by Barsik