### PR TITLE
feat(api): /admin/force-restart-agent/{name} for wedged agents (#103)

### DIFF
--- a/frontend-dist/index.html
+++ b/frontend-dist/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Pinky -- Personal AI Companion</title>
-    <script type="module" crossorigin src="/assets/index-BL9V9m37.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DEZ-UTz2.css">
+    <script type="module" crossorigin src="/assets/index-Dbf9b5fZ.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-B11RWiH1.css">
   </head>
   <body>
     <div id="app"></div>

--- a/frontend-dist/index.html
+++ b/frontend-dist/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Pinky -- Personal AI Companion</title>
-    <script type="module" crossorigin src="/assets/index-Dbf9b5fZ.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-B11RWiH1.css">
+    <script type="module" crossorigin src="/assets/index-BL9V9m37.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DEZ-UTz2.css">
   </head>
   <body>
     <div id="app"></div>

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2552,6 +2552,45 @@ except Exception:
             metadata=json.loads(row[6]), notes=row[7] or "", latency_ms=row[8] or 0,
         )
 
+    def get_latest_agent_heartbeat(
+        self, agent_name: str
+    ) -> AgentHeartbeat | None:
+        """Get the most recent **agent-origin** heartbeat — excludes
+        synthetic ``server_presence`` rows the scheduler writes when
+        the streaming session is merely ``CONNECTED``.
+
+        Use this when "is the agent actually responsive?" is the
+        question, not "has the daemon seen the session lately?". The
+        force-restart endpoint (#103) uses this distinction because
+        its target failure mode is exactly "transport CONNECTED but
+        reader loop wedged on an LLM call" — the scheduler keeps
+        writing fresh ``server_presence`` rows in that case, so
+        ``get_latest_heartbeat`` would look healthy while the agent
+        is actually dead in the water (Murzik review of #573).
+
+        Filter: ``metadata.source`` is NULL or != 'server_presence'.
+        Agent-side ``send_heartbeat()`` (pinky-self MCP) writes empty
+        metadata; only the scheduler's presence path sets
+        ``source='server_presence'``.
+        """
+        row = self._db.execute(
+            """SELECT agent_name, session_id, timestamp, status, context_pct, message_count,
+                      metadata, notes, latency_ms
+               FROM agent_heartbeats
+               WHERE agent_name=?
+                 AND (json_extract(metadata, '$.source') IS NULL
+                      OR json_extract(metadata, '$.source') != 'server_presence')
+               ORDER BY timestamp DESC LIMIT 1""",
+            (agent_name,),
+        ).fetchone()
+        if not row:
+            return None
+        return AgentHeartbeat(
+            agent_name=row[0], session_id=row[1], timestamp=row[2],
+            status=row[3], context_pct=row[4], message_count=row[5],
+            metadata=json.loads(row[6]), notes=row[7] or "", latency_ms=row[8] or 0,
+        )
+
     def get_heartbeats(self, agent_name: str, *, limit: int = 20) -> list[AgentHeartbeat]:
         """Get recent heartbeats for an agent."""
         rows = self._db.execute(

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2778,6 +2778,31 @@ except Exception:
         self._db.commit()
         return cursor.rowcount > 0
 
+    def bump_context_updated_at(
+        self, agent_name: str, *, ts: float | None = None
+    ) -> bool:
+        """Bump the ``updated_at`` timestamp on the saved context to ``ts``
+        (default: now). Used by the force-restart-agent escape hatch (task
+        #103) to satisfy the restart_safe gate's ``within_buffer`` check
+        when the agent is wedged and cannot call ``save_my_context``
+        itself.
+
+        Returns ``True`` if a row was updated, ``False`` if no saved
+        context exists for the agent.
+
+        Why a dedicated helper: the SQL touches a single column and the
+        force-restart code path needs to write it from api.py, which
+        should not reach into ``agents._db`` directly. Keeping the
+        UPDATE here keeps the persistence layer ownership clean.
+        """
+        when = ts if ts is not None else time.time()
+        cursor = self._db.execute(
+            "UPDATE agent_contexts SET updated_at=? WHERE agent_name=?",
+            (when, agent_name),
+        )
+        self._db.commit()
+        return cursor.rowcount > 0
+
     # ── Approved Users ─────────────────────────────────────
 
     def approve_user(

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2568,10 +2568,27 @@ except Exception:
         ``get_latest_heartbeat`` would look healthy while the agent
         is actually dead in the water (Murzik review of #573).
 
-        Filter: ``metadata.source`` is NULL or != 'server_presence'.
-        Agent-side ``send_heartbeat()`` (pinky-self MCP) writes empty
-        metadata; only the scheduler's presence path sets
-        ``source='server_presence'``.
+        Filter (two cuts, both required):
+
+        1. ``metadata.source`` is NULL or != 'server_presence' — drops
+           scheduler reconciliation rows written when the daemon sees
+           a CONNECTED transport. Those carry ``status='alive'`` and
+           would mask the wedge if used naively.
+
+        2. ``status NOT IN ('stale', 'dead')`` — drops scheduler
+           stale-out / dead-out rows written when an agent misses
+           heartbeat windows. Those carry no ``source`` field but
+           ``status='stale'`` or ``status='dead'`` — without this cut
+           a fresh ``dead`` row from the scheduler would still pass
+           the source filter and produce the wrong 'agent-origin
+           heartbeat is fresh; not wedged' conclusion (Murzik
+           round-2 review of #573).
+
+        Agent-origin heartbeats land with ``status`` in {ok, busy,
+        finishing, alive} (the pinky-self MCP ``send_heartbeat()`` uses
+        ok/busy/finishing; the tool-use hook + effort-drift recorder
+        write ``alive``). All have empty metadata. Both cuts together
+        give exactly the "agent actively said it's alive" set.
         """
         row = self._db.execute(
             """SELECT agent_name, session_id, timestamp, status, context_pct, message_count,
@@ -2580,6 +2597,7 @@ except Exception:
                WHERE agent_name=?
                  AND (json_extract(metadata, '$.source') IS NULL
                       OR json_extract(metadata, '$.source') != 'server_presence')
+                 AND status NOT IN ('stale', 'dead')
                ORDER BY timestamp DESC LIMIT 1""",
             (agent_name,),
         ).fetchone()

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7941,27 +7941,33 @@ def create_api(
         if not ss:
             raise HTTPException(404, f"No streaming session for '{name}'")
 
-        # Anti-abuse: refuse if agent is actively heartbeating. Use the
-        # caller-supplied threshold (default 10min) so an operator can
-        # override for special cases by passing a smaller value.
-        latest_hb = agents.get_latest_heartbeat(name)
+        # Anti-abuse: refuse if agent is actively heartbeating. Crucially
+        # uses ``get_latest_agent_heartbeat`` (NOT ``get_latest_heartbeat``)
+        # so synthetic ``server_presence`` rows the scheduler writes
+        # when the transport is merely CONNECTED don't mask a wedged
+        # reader loop — that's exactly the failure mode this endpoint
+        # targets (Murzik review of #573).
+        latest_hb = agents.get_latest_agent_heartbeat(name)
         heartbeat_age_sec: int | None = None
         if latest_hb and latest_hb.timestamp:
             heartbeat_age_sec = int(time.time() - float(latest_hb.timestamp))
             if heartbeat_age_sec < request.min_heartbeat_age_sec:
                 raise HTTPException(
                     409,
-                    f"Agent '{name}' heartbeat is {heartbeat_age_sec}s old "
-                    f"(< {request.min_heartbeat_age_sec}s threshold); not "
-                    f"wedged. Use /agents/{name}/streaming/restart for a "
-                    f"normal restart, or lower min_heartbeat_age_sec if "
-                    f"you have a genuine reason to override.",
+                    f"Agent '{name}' agent-origin heartbeat is "
+                    f"{heartbeat_age_sec}s old "
+                    f"(< {request.min_heartbeat_age_sec}s threshold); "
+                    f"not wedged. Use /agents/{name}/streaming/restart "
+                    f"for a normal restart, or lower "
+                    f"min_heartbeat_age_sec if you have a genuine "
+                    f"reason to override.",
                 )
 
         # Refuse if there's no saved context — fresh session would have
         # no orientation and the wake context would be empty. Better to
         # surface this as a 412 than to silently restart into a void.
-        if agents.get_context(name) is None:
+        prior_context = agents.get_context(name)
+        if prior_context is None:
             raise HTTPException(
                 412,
                 f"No saved context exists for '{name}'; cannot force-restart "
@@ -7969,6 +7975,18 @@ def create_api(
                 f"from any session (or use /agents/{name}/wake to start "
                 f"fresh).",
             )
+
+        # Capture pre-bump context age for the audit trail BEFORE the
+        # timestamp bump erases the diagnostic (Murzik review of #573).
+        # Operators reviewing 'why did we force-restart this agent'
+        # benefit from knowing the saved context was, e.g., 12h stale
+        # at force-restart time — that's the headline 'wedged' signal.
+        prior_context_updated_at = float(prior_context.updated_at or 0.0)
+        prior_context_age_sec: int | None = (
+            int(time.time() - prior_context_updated_at)
+            if prior_context_updated_at > 0
+            else None
+        )
 
         # The actual bypass: bump updated_at so the gate's within_buffer
         # check passes. Done BEFORE the restart so the existing
@@ -8008,6 +8026,8 @@ def create_api(
             "old_session_id": old_resume_handle[:12] if old_resume_handle else "",
             "reason": request.reason or "",
             "heartbeat_age_sec": heartbeat_age_sec,
+            "prior_context_updated_at": prior_context_updated_at,
+            "prior_context_age_sec": prior_context_age_sec,
             "source": "force_restart_endpoint",
         }
         try:
@@ -8040,6 +8060,7 @@ def create_api(
             "old_session_id": old_resume_handle[:12] if old_resume_handle else "",
             "old_turns": old_turns,
             "heartbeat_age_sec": heartbeat_age_sec,
+            "prior_context_age_sec": prior_context_age_sec,
             "reason": request.reason or "",
         }
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8060,6 +8060,7 @@ def create_api(
             "old_session_id": old_resume_handle[:12] if old_resume_handle else "",
             "old_turns": old_turns,
             "heartbeat_age_sec": heartbeat_age_sec,
+            "prior_context_updated_at": prior_context_updated_at,
             "prior_context_age_sec": prior_context_age_sec,
             "reason": request.reason or "",
         }

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -64,6 +64,7 @@ from pinky_daemon.api_models import (
     CreateSessionRequest,
     EffortDriftRequest,
     FederationPeerUpsertRequest,
+    ForceRestartAgentRequest,
     ForkSessionRequest,
     HistoryResponse,
     JoinGroupRequest,
@@ -1156,6 +1157,7 @@ def create_api(
         return result
 
     activity = ActivityStore(db_path=db_path.replace(".db", "_activity.db"))
+    app.state.activity = activity
 
     async def _broker_stop_agent(agent_name: str) -> dict:
         """Stop callback for broker command interception."""
@@ -1206,6 +1208,7 @@ def create_api(
     app.state.agents = agents
     app.state.conversation_store = store
     app.state.session_store = session_store
+    app.state.session_event_store = session_event_store
 
     _COST_MILESTONES = (1.0, 5.0, 10.0, 25.0, 50.0, 100.0)  # noqa: N806
 
@@ -7901,6 +7904,144 @@ def create_api(
 
         asyncio.create_task(_delayed_exit())
         return {"restarting": True, "git_hash": _git_hash}
+
+    @app.post("/admin/force-restart-agent/{name}")
+    async def admin_force_restart_agent(
+        name: str, req: ForceRestartAgentRequest | None = None
+    ):
+        """Force a fresh streaming session for a WEDGED agent (task #103).
+
+        Recovery escape hatch for the case where an agent's reader loop
+        is stalled on the LLM and it can no longer call
+        ``save_my_context``, so the normal ``/agents/{name}/streaming/
+        restart`` gate's ``within_buffer`` check fails permanently.
+
+        Bypass mechanism: bump ``agent_contexts.updated_at`` to NOW,
+        which satisfies the gate without requiring an agent-side save.
+        The saved context itself is preserved (we still wake into it);
+        only the timestamp is fudged. If no saved context exists at all
+        we refuse — there's nothing to wake into and the fresh session
+        would have no orientation.
+
+        Anti-abuse: requires the agent's last heartbeat to be at least
+        ``req.min_heartbeat_age_sec`` old (default 600s / 10 min). A
+        recently-alive agent is "busy," not "wedged." Agents that have
+        never recorded a heartbeat are allowed (genuinely fresh).
+
+        Audit: emits ``activity.log`` + ``session_event_store.log``
+        entries with event_type=``force_restart`` and the caller's
+        reason in metadata.
+
+        Validation reference: procedure validated 2026-05-06 on Sasha
+        (wedged 12h) + Ivan (wedged 9h); both recovered cleanly.
+        Reference memory: a29089c4e81a.
+        """
+        request = req or ForceRestartAgentRequest()
+        ss = broker._get_streaming_session(name)
+        if not ss:
+            raise HTTPException(404, f"No streaming session for '{name}'")
+
+        # Anti-abuse: refuse if agent is actively heartbeating. Use the
+        # caller-supplied threshold (default 10min) so an operator can
+        # override for special cases by passing a smaller value.
+        latest_hb = agents.get_latest_heartbeat(name)
+        heartbeat_age_sec: int | None = None
+        if latest_hb and latest_hb.timestamp:
+            heartbeat_age_sec = int(time.time() - float(latest_hb.timestamp))
+            if heartbeat_age_sec < request.min_heartbeat_age_sec:
+                raise HTTPException(
+                    409,
+                    f"Agent '{name}' heartbeat is {heartbeat_age_sec}s old "
+                    f"(< {request.min_heartbeat_age_sec}s threshold); not "
+                    f"wedged. Use /agents/{name}/streaming/restart for a "
+                    f"normal restart, or lower min_heartbeat_age_sec if "
+                    f"you have a genuine reason to override.",
+                )
+
+        # Refuse if there's no saved context — fresh session would have
+        # no orientation and the wake context would be empty. Better to
+        # surface this as a 412 than to silently restart into a void.
+        if agents.get_context(name) is None:
+            raise HTTPException(
+                412,
+                f"No saved context exists for '{name}'; cannot force-restart "
+                f"without state to wake into. Call save_my_context once "
+                f"from any session (or use /agents/{name}/wake to start "
+                f"fresh).",
+            )
+
+        # The actual bypass: bump updated_at so the gate's within_buffer
+        # check passes. Done BEFORE the restart so the existing
+        # restart_streaming_session logic (which gates internally on
+        # /streaming/restart) would also pass — but we don't call that
+        # endpoint, we inline the restart below to capture the audit
+        # metadata and avoid a second HTTP hop.
+        bumped = agents.bump_context_updated_at(name)
+        if not bumped:  # pragma: no cover — get_context() check above prevents this
+            raise HTTPException(412, f"No saved context for '{name}'")
+
+        # Inline the restart_streaming_session() body. We mirror it
+        # rather than calling the endpoint so we own the audit metadata
+        # (force_restart vs context_restart) and skip the guard recheck
+        # the public endpoint does — we just satisfied it.
+        old_resume_handle = ss.resume_handle
+        old_turns = ss._stats["turns"]
+
+        await ss.disconnect()
+        agents.set_streaming_session_id(name, "", label="main")
+
+        ss._config.wake_context = _build_streaming_wake_context(name)
+        ss._config.resume_handle = ""
+        ss._config.restart_reason = "force_restart"
+        ss._config.force_fresh_context_once = True
+        ss.resume_handle = ""
+        if hasattr(ss, "codex_session_id"):
+            if ss.codex_session_id:
+                _log(
+                    f"api: clearing stale codex thread {ss.codex_session_id[:12]} "
+                    f"for {name} (force-restart)"
+                )
+            ss.codex_session_id = ""
+
+        audit_meta = {
+            "label": "main",
+            "old_session_id": old_resume_handle[:12] if old_resume_handle else "",
+            "reason": request.reason or "",
+            "heartbeat_age_sec": heartbeat_age_sec,
+            "source": "force_restart_endpoint",
+        }
+        try:
+            await ss.connect()
+            _log(
+                f"api: FORCE-restarted streaming session for {name} "
+                f"(heartbeat_age={heartbeat_age_sec}s, "
+                f"reason={request.reason!r})"
+            )
+            activity.log(
+                agent_name=name,
+                event_type="force_restart",
+                title=f"{name} force-restarted via /admin/force-restart-agent",
+                metadata=audit_meta,
+            )
+            session_event_store.log(
+                session_id=ss.id,
+                agent_name=name,
+                event_type="force_restart",
+                metadata=audit_meta,
+            )
+        except Exception as e:
+            broker.unregister_streaming(name)
+            raise HTTPException(500, f"Failed to force-restart: {e}")
+
+        return {
+            "restarted": True,
+            "forced": True,
+            "agent": name,
+            "old_session_id": old_resume_handle[:12] if old_resume_handle else "",
+            "old_turns": old_turns,
+            "heartbeat_age_sec": heartbeat_age_sec,
+            "reason": request.reason or "",
+        }
 
     # ── Scheduler Control ──────────────────────────────────
 

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -404,13 +404,17 @@ class ForceRestartAgentRequest(BaseModel):
     on the LLM and it can no longer call ``save_my_context``, so the
     normal /agents/{name}/streaming/restart gate fails. Bumps the
     saved-context ``updated_at`` to satisfy ``within_buffer`` and
-    triggers the restart. Requires the agent's last heartbeat to be
-    at least ``min_heartbeat_age_sec`` old as anti-abuse — don't
-    force-restart a healthy agent that's just busy.
+    triggers the restart. Requires the agent's last **agent-origin**
+    heartbeat (excludes scheduler ``server_presence`` rows — Murzik
+    review of #573) to be at least ``min_heartbeat_age_sec`` old as
+    anti-abuse — don't force-restart a healthy agent that's just busy.
     """
 
     reason: str = ""
-    min_heartbeat_age_sec: int = 600  # 10 minutes — see memory a29089c4e81a
+    # 10 minutes default — see memory a29089c4e81a. ``Field(ge=0)``
+    # prevents a typo from silently disabling the gate by passing a
+    # negative value (which would always satisfy the freshness check).
+    min_heartbeat_age_sec: int = Field(default=600, ge=0)
 
 
 class AgentMessageRequest(BaseModel):

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -397,6 +397,22 @@ class SetModelRequest(BaseModel):
     model: str
 
 
+class ForceRestartAgentRequest(BaseModel):
+    """Force-restart a wedged agent (task #103).
+
+    Escape hatch for the case where an agent's reader loop is stalled
+    on the LLM and it can no longer call ``save_my_context``, so the
+    normal /agents/{name}/streaming/restart gate fails. Bumps the
+    saved-context ``updated_at`` to satisfy ``within_buffer`` and
+    triggers the restart. Requires the agent's last heartbeat to be
+    at least ``min_heartbeat_age_sec`` old as anti-abuse — don't
+    force-restart a healthy agent that's just busy.
+    """
+
+    reason: str = ""
+    min_heartbeat_age_sec: int = 600  # 10 minutes — see memory a29089c4e81a
+
+
 class AgentMessageRequest(BaseModel):
     """Send a message from one agent to another."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -845,14 +845,17 @@ class TestAPI:
     def _seed_heartbeat(
         self, app, agent_name: str, *, age_sec: float,
         metadata: dict | None = None,
+        status: str = "alive",
     ):
         """Insert a heartbeat row with a fudged timestamp so the
         force-restart heartbeat-staleness check can be exercised
         deterministically without sleeping. ``metadata`` defaults to
         an empty dict (= agent-origin). Pass
         ``metadata={"source":"server_presence"}`` to simulate the
-        synthetic scheduler heartbeat (Murzik #573 review test
-        reproducer)."""
+        synthetic scheduler reconciliation row, or
+        ``status="dead"`` / ``status="stale"`` (with no source) to
+        simulate scheduler stale-out / dead-out rows (Murzik #573
+        round-2 review test reproducer)."""
         import json as _json
         ts = time.time() - age_sec
         meta_json = _json.dumps(metadata or {})
@@ -861,7 +864,7 @@ class TestAPI:
                (agent_name, session_id, timestamp, status, context_pct,
                 message_count, metadata, notes, latency_ms)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (agent_name, "test-session", ts, "alive", 0.0, 0, meta_json, "", 0),
+            (agent_name, "test-session", ts, status, 0.0, 0, meta_json, "", 0),
         )
         app.state.agents._db.commit()
 
@@ -1143,6 +1146,75 @@ class TestAPI:
                 assert len(force_rows) == 1
                 assert force_rows[0]["metadata"]["heartbeat_age_sec"] >= 3600
 
+    def test_force_restart_ignores_scheduler_stale_dead_heartbeat(self):
+        """Murzik #573 round-2 regression. Distinct from the
+        server_presence case above: when the scheduler observes an
+        agent missing heartbeat windows, it writes a synthetic row
+        with ``status='stale'`` or ``status='dead'`` and metadata
+        like ``{"reason": "no heartbeat for 600s"}`` — no
+        ``source`` field. The previous filter (source-exclusion
+        only) would let those fresh dead rows through and produce
+        the wrong 'agent-origin heartbeat is N seconds old; not
+        wedged' conclusion, defeating the endpoint in the exact
+        target failure mode (scheduler has just marked the agent
+        dead and we're trying to force-restart it).
+
+        The fixed filter also rejects ``status IN ('stale', 'dead')``.
+
+        Setup: stale agent-origin ``status='ok'`` heartbeat (1h old,
+        no metadata) + FRESH synthetic scheduler ``status='dead'``
+        row (30s old, ``{"reason": ...}``). Force-restart must use
+        the 1h alive row and permit the restart.
+
+        Also covers the agent-origin status namespace: the
+        ``pinky-self`` MCP ``send_heartbeat()`` writes ``ok`` / ``busy``
+        / ``finishing`` — these are NOT ``alive`` and must still
+        count as "agent said it's alive recently."
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "wedged", "model": "sonnet"})
+                self._seed_wedged_agent(app)
+                # Stale genuine agent-origin "ok" heartbeat (1h).
+                # This is the status pinky-self.send_heartbeat actually
+                # writes — proves the filter doesn't accidentally
+                # require status='alive'.
+                self._seed_heartbeat(
+                    app, "wedged", age_sec=3600, status="ok", metadata={},
+                )
+                # FRESH scheduler dead-out row. Newer than the genuine
+                # one. No 'source' field — only 'reason'. The old
+                # source-only filter let this through.
+                self._seed_heartbeat(
+                    app, "wedged", age_sec=30, status="dead",
+                    metadata={"reason": "no heartbeat for 1200s"},
+                )
+
+                resp = client.post(
+                    "/admin/force-restart-agent/wedged",
+                    json={"reason": "scheduler-dead-row regression"},
+                )
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                # heartbeat_age_sec MUST come from the genuine 1h 'ok'
+                # row, not the synthetic 30s 'dead' row.
+                assert body["heartbeat_age_sec"] >= 3600, (
+                    f"heartbeat_age_sec must reflect the agent-origin "
+                    f"heartbeat (~3600s), not the scheduler-dead row "
+                    f"(30s); got {body['heartbeat_age_sec']}"
+                )
+                # And the audit row.
+                activity_rows = app.state.activity.list(
+                    agent_name="wedged", limit=10,
+                )
+                force_rows = [
+                    r for r in activity_rows if r["event_type"] == "force_restart"
+                ]
+                assert len(force_rows) == 1
+                assert force_rows[0]["metadata"]["heartbeat_age_sec"] >= 3600
+
     def test_force_restart_captures_prior_context_age_before_bump(self):
         """Murzik #573 review: the updated_at bump erases the 12h-stale
         diagnostic. Capture ``prior_context_updated_at`` and
@@ -1170,6 +1242,12 @@ class TestAPI:
                     f"prior_context_age_sec must capture pre-bump age "
                     f"(~3600s); got {body['prior_context_age_sec']}"
                 )
+                # Response contract also exposes the absolute
+                # pre-bump updated_at timestamp (matches audit row).
+                assert body["prior_context_updated_at"] > 0
+                assert (
+                    time.time() - body["prior_context_updated_at"]
+                ) >= 3600
 
                 # Same on the audit row.
                 activity_rows = app.state.activity.list(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -835,6 +835,262 @@ class TestAPI:
                 )
                 assert fake.resume_handle == ""
 
+    # ──────────────────────────────────────────────────────────────────
+    # Task #103 — /admin/force-restart-agent/{name}
+    # Wedged-agent recovery escape hatch. Bumps agent_contexts.updated_at
+    # to satisfy the streaming/restart guard's within_buffer check, then
+    # restarts. Anti-abuse: requires stale heartbeat (>10min by default).
+    # ──────────────────────────────────────────────────────────────────
+
+    def _seed_heartbeat(self, app, agent_name: str, *, age_sec: float):
+        """Insert a heartbeat row with a fudged timestamp so the
+        force-restart heartbeat-staleness check can be exercised
+        deterministically without sleeping."""
+        ts = time.time() - age_sec
+        app.state.agents._db.execute(
+            """INSERT INTO agent_heartbeats
+               (agent_name, session_id, timestamp, status, context_pct,
+                message_count, metadata, notes, latency_ms)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (agent_name, "test-session", ts, "alive", 0.0, 0, "{}", "", 0),
+        )
+        app.state.agents._db.commit()
+
+    def _seed_wedged_agent(self, app, agent_name: str = "wedged"):
+        """Create a fake streaming session + saved context whose
+        updated_at is too old to satisfy the normal restart guard.
+        Returns the fake session.
+        """
+        fake = self._FakeStreamingSession(agent_name, "main")
+        app.state.broker.register_streaming(agent_name, fake, label="main")
+        app.state.agents.set_context(
+            agent_name,
+            task="Wedged work to recover",
+            metadata={"source": "save_my_context"},
+            updated_by=fake.resume_handle,
+        )
+        # Force the save timestamp into the past — beyond the 5-min
+        # within_buffer window the normal restart endpoint requires.
+        app.state.agents._db.execute(
+            "UPDATE agent_contexts SET updated_at=? WHERE agent_name=?",
+            (time.time() - 3600, agent_name),
+        )
+        app.state.agents._db.commit()
+        return fake
+
+    def test_force_restart_succeeds_on_wedged_agent(self):
+        """Happy path: wedged agent with stale save + stale heartbeat
+        gets force-restarted. Saved context is preserved (we wake into
+        it); only updated_at is bumped to satisfy the gate."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "wedged", "model": "sonnet"})
+                fake = self._seed_wedged_agent(app)
+                self._seed_heartbeat(app, "wedged", age_sec=3600)  # 1hr stale
+
+                resp = client.post(
+                    "/admin/force-restart-agent/wedged",
+                    json={"reason": "Sasha-style wedge — kevin's questions ignored"},
+                )
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                assert body["restarted"] is True
+                assert body["forced"] is True
+                assert body["agent"] == "wedged"
+                assert body["heartbeat_age_sec"] >= 3600
+                assert body["reason"].startswith("Sasha-style")
+                assert fake.disconnect_calls == 1
+                assert fake.connect_calls == 1
+                assert fake.resume_handle == ""
+                # Saved context survives the force-restart (only the
+                # timestamp was touched); next session wakes into it.
+                ctx = app.state.agents.get_context("wedged")
+                assert ctx is not None
+                assert ctx.task == "Wedged work to recover"
+
+    def test_force_restart_rejects_when_heartbeat_is_recent(self):
+        """Anti-abuse contract: a recently-alive agent is "busy," not
+        "wedged." Refuse force-restart so an operator can't accidentally
+        nuke an active session."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "busy", "model": "sonnet"})
+                fake = self._seed_wedged_agent(app, "busy")
+                self._seed_heartbeat(app, "busy", age_sec=30)  # 30s ago — alive
+
+                resp = client.post(
+                    "/admin/force-restart-agent/busy",
+                    json={"reason": "I think it's wedged"},
+                )
+                assert resp.status_code == 409
+                assert "not\n                    wedged" in resp.text.replace(
+                    " ", " "
+                ) or "not " in resp.text  # message phrasing tolerance
+                assert "heartbeat" in resp.text.lower()
+                # No disconnect occurred — session left intact.
+                assert fake.disconnect_calls == 0
+
+    def test_force_restart_min_heartbeat_age_sec_can_be_overridden(self):
+        """Caller may lower the threshold for a deliberate override
+        (e.g. integration test or known-bad agent with frequent
+        heartbeat hook firing despite being wedged on real work)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "wedged", "model": "sonnet"})
+                self._seed_wedged_agent(app, "wedged")
+                self._seed_heartbeat(app, "wedged", age_sec=120)  # 2min ago
+
+                # Default threshold (600s) would reject — this one succeeds.
+                resp = client.post(
+                    "/admin/force-restart-agent/wedged",
+                    json={"min_heartbeat_age_sec": 60, "reason": "override"},
+                )
+                assert resp.status_code == 200, resp.text
+
+    def test_force_restart_allows_when_agent_never_heartbeated(self):
+        """An agent with no heartbeat row at all is allowed through
+        — interpreted as "genuinely never alive" rather than "alive
+        and busy." The recovery use-case includes never-booted
+        agents whose first wake hung."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "wedged", "model": "sonnet"})
+                self._seed_wedged_agent(app)
+                # NO heartbeat seeded.
+
+                resp = client.post(
+                    "/admin/force-restart-agent/wedged",
+                    json={"reason": "never booted"},
+                )
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                assert body["heartbeat_age_sec"] is None
+
+    def test_force_restart_rejects_when_no_saved_context(self):
+        """Refuse if there's nothing to wake into. A fresh session
+        without saved context would have empty wake_context and
+        the agent would boot disoriented — better to surface this
+        as a 412 than to silently restart into a void."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "blank", "model": "sonnet"})
+                fake = self._FakeStreamingSession("blank", "main")
+                app.state.broker.register_streaming("blank", fake, label="main")
+                self._seed_heartbeat(app, "blank", age_sec=3600)
+                # NO set_context call.
+
+                resp = client.post(
+                    "/admin/force-restart-agent/blank",
+                    json={"reason": "trying anyway"},
+                )
+                assert resp.status_code == 412
+                assert "saved context" in resp.text.lower()
+                assert fake.disconnect_calls == 0
+
+    def test_force_restart_rejects_when_no_streaming_session(self):
+        """404 if there's no session to restart. Different failure mode
+        from 412 (no context): nothing to even disconnect."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/admin/force-restart-agent/ghost",
+                    json={"reason": "trying"},
+                )
+                assert resp.status_code == 404
+                assert "ghost" in resp.text.lower()
+
+    def test_force_restart_emits_audit_log(self):
+        """Audit contract: activity.log + session_event_store.log must
+        both fire with event_type='force_restart' and the caller's
+        reason in metadata. This is the breadcrumb operators follow
+        when reviewing 'who killed my agent.'"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "wedged", "model": "sonnet"})
+                self._seed_wedged_agent(app)
+                self._seed_heartbeat(app, "wedged", age_sec=3600)
+
+                resp = client.post(
+                    "/admin/force-restart-agent/wedged",
+                    json={"reason": "audit-test reason string"},
+                )
+                assert resp.status_code == 200, resp.text
+
+                # Check the activity_log row landed.
+                activity_rows = app.state.activity.list(agent_name="wedged", limit=10)
+                force_rows = [r for r in activity_rows if r["event_type"] == "force_restart"]
+                assert len(force_rows) == 1, (
+                    f"expected one force_restart activity row; "
+                    f"got: {[r['event_type'] for r in activity_rows]}"
+                )
+                assert force_rows[0]["metadata"]["reason"] == "audit-test reason string"
+                assert force_rows[0]["metadata"]["source"] == "force_restart_endpoint"
+                assert force_rows[0]["metadata"]["heartbeat_age_sec"] >= 3600
+
+                # Check the session_events row landed.
+                session_rows = app.state.session_event_store.get_for_agent("wedged")
+                force_session_rows = [
+                    r for r in session_rows if r["event_type"] == "force_restart"
+                ]
+                assert len(force_session_rows) == 1
+                assert force_session_rows[0]["metadata"]["reason"] == (
+                    "audit-test reason string"
+                )
+
+    def test_force_restart_clears_codex_session_id(self):
+        """Sibling of the /streaming/restart codex-thread fix:
+        codex_session_id must be cleared on force-restart too or the
+        next turn would `codex exec resume <stale-id>`. Same bug class
+        as test_streaming_restart_clears_codex_session_id_on_codex_sessions
+        — pin the parity."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "wedged", "model": "sonnet"})
+                fake = self._seed_wedged_agent(app)
+                fake.codex_session_id = "019dc43b-99cd-7b81-884d-eb09a93f9144"
+                self._seed_heartbeat(app, "wedged", age_sec=3600)
+
+                resp = client.post(
+                    "/admin/force-restart-agent/wedged",
+                    json={"reason": "codex wedge"},
+                )
+                assert resp.status_code == 200, resp.text
+                assert fake.codex_session_id == ""
+                assert fake.resume_handle == ""
+
+    def test_force_restart_without_body_works(self):
+        """The reason field is optional. Calling with no body at all
+        must still succeed (reason defaults to empty string). Useful
+        for the eventual frontend "Force Restart" button which may
+        not collect a reason for first-cut UX."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "wedged", "model": "sonnet"})
+                self._seed_wedged_agent(app)
+                self._seed_heartbeat(app, "wedged", age_sec=3600)
+
+                resp = client.post("/admin/force-restart-agent/wedged")
+                assert resp.status_code == 200, resp.text
+                assert resp.json()["reason"] == ""
+
     def test_streaming_model_change_clears_codex_session_id(self):
         """When /streaming/model triggers a context-window restart, codex_session_id
         must also be cleared (sibling of the /streaming/restart bug fix)."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -842,17 +842,26 @@ class TestAPI:
     # restarts. Anti-abuse: requires stale heartbeat (>10min by default).
     # ──────────────────────────────────────────────────────────────────
 
-    def _seed_heartbeat(self, app, agent_name: str, *, age_sec: float):
+    def _seed_heartbeat(
+        self, app, agent_name: str, *, age_sec: float,
+        metadata: dict | None = None,
+    ):
         """Insert a heartbeat row with a fudged timestamp so the
         force-restart heartbeat-staleness check can be exercised
-        deterministically without sleeping."""
+        deterministically without sleeping. ``metadata`` defaults to
+        an empty dict (= agent-origin). Pass
+        ``metadata={"source":"server_presence"}`` to simulate the
+        synthetic scheduler heartbeat (Murzik #573 review test
+        reproducer)."""
+        import json as _json
         ts = time.time() - age_sec
+        meta_json = _json.dumps(metadata or {})
         app.state.agents._db.execute(
             """INSERT INTO agent_heartbeats
                (agent_name, session_id, timestamp, status, context_pct,
                 message_count, metadata, notes, latency_ms)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (agent_name, "test-session", ts, "alive", 0.0, 0, "{}", "", 0),
+            (agent_name, "test-session", ts, "alive", 0.0, 0, meta_json, "", 0),
         )
         app.state.agents._db.commit()
 
@@ -1073,6 +1082,126 @@ class TestAPI:
                 assert resp.status_code == 200, resp.text
                 assert fake.codex_session_id == ""
                 assert fake.resume_handle == ""
+
+    def test_force_restart_ignores_synthetic_server_presence_heartbeat(self):
+        """Murzik #573 review regression. The scheduler synthesizes
+        ``alive`` heartbeats from server presence whenever the streaming
+        session is CONNECTED (``source='server_presence'``). For the
+        exact failure mode this endpoint targets — transport CONNECTED
+        but reader loop wedged on an LLM call — those synthetic rows
+        keep landing fresh and would mask the wedge if we used the
+        latest heartbeat row blindly. Endpoint must look only at
+        agent-origin heartbeats (empty metadata, or
+        ``source != 'server_presence'``).
+
+        Setup: stale agent-origin heartbeat (1h old) + FRESH synthetic
+        ``server_presence`` heartbeat (30s old). With the pre-fix
+        ``get_latest_heartbeat`` call, the 30s row would 409. With the
+        fixed ``get_latest_agent_heartbeat``, the gate uses the 1h
+        agent-origin row and permits the restart.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "wedged", "model": "sonnet"})
+                self._seed_wedged_agent(app)
+                # Stale agent-origin heartbeat (genuine).
+                self._seed_heartbeat(app, "wedged", age_sec=3600, metadata={})
+                # Fresh synthetic row — newer than the genuine one. Would
+                # mask the wedge if we naively took the latest row.
+                self._seed_heartbeat(
+                    app, "wedged", age_sec=30,
+                    metadata={
+                        "source": "server_presence",
+                        "reason": "connected_streaming_session",
+                        "label": "main",
+                    },
+                )
+
+                resp = client.post(
+                    "/admin/force-restart-agent/wedged",
+                    json={"reason": "synthetic-row regression"},
+                )
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                # heartbeat_age_sec MUST come from the genuine row (3600s),
+                # not the synthetic row (30s). Allow loose lower bound for
+                # the few ms of test setup overhead.
+                assert body["heartbeat_age_sec"] >= 3600, (
+                    f"heartbeat_age_sec must reflect the agent-origin "
+                    f"heartbeat (~3600s), not the synthetic 30s row; "
+                    f"got {body['heartbeat_age_sec']}"
+                )
+                # Audit metadata must also reflect the genuine row.
+                activity_rows = app.state.activity.list(
+                    agent_name="wedged", limit=10,
+                )
+                force_rows = [
+                    r for r in activity_rows if r["event_type"] == "force_restart"
+                ]
+                assert len(force_rows) == 1
+                assert force_rows[0]["metadata"]["heartbeat_age_sec"] >= 3600
+
+    def test_force_restart_captures_prior_context_age_before_bump(self):
+        """Murzik #573 review: the updated_at bump erases the 12h-stale
+        diagnostic. Capture ``prior_context_updated_at`` and
+        ``prior_context_age_sec`` in the audit metadata + response
+        BEFORE the bump so operators reviewing 'why force-restart?'
+        can see the headline 'wedged' signal (saved-context was N
+        hours stale at the time)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "wedged", "model": "sonnet"})
+                # _seed_wedged_agent sets updated_at to NOW - 3600s.
+                self._seed_wedged_agent(app)
+                self._seed_heartbeat(app, "wedged", age_sec=3600)
+
+                resp = client.post(
+                    "/admin/force-restart-agent/wedged",
+                    json={"reason": "prior-context audit test"},
+                )
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                assert body["prior_context_age_sec"] is not None
+                assert body["prior_context_age_sec"] >= 3600, (
+                    f"prior_context_age_sec must capture pre-bump age "
+                    f"(~3600s); got {body['prior_context_age_sec']}"
+                )
+
+                # Same on the audit row.
+                activity_rows = app.state.activity.list(
+                    agent_name="wedged", limit=10,
+                )
+                force_meta = activity_rows[0]["metadata"]
+                assert force_meta["prior_context_age_sec"] >= 3600
+                assert force_meta["prior_context_updated_at"] > 0
+
+                # And post-bump the actual saved-context updated_at IS
+                # recent (the bypass worked, that's what we wanted).
+                ctx = app.state.agents.get_context("wedged")
+                assert (time.time() - ctx.updated_at) < 60
+
+    def test_force_restart_rejects_negative_min_heartbeat_age_sec(self):
+        """Murzik #573 review: ``Field(ge=0)`` on the Pydantic model
+        prevents a typo from silently disabling the gate by passing a
+        negative value (negative would always satisfy the freshness
+        check). Pydantic returns 422 on validation error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "wedged", "model": "sonnet"})
+                self._seed_wedged_agent(app)
+                self._seed_heartbeat(app, "wedged", age_sec=3600)
+
+                resp = client.post(
+                    "/admin/force-restart-agent/wedged",
+                    json={"min_heartbeat_age_sec": -1, "reason": "typo"},
+                )
+                assert resp.status_code == 422
 
     def test_force_restart_without_body_works(self):
         """The reason field is optional. Calling with no body at all


### PR DESCRIPTION
Closes #103.

## Why

Pre-this-change, recovering a wedged agent (reader loop stalled on the LLM, can't call `save_my_context`) was a 5-step manual ritual: SSH to Pi → INSERT/UPDATE on `agent_contexts` → POST `/agents/{name}/streaming/restart` → verify → clean up. Procedure validated 2026-05-06 on Sasha (12h wedged) + Ivan (9h wedged) — memory `a29089c4e81a`.

## How

`POST /admin/force-restart-agent/{name}` with optional body `{"reason": "...", "min_heartbeat_age_sec": 600}`. Steps:

1. **404** if no streaming session
2. **Anti-abuse**: if the agent's last heartbeat is more recent than `min_heartbeat_age_sec` (default 600s / 10 min) → **409** ("busy, not wedged"). Override available per-call. Agents that have never heartbeated are allowed (genuinely never alive).
3. **412** if no saved context exists — wake_context would be empty and the restart would boot the agent disoriented
4. **Bypass**: bump `agent_contexts.updated_at` to NOW. This satisfies the normal `/streaming/restart` gate's `within_buffer` check without touching the saved-context payload (only the timestamp is fudged; the actual `task`/`context`/`notes` are preserved and the next session wakes into them).
5. **Inline the restart flow** (mirror of `/agents/{name}/streaming/restart`): disconnect, clear session id, refresh wake_context, set `force_fresh_context_once`, clear `codex_session_id` if present, reconnect.
6. **Audit**: emits `activity.log` + `session_event_store.log` with `event_type='force_restart'` and metadata `{reason, heartbeat_age_sec, source, label, old_session_id}`.

Response:
```json
{
  "restarted": true,
  "forced": true,
  "agent": "wedged-name",
  "old_session_id": "abc123def456",
  "old_turns": 47,
  "heartbeat_age_sec": 3812,
  "reason": "Sasha-style wedge"
}
```

## What's in the diff

| File                                  | Lines | What                                                                                  |
|---------------------------------------|-------|---------------------------------------------------------------------------------------|
| `src/pinky_daemon/api_models.py`      | +16   | `ForceRestartAgentRequest` Pydantic model                                              |
| `src/pinky_daemon/agent_registry.py`  | +25   | `AgentRegistry.bump_context_updated_at(name, *, ts=None) -> bool` helper               |
| `src/pinky_daemon/api.py`             | +141  | `POST /admin/force-restart-agent/{name}` endpoint + 2 `app.state.*` exports for tests |
| `tests/test_api.py`                   | +256  | 9 new cases in `TestAPI`                                                              |

## Tests (9 cases)

- ✅ `succeeds_on_wedged_agent` — happy path, stale save + stale heartbeat → 200; saved context survives
- ✅ `rejects_when_heartbeat_is_recent` — 30s-old heartbeat → 409
- ✅ `min_heartbeat_age_sec_can_be_overridden` — caller may lower threshold
- ✅ `allows_when_agent_never_heartbeated` — no heartbeat row → allowed (and `heartbeat_age_sec=None` in response)
- ✅ `rejects_when_no_saved_context` — 412
- ✅ `rejects_when_no_streaming_session` — 404
- ✅ `emits_audit_log` — both `activity.log` and `session_event_store.log` rows present with correct metadata
- ✅ `clears_codex_session_id` — sibling of the `/streaming/restart` codex-thread fix; pins parity
- ✅ `without_body_works` — bodyless call defaults `reason=""`, useful for future "Force Restart" button

`tests/test_api.py`: 297/297 pass. `ruff check`: clean.

## Test plan

- [x] All unit tests pass
- [x] ruff clean
- [ ] @murzik review — particularly:
  1. **Is the inlined restart flow** (mirror of `/streaming/restart` body) the right call vs. extracting both into a shared helper? I picked inline so the audit metadata stays distinct (`force_restart` vs `context_restart`) and so we don't subtly couple two endpoints to each other's lifecycle. But it does duplicate ~30 LOC.
  2. **Heartbeat staleness threshold** — 600s default. Too generous? Too tight? The Sasha/Ivan incidents had multi-hour wedges so 10min is conservative-leaning.
  3. **Bypass safety** — bumping `updated_at` while preserving the rest of the saved-context payload is the intended semantic, but flagging in case you see a way it could surprise (e.g. interactions with the rollup-dirty markers or any cron consumer that watches `updated_at`).
  4. **Status code choice** — 409 for "not wedged," 412 for "no context to wake into," 404 for "no session." Picked deliberately but open to debate.

## Follow-ups (not in this PR)

- Frontend "Force Restart" button on agents whose latest heartbeat is stale (dashboard chip)
- Optional `GET /admin/force-restart-agent/{name}` dry-run that returns gate state + heartbeat age without performing the restart

🤖 Opened by Barsik