### PR TITLE
feat(chat): read-only live tmux pane viewer (xterm.js modal)

### DIFF
--- a/frontend-svelte/package-lock.json
+++ b/frontend-svelte/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend-svelte",
       "version": "0.0.0",
       "dependencies": {
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "svelte-i18n": "^4.0.1",
         "svelte-spa-router": "^5.0.1"
       },
@@ -504,6 +506,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/acorn": {
       "version": "8.16.0",

--- a/frontend-svelte/package.json
+++ b/frontend-svelte/package.json
@@ -15,6 +15,8 @@
     "vite": "^8.0.8"
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "svelte-i18n": "^4.0.1",
     "svelte-spa-router": "^5.0.1"
   }

--- a/frontend-svelte/src/components/TmuxPaneModal.svelte
+++ b/frontend-svelte/src/components/TmuxPaneModal.svelte
@@ -1,0 +1,180 @@
+<!--
+  TmuxPaneModal — read-only live viewer for a tmux agent's terminal pane.
+
+  Subscribes to `/agents/{agent}/tmux/pane/stream` (SSE, snapshot per frame)
+  and renders the captured ANSI output into an xterm.js terminal in
+  disableStdin mode. Each frame is a full pane snapshot — we clear + redraw
+  in one write so cursor/colours come through but the previous frame doesn't
+  leak. xterm.js is dynamic-imported so the ~150 KB dependency only loads
+  when the modal opens.
+
+  Props:
+    show:  bool   — modal open state (bind from parent)
+    agent: string — agent name (e.g. "barsik")
+    label: string — session label (default "main")
+
+  Dispatches: no custom events; toggle via bound `show`.
+-->
+<script>
+    import { onDestroy } from 'svelte';
+    import Modal from './Modal.svelte';
+    import { sse } from '../lib/api.js';
+
+    export let show = false;
+    export let agent = '';
+    export let label = 'main';
+
+    let hostEl;
+    let terminal = null;
+    let fitAddon = null;
+    let sseSource = null;
+    let resizeObserver = null;
+    let statusMessage = '';
+    let lastFrameAt = 0;
+
+    // Lifecycle reacts to (show, agent, label, hostEl). Mount when modal
+    // opens + host div is rendered + we have an agent. Teardown when the
+    // modal closes or the target changes.
+    $: void reconcile(show, agent, label, hostEl);
+
+    let lastKey = '';
+    async function reconcile(s, a, l, host) {
+        const key = s && host && a ? `${a}|${l}` : '';
+        if (key === lastKey) return;
+        if (lastKey) teardown();
+        lastKey = key;
+        if (key) await mount();
+    }
+
+    async function mount() {
+        statusMessage = 'Loading terminal…';
+        try {
+            const [{ Terminal }, { FitAddon }] = await Promise.all([
+                import('@xterm/xterm'),
+                import('@xterm/addon-fit'),
+            ]);
+            // CSS comes alongside the JS bundle — pulled in lazily too.
+            await import('@xterm/xterm/css/xterm.css');
+
+            terminal = new Terminal({
+                disableStdin: true,
+                cursorBlink: false,
+                convertEol: true,
+                scrollback: 5000,
+                fontSize: 12,
+                fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", "Roboto Mono", Consolas, monospace',
+                theme: {
+                    background: '#0a0a0a',
+                    foreground: '#e0e0e0',
+                    cursor: '#888',
+                },
+            });
+            fitAddon = new FitAddon();
+            terminal.loadAddon(fitAddon);
+
+            if (!hostEl) {
+                // Host unmounted before async resolved — abort.
+                teardown();
+                return;
+            }
+            terminal.open(hostEl);
+            try { fitAddon.fit(); } catch {}
+
+            // Track container resizes (modal resize, viewport rotate) so
+            // xterm reflows. ResizeObserver fires on initial observe too.
+            if (typeof ResizeObserver !== 'undefined') {
+                resizeObserver = new ResizeObserver(() => {
+                    try { fitAddon && fitAddon.fit(); } catch {}
+                });
+                resizeObserver.observe(hostEl);
+            }
+
+            statusMessage = 'Connecting to stream…';
+            sseSource = sse(`/agents/${encodeURIComponent(agent)}/tmux/pane/stream?label=${encodeURIComponent(label)}`);
+            sseSource.onmessage = (evt) => {
+                let data = null;
+                try { data = JSON.parse(evt.data || '{}'); } catch { return; }
+                if (!data || !data.type) return;
+                if (data.type === 'snapshot') {
+                    lastFrameAt = data.ts || (Date.now() / 1000);
+                    if (terminal) {
+                        // Clear screen + home + redraw. The captured output
+                        // already contains ANSI for colours/cursor.
+                        terminal.write('\x1b[2J\x1b[H' + (data.data || ''));
+                    }
+                    if (statusMessage) statusMessage = '';
+                } else if (data.type === 'not_tmux') {
+                    statusMessage = 'This agent is not running under the tmux transport — no pane to view.';
+                    if (sseSource) { sseSource.close(); sseSource = null; }
+                }
+            };
+            sseSource.onerror = () => {
+                statusMessage = 'Stream disconnected. Close + reopen to retry.';
+            };
+        } catch (e) {
+            statusMessage = `Failed to load terminal: ${e?.message || e}`;
+            teardown();
+        }
+    }
+
+    function teardown() {
+        if (sseSource) { try { sseSource.close(); } catch {} sseSource = null; }
+        if (resizeObserver) { try { resizeObserver.disconnect(); } catch {} resizeObserver = null; }
+        if (terminal) { try { terminal.dispose(); } catch {} terminal = null; }
+        fitAddon = null;
+        statusMessage = '';
+        lastFrameAt = 0;
+    }
+
+    onDestroy(teardown);
+</script>
+
+<Modal bind:show title={`Terminal · ${agent}${label && label !== 'main' ? ` · ${label}` : ''}`} maxWidth="1200px" width="92%" flush>
+    <div class="pane-wrap">
+        {#if statusMessage}
+            <div class="pane-status">{statusMessage}</div>
+        {/if}
+        <div class="pane-host" bind:this={hostEl}></div>
+        {#if lastFrameAt > 0}
+            <div class="pane-footer">read-only · live · last frame {new Date(lastFrameAt * 1000).toLocaleTimeString()}</div>
+        {/if}
+    </div>
+</Modal>
+
+<style>
+    .pane-wrap {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        height: 70vh;
+        background: #0a0a0a;
+    }
+    .pane-host {
+        flex: 1 1 auto;
+        min-height: 0;
+        background: #0a0a0a;
+        padding: 0.5rem;
+    }
+    /* xterm renders its own <canvas>; ensure the host fills the flex slot */
+    .pane-host :global(.xterm),
+    .pane-host :global(.xterm-viewport) {
+        background-color: #0a0a0a !important;
+        width: 100% !important;
+        height: 100% !important;
+    }
+    .pane-status {
+        font-family: var(--font-grotesk, monospace);
+        font-size: 0.75rem;
+        color: var(--text-muted, #888);
+        padding: 0.5rem 0.8rem;
+        border-bottom: 1px solid #222;
+    }
+    .pane-footer {
+        font-family: var(--font-grotesk, monospace);
+        font-size: 0.65rem;
+        color: var(--text-muted, #666);
+        padding: 0.3rem 0.8rem;
+        border-top: 1px solid #222;
+        text-align: right;
+    }
+</style>

--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -5,6 +5,7 @@
     import ChatSidebar from '../components/ChatSidebar.svelte';
     import ChatMessage from '../components/ChatMessage.svelte';
     import ChatInput from '../components/ChatInput.svelte';
+    import TmuxPaneModal from '../components/TmuxPaneModal.svelte';
     import { api, sse } from '../lib/api.js';
     import {
         parseBrokerMessage, groupByAgent, sortMessages,
@@ -78,6 +79,7 @@
     let showSettings = false;
     let showSessionInfo = false;
     let showForwardModal = false;
+    let showTmuxPane = false;
     let forwardMessage = null;
     let forwardAgents = [];
     let forwardSelected = {};
@@ -1184,6 +1186,7 @@
                 <div class="chat-actions">
                     <button class="btn-action" on:click={() => showSettings = !showSettings}>{$_('chat.model')}</button>
                     <button class="btn-action" on:click={() => showSessionInfo = !showSessionInfo}>info</button>
+                    <button class="btn-action" on:click={() => showTmuxPane = true} disabled={!activeAgent} title="Live tmux pane (read-only)">term</button>
                     <div class="restart-group">
                         <button class="btn-restart" class:restarting on:click={contextRestart} disabled={restarting}>{restarting ? $_('chat.restarting') : $_('chat.context_restart')}</button>
                         <button class="btn-restart-chevron" class:open={restartDropdownOpen} on:click|stopPropagation={() => restartDropdownOpen = !restartDropdownOpen} disabled={restarting}>&#x25BE;</button>
@@ -1526,6 +1529,13 @@
         {/if}
     </div>
 </Modal>
+
+<!-- Tmux Pane Modal (read-only live terminal viewer) -->
+<TmuxPaneModal
+    bind:show={showTmuxPane}
+    agent={activeAgent || ''}
+    label={activeSessionRecord?._streaming_label || activeSession?.split('-').slice(1).join('-') || 'main'}
+/>
 
 <style>
     .main { display: flex; flex: 1; overflow: hidden; height: 100vh; height: 100dvh; }

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6338,6 +6338,84 @@ def create_api(
 
         return StreamingResponse(event_generator(), media_type="text/event-stream")
 
+    @app.get("/agents/{agent_name}/tmux/pane/stream")
+    async def stream_tmux_pane(
+        agent_name: str,
+        label: str = "main",
+        interval_ms: int = 400,
+        lines: int = 200,
+    ):
+        """Stream the live tmux pane contents as SSE snapshots.
+
+        Read-only viewer for the agent's terminal — the chat UI's
+        xterm.js modal subscribes to this and renders each frame.
+        ANSI escape sequences are preserved (``capture-pane -e``) so
+        colors + cursor positioning come through.
+
+        Each SSE event is a JSON object:
+            {"type": "snapshot", "data": "...", "ts": 1234.5}
+        ``data`` is the raw ``capture-pane`` output. The client clears
+        + redraws on each frame (cheap because the captured content is
+        a static screen state, not an event log).
+
+        404 if the agent doesn't exist. If the session isn't a tmux
+        runtime (or hasn't booted yet) the stream emits a single
+        ``{"type": "not_tmux"}`` event and closes — the modal renders
+        a helpful message instead of an empty terminal.
+
+        ``interval_ms`` is clamped to [100, 2000] to bound the rate.
+        ``lines`` is clamped to [10, 1000] — generous range covers
+        short panes (tmux REPL header) up to long scrollback dumps.
+        """
+        agent = agents.get(agent_name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{agent_name}' not found")
+
+        # Clamp to defend against accidental tight loops or huge captures.
+        interval_s = max(0.1, min(2.0, interval_ms / 1000.0))
+        line_count = max(10, min(1000, lines))
+
+        async def event_generator():
+            session = broker.get_streaming_session(agent_name, label=label)
+            snap = getattr(session, "get_pane_snapshot", None)
+            if session is None or not callable(snap):
+                # SDK / codex / cold session — no tmux pane to show.
+                yield (
+                    'data: '
+                    + json.dumps({
+                        "type": "not_tmux",
+                        "agent": agent_name,
+                        "label": label,
+                    })
+                    + '\n\n'
+                )
+                return
+
+            try:
+                while True:
+                    try:
+                        snapshot = await snap(lines=line_count)
+                    except Exception as e:  # pragma: no cover — defensive
+                        _log(
+                            f"api: stream_tmux_pane snapshot raised for "
+                            f"{agent_name}: {e}"
+                        )
+                        snapshot = ""
+                    payload = {
+                        "type": "snapshot",
+                        "data": snapshot,
+                        "ts": time.time(),
+                    }
+                    yield f"data: {json.dumps(payload)}\n\n"
+                    await asyncio.sleep(interval_s)
+            except asyncio.CancelledError:
+                # Client disconnected — exit cleanly.
+                raise
+
+        return StreamingResponse(
+            event_generator(), media_type="text/event-stream",
+        )
+
     @app.post("/agents/{name}/upload")
     async def upload_file_to_agent(name: str, file: UploadFile):
         """Upload a file to an agent via the web UI."""

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -319,22 +319,30 @@ class _TmuxControl:
 
         return await self._run("send-keys", "-t", self.session_name, "Enter")
 
-    async def capture_pane(self, *, lines: int = 200) -> TmuxCommandResult:
+    async def capture_pane(
+        self, *, lines: int = 200, escapes: bool = False,
+    ) -> TmuxCommandResult:
         """Capture the last ``lines`` lines of the pane's visible content.
 
         Used by the response pipeline as a fallback when transcript-file
-        tailing isn't available. Not the primary capture mechanism
-        (transcripts are structured JSONL; capture-pane is text and
-        ANSI-laden) but useful for debugging and as a fallback.
+        tailing isn't available, and by the read-only pane-view SSE
+        endpoint (with ``escapes=True``) to stream the live pane to
+        xterm.js in the chat UI.
+
+        ``escapes=True`` adds ``-e`` so tmux includes the ANSI colour
+        and cursor escapes it stripped by default — needed for xterm
+        to render the pane faithfully. Default ``False`` preserves the
+        plain-text shape callers expect.
         """
-        return await self._run(
+        args = [
             "capture-pane",
-            "-t",
-            self.session_name,
+            "-t", self.session_name,
             "-p",  # print to stdout instead of paste buffer
-            "-S",
-            str(-abs(lines)),  # negative line offset = lines from bottom
-        )
+        ]
+        if escapes:
+            args.append("-e")  # include ANSI escape sequences
+        args.extend(["-S", str(-abs(lines))])
+        return await self._run(*args)
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -1250,6 +1258,33 @@ class TmuxSession:
                 f"tmux[{self.agent_name}]: transcript path updated to "
                 f"{path}"
             )
+
+    async def get_pane_snapshot(self, *, lines: int = 200) -> str:
+        """Return the last ``lines`` lines of the tmux pane, with ANSI
+        escape sequences preserved.
+
+        Used by the read-only pane-view SSE endpoint to stream live
+        terminal output to the chat UI's xterm.js modal. ANSI escapes
+        carry color + cursor positioning so xterm renders the pane the
+        way a human sees it.
+
+        Returns an empty string if the tmux subprocess fails — caller
+        decides whether to retry or surface to the UI. Mirrors the
+        defensive posture of ``_handle_turn_complete``: a transient
+        tmux blip never raises out of this layer.
+        """
+        try:
+            result = await self._tmux.capture_pane(
+                lines=lines, escapes=True,
+            )
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: get_pane_snapshot raised: {e}"
+            )
+            return ""
+        if not result.ok:
+            return ""
+        return result.stdout
 
     async def _handle_turn_complete(self, response: TurnResponse) -> None:
         """Tailer callback — fired once per ``stop_hook_summary`` entry.

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -521,3 +521,60 @@ class TestTransportEndpoints:
         # session: None (the path validation already succeeded, which is
         # what this test pins).
         assert body.get("session") is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tmux pane stream — read-only live viewer endpoint
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestTmuxPaneStream:
+    """Tests for ``GET /agents/<name>/tmux/pane/stream``.
+
+    SSE endpoint feeding xterm.js in the chat UI. Streams full
+    capture-pane snapshots (with ANSI escapes) on a timer. Tests
+    pin the boundary conditions; live snapshot streaming is exercised
+    by the TmuxSession-level get_pane_snapshot tests.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._db = os.path.join(self._tmpdir, "test.db")
+
+    def _client_with_agent(self, name: str = "dymok"):
+        app = _make_app(self._db)
+        client = TestClient(app)
+        r = client.post("/agents", json={"name": name, "model": "sonnet"})
+        assert r.status_code == 200
+        return client
+
+    def test_pane_stream_404_for_unknown_agent(self):
+        client = self._client_with_agent()
+        resp = client.get("/agents/nobody/tmux/pane/stream")
+        assert resp.status_code == 404
+
+    def test_pane_stream_emits_not_tmux_when_no_session(self):
+        """No streaming session registered (or session lacks
+        ``get_pane_snapshot``) → the generator emits a single
+        ``not_tmux`` event and closes. The UI renders a hint instead
+        of spinning forever on an empty terminal."""
+        import json as _json
+        client = self._client_with_agent()
+        # Stream the response in raw bytes; the first event should be
+        # the not_tmux signal and the stream should close immediately.
+        with client.stream("GET", "/agents/dymok/tmux/pane/stream") as resp:
+            assert resp.status_code == 200
+            assert resp.headers["content-type"].startswith(
+                "text/event-stream"
+            )
+            chunks = []
+            for chunk in resp.iter_bytes():
+                chunks.append(chunk)
+                if len(b"".join(chunks)) > 256:
+                    break
+            body = b"".join(chunks).decode("utf-8")
+            # SSE frame: "data: <json>\n\n"
+            assert body.startswith("data: ")
+            payload = _json.loads(body[6:].split("\n\n", 1)[0])
+            assert payload["type"] == "not_tmux"
+            assert payload["agent"] == "dymok"

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -269,6 +269,46 @@ def test_build_claude_cmd_includes_dangerously_skip_when_no_transcript(
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# capture_pane signature: escapes flag for the read-only pane viewer
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_capture_pane_default_omits_escapes_flag() -> None:
+    """Existing callers that want plain text shouldn't suddenly start
+    getting ANSI escapes back. Default ``escapes=False`` keeps the
+    response pipeline's fallback capture clean."""
+    tmux = _TmuxControl("pinky-test")
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        return _ok()
+
+    tmux._run = fake_run
+    await tmux.capture_pane(lines=50)
+    assert "-e" not in calls[0]
+    assert "-p" in calls[0]
+    assert "-S" in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_capture_pane_with_escapes_adds_e_flag() -> None:
+    """The pane-viewer endpoint needs ANSI escapes preserved for xterm.js
+    rendering. ``escapes=True`` adds ``-e`` to the tmux invocation."""
+    tmux = _TmuxControl("pinky-test")
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        return _ok()
+
+    tmux._run = fake_run
+    await tmux.capture_pane(lines=200, escapes=True)
+    assert "-e" in calls[0]
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # #514 — paste-buffer + delayed Enter for prompt delivery
 # ──────────────────────────────────────────────────────────────────────────
 
@@ -2332,3 +2372,51 @@ async def test_record_tool_use_finish_caps_huge_response_at_200() -> None:
         tool_response=huge,
     )
     assert len(events[0]["result_preview"]) == 200
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pane snapshot (read-only viewer endpoint)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_pane_snapshot_returns_stdout_with_escapes() -> None:
+    """``get_pane_snapshot`` calls capture_pane with escapes=True and
+    returns the raw stdout (ANSI escapes preserved for xterm.js)."""
+    ss, tmux = _make_session()
+    tmux.capture_pane = AsyncMock(return_value=TmuxCommandResult(
+        returncode=0,
+        stdout="\x1b[1;32mhello\x1b[0m",
+        stderr="",
+    ))
+    out = await ss.get_pane_snapshot(lines=150)
+    assert out == "\x1b[1;32mhello\x1b[0m"
+    # Verify escapes flag was passed through.
+    tmux.capture_pane.assert_awaited_once()
+    kwargs = tmux.capture_pane.await_args.kwargs
+    assert kwargs.get("escapes") is True
+    assert kwargs.get("lines") == 150
+
+
+@pytest.mark.asyncio
+async def test_get_pane_snapshot_returns_empty_on_tmux_failure() -> None:
+    """A non-zero return from tmux capture-pane (transient server blip,
+    session went away during a frame) must NOT raise — the SSE generator
+    just emits an empty frame and the next one will recover."""
+    ss, tmux = _make_session()
+    tmux.capture_pane = AsyncMock(return_value=TmuxCommandResult(
+        returncode=1, stdout="", stderr="lost server",
+    ))
+    out = await ss.get_pane_snapshot()
+    assert out == ""
+
+
+@pytest.mark.asyncio
+async def test_get_pane_snapshot_swallows_subprocess_exception() -> None:
+    """If capture_pane itself raises (e.g. the tmux binary disappeared
+    mid-flight), the snapshot helper must return "" rather than letting
+    the exception escape into the SSE generator and kill the stream."""
+    ss, tmux = _make_session()
+    tmux.capture_pane = AsyncMock(side_effect=RuntimeError("tmux gone"))
+    out = await ss.get_pane_snapshot()
+    assert out == ""


### PR DESCRIPTION
## Summary

Per msg #7960 — read-only viewer for an agent's live tmux pane, rendered as an xterm.js modal launched from a new **term** button next to the chat-actions toolbar.

**Server**
- New SSE endpoint `GET /agents/{name}/tmux/pane/stream?label=...&interval_ms=400&lines=200` streaming `capture-pane -e -p` snapshots as JSON `{"type": "snapshot", "data": ..., "ts": ...}` frames. Clamps interval to 100–2000 ms and lines to 10–1000. Emits a single `{"type": "not_tmux"}` and closes if the session isn't a tmux runtime.
- `TmuxSession.get_pane_snapshot(lines=200)` — defensive wrapper around `capture_pane(escapes=True)`; returns `""` on tmux failure so a transient blip doesn't crash the stream.
- `_TmuxControl.capture_pane()` grew an `escapes: bool = False` kwarg — default off keeps the response-pipeline fallback's plain-text shape; the viewer opts in.

**Frontend**
- `TmuxPaneModal.svelte` (new) — dynamically imports `@xterm/xterm` + `@xterm/addon-fit` + xterm CSS so the ~340 KB (86 KB gzip) terminal bundle only loads when the modal opens. xterm in `disableStdin` mode. Each snapshot is prefixed with `\x1b[2J\x1b[H` so frames are clean clear+redraws (preserves cursor + colours, no leakage). ResizeObserver re-fits on container resize.
- Chat.svelte: imports the component, adds `showTmuxPane` toggle + a **term** button next to **info**, renders the modal at the bottom. Label derived from `activeSessionRecord._streaming_label`.

## Test plan
- [x] `pytest tests/test_tmux_session.py tests/test_agent_status.py` — 96 pass including:
  - `test_get_pane_snapshot_returns_stdout_with_escapes`
  - `test_get_pane_snapshot_returns_empty_on_tmux_failure`
  - `test_get_pane_snapshot_swallows_subprocess_exception`
  - `test_capture_pane_default_omits_escapes_flag` / `test_capture_pane_with_escapes_adds_e_flag`
  - `test_pane_stream_404_for_unknown_agent` / `test_pane_stream_emits_not_tmux_when_no_session`
- [x] Wider sweep (tmux/agent_status/transcript/agent_registry/effort): 281 pass
- [x] `ruff check` clean
- [x] `npm run build` clean — main bundle +3 KB, xterm in its own lazy chunk
- [ ] Live verify: click **term** in Chat against a tmux agent (Barsik, Dymok, Pushok), verify the modal shows the live pane, colours preserved, footer shows "last frame" updating

## Scope notes
- **Read-only only.** Interactive ("take the wheel") was discussed in #7959 as a separate Phase 2 with control-claim affordances + input bidirectional WS — deliberately out of scope for this MVP.
- xterm.js v6 + addon-fit v0.11 are the current majors (Apr 2026 / Apr 2025 cuts). Powers VS Code / Hyper / Codespaces.

🤖 Opened by Barsik