### PR TITLE
feat(tmux): context-budget watchdog (task #95)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -447,6 +447,14 @@ class TmuxSession:
         }
         self.usage = SessionUsage()
 
+        # Context-budget watchdog state (task #95). The nudge latch
+        # prevents firing ``restart_nudge`` SSE events on every turn
+        # once we're above the agent's ``restart_threshold_pct`` — it
+        # re-arms only after context drops below the threshold (e.g.
+        # post-/compact). Per-turn token accumulation lives in
+        # ``self.usage`` (a SessionUsage dataclass).
+        self._restart_nudge_fired = False
+
         # Effort knob. tmux's claude REPL doesn't currently honor a
         # per-session effort override (CLAUDE_EFFORT env is set at
         # spawn time and we'd have to relaunch to change it). We accept
@@ -1303,6 +1311,213 @@ class TmuxSession:
             return ""
         return result.stdout
 
+    def _max_tokens_for_model(self) -> int:
+        """Return the model's context-window cap.
+
+        Mirrors ``api._streaming_context_info``'s logic: models in
+        ``_1M_MODELS`` cap at 1M tokens; everything else 200k. Lazy
+        import dodges the streaming_session ↔ tmux_session circle.
+        """
+        try:
+            from pinky_daemon.streaming_session import _1M_MODELS
+            big_models = _1M_MODELS  # noqa: N806 - alias for readability
+        except Exception:
+            big_models = set()
+        model = (self._config.model or "").strip()
+        return 1_000_000 if model in big_models else 200_000
+
+    def _restart_threshold_pct(self) -> float:
+        """Pull the agent's restart threshold from the registry.
+
+        Defaults to 80% if the registry isn't wired or doesn't carry
+        a value — matches AgentRegistry's default and StreamingSession's
+        behavior.
+        """
+        if not self._registry:
+            return 80.0
+        try:
+            agent = self._registry.get(self.agent_name)
+            if agent and getattr(agent, "restart_threshold_pct", None):
+                return float(agent.restart_threshold_pct)
+        except Exception:
+            pass
+        return 80.0
+
+    def _record_turn_usage(self, response: TurnResponse) -> None:
+        """Fold a turn's usage block into ``self.usage`` (SessionUsage).
+
+        ``SessionUsage.record`` expects a RunResult-shape object with
+        cost / duration / model_usage fields the tmux path doesn't
+        produce — so we accumulate the token fields directly here.
+        Defensive: a malformed usage dict (schema drift) is treated as
+        zero contributions rather than crashing the tailer.
+        """
+        u = response.usage if isinstance(response.usage, dict) else {}
+        try:
+            self.usage.input_tokens += int(u.get("input_tokens", 0) or 0)
+            self.usage.output_tokens += int(u.get("output_tokens", 0) or 0)
+            # Claude transcripts use ``cache_creation_input_tokens`` /
+            # ``cache_read_input_tokens``; SDK uses ``cache_write_tokens`` /
+            # ``cache_read_tokens``. Accept either.
+            self.usage.cache_read_tokens += int(
+                u.get("cache_read_input_tokens", 0)
+                or u.get("cache_read_tokens", 0)
+                or 0
+            )
+            self.usage.cache_write_tokens += int(
+                u.get("cache_creation_input_tokens", 0)
+                or u.get("cache_write_tokens", 0)
+                or 0
+            )
+        except (TypeError, ValueError) as e:
+            _log(
+                f"tmux[{self.agent_name}]: usage parse drifted, "
+                f"skipping turn ({type(e).__name__}: {e})"
+            )
+
+        self.usage.total_turns += 1
+        self.usage.total_duration_ms += max(0, int(response.duration_ms or 0))
+        self.usage.last_stop_reason = response.stop_reason or ""
+        if u:
+            self.usage.last_usage = dict(u)
+
+    def _current_total_tokens(self) -> int:
+        """Token count for the current *context window* (not cumulative).
+
+        Subtle: ``SessionUsage`` accumulates across turns for cost +
+        lifetime-usage tracking, but context-window size is a
+        per-API-call number — each Claude Code turn re-sends the full
+        prior conversation, so the LAST turn's ``input_tokens`` already
+        captures everything currently in context. Summing across turns
+        would multi-count.
+
+        Mirrors how the SDK reports context: its
+        ``client.get_context_usage()`` returns the live window state,
+        not a lifetime sum. We approximate that from ``last_usage`` —
+        the most recent assistant entry's usage block (captured by
+        ``_TurnBuffer._last_usage`` in the tailer, then folded into
+        ``SessionUsage.last_usage`` by ``_record_turn_usage``).
+
+        Formula: ``input_tokens + output_tokens + cache_read +
+        cache_write`` — Anthropic's prompt-cached tokens count toward
+        the window separately from the inline ``input_tokens``, so all
+        four kinds must be summed for parity with the SDK's reported
+        total.
+        """
+        last = self.usage.last_usage if isinstance(self.usage.last_usage, dict) else {}
+        try:
+            return (
+                int(last.get("input_tokens", 0) or 0)
+                + int(last.get("output_tokens", 0) or 0)
+                + int(
+                    last.get("cache_read_input_tokens", 0)
+                    or last.get("cache_read_tokens", 0)
+                    or 0
+                )
+                + int(
+                    last.get("cache_creation_input_tokens", 0)
+                    or last.get("cache_write_tokens", 0)
+                    or 0
+                )
+            )
+        except (TypeError, ValueError):
+            return 0
+
+    def get_context_info(self) -> dict:
+        """Return SDK-compatible context-window snapshot.
+
+        Consumed by ``api._streaming_context_info`` (which checks for
+        this method when ``ss._client`` is absent — the tmux case). The
+        return shape matches what the SDK's ``get_context_usage`` would
+        emit, so the existing ``/agents/{name}/streaming/status``
+        endpoint serves tmux sessions with zero downstream changes.
+        Frontend Chat.svelte already renders ``streamingStats.totalTokens``
+        / ``maxTokens`` / ``categories`` from that endpoint.
+
+        Categories are coarse-grained for tmux — we don't have the SDK's
+        per-tool / per-mcp breakdown, just the cumulative token rollups.
+        """
+        total = self._current_total_tokens()
+        max_tokens = self._max_tokens_for_model()
+        pct = (total / max_tokens * 100.0) if max_tokens > 0 else 0.0
+
+        # Categories breakdown reflects the *current* context window
+        # (same source as ``total``: ``last_usage``), so the chat UI's
+        # stacked bar adds up to ``total``. Pulling from cumulative
+        # SessionUsage counters would make the bar show lifetime
+        # totals and disagree with the percentage gauge.
+        last = self.usage.last_usage if isinstance(self.usage.last_usage, dict) else {}
+
+        def _int(d: dict, *keys: str) -> int:
+            for k in keys:
+                v = d.get(k)
+                if v:
+                    try:
+                        return int(v)
+                    except (TypeError, ValueError):
+                        return 0
+            return 0
+
+        categories = [
+            {"name": "Input", "tokens": _int(last, "input_tokens")},
+            {"name": "Output", "tokens": _int(last, "output_tokens")},
+            {"name": "Cache read",
+             "tokens": _int(last, "cache_read_input_tokens", "cache_read_tokens")},
+            {"name": "Cache write",
+             "tokens": _int(last, "cache_creation_input_tokens", "cache_write_tokens")},
+        ]
+        return {
+            "totalTokens": total,
+            "maxTokens": max_tokens,
+            # Snake-case alias for ``_streaming_context_info`` which
+            # also reads these (different code paths normalize via
+            # camelCase or snake_case depending on the caller).
+            "total_tokens": total,
+            "max_tokens": max_tokens,
+            "percentage": round(pct, 1),
+            "categories": categories,
+            "mcpTools": [],
+            "mcp_tools": [],
+        }
+
+    async def _emit_context_usage_event(self) -> None:
+        """Emit a ``context_usage`` SSE event and a ``restart_nudge``
+        when the cumulative token total crosses the agent's
+        ``restart_threshold_pct``.
+
+        The nudge is one-shot per crossing: once we've fired above the
+        threshold, we don't fire again until the total drops below it
+        (e.g. after a /compact). This protects against a cascade of
+        nudges every turn at high context.
+        """
+        info = self.get_context_info()
+        await self._emit_stream_event(
+            {
+                "type": "context_usage",
+                "agent_name": self.agent_name,
+                **info,
+            }
+        )
+
+        threshold = self._restart_threshold_pct()
+        pct = info.get("percentage", 0.0) or 0.0
+        if pct >= threshold and not self._restart_nudge_fired:
+            self._restart_nudge_fired = True
+            await self._emit_stream_event(
+                {
+                    "type": "restart_nudge",
+                    "agent_name": self.agent_name,
+                    "percentage": pct,
+                    "threshold_pct": threshold,
+                    "total_tokens": info["totalTokens"],
+                    "max_tokens": info["maxTokens"],
+                }
+            )
+        elif pct < threshold and self._restart_nudge_fired:
+            # Re-arm the latch once context drops back below threshold
+            # (e.g. /compact ran). Next crossing will fire a fresh nudge.
+            self._restart_nudge_fired = False
+
     async def _handle_turn_complete(self, response: TurnResponse) -> None:
         """Tailer callback — fired once per ``stop_hook_summary`` entry.
 
@@ -1323,6 +1538,17 @@ class TmuxSession:
                     f"tmux[{self.agent_name}]: conversation_store.append "
                     f"raised: {e}"
                 )
+
+        # Context-budget watchdog (task #95): accumulate per-turn usage
+        # into ``self.usage`` so ``stats`` + ``get_context_info`` surface
+        # cumulative + last-turn numbers. Tmux agents have been blind to
+        # their own context window forever — without this they can't
+        # make their own /compact / restart / sleep calls. The transcript
+        # tailer already pulled the usage dict out of each assistant
+        # entry's ``usage`` block; we just need to fold it into the
+        # session-level dataclass and emit it.
+        self._record_turn_usage(response)
+        await self._emit_context_usage_event()
 
         # Stream event for analytics (usage / duration). Named
         # ``turn_completed`` to match StreamingSession + CodexSession

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1259,17 +1259,24 @@ async def test_handle_turn_complete_fires_stream_event() -> None:
         tool_uses=[{"name": "Bash", "input": {}, "id": "t1"}],
     )
     await ss._handle_turn_complete(response)
-    assert len(events) == 1
-    evt = events[0]
-    assert evt["agent_name"] == "dymok"
+    # Two events fire per turn since task #95: a ``context_usage``
+    # event with the cumulative token snapshot, then the existing
+    # ``turn_completed`` event. The watchdog snapshot precedes the
+    # turn-end so the chat UI can update its session-info card
+    # *before* the thinking bubble clears.
+    types = [e["type"] for e in events]
+    assert types == ["context_usage", "turn_completed"]
+
+    turn_evt = events[1]
+    assert turn_evt["agent_name"] == "dymok"
     # Renamed from "turn_complete" to "turn_completed" for parity with
     # StreamingSession + CodexSession — Chat.svelte listens for the
     # -d suffix so the thinking-bubble clears at turn end.
-    assert evt["type"] == "turn_completed"
-    assert evt["stop_reason"] == "end_turn"
-    assert evt["duration_ms"] == 1500
-    assert evt["assistant_entry_count"] == 2
-    assert evt["tool_use_count"] == 1
+    assert turn_evt["type"] == "turn_completed"
+    assert turn_evt["stop_reason"] == "end_turn"
+    assert turn_evt["duration_ms"] == 1500
+    assert turn_evt["assistant_entry_count"] == 2
+    assert turn_evt["tool_use_count"] == 1
 
 
 @pytest.mark.asyncio
@@ -2432,3 +2439,244 @@ async def test_get_pane_snapshot_swallows_subprocess_exception() -> None:
     tmux.capture_pane = AsyncMock(side_effect=RuntimeError("tmux gone"))
     out = await ss.get_pane_snapshot()
     assert out == ""
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Context-budget watchdog (task #95)
+#
+# Per-turn usage accumulation + ``context_usage`` SSE emission +
+# ``restart_nudge`` when crossing the agent's restart_threshold_pct.
+# Tmux agents need this for parity with SDK agents — without it they're
+# blind to their own context window and can't make their own /compact /
+# restart / sleep decisions.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _turn_response(*, input_tokens: int, output_tokens: int = 0,
+                   cache_read: int = 0, cache_write: int = 0,
+                   text: str = "ok") -> TurnResponse:
+    """Build a TurnResponse with a realistic usage block.
+
+    Mirrors the Claude Code transcript schema: cache fields use the
+    ``cache_creation_input_tokens`` / ``cache_read_input_tokens`` names
+    rather than the SDK's shortened forms. The watchdog accepts either.
+    """
+    return TurnResponse(
+        text=text,
+        stop_reason="end_turn",
+        usage={
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_creation_input_tokens": cache_write,
+            "cache_read_input_tokens": cache_read,
+        },
+        duration_ms=100,
+        assistant_entry_count=1,
+        tool_uses=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_turn_usage_accumulates_across_turns() -> None:
+    """Cumulative token counts on ``self.usage`` grow turn over turn,
+    rather than getting overwritten. Without this, the chat UI's
+    context-percentage gauge sees only the latest turn's deltas and
+    can't show "approaching compaction"."""
+    ss, _ = _make_session_with_response_cb()
+    await ss._handle_turn_complete(
+        _turn_response(input_tokens=1000, output_tokens=100, cache_read=500)
+    )
+    await ss._handle_turn_complete(
+        _turn_response(input_tokens=2000, output_tokens=200, cache_write=300)
+    )
+    assert ss.usage.input_tokens == 3000
+    assert ss.usage.output_tokens == 300
+    assert ss.usage.cache_read_tokens == 500
+    assert ss.usage.cache_write_tokens == 300
+    assert ss.usage.total_turns == 2
+
+
+@pytest.mark.asyncio
+async def test_record_turn_usage_tolerates_schema_drift() -> None:
+    """A usage block with unexpected shapes (None values, strings,
+    missing keys) must not crash the tailer. Token visibility is
+    best-effort; the tailer's invariant is to keep running."""
+    ss, _ = _make_session_with_response_cb()
+    drift = TurnResponse(
+        text="ok",
+        stop_reason="end_turn",
+        usage={"input_tokens": None, "output_tokens": "definitely a number"},
+        duration_ms=50,
+        assistant_entry_count=1,
+        tool_uses=[],
+    )
+    # Must not raise.
+    await ss._handle_turn_complete(drift)
+    # Should still bump turn count + record stop_reason even if tokens drift.
+    assert ss.usage.total_turns == 1
+    assert ss.usage.last_stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_emits_context_usage_event_with_sdk_shape() -> None:
+    """``context_usage`` SSE event must carry the SDK-compatible fields
+    so Chat.svelte's session-info card renders for tmux agents the same
+    way it does for SDK ones (totalTokens / maxTokens / categories)."""
+    events: list[dict] = []
+
+    async def stream_cb(evt):
+        events.append(evt)
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    await ss._handle_turn_complete(
+        _turn_response(input_tokens=10_000, output_tokens=500, cache_read=2_000)
+    )
+
+    ctx_events = [e for e in events if e["type"] == "context_usage"]
+    assert len(ctx_events) == 1
+    evt = ctx_events[0]
+    assert evt["agent_name"] == "dymok"
+    assert evt["totalTokens"] == 12_500
+    assert evt["maxTokens"] == 200_000  # default for non-1M models
+    assert evt["percentage"] == round(12_500 / 200_000 * 100, 1)
+    # Category breakdown — coarse for tmux, but matches the SDK's shape.
+    names = {c["name"] for c in evt["categories"]}
+    assert names == {"Input", "Output", "Cache read", "Cache write"}
+
+
+@pytest.mark.asyncio
+async def test_get_context_info_returns_sdk_shape() -> None:
+    """``get_context_info()`` is the synchronous fallback that
+    ``api._streaming_context_info`` calls when no ``_client`` is
+    present (the tmux path). Shape must match what the existing
+    ``/streaming/status`` consumer expects."""
+    ss, _ = _make_session_with_response_cb()
+    await ss._handle_turn_complete(
+        _turn_response(input_tokens=5_000, output_tokens=200)
+    )
+    info = ss.get_context_info()
+    # camelCase + snake_case both populated — different call sites read
+    # different conventions.
+    assert info["totalTokens"] == 5_200
+    assert info["total_tokens"] == 5_200
+    assert info["maxTokens"] == info["max_tokens"]
+    assert info["percentage"] >= 0.0
+    assert isinstance(info["categories"], list)
+    assert info["mcpTools"] == info["mcp_tools"] == []
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_for_1m_model() -> None:
+    """Models in ``_1M_MODELS`` get the 1M cap instead of 200k.
+    Without this, tmux agents running on Opus 4.6 would see their
+    context-percentage gauge max out at 20% of actual capacity."""
+    from pinky_daemon import streaming_session as _ss_mod
+    # Pin a known 1M model so the test doesn't drift if the DB-backed
+    # set changes underneath us.
+    original = set(_ss_mod._1M_MODELS)
+    try:
+        _ss_mod._1M_MODELS = {"claude-opus-4-7"}
+        cfg = StreamingSessionConfig(
+            agent_name="dymok",
+            working_dir="/tmp/tmux-session-test",
+            model="claude-opus-4-7",
+        )
+        tmux = _make_mock_tmux()
+        ss = TmuxSession(cfg, tmux_control=tmux)
+        assert ss._max_tokens_for_model() == 1_000_000
+
+        cfg2 = StreamingSessionConfig(
+            agent_name="dymok",
+            working_dir="/tmp/tmux-session-test",
+            model="claude-haiku-4-5",
+        )
+        ss2 = TmuxSession(cfg2, tmux_control=tmux)
+        assert ss2._max_tokens_for_model() == 200_000
+    finally:
+        _ss_mod._1M_MODELS = original
+
+
+@pytest.mark.asyncio
+async def test_restart_nudge_fires_when_crossing_threshold() -> None:
+    """When per-turn context window crosses ``restart_threshold_pct``,
+    emit a ``restart_nudge`` SSE event so the chat UI can light up the
+    "you should /compact" indicator. SDK agents have had this for
+    months via the SDK's context callbacks; tmux now matches.
+
+    Each Claude Code turn re-sends the full prior conversation, so the
+    LAST turn's ``input_tokens`` already reflects the current window —
+    no summing needed. Threshold check rides off ``last_usage``.
+    """
+    events: list[dict] = []
+
+    async def stream_cb(evt):
+        events.append(evt)
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+
+    # Stub the threshold so we can hit it deterministically with small
+    # token counts (default is 80%, which is 160k tokens of 200k — too
+    # big to push through in a unit test usage block).
+    ss._restart_threshold_pct = lambda: 50.0
+
+    # Below threshold: no nudge. (50k / 200k = 25%.)
+    await ss._handle_turn_complete(_turn_response(input_tokens=50_000))
+    assert not [e for e in events if e["type"] == "restart_nudge"]
+
+    # Cross threshold: nudge fires. (110k / 200k = 55%.)
+    await ss._handle_turn_complete(_turn_response(input_tokens=110_000))
+    nudges = [e for e in events if e["type"] == "restart_nudge"]
+    assert len(nudges) == 1
+    assert nudges[0]["percentage"] >= 50.0
+    assert nudges[0]["threshold_pct"] == 50.0
+
+
+@pytest.mark.asyncio
+async def test_restart_nudge_does_not_refire_while_above_threshold() -> None:
+    """Once above threshold, subsequent turns must not fire the nudge
+    every time. The chat UI gets one signal per crossing, not a
+    cascade of identical events while context stays above the bar."""
+    events: list[dict] = []
+
+    async def stream_cb(evt):
+        events.append(evt)
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    ss._restart_threshold_pct = lambda: 50.0
+
+    # Three turns, all above threshold — only one nudge total.
+    await ss._handle_turn_complete(_turn_response(input_tokens=110_000))
+    await ss._handle_turn_complete(_turn_response(input_tokens=130_000))
+    await ss._handle_turn_complete(_turn_response(input_tokens=140_000))
+
+    nudges = [e for e in events if e["type"] == "restart_nudge"]
+    assert len(nudges) == 1
+
+
+@pytest.mark.asyncio
+async def test_restart_nudge_rearms_after_drop_below_threshold() -> None:
+    """After a /compact, the per-turn input_tokens drops sharply (the
+    conversation history was compressed). The next sub-threshold turn
+    re-arms the latch; a subsequent above-threshold turn fires a fresh
+    nudge."""
+    events: list[dict] = []
+
+    async def stream_cb(evt):
+        events.append(evt)
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    ss._restart_threshold_pct = lambda: 50.0
+
+    # Cross threshold (above 50% of 200k).
+    await ss._handle_turn_complete(_turn_response(input_tokens=110_000))
+    assert ss._restart_nudge_fired is True
+
+    # Simulate post-compact: a turn with low input_tokens. The latch
+    # resets because the window measurement is now below threshold.
+    await ss._handle_turn_complete(_turn_response(input_tokens=5_000))
+    assert ss._restart_nudge_fired is False
+
+    # Cross again — fresh nudge.
+    await ss._handle_turn_complete(_turn_response(input_tokens=110_000))
+    nudges = [e for e in events if e["type"] == "restart_nudge"]
+    assert len(nudges) == 2


### PR DESCRIPTION
## Summary

Closes #95. Origin: Dymok's tmux-backend gap analysis (telegram msg #7978) ranked this #1 of 3. Tmux-backed agents have been blind to their own per-turn token usage — they can't see how close to compaction they are, so they can't make their own /compact, restart, or sleep calls. SDK agents have had this for months via the SDK's \`get_context_usage()\` callback. This PR closes the parity gap.

## What was already there

The plumbing exists end-to-end; only the session-level fold-in was missing:

- The tailer (\`tmux_transcript.py\`) already parses the \`usage\` block out of each assistant entry in the Claude Code JSONL transcript and pipes it into \`TurnResponse.usage\`.
- \`TmuxSession._handle_turn_complete\` already emits a \`turn_completed\` SSE event with the per-turn usage dict.
- \`api._streaming_context_info\` (line 1742-1751) already falls back to \`ss.get_context_info()\` when the session has no \`_client\` — the tmux path.
- The chat UI (\`Chat.svelte\` line 1295+) already renders \`streamingStats.totalTokens\` / \`maxTokens\` / \`categories\` from \`/streaming/status\`.

What was missing: the SessionUsage dataclass was constructed but never populated, and \`TmuxSession\` didn't implement \`get_context_info()\`.

## Changes (\`tmux_session.py\`)

- **\`_record_turn_usage\`**: fold each turn's usage block into \`self.usage\` (SessionUsage). Accumulates input/output/cache tokens for lifetime/cost tracking. Defensive against schema drift — malformed blocks log + skip rather than crash the tailer (token visibility is best-effort, not flight-critical).

- **\`_current_total_tokens\`**: window estimate from \`SessionUsage.last_usage\` (NOT cumulative). Each Claude Code turn re-sends the full prior conversation, so the last turn's \`input_tokens\` already captures everything currently in context. Summing across turns would multi-count by ~Nx.

- **\`get_context_info\`**: SDK-compatible context snapshot dict (\`totalTokens\`, \`maxTokens\`, \`percentage\`, \`categories\`, \`mcpTools\`). Categories derived from \`last_usage\` so the stacked bar agrees with the percentage gauge. Both camelCase and snake_case keys populated since different callers normalize differently.

- **\`_max_tokens_for_model\`**: 1M for models in \`_1M_MODELS\`, else 200k. Lazy import keeps the module boundary clean.

- **\`_restart_threshold_pct\`**: pull from agent registry, default 80%.

- **\`_emit_context_usage_event\`**: emit a \`context_usage\` SSE event per turn with the SDK-shape snapshot. Also emit \`restart_nudge\` when crossing the threshold. One-shot latch — re-arms when context drops back below threshold, so \`/compact\` resets the nudge naturally without explicit reset hooks.

- **\`_handle_turn_complete\`**: wires the above into the existing per-turn dispatch, placed BEFORE the \`turn_completed\` event so the chat UI can refresh its session-info card before the thinking bubble clears.

## Frontend

**Zero changes.** \`Chat.svelte\`'s session-info card already renders the right fields from \`/streaming/status\`, which now returns them for tmux sessions via the new \`get_context_info()\` implementation. \`restart_nudge\` SSE event is fired but not yet consumed by the UI — that's a follow-up for the chat-UI "you should /compact" indicator.

## Test plan

- [x] \`pytest tests/test_tmux_session.py\` — 102 pass (94 existing + 8 new)
- [x] \`pytest tests/test_tmux_session.py tests/test_agent_status.py tests/test_analytics_store.py tests/test_streaming_session.py\` — 175 pass
- [x] \`ruff check src/pinky_daemon/tmux_session.py tests/test_tmux_session.py\` — clean
- [ ] Live: open a tmux agent's chat, send a few prompts, watch the session-info card light up with token totals and percentage
- [ ] Live: send enough turns to cross the agent's restart_threshold_pct, confirm \`restart_nudge\` event fires in SSE stream
- [ ] Live: \`/compact\` (or wait for input_tokens to drop), confirm the latch re-arms and a subsequent crossing fires a fresh nudge

## Followups (not in this PR)

- Chat.svelte UI handling for \`restart_nudge\` SSE event (banner / arrow indicator).
- Per-MCP-tool category breakdown (currently lumped into Input/Output/Cache).
- Wire \`turn_seq\` in \`start_tool_call\` so chip strips can group by explicit turn rather than timestamp window (deferred from PR #532).

🤖 Opened by Barsik