### PR TITLE
feat(transport): tmux idle_sleep parity + #545 follow-ups

### DIFF
--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -23,6 +23,7 @@ from pinky_daemon.transport_state import SessionState, StateMachine, Trigger
 from pinky_daemon.turn_response import TurnResponse
 from pinky_daemon.wake_prompt import (
     WakePromptInput,
+    build_idle_sleep_prompt,
     build_wake_prompt,
     wake_reason_from_runtime,
 )
@@ -1175,15 +1176,13 @@ class StreamingSession:
 
         _log(f"streaming[{self.agent_name}]: idle sleep triggered ({self._config.idle_timeout}s idle)")
 
-        # Ask agent to save state before sleeping
+        # Ask agent to save state before sleeping. Text moved to
+        # ``pinky_daemon.wake_prompt.build_idle_sleep_prompt`` (PR for
+        # #543 / idle-sleep parity) so tmux can use the same instruction
+        # via its internal-prompt mechanism with explicit
+        # wait_for_completion semantics.
         try:
-            await self._client.query(
-                "[SYSTEM] You've been idle for over an hour. Auto-sleep is activating.\n\n"
-                "Before your session is suspended:\n"
-                "1. Use reflect() to persist key learnings and current task state\n"
-                "2. Note what you were working on so you can resume later\n\n"
-                "Your session will be preserved and resumed when you're needed next."
-            )
+            await self._client.query(build_idle_sleep_prompt())
             _log(f"streaming[{self.agent_name}]: memory save prompt sent before idle sleep")
         except Exception as e:
             _log(f"streaming[{self.agent_name}]: memory save failed before idle sleep: {e}")

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1197,13 +1197,9 @@ class TmuxSession:
             ) from None
 
         # NOTE: ``force_fresh_context_once`` consumption is deferred to
-        # the END of ``_spawn_tmux_repl`` (after tailer startup also
-        # succeeds), NOT here. Murzik #545 follow-up round 2: the
-        # failure window includes tailer-start rollback, so clearing
-        # the flag immediately after ``_spawn()`` would still lose the
-        # fresh-context guarantee on retry if tailer-start failed
-        # afterward. Invariant: flag remains set until REPL + tailer
-        # are both up as a unit.
+        # the end of this method (after tailer startup also succeeds),
+        # NOT here — see the load-bearing comment at the consume site
+        # below for the full rationale (Murzik #545 follow-up round 2).
 
         # REPL is up — bring up the response capture pipeline (PR8b).
         # Kept OUTSIDE the cold-start timeout so tailer construction
@@ -2591,10 +2587,7 @@ class TmuxSession:
                 wait_for_completion=True,
                 timeout_sec=120.0,
             )
-            _log(
-                f"tmux[{self.agent_name}]: idle_sleep_presave completed "
-                f"(or in queue order if worker was busy)"
-            )
+            _log(f"tmux[{self.agent_name}]: idle_sleep_presave completed")
         except asyncio.TimeoutError:
             _log(
                 f"tmux[{self.agent_name}]: idle_sleep_presave timed out after "

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -81,6 +81,7 @@ from pinky_daemon.transport_state import (
 from pinky_daemon.wake_prompt import (
     WakePromptInput,
     WakeReason,
+    build_idle_sleep_prompt,
     build_wake_prompt,
 )
 
@@ -1195,6 +1196,15 @@ class TmuxSession:
                 f"{_COLD_START_TIMEOUT_SEC}s"
             ) from None
 
+        # NOTE: ``force_fresh_context_once`` consumption is deferred to
+        # the END of ``_spawn_tmux_repl`` (after tailer startup also
+        # succeeds), NOT here. Murzik #545 follow-up round 2: the
+        # failure window includes tailer-start rollback, so clearing
+        # the flag immediately after ``_spawn()`` would still lose the
+        # fresh-context guarantee on retry if tailer-start failed
+        # afterward. Invariant: flag remains set until REPL + tailer
+        # are both up as a unit.
+
         # REPL is up — bring up the response capture pipeline (PR8b).
         # Kept OUTSIDE the cold-start timeout so tailer construction
         # (which stats the project dir to guess the transcript path)
@@ -1224,6 +1234,17 @@ class TmuxSession:
                 pass
             raise
 
+        # REPL + tailer are both up as a unit — NOW it's safe to
+        # consume the one-shot ``force_fresh_context_once`` flag
+        # (Murzik #545 follow-up round 2). Clearing earlier (right
+        # after ``_spawn()`` returned) would still lose the fresh-
+        # context guarantee on retry if tailer startup then failed
+        # and rolled back the whole launch. The invariant pinned here:
+        # the flag remains set until launch (REPL + tailer) succeeds
+        # as a complete unit.
+        if self._last_launch_forced_fresh:
+            self._config.force_fresh_context_once = False
+
     def _build_claude_cmd(self) -> str:
         """Build the in-pane ``claude`` invocation as a single shell string.
 
@@ -1252,12 +1273,16 @@ class TmuxSession:
         root cause of #543 (tmux context_restart silently resumed the
         old transcript because we only checked transcript existence).
         """
-        # Resolve launch mode. One-shot consume of force_fresh_context_once
-        # is intentional — the flag is "next launch only," not "every
-        # launch from now on."
+        # Resolve launch mode. The flag is one-shot ("next launch only,"
+        # not "every launch from now on") but consumption happens in
+        # ``_spawn_tmux_repl`` AFTER ``_spawn()`` returns successfully —
+        # NOT here. Why: Murzik's #545 review caught that consuming the
+        # flag during command-build means a failed spawn + retry would
+        # silently lose the fresh-context guarantee and resume with
+        # ``--continue`` while still emitting context_restart wake copy.
+        # By deferring the consume, a retry sees the flag still set
+        # and honors it again. See ``_spawn_tmux_repl`` for the clear.
         force_fresh = bool(getattr(self._config, "force_fresh_context_once", False))
-        if force_fresh:
-            self._config.force_fresh_context_once = False
         has_prior = self._has_prior_transcript()
         use_continue = has_prior and not force_fresh
 
@@ -1444,7 +1469,7 @@ class TmuxSession:
         reason: str,
         wait_for_completion: bool = False,
         timeout_sec: float | None = None,
-    ) -> asyncio.Event | None:
+    ) -> None:
         """Queue a daemon-internal prompt with no external-side-effects.
 
         Differences vs ``send()``:
@@ -1474,10 +1499,14 @@ class TmuxSession:
         the instruction. Bounded by ``timeout_sec`` if provided — raises
         ``asyncio.TimeoutError`` on timeout.
 
-        Returns the completion ``asyncio.Event`` when
-        ``wait_for_completion=False`` so callers can optionally observe
-        it later (the worker still progresses); ``None`` when
-        ``wait_for_completion=True`` (the call has already waited).
+        Always returns ``None``. (Earlier drafts suggested returning the
+        completion event for lazy observation in fire-and-forget mode,
+        but the lazy-observe pattern isn't used by any current caller
+        and adds a footgun — the event would only be set when the
+        worker reaches that turn, which may be after several other
+        turns drain. Callers needing post-hoc completion signal must
+        opt into ``wait_for_completion=True`` and accept the inline
+        block. Murzik #545 follow-up.)
 
         Connection state: behaves like ``send()`` — drops with a log line
         if the session is not CONNECTED. Cold-start callers (``connect``)
@@ -1534,8 +1563,7 @@ class TmuxSession:
                 await asyncio.wait_for(completion.wait(), timeout=timeout_sec)
             else:
                 await completion.wait()
-            return None
-        return completion
+        return None
 
     # ── Response capture pipeline (PR8b) ────────────────────────────────
 
@@ -2521,11 +2549,62 @@ class TmuxSession:
         warm-wake on next inbound message.
 
         Drives ``CONNECTED → IDLE_SLEEPING`` via USER_AGENT.
+
+        **Pre-sleep save instruction** (PR for #543 idle-sleep parity).
+        Before the state transition + disconnect, send the agent the
+        same save-state instruction SDK sends in its
+        ``idle_sleep()``: "use reflect() / note your task so you can
+        resume." Delivery is via ``_enqueue_internal_prompt`` with
+        ``wait_for_completion=True`` — caller must NOT proceed to
+        disconnect until the agent has had a chance to honor the
+        instruction. Without that wait flag, tmux would paste the
+        instruction and kill the pane before the agent could call
+        reflect/save_my_context (the footgun Murzik flagged when
+        reviewing the internal-prompt API).
+
+        ``timeout_sec=120`` matches the conservative ceiling for a
+        single save turn — long enough for a typical reflect()/
+        save_my_context() roundtrip, tight enough that a wedged REPL
+        doesn't strand the session indefinitely in CONNECTED while
+        the operator/scheduler is trying to drive it to sleep.
+
+        Exceptions from the pre-sleep enqueue are logged + swallowed
+        (mirrors SDK's behavior) — a misbehaving REPL must not block
+        idle-sleep semantics. The session still transitions to
+        IDLE_SLEEPING + disconnects in that path; only the save-state
+        side-effect is lost.
         """
         if self.state != SessionState.CONNECTED:
             return False
 
         _log(f"tmux[{self.agent_name}]: idle_sleep")
+
+        # Pre-sleep save instruction. MUST run while still CONNECTED
+        # (``_enqueue_internal_prompt`` gates on state) and BEFORE the
+        # state-machine transition + disconnect below. The
+        # ``wait_for_completion=True`` semantic blocks here until the
+        # agent's turn ends so we don't disconnect mid-reflect.
+        try:
+            await self._enqueue_internal_prompt(
+                build_idle_sleep_prompt(),
+                reason="idle_sleep_presave",
+                wait_for_completion=True,
+                timeout_sec=120.0,
+            )
+            _log(
+                f"tmux[{self.agent_name}]: idle_sleep_presave completed "
+                f"(or in queue order if worker was busy)"
+            )
+        except asyncio.TimeoutError:
+            _log(
+                f"tmux[{self.agent_name}]: idle_sleep_presave timed out after "
+                f"120s — proceeding to disconnect anyway"
+            )
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: idle_sleep_presave failed: {e} — "
+                f"proceeding to disconnect anyway"
+            )
 
         # Pre-set IDLE_SLEEPING so disconnect's CONNECTED → DEAD fallback
         # doesn't fire (matches StreamingSession's choreography).

--- a/src/pinky_daemon/wake_prompt.py
+++ b/src/pinky_daemon/wake_prompt.py
@@ -41,8 +41,36 @@ __all__ = [
     "WakePromptInput",
     "build_wake_prompt",
     "wake_reason_from_runtime",
+    "build_idle_sleep_prompt",
     "DEFAULT_TIMEZONE",
 ]
+
+
+def build_idle_sleep_prompt() -> str:
+    """Pre-sleep instruction sent to the agent before idle-disconnect.
+
+    Separate text contract from the wake prompts: this is a save-state
+    instruction telling the agent to commit memory + note its task
+    before the session goes dormant. Both transports use the same text
+    but DIFFERENT delivery primitives — SDK does a synchronous
+    ``client.query`` (implicitly wait-for-completion), tmux must
+    enqueue via ``_enqueue_internal_prompt(wait_for_completion=True,
+    timeout_sec=...)``. Without the wait, tmux would paste the
+    instruction and kill the pane before the agent could honor it
+    (the footgun Murzik flagged in the internal-prompt API review).
+
+    Currently a static string for parity with SDK behavior. Future
+    versions could template by ``idle_timeout`` (the "over an hour"
+    phrasing is approximate — accurate for the default 3600s, but
+    not for an agent configured with a 30-min or 4-hour threshold).
+    """
+    return (
+        "[SYSTEM] You've been idle for over an hour. Auto-sleep is activating.\n\n"
+        "Before your session is suspended:\n"
+        "1. Use reflect() to persist key learnings and current task state\n"
+        "2. Note what you were working on so you can resume later\n\n"
+        "Your session will be preserved and resumed when you're needed next."
+    )
 
 
 def wake_reason_from_runtime(

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -951,6 +951,19 @@ async def test_idle_sleep_drives_to_idle_sleeping_not_dead() -> None:
     Same flicker-class bug as Pushok's PR #492 Nit 2 on CodexSession.
     """
     ss, tmux = _make_session(state=SessionState.CONNECTED)
+
+    # idle_sleep now enqueues a pre-sleep prompt via
+    # ``_enqueue_internal_prompt(wait_for_completion=True, timeout_sec=120)``
+    # before the state transition. This unit test doesn't run a real
+    # message queue/worker/tailer, so the wait would block on the
+    # 120s timeout. Stub the helper to a no-op (same pattern used by
+    # ``TestIdleSleepPresavePrompt`` below) so we exercise only the
+    # CONNECTED → IDLE_SLEEPING transition this test is pinning.
+    async def _noop(prompt, *, reason, wait_for_completion=False, timeout_sec=None):
+        return None
+
+    ss._enqueue_internal_prompt = _noop
+
     result = await ss.idle_sleep()
     assert result is True
     assert ss.state == SessionState.IDLE_SLEEPING

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3199,24 +3199,6 @@ class TestForceFreshContextOnce:
             "a prior transcript exists"
         )
 
-    def test_build_claude_cmd_consumes_flag_one_shot(self):
-        ss, _ = _make_session()
-        ss._has_prior_transcript = lambda: True
-        ss._config.force_fresh_context_once = True
-
-        # First call — consumed.
-        cmd1 = ss._build_claude_cmd()
-        assert "--continue" not in cmd1
-        # Flag is now reset to False.
-        assert ss._config.force_fresh_context_once is False
-
-        # Second call — back to normal behavior (--continue because
-        # prior transcript exists).
-        cmd2 = ss._build_claude_cmd()
-        assert "--continue" in cmd2, (
-            "flag is one-shot — second launch should resume normally"
-        )
-
     def test_build_claude_cmd_records_launch_mode_on_session(self):
         ss, _ = _make_session()
         ss._has_prior_transcript = lambda: True
@@ -3314,3 +3296,254 @@ class TestWakePromptEnqueueOnConnect:
         assert "## Continuation" in turn.prompt
         assert "Working on X" in turn.prompt
         await ss.disconnect()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Idle-sleep parity (PR B for #543) + #545 follow-ups (Murzik review)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestIdleSleepPresavePrompt:
+    """Pre-sleep save instruction parity with SDK.
+
+    Tmux ``idle_sleep()`` must enqueue the "use reflect()/save state"
+    prompt the SDK sends, with ``wait_for_completion=True`` so the
+    disconnect doesn't kill the pane before the agent honors the
+    instruction (the footgun Murzik flagged when reviewing the
+    internal-prompt API)."""
+
+    @pytest.mark.asyncio
+    async def test_idle_sleep_enqueues_presave_prompt_before_disconnect(self):
+        """The pre-sleep prompt must be enqueued via
+        ``_enqueue_internal_prompt`` BEFORE the state transition to
+        IDLE_SLEEPING — otherwise the enqueue gate (which requires
+        CONNECTED) would drop the prompt."""
+        ss, tmux = _make_session(state=SessionState.CONNECTED)
+        observed: list[tuple[str, dict]] = []
+
+        async def _spy(prompt, *, reason, wait_for_completion=False, timeout_sec=None):
+            observed.append(
+                (prompt, {"reason": reason, "wait": wait_for_completion, "timeout": timeout_sec})
+            )
+            # Don't actually call original — we don't want to involve the
+            # message queue + worker in this unit test (no transcript
+            # tailer to fire ``_handle_turn_complete``). The contract
+            # we're pinning is "idle_sleep called _enqueue_internal_prompt
+            # with the right args BEFORE state transition + disconnect."
+            return None
+
+        ss._enqueue_internal_prompt = _spy
+
+        result = await ss.idle_sleep()
+        assert result is True
+        assert ss.state == SessionState.IDLE_SLEEPING
+
+        # The pre-sleep prompt was sent.
+        assert len(observed) == 1, "exactly one pre-sleep prompt expected"
+        prompt, kwargs = observed[0]
+        assert "Auto-sleep is activating" in prompt
+        assert "reflect()" in prompt
+        assert kwargs["reason"] == "idle_sleep_presave"
+        assert kwargs["wait"] is True, (
+            "wait_for_completion MUST be True — otherwise disconnect "
+            "would kill the pane before the agent could honor the save "
+            "instruction (footgun from Murzik's API review)"
+        )
+        assert kwargs["timeout"] == 120.0
+
+    @pytest.mark.asyncio
+    async def test_idle_sleep_proceeds_on_presave_timeout(self):
+        """A wedged REPL must not block idle-sleep semantics. If the
+        pre-sleep enqueue times out, log + continue to disconnect."""
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+
+        async def _timeout(*args, **kwargs):
+            raise asyncio.TimeoutError("simulated")
+
+        ss._enqueue_internal_prompt = _timeout
+
+        result = await ss.idle_sleep()
+        assert result is True, (
+            "idle_sleep must complete even when pre-sleep enqueue raises"
+        )
+        assert ss.state == SessionState.IDLE_SLEEPING
+
+    @pytest.mark.asyncio
+    async def test_idle_sleep_proceeds_on_presave_arbitrary_failure(self):
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+
+        async def _raise(*args, **kwargs):
+            raise RuntimeError("simulated REPL failure")
+
+        ss._enqueue_internal_prompt = _raise
+
+        result = await ss.idle_sleep()
+        assert result is True
+        assert ss.state == SessionState.IDLE_SLEEPING
+
+
+class TestForceFreshContextOnceDeferredConsume:
+    """Murzik's #545 follow-up: the flag MUST stay set across a failed
+    spawn so a retry honors the fresh-context guarantee. Two regressions:
+
+    1. ``new_session`` fails first time → retry sees flag still set.
+    2. ``_start_tailer`` fails first time → retry sees flag still set
+       (this is the round-2 case that catches a post-``_spawn()``
+       clear instead of post-``_start_tailer()`` clear).
+    """
+
+    @pytest.mark.asyncio
+    async def test_build_claude_cmd_does_not_consume_flag(self):
+        """The flag must survive ``_build_claude_cmd`` so a failed
+        ``_spawn_tmux_repl`` leaves the flag observable for retry."""
+        ss, _ = _make_session()
+        ss._has_prior_transcript = lambda: True
+        ss._config.force_fresh_context_once = True
+
+        ss._build_claude_cmd()
+
+        assert ss._config.force_fresh_context_once is True, (
+            "_build_claude_cmd must NOT consume the flag — that's the "
+            "spawn-success path's job. Premature consumption is the bug "
+            "Murzik caught on PR #545 review."
+        )
+
+    @pytest.mark.asyncio
+    async def test_force_fresh_survives_failed_new_session_retry(self):
+        """Failure mode 1: ``new_session`` fails on first attempt.
+        Flag stays set; retry's ``_build_claude_cmd`` re-applies the
+        suppression."""
+        tmux = _make_mock_tmux()
+        # First call fails, second call succeeds.
+        tmux.new_session = AsyncMock(side_effect=[_fail("rc=1"), _ok()])
+        ss, _ = _make_session(tmux=tmux)
+
+        # Seed flag + prior transcript so suppression is meaningful.
+        ss._config.force_fresh_context_once = True
+        ss._has_prior_transcript = lambda: True
+
+        # First connect — should fail.
+        with pytest.raises(RuntimeError, match="new-session failed"):
+            await ss.connect()
+
+        # Flag must still be set so the retry honors it.
+        assert ss._config.force_fresh_context_once is True, (
+            "force_fresh_context_once was consumed despite spawn failure — "
+            "retry would silently lose the fresh-context guarantee"
+        )
+
+        # Reset state machine + recreate tmux (kept original behavior:
+        # second new_session call returns _ok()). Force CONNECTED-eligible
+        # state for retry.
+        ss._state_machine._state = SessionState.UNINITIALIZED
+        await ss.connect()
+        assert ss.state == SessionState.CONNECTED
+        # After successful spawn + tailer, flag is now consumed.
+        assert ss._config.force_fresh_context_once is False, (
+            "flag must consume on successful launch — otherwise it stays "
+            "set forever and every subsequent launch is fresh"
+        )
+
+    @pytest.mark.asyncio
+    async def test_force_fresh_survives_failed_tailer_start_retry(self):
+        """Failure mode 2 (the round-2 case): ``_start_tailer`` fails
+        after ``new_session`` succeeded. Flag stays set; retry honors it.
+
+        This is the test that catches a post-``_spawn()`` clear
+        (the round-1 fix that Murzik flagged as still buggy)."""
+        ss, _ = _make_session()
+        ss._config.force_fresh_context_once = True
+        ss._has_prior_transcript = lambda: True
+
+        # Make _start_tailer fail on first call, succeed on second.
+        call_count = {"n": 0}
+        real_start_tailer = ss._start_tailer
+
+        async def _flaky_start_tailer():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("simulated tailer-start failure")
+            await real_start_tailer()
+
+        ss._start_tailer = _flaky_start_tailer
+
+        # First connect — tailer-start raises, _spawn_tmux_repl rolls
+        # back the tmux session, exception propagates.
+        with pytest.raises(RuntimeError, match="tailer-start failure"):
+            await ss.connect()
+
+        # Round-2 case: even though ``_spawn()`` succeeded above, the
+        # tailer-start failure rolled back the whole launch — flag
+        # MUST still be set.
+        assert ss._config.force_fresh_context_once is True, (
+            "force_fresh_context_once was consumed after _spawn() but "
+            "before _start_tailer() succeeded — retry would lose the "
+            "fresh-context guarantee. This is the round-2 case from "
+            "Murzik's #545 review."
+        )
+
+        # Reset for retry.
+        ss._state_machine._state = SessionState.UNINITIALIZED
+        await ss.connect()
+        # After REPL + tailer both up, NOW the flag clears.
+        assert ss._config.force_fresh_context_once is False
+
+
+class TestInternalPromptReturnContract:
+    """Murzik #545 follow-up: ``_enqueue_internal_prompt`` always
+    returns None. Earlier drafts suggested lazy event observation on
+    wait=False but the pattern wasn't used and added a footgun."""
+
+    @pytest.mark.asyncio
+    async def test_wait_false_returns_none(self):
+        ss, _ = _make_session()
+        ss._state_machine._state = SessionState.CONNECTED
+        result = await ss._enqueue_internal_prompt(
+            "wake",
+            reason="wake_new_session",
+            wait_for_completion=False,
+        )
+        assert result is None, (
+            "wait_for_completion=False must return None — lazy event "
+            "observation is intentionally not part of the contract "
+            "(Murzik #545 follow-up; doc/impl mismatch fixed)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_wait_true_returns_none(self):
+        """For consistency: wait_for_completion=True also returns None
+        (the call already waited inline)."""
+        ss, _ = _make_session()
+        ss._state_machine._state = SessionState.CONNECTED
+
+        # Same simulation as test_wait_for_completion_true_blocks_until_event_fires.
+        async def _enqueue():
+            return await ss._enqueue_internal_prompt(
+                "presave",
+                reason="idle_sleep_presave",
+                wait_for_completion=True,
+                timeout_sec=2.0,
+            )
+
+        task = asyncio.create_task(_enqueue())
+        for _ in range(5):
+            await asyncio.sleep(0)
+            if ss._message_queue.qsize() >= 1:
+                break
+        turn = await ss._message_queue.get()
+        ss._inflight_turn = turn
+        assert turn.completion_event is not None
+        turn.completion_event.set()
+        result = await asyncio.wait_for(task, timeout=1.0)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_dropped_when_not_connected_returns_none(self):
+        ss, _ = _make_session()
+        ss._state_machine._state = SessionState.DEAD
+        result = await ss._enqueue_internal_prompt(
+            "wake",
+            reason="wake_new_session",
+            wait_for_completion=False,
+        )
+        assert result is None


### PR DESCRIPTION
## What's in this PR

Two bundled changes, both addressing #543. Bundled because they touch overlapping code (`tmux_session.py` lines near each other) and the second item came up in Murzik's review of #545 while I was already in a fresh worktree on this branch — splitting would have forced a rebase dance.

### 1. Tmux `idle_sleep()` parity (the original PR B scope)

SDK's `idle_sleep()` sends a pre-sleep save instruction ("use `reflect()` / note your task") via `client.query()` before disconnect. Tmux didn't — just transitioned + disconnected, losing the save-state semantic that keeps agent memory healthy across idle cycles.

- Extracted the SDK pre-sleep text into `wake_prompt.build_idle_sleep_prompt()` — separate text contract from wake prompts (per Murzik's earlier API review framing).
- Refactored SDK to use the shared builder.
- Wired tmux `idle_sleep()` to enqueue via `_enqueue_internal_prompt(prompt, reason="idle_sleep_presave", wait_for_completion=True, timeout_sec=120.0)`. The `wait_for_completion=True` flag is the contract that prevents disconnect from killing the pane before the agent honors the save instruction.
- Pre-sleep exceptions (TimeoutError or arbitrary) are logged + swallowed so a wedged REPL doesn't block idle-sleep — mirrors SDK behavior.

### 2. #545 follow-ups (Murzik review on already-merged PR)

Referenced comment: https://github.com/bradbrok/PinkyBot/pull/545#issuecomment-4480668146

**Follow-up A — defer `force_fresh_context_once` consume to launch-success.**

`_build_claude_cmd()` was consuming the one-shot flag at command-build time. If `_spawn_tmux_repl()` then failed and retried, the second attempt would silently lose the fresh-context guarantee — `--continue` re-applied while wake copy still claimed "context restarted." Same bug class as the original #543 defect, hiding inside the launch path itself.

Murzik's round-2 nuance: failure window includes tailer-start rollback. `_spawn()` succeeding isn't enough; if `_start_tailer()` raises afterward, the whole launch is rolled back and a retry should still honor the flag.

Fix: `_build_claude_cmd()` only READS the flag (no consume). The clear moves to the END of `_spawn_tmux_repl()`, AFTER `await self._start_tailer()` completes successfully. Invariant: **flag remains set until REPL + tailer are both up as a unit.**

Regression tests cover both failure modes:
- `new_session` fails first attempt → flag survives → retry succeeds
- `_start_tailer` fails first attempt (the round-2 case) → flag survives → retry succeeds

Removed the stale `test_build_claude_cmd_consumes_flag_one_shot` test from PR A (it pinned the old buggy behavior).

**Follow-up B — `_enqueue_internal_prompt` return-value contract.**

Docstring claimed `wait_for_completion=False` returns the completion event for lazy observation; implementation returned None (the event isn't constructed in fire-and-forget mode). The lazy-observe pattern wasn't used by any caller and adds a footgun — the event would only fire when the worker reaches that turn, potentially after several other turns drain, so a caller awaiting it would block on unrelated work.

Fix: standardize on always-None return. Signature updated to `-> None`. Docstring rewritten explaining the choice. Tests pin the contract for `wait=False`, `wait=True`, and the not-connected-drop path.

## Tests

9 new tests (3 idle_sleep + 3 deferred-consume regressions + 3 return-contract pins). 1 stale test removed (PR A's `test_build_claude_cmd_consumes_flag_one_shot`).

- `pytest tests/test_tmux_session.py tests/test_wake_prompt.py tests/test_streaming_session.py` → **189 passed**
- Full `pytest` → **2576 passed, 1 skipped** (+8 vs main post-#545)
- `ruff check src/ tests/` → **clean**

## Coordination

Murzik's PR #544 (TB-03 thinking metadata parity) was rebased onto current main; merges cleanly regardless of order vs this PR.

After this PR + #544 land:
- WC-01, CR-01, AS-01, TB-03 matrix items from the #543 validation runbook are all wired up in code.
- Live Dymok validation per `docs/runbooks/tmux-validation.md` is the next gate.

## Test plan

- [x] All pre-existing tests pass (no regressions, including PR A's still-applicable tests)
- [x] 9 new tests cover the new behavior + the Murzik-flagged regression cases
- [x] Ruff clean
- [ ] Manual: idle_sleep on a live Dymok session — verify pre-sleep prompt lands in transcript + Dymok calls reflect/save_my_context before pane disconnects (AS-01 in the runbook)
- [ ] Manual: trigger context_restart on a tmux agent + verify launch mode log shows `mode=fresh force_fresh=True` and the wake prompt body matches `CONTEXT_RESTART` copy (CR-01 in the runbook)

Refs #543, addresses Murzik review on #545.

🤖 Opened by Barsik