### PR TITLE
feat(api): add frontend build freshness guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ PinkyBot/
 │   ├── pinky_hub/          # Hub: cross-instance registry, presentation sync
 │   └── pinky_cli/          # CLI: init, serve, run
 ├── frontend-svelte/        # Svelte 5 SPA source
-├── frontend-dist/          # Built frontend (served by daemon)
+├── frontend-dist/          # Generated, gitignored frontend build (served by daemon)
 ├── docs/                   # Architecture docs and specs
 ├── tests/                  # pytest suite
 └── data/                   # Runtime data (SQLite, agent files) — gitignored

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -13,9 +13,11 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import hmac
 import json
 import os
+import re
 import sys
 import tempfile
 import time
@@ -172,6 +174,7 @@ MIN_UI_PASSWORD_LENGTH = 8
 CONTEXT_SAVE_SOURCE_SELF_TOOL = "save_my_context"
 CONTEXT_ACTIVITY_SAVE_BUFFER_SECONDS = 5 * 60
 CONTEXT_STALE_WARNING_SECONDS = 12 * 60 * 60
+FRONTEND_BUILD_MANIFEST = "build-manifest.json"
 
 # Outreach attempt outcome buckets (task #81 / issue #395 follow-up).
 # Splits the previous free-form "ok"/"error" outcome into 4 typed buckets so
@@ -624,6 +627,214 @@ def _check_installed_deps_drift(repo_dir: str) -> list[dict]:
                 "installed": installed,
             })
     return drifts
+
+
+def _sha256_file(path: Path) -> str | None:
+    """Return the SHA-256 hex digest for ``path``, or ``None`` if absent."""
+    if not path.exists() or not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _current_git_hash(repo_dir: str) -> str:
+    """Best-effort short HEAD hash for frontend build status."""
+    import subprocess as sp
+
+    try:
+        return sp.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
+        ).decode().strip()
+    except Exception:
+        return "unknown"
+
+
+def _frontend_index_assets(index_path: Path) -> list[str]:
+    """Extract /assets references from a built frontend index.html."""
+    if not index_path.exists():
+        return []
+    html = index_path.read_text(errors="replace")
+    assets = re.findall(r"""(?:src|href)=["']/assets/([^"']+)["']""", html)
+    # Stable order, no duplicates.
+    return list(dict.fromkeys(assets))
+
+
+def _write_frontend_build_manifest(
+    repo_dir: str,
+    *,
+    git_hash: str | None = None,
+    built_at: float | None = None,
+) -> dict:
+    """Write frontend-dist/build-manifest.json after a successful build.
+
+    The manifest is intentionally daemon-side rather than Vite-coupled:
+    it records the git hash, package-lock hash, and asset references
+    observed in the freshly-built index.html.
+    """
+    repo = Path(repo_dir)
+    dist = repo / "frontend-dist"
+    index_path = dist / "index.html"
+    if not index_path.exists():
+        raise FileNotFoundError(f"frontend index not found: {index_path}")
+
+    manifest = {
+        "version": 1,
+        "built_at": built_at if built_at is not None else time.time(),
+        "git_hash": git_hash or _current_git_hash(repo_dir),
+        "package_lock_sha256": _sha256_file(
+            repo / "frontend-svelte" / "package-lock.json"
+        ),
+        "assets": _frontend_index_assets(index_path),
+    }
+    manifest_path = dist / FRONTEND_BUILD_MANIFEST
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return manifest
+
+
+def _frontend_build_status(
+    repo_dir: str,
+    *,
+    current_git_hash: str | None = None,
+) -> dict:
+    """Return frontend build freshness diagnostics.
+
+    Status values:
+    - missing: frontend-dist or index.html is absent
+    - broken: index.html references missing assets or manifest is unreadable
+    - unverified: dist exists but no daemon-written manifest is present
+    - stale: manifest exists but git/package-lock hash differs
+    - ok: manifest matches current git/package-lock hash and assets exist
+    """
+    repo = Path(repo_dir)
+    dist = repo / "frontend-dist"
+    index_path = dist / "index.html"
+    manifest_path = dist / FRONTEND_BUILD_MANIFEST
+    current_hash = current_git_hash or _current_git_hash(repo_dir)
+    current_lock_hash = _sha256_file(repo / "frontend-svelte" / "package-lock.json")
+
+    base = {
+        "status": "unknown",
+        "message": "",
+        "dist_exists": dist.exists(),
+        "index_exists": index_path.exists(),
+        "manifest_exists": manifest_path.exists(),
+        "current_git_hash": current_hash,
+        "current_package_lock_sha256": current_lock_hash,
+        "built_git_hash": None,
+        "built_package_lock_sha256": None,
+        "assets": [],
+        "built_assets": [],
+        "missing_assets": [],
+        "stale_reasons": [],
+    }
+
+    if not dist.exists():
+        base.update({
+            "status": "missing",
+            "message": (
+                "Frontend build missing: frontend-dist does not exist. "
+                "Run /admin/update with npm available or build the frontend."
+            ),
+        })
+        return base
+
+    if not index_path.exists():
+        base.update({
+            "status": "missing",
+            "message": (
+                "Frontend build missing: frontend-dist/index.html does not exist. "
+                "Run /admin/update with npm available or build the frontend."
+            ),
+        })
+        return base
+
+    assets = _frontend_index_assets(index_path)
+    missing_assets = [
+        asset for asset in assets
+        if not (dist / "assets" / asset).exists()
+    ]
+    base["assets"] = assets
+    base["missing_assets"] = missing_assets
+    if missing_assets:
+        base.update({
+            "status": "broken",
+            "message": (
+                "Frontend build is broken: index.html references missing "
+                f"asset(s): {', '.join(missing_assets)}"
+            ),
+        })
+        return base
+
+    if not manifest_path.exists():
+        base.update({
+            "status": "unverified",
+            "message": (
+                "Frontend build present but unverified: build-manifest.json "
+                "is absent (expected for Docker images built before manifest "
+                "support, or manual builds)."
+            ),
+        })
+        return base
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except Exception as e:
+        base.update({
+            "status": "broken",
+            "message": f"Frontend build manifest is unreadable: {e}",
+        })
+        return base
+
+    built_hash = str(manifest.get("git_hash") or "")
+    built_lock_hash = manifest.get("package_lock_sha256")
+    raw_built_assets = manifest.get("assets")
+    built_assets = list(raw_built_assets or []) if isinstance(raw_built_assets, list) else []
+    base["built_git_hash"] = built_hash or None
+    base["built_package_lock_sha256"] = built_lock_hash
+    base["built_assets"] = built_assets
+
+    if not built_hash or not built_lock_hash or not isinstance(raw_built_assets, list):
+        base.update({
+            "status": "unverified",
+            "message": "Frontend build manifest is present but incomplete.",
+        })
+        return base
+
+    stale_reasons: list[str] = []
+    if (
+        built_hash
+        and current_hash
+        and built_hash != "unknown"
+        and current_hash != "unknown"
+        and built_hash != current_hash
+    ):
+        stale_reasons.append("git_hash")
+    if built_lock_hash and current_lock_hash and built_lock_hash != current_lock_hash:
+        stale_reasons.append("package_lock")
+    if built_assets != assets:
+        stale_reasons.append("assets")
+
+    base["stale_reasons"] = stale_reasons
+    if stale_reasons:
+        base.update({
+            "status": "stale",
+            "message": (
+                "Frontend build is stale: "
+                f"{', '.join(stale_reasons)} mismatch "
+                f"(built={built_hash or 'unknown'}, current={current_hash})."
+            ),
+        })
+        return base
+
+    base.update({
+        "status": "ok",
+        "message": "Frontend build manifest matches current source.",
+    })
+    return base
 
 
 # ── API Server ───────────────────────────────────────────────
@@ -2492,6 +2703,21 @@ def create_api(
     # daemon runs (was previously implicit local-tz). #294
     _now = _dt.datetime.now(_dt.timezone.utc)
     _pinky_version = f"{_now.strftime('%y')}.{int(_now.strftime('%m')):02d}.{_git_hash}"
+
+    app.state.frontend_build_status = _frontend_build_status(
+        str(_pkg_root), current_git_hash=_git_hash,
+    )
+    _frontend_status = app.state.frontend_build_status.get("status")
+    if _frontend_status in {"missing", "broken", "stale"}:
+        _log(
+            "frontend: WARNING "
+            f"{app.state.frontend_build_status.get('message', _frontend_status)}"
+        )
+    elif _frontend_status == "unverified":
+        _log(
+            "frontend: "
+            f"{app.state.frontend_build_status.get('message', _frontend_status)}"
+        )
 
     if not os.environ.get("PINKY_SESSION_SECRET", "").strip():
         _log("auth: WARNING PINKY_SESSION_SECRET is not set; UI login/setup cannot issue signed cookies")
@@ -7595,6 +7821,17 @@ def create_api(
 
     # ── Admin: Update & Restart ───────────────────────────
 
+    @app.get("/admin/update/status")
+    async def admin_update_status():
+        """Return update-adjacent status, including frontend build freshness."""
+        frontend_status = _frontend_build_status(str(_pkg_root), current_git_hash=_git_hash)
+        app.state.frontend_build_status = frontend_status
+        return {
+            "git_hash": _git_hash,
+            "git_branch": _git_branch,
+            "frontend": frontend_status,
+        }
+
     @app.post("/admin/update")
     async def admin_update(
         branch: str = "",
@@ -7844,6 +8081,7 @@ def create_api(
         # Always rebuild frontend on update to keep compiled assets fresh
         frontend_rebuilt = False
         frontend_error = ""
+        frontend_manifest: dict | None = None
         try:
             fe_dir = str(Path(repo_dir) / "frontend-svelte")
             npm_path = shutil.which("npm")
@@ -7855,6 +8093,9 @@ def create_api(
                 sp.check_output(
                     [npm_path, "run", "build"], cwd=fe_dir, stderr=sp.STDOUT, timeout=120
                 )
+                frontend_manifest = _write_frontend_build_manifest(
+                    repo_dir, git_hash=after_hash,
+                )
                 frontend_rebuilt = True
             elif not npm_path:
                 frontend_error = "npm not found — install Node.js 18+ to enable auto frontend builds"
@@ -7862,6 +8103,9 @@ def create_api(
         except Exception as e:
             frontend_error = f"Frontend build failed: {e}"
             _log(f"admin: {frontend_error}")
+
+        frontend_status = _frontend_build_status(repo_dir, current_git_hash=after_hash)
+        app.state.frontend_build_status = frontend_status
 
         result = {
             "updated": True,
@@ -7874,6 +8118,8 @@ def create_api(
             "deps_drift": deps_drift,
             "frontend_rebuilt": frontend_rebuilt,
             "frontend_error": frontend_error or None,
+            "frontend_manifest": frontend_manifest,
+            "frontend_status": frontend_status,
             "forced_reset": forced_reset,
             "forced_files": forced_files,
             "restarting": before_hash != after_hash or deps_rebuilt,

--- a/tests/test_admin_update.py
+++ b/tests/test_admin_update.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess as sp
 import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
@@ -239,6 +240,199 @@ class TestAdminUpdateBaseline:
         body = r.json()
         assert "error" in body
         assert "git pull failed" in body["error"]
+
+    def test_successful_frontend_rebuild_writes_manifest_and_status(self):
+        """When npm build succeeds, /admin/update writes and returns the build manifest."""
+        gm = _GitMock(dirty_files=[])
+        manifest = {"git_hash": "def5678", "assets": ["index.js"]}
+        frontend_status = {"status": "ok", "message": "fresh"}
+
+        with (
+            patch("subprocess.check_output", side_effect=gm),
+            patch("pinky_daemon.api._check_installed_deps_drift", return_value=[]),
+            patch("shutil.which", return_value="/usr/bin/npm"),
+            patch("pinky_daemon.api._write_frontend_build_manifest",
+                  return_value=manifest) as write_manifest,
+            patch("pinky_daemon.api._frontend_build_status",
+                  return_value=frontend_status),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=main")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["frontend_rebuilt"] is True
+        assert body["frontend_manifest"] == manifest
+        assert body["frontend_status"] == frontend_status
+        write_manifest.assert_called_once()
+        assert write_manifest.call_args.kwargs["git_hash"] == "def5678"
+
+
+class TestFrontendBuildManifest:
+    """Frontend build-manifest guard for untracked frontend-dist deployments."""
+
+    def _write_frontend_fixture(
+        self,
+        tmp: str,
+        *,
+        with_dist: bool = True,
+        with_manifest: bool = False,
+        manifest_git_hash: str = "abc1234",
+        manifest_lock_hash: str | None = None,
+        missing_asset: bool = False,
+    ) -> Path:
+        repo = Path(tmp)
+        (repo / "frontend-svelte").mkdir(parents=True)
+        (repo / "frontend-svelte" / "package-lock.json").write_text('{"lockfileVersion":3}\n')
+        if not with_dist:
+            return repo
+
+        dist = repo / "frontend-dist"
+        assets = dist / "assets"
+        assets.mkdir(parents=True)
+        (dist / "index.html").write_text(
+            '<script type="module" src="/assets/index-test.js"></script>\n'
+            '<link rel="stylesheet" href="/assets/index-test.css">\n'
+        )
+        if not missing_asset:
+            (assets / "index-test.js").write_text("console.log('ok')\n")
+            (assets / "index-test.css").write_text("body{}\n")
+        if with_manifest:
+            from pinky_daemon.api import _sha256_file
+
+            lock_hash = manifest_lock_hash or _sha256_file(
+                repo / "frontend-svelte" / "package-lock.json"
+            )
+            (dist / "build-manifest.json").write_text(
+                "{"
+                f'"git_hash":"{manifest_git_hash}",'
+                f'"package_lock_sha256":"{lock_hash}",'
+                '"assets":["index-test.js","index-test.css"],'
+                '"version":1'
+                "}\n"
+            )
+        return repo
+
+    def test_frontend_status_missing_when_dist_absent(self):
+        from pinky_daemon.api import _frontend_build_status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._write_frontend_fixture(tmp, with_dist=False)
+            status = _frontend_build_status(str(repo), current_git_hash="abc1234")
+
+        assert status["status"] == "missing"
+        assert "frontend-dist does not exist" in status["message"]
+
+    def test_frontend_status_unverified_when_manifest_absent(self):
+        from pinky_daemon.api import _frontend_build_status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._write_frontend_fixture(tmp, with_dist=True, with_manifest=False)
+            status = _frontend_build_status(str(repo), current_git_hash="abc1234")
+
+        assert status["status"] == "unverified"
+        assert status["manifest_exists"] is False
+
+    def test_frontend_status_stale_when_manifest_hash_differs(self):
+        from pinky_daemon.api import _frontend_build_status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._write_frontend_fixture(
+                tmp, with_dist=True, with_manifest=True, manifest_git_hash="old1111",
+            )
+            status = _frontend_build_status(str(repo), current_git_hash="new2222")
+
+        assert status["status"] == "stale"
+        assert status["built_git_hash"] == "old1111"
+        assert status["current_git_hash"] == "new2222"
+        assert "git_hash" in status["stale_reasons"]
+
+    def test_frontend_status_stale_when_manifest_assets_differ(self):
+        from pinky_daemon.api import _frontend_build_status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._write_frontend_fixture(
+                tmp, with_dist=True, with_manifest=True, manifest_git_hash="abc1234",
+            )
+            # Use the actual current lock hash so only the asset-list
+            # check drives staleness.
+            from pinky_daemon.api import _sha256_file
+
+            lock_hash = _sha256_file(repo / "frontend-svelte" / "package-lock.json")
+            (repo / "frontend-dist" / "build-manifest.json").write_text(
+                "{"
+                '"git_hash":"abc1234",'
+                f'"package_lock_sha256":"{lock_hash}",'
+                '"assets":["old.js"],'
+                '"version":1'
+                "}\n"
+            )
+            status = _frontend_build_status(str(repo), current_git_hash="abc1234")
+
+        assert status["status"] == "stale"
+        assert status["built_assets"] == ["old.js"]
+        assert status["assets"] == ["index-test.js", "index-test.css"]
+        assert "assets" in status["stale_reasons"]
+
+    def test_frontend_status_unverified_when_manifest_incomplete(self):
+        from pinky_daemon.api import _frontend_build_status, _sha256_file
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._write_frontend_fixture(
+                tmp, with_dist=True, with_manifest=True, manifest_git_hash="abc1234",
+            )
+            lock_hash = _sha256_file(repo / "frontend-svelte" / "package-lock.json")
+            (repo / "frontend-dist" / "build-manifest.json").write_text(
+                "{"
+                '"git_hash":"abc1234",'
+                f'"package_lock_sha256":"{lock_hash}",'
+                '"version":1'
+                "}\n"
+            )
+            status = _frontend_build_status(str(repo), current_git_hash="abc1234")
+
+        assert status["status"] == "unverified"
+        assert "incomplete" in status["message"]
+
+    def test_frontend_status_broken_when_index_references_missing_asset(self):
+        from pinky_daemon.api import _frontend_build_status
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._write_frontend_fixture(
+                tmp, with_dist=True, with_manifest=False, missing_asset=True,
+            )
+            status = _frontend_build_status(str(repo), current_git_hash="abc1234")
+
+        assert status["status"] == "broken"
+        assert status["missing_assets"] == ["index-test.js", "index-test.css"]
+
+    def test_write_frontend_manifest_records_hash_and_assets(self):
+        from pinky_daemon.api import _frontend_build_status, _write_frontend_build_manifest
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._write_frontend_fixture(tmp, with_dist=True, with_manifest=False)
+            manifest = _write_frontend_build_manifest(
+                str(repo), git_hash="abc1234", built_at=123.0,
+            )
+            status = _frontend_build_status(str(repo), current_git_hash="abc1234")
+
+        assert manifest["git_hash"] == "abc1234"
+        assert manifest["built_at"] == 123.0
+        assert manifest["assets"] == ["index-test.js", "index-test.css"]
+        assert status["status"] == "ok"
+
+    def test_admin_update_status_endpoint_exposes_frontend_status(self):
+        client = _make_client()
+        with patch(
+            "pinky_daemon.api._frontend_build_status",
+            return_value={"status": "unverified", "message": "test"},
+        ):
+            r = client.get("/admin/update/status")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["frontend"]["status"] == "unverified"
 
 
 class TestAdminUpdateForceDepsIntegration:


### PR DESCRIPTION
## Summary
- write `frontend-dist/build-manifest.json` after successful `/admin/update` frontend rebuilds
- expose frontend build freshness through startup logging, `/admin/update/status`, and `/admin/update` responses
- classify missing, broken, unverified, stale, and ok build states, including index.html asset reference checks
- clarify README that `frontend-dist/` is generated and gitignored

## Why
#581 stopped committing generated frontend artifacts. This adds the observability guard for the build-on-deploy contract so a missing, broken, or stale generated dist is loud instead of silently serving the wrong frontend.

## Validation
- `.venv/bin/ruff check src/pinky_daemon/api.py tests/test_admin_update.py`
- `.venv/bin/python -m pytest tests/test_admin_update.py -q`
- `.venv/bin/python -m pytest tests/test_api.py tests/test_admin_update.py -q`

Known test noise: existing FastAPI `on_event` deprecation warnings and the existing shared-MCP port 8890 warning in `tests/test_api.py`.
