### PR TITLE
fix(tmux): surface thinking metadata

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -530,6 +530,7 @@ class TmuxSession:
         self.last_active = self.created_at
         self.account_info: dict = {"apiProvider": "tmux_claude_repl"}
         self._current_activity = ""
+        self._current_thinking = ""
         self._activity_log: list[str] = []
 
         # Response capture pipeline (PR8b). Lazily constructed in
@@ -627,6 +628,7 @@ class TmuxSession:
             "state": self.state.value,
             "pending_responses": self._processing,
             "current_activity": self._current_activity,
+            "current_thinking": self._current_thinking,
             "activity_log": list(self._activity_log[-20:]),
             "account": self.account_info,
             "thinking_effort": self.effective_effort,
@@ -1899,6 +1901,16 @@ class TmuxSession:
         is_internal = bool(
             self._inflight_turn is not None and self._inflight_turn.internal
         )
+        thinking_text = (response.thinking or "").strip()
+        thinking_blocks = [thinking_text] if thinking_text else []
+        thinking_chars = len(thinking_text)
+
+        # Surface the latest completed thinking block briefly during turn
+        # finalization. Live streaming of tmux thinking requires tailer-side
+        # incremental events; this mirrors SDK state shape without leaving stale
+        # thinking in status after the turn completes.
+        if thinking_text:
+            self._current_thinking = thinking_text
 
         # Log to conversation store. role=assistant. Skip for internal
         # turns so wake-prompt responses don't pollute the user-visible
@@ -1906,9 +1918,17 @@ class TmuxSession:
         # transcript for audit).
         if not is_internal and self._conversation_store and response.text:
             try:
-                self._conversation_store.append(
-                    self.id, "assistant", response.text,
-                )
+                if thinking_blocks:
+                    self._conversation_store.append(
+                        self.id,
+                        "assistant",
+                        response.text,
+                        metadata={"thinking": thinking_blocks},
+                    )
+                else:
+                    self._conversation_store.append(
+                        self.id, "assistant", response.text,
+                    )
             except Exception as e:
                 _log(
                     f"tmux[{self.agent_name}]: conversation_store.append "
@@ -1940,6 +1960,8 @@ class TmuxSession:
                 "duration_ms": response.duration_ms,
                 "assistant_entry_count": response.assistant_entry_count,
                 "tool_use_count": len(response.tool_uses),
+                "thinking_chars": thinking_chars,
+                "thinking_block_count": len(thinking_blocks),
             }
         )
 
@@ -2005,10 +2027,12 @@ class TmuxSession:
         # keeps returning the previous turn's accumulated activity log
         # and Chat.svelte's thinking-bubble shows stale tool calls
         # blending across turns. ``_current_activity`` clears the
-        # "Bash — ..." chip in the UI; ``_activity_log`` clears the
-        # scrollback. The chip-strip from PR #528 has its own per-turn
-        # lifetime on the client and is unaffected.
+        # "Bash — ..." chip in the UI; ``_current_thinking`` clears the
+        # reasoning preview; ``_activity_log`` clears the scrollback. The
+        # chip-strip from PR #528 has its own per-turn lifetime on the client
+        # and is unaffected.
         self._current_activity = ""
+        self._current_thinking = ""
         self._activity_log = []
 
     async def _start_tailer(self) -> None:

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1163,7 +1163,8 @@ def test_stats_shape_matches_broker_consumer_keys() -> None:
     ss, _ = _make_session(state=SessionState.CONNECTED)
     stats = ss.stats
     for key in ("turns", "messages_sent", "errors", "reconnects",
-                "auto_restarts", "state", "thinking_effort"):
+                "auto_restarts", "state", "thinking_effort",
+                "current_thinking"):
         assert key in stats, f"stats missing required key: {key}"
     # state stringified for JSON-friendly transport over the API.
     assert stats["state"] == "connected"
@@ -1348,6 +1349,28 @@ async def test_handle_turn_complete_writes_to_conversation_store() -> None:
 
 
 @pytest.mark.asyncio
+async def test_handle_turn_complete_stores_thinking_metadata() -> None:
+    """Tmux thinking blocks persist in conversation metadata like SDK turns."""
+    conv = MagicMock()
+    ss, _ = _make_session_with_response_cb(conv_store=conv)
+    response = TurnResponse(
+        text="response text",
+        thinking="checked the transcript and tool state",
+        stop_reason="end_turn",
+    )
+
+    await ss._handle_turn_complete(response)
+
+    conv.append.assert_called_once_with(
+        ss.id,
+        "assistant",
+        "response text",
+        metadata={"thinking": ["checked the transcript and tool state"]},
+    )
+    assert ss.stats["current_thinking"] == ""
+
+
+@pytest.mark.asyncio
 async def test_handle_turn_complete_fires_stream_event() -> None:
     """stream_event_callback gets a turn_completed event with usage + duration."""
     events: list[dict] = []
@@ -1361,6 +1384,7 @@ async def test_handle_turn_complete_fires_stream_event() -> None:
         usage={"input_tokens": 100, "output_tokens": 50},
         duration_ms=1500,
         assistant_entry_count=2,
+        thinking="reasoned about the pane state",
         tool_uses=[{"name": "Bash", "input": {}, "id": "t1"}],
     )
     await ss._handle_turn_complete(response)
@@ -1382,6 +1406,8 @@ async def test_handle_turn_complete_fires_stream_event() -> None:
     assert turn_evt["duration_ms"] == 1500
     assert turn_evt["assistant_entry_count"] == 2
     assert turn_evt["tool_use_count"] == 1
+    assert turn_evt["thinking_chars"] == len("reasoned about the pane state")
+    assert turn_evt["thinking_block_count"] == 1
 
 
 @pytest.mark.asyncio
@@ -1396,12 +1422,14 @@ async def test_handle_turn_complete_resets_live_activity_state() -> None:
     # Simulate mid-turn state: chips pushed by PreToolUse hook before
     # the model finished responding.
     ss._current_activity = "Bash — echo hi"
+    ss._current_thinking = "working through the command output"
     ss._activity_log = ["ToolSearch", "Bash — echo test", "Bash — echo hi"]
     response = TurnResponse(text="done", stop_reason="end_turn")
 
     await ss._handle_turn_complete(response)
 
     assert ss._current_activity == ""
+    assert ss._current_thinking == ""
     assert ss._activity_log == []
 
 


### PR DESCRIPTION
## Summary

Implements the PR C slice from #543 for tmux thinking metadata parity.

- exposes `current_thinking` in `TmuxSession.stats`
- stores captured tmux thinking as conversation `metadata={"thinking": [...]}` when an assistant text response is persisted
- adds `thinking_chars` and `thinking_block_count` to tmux `turn_completed` stream events
- clears live thinking state at turn completion so status polling does not show stale reasoning

## Why

Dymok/tmux transcript parsing already captures Claude Code thinking blocks, but the tmux transport did not propagate that data into the same downstream surfaces the SDK path uses. This keeps the parser result durable and observable without touching the wake-prompt/context-restart work in PR A.

Refs #543.

## Validation

- `pytest tests/test_tmux_session.py -q` → 111 passed
- `pytest tests/test_tmux_transcript.py tests/test_tmux_session.py -q` → 153 passed
- `ruff check src/pinky_daemon/tmux_session.py tests/test_tmux_session.py` → passed