### PR TITLE
fix(messaging): map near-miss emojis to closest valid telegram reaction

### DIFF
--- a/src/pinky_outreach/telegram.py
+++ b/src/pinky_outreach/telegram.py
@@ -502,6 +502,84 @@ class TelegramAdapter:
         "angry": "\U0001f621", "rage": "\U0001f621",
     }
 
+    # Common emojis the model reaches for that Telegram doesn't accept, mapped
+    # to the closest allowed reaction. Preserves intent (joy -> rofl) instead
+    # of collapsing every miss to thumbs-up.
+    NEAREST_REACTION: dict[str, str] = {
+        # Laughter
+        "😂": "🤣",  # joy -> rofl
+        "😅": "🤣",  # sweat smile -> rofl
+        "😆": "🤣",  # laugh squint -> rofl
+        "💀": "🤣",  # skull -> rofl
+        "😄": "😁",  # grin big eyes -> grin
+        "😃": "😁",  # grinning -> grin
+        "🙂": "😁",  # slight smile -> grin
+        "😀": "😁",  # grinning face -> grin
+        # Affection / hearts
+        "😊": "🥰",  # smile blush -> smiling hearts
+        "☺": "🥰",      # relaxed -> smiling hearts
+        "🥲": "🥰",  # smiling tear -> smiling hearts
+        "😻": "😍",  # heart cat -> heart eyes
+        "💖": "❤",      # sparkling heart -> heart
+        "💕": "❤",      # two hearts -> heart
+        "💗": "❤",      # growing heart -> heart
+        "💓": "❤",      # beating heart -> heart
+        "💞": "❤",      # revolving hearts -> heart
+        "💜": "❤",      # purple heart -> heart
+        "💙": "❤",      # blue heart -> heart
+        "💚": "❤",      # green heart -> heart
+        "💛": "❤",      # yellow heart -> heart
+        "🧡": "❤",      # orange heart -> heart
+        "🤍": "❤",      # white heart -> heart
+        "🖤": "❤",      # black heart -> heart
+        "🤎": "❤",      # brown heart -> heart
+        "💝": "❤",      # heart with ribbon -> heart
+        "❣": "❤",          # heavy heart exclamation -> heart
+        # Celebration
+        "🥳": "🎉",  # partying face -> tada
+        "🎊": "🎉",  # confetti ball -> tada
+        "✨": "🎉",      # sparkles -> tada
+        # Shock / surprise
+        "😯": "😱",  # hushed -> scream
+        "😮": "😱",  # open mouth -> scream
+        "😦": "😱",  # frowning open mouth -> scream
+        "😧": "😱",  # anguished -> scream
+        "😲": "😱",  # astonished -> scream
+        "😳": "😱",  # flushed -> scream
+        # Sad
+        "😞": "😢",  # disappointed -> cry
+        "😔": "😢",  # pensive -> cry
+        "😟": "😢",  # worried -> cry
+        "🥺": "😢",  # pleading -> cry
+        "🥹": "😢",  # holding back tears -> cry
+        "😖": "😢",  # confounded -> cry
+        "😣": "😢",  # persevere -> cry
+        "😩": "😭",  # weary -> sob
+        "😫": "😭",  # tired -> sob
+        # Sleepy
+        "💤": "😴",  # zzz -> sleeping
+        "😪": "😴",  # sleepy -> sleeping
+        # Angry
+        "😠": "😡",  # angry -> rage
+        # Thinking / skeptical
+        "🧐": "🤔",  # monocle -> thinking
+        "🤥": "🤨",  # lying -> raised eyebrow
+        # Hot / fire
+        "🥵": "🔥",  # hot face -> fire
+        "💥": "🔥",  # collision -> fire
+        # Approval / gestures
+        "🙌": "👏",  # raising hands -> clap
+        "🤲": "🙏",  # open hands -> pray
+        "✌": "👌",      # peace -> ok
+        "🤙": "👌",  # call me -> ok
+        "☝": "👌",      # index pointing up -> ok
+        "🤘": "🔥",  # horns -> fire
+        "💪": "🔥",  # muscle -> fire
+        # Cold / winter
+        "🥶": "☃",      # cold face -> snowman
+        "❄": "☃",          # snowflake -> snowman
+    }
+
     def _resolve_emoji(self, emoji: str) -> str:
         """Resolve a shortcode or pass through a unicode emoji."""
         return self.EMOJI_SHORTCUTS.get(emoji.lower().strip(": "), emoji)
@@ -514,18 +592,22 @@ class TelegramAdapter:
     ) -> bool:
         """Set a reaction on a message.
 
-        Validates against Telegram's allowed reaction emoji set.
-        Falls back to 👍 if the resolved emoji isn't in the valid set.
+        Validates against Telegram's allowed reaction emoji set. Maps common
+        near-misses (e.g. joy -> rofl) via NEAREST_REACTION so the model's
+        intent survives the limited bot reaction set; otherwise falls back
+        to thumbs-up.
         """
         resolved = self._resolve_emoji(emoji) if emoji else ""
         if resolved and resolved not in self.VALID_REACTIONS:
-            # Try without variant selectors (some emojis add \ufe0f)
             stripped = resolved.replace("\ufe0f", "")
             if stripped in self.VALID_REACTIONS:
                 resolved = stripped
+            elif stripped in self.NEAREST_REACTION:
+                resolved = self.NEAREST_REACTION[stripped]
+            elif resolved in self.NEAREST_REACTION:
+                resolved = self.NEAREST_REACTION[resolved]
             else:
-                fallback = "👍"
-                resolved = fallback
+                resolved = "👍"
         reaction = [{"type": "emoji", "emoji": resolved}] if resolved else []
         self._request(
             "setMessageReaction",

--- a/tests/test_outreach.py
+++ b/tests/test_outreach.py
@@ -311,18 +311,41 @@ class TestTelegramAdapter:
         adapter.close()
 
     def test_set_reaction_invalid_emoji_falls_back(self):
-        """Invalid emoji (not in TG's allowed set) falls back to 👍."""
+        """Emoji with no nearest mapping falls back to 👍."""
         adapter = self._make_adapter()
         mock_response = MagicMock()
         mock_response.json.return_value = {"ok": True, "result": True}
         adapter._client.post = MagicMock(return_value=mock_response)
 
-        # 🤙 (call me hand) is NOT in Telegram's valid reaction set
-        adapter.set_reaction("12345", 42, "🤙")
+        # 🥨 (pretzel) is NOT a valid TG reaction and has no nearest mapping
+        adapter.set_reaction("12345", 42, "🥨")
         call_args = adapter._client.post.call_args
         payload = call_args[1].get("json", call_args[0][1] if len(call_args[0]) > 1 else {})
         assert any(r["emoji"] == "👍" for r in payload.get("reaction", []))
         adapter.close()
+
+    def test_set_reaction_near_emoji_maps_to_intended(self):
+        """Near-miss emoji (e.g. 😂) maps to its closest valid reaction (🤣)."""
+        adapter = self._make_adapter()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": True, "result": True}
+        adapter._client.post = MagicMock(return_value=mock_response)
+
+        adapter.set_reaction("12345", 42, "😂")
+        call_args = adapter._client.post.call_args
+        payload = call_args[1].get("json", call_args[0][1] if len(call_args[0]) > 1 else {})
+        assert any(r["emoji"] == "🤣" for r in payload.get("reaction", []))
+        adapter.close()
+
+    def test_nearest_reaction_targets_are_all_valid(self):
+        """Every NEAREST_REACTION target must be in VALID_REACTIONS."""
+        from pinky_outreach.telegram import TelegramAdapter
+        for src_emoji, target in TelegramAdapter.NEAREST_REACTION.items():
+            stripped = target.replace("️", "")
+            assert (
+                target in TelegramAdapter.VALID_REACTIONS
+                or stripped in TelegramAdapter.VALID_REACTIONS
+            ), f"NEAREST_REACTION[{src_emoji!r}] -> {target!r} is not in VALID_REACTIONS"
 
     def test_set_reaction_shortcode_resolves(self):
         """Shortcode like 'fire' resolves to a valid emoji."""


### PR DESCRIPTION
## Summary
- Telegram's bot reaction API only accepts a fixed ~70-emoji set. Previously, `set_reaction()` silently fell back to 👍 for anything outside it — so the model reacting with 😂 saw `reacted: true` while the user saw thumbs-up.
- Adds `NEAREST_REACTION` (61 entries) mapping common near-misses to their closest allowed reaction: 😂/😅/😆/💀 → 🤣, 💖/💕/💜/💙/etc → ❤, 🥳/🎊/✨ → 🎉, 🥺/🥹 → 😢, 🧐 → 🤔, 🥵/💥 → 🔥, 🙌 → 👏, etc.
- 👍 remains the last-resort fallback for truly unmappable emojis.

## Test plan
- [x] `pytest tests/test_outreach.py` — 30/30 pass (added `test_set_reaction_near_emoji_maps_to_intended` for 😂→🤣 and `test_nearest_reaction_targets_are_all_valid` to guarantee every mapping target is itself in `VALID_REACTIONS`)
- [x] Updated `test_set_reaction_invalid_emoji_falls_back` to use 🥨 (no nearest mapping) instead of 🤙 (now maps to 👌)
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)