### PR TITLE
feat(daemon): SIGUSR2 faulthandler — on-demand Python traceback dump

### DIFF
--- a/src/pinky_daemon/__main__.py
+++ b/src/pinky_daemon/__main__.py
@@ -15,8 +15,31 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import faulthandler
 import os
+import signal
 import sys
+
+
+def _install_faulthandler() -> None:
+    """Wire SIGUSR2 to dump Python tracebacks of every thread to stderr.
+
+    On-demand stack dump for diagnosing wedged daemons. macOS `sample` captures
+    C frames only; `py-spy` requires sudo. faulthandler.register gives us
+    per-thread Python tracebacks with no special perms.
+
+    Usage:
+        kill -USR2 <pid>     # prints tracebacks to stderr (-> api.log)
+
+    Cost: stdlib only, no overhead until the signal fires. Idempotent.
+    SIGUSR2 is reserved for application use; not consumed by Python or uvicorn.
+    """
+    try:
+        faulthandler.register(signal.SIGUSR2, all_threads=True, chain=False)
+    except (AttributeError, RuntimeError):
+        # SIGUSR2 is Unix-only; chain=False is 3.5+. Both hold on our targets,
+        # but degrade gracefully if a future runtime drops either.
+        pass
 
 
 def _load_dotenv() -> None:
@@ -37,6 +60,7 @@ def _load_dotenv() -> None:
 
 
 def main() -> None:
+    _install_faulthandler()
     _load_dotenv()
     parser = argparse.ArgumentParser(description="Pinky — headless Claude Code")
     parser.add_argument(


### PR DESCRIPTION
## Summary

Wire `faulthandler.register(SIGUSR2)` into the daemon entrypoint
(`pinky_daemon/__main__.py`). On `kill -USR2 <pid>`, per-thread Python
tracebacks are dumped to stderr (captured by `api.log` under our supervisor).

## Why

When a Python process wedges:
- macOS `sample` captures **C frames only**
- `py-spy` needs **sudo** (not available in autonomous sessions)
- `faulthandler.register` is **stdlib**, no runtime overhead until the
  signal fires, and dumps Python frames with **no special perms**

SIGUSR2 is application-reserved — not consumed by Python or uvicorn.

This is independently useful for any future wedge diagnosis — not coupled
to any specific incident. Keeps a permanent diagnostic lever in the box.

## Implementation

```python
def _install_faulthandler() -> None:
    try:
        faulthandler.register(signal.SIGUSR2, all_threads=True, chain=False)
    except (AttributeError, RuntimeError):
        # SIGUSR2 is Unix-only; chain=False is 3.5+.
        pass
```

Called from `main()` before `_load_dotenv()`. Idempotent. Degrades gracefully
off-Unix.

## Smoke test

```
$ python -c "import signal, faulthandler, os, threading, time;
faulthandler.register(signal.SIGUSR2, all_threads=True, chain=False);
threading.Thread(target=lambda: (time.sleep(0.1), os.kill(os.getpid(), signal.SIGUSR2))).start();
time.sleep(0.5)"

Current thread 0x0000000204d4f100 (most recent call first):
  File "<string>", line 1 in <module>
```

## Test plan

- [x] Local smoke: signal delivered, traceback dumped to stderr
- [x] No-op on import (function only runs when daemon starts)
- [ ] CI green

## Companion

Part of the 2026-05-18 wedge response. The flap-mechanism containment fix
ships in #539 (streaming-session async-wake). This PR is independent — wants
to ship even if the wedge never recurs.

## Reviewer focus (per Murzik)

- Faulthandler portability — try/except scope
- Comment scope — kept timeless, no incident-specific wording

🤖 Opened by Barsik