### PR TITLE
feat(chat): align tool-call chips + persist them across page refresh

### DIFF
--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -40,6 +40,52 @@
     // new user turn begins; persists between the streaming assistant
     // bubble and the next user send so finished calls stay visible.
     let liveToolCalls = [];
+    // Persisted tool calls fetched from analytics on chat load — same
+    // shape as liveToolCalls but with `_startedAtEpoch` for chronological
+    // interleaving with messages. Survives page refresh; PR #527 hooks
+    // write the rows, this list rebuilds the chip strips inline with
+    // the message history.
+    let persistedToolCalls = [];
+    // Reactive: chip strips slotted just before the message they precede.
+    // Both arrays are sorted ASC; chips with started_at in
+    // (messages[i-1].timestamp, messages[i].timestamp] land in bucket i.
+    // Numeric-coerced timestamps; non-numeric (e.g. ISO strings on some
+    // session_event rows) are skipped — they'd otherwise tank the math.
+    $: chipsByMessageIndex = computeChipsByMessage(messages, persistedToolCalls);
+
+    function tsAsEpoch(t) {
+        if (t == null) return null;
+        const n = Number(t);
+        if (Number.isFinite(n) && n > 0) return n;
+        const parsed = Date.parse(t);
+        return Number.isFinite(parsed) ? parsed / 1000 : null;
+    }
+
+    function computeChipsByMessage(msgs, chips) {
+        if (!msgs?.length || !chips?.length) return new Map();
+        const out = new Map();
+        let cursor = 0;
+        for (let i = 0; i < msgs.length; i++) {
+            const msgTs = tsAsEpoch(msgs[i]?.timestamp);
+            if (msgTs == null) continue;
+            const prevTs = i > 0
+                ? (tsAsEpoch(msgs[i - 1]?.timestamp) ?? -Infinity)
+                : -Infinity;
+            const bucket = [];
+            while (
+                cursor < chips.length &&
+                chips[cursor]._startedAtEpoch <= msgTs
+            ) {
+                if (chips[cursor]._startedAtEpoch > prevTs) {
+                    bucket.push(chips[cursor]);
+                }
+                cursor++;
+            }
+            if (bucket.length) out.set(i, bucket);
+        }
+        return out;
+    }
+
     let agentWorking = false;
     let activityPollInterval = null;
     let wasWorking = false;
@@ -415,6 +461,35 @@
                 nextPersisted = sortMessages([...nextPersisted, ...eventMessages]);
             }
         } catch { /* non-critical */ }
+
+        // Fetch persisted tool calls so the chip strips survive a page
+        // refresh. Same shape as liveToolCalls; the render loop later
+        // interleaves these chronologically with messages by timestamp.
+        try {
+            const refreshLabel = activeSessionRecord?._streaming_label
+                || sessionId?.split('-').slice(1).join('-')
+                || 'main';
+            const tcData = await api(
+                'GET',
+                `/agents/${agentName}/sessions/${encodeURIComponent(refreshLabel)}/tool-calls?limit=500`,
+            );
+            if (requestSeq !== chatRefreshSeq || sessionId !== activeSession) return;
+            persistedToolCalls = (tcData.tool_calls || []).map((tc) => {
+                const epoch = tc.started_at ? Date.parse(tc.started_at) : NaN;
+                return {
+                    id: tc.tool_use_id || `${tc.tool_name}-${tc.started_at || ''}`,
+                    toolName: tc.tool_name || '',
+                    namespace: tc.tool_namespace || '',
+                    description: tc.description || '',
+                    argKeys: Array.isArray(tc.arg_keys) ? tc.arg_keys : [],
+                    resultPreview: tc.result_preview || '',
+                    finished: !!tc.finished,
+                    isError: !!tc.is_error,
+                    _startedAtEpoch: Number.isFinite(epoch) ? epoch / 1000 : null,
+                };
+            }).filter((tc) => tc._startedAtEpoch != null)
+              .sort((a, b) => a._startedAtEpoch - b._startedAtEpoch);
+        } catch { persistedToolCalls = []; }
 
         if (preserveScroll) captureScroll('refresh');
 
@@ -1354,6 +1429,35 @@
                     <div class="loading-older"><button class="btn-load-more" on:click={loadOlderMessages}>{$_('chat.load_older')}</button></div>
                 {/if}
                 {#each messages as msg, index (deriveMessageKey(msg, index))}
+                    <!-- Historical tool-call chips: rendered inline before
+                         the message they precede, so chip strips survive a
+                         page refresh and slot into chronological place
+                         (analytics_tool_calls rows, fetched in refreshChat). -->
+                    {#if chipsByMessageIndex.has(index)}
+                        <div class="tool-call-strip">
+                            {#each chipsByMessageIndex.get(index) as tc (tc.id)}
+                                <div class="tool-call-chip" class:in-flight={!tc.finished} class:finished={tc.finished} class:tool-error={tc.finished && tc.isError}>
+                                    <span class="tc-head">
+                                        {#if tc.namespace}<span class="tc-ns">{tc.namespace}/</span>{/if}
+                                        <span class="tc-name">{tc.toolName || '(tool)'}</span>
+                                        {#if tc.finished}
+                                            <span class="tc-status">{tc.isError ? '×' : '✓'}</span>
+                                        {:else}
+                                            <span class="tc-spinner" aria-label="running">·</span>
+                                        {/if}
+                                    </span>
+                                    {#if tc.description}<span class="tc-desc">{tc.description}</span>{/if}
+                                    {#if tc.argKeys && tc.argKeys.length}<span class="tc-keys">[{tc.argKeys.join(', ')}]</span>{/if}
+                                    {#if tc.finished && tc.resultPreview}
+                                        <details class="tc-preview-wrap">
+                                            <summary class="tc-preview-summary">result</summary>
+                                            <pre class="tc-preview">{tc.resultPreview}</pre>
+                                        </details>
+                                    {/if}
+                                </div>
+                            {/each}
+                        </div>
+                    {/if}
                     {#if isHeartbeatMessage(msg)}
                         {@const hbTime = msg.content?.match(/\d{2}:\d{2}/)?.[0] || ''}
                         <div class="heartbeat-indicator">

--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -1643,9 +1643,12 @@
     .thinking-log-entry.current { color: var(--text-muted); font-weight: 600; }
 
     /* Task #94: tool-call chip strip (tmux SSE events from PR #527) */
-    .tool-call-strip { align-self: flex-start; display: flex; flex-direction: column; gap: 0.3rem; margin: 0.2rem 0 0.4rem; max-width: 80%; }
+    /* Width matches .message bubbles (75% / mobile 92%) so chips visually
+       line up with assistant/user messages instead of stretching wider. */
+    .tool-call-strip { align-self: flex-start; align-items: flex-start; display: flex; flex-direction: column; gap: 0.3rem; margin: 0.2rem 0 0.4rem; max-width: 75%; }
     .tool-call-chip {
         display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.4rem;
+        max-width: 100%; /* honor strip cap (75% of messages area) */
         padding: 0.3rem 0.6rem;
         background: var(--surface-1);
         border-left: 2px solid var(--border-subtle);
@@ -1689,7 +1692,7 @@
         overflow-y: auto;
     }
     @media (max-width: 768px) {
-        .tool-call-strip { max-width: 95%; }
+        .tool-call-strip { max-width: 92%; } /* matches .message mobile cap */
         .tc-desc { max-width: 200px; }
     }
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6416,6 +6416,79 @@ def create_api(
             event_generator(), media_type="text/event-stream",
         )
 
+    @app.get("/agents/{agent_name}/sessions/{label}/tool-calls")
+    async def list_session_tool_calls(
+        agent_name: str,
+        label: str = "main",
+        limit: int = 500,
+    ):
+        """Return persisted tool calls for an agent session, oldest first.
+
+        Backs the chat UI's chip-strip rebuild on refresh: ``liveToolCalls``
+        is transient SSE state and evaporates on reload, so on chat load
+        the frontend pulls the persisted analytics rows (tmux hooks write
+        them in PR #527) and interleaves them with messages by timestamp.
+
+        404 if the agent doesn't exist. Returns an empty list (not 404)
+        when the agent exists but has no analytics rows yet — keeps the
+        frontend's fetch + merge path branch-free.
+
+        ``limit`` is clamped by ``get_recent_tool_calls`` to [1, 500];
+        we accept a wider range and let the store cap it.
+        """
+        agent = agents.get(agent_name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{agent_name}' not found")
+
+        session_id = f"{agent_name}-{label or 'main'}"
+        try:
+            rows = analytics.get_recent_tool_calls(
+                agent_name=agent_name,
+                session_id=session_id,
+                limit=limit,
+            )
+        except Exception as e:
+            _log(
+                f"api: list_session_tool_calls fetch raised for "
+                f"{agent_name}/{label}: {e}"
+            )
+            rows = []
+
+        # get_recent_tool_calls returns newest-first; flip for chronological
+        # consumption (chat UI walks the array in display order).
+        rows.reverse()
+
+        out: list[dict] = []
+        for row in rows:
+            meta = row.get("metadata") or {}
+            err = row.get("error_type") or ""
+            out.append({
+                "tool_use_id": row.get("tool_call_key"),
+                "tool_name": row.get("tool_name") or "",
+                "tool_namespace": row.get("tool_namespace") or "",
+                "description": meta.get("description") or "",
+                "arg_keys": meta.get("arg_keys") or [],
+                "result_preview": meta.get("result_preview") or "",
+                "started_at": row.get("started_at"),
+                "ended_at": row.get("ended_at"),
+                "duration_ms": row.get("duration_ms"),
+                "success": (
+                    bool(row.get("success"))
+                    if row.get("success") is not None
+                    else None
+                ),
+                "error_type": err,
+                "status": row.get("status") or "",
+                "is_error": bool(err),
+                "finished": row.get("status") not in ("running", None, ""),
+            })
+        return {
+            "ok": True,
+            "agent": agent_name,
+            "session_id": session_id,
+            "tool_calls": out,
+        }
+
     @app.post("/agents/{name}/upload")
     async def upload_file_to_agent(name: str, file: UploadFile):
         """Upload a file to an agent via the web UI."""

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -630,6 +630,15 @@ class TmuxSession:
         if isinstance(tool_input, dict):
             arg_keys = sorted(tool_input.keys())
 
+        # Persist description alongside arg_keys so the chat UI can
+        # rebuild the chip strip after a page refresh (otherwise these
+        # only live in the transient tool_use_start SSE payload).
+        start_meta: dict = {}
+        if arg_keys:
+            start_meta["arg_keys"] = arg_keys
+        if desc:
+            start_meta["description"] = desc
+
         if self._analytics_store:
             try:
                 self._analytics_store.start_tool_call(
@@ -639,7 +648,7 @@ class TmuxSession:
                     tool_call_key=call_key,
                     tool_name=tool_name,
                     tool_namespace=tool_ns,
-                    metadata={"arg_keys": arg_keys} if arg_keys else None,
+                    metadata=start_meta or None,
                 )
             except Exception as e:
                 _log(
@@ -699,6 +708,14 @@ class TmuxSession:
             except Exception:
                 result_preview = str(tool_response)[:200]
 
+        # Persist result_preview so the chat UI's chip strip can show
+        # the truncated tool output after a page refresh. The same
+        # 200-char snippet that the live tool_use_finish SSE event
+        # carries — no new PII surface.
+        finish_meta: dict = {}
+        if result_preview:
+            finish_meta["result_preview"] = result_preview
+
         if tool_use_id and self._analytics_store:
             try:
                 self._analytics_store.finish_tool_call(
@@ -707,7 +724,7 @@ class TmuxSession:
                     tool_call_key=tool_use_id,
                     success=not is_error,
                     error_type="tool_error" if is_error else "",
-                    metadata=None,
+                    metadata=finish_meta or None,
                 )
             except Exception as e:
                 _log(

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -578,3 +578,182 @@ class TestTmuxPaneStream:
             payload = _json.loads(body[6:].split("\n\n", 1)[0])
             assert payload["type"] == "not_tmux"
             assert payload["agent"] == "dymok"
+
+
+class TestSessionToolCalls:
+    """Tests for ``GET /agents/<name>/sessions/<label>/tool-calls``.
+
+    Frontend Chat.svelte calls this on chat load so the per-turn chip
+    strips survive a page refresh — analytics_tool_calls rows (written
+    by the PR #527 tmux hooks via ``record_tool_use_start`` /
+    ``record_tool_use_finish``) are the source of truth.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._db = os.path.join(self._tmpdir, "test.db")
+
+    def _client_with_agent(self, name: str = "dymok"):
+        app = _make_app(self._db)
+        client = TestClient(app)
+        r = client.post("/agents", json={"name": name, "model": "sonnet"})
+        assert r.status_code == 200
+        return client
+
+    def _analytics_store(self):
+        from pinky_daemon.analytics_store import AnalyticsStore
+        return AnalyticsStore(
+            db_path=self._db.replace(".db", "_analytics.db"),
+        )
+
+    def test_404_for_unknown_agent(self):
+        client = self._client_with_agent()
+        resp = client.get("/agents/nobody/sessions/main/tool-calls")
+        assert resp.status_code == 404
+
+    def test_empty_list_when_no_rows(self):
+        client = self._client_with_agent()
+        resp = client.get("/agents/dymok/sessions/main/tool-calls")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["agent"] == "dymok"
+        assert body["session_id"] == "dymok-main"
+        assert body["tool_calls"] == []
+
+    def test_returns_oldest_first_with_normalized_fields(self):
+        """Returned rows must be chronologically ordered (oldest first)
+        and carry description + arg_keys + result_preview pulled from
+        the analytics row's metadata — the frontend reuses the
+        liveToolCalls chip shape, so all four fields need to be there.
+        """
+        client = self._client_with_agent()
+        store = self._analytics_store()
+
+        # Older call: pinky-self/send_to_agent — finished successfully.
+        store.start_tool_call(
+            session_id="dymok-main",
+            agent_name="dymok",
+            turn_seq=None,
+            tool_call_key="toolu_aaa",
+            tool_name="mcp__pinky-self__send_to_agent",
+            tool_namespace="pinky-self",
+            metadata={
+                "arg_keys": ["message", "to"],
+                "description": "send_to_agent → barsik",
+            },
+            ts="2026-05-17T19:00:00Z",
+        )
+        store.finish_tool_call(
+            session_id="dymok-main",
+            agent_name="dymok",
+            tool_call_key="toolu_aaa",
+            success=True,
+            metadata={"result_preview": "sent: true"},
+            ts="2026-05-17T19:00:01Z",
+        )
+
+        # Newer call: Bash — finished with error.
+        store.start_tool_call(
+            session_id="dymok-main",
+            agent_name="dymok",
+            turn_seq=None,
+            tool_call_key="toolu_bbb",
+            tool_name="Bash",
+            tool_namespace="",
+            metadata={"arg_keys": ["command"], "description": "Bash — ls /nope"},
+            ts="2026-05-17T19:00:10Z",
+        )
+        store.finish_tool_call(
+            session_id="dymok-main",
+            agent_name="dymok",
+            tool_call_key="toolu_bbb",
+            success=False,
+            error_type="tool_error",
+            metadata={"result_preview": "ls: /nope: no such file"},
+            ts="2026-05-17T19:00:11Z",
+        )
+
+        resp = client.get("/agents/dymok/sessions/main/tool-calls")
+        assert resp.status_code == 200
+        calls = resp.json()["tool_calls"]
+        assert len(calls) == 2
+
+        first, second = calls
+        # Oldest first — chronological order is what the chat UI walks.
+        assert first["tool_use_id"] == "toolu_aaa"
+        assert first["tool_name"] == "mcp__pinky-self__send_to_agent"
+        assert first["tool_namespace"] == "pinky-self"
+        assert first["description"] == "send_to_agent → barsik"
+        assert first["arg_keys"] == ["message", "to"]
+        assert first["result_preview"] == "sent: true"
+        assert first["success"] is True
+        assert first["is_error"] is False
+        assert first["finished"] is True
+        assert first["status"] == "ok"
+
+        assert second["tool_use_id"] == "toolu_bbb"
+        assert second["tool_name"] == "Bash"
+        assert second["description"] == "Bash — ls /nope"
+        assert second["result_preview"] == "ls: /nope: no such file"
+        assert second["is_error"] is True
+        assert second["error_type"] == "tool_error"
+        assert second["status"] == "error"
+        assert second["success"] is False
+
+    def test_filters_by_session_label(self):
+        """A label other than 'main' must scope to the matching
+        session_id; rows for other labels of the same agent are excluded.
+        """
+        client = self._client_with_agent()
+        store = self._analytics_store()
+        store.start_tool_call(
+            session_id="dymok-main",
+            agent_name="dymok",
+            turn_seq=None,
+            tool_call_key="toolu_main",
+            tool_name="Read",
+            metadata={"arg_keys": ["file_path"]},
+            ts="2026-05-17T19:00:00Z",
+        )
+        store.start_tool_call(
+            session_id="dymok-secondary",
+            agent_name="dymok",
+            turn_seq=None,
+            tool_call_key="toolu_other",
+            tool_name="Grep",
+            metadata={"arg_keys": ["pattern"]},
+            ts="2026-05-17T19:00:05Z",
+        )
+
+        resp = client.get("/agents/dymok/sessions/secondary/tool-calls")
+        assert resp.status_code == 200
+        calls = resp.json()["tool_calls"]
+        assert len(calls) == 1
+        assert calls[0]["tool_use_id"] == "toolu_other"
+        assert resp.json()["session_id"] == "dymok-secondary"
+
+    def test_in_flight_call_marked_not_finished(self):
+        """A row without an ended_at (status='running') must surface
+        with finished=False so the chip strip renders the in-flight
+        indicator instead of a success/error icon.
+        """
+        client = self._client_with_agent()
+        store = self._analytics_store()
+        store.start_tool_call(
+            session_id="dymok-main",
+            agent_name="dymok",
+            turn_seq=None,
+            tool_call_key="toolu_running",
+            tool_name="Bash",
+            metadata={"arg_keys": ["command"], "description": "Bash — long task"},
+            ts="2026-05-17T19:00:00Z",
+        )
+
+        resp = client.get("/agents/dymok/sessions/main/tool-calls")
+        assert resp.status_code == 200
+        calls = resp.json()["tool_calls"]
+        assert len(calls) == 1
+        assert calls[0]["finished"] is False
+        assert calls[0]["status"] == "running"
+        assert calls[0]["result_preview"] == ""

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -2243,14 +2243,19 @@ async def test_record_tool_use_start_emits_event_and_opens_analytics() -> None:
     # Activity surfaced for live status consumers.
     assert ss._current_activity  # non-empty human-readable description
 
-    # Analytics row opened with the correct key + PII-safe arg_keys only.
+    # Analytics row opened with the correct key + PII-safe arg_keys.
+    # ``description`` is now also persisted so the chip strip can be
+    # rebuilt after a chat-page refresh — it's the same human-readable
+    # label already in the live SSE event.
     analytics.start_tool_call.assert_called_once()
     kwargs = analytics.start_tool_call.call_args.kwargs
     assert kwargs["agent_name"] == "dymok"
     assert kwargs["tool_call_key"] == "toolu_abc123"
     assert kwargs["tool_name"] == "mcp__pinky-self__send_to_agent"
     assert kwargs["tool_namespace"] == "pinky-self"
-    assert kwargs["metadata"] == {"arg_keys": ["message", "to"]}
+    meta = kwargs["metadata"]
+    assert meta["arg_keys"] == ["message", "to"]
+    assert meta["description"]  # non-empty human-readable label
 
     # Stream event emitted with the expected shape.
     assert len(events) == 1
@@ -2310,6 +2315,13 @@ async def test_record_tool_use_finish_emits_finish_and_closes_analytics() -> Non
     assert kwargs["tool_call_key"] == "toolu_abc123"
     assert kwargs["success"] is True
     assert kwargs["error_type"] == ""
+    # ``result_preview`` now lands in metadata so the chip strip can
+    # surface the truncated tool output after a page refresh. Same
+    # 200-char cap as the live SSE event.
+    fmeta = kwargs["metadata"] or {}
+    assert "result_preview" in fmeta
+    assert fmeta["result_preview"]
+    assert len(fmeta["result_preview"]) <= 200
 
     assert len(events) == 1
     evt = events[0]


### PR DESCRIPTION
## Summary

Two related fixes to the per-turn tool-call chip strip (PR #527/#528):

1. **Alignment**: chips visually stretched wider than adjacent message bubbles. Now they cap at the same 75% / mobile 92% widths and size to content.
2. **Persistence**: chips evaporated on page refresh (they were transient SSE state). Now they survive — the analytics_tool_calls table is the source of truth, fetched on chat load and interleaved chronologically.

## Changes

### 1. Alignment (commit 42aa585)
Pure CSS in `Chat.svelte`:
- `.tool-call-strip` `max-width: 80% → 75%` (matches `.message`).
- Mobile `max-width: 95% → 92%`.
- Strip gains `align-items: flex-start` so children don't stretch (flex column default is `stretch`).
- Chip gains `max-width: 100%` so the strip cap still applies when content is long.

### 2. Persistence (commit 62bbed0)
**Server** — fill two metadata gaps in the existing `analytics_tool_calls` writes:
- `tmux_session.record_tool_use_start`: persist `description` alongside arg_keys.
- `tmux_session.record_tool_use_finish`: persist `result_preview` (same 200-char cap as the live SSE — no new PII surface).
- New endpoint `GET /agents/{name}/sessions/{label}/tool-calls?limit=N`. Returns rows oldest-first, normalized to the `liveToolCalls` shape so the frontend reuses the chip template verbatim.

**Frontend** (`Chat.svelte`):
- On chat load, fetch persisted tool calls alongside messages/session-events. Normalize to live-chip shape; stash `_startedAtEpoch` for sorting.
- Reactive `chipsByMessageIndex` two-pointer-walks messages + chips (both ASC) and buckets chips into the message whose `(prevTs, msgTs]` window contains them.
- In the message loop, render a chip strip inline **before** any message with bucketed chips — chronologically slotted after the user message and before the assistant reply.
- The live `liveToolCalls` bottom-strip is unchanged; it still owns the in-flight current turn until `turn_completed` fires.

## Test plan
- [x] `pytest tests/test_tmux_session.py tests/test_agent_status.py` — 127 passed (2 updated assertions + 5 new endpoint tests).
- [x] `pytest tests/test_analytics_store.py` — 15 passed (no schema regression).
- [x] `ruff check src/pinky_daemon/tmux_session.py src/pinky_daemon/api.py tests/test_*` — clean.
- [x] `npm run build` — clean (only pre-existing chunk-size warnings).
- [ ] Live: open a tmux agent's chat that has prior tool calls, refresh, confirm chip strips render inline between user/assistant turns.
- [ ] Live: kick off a fresh tool call, watch live chip appear at bottom, complete the turn, confirm chip migrates inline on next refresh.
- [ ] Live: mobile / narrow viewport — chip strips still 92% capped.

🤖 Opened by Barsik