### PR TITLE
feat(transport): shared wake-prompt builder + tmux wake injection (#543)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -5962,6 +5962,14 @@ def create_api(
         ss._config.wake_context = _build_streaming_wake_context(name)
         ss._config.resume_handle = ""
         ss._config.restart_reason = "context_restart"
+        # PR for #543: explicit launch-behavior contract — the next
+        # transport spawn must NOT resume the prior conversation. For
+        # SDK this is implicit (resume_handle="" already accomplishes
+        # it), but tmux ``_build_claude_cmd`` checks transcript existence
+        # only and would silently re-apply ``--continue`` unless this
+        # flag is set. One-shot: consumed by the transport on the next
+        # launch and reset to False.
+        ss._config.force_fresh_context_once = True
         ss.resume_handle = ""
         # Codex sessions track the thread_id separately on the session object;
         # clear it too or `codex exec resume <stale-id>` keeps firing next turn.

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -11,17 +11,21 @@ messages arrive asynchronously from platform users.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import sys
 import time
-import zoneinfo
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 
 from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.transport_state import SessionState, StateMachine, Trigger
 from pinky_daemon.turn_response import TurnResponse
+from pinky_daemon.wake_prompt import (
+    WakePromptInput,
+    build_wake_prompt,
+    wake_reason_from_runtime,
+)
 
 # Models with native 1M context (SDK reports 200k incorrectly)
 _1M_MODELS = {"claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7"}
@@ -72,6 +76,15 @@ class StreamingSessionConfig:
     # effort drifts from thinking_effort. Default False (warn-only). See #429.
     strict_effort_enforcement: bool = False
     restart_reason: str = ""  # "context_restart", "auto_restart", etc. — cleared after wake prompt
+    # When True, the NEXT transport launch starts with a fresh context
+    # (e.g. tmux suppresses ``claude --continue`` even if a prior transcript
+    # exists). The flag is one-shot — the transport clears it after
+    # honoring it. This is a SEPARATE contract from ``restart_reason``:
+    # the latter controls wake-prompt copy; this controls launch behavior.
+    # Coupling them caused #543 (tmux ``context_restart`` silently
+    # resumed the prior transcript because ``_build_claude_cmd`` only
+    # looked at transcript existence, not ``restart_reason``).
+    force_fresh_context_once: bool = False
 
 
 # Backward-compatible import name for older callers/tests. New code should use
@@ -482,68 +495,54 @@ class StreamingSession:
 
         _log(f"streaming[{self.agent_name}]: connected, reader loop started")
 
-        # Auto-send wake prompt with saved context injected
-        is_resume = bool(self.resume_handle)
-        ctx_block = ""
-        if self._config.wake_context:
-            ctx_block = f"\n\n── Saved State ──\n{self._config.wake_context}\n──────────────────"
-
-        # Current time for agent orientation
-        try:
-            _tz = zoneinfo.ZoneInfo(self._config.timezone or "America/Los_Angeles")
-            _now = datetime.now(_tz)
-            time_str = _now.strftime("%A, %B %-d, %Y at %-I:%M %p %Z")
-        except Exception:
-            # Fallback labelled "UTC" was previously using implicit local-tz
-            # datetime.now() — fix to actual UTC. #294
-            time_str = datetime.now(timezone.utc).strftime(
-                "%A, %B %-d, %Y at %-I:%M %p UTC"
+        # Auto-send wake prompt with saved context injected.
+        #
+        # Assembly moved to ``pinky_daemon.wake_prompt`` (PR for #543) so
+        # tmux and Codex can share the same contract. The pure builder is
+        # transport-neutral; this transport just delivers the result via
+        # ``client.query``.
+        #
+        # Visible copy change: ``WakeReason.RESUME`` now says "Session
+        # resumed." (neutral) instead of the prior "Session resumed after
+        # daemon restart." The old wording wasn't safe for tmux warm
+        # reconnect or idle-wake. Callers that explicitly know a daemon
+        # restart happened should encode it in the context body (e.g. via
+        # the restart manifest).
+        wake_reason = wake_reason_from_runtime(
+            resume_handle=self.resume_handle,
+            restart_reason=self._config.restart_reason,
+        )
+        wake_prompt = build_wake_prompt(
+            WakePromptInput(
+                reason=wake_reason,
+                context_body=self._config.wake_context or "",
+                timezone=self._config.timezone or "America/Los_Angeles",
             )
-
-        tools_hint = (
-            "You have explicit pinky-messaging outreach tools: "
-            "send, thread, react, send_gif, send_voice, send_photo, send_document, broadcast."
-            "\n\nIMPORTANT: If your tools are deferred (require ToolSearch before use), "
-            "immediately call ToolSearch with TWO queries to pre-load your core tools "
-            "(max 10 per call):\n"
-            '1. "select:mcp__pinky-messaging__send,mcp__pinky-messaging__thread,'
-            "mcp__pinky-messaging__react,mcp__pinky-self__send_heartbeat,"
-            "mcp__pinky-self__send_to_agent,mcp__pinky-self__check_inbox,"
-            "mcp__pinky-self__create_task,mcp__pinky-self__get_next_task,"
-            'mcp__pinky-self__complete_task,mcp__pinky-self__context_status"\n'
-            '2. "select:mcp__pinky-memory__reflect,mcp__pinky-memory__recall,'
-            "mcp__pinky-self__who_am_i,mcp__pinky-self__load_my_context,"
-            "mcp__pinky-self__save_my_context,mcp__pinky-self__check_my_health,"
-            'mcp__pinky-self__agent_status,mcp__pinky-self__claim_task"\n'
-            "Do this silently before any other action — do not mention it to the user. "
-            "Call both ToolSearch queries in parallel in a single response."
         )
-        restart_reason = self._config.restart_reason
-        if is_resume:
-            header = f"Session resumed after daemon restart. Current time: {time_str}."
-            instruction = "Pick up where you left off."
-        elif restart_reason == "context_restart":
-            header = f"Context restarted. Current time: {time_str}."
-            instruction = "Fresh context — pick up from saved state."
-        elif restart_reason == "auto_restart":
-            header = f"Auto-restarted (context limit). Current time: {time_str}."
-            instruction = "Context was getting full — pick up from saved state."
-        else:
-            header = f"New session started. Current time: {time_str}."
-            instruction = "You're connected via Pinky's message broker."
-        self._config.restart_reason = ""  # Clear after use
+        self._config.restart_reason = ""  # Clear after use.
 
-        wake_prompt = (
-            f"{header}{ctx_block}\n\n"
-            f"{instruction} Users will message you through Telegram. "
-            "Use send(chat_id, platform, text) for normal responses. "
-            "Use thread(message_id, text) only when you want to quote/thread a specific message. "
-            f"{tools_hint} If you do not call an outreach tool, Pinky may fall back to plain-text delivery based on agent settings."
+        # Instrumentation: a single structured log line per wake prompt
+        # gives validation tooling a grep-able marker. Tmux emits the
+        # same fields via ``_emit_stream_event`` because it has that
+        # surface; SDK lacks a stream-event callback today (deferred
+        # follow-up — would unify observability across transports).
+        _ctx_chars = len(self._config.wake_context or "")
+        _prompt_hash = hashlib.sha256(wake_prompt.encode("utf-8")).hexdigest()[:12]
+        _log(
+            f"streaming[{self.agent_name}]: wake_prompt_sent "
+            f"reason={wake_reason.value} "
+            f"context_chars={_ctx_chars} "
+            f"context_present={bool(self._config.wake_context)} "
+            f"prompt_hash={_prompt_hash}"
         )
+
         async def _send_wake_prompt() -> None:
             try:
                 await self._client.query(wake_prompt)
-                _log(f"streaming[{self.agent_name}]: sent wake prompt ({'resume' if is_resume else 'new'})")
+                _log(
+                    f"streaming[{self.agent_name}]: sent wake prompt "
+                    f"(reason={wake_reason.value})"
+                )
             except Exception as e:
                 _log(f"streaming[{self.agent_name}]: wake prompt failed: {e}")
 

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -78,6 +78,11 @@ from pinky_daemon.transport_state import (
     StateMachine,
     Trigger,
 )
+from pinky_daemon.wake_prompt import (
+    WakePromptInput,
+    WakeReason,
+    build_wake_prompt,
+)
 
 # ──────────────────────────────────────────────────────────────────────────
 # Tmux subprocess control
@@ -378,13 +383,40 @@ class _TmuxControl:
 
 @dataclass
 class _QueuedTurn:
-    """Inbound message awaiting delivery to the claude REPL."""
+    """Inbound message awaiting delivery to the claude REPL.
+
+    Two flavors share this dataclass:
+
+    - **External** (default): inbound user / broker messages. Counted as
+      ``messages_sent``, logged to conversation_store, routed back via
+      ``_response_callback`` with platform/chat_id/message_id.
+    - **Internal** (``internal=True``): daemon-side prompts for lifecycle
+      orientation — e.g. wake prompts at ``connect()``, pre-sleep save
+      reminders at ``idle_sleep()``. Skip conversation_store appends and
+      external-stats increments, do not route through response_callback,
+      do not write to ``_inflight_meta``. Optional ``completion_event`` is
+      set when the turn completes so callers can ``wait_for_completion``.
+    """
 
     prompt: str
     platform: str = ""
     chat_id: str = ""
     message_id: str = ""
     queued_at: float = field(default_factory=time.time)
+    # Internal-prompt flag set by ``_enqueue_internal_prompt``. See
+    # ``_deliver_turn`` and ``_handle_turn_complete`` for the
+    # conditional bypasses (no conversation_store append, no
+    # response_callback, no ``_inflight_meta`` writes).
+    internal: bool = False
+    # Human-readable label for the internal-turn audit log
+    # (``wake_prompt_sent``, ``idle_sleep_presave``, etc.). Ignored when
+    # ``internal=False``.
+    reason: str = ""
+    # Optional event set by ``_handle_turn_complete`` when this turn
+    # finishes — lets internal-prompt callers ``wait_for_completion`` so
+    # they don't progress (e.g. disconnect) before the agent honors the
+    # prompt. Ignored when ``None``.
+    completion_event: asyncio.Event | None = None
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -539,6 +571,25 @@ class TmuxSession:
         # lets the new REPL pick the same turn back up after a stuck-
         # REPL escalation.
         self._inflight_turn: _QueuedTurn | None = None
+
+        # Launch-mode snapshot written by ``_build_claude_cmd`` and read
+        # by ``connect()`` to derive wake-prompt orientation. None until
+        # the first launch. Cleared/overwritten on each launch.
+        self._last_launch_used_continue: bool = False
+        self._last_launch_forced_fresh: bool = False
+        self._last_launch_had_prior_transcript: bool = False
+
+        # Test seam: when True, ``connect()`` skips wake-prompt assembly
+        # + enqueue. Production callers must NOT flip this; it exists so
+        # unit tests that mock at the paste/queue layer can exercise
+        # ``connect()`` without stranding the worker on a never-
+        # completing wake-prompt turn (the worker awaits
+        # ``_turn_done`` between turns; without a simulated transcript
+        # tailer firing ``_handle_turn_complete``, the worker would
+        # block forever on the first dispatched turn — wake or otherwise).
+        # Dedicated wake-prompt tests leave this False and provide the
+        # tailer simulation explicitly.
+        self._skip_wake_prompt_for_tests: bool = False
 
     # ── Identity ────────────────────────────────────────────────────────
 
@@ -962,6 +1013,15 @@ class TmuxSession:
                     )
             raise
 
+        # Wake-prompt orientation snapshot (PR for #543). Read the
+        # launch-mode signals that ``_build_claude_cmd`` recorded on the
+        # session during ``_spawn_tmux_repl``. We snapshot now (pre-
+        # state-machine completion) for a stable read; the enqueue
+        # happens after CONNECTED + worker startup below.
+        _was_force_fresh_launch = self._last_launch_forced_fresh
+        _had_prior_transcript_pre_spawn = self._last_launch_had_prior_transcript
+        _restart_reason_snapshot = self._config.restart_reason
+
         # Spawn succeeded. Complete the appropriate in-flight transition.
         if cold_start_token is not None:
             # Cold-start: BOOTING → CONNECTED via BOOT_COMPLETE.
@@ -1004,9 +1064,64 @@ class TmuxSession:
             except Exception as e:
                 _log(f"tmux[{self.agent_name}]: resume_handle callback raised: {e}")
 
+        # Wake-prompt assembly + enqueue (PR for #543, parent defect:
+        # tmux had no wake-prompt path, so Saved State / current time /
+        # active channels / ToolSearch reminder all silently dropped on
+        # connect). Uses the shared ``build_wake_prompt`` builder so the
+        # contract matches SDK exactly.
+        #
+        # Reason mapping (tmux-specific because tmux ``resume_handle``
+        # is stable from construction and doesn't usefully discriminate
+        # fresh-vs-resume, per Murzik's pointer):
+        #   - ``force_fresh_context_once`` was honored      → CONTEXT_RESTART
+        #   - ``restart_reason == "auto_restart"``          → AUTO_RESTART
+        #   - prior transcript existed (warm reconnect)     → RESUME
+        #   - else                                          → NEW_SESSION
+        #
+        # Delivery: ``_enqueue_internal_prompt`` with
+        # ``wait_for_completion=False`` — the wake turn flows behind any
+        # external work in queue order. The internal-prompt path skips
+        # ``_inflight_meta`` and ``_response_callback`` (regression guard
+        # against PR #496 round-1 Case 1 surfacing through this path).
+        if _was_force_fresh_launch or _restart_reason_snapshot == "context_restart":
+            _wake_reason = WakeReason.CONTEXT_RESTART
+        elif _restart_reason_snapshot == "auto_restart":
+            _wake_reason = WakeReason.AUTO_RESTART
+        elif _had_prior_transcript_pre_spawn:
+            _wake_reason = WakeReason.RESUME
+        else:
+            _wake_reason = WakeReason.NEW_SESSION
+
+        # Clear restart_reason after consumption — matches SDK semantics.
+        self._config.restart_reason = ""
+
+        if not self._skip_wake_prompt_for_tests:
+            _wake_prompt = build_wake_prompt(
+                WakePromptInput(
+                    reason=_wake_reason,
+                    context_body=self._config.wake_context or "",
+                    timezone=self._config.timezone or "America/Los_Angeles",
+                )
+            )
+            try:
+                await self._enqueue_internal_prompt(
+                    _wake_prompt,
+                    reason=f"wake_{_wake_reason.value}",
+                    wait_for_completion=False,
+                )
+            except Exception as e:
+                # Wake-prompt enqueue failure must not strand the session
+                # in CONNECTED-but-orientationless. Log loudly; the
+                # session remains usable for external turns but the agent
+                # will lack saved-state context until the next restart.
+                _log(
+                    f"tmux[{self.agent_name}]: wake prompt enqueue failed: {e} "
+                    f"(reason={_wake_reason.value}) — session remains CONNECTED"
+                )
+
         _log(
             f"tmux[{self.agent_name}]: connected, session={self._session_name}, "
-            f"worker started"
+            f"worker started, wake_reason={_wake_reason.value}"
         )
 
     async def _spawn_tmux_repl(self) -> None:
@@ -1124,15 +1239,54 @@ class TmuxSession:
         must fall through to ``claude`` (no ``--continue``) so a new
         transcript is created on the first turn; subsequent reconnects
         will find that transcript and resume normally.
+
+        **Fresh-context suppression** (PR for #543): callers that need
+        to force a fresh conversation (e.g. ``/streaming/restart``,
+        ``context_restart`` MCP tool) set
+        ``config.force_fresh_context_once = True``. This launch will
+        skip ``--continue`` even when a prior transcript exists,
+        producing a fresh Claude Code session. The flag is one-shot —
+        consumed here and reset to False so the next spawn behaves
+        normally. This is a separate contract from ``restart_reason``,
+        which controls the wake-prompt TEXT; coupling them was the
+        root cause of #543 (tmux context_restart silently resumed the
+        old transcript because we only checked transcript existence).
         """
+        # Resolve launch mode. One-shot consume of force_fresh_context_once
+        # is intentional — the flag is "next launch only," not "every
+        # launch from now on."
+        force_fresh = bool(getattr(self._config, "force_fresh_context_once", False))
+        if force_fresh:
+            self._config.force_fresh_context_once = False
+        has_prior = self._has_prior_transcript()
+        use_continue = has_prior and not force_fresh
+
+        # Record launch mode on the session so ``connect()`` can derive
+        # the wake reason post-spawn (force_fresh / restart_reason both
+        # influence orientation copy). Read-only afterward.
+        self._last_launch_used_continue = use_continue
+        self._last_launch_forced_fresh = force_fresh
+        self._last_launch_had_prior_transcript = has_prior
+
         parts = ["claude"]
-        if self._has_prior_transcript():
+        if use_continue:
             parts.append("--continue")
         parts.append("--dangerously-skip-permissions")
         # Optional model override.
         if self._config.model:
             parts.extend(["--model", self._config.model])
-        return " ".join(shlex.quote(p) for p in parts)
+        cmd = " ".join(shlex.quote(p) for p in parts)
+
+        # Instrumentation: typed launch-mode log so validation tooling
+        # can grep for `claude_cmd_mode=fresh` after a context_restart
+        # to confirm the suppress-continue contract held.
+        _log(
+            f"tmux[{self.agent_name}]: claude_cmd_built "
+            f"mode={'continue' if use_continue else 'fresh'} "
+            f"force_fresh={force_fresh} "
+            f"prior_transcript={has_prior}"
+        )
+        return cmd
 
     def _build_repl_env(self) -> dict[str, str]:
         """Env vars injected into the tmux session.
@@ -1282,6 +1436,106 @@ class TmuxSession:
             message_id=message_id,
         ))
         _log(f"tmux[{self.agent_name}]: queued message (chat={chat_id})")
+
+    async def _enqueue_internal_prompt(
+        self,
+        prompt: str,
+        *,
+        reason: str,
+        wait_for_completion: bool = False,
+        timeout_sec: float | None = None,
+    ) -> asyncio.Event | None:
+        """Queue a daemon-internal prompt with no external-side-effects.
+
+        Differences vs ``send()``:
+
+        - **No conversation_store append** — the prompt is daemon-internal
+          (wake orientation, pre-sleep save reminder, etc.), not a user
+          message.
+        - **No ``messages_sent`` increment** — external-message stats stay
+          accurate for analytics / dashboards.
+        - **No ``_inflight_meta`` writes** — wake prompts have no chat
+          routing, and writing here would clobber a back-to-back external
+          turn's routing metadata (regression guard for PR #496 round-1
+          Case 1 surfacing through this path).
+        - **No ``_response_callback`` invocation** — there's no chat to
+          deliver the response back to. The agent's response is captured
+          in the transcript JSONL and counted toward ``stats["turns"]``
+          like any other turn.
+
+        ``wait_for_completion=False`` (default): fire-and-forget. Returns
+        immediately. Used by wake prompts at ``connect()`` time — the
+        session is starting and external work can flow behind the wake
+        turn in queue order.
+
+        ``wait_for_completion=True``: await the queued turn's completion
+        before returning. Used by pre-sleep save prompts where the caller
+        must not progress (e.g. disconnect) until the agent has honored
+        the instruction. Bounded by ``timeout_sec`` if provided — raises
+        ``asyncio.TimeoutError`` on timeout.
+
+        Returns the completion ``asyncio.Event`` when
+        ``wait_for_completion=False`` so callers can optionally observe
+        it later (the worker still progresses); ``None`` when
+        ``wait_for_completion=True`` (the call has already waited).
+
+        Connection state: behaves like ``send()`` — drops with a log line
+        if the session is not CONNECTED. Cold-start callers (``connect``)
+        invoke this immediately after the state machine reports
+        CONNECTED, so the gate passes.
+        """
+        if self.state != SessionState.CONNECTED:
+            _log(
+                f"tmux[{self.agent_name}]: not connected (state={self.state.value}), "
+                f"dropping internal prompt (reason={reason})"
+            )
+            return None
+
+        self.last_active = time.time()
+        # Audit log — the diagnostic marker validation tooling greps for.
+        # Hash gives a stable identity per prompt body without leaking the
+        # text into operator log streams.
+        import hashlib as _hashlib
+
+        _prompt_hash = _hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12]
+        _log(
+            f"tmux[{self.agent_name}]: wake_prompt_sent "
+            f"reason={reason} "
+            f"prompt_chars={len(prompt)} "
+            f"prompt_hash={_prompt_hash} "
+            f"wait={wait_for_completion}"
+        )
+        await self._emit_stream_event(
+            {
+                "type": "wake_prompt_sent",
+                "agent_name": self.agent_name,
+                "reason": reason,
+                "prompt_chars": len(prompt),
+                "prompt_hash": _prompt_hash,
+                "wait_for_completion": wait_for_completion,
+            }
+        )
+
+        completion = asyncio.Event() if wait_for_completion else None
+        await self._message_queue.put(
+            _QueuedTurn(
+                prompt=prompt,
+                platform="",
+                chat_id="",
+                message_id="",
+                internal=True,
+                reason=reason,
+                completion_event=completion,
+            )
+        )
+
+        if wait_for_completion and completion is not None:
+            if timeout_sec is not None:
+                await asyncio.wait_for(completion.wait(), timeout=timeout_sec)
+            else:
+                await completion.wait()
+            return None
+        return completion
 
     # ── Response capture pipeline (PR8b) ────────────────────────────────
 
@@ -1629,9 +1883,28 @@ class TmuxSession:
         for analytics. cost_callback is a no-op for tmux (subscription
         billing, no per-turn cost) but we still fire stream_event so
         usage telemetry is visible.
+
+        Internal-prompt branch (PR for #543): when ``_inflight_turn``
+        reports the just-finished turn was an internal-prompt (wake
+        orientation, pre-sleep save reminder, etc.), skip the
+        conversation_store assistant append and the response_callback —
+        no external recipient, no user-visible conversation. Still:
+        emit ``turn_completed`` for analytics parity, account usage
+        toward the context-budget watchdog, and signal ``_turn_done``
+        so the worker progresses. If the internal turn carried a
+        ``completion_event``, set it before ``_turn_done`` so a
+        ``wait_for_completion=True`` caller unblocks deterministically
+        with the worker advancing in lock-step.
         """
-        # Log to conversation store. role=assistant.
-        if self._conversation_store and response.text:
+        is_internal = bool(
+            self._inflight_turn is not None and self._inflight_turn.internal
+        )
+
+        # Log to conversation store. role=assistant. Skip for internal
+        # turns so wake-prompt responses don't pollute the user-visible
+        # conversation history (the response is still in the JSONL
+        # transcript for audit).
+        if not is_internal and self._conversation_store and response.text:
             try:
                 self._conversation_store.append(
                     self.id, "assistant", response.text,
@@ -1672,7 +1945,13 @@ class TmuxSession:
 
         # Response callback — the broker-routing payload. Includes the
         # captured inbound metadata so the broker can route the reply.
-        if self._response_callback and (response.text or response.tool_uses):
+        # Skip for internal turns: no chat target, and the metadata is
+        # intentionally empty (see ``_deliver_turn`` regression guard).
+        if (
+            not is_internal
+            and self._response_callback
+            and (response.text or response.tool_uses)
+        ):
             try:
                 meta = dict(self._inflight_meta)
                 turn_result = replace(
@@ -1699,6 +1978,19 @@ class TmuxSession:
 
         # Clear in-flight metadata — next send() will populate it.
         self._inflight_meta = {}
+
+        # Internal-prompt completion signal (PR for #543). MUST fire
+        # BEFORE ``_turn_done`` so a ``wait_for_completion=True`` caller
+        # can rely on the worker not having dispatched the next turn
+        # yet — the worker awaits ``_turn_done`` between turns, and
+        # advancing past that gate would change the in-flight bookkeeping
+        # the caller might be observing.
+        if (
+            is_internal
+            and self._inflight_turn is not None
+            and self._inflight_turn.completion_event is not None
+        ):
+            self._inflight_turn.completion_event.set()
 
         # Signal turn-complete to the worker UNCONDITIONALLY. Must be
         # outside any ``if response.text`` gate (Pushok's PR #496 round-1
@@ -2086,11 +2378,22 @@ class TmuxSession:
 
         # Capture routing metadata BEFORE send-keys so the tailer's callback
         # has access to it even if the tailer fires unusually quickly.
-        self._inflight_meta = {
-            "platform": turn.platform,
-            "chat_id": turn.chat_id,
-            "message_id": turn.message_id,
-        }
+        #
+        # Internal-prompt regression guard (PR for #543): only EXTERNAL
+        # turns own routing metadata. An internal turn that writes here
+        # would clobber a back-to-back external turn's routing fields
+        # (the #496 round-1 Case 1 defect surfacing through this path).
+        # Leave ``_inflight_meta`` empty for internal turns; they have no
+        # response delivery target and ``_handle_turn_complete`` skips
+        # the response_callback altogether when ``turn.internal``.
+        if turn.internal:
+            self._inflight_meta = {}
+        else:
+            self._inflight_meta = {
+                "platform": turn.platform,
+                "chat_id": turn.chat_id,
+                "message_id": turn.message_id,
+            }
 
         # Clear the turn-done gate BEFORE send-keys. Two reasons for
         # ordering this here (vs. after mark_active, the other reasonable

--- a/src/pinky_daemon/wake_prompt.py
+++ b/src/pinky_daemon/wake_prompt.py
@@ -1,0 +1,240 @@
+"""Transport-neutral wake-prompt assembly.
+
+Wake prompts orient an agent at session start / resume / restart by
+combining a header line, the current time, saved-state context body,
+session-purpose instruction, and an explicit messaging/tool reminder.
+
+The assembly contract is shared across all transports (SDK, tmux, Codex).
+Each transport decides HOW to deliver the prompt (background
+``client.query``, paste into a tmux pane, ``codex exec`` input) but the
+WHAT is assembled here so the contract doesn't drift per backend.
+
+**Two distinct contracts, easy to confuse:**
+
+- ``WakeReason`` controls PROMPT TEXT only — header line + first-sentence
+  instruction.
+- Whether a transport launches with ``--continue`` vs fresh-context is a
+  *separate* contract: ``force_fresh_context_once`` on the transport's
+  config. The two move together in the common case (a context_restart
+  sets both), but keeping them coupled was a known source of bugs
+  (tmux ``_build_claude_cmd`` always added ``--continue`` regardless of
+  ``restart_reason``, so a "context_restart" tmux launch would silently
+  resume the old transcript).
+
+The builder is pure: no I/O, no MCP, no broker. ``context_body`` is the
+already-assembled context string from the upstream context collector
+(e.g. ``api._build_streaming_wake_context``) which has the registry /
+broker dependencies and is responsible for saved state, restart manifest,
+freshness warnings, active-channel preamble, inbox/task previews, etc.
+"""
+
+from __future__ import annotations
+
+import zoneinfo
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone as _utc_timezone
+from enum import Enum
+
+__all__ = [
+    "WakeReason",
+    "WakePromptInput",
+    "build_wake_prompt",
+    "wake_reason_from_runtime",
+    "DEFAULT_TIMEZONE",
+]
+
+
+def wake_reason_from_runtime(
+    *,
+    resume_handle: str,
+    restart_reason: str,
+) -> "WakeReason":
+    """Map the legacy ``(resume_handle, restart_reason)`` pair to a
+    :class:`WakeReason`.
+
+    Helper for transports migrating off the old inline assembly. Mirrors
+    the SDK ``connect()`` decision tree:
+
+    - ``resume_handle`` non-empty → RESUME
+    - ``restart_reason == "context_restart"`` → CONTEXT_RESTART
+    - ``restart_reason == "auto_restart"`` → AUTO_RESTART
+    - otherwise → NEW_SESSION
+
+    Note: ``WakeReason.IDLE_WAKE`` is NOT produced by this helper because
+    the old string-typed ``restart_reason`` had no value for it. Callers
+    that want IDLE_WAKE must build :class:`WakePromptInput` directly.
+    """
+    if resume_handle:
+        return WakeReason.RESUME
+    if restart_reason == "context_restart":
+        return WakeReason.CONTEXT_RESTART
+    if restart_reason == "auto_restart":
+        return WakeReason.AUTO_RESTART
+    return WakeReason.NEW_SESSION
+
+
+DEFAULT_TIMEZONE = "America/Los_Angeles"
+
+
+class WakeReason(str, Enum):
+    """Why the agent is being oriented at session start.
+
+    Maps to header + instruction copy in the wake prompt. Callers decide
+    which value applies based on runtime facts (daemon resume vs context
+    restart vs auto restart vs fresh new session vs wake-after-idle-sleep).
+
+    Critical: this enum controls PROMPT TEXT only. Launch behavior
+    (``--continue`` suppression) is a separate contract; see
+    ``force_fresh_context_once`` on ``StreamingSessionConfig``.
+    """
+
+    NEW_SESSION = "new_session"
+    RESUME = "resume"
+    CONTEXT_RESTART = "context_restart"
+    AUTO_RESTART = "auto_restart"
+    IDLE_WAKE = "idle_wake"
+
+
+@dataclass(frozen=True)
+class WakePromptInput:
+    """Inputs to the wake-prompt builder.
+
+    ``context_body`` is the already-assembled context string from the
+    upstream collector (see module docstring). Pass an empty string when
+    there is no saved state to inject.
+
+    ``now`` is injectable for tests. When ``None`` (the production path),
+    the builder resolves ``datetime.now(zoneinfo.ZoneInfo(timezone))``
+    with a UTC fallback if the timezone string is invalid.
+    """
+
+    reason: WakeReason
+    context_body: str = ""
+    timezone: str = DEFAULT_TIMEZONE
+    now: datetime | None = None
+
+
+# Static tool / outreach hint block. Identical to the previous inline
+# assembly in ``StreamingSession.connect()`` so the SDK refactor is a
+# string-stable extraction.
+_TOOLS_HINT = (
+    "You have explicit pinky-messaging outreach tools: "
+    "send, thread, react, send_gif, send_voice, send_photo, send_document, broadcast."
+    "\n\nIMPORTANT: If your tools are deferred (require ToolSearch before use), "
+    "immediately call ToolSearch with TWO queries to pre-load your core tools "
+    "(max 10 per call):\n"
+    '1. "select:mcp__pinky-messaging__send,mcp__pinky-messaging__thread,'
+    "mcp__pinky-messaging__react,mcp__pinky-self__send_heartbeat,"
+    "mcp__pinky-self__send_to_agent,mcp__pinky-self__check_inbox,"
+    "mcp__pinky-self__create_task,mcp__pinky-self__get_next_task,"
+    'mcp__pinky-self__complete_task,mcp__pinky-self__context_status"\n'
+    '2. "select:mcp__pinky-memory__reflect,mcp__pinky-memory__recall,'
+    "mcp__pinky-self__who_am_i,mcp__pinky-self__load_my_context,"
+    "mcp__pinky-self__save_my_context,mcp__pinky-self__check_my_health,"
+    'mcp__pinky-self__agent_status,mcp__pinky-self__claim_task"\n'
+    "Do this silently before any other action — do not mention it to the user. "
+    "Call both ToolSearch queries in parallel in a single response."
+)
+
+
+def _resolve_now(timezone_name: str, now: datetime | None) -> datetime:
+    """Return a tz-aware ``now`` for header formatting.
+
+    If ``now`` is provided, use it as-is (tests inject this). Otherwise
+    resolve ``datetime.now(ZoneInfo(timezone_name))`` with a UTC fallback
+    if the timezone string is invalid — matching the prior inline
+    behavior in ``StreamingSession.connect()``.
+    """
+    if now is not None:
+        return now
+    try:
+        tz = zoneinfo.ZoneInfo(timezone_name or DEFAULT_TIMEZONE)
+        return datetime.now(tz)
+    except Exception:
+        # Fallback labelled "UTC" — issue #294 lineage: a previous
+        # version implicitly used local-tz datetime.now() and falsely
+        # labelled it UTC. Be explicit here.
+        return datetime.now(_utc_timezone.utc)
+
+
+def _format_time(now: datetime) -> str:
+    """Format a datetime for the wake-prompt header.
+
+    The ``%-d`` / ``%-I`` format directives are platform-specific
+    (Linux/macOS) and match the original inline SDK assembly. The
+    transport layer is expected to run on these platforms; if portability
+    to Windows ever matters, switch to ``str(dt.day)`` / ``str(dt.hour)``
+    in this helper.
+    """
+    tzname = now.tzname() or "UTC"
+    return now.strftime(f"%A, %B %-d, %Y at %-I:%M %p {tzname}")
+
+
+def _header_and_lead(reason: WakeReason, time_str: str) -> tuple[str, str]:
+    """Return ``(header, instruction_lead)`` for a wake reason.
+
+    ``header`` announces the wake event + current time. ``instruction_lead``
+    is the agent-facing first sentence after the saved-state block; it
+    leads into the static messaging/tool reminder.
+
+    The ``RESUME`` copy is intentionally neutral ("Session resumed.") —
+    the prior SDK copy claimed "Session resumed after daemon restart"
+    which is wrong for tmux warm reconnect and idle-wake. Callers that
+    explicitly know it was a daemon restart should encode that fact in
+    the ``context_body`` (e.g. via the restart manifest).
+    """
+    if reason == WakeReason.RESUME:
+        return (
+            f"Session resumed. Current time: {time_str}.",
+            "Pick up where you left off.",
+        )
+    if reason == WakeReason.CONTEXT_RESTART:
+        return (
+            f"Context restarted. Current time: {time_str}.",
+            "Fresh context — pick up from saved state.",
+        )
+    if reason == WakeReason.AUTO_RESTART:
+        return (
+            f"Auto-restarted (context limit). Current time: {time_str}.",
+            "Context was getting full — pick up from saved state.",
+        )
+    if reason == WakeReason.IDLE_WAKE:
+        return (
+            f"Waking from idle. Current time: {time_str}.",
+            "Pick up from saved state.",
+        )
+    # NEW_SESSION (default).
+    return (
+        f"New session started. Current time: {time_str}.",
+        "You're connected via Pinky's message broker.",
+    )
+
+
+def build_wake_prompt(inp: WakePromptInput) -> str:
+    """Assemble a wake prompt string. Pure: no I/O.
+
+    Structure (matches the prior inline SDK assembly):
+
+        {header}
+        ── Saved State ──    # only when context_body is non-empty
+        {context_body}
+        ──────────────────
+
+        {instruction_lead} {messaging_tool_reminder} {tools_hint} {fallback_note}
+    """
+    now = _resolve_now(inp.timezone, inp.now)
+    time_str = _format_time(now)
+    header, lead = _header_and_lead(inp.reason, time_str)
+
+    ctx_block = ""
+    if inp.context_body:
+        ctx_block = f"\n\n── Saved State ──\n{inp.context_body}\n──────────────────"
+
+    return (
+        f"{header}{ctx_block}\n\n"
+        f"{lead} Users will message you through Telegram. "
+        "Use send(chat_id, platform, text) for normal responses. "
+        "Use thread(message_id, text) only when you want to quote/thread a specific message. "
+        f"{_TOOLS_HINT} If you do not call an outreach tool, Pinky may fall back to plain-text delivery based on agent settings."
+    )

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -80,6 +80,12 @@ def _make_session(
     )
     tmux = tmux or _make_mock_tmux()
     ss = TmuxSession(cfg, tmux_control=tmux)
+    # Skip wake-prompt enqueue by default in unit tests — without a
+    # simulated transcript tailer the worker would block forever on the
+    # never-completing wake turn. Wake-prompt behavior has its own
+    # dedicated tests (see TestWakePromptEnqueue below) which set this
+    # flag explicitly to False and provide the tailer simulation.
+    ss._skip_wake_prompt_for_tests = True
     if state is not None:
         ss._state_machine._state = state
     return ss, tmux
@@ -1196,6 +1202,9 @@ def _make_session_with_response_cb(
         conversation_store=conv_store,
         stream_event_callback=stream_evt,
     )
+    # Skip wake-prompt enqueue — see _make_session docstring. Tests that
+    # specifically exercise wake-prompt behavior flip this back to False.
+    ss._skip_wake_prompt_for_tests = True
     return ss, tmux
 
 
@@ -2875,3 +2884,433 @@ async def test_restart_nudge_rearms_after_drop_below_threshold() -> None:
     await ss._handle_turn_complete(_turn_response(input_tokens=110_000))
     nudges = [e for e in events if e["type"] == "restart_nudge"]
     assert len(nudges) == 2
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Wake-prompt / internal-prompt path (PR for #543)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _turn_response(
+    *,
+    text: str = "",
+    input_tokens: int = 0,
+    cache_read: int = 0,
+    cache_write: int = 0,
+    output_tokens: int = 0,
+    thinking: str = "",
+    tool_uses: list | None = None,
+    stop_reason: str = "end_turn",
+) -> TurnResponse:
+    return TurnResponse(
+        text=text,
+        thinking=thinking,
+        tool_uses=tool_uses or [],
+        stop_reason=stop_reason,
+        usage={
+            "input_tokens": input_tokens,
+            "cache_read_input_tokens": cache_read,
+            "cache_creation_input_tokens": cache_write,
+            "output_tokens": output_tokens,
+        },
+        duration_ms=0,
+        assistant_entry_count=1 if text else 0,
+    )
+
+
+class TestInternalPromptBypasses:
+    """``_enqueue_internal_prompt`` must NOT mutate the external-stat
+    surfaces: no conversation_store user-message append, no
+    ``messages_sent`` increment, no ``_inflight_meta`` write.
+
+    These are the contractual guarantees Murzik called out — without
+    them, an internal turn would poison external-turn state (Case 1
+    regression from PR #496 round-1 surfacing through a new path).
+    """
+
+    @pytest.mark.asyncio
+    async def test_internal_prompt_does_not_append_to_conversation_store(self):
+        conv_store = MagicMock()
+        conv_store.append = MagicMock()
+        ss, _ = _make_session_with_response_cb(conv_store=conv_store)
+        # Force CONNECTED so the enqueue gate passes without running
+        # the full connect path.
+        ss._state_machine._state = SessionState.CONNECTED
+
+        await ss._enqueue_internal_prompt(
+            "wake prompt body",
+            reason="wake_new_session",
+            wait_for_completion=False,
+        )
+
+        conv_store.append.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_internal_prompt_does_not_increment_messages_sent(self):
+        ss, _ = _make_session()
+        ss._state_machine._state = SessionState.CONNECTED
+        before = ss._stats["messages_sent"]
+
+        await ss._enqueue_internal_prompt(
+            "wake prompt body",
+            reason="wake_new_session",
+            wait_for_completion=False,
+        )
+
+        assert ss._stats["messages_sent"] == before, (
+            "internal prompts are daemon-side; external-message stats "
+            "must stay at the pre-enqueue value"
+        )
+
+    @pytest.mark.asyncio
+    async def test_internal_prompt_does_not_write_inflight_meta(self):
+        """Murzik's regression guard against #496 round-1 Case 1 surfacing
+        via the internal-prompt path. An internal turn that wrote routing
+        metadata would clobber a back-to-back external turn's routing
+        fields. ``_deliver_turn`` is responsible for the actual decision
+        (internal vs external) — this test pins that contract."""
+        ss, tmux = _make_session()
+        # The internal turn dispatched through _deliver_turn must NOT
+        # set _inflight_meta. Seed it with sentinel values and verify
+        # they're cleared (not overwritten with another non-empty dict).
+        ss._inflight_meta = {
+            "platform": "EXTERNAL_SENTINEL",
+            "chat_id": "EXTERNAL_CHAT",
+            "message_id": "EXTERNAL_MSG",
+        }
+        internal_turn = _QueuedTurn(
+            prompt="wake prompt body",
+            platform="",
+            chat_id="",
+            message_id="",
+            internal=True,
+            reason="wake_new_session",
+        )
+
+        # _deliver_turn requires a paste_text mock + tmux not under
+        # context-lock. We seed those.
+        ss._state_machine._state = SessionState.CONNECTED
+
+        await ss._deliver_turn(internal_turn)
+
+        # Internal turn writes the EMPTY dict to _inflight_meta — not the
+        # sentinel values. This is the contract: internal turns own no
+        # routing metadata.
+        assert ss._inflight_meta == {}, (
+            "internal turn wrote routing metadata — would clobber a "
+            "back-to-back external turn's routing (regression of "
+            "#496 round-1 Case 1 via the wake-prompt path)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_internal_wake_prompt_does_not_clobber_external_routing(self):
+        """The full Case 1 regression guard. Enqueue an internal wake
+        prompt, then an external turn, dispatch both — the external
+        turn's ``_inflight_meta`` must carry its own routing through
+        ``_deliver_turn``."""
+        ss, tmux = _make_session()
+        ss._state_machine._state = SessionState.CONNECTED
+
+        # Internal turn first — must NOT touch _inflight_meta.
+        internal_turn = _QueuedTurn(
+            prompt="wake",
+            internal=True,
+            reason="wake_new_session",
+        )
+        await ss._deliver_turn(internal_turn)
+        assert ss._inflight_meta == {}
+
+        # External turn next — must populate _inflight_meta with its
+        # own routing fields.
+        external_turn = _QueuedTurn(
+            prompt="hello",
+            platform="telegram",
+            chat_id="42",
+            message_id="m1",
+        )
+        await ss._deliver_turn(external_turn)
+        assert ss._inflight_meta == {
+            "platform": "telegram",
+            "chat_id": "42",
+            "message_id": "m1",
+        }
+
+
+class TestInternalPromptCompletion:
+    """The ``wait_for_completion`` semantic. Without it, PR B (idle_sleep
+    parity) would paste a "please save state" instruction and kill the
+    pane before the agent could honor it. This contract is the lifecycle
+    primitive Murzik flagged as critical."""
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_false_returns_immediately(self):
+        ss, _ = _make_session()
+        ss._state_machine._state = SessionState.CONNECTED
+        result = await ss._enqueue_internal_prompt(
+            "wake",
+            reason="wake_new_session",
+            wait_for_completion=False,
+        )
+        # When wait=False, the helper returns the completion_event (or
+        # None if the caller doesn't need to observe). Per implementation
+        # it returns None because we don't construct the event in
+        # fire-and-forget mode. This pins that contract.
+        assert result is None or isinstance(result, asyncio.Event)
+        # The internal turn is in the queue.
+        assert ss._message_queue.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_true_blocks_until_event_fires(self):
+        """The caller awaits the completion event before returning. The
+        worker sets it from ``_handle_turn_complete``. We simulate that
+        sequence here without running the full worker loop."""
+        ss, _ = _make_session()
+        ss._state_machine._state = SessionState.CONNECTED
+
+        async def _enqueue():
+            await ss._enqueue_internal_prompt(
+                "presave",
+                reason="idle_sleep_presave",
+                wait_for_completion=True,
+                timeout_sec=2.0,
+            )
+
+        enqueue_task = asyncio.create_task(_enqueue())
+        # Yield so the enqueue task can put the turn on the queue + start
+        # awaiting the completion event.
+        for _ in range(5):
+            await asyncio.sleep(0)
+            if ss._message_queue.qsize() >= 1:
+                break
+
+        # Pull the queued turn, simulate the worker's "inflight" state,
+        # and fire the completion event the way ``_handle_turn_complete``
+        # would. The caller awaiting ``_enqueue`` should now return.
+        turn = await ss._message_queue.get()
+        ss._inflight_turn = turn
+        assert turn.completion_event is not None
+        turn.completion_event.set()
+
+        await asyncio.wait_for(enqueue_task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_timeout_raises(self):
+        ss, _ = _make_session()
+        ss._state_machine._state = SessionState.CONNECTED
+        with pytest.raises(asyncio.TimeoutError):
+            await ss._enqueue_internal_prompt(
+                "presave",
+                reason="idle_sleep_presave",
+                wait_for_completion=True,
+                timeout_sec=0.05,
+            )
+
+    @pytest.mark.asyncio
+    async def test_completion_event_fires_before_turn_done(self):
+        """Critical ordering: ``completion_event.set()`` MUST fire before
+        ``_turn_done.set()`` in ``_handle_turn_complete``. Otherwise the
+        worker advances past the wake-prompt turn before a
+        ``wait_for_completion=True`` caller observes its event — a race
+        that could break PR B's "save state before disconnect" contract."""
+        ss, _ = _make_session()
+        ss._state_machine._state = SessionState.CONNECTED
+
+        # Simulate the worker's inflight state: an internal turn with
+        # a completion event.
+        completion = asyncio.Event()
+        ss._inflight_turn = _QueuedTurn(
+            prompt="wake",
+            internal=True,
+            reason="wake_new_session",
+            completion_event=completion,
+        )
+        # _turn_done starts cleared — this is the worker's invariant
+        # between dispatches.
+        ss._turn_done.clear()
+
+        await ss._handle_turn_complete(_turn_response(text="ack"))
+
+        assert completion.is_set(), (
+            "completion_event must be set by _handle_turn_complete"
+        )
+        assert ss._turn_done.is_set(), (
+            "_turn_done must also be set so the worker progresses"
+        )
+
+
+class TestInternalTurnSkipsResponseCallback:
+    """Internal turns have no chat target — the response_callback must
+    not fire (no broker routing, no Telegram delivery)."""
+
+    @pytest.mark.asyncio
+    async def test_handle_turn_complete_skips_response_callback_for_internal(self):
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        ss._inflight_turn = _QueuedTurn(
+            prompt="wake",
+            internal=True,
+            reason="wake_new_session",
+        )
+
+        await ss._handle_turn_complete(_turn_response(text="agent reply"))
+
+        assert cb.calls == [], (
+            "internal turn must not invoke response_callback — no chat "
+            "to route the reply back to"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_turn_complete_skips_conversation_store_for_internal(self):
+        conv_store = MagicMock()
+        conv_store.append = MagicMock()
+        ss, _ = _make_session_with_response_cb(conv_store=conv_store)
+        ss._state_machine._state = SessionState.CONNECTED
+        ss._inflight_turn = _QueuedTurn(
+            prompt="wake",
+            internal=True,
+            reason="wake_new_session",
+        )
+
+        await ss._handle_turn_complete(_turn_response(text="agent reply"))
+
+        # No user-message append (handled in _enqueue_internal_prompt
+        # by not calling conv_store at all), no assistant-message append
+        # (this method's branch).
+        conv_store.append.assert_not_called()
+
+
+class TestForceFreshContextOnce:
+    """``--continue`` suppression flag — independent contract from
+    wake-prompt copy (per Murzik's separation principle)."""
+
+    @pytest.mark.asyncio
+    async def test_build_claude_cmd_suppresses_continue_when_flag_set(self, tmp_path):
+        ss, _ = _make_session()
+        # Force a prior-transcript condition so ``_build_claude_cmd``
+        # would normally add ``--continue``.
+        ss._has_prior_transcript = lambda: True
+
+        ss._config.force_fresh_context_once = True
+        cmd = ss._build_claude_cmd()
+
+        assert "--continue" not in cmd, (
+            "force_fresh_context_once must suppress --continue even when "
+            "a prior transcript exists"
+        )
+
+    def test_build_claude_cmd_consumes_flag_one_shot(self):
+        ss, _ = _make_session()
+        ss._has_prior_transcript = lambda: True
+        ss._config.force_fresh_context_once = True
+
+        # First call — consumed.
+        cmd1 = ss._build_claude_cmd()
+        assert "--continue" not in cmd1
+        # Flag is now reset to False.
+        assert ss._config.force_fresh_context_once is False
+
+        # Second call — back to normal behavior (--continue because
+        # prior transcript exists).
+        cmd2 = ss._build_claude_cmd()
+        assert "--continue" in cmd2, (
+            "flag is one-shot — second launch should resume normally"
+        )
+
+    def test_build_claude_cmd_records_launch_mode_on_session(self):
+        ss, _ = _make_session()
+        ss._has_prior_transcript = lambda: True
+        ss._config.force_fresh_context_once = True
+
+        ss._build_claude_cmd()
+
+        assert ss._last_launch_forced_fresh is True
+        assert ss._last_launch_used_continue is False
+        assert ss._last_launch_had_prior_transcript is True
+
+    def test_build_claude_cmd_default_uses_continue_with_prior_transcript(self):
+        ss, _ = _make_session()
+        ss._has_prior_transcript = lambda: True
+        # force_fresh defaults to False.
+        cmd = ss._build_claude_cmd()
+        assert "--continue" in cmd
+
+
+class TestWakePromptEnqueueOnConnect:
+    """Wake-prompt assembly + enqueue is the parent defect from #543.
+    These tests pin that ``connect()`` actually injects the wake prompt,
+    with the right WakeReason for each runtime signal."""
+
+    @pytest.mark.asyncio
+    async def test_connect_enqueues_wake_prompt_by_default(self):
+        ss, _ = _make_session()
+        # Override the test-default skip so the real path runs.
+        ss._skip_wake_prompt_for_tests = False
+        await ss.connect()
+
+        assert ss._message_queue.qsize() >= 1, (
+            "connect() must enqueue a wake prompt"
+        )
+        turn = ss._message_queue._queue[0]  # type: ignore[attr-defined]
+        assert turn.internal is True
+        assert turn.reason.startswith("wake_")
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_skips_wake_prompt_when_flag_set(self):
+        """Test seam — verifies the unit-test path doesn't queue the
+        wake prompt (otherwise the worker would hang waiting for the
+        transcript tailer to fire ``_handle_turn_complete``)."""
+        ss, _ = _make_session()
+        # Default: skip flag is True.
+        await ss.connect()
+        assert ss._message_queue.qsize() == 0
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_wake_reason_is_new_session_on_cold_start(self):
+        ss, _ = _make_session()
+        ss._skip_wake_prompt_for_tests = False
+        # No prior transcript, no restart_reason → NEW_SESSION.
+        await ss.connect()
+        turn = ss._message_queue._queue[0]  # type: ignore[attr-defined]
+        assert "new_session" in turn.reason
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_wake_reason_is_context_restart_when_flag_set(self):
+        ss, _ = _make_session()
+        ss._skip_wake_prompt_for_tests = False
+        ss._config.force_fresh_context_once = True
+
+        await ss.connect()
+
+        turn = ss._message_queue._queue[0]  # type: ignore[attr-defined]
+        assert "context_restart" in turn.reason
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_wake_reason_is_auto_restart_when_set(self):
+        ss, _ = _make_session()
+        ss._skip_wake_prompt_for_tests = False
+        ss._config.restart_reason = "auto_restart"
+
+        await ss.connect()
+
+        turn = ss._message_queue._queue[0]  # type: ignore[attr-defined]
+        assert "auto_restart" in turn.reason
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_wake_prompt_body_includes_saved_state_when_present(self):
+        ss, _ = _make_session()
+        ss._skip_wake_prompt_for_tests = False
+        ss._config.wake_context = "## Continuation\nWorking on X"
+
+        await ss.connect()
+
+        turn = ss._message_queue._queue[0]  # type: ignore[attr-defined]
+        assert "── Saved State ──" in turn.prompt
+        assert "## Continuation" in turn.prompt
+        assert "Working on X" in turn.prompt
+        await ss.disconnect()

--- a/tests/test_wake_prompt.py
+++ b/tests/test_wake_prompt.py
@@ -1,0 +1,216 @@
+"""Tests for the pure wake-prompt builder.
+
+The builder is contract-pinned: every transport (SDK / tmux / Codex)
+must produce identical output for equivalent inputs. These tests pin the
+exact string structure so a refactor that changes the header copy,
+saved-state delimiter, or tool hint will fail loudly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from pinky_daemon.wake_prompt import (
+    DEFAULT_TIMEZONE,
+    WakePromptInput,
+    WakeReason,
+    build_wake_prompt,
+)
+
+# A deterministic ``now`` used across tests so header formatting is
+# stable. Picks a wall-clock minute (no seconds rendered) and a known
+# tz so the ``%Z`` rendering is consistent.
+FIXED_PST = datetime(2026, 5, 18, 14, 30, tzinfo=ZoneInfo("America/Los_Angeles"))
+EXPECTED_TIME_STR = "Monday, May 18, 2026 at 2:30 PM PDT"
+
+
+def _input(reason: WakeReason, context_body: str = "") -> WakePromptInput:
+    return WakePromptInput(
+        reason=reason,
+        context_body=context_body,
+        timezone="America/Los_Angeles",
+        now=FIXED_PST,
+    )
+
+
+class TestHeaderPerReason:
+    """Each ``WakeReason`` produces a distinct header + lead sentence."""
+
+    def test_new_session_header(self):
+        out = build_wake_prompt(_input(WakeReason.NEW_SESSION))
+        assert out.startswith(f"New session started. Current time: {EXPECTED_TIME_STR}.")
+        assert "You're connected via Pinky's message broker." in out
+
+    def test_resume_header_is_neutral(self):
+        """RESUME copy should NOT claim 'after daemon restart' — that
+        wording was wrong for tmux warm reconnect and idle-wake. Callers
+        with explicit daemon-restart knowledge should encode it in
+        ``context_body`` instead."""
+        out = build_wake_prompt(_input(WakeReason.RESUME))
+        assert out.startswith(f"Session resumed. Current time: {EXPECTED_TIME_STR}.")
+        assert "Pick up where you left off." in out
+        assert "after daemon restart" not in out
+
+    def test_context_restart_header(self):
+        out = build_wake_prompt(_input(WakeReason.CONTEXT_RESTART))
+        assert out.startswith(f"Context restarted. Current time: {EXPECTED_TIME_STR}.")
+        assert "Fresh context — pick up from saved state." in out
+
+    def test_auto_restart_header(self):
+        out = build_wake_prompt(_input(WakeReason.AUTO_RESTART))
+        assert out.startswith(f"Auto-restarted (context limit). Current time: {EXPECTED_TIME_STR}.")
+        assert "Context was getting full — pick up from saved state." in out
+
+    def test_idle_wake_header(self):
+        out = build_wake_prompt(_input(WakeReason.IDLE_WAKE))
+        assert out.startswith(f"Waking from idle. Current time: {EXPECTED_TIME_STR}.")
+        assert "Pick up from saved state." in out
+
+
+class TestContextBody:
+    """The ``context_body`` field is fenced with the standard delimiters."""
+
+    def test_empty_context_omits_saved_state_block(self):
+        out = build_wake_prompt(_input(WakeReason.NEW_SESSION, context_body=""))
+        assert "── Saved State ──" not in out
+        assert "──────────────────" not in out
+
+    def test_context_body_is_fenced(self):
+        body = "## Continuation\nYou were working on: X\n\n### Context\nfoo bar"
+        out = build_wake_prompt(_input(WakeReason.RESUME, context_body=body))
+        assert "── Saved State ──" in out
+        assert "──────────────────" in out
+        # Body appears verbatim between the fences.
+        assert body in out
+        # And appears AFTER the header.
+        assert out.index("Session resumed.") < out.index("── Saved State ──")
+        assert out.index(body) < out.index("──────────────────")
+
+    def test_context_body_preserves_user_markup(self):
+        """The body is passed through verbatim — no markdown escaping,
+        no truncation, no normalization. Callers are responsible for
+        format. This pins that contract."""
+        weird = "**bold** and `code` and emoji 😅 and newline:\n\nline2"
+        out = build_wake_prompt(_input(WakeReason.NEW_SESSION, context_body=weird))
+        assert weird in out
+
+
+class TestToolHintIsAlwaysPresent:
+    """The static tools hint is part of every wake prompt regardless of
+    reason. The exact ToolSearch invocation strings are pinned because
+    agents key off them during cold start to pre-load deferred tools."""
+
+    @pytest.mark.parametrize("reason", list(WakeReason))
+    def test_tools_hint_present(self, reason: WakeReason):
+        out = build_wake_prompt(_input(reason))
+        # The block heading.
+        assert "If your tools are deferred (require ToolSearch before use)" in out
+        # The two specific ToolSearch queries the harness scripted us
+        # to call on cold start.
+        assert "select:mcp__pinky-messaging__send,mcp__pinky-messaging__thread" in out
+        assert "select:mcp__pinky-memory__reflect,mcp__pinky-memory__recall" in out
+        # The fallback note about Pinky plain-text delivery.
+        assert "Pinky may fall back to plain-text delivery" in out
+
+    @pytest.mark.parametrize("reason", list(WakeReason))
+    def test_messaging_tools_listed(self, reason: WakeReason):
+        out = build_wake_prompt(_input(reason))
+        # Explicit outreach tool surface.
+        assert "send, thread, react, send_gif, send_voice, send_photo, send_document, broadcast" in out
+        # The fundamental Telegram delivery instruction.
+        assert "Users will message you through Telegram" in out
+        assert "Use send(chat_id, platform, text) for normal responses" in out
+
+
+class TestTimeAndTimezone:
+    """``now`` injection is the test seam; live calls fall back to
+    ``datetime.now(ZoneInfo(timezone))``."""
+
+    def test_explicit_now_is_honored(self):
+        custom = datetime(2024, 1, 1, 9, 0, tzinfo=ZoneInfo("UTC"))
+        out = build_wake_prompt(
+            WakePromptInput(
+                reason=WakeReason.NEW_SESSION,
+                timezone="UTC",
+                now=custom,
+            )
+        )
+        # The full formatted line: "Monday, January 1, 2024 at 9:00 AM UTC".
+        assert "Monday, January 1, 2024 at 9:00 AM UTC" in out
+
+    def test_timezone_appears_in_header(self):
+        """The header uses the timezone's abbreviation (PDT, EST, etc.)."""
+        eastern = datetime(2026, 5, 18, 17, 30, tzinfo=ZoneInfo("America/New_York"))
+        out = build_wake_prompt(
+            WakePromptInput(
+                reason=WakeReason.NEW_SESSION,
+                timezone="America/New_York",
+                now=eastern,
+            )
+        )
+        # %Z renders the tz abbreviation (EDT for May).
+        assert "EDT" in out
+
+    def test_invalid_timezone_falls_back_to_utc(self):
+        """A broken timezone string should not crash the builder — fall
+        back to UTC. This matches the prior inline SDK behavior."""
+        out = build_wake_prompt(
+            WakePromptInput(
+                reason=WakeReason.NEW_SESSION,
+                timezone="Not/A/Real/Zone",
+                # now=None → builder resolves it; we just check it doesn't
+                # raise. UTC fallback path.
+            )
+        )
+        assert "Current time:" in out  # Header still emitted.
+
+    def test_default_timezone_constant_is_pacific(self):
+        """Soft pin: the default timezone is Pacific (Brad's). If this
+        ever changes, callers that omit the field will see a behavior
+        shift — flag it explicitly."""
+        assert DEFAULT_TIMEZONE == "America/Los_Angeles"
+
+
+class TestEnumValues:
+    """Enum string values pin the wire-format / instrumentation contract."""
+
+    def test_wake_reason_values(self):
+        # These strings appear in instrumentation logs (`wake_prompt_sent`
+        # events) and on-wire restart_reason fields. Don't rename without
+        # versioning the consumer.
+        assert WakeReason.NEW_SESSION.value == "new_session"
+        assert WakeReason.RESUME.value == "resume"
+        assert WakeReason.CONTEXT_RESTART.value == "context_restart"
+        assert WakeReason.AUTO_RESTART.value == "auto_restart"
+        assert WakeReason.IDLE_WAKE.value == "idle_wake"
+
+
+class TestContractRegression:
+    """Snapshot-style tests that pin the full assembled string for the
+    common cases. If a refactor accidentally drops a section or changes
+    a delimiter, these fail loudly.
+    """
+
+    def test_new_session_no_context_snapshot(self):
+        out = build_wake_prompt(_input(WakeReason.NEW_SESSION))
+        # The exact opening, the lead, and the messaging-tools sentence
+        # are all present in the right order.
+        idx_header = out.index("New session started")
+        idx_lead = out.index("You're connected via Pinky's message broker")
+        idx_msg = out.index("Users will message you through Telegram")
+        idx_hint = out.index("If your tools are deferred")
+        idx_fallback = out.index("Pinky may fall back to plain-text")
+        assert idx_header < idx_lead < idx_msg < idx_hint < idx_fallback
+
+    def test_context_restart_with_body_snapshot(self):
+        body = "Saved: do X\nThen Y"
+        out = build_wake_prompt(_input(WakeReason.CONTEXT_RESTART, context_body=body))
+        idx_header = out.index("Context restarted")
+        idx_saved_open = out.index("── Saved State ──")
+        idx_body = out.index(body)
+        idx_saved_close = out.index("──────────────────")
+        idx_lead = out.index("Fresh context — pick up from saved state")
+        assert idx_header < idx_saved_open < idx_body < idx_saved_close < idx_lead


### PR DESCRIPTION
## Why

#543 identified a **parent defect** in tmux transport: `StreamingSession.connect()` builds + sends a full wake prompt at session start (Saved State block, current time, active channels, ToolSearch reminder), but `TmuxSession.connect()` does no equivalent injection. Tmux agents silently lost saved-state-on-wake, the ToolSearch reminder, the active-channel preamble, and context-restart orientation.

Companion bug: `/streaming/restart` cleared `resume_handle` and set `restart_reason=context_restart`, but `TmuxSession._build_claude_cmd()` ignored both and added `--continue` whenever a prior cwd transcript existed — so tmux context_restart silently *resumed* the old conversation instead of starting fresh.

This is the prerequisite for migrating the rest of the agent fleet (Barsik / Pushok / Persik / Ryzhik) from SDK transport to tmux transport before the **June 15 2026 Anthropic billing change** moves Agent SDK / subscription-auth third-party apps into a metered credit pool. Tmux transport routes through the interactive subscription instead.

## What's in this PR

### New module: `pinky_daemon.wake_prompt`

Transport-neutral pure builder. Shared by SDK and tmux (Codex parity is a follow-up).

```python
class WakeReason(str, Enum):
    NEW_SESSION = "new_session"
    RESUME = "resume"
    CONTEXT_RESTART = "context_restart"
    AUTO_RESTART = "auto_restart"
    IDLE_WAKE = "idle_wake"  # reserved for future wake-after-idle path

@dataclass(frozen=True)
class WakePromptInput:
    reason: WakeReason
    context_body: str = ""
    timezone: str = "America/Los_Angeles"
    now: datetime | None = None  # injectable for tests

def build_wake_prompt(inp: WakePromptInput) -> str: ...
```

No I/O, no broker dependencies. `context_body` is the already-assembled context string from the upstream collector (`_build_streaming_wake_context` in api.py) which retains its registry/broker dependencies.

### Visible copy change

`WakeReason.RESUME` now says **"Session resumed."** (neutral) instead of the prior **"Session resumed after daemon restart."** The old wording was wrong for tmux warm reconnect + idle-wake. Callers that explicitly know it was a daemon restart should encode that fact in the `context_body` (e.g. via the restart manifest).

### `StreamingSessionConfig.force_fresh_context_once: bool = False`

- One-shot launch-behavior flag. Consumed by the transport on the next launch and reset to False.
- `/streaming/restart` now sets it alongside `restart_reason`.
- `TmuxSession._build_claude_cmd` checks it before adding `--continue`.
- **Separate contract from `restart_reason`** (text/prompt contract) — coupling them was the root cause of #543.

### `TmuxSession._enqueue_internal_prompt`

Daemon-side prompt delivery with no external side-effects:

```python
async def _enqueue_internal_prompt(
    self,
    prompt: str,
    *,
    reason: str,
    wait_for_completion: bool = False,
    timeout_sec: float | None = None,
) -> asyncio.Event | None
```

- No `conversation_store` user-message append
- No `messages_sent` increment
- No `_inflight_meta` write (regression guard against PR #496 round-1 Case 1 surfacing through this path — Murzik's specific ask)
- No `_response_callback` invocation
- `wait_for_completion=False`: fire-and-forget (wake prompts at connect time)
- `wait_for_completion=True`: caller awaits the completion event before returning, bounded by `timeout_sec` (future PR B — pre-sleep save prompt where caller must not disconnect before agent honors instruction)

### Wired into `TmuxSession.connect()`

After CONNECTED + worker startup:
1. Snapshot pre-spawn signals (`force_fresh_context_once`, `restart_reason`, `_has_prior_transcript`).
2. Derive `WakeReason`:
   - force_fresh OR restart_reason==context_restart → `CONTEXT_RESTART`
   - restart_reason==auto_restart → `AUTO_RESTART`
   - prior transcript existed → `RESUME`
   - otherwise → `NEW_SESSION`
3. Build wake prompt via shared `build_wake_prompt`.
4. Enqueue via `_enqueue_internal_prompt(wait_for_completion=False)`.

### Instrumentation

Each launch + wake-prompt enqueue emits structured log lines for the #543 validation harness:

- `claude_cmd_built mode=fresh|continue force_fresh=<bool> prior_transcript=<bool>`
- `wake_prompt_sent reason=<reason> prompt_chars=<n> prompt_hash=<12-hex> wait=<bool>`
- Tmux also emits a `wake_prompt_sent` stream event via `_emit_stream_event` for dashboard parity.
- SDK has log-only today (no stream_event_callback surface). Follow-up to unify.

## Tests

### `tests/test_wake_prompt.py` (25 tests, all new)
Pure builder contract pins:
- Each `WakeReason` produces a distinct header + lead sentence
- `context_body` is fenced with the standard `── Saved State ──` delimiters; passes through user markup verbatim
- Tool hint always present regardless of reason; specific ToolSearch invocation strings pinned (agents key off these on cold start)
- Time/timezone: explicit `now` honored; tz abbreviation appears in header; invalid tz falls back to UTC; default constant pinned
- Enum string values pinned (wire-format / instrumentation contract)

### `tests/test_tmux_session.py` (20 new tests)
- `_enqueue_internal_prompt` bypasses: no conv store append, no `messages_sent`++, no `_inflight_meta` write
- **The Murzik-flagged #496 round-1 Case 1 regression guard**: internal turn followed by external turn — external turn's `_inflight_meta` carries its own routing through `_deliver_turn` (the test you specifically asked for)
- `wait_for_completion` semantics: returns immediately on False; blocks on True; raises `asyncio.TimeoutError` on timeout; sets `completion_event` BEFORE `_turn_done` (worker-ordering invariant)
- `_handle_turn_complete` skips conversation_store + response_callback for internal turns
- `_build_claude_cmd` fresh suppression + one-shot consumption + launch-mode recording on session
- `connect()` enqueues wake prompt by default + `wake_reason` derivation per runtime signal (cold start → NEW_SESSION; force_fresh → CONTEXT_RESTART; restart_reason=="auto_restart" → AUTO_RESTART; wake_context preserved in prompt body)

### Test seam: `_skip_wake_prompt_for_tests`
Instance attribute on TmuxSession. The existing `_make_session` helpers default it to True so existing unit tests (which mock at the paste/queue layer and don't simulate the transcript tailer) don't strand the worker on a never-completing wake turn. Wake-prompt tests flip it to False explicitly.

### Validation locally
- `pytest tests/test_wake_prompt.py tests/test_streaming_session.py tests/test_tmux_session.py` → **181 passed**
- Full `pytest` → **2568 passed, 1 skipped**
- `ruff check src/ tests/` → **clean**

## What this PR does NOT do (and why)

- **TB-03 thinking metadata parity** — Murzik's PR C (#544), cleanly disjoint files.
- **PR B: idle_sleep parity** — separate PR, builds on this one's `_enqueue_internal_prompt(wait_for_completion=True)` mechanism.
- **Codex transport parity** — `codex_session.py` still has inline wake-prompt assembly. Follow-up.
- **SDK stream-event surface** — SDK emits `wake_prompt_sent` as a log line; tmux emits it as both log + stream event. Unifying SDK to stream-event-capable is a separate concern outside #543 scope.
- **Live Dymok validation** — that's the runbook at `docs/runbooks/tmux-validation.md` (local, `docs/` is gitignored). Runs after this lands + PR B + PR C.

## Test plan

- [x] All pre-existing tests pass (no regressions)
- [x] 45 new tests cover the new module + integration surface
- [x] Ruff clean across changed files + full repo
- [ ] Manual validation against live Dymok (per `docs/runbooks/tmux-validation.md` WC-01, CR-01) — post-merge with Murzik's PR C also merged

Refs #543, pairs with #544.

🤖 Opened by Barsik