### PR TITLE
chore(ci): bump softprops/action-gh-release v2 → v3 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
           git push origin "$version"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.validate.outputs.version }}
           name: ${{ needs.validate.outputs.version }}


### PR DESCRIPTION
## Summary

The 26.05.085 release run surfaced the Node 20 deprecation annotation from `softprops/action-gh-release@v2`. GitHub Actions forces Node 20 actions to Node 24 by default on **June 2nd, 2026** (10 days from now) and removes Node 20 from the runner on **Sept 16th, 2026**.

`v3.0.0` of the action is a clean runtime bump — only change is moving the action runtime + bundle target from Node 20 to Node 24. No API or input changes.

Quoting v3.0.0 release notes:
> 3.0.0 is a major release that moves the action runtime from Node 20 to Node 24. Use v3 on GitHub-hosted runners and self-hosted fleets that already support the Node 24 Actions runtime.

GitHub-hosted runners are already on Actions Runner v2.327+ (Node 24 compatible), so no other runtime adjustment needed.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: run the Release workflow once and confirm the Node 20 deprecation annotation no longer appears

🤖 Opened by Barsik