### PR TITLE
fix(messaging): prevent double-send via dedupe guard + timeout headroom (#113)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1130,29 +1130,40 @@ def create_api(
     ) -> dict:
         """Send a message back to the platform on behalf of an agent."""
         loop = asyncio.get_running_loop()
-        msg = await loop.run_in_executor(
-            None,
-            lambda: _send_text_message(
-                agent_name,
-                platform,
-                chat_id,
-                content,
-                reply_to=reply_to,
-                parse_mode=parse_mode,
-                silent=silent,
-            ),
+
+        async def _deliver() -> dict:
+            msg = await loop.run_in_executor(
+                None,
+                lambda: _send_text_message(
+                    agent_name,
+                    platform,
+                    chat_id,
+                    content,
+                    reply_to=reply_to,
+                    parse_mode=parse_mode,
+                    silent=silent,
+                ),
+            )
+            # Once an outbound message lands, the typing indicator becomes noise —
+            # Telegram has no "stop typing" API, but cancelling our 4s
+            # sendChatAction loop prevents the indicator from popping back up
+            # after the message arrives.
+            broker._stop_typing(agent_name, chat_id)
+            return {
+                "sent": True,
+                "agent": agent_name,
+                "platform": platform,
+                "chat_id": chat_id,
+                "message_id": msg.message_id,
+            }
+
+        # Dedupe guard (issue #113): an identical send already in flight or just
+        # delivered is suppressed and the original result returned, so a tool
+        # that retried after its own timeout doesn't deliver twice. Cancellation
+        # vs failure handling lives in deliver_deduped.
+        return await broker.deliver_deduped(
+            agent_name, platform, chat_id, content, _deliver, reply_to=reply_to
         )
-        # Once an outbound message lands, the typing indicator becomes noise —
-        # Telegram has no "stop typing" API, but cancelling our 4s sendChatAction
-        # loop prevents the indicator from popping back up after the message arrives.
-        broker._stop_typing(agent_name, chat_id)
-        return {
-            "sent": True,
-            "agent": agent_name,
-            "platform": platform,
-            "chat_id": chat_id,
-            "message_id": msg.message_id,
-        }
 
     async def _broker_react(
         agent_name: str,

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -192,7 +192,24 @@ class MessageBroker:
         self._activity = activity_store
         self._stop_callback = stop_callback
         self._stop_all_callback = stop_all_callback
-        self._stats = {"routed": 0, "pending": 0, "denied": 0, "errors": 0}
+        self._stats = {"routed": 0, "pending": 0, "denied": 0, "errors": 0, "deduped": 0}
+
+        # Outbound dedupe — suppress accidental duplicate sends. The usual
+        # trigger (issue #113): a slow platform leg makes the messaging tool
+        # bail on its own timeout *while the original delivery is still in
+        # flight*, so the agent retries and the user receives the message
+        # twice. We reserve a key per (agent, platform, chat, reply_to,
+        # content) on the way in; an identical send within the window is
+        # suppressed and the original delivery result is returned instead.
+        # Window <= 0 disables the guard. Tunable via PINKY_SEND_DEDUPE_WINDOW.
+        # Default 45s: comfortably covers the 30s tool-timeout retry while
+        # keeping the blast radius on legitimate identical sends (e.g. a second
+        # "ok") small.
+        try:
+            self._dedupe_window = float(os.environ.get("PINKY_SEND_DEDUPE_WINDOW", "45"))
+        except (TypeError, ValueError):
+            self._dedupe_window = 45.0
+        self._recent_sends: dict[tuple, dict] = {}
 
         # Optional callback to ensure (start/resume) a streaming session on
         # demand. Wired by api.py after `_ensure_streaming_session` is
@@ -290,6 +307,152 @@ class MessageBroker:
                 task.cancel()
         if keys:
             _log(f"broker: stopped {len(keys)} typing indicator(s) for {agent_name}")
+
+    # ------------------------------------------------------------------
+    # Outbound dedupe (issue #113)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _dedupe_key(
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        content: str,
+        reply_to: str = "",
+    ) -> tuple:
+        return (agent_name, platform, str(chat_id), reply_to or "", content)
+
+    def _prune_recent_sends(self, now: float | None = None) -> None:
+        if now is None:
+            now = time.monotonic()
+        window = self._dedupe_window
+        expired = [k for k, v in self._recent_sends.items() if now - v["ts"] > window]
+        for k in expired:
+            del self._recent_sends[k]
+
+    def register_outbound(
+        self,
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        content: str,
+        *,
+        reply_to: str = "",
+    ) -> dict | None:
+        """Reserve an outbound send for dedupe.
+
+        Returns ``None`` when this is a fresh send — the caller should
+        proceed to deliver and then call :meth:`finalize_outbound` (or
+        :meth:`clear_outbound` on failure). Returns a delivery-result dict
+        when an identical send is already in flight or completed within the
+        dedupe window — in that case the caller MUST skip delivery and return
+        the dict as-is (it carries ``"deduped": True``).
+        """
+        if self._dedupe_window <= 0:
+            return None
+        now = time.monotonic()
+        self._prune_recent_sends(now)
+        key = self._dedupe_key(agent_name, platform, chat_id, content, reply_to)
+        existing = self._recent_sends.get(key)
+        if existing is not None:
+            self._stats["deduped"] = self._stats.get("deduped", 0) + 1
+            _log(
+                f"broker: suppressed duplicate send for "
+                f"{agent_name} -> {platform}:{chat_id}"
+            )
+            result = existing.get("result")
+            if result is not None:
+                # Original already delivered — hand back its message_id so the
+                # retrying caller sees a clean, idempotent success.
+                return {**result, "deduped": True}
+            # Original still in flight — report success so the caller stops
+            # retrying. The real message_id lands on the first call's return.
+            return {
+                "sent": True,
+                "deduped": True,
+                "agent": agent_name,
+                "platform": platform,
+                "chat_id": chat_id,
+                "message_id": None,
+            }
+        self._recent_sends[key] = {"ts": now, "result": None}
+        return None
+
+    def finalize_outbound(
+        self,
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        content: str,
+        result: dict,
+        *,
+        reply_to: str = "",
+    ) -> None:
+        """Attach the delivery result to a reserved outbound entry so a later
+        duplicate within the window can return the original message_id."""
+        if self._dedupe_window <= 0:
+            return
+        key = self._dedupe_key(agent_name, platform, chat_id, content, reply_to)
+        entry = self._recent_sends.get(key)
+        if entry is not None:
+            entry["result"] = result
+
+    def clear_outbound(
+        self,
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        content: str,
+        *,
+        reply_to: str = "",
+    ) -> None:
+        """Release a reserved outbound entry — call when delivery fails so a
+        legitimate retry is not mistaken for a duplicate and silently dropped."""
+        key = self._dedupe_key(agent_name, platform, chat_id, content, reply_to)
+        self._recent_sends.pop(key, None)
+
+    async def deliver_deduped(
+        self,
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        content: str,
+        deliver,
+        *,
+        reply_to: str = "",
+    ) -> dict:
+        """Run ``deliver`` at most once per dedupe window.
+
+        ``deliver`` is a zero-arg callable returning an awaitable that performs
+        the actual platform send and resolves to a result dict. Identical sends
+        within the window are suppressed and the original result is returned
+        (carrying ``"deduped": True``).
+
+        Failure handling is deliberate (issue #113):
+
+        * A delivery *failure* (``Exception``) releases the reservation so a
+          genuine retry is not mistaken for a duplicate and silently dropped.
+        * ``asyncio.CancelledError`` (a ``BaseException``, not an ``Exception``)
+          is allowed to propagate **without** releasing the reservation: the
+          underlying ``run_in_executor`` worker cannot be cancelled, so the
+          platform delivery may still be in flight, and clearing the
+          reservation would reopen the duplicate window this guard closes.
+        """
+        dup = self.register_outbound(
+            agent_name, platform, chat_id, content, reply_to=reply_to
+        )
+        if dup is not None:
+            return dup
+        try:
+            result = await deliver()
+        except Exception:
+            self.clear_outbound(
+                agent_name, platform, chat_id, content, reply_to=reply_to
+            )
+            raise
+        self.finalize_outbound(
+            agent_name, platform, chat_id, content, result, reply_to=reply_to
+        )
+        return result
 
     async def _send_message(self, agent_name: str, platform: str, chat_id: str, content: str) -> None:
         """Send a message if the outbound callback is configured."""

--- a/src/pinky_messaging/server.py
+++ b/src/pinky_messaging/server.py
@@ -18,6 +18,21 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+# Timeout for the MCP tool's HTTP call to the PinkyBot API (the "outer" leg).
+# This MUST exceed the API's inner platform-delivery timeout (the Telegram
+# adapter's httpx client, default 30s) plus API/DB/network overhead. When the
+# two were equal (both 30s), a slow platform leg could make this outer call
+# time out *while the delivery was still in flight* — the tool reported a
+# timeout, the agent retried, and the user got the message twice (issue #113).
+# Giving the outer leg headroom means the tool waits for the real result
+# (success or a genuine error) instead of preempting it. Tunable via
+# PINKY_MCP_HTTP_TIMEOUT.
+try:
+    _API_HTTP_TIMEOUT = float(os.environ.get("PINKY_MCP_HTTP_TIMEOUT", "45"))
+except (TypeError, ValueError):
+    _API_HTTP_TIMEOUT = 45.0
+
+
 def create_server(
     *,
     agent_name: str = "",
@@ -47,7 +62,7 @@ def create_server(
             headers=headers,
         )
         try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
+            with urllib.request.urlopen(req, timeout=_API_HTTP_TIMEOUT) as resp:
                 return json.loads(resp.read())
         except urllib.error.HTTPError as e:
             error_body = e.read().decode("utf-8", errors="replace")

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -593,3 +593,172 @@ class TestMessageBrokerRouting:
             assert ctx.attachments == [{"type": "voice", "file_id": "file-1"}]
         finally:
             tmpdir.cleanup()
+
+
+class TestOutboundDedupe:
+    """Issue #113 — suppress accidental duplicate outbound sends."""
+
+    def _make_broker(self, **env):
+        tmpdir = tempfile.TemporaryDirectory()
+        registry = AgentRegistry(db_path=f"{tmpdir.name}/agents.db")
+        registry.register("barsik", model="sonnet", working_dir=tmpdir.name)
+        broker = MessageBroker(registry, SessionManager())
+        return tmpdir, broker
+
+    def test_first_send_is_not_a_duplicate(self):
+        tmpdir, broker = self._make_broker()
+        try:
+            dup = broker.register_outbound("barsik", "telegram", "111", "hello")
+            assert dup is None
+        finally:
+            tmpdir.cleanup()
+
+    def test_identical_inflight_send_is_suppressed(self):
+        tmpdir, broker = self._make_broker()
+        try:
+            # First reserve, delivery still "in flight" (no finalize yet).
+            assert broker.register_outbound("barsik", "telegram", "111", "hello") is None
+            dup = broker.register_outbound("barsik", "telegram", "111", "hello")
+            assert dup is not None
+            assert dup["deduped"] is True
+            # Reports success so the retrying caller stops retrying.
+            assert dup["sent"] is True
+            assert broker._stats["deduped"] == 1
+        finally:
+            tmpdir.cleanup()
+
+    def test_completed_send_returns_original_message_id(self):
+        tmpdir, broker = self._make_broker()
+        try:
+            assert broker.register_outbound("barsik", "telegram", "111", "hi") is None
+            broker.finalize_outbound(
+                "barsik", "telegram", "111", "hi",
+                {"sent": True, "message_id": "555", "chat_id": "111"},
+            )
+            dup = broker.register_outbound("barsik", "telegram", "111", "hi")
+            assert dup is not None
+            assert dup["deduped"] is True
+            assert dup["message_id"] == "555"
+        finally:
+            tmpdir.cleanup()
+
+    def test_different_content_is_not_deduped(self):
+        tmpdir, broker = self._make_broker()
+        try:
+            assert broker.register_outbound("barsik", "telegram", "111", "one") is None
+            assert broker.register_outbound("barsik", "telegram", "111", "two") is None
+        finally:
+            tmpdir.cleanup()
+
+    def test_different_chat_is_not_deduped(self):
+        """broadcast sends identical content to many chats — must not collide."""
+        tmpdir, broker = self._make_broker()
+        try:
+            assert broker.register_outbound("barsik", "telegram", "111", "x") is None
+            assert broker.register_outbound("barsik", "telegram", "222", "x") is None
+        finally:
+            tmpdir.cleanup()
+
+    def test_reply_to_is_part_of_identity(self):
+        tmpdir, broker = self._make_broker()
+        try:
+            assert broker.register_outbound(
+                "barsik", "telegram", "111", "x", reply_to="10"
+            ) is None
+            # Same text, different reply target → distinct send.
+            assert broker.register_outbound(
+                "barsik", "telegram", "111", "x", reply_to="20"
+            ) is None
+        finally:
+            tmpdir.cleanup()
+
+    def test_clear_outbound_allows_retry_after_failure(self):
+        tmpdir, broker = self._make_broker()
+        try:
+            assert broker.register_outbound("barsik", "telegram", "111", "hi") is None
+            # Delivery failed — release the reservation.
+            broker.clear_outbound("barsik", "telegram", "111", "hi")
+            # A genuine retry must now be allowed through.
+            assert broker.register_outbound("barsik", "telegram", "111", "hi") is None
+        finally:
+            tmpdir.cleanup()
+
+    def test_expired_entry_is_pruned(self):
+        tmpdir, broker = self._make_broker()
+        try:
+            broker._dedupe_window = 60.0
+            assert broker.register_outbound("barsik", "telegram", "111", "hi") is None
+            # Simulate the entry aging past the window.
+            key = broker._dedupe_key("barsik", "telegram", "111", "hi")
+            broker._recent_sends[key]["ts"] -= 120
+            # Next identical send is treated as fresh.
+            assert broker.register_outbound("barsik", "telegram", "111", "hi") is None
+        finally:
+            tmpdir.cleanup()
+
+    def test_window_zero_disables_dedupe(self):
+        tmpdir, broker = self._make_broker()
+        try:
+            broker._dedupe_window = 0
+            assert broker.register_outbound("barsik", "telegram", "111", "hi") is None
+            assert broker.register_outbound("barsik", "telegram", "111", "hi") is None
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_deliver_deduped_delivers_once_and_suppresses_repeat(self):
+        tmpdir, broker = self._make_broker()
+        try:
+            calls = []
+
+            async def deliver():
+                calls.append(1)
+                return {"sent": True, "message_id": "1", "chat_id": "111"}
+
+            r1 = await broker.deliver_deduped("barsik", "telegram", "111", "hi", deliver)
+            r2 = await broker.deliver_deduped("barsik", "telegram", "111", "hi", deliver)
+
+            assert calls == [1]  # second call never reached the deliver fn
+            assert r1["message_id"] == "1"
+            assert r2["deduped"] is True
+            assert r2["message_id"] == "1"  # idempotent: original message_id
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_deliver_deduped_failure_releases_reservation(self):
+        tmpdir, broker = self._make_broker()
+        try:
+            async def boom():
+                raise RuntimeError("telegram down")
+
+            with pytest.raises(RuntimeError):
+                await broker.deliver_deduped("barsik", "telegram", "111", "hi", boom)
+
+            # Reservation released — a genuine retry is allowed through.
+            assert broker.register_outbound("barsik", "telegram", "111", "hi") is None
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_deliver_deduped_cancellation_keeps_reservation(self):
+        """Regression guard (#113): CancelledError must NOT clear the
+        reservation — the executor delivery may still be in flight, so a retry
+        has to be deduped, not re-delivered. Broadening back to
+        `except BaseException` would break this test."""
+        tmpdir, broker = self._make_broker()
+        try:
+            import asyncio as _asyncio
+
+            async def cancelled():
+                raise _asyncio.CancelledError()
+
+            with pytest.raises(_asyncio.CancelledError):
+                await broker.deliver_deduped("barsik", "telegram", "111", "hi", cancelled)
+
+            # Reservation intact — an identical send is suppressed.
+            dup = broker.register_outbound("barsik", "telegram", "111", "hi")
+            assert dup is not None
+            assert dup["deduped"] is True
+        finally:
+            tmpdir.cleanup()

--- a/tests/test_messaging_server.py
+++ b/tests/test_messaging_server.py
@@ -374,3 +374,35 @@ class TestCreateServer:
             port=9000,
         )
         assert srv is not None
+
+
+class TestTimeoutHeadroom:
+    """Issue #113 — the MCP tool's outer HTTP timeout must exceed the inner
+    platform-delivery timeout, so the tool never preempts an in-flight send
+    (which would trigger an agent retry and a duplicate message)."""
+
+    def test_mcp_http_timeout_exceeds_platform_delivery_timeout(self):
+        import inspect
+
+        from pinky_messaging.server import _API_HTTP_TIMEOUT
+        from pinky_outreach.telegram import TelegramAdapter
+
+        inner_default = inspect.signature(
+            TelegramAdapter.__init__
+        ).parameters["timeout"].default
+        assert _API_HTTP_TIMEOUT > inner_default, (
+            f"MCP outer HTTP timeout ({_API_HTTP_TIMEOUT}s) must exceed the "
+            f"platform delivery timeout ({inner_default}s) so the messaging "
+            f"tool waits for the real result instead of timing out mid-delivery"
+        )
+
+    def test_mcp_http_timeout_env_override(self):
+        import importlib
+
+        import pinky_messaging.server as srv_mod
+
+        with patch.dict("os.environ", {"PINKY_MCP_HTTP_TIMEOUT": "90"}):
+            importlib.reload(srv_mod)
+            assert srv_mod._API_HTTP_TIMEOUT == 90.0
+        # Restore module-level default for any later tests.
+        importlib.reload(srv_mod)


### PR DESCRIPTION
## Problem (#113)

Agents occasionally deliver the same message twice. Root cause is a timeout race, not the plain-text fallback:

- The pinky-messaging MCP tool calls the API with `urlopen(timeout=30)`.
- The API's inner Telegram delivery (`httpx`) *also* uses 30s.
- Equal, nested timeouts leave the outer leg zero headroom. When a platform send is slow, the outer call times out **while the delivery is still in flight** → the tool reports a timeout → the agent retries → the user gets the message twice.

## Fix — defense in depth (two increments)

**1. Dedupe guard at the broker chokepoint** (`40c26f5`)
`send`/`thread`/`broadcast` all flow through `_broker_send`, which now delegates to `MessageBroker.deliver_deduped`. A send is keyed by `(agent, platform, chat_id, reply_to, content)` and reserved on the way in:
- An identical send already in flight or completed within a **45s window** (tunable via `PINKY_SEND_DEDUPE_WINDOW`, `<=0` disables) is suppressed and the original result returned — in-flight dups report success so the retrying caller stops; a completed dup returns the original `message_id` (idempotent).
- **Cancellation safety:** `deliver_deduped` catches `Exception`, **not** `BaseException`. A delivery *failure* releases the reservation so genuine retries proceed; `asyncio.CancelledError` propagates with the reservation **intact**, because `run_in_executor` cannot cancel the worker thread and the delivery may still land — clearing it would reopen the duplicate window. Locked by a regression test.

**2. Timeout headroom** (`f49acee`)
Raise the MCP HTTP timeout to **45s** (tunable via `PINKY_MCP_HTTP_TIMEOUT`) so the outer leg always outlasts the inner platform-delivery timeout and waits for the real result instead of preempting it. Mirrors the existing inbound-poller precedent (`api.py:4992`/`7635`: `TelegramAdapter(timeout=45)` > poll 30 "to avoid racing"). An invariant test couples outer > inner so the relationship can't silently regress.

Together: #2 makes false timeouts rare; #1 makes any retry that still happens idempotent.

## Tests
- `tests/test_broker.py` — `TestOutboundDedupe` (+ `deliver_deduped` delivers-once / failure-releases / **cancellation-keeps-reservation** regression)
- `tests/test_messaging_server.py` — `TestTimeoutHeadroom` (invariant + env override)
- Full run: `test_broker.py test_messaging_server.py test_pinky_messaging.py` → **61 passed**; `ruff` clean.

## Reviewed
Reviewed by Murzik across three passes (caught a P1: an earlier `except BaseException` would have cleared the reservation on cancellation while delivery was still in flight — fixed). Final: no findings.

## Deferred
Bit #3 ("treat a tool timeout as *unknown delivery state — do not auto-retry identical text*" rather than a generic failure) is intentionally **not** in this PR. Per discussion: ship #1+#2, observe in production, then reassess whether #3's extra layer is warranted.

🤖 Opened by Barsik