### PR TITLE
fix(tmux): gate wake-prompt paste on SessionStart hook (#570)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -539,16 +539,20 @@ _TURN_DONE_TIMEOUT_SEC = 600.0
 # in CPU profiles even with many active tmux sessions.
 _WATCHDOG_TICK_SEC = 15.0
 
-# Issue #570 — wake-prompt readiness-gate timeout. ``_enqueue_internal_prompt``
-# awaits ``_session_ready_event`` for ``wake_*`` reasons so the wake prompt's
-# paste doesn't land while Claude Code is still in its splash/MCP-bootstrap
-# phase (where bracketed-paste + 300ms-Enter is consumed by transition state
-# instead of submitting the turn). The event opens when ``set_transcript_path``
-# is called by the SessionStart hook. 30s is generous — the worst observed
-# claude boot on the prod Mac Mini takes ~5-15s loading shared-MCP + per-agent
-# MCP servers; the timeout exists as a safety fallback (not a target). On
-# timeout we proceed with the paste anyway (legacy behavior), so a regressed
-# hook degrades to the pre-#570 race rather than hanging the session.
+# Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
+# ``_session_ready_event`` for turns with ``internal=True and
+# reason.startswith("wake_")`` so the wake prompt's paste doesn't land while
+# Claude Code is still in its splash/MCP-bootstrap phase (where bracketed-paste
+# + 300ms-Enter is consumed by transition state instead of submitting the
+# turn). The event opens when ``set_transcript_path`` is called by the
+# SessionStart hook. 30s is generous — the worst observed claude boot on the
+# prod Mac Mini takes ~5-15s loading shared-MCP + per-agent MCP servers; the
+# timeout exists as a safety fallback (not a target). On timeout we proceed
+# with the paste anyway (legacy behavior), so a regressed hook degrades to
+# the pre-#570 race rather than hanging the session. Gate lives at delivery
+# time (not enqueue time) so the wake turn stays at the queue HEAD and
+# external sends arriving during the wait queue BEHIND it — preserves FIFO
+# across the bootstrap window (Murzik #571 review catch).
 _SESSION_READY_GATE_TIMEOUT_SEC = 30.0
 
 
@@ -733,17 +737,21 @@ class TmuxSession:
         # Issue #570 — wake-prompt readiness gate. Set when
         # ``set_transcript_path`` is called by the SessionStart hook
         # (signalling "claude is past splash/MCP-boot, input area is
-        # live"). ``_enqueue_internal_prompt`` awaits this for ``wake_*``
-        # reasons so the wake prompt's paste lands AFTER claude is ready
-        # to receive a submit Enter. Without the gate, on
-        # ``force_fresh_context_once`` respawn the bracketed-paste +
-        # 300ms-Enter sequence completes during MCP bootstrap and the
-        # Enter is consumed by transition state instead of submitting
-        # the turn (CR-01 failure mode from #543 validation matrix).
-        # Reset to a fresh ``Event()`` on every spawn in ``_start_tailer``
-        # — must NOT survive across respawns or a stale "open" state
-        # from the previous session would let wake prompts paste into
-        # a still-booting fresh REPL.
+        # live"). ``_deliver_turn`` awaits this for turns with
+        # ``internal=True and reason.startswith("wake_")`` so the wake
+        # prompt's paste lands AFTER claude is ready to receive a
+        # submit Enter. Without the gate, on ``force_fresh_context_once``
+        # respawn the bracketed-paste + 300ms-Enter sequence completes
+        # during MCP bootstrap and the Enter is consumed by transition
+        # state instead of submitting the turn (CR-01 failure mode
+        # from #543 validation matrix). Gate lives at delivery time
+        # (not enqueue time) so the wake turn stays at the queue HEAD
+        # and external sends arriving during the wait queue BEHIND it
+        # — preserves FIFO across the bootstrap window (Murzik #571
+        # review catch). Reset to a fresh ``Event()`` on every spawn
+        # in ``_start_tailer`` — must NOT survive across respawns or
+        # a stale "open" state from the previous session would let
+        # wake prompts paste into a still-booting fresh REPL.
         self._session_ready_event: asyncio.Event = asyncio.Event()
 
         # Test seam: when True, ``connect()`` skips wake-prompt assembly
@@ -1906,12 +1914,16 @@ class TmuxSession:
         **Issue #570 — wake-prompt readiness signal.** This method also
         opens ``_session_ready_event`` on first call after spawn (the
         SessionStart hook is our most reliable "claude is past splash
-        + MCP bootstrap, input area is live" signal). Any pending
-        wake-prompt enqueue in ``_enqueue_internal_prompt`` is gated
-        on this event, so the wake action paste doesn't land while CC
-        is still in a transition state that would consume its Enter
-        instead of submitting the turn. See ``_enqueue_internal_prompt``
-        for the gate logic; reset semantics live in ``_start_tailer``.
+        + MCP bootstrap, input area is live" signal). ``_deliver_turn``
+        awaits this event for any in-flight turn with ``internal=True
+        and reason.startswith("wake_")`` before calling ``paste_text``,
+        so the wake-action paste doesn't land while CC is still in a
+        transition state that would consume its Enter instead of
+        submitting the turn. See ``_deliver_turn`` for the gate logic;
+        reset semantics live in ``_start_tailer``. Gate lives at
+        delivery (not enqueue) so the wake turn stays at queue head
+        and external sends queue behind — FIFO preserved (Murzik #571
+        review).
         """
         if self._tailer is None:
             return

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1773,17 +1773,16 @@ class TmuxSession:
         invoke this immediately after the state machine reports
         CONNECTED, so the gate passes.
 
-        **Wake-prompt readiness gate (#570):** for ``reason`` values
-        starting with ``"wake_"`` (the orientation prompts injected at
-        ``connect()`` time), this method awaits ``_session_ready_event``
-        before enqueuing. The event opens when ``set_transcript_path``
-        is called by the SessionStart hook — the signal that claude has
-        finished its splash + MCP-bootstrap and the input area is live.
-        Bounded by ``_SESSION_READY_GATE_TIMEOUT_SEC`` (30s) with
-        proceed-anyway fallback on timeout. Non-wake reasons
-        (``idle_sleep_presave``, future internal prompts) skip the
-        gate — they're sent into already-live sessions and must not
-        block on a fresh-spawn signal.
+        **Wake-prompt readiness gate (#570) lives at delivery time**, not
+        here. ``_deliver_turn`` awaits ``_session_ready_event`` for
+        ``turn.internal and turn.reason.startswith("wake_")`` before
+        calling ``paste_text``, so the wake ``_QueuedTurn`` is enqueued
+        IMMEDIATELY by this method and sits at the queue HEAD while the
+        worker blocks. Any external ``send()`` calls during the gate
+        wait enqueue BEHIND the wake turn, preserving FIFO across the
+        bootstrap window. Gating here at enqueue time would let
+        concurrent external messages jump ahead while the wake sits in
+        the SessionStart wait (Murzik #571 review catch).
         """
         if self.state != SessionState.CONNECTED:
             _log(
@@ -1791,53 +1790,6 @@ class TmuxSession:
                 f"dropping internal prompt (reason={reason})"
             )
             return None
-
-        # Issue #570 — readiness gate for wake prompts. The wake-action
-        # turn of a fresh spawn (especially ``force_fresh_context_once``
-        # context_restart) can be silently dropped if the bracketed-
-        # paste + 300ms-Enter sequence completes while claude is still
-        # in splash / loading MCP servers — the Enter is consumed by
-        # transition state and the typed prompt sits in the input area
-        # unsubmitted. Wait for SessionStart to confirm the input area
-        # is live before pasting.
-        #
-        # SCOPE: only wake_* reasons. Pre-sleep save (``idle_sleep_presave``)
-        # is sent into an already-live session that's been processing
-        # turns; it MUST NOT block on a fresh-spawn signal that
-        # `set_transcript_path` may have set hours ago and reset
-        # afterward. External user turns are unaffected — they flow
-        # through `send()`, not this method.
-        #
-        # FALLBACK: on timeout we proceed with the paste anyway (legacy
-        # behavior). A regressed SessionStart hook degrades to the
-        # pre-#570 race window rather than hanging the session.
-        if reason.startswith("wake_") and not self._session_ready_event.is_set():
-            _gate_start = time.monotonic()
-            try:
-                await asyncio.wait_for(
-                    self._session_ready_event.wait(),
-                    timeout=_SESSION_READY_GATE_TIMEOUT_SEC,
-                )
-                _gate_ms = int((time.monotonic() - _gate_start) * 1000)
-                # Only log when the gate actually waited a noticeable
-                # amount — sub-100ms waits are uninteresting noise
-                # (covers the no-op case where the hook arrived before
-                # `connect()` returned). Above that, the duration is
-                # the diagnostic signal that the fix is doing work.
-                if _gate_ms > 100:
-                    _log(
-                        f"tmux[{self.agent_name}]: wake-prompt readiness "
-                        f"gate opened after {_gate_ms}ms (reason={reason})"
-                    )
-            except asyncio.TimeoutError:
-                _log(
-                    f"tmux[{self.agent_name}]: wake-prompt readiness "
-                    f"gate TIMEOUT after {_SESSION_READY_GATE_TIMEOUT_SEC}s — "
-                    f"proceeding with paste anyway (reason={reason}). "
-                    f"Hook may have failed to fire; check for stale or "
-                    f"missing hook_tmux_session_start.py in the agent's "
-                    f".claude/ directory."
-                )
 
         self.last_active = time.time()
         # Audit log — the diagnostic marker validation tooling greps for.
@@ -3180,14 +3132,30 @@ class TmuxSession:
 
         Splash-state paste handling lives in ``_TmuxControl.paste_text``
         (bracketed-paste + delayed-Enter, commit 0864f4e / issue #514).
-        Claude Code's splash dismisses on input focus, so pasting into
-        the splash works correctly; no readiness gate is needed.
+        For non-wake turns Claude Code's splash dismisses on input
+        focus, so pasting into the splash works correctly. The
+        wake-prompt case is more fragile because the bracketed-paste
+        + 300ms-Enter sequence can complete while CC is still in
+        MCP-bootstrap (the Enter is consumed by transition state and
+        the typed prompt sits in the input area unsubmitted). Issue
+        #570 added a per-turn readiness gate scoped to wake_* internal
+        prompts; see the ``_session_ready_event`` await below.
 
         **Paste-failure unblock (Murzik review point #2):** if
         ``paste_text`` reports !ok we do NOT append to
         ``_inflight_metas`` (no stop hook will fire), and we DO set
         the turn's ``completion_event`` so a ``wait_for_completion=True``
         caller (e.g. pre-sleep save) doesn't hang forever.
+
+        **#570 wake-prompt readiness gate (Murzik #571 review).** The
+        gate lives HERE at delivery time, not at enqueue time, to
+        preserve queue-order FIFO across the bootstrap window. While
+        the worker blocks on the gate the wake turn sits at the
+        ``_message_queue`` HEAD; any external ``send()`` calls during
+        the wait enqueue BEHIND the wake turn and run AFTER it.
+        Gating at enqueue time would let those external messages jump
+        the wake prompt (broker calls ``send`` the moment ``state ==
+        CONNECTED``, which fires before this wait would have ended).
         """
         # Pulse-v2 safety primitive: context-lock check. Cheap fs stat;
         # do this first so we bail before mutating any state. The lock
@@ -3203,6 +3171,53 @@ class TmuxSession:
                 f"deferring paste; worker will retry on next iteration"
             )
 
+        # Issue #570 — wake-prompt readiness gate. Wake_* internal
+        # prompts must not paste until SessionStart confirms claude
+        # is past splash + MCP-bootstrap and the input area is live
+        # (otherwise the bracketed-paste + 300ms-Enter race loses the
+        # Enter to transition state and the wake turn never fires).
+        # Scope: only internal turns whose reason starts with "wake_"
+        # — external turns and non-wake internal turns (e.g.
+        # ``idle_sleep_presave``) are sent into already-live sessions
+        # and skip the gate. Fallback on timeout: proceed with the
+        # paste anyway (degrades to pre-#570 race rather than hanging
+        # the session). The worker is single-threaded; blocking here
+        # blocks the worker, which keeps the wake turn at the queue
+        # head and preserves FIFO for any external messages enqueued
+        # during the gate wait (Murzik #571 review).
+        if (
+            turn.internal
+            and turn.reason.startswith("wake_")
+            and not self._session_ready_event.is_set()
+        ):
+            _gate_start = time.monotonic()
+            try:
+                await asyncio.wait_for(
+                    self._session_ready_event.wait(),
+                    timeout=_SESSION_READY_GATE_TIMEOUT_SEC,
+                )
+                _gate_ms = int((time.monotonic() - _gate_start) * 1000)
+                # Only log when the wait was noticeable — sub-100ms
+                # waits are uninteresting (covers the case where the
+                # hook arrived before the worker popped the turn).
+                # Above that, the duration is the diagnostic that the
+                # fix is doing work.
+                if _gate_ms > 100:
+                    _log(
+                        f"tmux[{self.agent_name}]: wake-prompt readiness "
+                        f"gate opened after {_gate_ms}ms "
+                        f"(reason={turn.reason})"
+                    )
+            except asyncio.TimeoutError:
+                _log(
+                    f"tmux[{self.agent_name}]: wake-prompt readiness "
+                    f"gate TIMEOUT after {_SESSION_READY_GATE_TIMEOUT_SEC}s "
+                    f"— proceeding with paste anyway "
+                    f"(reason={turn.reason}). Hook may have failed to "
+                    f"fire; check the agent's "
+                    f".claude/hook_tmux_session_start.py."
+                )
+
         # Clear the back-compat ``_turn_done`` event before pasting.
         # Under #560 the worker no longer awaits this between dispatches
         # — the clear is purely for legacy observers and for tests that
@@ -3215,6 +3230,8 @@ class TmuxSession:
         # Enter gives claude's cold-start splash UI time to dismiss
         # before the submit Enter arrives, so the first prompt of a
         # fresh session doesn't get wedged in claude's input buffer.
+        # Wake-prompt timing is additionally protected by the readiness
+        # gate above (#570 / Murzik #571 review).
         result = await self._tmux.paste_text(turn.prompt, enter=True)
         if not result.ok:
             # Send failed — no response will arrive. Re-arm turn_done

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -539,6 +539,18 @@ _TURN_DONE_TIMEOUT_SEC = 600.0
 # in CPU profiles even with many active tmux sessions.
 _WATCHDOG_TICK_SEC = 15.0
 
+# Issue #570 — wake-prompt readiness-gate timeout. ``_enqueue_internal_prompt``
+# awaits ``_session_ready_event`` for ``wake_*`` reasons so the wake prompt's
+# paste doesn't land while Claude Code is still in its splash/MCP-bootstrap
+# phase (where bracketed-paste + 300ms-Enter is consumed by transition state
+# instead of submitting the turn). The event opens when ``set_transcript_path``
+# is called by the SessionStart hook. 30s is generous — the worst observed
+# claude boot on the prod Mac Mini takes ~5-15s loading shared-MCP + per-agent
+# MCP servers; the timeout exists as a safety fallback (not a target). On
+# timeout we proceed with the paste anyway (legacy behavior), so a regressed
+# hook degrades to the pre-#570 race rather than hanging the session.
+_SESSION_READY_GATE_TIMEOUT_SEC = 30.0
+
 
 class TmuxSession:
     """Agent session backed by an interactive ``claude`` REPL in tmux.
@@ -717,6 +729,22 @@ class TmuxSession:
         # so a torn-down session doesn't have a stray task firing
         # ``set_transcript_path`` against a stopped tailer.
         self._first_bind_recovery_task: asyncio.Task[None] | None = None
+
+        # Issue #570 — wake-prompt readiness gate. Set when
+        # ``set_transcript_path`` is called by the SessionStart hook
+        # (signalling "claude is past splash/MCP-boot, input area is
+        # live"). ``_enqueue_internal_prompt`` awaits this for ``wake_*``
+        # reasons so the wake prompt's paste lands AFTER claude is ready
+        # to receive a submit Enter. Without the gate, on
+        # ``force_fresh_context_once`` respawn the bracketed-paste +
+        # 300ms-Enter sequence completes during MCP bootstrap and the
+        # Enter is consumed by transition state instead of submitting
+        # the turn (CR-01 failure mode from #543 validation matrix).
+        # Reset to a fresh ``Event()`` on every spawn in ``_start_tailer``
+        # — must NOT survive across respawns or a stale "open" state
+        # from the previous session would let wake prompts paste into
+        # a still-booting fresh REPL.
+        self._session_ready_event: asyncio.Event = asyncio.Event()
 
         # Test seam: when True, ``connect()`` skips wake-prompt assembly
         # + enqueue. Production callers must NOT flip this; it exists so
@@ -1744,6 +1772,18 @@ class TmuxSession:
         if the session is not CONNECTED. Cold-start callers (``connect``)
         invoke this immediately after the state machine reports
         CONNECTED, so the gate passes.
+
+        **Wake-prompt readiness gate (#570):** for ``reason`` values
+        starting with ``"wake_"`` (the orientation prompts injected at
+        ``connect()`` time), this method awaits ``_session_ready_event``
+        before enqueuing. The event opens when ``set_transcript_path``
+        is called by the SessionStart hook — the signal that claude has
+        finished its splash + MCP-bootstrap and the input area is live.
+        Bounded by ``_SESSION_READY_GATE_TIMEOUT_SEC`` (30s) with
+        proceed-anyway fallback on timeout. Non-wake reasons
+        (``idle_sleep_presave``, future internal prompts) skip the
+        gate — they're sent into already-live sessions and must not
+        block on a fresh-spawn signal.
         """
         if self.state != SessionState.CONNECTED:
             _log(
@@ -1751,6 +1791,53 @@ class TmuxSession:
                 f"dropping internal prompt (reason={reason})"
             )
             return None
+
+        # Issue #570 — readiness gate for wake prompts. The wake-action
+        # turn of a fresh spawn (especially ``force_fresh_context_once``
+        # context_restart) can be silently dropped if the bracketed-
+        # paste + 300ms-Enter sequence completes while claude is still
+        # in splash / loading MCP servers — the Enter is consumed by
+        # transition state and the typed prompt sits in the input area
+        # unsubmitted. Wait for SessionStart to confirm the input area
+        # is live before pasting.
+        #
+        # SCOPE: only wake_* reasons. Pre-sleep save (``idle_sleep_presave``)
+        # is sent into an already-live session that's been processing
+        # turns; it MUST NOT block on a fresh-spawn signal that
+        # `set_transcript_path` may have set hours ago and reset
+        # afterward. External user turns are unaffected — they flow
+        # through `send()`, not this method.
+        #
+        # FALLBACK: on timeout we proceed with the paste anyway (legacy
+        # behavior). A regressed SessionStart hook degrades to the
+        # pre-#570 race window rather than hanging the session.
+        if reason.startswith("wake_") and not self._session_ready_event.is_set():
+            _gate_start = time.monotonic()
+            try:
+                await asyncio.wait_for(
+                    self._session_ready_event.wait(),
+                    timeout=_SESSION_READY_GATE_TIMEOUT_SEC,
+                )
+                _gate_ms = int((time.monotonic() - _gate_start) * 1000)
+                # Only log when the gate actually waited a noticeable
+                # amount — sub-100ms waits are uninteresting noise
+                # (covers the no-op case where the hook arrived before
+                # `connect()` returned). Above that, the duration is
+                # the diagnostic signal that the fix is doing work.
+                if _gate_ms > 100:
+                    _log(
+                        f"tmux[{self.agent_name}]: wake-prompt readiness "
+                        f"gate opened after {_gate_ms}ms (reason={reason})"
+                    )
+            except asyncio.TimeoutError:
+                _log(
+                    f"tmux[{self.agent_name}]: wake-prompt readiness "
+                    f"gate TIMEOUT after {_SESSION_READY_GATE_TIMEOUT_SEC}s — "
+                    f"proceeding with paste anyway (reason={reason}). "
+                    f"Hook may have failed to fire; check for stale or "
+                    f"missing hook_tmux_session_start.py in the agent's "
+                    f".claude/ directory."
+                )
 
         self.last_active = time.time()
         # Audit log — the diagnostic marker validation tooling greps for.
@@ -1863,6 +1950,16 @@ class TmuxSession:
         changed (the tailer's own equality guard handles no-ops). This
         prevents repeated SessionStart posts later in the session from
         accidentally being treated as a "first bind" again.
+
+        **Issue #570 — wake-prompt readiness signal.** This method also
+        opens ``_session_ready_event`` on first call after spawn (the
+        SessionStart hook is our most reliable "claude is past splash
+        + MCP bootstrap, input area is live" signal). Any pending
+        wake-prompt enqueue in ``_enqueue_internal_prompt`` is gated
+        on this event, so the wake action paste doesn't land while CC
+        is still in a transition state that would consume its Enter
+        instead of submitting the turn. See ``_enqueue_internal_prompt``
+        for the gate logic; reset semantics live in ``_start_tailer``.
         """
         if self._tailer is None:
             return
@@ -1880,6 +1977,19 @@ class TmuxSession:
             f"tmux[{self.agent_name}]: transcript path updated to {path}"
             + (" (first-bind — seek_to_start)" if seek_to_start else "")
         )
+
+        # Issue #570: SessionStart hook firing is our "claude is past
+        # splash + MCP boot, input area is live" signal — open the
+        # readiness gate so any pending wake prompt's paste can land.
+        # Idempotent under .set() so a hook that re-fires later in the
+        # session is a harmless no-op (existing tests confirm hook can
+        # fire on every CC SessionStart event, not just first launch).
+        if not self._session_ready_event.is_set():
+            self._session_ready_event.set()
+            _log(
+                f"tmux[{self.agent_name}]: session-ready gate opened "
+                f"(SessionStart hook)"
+            )
 
     async def get_pane_snapshot(self, *, lines: int = 200) -> str:
         """Return the last ``lines`` lines of the tmux pane, with ANSI
@@ -2482,6 +2592,21 @@ class TmuxSession:
         # silently lost the #564 first-bind seek AND the #565
         # delayed recovery for the rest of its lifetime.
         self._tailer_first_bind_pending = True
+
+        # Issue #570: reset the wake-prompt readiness gate to a fresh
+        # unset Event on every spawn. The previous spawn's event may
+        # have been set (SessionStart hook fired) or pending (hook
+        # never arrived) — either way it's stale for the new REPL.
+        # Reassigning the binding is safe under asyncio's
+        # single-threaded model: no awaiter can hold a reference to
+        # the old Event between this line and the next paste because
+        # the worker that would await it is started AFTER
+        # ``_start_tailer`` returns (see ``_spawn_tmux_repl`` order).
+        # Plan/Murzik review note: don't try to ``.clear()`` the
+        # existing event — a stale waiter from the old spawn could
+        # race-reset it back to unset while the new spawn's hook is
+        # firing. Fresh binding is unambiguous.
+        self._session_ready_event = asyncio.Event()
 
         # Issue #565: schedule a fresh delayed recovery for this
         # spawn. Cancel any leftover task from a previous spawn

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -131,6 +131,15 @@ def _make_session(
     # dedicated tests (see TestWakePromptEnqueue below) which set this
     # flag explicitly to False and provide the tailer simulation.
     ss._skip_wake_prompt_for_tests = True
+    # Issue #570 — pre-open the wake-prompt readiness gate for tests
+    # that engage the real path (``_skip_wake_prompt_for_tests = False``).
+    # Production opens this via ``set_transcript_path`` (SessionStart
+    # hook); unit tests don't fire that hook, so without pre-opening,
+    # every ``connect()`` that exercises the wake path would block on
+    # the 30s gate timeout. Dedicated gate tests (see
+    # ``TestWakePromptReadinessGate``) re-assign the event to an unset
+    # one to exercise the wait behavior explicitly.
+    ss._session_ready_event.set()
     if state is not None:
         ss._state_machine._state = state
     return ss, tmux
@@ -4179,6 +4188,23 @@ class TestWakePromptEnqueueOnConnect:
     These tests pin that ``connect()`` actually injects the wake prompt,
     with the right WakeReason for each runtime signal."""
 
+    @pytest.fixture(autouse=True)
+    def _fast_readiness_gate(self, monkeypatch):
+        """Issue #570 added a 30s SessionStart readiness gate inside
+        ``_enqueue_internal_prompt`` for ``wake_*`` reasons. Without
+        the SessionStart hook firing (no real tailer in unit tests),
+        each ``await ss.connect()`` would wait the full 30s timeout
+        before proceeding — turning this test class into a 3-min
+        wall-clock drag (5×30s). The pre-set event from
+        ``_make_session()`` is clobbered by ``_start_tailer()``'s
+        per-spawn reset, so the helper-level fix doesn't help here.
+        Shrink the timeout for this class only; the proceed-anyway
+        fallback semantics are what these tests already pin (queue
+        gets the put after the gate elapses)."""
+        monkeypatch.setattr(
+            tmux_session, "_SESSION_READY_GATE_TIMEOUT_SEC", 0.05,
+        )
+
     @pytest.mark.asyncio
     async def test_connect_enqueues_wake_prompt_by_default(self):
         ss, _ = _make_session()
@@ -4252,6 +4278,193 @@ class TestWakePromptEnqueueOnConnect:
         assert "## Continuation" in turn.prompt
         assert "Working on X" in turn.prompt
         await ss.disconnect()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Issue #570 — wake-prompt readiness gate (CR-01 from #543 validation)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestWakePromptReadinessGate:
+    """The wake-prompt readiness gate (#570) is the fix for CR-01: after
+    ``force_fresh_context_once`` (context_restart) respawns the REPL,
+    the wake prompt's bracketed-paste + 300ms-Enter sequence completes
+    before claude is ready to receive the submit Enter — the Enter is
+    consumed by splash/MCP-loading transition state and the typed
+    prompt sits in the input area unsubmitted.
+
+    Fix: ``_enqueue_internal_prompt`` awaits ``_session_ready_event``
+    for ``wake_*`` reasons. The event opens when ``set_transcript_path``
+    is called by the SessionStart hook — the most reliable "claude is
+    past splash + MCP-bootstrap, input area is live" signal we have.
+    Bounded by ``_SESSION_READY_GATE_TIMEOUT_SEC`` (30s) with proceed-
+    anyway fallback on timeout.
+
+    Scope check: only ``wake_*`` reasons gate. Pre-sleep save and
+    future internal prompts skip the gate (sent into already-live
+    sessions; must not block on a fresh-spawn signal).
+    """
+
+    @pytest.mark.asyncio
+    async def test_wake_prompt_waits_for_session_ready_event(self):
+        """When the gate is closed, the wake-prompt enqueue blocks
+        until ``set_transcript_path`` fires (simulating the SessionStart
+        hook). The put into ``_message_queue`` must NOT happen before
+        the event opens."""
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        # Reset the helper's pre-set — exercise the real gate.
+        ss._session_ready_event = asyncio.Event()
+        # Build a minimal tailer so set_transcript_path doesn't no-op
+        # on the ``self._tailer is None`` early return.
+        ss._tailer = MagicMock()
+        ss._tailer.set_transcript_path = MagicMock()
+
+        enqueue_task = asyncio.create_task(
+            ss._enqueue_internal_prompt(
+                "wake body", reason="wake_context_restart",
+            )
+        )
+        # Give the task a tick to hit the gate.
+        await asyncio.sleep(0.05)
+        assert not enqueue_task.done(), (
+            "enqueue must block on the closed gate"
+        )
+        assert ss._message_queue.qsize() == 0, (
+            "no put into the queue while the gate is closed"
+        )
+
+        # Simulate SessionStart hook arriving.
+        ss.set_transcript_path("/tmp/fake-transcript.jsonl")
+        assert ss._session_ready_event.is_set(), (
+            "set_transcript_path must open the gate"
+        )
+
+        await asyncio.wait_for(enqueue_task, timeout=2.0)
+        assert ss._message_queue.qsize() == 1, (
+            "enqueue must put exactly once after the gate opens"
+        )
+
+    @pytest.mark.asyncio
+    async def test_wake_prompt_skips_gate_when_already_open(self):
+        """If the gate is already open (e.g. SessionStart fired before
+        ``connect()`` finished), the wake prompt enqueues immediately
+        without waiting."""
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        # Helper pre-set the event; verify the fast path.
+        assert ss._session_ready_event.is_set()
+
+        start = _time.monotonic()
+        await ss._enqueue_internal_prompt(
+            "wake body", reason="wake_new_session",
+        )
+        elapsed_ms = (_time.monotonic() - start) * 1000
+
+        assert ss._message_queue.qsize() == 1
+        # Sub-100ms is the no-noticeable-wait band — confirms the
+        # gate's already-set fast-path short-circuit works.
+        assert elapsed_ms < 100, (
+            f"already-open gate must short-circuit; took {elapsed_ms:.1f}ms"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_wake_internal_prompt_skips_gate(self):
+        """``idle_sleep_presave`` (and any other non-wake reason) MUST
+        NOT block on the gate. The pre-sleep save is sent into an
+        already-live session whose gate may have been set hours ago
+        and reset during a respawn — gating it would deadlock the
+        idle-sleep flow."""
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        # Force the gate CLOSED so we'd hang if the code wrongly
+        # awaited it for a non-wake reason.
+        ss._session_ready_event = asyncio.Event()
+
+        start = _time.monotonic()
+        await asyncio.wait_for(
+            ss._enqueue_internal_prompt(
+                "save state please", reason="idle_sleep_presave",
+            ),
+            timeout=2.0,  # if the gate wrongly engages, this fires
+        )
+        elapsed_ms = (_time.monotonic() - start) * 1000
+
+        assert ss._message_queue.qsize() == 1
+        assert elapsed_ms < 100, (
+            f"non-wake reason must skip the gate; took {elapsed_ms:.1f}ms"
+        )
+        assert not ss._session_ready_event.is_set(), (
+            "non-wake enqueue must not mutate the gate event"
+        )
+
+    @pytest.mark.asyncio
+    async def test_wake_prompt_proceeds_after_gate_timeout(self):
+        """Fallback contract: if SessionStart hook never fires (broken
+        hook, missing hook script), the gate times out and the wake
+        prompt enqueues anyway — degrades to pre-#570 race behavior
+        rather than hanging the session indefinitely."""
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        ss._session_ready_event = asyncio.Event()
+
+        # Monkey-patch the gate timeout down to something testable.
+        # Targeting the module-level constant via the local import
+        # name preserves the production value for other tests in
+        # the same process.
+        original_timeout = tmux_session._SESSION_READY_GATE_TIMEOUT_SEC
+        tmux_session._SESSION_READY_GATE_TIMEOUT_SEC = 0.2
+        try:
+            start = _time.monotonic()
+            await ss._enqueue_internal_prompt(
+                "wake body", reason="wake_context_restart",
+            )
+            elapsed = _time.monotonic() - start
+        finally:
+            tmux_session._SESSION_READY_GATE_TIMEOUT_SEC = original_timeout
+
+        assert ss._message_queue.qsize() == 1, (
+            "wake prompt must enqueue after timeout (not hang or drop)"
+        )
+        # Elapsed should be roughly the timeout — give some headroom
+        # for the event-loop scheduler.
+        assert 0.15 < elapsed < 1.0, (
+            f"expected ~0.2s timeout wait; got {elapsed:.3f}s"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_transcript_path_opens_gate(self):
+        """``set_transcript_path`` is the production code path that
+        opens the gate (called by the SessionStart hook via the
+        ``/transport/transcript-path`` API endpoint). Verify the side
+        effect is unconditional on first call after spawn."""
+        ss, _ = _make_session()
+        ss._session_ready_event = asyncio.Event()  # closed
+        ss._tailer = MagicMock()
+        ss._tailer.set_transcript_path = MagicMock()
+
+        assert not ss._session_ready_event.is_set()
+        ss.set_transcript_path("/tmp/fake-transcript.jsonl")
+        assert ss._session_ready_event.is_set(), (
+            "set_transcript_path must open the readiness gate"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_transcript_path_idempotent_gate_open(self):
+        """Subsequent ``set_transcript_path`` calls (e.g. CC firing
+        SessionStart on resume) must not error or churn the gate
+        state. Idempotent ``.set()`` is the asyncio.Event contract;
+        this test pins that the wrapper doesn't accidentally clear
+        or reassign on repeat calls."""
+        ss, _ = _make_session()
+        ss._tailer = MagicMock()
+        ss._tailer.set_transcript_path = MagicMock()
+
+        ss.set_transcript_path("/tmp/fake-transcript.jsonl")
+        first_event = ss._session_ready_event
+        assert first_event.is_set()
+
+        ss.set_transcript_path("/tmp/fake-transcript.jsonl")
+        assert ss._session_ready_event is first_event, (
+            "repeat set_transcript_path must not reassign the event"
+        )
+        assert ss._session_ready_event.is_set()
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -131,15 +131,6 @@ def _make_session(
     # dedicated tests (see TestWakePromptEnqueue below) which set this
     # flag explicitly to False and provide the tailer simulation.
     ss._skip_wake_prompt_for_tests = True
-    # Issue #570 — pre-open the wake-prompt readiness gate for tests
-    # that engage the real path (``_skip_wake_prompt_for_tests = False``).
-    # Production opens this via ``set_transcript_path`` (SessionStart
-    # hook); unit tests don't fire that hook, so without pre-opening,
-    # every ``connect()`` that exercises the wake path would block on
-    # the 30s gate timeout. Dedicated gate tests (see
-    # ``TestWakePromptReadinessGate``) re-assign the event to an unset
-    # one to exercise the wait behavior explicitly.
-    ss._session_ready_event.set()
     if state is not None:
         ss._state_machine._state = state
     return ss, tmux
@@ -4186,24 +4177,15 @@ class TestForceFreshContextOnce:
 class TestWakePromptEnqueueOnConnect:
     """Wake-prompt assembly + enqueue is the parent defect from #543.
     These tests pin that ``connect()`` actually injects the wake prompt,
-    with the right WakeReason for each runtime signal."""
+    with the right WakeReason for each runtime signal.
 
-    @pytest.fixture(autouse=True)
-    def _fast_readiness_gate(self, monkeypatch):
-        """Issue #570 added a 30s SessionStart readiness gate inside
-        ``_enqueue_internal_prompt`` for ``wake_*`` reasons. Without
-        the SessionStart hook firing (no real tailer in unit tests),
-        each ``await ss.connect()`` would wait the full 30s timeout
-        before proceeding — turning this test class into a 3-min
-        wall-clock drag (5×30s). The pre-set event from
-        ``_make_session()`` is clobbered by ``_start_tailer()``'s
-        per-spawn reset, so the helper-level fix doesn't help here.
-        Shrink the timeout for this class only; the proceed-anyway
-        fallback semantics are what these tests already pin (queue
-        gets the put after the gate elapses)."""
-        monkeypatch.setattr(
-            tmux_session, "_SESSION_READY_GATE_TIMEOUT_SEC", 0.05,
-        )
+    Note (#570 / Murzik #571): the readiness gate lives in
+    ``_deliver_turn`` (delivery time), NOT in ``_enqueue_internal_prompt``.
+    The wake ``_QueuedTurn`` is put into ``_message_queue`` immediately
+    when ``connect()`` calls ``_enqueue_internal_prompt`` — these tests
+    can inspect queue contents synchronously without waiting on the
+    gate. See ``TestWakePromptReadinessGate`` for the delivery-time
+    behavior tests."""
 
     @pytest.mark.asyncio
     async def test_connect_enqueues_wake_prompt_by_default(self):
@@ -4293,137 +4275,161 @@ class TestWakePromptReadinessGate:
     consumed by splash/MCP-loading transition state and the typed
     prompt sits in the input area unsubmitted.
 
-    Fix: ``_enqueue_internal_prompt`` awaits ``_session_ready_event``
-    for ``wake_*`` reasons. The event opens when ``set_transcript_path``
+    Fix: ``_deliver_turn`` awaits ``_session_ready_event`` for turns
+    with ``internal=True and reason.startswith("wake_")`` before
+    calling ``paste_text``. The event opens when ``set_transcript_path``
     is called by the SessionStart hook — the most reliable "claude is
     past splash + MCP-bootstrap, input area is live" signal we have.
     Bounded by ``_SESSION_READY_GATE_TIMEOUT_SEC`` (30s) with proceed-
     anyway fallback on timeout.
 
-    Scope check: only ``wake_*`` reasons gate. Pre-sleep save and
-    future internal prompts skip the gate (sent into already-live
-    sessions; must not block on a fresh-spawn signal).
+    **Gate at delivery time, not enqueue time** (Murzik #571 review).
+    Gating at enqueue time would let concurrent external messages
+    jump the queue while the wake sits in the SessionStart wait —
+    broker calls ``send()`` the moment ``state == CONNECTED``, which
+    fires before the gate would have ended. Gating at delivery keeps
+    the wake at the queue HEAD; the worker blocks; external sends
+    enqueue BEHIND the wake; FIFO preserved.
     """
 
     @pytest.mark.asyncio
-    async def test_wake_prompt_waits_for_session_ready_event(self):
-        """When the gate is closed, the wake-prompt enqueue blocks
-        until ``set_transcript_path`` fires (simulating the SessionStart
-        hook). The put into ``_message_queue`` must NOT happen before
-        the event opens."""
-        ss, _ = _make_session(state=SessionState.CONNECTED)
-        # Reset the helper's pre-set — exercise the real gate.
-        ss._session_ready_event = asyncio.Event()
-        # Build a minimal tailer so set_transcript_path doesn't no-op
-        # on the ``self._tailer is None`` early return.
+    async def test_wake_turn_delivery_blocks_on_closed_gate(self):
+        """When the gate is closed, ``_deliver_turn`` for a wake_*
+        internal turn must NOT call ``paste_text`` until
+        ``set_transcript_path`` opens the gate."""
+        ss, tmux = _make_session(state=SessionState.CONNECTED)
+        ss._session_ready_event = asyncio.Event()  # closed
         ss._tailer = MagicMock()
         ss._tailer.set_transcript_path = MagicMock()
 
-        enqueue_task = asyncio.create_task(
-            ss._enqueue_internal_prompt(
-                "wake body", reason="wake_context_restart",
-            )
+        wake_turn = _QueuedTurn(
+            prompt="WAKE_BODY",
+            platform="", chat_id="", message_id="",
+            internal=True, reason="wake_context_restart",
         )
-        # Give the task a tick to hit the gate.
+
+        deliver_task = asyncio.create_task(ss._deliver_turn(wake_turn))
+        # Give the task a tick to enter the gate await.
         await asyncio.sleep(0.05)
-        assert not enqueue_task.done(), (
-            "enqueue must block on the closed gate"
+        assert not deliver_task.done(), (
+            "_deliver_turn must block on the closed gate"
         )
-        assert ss._message_queue.qsize() == 0, (
-            "no put into the queue while the gate is closed"
-        )
+        tmux.paste_text.assert_not_called()
 
         # Simulate SessionStart hook arriving.
         ss.set_transcript_path("/tmp/fake-transcript.jsonl")
-        assert ss._session_ready_event.is_set(), (
-            "set_transcript_path must open the gate"
-        )
-
-        await asyncio.wait_for(enqueue_task, timeout=2.0)
-        assert ss._message_queue.qsize() == 1, (
-            "enqueue must put exactly once after the gate opens"
-        )
-
-    @pytest.mark.asyncio
-    async def test_wake_prompt_skips_gate_when_already_open(self):
-        """If the gate is already open (e.g. SessionStart fired before
-        ``connect()`` finished), the wake prompt enqueues immediately
-        without waiting."""
-        ss, _ = _make_session(state=SessionState.CONNECTED)
-        # Helper pre-set the event; verify the fast path.
         assert ss._session_ready_event.is_set()
 
-        start = _time.monotonic()
-        await ss._enqueue_internal_prompt(
-            "wake body", reason="wake_new_session",
+        await asyncio.wait_for(deliver_task, timeout=2.0)
+        tmux.paste_text.assert_called_once_with("WAKE_BODY", enter=True)
+
+    @pytest.mark.asyncio
+    async def test_wake_turn_delivery_fast_when_gate_already_open(self):
+        """If the gate is already open (SessionStart fired before the
+        worker pulled the turn), delivery must short-circuit and
+        paste immediately."""
+        ss, tmux = _make_session(state=SessionState.CONNECTED)
+        ss._session_ready_event.set()  # pre-open
+
+        wake_turn = _QueuedTurn(
+            prompt="WAKE_BODY",
+            platform="", chat_id="", message_id="",
+            internal=True, reason="wake_new_session",
         )
+
+        start = _time.monotonic()
+        await ss._deliver_turn(wake_turn)
         elapsed_ms = (_time.monotonic() - start) * 1000
 
-        assert ss._message_queue.qsize() == 1
-        # Sub-100ms is the no-noticeable-wait band — confirms the
-        # gate's already-set fast-path short-circuit works.
         assert elapsed_ms < 100, (
             f"already-open gate must short-circuit; took {elapsed_ms:.1f}ms"
         )
+        tmux.paste_text.assert_called_once_with("WAKE_BODY", enter=True)
 
     @pytest.mark.asyncio
-    async def test_non_wake_internal_prompt_skips_gate(self):
-        """``idle_sleep_presave`` (and any other non-wake reason) MUST
-        NOT block on the gate. The pre-sleep save is sent into an
-        already-live session whose gate may have been set hours ago
-        and reset during a respawn — gating it would deadlock the
+    async def test_non_wake_internal_turn_skips_gate(self):
+        """``idle_sleep_presave`` (and any other non-wake internal
+        reason) MUST NOT block on the gate. The pre-sleep save is
+        delivered into an already-live session whose gate event may
+        have been reset during a respawn — gating would deadlock the
         idle-sleep flow."""
-        ss, _ = _make_session(state=SessionState.CONNECTED)
-        # Force the gate CLOSED so we'd hang if the code wrongly
-        # awaited it for a non-wake reason.
-        ss._session_ready_event = asyncio.Event()
+        ss, tmux = _make_session(state=SessionState.CONNECTED)
+        ss._session_ready_event = asyncio.Event()  # closed
+
+        presave_turn = _QueuedTurn(
+            prompt="save state please",
+            platform="", chat_id="", message_id="",
+            internal=True, reason="idle_sleep_presave",
+        )
 
         start = _time.monotonic()
         await asyncio.wait_for(
-            ss._enqueue_internal_prompt(
-                "save state please", reason="idle_sleep_presave",
-            ),
-            timeout=2.0,  # if the gate wrongly engages, this fires
+            ss._deliver_turn(presave_turn), timeout=2.0,
         )
         elapsed_ms = (_time.monotonic() - start) * 1000
 
-        assert ss._message_queue.qsize() == 1
         assert elapsed_ms < 100, (
             f"non-wake reason must skip the gate; took {elapsed_ms:.1f}ms"
         )
+        tmux.paste_text.assert_called_once()
         assert not ss._session_ready_event.is_set(), (
-            "non-wake enqueue must not mutate the gate event"
+            "non-wake delivery must not mutate the gate event"
         )
 
     @pytest.mark.asyncio
-    async def test_wake_prompt_proceeds_after_gate_timeout(self):
+    async def test_external_turn_skips_gate(self):
+        """External turns (``internal=False``) MUST skip the gate even
+        when closed — they flow through ``send()`` and are routed by
+        the broker the moment ``state == CONNECTED``. The gate is a
+        wake-prompt-only protection."""
+        ss, tmux = _make_session(state=SessionState.CONNECTED)
+        ss._session_ready_event = asyncio.Event()  # closed
+
+        external_turn = _QueuedTurn(
+            prompt="hi from user",
+            platform="telegram", chat_id="123", message_id="msg1",
+            internal=False, reason="",
+        )
+
+        start = _time.monotonic()
+        await asyncio.wait_for(
+            ss._deliver_turn(external_turn), timeout=2.0,
+        )
+        elapsed_ms = (_time.monotonic() - start) * 1000
+
+        assert elapsed_ms < 100, (
+            f"external turn must skip the gate; took {elapsed_ms:.1f}ms"
+        )
+        tmux.paste_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_wake_turn_proceeds_after_gate_timeout(self):
         """Fallback contract: if SessionStart hook never fires (broken
         hook, missing hook script), the gate times out and the wake
-        prompt enqueues anyway — degrades to pre-#570 race behavior
-        rather than hanging the session indefinitely."""
-        ss, _ = _make_session(state=SessionState.CONNECTED)
+        turn pastes anyway — degrades to pre-#570 race behavior rather
+        than hanging the session indefinitely."""
+        ss, tmux = _make_session(state=SessionState.CONNECTED)
         ss._session_ready_event = asyncio.Event()
 
+        wake_turn = _QueuedTurn(
+            prompt="WAKE_BODY",
+            platform="", chat_id="", message_id="",
+            internal=True, reason="wake_context_restart",
+        )
+
         # Monkey-patch the gate timeout down to something testable.
-        # Targeting the module-level constant via the local import
-        # name preserves the production value for other tests in
-        # the same process.
         original_timeout = tmux_session._SESSION_READY_GATE_TIMEOUT_SEC
         tmux_session._SESSION_READY_GATE_TIMEOUT_SEC = 0.2
         try:
             start = _time.monotonic()
-            await ss._enqueue_internal_prompt(
-                "wake body", reason="wake_context_restart",
-            )
+            await ss._deliver_turn(wake_turn)
             elapsed = _time.monotonic() - start
         finally:
             tmux_session._SESSION_READY_GATE_TIMEOUT_SEC = original_timeout
 
-        assert ss._message_queue.qsize() == 1, (
-            "wake prompt must enqueue after timeout (not hang or drop)"
+        tmux.paste_text.assert_called_once(), (
+            "wake turn must paste after timeout (not hang or drop)"
         )
-        # Elapsed should be roughly the timeout — give some headroom
-        # for the event-loop scheduler.
         assert 0.15 < elapsed < 1.0, (
             f"expected ~0.2s timeout wait; got {elapsed:.3f}s"
         )
@@ -4465,6 +4471,77 @@ class TestWakePromptReadinessGate:
             "repeat set_transcript_path must not reassign the event"
         )
         assert ss._session_ready_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_external_send_during_gate_wait_stays_behind_wake(self):
+        """Murzik #571 regression — FIFO across the bootstrap window.
+
+        With the gate at delivery time (not enqueue), an external
+        ``send()`` arriving WHILE the worker is blocked on the wake
+        gate must enqueue BEHIND the wake turn. When the gate opens,
+        paste order must be [wake, external] — not [external, wake].
+
+        This is the regression that gating-at-enqueue would have
+        introduced: the broker calls ``send`` the moment ``state ==
+        CONNECTED`` (well before this gate would have ended for a
+        cold-spawn ~5-15s MCP boot), so an external message would
+        have jumped ahead of the wake prompt the user/restart-handler
+        relied on as orientation context.
+        """
+        ss, tmux = _make_session(state=SessionState.CONNECTED)
+        ss._session_ready_event = asyncio.Event()  # closed
+
+        paste_order: list[str] = []
+
+        async def _track_paste(text, *, enter=True, enter_delay_ms=300):
+            paste_order.append(text)
+            return _ok()
+
+        tmux.paste_text = AsyncMock(side_effect=_track_paste)
+
+        # Start the worker manually — we want a real worker draining
+        # the queue but no full connect() flow (which would also
+        # enqueue its own wake prompt).
+        ss._worker_task = asyncio.create_task(ss._message_worker())
+
+        try:
+            # Enqueue wake first.
+            await ss._enqueue_internal_prompt(
+                "WAKE", reason="wake_context_restart",
+            )
+            # Let the worker pop the wake turn and hit the gate.
+            await asyncio.sleep(0.05)
+
+            # Now an external send arrives while the worker is gated.
+            await ss.send(
+                "EXTERNAL",
+                platform="telegram", chat_id="123", message_id="msg1",
+            )
+            await asyncio.sleep(0.05)
+
+            assert paste_order == [], (
+                f"gate must hold both turns until it opens; "
+                f"unexpected paste order: {paste_order}"
+            )
+
+            # Open the gate — worker proceeds wake first, then external.
+            ss._session_ready_event.set()
+            # Generous wait for both to drain through the worker.
+            for _ in range(40):
+                if len(paste_order) >= 2:
+                    break
+                await asyncio.sleep(0.05)
+
+            assert paste_order == ["WAKE", "EXTERNAL"], (
+                f"FIFO violated — paste order was {paste_order}; "
+                f"the regression Murzik flagged in #571 review"
+            )
+        finally:
+            ss._worker_task.cancel()
+            try:
+                await ss._worker_task
+            except asyncio.CancelledError:
+                pass
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #570 — after ``context_restart`` respawns the tmux REPL, the wake prompt's bracketed-paste + 300ms-Enter sequence completes before claude has finished splash + MCP-bootstrap. The Enter is consumed by transition state and the typed prompt sits in the input area unsubmitted. The wake turn never fires; the session is silently dormant until an external message arrives.

This is the **gating P0 for the June 15 fleet migration** — any auto-restart guard (high-context-%, heartbeat recovery, agent-self-initiated) flows through ``context_restart`` and would leave tmux panes silently dormant without this fix.

## The race (CR-01 evidence)

From this morning's #543 validation matrix run against Dymok (api.log around prompt_hash ``6f1a83d511f1``):

```
tmux[dymok]: claude_cmd_built mode=fresh force_fresh=True prior_transcript=False
transport_state[dymok-tmux]: reconnecting → connected via internal
tmux[dymok]: wake_prompt_sent reason=wake_context_restart prompt_chars=2620
tmux[dymok]: connected, session=pinky-dymok, worker started, wake_reason=context_restart
tmux[dymok]: message worker started
  <~21 lines of MCP "Processing request of type ListToolsRequest" — claude booting>
tmux[dymok]: transcript path updated to /Users/.../.jsonl   ← SessionStart hook
  <no Stop hook, no turn completion — wake turn never fired>
```

The worker pops the wake prompt and dispatches it via ``paste_text`` within milliseconds of CONNECTED. ``paste_text`` does ``set-buffer`` → ``paste-buffer -p`` (bracketed) → ``asyncio.sleep(300ms)`` → ``send-keys Enter``. All of this completes while claude is still in MCP-bootstrap; Enter arrives during a transition state. Cold-start happens to work empirically (longer spawn, race window hidden), but is structurally broken too.

## The fix

``_enqueue_internal_prompt`` now awaits ``_session_ready_event`` for ``wake_*`` reasons. The event opens when ``set_transcript_path`` is called by the SessionStart hook — the most reliable "claude is past splash + MCP boot, input area is live" signal we have. Bounded by ``_SESSION_READY_GATE_TIMEOUT_SEC`` (30s) with **proceed-anyway fallback** so a regressed hook degrades to pre-#570 race behavior rather than hanging the session.

### Scope

- **Gated:** ``wake_*`` reasons (``wake_new_session``, ``wake_context_restart``, ``wake_auto_restart``, ``wake_resume``).
- **Not gated:** ``idle_sleep_presave`` and any future internal prompts — they're sent into already-live sessions and must not block on a fresh-spawn signal.
- **Not gated:** external user turns via ``send()`` — they flow through a different method.

### Event lifecycle

- Created in ``__init__`` (same pattern as ``_message_queue``).
- Reassigned to a fresh ``Event()`` in ``_start_tailer``'s per-spawn arming block (alongside ``_tailer_first_bind_pending``). **Reassign rather than ``.clear()``** to avoid a stale waiter from the old spawn racing the new one back to unset (per Plan/Murzik-review pattern).

### Why SessionStart, not pane content?

A previous attempt at a pre-paste readiness gate (#522, removed in #525) watched for a bare ``❯`` in the pane — a signal Claude Code's splash never emits, which killed every cold-start. This gate uses the HTTP-driven SessionStart hook event that already drives ``set_transcript_path`` in production — different signal source, different failure mode, with a timeout-fallback safety net.

### Cost

The gate adds a ~5–15s wait on first wake-prompt after every spawn (cold-start + context_restart). That's the duration of claude's MCP-bootstrap, which we're now correctly waiting for instead of paste-and-pray. Wake prompts aren't time-critical; this is strictly an improvement over silent failure.

## Test plan

- [x] ``TestWakePromptReadinessGate`` (6 new tests): closed-gate blocks; pre-open fast-paths; non-wake skips gate; timeout fallback proceeds; ``set_transcript_path`` opens gate; idempotent repeat opens.
- [x] ``TestWakePromptEnqueueOnConnect`` (existing 6 tests): autouse fixture shrinks gate timeout to 0.05s so the suite doesn't pay 5×30s on each ``connect()``.
- [x] Full ``tests/test_tmux_session.py`` (173 tests) — green in 31s.
- [x] Full ``tests/test_wake_prompt.py`` + ``tests/test_streaming_session.py`` — green.
- [x] All tests touching ``transcript_path`` / SessionStart endpoint — 15 passed, 1 skipped (pre-existing).
- [ ] Live CR-01 re-test against Dymok after daemon restart picks up the fix. Dymok is currently online in tmux session ``pinky-dymok`` for this test.

## Observability

New log lines on the gate path:

- ``session-ready gate opened (SessionStart hook)`` — when ``set_transcript_path`` fires and the gate transitions closed→open.
- ``wake-prompt readiness gate opened after {N}ms (reason=wake_*)`` — emitted only when wait was >100ms (sub-100ms is the no-noticeable-wait band; logging it would spam the no-op cold-start case).
- ``wake-prompt readiness gate TIMEOUT after 30.0s — proceeding with paste anyway`` — fallback warning; should never fire in healthy operation.

## Risks

- **Behavioral change visible to operators:** wake prompts now take ~5–15s longer to fire on cold-start. Acceptable IMO — the alternative is silent failure on ``context_restart``.
- **Tight coupling to SessionStart hook reliability:** if the hook script breaks (e.g. agent ``.claude/hook_tmux_session_start.py`` deleted), the gate falls back to timeout-then-proceed — same race window as today, plus a 30s wait. Logged loudly so it's diagnosable.

🤖 Opened by Barsik