### PR TITLE
fix(streaming-session): detach wake-prompt from connect() to unhostage daemon startup

### DIFF
--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -217,6 +217,13 @@ class StreamingSession:
         self._auth_success_callback = auth_success_callback
         self._client = None
         self._reader_task: asyncio.Task | None = None
+        # Strong refs to background tasks (e.g. the post-handshake wake
+        # prompt detached from connect()). Python's asyncio docs warn:
+        # tasks created via asyncio.create_task() must have a strong
+        # reference, otherwise the GC can collect them mid-flight. We
+        # keep them in a set and have each task auto-discard itself via
+        # add_done_callback when it finishes.
+        self._background_tasks: set[asyncio.Task] = set()
         # PR3 (#486 sequence): formal adoption of the Transport protocol.
         # The pre-PR3 ``_connected`` + ``_idle_sleeping`` two-bool inference
         # was replaced by an explicit state machine. PR4 deleted the legacy
@@ -542,7 +549,12 @@ class StreamingSession:
 
         # Do not block daemon startup on the agent's first turn. Wake prompts
         # may immediately use MCP tools that depend on the API listener.
-        asyncio.create_task(_send_wake_prompt())
+        # Retain a strong reference via ``self._background_tasks`` per the
+        # asyncio docs: tasks created here can otherwise be GC'd mid-flight,
+        # which would silently drop the wake prompt.
+        wake_task = asyncio.create_task(_send_wake_prompt())
+        self._background_tasks.add(wake_task)
+        wake_task.add_done_callback(self._background_tasks.discard)
 
     async def send(
         self,

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -533,11 +533,16 @@ class StreamingSession:
             "Use thread(message_id, text) only when you want to quote/thread a specific message. "
             f"{tools_hint} If you do not call an outreach tool, Pinky may fall back to plain-text delivery based on agent settings."
         )
-        try:
-            await self._client.query(wake_prompt)
-            _log(f"streaming[{self.agent_name}]: sent wake prompt ({'resume' if is_resume else 'new'})")
-        except Exception as e:
-            _log(f"streaming[{self.agent_name}]: wake prompt failed: {e}")
+        async def _send_wake_prompt() -> None:
+            try:
+                await self._client.query(wake_prompt)
+                _log(f"streaming[{self.agent_name}]: sent wake prompt ({'resume' if is_resume else 'new'})")
+            except Exception as e:
+                _log(f"streaming[{self.agent_name}]: wake prompt failed: {e}")
+
+        # Do not block daemon startup on the agent's first turn. Wake prompts
+        # may immediately use MCP tools that depend on the API listener.
+        asyncio.create_task(_send_wake_prompt())
 
     async def send(
         self,

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -888,11 +888,33 @@ async def test_connect_returns_when_wake_prompt_query_blocks(monkeypatch) -> Non
 
     assert ss.state == SessionState.CONNECTED
 
-    # Drain the still-parked wake task so pytest doesn't warn about a
-    # pending task at teardown.
+    # Strong-ref pin (Murzik PR #539 review blocker): the wake task must
+    # be retained on the session so the GC cannot collect it mid-flight
+    # while query() is still parked. Force a GC cycle and assert the task
+    # is still tracked + still alive.
+    import gc
+
+    gc.collect()
+    assert len(ss._background_tasks) == 1, (
+        "Wake task must be retained in self._background_tasks while in "
+        "flight. If empty, the asyncio.create_task() reference was lost "
+        "and the GC may collect the task before query() completes — "
+        "silently dropping the wake prompt in production."
+    )
+    [wake_task] = ss._background_tasks
+    assert not wake_task.done(), "Parked wake task must still be alive"
+
+    # Drain: release query(), let the wake task complete, then assert
+    # the done_callback discarded it from the strong-ref set.
     release_query.set()
     for _ in range(5):
         await asyncio.sleep(0)
+    assert wake_task.done()
+    assert len(ss._background_tasks) == 0, (
+        "Completed wake task must auto-discard from _background_tasks via "
+        "the done_callback registered at create time. Otherwise the set "
+        "leaks one entry per cold start."
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -810,6 +810,91 @@ async def test_concurrent_cold_start_rejection_post_dead_raises(monkeypatch) -> 
     ss._state_machine.request_transition = real_request_transition  # type: ignore[assignment]
 
 
+# -- Non-blocking wake-prompt (post-2026-05-18 wedge) ------------------------
+#
+# Background: connect()'s post-handshake wake prompt used to be a plain
+# ``await self._client.query(wake_prompt)``. The wake prompt explicitly
+# instructs the agent to ToolSearch/preload MCP tools — i.e. the agent's
+# very first turn touches the shared-MCP listener that daemon startup is
+# coupled to via FastAPI's startup awaiting _start_streaming_session().
+#
+# Under load (or against a pathological MCP request that backtracks inside
+# pydantic validation), this could keep startup from completing — supervisor
+# saw startup timeout, killed the process, flap loop. Containment fix:
+# detach the wake prompt into ``asyncio.create_task(...)`` so connect()
+# returns as soon as the SDK handshake settles. The underlying regex hazard
+# in shared-MCP validation is tracked separately.
+#
+# Pin: even if the wake-prompt query() blocks forever, connect() returns
+# within a short timeout. If this regresses, daemon startup is hostage to
+# the agent's first turn again.
+
+
+@pytest.mark.asyncio
+async def test_connect_returns_when_wake_prompt_query_blocks(monkeypatch) -> None:
+    """connect() must NOT await the wake-prompt query. The wake prompt is
+    scheduled as a background task so daemon startup can complete even when
+    the agent's first turn (or its MCP tool preload) hangs.
+
+    Pre-fix: ``await self._client.query(wake_prompt)`` inside connect() —
+    startup hostage to first-turn latency.
+    Post-fix: ``asyncio.create_task(_send_wake_prompt())`` — connect()
+    returns once handshake + analytics + reader-loop spawn complete.
+    """
+    import claude_agent_sdk
+
+    cfg = StreamingSessionConfig(agent_name="test-wake-nonblock")
+    ss = StreamingSession(cfg)
+
+    query_entered = asyncio.Event()
+    release_query = asyncio.Event()  # Stays unset until cleanup.
+
+    class FakeClient:
+        def __init__(self, options):
+            self._options = options
+
+        async def connect(self):
+            return None
+
+        async def get_server_info(self):
+            return None
+
+        async def query(self, prompt):
+            # Signal we got here, then block. If connect() awaited this,
+            # the asyncio.wait_for below would time out.
+            query_entered.set()
+            await release_query.wait()
+
+        async def disconnect(self):
+            pass
+
+    monkeypatch.setattr(claude_agent_sdk, "ClaudeSDKClient", FakeClient)
+    ss._analytics_session_started = MagicMock()
+
+    async def _noop_reader_loop():
+        pass
+
+    ss._reader_loop = _noop_reader_loop  # type: ignore[assignment]
+
+    # The load-bearing assertion: connect() returns even though query()
+    # is parked. Generous timeout to avoid CI flake; a regression would
+    # hang here until asyncio.wait_for trips.
+    await asyncio.wait_for(ss.connect(), timeout=2.0)
+
+    # Cross-check: the wake task DID get scheduled and entered query().
+    # If this assertion fails, connect() returned without dispatching the
+    # wake prompt at all — a different regression (silent loss of wake).
+    await asyncio.wait_for(query_entered.wait(), timeout=1.0)
+
+    assert ss.state == SessionState.CONNECTED
+
+    # Drain the still-parked wake task so pytest doesn't warn about a
+    # pending task at teardown.
+    release_query.set()
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
 @pytest.mark.asyncio
 async def test_billing_error_assistant_does_not_block_subsequent_auth_alert() -> None:
     """Edge case: AssistantMessage with error="billing_error" (NOT auth) on


### PR DESCRIPTION
## Summary

Containment fix for the 2026-05-18 daemon flap (release `26.05.078`).
Detaches the post-handshake wake prompt from `StreamingSession.connect()`
so daemon startup is no longer hostage to the agent's first turn.

## Background

After release `.078` (PR #537 — codex Tier 1) the daemon began flapping
every ~5min:
- API port stopped listening, log filled with hundreds of "ASGI callable
  returned without completing response"
- Two macOS `sample` dumps on wedged PIDs (`/tmp/wedge-2026-05-18/`)
  both show deep `sre_ucs1_match + 4404` from `slot_tp_init` with
  `_pydantic_core` in the chain — **probable** catastrophic regex
  backtracking inside pydantic / FastMCP validation on the shared-MCP
  request path. Exact regex / input not pinpointed yet (py-spy needs
  sudo on macOS).

### Root hazard vs flap mechanism

- **Root hazard:** regex CPU burn inside shared-MCP request validation.
  Same process, different thread → pathological backtracking starves
  the GIL even if the uvicorn loop is otherwise healthy. **Open
  follow-up.**
- **Flap mechanism (this PR):** old `connect()` did
  `await self._client.query(wake_prompt)` after the SDK handshake.
  The wake prompt explicitly instructs the agent to ToolSearch /
  preload MCP tools, i.e. the very first turn touches the shared-MCP
  listener that daemon startup is coupled to. Result: when shared-MCP
  validation hangs, FastAPI startup never completes, supervisor times
  out and respawns.

## Fix

Wrap the wake-prompt send in `asyncio.create_task(_send_wake_prompt())`:

```python
async def _send_wake_prompt() -> None:
    try:
        await self._client.query(wake_prompt)
        _log(f"streaming[{self.agent_name}]: sent wake prompt ({'resume' if is_resume else 'new'})")
    except Exception as e:
        _log(f"streaming[{self.agent_name}]: wake prompt failed: {e}")

# Do not block daemon startup on the agent's first turn. Wake prompts
# may immediately use MCP tools that depend on the API listener.
asyncio.create_task(_send_wake_prompt())
```

`connect()` returns as soon as handshake + analytics + reader-loop
spawn complete. The wake prompt still fires; it just stops being on
the startup-critical path.

## Regression test

`tests/test_streaming_session.py::test_connect_returns_when_wake_prompt_query_blocks`

Mocks `_client.query()` to block forever, asserts `connect()` returns
within 2s. Pre-fix this would have hung; load-bearing because
`asyncio.wait_for(..., timeout=2.0)` enforces the contract.

Also asserts the wake task **was** scheduled (cross-check against a
"silently lost wake prompt" regression).

## Test plan

- [x] `pytest tests/test_streaming_session.py` — 26 passed (incl. new test)
- [ ] CI green
- [ ] Murzik review

## Follow-ups (separate work)

- `__main__.py` faulthandler SIGUSR2 hook (separate PR, queued)
- Identify the actual regex / payload — needs sudo'd py-spy on a live
  wedged PID, or fall back to faulthandler.dump_traceback after the
  SIGUSR2 hook lands
- `SharedMcpManager.start()` readiness barrier: currently starts the
  thread and returns before proving listener / session managers are
  ready

## Reviewer focus (per Murzik)

- Non-blocking wake semantics — confirm scheduled task doesn't get
  garbage-collected before query() fires
- No accidental behavior change in connect / reconnect paths
- Test asserts the *load-bearing* property (timeout-bounded connect)

🤖 Opened by Barsik