### PR TITLE
fix(tmux): concurrent dispatch via _inflight_metas deque (#560)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2731,7 +2731,21 @@ class TmuxSession:
                 # await it here because force_restart→disconnect cancels
                 # this watchdog task and awaits its completion, which
                 # would deadlock.
-                asyncio.create_task(self.force_restart())
+                #
+                # ``bypass_guard=True``: Murzik review on commit 3.
+                # The watchdog has already (a) abandoned the head's
+                # completion_event, (b) moved tail/in_hand replay into
+                # ``_message_queue``, (c) cancelled the only worker.
+                # If ``force_restart`` honored the persistence guard
+                # and returned False, the session would stay CONNECTED
+                # with no worker and no watchdog to consume the replay
+                # queue or recover — silently inert. The guard exists
+                # to preserve completed-but-unsaved state mid-
+                # conversation; once the head has wedged for
+                # ``_TURN_DONE_TIMEOUT_SEC``, that conversation state
+                # is already corrupted, so the guard's premise no
+                # longer holds. See ``force_restart`` docstring.
+                asyncio.create_task(self.force_restart(bypass_guard=True))
                 return
         except asyncio.CancelledError:
             _log(f"tmux[{self.agent_name}]: inflight watchdog cancelled")
@@ -2888,13 +2902,29 @@ class TmuxSession:
         if self._tailer is not None:
             self._tailer.mark_active()
 
-    async def force_restart(self) -> bool:
+    async def force_restart(self, *, bypass_guard: bool = False) -> bool:
         """Tear down the tmux session and start a fresh one.
 
         Drives ``CONNECTED → RECONNECTING → CONNECTED|DEAD``. Returns True
         on success, False if blocked by the restart guard.
+
+        **``bypass_guard``** (Murzik review on commit 3 of PR #561).
+        The persistence guard exists to prevent restarts that would
+        drop completed-but-unsaved agent state mid-conversation. The
+        inflight watchdog calls this with ``bypass_guard=True``
+        because by the time the watchdog fires, the REPL is already
+        wedged — its head turn timed out, the conversation state is
+        already corrupted from the agent's POV. Leaving the session
+        "intact" doesn't preserve anything useful; it only strands
+        the replay queue with no worker to consume it (the watchdog
+        had to cancel the old worker to prevent the race window
+        Murzik flagged on commit 2).
         """
-        if self._has_completed_turn and self._config.restart_guard:
+        if (
+            not bypass_guard
+            and self._has_completed_turn
+            and self._config.restart_guard
+        ):
             try:
                 guard = self._config.restart_guard(self)
             except Exception:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -60,6 +60,7 @@ import asyncio
 import os
 import shlex
 import time
+from collections import deque
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
@@ -395,7 +396,7 @@ class _QueuedTurn:
       orientation — e.g. wake prompts at ``connect()``, pre-sleep save
       reminders at ``idle_sleep()``. Skip conversation_store appends and
       external-stats increments, do not route through response_callback,
-      do not write to ``_inflight_meta``. Optional ``completion_event`` is
+      do not write to ``_inflight_metas``. Optional ``completion_event`` is
       set when the turn completes so callers can ``wait_for_completion``.
     """
 
@@ -407,7 +408,7 @@ class _QueuedTurn:
     # Internal-prompt flag set by ``_enqueue_internal_prompt``. See
     # ``_deliver_turn`` and ``_handle_turn_complete`` for the
     # conditional bypasses (no conversation_store append, no
-    # response_callback, no ``_inflight_meta`` writes).
+    # response_callback, no ``_inflight_metas`` writes).
     internal: bool = False
     # Human-readable label for the internal-turn audit log
     # (``wake_prompt_sent``, ``idle_sleep_presave``, etc.). Ignored when
@@ -418,6 +419,55 @@ class _QueuedTurn:
     # they don't progress (e.g. disconnect) before the agent honors the
     # prompt. Ignored when ``None``.
     completion_event: asyncio.Event | None = None
+
+
+@dataclass
+class _InflightMeta:
+    """One in-flight turn's routing metadata + completion signal.
+
+    Issue #560 / PR for concurrent dispatch. Appended to
+    ``_inflight_metas`` by ``_deliver_turn`` after a successful paste;
+    popped FIFO by ``_handle_turn_complete`` on each ``stop_hook_summary``.
+    Multiple entries co-exist when steering messages are pasted back-to-
+    back into a busy REPL — Claude Code's native queued-prompt feature
+    handles the in-pane queue; this deque tracks OUR routing/completion
+    state per pending turn.
+
+    Replaces PR #496 round-2's single ``_inflight_meta`` dict, which was
+    the chokepoint forcing strictly serial dispatch and made mid-turn
+    steering impossible (the worker awaited ``_turn_done`` between
+    dispatches to protect the dict from being clobbered).
+
+    **Ordering** is preserved end-to-end: Claude Code processes pasted
+    prompts sequentially (its native input queue is FIFO); the transcript
+    tailer reads the JSONL file in line order; FIFO pop matches FIFO
+    append. The single-meta-clobber bug (#496 Case 1) is defended by
+    each turn carrying its OWN routing dict that lives in the deque
+    entry — no shared mutable cell.
+    """
+
+    # Routing metadata: {"platform", "chat_id", "message_id"}. Empty
+    # dict for internal turns (wake prompts, pre-sleep save reminders) —
+    # they have no external recipient. Used by ``_handle_turn_complete``
+    # to populate the ``TurnResponse`` it passes to ``_response_callback``.
+    meta: dict
+    # Per-turn completion event. Set by ``_handle_turn_complete`` when
+    # THIS entry is popleft'd from the deque. Used by callers with
+    # ``wait_for_completion=True`` (e.g. pre-sleep save) to block until
+    # their specific turn finishes — NOT some later turn. Also set on
+    # ``force_restart``/paste-failure paths so a waiter doesn't hang
+    # forever when its turn is abandoned. None for fire-and-forget.
+    completion_event: asyncio.Event | None
+    # True for daemon-internal turns. ``_handle_turn_complete`` skips the
+    # ``conversation_store.append`` + ``_response_callback`` calls when
+    # this flag is set. The turn's response still flows through the
+    # transcript JSONL (audit), just not into the chat-side surfaces.
+    internal: bool
+    # When the paste+Enter succeeded. Informational only — the watchdog
+    # ages turns by deque-head transitions (``_head_started_at``), NOT
+    # by ``dispatched_at``, so a queued turn gets its OWN fair timeout
+    # window once it becomes the head (Murzik review on PR for #560).
+    dispatched_at: float
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -436,11 +486,24 @@ _RECONNECT_BACKOFF = (2, 8, 30)
 # to authenticate / fetch first turn / load CLAUDE.md.
 _COLD_START_TIMEOUT_SEC = 60.0
 
-# Per-turn timeout: how long the worker waits for ``_turn_done`` between
-# dispatching a prompt and the tailer firing ``_handle_turn_complete``.
+# Per-turn timeout: how long ANY single in-flight turn can be at the
+# HEAD of ``_inflight_metas`` without its ``stop_hook_summary`` landing
+# before the watchdog considers it stuck and triggers ``force_restart``.
 # Generous (10 min) to cover tool-use loops + slow models + cold-model
-# dispatch. Anything longer is "stuck" — caller / watchdog retries.
+# dispatch. Anything longer is "stuck".
+#
+# Note (#560): pre-PR this was the worker's per-iteration ``_turn_done``
+# wait timeout. With concurrent dispatch, the worker no longer awaits
+# between turns — the watchdog ages turns by deque-HEAD transitions
+# (``_head_started_at``) so each queued turn gets its own fair timeout
+# window once it becomes the head (Murzik review).
 _TURN_DONE_TIMEOUT_SEC = 600.0
+
+# Watchdog poll cadence. 15s strikes a balance: tight enough that a
+# stuck REPL gets force_restarted inside one cycle past
+# ``_TURN_DONE_TIMEOUT_SEC``; loose enough that the loop is invisible
+# in CPU profiles even with many active tmux sessions.
+_WATCHDOG_TICK_SEC = 15.0
 
 
 class TmuxSession:
@@ -492,6 +555,13 @@ class TmuxSession:
         # Worker queue + task.
         self._message_queue: asyncio.Queue[_QueuedTurn] = asyncio.Queue()
         self._worker_task: asyncio.Task | None = None
+        # Background watchdog that ages the deque head against
+        # ``_TURN_DONE_TIMEOUT_SEC`` and triggers ``force_restart`` when
+        # a stop hook fails to land. Issue #560 replaces the per-iter
+        # worker timeout with a separate task so concurrent dispatch
+        # isn't blocked behind a per-turn wait. Started/cancelled
+        # alongside ``_worker_task``.
+        self._watchdog_task: asyncio.Task | None = None
         self._processing = False
 
         # Operational stats. Shape matches StreamingSession.stats for the
@@ -541,22 +611,39 @@ class TmuxSession:
         # on every ``stop_hook_summary`` entry — which routes to
         # ``_response_callback`` to deliver the response upstream.
         self._tailer: TmuxTranscriptTailer | None = None
-        # Last user-message metadata (platform / chat_id / message_id),
-        # captured at send() time. Forwarded to ``_response_callback``
-        # so the broker can route the reply back to the right channel.
-        # Worker awaits ``_turn_done`` between turns so exactly one turn
-        # is in flight at any time — meta is set in ``_deliver_turn`` and
-        # cleared in ``_handle_turn_complete``, with the turn-done gate
-        # preventing the worker from overwriting it before the tailer
-        # consumes it. Pushok's PR #496 round-1 critical finding (Case 1).
-        self._inflight_meta: dict = {}
-        # Set by ``_handle_turn_complete`` at the end of every turn;
-        # awaited by ``_message_worker`` after ``_deliver_turn`` so the
-        # next dispatch can't clobber ``_inflight_meta`` mid-flight.
-        # Invariant: between dispatches, turn_done is CLEARED; it's set
-        # only after a callback fires. The first ``_deliver_turn`` clears
-        # it (no-op on a fresh Event) before send-keys; the worker only
-        # awaits on subsequent iterations.
+        # FIFO of in-flight turn routing metadata. Issue #560 replaces
+        # PR #496 round-2's single ``_inflight_meta`` dict (which forced
+        # strictly serial dispatch via a worker gate, breaking mid-turn
+        # steering). Each successful ``paste_text(..., enter=True)`` in
+        # ``_deliver_turn`` appends one ``_InflightMeta``; each
+        # ``stop_hook_summary`` in ``_handle_turn_complete`` pops the
+        # oldest. Multiple entries co-exist while Claude Code's native
+        # queued-prompt feature drains the in-pane queue.
+        #
+        # Defense of #496 Case 1 (response routed to wrong chat_id):
+        # each entry carries its OWN routing dict; there is no shared
+        # mutable cell to clobber. Ordering is FIFO end-to-end because
+        # CC processes pasted prompts sequentially, the tailer reads
+        # transcript JSONL in line order, and ``popleft`` matches
+        # ``append``.
+        self._inflight_metas: deque[_InflightMeta] = deque()
+        # Timestamp (``time.time()``) of when the CURRENT deque HEAD
+        # became the head — either via empty→nonempty append, or via
+        # popleft when entries remain behind it. Reset to ``None`` when
+        # the deque drains. The ``_inflight_watchdog`` ages turns
+        # against this, NOT against ``dispatched_at``, so a queued turn
+        # gets its own ``_TURN_DONE_TIMEOUT_SEC`` window once it becomes
+        # the head (Murzik review on PR for #560).
+        self._head_started_at: float | None = None
+        # Back-compat advisory signal. Pre-#560 this was the worker's
+        # per-iteration gate (the bottleneck that broke steering).
+        # Post-#560 the worker no longer awaits it between dispatches;
+        # ``_handle_turn_complete`` still ``.set()``s it on every turn
+        # so external observers (tests, ``_enqueue_internal_prompt`` with
+        # ``wait_for_completion=True`` callers via the per-turn
+        # ``completion_event``, ``connect``-time clears, etc.) keep
+        # working unchanged. Treat as "ANY turn completed since last
+        # clear", not "exactly one turn was inflight".
         self._turn_done: asyncio.Event = asyncio.Event()
         # Becomes true only after the worker observes a successful turn_done.
         # Before that, restart cannot discard completed agent work, so
@@ -611,6 +698,53 @@ class TmuxSession:
         return f"pinky-{self.agent_name}"
 
     # ── State ───────────────────────────────────────────────────────────
+
+    @property
+    def _inflight_meta(self) -> dict:
+        """Back-compat view: routing metadata of the OLDEST in-flight turn.
+
+        Pre-#560 this was a single mutable dict cell — the chokepoint the
+        worker serialized dispatch around. Post-#560 the source of truth
+        is ``_inflight_metas`` (FIFO deque); this property returns the
+        OLDEST entry's meta (or ``{}`` when no turn is in flight) so
+        pre-#560 tests + any external observers keep working without
+        mass-rewrites. Returns a copy so callers can't mutate the deque
+        through it.
+
+        Production code (``_deliver_turn``, ``_handle_turn_complete``)
+        operates on ``_inflight_metas`` directly. Do NOT introduce new
+        readers of ``_inflight_meta`` — read the deque or its head.
+        """
+        if self._inflight_metas:
+            return dict(self._inflight_metas[0].meta)
+        return {}
+
+    @_inflight_meta.setter
+    def _inflight_meta(self, value: dict) -> None:
+        """Back-compat setter for pre-#560 test fixtures.
+
+        Old idiom:
+            ``ss._inflight_meta = {"platform": ..., "chat_id": ..., "message_id": ...}``
+
+        New equivalent: clear the deque, append one entry carrying
+        ``value`` as its routing meta. ``ss._inflight_meta = {}`` clears
+        the deque entirely.
+
+        Production code does NOT use this setter — it goes through
+        ``_inflight_metas.append`` directly in ``_deliver_turn``. The
+        setter exists only so pre-#560 test fixtures don't need a
+        sed-rewrite. New tests should populate the deque explicitly.
+        """
+        self._inflight_metas.clear()
+        self._head_started_at = None
+        if value:
+            self._inflight_metas.append(_InflightMeta(
+                meta=dict(value),
+                completion_event=None,
+                internal=False,
+                dispatched_at=time.time(),
+            ))
+            self._head_started_at = time.time()
 
     @property
     def state(self) -> SessionState:
@@ -1057,6 +1191,11 @@ class TmuxSession:
         # Start the worker.
         if not self._worker_task or self._worker_task.done():
             self._worker_task = asyncio.create_task(self._message_worker())
+        # Start the inflight watchdog (#560). Independent of the worker
+        # so concurrent dispatch isn't bottlenecked behind a per-turn
+        # ``_turn_done`` wait. Idle when ``_inflight_metas`` is empty.
+        if not self._watchdog_task or self._watchdog_task.done():
+            self._watchdog_task = asyncio.create_task(self._inflight_watchdog())
 
         # Fire resume-handle persistence callback (one-shot for tmux —
         # session name is stable from construction but the persistence
@@ -1373,12 +1512,34 @@ class TmuxSession:
             except asyncio.CancelledError:
                 pass
         self._worker_task = None
+        # Cancel watchdog (#560). Mirrors the worker shutdown — must be
+        # before the deque drain so it doesn't race a force_restart it
+        # may have just scheduled.
+        if self._watchdog_task and not self._watchdog_task.done():
+            self._watchdog_task.cancel()
+            try:
+                await self._watchdog_task
+            except asyncio.CancelledError:
+                pass
+        self._watchdog_task = None
         self._processing = False
 
-        # Clear in-flight routing metadata so a straggler stop_hook_summary
-        # (e.g. read from a stale transcript on reconnect) can't route a
-        # late response to a stale chat. Pushok's PR #496 round-1 Case 2.
-        self._inflight_meta = {}
+        # Drain the in-flight metadata deque (#560 replaces PR #496
+        # round-2's single-dict clear). Critical safety: unblock every
+        # pending ``completion_event`` BEFORE clearing the deque, so a
+        # ``wait_for_completion=True`` caller (e.g. pre-sleep save)
+        # doesn't hang forever when its turn is abandoned by a
+        # disconnect / force_restart cycle. Murzik review point #2.
+        #
+        # Also defends #496 round-1 Case 2: a straggler stop_hook_summary
+        # read from a stale transcript on reconnect can't route a late
+        # response — the deque it would popleft from is empty.
+        drained = list(self._inflight_metas)
+        self._inflight_metas.clear()
+        self._head_started_at = None
+        for entry in drained:
+            if entry.completion_event is not None and not entry.completion_event.is_set():
+                entry.completion_event.set()
 
         # Stop the response tailer (PR8b). Tailer instance is retained
         # so stats/path persist; only the background task is cancelled.
@@ -1910,21 +2071,72 @@ class TmuxSession:
         billing, no per-turn cost) but we still fire stream_event so
         usage telemetry is visible.
 
-        Internal-prompt branch (PR for #543): when ``_inflight_turn``
-        reports the just-finished turn was an internal-prompt (wake
-        orientation, pre-sleep save reminder, etc.), skip the
-        conversation_store assistant append and the response_callback —
-        no external recipient, no user-visible conversation. Still:
-        emit ``turn_completed`` for analytics parity, account usage
-        toward the context-budget watchdog, and signal ``_turn_done``
-        so the worker progresses. If the internal turn carried a
-        ``completion_event``, set it before ``_turn_done`` so a
-        ``wait_for_completion=True`` caller unblocks deterministically
-        with the worker advancing in lock-step.
+        **#560 — concurrent dispatch.** Each stop hook pops the OLDEST
+        in-flight meta from ``_inflight_metas`` (FIFO). Internal-vs-
+        external + per-turn completion event come from the popped
+        entry's own fields — NOT from ``_inflight_turn`` (which under
+        concurrent dispatch may already point at a later turn that's
+        also pasted). This is the deque equivalent of PR #543's
+        internal-prompt branch.
+
+        Critical-section discipline (Murzik review point #6): the
+        synchronous block at the top — popleft, set ``completion_event``,
+        advance ``_head_started_at``, set back-compat ``_turn_done`` —
+        runs without ``await`` so concurrent stop hooks (in practice
+        serialized by the tailer's single-task read loop, but defended
+        here too) can't interleave with deque mutation. The async
+        callback chain (``conversation_store.append`` is sync, but
+        ``_emit_stream_event`` / ``_response_callback`` / context-budget
+        emission ARE awaited) runs AFTER, against local copies of the
+        popped state. By the time we await anything, the deque is
+        consistent.
+
+        Empty-on-pop defense (Murzik review point #7): if a stop hook
+        arrives with an empty deque (race, stale tailer, double-fire,
+        force_restart in-flight), log and bail. Do NOT synthesize routing
+        metadata — that would resurrect the #496 Case 1 defect with a
+        twist (route to wrong chat from an empty/zero state).
         """
-        is_internal = bool(
-            self._inflight_turn is not None and self._inflight_turn.internal
-        )
+        # ── Critical section: synchronous deque mutation + signals ────
+        if not self._inflight_metas:
+            # No meta to pop. Stop hook arrived without a dispatch
+            # behind it — race or stale tailer firing post-reconnect.
+            # Bail cleanly; routing must NOT be synthesized.
+            _log(
+                f"tmux[{self.agent_name}]: stop hook with empty inflight_metas "
+                f"(race/stale tailer) — skipping callback chain"
+            )
+            return
+
+        entry = self._inflight_metas.popleft()
+        # Unblock any wait_for_completion caller for THIS entry's turn
+        # before the awaitable callbacks run — keeps the caller's wakeup
+        # tight (no waiting on conversation_store / response_callback /
+        # stream_event latency). Idempotent: ``.set()`` on a set Event
+        # is a no-op.
+        if entry.completion_event is not None and not entry.completion_event.is_set():
+            entry.completion_event.set()
+        # Advance the head-age watchdog (Murzik review point #1). If
+        # entries remain, the NEW head's clock starts NOW so it gets
+        # its own ``_TURN_DONE_TIMEOUT_SEC`` window. If the deque is
+        # empty, the watchdog has nothing to age.
+        if self._inflight_metas:
+            self._head_started_at = time.time()
+        else:
+            self._head_started_at = None
+        # Back-compat advisory signal. Worker no longer gates on this
+        # (#560), but tests + external observers still listen.
+        self._turn_done.set()
+        # ``_has_completed_turn`` gates the restart_guard: once ANY
+        # turn has completed in this session's lifetime, force_restart
+        # asks the guard whether unsaved state should block teardown.
+        # Pre-#560 the worker set this after observing ``_turn_done``;
+        # under concurrent dispatch the worker no longer waits between
+        # turns, so the canonical "first completion" signal moves here.
+        self._has_completed_turn = True
+        # ── End critical section ──────────────────────────────────────
+
+        is_internal = entry.internal
         thinking_text = (response.thinking or "").strip()
         thinking_blocks = [thinking_text] if thinking_text else []
         thinking_chars = len(thinking_text)
@@ -1990,16 +2202,17 @@ class TmuxSession:
         )
 
         # Response callback — the broker-routing payload. Includes the
-        # captured inbound metadata so the broker can route the reply.
+        # captured inbound metadata (from the popped deque entry, NOT
+        # the legacy single-dict cell) so the broker can route the reply.
         # Skip for internal turns: no chat target, and the metadata is
-        # intentionally empty (see ``_deliver_turn`` regression guard).
+        # intentionally empty (see ``_deliver_turn``).
         if (
             not is_internal
             and self._response_callback
             and (response.text or response.tool_uses)
         ):
             try:
-                meta = dict(self._inflight_meta)
+                meta = entry.meta
                 turn_result = replace(
                     response,
                     agent_name=self.agent_name,
@@ -2022,29 +2235,13 @@ class TmuxSession:
                     f"tmux[{self.agent_name}]: response_callback raised: {e}"
                 )
 
-        # Clear in-flight metadata — next send() will populate it.
-        self._inflight_meta = {}
-
-        # Internal-prompt completion signal (PR for #543). MUST fire
-        # BEFORE ``_turn_done`` so a ``wait_for_completion=True`` caller
-        # can rely on the worker not having dispatched the next turn
-        # yet — the worker awaits ``_turn_done`` between turns, and
-        # advancing past that gate would change the in-flight bookkeeping
-        # the caller might be observing.
-        if (
-            is_internal
-            and self._inflight_turn is not None
-            and self._inflight_turn.completion_event is not None
-        ):
-            self._inflight_turn.completion_event.set()
-
-        # Signal turn-complete to the worker UNCONDITIONALLY. Must be
-        # outside any ``if response.text`` gate (Pushok's PR #496 round-1
-        # Case 1 follow-up): empty-text turns (e.g. pure tool-use that
-        # hit max_tokens) still complete a turn, and the worker is
-        # awaiting this event regardless. Gating on text would deadlock
-        # the worker forever on a tool-use-only turn.
-        self._turn_done.set()
+        # NOTE: deque pop + completion_event + ``_turn_done`` + head-age
+        # advance all happened in the critical section at the top.
+        # Don't re-emit them here — that would (a) double-fire events
+        # on a now-stale ``entry``, and (b) defeat the "fire before
+        # awaits so waiters wake promptly" discipline. This block used
+        # to clear ``_inflight_meta = {}`` and set ``_turn_done`` /
+        # ``completion_event``; under #560 the deque carries the state.
 
         # Reset per-turn live-activity state so the next turn starts
         # clean. Without this the polling endpoint ``/streaming/status``
@@ -2213,19 +2410,26 @@ class TmuxSession:
         return jsonls[0] if jsonls else None
 
     async def _message_worker(self) -> None:
-        """Drain the message queue sequentially, delivering each turn to
-        the tmux pane and waiting for it to complete before the next.
+        """Drain ``_message_queue``, pasting each turn into the tmux pane.
 
-        PR8b round-2 (Pushok's Case 1 fix): the worker gates dispatch
-        on ``_turn_done``, which ``_handle_turn_complete`` sets at the
-        end of every turn (including empty-text / tool-use-only turns).
-        This ensures ``_inflight_meta`` is never overwritten while the
-        tailer still has work to fire for the in-flight turn, AND bounds
-        the prompts that get stacked into Claude Code's input queue
-        (UX win — CC's queued-prompt indicator is non-obvious).
+        **#560 — concurrent dispatch.** Pre-#560 the worker dispatched
+        each turn and then awaited ``_turn_done`` before pulling the
+        next one. That serialization protected the single
+        ``_inflight_meta`` cell from being clobbered (Pushok's PR #496
+        round-2 fix), at the cost of making mid-turn steering impossible
+        — a second ``send()`` while a turn ran sat invisibly in the
+        queue until the first turn's stop_hook_summary landed.
 
-        Murzik #522 round-1 (data-loss fix): the worker now keeps the
-        current turn IN-HAND across transient failures via
+        Under the deque-based design the worker no longer awaits
+        between dispatches. ``_deliver_turn`` appends each successful
+        paste's meta to ``_inflight_metas``; ``_handle_turn_complete``
+        pops them FIFO. The watchdog (``_inflight_watchdog``) handles
+        the "stop hook never fires" failure mode by aging the deque
+        head and force_restarting if it exceeds ``_TURN_DONE_TIMEOUT_SEC``
+        — replacing the pre-#560 per-iter timeout.
+
+        Murzik #522 round-1 (data-loss fix), preserved: the worker keeps
+        the current turn IN-HAND across transient failures via
         ``self._inflight_turn``. The previous shape — ``get()`` a turn,
         run ``_deliver_turn``, let any exception fall through the
         catch-all — silently dropped messages when the context-lock
@@ -2263,66 +2467,20 @@ class TmuxSession:
                     self._processing = True
                     await self._deliver_turn(turn)
                     self._stats["turns"] += 1
-
-                    # Wait for THIS turn's stop_hook_summary to fire
-                    # _handle_turn_complete, which sets _turn_done.
-                    # Bounded so a missed Stop hook (e.g. transcript path
-                    # never reported, hook script removed) doesn't strand
-                    # the worker forever — 10 minutes is generous enough
-                    # for long tool-use loops + slow models, tight enough
-                    # that a real wedge surfaces in operations.
-                    try:
-                        await asyncio.wait_for(
-                            self._turn_done.wait(),
-                            timeout=_TURN_DONE_TIMEOUT_SEC,
-                        )
-                        self._has_completed_turn = True
-                        # Success — clear inflight so the next
-                        # iteration pulls a fresh turn.
-                        self._inflight_turn = None
-                    except asyncio.TimeoutError:
-                        # The REPL is stuck. Pushok's PR #496 round-2
-                        # follow-up: just "continue" leaves the stuck
-                        # turn's stop_hook_summary free to land later
-                        # and route to the *next* dispatch's meta —
-                        # exactly the original Case 1 bug, slow-motion.
-                        # Solution: force_restart the tmux pane. The
-                        # orphaned turn dies with the REPL; SessionStart
-                        # hook repoints the tailer at the new transcript
-                        # file, so any late stop_hook_summary from the
-                        # dead session can't poison the new one. The
-                        # cancelled worker exits; ``_spawn_tmux_repl``
-                        # spawns a fresh worker that resumes the queue
-                        # in a clean state.
-                        _log(
-                            f"tmux[{self.agent_name}]: turn_done timeout "
-                            f"after {_TURN_DONE_TIMEOUT_SEC}s — REPL stuck; "
-                            f"scheduling force_restart and exiting worker"
-                        )
-                        self._inflight_meta = {}
-                        self._turn_done.set()
-                        self._stats["errors"] += 1
-                        self._stats["turn_timeouts"] = (
-                            self._stats.get("turn_timeouts", 0) + 1
-                        )
-                        # Turn-done timeout means the prompt DID land in
-                        # the REPL but the response never completed.
-                        # Treat as permanent for this turn — clear
-                        # inflight so a stale prompt doesn't get re-
-                        # pasted into the fresh REPL after force_restart.
-                        self._inflight_turn = None
-                        # Schedule force_restart in the background so this
-                        # worker can exit cleanly without awaiting its own
-                        # cancellation (force_restart calls disconnect →
-                        # worker_task.cancel + await, which would deadlock
-                        # if invoked synchronously from inside the worker).
-                        asyncio.create_task(self.force_restart())
-                        return
+                    # Success — paste landed, meta appended to the
+                    # deque. ``_has_completed_turn`` advances when the
+                    # first stop_hook_summary pops anything (see
+                    # ``_handle_turn_complete``). Worker clears its
+                    # in-hand turn and immediately iterates to the
+                    # next queued message — no _turn_done wait under
+                    # #560. CC's native queued-prompt feature absorbs
+                    # the second/third/Nth pasted turn while the first
+                    # is still running.
+                    self._inflight_turn = None
                 except _ContextLockDeferral as e:
                     # Transient: lock file present. Don't touch
-                    # _inflight_turn or _turn_done — _deliver_turn raised
-                    # BEFORE clearing turn_done or mutating meta, so the
-                    # signal/meta from any prior turn is still consistent.
+                    # _inflight_turn or any deque state — _deliver_turn
+                    # raised BEFORE pasting, so no meta was appended.
                     _log(
                         f"tmux[{self.agent_name}]: turn deferred "
                         f"(context lock); retrying in "
@@ -2337,17 +2495,17 @@ class TmuxSession:
                     # broken pane on the next iteration.
                     self._stats["errors"] += 1
                     _log(f"tmux[{self.agent_name}]: turn delivery raised: {e}")
-                    # _deliver_turn already re-armed turn_done on send-keys
-                    # failure; defensively re-arm here in case some other
-                    # path raised (e.g. tailer state corruption).
+                    # _deliver_turn already re-armed _turn_done and
+                    # fired the per-turn completion_event on send-keys
+                    # failure (Murzik review point #2); defensively
+                    # re-arm _turn_done here in case some other path
+                    # raised (e.g. tailer state corruption).
                     self._turn_done.set()
                     self._inflight_turn = None
                     # Task #90: dead-pane already scheduled disconnect from
                     # inside _deliver_turn. Exit the worker cleanly so we
-                    # don't retry into the now-being-torn-down pane.
-                    # Mirrors the turn_done timeout path's create_task +
-                    # return pattern above (the finally block below still
-                    # runs and resets _processing).
+                    # don't retry into the now-being-torn-down pane. The
+                    # watchdog also exits when CONNECTED → DEAD.
                     if "can't find pane" in str(e):
                         return
                 finally:
@@ -2356,6 +2514,72 @@ class TmuxSession:
             _log(f"tmux[{self.agent_name}]: worker cancelled")
         except Exception as e:
             _log(f"tmux[{self.agent_name}]: worker error: {e}")
+
+    async def _inflight_watchdog(self) -> None:
+        """Age the ``_inflight_metas`` head; force_restart if it sticks.
+
+        Issue #560 — replaces the per-iter ``_turn_done`` timeout the
+        worker used to enforce. With concurrent dispatch the worker no
+        longer waits between turns, so the "stop hook never fires"
+        failure mode needs a separate watcher.
+
+        **Head-age, not paste-age** (Murzik review point #1). When a
+        turn becomes the deque head (either by being the first append
+        into an empty deque, or by inheriting the head spot after the
+        previous head was popped), its ``_head_started_at`` clock
+        starts. Each turn gets its own ``_TURN_DONE_TIMEOUT_SEC``
+        window once it's the head — a queued turn doesn't get
+        force_restarted for ageing while ANOTHER turn was running.
+
+        On timeout: drain the deque (unblocking every pending
+        completion_event so wait_for_completion callers don't hang),
+        bump ``turn_timeouts`` stats, schedule ``force_restart``, and
+        exit. ``force_restart`` cancels this task as part of its
+        ``disconnect`` shutdown; the new connect's ``_spawn_tmux_repl``
+        respawns a fresh watchdog.
+        """
+        _log(f"tmux[{self.agent_name}]: inflight watchdog started")
+        try:
+            while self.state == SessionState.CONNECTED:
+                await asyncio.sleep(_WATCHDOG_TICK_SEC)
+                if not self._inflight_metas or self._head_started_at is None:
+                    continue
+                age = time.time() - self._head_started_at
+                if age <= _TURN_DONE_TIMEOUT_SEC:
+                    continue
+                _log(
+                    f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
+                    f"> {_TURN_DONE_TIMEOUT_SEC}s — REPL stuck; scheduling "
+                    f"force_restart (deque depth={len(self._inflight_metas)})"
+                )
+                # Drain + unblock every pending completion_event
+                # (Murzik review point #2). Snapshot before clear so
+                # in-flight readers in another coro can't observe a
+                # partial state.
+                drained = list(self._inflight_metas)
+                self._inflight_metas.clear()
+                self._head_started_at = None
+                for entry in drained:
+                    if (
+                        entry.completion_event is not None
+                        and not entry.completion_event.is_set()
+                    ):
+                        entry.completion_event.set()
+                self._turn_done.set()
+                self._stats["errors"] += 1
+                self._stats["turn_timeouts"] = (
+                    self._stats.get("turn_timeouts", 0) + 1
+                )
+                # Schedule force_restart in the background — must NOT
+                # await it here because force_restart→disconnect cancels
+                # this watchdog task and awaits its completion, which
+                # would deadlock.
+                asyncio.create_task(self.force_restart())
+                return
+        except asyncio.CancelledError:
+            _log(f"tmux[{self.agent_name}]: inflight watchdog cancelled")
+        except Exception as e:
+            _log(f"tmux[{self.agent_name}]: inflight watchdog error: {e}")
 
     def _context_lock_path(self) -> Path:
         """Path of this agent's daemon-level context lock file.
@@ -2371,29 +2595,31 @@ class TmuxSession:
 
         PR8b: the response side is handled asynchronously by the
         transcript tailer (set up in ``_spawn_tmux_repl``). This method
-        handles the inbound half — push the prompt, capture the routing
-        metadata for the tailer to use when it fires the response_callback,
-        clear the turn-done gate so the worker waits for THIS turn's
-        completion before dispatching the next prompt, and signal the
-        tailer to switch to the tighter active-poll cadence.
+        handles the inbound half — push the prompt and, on successful
+        paste, **append** the routing metadata to ``_inflight_metas``
+        so the tailer's ``_handle_turn_complete`` can pop it (FIFO)
+        when this turn's ``stop_hook_summary`` lands.
 
-        Pushok's PR #496 round-1 Case 1 fix: the turn_done gate is what
-        prevents ``_inflight_meta`` from being clobbered between back-to-
-        back ``send()`` calls. The previous design assumed worker
-        sequentiality alone was enough — but the worker is a dispatch
-        pump, not a request/response broker, so a fast second prompt
-        would overwrite meta before the first turn's stop_hook_summary
-        landed.
+        **#560 — concurrent dispatch.** The pre-#560 design wrote a
+        single ``_inflight_meta`` dict here and waited (in the worker)
+        for ``_turn_done`` to fire before dispatching the next turn.
+        That gate is what made mid-turn steering impossible — a second
+        send() while a turn was running sat invisibly in
+        ``_message_queue`` until the first turn fully resolved. The
+        deque replaces the single-cell shared mutable; the worker no
+        longer waits between dispatches; each entry carries its own
+        routing dict so #496 Case 1 (clobber → wrong-chat routing) is
+        impossible by construction.
 
-        Pulse-v2 port (task #92): one safety primitive gates the paste —
-        the context-lock check — raising a **typed transient exception**
-        the worker catches in its retry loop (Murzik #522 round-1).
-        Because the worker pops the turn from the queue before calling
-        ``_deliver_turn``, a bare exception would silently drop the
-        message; the worker keeps the turn in ``_inflight_turn`` and
-        re-pastes the same prompt on the next iteration. The deferral
-        path does not schedule disconnect — this is transient state,
-        not a dead-pane.
+        Pulse-v2 port (task #92): the context-lock check still raises a
+        typed transient exception the worker catches in its retry loop
+        (Murzik #522 round-1). Because the worker pops the turn from
+        ``_message_queue`` BEFORE calling ``_deliver_turn``, a bare
+        exception would silently drop the message; the worker keeps
+        the turn in ``_inflight_turn`` and re-pastes on the next
+        iteration. The deferral path does NOT append to
+        ``_inflight_metas`` (no paste happened, no stop hook will
+        fire).
 
         **Context-lock check.** If the daemon-level context manager has
         touched ``data/transport-locks/<agent>.lock``, it's mid-rewrite
@@ -2405,10 +2631,13 @@ class TmuxSession:
         Splash-state paste handling lives in ``_TmuxControl.paste_text``
         (bracketed-paste + delayed-Enter, commit 0864f4e / issue #514).
         Claude Code's splash dismisses on input focus, so pasting into
-        the splash works correctly; no readiness gate is needed. (Prior
-        to #525, a pane-scraping idle-prompt gate from #522 / #524 sat
-        here; it waited for a bare ``❯`` signal that the splash never
-        produces, killing every cold start.)
+        the splash works correctly; no readiness gate is needed.
+
+        **Paste-failure unblock (Murzik review point #2):** if
+        ``paste_text`` reports !ok we do NOT append to
+        ``_inflight_metas`` (no stop hook will fire), and we DO set
+        the turn's ``completion_event`` so a ``wait_for_completion=True``
+        caller (e.g. pre-sleep save) doesn't hang forever.
         """
         # Pulse-v2 safety primitive: context-lock check. Cheap fs stat;
         # do this first so we bail before mutating any state. The lock
@@ -2424,39 +2653,11 @@ class TmuxSession:
                 f"deferring paste; worker will retry on next iteration"
             )
 
-        # Capture routing metadata BEFORE send-keys so the tailer's callback
-        # has access to it even if the tailer fires unusually quickly.
-        #
-        # Internal-prompt regression guard (PR for #543): only EXTERNAL
-        # turns own routing metadata. An internal turn that writes here
-        # would clobber a back-to-back external turn's routing fields
-        # (the #496 round-1 Case 1 defect surfacing through this path).
-        # Leave ``_inflight_meta`` empty for internal turns; they have no
-        # response delivery target and ``_handle_turn_complete`` skips
-        # the response_callback altogether when ``turn.internal``.
-        if turn.internal:
-            self._inflight_meta = {}
-        else:
-            self._inflight_meta = {
-                "platform": turn.platform,
-                "chat_id": turn.chat_id,
-                "message_id": turn.message_id,
-            }
-
-        # Clear the turn-done gate BEFORE send-keys. Two reasons for
-        # ordering this here (vs. after mark_active, the other reasonable
-        # spot):
-        #   1. ANY stop_hook_summary that arrives after this clear must
-        #      come from THIS turn (we haven't yet delivered the prompt,
-        #      let alone produced a response). So waiting on the next set
-        #      is unambiguous.
-        #   2. If we cleared after mark_active, a degenerate-fast tailer
-        #      (test fixture, or a claude refusal turn) could conceivably
-        #      set turn_done between mark_active and clear, then we'd
-        #      wipe the signal and the worker would block forever.
-        # Cost is one extra .clear() call that wipes a stale signal from
-        # the previous turn — already-consumed by the previous worker
-        # iteration's await, so wiping it is a no-op.
+        # Clear the back-compat ``_turn_done`` event before pasting.
+        # Under #560 the worker no longer awaits this between dispatches
+        # — the clear is purely for legacy observers and for tests that
+        # pin the "cleared on dispatch, set on completion" pattern.
+        # ``_handle_turn_complete`` re-sets it on every successful pop.
         self._turn_done.clear()
 
         # Use paste_text (bracketed paste + delayed Enter) instead of raw
@@ -2466,11 +2667,13 @@ class TmuxSession:
         # fresh session doesn't get wedged in claude's input buffer.
         result = await self._tmux.paste_text(turn.prompt, enter=True)
         if not result.ok:
-            # Send failed — no response will arrive. Re-arm turn_done so
-            # the worker's next iteration doesn't deadlock; clear meta
-            # so a stale value doesn't leak to a later (unrelated) turn.
-            self._inflight_meta = {}
+            # Send failed — no response will arrive. Re-arm turn_done
+            # (back-compat) and unblock any wait_for_completion caller
+            # for THIS turn so they don't hang forever — Murzik review
+            # point #2.
             self._turn_done.set()
+            if turn.completion_event is not None and not turn.completion_event.is_set():
+                turn.completion_event.set()
             # Task #90: detect dead-pane (tmux session killed externally,
             # tmux server crashed, etc.). Without this, the worker would
             # loop forever pasting into a non-existent pane. Schedule
@@ -2493,6 +2696,32 @@ class TmuxSession:
                 f"tmux paste-buffer / send-keys failed: rc={result.returncode} "
                 f"stderr={result.stderr.strip()!r}"
             )
+
+        # Paste succeeded — append routing metadata to the deque so
+        # ``_handle_turn_complete`` can popleft it when this turn's
+        # stop_hook_summary lands. Internal turns get an empty meta
+        # dict (no external recipient).
+        if turn.internal:
+            meta_dict: dict = {}
+        else:
+            meta_dict = {
+                "platform": turn.platform,
+                "chat_id": turn.chat_id,
+                "message_id": turn.message_id,
+            }
+        was_empty = not self._inflight_metas
+        self._inflight_metas.append(_InflightMeta(
+            meta=meta_dict,
+            completion_event=turn.completion_event,
+            internal=turn.internal,
+            dispatched_at=time.time(),
+        ))
+        # Watchdog head-clock. If this entry just became the head (deque
+        # was empty before append), start its timeout window NOW. If
+        # other entries are ahead, the head's clock was set when IT
+        # became the head — leave it alone (Murzik review point #1).
+        if was_empty:
+            self._head_started_at = time.time()
 
         # Hint to the tailer that a turn is in flight — switches to the
         # active-poll cadence (200ms vs 2s) for low-latency response
@@ -2550,6 +2779,11 @@ class TmuxSession:
             )
             if not self._worker_task or self._worker_task.done():
                 self._worker_task = asyncio.create_task(self._message_worker())
+            # Respawn the watchdog too (#560). disconnect() above
+            # cancelled it; without this, force_restart-then-stuck-turn
+            # wouldn't be caught.
+            if not self._watchdog_task or self._watchdog_task.done():
+                self._watchdog_task = asyncio.create_task(self._inflight_watchdog())
             _log(f"tmux[{self.agent_name}]: force_restart complete")
             return True
         except Exception as e:
@@ -2738,6 +2972,9 @@ class TmuxSession:
                 # the queue would otherwise have no drainer on success.
                 if not self._worker_task or self._worker_task.done():
                     self._worker_task = asyncio.create_task(self._message_worker())
+                # Respawn the watchdog too (#560).
+                if not self._watchdog_task or self._watchdog_task.done():
+                    self._watchdog_task = asyncio.create_task(self._inflight_watchdog())
                 _log(f"tmux[{self.agent_name}]: reconnected successfully")
                 return
             except Exception as e:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2593,8 +2593,24 @@ class TmuxSession:
 
         Also covers the worker's in-hand-but-not-pasted turn (e.g.
         mid context-lock retry) — that turn's meta isn't in the deque
-        yet, but it must replay too. Requeued at the front BEFORE
-        the tail (it was earlier in original send-order).
+        yet, but it must replay too. Requeued AFTER the tail entries:
+        the worker is single-threaded so the in-hand turn was pulled
+        from the queue AFTER the tail entries were pasted, so in
+        original send-order it comes LAST. (Murzik review on commit 2:
+        commit 2 had this backwards — fixed in commit 3.)
+
+        **Atomic handoff with worker shutdown** (Murzik review on
+        commit 2). The live worker is cancelled SYNCHRONOUSLY before
+        the requeue is made visible to ``_message_queue``. Without
+        this, the worker (parked in ``_message_queue.get()``) would
+        race the post-watchdog ``force_restart()``: ``put_nowait``
+        resolves the pending getter future synchronously, the worker
+        wakes up and pastes B/C back into the still-wedged REPL,
+        ``disconnect()``'s drain fires their completion_events on
+        abandoned deque entries → loss/false-completion bug returns.
+        Cancelling the worker first transitions its getter future
+        to CANCELLED; ``asyncio.Queue._wakeup_next`` skips done
+        waiters, so the subsequent ``put_nowait`` cannot wake it.
 
         On the watchdog timeout path, ``_inflight_turn`` is also
         cleared so the post-restart worker doesn't try to redeliver
@@ -2632,15 +2648,46 @@ class TmuxSession:
                 in_hand = self._inflight_turn
                 self._inflight_turn = None
 
-                # Replay list: in_hand (was the earliest pending —
-                # pulled from queue but not pasted) goes first, then
-                # tail entries in FIFO order. Each carries its full
-                # ``_QueuedTurn`` so the new worker re-dispatches with
-                # the original prompt + completion_event.
+                # **CRITICAL — kill the live worker BEFORE making the
+                # replay queue visible** (Murzik review on commit 2 of
+                # PR #561). The worker is almost certainly parked in
+                # ``_message_queue.get()``; ``put_nowait`` resolves
+                # that pending getter future synchronously. If we
+                # requeued first, the still-live worker would wake up,
+                # pull B/C, and ``_deliver_turn`` them back into the
+                # STILL-WEDGED REPL before ``force_restart()``'s
+                # disconnect could cancel it. Then disconnect's drain
+                # would fire B/C's completion_events on the freshly-
+                # appended (and abandoned) deque entries — recreating
+                # the loss/false-completion bug we're trying to fix,
+                # just with a race window.
+                #
+                # ``Task.cancel()`` synchronously transitions the
+                # task's awaited future (the queue getter) to CANCELLED.
+                # ``asyncio.Queue._wakeup_next`` skips done waiters, so
+                # the subsequent ``put_nowait`` cannot wake the cancelled
+                # worker. The new worker spawned by ``force_restart()``'s
+                # post-disconnect branch is the only consumer of the
+                # replay. ``disconnect()``'s own worker cancel is
+                # idempotent (no-op on an already-cancelled task).
+                if self._worker_task is not None and not self._worker_task.done():
+                    self._worker_task.cancel()
+
+                # Replay list: tail entries FIRST (FIFO from deque),
+                # then in_hand LAST. The worker is single-threaded —
+                # it pulls one turn from the queue, pastes it (appends
+                # to ``_inflight_metas``), then pulls the next. So
+                # tail entries B were pasted EARLIER than whatever
+                # the worker is currently holding in ``_inflight_turn``
+                # (in_hand C). Original send-order: A (head) → B
+                # (tail) → C (in_hand). On A timeout, replay must be
+                # B then C. (Pre-paste-retry edge: deque empty, in_hand
+                # is the sole entry — ``tail_entries`` is empty, so
+                # in_hand becomes the lone replay entry, correct.)
                 replay: list[_QueuedTurn] = []
+                replay.extend(entry.turn for entry in tail_entries)
                 if in_hand is not None:
                     replay.append(in_hand)
-                replay.extend(entry.turn for entry in tail_entries)
                 if replay:
                     # Prepend ``replay`` to ``_message_queue``: drain
                     # current queue contents, push replay first, then

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -455,8 +455,9 @@ class _InflightMeta:
     # THIS entry is popleft'd from the deque. Used by callers with
     # ``wait_for_completion=True`` (e.g. pre-sleep save) to block until
     # their specific turn finishes — NOT some later turn. Also set on
-    # ``force_restart``/paste-failure paths so a waiter doesn't hang
-    # forever when its turn is abandoned. None for fire-and-forget.
+    # the watchdog timeout path for the HEAD only (tail entries get
+    # requeued instead; their event fires when they're actually rerun).
+    # None for fire-and-forget.
     completion_event: asyncio.Event | None
     # True for daemon-internal turns. ``_handle_turn_complete`` skips the
     # ``conversation_store.append`` + ``_response_callback`` calls when
@@ -468,6 +469,17 @@ class _InflightMeta:
     # by ``dispatched_at``, so a queued turn gets its OWN fair timeout
     # window once it becomes the head (Murzik review on PR for #560).
     dispatched_at: float
+    # Original ``_QueuedTurn`` carried so the watchdog can REQUEUE the
+    # tail entries for replay after a stuck-head force_restart, instead
+    # of silently dropping them. Murzik review on PR #561 found that
+    # the initial deque shape only stored routing metadata; when A
+    # wedged and the watchdog force-restarted, B/C (already dispatched
+    # into CC's native queue but not yet run) were killed with the old
+    # REPL and could not be replayed. The replay path uses ``turn`` to
+    # push the original prompt + completion_event back to the front of
+    # ``_message_queue`` so the new worker re-dispatches them after
+    # the restart settles.
+    turn: _QueuedTurn
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -738,11 +750,21 @@ class TmuxSession:
         self._inflight_metas.clear()
         self._head_started_at = None
         if value:
+            # Synthesize a minimal _QueuedTurn for the entry's ``turn``
+            # field — tests using this setter don't care about replay
+            # semantics, only routing-meta reads.
+            synthetic = _QueuedTurn(
+                prompt="",
+                platform=value.get("platform", ""),
+                chat_id=value.get("chat_id", ""),
+                message_id=value.get("message_id", ""),
+            )
             self._inflight_metas.append(_InflightMeta(
                 meta=dict(value),
                 completion_event=None,
                 internal=False,
                 dispatched_at=time.time(),
+                turn=synthetic,
             ))
             self._head_started_at = time.time()
 
@@ -1540,6 +1562,19 @@ class TmuxSession:
         for entry in drained:
             if entry.completion_event is not None and not entry.completion_event.is_set():
                 entry.completion_event.set()
+
+        # Issue #547: also unblock ``_inflight_turn`` — the turn the
+        # worker pulled from the queue but had NOT yet pasted (e.g.
+        # mid context-lock retry, or worker cancelled before
+        # _deliver_turn ran). Its meta isn't in the deque yet, so the
+        # drain loop above missed it. Without this, an unbounded
+        # ``wait_for_completion=True`` caller hangs forever when its
+        # internal turn is interrupted pre-paste.
+        if self._inflight_turn is not None:
+            evt = self._inflight_turn.completion_event
+            if evt is not None and not evt.is_set():
+                evt.set()
+            self._inflight_turn = None
 
         # Stop the response tailer (PR8b). Tailer instance is retained
         # so stats/path persist; only the background task is cancelled.
@@ -2496,11 +2531,22 @@ class TmuxSession:
                     self._stats["errors"] += 1
                     _log(f"tmux[{self.agent_name}]: turn delivery raised: {e}")
                     # _deliver_turn already re-armed _turn_done and
-                    # fired the per-turn completion_event on send-keys
-                    # failure (Murzik review point #2); defensively
+                    # fired the per-turn completion_event on the explicit
+                    # !ok branch (Murzik review point #2); defensively
                     # re-arm _turn_done here in case some other path
-                    # raised (e.g. tailer state corruption).
+                    # raised (e.g. tailer state corruption, paste_text
+                    # itself raising before the !ok handler ran).
                     self._turn_done.set()
+                    # Issue #547: a wait_for_completion=True caller for
+                    # THIS turn must unblock even when delivery raised
+                    # before _deliver_turn's own completion_event branch.
+                    # Idempotent — .set() on an already-set Event is a
+                    # no-op.
+                    if (
+                        turn.completion_event is not None
+                        and not turn.completion_event.is_set()
+                    ):
+                        turn.completion_event.set()
                     self._inflight_turn = None
                     # Task #90: dead-pane already scheduled disconnect from
                     # inside _deliver_turn. Exit the worker cleanly so we
@@ -2531,10 +2577,30 @@ class TmuxSession:
         window once it's the head — a queued turn doesn't get
         force_restarted for ageing while ANOTHER turn was running.
 
-        On timeout: drain the deque (unblocking every pending
-        completion_event so wait_for_completion callers don't hang),
-        bump ``turn_timeouts`` stats, schedule ``force_restart``, and
-        exit. ``force_restart`` cancels this task as part of its
+        **Tail requeue on timeout** (Murzik review on PR #561).
+        When the head wedges, ONLY the head is abandoned — its
+        ``completion_event`` fires (signal of "definitively failed"),
+        but its prompt is NOT replayed. Tail entries (B, C, ... that
+        were already dispatched into Claude Code's native queue but
+        never got to run because A wedged) carry intact prompts +
+        completion_events; we requeue them at the FRONT of
+        ``_message_queue`` in FIFO order so the new worker (spawned
+        by force_restart's disconnect→connect cycle) re-dispatches
+        them after the restart. Their ``completion_event`` stays
+        UNSET so a ``wait_for_completion=True`` caller still waits
+        for the actual rerun, not for a phantom "completion" the
+        watchdog falsely signaled.
+
+        Also covers the worker's in-hand-but-not-pasted turn (e.g.
+        mid context-lock retry) — that turn's meta isn't in the deque
+        yet, but it must replay too. Requeued at the front BEFORE
+        the tail (it was earlier in original send-order).
+
+        On the watchdog timeout path, ``_inflight_turn`` is also
+        cleared so the post-restart worker doesn't try to redeliver
+        a stale reference (the requeued copy is the canonical replay).
+
+        ``force_restart`` cancels this task as part of its
         ``disconnect`` shutdown; the new connect's ``_spawn_tmux_repl``
         respawns a fresh watchdog.
         """
@@ -2552,19 +2618,63 @@ class TmuxSession:
                     f"> {_TURN_DONE_TIMEOUT_SEC}s — REPL stuck; scheduling "
                     f"force_restart (deque depth={len(self._inflight_metas)})"
                 )
-                # Drain + unblock every pending completion_event
-                # (Murzik review point #2). Snapshot before clear so
-                # in-flight readers in another coro can't observe a
-                # partial state.
-                drained = list(self._inflight_metas)
+                # Snapshot deque state before mutation so this critical
+                # section is atomic from the outside (no awaits between
+                # snapshot and mutation).
+                head = self._inflight_metas.popleft()
+                tail_entries = list(self._inflight_metas)
                 self._inflight_metas.clear()
                 self._head_started_at = None
-                for entry in drained:
-                    if (
-                        entry.completion_event is not None
-                        and not entry.completion_event.is_set()
-                    ):
-                        entry.completion_event.set()
+                # Also capture any in-hand-but-not-pasted turn (e.g.
+                # worker mid context-lock retry). Cleared so the
+                # post-restart worker doesn't redeliver from the stale
+                # reference.
+                in_hand = self._inflight_turn
+                self._inflight_turn = None
+
+                # Replay list: in_hand (was the earliest pending —
+                # pulled from queue but not pasted) goes first, then
+                # tail entries in FIFO order. Each carries its full
+                # ``_QueuedTurn`` so the new worker re-dispatches with
+                # the original prompt + completion_event.
+                replay: list[_QueuedTurn] = []
+                if in_hand is not None:
+                    replay.append(in_hand)
+                replay.extend(entry.turn for entry in tail_entries)
+                if replay:
+                    # Prepend ``replay`` to ``_message_queue``: drain
+                    # current queue contents, push replay first, then
+                    # the original backlog. Preserves FIFO across the
+                    # boundary. ``asyncio.Queue`` has no put-front, so
+                    # the drain+repush is the canonical pattern.
+                    backlog: list[_QueuedTurn] = []
+                    while not self._message_queue.empty():
+                        try:
+                            backlog.append(self._message_queue.get_nowait())
+                        except asyncio.QueueEmpty:
+                            break
+                    for t in replay:
+                        self._message_queue.put_nowait(t)
+                    for t in backlog:
+                        self._message_queue.put_nowait(t)
+                    _log(
+                        f"tmux[{self.agent_name}]: requeued "
+                        f"{len(replay)} turn(s) for replay after "
+                        f"force_restart (tail={len(tail_entries)}, "
+                        f"in_hand={'yes' if in_hand else 'no'})"
+                    )
+
+                # HEAD ONLY: fire its completion_event. Head was
+                # definitively abandoned (its prompt is NOT replayed —
+                # the wedge invalidated whatever progress it made).
+                # Tail entries' events stay UNSET so wait_for_completion
+                # callers wait for the actual rerun, not the watchdog
+                # itself. Critical contract — Murzik review on PR #561.
+                if (
+                    head.completion_event is not None
+                    and not head.completion_event.is_set()
+                ):
+                    head.completion_event.set()
                 self._turn_done.set()
                 self._stats["errors"] += 1
                 self._stats["turn_timeouts"] = (
@@ -2715,6 +2825,7 @@ class TmuxSession:
             completion_event=turn.completion_event,
             internal=turn.internal,
             dispatched_at=time.time(),
+            turn=turn,
         ))
         # Watchdog head-clock. If this entry just became the head (deque
         # was empty before append), start its timeout window NOW. If

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -2031,11 +2031,13 @@ async def test_worker_force_restarts_on_turn_done_timeout(monkeypatch) -> None:
     force_restart_results: list[bool] = []
     original_force_restart = ss.force_restart
 
-    async def stub_force_restart():
+    async def stub_force_restart(*, bypass_guard: bool = False):
         force_restart_called.set()
         # Call original to drive state machine through reconnect.
+        # Propagate bypass_guard so the watchdog's recovery path is
+        # exercised end-to-end (Murzik review on commit 3 of PR #561).
         try:
-            result = await original_force_restart()
+            result = await original_force_restart(bypass_guard=bypass_guard)
             force_restart_results.append(result)
             return result
         finally:
@@ -4006,7 +4008,7 @@ class TestInflightDequeConcurrentDispatch:
         # Stub force_restart so we don't actually drive the full
         # disconnect→reconnect cycle.
         force_called = asyncio.Event()
-        async def _stub_force_restart():
+        async def _stub_force_restart(*, bypass_guard: bool = False):
             force_called.set()
             return True
         ss.force_restart = _stub_force_restart
@@ -4093,7 +4095,7 @@ class TestInflightDequeConcurrentDispatch:
         except asyncio.CancelledError:
             pass
         force_called = asyncio.Event()
-        async def _stub():
+        async def _stub(*, bypass_guard: bool = False):
             force_called.set()
             return True
         ss.force_restart = _stub
@@ -4183,7 +4185,7 @@ class TestInflightDequeConcurrentDispatch:
         # post-restart machinery runs. The stub also confirms the
         # watchdog reached scheduling.
         force_called = asyncio.Event()
-        async def _stub_force_restart():
+        async def _stub_force_restart(*, bypass_guard: bool = False):
             force_called.set()
             return True
         ss.force_restart = _stub_force_restart
@@ -4253,6 +4255,112 @@ class TestInflightDequeConcurrentDispatch:
         # No deque entries leaked.
         assert len(ss._inflight_metas) == 0
         assert ss._inflight_turn is None
+
+    @pytest.mark.asyncio
+    async def test_force_restart_bypass_guard_ignores_blocking_guard(self) -> None:
+        """``force_restart(bypass_guard=True)`` ignores a guard that
+        would otherwise block.
+
+        Murzik review on commit 3 of PR #561. The persistence guard
+        preserves completed-but-unsaved state across direct restart
+        calls. The watchdog calls with ``bypass_guard=True`` because
+        by the time the watchdog fires, the REPL is wedged — the
+        guard's "preserve mid-conversation state" premise no longer
+        holds. Without this, the watchdog would cancel the worker,
+        move replay into the queue, then ``force_restart()`` would
+        return False with the session inert (no worker, no watchdog,
+        stranded queue).
+        """
+        guard = MagicMock(return_value={"restart_safe": False, "reason": "stale"})
+        ss, tmux = _make_session(restart_guard=guard)
+        await ss.connect()
+        # Manually mark _has_completed_turn so the guard would trip
+        # under a normal force_restart call.
+        ss._has_completed_turn = True
+
+        # Sanity: without bypass, the guard blocks.
+        result_blocked = await ss.force_restart()
+        assert result_blocked is False
+        assert tmux.kill_session.await_count == 0, (
+            "guard must block kill when bypass_guard=False"
+        )
+
+        # With bypass, restart proceeds despite the guard saying no.
+        result_bypassed = await ss.force_restart(bypass_guard=True)
+        assert result_bypassed is True
+        assert tmux.kill_session.await_count >= 1, (
+            "bypass_guard=True must drive disconnect→reconnect even when "
+            "the persistence guard says no"
+        )
+        assert ss.state == SessionState.CONNECTED
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_bypasses_guard_to_recover_wedged_repl(self, monkeypatch):
+        """Murzik review on commit 3 of PR #561 — full-stack regression.
+
+        The watchdog must drive a reconnect even when a persistence
+        guard would otherwise block ``force_restart``. If it didn't,
+        the session would silently strand:
+        - head's completion_event already fired (abandoned),
+        - tail/in_hand replay already moved into ``_message_queue``,
+        - the only worker already cancelled,
+        - ``force_restart`` returns False, no new worker, no new
+          watchdog → session stays CONNECTED but inert.
+
+        Contract: watchdog → ``force_restart(bypass_guard=True)`` →
+        disconnect + fresh spawn + fresh worker that drains the
+        replay queue.
+        """
+        from pinky_daemon import tmux_session as _ts
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.02)
+
+        # Guard that would block any normal force_restart.
+        guard = MagicMock(return_value={"restart_safe": False, "reason": "stale"})
+        ss, tmux = _make_session(restart_guard=guard)
+        await ss.connect()
+        # Mark completed-turn so guard becomes active.
+        ss._has_completed_turn = True
+        original_worker = ss._worker_task
+
+        # Seed head + tail to trip the watchdog. Head has a completion
+        # event so we can verify head-only abandonment ran.
+        completion_a = asyncio.Event()
+        _seed_inflight(ss, prompt="A", meta={"chat_id": "A"}, completion_event=completion_a)
+        _seed_inflight(ss, prompt="B", meta={"chat_id": "B"})
+        ss._head_started_at = 0.0
+
+        # Wait until the watchdog has driven the reconnect: kill_session
+        # called (disconnect) AND a new worker task spawned that isn't
+        # the original.
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if (
+                tmux.kill_session.await_count >= 1
+                and ss._worker_task is not None
+                and ss._worker_task is not original_worker
+                and not ss._worker_task.done()
+            ):
+                break
+        assert tmux.kill_session.await_count >= 1, (
+            "watchdog must drive disconnect (kill_session) via "
+            "force_restart(bypass_guard=True) — guard would have blocked "
+            "a normal force_restart and stranded the session"
+        )
+        assert ss._worker_task is not None
+        assert ss._worker_task is not original_worker, (
+            "watchdog's reconnect must spawn a FRESH worker task — the "
+            "original was cancelled in the critical path"
+        )
+        assert not ss._worker_task.done(), (
+            "fresh worker should be live to consume the replay queue"
+        )
+        assert ss.state == SessionState.CONNECTED
+        # Head abandoned, tail's event still unset (waits for replay).
+        assert completion_a.is_set()
+
+        await ss.disconnect()
 
     @pytest.mark.asyncio
     async def test_head_clock_does_not_advance_on_subsequent_append(self):

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -4073,8 +4073,12 @@ class TestInflightDequeConcurrentDispatch:
     async def test_watchdog_requeues_in_hand_turn_with_tail(self, monkeypatch):
         """Tail-requeue must also handle the worker's
         ``_inflight_turn`` (a turn pulled from the queue but not yet
-        pasted — e.g. mid context-lock retry). It was earlier in
-        original send-order than the deque tail; replay before the tail.
+        pasted — e.g. mid context-lock retry). Murzik review on
+        commit 2 of PR #561: it was LATER in original send-order than
+        the deque tail (the worker is single-threaded — it pulls one,
+        pastes it, pulls the next; tail entries had already been
+        pasted by the time in_hand was pulled), so replay AFTER the
+        tail, not before.
         """
         from pinky_daemon import tmux_session as _ts
         monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
@@ -4094,12 +4098,14 @@ class TestInflightDequeConcurrentDispatch:
             return True
         ss.force_restart = _stub
 
-        # Deque: [A (stuck head), B]
+        # Deque: [A (stuck head), B] — A and B were pasted by the
+        # worker in that order.
         _seed_inflight(ss, prompt="A", meta={"chat_id": "A"})
         _seed_inflight(ss, prompt="B", meta={"chat_id": "B"})
-        # In-hand: a turn the worker had pulled but not yet pasted
-        # (context-lock retry). Original send-order: came AFTER B.
-        in_hand_turn = _QueuedTurn(prompt="F", platform="t", chat_id="F", message_id="mF")
+        # In-hand: a turn the worker pulled AFTER pasting B but had
+        # not yet pasted (e.g. context-lock retry). Original send-order:
+        # A → B → C.
+        in_hand_turn = _QueuedTurn(prompt="C", platform="t", chat_id="C", message_id="mC")
         ss._inflight_turn = in_hand_turn
         ss._head_started_at = 0.0
 
@@ -4109,16 +4115,144 @@ class TestInflightDequeConcurrentDispatch:
             pytest.fail("watchdog must trigger force_restart")
 
         assert ss._inflight_turn is None, "in-hand turn cleared after requeue"
-        # Replay order: in_hand FIRST (was earliest pending), then tail B.
+        # Replay order: tail B FIRST (pasted before C was pulled),
+        # then in_hand C LAST. Preserves original send-order.
         assert ss._message_queue.qsize() == 2
         first = ss._message_queue.get_nowait()
         second = ss._message_queue.get_nowait()
-        assert first.prompt == "F", (
-            "in-hand turn was earlier in send-order than tail — replay first"
+        assert first.prompt == "B", (
+            "tail entry B was pasted before in_hand C was pulled — "
+            "replay first to preserve A→B→C send-order"
         )
-        assert second.prompt == "B"
+        assert second.prompt == "C", (
+            "in_hand C was pulled from queue AFTER B was pasted — "
+            "replay last"
+        )
 
         await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_cancels_live_worker_before_requeue(self, monkeypatch):
+        """Race-window regression. Murzik review on commit 2 of PR #561.
+
+        In commit 2, the watchdog requeued tail/in-hand turns into
+        ``_message_queue`` while the worker was still alive. The worker
+        is parked in ``_message_queue.get()`` waiting for the next turn;
+        ``put_nowait`` resolves that getter future SYNCHRONOUSLY. So
+        the live worker could wake up, pull B/C from the queue, and
+        ``_deliver_turn`` them back into the still-wedged REPL BEFORE
+        ``force_restart()`` could call ``disconnect()`` and cancel the
+        worker. Then ``disconnect()``'s drain would fire B/C's
+        completion_events on those abandoned new deque entries —
+        recreating the loss/false-completion bug.
+
+        Commit 3 fix: cancel the worker SYNCHRONOUSLY in the watchdog
+        critical path BEFORE making the replay visible. The cancelled
+        worker's getter future is in CANCELLED state;
+        ``asyncio.Queue._wakeup_next`` skips done waiters; so the
+        subsequent ``put_nowait`` cannot wake the worker. The replay
+        sits in the queue untouched until ``force_restart()`` spawns
+        the fresh worker.
+
+        Asserts:
+        - Old worker task is done (cancelled) after watchdog trips
+        - Replay turns (B, C) are sitting in the queue undisturbed
+        - In FIFO order matching original send-order (A→B→C, with A
+          abandoned)
+        """
+        from pinky_daemon import tmux_session as _ts
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.02)
+
+        ss, _ = _make_session()
+        await ss.connect()
+        # CRITICAL DIFFERENCE FROM SIBLING TESTS: do NOT cancel the
+        # worker here. The whole point of this regression is that the
+        # watchdog must cancel the LIVE worker itself before exposing
+        # replay. The worker should be parked in ``_message_queue.get()``
+        # right now (queue is empty after connect's wake-prompt skip).
+        assert ss._worker_task is not None
+        assert not ss._worker_task.done(), (
+            "worker should be live and parked on _message_queue.get() "
+            "before watchdog trips"
+        )
+        worker_task_ref = ss._worker_task
+
+        # Stub force_restart so we don't actually disconnect+spawn.
+        # We want to inspect post-watchdog state IN PLACE before any
+        # post-restart machinery runs. The stub also confirms the
+        # watchdog reached scheduling.
+        force_called = asyncio.Event()
+        async def _stub_force_restart():
+            force_called.set()
+            return True
+        ss.force_restart = _stub_force_restart
+
+        # Seed: A (stuck head) + B (tail, pasted) + C (in_hand, pulled
+        # but not yet pasted). Original send-order A→B→C.
+        completion_a = asyncio.Event()
+        completion_b = asyncio.Event()
+        completion_c = asyncio.Event()
+        _seed_inflight(
+            ss, prompt="A", meta={"chat_id": "A"}, completion_event=completion_a,
+        )
+        _seed_inflight(
+            ss, prompt="B", meta={"chat_id": "B"}, completion_event=completion_b,
+        )
+        ss._inflight_turn = _QueuedTurn(
+            prompt="C",
+            platform="telegram",
+            chat_id="C",
+            message_id="mC",
+            completion_event=completion_c,
+        )
+        ss._head_started_at = 0.0
+
+        try:
+            await asyncio.wait_for(force_called.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pytest.fail("watchdog must trigger force_restart when head ages out")
+
+        # Give cancellation a tick to propagate through the worker's
+        # parked ``_message_queue.get()`` awaitable. The watchdog called
+        # ``cancel()`` synchronously but the worker's CancelledError
+        # handler only runs when the event loop reschedules it.
+        for _ in range(20):
+            if worker_task_ref.done():
+                break
+            await asyncio.sleep(0.01)
+
+        # PRIMARY CLAIM: the old worker is done. No way it can consume
+        # replay turns out of the queue.
+        assert worker_task_ref.done(), (
+            "watchdog must cancel the live worker synchronously before "
+            "exposing replay — otherwise the worker races force_restart "
+            "and pastes B/C back into the still-wedged REPL"
+        )
+
+        # SECONDARY CLAIM: the replay turns are sitting in the queue
+        # undisturbed, in FIFO order (B then C). If the live worker
+        # had consumed them, the queue would be empty (or contain a
+        # subset), and B/C would have been re-pasted into the wedged
+        # REPL.
+        assert ss._message_queue.qsize() == 2, (
+            f"replay must be intact in queue, got qsize="
+            f"{ss._message_queue.qsize()}"
+        )
+        first = ss._message_queue.get_nowait()
+        second = ss._message_queue.get_nowait()
+        assert first.prompt == "B", "tail entry B replays first (FIFO)"
+        assert second.prompt == "C", "in_hand C replays after B"
+
+        # Tail/in_hand events stay UNSET (per the head-only-abandons
+        # contract) so the post-restart rerun is what unblocks them.
+        assert completion_a.is_set(), "head A's event fires (abandoned)"
+        assert not completion_b.is_set(), "tail B's event waits for actual rerun"
+        assert not completion_c.is_set(), "in_hand C's event waits for actual rerun"
+
+        # No deque entries leaked.
+        assert len(ss._inflight_metas) == 0
+        assert ss._inflight_turn is None
 
     @pytest.mark.asyncio
     async def test_head_clock_does_not_advance_on_subsequent_append(self):

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -41,6 +41,7 @@ def _seed_inflight(
     meta: dict | None = None,
     internal: bool = False,
     completion_event: asyncio.Event | None = None,
+    prompt: str = "",
 ) -> _InflightMeta:
     """Append one ``_InflightMeta`` entry to ``ss._inflight_metas``.
 
@@ -48,16 +49,27 @@ def _seed_inflight(
     back-compat setter still does that for ROUTING-only seeds. This
     helper is the modern path — needed when tests want to seed an
     ``internal=True`` or ``completion_event`` entry, or chain multiple
-    entries to exercise FIFO behavior. Also bumps ``_head_started_at``
-    if this is the new head.
+    entries to exercise FIFO + watchdog tail-requeue behavior. Also
+    bumps ``_head_started_at`` if this is the new head.
 
-    Returns the entry so the test can assert on it.
+    Returns the entry so the test can assert on it. ``prompt`` lets
+    watchdog-requeue tests verify the right turn body is replayed.
     """
+    m = meta or {}
+    synthetic_turn = _QueuedTurn(
+        prompt=prompt,
+        platform=m.get("platform", ""),
+        chat_id=m.get("chat_id", ""),
+        message_id=m.get("message_id", ""),
+        internal=internal,
+        completion_event=completion_event,
+    )
     entry = _InflightMeta(
-        meta=meta or {},
+        meta=m,
         completion_event=completion_event,
         internal=internal,
         dispatched_at=_time.time(),
+        turn=synthetic_turn,
     )
     was_empty = not ss._inflight_metas
     ss._inflight_metas.append(entry)
@@ -3877,6 +3889,236 @@ class TestInflightDequeConcurrentDispatch:
         await ss._handle_turn_complete(TurnResponse(text="B", stop_reason="end_turn"))
         assert ss._head_started_at is None
         assert len(ss._inflight_metas) == 0
+
+    @pytest.mark.asyncio
+    async def test_worker_permanent_failure_unblocks_inflight_turn_completion_event(self):
+        """Issue #547: a turn the worker had in-hand whose delivery
+        raised — for any reason other than the explicit !ok branch in
+        ``_deliver_turn`` that already fires the event — must still
+        unblock its ``completion_event``. Otherwise an unbounded
+        ``wait_for_completion=True`` caller (timeout_sec=None) deadlocks
+        forever.
+
+        Repro by stubbing ``_deliver_turn`` to raise directly,
+        bypassing its own completion_event handling — the catch-all in
+        the worker's except branch is what saves the caller.
+        """
+        ss, _ = _make_session()
+        await ss.connect()
+        # Stub _deliver_turn to raise unconditionally.
+        async def _raise(turn):
+            raise RuntimeError("tailer state corruption simulated")
+        ss._deliver_turn = _raise
+
+        completion = asyncio.Event()
+        internal_turn = _QueuedTurn(
+            prompt="presave",
+            internal=True,
+            reason="idle_sleep_presave",
+            completion_event=completion,
+        )
+        await ss._message_queue.put(internal_turn)
+
+        # Worker should hit the permanent-failure branch and fire the
+        # completion event. Tight timeout — a regression manifests as
+        # test hang→fail, not a silent deadlock.
+        try:
+            await asyncio.wait_for(completion.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pytest.fail(
+                "completion_event must fire on worker permanent-failure "
+                "path (#547) so unbounded wait_for_completion can't deadlock"
+            )
+
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_unblocks_pre_paste_inflight_turn(self):
+        """Issue #547 (extended): the worker may hold ``_inflight_turn``
+        for a turn it pulled from the queue but hadn't yet pasted
+        (e.g. mid context-lock retry, or worker cancelled before
+        ``_deliver_turn`` ran). The meta isn't in ``_inflight_metas``
+        yet, so the disconnect drain loop misses it. ``disconnect``
+        must explicitly unblock the in-hand turn's ``completion_event``.
+        """
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        await ss.connect()
+        # Inject a pre-paste in-hand turn directly (the worker would
+        # normally set this during a context-lock retry).
+        completion = asyncio.Event()
+        ss._inflight_turn = _QueuedTurn(
+            prompt="presave",
+            internal=True,
+            reason="idle_sleep_presave",
+            completion_event=completion,
+        )
+        # No entry in the deque yet — the paste never happened.
+        assert len(ss._inflight_metas) == 0
+
+        await ss.disconnect()
+
+        assert completion.is_set(), (
+            "disconnect must unblock the worker's pre-paste in-hand "
+            "turn (#547) — otherwise unbounded wait_for_completion hangs"
+        )
+        assert ss._inflight_turn is None, (
+            "disconnect must also clear the in-hand reference so the "
+            "next connect doesn't redeliver a stale turn"
+        )
+
+    @pytest.mark.asyncio
+    async def test_watchdog_requeues_tail_on_stuck_head(self, monkeypatch):
+        """Murzik review on PR #561 — critical data-loss fix.
+
+        Before this fix the watchdog drained the WHOLE deque, fired
+        all completion_events, and force_restarted — silently dropping
+        every queued turn behind the stuck head. With CC's native
+        queue absorbing back-to-back pastes, that's a regression vs
+        the pre-#560 serial dispatch (where B/C would still be in
+        _message_queue when A timed out).
+
+        New contract:
+        - HEAD ONLY is abandoned (its completion_event fires)
+        - TAIL entries are requeued at the front of _message_queue in
+          FIFO order, with their original ``_QueuedTurn`` (prompt +
+          completion_event) intact for replay after force_restart
+        - Tail completion_events stay UNSET — they fire only when the
+          rerun actually completes
+        """
+        from pinky_daemon import tmux_session as _ts
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.02)
+
+        ss, _ = _make_session()
+        await ss.connect()
+        # Cancel the worker so the test isolates the watchdog's
+        # drain+requeue behavior. In production, force_restart's
+        # disconnect cancels the worker BEFORE it can re-pull the
+        # requeued turns from _message_queue; without cancelling here
+        # the worker would immediately re-dispatch B/C back into the
+        # deque, masking the requeue we want to assert.
+        ss._worker_task.cancel()
+        try:
+            await ss._worker_task
+        except asyncio.CancelledError:
+            pass
+
+        # Stub force_restart so we don't actually drive the full
+        # disconnect→reconnect cycle.
+        force_called = asyncio.Event()
+        async def _stub_force_restart():
+            force_called.set()
+            return True
+        ss.force_restart = _stub_force_restart
+
+        # Seed three in-flight entries (A=internal-with-event,
+        # B=external, C=external-with-event). Distinct prompts so we
+        # can assert replay order. ``_seed_inflight`` synthesizes the
+        # _QueuedTurn so the requeue has something to push.
+        completion_a = asyncio.Event()
+        completion_c = asyncio.Event()
+        _seed_inflight(ss, internal=True, completion_event=completion_a, prompt="A")
+        _seed_inflight(
+            ss,
+            meta={"platform": "telegram", "chat_id": "B", "message_id": "mB"},
+            prompt="B",
+        )
+        _seed_inflight(
+            ss,
+            meta={"platform": "telegram", "chat_id": "C", "message_id": "mC"},
+            completion_event=completion_c,
+            prompt="C",
+        )
+        # Force the head clock to look ancient so the watchdog trips
+        # immediately on its next tick.
+        ss._head_started_at = 0.0
+        assert len(ss._inflight_metas) == 3
+        # Sanity: queue is empty pre-timeout.
+        assert ss._message_queue.qsize() == 0
+
+        try:
+            await asyncio.wait_for(force_called.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pytest.fail("watchdog must trigger force_restart when head ages out")
+
+        # HEAD only fired its completion_event. Tail events stayed unset.
+        assert completion_a.is_set(), "head's completion_event must fire (abandoned)"
+        assert not completion_c.is_set(), (
+            "tail entry's completion_event must NOT fire — it'll fire when "
+            "the rerun actually completes after force_restart"
+        )
+
+        # Deque drained.
+        assert len(ss._inflight_metas) == 0
+        assert ss._head_started_at is None
+
+        # B and C requeued at the front of _message_queue in FIFO order.
+        assert ss._message_queue.qsize() == 2, (
+            "tail entries B and C must be requeued for replay"
+        )
+        b_replay = ss._message_queue.get_nowait()
+        c_replay = ss._message_queue.get_nowait()
+        assert b_replay.prompt == "B", "B must be at the front (FIFO)"
+        assert c_replay.prompt == "C", "C must follow B"
+        # Replay carries the original completion_event so the eventual
+        # rerun unblocks the right caller.
+        assert c_replay.completion_event is completion_c
+
+        # Stats updated.
+        assert ss._stats.get("turn_timeouts", 0) == 1
+
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_requeues_in_hand_turn_with_tail(self, monkeypatch):
+        """Tail-requeue must also handle the worker's
+        ``_inflight_turn`` (a turn pulled from the queue but not yet
+        pasted — e.g. mid context-lock retry). It was earlier in
+        original send-order than the deque tail; replay before the tail.
+        """
+        from pinky_daemon import tmux_session as _ts
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.02)
+
+        ss, _ = _make_session()
+        await ss.connect()
+        # Same worker-cancel guard as the sibling test above.
+        ss._worker_task.cancel()
+        try:
+            await ss._worker_task
+        except asyncio.CancelledError:
+            pass
+        force_called = asyncio.Event()
+        async def _stub():
+            force_called.set()
+            return True
+        ss.force_restart = _stub
+
+        # Deque: [A (stuck head), B]
+        _seed_inflight(ss, prompt="A", meta={"chat_id": "A"})
+        _seed_inflight(ss, prompt="B", meta={"chat_id": "B"})
+        # In-hand: a turn the worker had pulled but not yet pasted
+        # (context-lock retry). Original send-order: came AFTER B.
+        in_hand_turn = _QueuedTurn(prompt="F", platform="t", chat_id="F", message_id="mF")
+        ss._inflight_turn = in_hand_turn
+        ss._head_started_at = 0.0
+
+        try:
+            await asyncio.wait_for(force_called.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pytest.fail("watchdog must trigger force_restart")
+
+        assert ss._inflight_turn is None, "in-hand turn cleared after requeue"
+        # Replay order: in_hand FIRST (was earliest pending), then tail B.
+        assert ss._message_queue.qsize() == 2
+        first = ss._message_queue.get_nowait()
+        second = ss._message_queue.get_nowait()
+        assert first.prompt == "F", (
+            "in-hand turn was earlier in send-order than tail — replay first"
+        )
+        assert second.prompt == "B"
+
+        await ss.disconnect()
 
     @pytest.mark.asyncio
     async def test_head_clock_does_not_advance_on_subsequent_append(self):

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
+import time as _time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -26,11 +27,43 @@ from pinky_daemon.streaming_session import StreamingSessionConfig
 from pinky_daemon.tmux_session import (
     TmuxCommandResult,
     TmuxSession,
+    _InflightMeta,
     _QueuedTurn,
     _TmuxControl,
 )
 from pinky_daemon.tmux_transcript import TurnResponse
 from pinky_daemon.transport_state import SessionState, TransitionResult, Trigger
+
+
+def _seed_inflight(
+    ss: TmuxSession,
+    *,
+    meta: dict | None = None,
+    internal: bool = False,
+    completion_event: asyncio.Event | None = None,
+) -> _InflightMeta:
+    """Append one ``_InflightMeta`` entry to ``ss._inflight_metas``.
+
+    Pre-#560 tests injected state via ``ss._inflight_meta = {...}``; the
+    back-compat setter still does that for ROUTING-only seeds. This
+    helper is the modern path — needed when tests want to seed an
+    ``internal=True`` or ``completion_event`` entry, or chain multiple
+    entries to exercise FIFO behavior. Also bumps ``_head_started_at``
+    if this is the new head.
+
+    Returns the entry so the test can assert on it.
+    """
+    entry = _InflightMeta(
+        meta=meta or {},
+        completion_event=completion_event,
+        internal=internal,
+        dispatched_at=_time.time(),
+    )
+    was_empty = not ss._inflight_metas
+    ss._inflight_metas.append(entry)
+    if was_empty:
+        ss._head_started_at = _time.time()
+    return entry
 
 
 def _ok() -> TmuxCommandResult:
@@ -1356,6 +1389,10 @@ async def test_handle_turn_complete_writes_to_conversation_store() -> None:
     """assistant response is appended to the conversation store."""
     conv = MagicMock()
     ss, _ = _make_session_with_response_cb(conv_store=conv)
+    # #560: handler now requires an in-flight meta entry; seed one with
+    # empty routing (this test only exercises the conversation_store side
+    # effect, not the broker callback).
+    _seed_inflight(ss)
     response = TurnResponse(text="response text", stop_reason="end_turn")
     await ss._handle_turn_complete(response)
     conv.append.assert_called_once_with(ss.id, "assistant", "response text")
@@ -1366,6 +1403,7 @@ async def test_handle_turn_complete_stores_thinking_metadata() -> None:
     """Tmux thinking blocks persist in conversation metadata like SDK turns."""
     conv = MagicMock()
     ss, _ = _make_session_with_response_cb(conv_store=conv)
+    _seed_inflight(ss)  # #560
     response = TurnResponse(
         text="response text",
         thinking="checked the transcript and tool state",
@@ -1392,6 +1430,7 @@ async def test_handle_turn_complete_fires_stream_event() -> None:
         events.append(evt)
 
     ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    _seed_inflight(ss)  # #560
     response = TurnResponse(
         text="x", stop_reason="end_turn",
         usage={"input_tokens": 100, "output_tokens": 50},
@@ -1437,6 +1476,7 @@ async def test_handle_turn_complete_resets_live_activity_state() -> None:
     ss._current_activity = "Bash — echo hi"
     ss._current_thinking = "working through the command output"
     ss._activity_log = ["ToolSearch", "Bash — echo test", "Bash — echo hi"]
+    _seed_inflight(ss)  # #560
     response = TurnResponse(text="done", stop_reason="end_turn")
 
     await ss._handle_turn_complete(response)
@@ -1615,6 +1655,11 @@ async def test_turn_done_set_unconditionally_for_empty_text_turn() -> None:
     # Pre-clear turn_done to mimic what _deliver_turn does.
     ss._turn_done.clear()
     assert not ss._turn_done.is_set()
+    # #560: handler now requires an in-flight meta entry. The contract
+    # this test pins (empty-text turn still sets turn_done) is preserved
+    # because the critical-section block at the top of the handler sets
+    # turn_done before any text/tool gating.
+    _seed_inflight(ss)
 
     # Empty-text turn — pure tool-use refusal, max_tokens, etc.
     empty_response = TurnResponse(text="", stop_reason="max_tokens")
@@ -1827,14 +1872,22 @@ async def test_disconnect_clears_inflight_meta() -> None:
 
 @pytest.mark.asyncio
 async def test_multi_prompt_routing_no_cross_user_leak(tmp_path) -> None:
-    """Pushok's PR #496 round-1 critical Case 1 repro: two send() calls
-    in quick succession must route response 1 to chat A and response 2
-    to chat B. The worker's turn_done gate enforces this by blocking
-    dispatch of turn 2 until turn 1's stop_hook_summary lands.
+    """#560 / Pushok PR #496 round-1 Case 1 — preserved with concurrent
+    dispatch: two ``send()`` calls in quick succession must route response
+    A to chat A and response B to chat B, regardless of how quickly the
+    worker dispatched them.
 
-    This is the canonical regression test for the bug: pre-fix, the
-    second send() would clobber _inflight_meta before turn 1's
-    response_callback fired, routing response 1 to chat B."""
+    Pre-#560 contract: worker awaited ``_turn_done`` between dispatches,
+    so turn B sat in ``_message_queue`` until turn A finished. The
+    in-flight meta cell was always exactly turn A's.
+
+    Post-#560 contract: worker dispatches both back-to-back (paste-with-
+    Enter), Claude Code's native queued-prompt feature absorbs turn B
+    while turn A runs, ``_inflight_metas`` holds BOTH metas in FIFO
+    order. The router still routes A→A, B→B because the deque pops
+    oldest-first and each entry carries its own routing dict (no
+    shared mutable cell to clobber).
+    """
     cb = _AsyncCollector()
     ss, _ = _make_session_with_response_cb(response_cb=cb)
     await ss.connect()
@@ -1851,20 +1904,23 @@ async def test_multi_prompt_routing_no_cross_user_leak(tmp_path) -> None:
     await ss.send(prompt="from A", platform="telegram", chat_id="A", message_id="mA")
     await ss.send(prompt="from B", platform="telegram", chat_id="B", message_id="mB")
 
-    # Worker should have dispatched turn 1 but be blocked on turn_done
-    # for turn 1's completion. Verify by checking the queue still has
-    # turn 2 (give the worker a tick to drain turn 1).
-    for _ in range(20):
+    # Under #560 the worker dispatches both turns; both metas land in
+    # ``_inflight_metas`` in order. Spin until both are appended.
+    for _ in range(50):
         await asyncio.sleep(0.01)
-        if ss._inflight_meta.get("chat_id") == "A":
+        if len(ss._inflight_metas) >= 2:
             break
-    assert ss._inflight_meta == {
-        "platform": "telegram", "chat_id": "A", "message_id": "mA",
-    }, "worker should be holding turn A's meta while awaiting turn_done"
-    assert ss._message_queue.qsize() == 1, (
-        "turn B must still be queued — worker should not dispatch it "
-        "until turn A's stop_hook_summary lands"
+    assert len(ss._inflight_metas) == 2, (
+        "worker should dispatch BOTH turns back-to-back under concurrent "
+        f"dispatch (#560); got {len(ss._inflight_metas)} in-flight metas"
     )
+    # FIFO check: oldest entry (deque head) is A, next is B.
+    assert ss._inflight_metas[0].meta == {
+        "platform": "telegram", "chat_id": "A", "message_id": "mA",
+    }, "deque head must be turn A's meta"
+    assert ss._inflight_metas[1].meta == {
+        "platform": "telegram", "chat_id": "B", "message_id": "mB",
+    }, "deque second must be turn B's meta"
 
     # Write turn A's response + stop_hook_summary to the transcript.
     # (``_json`` is imported at file scope; no local re-import needed.)
@@ -1882,23 +1938,24 @@ async def test_multi_prompt_routing_no_cross_user_leak(tmp_path) -> None:
     )
     ss._tailer.wake()
 
-    # Wait for response A to be delivered AND for the worker to dispatch
-    # turn B.
+    # Wait for response A to fire its callback. After popleft, the deque
+    # head should advance to B.
     for _ in range(50):
         await asyncio.sleep(0.02)
-        if cb.calls and ss._inflight_meta.get("chat_id") == "B":
+        if cb.calls and len(ss._inflight_metas) == 1:
             break
 
-    # Critical: response A was routed to chat A, NOT chat B (the original bug).
+    # Critical: response A was routed to chat A, NOT chat B (the original
+    # Case 1 leak). With the deque each entry carries its own routing
+    # dict — there is no shared mutable cell to clobber.
     assert len(cb.calls) == 1
     result = cb.calls[0]
     assert result.response_text == "response A"
     assert result.chat_id == "A", (
-        f"response A leaked to wrong chat: {result} — original Case 1 bug regression"
+        f"response A leaked to wrong chat: {result} — Case 1 regression"
     )
-
-    # Worker has now dispatched turn B (meta swapped).
-    assert ss._inflight_meta["chat_id"] == "B"
+    # Deque head is now B.
+    assert ss._inflight_metas[0].meta["chat_id"] == "B"
 
     # Append turn B's response + stop_hook_summary.
     turn_b_entries = [
@@ -1924,22 +1981,33 @@ async def test_multi_prompt_routing_no_cross_user_leak(tmp_path) -> None:
     result = cb.calls[1]
     assert result.response_text == "response B"
     assert result.chat_id == "B"
+    # Deque is now empty.
+    assert len(ss._inflight_metas) == 0
 
     await ss.disconnect()
 
 
 @pytest.mark.asyncio
 async def test_worker_force_restarts_on_turn_done_timeout(monkeypatch) -> None:
-    """Pushok's PR #496 round-1 Case 1 follow-up: when the model gets
-    stuck and turn_done never fires, the worker times out and triggers
-    force_restart instead of just clearing meta and continuing. The
-    latter would re-introduce the original Case 1 cross-routing bug —
-    a late-arriving stop_hook_summary for the stuck turn would route
-    to the *next* turn's meta.
+    """#560 retargeting note: pre-#560 this contract was enforced by
+    the worker's per-iter ``_turn_done`` timeout. Under concurrent
+    dispatch the worker no longer waits between turns, so the "stop
+    hook never fires → force_restart" failure mode moves to the
+    ``_inflight_watchdog`` background task — which ages the deque
+    HEAD (not paste age) so each queued turn gets its own fair
+    window once it becomes the head (Murzik review point #1).
+
+    Test name preserved for `git blame` continuity; behavior pinned
+    on the new mechanism. Original Case 1 protection (no cross-routing
+    leak) is now structural via the per-entry routing dicts in
+    ``_inflight_metas``.
     """
     from pinky_daemon import tmux_session
-    # Shorten the timeout so the test doesn't take 10 minutes.
-    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.1)
+    # Shorten both timers so the test doesn't take 10 minutes. Watchdog
+    # ticks at _WATCHDOG_TICK_SEC; head age must exceed _TURN_DONE_TIMEOUT_SEC
+    # before force_restart fires.
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.02)
 
     guard = MagicMock(return_value={"restart_safe": False, "reason": "no save"})
     ss, _ = _make_session(restart_guard=guard)
@@ -1963,26 +2031,32 @@ async def test_worker_force_restarts_on_turn_done_timeout(monkeypatch) -> None:
 
     ss.force_restart = stub_force_restart
 
-    # Send one prompt — worker dispatches and waits for turn_done.
-    # No stop_hook_summary will ever be written, so timeout fires.
+    # Send one prompt — worker dispatches; deque grows by one; no stop
+    # hook ever fires, so the watchdog detects the stuck head and
+    # schedules force_restart.
     await ss.send(prompt="stuck", platform="t", chat_id="c", message_id="m")
 
-    # Wait for the timeout path to fire force_restart.
+    # Wait for the watchdog to detect + fire force_restart.
     try:
         await asyncio.wait_for(force_restart_called.wait(), timeout=2.0)
     except asyncio.TimeoutError:
-        pytest.fail("force_restart should have been called after turn_done timeout")
+        pytest.fail(
+            "force_restart should have been called after inflight watchdog "
+            "head-age exceeded _TURN_DONE_TIMEOUT_SEC"
+        )
 
     try:
         await asyncio.wait_for(force_restart_done.wait(), timeout=2.0)
     except asyncio.TimeoutError:
         pytest.fail("pre-first-turn force_restart should not be blocked by guard")
 
-    # Turn-timeout counter incremented.
+    # Turn-timeout counter incremented (now in the watchdog).
     assert ss._stats.get("turn_timeouts", 0) == 1
     assert ss._has_completed_turn is False
     assert force_restart_results == [True]
     guard.assert_not_called()
+    # Deque was drained by the watchdog's force_restart path.
+    assert len(ss._inflight_metas) == 0
 
     await ss.disconnect()
 
@@ -2629,9 +2703,11 @@ async def test_record_turn_usage_accumulates_across_turns() -> None:
     context-percentage gauge sees only the latest turn's deltas and
     can't show "approaching compaction"."""
     ss, _ = _make_session_with_response_cb()
+    _seed_inflight(ss)  # #560
     await ss._handle_turn_complete(
         _turn_response(input_tokens=1000, output_tokens=100, cache_read=500)
     )
+    _seed_inflight(ss)  # #560 — second turn
     await ss._handle_turn_complete(
         _turn_response(input_tokens=2000, output_tokens=200, cache_write=300)
     )
@@ -2648,6 +2724,7 @@ async def test_record_turn_usage_tolerates_schema_drift() -> None:
     missing keys) must not crash the tailer. Token visibility is
     best-effort; the tailer's invariant is to keep running."""
     ss, _ = _make_session_with_response_cb()
+    _seed_inflight(ss)  # #560
     drift = TurnResponse(
         text="ok",
         stop_reason="end_turn",
@@ -2674,6 +2751,7 @@ async def test_emits_context_usage_event_with_sdk_shape() -> None:
         events.append(evt)
 
     ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    _seed_inflight(ss)  # #560
     await ss._handle_turn_complete(
         _turn_response(input_tokens=10_000, output_tokens=500, cache_read=2_000)
     )
@@ -2702,6 +2780,7 @@ async def test_get_context_info_returns_sdk_shape() -> None:
     present (the tmux path). Shape must match what the existing
     ``/streaming/status`` consumer expects."""
     ss, _ = _make_session_with_response_cb()
+    _seed_inflight(ss)  # #560
     await ss._handle_turn_complete(
         _turn_response(input_tokens=5_000, output_tokens=200)
     )
@@ -2865,10 +2944,12 @@ async def test_restart_nudge_fires_when_crossing_threshold() -> None:
     ss._restart_threshold_pct = lambda: 50.0
 
     # Below threshold: no nudge. (50k / 200k = 25%.)
+    _seed_inflight(ss)  # #560
     await ss._handle_turn_complete(_turn_response(input_tokens=50_000))
     assert not [e for e in events if e["type"] == "restart_nudge"]
 
     # Cross threshold: nudge fires. (110k / 200k = 55%.)
+    _seed_inflight(ss)  # #560
     await ss._handle_turn_complete(_turn_response(input_tokens=110_000))
     nudges = [e for e in events if e["type"] == "restart_nudge"]
     assert len(nudges) == 1
@@ -2890,8 +2971,11 @@ async def test_restart_nudge_does_not_refire_while_above_threshold() -> None:
     ss._restart_threshold_pct = lambda: 50.0
 
     # Three turns, all above threshold — only one nudge total.
+    _seed_inflight(ss)  # #560
     await ss._handle_turn_complete(_turn_response(input_tokens=110_000))
+    _seed_inflight(ss)
     await ss._handle_turn_complete(_turn_response(input_tokens=130_000))
+    _seed_inflight(ss)
     await ss._handle_turn_complete(_turn_response(input_tokens=140_000))
 
     nudges = [e for e in events if e["type"] == "restart_nudge"]
@@ -2913,15 +2997,18 @@ async def test_restart_nudge_rearms_after_drop_below_threshold() -> None:
     ss._restart_threshold_pct = lambda: 50.0
 
     # Cross threshold (above 50% of 200k).
+    _seed_inflight(ss)  # #560
     await ss._handle_turn_complete(_turn_response(input_tokens=110_000))
     assert ss._restart_nudge_fired is True
 
     # Simulate post-compact: a turn with low input_tokens. The latch
     # resets because the window measurement is now below threshold.
+    _seed_inflight(ss)
     await ss._handle_turn_complete(_turn_response(input_tokens=5_000))
     assert ss._restart_nudge_fired is False
 
     # Cross again — fresh nudge.
+    _seed_inflight(ss)
     await ss._handle_turn_complete(_turn_response(input_tokens=110_000))
     nudges = [e for e in events if e["type"] == "restart_nudge"]
     assert len(nudges) == 2
@@ -3008,17 +3095,17 @@ class TestInternalPromptBypasses:
         """Murzik's regression guard against #496 round-1 Case 1 surfacing
         via the internal-prompt path. An internal turn that wrote routing
         metadata would clobber a back-to-back external turn's routing
-        fields. ``_deliver_turn`` is responsible for the actual decision
-        (internal vs external) — this test pins that contract."""
+        fields.
+
+        #560 retargeting: ``_deliver_turn`` now APPENDS to
+        ``_inflight_metas`` (FIFO) instead of overwriting a single dict.
+        Internal turns still append with empty meta + ``internal=True``,
+        so an external turn dispatched after carries its OWN routing
+        in its OWN deque entry — no shared mutable cell to clobber.
+        """
         ss, tmux = _make_session()
-        # The internal turn dispatched through _deliver_turn must NOT
-        # set _inflight_meta. Seed it with sentinel values and verify
-        # they're cleared (not overwritten with another non-empty dict).
-        ss._inflight_meta = {
-            "platform": "EXTERNAL_SENTINEL",
-            "chat_id": "EXTERNAL_CHAT",
-            "message_id": "EXTERNAL_MSG",
-        }
+        ss._state_machine._state = SessionState.CONNECTED
+
         internal_turn = _QueuedTurn(
             prompt="wake prompt body",
             platform="",
@@ -3028,41 +3115,44 @@ class TestInternalPromptBypasses:
             reason="wake_new_session",
         )
 
-        # _deliver_turn requires a paste_text mock + tmux not under
-        # context-lock. We seed those.
-        ss._state_machine._state = SessionState.CONNECTED
-
         await ss._deliver_turn(internal_turn)
 
-        # Internal turn writes the EMPTY dict to _inflight_meta — not the
-        # sentinel values. This is the contract: internal turns own no
-        # routing metadata.
+        # Internal turn appended an entry with EMPTY meta + internal=True.
+        # The back-compat ``_inflight_meta`` property reads the oldest
+        # entry's meta — which is empty for this internal turn.
         assert ss._inflight_meta == {}, (
-            "internal turn wrote routing metadata — would clobber a "
-            "back-to-back external turn's routing (regression of "
-            "#496 round-1 Case 1 via the wake-prompt path)"
+            "internal turn wrote routing metadata — would have clobbered "
+            "back-to-back external routing pre-#560; under #560 each "
+            "entry carries its own dict so this is structurally impossible"
         )
+        assert len(ss._inflight_metas) == 1
+        assert ss._inflight_metas[0].internal is True
+        assert ss._inflight_metas[0].meta == {}
 
     @pytest.mark.asyncio
     async def test_internal_wake_prompt_does_not_clobber_external_routing(self):
-        """The full Case 1 regression guard. Enqueue an internal wake
-        prompt, then an external turn, dispatch both — the external
-        turn's ``_inflight_meta`` must carry its own routing through
-        ``_deliver_turn``."""
+        """The full Case 1 regression guard, post-#560: enqueue an
+        internal wake prompt, then an external turn, dispatch both —
+        each entry in ``_inflight_metas`` must carry its OWN routing.
+        Pre-#560 the single ``_inflight_meta`` cell would have been
+        overwritten by whichever turn dispatched last; post-#560 the
+        deque holds both side-by-side."""
         ss, tmux = _make_session()
         ss._state_machine._state = SessionState.CONNECTED
 
-        # Internal turn first — must NOT touch _inflight_meta.
+        # Internal turn first — appends an empty-meta + internal=True entry.
         internal_turn = _QueuedTurn(
             prompt="wake",
             internal=True,
             reason="wake_new_session",
         )
         await ss._deliver_turn(internal_turn)
-        assert ss._inflight_meta == {}
+        assert len(ss._inflight_metas) == 1
+        assert ss._inflight_metas[0].internal is True
+        assert ss._inflight_metas[0].meta == {}
 
-        # External turn next — must populate _inflight_meta with its
-        # own routing fields.
+        # External turn next — appends its own routing dict + internal=False.
+        # The internal turn's entry is unaffected.
         external_turn = _QueuedTurn(
             prompt="hello",
             platform="telegram",
@@ -3070,7 +3160,12 @@ class TestInternalPromptBypasses:
             message_id="m1",
         )
         await ss._deliver_turn(external_turn)
-        assert ss._inflight_meta == {
+        assert len(ss._inflight_metas) == 2
+        # FIFO: internal first, external second.
+        assert ss._inflight_metas[0].internal is True
+        assert ss._inflight_metas[0].meta == {}
+        assert ss._inflight_metas[1].internal is False
+        assert ss._inflight_metas[1].meta == {
             "platform": "telegram",
             "chat_id": "42",
             "message_id": "m1",
@@ -3149,24 +3244,25 @@ class TestInternalPromptCompletion:
     @pytest.mark.asyncio
     async def test_completion_event_fires_before_turn_done(self):
         """Critical ordering: ``completion_event.set()`` MUST fire before
-        ``_turn_done.set()`` in ``_handle_turn_complete``. Otherwise the
-        worker advances past the wake-prompt turn before a
-        ``wait_for_completion=True`` caller observes its event — a race
-        that could break PR B's "save state before disconnect" contract."""
+        ``_turn_done.set()`` in ``_handle_turn_complete``. Otherwise a
+        ``wait_for_completion=True`` caller might observe ``_turn_done``
+        without its own event being set — a race that could break PR B's
+        "save state before disconnect" contract.
+
+        #560 retargeting: pre-#560 the completion_event lived on
+        ``self._inflight_turn`` (the worker's current dispatch). Under
+        concurrent dispatch each entry in ``_inflight_metas`` carries
+        its OWN completion_event; the handler popleft's the entry and
+        fires its event. Still in the synchronous critical section,
+        still before ``_turn_done``.
+        """
         ss, _ = _make_session()
         ss._state_machine._state = SessionState.CONNECTED
 
-        # Simulate the worker's inflight state: an internal turn with
-        # a completion event.
+        # Seed an internal entry with a completion_event into the deque.
         completion = asyncio.Event()
-        ss._inflight_turn = _QueuedTurn(
-            prompt="wake",
-            internal=True,
-            reason="wake_new_session",
-            completion_event=completion,
-        )
-        # _turn_done starts cleared — this is the worker's invariant
-        # between dispatches.
+        _seed_inflight(ss, internal=True, completion_event=completion)
+        # _turn_done starts cleared.
         ss._turn_done.clear()
 
         await ss._handle_turn_complete(_turn_response(text="ack"))
@@ -3588,3 +3684,216 @@ class TestInternalPromptReturnContract:
             wait_for_completion=False,
         )
         assert result is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #560 — concurrent dispatch / inflight deque
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestInflightDequeConcurrentDispatch:
+    """The contract block #560 introduces.
+
+    Murzik's review points pinned as named tests:
+    1. FIFO response routing across three back-to-back chat_ids
+    2. Internal-prompt completion_event fires only on its own popleft
+    3. Paste failure → no deque append + immediate completion_event set
+    4. Force_restart / disconnect drains the deque and unblocks every
+       pending completion_event so wait_for_completion callers can't
+       hang on an abandoned turn
+    5. Watchdog ages the HEAD, not paste_time — a queued turn gets its
+       own full timeout window once it becomes the head
+    """
+
+    @pytest.mark.asyncio
+    async def test_fifo_routing_a_b_c_no_cross_leak(self):
+        """Three turns with distinct chat_ids → three stop hooks → each
+        response routes to its own chat in FIFO order. Pinned per
+        Murzik review point #3."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+
+        # Seed three external entries directly (bypass paste — this
+        # test pins the deque + routing contract, not the paste path).
+        _seed_inflight(ss, meta={"platform": "telegram", "chat_id": "A", "message_id": "mA"})
+        _seed_inflight(ss, meta={"platform": "telegram", "chat_id": "B", "message_id": "mB"})
+        _seed_inflight(ss, meta={"platform": "telegram", "chat_id": "C", "message_id": "mC"})
+        assert len(ss._inflight_metas) == 3
+
+        # Fire stop hooks in order.
+        await ss._handle_turn_complete(TurnResponse(text="reply A", stop_reason="end_turn"))
+        await ss._handle_turn_complete(TurnResponse(text="reply B", stop_reason="end_turn"))
+        await ss._handle_turn_complete(TurnResponse(text="reply C", stop_reason="end_turn"))
+
+        assert len(cb.calls) == 3
+        assert (cb.calls[0].response_text, cb.calls[0].chat_id) == ("reply A", "A")
+        assert (cb.calls[1].response_text, cb.calls[1].chat_id) == ("reply B", "B")
+        assert (cb.calls[2].response_text, cb.calls[2].chat_id) == ("reply C", "C")
+        assert len(ss._inflight_metas) == 0
+
+    @pytest.mark.asyncio
+    async def test_internal_in_middle_completion_event_fires_only_on_own_pop(self):
+        """Queue: external, internal-with-event, external. The
+        completion_event for the middle internal entry must fire ONLY
+        when that entry pops — not on the first external's stop hook,
+        not on the last external's. Murzik review point #4."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+
+        completion = asyncio.Event()
+        _seed_inflight(ss, meta={"platform": "telegram", "chat_id": "A", "message_id": "mA"})
+        _seed_inflight(ss, internal=True, completion_event=completion)
+        _seed_inflight(ss, meta={"platform": "telegram", "chat_id": "C", "message_id": "mC"})
+
+        # First stop hook: pops external A. completion_event NOT set yet.
+        await ss._handle_turn_complete(TurnResponse(text="reply A", stop_reason="end_turn"))
+        assert not completion.is_set(), (
+            "completion_event must NOT fire when an unrelated entry pops"
+        )
+        assert len(cb.calls) == 1
+        assert cb.calls[0].chat_id == "A"
+
+        # Second stop hook: pops the internal middle entry. NOW completion fires.
+        await ss._handle_turn_complete(TurnResponse(text="ack", stop_reason="end_turn"))
+        assert completion.is_set(), (
+            "completion_event MUST fire when its own internal entry pops"
+        )
+        # Internal entry skips response_callback — callback count unchanged.
+        assert len(cb.calls) == 1
+
+        # Third stop hook: pops external C.
+        await ss._handle_turn_complete(TurnResponse(text="reply C", stop_reason="end_turn"))
+        assert len(cb.calls) == 2
+        assert cb.calls[1].chat_id == "C"
+
+    @pytest.mark.asyncio
+    async def test_paste_failure_does_not_append_to_deque(self):
+        """``_deliver_turn`` must not append an entry to
+        ``_inflight_metas`` when ``paste_text`` reports !ok. Otherwise a
+        future stop hook would pop a meta with no corresponding CC
+        turn, routing a later response to the wrong chat."""
+        tmux = _make_mock_tmux()
+        tmux.paste_text = AsyncMock(return_value=_fail("rc=1"))
+        ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+        turn = _QueuedTurn(prompt="x", platform="t", chat_id="c", message_id="m")
+        with pytest.raises(RuntimeError, match="tmux paste-buffer"):
+            await ss._deliver_turn(turn)
+        assert len(ss._inflight_metas) == 0, (
+            "paste failure must NOT leave a phantom meta entry"
+        )
+
+    @pytest.mark.asyncio
+    async def test_paste_failure_unblocks_pending_completion_event(self):
+        """Murzik review point #2 — explicit: a turn with
+        ``completion_event`` whose paste fails must NOT hang the caller.
+        ``_deliver_turn`` fires the event on the failure path."""
+        tmux = _make_mock_tmux()
+        tmux.paste_text = AsyncMock(return_value=_fail("rc=1"))
+        ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+        completion = asyncio.Event()
+        turn = _QueuedTurn(
+            prompt="x", internal=True, reason="presave",
+            completion_event=completion,
+        )
+        with pytest.raises(RuntimeError):
+            await ss._deliver_turn(turn)
+        assert completion.is_set(), (
+            "paste failure must unblock the caller waiting on completion_event"
+        )
+
+    @pytest.mark.asyncio
+    async def test_disconnect_unblocks_pending_completion_events(self):
+        """Disconnect drains ``_inflight_metas`` and sets every pending
+        ``completion_event`` so a ``wait_for_completion=True`` caller
+        doesn't hang on an abandoned turn (e.g. force_restart cycling
+        the pane mid-save). Murzik review point #2 — explicit."""
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        await ss.connect()
+
+        event1 = asyncio.Event()
+        event2 = asyncio.Event()
+        _seed_inflight(ss, internal=True, completion_event=event1)
+        _seed_inflight(ss, meta={"platform": "t", "chat_id": "c", "message_id": "m"})
+        # No event on the second; the entry is external — disconnect
+        # still drains it, just doesn't have anything to signal.
+        _seed_inflight(ss, internal=True, completion_event=event2)
+        assert len(ss._inflight_metas) == 3
+
+        await ss.disconnect()
+
+        assert len(ss._inflight_metas) == 0
+        assert event1.is_set(), "disconnect must unblock event1"
+        assert event2.is_set(), "disconnect must unblock event2"
+
+    @pytest.mark.asyncio
+    async def test_handle_turn_complete_with_empty_deque_logs_and_bails(self):
+        """Empty-deque defense (Murzik review point #7): a stop hook
+        with no pending meta must not synthesize routing. It logs and
+        skips the callback chain — better silent than wrong-routed.
+        """
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        # Deque is empty.
+        assert len(ss._inflight_metas) == 0
+
+        # Handler should bail cleanly without raising or calling cb.
+        await ss._handle_turn_complete(TurnResponse(text="orphan", stop_reason="end_turn"))
+
+        assert cb.calls == [], (
+            "empty-deque path must NOT synthesize routing — would "
+            "re-introduce #496 Case 1 from zero state"
+        )
+
+    @pytest.mark.asyncio
+    async def test_head_clock_resets_on_popleft_with_remaining_entries(self):
+        """Murzik review point #1: when the head pops and entries remain,
+        the NEW head's clock starts fresh so it gets its own full
+        ``_TURN_DONE_TIMEOUT_SEC`` window (rather than inheriting the
+        previous head's age)."""
+        ss, _ = _make_session_with_response_cb()
+        ss._state_machine._state = SessionState.CONNECTED
+
+        _seed_inflight(ss, meta={"platform": "t", "chat_id": "A", "message_id": "mA"})
+        _seed_inflight(ss, meta={"platform": "t", "chat_id": "B", "message_id": "mB"})
+        first_head_at = ss._head_started_at
+        assert first_head_at is not None
+
+        # Sleep a tiny bit so the new head_started_at differs.
+        await asyncio.sleep(0.01)
+        await ss._handle_turn_complete(TurnResponse(text="A", stop_reason="end_turn"))
+
+        # Deque still has one entry; head clock should have advanced.
+        assert len(ss._inflight_metas) == 1
+        assert ss._head_started_at is not None
+        assert ss._head_started_at > first_head_at, (
+            "post-popleft head clock must reset so the new head gets "
+            "its own full timeout window (Murzik #560 review point #1)"
+        )
+
+        # Drain — clock becomes None.
+        await ss._handle_turn_complete(TurnResponse(text="B", stop_reason="end_turn"))
+        assert ss._head_started_at is None
+        assert len(ss._inflight_metas) == 0
+
+    @pytest.mark.asyncio
+    async def test_head_clock_does_not_advance_on_subsequent_append(self):
+        """Appending another entry behind an existing head must NOT
+        reset the head clock — that would game the watchdog. The clock
+        only resets on empty→nonempty append (new head) or on popleft
+        with remaining entries (new head)."""
+        ss, _ = _make_session_with_response_cb()
+        ss._state_machine._state = SessionState.CONNECTED
+
+        _seed_inflight(ss, meta={"chat_id": "A"})
+        first_head_at = ss._head_started_at
+        assert first_head_at is not None
+        await asyncio.sleep(0.01)
+        # Append second entry — head clock must NOT advance.
+        _seed_inflight(ss, meta={"chat_id": "B"})
+        assert ss._head_started_at == first_head_at, (
+            "appending behind an existing head must not reset the head "
+            "clock — the original head is what the watchdog ages"
+        )


### PR DESCRIPTION
## Summary

Fixes #560 — Dymok messages weren't queuing properly. A second `send()` while a turn was running sat invisibly in `_message_queue` until the first turn completed → no mid-turn steering possible.

**Root cause:** PR #496 round-2 introduced a worker `_turn_done` gate to protect a single shared `_inflight_meta` dict from being clobbered between back-to-back sends. The gate worked, but it forced strictly serial dispatch — exactly the bottleneck that broke steering.

**Fix:** Replace the single-dict cell with a FIFO deque (`_inflight_metas`). Each successful paste-with-Enter appends an `_InflightMeta` entry carrying its OWN routing dict; each `stop_hook_summary` popleft's the oldest entry. With per-entry storage there is no shared mutable cell to clobber → #496 Case 1 is impossible by construction. The worker no longer awaits between dispatches; Claude Code's native queued-prompt feature absorbs back-to-back paste turns.

## Key changes

- **`_InflightMeta` dataclass**: meta dict, completion_event, internal flag, dispatched_at
- **`_inflight_metas: deque[_InflightMeta]`** + **`_head_started_at`** (deque-head age clock)
- **`_inflight_watchdog` background task** — replaces the worker's per-iter `_turn_done` timeout. Ages the deque HEAD (not paste time) so each queued turn gets its own fair `_TURN_DONE_TIMEOUT_SEC` window once it becomes the head (Murzik review point #1)
- **`_deliver_turn`**: append to deque AFTER successful paste; on paste failure, set the turn's `completion_event` so `wait_for_completion` callers don't hang (Murzik review point #2)
- **`_handle_turn_complete`**: synchronous critical section at the top (popleft → set completion_event → advance head clock → set `_turn_done` → set `_has_completed_turn`) with no awaits, THEN the awaitable callback chain runs against the popped entry (Murzik review point #6). Empty-deque path log-only — no synthesized routing (Murzik review point #7)
- **`disconnect`**: drains deque AND unblocks every pending `completion_event` before clearing (Murzik review point #2)
- **Back-compat `_inflight_meta` property + setter**: reads oldest entry's meta / writes via clear+append. Lets pre-#560 test fixtures keep working without mass-rewrites; new code goes through `_inflight_metas` directly

## Murzik review checklist (pre-PR alignment)

All 7 points pinned with named tests:

| # | Murzik point | Implementation | Test |
|---|---|---|---|
| 1 | Head-age, not paste-age | `_head_started_at` reset on empty→nonempty + on popleft when entries remain | `test_head_clock_resets_on_popleft_with_remaining_entries` + `test_head_clock_does_not_advance_on_subsequent_append` |
| 2 | force_restart / paste-fail unblock | `disconnect` drain loop + `_deliver_turn` !ok path both fire pending completion_events | `test_disconnect_unblocks_pending_completion_events` + `test_paste_failure_unblocks_pending_completion_event` |
| 3 | FIFO routing test | A/B/C distinct chat_ids, FIFO popleft | `test_fifo_routing_a_b_c_no_cross_leak` |
| 4 | Internal in middle of queue | external/internal-with-event/external; event fires only on its own pop | `test_internal_in_middle_completion_event_fires_only_on_own_pop` |
| 5 | Append meta only after paste+Enter succeeds | append happens after `if not result.ok: return`; failure path leaves deque untouched | `test_paste_failure_does_not_append_to_deque` |
| 6 | Critical-section discipline | sync-only block at top of `_handle_turn_complete`: popleft → event → head clock → turn_done → has_completed_turn; awaits run after | Pinned in code comments + implicit in FIFO test |
| 7 | Empty-on-completion log-only | empty-deque branch returns without callback | `test_handle_turn_complete_with_empty_deque_logs_and_bails` |

## Test plan

- [x] `tests/test_tmux_session.py`: 147 passed (139 existing updated + 8 new)
- [x] Full suite: **2232 passed, 1 skipped**, no regressions (pre-existing `nacl`-missing collection errors ignored — unrelated)
- [x] `ruff check src/pinky_daemon/tmux_session.py tests/test_tmux_session.py` clean
- [x] Regression test `test_multi_prompt_routing_no_cross_user_leak` (canonical #496 Case 1 guard) rewritten for the new contract: both turns dispatch back-to-back, deque holds both metas in FIFO, popleft routes each correctly
- [x] `test_worker_force_restarts_on_turn_done_timeout` retargeted at the watchdog (name preserved for `git blame` continuity)
- [ ] Post-merge smoke: Brad sends a steering message to Dymok mid-turn and confirms it lands visibly in the pane within ~2-3s

Fixes #560.

🤖 Opened by Barsik