### PR TITLE
fix(tmux): seek to byte 0 on placeholder→real transcript path swap (#563)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -691,6 +691,16 @@ class TmuxSession:
         self._last_launch_forced_fresh: bool = False
         self._last_launch_had_prior_transcript: bool = False
 
+        # Issue #563 — "first transcript bind" tracking. Set to True in
+        # ``_start_tailer`` after the tailer is constructed; consumed
+        # on the first ``set_transcript_path`` call. Combined with
+        # ``not _last_launch_used_continue``, drives the seek-to-byte-0
+        # behavior for fresh launches whose SessionStart hook arrives
+        # AFTER CC has already written the first turn's
+        # ``stop_hook_summary``. Continue launches preserve the
+        # seek-to-EOF default (#496 round-1 Case 3 reply-spam defense).
+        self._tailer_first_bind_pending: bool = False
+
         # Test seam: when True, ``connect()`` skips wake-prompt assembly
         # + enqueue. Production callers must NOT flip this; it exists so
         # unit tests that mock at the paste/queue layer can exercise
@@ -1790,35 +1800,68 @@ class TmuxSession:
         hook fires before the first model call, so the tailer is
         repointed at the right file before any response data arrives.
 
-        **Placeholder→real transition** (issue #563). The hook's
-        "fires before the first model call" claim is empirically false
-        on cold-start: the wake-action turn can complete in <1s
-        (final text + `stop_hook_summary` written to the JSONL) while
-        the hook arrival is 50-200ms after. If we let the tailer seek
-        to current-EOF on the first real path (the default behavior
-        designed for compact-resume to defend against #496 reply-spam),
-        we skip past the first turn's `stop_hook_summary` forever —
-        the deque head meta stays unresolved, subsequent turns pile up
-        behind it as tail entries, and the watchdog eventually fires
-        at 600s. Observed 4 times on Dymok across the log history.
+        **First bind for a fresh launch reads from byte 0** (issue
+        #563, with Murzik review on PR #564 commit 1 extending the
+        invariant beyond the cold-start placeholder case).
 
-        Fix: detect the placeholder→real transition (current path is
-        the cold-start placeholder) and pass `seek_to_start=True` so
-        the tailer reads the JSONL from byte 0. Subsequent real→real
-        swaps (compact-resume) still seek to EOF — the reply-spam
-        defense from #496 is unchanged for the live-session case.
+        The hook's "fires before the first model call" claim is
+        empirically false: the wake-action turn can complete in <1s
+        (final text + ``stop_hook_summary`` written to the JSONL)
+        while the hook arrival is 50-200ms after. If we let the
+        tailer seek to current-EOF on the first real path bind (the
+        default behavior designed for compact-resume to defend
+        against #496 round-1 Case 3 reply-spam), we skip past the
+        first turn's ``stop_hook_summary`` forever — the deque head
+        meta stays unresolved, subsequent turns pile up behind it
+        as tail entries, and the watchdog fires at 600s. Observed
+        4 times on Dymok across the log history.
+
+        Two flavors of this race:
+          1. **Cold-start placeholder→real:** ``_start_tailer`` found
+             no prior transcript and used the placeholder; SessionStart
+             hook reports the fresh JSONL after CC's first turn lands.
+          2. **Forced-fresh old-real→new-real:** ``force_fresh_context_once``
+             made this launch fresh despite prior history;
+             ``_start_tailer`` discovered the OLD JSONL via mtime scan;
+             SessionStart hook reports the NEW JSONL that CC just
+             created — same late-hook race against CC's first turn.
+
+        Both share the invariant: **the first ``set_transcript_path``
+        call after ``_start_tailer`` for a fresh launch should seek
+        to byte 0**. The ``_tailer_first_bind_pending`` flag (set in
+        ``_start_tailer``, consumed here) tracks "first call since
+        spawn"; ``not self._last_launch_used_continue`` qualifies
+        "fresh launch."
+
+        For continue launches, the seek-to-EOF default is preserved
+        — the JSONL has prior history and we must not replay it
+        (#496 reply-spam defense unchanged for the live-session case).
+        Even if a continue launch races and ends up on a placeholder
+        in ``_start_tailer`` (unlikely but possible if
+        ``_has_prior_transcript`` and ``_discover_transcript_path``
+        disagree under a project-dir mutation race), the predicate
+        evaluates ``True AND not True = False`` → seek to EOF, safe.
+
+        The flag is consumed regardless of whether the path actually
+        changed (the tailer's own equality guard handles no-ops). This
+        prevents repeated SessionStart posts later in the session from
+        accidentally being treated as a "first bind" again.
         """
         if self._tailer is None:
             return
-        is_placeholder_transition = (
-            self._tailer.transcript_path == _PLACEHOLDER_TRANSCRIPT_PATH
+        seek_to_start = (
+            self._tailer_first_bind_pending
+            and not self._last_launch_used_continue
         )
+        # Consume the first-bind flag now — even if the tailer's
+        # internal equality guard short-circuits the actual swap.
+        self._tailer_first_bind_pending = False
         self._tailer.set_transcript_path(
-            Path(path), seek_to_start=is_placeholder_transition,
+            Path(path), seek_to_start=seek_to_start,
         )
         _log(
             f"tmux[{self.agent_name}]: transcript path updated to {path}"
-            + (" (from placeholder — seek_to_start)" if is_placeholder_transition else "")
+            + (" (first-bind — seek_to_start)" if seek_to_start else "")
         )
 
     async def get_pane_snapshot(self, *, lines: int = 200) -> str:
@@ -2357,6 +2400,21 @@ class TmuxSession:
             # tailer becomes correct independently of the hook firing.
             path_discovery=self._discover_transcript_path,
         )
+        # Issue #563 — mark this spawn as needing a "first bind" call so
+        # ``set_transcript_path`` can seek to byte 0 on the FIRST swap
+        # after spawn when the launch is fresh (no --continue). Two
+        # scenarios this covers:
+        #   1. Dymok cold-start: ``guessed is None`` → placeholder path,
+        #      SessionStart hook arrives after CC's first stop_hook_summary.
+        #   2. ``force_fresh_context_once=True`` with prior transcripts:
+        #      ``guessed`` points at an OLD JSONL, SessionStart hook
+        #      rebinds to the NEW JSONL that CC just created — same
+        #      late-hook race against CC's first turn.
+        # The flag is consumed by ``set_transcript_path`` regardless of
+        # whether the path actually changed, so repeated SessionStart
+        # posts cannot later turn into replay risk (Murzik review on
+        # PR #564 commit 1).
+        self._tailer_first_bind_pending = True
         await self._tailer.start()
         if guessed is None:
             _log(

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -108,6 +108,17 @@ _TRANSPORT_LOCK_DIR = Path("data/transport-locks")
 # either succeeds or hits a permanent failure.
 _TRANSIENT_RETRY_BACKOFF_SEC = 2.0
 
+# Sentinel path used by ``_start_tailer`` when the transcript JSONL
+# doesn't exist yet (cold-start). The tailer's ``read_once`` treats
+# the non-existent file as "no data" and waits; once the SessionStart
+# hook reports the real path, ``set_transcript_path`` swaps to it.
+#
+# Defined as a module-level constant (issue #563) so the placeholder→real
+# transition can be detected reliably in ``TmuxSession.set_transcript_path``:
+# the seek-to-byte-0 behavior only applies on that first transition, not
+# on subsequent real→real swaps (compact-resume protected by #496).
+_PLACEHOLDER_TRANSCRIPT_PATH = Path("/dev/null/no-transcript-yet")
+
 
 class _ContextLockDeferral(Exception):  # noqa: N818
     """Transient: context-lock file present at paste time.
@@ -1778,13 +1789,37 @@ class TmuxSession:
         Cleaner than guessing the path via mtime glob: the SessionStart
         hook fires before the first model call, so the tailer is
         repointed at the right file before any response data arrives.
+
+        **Placeholder→real transition** (issue #563). The hook's
+        "fires before the first model call" claim is empirically false
+        on cold-start: the wake-action turn can complete in <1s
+        (final text + `stop_hook_summary` written to the JSONL) while
+        the hook arrival is 50-200ms after. If we let the tailer seek
+        to current-EOF on the first real path (the default behavior
+        designed for compact-resume to defend against #496 reply-spam),
+        we skip past the first turn's `stop_hook_summary` forever —
+        the deque head meta stays unresolved, subsequent turns pile up
+        behind it as tail entries, and the watchdog eventually fires
+        at 600s. Observed 4 times on Dymok across the log history.
+
+        Fix: detect the placeholder→real transition (current path is
+        the cold-start placeholder) and pass `seek_to_start=True` so
+        the tailer reads the JSONL from byte 0. Subsequent real→real
+        swaps (compact-resume) still seek to EOF — the reply-spam
+        defense from #496 is unchanged for the live-session case.
         """
-        if self._tailer is not None:
-            self._tailer.set_transcript_path(Path(path))
-            _log(
-                f"tmux[{self.agent_name}]: transcript path updated to "
-                f"{path}"
-            )
+        if self._tailer is None:
+            return
+        is_placeholder_transition = (
+            self._tailer.transcript_path == _PLACEHOLDER_TRANSCRIPT_PATH
+        )
+        self._tailer.set_transcript_path(
+            Path(path), seek_to_start=is_placeholder_transition,
+        )
+        _log(
+            f"tmux[{self.agent_name}]: transcript path updated to {path}"
+            + (" (from placeholder — seek_to_start)" if is_placeholder_transition else "")
+        )
 
     async def get_pane_snapshot(self, *, lines: int = 200) -> str:
         """Return the last ``lines`` lines of the tmux pane, with ANSI
@@ -2310,7 +2345,7 @@ class TmuxSession:
         # SessionStart hook reports a path. Use a placeholder path that
         # .exists() returns False for — the tailer's read_once handles
         # that gracefully.
-        path = guessed or Path("/dev/null/no-transcript-yet")
+        path = guessed or _PLACEHOLDER_TRANSCRIPT_PATH
         self._tailer = TmuxTranscriptTailer(
             transcript_path=path,
             on_turn_complete=self._handle_turn_complete,

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1649,6 +1649,168 @@ async def test_discover_transcript_path_returns_none_for_empty_project_dir(tmp_p
     assert ss._discover_transcript_path() is None
 
 
+@pytest.mark.asyncio
+async def test_set_transcript_path_from_placeholder_seeks_to_start(tmp_path) -> None:
+    """Issue #563 — placeholder→real path transition must seek to byte 0.
+
+    Cold-start sequence observed on Dymok:
+    1. ``_start_tailer`` constructs the tailer with the cold-start
+       placeholder (`/dev/null/no-transcript-yet`).
+    2. Worker pastes the wake-action prompt; Claude Code writes its
+       response + ``stop_hook_summary`` to the real JSONL.
+    3. SessionStart hook fires AFTER the response is written and calls
+       ``set_transcript_path(real_path)``.
+
+    The pre-#563 default was to seek to ``stat().st_size`` (EOF) on
+    path swap — that defends against the compact-resume reply-spam
+    (#496 round-1 Case 3) BUT skips past every line CC already wrote
+    for the wake-action turn, including the ``stop_hook_summary``. The
+    deque head meta then stays unresolved, the watchdog ages it out
+    at 600s, and the visible symptom is "Dymok restarted and re-sent
+    messages" (4 observed instances on Dymok across log history).
+
+    Fix: detect the placeholder source path and pass
+    ``seek_to_start=True`` to the tailer. This test pre-seeds a
+    complete turn into the JSONL BEFORE calling
+    ``set_transcript_path``; under the buggy default-EOF behavior,
+    ``read_once`` would observe nothing. Under the fix, it observes
+    the stop_hook_summary and the response callback fires.
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+    # Sanity: post-connect, tailer is on the placeholder (no prior transcript
+    # in the test fixture's working_dir).
+    from pinky_daemon.tmux_session import _PLACEHOLDER_TRANSCRIPT_PATH
+    assert ss._tailer.transcript_path == _PLACEHOLDER_TRANSCRIPT_PATH
+
+    # Simulate routing meta for an in-flight turn (the wake-action equivalent).
+    ss._inflight_meta = {
+        "platform": "telegram",
+        "chat_id": "777",
+        "message_id": "mWake",
+    }
+
+    # CC has already written a full turn (response + stop_hook_summary)
+    # by the time the SessionStart hook lands.
+    transcript = tmp_path / "preexisting-content.jsonl"
+    entries = [
+        {
+            "type": "user",
+            "timestamp": "2026-05-20T15:59:18.000Z",
+            "message": {"role": "user", "content": "wake action"},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-20T15:59:44.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Replied on Telegram. Standing by."}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "timestamp": "2026-05-20T15:59:44.366Z",
+        },
+    ]
+    transcript.write_text("\n".join(_json.dumps(e) for e in entries) + "\n")
+    assert transcript.stat().st_size > 0, "pre-condition: JSONL has content"
+
+    # SessionStart hook fires AFTER the content was written.
+    ss.set_transcript_path(transcript)
+    assert ss._tailer.transcript_path == transcript
+    assert ss._tailer.offset == 0, (
+        "placeholder→real transition must seek to byte 0 — otherwise "
+        "the pre-existing stop_hook_summary is skipped forever"
+    )
+
+    # Drive the tailer to read. Under the fix, this observes the turn
+    # and fires the response callback; under the bug it sees nothing.
+    await ss._tailer.read_once()
+    assert len(cb.calls) == 1, (
+        "stop_hook_summary written before set_transcript_path must still "
+        "fire the response callback under the placeholder→real fix"
+    )
+    assert cb.calls[0].response_text == "Replied on Telegram. Standing by."
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_set_transcript_path_real_to_real_preserves_seek_to_eof(tmp_path) -> None:
+    """Issue #563 fix must NOT break the compact-resume defense from
+    #496 round-1 Case 3. Real→real path swap (e.g. compact-resume
+    binds a fresh transcript while the same agent session continues)
+    must still seek to EOF so historical turns in the new transcript
+    don't replay through the response callback.
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+
+    # First real path — empty, swap to it (placeholder→real transition,
+    # seeks to start, but file is empty so offset stays 0).
+    first_real = tmp_path / "first.jsonl"
+    first_real.write_text("")
+    ss.set_transcript_path(first_real)
+    assert ss._tailer.transcript_path == first_real
+
+    # Second real path — has prior turns already (simulating compact-resume
+    # binding to a transcript with historical content). The real→real swap
+    # must seek to EOF so we don't replay them.
+    second_real = tmp_path / "second.jsonl"
+    historical_entries = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-19T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "old reply 1"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "timestamp": "2026-05-19T10:00:00.500Z",
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-19T10:01:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "old reply 2"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "timestamp": "2026-05-19T10:01:00.500Z",
+        },
+    ]
+    second_real.write_text("\n".join(_json.dumps(e) for e in historical_entries) + "\n")
+    historical_size = second_real.stat().st_size
+
+    ss.set_transcript_path(second_real)
+    assert ss._tailer.transcript_path == second_real
+    assert ss._tailer.offset == historical_size, (
+        "real→real swap must seek to EOF (#496 reply-spam defense) — "
+        "historical stop_hooks in the new transcript must NOT re-fire"
+    )
+
+    # Read confirms no historical replay.
+    await ss._tailer.read_once()
+    assert len(cb.calls) == 0, "historical turns must not replay on real→real swap"
+
+    await ss.disconnect()
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # PR8b round 2 — Pushok's review fixes
 # ──────────────────────────────────────────────────────────────────────────

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1740,6 +1740,155 @@ async def test_set_transcript_path_from_placeholder_seeks_to_start(tmp_path) -> 
 
 
 @pytest.mark.asyncio
+async def test_set_transcript_path_fresh_launch_old_real_to_new_real_seeks_to_start(tmp_path) -> None:
+    """Issue #563 — fresh-launch case with prior history (Murzik review
+    on PR #564 commit 1).
+
+    ``force_fresh_context_once=True`` (e.g. ``context_restart``) means
+    the launch is fresh even though prior transcripts exist. The
+    ``_start_tailer`` discovery via mtime scan finds the OLD JSONL
+    and seeks the tailer to its EOF. Then CC creates a NEW JSONL for
+    this fresh session, writes the wake-action's first turn including
+    ``stop_hook_summary``, and SessionStart hook lands AFTER that —
+    same late-hook race as the placeholder case, just with an old-real
+    starting point instead of the placeholder.
+
+    Pre-#564-commit-2 the predicate was ``current path is the
+    placeholder``, which missed this case. Post-fix the predicate is
+    ``_tailer_first_bind_pending AND not _last_launch_used_continue``
+    — both flavors of fresh-launch race now seek to byte 0 on the
+    first hook bind. Continue launches still seek to EOF (#496
+    defense unchanged).
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+    # Simulate post-_start_tailer state: tailer bound to an OLD real
+    # JSONL (discovered via mtime scan) + fresh-launch flags set.
+    old_real = tmp_path / "old-history.jsonl"
+    old_real.write_text(_json.dumps({
+        "type": "system", "subtype": "stop_hook_summary",
+        "timestamp": "2026-05-01T00:00:00.000Z",
+    }) + "\n")
+    ss._tailer._path = old_real
+    ss._tailer._offset = old_real.stat().st_size  # seek-to-EOF of OLD
+    ss._tailer_first_bind_pending = True
+    ss._last_launch_used_continue = False  # fresh launch — explicit
+
+    ss._inflight_meta = {
+        "platform": "telegram",
+        "chat_id": "777",
+        "message_id": "mWake",
+    }
+
+    # CC creates a NEW JSONL for the fresh session and writes the
+    # wake-action's first turn including stop_hook_summary BEFORE the
+    # hook lands.
+    new_real = tmp_path / "fresh-session.jsonl"
+    entries = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-20T16:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "fresh-session reply"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "timestamp": "2026-05-20T16:00:00.500Z",
+        },
+    ]
+    new_real.write_text("\n".join(_json.dumps(e) for e in entries) + "\n")
+
+    # SessionStart hook lands.
+    ss.set_transcript_path(new_real)
+    assert ss._tailer.transcript_path == new_real
+    assert ss._tailer.offset == 0, (
+        "fresh-launch old-real→new-real transition must seek to byte 0 — "
+        "otherwise CC's pre-hook-write stop_hook_summary is skipped "
+        "(same race as the placeholder case, just with a real old path)"
+    )
+    # First-bind flag must be consumed regardless of path change.
+    assert ss._tailer_first_bind_pending is False
+
+    await ss._tailer.read_once()
+    assert len(cb.calls) == 1
+    assert cb.calls[0].response_text == "fresh-session reply"
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_set_transcript_path_continue_launch_old_real_to_new_real_preserves_eof(tmp_path) -> None:
+    """Issue #563 — continue-launch case must NOT seek to byte 0
+    (Murzik review on PR #564 commit 1).
+
+    For ``claude --continue`` launches the predicate must evaluate
+    False so the seek-to-EOF default fires — even if a hook later
+    rebinds to a different transcript that has historical turns.
+    Replaying those would be exactly the #496 round-1 Case 3
+    reply-spam scenario.
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+    # Simulate continue-launch state: tailer bound to the historical
+    # JSONL (which is the canonical continued transcript), first-bind
+    # pending, but ``_last_launch_used_continue=True``.
+    historical = tmp_path / "historical.jsonl"
+    historical.write_text(_json.dumps({
+        "type": "system", "subtype": "stop_hook_summary",
+        "timestamp": "2026-05-01T00:00:00.000Z",
+    }) + "\n")
+    ss._tailer._path = historical
+    ss._tailer._offset = historical.stat().st_size
+    ss._tailer_first_bind_pending = True
+    ss._last_launch_used_continue = True  # continue launch
+
+    # Hook reports a transcript with PRIOR content — under a buggy
+    # seek-to-start, this would replay through the callback.
+    other = tmp_path / "other-with-history.jsonl"
+    historical_entries = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-10T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "old continued reply"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "timestamp": "2026-05-10T10:00:00.500Z",
+        },
+    ]
+    other.write_text("\n".join(_json.dumps(e) for e in historical_entries) + "\n")
+    historical_size = other.stat().st_size
+
+    ss.set_transcript_path(other)
+    assert ss._tailer.transcript_path == other
+    assert ss._tailer.offset == historical_size, (
+        "continue-launch path swap must seek to EOF — #496 reply-spam "
+        "defense applies regardless of first-bind state"
+    )
+    assert ss._tailer_first_bind_pending is False, (
+        "first-bind flag must be consumed even when predicate evaluates False"
+    )
+
+    await ss._tailer.read_once()
+    assert len(cb.calls) == 0, "historical turns must not replay on continue launch"
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_set_transcript_path_real_to_real_preserves_seek_to_eof(tmp_path) -> None:
     """Issue #563 fix must NOT break the compact-resume defense from
     #496 round-1 Case 3. Real→real path swap (e.g. compact-resume


### PR DESCRIPTION
Closes #563.

## Summary
- `TmuxSession.set_transcript_path()` now detects the cold-start placeholder→real transition and passes `seek_to_start=True` so the tailer reads the JSONL from byte 0.
- Compact-resume (real→real) swap still seeks to EOF — #496 reply-spam defense unchanged.
- Extracted `_PLACEHOLDER_TRANSCRIPT_PATH` to a module constant so the transition is detected reliably.

## Root cause recap

CC's SessionStart hook is documented as "fires before the first model call," but on cold-start the wake-action turn can complete in <1s while the hook arrival is 50-200ms after. The tailer's default EOF-seek then skips past the wake-action's stop_hook_summary forever, the deque head stays unresolved, subsequent turns pile up as tail, and the watchdog fires at 600s. Visible symptom: "Dymok restarted and re-sent messages" (post-#561 replay path doing its job, but firing because of this upstream bug).

4 observed REPL-stuck events on Dymok across the log history. Pre-#561 those silently dropped tail messages; post-#561 the new tail-requeue made the recovery visible (which is how we caught it).

Receipts in #563 — Dymok session 2449d421, wake-action turn 15:59:18Z→15:59:44Z, stop_hook_summary in JSONL at 15:59:44.366Z, daemon's `_handle_turn_complete` never fired, watchdog aged head out at 16:09:42Z.

## Test plan
- [x] `test_set_transcript_path_from_placeholder_seeks_to_start` — pre-seeds a complete turn into the JSONL BEFORE the hook lands, asserts offset==0 + response_callback fires. Would fail under the buggy default-EOF.
- [x] `test_set_transcript_path_real_to_real_preserves_seek_to_eof` — pins the #496 defense: real→real swap with historical content must NOT replay historical turns. Asserts offset == file size.
- [x] 156/156 tmux tests (+2 new since 154 on main)
- [x] 42/42 transcript tests
- [x] 2591 full suite
- [x] ruff lint clean
- [ ] **Deploy + live-watch Dymok cold-start cycle** — the real proof. Will smoke after merge.

Cross-refs: #560 (mid-turn steering), #561 (watchdog + tail-requeue), #496 (set_transcript_path reply-spam defense), #515 (self-heal mtime-scan — which already correctly passes seek_to_start=True; this PR brings the SessionStart-hook path into parity).

🤖 Opened by Barsik