### PR TITLE
feat(tmux): wake_gate observability metrics for #570 readiness gate

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3197,38 +3197,69 @@ class TmuxSession:
         # blocks the worker, which keeps the wake turn at the queue
         # head and preserves FIFO for any external messages enqueued
         # during the gate wait (Murzik #571 review).
-        if (
-            turn.internal
-            and turn.reason.startswith("wake_")
-            and not self._session_ready_event.is_set()
-        ):
-            _gate_start = time.monotonic()
-            try:
-                await asyncio.wait_for(
-                    self._session_ready_event.wait(),
-                    timeout=_SESSION_READY_GATE_TIMEOUT_SEC,
-                )
-                _gate_ms = int((time.monotonic() - _gate_start) * 1000)
-                # Only log when the wait was noticeable — sub-100ms
-                # waits are uninteresting (covers the case where the
-                # hook arrived before the worker popped the turn).
-                # Above that, the duration is the diagnostic that the
-                # fix is doing work.
-                if _gate_ms > 100:
+        #
+        # Observability: every wake_* turn emits one ``wake_gate``
+        # activity event with subtype ``instant`` | ``opened`` |
+        # ``timeout`` and metadata ``{reason, latency_ms}``. This is
+        # the source for the gate-latency histogram + timeout counter
+        # we need to validate the #570 fix in production and decide
+        # whether the substrate stays tmux long-term. Sub-100ms log
+        # suppression is preserved (operator noise) but analytics
+        # records the full distribution.
+        is_wake_turn = turn.internal and turn.reason.startswith("wake_")
+        if is_wake_turn:
+            if self._session_ready_event.is_set():
+                gate_subtype = "instant"
+                gate_latency_ms = 0
+            else:
+                _gate_start = time.monotonic()
+                try:
+                    await asyncio.wait_for(
+                        self._session_ready_event.wait(),
+                        timeout=_SESSION_READY_GATE_TIMEOUT_SEC,
+                    )
+                    gate_latency_ms = int((time.monotonic() - _gate_start) * 1000)
+                    gate_subtype = "opened"
+                    # Only log when the wait was noticeable — sub-100ms
+                    # waits are uninteresting (covers the case where the
+                    # hook arrived before the worker popped the turn).
+                    # Above that, the duration is the diagnostic that the
+                    # fix is doing work.
+                    if gate_latency_ms > 100:
+                        _log(
+                            f"tmux[{self.agent_name}]: wake-prompt readiness "
+                            f"gate opened after {gate_latency_ms}ms "
+                            f"(reason={turn.reason})"
+                        )
+                except asyncio.TimeoutError:
+                    gate_latency_ms = int(_SESSION_READY_GATE_TIMEOUT_SEC * 1000)
+                    gate_subtype = "timeout"
                     _log(
                         f"tmux[{self.agent_name}]: wake-prompt readiness "
-                        f"gate opened after {_gate_ms}ms "
-                        f"(reason={turn.reason})"
+                        f"gate TIMEOUT after {_SESSION_READY_GATE_TIMEOUT_SEC}s "
+                        f"— proceeding with paste anyway "
+                        f"(reason={turn.reason}). Hook may have failed to "
+                        f"fire; check the agent's "
+                        f".claude/hook_tmux_session_start.py."
                     )
-            except asyncio.TimeoutError:
-                _log(
-                    f"tmux[{self.agent_name}]: wake-prompt readiness "
-                    f"gate TIMEOUT after {_SESSION_READY_GATE_TIMEOUT_SEC}s "
-                    f"— proceeding with paste anyway "
-                    f"(reason={turn.reason}). Hook may have failed to "
-                    f"fire; check the agent's "
-                    f".claude/hook_tmux_session_start.py."
-                )
+
+            if self._analytics_store:
+                try:
+                    self._analytics_store.log_activity(
+                        session_id=self.id,
+                        agent_name=self.agent_name,
+                        event_type="wake_gate",
+                        subtype=gate_subtype,
+                        metadata={
+                            "reason": turn.reason,
+                            "latency_ms": gate_latency_ms,
+                        },
+                    )
+                except Exception as e:  # pragma: no cover — defensive
+                    _log(
+                        f"tmux[{self.agent_name}]: analytics wake_gate "
+                        f"emit failed ({gate_subtype}, {gate_latency_ms}ms): {e}"
+                    )
 
         # Clear the back-compat ``_turn_done`` event before pasting.
         # Under #560 the worker no longer awaits this between dispatches

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -111,12 +111,15 @@ def _make_session(
     state: SessionState | None = None,
     restart_guard=None,
     tmux: MagicMock | None = None,
+    analytics_store=None,
 ) -> tuple[TmuxSession, MagicMock]:
     """Build a TmuxSession with mocked tmux control.
 
     Returns (session, tmux_mock). Tests that need to start in a specific
     state pass ``state=...``; the state machine is direct-mutated to that
     state (same bypass pattern existing StreamingSession tests use).
+    Optional ``analytics_store`` for tests that pin emission behavior
+    (e.g. wake_gate metrics — #570 follow-up).
     """
     cfg = StreamingSessionConfig(
         agent_name=agent_name,
@@ -124,7 +127,7 @@ def _make_session(
         restart_guard=restart_guard,
     )
     tmux = tmux or _make_mock_tmux()
-    ss = TmuxSession(cfg, tmux_control=tmux)
+    ss = TmuxSession(cfg, tmux_control=tmux, analytics_store=analytics_store)
     # Skip wake-prompt enqueue by default in unit tests — without a
     # simulated transcript tailer the worker would block forever on the
     # never-completing wake turn. Wake-prompt behavior has its own
@@ -4542,6 +4545,228 @@ class TestWakePromptReadinessGate:
                 await ss._worker_task
             except asyncio.CancelledError:
                 pass
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Issue #570 follow-up — wake-prompt gate observability metrics
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestWakePromptGateMetrics:
+    """The #570 fix proceeds-on-timeout if the SessionStart hook ever
+    fails to fire — which silently degrades to the pre-#570 race. We
+    need production visibility into:
+
+      1. Gate-latency distribution: is the hook actually firing fast?
+      2. Timeout count: are we hitting the fallback path at all?
+      3. Total wake count: denominator for ratios.
+
+    Implementation: ``_deliver_turn`` emits one ``wake_gate`` activity
+    event per wake_* turn with subtype ``instant`` (gate already open),
+    ``opened`` (gate waited, then opened in time), or ``timeout`` (gate
+    hit the 30s fallback). Metadata carries ``reason`` and
+    ``latency_ms``. Queryable via ``analytics_activity_events`` with no
+    new schema.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pre_open_gate_emits_instant_event(self):
+        """When the gate is already open before the worker pops the
+        turn (SessionStart hook beat the worker), the metric must
+        record a ``instant`` event with latency_ms=0. Without this
+        the denominator is wrong — fast paths would be invisible and
+        the distribution would look slower than reality."""
+        analytics = MagicMock()
+        ss, _tmux = _make_session(
+            state=SessionState.CONNECTED, analytics_store=analytics,
+        )
+        ss._session_ready_event.set()  # pre-open
+
+        wake_turn = _QueuedTurn(
+            prompt="WAKE_BODY",
+            platform="", chat_id="", message_id="",
+            internal=True, reason="wake_new_session",
+        )
+
+        await ss._deliver_turn(wake_turn)
+
+        analytics.log_activity.assert_called_once()
+        kwargs = analytics.log_activity.call_args.kwargs
+        assert kwargs["event_type"] == "wake_gate"
+        assert kwargs["subtype"] == "instant"
+        assert kwargs["agent_name"] == ss.agent_name
+        assert kwargs["session_id"] == ss.id
+        assert kwargs["metadata"]["reason"] == "wake_new_session"
+        assert kwargs["metadata"]["latency_ms"] == 0
+
+    @pytest.mark.asyncio
+    async def test_gate_wait_then_open_emits_opened_with_latency(self):
+        """When the gate is closed and SessionStart opens it mid-wait,
+        the metric must record subtype ``opened`` with a positive
+        latency_ms. This is the primary production metric — the
+        distribution tells us how long the bootstrap actually takes
+        in the wild."""
+        analytics = MagicMock()
+        ss, _tmux = _make_session(
+            state=SessionState.CONNECTED, analytics_store=analytics,
+        )
+        ss._session_ready_event = asyncio.Event()  # closed
+        ss._tailer = MagicMock()
+        ss._tailer.set_transcript_path = MagicMock()
+
+        wake_turn = _QueuedTurn(
+            prompt="WAKE_BODY",
+            platform="", chat_id="", message_id="",
+            internal=True, reason="wake_context_restart",
+        )
+
+        deliver_task = asyncio.create_task(ss._deliver_turn(wake_turn))
+        # Let the deliver task park in the gate await.
+        await asyncio.sleep(0.15)
+        ss.set_transcript_path("/tmp/fake-transcript.jsonl")
+        await asyncio.wait_for(deliver_task, timeout=2.0)
+
+        analytics.log_activity.assert_called_once()
+        kwargs = analytics.log_activity.call_args.kwargs
+        assert kwargs["event_type"] == "wake_gate"
+        assert kwargs["subtype"] == "opened"
+        assert kwargs["metadata"]["reason"] == "wake_context_restart"
+        # ~150ms wait; allow loose bounds for CI jitter.
+        latency_ms = kwargs["metadata"]["latency_ms"]
+        assert 100 <= latency_ms < 2000, (
+            f"expected gate latency in [100ms, 2000ms]; got {latency_ms}ms"
+        )
+
+    @pytest.mark.asyncio
+    async def test_gate_timeout_emits_timeout_event(self):
+        """When the gate times out (hook never fires), the metric
+        must record subtype ``timeout`` with latency_ms set to the
+        full timeout window. This is the alarm signal — a non-zero
+        timeout rate in production means we've silently regressed to
+        the pre-#570 race and need to investigate the hook."""
+        analytics = MagicMock()
+        ss, _tmux = _make_session(
+            state=SessionState.CONNECTED, analytics_store=analytics,
+        )
+        ss._session_ready_event = asyncio.Event()  # closed, never opens
+
+        wake_turn = _QueuedTurn(
+            prompt="WAKE_BODY",
+            platform="", chat_id="", message_id="",
+            internal=True, reason="wake_context_restart",
+        )
+
+        original_timeout = tmux_session._SESSION_READY_GATE_TIMEOUT_SEC
+        tmux_session._SESSION_READY_GATE_TIMEOUT_SEC = 0.2
+        try:
+            await ss._deliver_turn(wake_turn)
+        finally:
+            tmux_session._SESSION_READY_GATE_TIMEOUT_SEC = original_timeout
+
+        analytics.log_activity.assert_called_once()
+        kwargs = analytics.log_activity.call_args.kwargs
+        assert kwargs["event_type"] == "wake_gate"
+        assert kwargs["subtype"] == "timeout"
+        assert kwargs["metadata"]["reason"] == "wake_context_restart"
+        # latency_ms recorded as full timeout window (200ms in this test
+        # after the monkey-patch — 30000 in production).
+        assert kwargs["metadata"]["latency_ms"] == 200
+
+    @pytest.mark.asyncio
+    async def test_non_wake_turn_does_not_emit_wake_gate_event(self):
+        """Scope guard: ``idle_sleep_presave`` and other non-wake
+        internal reasons (which skip the gate entirely) must NOT
+        emit a wake_gate event. Otherwise the metric is meaningless
+        — we'd count turns that never touched the gate code path."""
+        analytics = MagicMock()
+        ss, _tmux = _make_session(
+            state=SessionState.CONNECTED, analytics_store=analytics,
+        )
+
+        presave_turn = _QueuedTurn(
+            prompt="save state please",
+            platform="", chat_id="", message_id="",
+            internal=True, reason="idle_sleep_presave",
+        )
+        await ss._deliver_turn(presave_turn)
+
+        # No wake_gate event for non-wake internal turns. Other
+        # analytics calls (e.g. tool_use) may still fire — assert
+        # only that no wake_gate emission happened.
+        wake_gate_calls = [
+            c for c in analytics.log_activity.call_args_list
+            if c.kwargs.get("event_type") == "wake_gate"
+        ]
+        assert wake_gate_calls == [], (
+            f"non-wake turn must not emit wake_gate; got {wake_gate_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_turn_does_not_emit_wake_gate_event(self):
+        """External turns flow through ``send()`` and skip the gate.
+        They must also skip the wake_gate metric — mixing external
+        turns into the wake distribution would dilute the signal."""
+        analytics = MagicMock()
+        ss, _tmux = _make_session(
+            state=SessionState.CONNECTED, analytics_store=analytics,
+        )
+
+        external_turn = _QueuedTurn(
+            prompt="hi from user",
+            platform="telegram", chat_id="123", message_id="msg1",
+            internal=False, reason="",
+        )
+        await ss._deliver_turn(external_turn)
+
+        wake_gate_calls = [
+            c for c in analytics.log_activity.call_args_list
+            if c.kwargs.get("event_type") == "wake_gate"
+        ]
+        assert wake_gate_calls == [], (
+            f"external turn must not emit wake_gate; got {wake_gate_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_analytics_emit_failure_is_swallowed_not_raised(self):
+        """A flaky analytics_store must not break wake-turn delivery.
+        The gate code is in the hot path of every cold-start —
+        analytics is a side observation, not a correctness
+        precondition. Emission failure should log and proceed."""
+        analytics = MagicMock()
+        analytics.log_activity.side_effect = RuntimeError("db locked")
+        ss, tmux = _make_session(
+            state=SessionState.CONNECTED, analytics_store=analytics,
+        )
+        ss._session_ready_event.set()  # pre-open path, fastest
+
+        wake_turn = _QueuedTurn(
+            prompt="WAKE_BODY",
+            platform="", chat_id="", message_id="",
+            internal=True, reason="wake_new_session",
+        )
+
+        # Must not raise even though log_activity errors.
+        await ss._deliver_turn(wake_turn)
+        # And the paste must still have fired — delivery contract intact.
+        tmux.paste_text.assert_called_once_with("WAKE_BODY", enter=True)
+
+    @pytest.mark.asyncio
+    async def test_no_analytics_store_is_safe(self):
+        """Sessions without an analytics_store (existing default) must
+        not crash on the gate code path. Back-compat for callers that
+        haven't wired the analytics surface."""
+        ss, tmux = _make_session(
+            state=SessionState.CONNECTED, analytics_store=None,
+        )
+        ss._session_ready_event.set()
+
+        wake_turn = _QueuedTurn(
+            prompt="WAKE_BODY",
+            platform="", chat_id="", message_id="",
+            internal=True, reason="wake_new_session",
+        )
+        await ss._deliver_turn(wake_turn)
+        tmux.paste_text.assert_called_once_with("WAKE_BODY", enter=True)
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to **#570** (wake-prompt readiness gate). Adds production observability so we can:

1. Validate the gate is actually doing work — distribution of `latency_ms` in production
2. Alarm on silent regression — `timeout` subtype count is the canary signal that the SessionStart hook stopped firing and we've degraded back to the pre-#570 race
3. Inform the bigger architecture call (tmux vs. subprocess-per-agent) with real data instead of vibes

## Design

One `wake_gate` activity event per wake_* turn, three subtypes:

| Subtype  | When                                                | latency_ms      |
|----------|-----------------------------------------------------|-----------------|
| `instant`| Gate was already open when worker popped the turn   | `0`             |
| `opened` | Gate was closed; SessionStart hook opened it in time| Actual wait ms  |
| `timeout`| 30s fallback fired; hook may have failed            | Full timeout ms |

Metadata: `{reason, latency_ms}`. Routed via existing `log_activity` → `analytics_activity_events`. **No schema change.**

### Why every wake turn (incl. `instant`)
Denominator matters. If we only emitted on the wait path, the distribution would look slower than reality and we couldn't compute a meaningful timeout ratio (`timeout_count / total_wake_count`).

### Behavior preserved
- Sub-100ms log suppression for operator noise: unchanged
- Timeout log line + hook-fail diagnostic: unchanged
- Gate timing semantics (delivery-time, FIFO-preserving): unchanged

### Safety
- None-safe on `_analytics_store` (existing pattern)
- Exception-swallowing — a flaky analytics_store must not break wake delivery
- Two regression tests pin both of these contracts

## Tests

7 new cases in `TestWakePromptGateMetrics`:
- pre-open gate → `instant` event with latency=0
- wait + open → `opened` event with positive latency
- timeout → `timeout` event with full window
- non-wake internal turn → NO wake_gate emission (scope guard)
- external turn → NO wake_gate emission (scope guard)
- analytics raise → swallowed, paste still fires (safety contract)
- analytics_store=None → no crash (back-compat)

All 182 tests in `tests/test_tmux_session.py` pass. ruff clean.

## Diff size

+286 / −30. Source change is ~60 net LOC (the refactor restructures the existing `if (...and not is_set())` into an explicit `if/else` so the `instant` branch is distinct and emit-able). The bulk of the diff is the test class with full docstrings.

## Test plan

- [x] Unit tests pass (15/15 gate tests, 182/182 full file)
- [x] ruff check clean
- [ ] Murzik review — particularly: is the `instant` subtype the right design choice for denominator visibility? Or do you prefer omitting it and computing total elsewhere?
- [ ] After merge: query `analytics_activity_events WHERE event_type='wake_gate'` for a few days and confirm distribution looks healthy (most `opened` events should be <2s based on the 520ms we saw in today's CR-01 re-test)

## Follow-ups (not in this PR)

- Once a week of data accrues: add a small `AnalyticsStore.get_wake_gate_stats(range)` helper (p50/p95/timeout_count) and a dashboard panel
- Pair with #89 (burn-overlay alerting) to fire a notification on non-zero `timeout` count

🤖 Opened by Barsik