### PR TITLE
chore(deps): bump claude-agent-sdk to >=0.2.82,<0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "httpx>=0.28",
     "fastapi>=0.135",
     "uvicorn>=0.44",
-    "claude-agent-sdk>=0.1.80,<0.2",
+    "claude-agent-sdk>=0.2.82,<0.3",
     "Pillow>=10.0",
     # Federation crypto (sealed_box_v1): X25519, Ed25519, HKDF, XChaCha20-Poly1305.
     "cryptography>=41.0",


### PR DESCRIPTION
## Summary

Previously pinned to `>=0.1.80,<0.2` — that cap was a deliberate guard against unvetted major-version drift. The cap is now stale: latest upstream is 0.2.87.

The 0.1 → 0.2 jump is effectively a renumbering, not a semantic break. Upstream version history: 0.1.81 → 0.2.82 directly (no 0.2.0–0.2.81 tags exist).

## Every 0.2.x change, reviewed

**0.2.82** (the first 0.2.x):
- `EffortLevel` type export added (additive)
- Stderr callback isolation fix — callbacks raising no longer kill the reader loop
- `CancelledError` noise fix in eager-flush done callback
- Tighter `permission_suggestions` type: `list[Any]` → `list[dict[str, Any]]`
- Docs clarified that hook dispatch for a given event is **concurrent**, not sequential (doc-only fix — behavior was already concurrent)
- `mcp` lower-bound bumped to `>=1.23.0` for GHSA-9h52-p55h-vw2f / CVE-2025-66416

**0.2.83 → 0.2.87**: bundled Claude CLI version bumps (2.1.142 → 2.1.150) and CI auth migration to Workload Identity Federation (upstream-only, doesn't affect consumers).

**No API breaks. No imports or signatures we use have changed.**

Floor set to 0.2.82 (the first real 0.2.x release) so a fresh install can't accidentally land on a non-existent earlier 0.2.

## Verification

On the bumped venv (`claude-agent-sdk==0.2.87`):
```
$ .venv/bin/python -m pytest -q
2630 passed, 1 skipped in 183s
```

## Test plan
- [ ] PR CI green across Python 3.11/3.12/3.13 matrix
- [ ] After merge: deploy daemon with new SDK, watch all agents come up cleanly on first wake

🤖 Opened by Barsik