### PR TITLE
fix(api): separate frontend manifest write errors

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8093,9 +8093,6 @@ def create_api(
                 sp.check_output(
                     [npm_path, "run", "build"], cwd=fe_dir, stderr=sp.STDOUT, timeout=120
                 )
-                frontend_manifest = _write_frontend_build_manifest(
-                    repo_dir, git_hash=after_hash,
-                )
                 frontend_rebuilt = True
             elif not npm_path:
                 frontend_error = "npm not found — install Node.js 18+ to enable auto frontend builds"
@@ -8103,6 +8100,15 @@ def create_api(
         except Exception as e:
             frontend_error = f"Frontend build failed: {e}"
             _log(f"admin: {frontend_error}")
+
+        if frontend_rebuilt:
+            try:
+                frontend_manifest = _write_frontend_build_manifest(
+                    repo_dir, git_hash=after_hash,
+                )
+            except Exception as e:
+                frontend_error = f"Frontend build manifest failed: {e}"
+                _log(f"admin: {frontend_error}")
 
         frontend_status = _frontend_build_status(repo_dir, current_git_hash=after_hash)
         app.state.frontend_build_status = frontend_status

--- a/tests/test_admin_update.py
+++ b/tests/test_admin_update.py
@@ -268,6 +268,32 @@ class TestAdminUpdateBaseline:
         write_manifest.assert_called_once()
         assert write_manifest.call_args.kwargs["git_hash"] == "def5678"
 
+    def test_successful_frontend_rebuild_reports_manifest_error_separately(self):
+        """A post-build manifest failure should not be mislabeled as a build failure."""
+        gm = _GitMock(dirty_files=[])
+        frontend_status = {"status": "unverified", "message": "manifest missing"}
+
+        with (
+            patch("subprocess.check_output", side_effect=gm),
+            patch("pinky_daemon.api._check_installed_deps_drift", return_value=[]),
+            patch("shutil.which", return_value="/usr/bin/npm"),
+            patch("pinky_daemon.api._write_frontend_build_manifest",
+                  side_effect=OSError("disk full")) as write_manifest,
+            patch("pinky_daemon.api._frontend_build_status",
+                  return_value=frontend_status),
+            patch("os.kill"),
+        ):
+            client = _make_client()
+            r = client.post("/admin/update?branch=main")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["frontend_rebuilt"] is True
+        assert body["frontend_manifest"] is None
+        assert body["frontend_error"] == "Frontend build manifest failed: disk full"
+        assert body["frontend_status"] == frontend_status
+        write_manifest.assert_called_once()
+
 
 class TestFrontendBuildManifest:
     """Frontend build-manifest guard for untracked frontend-dist deployments."""


### PR DESCRIPTION
## Summary
- keep `frontend_rebuilt=true` when npm build succeeds but manifest writing fails
- report manifest write failures as `Frontend build manifest failed: ...` instead of `Frontend build failed: ...`
- add regression coverage for the separate failure mode

## Why
Follow-up to #582 review: the manifest write happens after a successful frontend build, so failures there should not be mislabeled as npm build failures.

## Validation
- `.venv/bin/ruff check src/pinky_daemon/api.py tests/test_admin_update.py`
- `.venv/bin/python -m pytest tests/test_admin_update.py -q`
- `.venv/bin/python -m pytest tests/test_api.py tests/test_admin_update.py -q`
