### PR TITLE
feat(tmux): tool-use tracking via PreToolUse/PostToolUse hooks (task #93)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -683,6 +683,152 @@ except Exception:
 '''
 
 
+def _tmux_pre_tool_hook_source(agent_name: str) -> str:
+    """Return the source for ``.claude/hook_tmux_pre_tool.py``.
+
+    Fires on Claude Code's ``PreToolUse``. Reads the hook payload from
+    stdin (``session_id``, ``tool_name``, ``tool_input``, ``tool_use_id``)
+    and POSTs to ``/agents/{name}/transport/tool-use`` so the daemon
+    can record the tool call to analytics and emit a live stream event.
+
+    Task #93: tmux parity with SDK's tool tracking (see
+    ``streaming_session.py``'s ``_analytics_start_tool_call``).
+
+    No-op for non-tmux runtimes (daemon returns 200 session: None).
+    Idempotent + fire-and-forget — failures are swallowed so a daemon
+    outage doesn't block the model turn.
+    """
+    return f'''\
+#!/usr/bin/env python3
+"""PinkyBot PreToolUse hook (task #93).
+
+POSTs the tool-call start to the daemon so tmux-transport agents
+record analytics + emit live SSE events matching SDK parity.
+"""
+import hashlib, hmac, base64, time, urllib.request, json, os, sys
+
+secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+if not secret:
+    sys.exit(0)
+
+try:
+    raw = sys.stdin.read()
+    payload_in = json.loads(raw) if raw else {{}}
+except Exception:
+    sys.exit(0)
+
+tool_name = payload_in.get("tool_name", "")
+if not tool_name:
+    sys.exit(0)
+
+agent = "{agent_name}"
+path = "/agents/{agent_name}/transport/tool-use"
+ts = int(time.time())
+payload_sig = f"{{agent}}\\nPOST\\n{{path}}\\n{{ts}}".encode()
+digest = hmac.new(secret.encode(), payload_sig, hashlib.sha256).digest()
+sig = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+body = {{
+    "session_id": payload_in.get("session_id", ""),
+    "tool_use_id": payload_in.get("tool_use_id", ""),
+    "tool_name": tool_name,
+    "tool_input": payload_in.get("tool_input") or {{}},
+}}
+
+req = urllib.request.Request(
+    f"http://localhost:8888{{path}}",
+    data=json.dumps(body).encode(),
+    method="POST",
+)
+req.add_header("Content-Type", "application/json")
+req.add_header("x-pinky-agent", agent)
+req.add_header("x-pinky-timestamp", str(ts))
+req.add_header("x-pinky-signature", sig)
+try:
+    urllib.request.urlopen(req, timeout=2)
+except Exception:
+    pass
+'''
+
+
+def _tmux_post_tool_hook_source(agent_name: str) -> str:
+    """Return the source for ``.claude/hook_tmux_post_tool.py``.
+
+    Fires on Claude Code's ``PostToolUse``. Reads the hook payload
+    from stdin (includes ``tool_response`` with success / error info)
+    and POSTs to ``/agents/{name}/transport/tool-result`` so the
+    daemon can mark the analytics row finished and emit the result
+    stream event.
+
+    Task #93. No-op for non-tmux runtimes. Fire-and-forget.
+    """
+    return f'''\
+#!/usr/bin/env python3
+"""PinkyBot PostToolUse hook (task #93).
+
+POSTs the tool-call result to the daemon so tmux-transport agents
+record analytics + emit live SSE events matching SDK parity.
+"""
+import hashlib, hmac, base64, time, urllib.request, json, os, sys
+
+secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+if not secret:
+    sys.exit(0)
+
+try:
+    raw = sys.stdin.read()
+    payload_in = json.loads(raw) if raw else {{}}
+except Exception:
+    sys.exit(0)
+
+tool_name = payload_in.get("tool_name", "")
+if not tool_name:
+    sys.exit(0)
+
+# Claude Code's PostToolUse payload carries `tool_response` (the
+# tool's actual return value/error). Shape varies by tool, so we
+# pass it through verbatim and let the daemon decide what to extract.
+tool_response = payload_in.get("tool_response")
+is_error = False
+if isinstance(tool_response, dict):
+    # Common shapes: {{"is_error": true, ...}}, {{"error": "..."}},
+    # or {{"content": [{{"type": "text", "text": "..."}}], "is_error": bool}}
+    is_error = bool(
+        tool_response.get("is_error")
+        or tool_response.get("error")
+    )
+
+agent = "{agent_name}"
+path = "/agents/{agent_name}/transport/tool-result"
+ts = int(time.time())
+payload_sig = f"{{agent}}\\nPOST\\n{{path}}\\n{{ts}}".encode()
+digest = hmac.new(secret.encode(), payload_sig, hashlib.sha256).digest()
+sig = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+body = {{
+    "session_id": payload_in.get("session_id", ""),
+    "tool_use_id": payload_in.get("tool_use_id", ""),
+    "tool_name": tool_name,
+    "is_error": is_error,
+    "tool_response": tool_response if isinstance(tool_response, (dict, list, str)) else None,
+}}
+
+req = urllib.request.Request(
+    f"http://localhost:8888{{path}}",
+    data=json.dumps(body, default=str).encode(),
+    method="POST",
+)
+req.add_header("Content-Type", "application/json")
+req.add_header("x-pinky-agent", agent)
+req.add_header("x-pinky-timestamp", str(ts))
+req.add_header("x-pinky-signature", sig)
+try:
+    urllib.request.urlopen(req, timeout=2)
+except Exception:
+    pass
+'''
+
+
 def _tmux_session_start_hook_source(agent_name: str) -> str:
     """Return the source for ``.claude/hook_tmux_session_start.py``.
 
@@ -1264,6 +1410,8 @@ except Exception:
         verify_effort_path = claude_dir / "hook_verify_effort.py"
         tmux_wake_path = claude_dir / "hook_tmux_wake.py"
         tmux_session_start_path = claude_dir / "hook_tmux_session_start.py"
+        tmux_pre_tool_path = claude_dir / "hook_tmux_pre_tool.py"
+        tmux_post_tool_path = claude_dir / "hook_tmux_post_tool.py"
 
         if not working_path.exists():
             working_path.write_text(
@@ -1326,6 +1474,34 @@ except Exception:
                 f"for {agent_name}"
             )
 
+        # Task #93: PreToolUse + PostToolUse hooks for tmux tool-use
+        # tracking. Always rewritten so updates to the script body land
+        # without manual cleanup. No-op for non-tmux runtimes (daemon
+        # returns 200 session: None).
+        existing_pre = (
+            tmux_pre_tool_path.read_text() if tmux_pre_tool_path.exists() else ""
+        )
+        new_pre = _tmux_pre_tool_hook_source(agent_name)
+        if existing_pre != new_pre:
+            tmux_pre_tool_path.write_text(new_pre)
+            verb = "updated" if existing_pre else "created"
+            _log(
+                f"agent_registry: {verb} hook_tmux_pre_tool.py "
+                f"for {agent_name}"
+            )
+
+        existing_post = (
+            tmux_post_tool_path.read_text() if tmux_post_tool_path.exists() else ""
+        )
+        new_post = _tmux_post_tool_hook_source(agent_name)
+        if existing_post != new_post:
+            tmux_post_tool_path.write_text(new_post)
+            verb = "updated" if existing_post else "created"
+            _log(
+                f"agent_registry: {verb} hook_tmux_post_tool.py "
+                f"for {agent_name}"
+            )
+
         AgentRegistry._sync_hooks_settings(
             claude_dir / "settings.json",
             working_path=working_path.resolve(),
@@ -1333,6 +1509,8 @@ except Exception:
             verify_effort_path=verify_effort_path.resolve(),
             tmux_wake_path=tmux_wake_path.resolve(),
             tmux_session_start_path=tmux_session_start_path.resolve(),
+            tmux_pre_tool_path=tmux_pre_tool_path.resolve(),
+            tmux_post_tool_path=tmux_post_tool_path.resolve(),
             agent_name=agent_name,
         )
 
@@ -1345,13 +1523,16 @@ except Exception:
         verify_effort_path: Path,
         tmux_wake_path: Path,
         tmux_session_start_path: Path,
+        tmux_pre_tool_path: Path,
+        tmux_post_tool_path: Path,
         agent_name: str,
     ) -> None:
         """Idempotently ensure settings.json has all PinkyBot hooks wired up.
 
         - Creates settings.json with the full hook set if missing.
         - If present, adds any missing PinkyBot-managed hook entries to
-          PreToolUse / Stop / SessionStart, preserving user-added entries.
+          PreToolUse / PostToolUse / Stop / SessionStart, preserving
+          user-added entries.
         - Identifies PinkyBot-managed entries by the absolute script path
           appearing in the command string.
         """
@@ -1367,6 +1548,8 @@ except Exception:
         tmux_session_start_cmd = (
             f"python3 {tmux_session_start_path} 2>/dev/null || true"
         )
+        tmux_pre_tool_cmd = f"python3 {tmux_pre_tool_path} 2>/dev/null || true"
+        tmux_post_tool_cmd = f"python3 {tmux_post_tool_path} 2>/dev/null || true"
 
         if not settings_path.exists():
             settings = {
@@ -1377,6 +1560,17 @@ except Exception:
                             "hooks": [
                                 {"type": "command", "command": working_cmd},
                                 {"type": "command", "command": verify_cmd},
+                                # Task #93: tool-use start (no-op for non-tmux).
+                                {"type": "command", "command": tmux_pre_tool_cmd},
+                            ],
+                        }
+                    ],
+                    "PostToolUse": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [
+                                # Task #93: tool-use finish (no-op for non-tmux).
+                                {"type": "command", "command": tmux_post_tool_cmd},
                             ],
                         }
                     ],
@@ -1446,6 +1640,20 @@ except Exception:
             hooks, "SessionStart",
             needle=str(tmux_session_start_path),
             command=tmux_session_start_cmd,
+        )
+
+        # Task #93: tmux_pre_tool → PreToolUse bucket
+        changed |= AgentRegistry._merge_hook_into_event(
+            hooks, "PreToolUse",
+            needle=str(tmux_pre_tool_path),
+            command=tmux_pre_tool_cmd,
+        )
+
+        # Task #93: tmux_post_tool → PostToolUse bucket (new bucket if needed)
+        changed |= AgentRegistry._merge_hook_into_event(
+            hooks, "PostToolUse",
+            needle=str(tmux_post_tool_path),
+            command=tmux_post_tool_cmd,
         )
 
         if changed:

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1356,6 +1356,36 @@ class AgentRegistry:
             AgentRegistry._setup_hooks(work_dir, agent_name)
 
     @staticmethod
+    def _write_hook_if_changed(
+        *,
+        hook_path: Path,
+        new_source: str,
+        hook_filename: str,
+        agent_name: str,
+    ) -> None:
+        """Rewrite a pinky-managed hook file when its content changed.
+
+        No-op when on-disk content already matches ``new_source``. The
+        read/compare/write sequence is identical for every hook script
+        managed under ``.claude/`` (verify_effort, tmux_wake,
+        tmux_session_start, tmux_pre_tool, tmux_post_tool); the helper
+        consolidates it in one place.
+
+        ``agent_name`` is re-validated as a sanitizer signal for static
+        analysis — every path passing through this helper is rooted in
+        an agent_name that matches the safe-char allowlist (see
+        ``_validate_agent_name``). The validation is cheap and raises
+        ``ValueError`` on bad input rather than corrupting disk layout.
+        """
+        _validate_agent_name(agent_name)
+        existing = hook_path.read_text() if hook_path.exists() else ""
+        if existing == new_source:
+            return
+        hook_path.write_text(new_source)
+        verb = "updated" if existing else "created"
+        _log(f"agent_registry: {verb} {hook_filename} for {agent_name}")
+
+    @staticmethod
     def _setup_hooks(work_dir: Path, agent_name: str) -> None:
         """Generate Claude Code hooks for agent working/idle status reporting
         and (since #429) effort-drift verification.
@@ -1430,77 +1460,48 @@ except Exception:
         # posts to /agents/{name}/effort-drift; under strict mode also emits
         # a block decision so Claude Code refuses the tool call.
         #
-        # We ALWAYS rewrite this script (unlike hook_working / hook_idle
-        # which are left alone if present) — it's fully PinkyBot-managed
-        # and getting the latest semantics on disk matters: e.g. the
-        # remediation-tool allowlist fix shipped after the initial cut.
-        existing_source = (
-            verify_effort_path.read_text() if verify_effort_path.exists() else ""
-        )
-        new_source = _verify_effort_hook_source()
-        if existing_source != new_source:
-            verify_effort_path.write_text(new_source)
-            verb = "updated" if existing_source else "created"
-            _log(f"agent_registry: {verb} hook_verify_effort.py for {agent_name}")
-
-        # PR8b: TmuxSession response capture pipeline. Two new hook scripts:
+        # PR8b: TmuxSession response capture pipeline adds two more hooks:
         #   - hook_tmux_wake.py: fires on Stop, POSTs /transport/wake
-        #   - hook_tmux_session_start.py: fires on SessionStart, POSTs the
-        #     transcript_path so the tailer watches the right file.
-        # Installed unconditionally; the daemon endpoint returns ``ok: True,
-        # session: None`` for non-tmux runtimes, so the hook is a cheap no-op
-        # for SDK / codex agents (one extra POST per turn). Daemon-side
-        # cost is negligible (HMAC verify + dict lookup). Worth the
-        # simplicity of not threading runtime through _setup_hooks.
-        existing_wake = (
-            tmux_wake_path.read_text() if tmux_wake_path.exists() else ""
+        #   - hook_tmux_session_start.py: SessionStart, POSTs transcript_path
+        #
+        # Task #93: PreToolUse + PostToolUse hooks for tmux tool-use tracking.
+        #
+        # All five are ALWAYS rewritten (unlike hook_working / hook_idle which
+        # are left alone if present) — they're fully PinkyBot-managed and
+        # getting the latest semantics on disk matters across releases. The
+        # tmux hooks are installed unconditionally; the daemon endpoint
+        # returns ``ok: True, session: None`` for non-tmux runtimes, so each
+        # is a cheap no-op for SDK / codex agents (one extra POST per turn).
+        AgentRegistry._write_hook_if_changed(
+            hook_path=verify_effort_path,
+            new_source=_verify_effort_hook_source(),
+            hook_filename="hook_verify_effort.py",
+            agent_name=agent_name,
         )
-        new_wake = _tmux_wake_hook_source(agent_name)
-        if existing_wake != new_wake:
-            tmux_wake_path.write_text(new_wake)
-            verb = "updated" if existing_wake else "created"
-            _log(f"agent_registry: {verb} hook_tmux_wake.py for {agent_name}")
-
-        existing_ss = (
-            tmux_session_start_path.read_text()
-            if tmux_session_start_path.exists() else ""
+        AgentRegistry._write_hook_if_changed(
+            hook_path=tmux_wake_path,
+            new_source=_tmux_wake_hook_source(agent_name),
+            hook_filename="hook_tmux_wake.py",
+            agent_name=agent_name,
         )
-        new_ss = _tmux_session_start_hook_source(agent_name)
-        if existing_ss != new_ss:
-            tmux_session_start_path.write_text(new_ss)
-            verb = "updated" if existing_ss else "created"
-            _log(
-                f"agent_registry: {verb} hook_tmux_session_start.py "
-                f"for {agent_name}"
-            )
-
-        # Task #93: PreToolUse + PostToolUse hooks for tmux tool-use
-        # tracking. Always rewritten so updates to the script body land
-        # without manual cleanup. No-op for non-tmux runtimes (daemon
-        # returns 200 session: None).
-        existing_pre = (
-            tmux_pre_tool_path.read_text() if tmux_pre_tool_path.exists() else ""
+        AgentRegistry._write_hook_if_changed(
+            hook_path=tmux_session_start_path,
+            new_source=_tmux_session_start_hook_source(agent_name),
+            hook_filename="hook_tmux_session_start.py",
+            agent_name=agent_name,
         )
-        new_pre = _tmux_pre_tool_hook_source(agent_name)
-        if existing_pre != new_pre:
-            tmux_pre_tool_path.write_text(new_pre)
-            verb = "updated" if existing_pre else "created"
-            _log(
-                f"agent_registry: {verb} hook_tmux_pre_tool.py "
-                f"for {agent_name}"
-            )
-
-        existing_post = (
-            tmux_post_tool_path.read_text() if tmux_post_tool_path.exists() else ""
+        AgentRegistry._write_hook_if_changed(
+            hook_path=tmux_pre_tool_path,
+            new_source=_tmux_pre_tool_hook_source(agent_name),
+            hook_filename="hook_tmux_pre_tool.py",
+            agent_name=agent_name,
         )
-        new_post = _tmux_post_tool_hook_source(agent_name)
-        if existing_post != new_post:
-            tmux_post_tool_path.write_text(new_post)
-            verb = "updated" if existing_post else "created"
-            _log(
-                f"agent_registry: {verb} hook_tmux_post_tool.py "
-                f"for {agent_name}"
-            )
+        AgentRegistry._write_hook_if_changed(
+            hook_path=tmux_post_tool_path,
+            new_source=_tmux_post_tool_hook_source(agent_name),
+            hook_filename="hook_tmux_post_tool.py",
+            agent_name=agent_name,
+        )
 
         AgentRegistry._sync_hooks_settings(
             claude_dir / "settings.json",

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -88,6 +88,8 @@ from pinky_daemon.api_models import (
     SetMainAgentRequest,
     SetModelRequest,
     SpawnSessionRequest,
+    TransportToolResultRequest,
+    TransportToolUseRequest,
     TransportTranscriptPathRequest,
     TransportWakeRequest,
     UpdateAgentRequest,
@@ -4258,6 +4260,73 @@ def create_api(
                 )
                 raise HTTPException(500, str(e))
         return {"ok": True, "agent": name, "transcript_path": str(normalised)}
+
+    @app.post("/agents/{name}/transport/tool-use")
+    async def transport_tool_use(name: str, req: TransportToolUseRequest):
+        """Record a tool-call start — POSTed by the PreToolUse hook (task #93).
+
+        Generic across runtimes: ``TmuxSession`` records the call to
+        analytics + emits a stream event for SSE consumers, matching
+        what ``StreamingSession`` already does for SDK agents.
+        ``StreamingSession`` ignores this — it captures tool calls in-
+        band via the SDK callback.
+
+        Fire-and-forget: returns 200 immediately. Hook scripts wrap the
+        request in ``|| true`` so a 404/500 doesn't fail the model turn.
+        """
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+
+        session = broker.get_streaming_session(name, label=req.label)
+        if session is None:
+            return {"ok": True, "agent": name, "session": None}
+
+        record = getattr(session, "record_tool_use_start", None)
+        if callable(record):
+            try:
+                await record(
+                    tool_use_id=req.tool_use_id,
+                    tool_name=req.tool_name,
+                    tool_input=req.tool_input or {},
+                )
+            except Exception as e:
+                _log(
+                    f"api: transport_tool_use record_tool_use_start "
+                    f"raised for {name}: {e}"
+                )
+        return {"ok": True, "agent": name, "tool_use_id": req.tool_use_id}
+
+    @app.post("/agents/{name}/transport/tool-result")
+    async def transport_tool_result(name: str, req: TransportToolResultRequest):
+        """Record a tool-call result — POSTed by the PostToolUse hook (task #93).
+
+        Companion to ``/transport/tool-use``. Closes out the analytics
+        row and emits the finish stream event.
+        """
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+
+        session = broker.get_streaming_session(name, label=req.label)
+        if session is None:
+            return {"ok": True, "agent": name, "session": None}
+
+        record = getattr(session, "record_tool_use_finish", None)
+        if callable(record):
+            try:
+                await record(
+                    tool_use_id=req.tool_use_id,
+                    tool_name=req.tool_name,
+                    is_error=req.is_error,
+                    tool_response=req.tool_response,
+                )
+            except Exception as e:
+                _log(
+                    f"api: transport_tool_result record_tool_use_finish "
+                    f"raised for {name}: {e}"
+                )
+        return {"ok": True, "agent": name, "tool_use_id": req.tool_use_id}
 
     @app.get("/agents/{name}/effort-drift")
     async def list_effort_drift_events(

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -852,6 +852,44 @@ class TransportTranscriptPathRequest(BaseModel):
     label: str = "main"
 
 
+class TransportToolUseRequest(BaseModel):
+    """Per-tool-call start — POSTed by the PreToolUse hook (task #93).
+
+    Mirrors what ``StreamingSession._analytics_start_tool_call`` records
+    for SDK agents so tmux-transport agents reach analytics + the SSE
+    stream with the same shape.
+
+    ``tool_use_id`` is Claude Code's per-call identifier; the daemon
+    uses it as the key for matching the later ``tool-result`` POST.
+    ``tool_input`` is the raw input dict from Claude Code — passed
+    through verbatim; the daemon extracts arg keys (not values) for
+    PII-safe analytics metadata.
+    """
+
+    tool_use_id: str = ""
+    tool_name: str
+    tool_input: dict = {}
+    session_id: str = ""
+    label: str = "main"
+
+
+class TransportToolResultRequest(BaseModel):
+    """Per-tool-call result — POSTed by the PostToolUse hook (task #93).
+
+    ``tool_use_id`` matches an earlier ``tool-use`` POST so the daemon
+    can close out the analytics row and emit the finish stream event.
+    ``is_error`` is the consolidated success/error flag; ``tool_response``
+    is the raw response payload, useful for the result_preview snippet.
+    """
+
+    tool_use_id: str = ""
+    tool_name: str = ""
+    is_error: bool = False
+    tool_response: dict | list | str | None = None
+    session_id: str = ""
+    label: str = "main"
+
+
 class FederationPeerUpsertRequest(BaseModel):
     """Insert or update a federation peer (admin / config-seeded path).
 

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -603,6 +603,9 @@ class TmuxSession:
         try:
             self._activity_log.append(desc)
         except Exception:
+            # Activity log is best-effort UI plumbing — never let a
+            # logging quirk break tool-use tracking. Real errors below
+            # surface via _log calls in the analytics block.
             pass
 
         # Analytics: open a row keyed by tool_use_id (or a synthetic

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -559,6 +559,162 @@ class TmuxSession:
         except Exception as e:
             _log(f"tmux[{self.agent_name}]: stream_event_callback raised: {e}")
 
+    async def record_tool_use_start(
+        self,
+        *,
+        tool_use_id: str,
+        tool_name: str,
+        tool_input: dict,
+    ) -> None:
+        """Record a tool-call start (task #93).
+
+        Called by the PreToolUse hook via
+        ``POST /agents/{name}/transport/tool-use``. Mirrors what
+        ``StreamingSession`` does in-band for SDK agents:
+
+        - Update ``_current_activity`` so live status surfaces show
+          which tool the agent is running right now.
+        - Append a human-readable line to ``_activity_log``.
+        - Open an analytics row via ``start_tool_call`` (PII-safe —
+          only arg KEYS are recorded, not values).
+        - Emit a ``tool_use_start`` stream event for SSE consumers.
+
+        ``tool_use_id`` is Claude Code's per-call identifier — used
+        as the analytics key so the later ``record_tool_use_finish``
+        can close it out.
+
+        Fire-and-forget semantics: failures are logged but never
+        propagate to the caller (the hook is wrapped in ``|| true``
+        anyway, but we'd rather have telemetry than no telemetry).
+        """
+        if not tool_name:
+            return
+
+        # Human-readable activity line — mirror SDK by importing the
+        # shared describer if available, falling back to a basic format.
+        try:
+            from pinky_daemon.streaming_session import _describe_tool_use
+            desc = _describe_tool_use(tool_name, tool_input or {})
+        except Exception:
+            # Defensive fallback — keeps record_tool_use_start working
+            # if streaming_session ever moves or renames the helper.
+            desc = tool_name.rsplit("__", 1)[-1] if "__" in tool_name else tool_name
+        self._current_activity = desc
+        try:
+            self._activity_log.append(desc)
+        except Exception:
+            pass
+
+        # Analytics: open a row keyed by tool_use_id (or a synthetic
+        # key if the hook didn't see one — Claude Code's payload
+        # always includes it for normal tool calls, but defending
+        # against schema drift).
+        call_key = tool_use_id or f"{tool_name}_{int(time.time() * 1000)}"
+        tool_ns = ""
+        if "__" in tool_name:
+            parts = tool_name.split("__", 2)
+            if len(parts) >= 3:
+                tool_ns = parts[1]
+        arg_keys: list[str] = []
+        if isinstance(tool_input, dict):
+            arg_keys = sorted(tool_input.keys())
+
+        if self._analytics_store:
+            try:
+                self._analytics_store.start_tool_call(
+                    session_id=self.id,
+                    agent_name=self.agent_name,
+                    turn_seq=None,
+                    tool_call_key=call_key,
+                    tool_name=tool_name,
+                    tool_namespace=tool_ns,
+                    metadata={"arg_keys": arg_keys} if arg_keys else None,
+                )
+            except Exception as e:
+                _log(
+                    f"tmux[{self.agent_name}]: analytics tool start "
+                    f"failed: {e}"
+                )
+
+        await self._emit_stream_event(
+            {
+                "type": "tool_use_start",
+                "agent_name": self.agent_name,
+                "tool_use_id": call_key,
+                "tool_name": tool_name,
+                "tool_namespace": tool_ns,
+                "arg_keys": arg_keys,
+                "description": desc,
+            }
+        )
+
+    async def record_tool_use_finish(
+        self,
+        *,
+        tool_use_id: str,
+        tool_name: str = "",
+        is_error: bool = False,
+        tool_response: object = None,
+    ) -> None:
+        """Record a tool-call result (task #93).
+
+        Called by the PostToolUse hook via
+        ``POST /agents/{name}/transport/tool-result``. Closes the
+        analytics row opened by ``record_tool_use_start`` and emits
+        a ``tool_use_finish`` stream event with a short result snippet
+        (capped — same 200-char cap SDK uses).
+
+        Tolerates a missing ``tool_use_id`` (some Claude Code event
+        flows omit it for synthetic tool calls); the analytics close
+        is skipped in that case but the stream event still fires so
+        UI consumers see the finish signal.
+        """
+        if not tool_name and not tool_use_id:
+            return
+
+        # Short result snippet for the stream event — same cap SDK
+        # uses for parity. Tool responses can be huge (file contents,
+        # search results); never emit the full payload.
+        result_preview = ""
+        if tool_response is not None:
+            try:
+                if isinstance(tool_response, str):
+                    result_preview = tool_response[:200]
+                else:
+                    import json as _json
+                    result_preview = _json.dumps(
+                        tool_response, default=str
+                    )[:200]
+            except Exception:
+                result_preview = str(tool_response)[:200]
+
+        if tool_use_id and self._analytics_store:
+            try:
+                self._analytics_store.finish_tool_call(
+                    session_id=self.id,
+                    agent_name=self.agent_name,
+                    tool_call_key=tool_use_id,
+                    success=not is_error,
+                    error_type="tool_error" if is_error else "",
+                    metadata=None,
+                )
+            except Exception as e:
+                _log(
+                    f"tmux[{self.agent_name}]: analytics tool finish "
+                    f"failed: {e}"
+                )
+
+        await self._emit_stream_event(
+            {
+                "type": "tool_use_finish",
+                "agent_name": self.agent_name,
+                "tool_use_id": tool_use_id,
+                "tool_name": tool_name,
+                "is_error": is_error,
+                "result_preview": result_preview,
+            }
+        )
+
     def set_effort(self, level: str) -> None:
         """Accept the call for protocol parity. tmux's claude REPL doesn't
         honor mid-session effort changes — log a warning and stash the

--- a/tests/test_effort_verification.py
+++ b/tests/test_effort_verification.py
@@ -324,6 +324,86 @@ class TestHookInstaller:
         registry.ensure_workspace_hooks("alpha")
         assert "hook_verify_effort" in settings_path.read_text()
 
+    # ── Task #93: tmux tool-use hooks ────────────────────────
+
+    def test_setup_creates_tmux_tool_use_scripts(self, tmp_path):
+        """PreToolUse + PostToolUse hook scripts must be written so tmux
+        agents POST tool events to the daemon (task #93)."""
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        pre = tmp_path / ".claude" / "hook_tmux_pre_tool.py"
+        post = tmp_path / ".claude" / "hook_tmux_post_tool.py"
+        assert pre.exists()
+        assert post.exists()
+        # Sanity: scripts target the right endpoints
+        assert "/agents/alpha/transport/tool-use" in pre.read_text()
+        assert "/agents/alpha/transport/tool-result" in post.read_text()
+        # Both scripts read JSON from stdin (Claude Code hook spec)
+        assert "sys.stdin.read()" in pre.read_text()
+        assert "sys.stdin.read()" in post.read_text()
+
+    def test_setup_settings_wires_pre_and_post_tool_use(self, tmp_path):
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        settings = json.loads(
+            (tmp_path / ".claude" / "settings.json").read_text()
+        )
+        pre_commands = [
+            h["command"]
+            for entry in settings["hooks"]["PreToolUse"]
+            for h in entry["hooks"]
+        ]
+        post_commands = [
+            h["command"]
+            for entry in settings["hooks"]["PostToolUse"]
+            for h in entry["hooks"]
+        ]
+        assert any("hook_tmux_pre_tool.py" in c for c in pre_commands), pre_commands
+        assert any("hook_tmux_post_tool.py" in c for c in post_commands), post_commands
+
+    def test_setup_tool_use_hooks_idempotent(self, tmp_path):
+        """Repeated _setup_hooks must not duplicate the tool-use entries."""
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        settings_text = (tmp_path / ".claude" / "settings.json").read_text()
+        assert settings_text.count("hook_tmux_pre_tool.py") == 1
+        assert settings_text.count("hook_tmux_post_tool.py") == 1
+
+    def test_setup_merges_tool_use_into_legacy_settings(self, tmp_path):
+        """Pre-#93 agents have settings.json without PostToolUse. Merge
+        must add the new bucket without nuking existing entries."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        legacy = {
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": ".*",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "python3 /custom/user-hook.py || true",
+                    }],
+                }],
+            }
+        }
+        (claude_dir / "settings.json").write_text(json.dumps(legacy))
+
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        merged = json.loads((claude_dir / "settings.json").read_text())
+
+        # User hook preserved
+        pre_commands = [
+            h["command"]
+            for entry in merged["hooks"]["PreToolUse"]
+            for h in entry["hooks"]
+        ]
+        assert any("user-hook.py" in c for c in pre_commands), pre_commands
+        # Tool-use hooks added
+        assert any("hook_tmux_pre_tool.py" in c for c in pre_commands), pre_commands
+        post_commands = [
+            h["command"]
+            for entry in merged["hooks"]["PostToolUse"]
+            for h in entry["hooks"]
+        ]
+        assert any("hook_tmux_post_tool.py" in c for c in post_commands), post_commands
+
 
 # ── Hook subprocess behavior ───────────────────────────────
 

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -2124,3 +2124,187 @@ async def test_context_lock_preserves_turn_until_released(
 # - test_pre_first_turn_restart_circuit_breaker_marks_dead
 # Splash-state paste is handled by `paste_text` (splash dismisses on
 # input focus); no readiness gate is needed.
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Task #93: tool-use tracking via PreToolUse / PostToolUse hooks
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _make_session_with_analytics(
+    *, agent_name: str = "dymok"
+) -> tuple[TmuxSession, MagicMock, MagicMock]:
+    """Build a TmuxSession with a mocked analytics_store + stream callback.
+
+    Returns (session, analytics_mock, events_list). The session is in
+    CONNECTED state so the methods under test (which don't touch state)
+    are reachable without going through cold-start.
+    """
+    cfg = StreamingSessionConfig(
+        agent_name=agent_name,
+        working_dir="/tmp/tmux-session-test",
+    )
+    tmux = _make_mock_tmux()
+    analytics = MagicMock()
+    analytics.start_tool_call = MagicMock()
+    analytics.finish_tool_call = MagicMock()
+    events: list[dict] = []
+
+    async def stream_cb(event: dict) -> None:
+        events.append(event)
+
+    ss = TmuxSession(
+        cfg,
+        tmux_control=tmux,
+        analytics_store=analytics,
+        stream_event_callback=stream_cb,
+    )
+    return ss, analytics, events
+
+
+@pytest.mark.asyncio
+async def test_record_tool_use_start_emits_event_and_opens_analytics() -> None:
+    """``record_tool_use_start`` must update activity, open an analytics
+    row keyed by tool_use_id, and emit a ``tool_use_start`` stream event
+    matching SDK parity (task #93).
+    """
+    ss, analytics, events = _make_session_with_analytics()
+
+    await ss.record_tool_use_start(
+        tool_use_id="toolu_abc123",
+        tool_name="mcp__pinky-self__send_to_agent",
+        tool_input={"to": "dymok", "message": "hi"},
+    )
+
+    # Activity surfaced for live status consumers.
+    assert ss._current_activity  # non-empty human-readable description
+
+    # Analytics row opened with the correct key + PII-safe arg_keys only.
+    analytics.start_tool_call.assert_called_once()
+    kwargs = analytics.start_tool_call.call_args.kwargs
+    assert kwargs["agent_name"] == "dymok"
+    assert kwargs["tool_call_key"] == "toolu_abc123"
+    assert kwargs["tool_name"] == "mcp__pinky-self__send_to_agent"
+    assert kwargs["tool_namespace"] == "pinky-self"
+    assert kwargs["metadata"] == {"arg_keys": ["message", "to"]}
+
+    # Stream event emitted with the expected shape.
+    assert len(events) == 1
+    evt = events[0]
+    assert evt["type"] == "tool_use_start"
+    assert evt["agent_name"] == "dymok"
+    assert evt["tool_use_id"] == "toolu_abc123"
+    assert evt["tool_name"] == "mcp__pinky-self__send_to_agent"
+    assert evt["tool_namespace"] == "pinky-self"
+    assert evt["arg_keys"] == ["message", "to"]
+    assert evt["description"]  # non-empty
+
+
+@pytest.mark.asyncio
+async def test_record_tool_use_start_noops_on_empty_tool_name() -> None:
+    """Defensive: an empty tool_name should not open analytics or emit."""
+    ss, analytics, events = _make_session_with_analytics()
+    await ss.record_tool_use_start(
+        tool_use_id="x", tool_name="", tool_input={}
+    )
+    analytics.start_tool_call.assert_not_called()
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_record_tool_use_start_synthesizes_key_when_missing() -> None:
+    """Some Claude Code event flows omit tool_use_id. We must still open
+    an analytics row using a synthetic key so the call shows up in the
+    feed instead of being silently dropped.
+    """
+    ss, analytics, events = _make_session_with_analytics()
+    await ss.record_tool_use_start(
+        tool_use_id="", tool_name="Bash", tool_input={"command": "ls"}
+    )
+    analytics.start_tool_call.assert_called_once()
+    key = analytics.start_tool_call.call_args.kwargs["tool_call_key"]
+    assert key.startswith("Bash_")
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_record_tool_use_finish_emits_finish_and_closes_analytics() -> None:
+    """``record_tool_use_finish`` must close the analytics row keyed by
+    tool_use_id with success=True (when not is_error) and emit a
+    ``tool_use_finish`` stream event with a capped result_preview.
+    """
+    ss, analytics, events = _make_session_with_analytics()
+    await ss.record_tool_use_finish(
+        tool_use_id="toolu_abc123",
+        tool_name="Bash",
+        is_error=False,
+        tool_response={"content": [{"type": "text", "text": "ok"}]},
+    )
+
+    analytics.finish_tool_call.assert_called_once()
+    kwargs = analytics.finish_tool_call.call_args.kwargs
+    assert kwargs["tool_call_key"] == "toolu_abc123"
+    assert kwargs["success"] is True
+    assert kwargs["error_type"] == ""
+
+    assert len(events) == 1
+    evt = events[0]
+    assert evt["type"] == "tool_use_finish"
+    assert evt["tool_use_id"] == "toolu_abc123"
+    assert evt["is_error"] is False
+    assert evt["result_preview"]  # non-empty snippet
+    assert len(evt["result_preview"]) <= 200
+
+
+@pytest.mark.asyncio
+async def test_record_tool_use_finish_marks_error_when_is_error() -> None:
+    """When ``is_error=True``, analytics gets success=False + error_type
+    and the stream event carries the flag through for UI consumers.
+    """
+    ss, analytics, events = _make_session_with_analytics()
+    await ss.record_tool_use_finish(
+        tool_use_id="toolu_err",
+        tool_name="Bash",
+        is_error=True,
+        tool_response="command not found: blorp",
+    )
+
+    analytics.finish_tool_call.assert_called_once()
+    kwargs = analytics.finish_tool_call.call_args.kwargs
+    assert kwargs["success"] is False
+    assert kwargs["error_type"] == "tool_error"
+
+    assert events[0]["is_error"] is True
+
+
+@pytest.mark.asyncio
+async def test_record_tool_use_finish_skips_analytics_without_id() -> None:
+    """No tool_use_id → skip analytics close (no row to close), but
+    still emit the stream event so consumers see the finish signal.
+    """
+    ss, analytics, events = _make_session_with_analytics()
+    await ss.record_tool_use_finish(
+        tool_use_id="",
+        tool_name="Bash",
+        is_error=False,
+        tool_response="ok",
+    )
+    analytics.finish_tool_call.assert_not_called()
+    assert len(events) == 1
+    assert events[0]["type"] == "tool_use_finish"
+
+
+@pytest.mark.asyncio
+async def test_record_tool_use_finish_caps_huge_response_at_200() -> None:
+    """``result_preview`` must be capped to match SDK's 200-char cap;
+    tool responses can be enormous (file contents, search results).
+    """
+    ss, analytics, events = _make_session_with_analytics()
+    huge = "x" * 5000
+    await ss.record_tool_use_finish(
+        tool_use_id="toolu_huge",
+        tool_name="Read",
+        is_error=False,
+        tool_response=huge,
+    )
+    assert len(events[0]["result_preview"]) == 200


### PR DESCRIPTION
Closes task #93 (Tmux tool-use tracking + streaming via Claude Code hooks).

## Summary

SDK-transport agents already track tool calls in-band via the SDK callback: per-call analytics rows, live ``_current_activity`` updates, and a per-turn ``tool_uses`` list. Tmux-transport agents had none of this — Claude Code runs as a subprocess, the SDK callback doesn't apply, and the transcript JSONL fires too late for live UI signals.

This patch wires Claude Code's ``PreToolUse`` / ``PostToolUse`` hooks so tmux agents emit the same analytics + stream events the SDK already does.

## How it works

```
Claude Code's PreToolUse fires
   ↓
.claude/hook_tmux_pre_tool.py reads stdin JSON,
HMAC-signs, POSTs /agents/{name}/transport/tool-use
   ↓
auth middleware verifies signature
   ↓
endpoint → TmuxSession.record_tool_use_start
   ↓
   • update _current_activity ("Bash — echo hi")
   • append to _activity_log
   • analytics_store.start_tool_call(tool_call_key, ...)
   • _emit_stream_event({"type": "tool_use_start", ...})
```

PostToolUse mirrors with ``record_tool_use_finish`` → analytics close + ``tool_use_finish`` event.

## Live verification on production

```
$ curl /agents/dymok/streaming/status | jq .stats
{
  "current_activity": "Bash — echo hi",
  "activity_log": [
    "Bash — Read first three lines of /etc/hosts",  ← real tool call by Dymok
    ...
  ]
}
```

PR #526 fixed cold-start; this patch is the next layer (observability of what the agent is doing once it's running).

## Changes

- ``src/pinky_daemon/agent_registry.py`` — ``_tmux_pre_tool_hook_source`` + ``_tmux_post_tool_hook_source`` generators, ``_setup_hooks`` writes the scripts, ``_sync_hooks_settings`` wires them into ``PreToolUse`` / ``PostToolUse`` buckets (create + legacy-merge paths).
- ``src/pinky_daemon/api.py`` — two new ``/transport/*`` endpoints under the existing internal-auth middleware.
- ``src/pinky_daemon/api_models.py`` — request schemas.
- ``src/pinky_daemon/tmux_session.py`` — ``record_tool_use_start`` / ``record_tool_use_finish`` methods. Activity update, PII-safe analytics (arg KEYS only), stream events. Synthesises a ``tool_use_id`` when the hook doesn't supply one; caps result_preview at 200 chars (SDK parity).
- ``tests/test_tmux_session.py`` — 7 new tests covering happy path, empty tool_name, missing tool_use_id, error flag, result truncation.
- ``tests/test_effort_verification.py`` — 4 new tests covering hook installation, settings.json wiring, idempotency, legacy merge.

## Test plan

- [x] ``pytest`` — 2482 passed / 1 skipped
- [x] ``ruff check src tests`` — clean
- [x] Live: cold-start Dymok, send a tool-using prompt, confirm ``_current_activity`` reflects the tool call and ``activity_log`` accumulates entries
- [ ] Brad's review

## Out of scope (next PR)

Frontend ``Chat.svelte`` rendering for ``tool_use_start`` / ``tool_use_finish`` event types. The tmux-transport path now produces these but the UI doesn't yet display them differently from the SDK feed.

🤖 Opened by Barsik