### PR TITLE
fix(tmux): clear per-turn activity state at turn end; rename event for parity

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1272,10 +1272,14 @@ class TmuxSession:
                     f"raised: {e}"
                 )
 
-        # Stream event for analytics (usage / duration).
+        # Stream event for analytics (usage / duration). Named
+        # ``turn_completed`` to match StreamingSession + CodexSession
+        # (see ``streaming_session.py:942`` and ``codex_session.py:753``)
+        # — Chat.svelte's SSE handler listens for ``turn_completed`` so
+        # the UI clears pending-assistant-stream state at turn end.
         await self._emit_stream_event(
             {
-                "type": "turn_complete",
+                "type": "turn_completed",
                 "agent_name": self.agent_name,
                 "stop_reason": response.stop_reason,
                 "usage": response.usage,
@@ -1322,6 +1326,17 @@ class TmuxSession:
         # awaiting this event regardless. Gating on text would deadlock
         # the worker forever on a tool-use-only turn.
         self._turn_done.set()
+
+        # Reset per-turn live-activity state so the next turn starts
+        # clean. Without this the polling endpoint ``/streaming/status``
+        # keeps returning the previous turn's accumulated activity log
+        # and Chat.svelte's thinking-bubble shows stale tool calls
+        # blending across turns. ``_current_activity`` clears the
+        # "Bash — ..." chip in the UI; ``_activity_log`` clears the
+        # scrollback. The chip-strip from PR #528 has its own per-turn
+        # lifetime on the client and is unaffected.
+        self._current_activity = ""
+        self._activity_log = []
 
     async def _start_tailer(self) -> None:
         """Construct + start the transcript tailer.

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1204,7 +1204,7 @@ async def test_handle_turn_complete_writes_to_conversation_store() -> None:
 
 @pytest.mark.asyncio
 async def test_handle_turn_complete_fires_stream_event() -> None:
-    """stream_event_callback gets a turn_complete event with usage + duration."""
+    """stream_event_callback gets a turn_completed event with usage + duration."""
     events: list[dict] = []
 
     async def stream_cb(evt):
@@ -1222,11 +1222,35 @@ async def test_handle_turn_complete_fires_stream_event() -> None:
     assert len(events) == 1
     evt = events[0]
     assert evt["agent_name"] == "dymok"
-    assert evt["type"] == "turn_complete"
+    # Renamed from "turn_complete" to "turn_completed" for parity with
+    # StreamingSession + CodexSession — Chat.svelte listens for the
+    # -d suffix so the thinking-bubble clears at turn end.
+    assert evt["type"] == "turn_completed"
     assert evt["stop_reason"] == "end_turn"
     assert evt["duration_ms"] == 1500
     assert evt["assistant_entry_count"] == 2
     assert evt["tool_use_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_turn_complete_resets_live_activity_state() -> None:
+    """Activity log + current activity must clear at turn end.
+
+    Without this reset, the polling endpoint ``/streaming/status``
+    keeps returning the previous turn's accumulated tool-call lines
+    and Chat.svelte's thinking-bubble shows stale activity blending
+    across turns (Brad's msg #7950 with screenshot, 2026-05-17)."""
+    ss, _ = _make_session_with_response_cb()
+    # Simulate mid-turn state: chips pushed by PreToolUse hook before
+    # the model finished responding.
+    ss._current_activity = "Bash — echo hi"
+    ss._activity_log = ["ToolSearch", "Bash — echo test", "Bash — echo hi"]
+    response = TurnResponse(text="done", stop_reason="end_turn")
+
+    await ss._handle_turn_complete(response)
+
+    assert ss._current_activity == ""
+    assert ss._activity_log == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Brad reported (msg #7950, screenshot 2026-05-17 17:58 PDT) the Chat.svelte thinking-bubble accumulating tool-call lines across turns for tmux agents — `Bash — echo hi`, `ToolSearch`, `pinky-messaging: send` all piling up because the per-turn state never resets between turns.

Root cause: two related misses in `_handle_turn_complete`:

1. **No state reset.** `_current_activity` and `_activity_log` are populated by the PreToolUse hook (PR #527) and surfaced via `/streaming/status` polling. Nothing was clearing them between turns, so the polling endpoint kept returning a growing log forever.

2. **Event name mismatch.** tmux emitted `turn_complete`; Chat.svelte (and StreamingSession + CodexSession) use `turn_completed` (with -d). tmux's event silently dropped on the floor — the UI never got the turn-end signal.

## Fix
- Reset `_current_activity = ""` and `_activity_log = []` at the end of `_handle_turn_complete`, after dispatch + worker signal so the final response lands first and only then the UI clears.
- Rename the stream event `turn_complete` → `turn_completed` for parity with the other two session types. Chat.svelte's existing handler now fires for tmux agents too, clearing pending-assistant-stream state at turn end.
- The chip-strip from PR #528 has its own per-turn lifetime on the client (cleared on user-send / session-switch, persists past turn_completed by design) and is unaffected.

## Test plan
- [x] `pytest tests/test_tmux_session.py` — 89 pass, including new `test_handle_turn_complete_resets_live_activity_state` and updated event-name assertion
- [x] Full sweep: `tests/{test_tmux_session,test_tmux_transcript,test_agent_registry,test_effort_verification}.py` — 248 pass
- [x] `ruff check` clean
- [ ] Live verification: chat with a tmux agent, trigger tool calls, send a follow-up message — verify thinking-bubble's activity log clears between turns (requires daemon restart since the fix lives in tmux_session.py state)

🤖 Opened by Barsik

Refs #527, #528, msg #7950.