### PR TITLE
fix(tmux): resume conversation + re-prime wake prompt on restart

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import shlex
 import time
 from collections import deque
@@ -1333,34 +1334,55 @@ class TmuxSession:
         # Clear restart_reason after consumption — matches SDK semantics.
         self._config.restart_reason = ""
 
-        if not self._skip_wake_prompt_for_tests:
-            _wake_prompt = build_wake_prompt(
-                WakePromptInput(
-                    reason=_wake_reason,
-                    context_body=self._config.wake_context or "",
-                    timezone=self._config.timezone or "America/Los_Angeles",
-                )
-            )
-            try:
-                await self._enqueue_internal_prompt(
-                    _wake_prompt,
-                    reason=f"wake_{_wake_reason.value}",
-                    wait_for_completion=False,
-                )
-            except Exception as e:
-                # Wake-prompt enqueue failure must not strand the session
-                # in CONNECTED-but-orientationless. Log loudly; the
-                # session remains usable for external turns but the agent
-                # will lack saved-state context until the next restart.
-                _log(
-                    f"tmux[{self.agent_name}]: wake prompt enqueue failed: {e} "
-                    f"(reason={_wake_reason.value}) — session remains CONNECTED"
-                )
+        await self._enqueue_wake_prompt(_wake_reason)
 
         _log(
             f"tmux[{self.agent_name}]: connected, session={self._session_name}, "
             f"worker started, wake_reason={_wake_reason.value}"
         )
+
+    async def _enqueue_wake_prompt(self, reason: WakeReason) -> None:
+        """Build + enqueue the orientation wake prompt for ``reason``
+        (``wait_for_completion=False`` so it flows behind any queued
+        external work, in queue order).
+
+        Shared by ``connect()`` and ``force_restart()``. Before this was
+        extracted, ``force_restart`` respawned the REPL but — unlike
+        ``connect`` — never enqueued a wake prompt, so a watchdog-driven
+        restart dropped the agent onto a blank session with no
+        saved-state context (the "comes back idle / no anything"
+        symptom Brad reported). Routing both paths through here keeps the
+        re-prime behavior identical.
+
+        The ``_skip_wake_prompt_for_tests`` seam short-circuits here so
+        unit tests without a transcript-tailer simulation don't hang the
+        worker on a never-completing wake turn.
+
+        Enqueue failure is logged, never raised — a wake-prompt hiccup
+        must not strand the session in CONNECTED-but-orientationless. It
+        remains usable for external turns; the agent just lacks
+        saved-state context until the next restart.
+        """
+        if self._skip_wake_prompt_for_tests:
+            return
+        wake_prompt = build_wake_prompt(
+            WakePromptInput(
+                reason=reason,
+                context_body=self._config.wake_context or "",
+                timezone=self._config.timezone or "America/Los_Angeles",
+            )
+        )
+        try:
+            await self._enqueue_internal_prompt(
+                wake_prompt,
+                reason=f"wake_{reason.value}",
+                wait_for_completion=False,
+            )
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: wake prompt enqueue failed: {e} "
+                f"(reason={reason.value}) — session remains CONNECTED"
+            )
 
     async def _spawn_tmux_repl(self) -> None:
         """Spawn the tmux session and the in-pane claude REPL, then start
@@ -2846,13 +2868,32 @@ class TmuxSession:
         for this agent's working_dir. The directory may not exist yet —
         callers must handle that case.
 
-        ``encoded-cwd``: the absolute cwd with the leading ``/`` consumed
-        and remaining ``/`` replaced with ``-`` (e.g.
-        ``/Users/oleg/foo`` → ``-Users-oleg-foo``). Mirrors Claude Code's
-        own encoding so the glob targets the right directory.
+        ``encoded-cwd``: Claude Code slugs the absolute cwd by replacing
+        every non-alphanumeric character with ``-`` (the JS encoder is
+        ``cwd.replace(/[^a-zA-Z0-9]/g, '-')``). For an absolute path the
+        leading ``/`` therefore becomes the leading ``-`` — e.g.
+        ``/Users/oleg/foo`` → ``-Users-oleg-foo`` and
+        ``/Users/oleg/.pulse-v2/x`` → ``-Users-oleg--pulse-v2-x`` (the
+        dot collapses to a dash too). Mirroring that exactly is what
+        lets the glob target the real directory.
+
+        **History (this is a real bug fix, not cosmetics):** the prior
+        implementation was ``"-" + str(cwd).replace("/", "-")``. Because
+        ``str(cwd)`` already starts with ``/`` (which the replace turns
+        into a leading ``-``), prepending another ``-`` produced a
+        *double-dash* path (``--Users-oleg-...``) that never exists on
+        disk. ``_has_prior_transcript()`` then always returned False, so
+        ``_build_claude_cmd`` never passed ``--continue`` — every tmux
+        restart silently cold-started a fresh conversation, dropping all
+        prior context. It also dropped dot-containing paths
+        (``.pulse-v2``). Using Claude Code's actual slug algorithm fixes
+        both. See ``test_project_dir_matches_claude_code_encoding``.
         """
         cwd = Path(self._config.working_dir or ".").resolve()
-        encoded = "-" + str(cwd).replace("/", "-")
+        # Match Claude Code's encoder exactly: every non-alphanumeric char
+        # → '-'. For an absolute path the leading '/' yields the leading
+        # '-' on its own; do NOT prepend an extra dash (that was the bug).
+        encoded = re.sub(r"[^a-zA-Z0-9]", "-", str(cwd))
         return Path.home() / ".claude" / "projects" / encoded
 
     def _has_prior_transcript(self) -> bool:
@@ -3530,7 +3571,26 @@ class TmuxSession:
             # wouldn't be caught.
             if not self._watchdog_task or self._watchdog_task.done():
                 self._watchdog_task = asyncio.create_task(self._inflight_watchdog())
-            _log(f"tmux[{self.agent_name}]: force_restart complete")
+            # Re-prime the agent with an orientation wake prompt. Without
+            # this, force_restart respawned the REPL but — unlike
+            # connect() — left the agent on a blank session with no
+            # saved-state context ("comes back idle / no anything"). Reason
+            # derives from the launch signals _build_claude_cmd just
+            # recorded: a normal watchdog restart has a prior transcript
+            # (now that _project_dir is fixed) → RESUME ("pick up where you
+            # left off"); a forced-fresh respawn → CONTEXT_RESTART; a
+            # genuinely transcript-less respawn → NEW_SESSION.
+            if self._last_launch_forced_fresh:
+                wake_reason = WakeReason.CONTEXT_RESTART
+            elif self._last_launch_had_prior_transcript:
+                wake_reason = WakeReason.RESUME
+            else:
+                wake_reason = WakeReason.NEW_SESSION
+            await self._enqueue_wake_prompt(wake_reason)
+            _log(
+                f"tmux[{self.agent_name}]: force_restart complete "
+                f"(wake_reason={wake_reason.value})"
+            )
             return True
         except Exception as e:
             _log(f"tmux[{self.agent_name}]: force_restart spawn failed: {e}")

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1341,7 +1341,7 @@ class TmuxSession:
             f"worker started, wake_reason={_wake_reason.value}"
         )
 
-    async def _enqueue_wake_prompt(self, reason: WakeReason) -> None:
+    async def _enqueue_wake_prompt(self, reason: WakeReason, *, front: bool = False) -> None:
         """Build + enqueue the orientation wake prompt for ``reason``
         (``wait_for_completion=False`` so it flows behind any queued
         external work, in queue order).
@@ -1353,6 +1353,14 @@ class TmuxSession:
         saved-state context (the "comes back idle / no anything"
         symptom Brad reported). Routing both paths through here keeps the
         re-prime behavior identical.
+
+        ``front=True`` prepends the wake prompt at the queue HEAD ahead
+        of any existing contents. ``force_restart`` uses this because the
+        inflight watchdog requeues replay/backlog at the front of the
+        queue before scheduling the restart; a trailing wake prompt would
+        let the resumed REPL process user turns before orientation
+        (Murzik #589 review). ``connect()`` uses the default tail enqueue
+        — its bootstrap queue is empty so head == tail.
 
         The ``_skip_wake_prompt_for_tests`` seam short-circuits here so
         unit tests without a transcript-tailer simulation don't hang the
@@ -1377,6 +1385,7 @@ class TmuxSession:
                 wake_prompt,
                 reason=f"wake_{reason.value}",
                 wait_for_completion=False,
+                front=front,
             )
         except Exception as e:
             _log(
@@ -1759,6 +1768,7 @@ class TmuxSession:
         reason: str,
         wait_for_completion: bool = False,
         timeout_sec: float | None = None,
+        front: bool = False,
     ) -> None:
         """Queue a daemon-internal prompt with no external-side-effects.
 
@@ -1813,6 +1823,19 @@ class TmuxSession:
         bootstrap window. Gating here at enqueue time would let
         concurrent external messages jump ahead while the wake sits in
         the SessionStart wait (Murzik #571 review catch).
+
+        ``front=True``: prepend the turn at the HEAD of ``_message_queue``
+        ahead of any existing contents, instead of the default tail
+        ``put()``. Used by ``force_restart``'s wake-prompt re-prime: the
+        inflight watchdog requeues replay/backlog at the front of the
+        queue *before* scheduling the restart, so a tail-enqueued wake
+        prompt would sit behind that backlog and the resumed REPL would
+        process user turns before ever seeing orientation (Murzik #589
+        review). ``asyncio.Queue`` has no put-front, so we use the same
+        drain+repush pattern the watchdog uses; it is synchronous (no
+        ``await`` between drain and repush) so it's atomic w.r.t. other
+        tasks. Caller is responsible for invoking this BEFORE the worker
+        starts draining when strict head placement is required.
         """
         if self.state != SessionState.CONNECTED:
             _log(
@@ -1847,17 +1870,31 @@ class TmuxSession:
         )
 
         completion = asyncio.Event() if wait_for_completion else None
-        await self._message_queue.put(
-            _QueuedTurn(
-                prompt=prompt,
-                platform="",
-                chat_id="",
-                message_id="",
-                internal=True,
-                reason=reason,
-                completion_event=completion,
-            )
+        turn = _QueuedTurn(
+            prompt=prompt,
+            platform="",
+            chat_id="",
+            message_id="",
+            internal=True,
+            reason=reason,
+            completion_event=completion,
         )
+        if front:
+            # Prepend ahead of existing queue contents. Synchronous
+            # drain+repush (no await between) so it's atomic w.r.t. the
+            # worker and any concurrent enqueues. Mirrors the watchdog's
+            # replay-requeue pattern (asyncio.Queue has no put-front).
+            backlog: list[_QueuedTurn] = []
+            while not self._message_queue.empty():
+                try:
+                    backlog.append(self._message_queue.get_nowait())
+                except asyncio.QueueEmpty:
+                    break
+            self._message_queue.put_nowait(turn)
+            for t in backlog:
+                self._message_queue.put_nowait(t)
+        else:
+            await self._message_queue.put(turn)
 
         if wait_for_completion and completion is not None:
             if timeout_sec is not None:
@@ -3564,18 +3601,22 @@ class TmuxSession:
                 SessionState.CONNECTED,
                 trigger=Trigger.INTERNAL,
             )
-            if not self._worker_task or self._worker_task.done():
-                self._worker_task = asyncio.create_task(self._message_worker())
-            # Respawn the watchdog too (#560). disconnect() above
-            # cancelled it; without this, force_restart-then-stuck-turn
-            # wouldn't be caught.
-            if not self._watchdog_task or self._watchdog_task.done():
-                self._watchdog_task = asyncio.create_task(self._inflight_watchdog())
-            # Re-prime the agent with an orientation wake prompt. Without
-            # this, force_restart respawned the REPL but — unlike
-            # connect() — left the agent on a blank session with no
-            # saved-state context ("comes back idle / no anything"). Reason
-            # derives from the launch signals _build_claude_cmd just
+            # Re-prime the agent with an orientation wake prompt BEFORE the
+            # worker can start draining. Without this, force_restart
+            # respawned the REPL but — unlike connect() — left the agent on
+            # a blank session with no saved-state context ("comes back idle
+            # / no anything").
+            #
+            # Ordering is load-bearing (Murzik #589 review): the inflight
+            # watchdog requeues replay/backlog at the FRONT of
+            # _message_queue *before* scheduling this restart, so the wake
+            # prompt must (a) be front-enqueued ahead of that backlog and
+            # (b) land before the worker starts — otherwise the resumed
+            # REPL could process a user turn before ever seeing
+            # orientation. We enqueue at the head here, then start the
+            # worker, guaranteeing wake leads.
+            #
+            # Reason derives from the launch signals _build_claude_cmd just
             # recorded: a normal watchdog restart has a prior transcript
             # (now that _project_dir is fixed) → RESUME ("pick up where you
             # left off"); a forced-fresh respawn → CONTEXT_RESTART; a
@@ -3586,7 +3627,15 @@ class TmuxSession:
                 wake_reason = WakeReason.RESUME
             else:
                 wake_reason = WakeReason.NEW_SESSION
-            await self._enqueue_wake_prompt(wake_reason)
+            await self._enqueue_wake_prompt(wake_reason, front=True)
+
+            if not self._worker_task or self._worker_task.done():
+                self._worker_task = asyncio.create_task(self._message_worker())
+            # Respawn the watchdog too (#560). disconnect() above
+            # cancelled it; without this, force_restart-then-stuck-turn
+            # wouldn't be caught.
+            if not self._watchdog_task or self._watchdog_task.done():
+                self._watchdog_task = asyncio.create_task(self._inflight_watchdog())
             _log(
                 f"tmux[{self.agent_name}]: force_restart complete "
                 f"(wake_reason={wake_reason.value})"

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
+import re
 import time as _time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -304,6 +305,50 @@ def test_has_prior_transcript_true_when_jsonl_exists(tmp_path, monkeypatch) -> N
     project_dir = ss._project_dir()
     project_dir.mkdir(parents=True, exist_ok=True)
     (project_dir / "abc123.jsonl").write_text("")
+    assert ss._has_prior_transcript() is True
+
+
+def test_project_dir_matches_claude_code_encoding(tmp_path, monkeypatch) -> None:
+    """Regression guard for the double-dash ``_project_dir`` bug.
+
+    The previous encoder was ``"-" + str(cwd).replace("/", "-")``. Because
+    an absolute ``cwd`` already starts with ``/`` (which the replace turns
+    into a leading ``-``), prepending another ``-`` produced a *double-dash*
+    path (``--Users-...``) that never exists on disk. That made
+    ``_has_prior_transcript()`` always return False → ``--continue`` was
+    never passed → every tmux restart silently dropped the conversation.
+
+    This test pins ``_project_dir`` to Claude Code's *actual* slug
+    algorithm (``[^a-zA-Z0-9]`` → ``-``). Crucially the expected path is
+    computed INDEPENDENTLY (not by calling ``_project_dir`` to seed it,
+    which is how the prior True-case test hid the bug). It also exercises
+    a dot-containing segment (``.pulse-v2``), which the old encoder
+    silently mangled.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # A working_dir with a dot segment — guards both the double-dash bug
+    # and the dot-collapse case. tmp_path is already canonical, so the
+    # session's internal ``.resolve()`` is idempotent here.
+    wd = tmp_path / ".pulse-v2" / "agents" / "dymok"
+    wd.mkdir(parents=True)
+    cfg = StreamingSessionConfig(agent_name="dymok", working_dir=str(wd))
+    ss = TmuxSession(cfg, tmux_control=_make_mock_tmux())
+
+    # Independently reproduce Claude Code's encoder. Do NOT route through
+    # _project_dir — the whole point is to catch _project_dir diverging.
+    expected_name = re.sub(r"[^a-zA-Z0-9]", "-", str(wd.resolve()))
+    canonical = tmp_path / ".claude" / "projects" / expected_name
+
+    assert ss._project_dir() == canonical
+    # Explicit invariant: the historical bug was a leading double-dash.
+    assert not ss._project_dir().name.startswith("--")
+    assert ss._project_dir().name.startswith("-")
+
+    # End-to-end: seed at the canonical path and confirm the gate sees it.
+    # Under the old buggy encoder, _project_dir would look at the
+    # double-dash sibling and this assertion would fail.
+    canonical.mkdir(parents=True)
+    (canonical / "abc123.jsonl").write_text("")
     assert ss._has_prior_transcript() is True
 
 
@@ -1068,6 +1113,59 @@ async def test_force_restart_failure_lands_in_dead() -> None:
 
 
 @pytest.mark.asyncio
+async def test_force_restart_enqueues_resume_wake_prompt() -> None:
+    """force_restart must re-prime the agent with an orientation wake
+    prompt after respawn. Before this fix it respawned the REPL but —
+    unlike connect() — never enqueued a wake prompt, leaving the agent
+    on a blank session with no saved-state context (the "comes back
+    idle / no anything" symptom). With a prior transcript present the
+    reason is RESUME.
+    """
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._skip_wake_prompt_for_tests = False
+    # Pin a prior transcript so the launch records had_prior=True → RESUME.
+    ss._has_prior_transcript = lambda: True
+
+    enqueued: list[tuple[str, str]] = []
+
+    async def _record(prompt, *, reason, wait_for_completion=False, timeout_sec=None):
+        enqueued.append((reason, prompt))
+        return None
+
+    ss._enqueue_internal_prompt = _record
+
+    result = await ss.force_restart()
+    assert result is True
+    assert ss.state == SessionState.CONNECTED
+    wake = [e for e in enqueued if e[0].startswith("wake_")]
+    assert len(wake) == 1, f"expected exactly one wake prompt, got {enqueued}"
+    assert wake[0][0] == "wake_resume"
+
+
+@pytest.mark.asyncio
+async def test_force_restart_skips_wake_prompt_under_test_seam() -> None:
+    """The ``_skip_wake_prompt_for_tests`` seam must short-circuit the
+    force_restart re-prime too, so existing force_restart unit tests
+    (which don't simulate a tailer) don't hang the worker on a
+    never-completing wake turn."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    # Default skip flag is True.
+    ss._has_prior_transcript = lambda: True
+
+    enqueued: list[str] = []
+
+    async def _record(prompt, *, reason, wait_for_completion=False, timeout_sec=None):
+        enqueued.append(reason)
+        return None
+
+    ss._enqueue_internal_prompt = _record
+
+    result = await ss.force_restart()
+    assert result is True
+    assert not any(r.startswith("wake_") for r in enqueued)
+
+
+@pytest.mark.asyncio
 async def test_force_restart_skips_restart_guard_before_first_completed_turn() -> None:
     """A pre-first-turn tmux restart cannot lose completed work, so the
     persistence guard must not block watchdog recovery from a cold-start wedge.
@@ -1653,7 +1751,9 @@ async def test_discover_transcript_path_returns_none_for_empty_project_dir(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_set_transcript_path_from_placeholder_seeks_to_start(tmp_path) -> None:
+async def test_set_transcript_path_from_placeholder_seeks_to_start(
+    tmp_path, monkeypatch
+) -> None:
     """Issue #563 — placeholder→real path transition must seek to byte 0.
 
     Cold-start sequence observed on Dymok:
@@ -1679,6 +1779,13 @@ async def test_set_transcript_path_from_placeholder_seeks_to_start(tmp_path) -> 
     ``read_once`` would observe nothing. Under the fix, it observes
     the stop_hook_summary and the response callback fires.
     """
+    # Isolate HOME to a clean dir so _discover_transcript_path finds no
+    # prior transcript for the fixture's working_dir and the tailer falls
+    # through to the placeholder. Pre-fix this held only because the buggy
+    # _project_dir double-dash never matched a real dir; the now-correct
+    # encoder would otherwise discover a stray transcript under the real
+    # ~/.claude/projects and start the tailer there instead.
+    monkeypatch.setenv("HOME", str(tmp_path))
     cb = _AsyncCollector()
     ss, _ = _make_session_with_response_cb(response_cb=cb)
     await ss.connect()
@@ -4217,7 +4324,17 @@ class TestWakePromptEnqueueOnConnect:
         await ss.disconnect()
 
     @pytest.mark.asyncio
-    async def test_connect_wake_reason_is_new_session_on_cold_start(self):
+    async def test_connect_wake_reason_is_new_session_on_cold_start(
+        self, tmp_path, monkeypatch
+    ):
+        # Isolate HOME to a clean dir so NO transcript exists for the
+        # agent's cwd. Otherwise the (now-correct) _has_prior_transcript
+        # gate finds a stray transcript and resolves the wake reason to
+        # RESUME instead of NEW_SESSION. Pre-fix this test only passed
+        # because the buggy _project_dir double-dash never matched any
+        # real directory — i.e. the test was implicitly relying on the
+        # bug. See test_project_dir_matches_claude_code_encoding.
+        monkeypatch.setenv("HOME", str(tmp_path))
         ss, _ = _make_session()
         ss._skip_wake_prompt_for_tests = False
         # No prior transcript, no restart_reason → NEW_SESSION.

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1126,10 +1126,12 @@ async def test_force_restart_enqueues_resume_wake_prompt() -> None:
     # Pin a prior transcript so the launch records had_prior=True → RESUME.
     ss._has_prior_transcript = lambda: True
 
-    enqueued: list[tuple[str, str]] = []
+    enqueued: list[tuple[str, bool]] = []
 
-    async def _record(prompt, *, reason, wait_for_completion=False, timeout_sec=None):
-        enqueued.append((reason, prompt))
+    async def _record(
+        prompt, *, reason, wait_for_completion=False, timeout_sec=None, front=False
+    ):
+        enqueued.append((reason, front))
         return None
 
     ss._enqueue_internal_prompt = _record
@@ -1140,6 +1142,9 @@ async def test_force_restart_enqueues_resume_wake_prompt() -> None:
     wake = [e for e in enqueued if e[0].startswith("wake_")]
     assert len(wake) == 1, f"expected exactly one wake prompt, got {enqueued}"
     assert wake[0][0] == "wake_resume"
+    # Must front-enqueue so it leads any watchdog-replayed backlog
+    # (Murzik #589). See test_force_restart_wake_prompt_leads_backlog.
+    assert wake[0][1] is True, "force_restart wake prompt must be front-enqueued"
 
 
 @pytest.mark.asyncio
@@ -1154,7 +1159,9 @@ async def test_force_restart_skips_wake_prompt_under_test_seam() -> None:
 
     enqueued: list[str] = []
 
-    async def _record(prompt, *, reason, wait_for_completion=False, timeout_sec=None):
+    async def _record(
+        prompt, *, reason, wait_for_completion=False, timeout_sec=None, front=False
+    ):
         enqueued.append(reason)
         return None
 
@@ -1163,6 +1170,63 @@ async def test_force_restart_skips_wake_prompt_under_test_seam() -> None:
     result = await ss.force_restart()
     assert result is True
     assert not any(r.startswith("wake_") for r in enqueued)
+
+
+@pytest.mark.asyncio
+async def test_force_restart_wake_prompt_leads_backlog() -> None:
+    """Murzik #589 review (blocker): the inflight watchdog requeues
+    replay/backlog at the FRONT of _message_queue *before* scheduling
+    force_restart. The re-prime wake prompt must still lead — otherwise
+    the resumed REPL processes a user turn before ever seeing the
+    saved-state/current-time orientation, defeating the exact recovery
+    path this fix targets.
+
+    This preloads the queue with a pending user turn (as the watchdog
+    would have requeued), runs force_restart with a prior transcript,
+    and asserts the wake prompt sits at the HEAD ahead of that backlog.
+    The worker is stubbed to a no-op so the queue can be inspected in
+    order rather than being drained mid-test.
+    """
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._skip_wake_prompt_for_tests = False
+    ss._has_prior_transcript = lambda: True
+
+    # A pending user turn already in the queue (watchdog-requeued backlog).
+    ss._message_queue.put_nowait(
+        _QueuedTurn(
+            prompt="user backlog turn",
+            platform="telegram",
+            chat_id="c",
+            message_id="m1",
+            internal=False,
+            reason="external",
+        )
+    )
+
+    # Stub the worker to a no-op so force_restart doesn't drain the queue;
+    # we inspect ordering directly.
+    async def _noop_worker():
+        return None
+
+    ss._message_worker = _noop_worker
+
+    result = await ss.force_restart()
+    assert result is True
+    assert ss.state == SessionState.CONNECTED
+
+    drained: list[_QueuedTurn] = []
+    while not ss._message_queue.empty():
+        drained.append(ss._message_queue.get_nowait())
+
+    reasons = [t.reason for t in drained]
+    assert "wake_resume" in reasons, f"wake prompt missing: {reasons}"
+    assert "external" in reasons, f"backlog turn missing: {reasons}"
+    # The wake prompt must be delivered BEFORE the preexisting user turn.
+    assert reasons.index("wake_resume") < reasons.index("external"), (
+        f"wake_resume must lead the backlog, got order: {reasons}"
+    )
+    # Specifically, it must be at the very head.
+    assert reasons[0] == "wake_resume", f"wake must be at queue head, got {reasons}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Brad reported tmux agents (Dymok) getting **silently restarted mid-conversation**, coming back as a *fresh, empty Claude session with no context and nothing happening*. Confirmed in the daemon logs: every relaunch logged `claude_cmd_built mode=fresh prior_transcript=False` despite 9+ transcripts on disk.

Two stacked bugs:

### 1. `_project_dir()` double-dash → `--continue` never used (root cause of "no resume")
The encoder was `"-" + str(cwd).replace("/", "-")`. An absolute cwd already starts with `/` (which the replace turns into a leading `-`), so prepending another `-` produced a **double-dash** path (`--Users-oleg-...-dymok`) that *never exists on disk*. Therefore:
- `_has_prior_transcript()` always returned `False`
- `_build_claude_cmd()` never appended `--continue`
- **every tmux restart cold-started a fresh conversation, dropping all prior context**

It also mangled dot-containing paths (`/Users/oleg/.pulse-v2/...`).

**Fix:** use Claude Code's actual slug algorithm — `re.sub(r"[^a-zA-Z0-9]", "-", cwd)`. Verified against every real `~/.claude/projects` dir on the box, including the `.pulse-v2` dot case.

### 2. `force_restart()` never re-primed a wake prompt (root cause of "comes back idle / no anything")
`force_restart()` respawned the REPL via `_spawn_tmux_repl()` but — unlike `connect()` — never enqueued a wake prompt, so the agent landed on a blank session with no saved-state orientation.

**Fix:** extracted `connect()`'s wake-prompt enqueue into a shared `_enqueue_wake_prompt()` helper and wired `force_restart()` to it. Reason derives from the launch signals: a normal watchdog restart has a prior transcript → `RESUME` ("pick up where you left off").

## Why tests didn't catch bug #1
`test_has_prior_transcript_true_when_jsonl_exists` seeded the fake transcript via the **same buggy `_project_dir()`**, so read+write were self-consistent and it passed green. Two other tests (`..._new_session_on_cold_start`, `..._placeholder_seeks_to_start`) only passed because they don't isolate `$HOME` and the buggy double-dash path never matched a real dir — i.e. they were *implicitly relying on the bug*.

## Tests
- **New** `test_project_dir_matches_claude_code_encoding`: computes the expected path **independently** (not via `_project_dir`), pins the no-double-dash + dot-collapse invariants, and seeds at the canonical path so the old encoder would fail it.
- **New** `test_force_restart_enqueues_resume_wake_prompt` + `test_force_restart_skips_wake_prompt_under_test_seam`.
- **Isolated** the two `$HOME`-leaky tests so they're deterministic in CI and locally.
- Full `tests/test_tmux_session.py` (197) green; `test_session_watchdog`, `test_transport`, `test_agent_status`, `test_stop_failure_hook`, `test_api` all green; ruff clean.

## Scope / follow-up
This makes the restart **non-destructive** (resumes + re-orients). It does **not** change *why* the watchdog fires. The trigger — the inflight-deque head ageing past 600s because paste-count drifts from `stop_hook_summary`-count under the #560 concurrent-dispatch design — is a separate, deeper issue I'm tracking as a fast-follow.

🤖 Opened by Barsik