### PR TITLE
fix(tmux): only force-restart a wedged REPL, not a drifted/idle one (#118)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2194,6 +2194,7 @@ def create_api(
             wake_context=_build_streaming_wake_context(agent_name),
             wake_context_builder=_build_streaming_wake_context,
             restart_guard=lambda session, _agent_name=agent_name: _get_streaming_restart_guard(_agent_name, session),
+            live_status_fn=lambda _agent_name=agent_name: _agent_live_status.get(_agent_name),
             context_warn_pct=warn_pct,
             context_restart_pct=restart_pct,
             timezone=agents.get_owner_profile().get("timezone", "America/Los_Angeles"),

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -64,6 +64,7 @@ class StreamingSessionConfig:
     wake_context: str = ""  # Saved continuation context to inject on wake
     wake_context_builder: object = None  # Callable(agent_name) -> str; refreshes wake_context on restart
     restart_guard: object = None  # Callable(session) -> dict; blocks restart if persistence is stale
+    live_status_fn: object = None  # Callable() -> dict|None; agent's live REPL status {"status","last_updated"} from Claude Code working/idle hooks. Tmux inflight watchdog uses it to avoid force-restarting an idle (not wedged) REPL (#118).
     context_warn_pct: int = 40  # Warn agent to save state at this %
     context_restart_pct: int = 80  # Force restart at this %
     restart_guard_cooldown_sec: int = 60  # Minimum gap between restart-block warnings

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -540,13 +540,14 @@ _TURN_DONE_TIMEOUT_SEC = 600.0
 # in CPU profiles even with many active tmux sessions.
 _WATCHDOG_TICK_SEC = 15.0
 
-# #118 — clock slack when trusting Claude Code's "idle" hook signal to
-# reconcile a phantom inflight head. The Stop hook that flips the REPL to
-# "idle" and the tailer pop that re-bases ``_head_started_at`` are driven
-# by the same turn-completion event but arrive on independent paths, so
-# allow a few seconds of ordering jitter when checking "did the REPL go
-# idle at-or-after this head started?".
-_IDLE_SIGNAL_SLACK_SEC = 5.0
+# #118 — idle-signal freshness floor. When trusting Claude Code's "idle"
+# hook signal to reconcile a phantom inflight head, the idle must be
+# at-or-after when the CURRENT head was pasted (``min(_head_started_at,
+# head.dispatched_at)``). No fixed slack window: the Stop-hook idle stamp
+# and the dispatch stamp share the daemon clock (no skew), so a stale idle
+# left over from the previous turn is rejected outright — a genuine
+# hang-on-paste is classified ``wedged``, not phantom-drained. (Replaces the
+# unsafe ``_head_started_at - 5s`` window flagged in Murzik's round-2 review.)
 
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
 # ``_session_ready_event`` for turns with ``internal=True and
@@ -3163,8 +3164,8 @@ class TmuxSession:
         # (b) REPL reported idle? Consult Claude Code's working/idle hook
         # signal (Stop hook → "idle"; PreToolUse/etc → "working"). An idle
         # REPL has nothing in flight. Require the idle to be at-least-as-recent
-        # as the head start (minus slack) — otherwise a turn was pasted that
-        # the REPL never came alive for (hang-on-paste), which IS a wedge.
+        # as when the CURRENT head was pasted — otherwise a turn was pasted
+        # that the REPL never came alive for (hang-on-paste), which IS a wedge.
         live = None
         fn = getattr(self._config, "live_status_fn", None)
         if fn is not None:
@@ -3174,7 +3175,23 @@ class TmuxSession:
                 live = None
         if live and live.get("status") == "idle":
             last_updated = live.get("last_updated") or 0.0
-            if last_updated >= self._head_started_at - _IDLE_SIGNAL_SLACK_SEC:
+            # Floor the idle-freshness check at when the current head was
+            # actually pasted (#118 / Murzik round-2). The earlier of:
+            #   - ``head.dispatched_at`` — this turn's paste+Enter time, and
+            #   - ``_head_started_at``    — the deque-head transition clock.
+            # For a queued turn that inherited the head spot, dispatched_at
+            # (paste time, while the prior head was still running) predates
+            # the head re-base, so ``min`` picks it and still tolerates
+            # tailer/status ordering jitter for queued turns. For a fresh
+            # first turn into an empty deque the two are equal, so a STALE
+            # idle left over from the PREVIOUS turn (reported BEFORE this turn
+            # was pasted) is correctly rejected → wedged. No fixed slack
+            # window: both timestamps come from the same daemon clock (no
+            # skew), and a turn's own idle always postdates its own paste, so
+            # an idle that predates the paste cannot belong to this turn.
+            head = self._inflight_metas[0]
+            idle_floor = min(self._head_started_at, head.dispatched_at)
+            if last_updated >= idle_floor:
                 return "idle"
         return "wedged"
 

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -540,6 +540,14 @@ _TURN_DONE_TIMEOUT_SEC = 600.0
 # in CPU profiles even with many active tmux sessions.
 _WATCHDOG_TICK_SEC = 15.0
 
+# #118 — clock slack when trusting Claude Code's "idle" hook signal to
+# reconcile a phantom inflight head. The Stop hook that flips the REPL to
+# "idle" and the tailer pop that re-bases ``_head_started_at`` are driven
+# by the same turn-completion event but arrive on independent paths, so
+# allow a few seconds of ordering jitter when checking "did the REPL go
+# idle at-or-after this head started?".
+_IDLE_SIGNAL_SLACK_SEC = 5.0
+
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
 # ``_session_ready_event`` for turns with ``internal=True and
 # reason.startswith("wake_")`` so the wake prompt's paste doesn't land while
@@ -3101,6 +3109,75 @@ class TmuxSession:
         except Exception as e:
             _log(f"tmux[{self.agent_name}]: worker error: {e}")
 
+    def _transcript_recently_grew(self, now: float, window: float) -> bool:
+        """True if the transcript file was written within ``window`` seconds.
+
+        A growing transcript means the REPL is actively emitting output (a
+        long or streaming turn), so it is NOT wedged. Returns False when the
+        path is the cold-start placeholder, missing, or unstattable —
+        absence of evidence is treated as "not growing" so the caller falls
+        through to the idle/wedged checks rather than masking a real stall.
+        """
+        tailer = self._tailer
+        path = getattr(tailer, "transcript_path", None) if tailer else None
+        if not path:
+            return False
+        try:
+            mtime = Path(path).stat().st_mtime
+        except OSError:
+            return False
+        return (now - mtime) < window
+
+    def _inflight_stall_verdict(self, now: float) -> str:
+        """Classify a possibly-stalled inflight head for the watchdog (#118).
+
+        Returns one of:
+          - ``"ok"``      — head not (yet) aged past ``_TURN_DONE_TIMEOUT_SEC``.
+          - ``"growing"`` — aged out BUT the transcript is still being written
+                            → a long/streaming turn, not wedged.
+          - ``"idle"``    — aged out, transcript quiet, and Claude Code last
+                            reported *idle* (Stop hook) at-or-after this head
+                            started → the REPL finished and is waiting for
+                            input, so the lingering meta(s) are phantom (a
+                            paste with no matching stop_hook). Reconcile, don't
+                            restart.
+          - ``"wedged"``  — aged out, transcript quiet, REPL not idle →
+                            genuinely stuck; force_restart.
+
+        Brad's directive (#118): never tear a session down unless it is
+        *actually* wedged. ``growing`` and ``idle`` are the two "positive
+        evidence it's fine" carve-outs that stop the watchdog from
+        force-restarting a healthy session just because the deque count
+        drifted (paste-vs-stop_hook) or a turn ran long. When the liveness
+        signals are unavailable (e.g. no ``live_status_fn`` wired in tests),
+        the verdict falls through to ``"wedged"`` — preserving the original
+        stuck-REPL recovery behavior.
+        """
+        if not self._inflight_metas or self._head_started_at is None:
+            return "ok"
+        if (now - self._head_started_at) <= _TURN_DONE_TIMEOUT_SEC:
+            return "ok"
+        # (a) Still producing output? Long/streaming turn — not wedged.
+        if self._transcript_recently_grew(now, _TURN_DONE_TIMEOUT_SEC):
+            return "growing"
+        # (b) REPL reported idle? Consult Claude Code's working/idle hook
+        # signal (Stop hook → "idle"; PreToolUse/etc → "working"). An idle
+        # REPL has nothing in flight. Require the idle to be at-least-as-recent
+        # as the head start (minus slack) — otherwise a turn was pasted that
+        # the REPL never came alive for (hang-on-paste), which IS a wedge.
+        live = None
+        fn = getattr(self._config, "live_status_fn", None)
+        if fn is not None:
+            try:
+                live = fn()
+            except Exception:
+                live = None
+        if live and live.get("status") == "idle":
+            last_updated = live.get("last_updated") or 0.0
+            if last_updated >= self._head_started_at - _IDLE_SIGNAL_SLACK_SEC:
+                return "idle"
+        return "wedged"
+
     async def _inflight_watchdog(self) -> None:
         """Age the ``_inflight_metas`` head; force_restart if it sticks.
 
@@ -3164,15 +3241,51 @@ class TmuxSession:
         try:
             while self.state == SessionState.CONNECTED:
                 await asyncio.sleep(_WATCHDOG_TICK_SEC)
-                if not self._inflight_metas or self._head_started_at is None:
+                now = time.time()
+                verdict = self._inflight_stall_verdict(now)
+                if verdict == "ok":
                     continue
-                age = time.time() - self._head_started_at
-                if age <= _TURN_DONE_TIMEOUT_SEC:
+                age = now - (self._head_started_at or now)
+                depth = len(self._inflight_metas)
+                if verdict == "growing":
+                    # #118: head aged out BUT the transcript is still being
+                    # written — a long/streaming turn, NOT a wedge. Extend
+                    # the window instead of tearing the session down.
+                    self._head_started_at = now
+                    _log(
+                        f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
+                        f"but transcript still growing — not wedged, extending "
+                        f"window (deque depth={depth})"
+                    )
                     continue
+                if verdict == "idle":
+                    # #118: head aged out, transcript quiet, and the REPL last
+                    # reported idle — nothing is actually in flight, so the
+                    # lingering meta(s) are phantom (a paste with no matching
+                    # stop_hook). Reconcile by draining + firing their
+                    # completion events; do NOT restart an idle REPL. This is
+                    # the core fix for "torn down ~10min after activity even
+                    # though nothing was wedged."
+                    drained = list(self._inflight_metas)
+                    self._inflight_metas.clear()
+                    self._head_started_at = None
+                    for m in drained:
+                        ev = m.completion_event
+                        if ev is not None and not ev.is_set():
+                            ev.set()
+                    _log(
+                        f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
+                        f"but REPL is idle — reconciled {len(drained)} phantom "
+                        f"meta(s), NOT restarting (#118)"
+                    )
+                    continue
+                # verdict == "wedged": no output + REPL not idle → genuinely
+                # stuck. Fall through to the force_restart recovery path.
                 _log(
                     f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
-                    f"> {_TURN_DONE_TIMEOUT_SEC}s — REPL stuck; scheduling "
-                    f"force_restart (deque depth={len(self._inflight_metas)})"
+                    f"> {_TURN_DONE_TIMEOUT_SEC}s, transcript quiet + REPL not "
+                    f"idle — REPL stuck; scheduling force_restart "
+                    f"(deque depth={depth})"
                 )
                 # Snapshot deque state before mutation so this critical
                 # section is atomic from the outside (no awaits between

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3054,6 +3054,166 @@ async def test_worker_force_restarts_on_turn_done_timeout(monkeypatch) -> None:
     await ss.disconnect()
 
 
+# ──────────────────────────────────────────────────────────────────────────
+# #118 — watchdog only restarts when ACTUALLY wedged (verdict carve-outs)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _mk_inflight_meta(completion_event=None):
+    """Build an _InflightMeta with all required fields for watchdog tests."""
+    return tmux_session._InflightMeta(
+        meta={},
+        completion_event=completion_event,
+        internal=False,
+        dispatched_at=_time.time(),
+        turn=_QueuedTurn(prompt="x", platform="t", chat_id="c", message_id="m"),
+    )
+
+
+def _age_out_head(ss) -> None:
+    """Put the inflight head well past _TURN_DONE_TIMEOUT_SEC with one meta."""
+    ss._inflight_metas.append(_mk_inflight_meta())
+    ss._head_started_at = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+
+
+def test_inflight_verdict_ok_when_not_aged() -> None:
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._inflight_metas.append(_mk_inflight_meta())
+    ss._head_started_at = _time.time()  # age ~0
+    assert ss._inflight_stall_verdict(_time.time()) == "ok"
+
+
+def test_inflight_verdict_ok_when_empty() -> None:
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._head_started_at = None
+    assert ss._inflight_stall_verdict(_time.time()) == "ok"
+
+
+def test_inflight_verdict_growing_when_transcript_fresh() -> None:
+    """A long/streaming turn keeps writing the transcript — not wedged."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    _age_out_head(ss)
+    ss._transcript_recently_grew = lambda now, window: True
+    assert ss._inflight_stall_verdict(_time.time()) == "growing"
+
+
+def test_inflight_verdict_idle_when_repl_idle_recent() -> None:
+    """REPL reported idle after the head started → phantom meta, not wedged."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    _age_out_head(ss)
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+    assert ss._inflight_stall_verdict(_time.time()) == "idle"
+
+
+def test_inflight_verdict_wedged_when_working_and_quiet() -> None:
+    """REPL says working but produced nothing → genuinely wedged."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    _age_out_head(ss)
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": _time.time(),
+    }
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
+def test_inflight_verdict_wedged_when_no_live_status_fn() -> None:
+    """Signal unavailable (e.g. tests) → preserve original recovery
+    behavior: treat a quiet aged-out head as wedged."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    _age_out_head(ss)
+    ss._transcript_recently_grew = lambda now, window: False
+    assert ss._config.live_status_fn is None
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
+def test_inflight_verdict_wedged_when_idle_predates_head() -> None:
+    """Hang-on-paste: a turn was pasted (head started) but the REPL's idle
+    status is STALE (predates the head) — the REPL never came alive for this
+    turn, so it IS a wedge, not a phantom."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    ss._inflight_metas.append(_mk_inflight_meta())
+    ss._head_started_at = head
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head - 100.0,  # idle reported BEFORE this head started
+    }
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
+def test_transcript_recently_grew(tmp_path) -> None:
+    import os
+
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("{}\n")
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = f
+
+    now = _time.time()
+    assert ss._transcript_recently_grew(now, 600.0) is True
+
+    old = now - 10_000
+    os.utime(f, (old, old))
+    assert ss._transcript_recently_grew(now, 600.0) is False
+
+    # No tailer / no path → False (not growing).
+    ss._tailer = None
+    assert ss._transcript_recently_grew(now, 600.0) is False
+
+
+@pytest.mark.asyncio
+async def test_inflight_watchdog_drains_phantom_when_repl_idle(monkeypatch) -> None:
+    """#118 end-to-end: an aged-out head with a quiet transcript and an idle
+    REPL must be RECONCILED (deque drained, completion events fired) — NOT
+    force_restarted. This is the core "stop tearing sessions down when nothing
+    is wedged" fix.
+    """
+    from pinky_daemon import tmux_session
+
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.02)
+
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {"status": "idle", "last_updated": _time.time()}
+    ss._transcript_recently_grew = lambda now, window: False
+
+    restarted = {"v": False}
+
+    async def _no_restart(*, bypass_guard: bool = False):
+        restarted["v"] = True
+        return True
+
+    ss.force_restart = _no_restart
+
+    ev = asyncio.Event()
+    ss._inflight_metas.append(_mk_inflight_meta(completion_event=ev))
+    ss._head_started_at = _time.time() - 1.0  # aged past the 0.05s timeout
+
+    task = asyncio.create_task(ss._inflight_watchdog())
+    try:
+        # The drain fires the phantom's completion_event.
+        await asyncio.wait_for(ev.wait(), timeout=2.0)
+    except asyncio.TimeoutError:
+        pytest.fail("watchdog should have reconciled the phantom meta")
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert restarted["v"] is False, "must NOT restart an idle REPL"
+    assert len(ss._inflight_metas) == 0, "phantom meta must be drained"
+    assert ss._head_started_at is None
+
+
 @pytest.mark.asyncio
 async def test_spawn_clears_turn_done_after_reconnect() -> None:
     """The turn_done invariant ("cleared between dispatches") must be

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3147,6 +3147,54 @@ def test_inflight_verdict_wedged_when_idle_predates_head() -> None:
     assert ss._inflight_stall_verdict(_time.time()) == "wedged"
 
 
+def test_inflight_verdict_wedged_when_stale_idle_within_old_slack() -> None:
+    """Regression (#118 / Murzik round-2): a FRESH first turn whose idle status
+    is stale — left over from the PREVIOUS turn, reported just 1s before this
+    turn was pasted — must be ``wedged``, not phantom-drained.
+
+    The earlier ``_head_started_at - 5s`` slack window accepted this stale idle
+    (``head - 1 >= head - 5``) and silently dropped a real hang-on-paste. The
+    freshness floor is now ``min(_head_started_at, head.dispatched_at)`` with no
+    slack; for a fresh first turn the two are equal, so any pre-dispatch idle is
+    rejected.
+    """
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head  # fresh first turn: dispatched == head start
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head - 1.0,  # 1s stale — inside the OLD 5s slack window
+    }
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
+def test_inflight_verdict_idle_for_queued_turn_uses_dispatch_floor() -> None:
+    """A queued turn that inherited the head spot was pasted (``dispatched_at``)
+    BEFORE the head re-based to it (``_head_started_at``). An idle reported after
+    its paste but before the re-base is still a valid phantom signal → ``idle``.
+
+    The floor is ``min(_head_started_at, dispatched_at) = dispatched_at``, so
+    tailer/status ordering jitter for queued turns is tolerated. (Under the old
+    fixed-slack rule this would have been mis-classified ``wedged``.)
+    """
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head - 50.0  # pasted 50s before the head re-base
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head - 25.0,  # after this turn's paste, before re-base
+    }
+    assert ss._inflight_stall_verdict(_time.time()) == "idle"
+
+
 def test_transcript_recently_grew(tmp_path) -> None:
     import os
 


### PR DESCRIPTION
## Problem

The per-session inflight watchdog force-restarted a tmux session whenever the head of `_inflight_metas` aged past `_TURN_DONE_TIMEOUT_SEC` (600s). That fired as a **false positive**, tearing down healthy sessions ~10 min after activity (well before the 8h idle timeout — Brad noticed sessions "torn down way before the 8h idle timeout"):

1. **Deque drift** — paste-count vs `stop_hook_summary`-count diverges under the #560 concurrent-dispatch design, so a *completed* turn's meta lingers as a phantom head and ages out even though the REPL is idle.
2. **Long/streaming turn** — a single turn legitimately running >600s while actively emitting output got killed mid-work.

This is the deferred root-cause from #589 (which made the restart *non-destructive*; this PR stops the unnecessary restart from happening at all).

## Approach

Brad's directive: **never tear a session down unless it's *actually* wedged.** Gate the restart on positive evidence of a wedge.

New `_inflight_stall_verdict(now)` classifies an aged-out head:

| verdict | condition | action |
|---|---|---|
| `growing` | transcript file still being written (mtime within window) | long/streaming turn → extend window, no restart |
| `idle` | transcript quiet **and** REPL last reported *idle* at-or-after head start | phantom meta(s) → drain + fire completion events, **no restart** |
| `wedged` | transcript quiet **and** REPL not idle (working/thinking/tool_use, or signal unavailable) | genuinely stuck → `force_restart` (unchanged path) |

**Liveness signals:**
- Transcript mtime via `_transcript_recently_grew` (no new wiring).
- REPL working/idle via a new `live_status_fn` on the session config, wired in `api.py` from `_agent_live_status` — the same dict Claude Code's working/idle hooks already populate via `POST /agents/{name}/status`.

The `idle` carve-out requires the idle status to be at-least-as-recent as the head start (minus slack) — otherwise a turn was pasted that the REPL never came alive for (hang-on-paste), which **is** a wedge. When `live_status_fn` is absent (tests), the verdict falls through to `wedged`, preserving the original recovery behavior.

## Tests
- Verdict classifier: `ok` / `growing` / `idle` / `wedged` + the idle-predates-head (hang-on-paste) edge + no-signal fallback.
- `_transcript_recently_grew` (fresh vs stale mtime, missing path).
- End-to-end: an idle REPL with a quiet transcript **reconciles** the phantom deque (drains + fires completion events) instead of force_restarting.
- Existing "wedged → force_restart" watchdog test passes unchanged.
- Full `tests/test_tmux_session.py` + `test_session_watchdog` (238) green; `test_api` + `test_streaming_session` (327) green; ruff clean.

## Verified in the wild (26.05.091)
dymok's watchdog fired at 610s, but post-#589 the restart resumed cleanly (`mode=continue`, `wake_reason=resume`) and he retained conversation context across it. With this PR, that restart wouldn't fire at all — nothing was wedged.

🤖 Opened by Barsik