### PR TITLE
feat(tmux-pane-viewer): pane-resize endpoint + auto-fit modal + scrollback fix

### DIFF
--- a/frontend-svelte/src/components/TmuxPaneModal.svelte
+++ b/frontend-svelte/src/components/TmuxPaneModal.svelte
@@ -60,7 +60,12 @@
                 disableStdin: true,
                 cursorBlink: false,
                 convertEol: true,
-                scrollback: 5000,
+                // Snapshot model: each frame is a full pane redraw, so we
+                // don't want scrollback at all. Keeping a buffer would mean
+                // every \x1b[2J pushes the previous frame into history,
+                // accumulating frame-after-frame as a memory + UX leak
+                // (modal grows an endless scroll of stale frames).
+                scrollback: 0,
                 fontSize: 12,
                 fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", "Roboto Mono", Consolas, monospace',
                 theme: {
@@ -98,9 +103,12 @@
                 if (data.type === 'snapshot') {
                     lastFrameAt = data.ts || (Date.now() / 1000);
                     if (terminal) {
-                        // Clear screen + home + redraw. The captured output
-                        // already contains ANSI for colours/cursor.
-                        terminal.write('\x1b[2J\x1b[H' + (data.data || ''));
+                        // Reset + clear viewport + clear scrollback + home,
+                        // then redraw. The captured output already contains
+                        // ANSI for colours/cursor. \x1b[3J clears scrollback
+                        // (belt-and-suspenders alongside scrollback:0) so
+                        // previous frames never accumulate in history.
+                        terminal.write('\x1b[2J\x1b[3J\x1b[H' + (data.data || ''));
                     }
                     if (statusMessage) statusMessage = '';
                 } else if (data.type === 'not_tmux') {
@@ -129,7 +137,7 @@
     onDestroy(teardown);
 </script>
 
-<Modal bind:show title={`Terminal · ${agent}${label && label !== 'main' ? ` · ${label}` : ''}`} maxWidth="1200px" width="92%" flush>
+<Modal bind:show title={`Terminal · ${agent}${label && label !== 'main' ? ` · ${label}` : ''}`} maxWidth="1800px" width="96%" flush>
     <div class="pane-wrap">
         {#if statusMessage}
             <div class="pane-status">{statusMessage}</div>
@@ -146,7 +154,7 @@
         display: flex;
         flex-direction: column;
         min-height: 0;
-        height: 70vh;
+        height: 88vh;
         background: #0a0a0a;
     }
     .pane-host {

--- a/frontend-svelte/src/components/TmuxPaneModal.svelte
+++ b/frontend-svelte/src/components/TmuxPaneModal.svelte
@@ -31,6 +31,14 @@
     let resizeObserver = null;
     let statusMessage = '';
     let lastFrameAt = 0;
+    // Last dims we asked the backend to resize the pane to. Used to
+    // skip no-op reconnects when ResizeObserver fires for changes that
+    // didn't move the character grid (e.g. sub-pixel reflows).
+    let lastReqCols = 0;
+    let lastReqRows = 0;
+    // Debounce timer for reconnect-on-resize. ResizeObserver can fire
+    // a flurry of events during drag-resize; we want to coalesce.
+    let resizeDebounceId = null;
 
     // Lifecycle reacts to (show, agent, label, hostEl). Mount when modal
     // opens + host div is rendered + we have an agent. Teardown when the
@@ -44,6 +52,60 @@
         if (lastKey) teardown();
         lastKey = key;
         if (key) await mount();
+    }
+
+    // Build the SSE URL with the current xterm grid dims so the
+    // backend reshapes the tmux pane to fill the viewer.
+    function streamUrl() {
+        const params = new URLSearchParams({ label });
+        if (terminal && terminal.cols > 0 && terminal.rows > 0) {
+            params.set('cols', String(terminal.cols));
+            params.set('rows', String(terminal.rows));
+            lastReqCols = terminal.cols;
+            lastReqRows = terminal.rows;
+        }
+        return `/agents/${encodeURIComponent(agent)}/tmux/pane/stream?${params.toString()}`;
+    }
+
+    // Close + reopen the stream with the current grid dims. The
+    // backend resizes the pane on stream-open, so a reconnect is how
+    // we propagate a resize. Cheap because SSE is HTTP/1.1 + the
+    // pane snapshot rate is ~2.5 Hz.
+    function reconnectStream() {
+        if (!terminal || !agent) return;
+        if (terminal.cols === lastReqCols && terminal.rows === lastReqRows) return;
+        if (sseSource) {
+            try { sseSource.close(); } catch {}
+            sseSource = null;
+        }
+        attachStream();
+    }
+
+    function attachStream() {
+        sseSource = sse(streamUrl());
+        sseSource.onmessage = (evt) => {
+            let data = null;
+            try { data = JSON.parse(evt.data || '{}'); } catch { return; }
+            if (!data || !data.type) return;
+            if (data.type === 'snapshot') {
+                lastFrameAt = data.ts || (Date.now() / 1000);
+                if (terminal) {
+                    // Reset + clear viewport + clear scrollback + home,
+                    // then redraw. The captured output already contains
+                    // ANSI for colours/cursor. \x1b[3J clears scrollback
+                    // (belt-and-suspenders alongside scrollback:0) so
+                    // previous frames never accumulate in history.
+                    terminal.write('\x1b[2J\x1b[3J\x1b[H' + (data.data || ''));
+                }
+                if (statusMessage) statusMessage = '';
+            } else if (data.type === 'not_tmux') {
+                statusMessage = 'This agent is not running under the tmux transport — no pane to view.';
+                if (sseSource) { sseSource.close(); sseSource = null; }
+            }
+        };
+        sseSource.onerror = () => {
+            statusMessage = 'Stream disconnected. Close + reopen to retry.';
+        };
     }
 
     async function mount() {
@@ -85,40 +147,27 @@
             terminal.open(hostEl);
             try { fitAddon.fit(); } catch {}
 
-            // Track container resizes (modal resize, viewport rotate) so
-            // xterm reflows. ResizeObserver fires on initial observe too.
+            // Track container resizes (modal resize, viewport rotate)
+            // so xterm reflows AND so we reshape the backend tmux pane
+            // to the new grid dims. Debounced (200ms) so drag-resize
+            // doesn't spam the stream with reconnects. ResizeObserver
+            // fires on initial observe — that first fire is harmless
+            // because lastReqCols/Rows match (we just attached with
+            // them).
             if (typeof ResizeObserver !== 'undefined') {
                 resizeObserver = new ResizeObserver(() => {
                     try { fitAddon && fitAddon.fit(); } catch {}
+                    if (resizeDebounceId) clearTimeout(resizeDebounceId);
+                    resizeDebounceId = setTimeout(() => {
+                        resizeDebounceId = null;
+                        reconnectStream();
+                    }, 200);
                 });
                 resizeObserver.observe(hostEl);
             }
 
             statusMessage = 'Connecting to stream…';
-            sseSource = sse(`/agents/${encodeURIComponent(agent)}/tmux/pane/stream?label=${encodeURIComponent(label)}`);
-            sseSource.onmessage = (evt) => {
-                let data = null;
-                try { data = JSON.parse(evt.data || '{}'); } catch { return; }
-                if (!data || !data.type) return;
-                if (data.type === 'snapshot') {
-                    lastFrameAt = data.ts || (Date.now() / 1000);
-                    if (terminal) {
-                        // Reset + clear viewport + clear scrollback + home,
-                        // then redraw. The captured output already contains
-                        // ANSI for colours/cursor. \x1b[3J clears scrollback
-                        // (belt-and-suspenders alongside scrollback:0) so
-                        // previous frames never accumulate in history.
-                        terminal.write('\x1b[2J\x1b[3J\x1b[H' + (data.data || ''));
-                    }
-                    if (statusMessage) statusMessage = '';
-                } else if (data.type === 'not_tmux') {
-                    statusMessage = 'This agent is not running under the tmux transport — no pane to view.';
-                    if (sseSource) { sseSource.close(); sseSource = null; }
-                }
-            };
-            sseSource.onerror = () => {
-                statusMessage = 'Stream disconnected. Close + reopen to retry.';
-            };
+            attachStream();
         } catch (e) {
             statusMessage = `Failed to load terminal: ${e?.message || e}`;
             teardown();
@@ -126,12 +175,15 @@
     }
 
     function teardown() {
+        if (resizeDebounceId) { clearTimeout(resizeDebounceId); resizeDebounceId = null; }
         if (sseSource) { try { sseSource.close(); } catch {} sseSource = null; }
         if (resizeObserver) { try { resizeObserver.disconnect(); } catch {} resizeObserver = null; }
         if (terminal) { try { terminal.dispose(); } catch {} terminal = null; }
         fitAddon = null;
         statusMessage = '';
         lastFrameAt = 0;
+        lastReqCols = 0;
+        lastReqRows = 0;
     }
 
     onDestroy(teardown);

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6344,6 +6344,8 @@ def create_api(
         label: str = "main",
         interval_ms: int = 400,
         lines: int = 200,
+        cols: int = 0,
+        rows: int = 0,
     ):
         """Stream the live tmux pane contents as SSE snapshots.
 
@@ -6366,6 +6368,14 @@ def create_api(
         ``interval_ms`` is clamped to [100, 2000] to bound the rate.
         ``lines`` is clamped to [10, 1000] — generous range covers
         short panes (tmux REPL header) up to long scrollback dumps.
+
+        ``cols`` / ``rows`` (optional) reshape the agent's tmux pane
+        to those dimensions before streaming begins. Used by the modal
+        to make the captured snapshot fill the viewer instead of
+        sitting at tmux's 80×24 detached default. The pane is shared
+        across viewers — last writer wins. Reconnect with new dims to
+        resize again (modal does this on container resize). ``0``
+        (default) means "don't touch the pane size."
         """
         agent = agents.get(agent_name)
         if not agent:
@@ -6374,6 +6384,9 @@ def create_api(
         # Clamp to defend against accidental tight loops or huge captures.
         interval_s = max(0.1, min(2.0, interval_ms / 1000.0))
         line_count = max(10, min(1000, lines))
+        # Honour caller dims only when both are positive; tmux's own
+        # clamping (in TmuxRunner.resize_window) handles upper bounds.
+        want_resize = cols > 0 and rows > 0
 
         async def event_generator():
             session = broker.get_streaming_session(agent_name, label=label)
@@ -6390,6 +6403,20 @@ def create_api(
                     + '\n\n'
                 )
                 return
+
+            if want_resize:
+                resize = getattr(session, "resize_pane", None)
+                if callable(resize):
+                    try:
+                        await resize(cols=cols, rows=rows)
+                    except Exception as e:  # pragma: no cover — defensive
+                        _log(
+                            f"api: stream_tmux_pane resize raised for "
+                            f"{agent_name}: {e}"
+                        )
+                    # Brief settle so the first capture reflects the new
+                    # geometry (Claude Code's TUI redraws on SIGWINCH).
+                    await asyncio.sleep(0.15)
 
             try:
                 while True:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -231,6 +231,32 @@ class _TmuxControl:
             return TmuxCommandResult(returncode=0, stdout="", stderr=result.stderr)
         return result
 
+    async def resize_window(
+        self, *, cols: int, rows: int,
+    ) -> TmuxCommandResult:
+        """Resize the session's window to ``cols`` × ``rows`` characters.
+
+        Used by the read-only pane viewer so the agent's tmux pane
+        reflows to match the modal's xterm grid dimensions — without
+        this the pane stays at tmux's detached default (80×24) and the
+        captured snapshot looks like a postage stamp inside a larger
+        modal.
+
+        Dims are clamped defensively to ``[20, 500]`` cols and
+        ``[10, 200]`` rows: tmux itself caps around 500×200, and
+        anything below 20×10 is too small for Claude Code's TUI to
+        render coherently. The session's pane (active by default in
+        single-pane layouts) follows the window size automatically.
+        """
+        cols = max(20, min(500, int(cols)))
+        rows = max(10, min(200, int(rows)))
+        return await self._run(
+            "resize-window",
+            "-t", self.session_name,
+            "-x", str(cols),
+            "-y", str(rows),
+        )
+
     async def send_keys(self, text: str, *, enter: bool = True) -> TmuxCommandResult:
         """Send ``text`` to the active pane of the session.
 
@@ -1310,6 +1336,35 @@ class TmuxSession:
         if not result.ok:
             return ""
         return result.stdout
+
+    async def resize_pane(self, *, cols: int, rows: int) -> bool:
+        """Resize the tmux window (and therefore its single pane) to
+        ``cols`` × ``rows`` characters.
+
+        Called by the read-only pane-view endpoint so the agent's
+        terminal reflows to match the viewer's xterm grid — without
+        this, a detached session stays at tmux's 80×24 default and the
+        captured snapshot looks tiny inside a larger modal.
+
+        Returns ``True`` on success. Failures are swallowed (logged
+        only): the viewer would rather display a slightly-misfit
+        snapshot than abort the whole stream over a transient tmux
+        error. Dim clamping happens in ``TmuxRunner.resize_window``.
+        """
+        try:
+            result = await self._tmux.resize_window(cols=cols, rows=rows)
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: resize_pane raised: {e}"
+            )
+            return False
+        if not result.ok:
+            _log(
+                f"tmux[{self.agent_name}]: resize_pane failed "
+                f"(rc={result.returncode}): {result.stderr.strip()}"
+            )
+            return False
+        return True
 
     def _max_tokens_for_model(self) -> int:
         """Return the model's context-window cap.

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -56,6 +56,7 @@ def _make_mock_tmux(*, has_session_initial: bool = False) -> MagicMock:
     tmux.send_keys = AsyncMock(return_value=_ok())
     tmux.paste_text = AsyncMock(return_value=_ok())
     tmux.capture_pane = AsyncMock(return_value=_ok())
+    tmux.resize_window = AsyncMock(return_value=_ok())
     return tmux
 
 
@@ -306,6 +307,101 @@ async def test_capture_pane_with_escapes_adds_e_flag() -> None:
     tmux._run = fake_run
     await tmux.capture_pane(lines=200, escapes=True)
     assert "-e" in calls[0]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# resize_window / resize_pane: viewer reshapes tmux pane to fit the modal
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resize_window_invokes_tmux_with_xy_flags() -> None:
+    """``_TmuxControl.resize_window`` must call ``tmux resize-window``
+    targeting the session with ``-x cols -y rows`` — that's what
+    propagates the new geometry to the single pane (Claude Code's TUI
+    then redraws on SIGWINCH)."""
+    tmux = _TmuxControl("pinky-test")
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        return _ok()
+
+    tmux._run = fake_run
+    await tmux.resize_window(cols=180, rows=48)
+
+    assert len(calls) == 1
+    args = calls[0]
+    assert args[0] == "resize-window"
+    assert "-t" in args and "pinky-test" in args
+    assert "-x" in args and "180" in args
+    assert "-y" in args and "48" in args
+
+
+@pytest.mark.asyncio
+async def test_resize_window_clamps_dims_into_safe_range() -> None:
+    """Defensive clamping: callers come from the network (query params)
+    so we don't trust them. Below-floor values clamp up to a Claude-
+    Code-renderable size; above-ceiling values clamp down to a tmux-
+    accepting size."""
+    tmux = _TmuxControl("pinky-test")
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        return _ok()
+
+    tmux._run = fake_run
+
+    # Below floor: cols<20 → 20, rows<10 → 10.
+    await tmux.resize_window(cols=5, rows=2)
+    assert "20" in calls[-1] and "10" in calls[-1]
+
+    # Above ceiling: cols>500 → 500, rows>200 → 200.
+    await tmux.resize_window(cols=9999, rows=9999)
+    assert "500" in calls[-1] and "200" in calls[-1]
+
+
+@pytest.mark.asyncio
+async def test_resize_pane_returns_true_on_success() -> None:
+    """Happy path: tmux returns 0, ``resize_pane`` returns ``True`` so
+    the caller can log success / proceed."""
+    session, tmux = _make_session()
+    tmux.resize_window = AsyncMock(return_value=_ok())
+
+    ok = await session.resize_pane(cols=200, rows=60)
+
+    assert ok is True
+    tmux.resize_window.assert_awaited_once_with(cols=200, rows=60)
+
+
+@pytest.mark.asyncio
+async def test_resize_pane_returns_false_on_tmux_failure() -> None:
+    """tmux non-zero exit shouldn't bubble — the snapshot stream is
+    more valuable than the resize. ``resize_pane`` returns ``False``
+    and the stream continues (slightly mis-sized snapshot is better
+    than aborting the modal)."""
+    session, tmux = _make_session()
+    tmux.resize_window = AsyncMock(
+        return_value=_fail("can't find window")
+    )
+
+    ok = await session.resize_pane(cols=200, rows=60)
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_resize_pane_swallows_subprocess_exceptions() -> None:
+    """Defensive: any unexpected raise from the subprocess layer is
+    logged + returns ``False`` instead of crashing the SSE generator
+    (which would close the viewer mid-stream)."""
+    session, tmux = _make_session()
+    tmux.resize_window = AsyncMock(side_effect=RuntimeError("kaboom"))
+
+    ok = await session.resize_pane(cols=120, rows=40)
+
+    assert ok is False
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Brad's complaint: terminal modal had a tiny 80×24 postage stamp of content sitting inside a much larger empty modal, because the tmux pane was stuck at tmux's detached-session default (80×24) regardless of the viewer's xterm grid dims.

**Fix: dynamic resize.** The modal now passes its current xterm cols×rows to the stream endpoint, which reshapes the tmux pane to match before emitting snapshots. On container resize, ResizeObserver fires → FitAddon recomputes grid → debounced reconnect with new dims → tmux pane reflows → Claude Code TUI redraws on SIGWINCH.

### Backend
- `TmuxRunner.resize_window(cols, rows)` — `tmux resize-window -x -y`, defensive clamping [20..500] × [10..200]
- `TmuxSession.resize_pane(cols, rows)` — public wrapper that swallows errors (snapshot stream worth more than a clean resize)
- `/agents/{name}/tmux/pane/stream` now accepts `cols=` / `rows=` query params; calls `resize_pane` on stream open + 150ms settle before first capture (lets TUI redraw)

### Frontend (`TmuxPaneModal.svelte`)
- `streamUrl()` builds URL with current xterm grid dims
- `attachStream()` factored out for reuse on reconnect
- ResizeObserver fires → 200ms debounce → `reconnectStream()` (no-op if dims unchanged, otherwise close+reopen with new dims)
- `teardown` clears the debounce timer

### Plus the previously-staged fixes from this branch
- `scrollback: 0` (snapshot model — no history needed; previous frames were leaking into xterm's 5000-line scrollback every `\x1b[2J`, accumulating endless ghost frames over time)
- Clear sequence now includes `\x1b[3J` (clears scrollback too; belt-and-suspenders against a future scrollback bump reintroducing the leak)
- Modal size bumped: maxWidth 1200→1800px, width 92→96%, height 70→88vh (now actually fillable thanks to dynamic resize)

### Tests
5 new tests for `resize_window` / `resize_pane` (107 total in `test_tmux_session.py` pass, ruff clean):
- `resize_window` invokes correct tmux command with `-x`/`-y`
- Dim clamping at both ends (5×2 → 20×10, 9999×9999 → 500×200)
- `resize_pane` returns `True` on success, `False` on tmux failure
- `resize_pane` swallows subprocess exceptions (logged not raised)

### Note on shared-pane semantics
The tmux pane is shared across all viewers; last writer wins on dims. Acceptable trade-off — multi-viewer terminal modals are vanishingly rare in practice and the single-viewer UX win is large.

## Test plan

- [ ] Open Chat → click agent's tmux pane button → modal opens, terminal content fills modal (not a postage stamp in a corner)
- [ ] Drag-resize browser window → terminal pane reflows to new size after ~200ms (one reconnect, not a flurry)
- [ ] Watch the terminal for a few minutes — confirm no scrollbar accumulates (scrollback fix)
- [ ] Verify ANSI colors + cursor render correctly through resize
- [ ] Close + reopen the modal → fresh stream connects cleanly
- [ ] If the agent is mid-task, confirm Claude Code's TUI redraws gracefully on the resize (it does — SIGWINCH-aware)

🤖 Opened by Barsik