### PR TITLE
fix(analytics): add SDK 0.2.x Task tools to plan-activity classifier

### DIFF
--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -829,7 +829,7 @@ class AnalyticsStore:
         "send_message", "add_reaction", "send_voice_note",
     }
     _DELEGATION_TOOLS = {"Agent", "send_to_agent"}
-    _PLAN_TOOLS = {"EnterPlanMode", "TodoWrite", "create_task", "bulk_create_tasks"}
+    _PLAN_TOOLS = {"EnterPlanMode", "TodoWrite", "create_task", "bulk_create_tasks", "TaskCreate", "TaskUpdate", "TaskGet", "TaskList"}
     _SKILL_TOOLS = {"Skill", "load_skill", "install_skill"}
 
     # Bash command patterns (compiled regexes)


### PR DESCRIPTION
## Summary

- Adds `TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList` to `AnalyticsStore._PLAN_TOOLS` so turns from SDK 0.2.82 agents (which use Task tools instead of `TodoWrite`) continue to classify as `"planning"` activity.
- `TodoWrite` is kept for backward-compatibility with historical analytics events already in the DB.

## Why

SDK 0.2.82 (now pinned via #577) replaces `TodoWrite` with Task tools in headless/SDK sessions. Without this patch, any planning turn from an upgraded agent would fall through to `"general"` classification, causing the dashboard and burn analytics to misattribute planning work.

## Test plan

- [ ] Confirm `_PLAN_TOOLS` set contains all four Task tool names after merge
- [ ] Smoke: send a turn containing a `TaskCreate` call through a dev agent and verify the analytics row shows `category = "planning"`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzstbRc7bGfaWG3ZebdDSw)_