### PR TITLE
chore(tmux): instrument verdict inputs at the wedged decision (#592)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3193,7 +3193,54 @@ class TmuxSession:
             idle_floor = min(self._head_started_at, head.dispatched_at)
             if last_updated >= idle_floor:
                 return "idle"
+        self._log_wedged_inputs(now, live)
         return "wedged"
+
+    def _log_wedged_inputs(self, now: float, live: dict | None) -> None:
+        """Dump verdict inputs at the wedged decision point (#592).
+
+        Why: distinguishes (A) stale-idle from (B) stuck-working false-positives
+        in production logs without changing classifier behavior. Read alongside
+        the existing "REPL stuck; scheduling force_restart" line to confirm
+        which case fired.
+        """
+        head_dispatched_at: float | None = None
+        if self._inflight_metas:
+            head_dispatched_at = getattr(
+                self._inflight_metas[0], "dispatched_at", None
+            )
+        live_status = live.get("status") if live else None
+        live_last_updated = live.get("last_updated") if live else None
+        idle_floor: float | None = None
+        if self._head_started_at is not None and head_dispatched_at is not None:
+            idle_floor = min(self._head_started_at, head_dispatched_at)
+        transcript_mtime: float | None = None
+        tailer = self._tailer
+        transcript_path = (
+            getattr(tailer, "transcript_path", None) if tailer else None
+        )
+        if transcript_path:
+            try:
+                transcript_mtime = Path(transcript_path).stat().st_mtime
+            except OSError:
+                pass
+        age = (
+            (now - self._head_started_at)
+            if self._head_started_at is not None
+            else None
+        )
+        age_str = f"{age:.1f}" if age is not None else "None"
+        _log(
+            f"tmux[{self.agent_name}]: verdict_wedged_inputs "
+            f"live_status={live_status!r} "
+            f"live_last_updated={live_last_updated} "
+            f"idle_floor={idle_floor} "
+            f"head_dispatched_at={head_dispatched_at} "
+            f"head_started_at={self._head_started_at} "
+            f"transcript_mtime={transcript_mtime} "
+            f"age_s={age_str} "
+            f"depth={len(self._inflight_metas)}"
+        )
 
     async def _inflight_watchdog(self) -> None:
         """Age the ``_inflight_metas`` head; force_restart if it sticks.


### PR DESCRIPTION
## Summary

- Add a single instrumentation log line at the moment `_inflight_stall_verdict` returns `\"wedged\"`, capturing every input the classifier used to reach that decision
- Strictly observational — **no behavior change**; the existing force_restart path runs unchanged
- Phase 1 of the #592 plan: prove (A) stale-idle vs (B) stuck-working scope before changing the classifier

## Why

Per #592, the inflight watchdog is force-restarting `dymok` and `barsik` ~10 minutes after activity even though PR #590 was supposed to prevent that. Two candidate failure modes can produce the same `\"wedged\"` outcome:

- **(A) Stale-idle**: `live_status == \"idle\"` but `last_updated < idle_floor` (stamp from the prior turn) → classifier rejects → wedged
- **(B) Stuck-working**: `live_status == \"working\"`, never transitions back to idle for this turn → skips the idle branch entirely → wedged

The existing log line (`tmux[...]: inflight head aged ...s — REPL stuck; scheduling force_restart`) doesn't tell them apart. The chosen Phase 2 fix (OR `mtime > head.dispatched_at` into the idle-branch acceptance) **only addresses (A)**. We need to measure how much of the population is (A) vs (B) before deciding whether Phase 3 (transcript-tail JSONL inspection in the working branch) is needed at all.

## What the new log line emits

```
tmux[<agent>]: verdict_wedged_inputs live_status=<str|None> live_last_updated=<float|None>
idle_floor=<float|None> head_dispatched_at=<float|None> head_started_at=<float|None>
transcript_mtime=<float|None> age_s=<str> depth=<int>
```

Sits immediately before the existing `REPL stuck; scheduling force_restart` line so both are findable in the same grep.

## Test plan

- [x] `ruff check src/pinky_daemon/tmux_session.py` — clean
- [x] `.venv/bin/pytest tests/test_tmux_session.py -k \"verdict or stall or wedge or idle or inflight\"` — 38 passed
- [x] Module import smoke test — clean
- [ ] Verify in prod after deploy: trigger or wait for next force_restart, confirm `verdict_wedged_inputs` line precedes the existing `REPL stuck` line with sensible values

## Follow-ups (out of scope for this PR)

- **Phase 2** — once measurement confirms (A) is the dominant case, swap the idle-branch check to `last_updated >= idle_floor or mtime > head.dispatched_at`. Preserves fast path; adds phantom-recovery; hang-on-paste still caught (both conditions false).
- **Phase 3** — if (B) is also a meaningful share, add transcript-tail JSONL inspection (last record = completed assistant turn vs pending tool_use) in the working branch.

## Review

- @murzik — wrote the original floor logic (cited \"Murzik round-2\" at lines 3186-3191) and reviewed #590; would value your sanity check
- @barsik — agreed to second-review (per #592 discussion)

Refs #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)