### PR TITLE
feat(agents-ui): move transport toggle to Configure → RUNTIME tab

### DIFF
--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -2142,8 +2142,28 @@
             {/if}<!-- end scheduling tab -->
 
             {#if activeTab === 'runtime'}
+            {@const currentAgentData = agentList.find(a => a.name === currentAgent) || {}}
+            {@const detailTransport = (currentAgentData.transport || 'sdk').toLowerCase()}
+            {@const detailRuntime = currentAgentData.runtime || 'claude_sdk'}
+            {@const detailTransportDisabled = detailRuntime !== 'claude_sdk'}
+            <!-- Transport -->
+            <SectionHeader title="Transport" variant="detail" />
+            <div class="token-item">
+                <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700">{detailTransport.toUpperCase()}</span>
+                <StatusBadge status={detailTransport === 'tmux' ? 'on' : 'off'} label={detailTransport === 'tmux' ? 'Claude CLI in tmux' : 'In-process Agent SDK'} />
+                <span style="flex:1"></span>
+                <span style="font-size:0.7rem;color:var(--gray-mid)">stop &amp; restart agent to apply</span>
+                <button class="btn btn-sm"
+                        style={detailTransportDisabled ? 'opacity:0.4;cursor:not-allowed' : ''}
+                        disabled={detailTransportDisabled}
+                        title={detailTransportDisabled ? 'Tmux transport requires claude_sdk runtime' : 'Switch transport'}
+                        on:click={() => toggleAgentTransport(currentAgent, detailTransport, detailRuntime)}>
+                    → {detailTransport === 'tmux' ? 'SDK' : 'TMUX'}
+                </button>
+            </div>
+
             <!-- Live Sessions (formerly Streaming Sessions) -->
-            <SectionHeader title={$_('agents.live_sessions')} variant="detail">
+            <SectionHeader title={$_('agents.live_sessions')} variant="detail" style="margin-top:0.5rem">
                 <button slot="actions" class="btn btn-sm btn-primary" on:click={createStreamingSession}>+ {$_('agents.session')}</button>
             </SectionHeader>
             <div>

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -1249,22 +1249,7 @@
 
                             <!-- Expanded detail -->
                             {#if isExpanded}
-                                {@const aTransport = (a.transport || 'sdk').toLowerCase()}
-                                {@const aRuntime = a.runtime || 'claude_sdk'}
-                                {@const transportToggleDisabled = aRuntime !== 'claude_sdk'}
                                 <div class="agent-inline-detail">
-                                    <div class="outreach-row" style="gap:0.5rem">
-                                        <span class="badge badge-platform">transport</span>
-                                        <span class="badge badge-{aTransport === 'tmux' ? 'on' : 'off'}">{aTransport.toUpperCase()}</span>
-                                        <button class="btn btn-sm"
-                                                style={transportToggleDisabled ? 'opacity:0.4;cursor:not-allowed' : ''}
-                                                disabled={transportToggleDisabled}
-                                                title={transportToggleDisabled ? 'Tmux transport requires claude_sdk runtime' : 'Switch transport (stop and restart agent to apply)'}
-                                                on:click|stopPropagation={() => toggleAgentTransport(a.name, aTransport, aRuntime)}>
-                                            → {aTransport === 'tmux' ? 'SDK' : 'TMUX'}
-                                        </button>
-                                        <span style="font-size:0.65rem;color:var(--gray-mid)">stop &amp; restart agent to apply</span>
-                                    </div>
                                     {#each aTokens as t}
                                         <div class="outreach-row">
                                             <span class="badge badge-platform">{t.platform}</span>


### PR DESCRIPTION
## Summary

Follow-up to #554. Two changes based on Brad's UX feedback:

1. **Add transport toggle to Configure → RUNTIME tab** — the canonical agent-settings surface, where users naturally look first. Shows current transport with a status badge, one-click TMUX⇄SDK button, "stop and restart agent to apply" hint, disabled on non-`claude_sdk` runtimes.
2. **Remove the inline-card transport row** — too prominent for a rare action. Brad's call: "this shouldn't happen frequently so needs to be less accessible."

The wizard's Advanced Settings transport toggle stays as-is (at-creation, belongs in setup flow).

## Where users find the toggle after this PR

- **New agent**: wizard → step 2 (Brain) → Advanced Settings → Transport
- **Existing agent**: agent card → Configure → RUNTIME tab → Transport section (above Live Sessions)

## Implementation notes

The RUNTIME-tab toggle derives its current value from `agentList.find(...)` rather than from a stale detail-modal state var — so after the PUT + `refreshAgents()`, the displayed transport updates correctly without needing to close and reopen the modal.

Reuses the existing `toggleAgentTransport()` handler from #554 so behavior matches exactly.

## Test plan

- [ ] Configure any Anthropic agent → RUNTIME tab → see "Transport: TMUX/SDK" row above Live Sessions
- [ ] Click `→ SDK` (or `→ TMUX`) — toast appears, row updates to new value without reopening modal
- [ ] Stop and start the agent — confirm new session spawns under the new transport
- [ ] Configure a Codex agent (after #555 backfill) → RUNTIME tab → button disabled, tooltip says "Tmux transport requires claude_sdk runtime"
- [ ] Expand any agent card on the Agents page — confirm the inline transport row is GONE

🤖 Opened by Barsik