### PR TITLE
fix(context-watchdog): subtract Claude Code autocompact buffer from effective max

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1769,10 +1769,16 @@ def create_api(
             actual_max = reported_max
             if (ss._config.model or "") in _1M_MODELS and reported_max <= 200_000:
                 actual_max = 1_000_000
+            # rawMaxTokens (SDK ≥ 0.1.x) is the raw model cap; maxTokens
+            # is effective (autocompact buffer subtracted). Pass both
+            # through so the frontend can show either; default to
+            # actual_max if the SDK doesn't populate it (older SDK).
+            raw_max = ctx.get("rawMaxTokens", 0) or actual_max
             pct = round(total / actual_max * 100, 1) if actual_max > 0 else 0.0
             info = {
                 "total_tokens": total,
                 "max_tokens": actual_max,
+                "raw_max_tokens": raw_max,
                 "percentage": pct,
                 "categories": ctx.get("categories", []),
                 "mcp_tools": ctx.get("mcpTools", []),

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1366,12 +1366,27 @@ class TmuxSession:
             return False
         return True
 
-    def _max_tokens_for_model(self) -> int:
-        """Return the model's context-window cap.
+    # Claude Code reserves a buffer below the raw model cap so the
+    # ``/compact`` autocompact step fires before the API rejects the
+    # next turn for context exhaustion. Empirically 33K on the 200K
+    # window (≈16.5%); per the GH discussion thread (anthropics/
+    # claude-code#27189) and the SDK's ``ContextUsageResponse``
+    # docstring this is a fixed constant — not a percentage — so 1M-
+    # window models reserve the same 33K, not a proportionally larger
+    # buffer.
+    _AUTOCOMPACT_BUFFER_TOKENS = 33_000
 
-        Mirrors ``api._streaming_context_info``'s logic: models in
-        ``_1M_MODELS`` cap at 1M tokens; everything else 200k. Lazy
-        import dodges the streaming_session ↔ tmux_session circle.
+    def _raw_max_tokens_for_model(self) -> int:
+        """Return the model's **raw** context-window cap (no buffer).
+
+        Mirrors ``api._streaming_context_info``'s 1M-model logic: models
+        listed in ``_1M_MODELS`` cap at 1M tokens; everything else 200k.
+        Lazy import dodges the streaming_session ↔ tmux_session circle.
+
+        Use this for parity with the SDK's ``rawMaxTokens`` field;
+        callers measuring real headroom should use
+        ``_max_tokens_for_model`` (the effective cap with the
+        autocompact buffer subtracted).
         """
         try:
             from pinky_daemon.streaming_session import _1M_MODELS
@@ -1380,6 +1395,36 @@ class TmuxSession:
             big_models = set()
         model = (self._config.model or "").strip()
         return 1_000_000 if model in big_models else 200_000
+
+    def _max_tokens_for_model(self) -> int:
+        """Return the model's **effective** context-window cap.
+
+        Effective = raw cap minus Claude Code's autocompact buffer.
+        Without this subtraction our percentage gauge under-reports by
+        ~16 points on the 200K window (gauge shows 50% at 100K real
+        tokens; ``/context`` shows ~60%), and the restart-nudge fires
+        ~16% later than it should.
+
+        Honours ``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`` (Claude Code's own
+        env var) as the **effective-cap percentage of raw** — e.g.
+        ``85`` means autocompact triggers at 85% so effective = 85% of
+        raw. Setting it to ``100`` disables the buffer entirely
+        (effective == raw); malformed values fall back to the default.
+        """
+        raw = self._raw_max_tokens_for_model()
+        override = os.environ.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "").strip()
+        if override:
+            try:
+                pct = float(override)
+                if pct > 0:
+                    return max(1, int(raw * pct / 100.0))
+            except (TypeError, ValueError):
+                # Bad env value — log and fall through to default.
+                _log(
+                    f"tmux[{self.agent_name}]: ignoring malformed "
+                    f"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE={override!r}"
+                )
+        return max(1, raw - self._AUTOCOMPACT_BUFFER_TOKENS)
 
     def _restart_threshold_pct(self) -> float:
         """Pull the agent's restart threshold from the registry.
@@ -1494,6 +1539,7 @@ class TmuxSession:
         """
         total = self._current_total_tokens()
         max_tokens = self._max_tokens_for_model()
+        raw_max_tokens = self._raw_max_tokens_for_model()
         pct = (total / max_tokens * 100.0) if max_tokens > 0 else 0.0
 
         # Categories breakdown reflects the *current* context window
@@ -1524,11 +1570,13 @@ class TmuxSession:
         return {
             "totalTokens": total,
             "maxTokens": max_tokens,
+            "rawMaxTokens": raw_max_tokens,
             # Snake-case alias for ``_streaming_context_info`` which
             # also reads these (different code paths normalize via
             # camelCase or snake_case depending on the caller).
             "total_tokens": total,
             "max_tokens": max_tokens,
+            "raw_max_tokens": raw_max_tokens,
             "percentage": round(pct, 1),
             "categories": categories,
             "mcpTools": [],

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -2633,8 +2633,13 @@ async def test_emits_context_usage_event_with_sdk_shape() -> None:
     evt = ctx_events[0]
     assert evt["agent_name"] == "dymok"
     assert evt["totalTokens"] == 12_500
-    assert evt["maxTokens"] == 200_000  # default for non-1M models
-    assert evt["percentage"] == round(12_500 / 200_000 * 100, 1)
+    # Effective max for a 200K-raw model = 200K - 33K autocompact
+    # buffer (Claude Code reserves room for /compact to fire before
+    # the API rejects for context exhaustion). ``rawMaxTokens`` keeps
+    # the raw cap visible for any UI that wants both.
+    assert evt["maxTokens"] == 200_000 - 33_000
+    assert evt["rawMaxTokens"] == 200_000
+    assert evt["percentage"] == round(12_500 / (200_000 - 33_000) * 100, 1)
     # Category breakdown — coarse for tmux, but matches the SDK's shape.
     names = {c["name"] for c in evt["categories"]}
     assert names == {"Input", "Output", "Cache read", "Cache write"}
@@ -2662,10 +2667,11 @@ async def test_get_context_info_returns_sdk_shape() -> None:
 
 
 @pytest.mark.asyncio
-async def test_max_tokens_for_1m_model() -> None:
-    """Models in ``_1M_MODELS`` get the 1M cap instead of 200k.
-    Without this, tmux agents running on Opus 4.6 would see their
-    context-percentage gauge max out at 20% of actual capacity."""
+async def test_raw_max_tokens_for_1m_vs_200k_model() -> None:
+    """``_raw_max_tokens_for_model`` returns the raw cap unaltered —
+    1M for ``_1M_MODELS`` members, 200k otherwise. Without this split,
+    tmux agents on Opus 4.7 would peg their context gauge at 20% of
+    real capacity."""
     from pinky_daemon import streaming_session as _ss_mod
     # Pin a known 1M model so the test doesn't drift if the DB-backed
     # set changes underneath us.
@@ -2679,7 +2685,7 @@ async def test_max_tokens_for_1m_model() -> None:
         )
         tmux = _make_mock_tmux()
         ss = TmuxSession(cfg, tmux_control=tmux)
-        assert ss._max_tokens_for_model() == 1_000_000
+        assert ss._raw_max_tokens_for_model() == 1_000_000
 
         cfg2 = StreamingSessionConfig(
             agent_name="dymok",
@@ -2687,9 +2693,102 @@ async def test_max_tokens_for_1m_model() -> None:
             model="claude-haiku-4-5",
         )
         ss2 = TmuxSession(cfg2, tmux_control=tmux)
-        assert ss2._max_tokens_for_model() == 200_000
+        assert ss2._raw_max_tokens_for_model() == 200_000
     finally:
         _ss_mod._1M_MODELS = original
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_subtracts_autocompact_buffer(monkeypatch) -> None:
+    """Effective cap = raw - 33K. Critical: Claude Code's ``/compact``
+    fires before the API rejects for context exhaustion, so the gauge
+    must measure against effective max not raw — otherwise we
+    under-report by ~16 points on the 200K window and the
+    restart-nudge fires too late."""
+    monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)
+
+    from pinky_daemon import streaming_session as _ss_mod
+    original = set(_ss_mod._1M_MODELS)
+    try:
+        _ss_mod._1M_MODELS = {"claude-opus-4-7"}
+
+        cfg = StreamingSessionConfig(
+            agent_name="dymok",
+            working_dir="/tmp/tmux-session-test",
+            model="claude-haiku-4-5",
+        )
+        ss = TmuxSession(cfg, tmux_control=_make_mock_tmux())
+        # 200K raw → 167K effective.
+        assert ss._max_tokens_for_model() == 200_000 - 33_000
+
+        cfg_big = StreamingSessionConfig(
+            agent_name="dymok",
+            working_dir="/tmp/tmux-session-test",
+            model="claude-opus-4-7",
+        )
+        ss_big = TmuxSession(cfg_big, tmux_control=_make_mock_tmux())
+        # 1M raw → 967K effective. Per SDK source the autocompact
+        # buffer is a fixed 33K, not a proportional fraction.
+        assert ss_big._max_tokens_for_model() == 1_000_000 - 33_000
+    finally:
+        _ss_mod._1M_MODELS = original
+
+
+@pytest.mark.asyncio
+async def test_autocompact_override_env_sets_effective_cap(monkeypatch) -> None:
+    """``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`` is Claude Code's own env
+    var — the percentage at which autocompact triggers. We interpret
+    it as effective-cap percentage of raw, matching the docs and the
+    SDK behavior."""
+    cfg = StreamingSessionConfig(
+        agent_name="dymok",
+        working_dir="/tmp/tmux-session-test",
+        model="claude-haiku-4-5",
+    )
+    tmux = _make_mock_tmux()
+    ss = TmuxSession(cfg, tmux_control=tmux)
+
+    # 85% → effective = 0.85 * 200K = 170K.
+    monkeypatch.setenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "85")
+    assert ss._max_tokens_for_model() == 170_000
+
+    # 100 → autocompact disabled, effective == raw.
+    monkeypatch.setenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "100")
+    assert ss._max_tokens_for_model() == 200_000
+
+    # Malformed value falls back to the default 33K buffer.
+    monkeypatch.setenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "not-a-number")
+    assert ss._max_tokens_for_model() == 200_000 - 33_000
+
+    # Empty / zero values also fall back (zero would imply effective=0,
+    # which would be a divide-by-zero waiting to happen).
+    monkeypatch.setenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "0")
+    assert ss._max_tokens_for_model() == 200_000 - 33_000
+
+
+@pytest.mark.asyncio
+async def test_get_context_info_exposes_raw_and_effective_caps(monkeypatch) -> None:
+    """``get_context_info`` returns both ``maxTokens`` (effective) and
+    ``rawMaxTokens`` (raw cap) for SDK parity — matches the shape of
+    ``ContextUsageResponse`` so the same frontend can render tmux and
+    SDK sessions interchangeably. Snake-case aliases mirror the
+    existing camelCase fields."""
+    monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)
+
+    cfg = StreamingSessionConfig(
+        agent_name="dymok",
+        working_dir="/tmp/tmux-session-test",
+        model="claude-haiku-4-5",
+    )
+    ss = TmuxSession(cfg, tmux_control=_make_mock_tmux())
+
+    info = ss.get_context_info()
+
+    assert info["rawMaxTokens"] == 200_000
+    assert info["maxTokens"] == 200_000 - 33_000
+    # Snake-case aliases populated identically.
+    assert info["raw_max_tokens"] == info["rawMaxTokens"]
+    assert info["max_tokens"] == info["maxTokens"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

PR #533 (context-budget watchdog for tmux agents) used the **raw** model cap as the denominator for the percentage gauge, but Claude Code reserves ~33K of the window as an autocompact buffer — `/compact` fires before the API rejects for context exhaustion. **Effect:** gauge under-reports by ~16 points on the 200K window and the restart-nudge fires ~16% later than it should. At 100K real tokens / 200K cap we showed 50%; Claude Code's `/context` shows ~60%.

Fix matches the SDK's `ContextUsageResponse` shape (`claude_agent_sdk/types.py:758`): `maxTokens` is **effective** (autocompact buffer subtracted); `rawMaxTokens` is the **raw** model cap.

### `tmux_session.py`
- Split `_max_tokens_for_model()` into:
  - `_raw_max_tokens_for_model()` — raw cap (200K, or 1M for `_1M_MODELS`)
  - `_max_tokens_for_model()` — effective: `raw - 33K`
- Honour `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` (Claude Code's own env var) as the **effective-cap percentage of raw**:
  - `85` → 85% of raw (170K for 200K models)
  - `100` → autocompact disabled (`effective == raw`)
  - malformed / `0` → fallback to default 33K buffer
- Per the SDK source, the buffer is a **fixed constant** (not proportional), so 1M models reserve the same 33K → 967K effective. Captured as `_AUTOCOMPACT_BUFFER_TOKENS` class constant.
- `get_context_info()` now exposes both `maxTokens` (effective) and `rawMaxTokens` (raw) — snake_case aliases too, matching existing convention.

### `api.py` SDK path
- `_streaming_context_info` passes through `rawMaxTokens` from SDK response (defaults to `actual_max` for older SDKs that don't populate it) so the frontend can render parity for both tmux and SDK sessions.

### Tests — 4 new + 1 updated
110 total in `test_tmux_session.py` pass, ruff clean, 315 pass across streaming + api suites:
- `test_raw_max_tokens_for_1m_vs_200k_model` — renamed from `test_max_tokens_for_1m_model`; now tests the raw helper
- `test_max_tokens_subtracts_autocompact_buffer` — 200K → 167K, 1M → 967K, both with fixed 33K buffer
- `test_autocompact_override_env_sets_effective_cap` — 85% → 170K, 100 → 200K, malformed → fallback, "0" → fallback (avoid div-by-0)
- `test_get_context_info_exposes_raw_and_effective_caps` — both fields populated, snake_case aliases match
- `test_emits_context_usage_event_with_sdk_shape` — updated to expect 167K effective + 200K raw + corrected percentage

### Origin
Caught by Dymok during a follow-up audit of PR #533. Brad asked us to sort it. The formula in `_current_total_tokens` was already correct — only the denominator (max cap) was off.

## Test plan
- [ ] CI green on the new + updated tests
- [ ] Smoke: open Chat → any tmux agent → session-info card percentage should now match Claude Code's `/context` reading within rounding
- [ ] Optional: `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=100 systemctl restart pinky-daemon` → gauge denominator becomes raw

🤖 Opened by Barsik