### PR TITLE
remove agent-initiated deep sleep (Pulse v2 carry-over)

### DIFF
--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -1238,7 +1238,7 @@
                                 {#if a.name !== mainAgent}
                                     <button class="btn btn-sm" on:click|stopPropagation={() => setMainAgent(a.name)}>{$_('agents.set_main')}</button>
                                 {/if}
-                                <!-- "Sleep" button removed in #549 — sleep is now exclusively
+                                <!-- "Sleep" button removed in #552 — sleep is now exclusively
                                      watchdog-driven so the resume handle is preserved and
                                      inbound platform messages can warm-wake the agent. -->
                                 <button class="btn-danger-text" on:click|stopPropagation={() => openRetireModal(a.name)}>{$_('agents.retire')}</button>

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -488,16 +488,6 @@
         toast(`${name} is now the main agent`);
     }
 
-    async function sleepAgent(name) {
-        try {
-            const result = await api('POST', `/agents/${name}/sleep`);
-            toast(`${name} put to sleep (${result.sessions_closed} session${result.sessions_closed !== 1 ? 's' : ''} closed)`);
-            refreshAgents();
-        } catch (e) {
-            toast(`Can't sleep ${name}: ${e.message}`);
-        }
-    }
-
     async function openDetail(name) {
         currentAgent = name;
         activeTab = 'identity';
@@ -1248,11 +1238,9 @@
                                 {#if a.name !== mainAgent}
                                     <button class="btn btn-sm" on:click|stopPropagation={() => setMainAgent(a.name)}>{$_('agents.set_main')}</button>
                                 {/if}
-                                {#if agentPresence.streaming || aSessions.length > 0}
-                                    <button class="btn btn-sm btn-sleep" on:click|stopPropagation={() => sleepAgent(a.name)} title="Put agent to sleep">
-                                        <span class="material-symbols-outlined" style="font-size:14px">dark_mode</span> Sleep
-                                    </button>
-                                {/if}
+                                <!-- "Sleep" button removed in #549 — sleep is now exclusively
+                                     watchdog-driven so the resume handle is preserved and
+                                     inbound platform messages can warm-wake the agent. -->
                                 <button class="btn-danger-text" on:click|stopPropagation={() => openRetireModal(a.name)}>{$_('agents.retire')}</button>
                             </div>
                         </div>

--- a/frontend-svelte/src/pages/Dashboard.svelte
+++ b/frontend-svelte/src/pages/Dashboard.svelte
@@ -51,17 +51,6 @@
         return 'var(--green)';
     }
 
-    async function sleepAgent(name, event) {
-        event.preventDefault();
-        event.stopPropagation();
-        try {
-            await api('POST', `/agents/${name}/sleep`);
-            refresh();
-        } catch (e) {
-            toast(`Failed to sleep ${name}`, 'error');
-        }
-    }
-
     async function stopAgent(name, event) {
         event.preventDefault();
         event.stopPropagation();
@@ -334,9 +323,12 @@
                                     <button class="btn-stop" on:click={(e) => stopAgent(agent.name, e)} title="Force stop" aria-label="Force stop {agent.name}">
                                         <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><rect x="4" y="4" width="16" height="16" rx="2"/></svg>
                                     </button>
-                                    <button class="btn-sleep" on:click={(e) => sleepAgent(agent.name, e)} title="Put to sleep" aria-label="Put {agent.name} to sleep">
-                                        <span class="material-symbols-outlined" style="font-size:14px">dark_mode</span>
-                                    </button>
+                                    <!-- The "put to sleep" button was removed in #549 along with the
+                                         /agents/{name}/sleep endpoint and request_sleep MCP tool.
+                                         Sleep is now exclusively watchdog-driven idle-sleep, which
+                                         preserves the resume handle so any platform's inbound
+                                         message warm-wakes the agent. For forced shutdown, use
+                                         the existing Stop button. -->
                                 {/if}
                             </div>
                         </div>

--- a/frontend-svelte/src/pages/Dashboard.svelte
+++ b/frontend-svelte/src/pages/Dashboard.svelte
@@ -323,7 +323,7 @@
                                     <button class="btn-stop" on:click={(e) => stopAgent(agent.name, e)} title="Force stop" aria-label="Force stop {agent.name}">
                                         <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><rect x="4" y="4" width="16" height="16" rx="2"/></svg>
                                     </button>
-                                    <!-- The "put to sleep" button was removed in #549 along with the
+                                    <!-- The "put to sleep" button was removed in #552 along with the
                                          /agents/{name}/sleep endpoint and request_sleep MCP tool.
                                          Sleep is now exclusively watchdog-driven idle-sleep, which
                                          preserves the resume handle so any platform's inbound

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6913,7 +6913,7 @@ def create_api(
         return {"cleared": True}
 
     # Note: `POST /agents/{name}/sleep` (deep_sleep_agent) was removed
-    # in #549. It was a Pulse v2 carry-over that fully closed sessions
+    # in #552. It was a Pulse v2 carry-over that fully closed sessions
     # — bypassing the IDLE_SLEEPING state — so broker auto-wake on
     # inbound platform messages had no resume handle to grab onto
     # (Telegram, Discord, etc. hit the "not running" path; web chat

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6912,42 +6912,16 @@ def create_api(
         agents.clear_context(agent_name)
         return {"cleared": True}
 
-    @app.post("/agents/{agent_name}/sleep")
-    async def deep_sleep_agent(agent_name: str):
-        """Put an agent into deep sleep after a recent explicit save.
-
-        All sessions are closed only if the current session has a
-        recent save_my_context() checkpoint. On next wake, that
-        saved continuation context is restored.
-        """
-        agent = agents.get(agent_name)
-        if not agent:
-            raise HTTPException(404, f"Agent '{agent_name}' not found")
-
-        ss = broker._get_streaming_session(agent_name)
-        if ss:
-            guard = _get_streaming_restart_guard(agent_name, ss)
-            if not guard["restart_safe"]:
-                raise HTTPException(409, _guard_message("sleep", guard))
-
-        streaming_closed = await _disconnect_streaming_sessions(agent_name)
-
-        # Close legacy manager-backed sessions for this agent
-        closed = 0
-        for s in list(manager.list()):
-            if s.agent_name == agent_name:
-                manager.delete(s.id)
-                closed += 1
-
-        total_closed = streaming_closed + closed
-        _log(f"api: agent {agent_name} entered deep sleep, closed {total_closed} session(s)")
-        activity.log(agent_name, "agent_sleep", f"{agent_name} put to sleep manually")
-        return {
-            "agent": agent_name,
-            "status": "sleeping",
-            "sessions_closed": total_closed,
-            "context_saved": agents.get_context(agent_name) is not None,
-        }
+    # Note: `POST /agents/{name}/sleep` (deep_sleep_agent) was removed
+    # in #549. It was a Pulse v2 carry-over that fully closed sessions
+    # — bypassing the IDLE_SLEEPING state — so broker auto-wake on
+    # inbound platform messages had no resume handle to grab onto
+    # (Telegram, Discord, etc. hit the "not running" path; web chat
+    # masked the bug by cold-starting via its own /chat endpoint).
+    # The watchdog's idle-sleep at the agent's idle threshold is now
+    # the single sleep path; it transitions to IDLE_SLEEPING with the
+    # resume handle preserved, so the broker can warm-wake from any
+    # platform's inbound message via `_route_streaming`.
 
     @app.post("/agents/{agent_name}/stop")
     async def stop_agent(agent_name: str):

--- a/src/pinky_daemon/transport.py
+++ b/src/pinky_daemon/transport.py
@@ -285,7 +285,7 @@ class Transport(Protocol):
         cheaply re-woken on the next inbound message.
 
         Called by the watchdog when an agent exceeds its idle threshold.
-        (Agent-initiated ``request_sleep`` was removed in #549 — it
+        (Agent-initiated ``request_sleep`` was removed in #552 — it
         bypassed the IDLE_SLEEPING state and broke broker auto-wake.)
 
         Returns ``True`` if the sleep completed successfully.

--- a/src/pinky_daemon/transport.py
+++ b/src/pinky_daemon/transport.py
@@ -284,8 +284,9 @@ class Transport(Protocol):
         """Disconnect the transport but preserve resume info so it can be
         cheaply re-woken on the next inbound message.
 
-        Used by the agent's ``request_sleep`` MCP tool and by the watchdog
-        when an agent exceeds its idle threshold.
+        Called by the watchdog when an agent exceeds its idle threshold.
+        (Agent-initiated ``request_sleep`` was removed in #549 — it
+        bypassed the IDLE_SLEEPING state and broke broker auto-wake.)
 
         Returns ``True`` if the sleep completed successfully.
 

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -5,11 +5,21 @@ Gives agents tools to manage their own lifecycle:
 - Context management (save/load continuation state)
 - Task management (claim, complete, block, get next)
 - Health monitoring (check own status)
-- Sleep/wake control (request deep sleep, set wake timers)
 
 This server runs alongside the agent and connects to the
 PinkyBot API on localhost. Agents call these tools naturally
 during their work loop.
+
+Note: agent-initiated deep sleep (`request_sleep` tool +
+`POST /agents/{name}/sleep` endpoint) was removed in PR #549.
+It was a Pulse v2 carry-over: it fully closed the session
+instead of idle-sleeping with a retained resume_handle, which
+broke broker auto-wake from inbound platform messages
+(Telegram in particular — web chat hid the bug by cold-
+starting a fresh session via its own path). The watchdog
+idle-sleep at the agent's idle threshold is now the single
+sleep path; it preserves the resume handle so any platform's
+inbound message can warm-wake the agent.
 """
 
 from __future__ import annotations
@@ -175,7 +185,7 @@ def create_server(
         wake_action: str = "",
     ) -> str:
         """Snapshot working state for restoration after restart/sleep.
-        Required by restart guard — MUST call before context_restart or request_sleep.
+        Required by restart guard — MUST call before context_restart.
         Not for long-term memory (use reflect).
 
         wake_action: Required first thing to do on wake-up. Injected prominently
@@ -1099,29 +1109,11 @@ def create_server(
         old_turns = result.get("old_turns", 0)
         return f"Context restarted. Previous session: {old_id} ({old_turns} turns). Fresh context ready."
 
-    # ── Sleep/Wake Control ─────────────────────────────────
-
-    @mcp.tool()
-    def request_sleep(wake_cron: str = "", wake_prompt: str = "") -> str:
-        """Shut down session to conserve resources. Requires save_my_context() first.
-        Optionally set a wake_cron to auto-wake later.
-        """
-        # Set a wake schedule if requested
-        if wake_cron:
-            _api("POST", f"/agents/{agent_name}/schedules", {
-                "name": "sleep_wake",
-                "cron": wake_cron,
-                "prompt": wake_prompt or "Waking from requested sleep. Check context and resume.",
-            })
-
-        # Request deep sleep
-        result = _api("POST", f"/agents/{agent_name}/sleep")
-        if "error" in result:
-            return f"Sleep request failed: {result['error']}"
-
-        sessions_closed = result.get("sessions_closed", 0)
-        wake_info = f" Wake scheduled: {wake_cron}" if wake_cron else " No wake scheduled — rely on existing schedules."
-        return f"Entering deep sleep. {sessions_closed} session(s) closed. Context preserved.{wake_info}"
+    # ── Heartbeat ──────────────────────────────────────────
+    # Note: agent-initiated `request_sleep` tool was removed in #549.
+    # Sleep is now driven by the watchdog's idle threshold, which
+    # leaves the session in IDLE_SLEEPING with a retained resume
+    # handle so inbound platform messages warm-wake the agent.
 
     @mcp.tool()
     def send_heartbeat(status: str = "ok", context_pct: float = 0.0, notes: str = "") -> str:

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -11,7 +11,7 @@ PinkyBot API on localhost. Agents call these tools naturally
 during their work loop.
 
 Note: agent-initiated deep sleep (`request_sleep` tool +
-`POST /agents/{name}/sleep` endpoint) was removed in PR #549.
+`POST /agents/{name}/sleep` endpoint) was removed in PR #552.
 It was a Pulse v2 carry-over: it fully closed the session
 instead of idle-sleeping with a retained resume_handle, which
 broke broker auto-wake from inbound platform messages
@@ -1110,7 +1110,7 @@ def create_server(
         return f"Context restarted. Previous session: {old_id} ({old_turns} turns). Fresh context ready."
 
     # ── Heartbeat ──────────────────────────────────────────
-    # Note: agent-initiated `request_sleep` tool was removed in #549.
+    # Note: agent-initiated `request_sleep` tool was removed in #552.
     # Sleep is now driven by the watchdog's idle threshold, which
     # leaves the session in IDLE_SLEEPING with a retained resume
     # handle so inbound platform messages warm-wake the agent.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -537,42 +537,16 @@ class TestAPI:
                 assert len(data) == 1
                 assert data[0]["id"] == "adhoc"
 
-    def test_sleep_disconnects_streaming_main(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            db_path = os.path.join(tmpdir, "test.db")
-            app = self._make_app(db_path)
-            with TestClient(app) as client:
-                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
-                app.state.agents.set_streaming_session_id("test-agent", "persisted-main", label="main")
-                fake = self._FakeStreamingSession("test-agent", "main")
-                app.state.broker.register_streaming("test-agent", fake, label="main")
-                app.state.agents.set_context(
-                    "test-agent",
-                    task="Ready for sleep",
-                    metadata={"source": "save_my_context"},
-                    updated_by=fake.resume_handle,
-                )
-
-                resp = client.post("/agents/test-agent/sleep")
-                assert resp.status_code == 200
-                assert resp.json()["status"] == "sleeping"
-                assert fake.disconnect_calls == 1
-                assert app.state.broker._streaming.get("test-agent") is None
-                assert app.state.agents.get_streaming_session_id("test-agent", label="main") == ""
-
-    def test_sleep_requires_recent_explicit_context_save(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            db_path = os.path.join(tmpdir, "test.db")
-            app = self._make_app(db_path)
-            with TestClient(app) as client:
-                client.post("/agents", json={"name": "test-agent", "model": "sonnet"})
-                fake = self._FakeStreamingSession("test-agent", "main")
-                app.state.broker.register_streaming("test-agent", fake, label="main")
-
-                resp = client.post("/agents/test-agent/sleep")
-                assert resp.status_code == 409
-                assert "save_my_context" in resp.text
-                assert fake.disconnect_calls == 0
+    # Note: `test_sleep_disconnects_streaming_main` and
+    # `test_sleep_requires_recent_explicit_context_save` were removed
+    # in #549 along with the `POST /agents/{name}/sleep` endpoint
+    # (Pulse v2 carry-over). Agent-initiated deep sleep fully closed
+    # the session, breaking broker auto-wake from inbound platform
+    # messages (Telegram in particular — web chat masked the bug via
+    # its own cold-start path). Sleep is now exclusively watchdog-
+    # driven idle-sleep, which preserves the resume handle so any
+    # platform's inbound message warm-wakes the agent. See module
+    # docstring in pinky_self/server.py.
 
     def test_health_prefers_streaming_main(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -539,7 +539,7 @@ class TestAPI:
 
     # Note: `test_sleep_disconnects_streaming_main` and
     # `test_sleep_requires_recent_explicit_context_save` were removed
-    # in #549 along with the `POST /agents/{name}/sleep` endpoint
+    # in #552 along with the `POST /agents/{name}/sleep` endpoint
     # (Pulse v2 carry-over). Agent-initiated deep sleep fully closed
     # the session, breaking broker auto-wake from inbound platform
     # messages (Telegram in particular — web chat masked the bug via

--- a/tests/test_pinky_self.py
+++ b/tests/test_pinky_self.py
@@ -157,7 +157,7 @@ class TestSelfToolsWithAPI:
 
         os.unlink(path)
 
-    # `test_deep_sleep` was removed in #549 along with the
+    # `test_deep_sleep` was removed in #552 along with the
     # `POST /agents/{name}/sleep` endpoint and the `request_sleep`
     # MCP tool — see module docstring in pinky_self/server.py for
     # the rationale.

--- a/tests/test_pinky_self.py
+++ b/tests/test_pinky_self.py
@@ -45,7 +45,6 @@ class TestSelfServerCreation:
             "create_task",
             "check_my_health",
             "get_owner_profile",
-            "request_sleep",
             "send_heartbeat",
         ]
         for name in expected:
@@ -158,11 +157,7 @@ class TestSelfToolsWithAPI:
 
         os.unlink(path)
 
-    def test_deep_sleep(self):
-        client, path = self._make_client_and_server()
-
-        resp = client.post("/agents/test-agent/sleep")
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "sleeping"
-
-        os.unlink(path)
+    # `test_deep_sleep` was removed in #549 along with the
+    # `POST /agents/{name}/sleep` endpoint and the `request_sleep`
+    # MCP tool — see module docstring in pinky_self/server.py for
+    # the rationale.

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -963,45 +963,9 @@ class TestGetPresentationTemplate:
         assert "Brand template" in result
 
 
-# ── request_sleep ─────────────────────────────────────────────────────────────
-
-class TestRequestSleep:
-    def test_simple_sleep(self, srv):
-        with _ok({"sessions_closed": 1}):
-            result = _tools(srv)["request_sleep"]()
-        assert "sleep" in result.lower()
-        assert "1" in result
-
-    def test_sleep_with_wake_cron(self, srv):
-        call_count = [0]
-
-        def _urlopen(req, timeout=30):
-            call_count[0] += 1
-            if call_count[0] == 1:
-                # Schedule creation
-                data = {"id": 10, "name": "sleep_wake"}
-            else:
-                # Sleep request
-                data = {"sessions_closed": 2}
-            body = json.dumps(data).encode()
-            resp = MagicMock()
-            resp.read.return_value = body
-            resp.__enter__ = lambda s: s
-            resp.__exit__ = MagicMock(return_value=False)
-            return resp
-
-        with patch("urllib.request.urlopen", side_effect=_urlopen):
-            result = _tools(srv)["request_sleep"](
-                wake_cron="0 8 * * *",
-                wake_prompt="Morning tasks",
-            )
-        assert "sleep" in result.lower()
-        assert "0 8 * * *" in result
-
-    def test_error(self, srv):
-        with _ok({"error": "no session"}):
-            result = _tools(srv)["request_sleep"]()
-        assert "failed" in result.lower() or "Sleep request failed" in result
+# Note: `TestRequestSleep` was removed in #549 along with the
+# `request_sleep` MCP tool (Pulse v2 carry-over). Sleep is now
+# watchdog-driven; see module docstring in pinky_self/server.py.
 
 
 # ── send_to_agent ─────────────────────────────────────────────────────────────
@@ -1987,7 +1951,7 @@ CORE_TOOLS = {
     "claim_task", "complete_task", "context_restart", "context_status",
     "create_task", "get_next_task", "get_owner_profile",
     "list_agents", "list_my_skills", "load_my_context",
-    "load_skill", "mesh_remote_send", "request_sleep", "save_my_context",
+    "load_skill", "mesh_remote_send", "save_my_context",
     "search_history", "send_file_to_agent", "send_heartbeat",
     "send_to_agent", "set_thinking_effort", "who_am_i",
 }
@@ -2040,21 +2004,27 @@ class TestKbUrlEncoding:
 
 
 class TestToolGates:
-    def test_core_only_has_24_tools(self):
-        """No gates → only core tools registered."""
+    def test_core_only_has_23_tools(self):
+        """No gates → only core tools registered.
+
+        Drop from 24 in #549 with the removal of ``request_sleep``.
+        """
         srv = create_server(agent_name="test", tool_gates=[])
         tools = {t.name for t in srv._tool_manager.list_tools()}
         assert tools == CORE_TOOLS
 
-    def test_all_gates_has_69_tools(self):
-        """All gates → full tool set."""
+    def test_all_gates_has_68_tools(self):
+        """All gates → full tool set.
+
+        Drop from 69 in #549 with the removal of ``request_sleep``.
+        """
         all_gates = [
             "extras", "kb", "research", "presentations", "triggers",
             "schedule", "skill-admin", "admin", "tasks-admin",
         ]
         srv = create_server(agent_name="test", tool_gates=all_gates)
         tools = srv._tool_manager.list_tools()
-        assert len(tools) == 69
+        assert len(tools) == 68
 
     def test_extras_gate_adds_extras_tools(self):
         """Enabling 'extras' gate adds get_attribution, render_pdf, etc."""

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -963,7 +963,7 @@ class TestGetPresentationTemplate:
         assert "Brand template" in result
 
 
-# Note: `TestRequestSleep` was removed in #549 along with the
+# Note: `TestRequestSleep` was removed in #552 along with the
 # `request_sleep` MCP tool (Pulse v2 carry-over). Sleep is now
 # watchdog-driven; see module docstring in pinky_self/server.py.
 
@@ -2007,7 +2007,7 @@ class TestToolGates:
     def test_core_only_has_23_tools(self):
         """No gates → only core tools registered.
 
-        Drop from 24 in #549 with the removal of ``request_sleep``.
+        Drop from 24 in #552 with the removal of ``request_sleep``.
         """
         srv = create_server(agent_name="test", tool_gates=[])
         tools = {t.name for t in srv._tool_manager.list_tools()}
@@ -2016,7 +2016,7 @@ class TestToolGates:
     def test_all_gates_has_68_tools(self):
         """All gates → full tool set.
 
-        Drop from 69 in #549 with the removal of ``request_sleep``.
+        Drop from 69 in #552 with the removal of ``request_sleep``.
         """
         all_gates = [
             "extras", "kb", "research", "presentations", "triggers",


### PR DESCRIPTION
## Summary

Brad reported that when `dymok` (a tmux agent) calls `request_sleep`, **Telegram messages don't wake him back up — but web chat does.**

Root cause: `request_sleep` → `POST /agents/{name}/sleep` → fully closes the session (no `IDLE_SLEEPING` state, resume handle gone). When a TG message arrives, the broker's `_route_streaming` auto-wake path finds no session in `IDLE_SLEEPING` and the resume handle is wiped, so warm-wake can't fire. Web chat masks the bug because the `/agents/{name}/chat` endpoint has its own cold-start path that creates a fresh session.

Per Brad: "deep sleep is an artifact of Pulse v2 we brought over. We control it via Pinky anyways." Watchdog idle-sleep is the right path — it preserves the resume handle, so any platform's inbound message can warm-wake the agent.

## What's removed

- **MCP tool** `request_sleep` (`src/pinky_self/server.py`)
- **API endpoint** `POST /agents/{name}/sleep` (`src/pinky_daemon/api.py`)
- **Frontend** "Put to sleep" buttons + `sleepAgent` handlers in `Dashboard.svelte` and `Agents.svelte` (the only frontend callers of the removed endpoint)
- **Tests** referencing the removed surface: `TestRequestSleep` class, `test_deep_sleep`, `test_sleep_disconnects_streaming_main`, `test_sleep_requires_recent_explicit_context_save`; expected-tools lists updated (core 24→23, all-gates 69→68)

Module docstrings and `transport.idle_sleep` docstring updated to point at this PR for the rationale.

## What's kept (these are correct, not buggy)

- `transport.idle_sleep()` + `SessionState.IDLE_SLEEPING` — the good sleep path, driven by the watchdog
- `_disconnect_streaming_sessions` helper — also used by `/stop` and restart paths
- `POST /agents/{name}/stop` — emergency force-stop, deliberately distinct from the removed soft sleep
- `set_wake_schedule` MCP tool — still useful for non-sleep-coupled cron wakes

## Test plan

- [x] `pytest tests/test_api.py tests/test_pinky_self.py tests/test_pinky_self_tools.py` — 466 passing
- [x] `ruff check` on touched files — clean
- [ ] @murzik review before merge (per the new tod-dashboard rule, applying to PinkyBot daemon PRs too)
- [ ] Post-merge smoke: pick a tmux agent (e.g. dymok), let watchdog idle-sleep it, send a Telegram message, confirm warm-wake fires

## Notes

- Diff is ~70 LOC additions (mostly historical-note comments) and ~180 LOC deletions. No new behavior.
- This is a `chore:` / removal PR — no migration step, no DB change, no config change. Merge-and-deploy is the entire rollout.
- Frontend buttons are removed entirely rather than redirecting to `/stop` — sleep and stop have semantically different meanings and silently switching one to the other would be confusing UX. If a manual "make agent inactive now" path is desired, the existing Stop button on Dashboard.svelte covers it.

---

🤖 Opened by Barsik