### PR TITLE
ci: bump Node 20 → 24 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend-svelte/package-lock.json
 


### PR DESCRIPTION
Closes #578.

## What

Bumps the frontend CI job from **Node 20 → Node 24** in `.github/workflows/ci.yml`.

```diff
-          node-version: "20"
+          node-version: "24"
```

## Why

- **Node 20 is EOL** (2026-04-30) — CI was running on an unmaintained runtime.
- **Node 24 is the current Active LTS** (supported through April 2028). Node 22 is already in Maintenance LTS (EOL April 2027), so going straight to 24 gives ~2x the runway and avoids a near-term re-bump. Node 26 is still *Current* (not LTS until Oct 2026), too early to pin CI to.
- **Bonus:** Node 24 ships npm 11, which sidesteps the npm 10/11 lockfile incompatibility that complicated #576.

## Validation

This PR's own CI run is the test — if the frontend builds, lints, and tests green on Node 24, we're good. No source changes; workflow-only.

🤖 Opened by Barsik