### PR TITLE
chore(ci): bump docker action family to Node 24 majors

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,10 +37,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64
@@ -88,15 +88,15 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image (arm64, no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/arm64
@@ -119,13 +119,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up QEMU (for arm64 emulation on x86 runner)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -133,7 +133,7 @@ jobs:
 
       - name: Compute image tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Tagging strategy:
@@ -147,7 +147,7 @@ jobs:
             type=sha,prefix=sha-,format=short
 
       - name: Build + push (linux/amd64, linux/arm64)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Same Node 20 deprecation that drove #574 is coming for the docker action family. All five bump to the Node 24 runtime in their next major:

- `docker/setup-buildx-action` v3 → v4
- `docker/setup-qemu-action` v3 → v4
- `docker/build-push-action` v6 → v7
- `docker/login-action` v3 → v4
- `docker/metadata-action` v5 → v6

Verified against the v*.0.0 release notes that none of the removed or changed features touch our usage:

- **build-push v7** removed `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs — we don't set either.
- **setup-buildx v4** removed "deprecated inputs/outputs" — our usage is bare (no inputs after `uses:`) for all three call sites.
- **metadata v6** changed `#` handling inside list-input values to preserve them while still treating full-line `#` as a comment. Our `tags:` block has no `#` inside any value — all `#` are start-of-line comments.
- All five require Actions Runner ≥ v2.327.1 for Node 24. GitHub-hosted ubuntu-latest is well past that (we just saw v3.0.0 softprops succeed in #574 / 26.05.085 release).

## Test plan
- [ ] PR CI green (this PR triggers the docker build + smoke on both amd64 and arm64 since the workflow file is in the path filter)
- [ ] After merge: next push to main triggers the multi-arch publish and image lands in GHCR cleanly

🤖 Opened by Barsik