### PR TITLE
feat(hooks): StopFailure → proactive auth-failure alerts for tmux/CLI agents

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -829,6 +829,77 @@ except Exception:
 '''
 
 
+def _tmux_stop_failure_hook_source(agent_name: str) -> str:
+    """Return the source for ``.claude/hook_tmux_stop_failure.py``.
+
+    Fires on Claude Code's ``StopFailure`` — a turn that ended due to an
+    API error. Reads the hook payload from stdin (``error_type`` carries
+    the typed failure: ``authentication_failed`` / ``rate_limit`` /
+    ``billing_error`` / ``server_error`` / …) and POSTs it to
+    ``/agents/{name}/transport/stop-failure`` so the daemon can alert the
+    owner on actionable failures (auth / billing) — instead of the agent
+    going silently dark — and log the transient ones.
+
+    StopFailure hook output/exit code is ignored by Claude Code
+    (observability-only), so this can never affect the turn. Fire-and-
+    forget; no-op when PINKY_SESSION_SECRET is unset.
+    """
+    return f'''\
+#!/usr/bin/env python3
+"""PinkyBot StopFailure hook.
+
+POSTs the typed turn-failure (error_type) to the daemon so it can alert
+on auth/billing failures proactively rather than the agent going dark.
+"""
+import hashlib, hmac, base64, time, urllib.request, json, os, sys
+
+secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+if not secret:
+    sys.exit(0)
+
+try:
+    raw = sys.stdin.read()
+    payload_in = json.loads(raw) if raw else {{}}
+except Exception:
+    payload_in = {{}}
+
+error_type = payload_in.get("error_type") or "unknown"
+message = ""
+for _k in ("message", "error", "error_message"):
+    _v = payload_in.get(_k)
+    if isinstance(_v, str) and _v:
+        message = _v
+        break
+
+agent = "{agent_name}"
+path = "/agents/{agent_name}/transport/stop-failure"
+ts = int(time.time())
+payload_sig = f"{{agent}}\\nPOST\\n{{path}}\\n{{ts}}".encode()
+digest = hmac.new(secret.encode(), payload_sig, hashlib.sha256).digest()
+sig = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+body = {{
+    "error_type": error_type,
+    "message": message,
+    "session_id": payload_in.get("session_id", ""),
+}}
+
+req = urllib.request.Request(
+    f"http://localhost:8888{{path}}",
+    data=json.dumps(body).encode(),
+    method="POST",
+)
+req.add_header("Content-Type", "application/json")
+req.add_header("x-pinky-agent", agent)
+req.add_header("x-pinky-timestamp", str(ts))
+req.add_header("x-pinky-signature", sig)
+try:
+    urllib.request.urlopen(req, timeout=2)
+except Exception:
+    pass
+'''
+
+
 def _tmux_session_start_hook_source(agent_name: str) -> str:
     """Return the source for ``.claude/hook_tmux_session_start.py``.
 
@@ -1467,6 +1538,7 @@ except Exception:
         tmux_session_start_path = claude_dir / "hook_tmux_session_start.py"
         tmux_pre_tool_path = claude_dir / "hook_tmux_pre_tool.py"
         tmux_post_tool_path = claude_dir / "hook_tmux_post_tool.py"
+        tmux_stop_failure_path = claude_dir / "hook_tmux_stop_failure.py"
 
         if not working_path.exists():
             working_path.write_text(
@@ -1527,6 +1599,12 @@ except Exception:
             hook_filename="hook_tmux_post_tool.py",
             agent_name=agent_name,
         )
+        AgentRegistry._write_hook_if_changed(
+            hook_path=tmux_stop_failure_path,
+            new_source=_tmux_stop_failure_hook_source(agent_name),
+            hook_filename="hook_tmux_stop_failure.py",
+            agent_name=agent_name,
+        )
 
         AgentRegistry._sync_hooks_settings(
             claude_dir / "settings.json",
@@ -1537,6 +1615,7 @@ except Exception:
             tmux_session_start_path=tmux_session_start_path.resolve(),
             tmux_pre_tool_path=tmux_pre_tool_path.resolve(),
             tmux_post_tool_path=tmux_post_tool_path.resolve(),
+            tmux_stop_failure_path=tmux_stop_failure_path.resolve(),
             agent_name=agent_name,
         )
 
@@ -1551,6 +1630,7 @@ except Exception:
         tmux_session_start_path: Path,
         tmux_pre_tool_path: Path,
         tmux_post_tool_path: Path,
+        tmux_stop_failure_path: Path,
         agent_name: str,
     ) -> None:
         """Idempotently ensure settings.json has all PinkyBot hooks wired up.
@@ -1576,6 +1656,9 @@ except Exception:
         )
         tmux_pre_tool_cmd = f"python3 {tmux_pre_tool_path} 2>/dev/null || true"
         tmux_post_tool_cmd = f"python3 {tmux_post_tool_path} 2>/dev/null || true"
+        tmux_stop_failure_cmd = (
+            f"python3 {tmux_stop_failure_path} 2>/dev/null || true"
+        )
 
         if not settings_path.exists():
             settings = {
@@ -1622,6 +1705,21 @@ except Exception:
                                 {
                                     "type": "command",
                                     "command": tmux_session_start_cmd,
+                                },
+                            ],
+                        }
+                    ],
+                    "StopFailure": [
+                        {
+                            # StopFailure fires when a turn ends on an API error.
+                            # matcher ".*" catches every error_type; the hook
+                            # forwards the typed failure so the daemon can alert
+                            # on auth/billing and log transient classes.
+                            "matcher": ".*",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": tmux_stop_failure_cmd,
                                 },
                             ],
                         }
@@ -1680,6 +1778,14 @@ except Exception:
             hooks, "PostToolUse",
             needle=str(tmux_post_tool_path),
             command=tmux_post_tool_cmd,
+        )
+
+        # tmux_stop_failure → StopFailure bucket (new bucket if needed).
+        # Backfills agents whose settings.json predates the hook.
+        changed |= AgentRegistry._merge_hook_into_event(
+            hooks, "StopFailure",
+            needle=str(tmux_stop_failure_path),
+            command=tmux_stop_failure_cmd,
         )
 
         if changed:

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -833,12 +833,12 @@ def _tmux_stop_failure_hook_source(agent_name: str) -> str:
     """Return the source for ``.claude/hook_tmux_stop_failure.py``.
 
     Fires on Claude Code's ``StopFailure`` — a turn that ended due to an
-    API error. Reads the hook payload from stdin (``error_type`` carries
-    the typed failure: ``authentication_failed`` / ``rate_limit`` /
-    ``billing_error`` / ``server_error`` / …) and POSTs it to
+    API error. Reads the hook payload from stdin (CC's ``error`` field
+    carries the typed failure: ``authentication_failed`` / ``rate_limit``
+    / ``billing_error`` / ``server_error`` / …) and POSTs it to
     ``/agents/{name}/transport/stop-failure`` so the daemon can alert the
-    owner on actionable failures (auth / billing) — instead of the agent
-    going silently dark — and log the transient ones.
+    owner on auth-class failures — instead of the agent going silently
+    dark — and log the rest (rate_limit / billing) for observability.
 
     StopFailure hook output/exit code is ignored by Claude Code
     (observability-only), so this can never affect the turn. Fire-and-
@@ -848,8 +848,9 @@ def _tmux_stop_failure_hook_source(agent_name: str) -> str:
 #!/usr/bin/env python3
 """PinkyBot StopFailure hook.
 
-POSTs the typed turn-failure (error_type) to the daemon so it can alert
-on auth/billing failures proactively rather than the agent going dark.
+Reads CC's StopFailure payload (the typed failure is in the ``error``
+field) and POSTs it to the daemon so it can alert on auth-class
+failures proactively rather than the agent going silently dark.
 """
 import hashlib, hmac, base64, time, urllib.request, json, os, sys
 
@@ -863,9 +864,16 @@ try:
 except Exception:
     payload_in = {{}}
 
-error_type = payload_in.get("error_type") or "unknown"
+# Claude Code delivers the typed failure in ``error`` (NOT
+# ``error_type``); ``error_type`` is kept as a defensive alias for
+# our own internal posts. See StopFailure input schema:
+# https://code.claude.com/docs/en/hooks#stopfailure-input
+error_type = payload_in.get("error") or payload_in.get("error_type") or "unknown"
+# ``error`` is the type, not a message — for human-readable detail CC
+# gives ``last_assistant_message`` (the rendered API-error string) and
+# ``error_details``; fall back to our internal message keys.
 message = ""
-for _k in ("message", "error", "error_message"):
+for _k in ("last_assistant_message", "error_details", "message", "error_message"):
     _v = payload_in.get(_k)
     if isinstance(_v, str) and _v:
         message = _v
@@ -1712,9 +1720,10 @@ except Exception:
                     "StopFailure": [
                         {
                             # StopFailure fires when a turn ends on an API error.
-                            # matcher ".*" catches every error_type; the hook
-                            # forwards the typed failure so the daemon can alert
-                            # on auth/billing and log transient classes.
+                            # matcher ".*" catches every error class; the hook
+                            # forwards the typed failure (CC's ``error`` field)
+                            # so the daemon can alert on auth-class failures and
+                            # log the rest (rate_limit / billing).
                             "matcher": ".*",
                             "hooks": [
                                 {

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -91,6 +91,7 @@ from pinky_daemon.api_models import (
     SetMainAgentRequest,
     SetModelRequest,
     SpawnSessionRequest,
+    TransportStopFailureRequest,
     TransportToolResultRequest,
     TransportToolUseRequest,
     TransportTranscriptPathRequest,
@@ -175,6 +176,16 @@ CONTEXT_SAVE_SOURCE_SELF_TOOL = "save_my_context"
 CONTEXT_ACTIVITY_SAVE_BUFFER_SECONDS = 5 * 60
 CONTEXT_STALE_WARNING_SECONDS = 12 * 60 * 60
 FRONTEND_BUILD_MANIFEST = "build-manifest.json"
+
+# StopFailure hook (CC typed turn-failure signal). Auth-class failures are
+# routed into the shared AuthFailureTracker so tmux/CLI sessions get the same
+# proactive operator alert (threshold + cooldown + operator resolution) the
+# SDK reader loop already triggers; other classes (rate_limit, billing_error,
+# server_error, …) are logged for observability. oauth_org_not_allowed is
+# auth-adjacent — same re-auth remedy — so it rides the auth path too.
+_STOP_FAILURE_AUTH_TYPES = frozenset(
+    {"authentication_failed", "oauth_org_not_allowed"}
+)
 
 # Outreach attempt outcome buckets (task #81 / issue #395 follow-up).
 # Splits the previous free-form "ok"/"error" outcome into 4 typed buckets so
@@ -1417,6 +1428,7 @@ def create_api(
     app.state.manager = manager
     app.state.broker = broker
     app.state.agents = agents
+    app.state.auth_tracker = auth_tracker
     app.state.conversation_store = store
     app.state.session_store = session_store
     app.state.session_event_store = session_event_store
@@ -4434,6 +4446,60 @@ def create_api(
             except Exception as e:
                 _log(f"api: transport_wake notify_tail raised for {name}: {e}")
         return {"ok": True, "agent": name, "event": req.event}
+
+    @app.post("/agents/{name}/transport/stop-failure")
+    async def transport_stop_failure(name: str, req: TransportStopFailureRequest):
+        """Typed turn-failure signal — POSTed by the ``StopFailure`` hook.
+
+        Claude Code fires ``StopFailure`` when a turn ends due to an API
+        error, carrying a typed ``error_type``. Every failure is logged for
+        observability. Auth-class failures (``authentication_failed`` /
+        ``oauth_org_not_allowed``) are routed into the shared
+        ``AuthFailureTracker`` via ``_on_auth_failure`` — the same
+        threshold + cooldown + operator-resolution path the SDK reader loop
+        uses. tmux/CLI agents have no SDK reader loop, so this hook is the
+        only thing that surfaces a dead token before the agent goes
+        silently dark.
+
+        Fire-and-forget: returns 200 even with no live session so the
+        hook's ``|| true`` never fails the model turn. Runtime-agnostic —
+        the alert matters regardless of transport.
+        """
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+
+        error_type = (req.error_type or "unknown").strip() or "unknown"
+
+        # Observability: every failure class is recorded.
+        try:
+            activity.log(
+                agent_name=name,
+                event_type="cc_stop_failure",
+                title=f"StopFailure: {error_type}"[:200],
+            )
+        except Exception:
+            pass
+        _log(
+            f"api: StopFailure for {name} — error_type={error_type}"
+            + (f" — {req.message[:200]}" if req.message else "")
+        )
+
+        # Auth-class failures → shared auth-alert path (tracker decides
+        # whether the threshold + cooldown warrant an operator DM).
+        auth_failure = error_type in _STOP_FAILURE_AUTH_TYPES
+        if auth_failure:
+            try:
+                await _on_auth_failure(name, error_type)
+            except Exception as e:
+                _log(f"api: StopFailure auth routing failed for {name}: {e}")
+
+        return {
+            "ok": True,
+            "agent": name,
+            "error_type": error_type,
+            "auth_failure": auth_failure,
+        }
 
     @app.post("/agents/{name}/transport/transcript-path")
     async def transport_transcript_path(

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -914,11 +914,12 @@ class TransportStopFailureRequest(BaseModel):
     """Typed turn-failure signal — POSTed by the ``StopFailure`` hook.
 
     Claude Code fires ``StopFailure`` when a turn ends due to an API
-    error, carrying a typed ``error_type`` (e.g. ``authentication_failed``,
-    ``rate_limit``, ``billing_error``, ``server_error``). Forwarding it
-    lets the daemon alert the owner on auth/billing failures proactively
-    — instead of an agent going silently dark — and feed transient
-    classes (rate_limit) to logs/observability.
+    error. CC delivers the typed failure in its ``error`` field
+    (``authentication_failed``, ``rate_limit``, ``billing_error``,
+    ``server_error``, …); the hook maps that onto this ``error_type``.
+    Forwarding it lets the daemon alert the owner on auth-class failures
+    proactively — instead of an agent going silently dark — and feed the
+    rest (rate_limit / billing) to logs/observability.
 
     Fire-and-forget like the other transport hooks: the hook wraps the
     POST in ``|| true`` so a daemon hiccup never fails the model turn.

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -910,6 +910,26 @@ class TransportToolResultRequest(BaseModel):
     label: str = "main"
 
 
+class TransportStopFailureRequest(BaseModel):
+    """Typed turn-failure signal — POSTed by the ``StopFailure`` hook.
+
+    Claude Code fires ``StopFailure`` when a turn ends due to an API
+    error, carrying a typed ``error_type`` (e.g. ``authentication_failed``,
+    ``rate_limit``, ``billing_error``, ``server_error``). Forwarding it
+    lets the daemon alert the owner on auth/billing failures proactively
+    — instead of an agent going silently dark — and feed transient
+    classes (rate_limit) to logs/observability.
+
+    Fire-and-forget like the other transport hooks: the hook wraps the
+    POST in ``|| true`` so a daemon hiccup never fails the model turn.
+    """
+
+    error_type: str = "unknown"
+    message: str = ""
+    session_id: str = ""
+    label: str = "main"
+
+
 class FederationPeerUpsertRequest(BaseModel):
     """Insert or update a federation peer (admin / config-seeded path).
 

--- a/tests/test_stop_failure_hook.py
+++ b/tests/test_stop_failure_hook.py
@@ -1,0 +1,227 @@
+"""Tests for the StopFailure CC hook + the
+``/agents/{name}/transport/stop-failure`` endpoint.
+
+Claude Code fires ``StopFailure`` when a turn ends due to an API error,
+carrying a typed ``error_type``. The hook forwards it so the daemon can:
+
+  - log every failure for observability (all classes), and
+  - route auth-class failures (authentication_failed / oauth_org_not_allowed)
+    into the shared ``AuthFailureTracker`` — the same proactive operator-alert
+    path the SDK reader loop uses. tmux/CLI agents have no SDK reader loop, so
+    this hook is the only thing that surfaces a dead token before the agent
+    goes silently dark.
+
+The tracker's threshold/cooldown/host-wide logic and alert formatting are
+covered by ``test_auth_alerts.py`` — here we pin that the endpoint *routes*
+correctly and classifies error types.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+from fastapi.testclient import TestClient
+
+from pinky_daemon.agent_registry import AgentRegistry
+
+
+def _make_app(db_path: str):
+    from pinky_daemon.api import create_api
+    return create_api(max_sessions=10, default_working_dir="/tmp", db_path=db_path)
+
+
+# ── Endpoint routing ───────────────────────────────────────────
+
+
+class TestStopFailureEndpoint:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._db = os.path.join(self._tmpdir, "test.db")
+
+    def _client_with_agent(self, name: str = "dymok"):
+        app = _make_app(self._db)
+        client = TestClient(app)
+        r = client.post("/agents", json={"name": name, "model": "sonnet"})
+        assert r.status_code == 200
+        # Spy the shared auth tracker's record_failure so we can assert the
+        # endpoint routes auth-class failures into it without triggering a
+        # real operator DM. Returning should_alert=False short-circuits
+        # _on_auth_failure before any send.
+        calls: list[tuple[str, str]] = []
+
+        def _spy(agent_name, error=""):
+            calls.append((agent_name, error))
+            return {
+                "should_alert": False,
+                "reason": "below_threshold",
+                "count": len(calls),
+                "agents_failing": 1,
+            }
+
+        app.state.auth_tracker.record_failure = _spy
+        return client, calls
+
+    def test_unknown_agent_404(self):
+        client, calls = self._client_with_agent()
+        r = client.post(
+            "/agents/nobody/transport/stop-failure",
+            json={"error_type": "authentication_failed"},
+        )
+        assert r.status_code == 404
+        assert calls == []
+
+    def test_auth_failed_routes_to_tracker(self):
+        client, calls = self._client_with_agent()
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={"error_type": "authentication_failed", "message": "401"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["error_type"] == "authentication_failed"
+        assert body["auth_failure"] is True
+        assert calls == [("dymok", "authentication_failed")]
+
+    def test_oauth_org_not_allowed_routes_to_tracker(self):
+        """oauth_org_not_allowed is auth-adjacent (same re-auth remedy)."""
+        client, calls = self._client_with_agent()
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={"error_type": "oauth_org_not_allowed"},
+        )
+        assert r.status_code == 200
+        assert r.json()["auth_failure"] is True
+        assert calls == [("dymok", "oauth_org_not_allowed")]
+
+    def test_rate_limit_not_routed(self):
+        """Transient class — logged for observability, not routed to the
+        auth tracker, no operator alert."""
+        client, calls = self._client_with_agent()
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={"error_type": "rate_limit"},
+        )
+        assert r.status_code == 200
+        assert r.json()["auth_failure"] is False
+        assert calls == []
+
+    def test_billing_error_not_routed_to_auth(self):
+        """billing_error is a different remedy than re-auth — logged, not
+        routed through the auth tracker."""
+        client, calls = self._client_with_agent()
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={"error_type": "billing_error"},
+        )
+        assert r.status_code == 200
+        assert r.json()["auth_failure"] is False
+        assert calls == []
+
+    def test_missing_error_type_defaults_unknown(self):
+        client, calls = self._client_with_agent()
+        r = client.post("/agents/dymok/transport/stop-failure", json={})
+        assert r.status_code == 200
+        assert r.json()["error_type"] == "unknown"
+        assert r.json()["auth_failure"] is False
+        assert calls == []
+
+    def test_repeated_auth_failures_each_recorded(self):
+        """Each StopFailure is one tracker record — the threshold logic
+        (3-in-window) then lives in the tracker, covered by
+        test_auth_alerts.py. Here we pin that N posts → N records."""
+        client, calls = self._client_with_agent()
+        for _ in range(3):
+            client.post(
+                "/agents/dymok/transport/stop-failure",
+                json={"error_type": "authentication_failed"},
+            )
+        assert calls == [("dymok", "authentication_failed")] * 3
+
+
+# ── Observability ──────────────────────────────────────────────
+
+
+class TestStopFailureObservability:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._db = os.path.join(self._tmpdir, "test.db")
+
+    def test_failure_logged_to_activity(self):
+        app = _make_app(self._db)
+        with TestClient(app) as client:
+            client.post("/agents", json={"name": "pix", "model": "sonnet"})
+            client.post(
+                "/agents/pix/transport/stop-failure",
+                json={"error_type": "rate_limit"},
+            )
+            resp = client.get("/activity", params={"agent_name": "pix"})
+            assert resp.status_code == 200
+            types = [e["event_type"] for e in resp.json()["events"]]
+            assert "cc_stop_failure" in types
+
+
+# ── Hook installation ──────────────────────────────────────────
+
+
+class TestStopFailureHookInstall:
+    def test_setup_creates_stop_failure_script(self, tmp_path):
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        script = tmp_path / ".claude" / "hook_tmux_stop_failure.py"
+        assert script.exists()
+        src = script.read_text()
+        assert "transport/stop-failure" in src
+        assert "error_type" in src
+
+    def test_settings_wires_stop_failure_event(self, tmp_path):
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        settings = json.loads(
+            (tmp_path / ".claude" / "settings.json").read_text()
+        )
+        assert "StopFailure" in settings["hooks"]
+        cmds = [
+            h["command"]
+            for entry in settings["hooks"]["StopFailure"]
+            for h in entry["hooks"]
+        ]
+        assert any("hook_tmux_stop_failure.py" in c for c in cmds)
+
+    def test_merge_into_legacy_settings(self, tmp_path):
+        """An agent whose settings.json predates StopFailure gets the
+        bucket backfilled without nuking existing hooks."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        legacy = {
+            "hooks": {
+                "Stop": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "command", "command": "echo legacy"}],
+                    }
+                ]
+            }
+        }
+        (claude_dir / "settings.json").write_text(json.dumps(legacy))
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        merged = json.loads((claude_dir / "settings.json").read_text())
+        assert "StopFailure" in merged["hooks"]
+        cmds = [
+            h["command"]
+            for entry in merged["hooks"]["StopFailure"]
+            for h in entry["hooks"]
+        ]
+        assert any("hook_tmux_stop_failure.py" in c for c in cmds)
+        stop_cmds = [
+            h["command"]
+            for entry in merged["hooks"]["Stop"]
+            for h in entry["hooks"]
+        ]
+        assert any("echo legacy" in c for c in stop_cmds)
+
+    def test_setup_idempotent(self, tmp_path):
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        first = (tmp_path / ".claude" / "settings.json").read_text()
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        second = (tmp_path / ".claude" / "settings.json").read_text()
+        assert first == second

--- a/tests/test_stop_failure_hook.py
+++ b/tests/test_stop_failure_hook.py
@@ -173,6 +173,9 @@ class TestStopFailureHookInstall:
         src = script.read_text()
         assert "transport/stop-failure" in src
         assert "error_type" in src
+        # Reads CC's real ``error`` field — regression: the hook used to
+        # read only ``error_type``, which CC never sends.
+        assert 'payload_in.get("error")' in src
 
     def test_settings_wires_stop_failure_event(self, tmp_path):
         AgentRegistry._setup_hooks(tmp_path, "alpha")
@@ -225,3 +228,90 @@ class TestStopFailureHookInstall:
         AgentRegistry._setup_hooks(tmp_path, "alpha")
         second = (tmp_path / ".claude" / "settings.json").read_text()
         assert first == second
+
+
+# ── Hook payload contract (real Claude Code StopFailure schema) ──
+
+
+class TestStopFailureHookPayloadContract:
+    """Exercise the *generated hook source* against Claude Code's real
+    StopFailure payload. CC delivers the typed failure in the ``error``
+    field (NOT ``error_type``):
+    https://code.claude.com/docs/en/hooks#stopfailure-input
+
+    Regression for the silent no-op where the hook read ``error_type`` — a
+    field CC never sends — so every production StopFailure posted
+    ``unknown`` and auth failures never reached the tracker. The endpoint
+    tests above post ``error_type`` directly, so they never caught this;
+    these run the hook's actual stdin parse.
+    """
+
+    def _run_hook(self, payload: dict) -> dict:
+        """Run the generated hook source against ``payload`` on stdin,
+        intercepting urllib so nothing leaves the process. Returns the
+        decoded JSON body the hook would POST."""
+        import io
+        import sys
+        import urllib.request
+
+        from pinky_daemon.agent_registry import _tmux_stop_failure_hook_source
+
+        src = _tmux_stop_failure_hook_source("dymok")
+        captured: dict = {}
+
+        def _fake_urlopen(req, timeout=0):
+            captured["url"] = req.full_url
+            captured["body"] = json.loads(req.data.decode())
+            return None
+
+        real_stdin, real_urlopen = sys.stdin, urllib.request.urlopen
+        real_secret = os.environ.get("PINKY_SESSION_SECRET")
+        try:
+            sys.stdin = io.StringIO(json.dumps(payload))
+            urllib.request.urlopen = _fake_urlopen
+            os.environ["PINKY_SESSION_SECRET"] = "test-secret"
+            exec(
+                compile(src, "<stop_failure_hook>", "exec"),
+                {"__name__": "__main__"},
+            )
+        finally:
+            sys.stdin = real_stdin
+            urllib.request.urlopen = real_urlopen
+            if real_secret is None:
+                os.environ.pop("PINKY_SESSION_SECRET", None)
+            else:
+                os.environ["PINKY_SESSION_SECRET"] = real_secret
+        return captured
+
+    def test_cc_error_field_maps_to_error_type(self):
+        """The real CC payload carries the typed failure in ``error``."""
+        captured = self._run_hook(
+            {
+                "hook_event_name": "StopFailure",
+                "error": "authentication_failed",
+                "error_details": "401 Unauthorized",
+                "last_assistant_message": "API Error: authentication_failed",
+                "session_id": "abc123",
+            }
+        )
+        assert captured["url"].endswith("/agents/dymok/transport/stop-failure")
+        assert captured["body"]["error_type"] == "authentication_failed"
+        assert captured["body"]["session_id"] == "abc123"
+        # message prefers the rendered error text CC surfaces
+        assert captured["body"]["message"] == "API Error: authentication_failed"
+
+    def test_error_details_used_when_no_last_message(self):
+        captured = self._run_hook(
+            {"error": "rate_limit", "error_details": "429 Too Many Requests"}
+        )
+        assert captured["body"]["error_type"] == "rate_limit"
+        assert captured["body"]["message"] == "429 Too Many Requests"
+
+    def test_error_type_alias_still_honored(self):
+        """Defensive: internal callers/tests that post ``error_type`` work."""
+        captured = self._run_hook({"error_type": "billing_error"})
+        assert captured["body"]["error_type"] == "billing_error"
+
+    def test_no_typed_field_defaults_unknown(self):
+        captured = self._run_hook({"hook_event_name": "StopFailure"})
+        assert captured["body"]["error_type"] == "unknown"


### PR DESCRIPTION
## What

Wires Claude Code's **`StopFailure`** lifecycle hook so tmux/CLI agents surface typed turn-failures to the daemon — closing the gap where a dead auth token left an agent **silently dark**.

A new per-agent hook (`hook_tmux_stop_failure.py`, installed via the existing `.claude/settings.json` machinery) POSTs the typed `error_type` to a new endpoint `POST /agents/{name}/transport/stop-failure`, which:

1. **Logs every failure class** to activity (`cc_stop_failure`) for observability.
2. **Routes auth-class failures** (`authentication_failed`, `oauth_org_not_allowed`) into the **shared `AuthFailureTracker`** via the existing `_on_auth_failure` path — same threshold + cooldown + operator-resolution the SDK reader loop already uses.

## Why

Per tonight's CC+tmux research: the SDK reader loop already detects auth failures and alerts the operator, but **tmux/CLI sessions had no equivalent** — `StopFailure` is the structured signal that fills it. This is the exact failure class behind the past **Pi `credentials.json` outage** (agent went quiet, no alert). Now a dead token on *any* transport trips the same proactive operator DM.

## Design notes

- **Reuses, doesn't reinvent:** routes into the existing, well-tested `auth_alerts` infra (`test_auth_alerts.py` covers threshold/cooldown/host-wide). The endpoint's job is just classification + routing. `auth_tracker` is now exposed on `app.state` for that wiring + diagnostics.
- **Scope:** non-auth classes (`rate_limit`, `billing_error`, `server_error`) are **logged, not alerted** — billing/rate-limit alerting is a clean fast-follow rather than a second parallel alert mechanism.
- **Hook pattern:** mirrors the existing PinkyBot-managed hooks (HMAC-signed POST, `|| true` fire-and-forget, idempotent install + legacy-settings backfill). No-op when `PINKY_SESSION_SECRET` is unset.
- Confirmed via official docs that `StopFailure` + `error_type` (`authentication_failed`/`rate_limit`/`billing_error`/…) are native CC hook semantics.

## Changes
- `api_models.py`: `TransportStopFailureRequest`
- `api.py`: `_STOP_FAILURE_AUTH_TYPES`, expose `auth_tracker` on `app.state`, new endpoint
- `agent_registry.py`: `hook_tmux_stop_failure.py` source + `StopFailure` wiring (create + idempotent merge/backfill)
- `tests/test_stop_failure_hook.py`: 15 tests — routing, classification, observability, hook install

## Validation
- `ruff check` clean
- **384 tests green** locally (incl. `test_api`, `test_agent_status`, `test_admin_update`, `test_auth_alerts`, `test_effort_verification`, and the new suite)

🤖 Opened by Barsik