### PR TITLE
fix(tmux): StopFailure POST resolves in-flight turn (close turn-end gap) (#108)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -4494,11 +4494,35 @@ def create_api(
             except Exception as e:
                 _log(f"api: StopFailure auth routing failed for {name}: {e}")
 
+        # #108 — make the StopFailure POST the authoritative turn-end
+        # signal for tmux turns. A terminal API-error turn doesn't
+        # reliably emit a ``stop_hook_summary``, so without this the failed
+        # turn wedges at the head of the session's in-flight deque until
+        # the 10-min inflight watchdog force-restarts it. Look up the live
+        # session and duck-call ``handle_stop_failure`` AFTER the auth
+        # routing above (preserves #584). Only ``TmuxSession`` exposes it;
+        # SDK / Codex sessions detect turn-end in-band and don't. Fire-and-
+        # forget like the rest of this hook — never fail the model turn.
+        turn_resolved = False
+        session = broker.get_streaming_session(name, label=req.label)
+        if session is not None:
+            resolver = getattr(session, "handle_stop_failure", None)
+            if callable(resolver):
+                try:
+                    turn_resolved = bool(
+                        await resolver(error_type, req.message, req.session_id)
+                    )
+                except Exception as e:
+                    _log(
+                        f"api: StopFailure turn-resolve raised for {name}: {e}"
+                    )
+
         return {
             "ok": True,
             "agent": name,
             "error_type": error_type,
             "auth_failure": auth_failure,
+            "turn_resolved": turn_resolved,
         }
 
     @app.post("/agents/{name}/transport/transcript-path")

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2502,11 +2502,17 @@ class TmuxSession:
           ``response_callback`` so the waiting caller learns the turn
           ended. Internal-turn suppression (no conversation_store append,
           no response_callback) is honored by ``_handle_turn_complete``
-          unchanged. Then drain the tailer's in-progress buffer so partial
-          assistant / api-error text from the failed turn can't bleed into
-          the next real ``stop_hook_summary``; a late ``stop_hook_summary``
-          for the failed turn then finds an empty (or advanced) deque and
-          is a harmless no-op (no double callback).
+          unchanged. The tailer's in-progress buffer is drained FIRST — in
+          the same no-await span as the synchronous pop — so (a) partial
+          failed-turn text can't bleed into the next real
+          ``stop_hook_summary``, and (b) a late ``stop_hook_summary``
+          arriving while a queued turn (B) is the new head is absorbed
+          silently (empty buffer → the tailer's ``is_empty`` branch never
+          fires the callback) instead of falsely completing B. On the
+          single-inflight path a late stop hook likewise finds an empty
+          buffer / empty deque and is a harmless no-op (no double callback).
+          See the drain-ordering note at the call site for why
+          drain-after-await reopens the FIFO window.
 
         ``session_id`` is **log context only** — never a routing/match
         gate. A mismatch or empty value must NOT block unwedging the only
@@ -2532,23 +2538,35 @@ class TmuxSession:
             f"in-flight turn (deque depth={len(self._inflight_metas)}){sid_ctx}"
         )
 
-        # Synthesize a terminal turn payload and route it through the
-        # normal completion path. ``_handle_turn_complete`` reads
-        # ``response.text`` (not the tailer buffer), so the synthesized
-        # text is what reaches the caller — a human-legible failure note.
+        # Synthesize a terminal turn payload to route through the normal
+        # completion path. ``_handle_turn_complete`` reads ``response.text``
+        # (not the tailer buffer), so the synthesized text is what reaches
+        # the caller — a human-legible failure note.
         synthesized = TurnResponse(
             text=message or f"Claude Code turn failed: {error_type}",
             stop_reason=f"stop_failure:{error_type}",
             usage={},
         )
-        await self._handle_turn_complete(synthesized)
 
-        # Drain the tailer's in-progress turn buffer so partial assistant /
-        # api-error text from the now-resolved failed turn can't merge into
-        # the next real ``stop_hook_summary``. Mirrors the drain discipline
-        # in ``_stop_tailer`` / ``set_transcript_path``. Guarded: the tailer
-        # may be absent in unit tests or before the first spawn. Best-effort
-        # — a drain hiccup must not undo the resolve we just did.
+        # Drain the tailer's in-progress turn buffer BEFORE resolving — in
+        # the same no-await span as the synchronous deque pop at the top of
+        # ``_handle_turn_complete`` (no event-loop yield occurs between this
+        # drain and that pop). This ordering is load-bearing for the FIFO
+        # case (Murzik review, PR #585): when A fails while B is queued
+        # behind it, ``_handle_turn_complete`` pops A synchronously but then
+        # awaits its stream/context/response_callback chain while B is the
+        # NEW head. If the failed turn's partial assistant text were still
+        # buffered, a late ``stop_hook_summary`` read by the tailer DURING
+        # those awaits would fire ``_handle_turn_complete`` again and falsely
+        # pop/complete B — the tailer fires its callback only when the buffer
+        # is non-empty (``_read_and_dispatch``: ``closes_turn and not
+        # is_empty``); an empty buffer takes the silent ``is_empty`` drain
+        # branch and never fires. Draining first guarantees that late stop
+        # hook finds an empty buffer and is absorbed silently, so B stays in
+        # flight. Draining AFTER the await reopens exactly this window.
+        # Guarded + best-effort: a drain hiccup must not block the resolve.
+        # Mirrors the drain discipline in ``_stop_tailer`` /
+        # ``set_transcript_path``.
         if self._tailer is not None:
             try:
                 self._tailer.drain_buffer()
@@ -2557,6 +2575,8 @@ class TmuxSession:
                     f"tmux[{self.agent_name}]: StopFailure drain_buffer "
                     f"raised: {e}"
                 )
+
+        await self._handle_turn_complete(synthesized)
         return True
 
     async def _start_tailer(self) -> None:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2460,6 +2460,105 @@ class TmuxSession:
         self._current_thinking = ""
         self._activity_log = []
 
+    async def handle_stop_failure(
+        self,
+        error_type: str,
+        message: str = "",
+        session_id: str = "",
+    ) -> bool:
+        """Resolve the in-flight turn when Claude Code reports a StopFailure.
+
+        Issue #108 — close the turn-end-detection gap. The transcript
+        tailer detects turn-end ONLY via ``system/stop_hook_summary``
+        entries, which terminal API-error / StopFailure turns don't
+        reliably emit. Without this, a failed turn wedges at the HEAD of
+        ``_inflight_metas`` until the 10-minute ``_inflight_watchdog``
+        force-restarts the session — the caller's ``completion_event``
+        never fires, the chat gets no reply, and the deque ages for the
+        full timeout.
+
+        The ``StopFailure`` hook (#584) already POSTs a typed, explicitly
+        terminal signal; this makes that POST the authoritative turn-end
+        marker for failed turns (avoids the ``type==user``/``tool_result``
+        ambiguity a transcript-scan heuristic would hit). Called by the
+        ``/transport/stop-failure`` endpoint AFTER its existing logging +
+        auth-alert routing, so #584's behavior is fully preserved.
+
+        Behavior:
+
+        - **Empty ``_inflight_metas``** → idempotent no-op. The turn
+          already resolved (a real ``stop_hook_summary`` landed first, or
+          a prior StopFailure POST cleared it). Log + return ``False``.
+          Deliberately does NOT drain or synthesize: there is no in-flight
+          turn to fail, and draining here could discard a legitimately
+          accumulating *next* turn's partial buffer.
+        - **Non-empty** → synthesize a ``TurnResponse`` carrying
+          ``stop_reason="stop_failure:<error_type>"`` and feed it through
+          ``_handle_turn_complete``. That reuses the full FIFO machinery:
+          popleft the oldest meta, fire its ``completion_event``, advance
+          ``_head_started_at`` so the next entry (FIFO advance: A fails →
+          B becomes head) gets its own fresh timeout window, set the
+          back-compat ``_turn_done``, and — for external turns — fire
+          ``response_callback`` so the waiting caller learns the turn
+          ended. Internal-turn suppression (no conversation_store append,
+          no response_callback) is honored by ``_handle_turn_complete``
+          unchanged. Then drain the tailer's in-progress buffer so partial
+          assistant / api-error text from the failed turn can't bleed into
+          the next real ``stop_hook_summary``; a late ``stop_hook_summary``
+          for the failed turn then finds an empty (or advanced) deque and
+          is a harmless no-op (no double callback).
+
+        ``session_id`` is **log context only** — never a routing/match
+        gate. A mismatch or empty value must NOT block unwedging the only
+        live in-flight turn: the hook's ``session_id`` and the tailer's
+        notion of the current turn can legitimately differ across a
+        ``--continue`` resume.
+
+        Returns ``True`` if an in-flight turn was resolved, ``False`` on
+        the idempotent empty-deque path.
+        """
+        error_type = (error_type or "unknown").strip() or "unknown"
+        sid_ctx = f" [session_id={session_id}]" if session_id else ""
+
+        if not self._inflight_metas:
+            _log(
+                f"tmux[{self.agent_name}]: StopFailure ({error_type}) with no "
+                f"in-flight turn — idempotent no-op{sid_ctx}"
+            )
+            return False
+
+        _log(
+            f"tmux[{self.agent_name}]: StopFailure ({error_type}) resolving "
+            f"in-flight turn (deque depth={len(self._inflight_metas)}){sid_ctx}"
+        )
+
+        # Synthesize a terminal turn payload and route it through the
+        # normal completion path. ``_handle_turn_complete`` reads
+        # ``response.text`` (not the tailer buffer), so the synthesized
+        # text is what reaches the caller — a human-legible failure note.
+        synthesized = TurnResponse(
+            text=message or f"Claude Code turn failed: {error_type}",
+            stop_reason=f"stop_failure:{error_type}",
+            usage={},
+        )
+        await self._handle_turn_complete(synthesized)
+
+        # Drain the tailer's in-progress turn buffer so partial assistant /
+        # api-error text from the now-resolved failed turn can't merge into
+        # the next real ``stop_hook_summary``. Mirrors the drain discipline
+        # in ``_stop_tailer`` / ``set_transcript_path``. Guarded: the tailer
+        # may be absent in unit tests or before the first spawn. Best-effort
+        # — a drain hiccup must not undo the resolve we just did.
+        if self._tailer is not None:
+            try:
+                self._tailer.drain_buffer()
+            except Exception as e:
+                _log(
+                    f"tmux[{self.agent_name}]: StopFailure drain_buffer "
+                    f"raised: {e}"
+                )
+        return True
+
     async def _start_tailer(self) -> None:
         """Construct (if needed) + start the transcript tailer, then arm
         the per-spawn first-bind state.

--- a/tests/test_stop_failure_hook.py
+++ b/tests/test_stop_failure_hook.py
@@ -315,3 +315,129 @@ class TestStopFailureHookPayloadContract:
     def test_no_typed_field_defaults_unknown(self):
         captured = self._run_hook({"hook_event_name": "StopFailure"})
         assert captured["body"]["error_type"] == "unknown"
+
+
+# ── In-flight turn resolution (#108) ───────────────────────────
+
+
+class _FakeTmuxSession:
+    """Minimal stand-in exposing ``handle_stop_failure`` so the endpoint's
+    duck-typed resolve path can be exercised without a real tmux REPL."""
+
+    def __init__(self, resolved: bool = True):
+        self.calls: list[tuple[str, str, str]] = []
+        self._resolved = resolved
+
+    async def handle_stop_failure(
+        self, error_type: str, message: str = "", session_id: str = "",
+    ) -> bool:
+        self.calls.append((error_type, message, session_id))
+        return self._resolved
+
+
+class TestStopFailureTurnResolve:
+    """#108 — the endpoint duck-calls ``TmuxSession.handle_stop_failure``
+    AFTER its #584 logging + auth routing, so a StopFailure-ended tmux turn
+    is unwedged immediately instead of aging out the 10-min inflight
+    watchdog. Sessions without the method (SDK/Codex) and absent sessions
+    degrade to ``turn_resolved=False`` without failing the hook.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._db = os.path.join(self._tmpdir, "test.db")
+
+    def _client(self, name: str = "dymok"):
+        app = _make_app(self._db)
+        client = TestClient(app)
+        r = client.post("/agents", json={"name": name, "model": "sonnet"})
+        assert r.status_code == 200
+        calls: list[tuple[str, str]] = []
+
+        def _spy(agent_name, error=""):
+            calls.append((agent_name, error))
+            return {
+                "should_alert": False,
+                "reason": "below_threshold",
+                "count": len(calls),
+                "agents_failing": 1,
+            }
+
+        app.state.auth_tracker.record_failure = _spy
+        return client, app, calls
+
+    def test_no_live_session_resolves_false(self):
+        """No registered session → turn_resolved False, no crash."""
+        client, _app, _calls = self._client()
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={"error_type": "rate_limit"},
+        )
+        assert r.status_code == 200
+        assert r.json()["turn_resolved"] is False
+
+    def test_resolves_inflight_via_live_session(self):
+        """A live tmux session gets handle_stop_failure called with the
+        forwarded error_type / message / session_id."""
+        client, app, _calls = self._client()
+        fake = _FakeTmuxSession(resolved=True)
+        app.state.broker._streaming["dymok"] = {"main": fake}
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={
+                "error_type": "rate_limit",
+                "message": "429 Too Many Requests",
+                "session_id": "s1",
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["turn_resolved"] is True
+        assert fake.calls == [("rate_limit", "429 Too Many Requests", "s1")]
+
+    def test_auth_routing_preserved_alongside_resolve(self):
+        """#584 auth alert AND #108 turn resolve both fire for an
+        auth-class failure — the resolve is additive, not a replacement."""
+        client, app, calls = self._client()
+        fake = _FakeTmuxSession(resolved=True)
+        app.state.broker._streaming["dymok"] = {"main": fake}
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={"error_type": "authentication_failed"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["auth_failure"] is True
+        assert body["turn_resolved"] is True
+        # #584 path intact.
+        assert calls == [("dymok", "authentication_failed")]
+        # #108 path also ran.
+        assert fake.calls and fake.calls[0][0] == "authentication_failed"
+
+    def test_session_without_method_degrades(self):
+        """An SDK/Codex session lacking handle_stop_failure → turn_resolved
+        False, hook still 200 (duck-typed, tolerated absence)."""
+        client, app, _calls = self._client()
+        app.state.broker._streaming["dymok"] = {"main": object()}
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={"error_type": "rate_limit"},
+        )
+        assert r.status_code == 200
+        assert r.json()["turn_resolved"] is False
+
+    def test_resolver_exception_does_not_fail_hook(self):
+        """A raising handle_stop_failure is swallowed — fire-and-forget; the
+        hook must never fail the model turn."""
+        client, app, _calls = self._client()
+
+        class _Boom:
+            async def handle_stop_failure(self, *a, **k):
+                raise RuntimeError("boom")
+
+        app.state.broker._streaming["dymok"] = {"main": _Boom()}
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={"error_type": "rate_limit"},
+        )
+        assert r.status_code == 200
+        assert r.json()["turn_resolved"] is False

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -5701,3 +5701,214 @@ class TestInflightDequeConcurrentDispatch:
             "appending behind an existing head must not reset the head "
             "clock — the original head is what the watchdog ages"
         )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #108 — StopFailure POST resolves the in-flight turn (turn-end-detection gap)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestHandleStopFailure:
+    """``TmuxSession.handle_stop_failure`` — make the #584 StopFailure POST
+    the authoritative turn-end signal so a terminal API-error turn doesn't
+    wedge at the deque head until the 10-min inflight watchdog.
+
+    Test matrix (Murzik, #108): external inflight, internal inflight,
+    no-inflight idempotence, FIFO advance (A fails → B becomes head),
+    late stop_hook_summary → no double callback, buffer drain, session_id
+    is log-only.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resolves_external_inflight(self) -> None:
+        """External in-flight turn → response_callback fires with a
+        ``stop_failure:<type>`` stop_reason and the deque drains."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        _seed_inflight(
+            ss,
+            meta={"platform": "telegram", "chat_id": "123", "message_id": "m1"},
+        )
+
+        resolved = await ss.handle_stop_failure("rate_limit")
+
+        assert resolved is True
+        assert len(cb.calls) == 1
+        result = cb.calls[0]
+        assert result.stop_reason == "stop_failure:rate_limit"
+        assert result.chat_id == "123"
+        assert result.message_id == "m1"
+        # Default human-legible failure note when CC sent no message.
+        assert result.response_text == "Claude Code turn failed: rate_limit"
+        # Turn fully resolved — deque empty, back-compat signal set.
+        assert len(ss._inflight_metas) == 0
+        assert ss._head_started_at is None
+        assert ss._turn_done.is_set()
+
+    @pytest.mark.asyncio
+    async def test_uses_cc_message_as_text_when_provided(self) -> None:
+        """CC's rendered error text (``message``) is surfaced verbatim
+        when present, instead of the synthesized fallback."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        _seed_inflight(ss, meta={"chat_id": "c"})
+
+        await ss.handle_stop_failure(
+            "authentication_failed", "API Error: 401 Unauthorized"
+        )
+
+        assert cb.calls[0].response_text == "API Error: 401 Unauthorized"
+        assert cb.calls[0].stop_reason == "stop_failure:authentication_failed"
+
+    @pytest.mark.asyncio
+    async def test_resolves_internal_inflight_suppresses_callback(self) -> None:
+        """Internal in-flight turn → completion_event fires + deque drains,
+        but response_callback is suppressed (no external recipient)."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        ev = asyncio.Event()
+        _seed_inflight(ss, internal=True, completion_event=ev)
+
+        resolved = await ss.handle_stop_failure("server_error")
+
+        assert resolved is True
+        # Internal turn: no broker callback (its routing meta is empty).
+        assert cb.calls == []
+        # But the waiter is released and the deque drained.
+        assert ev.is_set()
+        assert len(ss._inflight_metas) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_inflight_is_idempotent_noop(self) -> None:
+        """Empty deque → idempotent no-op: return False, fire nothing.
+        Covers the double-POST / already-resolved race."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        assert len(ss._inflight_metas) == 0
+
+        resolved = await ss.handle_stop_failure("rate_limit")
+
+        assert resolved is False
+        assert cb.calls == []
+
+    @pytest.mark.asyncio
+    async def test_fifo_advance_a_fails_b_becomes_head(self) -> None:
+        """A (head) + B in flight; A's StopFailure pops A and B inherits
+        the head with a fresh timeout window. Only A is resolved."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        _seed_inflight(ss, meta={"chat_id": "A", "message_id": "ma"})
+        head_at_before = ss._head_started_at
+        _seed_inflight(ss, meta={"chat_id": "B", "message_id": "mb"})
+        await asyncio.sleep(0.01)
+
+        resolved = await ss.handle_stop_failure("rate_limit")
+
+        assert resolved is True
+        # Exactly A resolved through the callback.
+        assert len(cb.calls) == 1
+        assert cb.calls[0].chat_id == "A"
+        # B is now the head, deque depth 1.
+        assert len(ss._inflight_metas) == 1
+        assert ss._inflight_metas[0].meta["chat_id"] == "B"
+        # Head clock advanced to B's window (fresh, not A's original).
+        assert ss._head_started_at is not None
+        assert ss._head_started_at > head_at_before
+
+    @pytest.mark.asyncio
+    async def test_late_stop_hook_summary_no_double_callback(self) -> None:
+        """After StopFailure resolves the only in-flight turn, a late
+        ``stop_hook_summary`` for that turn finds an empty deque and is a
+        harmless no-op — no second callback (#496 Case-1 defense reused)."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        _seed_inflight(ss, meta={"chat_id": "c", "message_id": "m1"})
+
+        await ss.handle_stop_failure("rate_limit")
+        assert len(cb.calls) == 1
+
+        # Late stop_hook_summary lands for the already-resolved turn.
+        await ss._handle_turn_complete(
+            TurnResponse(text="late straggler", stop_reason="end_turn")
+        )
+
+        # Still exactly one callback — the stop_failure resolve. The late
+        # hook hit the empty-on-pop defense and bailed.
+        assert len(cb.calls) == 1
+        assert cb.calls[0].stop_reason == "stop_failure:rate_limit"
+
+    @pytest.mark.asyncio
+    async def test_drains_tailer_buffer_on_resolve(self) -> None:
+        """The tailer's in-progress buffer is drained so partial failed-turn
+        text can't bleed into the next real stop_hook_summary."""
+        ss, _ = _make_session_with_response_cb()
+        ss._state_machine._state = SessionState.CONNECTED
+        ss._tailer = MagicMock()
+        _seed_inflight(ss, meta={"chat_id": "c"})
+
+        await ss.handle_stop_failure("rate_limit")
+
+        ss._tailer.drain_buffer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_deque_does_not_drain(self) -> None:
+        """The idempotent empty-deque path must NOT drain — there's no
+        failed turn, and draining could discard an accumulating next turn."""
+        ss, _ = _make_session_with_response_cb()
+        ss._state_machine._state = SessionState.CONNECTED
+        ss._tailer = MagicMock()
+
+        resolved = await ss.handle_stop_failure("rate_limit")
+
+        assert resolved is False
+        ss._tailer.drain_buffer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_tailer_does_not_crash(self) -> None:
+        """Resolve still works when no tailer is attached (pre-spawn / unit
+        seams) — the drain is guarded."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        assert ss._tailer is None
+        _seed_inflight(ss, meta={"chat_id": "c"})
+
+        resolved = await ss.handle_stop_failure("rate_limit")
+
+        assert resolved is True
+        assert len(cb.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_session_id_is_log_context_not_a_gate(self) -> None:
+        """A mismatched / foreign session_id must NOT block unwedging the
+        only live in-flight turn — it's log context only."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        _seed_inflight(ss, meta={"chat_id": "c", "message_id": "m1"})
+
+        resolved = await ss.handle_stop_failure(
+            "rate_limit", "", session_id="some-other-session-uuid"
+        )
+
+        assert resolved is True
+        assert len(cb.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_blank_error_type_defaults_unknown(self) -> None:
+        """A blank/whitespace error_type normalizes to ``unknown`` in the
+        stop_reason."""
+        cb = _AsyncCollector()
+        ss, _ = _make_session_with_response_cb(response_cb=cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        _seed_inflight(ss, meta={"chat_id": "c"})
+
+        await ss.handle_stop_failure("   ")
+
+        assert cb.calls[0].stop_reason == "stop_failure:unknown"

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -31,7 +31,7 @@ from pinky_daemon.tmux_session import (
     _QueuedTurn,
     _TmuxControl,
 )
-from pinky_daemon.tmux_transcript import TurnResponse
+from pinky_daemon.tmux_transcript import TmuxTranscriptTailer, TurnResponse
 from pinky_daemon.transport_state import SessionState, TransitionResult, Trigger
 
 
@@ -5912,3 +5912,117 @@ class TestHandleStopFailure:
         await ss.handle_stop_failure("   ")
 
         assert cb.calls[0].stop_reason == "stop_failure:unknown"
+
+    @pytest.mark.asyncio
+    async def test_late_a_stop_hook_does_not_false_complete_b(
+        self, tmp_path
+    ) -> None:
+        """FIFO false-completion regression (Murzik, PR #585).
+
+        A + B in flight. A's StopFailure resolves A, and A's late
+        ``stop_hook_summary`` lands WHILE B is the new head — during the
+        very await window inside ``_handle_turn_complete`` (the buffer
+        drain must therefore run BEFORE that method's first await, in the
+        same no-await span as the synchronous pop).
+
+        The race is reproduced deterministically by driving the late tailer
+        read from inside the response_callback — which IS one of
+        ``_handle_turn_complete``'s awaited steps, i.e. exactly the
+        interleaving point. With the drain ordered correctly the late stop
+        hook reads an empty buffer and is absorbed by the tailer's
+        ``is_empty`` branch (no callback); B stays in flight. With the
+        buggy drain-after-await ordering, the late stop hook reads A's
+        stale buffered text and falsely pops/completes B.
+        """
+        transcript = tmp_path / "synthetic.jsonl"
+        transcript.write_text("")
+
+        # A's content WITHOUT a stop_hook yet — accumulates in the buffer.
+        a_entries = [
+            {
+                "type": "user",
+                "timestamp": "2026-05-14T05:00:00.000Z",
+                "message": {"role": "user", "content": "hi"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-05-14T05:00:00.100Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "partial A work"}],
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 5, "output_tokens": 3},
+                },
+            },
+        ]
+        a_text = "\n".join(_json.dumps(e) for e in a_entries) + "\n"
+        late_stop_hook = (
+            _json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "stop_hook_summary",
+                    "timestamp": "2026-05-14T05:00:01.000Z",
+                }
+            )
+            + "\n"
+        )
+
+        calls: list[TurnResponse] = []
+        fired = {"done": False}
+
+        async def _cb(response):
+            calls.append(response)
+            # On A's resolve callback (which runs DURING
+            # _handle_turn_complete's await chain), simulate A's late
+            # stop_hook_summary landing while B is the head.
+            if not fired["done"]:
+                fired["done"] = True
+                transcript.write_text(a_text + late_stop_hook)
+                await ss._tailer.read_once()
+
+        ss, _ = _make_session_with_response_cb(response_cb=_cb)
+        ss._state_machine._state = SessionState.CONNECTED
+        # Real tailer wired to this session — but DON'T start its background
+        # loop; drive reads manually via read_once() for determinism.
+        ss._tailer = TmuxTranscriptTailer(
+            transcript_path=transcript,
+            on_turn_complete=ss._handle_turn_complete,
+            agent_name=ss.agent_name,
+        )
+        ss._tailer.set_offset(0)
+
+        # Pre-read A's assistant content into the buffer (no stop_hook → no
+        # fire), so the buggy drain-after path would still see A's stale
+        # text when the late stop_hook is read.
+        transcript.write_text(a_text)
+        await ss._tailer.read_once()
+        assert not ss._tailer._buffer.is_empty
+        assert calls == []  # nothing fired yet — no stop_hook seen
+
+        # Seed A (head) + B; B carries a completion_event to prove it is
+        # NOT falsely released by the late A stop hook.
+        b_event = asyncio.Event()
+        _seed_inflight(
+            ss, meta={"platform": "telegram", "chat_id": "A", "message_id": "ma"}
+        )
+        _seed_inflight(
+            ss,
+            meta={"platform": "telegram", "chat_id": "B", "message_id": "mb"},
+            completion_event=b_event,
+        )
+
+        resolved = await ss.handle_stop_failure("rate_limit")
+
+        assert resolved is True
+        # Exactly ONE callback — A's resolve. B must NOT have been completed
+        # by the late A stop hook.
+        assert len(calls) == 1, (
+            "late A stop_hook falsely fired a second completion — drain must "
+            "run before _handle_turn_complete's awaits"
+        )
+        assert calls[0].chat_id == "A"
+        assert calls[0].stop_reason == "stop_failure:rate_limit"
+        # B still in flight, waiter still waiting.
+        assert len(ss._inflight_metas) == 1
+        assert ss._inflight_metas[0].meta["chat_id"] == "B"
+        assert not b_event.is_set()


### PR DESCRIPTION
## What & why

Follow-up to the #107 tmux watchdog audit (Barsik + Murzik consensus). The tmux transcript tailer detects turn-end **only** via `system/stop_hook_summary` entries, which terminal API-error / `StopFailure` turns don't reliably emit. Without a turn-end signal, a failed turn **wedges at the head of `_inflight_metas` until the 10-minute `_inflight_watchdog`** force-restarts the session — meanwhile the caller's `completion_event` never fires, the chat gets no reply, and the deque ages for the full timeout.

This makes the #584 `StopFailure` POST the **authoritative turn-end signal** for failed turns. It's typed by Claude Code and explicitly terminal, so it sidesteps the `type==user` / `tool_result` ambiguity a transcript-scan heuristic would hit.

## Changes

**`TmuxSession.handle_stop_failure(error_type, message, session_id="")`**
- **Empty `_inflight_metas`** → idempotent no-op: log + return `False`. No drain, no synthesize (covers double-POST / already-resolved race; avoids discarding a legitimately-accumulating next turn).
- **Non-empty** → synthesize `TurnResponse(text=message or "Claude Code turn failed: <type>", stop_reason="stop_failure:<type>", usage={})` and feed it through the existing `_handle_turn_complete`, reusing the full FIFO machinery: popleft oldest meta, fire its `completion_event`, advance `_head_started_at` (FIFO advance — A fails → B inherits head with a fresh timeout window), set `_turn_done`, fire `response_callback` for external turns. Internal-turn suppression honored unchanged.
- Then **drain the tailer buffer** so partial assistant / api-error text from the failed turn can't bleed into the next real `stop_hook_summary`; a late `stop_hook_summary` finds an empty/advanced deque and is a harmless no-op (no double callback). Guarded — tolerates an absent tailer.
- `session_id` is **log context only**, never a routing/match gate — a mismatch must not block unwedging the only live in-flight turn.

**Endpoint** `POST /agents/{name}/transport/stop-failure`
- Duck-calls `handle_stop_failure` **after** the existing logging + auth-alert routing, so #584 behavior is fully preserved. Only `TmuxSession` exposes the method; SDK / Codex sessions detect turn-end in-band and degrade to `turn_resolved=False`. Fire-and-forget — a raising resolver is swallowed so the hook never fails the model turn. Adds `turn_resolved` to the response for observability.

## Tests (Murzik's agreed matrix)

`TestHandleStopFailure` (unit) + `TestStopFailureTurnResolve` (endpoint):
- external inflight, internal inflight (callback suppressed, waiter released)
- no-inflight idempotence; empty deque does **not** drain
- FIFO advance (A fails → B becomes head, fresh head clock)
- late `stop_hook_summary` → no double callback
- buffer drain on resolve; missing-tailer doesn't crash
- `session_id` is log-only (mismatch still resolves)
- blank `error_type` → `stop_failure:unknown`
- endpoint: no-session false, live-session resolve, **auth routing preserved alongside resolve**, SDK/Codex degrade, raising resolver swallowed

Full local run: `test_tmux_session.py` + `test_tmux_transcript.py` (235) + `test_stop_failure_hook.py` + `test_auth_alerts.py` (28) green; ruff clean.

@murzik — review please, this is the shape we agreed on #108. Holding for Brad sign-off before merge.

🤖 Opened by Barsik