### PR TITLE
fix(watchdog): transition-age watchdog for stuck RECONNECTING sessions (#109)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7493,19 +7493,9 @@ def create_api(
         agent = agents.get(agent_name)
         if not agent:
             return WatchdogConfig()
-        raw = agent.watchdog_config or {}
-        if not raw:
-            return WatchdogConfig()
-        return WatchdogConfig(
-            enabled=raw.get("enabled", True),
-            mode=raw.get("mode", WatchdogConfig.mode),
-            warn_after_seconds=raw.get("warn_after_seconds", WatchdogConfig.warn_after_seconds),
-            recover_after_seconds=raw.get(
-                "recover_after_seconds", WatchdogConfig.recover_after_seconds
-            ),
-            require_backlog=raw.get("require_backlog", True),
-            min_pending=raw.get("min_pending", 1),
-        )
+        # Single-source merge (incl. the #109 transition-* thresholds) so new
+        # fields can't be silently dropped here.
+        return WatchdogConfig.from_raw(agent.watchdog_config)
 
     async def _watchdog_recover(agent_name: str, label: str, reason: str) -> None:
         """Recovery callback: stop + reconnect a single stuck streaming session."""

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -1101,6 +1101,11 @@ class CodexSession:
         return {
             **self._stats,
             "connected": self._connected,
+            # Consistency with tmux/streaming stats (#109). Codex only ever
+            # reports CONNECTED/IDLE_SLEEPING/UNINITIALIZED/DEAD — it never
+            # models BOOTING/RECONNECTING — so it's naturally excluded from
+            # the lifecycle transition-age watchdog.
+            "state": self.state.value,
             "idle_sleeping": self._idle_sleeping,
             "processing": self._processing,
             "pending_messages": self._message_queue.qsize(),

--- a/src/pinky_daemon/session_watchdog.py
+++ b/src/pinky_daemon/session_watchdog.py
@@ -18,8 +18,20 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine
 
+from pinky_daemon.transport_state import SessionState
+
 _log = logging.getLogger("pinky.watchdog").info
 _warn = logging.getLogger("pinky.watchdog").warning
+
+# Lifecycle states a session passes THROUGH on its way to CONNECTED. If a
+# session sits in one of these past a bound it's wedged (#109) — the normal
+# progress logic can't see it (it bails on ``not connected``) and the
+# per-session ``_inflight_watchdog`` is CONNECTED-only. CONNECTED is watched
+# by the progress logic; IDLE_SLEEPING (intentional rest) and DEAD (its own
+# resurrection path) are deliberately excluded.
+_TRANSITION_STATES = frozenset(
+    {SessionState.BOOTING.value, SessionState.RECONNECTING.value}
+)
 
 # ── Defaults ────────────────────────────────────────────────────────
 
@@ -27,6 +39,11 @@ DEFAULT_CHECK_INTERVAL = 60  # seconds between watchdog sweeps
 DEFAULT_WARN_AFTER = 600  # 10 min — notify owner
 DEFAULT_RECOVER_AFTER = 900  # 15 min — auto-recover
 DEFAULT_MODE = "recover"  # "alert" = warn only, "recover" = warn + auto-fix
+# Lifecycle transition-age bounds (#109) — for sessions stuck in
+# BOOTING/RECONNECTING. Kept above the reconnect-retry worst case (~220s)
+# so a legitimately slow transition isn't force-recovered mid-retry.
+DEFAULT_TRANSITION_WARN_AFTER = 240  # 4 min stuck in a transition — notify
+DEFAULT_TRANSITION_RECOVER_AFTER = 360  # 6 min — hard-recover
 
 
 @dataclass
@@ -39,6 +56,14 @@ class WatchdogConfig:
     recover_after_seconds: int = DEFAULT_RECOVER_AFTER
     require_backlog: bool = True  # only flag if pending queue > 0
     min_pending: int = 1
+    # Lifecycle transition-age thresholds (#109). A session stuck in
+    # BOOTING/RECONNECTING is a different failure class from a connected-
+    # but-stalled session, so it gets its own bounds. Defaults sit above the
+    # designed reconnect-retry envelope (worst case ~220s across spawn
+    # attempts) so the watchdog never races a legitimate-but-slow transition,
+    # while still recovering far faster than the 10-15min progress bounds.
+    transition_warn_after_seconds: int = DEFAULT_TRANSITION_WARN_AFTER
+    transition_recover_after_seconds: int = DEFAULT_TRANSITION_RECOVER_AFTER
 
 
 @dataclass
@@ -52,6 +77,7 @@ class _SessionSnapshot:
     pending: int
     current_activity: str
     sample_time: float
+    state: str = ""  # lifecycle state value (e.g. "booting"); "" if unknown
 
 
 @dataclass
@@ -63,6 +89,15 @@ class _AgentState:
     last_progress_at: float = field(default_factory=time.time)
     warned: bool = False
     recovered_at: float = 0.0  # grace period after recovery
+    # Lifecycle transition-age tracking (#109). Kept separate from the
+    # progress fields above — different failure class, different reset rules.
+    # ``transition_since`` is sampling-based: it starts when a sweep first
+    # observes the current transition state and resets when that state
+    # changes (e.g. BOOTING → RECONNECTING).
+    transition_state: str = ""  # "" when not in a tracked transition
+    transition_since: float = 0.0
+    transition_warned: bool = False
+    transition_recovered_at: float = 0.0  # grace period after transition recovery
 
 
 class SessionWatchdog:
@@ -164,14 +199,24 @@ class SessionWatchdog:
         self, agent_name: str, label: str, ss: Any
     ) -> _SessionSnapshot:
         stats = ss.stats if hasattr(ss, "stats") else {}
+        state = stats.get("state", "")
+        # Derive ``connected`` when the session doesn't expose it directly.
+        # tmux ``stats`` exposes ``state`` but not ``connected``, so without
+        # this the progress watchdog treated every tmux session as
+        # permanently disconnected (and never flagged stalls). Codex/streaming
+        # expose ``connected`` directly and keep their own value.
+        connected = stats.get("connected")
+        if connected is None:
+            connected = state == SessionState.CONNECTED.value
         return _SessionSnapshot(
             agent_name=agent_name,
             label=label,
-            connected=stats.get("connected", False),
+            connected=bool(connected),
             turns=stats.get("turns", 0),
             pending=(stats.get("pending_responses", 0) or stats.get("pending_messages", 0)),
             current_activity=stats.get("current_activity", ""),
             sample_time=time.time(),
+            state=state,
         )
 
     async def _evaluate(self, snap: _SessionSnapshot, now: float) -> None:
@@ -185,6 +230,22 @@ class SessionWatchdog:
             last_progress_activity=snap.current_activity,
             last_progress_at=now,
         ))
+
+        # ── Lifecycle transition-age branch (#109) ──────────────────
+        # Handled BEFORE the progress/backlog logic: a session wedged in
+        # BOOTING/RECONNECTING reports connected=False and would be dropped
+        # by the ``not snap.connected`` guard below, and the per-session
+        # _inflight_watchdog is CONNECTED-only — so nothing else ages it.
+        if snap.state in _TRANSITION_STATES:
+            await self._evaluate_transition(snap, state, cfg, now)
+            return
+        # Exited any transition (now connected/idle/dead/uninitialized) —
+        # clear lifecycle tracking before the normal progress logic runs.
+        if state.transition_state:
+            state.transition_state = ""
+            state.transition_since = 0.0
+            state.transition_warned = False
+            state.transition_recovered_at = 0.0
 
         # Detect progress: turn count increased or activity changed
         made_progress = (
@@ -259,6 +320,98 @@ class SessionWatchdog:
                         snap.agent_name, exc,
                     )
 
+    async def _evaluate_transition(
+        self, snap: _SessionSnapshot, state: _AgentState,
+        cfg: WatchdogConfig, now: float,
+    ) -> None:
+        """Warn / hard-recover a session stuck in a BOOTING/RECONNECTING transition.
+
+        Separate failure class from the progress watchdog: the session never
+        completes its lifecycle transition (vs. a CONNECTED session making no
+        progress). Recovery deliberately goes through the generic
+        ``_recover_fn`` (disconnect → clear persisted id → unregister → fresh
+        ``_ensure_streaming_session``), which abandons the wedged state-machine
+        owner. It does NOT call ``force_restart`` — that primitive starts by
+        requesting RECONNECTING, the wrong edge from BOOTING and a no-op/reject
+        from RECONNECTING, i.e. it would try to drive another edge through the
+        already-wedged owner.
+
+        Age is sampling-based: it starts when a sweep first observes the
+        current transition state and resets if that state changes
+        (BOOTING → RECONNECTING counts as a fresh transition). Backlog is NOT
+        required — a session stuck BOOTING can't receive anything regardless of
+        queue depth.
+        """
+        # (Re)start the sampled timer on first observation of this transition
+        # state, or when it changed since the last sweep. No age has accrued
+        # yet, so don't warn/recover on the same sweep.
+        if state.transition_state != snap.state:
+            state.transition_state = snap.state
+            state.transition_since = now
+            state.transition_warned = False
+            return
+
+        age = now - state.transition_since
+
+        # Grace window after a recovery so we don't immediately re-fire on the
+        # fresh session's own (legitimate) BOOTING.
+        if (
+            state.transition_recovered_at
+            and (now - state.transition_recovered_at)
+            < cfg.transition_warn_after_seconds
+        ):
+            return
+
+        # Warn tier
+        if (
+            not state.transition_warned
+            and age >= cfg.transition_warn_after_seconds
+        ):
+            state.transition_warned = True
+            msg = (
+                f"⚠️ {snap.agent_name} stuck in '{snap.state}' for "
+                f"{int(age // 60)}min — lifecycle transition not completing."
+            )
+            _warn(msg)
+            if self._alert_fn:
+                try:
+                    await self._alert_fn(snap.agent_name, msg)
+                except Exception as exc:
+                    _warn(
+                        "watchdog transition alert failed for %s: %s",
+                        snap.agent_name, exc,
+                    )
+
+        # Recover tier — hard recovery via the generic callback (abandon the
+        # wedged owner + fresh start). Never force_restart.
+        if (
+            cfg.mode == "recover"
+            and age >= cfg.transition_recover_after_seconds
+        ):
+            reason = (
+                f"Stuck in '{snap.state}' lifecycle transition for "
+                f"{int(age // 60)}min"
+            )
+            _warn(
+                "watchdog transition-recovering %s: %s",
+                snap.agent_name, reason,
+            )
+            if self._recover_fn:
+                try:
+                    await self._recover_fn(snap.agent_name, snap.label, reason)
+                    # Reset with a grace period; the fresh session will pass
+                    # through BOOTING legitimately and must not re-trip.
+                    now_t = time.time()
+                    state.transition_recovered_at = now_t
+                    state.transition_since = now_t
+                    state.transition_warned = False
+                    state.transition_state = ""
+                except Exception as exc:
+                    _warn(
+                        "watchdog transition recovery failed for %s: %s",
+                        snap.agent_name, exc,
+                    )
+
     # ── Status ───────────────────────────────────────────────
 
     def status(self) -> dict:
@@ -275,6 +428,12 @@ class SessionWatchdog:
                 "last_progress_activity": state.last_progress_activity,
                 "stale_seconds": round(stale_s, 1),
                 "warned": state.warned,
+                "transition_state": state.transition_state,
+                "transition_age": (
+                    round(time.time() - state.transition_since, 1)
+                    if state.transition_since else 0.0
+                ),
+                "transition_warned": state.transition_warned,
             }
         return {
             "running": self._running,

--- a/src/pinky_daemon/session_watchdog.py
+++ b/src/pinky_daemon/session_watchdog.py
@@ -29,6 +29,16 @@ _warn = logging.getLogger("pinky.watchdog").warning
 # per-session ``_inflight_watchdog`` is CONNECTED-only. CONNECTED is watched
 # by the progress logic; IDLE_SLEEPING (intentional rest) and DEAD (its own
 # resurrection path) are deliberately excluded.
+#
+# VISIBILITY CAVEAT: this watchdog only samples *registered* sessions
+# (``broker._streaming``). Production registers a session only AFTER
+# ``ss.connect()`` returns (``_start_streaming_session``), so a fresh
+# cold-start wedged in BOOTING is not yet registered and is NOT observed
+# here — that gap needs a separate start-task watchdog (follow-up #110).
+# RECONNECTING (and any transition on an already-registered session) IS
+# observable and is the failure class #109 actually recovers. BOOTING is
+# kept in the set so the branch stays correct if/when such sessions become
+# observable; the branch logic itself is state-agnostic.
 _TRANSITION_STATES = frozenset(
     {SessionState.BOOTING.value, SessionState.RECONNECTING.value}
 )
@@ -64,6 +74,37 @@ class WatchdogConfig:
     # while still recovering far faster than the 10-15min progress bounds.
     transition_warn_after_seconds: int = DEFAULT_TRANSITION_WARN_AFTER
     transition_recover_after_seconds: int = DEFAULT_TRANSITION_RECOVER_AFTER
+
+    @classmethod
+    def from_raw(cls, raw: dict | None) -> "WatchdogConfig":
+        """Merge a per-agent ``watchdog_config`` dict onto the defaults.
+
+        Single source of truth for the merge so a caller can't silently drop
+        newly-added fields by forgetting to thread them (this is exactly how
+        the #109 transition thresholds were initially missed in the API
+        layer). Unknown keys are ignored; missing keys fall back to defaults.
+        """
+        raw = raw or {}
+        if not raw:
+            return cls()
+        return cls(
+            enabled=raw.get("enabled", cls.enabled),
+            mode=raw.get("mode", cls.mode),
+            warn_after_seconds=raw.get("warn_after_seconds", cls.warn_after_seconds),
+            recover_after_seconds=raw.get(
+                "recover_after_seconds", cls.recover_after_seconds
+            ),
+            require_backlog=raw.get("require_backlog", cls.require_backlog),
+            min_pending=raw.get("min_pending", cls.min_pending),
+            transition_warn_after_seconds=raw.get(
+                "transition_warn_after_seconds",
+                cls.transition_warn_after_seconds,
+            ),
+            transition_recover_after_seconds=raw.get(
+                "transition_recover_after_seconds",
+                cls.transition_recover_after_seconds,
+            ),
+        )
 
 
 @dataclass

--- a/tests/test_session_watchdog.py
+++ b/tests/test_session_watchdog.py
@@ -543,3 +543,36 @@ class TestLifecycleTransition:
         await wd._evaluate(_transition_snap("reconnecting"), now)
         assert recoveries == ["a"]
         assert force_restart_calls == []
+
+
+class TestConfigMerge:
+    """WatchdogConfig.from_raw is the single merge seam used by the API layer
+    (_get_watchdog_config). Pins that per-agent overrides — including the
+    #109 transition thresholds — are actually threaded through."""
+
+    def test_from_raw_empty_returns_defaults(self):
+        assert WatchdogConfig.from_raw(None) == WatchdogConfig()
+        assert WatchdogConfig.from_raw({}) == WatchdogConfig()
+
+    def test_from_raw_merges_transition_thresholds(self):
+        cfg = WatchdogConfig.from_raw({
+            "transition_warn_after_seconds": 90,
+            "transition_recover_after_seconds": 150,
+        })
+        assert cfg.transition_warn_after_seconds == 90
+        assert cfg.transition_recover_after_seconds == 150
+        # Untouched fields keep their defaults.
+        assert cfg.mode == "recover"
+        assert cfg.warn_after_seconds == 600
+
+    def test_from_raw_merges_legacy_fields(self):
+        cfg = WatchdogConfig.from_raw({"mode": "alert", "min_pending": 3})
+        assert cfg.mode == "alert"
+        assert cfg.min_pending == 3
+        # New transition fields fall back to defaults when unspecified.
+        assert cfg.transition_warn_after_seconds == 240
+        assert cfg.transition_recover_after_seconds == 360
+
+    def test_from_raw_ignores_unknown_keys(self):
+        cfg = WatchdogConfig.from_raw({"bogus_key": 123, "mode": "alert"})
+        assert cfg.mode == "alert"

--- a/tests/test_session_watchdog.py
+++ b/tests/test_session_watchdog.py
@@ -312,3 +312,234 @@ class TestStatus:
         assert "barsik/main" in s["agents"]
         assert s["agents"]["barsik/main"]["last_progress_turns"] == 10
         assert s["agents"]["barsik/main"]["stale_seconds"] >= 29
+
+
+# ── #109: lifecycle transition-age watchdog ─────────────────────────
+
+
+class TestSnapshotState:
+    def test_derives_connected_from_state_when_absent(self, make_watchdog):
+        """tmux stats expose `state` but not `connected` — derive it so the
+        progress watchdog doesn't treat every tmux session as disconnected."""
+
+        class TmuxLikeSession:
+            @property
+            def stats(self):
+                return {
+                    "turns": 4,
+                    "pending_responses": 0,
+                    "current_activity": "Bash",
+                    "state": "connected",
+                }
+
+        wd = make_watchdog()
+        snap = wd._take_snapshot("tmux-agent", "main", TmuxLikeSession())
+        assert snap.state == "connected"
+        assert snap.connected is True
+
+    def test_derived_connected_false_for_transition_state(self, make_watchdog):
+        class TmuxLikeSession:
+            @property
+            def stats(self):
+                return {"state": "reconnecting", "turns": 0}
+
+        wd = make_watchdog()
+        snap = wd._take_snapshot("tmux-agent", "main", TmuxLikeSession())
+        assert snap.state == "reconnecting"
+        assert snap.connected is False
+
+    def test_explicit_connected_preserved(self, make_watchdog):
+        """Streaming/Codex expose `connected` directly — keep their value
+        even when `state` is also present."""
+
+        class StreamingLike:
+            @property
+            def stats(self):
+                return {"state": "reconnecting", "connected": False, "turns": 1}
+
+        wd = make_watchdog()
+        snap = wd._take_snapshot("s", "main", StreamingLike())
+        assert snap.connected is False
+        assert snap.state == "reconnecting"
+
+
+def _transition_snap(state, *, agent="a", label="main", connected=False, pending=0):
+    return _SessionSnapshot(
+        agent_name=agent, label=label, connected=connected,
+        turns=0, pending=pending, current_activity="",
+        sample_time=time.time(), state=state,
+    )
+
+
+class TestLifecycleTransition:
+    def test_config_transition_defaults(self):
+        cfg = WatchdogConfig()
+        assert cfg.transition_warn_after_seconds == 240
+        assert cfg.transition_recover_after_seconds == 360
+
+    @pytest.mark.asyncio
+    async def test_first_observation_starts_timer_no_warn(self, make_watchdog):
+        """First sweep observing a transition starts the sampled timer; no
+        age has accrued, so it must not warn/recover yet."""
+        alerts = []
+
+        async def _alert(a, m):
+            alerts.append(m)
+
+        wd = make_watchdog(alert_fn=_alert)
+        now = time.time()
+        await wd._evaluate(_transition_snap("reconnecting"), now)
+        st = wd._states[("a", "main")]
+        assert st.transition_state == "reconnecting"
+        assert abs(st.transition_since - now) < 1.0
+        assert st.transition_warned is False
+        assert alerts == []
+
+    @pytest.mark.asyncio
+    async def test_booting_warns_without_backlog(self, make_watchdog):
+        """BOOTING warns despite connected=False and zero backlog; in alert
+        mode it warns but does not recover."""
+        alerts, recoveries = [], []
+
+        async def _alert(a, m):
+            alerts.append(m)
+
+        async def _recover(a, label, r):
+            recoveries.append(a)
+
+        wd = make_watchdog(
+            alert_fn=_alert, recover_fn=_recover,
+            agent_config_fn=lambda _: WatchdogConfig(mode="alert"),
+        )
+        now = time.time()
+        wd._states[("a", "main")] = _AgentState(
+            transition_state="booting", transition_since=now - 300,
+        )
+        await wd._evaluate(_transition_snap("booting"), now)
+        assert len(alerts) == 1
+        assert "booting" in alerts[0]
+        assert wd._states[("a", "main")].transition_warned is True
+        assert recoveries == []
+
+    @pytest.mark.asyncio
+    async def test_reconnecting_recovers_once(self, make_watchdog):
+        recoveries = []
+
+        async def _recover(a, label, r):
+            recoveries.append((a, label, r))
+
+        wd = make_watchdog(recover_fn=_recover)  # default mode == "recover"
+        now = time.time()
+        wd._states[("a", "main")] = _AgentState(
+            transition_state="reconnecting", transition_since=now - 400,
+            transition_warned=True,
+        )
+        await wd._evaluate(_transition_snap("reconnecting"), now)
+        assert len(recoveries) == 1
+        st = wd._states[("a", "main")]
+        assert st.transition_recovered_at > 0
+        assert st.transition_state == ""  # cleared after recovery
+
+    @pytest.mark.asyncio
+    async def test_recover_grace_prevents_refire(self, make_watchdog):
+        """After a recovery, the fresh session's own BOOTING must not
+        immediately re-trip within the grace window."""
+        recoveries = []
+
+        async def _recover(a, label, r):
+            recoveries.append(a)
+
+        wd = make_watchdog(recover_fn=_recover)
+        now = time.time()
+        wd._states[("a", "main")] = _AgentState(
+            transition_state="booting", transition_since=now - 400,
+            transition_recovered_at=now - 10,  # just recovered
+        )
+        await wd._evaluate(_transition_snap("booting"), now)
+        assert recoveries == []
+
+    @pytest.mark.asyncio
+    async def test_transition_state_change_resets_timer(self, make_watchdog):
+        alerts = []
+
+        async def _alert(a, m):
+            alerts.append(m)
+
+        wd = make_watchdog(alert_fn=_alert)
+        now = time.time()
+        wd._states[("a", "main")] = _AgentState(
+            transition_state="booting", transition_since=now - 300,
+        )
+        await wd._evaluate(_transition_snap("reconnecting"), now)
+        st = wd._states[("a", "main")]
+        assert st.transition_state == "reconnecting"
+        assert abs(st.transition_since - now) < 1.0  # reset
+        assert alerts == []
+
+    @pytest.mark.asyncio
+    async def test_exit_to_connected_clears_and_progress_runs(self, make_watchdog):
+        wd = make_watchdog()
+        now = time.time()
+        wd._states[("a", "main")] = _AgentState(
+            last_progress_turns=0,
+            transition_state="reconnecting", transition_since=now - 300,
+        )
+        snap = _SessionSnapshot(
+            agent_name="a", label="main", connected=True,
+            turns=5, pending=0, current_activity="Edit",
+            sample_time=now, state="connected",
+        )
+        await wd._evaluate(snap, now)
+        st = wd._states[("a", "main")]
+        assert st.transition_state == ""
+        assert st.transition_since == 0.0
+        assert st.last_progress_turns == 5  # normal progress logic ran
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("rest_state", ["idle_sleeping", "dead", "uninitialized"])
+    async def test_non_transition_states_no_action(self, make_watchdog, rest_state):
+        """IDLE_SLEEPING/DEAD/UNINITIALIZED are not transition-wedges — the
+        transition branch must not warn or recover for them (even with backlog)."""
+        alerts, recoveries = [], []
+
+        async def _alert(a, m):
+            alerts.append(m)
+
+        async def _recover(a, label, r):
+            recoveries.append(a)
+
+        wd = make_watchdog(alert_fn=_alert, recover_fn=_recover)
+        now = time.time()
+        await wd._evaluate(
+            _transition_snap(rest_state, connected=False, pending=5), now
+        )
+        assert alerts == []
+        assert recoveries == []
+        assert wd._states[("a", "main")].transition_state == ""
+
+    @pytest.mark.asyncio
+    async def test_recovery_uses_callback_not_force_restart(self, make_watchdog):
+        """Transition recovery goes through the generic _recover_fn (the
+        already-hard recovery path). The watchdog must never drive
+        force_restart — that would request the wrong edge through the wedged
+        owner. Pinned against future regressions."""
+        force_restart_calls = []
+        recoveries = []
+
+        class FakeTmuxSession:
+            async def force_restart(self, *, bypass_guard=False):
+                force_restart_calls.append(bypass_guard)
+                return True
+
+        async def _recover(a, label, r):
+            recoveries.append(a)  # hard recovery path — no force_restart
+
+        wd = make_watchdog(recover_fn=_recover)
+        now = time.time()
+        wd._states[("a", "main")] = _AgentState(
+            transition_state="reconnecting", transition_since=now - 400,
+            transition_warned=True,
+        )
+        await wd._evaluate(_transition_snap("reconnecting"), now)
+        assert recoveries == ["a"]
+        assert force_restart_calls == []


### PR DESCRIPTION
## Problem (#109, gap from audit #107)

A streaming session wedged in a lifecycle **transition** state was completely unwatched:

1. The per-session `_inflight_watchdog` loops `while self.state == CONNECTED` (`tmux_session.py:3087`) → it **exits the moment** a session enters a transition.
2. The global `SessionWatchdog._evaluate` bails at `if not snap.connected: return` → a transition-wedged session reports `connected=False` and is **skipped there too**.

Result: nothing ages a session stuck mid-transition — it can sit wedged indefinitely.

## Scope (post-review, see Murzik review thread)

This watchdog samples **registered** sessions (`broker._streaming`). Production registers a session only *after* `ss.connect()` returns (`_start_streaming_session`), so:

- **RECONNECTING** (and any transition on an already-registered session) — **observable and recovered here.** This is the higher-risk unwatched failure class #109 targets.
- **Fresh cold-start BOOTING** — *not* registered until after `connect()`, so **not observable by this watchdog.** Tracked as follow-up **#110** (separate start-task watchdog). `BOOTING` is kept in the watched set because the branch is state-agnostic and correct if/when such sessions become observable; it simply doesn't fire for cold-starts today.

## Fix

A **separate** transition-age branch in `SessionWatchdog._evaluate`, handled **before** the connected-guard (leaves `_inflight_watchdog` untouched — different failure class, different recovery):

- **Scope:** `{BOOTING, RECONNECTING}` (see visibility caveat above). `IDLE_SLEEPING` (intentional) and `DEAD` (own resurrection path) excluded.
- **Sampling-based age** in `_AgentState` (`transition_state` / `transition_since` / `transition_warned` / `transition_recovered_at`). Starts when a sweep first sees the state, resets on state change, cleared on exit to connected/idle/dead/uninitialized.
- **Bounds:** warn `transition_warn_after_seconds=240`, hard-recover `transition_recover_after_seconds=360` — both above the ~220s reconnect-retry worst case, so a slow-but-legitimate transition is never force-recovered mid-retry. Per-agent configurable via `WatchdogConfig.from_raw` (the single merge seam — see review fix #1).
- **Recovery reuses the existing generic `_recover_fn`** (disconnect → clear persisted session id → unregister → fresh `_ensure_streaming_session`), abandoning the wedged owner. **Never `force_restart`** — that requests RECONNECTING, the wrong edge from BOOTING / a reject from RECONNECTING. Keeps `SessionWatchdog` transport-agnostic.

### Also
- `_take_snapshot` now **derives `connected` from `state`** when the `connected` key is absent — fixes a **latent bug**: tmux `stats` expose `state` but not `connected`, so the progress watchdog was treating *every* tmux session as permanently disconnected. Codex/streaming keep their explicit `connected`.
- Codex `stats` expose `state` for consistency (Codex never enters BOOTING/RECONNECTING → naturally excluded).

## Review fixes (Murzik on PR #586)
1. **Per-agent transition thresholds were silently dropped** — `_get_watchdog_config` only threaded the legacy fields. Extracted the merge into `WatchdogConfig.from_raw()` as the single source of truth and routed the API layer through it. + merge tests.
2. **BOOTING cold-start visibility** — documented the caveat (above), filed follow-up #110, narrowed the claim to RECONNECTING.

## Tests
16 tests (12 transition + 4 config-merge): snapshot `state` + `connected` derivation; warn-without-backlog; RECONNECTING recovers once + grace; state-change resets timer; exit-to-CONNECTED clears tracking and progress logic still runs; IDLE_SLEEPING/DEAD/UNINITIALIZED no-op; recovery uses callback not `force_restart`; `from_raw` merges legacy + transition fields and ignores unknown keys. Local: `test_session_watchdog` + `test_codex_session` → 69 passed, ruff clean.

## Design
Designed and reviewed async with **Murzik** (who found the gap in audit #107). Out of scope by agreement: exact `state_entered_at` on the state machine, DEAD+backlog handling, and cold-start BOOTING (#110).

🤖 Opened by Barsik