### PR TITLE
fix(tmux): phantom-drain via transcript mtime + one-shot wake context (#591 #592)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1693,6 +1693,7 @@ def create_api(
             ctx_prompt = saved.to_prompt()
             if ctx_prompt:
                 wake_ctx = ctx_prompt
+                agents.clear_context(agent_name)  # one-shot: consumed on first wake (#591)
 
         freshness = _get_saved_context_freshness(agent_name)
         if freshness.get("stale_warning"):

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -503,6 +503,14 @@ class _InflightMeta:
     # ``_message_queue`` so the new worker re-dispatches them after
     # the restart settles.
     turn: _QueuedTurn
+    # Transcript file mtime sampled immediately after the paste succeeded.
+    # The watchdog's secondary stall verdict (#592) compares this against
+    # the current transcript mtime: growth of more than ``_TRANSCRIPT_PASTE_SLACK``
+    # seconds post-paste means the REPL was active on this turn, so a stale
+    # live_status.last_updated (Stop hook missed advancing it) can be safely
+    # ignored and the meta drained as phantom. None when the transcript path
+    # is unavailable at paste time — watchdog falls back to the idle_floor check.
+    transcript_mtime_at_paste: float | None = None
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -548,6 +556,15 @@ _WATCHDOG_TICK_SEC = 15.0
 # left over from the previous turn is rejected outright — a genuine
 # hang-on-paste is classified ``wedged``, not phantom-drained. (Replaces the
 # unsafe ``_head_started_at - 5s`` window flagged in Murzik's round-2 review.)
+
+# #592 — transcript-activity slack for the secondary stall-verdict check.
+# After the idle-freshness floor check fails (Stop hook didn't advance
+# live_status.last_updated for this turn), we fall back to transcript mtime:
+# if the transcript grew more than this many seconds after the paste, the
+# REPL was active on the turn and the meta is phantom. The slack prevents the
+# paste echo itself (~0–1 s in the transcript) from triggering the check —
+# we want evidence of a *response*, not just the pasted text landing.
+_TRANSCRIPT_PASTE_SLACK = 5.0
 
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
 # ``_session_ready_event`` for turns with ``internal=True and
@@ -3193,6 +3210,26 @@ class TmuxSession:
             idle_floor = min(self._head_started_at, head.dispatched_at)
             if last_updated >= idle_floor:
                 return "idle"
+            # (#592) Secondary: the Stop hook may have fired for this turn
+            # but failed to advance live_status.last_updated (concurrent-
+            # dispatch phantom — e.g. two turns complete close together and
+            # the second hook's write is lost). Transcript evidence is more
+            # reliable: if the transcript grew meaningfully AFTER this head's
+            # paste, the REPL was active on this turn and has since gone idle,
+            # so the lingering meta is phantom. _TRANSCRIPT_PASTE_SLACK guards
+            # against the paste echo itself (~0–1 s) triggering the check —
+            # a hang-on-paste (REPL never processed the turn) stays at the
+            # paste-echo level and is still classified ``"wedged"``.
+            mtime_at = head.transcript_mtime_at_paste
+            if mtime_at is not None:
+                _t = self._tailer
+                _tp = getattr(_t, "transcript_path", None) if _t else None
+                if _tp:
+                    try:
+                        if Path(_tp).stat().st_mtime > mtime_at + _TRANSCRIPT_PASTE_SLACK:
+                            return "idle"
+                    except OSError:
+                        pass
         return "wedged"
 
     async def _inflight_watchdog(self) -> None:
@@ -3646,6 +3683,18 @@ class TmuxSession:
                 "chat_id": turn.chat_id,
                 "message_id": turn.message_id,
             }
+        # #592: sample transcript mtime right after paste so the watchdog
+        # can detect post-paste REPL activity even when the Stop hook's
+        # live_status update is stale. Errors are silently swallowed —
+        # None is a safe sentinel (watchdog falls back to the idle_floor check).
+        _tailer_ref = self._tailer
+        _tpath = getattr(_tailer_ref, "transcript_path", None) if _tailer_ref else None
+        _tmtime_at_paste: float | None = None
+        if _tpath:
+            try:
+                _tmtime_at_paste = Path(_tpath).stat().st_mtime
+            except OSError:
+                pass
         was_empty = not self._inflight_metas
         self._inflight_metas.append(_InflightMeta(
             meta=meta_dict,
@@ -3653,6 +3702,7 @@ class TmuxSession:
             internal=turn.internal,
             dispatched_at=time.time(),
             turn=turn,
+            transcript_mtime_at_paste=_tmtime_at_paste,
         ))
         # Watchdog head-clock. If this entry just became the head (deque
         # was empty before append), start its timeout window NOW. If

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3195,6 +3195,91 @@ def test_inflight_verdict_idle_for_queued_turn_uses_dispatch_floor() -> None:
     assert ss._inflight_stall_verdict(_time.time()) == "idle"
 
 
+def test_inflight_verdict_idle_via_transcript_mtime(tmp_path) -> None:
+    """#592: stale live_status but transcript grew well after paste → phantom, not wedged.
+
+    The REPL processed the turn (transcript has a response) but the Stop hook
+    failed to advance last_updated.  The secondary transcript-mtime check should
+    return ``"idle"`` so the phantom meta is drained instead of force-restarting.
+    """
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head_t = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head_t
+    # transcript mtime at paste: set to head_t (paste time)
+    meta.transcript_mtime_at_paste = head_t
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head_t
+    ss._transcript_recently_grew = lambda now, window: False
+
+    # live_status is idle but last_updated is stale (from prior turn)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head_t - 50.0,  # predates this turn's paste
+    }
+
+    # Tailer transcript mtime: well after paste (response was written 30s post-paste)
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("{}\n")
+    import os
+    mtime_with_response = head_t + 30.0  # 30s after paste → well past _TRANSCRIPT_PASTE_SLACK
+    os.utime(f, (mtime_with_response, mtime_with_response))
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = f
+
+    assert ss._inflight_stall_verdict(_time.time()) == "idle"
+
+
+def test_inflight_verdict_wedged_when_transcript_only_paste_echo(tmp_path) -> None:
+    """#592: stale live_status, transcript mtime is only the paste echo (< slack)
+    → hang-on-paste, still classified ``"wedged"``."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head_t = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head_t
+    # mtime_at_paste = head_t; current mtime = head_t + 1s (paste echo only)
+    meta.transcript_mtime_at_paste = head_t
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head_t
+    ss._transcript_recently_grew = lambda now, window: False
+
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head_t - 50.0,
+    }
+
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("{}\n")
+    import os
+    # Only 1s after paste — within _TRANSCRIPT_PASTE_SLACK (5s); counts as paste echo
+    mtime_paste_echo = head_t + 1.0
+    os.utime(f, (mtime_paste_echo, mtime_paste_echo))
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = f
+
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
+def test_inflight_verdict_wedged_when_no_transcript_mtime_at_paste(tmp_path) -> None:
+    """#592: when transcript_mtime_at_paste is None (path unavailable at paste),
+    the secondary check is skipped and stale-idle still returns ``"wedged"``."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head_t = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head_t
+    meta.transcript_mtime_at_paste = None  # unavailable
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head_t
+    ss._transcript_recently_grew = lambda now, window: False
+
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head_t - 50.0,
+    }
+
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
 def test_transcript_recently_grew(tmp_path) -> None:
     import os
 


### PR DESCRIPTION
Closing in favour of #595 — rebased on post-#594 main to resolve merge conflict in `_inflight_stall_verdict`.