### PR TITLE
fix(tmux): self-heal recovery for fresh launches with prior history (#565)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2387,88 +2387,111 @@ class TmuxSession:
         self._activity_log = []
 
     async def _start_tailer(self) -> None:
-        """Construct + start the transcript tailer.
+        """Construct (if needed) + start the transcript tailer, then arm
+        the per-spawn first-bind state.
 
-        Called from ``_spawn_tmux_repl`` after the REPL boots. Uses the
-        best-effort path guess (newest .jsonl in the project dir);
-        SessionStart hook later repoints us at the canonical path.
+        Called from ``_spawn_tmux_repl`` after every REPL boot —
+        including ``force_restart`` / ``attempt_reconnect`` paths where
+        ``_stop_tailer`` previously ran but the tailer **instance** is
+        intentionally retained so stats and last-known path survive.
 
-        Idempotent — calling twice is a no-op.
+        Two responsibilities, split clearly:
+
+        1. **Construction (first call only):** discover an initial
+           transcript path, build the ``TmuxTranscriptTailer``, seek
+           to EOF on an existing file (or accept the placeholder for
+           cold start). Subsequent calls re-use the instance.
+        2. **Per-spawn arming (every call):** arm
+           ``_tailer_first_bind_pending = True`` and (re)schedule the
+           ``#565`` delayed recovery task. This MUST run on every
+           ``_start_tailer`` invocation, not just the first one —
+           Murzik's PR #566 round-1 review pointed out that the
+           retained-instance respawn path skipped both pieces of
+           setup, silently breaking ``#564``'s first-bind seek and
+           ``#565``'s recovery for any second-and-later spawn.
+
+        See ``set_transcript_path`` for what consumes the flag and
+        ``_attempt_first_bind_recovery`` for what the scheduled task
+        does on the deadline.
         """
-        if self._tailer is not None:
-            await self._tailer.start()  # idempotent
-            return
-
-        guessed = self._discover_transcript_path()
-        # Even if guessed is None (cold start, no transcript yet) we still
-        # construct the tailer so notify_tail() works as soon as the
-        # SessionStart hook reports a path. Use a placeholder path that
-        # .exists() returns False for — the tailer's read_once handles
-        # that gracefully.
-        path = guessed or _PLACEHOLDER_TRANSCRIPT_PATH
-        self._tailer = TmuxTranscriptTailer(
-            transcript_path=path,
-            on_turn_complete=self._handle_turn_complete,
-            agent_name=self.agent_name,
-            # #515 self-heal: hand the tailer our discovery callback so
-            # it can mtime-scan and rebind on its own if the SessionStart
-            # hook never fires (e.g. when tmux strips PINKY_SESSION_SECRET
-            # from the hook script's env — see ``_build_repl_env``). The
-            # tailer becomes correct independently of the hook firing.
-            path_discovery=self._discover_transcript_path,
-        )
-        # Issue #563 — mark this spawn as needing a "first bind" call so
-        # ``set_transcript_path`` can seek to byte 0 on the FIRST swap
-        # after spawn when the launch is fresh (no --continue). Two
-        # scenarios this covers:
-        #   1. Dymok cold-start: ``guessed is None`` → placeholder path,
-        #      SessionStart hook arrives after CC's first stop_hook_summary.
-        #   2. ``force_fresh_context_once=True`` with prior transcripts:
-        #      ``guessed`` points at an OLD JSONL, SessionStart hook
-        #      rebinds to the NEW JSONL that CC just created — same
-        #      late-hook race against CC's first turn.
-        # The flag is consumed by ``set_transcript_path`` regardless of
-        # whether the path actually changed, so repeated SessionStart
-        # posts cannot later turn into replay risk (Murzik review on
-        # PR #564 commit 1).
-        self._tailer_first_bind_pending = True
-        await self._tailer.start()
-        if guessed is None:
-            _log(
-                f"tmux[{self.agent_name}]: tailer started with placeholder "
-                f"path — awaiting SessionStart hook to report actual transcript"
+        if self._tailer is None:
+            # ── Construction (first call only) ──────────────────────
+            guessed = self._discover_transcript_path()
+            # Even if guessed is None (cold start, no transcript yet)
+            # we still construct the tailer so ``notify_tail()`` works
+            # as soon as the SessionStart hook reports a path. Use a
+            # placeholder path that ``.exists()`` returns False for —
+            # the tailer's read_once handles that gracefully.
+            path = guessed or _PLACEHOLDER_TRANSCRIPT_PATH
+            self._tailer = TmuxTranscriptTailer(
+                transcript_path=path,
+                on_turn_complete=self._handle_turn_complete,
+                agent_name=self.agent_name,
+                # #515 self-heal: hand the tailer our discovery
+                # callback so it can mtime-scan and rebind on its own
+                # if the SessionStart hook never fires. Closes the
+                # placeholder-flavor gap; the stale-real-path flavor
+                # is covered by ``_attempt_first_bind_recovery``
+                # (issue #565).
+                path_discovery=self._discover_transcript_path,
             )
+            await self._tailer.start()
+            if guessed is None:
+                _log(
+                    f"tmux[{self.agent_name}]: tailer started with placeholder "
+                    f"path — awaiting SessionStart hook to report actual transcript"
+                )
+            else:
+                # Seek to EOF on the existing file so we don't replay
+                # historical turns on a warm-wake / resume. The
+                # SessionStart hook (or the #565 delayed recovery)
+                # can ``set_offset(0)`` if a fresh backfill is wanted.
+                try:
+                    self._tailer.set_offset(guessed.stat().st_size)
+                except OSError:
+                    # File disappeared between exists() check and
+                    # stat() — race with Claude Code rotating /
+                    # clearing the project dir. Fall through with
+                    # offset=0; the hook will reset us shortly.
+                    pass
+                _log(
+                    f"tmux[{self.agent_name}]: tailer started at {guessed} "
+                    f"(offset={self._tailer.offset})"
+                )
         else:
-            # Seek to EOF on the existing file so we don't replay historical
-            # turns on a warm-wake / resume. The SessionStart hook can
-            # set_offset(0) if a fresh backfill is wanted.
-            try:
-                self._tailer.set_offset(guessed.stat().st_size)
-            except OSError:
-                # File disappeared between exists() check and stat() — race
-                # with Claude Code rotating/clearing the project dir. Fall
-                # through with offset=0 (the SessionStart hook will reset
-                # us to the canonical path shortly).
-                pass
-            _log(
-                f"tmux[{self.agent_name}]: tailer started at {guessed} "
-                f"(offset={self._tailer.offset})"
-            )
+            # ── Re-spawn (force_restart, attempt_reconnect) ─────────
+            # Tailer instance retained across ``_stop_tailer``;
+            # restart its background task. Path + offset are
+            # intentionally preserved so a same-path resume sees its
+            # own EOF (Murzik's PR #496 round-3 Case 2'' relies on
+            # the path-equality guard in ``set_transcript_path``).
+            # The new REPL's path may differ (force_fresh_context_once
+            # creates a new JSONL); the per-spawn arming below lets
+            # the upcoming ``set_transcript_path`` or the delayed
+            # recovery handle that rebind correctly.
+            await self._tailer.start()
 
-        # Issue #565 — schedule the delayed first-bind recovery. If no
-        # explicit ``set_transcript_path`` lands within the deadline AND
-        # the launch is fresh, we re-discover and rebind even when the
-        # current watched path exists. The predicate guards inside
-        # ``_attempt_first_bind_recovery`` make this a no-op for
-        # continue launches and for any case where the hook already
-        # consumed the first-bind flag.
+        # ── Per-spawn arming (every call) ───────────────────────────
+        # Issue #563/#564: arm the first-bind flag so the next
+        # ``set_transcript_path`` call (or the #565 delayed recovery)
+        # can seek to byte 0 on fresh launches. Pre-PR-#566-round-2
+        # this lived inside the construction branch — Murzik's review
+        # caught that ``force_restart()`` → ``_stop_tailer`` →
+        # ``_start_tailer`` (retained instance) skipped the arming.
+        # Result was that any second-or-later fresh-launch spawn
+        # silently lost the #564 first-bind seek AND the #565
+        # delayed recovery for the rest of its lifetime.
+        self._tailer_first_bind_pending = True
+
+        # Issue #565: schedule a fresh delayed recovery for this
+        # spawn. Cancel any leftover task from a previous spawn
+        # defensively — ``_stop_tailer`` also cancels, but a future
+        # caller might skip ``_stop_tailer``, and double-scheduling
+        # would race two recoveries against one spawn.
         if (
             self._first_bind_recovery_task is not None
             and not self._first_bind_recovery_task.done()
         ):
-            # Idempotency: should not happen given the tailer-already-
-            # constructed guard above, but cancel any leftover task to
-            # keep a single recovery in flight per spawn.
             self._first_bind_recovery_task.cancel()
         self._first_bind_recovery_task = asyncio.create_task(
             self._delayed_first_bind_recovery()

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -119,6 +119,17 @@ _TRANSIENT_RETRY_BACKOFF_SEC = 2.0
 # on subsequent real→real swaps (compact-resume protected by #496).
 _PLACEHOLDER_TRANSCRIPT_PATH = Path("/dev/null/no-transcript-yet")
 
+# Issue #565 — delayed first-bind recovery delay. After ``_start_tailer``
+# schedules a recovery task; if no explicit ``set_transcript_path`` bind
+# has consumed ``_tailer_first_bind_pending`` by this deadline AND the
+# launch is fresh, we re-run ``_discover_transcript_path()`` and rebind
+# even if the currently watched path exists. Covers the bind-never-arrives
+# case for fresh-launch-with-prior-history (the existing #515 self-heal
+# only fires when the current watched path is missing; a stale real path
+# blocks it forever). 5 seconds is generous slack vs. typical
+# SessionStart hook latency (sub-second to ~200ms).
+_FIRST_BIND_RECOVERY_DELAY_SEC = 5.0
+
 
 class _ContextLockDeferral(Exception):  # noqa: N818
     """Transient: context-lock file present at paste time.
@@ -700,6 +711,12 @@ class TmuxSession:
         # ``stop_hook_summary``. Continue launches preserve the
         # seek-to-EOF default (#496 round-1 Case 3 reply-spam defense).
         self._tailer_first_bind_pending: bool = False
+
+        # Issue #565 — handle to the delayed first-bind recovery task
+        # scheduled from ``_start_tailer``. Cancelled in ``_stop_tailer``
+        # so a torn-down session doesn't have a stray task firing
+        # ``set_transcript_path`` against a stopped tailer.
+        self._first_bind_recovery_task: asyncio.Task[None] | None = None
 
         # Test seam: when True, ``connect()`` skips wake-prompt assembly
         # + enqueue. Production callers must NOT flip this; it exists so
@@ -2438,6 +2455,115 @@ class TmuxSession:
                 f"(offset={self._tailer.offset})"
             )
 
+        # Issue #565 — schedule the delayed first-bind recovery. If no
+        # explicit ``set_transcript_path`` lands within the deadline AND
+        # the launch is fresh, we re-discover and rebind even when the
+        # current watched path exists. The predicate guards inside
+        # ``_attempt_first_bind_recovery`` make this a no-op for
+        # continue launches and for any case where the hook already
+        # consumed the first-bind flag.
+        if (
+            self._first_bind_recovery_task is not None
+            and not self._first_bind_recovery_task.done()
+        ):
+            # Idempotency: should not happen given the tailer-already-
+            # constructed guard above, but cancel any leftover task to
+            # keep a single recovery in flight per spawn.
+            self._first_bind_recovery_task.cancel()
+        self._first_bind_recovery_task = asyncio.create_task(
+            self._delayed_first_bind_recovery()
+        )
+
+    async def _delayed_first_bind_recovery(self) -> None:
+        """Issue #565 — wait, then attempt first-bind recovery.
+
+        Sleeps for ``_FIRST_BIND_RECOVERY_DELAY_SEC`` and then calls
+        ``_attempt_first_bind_recovery()``. Split from the sync
+        recovery method so tests can exercise the recovery logic
+        without dealing with timer-based scheduling.
+
+        Cancellation during the sleep is the expected unwind on
+        ``_stop_tailer``: ``asyncio.CancelledError`` propagates so the
+        task is marked cancelled (don't swallow it — that would mask
+        the intent and confuse anything inspecting the task state).
+        Any non-cancel exception from ``_attempt_first_bind_recovery``
+        is caught and logged; the task must not crash unhandled.
+        """
+        await asyncio.sleep(_FIRST_BIND_RECOVERY_DELAY_SEC)
+        try:
+            self._attempt_first_bind_recovery()
+        except Exception as e:  # defensive — must never crash a task
+            _log(
+                f"tmux[{self.agent_name}]: #565 first-bind recovery raised "
+                f"({type(e).__name__}: {e})"
+            )
+
+    def _attempt_first_bind_recovery(self) -> None:
+        """Issue #565 — recover from the bind-never-arrives case on a
+        fresh launch with prior history.
+
+        The pre-#565 self-heal in ``TmuxTranscriptTailer`` only fires
+        when the current watched path is **missing**. That covers the
+        cold-start placeholder flavor (the placeholder path doesn't
+        exist on disk). It does **not** cover the fresh-launch-with-
+        prior-history flavor: ``_start_tailer`` discovers an OLD real
+        JSONL via mtime scan, seeks the tailer to its EOF, and waits
+        for the SessionStart hook. If the hook never arrives, the
+        tailer remains bound to the stale path forever — the existing
+        self-heal's ``self._path.exists()`` early-return blocks it.
+
+        Recovery decision needs ``_tailer_first_bind_pending`` and
+        ``_last_launch_used_continue``, which the tailer doesn't know
+        about — keep it here at ``TmuxSession``. Route the rebind
+        through ``set_transcript_path`` so the existing first-bind
+        seek-to-start path (PR #564) handles the seek + flag-consume,
+        and so the #496 continue-launch reply-spam defense remains
+        intact for the predicate-evaluates-False branch.
+
+        No-op when:
+          - Continue launch (predicate-False, EOF defense preserved).
+          - First-bind flag already consumed by the explicit hook.
+          - Tailer has been torn down (``_stop_tailer`` ran).
+          - Discovery returns None (no real transcript on disk yet).
+          - Discovery returns the same path we're already on.
+        """
+        # Guard: only fresh launches need recovery — continue launches
+        # already seek EOF for #496 reply-spam defense.
+        if self._last_launch_used_continue:
+            return
+        # Guard: explicit hook bind already arrived → flag consumed →
+        # nothing to recover.
+        if not self._tailer_first_bind_pending:
+            return
+        # Guard: tailer was torn down before the deadline (e.g.
+        # ``_stop_tailer`` was called between sleep completion and the
+        # recovery firing). Cancellation usually catches this, but
+        # the gap between sleep return and ``_attempt`` is non-zero.
+        if self._tailer is None:
+            return
+        try:
+            discovered = self._discover_transcript_path()
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: #565 recovery discovery raised "
+                f"({type(e).__name__}: {e})"
+            )
+            return
+        if discovered is None:
+            return
+        # No-change → no work. The tailer's own equality guard would
+        # handle this, but checking here keeps the log noise honest.
+        if Path(discovered) == Path(self._tailer.transcript_path):
+            return
+        _log(
+            f"tmux[{self.agent_name}]: #565 first-bind recovery — no "
+            f"explicit bind in {_FIRST_BIND_RECOVERY_DELAY_SEC}s, "
+            f"rebinding {self._tailer.transcript_path} → {discovered}"
+        )
+        # Routes through the standard first-bind path → seeks to byte 0
+        # and consumes the ``_tailer_first_bind_pending`` flag (PR #564).
+        self.set_transcript_path(discovered)
+
     async def _stop_tailer(self) -> None:
         """Stop the tailer if running. Idempotent.
 
@@ -2454,7 +2580,19 @@ class TmuxSession:
         drain here unconditionally and the path-equality guard in
         ``set_transcript_path`` becomes belt-and-suspenders rather
         than the sole defense.
+
+        Issue #565: cancel any pending first-bind recovery task before
+        the tailer goes away — otherwise the task can wake after
+        ``_stop_tailer`` and call ``set_transcript_path`` against a
+        stopped tailer. The ``_attempt_first_bind_recovery`` method
+        also re-checks ``self._tailer is None`` defensively.
         """
+        if (
+            self._first_bind_recovery_task is not None
+            and not self._first_bind_recovery_task.done()
+        ):
+            self._first_bind_recovery_task.cancel()
+        self._first_bind_recovery_task = None
         if self._tailer is not None:
             try:
                 await self._tailer.stop()

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1888,6 +1888,333 @@ async def test_set_transcript_path_continue_launch_old_real_to_new_real_preserve
     await ss.disconnect()
 
 
+# ── Issue #565 — delayed first-bind recovery for the bind-never-arrives
+# ── case on a fresh launch with prior history.
+# ──
+# ── Setup invariant for these tests: PR #564 fixed the seek position
+# ── for the case where SessionStart hook DOES arrive. #565 covers the
+# ── separate case where the hook never arrives but the tailer is bound
+# ── to a stale real path (so the existing #515 self-heal's
+# ── ``self._path.exists()`` early-return blocks recovery forever).
+@pytest.mark.asyncio
+async def test_first_bind_recovery_fresh_with_prior_history_rebinds_and_seeks_to_start(
+    tmp_path, monkeypatch,
+) -> None:
+    """Issue #565 — fresh launch with prior history + no explicit
+    SessionStart bind must self-heal to the newer JSONL and seek to
+    byte 0 so the wake-action turn's ``stop_hook_summary`` is observed.
+
+    Reproduction shape:
+      1. ``_start_tailer`` discovers an OLD real JSONL and seeks EOF
+         (warm-wake protection from pre-#564 behavior).
+      2. CC creates a NEW JSONL for this fresh session and writes its
+         first turn (assistant + ``stop_hook_summary``).
+      3. SessionStart hook never lands (dropped, env stripped, etc.).
+      4. After ``_FIRST_BIND_RECOVERY_DELAY_SEC`` the scheduled
+         recovery runs: re-discovers, sees a different newer path,
+         routes through ``set_transcript_path`` → seeks to byte 0.
+
+    Pre-#565 the tailer's existing self-heal returned early because
+    the OLD path still existed on disk, so the new ``stop_hook_summary``
+    was never observed and the head meta hung until the watchdog.
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+
+    # Simulate post-_start_tailer state: tailer bound to an OLD real
+    # JSONL via mtime-scan discovery + fresh-launch flags set.
+    old_real = tmp_path / "old-history.jsonl"
+    old_real.write_text(_json.dumps({
+        "type": "system", "subtype": "stop_hook_summary",
+        "timestamp": "2026-05-01T00:00:00.000Z",
+    }) + "\n")
+    ss._tailer._path = old_real
+    ss._tailer._offset = old_real.stat().st_size  # seek-to-EOF of OLD
+    ss._tailer_first_bind_pending = True
+    ss._last_launch_used_continue = False  # fresh launch — explicit
+
+    ss._inflight_meta = {
+        "platform": "telegram",
+        "chat_id": "777",
+        "message_id": "mWake",
+    }
+
+    # CC creates a NEW JSONL for the fresh session and writes the first
+    # turn including ``stop_hook_summary`` — but the SessionStart hook
+    # never lands. The delayed recovery is what must observe this.
+    new_real = tmp_path / "fresh-session.jsonl"
+    entries = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-20T16:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "recovered fresh reply"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "timestamp": "2026-05-20T16:00:00.500Z",
+        },
+    ]
+    new_real.write_text("\n".join(_json.dumps(e) for e in entries) + "\n")
+
+    # Stub discovery to return the new fresh path. Avoids needing a
+    # full encoded-cwd project dir in the test fixture.
+    monkeypatch.setattr(ss, "_discover_transcript_path", lambda: new_real)
+
+    # Drive the recovery directly — bypasses the ``asyncio.sleep`` in
+    # ``_delayed_first_bind_recovery`` so the test stays fast and
+    # deterministic. The integration of sleep+attempt is exercised by
+    # the recovery-task lifecycle tests below.
+    ss._attempt_first_bind_recovery()
+
+    assert ss._tailer.transcript_path == new_real, (
+        "bind-never-arrives recovery must rebind to the discovered "
+        "newer JSONL even though the old path still exists on disk"
+    )
+    assert ss._tailer.offset == 0, (
+        "recovery must seek to byte 0 — otherwise CC's pre-hook-write "
+        "stop_hook_summary is skipped (same race as the #563 cold-start "
+        "case, just driven by recovery instead of the hook)"
+    )
+    assert ss._tailer_first_bind_pending is False, (
+        "recovery must consume the first-bind flag so a late hook "
+        "arrival doesn't double-trigger seek-to-start"
+    )
+
+    await ss._tailer.read_once()
+    assert len(cb.calls) == 1
+    assert cb.calls[0].response_text == "recovered fresh reply"
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_first_bind_recovery_continue_launch_noops_and_preserves_eof(
+    tmp_path, monkeypatch,
+) -> None:
+    """Issue #565 — continue launches must NEVER trigger recovery.
+
+    The recovery's whole motivation is the fresh-launch race. On a
+    continue launch the tailer is correctly bound to the continued
+    transcript and we explicitly want to seek to EOF (#496 round-1
+    Case 3 reply-spam defense). If recovery fired here it would bind
+    to whatever ``_discover_transcript_path`` returns and seek to
+    byte 0 — replaying every historical turn.
+
+    Asserts the predicate-False branch of ``_attempt_first_bind_recovery``.
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+
+    # Continue-launch state: tailer bound to the continued JSONL with
+    # prior history, seeked to EOF, first-bind flag still pending
+    # (continue launches set the flag too — predicate-False is the
+    # gate, not flag-False).
+    continued = tmp_path / "continued.jsonl"
+    historical_entries = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-10T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "old continued reply"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "timestamp": "2026-05-10T10:00:00.500Z",
+        },
+    ]
+    continued.write_text("\n".join(_json.dumps(e) for e in historical_entries) + "\n")
+    continued_size = continued.stat().st_size
+    ss._tailer._path = continued
+    ss._tailer._offset = continued_size  # EOF
+    ss._tailer_first_bind_pending = True
+    ss._last_launch_used_continue = True  # continue — predicate False
+
+    # Even though discovery would return a *different* fresh path, the
+    # predicate guards against acting on it for continue launches.
+    other = tmp_path / "other-fresh.jsonl"
+    other.write_text(_json.dumps({
+        "type": "system", "subtype": "stop_hook_summary",
+        "timestamp": "2026-05-20T16:00:00.000Z",
+    }) + "\n")
+    monkeypatch.setattr(ss, "_discover_transcript_path", lambda: other)
+
+    ss._attempt_first_bind_recovery()
+
+    assert ss._tailer.transcript_path == continued, (
+        "continue-launch recovery must no-op — rebinding would break "
+        "the #496 reply-spam defense"
+    )
+    assert ss._tailer.offset == continued_size, (
+        "offset must remain at EOF — recovery must not seek to byte 0 "
+        "on continue launches"
+    )
+    assert ss._tailer_first_bind_pending is True, (
+        "first-bind flag must NOT be consumed when recovery no-ops — "
+        "an explicit hook arrival can still take the seek-to-EOF path"
+    )
+
+    await ss._tailer.read_once()
+    assert len(cb.calls) == 0, "historical turns must not replay on continue launch"
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_first_bind_recovery_noops_when_flag_already_consumed(
+    tmp_path, monkeypatch,
+) -> None:
+    """Issue #565 — recovery must no-op when an explicit
+    ``set_transcript_path`` already consumed the first-bind flag.
+
+    The realistic shape: SessionStart hook arrives within the deadline
+    → ``_tailer_first_bind_pending`` flips False → the still-scheduled
+    recovery task wakes and the attempt method sees the consumed flag
+    and returns without doing anything.
+
+    Without this guard the recovery could rebind a second time after
+    the hook already handled things — potentially redirecting to a
+    different newest JSONL if CC rotated transcripts during the
+    deadline window.
+    """
+    ss, _ = _make_session_with_response_cb()
+    await ss.connect()
+
+    real = tmp_path / "real.jsonl"
+    real.write_text("")
+    ss._tailer._path = real
+    ss._tailer._offset = 0
+    ss._tailer_first_bind_pending = False  # explicit hook already ran
+    ss._last_launch_used_continue = False  # fresh launch
+
+    # Discovery returns a *different* path — but recovery must ignore
+    # it because the flag is already consumed.
+    other = tmp_path / "newer.jsonl"
+    other.write_text("")
+    monkeypatch.setattr(ss, "_discover_transcript_path", lambda: other)
+
+    ss._attempt_first_bind_recovery()
+
+    assert ss._tailer.transcript_path == real, (
+        "consumed-flag guard must prevent recovery from rebinding"
+    )
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_first_bind_recovery_noops_when_discovery_returns_same_path(
+    tmp_path, monkeypatch,
+) -> None:
+    """Issue #565 — recovery must no-op (no log spam, no seek reset)
+    when discovery returns the path the tailer is already bound to.
+
+    This is the common case when the SessionStart hook arrives at the
+    same time discovery would have found the right path (CC just
+    happens to have its newest JSONL be the one the tailer already
+    points at). The attempt should detect the same-path case and
+    return without going through ``set_transcript_path``.
+    """
+    ss, _ = _make_session_with_response_cb()
+    await ss.connect()
+
+    current = tmp_path / "current.jsonl"
+    current.write_text("")
+    ss._tailer._path = current
+    ss._tailer._offset = 1234  # arbitrary non-zero, must stay put
+    ss._tailer_first_bind_pending = True
+    ss._last_launch_used_continue = False
+
+    monkeypatch.setattr(ss, "_discover_transcript_path", lambda: current)
+
+    ss._attempt_first_bind_recovery()
+
+    assert ss._tailer.transcript_path == current
+    assert ss._tailer.offset == 1234, "same-path recovery must not reset offset"
+    assert ss._tailer_first_bind_pending is True, (
+        "same-path no-op must not consume the first-bind flag — "
+        "the real bind hasn't happened yet"
+    )
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_first_bind_recovery_noops_when_discovery_returns_none(
+    tmp_path, monkeypatch,
+) -> None:
+    """Issue #565 — recovery must no-op when discovery finds nothing.
+
+    Cold-start with no transcripts on disk at all. The tailer should
+    keep waiting for the hook; rebinding to None would be a regression.
+    """
+    ss, _ = _make_session_with_response_cb()
+    await ss.connect()
+
+    placeholder_like = tmp_path / "placeholder-like.jsonl"
+    placeholder_like.write_text("")
+    ss._tailer._path = placeholder_like
+    ss._tailer._offset = 0
+    ss._tailer_first_bind_pending = True
+    ss._last_launch_used_continue = False
+
+    monkeypatch.setattr(ss, "_discover_transcript_path", lambda: None)
+
+    ss._attempt_first_bind_recovery()
+
+    assert ss._tailer.transcript_path == placeholder_like
+    assert ss._tailer_first_bind_pending is True
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_start_tailer_schedules_recovery_task() -> None:
+    """Issue #565 — ``_start_tailer`` must schedule a recovery task so
+    the bind-never-arrives gap is actually closed (not just covered by
+    a method nobody calls).
+    """
+    ss, _ = _make_session_with_response_cb()
+    await ss.connect()
+    assert ss._first_bind_recovery_task is not None
+    assert not ss._first_bind_recovery_task.done(), (
+        "recovery task must be live until the deadline or cancellation"
+    )
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_stop_tailer_cancels_pending_recovery_task() -> None:
+    """Issue #565 — ``_stop_tailer`` must cancel the pending recovery
+    task so a torn-down session doesn't have a stray timer firing
+    ``set_transcript_path`` against a stopped tailer.
+    """
+    ss, _ = _make_session_with_response_cb()
+    await ss.connect()
+    task = ss._first_bind_recovery_task
+    assert task is not None
+    await ss.disconnect()
+    # ``disconnect`` → ``_stop_tailer`` cancels + clears the handle.
+    assert ss._first_bind_recovery_task is None
+    # Give the cancellation a moment to propagate; the task should be
+    # done (cancelled) by now.
+    await asyncio.sleep(0)
+    assert task.done()
+    assert task.cancelled()
+
+
 @pytest.mark.asyncio
 async def test_set_transcript_path_real_to_real_preserves_seek_to_eof(tmp_path) -> None:
     """Issue #563 fix must NOT break the compact-resume defense from

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -2216,6 +2216,172 @@ async def test_stop_tailer_cancels_pending_recovery_task() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_tailer_rearms_first_bind_state_on_retained_instance_respawn() -> None:
+    """Issue #565 — Murzik's PR #566 round-1 finding: per-spawn first-
+    bind state must be re-armed on every ``_start_tailer`` call,
+    including the retained-instance respawn path (force_restart /
+    attempt_reconnect).
+
+    Pre-fix shape: ``_start_tailer`` early-returned when
+    ``self._tailer is not None`` and never re-armed
+    ``_tailer_first_bind_pending`` nor (re)scheduled the recovery
+    task. Result: any second-or-later fresh-launch spawn silently
+    lost both PR #564's first-bind seek-to-start AND PR #566's
+    delayed recovery for the rest of its lifetime.
+
+    This test exercises the bug pattern: consume the flag via an
+    explicit bind, stop the tailer (instance retained per #496
+    round-3 Case 2''), restart the tailer, and assert the per-spawn
+    arming ran.
+    """
+    ss, _ = _make_session_with_response_cb()
+    await ss.connect()
+    # Sanity: cold-start arming worked.
+    assert ss._tailer_first_bind_pending is True
+    initial_recovery_task = ss._first_bind_recovery_task
+    assert initial_recovery_task is not None
+    tailer_instance_id_before = id(ss._tailer)
+
+    # Simulate the SessionStart hook arriving and consuming the flag.
+    # ``_stop_tailer`` will tear down the task but keep the tailer
+    # instance so the next spawn can resume from its last path.
+    from pathlib import Path as _Path
+    fake_path = _Path("/tmp/test-retained-instance.jsonl")
+    fake_path.write_text("")
+    ss.set_transcript_path(fake_path)
+    assert ss._tailer_first_bind_pending is False, (
+        "explicit bind must consume the flag — sanity check before "
+        "exercising the respawn re-arm"
+    )
+
+    # Tear down and restart, retaining the instance (the contract
+    # ``_stop_tailer``'s docstring describes for #496 Case 2'' and
+    # the force_restart flow Pushok wired up).
+    await ss._stop_tailer()
+    # Sanity: the recovery task was cancelled by _stop_tailer.
+    assert ss._first_bind_recovery_task is None
+
+    # Mark this spawn as fresh — the predicate that gates the
+    # delayed recovery depends on ``_last_launch_used_continue``.
+    ss._last_launch_used_continue = False
+    await ss._start_tailer()
+
+    # Critical invariants for the fix:
+    assert id(ss._tailer) == tailer_instance_id_before, (
+        "tailer instance must be retained across stop/start — this is "
+        "the bug-reproducing path; if the instance is fresh, the test "
+        "isn't exercising the retained-instance scenario"
+    )
+    assert ss._tailer_first_bind_pending is True, (
+        "per-spawn arming must reset _tailer_first_bind_pending so the "
+        "next set_transcript_path or the #565 delayed recovery seeks "
+        "to byte 0 (Murzik PR #566 round-1 finding)"
+    )
+    assert ss._first_bind_recovery_task is not None, (
+        "per-spawn arming must (re)schedule the #565 recovery task on "
+        "respawn — without this the bind-never-arrives gap reopens "
+        "for the second and later spawns"
+    )
+    assert not ss._first_bind_recovery_task.done(), (
+        "the freshly scheduled recovery task must still be live "
+        "(it will only fire after ``_FIRST_BIND_RECOVERY_DELAY_SEC``)"
+    )
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_first_bind_recovery_after_retained_instance_respawn_rebinds_and_seeks(
+    tmp_path, monkeypatch,
+) -> None:
+    """Issue #565 — stronger variant of the retained-instance respawn
+    test (Murzik's PR #566 round-1 stronger-version suggestion):
+    after the respawn, simulate the bind-never-arrives shape with a
+    new JSONL on disk and assert the recovery actually rebinds +
+    seeks to 0.
+
+    This is the end-to-end version of what the previous test pins
+    structurally. Together they prevent regression of both:
+      - the per-spawn arming itself, and
+      - the arming actually producing a working recovery on the
+        second spawn (e.g. a future refactor could re-arm the flag
+        but forget to schedule the task, or vice versa).
+    """
+    cb = _AsyncCollector()
+    ss, _ = _make_session_with_response_cb(response_cb=cb)
+    await ss.connect()
+
+    # First spawn: consume the flag via an explicit bind, then stop
+    # the tailer (retaining the instance).
+    first_real = tmp_path / "first.jsonl"
+    first_real.write_text("")
+    ss.set_transcript_path(first_real)
+    assert ss._tailer_first_bind_pending is False
+    await ss._stop_tailer()
+
+    # Respawn — force_fresh shape: the previous tailer was bound to
+    # ``first_real`` (still on disk), the new REPL will write to
+    # ``second_real``. The SessionStart hook never lands; only the
+    # #565 delayed recovery saves us.
+    ss._last_launch_used_continue = False
+    await ss._start_tailer()
+    # Sanity: the retained tailer is still on ``first_real``.
+    assert ss._tailer.transcript_path == first_real
+
+    # Simulate the in-flight wake-action turn meta the way #563/#564
+    # tests do — so the recovery's read_once will fire the response
+    # callback rather than swallow the entry as unrouted.
+    ss._inflight_meta = {
+        "platform": "telegram",
+        "chat_id": "777",
+        "message_id": "m_post_respawn",
+    }
+
+    # Newer real JSONL exists on disk and already has a complete turn
+    # written by Claude Code before any hook would have landed.
+    second_real = tmp_path / "second.jsonl"
+    entries = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-05-20T17:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "post-respawn reply"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "timestamp": "2026-05-20T17:00:00.500Z",
+        },
+    ]
+    second_real.write_text("\n".join(_json.dumps(e) for e in entries) + "\n")
+
+    monkeypatch.setattr(ss, "_discover_transcript_path", lambda: second_real)
+
+    # Drive the recovery directly (the same trick the other #565
+    # tests use to skip the timer).
+    ss._attempt_first_bind_recovery()
+
+    assert ss._tailer.transcript_path == second_real, (
+        "post-respawn recovery must rebind to the newer JSONL — this "
+        "is the regression Murzik's PR #566 round-1 finding warned "
+        "about: pre-fix the recovery wasn't even scheduled on the "
+        "second spawn, so this rebind never happens"
+    )
+    assert ss._tailer.offset == 0
+    assert ss._tailer_first_bind_pending is False
+
+    await ss._tailer.read_once()
+    assert len(cb.calls) == 1
+    assert cb.calls[0].response_text == "post-respawn reply"
+
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_set_transcript_path_real_to_real_preserves_seek_to_eof(tmp_path) -> None:
     """Issue #563 fix must NOT break the compact-resume defense from
     #496 round-1 Case 3. Real→real path swap (e.g. compact-resume

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -2216,7 +2216,9 @@ async def test_stop_tailer_cancels_pending_recovery_task() -> None:
 
 
 @pytest.mark.asyncio
-async def test_start_tailer_rearms_first_bind_state_on_retained_instance_respawn() -> None:
+async def test_start_tailer_rearms_first_bind_state_on_retained_instance_respawn(
+    tmp_path,
+) -> None:
     """Issue #565 — Murzik's PR #566 round-1 finding: per-spawn first-
     bind state must be re-armed on every ``_start_tailer`` call,
     including the retained-instance respawn path (force_restart /
@@ -2245,8 +2247,7 @@ async def test_start_tailer_rearms_first_bind_state_on_retained_instance_respawn
     # Simulate the SessionStart hook arriving and consuming the flag.
     # ``_stop_tailer`` will tear down the task but keep the tailer
     # instance so the next spawn can resume from its last path.
-    from pathlib import Path as _Path
-    fake_path = _Path("/tmp/test-retained-instance.jsonl")
+    fake_path = tmp_path / "retained-instance.jsonl"
     fake_path.write_text("")
     ss.set_transcript_path(fake_path)
     assert ss._tailer_first_bind_pending is False, (


### PR DESCRIPTION
## Summary

Closes #565.

- Adds a `TmuxSession`-level delayed first-bind recovery so the bind-never-arrives flavor of late-hook race is actually recoverable.
- Reuses PR #564's first-bind seek-to-start logic by routing the discovered rebind through `set_transcript_path` — no duplication, and the #496 reply-spam defense on continue launches is unchanged (predicate-False → no-op).
- Cancels the pending recovery task in `_stop_tailer`; `_attempt_first_bind_recovery` also re-checks `self._tailer is None` defensively.

## The gap (recap from #565)

The existing #515 tailer self-heal only fires when `self._path.exists()` returns False. That covers the placeholder flavor. It does NOT cover the case `_start_tailer` already discovered an OLD real JSONL on disk: the path exists, the self-heal returns early forever, and if the `SessionStart` hook never lands the tailer stays pinned to the stale path.

This is structurally adjacent to #563/#564 but not what those fix — #564 fixes the seek position *when* the bind happens. #565 is about the bind not happening at all on a fresh launch with prior history.

## What changed

- `tmux_session.py`:
  - `_FIRST_BIND_RECOVERY_DELAY_SEC = 5.0` (constant — generous slack vs. sub-second hook latency).
  - `_first_bind_recovery_task` field on `TmuxSession`.
  - `_start_tailer` schedules `_delayed_first_bind_recovery` (an `asyncio.Task`).
  - `_delayed_first_bind_recovery` sleeps then calls the sync recovery; `CancelledError` propagates cleanly (don't mask the cancel intent).
  - `_attempt_first_bind_recovery` (sync, directly testable): predicate guards on continue launch, consumed flag, torn-down tailer, discovery returning None, and same-path discovery; otherwise routes the new path through `set_transcript_path()`.
  - `_stop_tailer` cancels the recovery task + clears the handle.

- `tests/test_tmux_session.py`: 7 new tests pinning the behavior per the test shape Murzik called out on `#565`.

## Tests

**Positive — bind-never-arrives recovers:**

- `test_first_bind_recovery_fresh_with_prior_history_rebinds_and_seeks_to_start` — force fresh with prior old JSONL → tailer bound to old real at EOF → create newer fresh JSONL with assistant + `stop_hook_summary` → never call explicit `set_transcript_path` → `_attempt_first_bind_recovery()` → assert path becomes new JSONL, offset is 0, first-bind flag consumed, callback fires once on `read_once`.

**Negatives — recovery must not trigger:**

- `test_first_bind_recovery_continue_launch_noops_and_preserves_eof` — continue launch with prior content → predicate-False → no rebind, offset stays at EOF, flag stays pending, no replay (#496 defense preserved).
- `test_first_bind_recovery_noops_when_flag_already_consumed` — explicit hook already ran → recovery no-ops even though discovery returns a different newer path.
- `test_first_bind_recovery_noops_when_discovery_returns_same_path` — same-path discovery → no offset reset, flag stays pending (real bind hasn't happened).
- `test_first_bind_recovery_noops_when_discovery_returns_none` — no transcript on disk → no rebind.

**Lifecycle:**

- `test_start_tailer_schedules_recovery_task` — recovery task exists post-`connect()`.
- `test_stop_tailer_cancels_pending_recovery_task` — `disconnect()` cancels + clears the handle; task is marked cancelled (CancelledError propagates).

## Test plan

- [x] `pytest tests/test_tmux_session.py tests/test_tmux_transcript.py` → 207 passed (+7)
- [x] `pytest` full suite → 2250 passed, 1 skipped (modulo unrelated `nacl`-missing collection errors local to my dev env; CI environment has it)
- [x] `ruff check src/pinky_daemon/tmux_session.py tests/test_tmux_session.py` → clean
- [ ] Manual smoke after deploy: trigger a fresh-context Dymok cycle with prior history present, dropped `SessionStart` hook (mocked), confirm recovery fires within 5s — leaving this until after Murzik's review since the unit test coverage is the load-bearing artifact.

## Related

- PR #564 — placeholder→real tailer seek fix (merged, 26.05.081). Provides the `_tailer_first_bind_pending` flag this PR re-uses.
- #563 — original placeholder→real bug report.
- #515 — original tailer self-heal (covers the placeholder flavor; this PR covers the stale-real-path flavor).
- #496 — reply-spam defense on continue launches (constraint preserved by the predicate).

🤖 Opened by Barsik
