### PR TITLE
[codex] add Codex runtime backfill

### DIFF
--- a/scripts/backfill_codex_runtime.py
+++ b/scripts/backfill_codex_runtime.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Backfill Codex CLI agents from legacy provider_url runtime selection.
+
+Dry-run by default. Pass --apply to update matching rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DB_PATH = Path("data/pinky_agents.db")
+
+MATCH_QUERY = """
+    SELECT name, runtime, transport, provider_url, provider_model, provider_ref
+    FROM agents
+    WHERE provider_url = 'codex_cli'
+      AND runtime = 'claude_sdk'
+    ORDER BY name
+"""
+
+UPDATE_QUERY = """
+    UPDATE agents
+    SET runtime = 'codex_cli',
+        transport = 'sdk',
+        updated_at = ?
+    WHERE provider_url = 'codex_cli'
+      AND runtime = 'claude_sdk'
+"""
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    if not db_path.exists():
+        raise FileNotFoundError(f"agents database not found: {db_path}")
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _require_agents_columns(conn: sqlite3.Connection) -> None:
+    try:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(agents)").fetchall()}
+    except sqlite3.Error as exc:
+        raise RuntimeError(f"failed to inspect agents table: {exc}") from exc
+
+    required = {"name", "runtime", "transport", "provider_url", "updated_at"}
+    missing = sorted(required - columns)
+    if missing:
+        raise RuntimeError(f"agents table is missing required column(s): {', '.join(missing)}")
+
+
+def find_codex_runtime_mismatches(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """Return agents that should run codex_cli but are still marked claude_sdk."""
+    _require_agents_columns(conn)
+    return [dict(row) for row in conn.execute(MATCH_QUERY).fetchall()]
+
+
+def apply_codex_runtime_backfill(conn: sqlite3.Connection, *, now: float | None = None) -> int:
+    """Update mismatched Codex CLI rows and force their transport to sdk."""
+    _require_agents_columns(conn)
+    cursor = conn.execute(UPDATE_QUERY, (time.time() if now is None else now,))
+    conn.commit()
+    return int(cursor.rowcount)
+
+
+def _print_report(rows: list[dict[str, Any]], *, applied: bool, updated: int) -> None:
+    mode = "APPLY" if applied else "DRY RUN"
+    print(f"{mode}: {len(rows)} Codex runtime mismatch(es) found")
+    for row in rows:
+        transport_note = ""
+        if row.get("transport") != "sdk":
+            transport_note = f" transport {row.get('transport')!r}->'sdk'"
+        print(
+            f"- {row['name']}: runtime 'claude_sdk'->'codex_cli'"
+            f"{transport_note}; provider_model={row.get('provider_model') or '<empty>'}"
+        )
+    if applied:
+        print(f"Updated {updated} row(s).")
+    elif rows:
+        print("No rows changed. Re-run with --apply to write the backfill.")
+    else:
+        print("No rows changed.")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill agents with provider_url='codex_cli' and runtime='claude_sdk' "
+            "to runtime='codex_cli'. Dry-run by default."
+        )
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=DEFAULT_DB_PATH,
+        help=f"path to agents SQLite database (default: {DEFAULT_DB_PATH})",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="write the backfill; without this flag the script only reports matches",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        with _connect(args.db) as conn:
+            rows = find_codex_runtime_mismatches(conn)
+            updated = apply_codex_runtime_backfill(conn) if args.apply and rows else 0
+    except (FileNotFoundError, RuntimeError, sqlite3.Error) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    _print_report(rows, applied=args.apply, updated=updated)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1222,6 +1222,7 @@ class AgentRegistry:
                 _log(f"agent_registry: migrated — added column {col}")
         self._db.commit()
         self._backfill_runtime_from_provider_url()
+        self._warn_codex_runtime_mismatches()
 
         # Migrate agent_schedules table
         sched_existing = {
@@ -1299,7 +1300,7 @@ class AgentRegistry:
             return
 
         cursor = self._db.execute(
-            "UPDATE agents SET runtime='codex_cli' "
+            "UPDATE agents SET runtime='codex_cli', transport='sdk' "
             "WHERE provider_url='codex_cli' AND runtime='claude_sdk'"
         )
         self._db.execute(
@@ -1310,6 +1311,30 @@ class AgentRegistry:
         self._db.commit()
         if cursor.rowcount:
             _log(f"agent_registry: backfilled runtime=codex_cli for {cursor.rowcount} agent(s)")
+
+    def _warn_codex_runtime_mismatches(self) -> None:
+        """Warn when Codex provider rows still have the Claude SDK runtime.
+
+        The one-shot migration above covers rows that existed when the runtime
+        column landed. Rows created after that marker was set can still drift if
+        a caller persists provider_url='codex_cli' without runtime='codex_cli'.
+        Warn only: startup should not mutate post-migration rows unexpectedly.
+        """
+        rows = self._db.execute(
+            "SELECT name FROM agents "
+            "WHERE provider_url='codex_cli' AND runtime='claude_sdk' "
+            "ORDER BY name"
+        ).fetchall()
+        if not rows:
+            return
+
+        sample = ", ".join(row[0] for row in rows[:5])
+        suffix = "" if len(rows) <= 5 else f", +{len(rows) - 5} more"
+        _log(
+            "agent_registry: warning: "
+            f"{len(rows)} Codex CLI agent(s) have runtime=claude_sdk "
+            f"({sample}{suffix}); run scripts/backfill_codex_runtime.py"
+        )
 
     # ── Workspace Init ─────────────────────────────────────
 

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -192,7 +192,12 @@ class TestAgentCRUD:
         assert fetched.transport == "tmux"
 
     def test_runtime_codex_cli_backfill_is_one_shot_and_idempotent(self, registry):
-        registry.register("legacy-codex", provider_url="codex_cli", runtime="claude_sdk")
+        registry.register(
+            "legacy-codex",
+            provider_url="codex_cli",
+            runtime="claude_sdk",
+            transport="tmux",
+        )
         registry.register("explicit-claude", provider_url="codex_cli", runtime="claude_sdk")
         registry.register("already-codex", provider_url="codex_cli", runtime="codex_cli")
         registry.register("opencode-agent", provider_url="codex_cli", runtime="opencode")
@@ -201,6 +206,7 @@ class TestAgentCRUD:
         registry.set_setting(marker, "")
         registry._backfill_runtime_from_provider_url()
         assert registry.get("legacy-codex").runtime == "codex_cli"
+        assert registry.get("legacy-codex").transport == "sdk"
         assert registry.get("explicit-claude").runtime == "codex_cli"
         assert registry.get("already-codex").runtime == "codex_cli"
         assert registry.get("opencode-agent").runtime == "opencode"
@@ -215,6 +221,16 @@ class TestAgentCRUD:
         registry.register("explicit-claude", runtime="claude_sdk")
         registry._backfill_runtime_from_provider_url()
         assert registry.get("explicit-claude").runtime == "claude_sdk"
+
+    def test_warn_codex_runtime_mismatch_after_one_shot_backfill(self, registry, capsys):
+        registry.register("late-codex", provider_url="codex_cli", runtime="claude_sdk")
+
+        registry._warn_codex_runtime_mismatches()
+
+        err = capsys.readouterr().err
+        assert "warning" in err
+        assert "late-codex" in err
+        assert "runtime=claude_sdk" in err
 
     def test_stamp_last_seen_updates_column(self, registry):
         registry.register("seen")

--- a/tests/test_backfill_codex_runtime.py
+++ b/tests/test_backfill_codex_runtime.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "backfill_codex_runtime.py"
+SPEC = importlib.util.spec_from_file_location("backfill_codex_runtime", SCRIPT_PATH)
+assert SPEC is not None
+backfill_codex_runtime = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(backfill_codex_runtime)
+
+
+def _make_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE agents (
+            name TEXT PRIMARY KEY,
+            runtime TEXT NOT NULL,
+            transport TEXT NOT NULL,
+            provider_url TEXT NOT NULL,
+            provider_model TEXT NOT NULL DEFAULT '',
+            provider_ref TEXT NOT NULL DEFAULT '',
+            updated_at REAL NOT NULL DEFAULT 0
+        )
+        """
+    )
+    return conn
+
+
+def test_dry_run_reports_only_codex_provider_claude_runtime_rows(tmp_path):
+    db_path = tmp_path / "agents.db"
+    conn = _make_db(db_path)
+    conn.executemany(
+        """
+        INSERT INTO agents (name, runtime, transport, provider_url, provider_model)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        [
+            ("bad-codex", "claude_sdk", "sdk", "codex_cli", "gpt-5.4"),
+            ("already-codex", "codex_cli", "sdk", "codex_cli", "gpt-5.4"),
+            ("opencode-future", "opencode", "sdk", "codex_cli", "deepseek"),
+            ("plain-claude", "claude_sdk", "sdk", "", "claude-opus-4-6"),
+        ],
+    )
+    conn.commit()
+
+    rows = backfill_codex_runtime.find_codex_runtime_mismatches(conn)
+
+    assert [row["name"] for row in rows] == ["bad-codex"]
+    assert conn.execute("SELECT runtime FROM agents WHERE name='bad-codex'").fetchone()[0] == "claude_sdk"
+
+
+def test_apply_updates_runtime_and_forces_sdk_transport(tmp_path):
+    db_path = tmp_path / "agents.db"
+    conn = _make_db(db_path)
+    conn.executemany(
+        """
+        INSERT INTO agents (name, runtime, transport, provider_url, provider_model)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        [
+            ("bad-codex", "claude_sdk", "tmux", "codex_cli", "gpt-5.4"),
+            ("already-codex", "codex_cli", "sdk", "codex_cli", "gpt-5.4"),
+            ("opencode-future", "opencode", "sdk", "codex_cli", "deepseek"),
+        ],
+    )
+    conn.commit()
+
+    updated = backfill_codex_runtime.apply_codex_runtime_backfill(conn, now=123.0)
+
+    assert updated == 1
+    row = conn.execute(
+        "SELECT runtime, transport, updated_at FROM agents WHERE name='bad-codex'"
+    ).fetchone()
+    assert dict(row) == {"runtime": "codex_cli", "transport": "sdk", "updated_at": 123.0}
+    assert conn.execute(
+        "SELECT runtime FROM agents WHERE name='opencode-future'"
+    ).fetchone()[0] == "opencode"


### PR DESCRIPTION
## Summary

- Adds `scripts/backfill_codex_runtime.py`, a dry-run-by-default one-shot that finds agents with `provider_url='codex_cli'` and `runtime='claude_sdk'`, then updates them to `runtime='codex_cli'` and `transport='sdk'` when run with `--apply`.
- Tightens the existing one-shot registry migration so it also forces `transport='sdk'` for Codex CLI rows it migrates.
- Adds a startup warning when post-migration drift leaves Codex CLI provider rows on the Claude SDK runtime.

## Root Cause

PR #554 exposed that the wizard used `provider_url='codex_cli'` as the runtime signal, but new rows created after the original one-shot runtime migration could still persist with the default `runtime='claude_sdk'`. Those rows should run through `CodexSession`, and Codex runtime only supports `transport='sdk'`.

## Production Dry Run

Ran against the active daemon agents DB:

```text
python3 scripts/backfill_codex_runtime.py --db /Users/oleg/PinkyBot/data/pinky_agents.db
DRY RUN: 0 Codex runtime mismatch(es) found
No rows changed.
```

No production rows would be changed right now.

## Validation

- `python3 -m pytest tests/test_backfill_codex_runtime.py tests/test_agent_registry.py -q` -> 74 passed
- `uv run pytest tests/test_backfill_codex_runtime.py tests/test_agent_registry.py -q` -> 74 passed
- `uv run pytest -q` -> 2574 passed, 1 skipped
- `uv run ruff check scripts/backfill_codex_runtime.py src/pinky_daemon/agent_registry.py tests/test_backfill_codex_runtime.py tests/test_agent_registry.py` -> pass

Note: plain `python3 -m pytest -q` on the system interpreter failed during collection because that interpreter lacks `nacl`; the managed `uv` environment has the repo dependencies and passed the full suite. Full suite emitted existing FastAPI deprecation warnings and a shared-MCP port 8890 already-in-use warning, but returned success.