### PR TITLE
feat(agents-ui): expose tmux transport + default it for Anthropic

### DIFF
--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -205,6 +205,8 @@
     let wizTimeout = 300;
     let wizMaxSessions = 5;
     let wizPlainTextFallback = false;
+    let wizTransport = 'tmux';        // 'tmux' | 'sdk' — defaults to tmux for Anthropic, sdk for others
+    let wizTransportUserSet = false;  // tracks whether user manually changed the toggle (suppresses auto-default)
     let wizCustomSoul = '';
     let wizTelegramToken = '';
     let wizDiscordToken = '';
@@ -430,6 +432,28 @@
     async function restartSession(id) {
         await api('POST', `/sessions/${id}/restart`);
         refreshAgents();
+    }
+
+    /**
+     * Flip an agent's transport between 'tmux' and 'sdk'.
+     * The change is persisted immediately but only takes effect when the
+     * agent's sessions are restarted — the runtime selects the transport
+     * at spawn time.
+     */
+    async function toggleAgentTransport(agentName, currentTransport, runtime) {
+        if (runtime && runtime !== 'claude_sdk') {
+            toast('Tmux transport requires claude_sdk runtime', 'error');
+            return;
+        }
+        const current = (currentTransport || 'sdk').toLowerCase();
+        const next = current === 'tmux' ? 'sdk' : 'tmux';
+        try {
+            await api('PUT', `/agents/${agentName}`, { transport: next });
+            toast(`Transport → ${next.toUpperCase()} (restart session to apply)`);
+            refreshAgents();
+        } catch (e) {
+            toast('Failed to update transport: ' + (e?.message || e), 'error');
+        }
     }
 
     function openChat(id) {
@@ -966,7 +990,7 @@
 
     // Wizard
     let wizPronouns = '';
-    function openWizard() { wizStep = -1; importMode = false; importStep = 1; importFiles = { workspace: null, config: null, lock: null }; importDirPath = ''; importParseId = null; importPreview = null; importLoading = false; importTaskId = null; importProgress = { total: 0, imported: 0, failed: 0, done: false }; importDragover = false; importError = null; importAgentName = null; if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizName = ''; wizDisplayName = ''; wizPronouns = ''; wizModel = 'claude-opus-4-6'; wizProviderRef = ''; wizCustomProvider = false; wizProviderPreset = 'anthropic'; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; wizMode = 'bypassPermissions'; wizHeart = 'sidekick'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizThinkingEffort = 'medium'; wizShowAdvanced = false; wizMaxTurns = 0; wizTimeout = 300; wizMaxSessions = 5; wizPlainTextFallback = false; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; globalProviders = api('GET', '/providers').then(d => globalProviders = d || []).catch(() => []); wizardOpen = true; }
+    function openWizard() { wizStep = -1; importMode = false; importStep = 1; importFiles = { workspace: null, config: null, lock: null }; importDirPath = ''; importParseId = null; importPreview = null; importLoading = false; importTaskId = null; importProgress = { total: 0, imported: 0, failed: 0, done: false }; importDragover = false; importError = null; importAgentName = null; if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizName = ''; wizDisplayName = ''; wizPronouns = ''; wizModel = 'claude-opus-4-6'; wizProviderRef = ''; wizCustomProvider = false; wizProviderPreset = 'anthropic'; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; wizMode = 'bypassPermissions'; wizHeart = 'sidekick'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizThinkingEffort = 'medium'; wizShowAdvanced = false; wizMaxTurns = 0; wizTimeout = 300; wizMaxSessions = 5; wizPlainTextFallback = false; wizTransport = 'tmux'; wizTransportUserSet = false; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; globalProviders = api('GET', '/providers').then(d => globalProviders = d || []).catch(() => []); wizardOpen = true; }
     function closeWizard() { if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizardOpen = false; }
 
     // Import (OpenClaw migration) helpers
@@ -1082,7 +1106,7 @@
         let soul = soulResp.soul;
         // Determine the model alias to register — use 'opus' default if using a provider
         const registerModel = (!wizProviderRef && !wizCustomProvider && wizProviderUrl !== 'codex_cli') ? wizModel : (wizProviderModel || 'claude-sonnet-4-6');
-        await api('POST', '/agents', { name: wizName, display_name: wizDisplayName, model: registerModel, permission_mode: wizMode, soul, role: wizRole, auto_start: wizAutoStart, heartbeat_interval: wizHeartbeatInterval, thinking_effort: wizThinkingEffort, max_turns: wizMaxTurns, timeout: wizTimeout, max_sessions: wizMaxSessions, plain_text_fallback: wizPlainTextFallback });
+        await api('POST', '/agents', { name: wizName, display_name: wizDisplayName, model: registerModel, permission_mode: wizMode, soul, role: wizRole, auto_start: wizAutoStart, heartbeat_interval: wizHeartbeatInterval, thinking_effort: wizThinkingEffort, max_turns: wizMaxTurns, timeout: wizTimeout, max_sessions: wizMaxSessions, plain_text_fallback: wizPlainTextFallback, transport: wizIsAnthropic ? wizTransport : 'sdk' });
         // Apply provider config if a global provider, custom endpoint, or Codex was selected
         if (wizProviderRef || wizCustomProvider || wizProviderUrl === 'codex_cli') {
             await api('PUT', `/agents/${wizName}/provider`, {
@@ -1110,6 +1134,19 @@
         (wizDiscordToken || (wizDiscordRef && wizDiscordRef !== '__manual__')) && 'Discord',
         (wizSlackToken || (wizSlackRef && wizSlackRef !== '__manual__')) && 'Slack',
     ].filter(Boolean);
+
+    // Anthropic-runtime detection: true when the wizard is configured for the built-in Claude SDK path.
+    // Tmux transport only works on runtime=claude_sdk, so this gates the toggle.
+    $: wizIsAnthropic = !wizProviderRef && !wizCustomProvider && wizProviderUrl !== 'codex_cli';
+
+    // Auto-default transport based on provider, unless user has manually flipped the toggle.
+    // Anthropic → tmux (the new default). Codex/custom → sdk (tmux is incompatible).
+    $: if (!wizTransportUserSet) {
+        wizTransport = wizIsAnthropic ? 'tmux' : 'sdk';
+    } else if (!wizIsAnthropic && wizTransport === 'tmux') {
+        // Hard override: tmux is incompatible with non-Anthropic runtimes; force sdk even if user picked tmux.
+        wizTransport = 'sdk';
+    }
 
     async function loadModels() {
         try { modelRegistry = await api('/models'); } catch(e) { console.warn('Failed to load models:', e); }
@@ -1203,7 +1240,22 @@
 
                             <!-- Expanded detail -->
                             {#if isExpanded}
+                                {@const aTransport = (a.transport || 'sdk').toLowerCase()}
+                                {@const aRuntime = a.runtime || 'claude_sdk'}
+                                {@const transportToggleDisabled = aRuntime !== 'claude_sdk'}
                                 <div class="agent-inline-detail">
+                                    <div class="outreach-row" style="gap:0.5rem">
+                                        <span class="badge badge-platform">transport</span>
+                                        <span class="badge badge-{aTransport === 'tmux' ? 'on' : 'off'}">{aTransport.toUpperCase()}</span>
+                                        <button class="btn btn-sm"
+                                                style={transportToggleDisabled ? 'opacity:0.4;cursor:not-allowed' : ''}
+                                                disabled={transportToggleDisabled}
+                                                title={transportToggleDisabled ? 'Tmux transport requires claude_sdk runtime' : 'Switch transport (restart session to apply)'}
+                                                on:click|stopPropagation={() => toggleAgentTransport(a.name, aTransport, aRuntime)}>
+                                            → {aTransport === 'tmux' ? 'SDK' : 'TMUX'}
+                                        </button>
+                                        <span style="font-size:0.65rem;color:var(--gray-mid)">restart session to apply</span>
+                                    </div>
                                     {#each aTokens as t}
                                         <div class="outreach-row">
                                             <span class="badge badge-platform">{t.platform}</span>
@@ -2557,6 +2609,27 @@
                                 <label style="display:flex;align-items:center;gap:0.5rem;font-family:var(--font-grotesk);font-size:0.78rem;cursor:pointer">
                                     <input type="checkbox" bind:checked={wizPlainTextFallback}> {$_('agents_extra.advanced_plain_text')}
                                 </label>
+                                <div>
+                                    <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">Transport</div>
+                                    <div style="display:flex;gap:0.5rem">
+                                        <button type="button" class="wizard-option" class:selected={wizTransport === 'tmux'}
+                                                style="flex:1;text-align:left;padding:0.5rem 0.7rem;{!wizIsAnthropic ? 'opacity:0.4;cursor:not-allowed' : 'cursor:pointer'}"
+                                                disabled={!wizIsAnthropic}
+                                                on:click={() => { wizTransport = 'tmux'; wizTransportUserSet = true; }}>
+                                            <div class="wizard-option-title">TMUX</div>
+                                            <div class="wizard-option-desc">Claude CLI in tmux. Default for Anthropic.</div>
+                                        </button>
+                                        <button type="button" class="wizard-option" class:selected={wizTransport === 'sdk'}
+                                                style="flex:1;text-align:left;padding:0.5rem 0.7rem;cursor:pointer"
+                                                on:click={() => { wizTransport = 'sdk'; wizTransportUserSet = true; }}>
+                                            <div class="wizard-option-title">SDK</div>
+                                            <div class="wizard-option-desc">In-process Agent SDK. Required for non-Anthropic.</div>
+                                        </button>
+                                    </div>
+                                    {#if !wizIsAnthropic}
+                                        <div style="font-size:0.7rem;color:var(--gray-mid);margin-top:0.3rem">Tmux is only available with Anthropic models (claude_sdk runtime).</div>
+                                    {/if}
+                                </div>
                             </div>
                             {/if}
                         </div>
@@ -2613,6 +2686,7 @@
                             Auto-Start: <span class="val">{wizAutoStart ? 'Yes' : 'No'}</span><br>
                             Heartbeat: <span class="val">{wizHeartbeatInterval ? wizHeartbeatInterval + 's' : 'Disabled'}</span><br>
                             Outreach: <span class="val">{wizSummaryPlatforms.length ? wizSummaryPlatforms.join(', ') : 'None (local only)'}</span>
+                            <br>Transport: <span class="val">{(wizIsAnthropic ? wizTransport : 'sdk').toUpperCase()}</span>
                             {#if wizThinkingEffort !== 'medium'}
                             <br>Effort: <span class="val">{wizThinkingEffort.toUpperCase()}</span>
                             {/if}

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -436,9 +436,12 @@
 
     /**
      * Flip an agent's transport between 'tmux' and 'sdk'.
-     * The change is persisted immediately but only takes effect when the
-     * agent's sessions are restarted — the runtime selects the transport
-     * at spawn time.
+     * The change is persisted immediately. To take effect, the agent must
+     * be STOPPED and re-started (not session-restarted): the transport
+     * class is selected when a fresh live session is created, not when an
+     * existing session reconnects. See api.py:1975-1981 vs the
+     * /agents/{name}/streaming/restart path that only reconnects the
+     * existing StreamingSession/TmuxSession instance.
      */
     async function toggleAgentTransport(agentName, currentTransport, runtime) {
         if (runtime && runtime !== 'claude_sdk') {
@@ -449,7 +452,7 @@
         const next = current === 'tmux' ? 'sdk' : 'tmux';
         try {
             await api('PUT', `/agents/${agentName}`, { transport: next });
-            toast(`Transport → ${next.toUpperCase()} (restart session to apply)`);
+            toast(`Transport → ${next.toUpperCase()} (stop and restart agent to apply)`);
             refreshAgents();
         } catch (e) {
             toast('Failed to update transport: ' + (e?.message || e), 'error');
@@ -1106,7 +1109,10 @@
         let soul = soulResp.soul;
         // Determine the model alias to register — use 'opus' default if using a provider
         const registerModel = (!wizProviderRef && !wizCustomProvider && wizProviderUrl !== 'codex_cli') ? wizModel : (wizProviderModel || 'claude-sonnet-4-6');
-        await api('POST', '/agents', { name: wizName, display_name: wizDisplayName, model: registerModel, permission_mode: wizMode, soul, role: wizRole, auto_start: wizAutoStart, heartbeat_interval: wizHeartbeatInterval, thinking_effort: wizThinkingEffort, max_turns: wizMaxTurns, timeout: wizTimeout, max_sessions: wizMaxSessions, plain_text_fallback: wizPlainTextFallback, transport: wizIsAnthropic ? wizTransport : 'sdk' });
+        // Runtime selection: codex_cli runtime when Codex is picked, else claude_sdk.
+        // Custom Anthropic-compatible providers still use claude_sdk (provider_url overrides at SDK level).
+        const registerRuntime = wizProviderUrl === 'codex_cli' ? 'codex_cli' : 'claude_sdk';
+        await api('POST', '/agents', { name: wizName, display_name: wizDisplayName, model: registerModel, permission_mode: wizMode, soul, role: wizRole, auto_start: wizAutoStart, heartbeat_interval: wizHeartbeatInterval, thinking_effort: wizThinkingEffort, max_turns: wizMaxTurns, timeout: wizTimeout, max_sessions: wizMaxSessions, plain_text_fallback: wizPlainTextFallback, runtime: registerRuntime, transport: wizIsAnthropic ? wizTransport : 'sdk' });
         // Apply provider config if a global provider, custom endpoint, or Codex was selected
         if (wizProviderRef || wizCustomProvider || wizProviderUrl === 'codex_cli') {
             await api('PUT', `/agents/${wizName}/provider`, {
@@ -1144,8 +1150,11 @@
     $: if (!wizTransportUserSet) {
         wizTransport = wizIsAnthropic ? 'tmux' : 'sdk';
     } else if (!wizIsAnthropic && wizTransport === 'tmux') {
-        // Hard override: tmux is incompatible with non-Anthropic runtimes; force sdk even if user picked tmux.
+        // Hard override: tmux is incompatible with non-Anthropic runtimes; force sdk.
+        // Also clear the user-set flag so flipping back to Anthropic re-applies the
+        // tmux default — otherwise the override would be sticky across provider flips.
         wizTransport = 'sdk';
+        wizTransportUserSet = false;
     }
 
     async function loadModels() {
@@ -1250,11 +1259,11 @@
                                         <button class="btn btn-sm"
                                                 style={transportToggleDisabled ? 'opacity:0.4;cursor:not-allowed' : ''}
                                                 disabled={transportToggleDisabled}
-                                                title={transportToggleDisabled ? 'Tmux transport requires claude_sdk runtime' : 'Switch transport (restart session to apply)'}
+                                                title={transportToggleDisabled ? 'Tmux transport requires claude_sdk runtime' : 'Switch transport (stop and restart agent to apply)'}
                                                 on:click|stopPropagation={() => toggleAgentTransport(a.name, aTransport, aRuntime)}>
                                             → {aTransport === 'tmux' ? 'SDK' : 'TMUX'}
                                         </button>
-                                        <span style="font-size:0.65rem;color:var(--gray-mid)">restart session to apply</span>
+                                        <span style="font-size:0.65rem;color:var(--gray-mid)">stop &amp; restart agent to apply</span>
                                     </div>
                                     {#each aTokens as t}
                                         <div class="outreach-row">


### PR DESCRIPTION
## Summary

- Wizard now exposes `transport` (sdk | tmux) in Advanced Settings — defaults to `tmux` for Anthropic agents, `sdk` for Codex/custom (tmux requires `runtime=claude_sdk`)
- Existing agent cards get a one-click TMUX ⇄ SDK toggle in the expanded detail panel, with a 'stop and restart agent to apply' hint (transport class is selected only at fresh live-session creation, not on session reconnect)
- Frontend-only — backend already supported `transport` on both `RegisterAgentRequest` and `UpdateAgentRequest` and validates the runtime combo at session spawn (`api.py:1907-1913`)

Driven by a Telegram discussion — request was to make tmux discoverable and the default for new Anthropic agents, plus an easy way to flip existing agents back and forth.

## Behavior matrix

| Provider in wizard | Default transport | Toggle enabled? |
|---|---|---|
| Anthropic (default) | **tmux** | ✅ both options |
| Codex CLI | sdk | ❌ tmux disabled with explainer |
| Custom endpoint | sdk | ❌ tmux disabled with explainer |
| Global provider (custom) | sdk | ❌ tmux disabled with explainer |

If the user picks tmux explicitly on Anthropic and then switches provider to a non-Anthropic option, the auto-reactive forces transport back to `sdk` (incompatible combo) **and clears the manual-override flag** so flipping back to Anthropic re-applies the TMUX default.

## How transport actually applies (important nuance)

Transport class (`StreamingSession` vs `TmuxSession`) is selected only when a fresh live session is **created** (`api.py:1975-1981`). The visible `/sessions/{id}/restart` button reconnects the existing in-memory session object — it does **not** swap transports. So switching transport requires:

1. Click the TMUX/SDK toggle on the agent card (persists to DB)
2. Stop the agent (`POST /agents/{name}/stop`)
3. Start a new main session (`POST /agents/{name}/streaming-sessions?label=main` or via the standard agent boot flow)

The card hint and toast both say "stop and restart agent to apply" to make this clear. Auto stop/start on toggle was considered and deferred — interrupting active work is a separate UX decision.

## Codex runtime fix (incidental)

Pre-existing bug surfaced by this PR: the wizard never sent `runtime` in the create-agent POST, so Codex-via-wizard agents got stored as `runtime=claude_sdk, provider_url=codex_cli`. Spawn-time fallback masked the inconsistency, but the new card-toggle's runtime check would have allowed flipping a Codex agent to TMUX silently. Now sends `runtime=codex_cli` for Codex, `claude_sdk` otherwise.

Existing inconsistent rows in DB need a one-time backfill — owned by @murzik in a separate PR (find rows where `provider_url='codex_cli' AND runtime='claude_sdk'`, flip runtime, leave transport=sdk).

## Test plan

- [ ] Open wizard, default Anthropic — confirm Advanced Settings → Transport shows TMUX selected
- [ ] Switch provider to Codex CLI — Transport flips to SDK, TMUX button disabled
- [ ] Switch back to Anthropic — Transport flips back to TMUX (auto-default re-applies after the cross-provider override)
- [ ] Pick TMUX explicitly on Anthropic, switch to Codex (forces SDK + clears override flag), switch back to Anthropic — Transport returns to TMUX (verifying the sticky-override fix)
- [ ] Create a new Anthropic agent — confirm `agent.transport == 'tmux'`, `agent.runtime == 'claude_sdk'` in DB
- [ ] Create a new Codex agent — confirm `agent.transport == 'sdk'`, `agent.runtime == 'codex_cli'` in DB
- [ ] On an existing SDK agent: expand card, click `→ TMUX` button — toast says "stop and restart agent to apply", `PUT /agents/{name}` fires, refreshed card shows TMUX
- [ ] Stop the agent, start it again — verify the new live session spawns under tmux (`tmux ls` should show a new session named after the agent)
- [ ] Flip back: click `→ SDK`, stop + start agent, verify the new session is `StreamingSession` (no tmux session)
- [ ] On a Codex agent card: confirm the toggle button is disabled with the "Tmux transport requires claude_sdk runtime" tooltip

## Notes for reviewer

Frontend-only change. Reviewed by @murzik on commits 86a47ff and 20eafec — second pass returned clean.

🤖 Opened by Barsik