### PR TITLE
fix(tmux): phantom-drain via transcript mtime (#592)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -616,6 +616,14 @@ class _InflightMeta:
     # ``_message_queue`` so the new worker re-dispatches them after
     # the restart settles.
     turn: _QueuedTurn
+    # Transcript file mtime sampled immediately after the paste succeeded.
+    # The watchdog's secondary stall verdict (#592) compares this against
+    # the current transcript mtime: growth of more than ``_TRANSCRIPT_PASTE_SLACK``
+    # seconds post-paste means the REPL was active on this turn, so a stale
+    # live_status.last_updated (Stop hook missed advancing it) can be safely
+    # ignored and the meta drained as phantom. None when the transcript path
+    # is unavailable at paste time — watchdog falls back to the idle_floor check.
+    transcript_mtime_at_paste: float | None = None
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -661,6 +669,15 @@ _WATCHDOG_TICK_SEC = 15.0
 # left over from the previous turn is rejected outright — a genuine
 # hang-on-paste is classified ``wedged``, not phantom-drained. (Replaces the
 # unsafe ``_head_started_at - 5s`` window flagged in Murzik's round-2 review.)
+
+# #592 — transcript-activity slack for the secondary stall-verdict check.
+# After the idle-freshness floor check fails (Stop hook didn't advance
+# live_status.last_updated for this turn), we fall back to transcript mtime:
+# if the transcript grew more than this many seconds after the paste, the
+# REPL was active on the turn and the meta is phantom. The slack prevents the
+# paste echo itself (~0–1 s in the transcript) from triggering the check —
+# we want evidence of a *response*, not just the pasted text landing.
+_TRANSCRIPT_PASTE_SLACK = 5.0
 
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
 # ``_session_ready_event`` for turns with ``internal=True and
@@ -3373,6 +3390,26 @@ class TmuxSession:
             idle_floor = min(self._head_started_at, head.dispatched_at)
             if last_updated >= idle_floor:
                 return "idle"
+            # (#592) Secondary: the Stop hook may have fired for this turn
+            # but failed to advance live_status.last_updated (concurrent-
+            # dispatch phantom — e.g. two turns complete close together and
+            # the second hook's write is lost). Transcript evidence is more
+            # reliable: if the transcript grew meaningfully AFTER this head's
+            # paste, the REPL was active on this turn and has since gone idle,
+            # so the lingering meta is phantom. _TRANSCRIPT_PASTE_SLACK guards
+            # against the paste echo itself (~0–1 s) triggering the check —
+            # a hang-on-paste (REPL never processed the turn) stays at the
+            # paste-echo level and is still classified ``"wedged"``.
+            mtime_at = head.transcript_mtime_at_paste
+            if mtime_at is not None:
+                _t = self._tailer
+                _tp = getattr(_t, "transcript_path", None) if _t else None
+                if _tp:
+                    try:
+                        if Path(_tp).stat().st_mtime > mtime_at + _TRANSCRIPT_PASTE_SLACK:
+                            return "idle"
+                    except OSError:
+                        pass
         self._log_wedged_inputs(now, live)
         return "wedged"
 
@@ -3892,6 +3929,18 @@ class TmuxSession:
                 "chat_id": turn.chat_id,
                 "message_id": turn.message_id,
             }
+        # #592: sample transcript mtime right after paste so the watchdog
+        # can detect post-paste REPL activity even when the Stop hook's
+        # live_status update is stale. Errors are silently swallowed —
+        # None is a safe sentinel (watchdog falls back to the idle_floor check).
+        _tailer_ref = self._tailer
+        _tpath = getattr(_tailer_ref, "transcript_path", None) if _tailer_ref else None
+        _tmtime_at_paste: float | None = None
+        if _tpath:
+            try:
+                _tmtime_at_paste = Path(_tpath).stat().st_mtime
+            except OSError:
+                pass
         was_empty = not self._inflight_metas
         self._inflight_metas.append(_InflightMeta(
             meta=meta_dict,
@@ -3899,6 +3948,7 @@ class TmuxSession:
             internal=turn.internal,
             dispatched_at=time.time(),
             turn=turn,
+            transcript_mtime_at_paste=_tmtime_at_paste,
         ))
         # Watchdog head-clock. If this entry just became the head (deque
         # was empty before append), start its timeout window NOW. If

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -616,14 +616,23 @@ class _InflightMeta:
     # ``_message_queue`` so the new worker re-dispatches them after
     # the restart settles.
     turn: _QueuedTurn
-    # Transcript file mtime sampled immediately after the paste succeeded.
-    # The watchdog's secondary stall verdict (#592) compares this against
-    # the current transcript mtime: growth of more than ``_TRANSCRIPT_PASTE_SLACK``
-    # seconds post-paste means the REPL was active on this turn, so a stale
-    # live_status.last_updated (Stop hook missed advancing it) can be safely
-    # ignored and the meta drained as phantom. None when the transcript path
-    # is unavailable at paste time — watchdog falls back to the idle_floor check.
+    # Paste-time baselines for the watchdog's secondary stall verdict (#592).
+    # The verdict compares the CURRENT transcript mtime against
+    # ``max(transcript_mtime_at_paste, paste_succeeded_at) + _TRANSCRIPT_PASTE_SLACK``:
+    # growth past that floor means the REPL was active on this turn, so a stale
+    # live_status.last_updated (Stop hook missed advancing it) can be ignored and
+    # the meta drained as phantom.
+    #
+    # ``paste_succeeded_at`` is a daemon-clock stamp taken right after paste
+    # success; it is the authoritative floor. ``transcript_mtime_at_paste`` is the
+    # file mtime sampled at the same moment, but the file write can LAG the tmux
+    # paste (paste_text only waits on paste-buffer + 300 ms + Enter, not on Claude
+    # writing the JSONL), so on its own it can be a stale PREVIOUS-turn mtime far in
+    # the past — which would let a real hang-on-paste's echo clear the slack and
+    # false-drain as idle (Murzik, #595 review). Taking the max anchors the floor to
+    # this turn's paste time regardless of write lag. Both None ⇒ fall back to wedged.
     transcript_mtime_at_paste: float | None = None
+    paste_succeeded_at: float | None = None
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -3400,13 +3409,20 @@ class TmuxSession:
             # against the paste echo itself (~0–1 s) triggering the check —
             # a hang-on-paste (REPL never processed the turn) stays at the
             # paste-echo level and is still classified ``"wedged"``.
+            # Baseline = max(file mtime at paste, daemon-clock paste time). The
+            # daemon stamp anchors the floor to THIS turn even when the JSONL
+            # write lags the tmux paste; without it a stale previous-turn mtime
+            # could let a real hang-on-paste's echo clear the slack (#595 review).
+            baseline = head.paste_succeeded_at
             mtime_at = head.transcript_mtime_at_paste
-            if mtime_at is not None:
+            if mtime_at is not None and (baseline is None or mtime_at > baseline):
+                baseline = mtime_at
+            if baseline is not None:
                 _t = self._tailer
                 _tp = getattr(_t, "transcript_path", None) if _t else None
                 if _tp:
                     try:
-                        if Path(_tp).stat().st_mtime > mtime_at + _TRANSCRIPT_PASTE_SLACK:
+                        if Path(_tp).stat().st_mtime > baseline + _TRANSCRIPT_PASTE_SLACK:
                             return "idle"
                     except OSError:
                         pass
@@ -3929,10 +3945,13 @@ class TmuxSession:
                 "chat_id": turn.chat_id,
                 "message_id": turn.message_id,
             }
-        # #592: sample transcript mtime right after paste so the watchdog
-        # can detect post-paste REPL activity even when the Stop hook's
-        # live_status update is stale. Errors are silently swallowed —
-        # None is a safe sentinel (watchdog falls back to the idle_floor check).
+        # #592: capture paste-time baselines so the watchdog can detect post-paste
+        # REPL activity even when the Stop hook's live_status update is stale.
+        # ``_paste_succeeded_at`` (daemon clock) is the authoritative floor; the
+        # transcript mtime is sampled too but can lag the paste (see _InflightMeta),
+        # so the verdict uses max(...). Errors are swallowed — the daemon-clock
+        # stamp alone is a safe baseline.
+        _paste_succeeded_at = time.time()
         _tailer_ref = self._tailer
         _tpath = getattr(_tailer_ref, "transcript_path", None) if _tailer_ref else None
         _tmtime_at_paste: float | None = None
@@ -3949,6 +3968,7 @@ class TmuxSession:
             dispatched_at=time.time(),
             turn=turn,
             transcript_mtime_at_paste=_tmtime_at_paste,
+            paste_succeeded_at=_paste_succeeded_at,
         ))
         # Watchdog head-clock. If this entry just became the head (deque
         # was empty before append), start its timeout window NOW. If

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3207,6 +3207,90 @@ def test_inflight_verdict_idle_for_queued_turn_uses_dispatch_floor() -> None:
     assert ss._inflight_stall_verdict(_time.time()) == "idle"
 
 
+def test_inflight_verdict_idle_via_transcript_mtime(tmp_path) -> None:
+    """#592: stale live_status but transcript grew well after paste → phantom, not wedged."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head_t = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head_t
+    meta.transcript_mtime_at_paste = head_t
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head_t
+    ss._transcript_recently_grew = lambda now, window: False
+
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head_t - 50.0,  # predates this turn's paste
+    }
+
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("{}\n")
+    import os
+
+    mtime_with_response = head_t + 30.0  # well past _TRANSCRIPT_PASTE_SLACK
+    os.utime(f, (mtime_with_response, mtime_with_response))
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = f
+
+    assert ss._inflight_stall_verdict(_time.time()) == "idle"
+
+
+def test_inflight_verdict_wedged_when_transcript_only_paste_echo(tmp_path) -> None:
+    """#592: stale live_status, transcript mtime is only the paste echo (< slack) → wedged."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head_t = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head_t
+    meta.transcript_mtime_at_paste = head_t
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head_t
+    ss._transcript_recently_grew = lambda now, window: False
+
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head_t - 50.0,
+    }
+
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("{}\n")
+    import os
+
+    mtime_paste_echo = head_t + 1.0  # within _TRANSCRIPT_PASTE_SLACK (5s)
+    os.utime(f, (mtime_paste_echo, mtime_paste_echo))
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = f
+
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
+def test_inflight_verdict_wedged_when_no_transcript_mtime_at_paste(tmp_path) -> None:
+    """#592: stale live_status, transcript_mtime_at_paste is None → falls back to wedged."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head_t = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head_t
+    meta.transcript_mtime_at_paste = None  # unavailable at paste time
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head_t
+    ss._transcript_recently_grew = lambda now, window: False
+
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head_t - 50.0,
+    }
+
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("{}\n")
+    import os
+
+    mtime_with_response = head_t + 30.0
+    os.utime(f, (mtime_with_response, mtime_with_response))
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = f
+
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
 def test_transcript_recently_grew(tmp_path) -> None:
     import os
 

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3214,6 +3214,7 @@ def test_inflight_verdict_idle_via_transcript_mtime(tmp_path) -> None:
     meta = _mk_inflight_meta()
     meta.dispatched_at = head_t
     meta.transcript_mtime_at_paste = head_t
+    meta.paste_succeeded_at = head_t
     ss._inflight_metas.append(meta)
     ss._head_started_at = head_t
     ss._transcript_recently_grew = lambda now, window: False
@@ -3242,6 +3243,7 @@ def test_inflight_verdict_wedged_when_transcript_only_paste_echo(tmp_path) -> No
     meta = _mk_inflight_meta()
     meta.dispatched_at = head_t
     meta.transcript_mtime_at_paste = head_t
+    meta.paste_succeeded_at = head_t
     ss._inflight_metas.append(meta)
     ss._head_started_at = head_t
     ss._transcript_recently_grew = lambda now, window: False
@@ -3263,13 +3265,14 @@ def test_inflight_verdict_wedged_when_transcript_only_paste_echo(tmp_path) -> No
     assert ss._inflight_stall_verdict(_time.time()) == "wedged"
 
 
-def test_inflight_verdict_wedged_when_no_transcript_mtime_at_paste(tmp_path) -> None:
-    """#592: stale live_status, transcript_mtime_at_paste is None → falls back to wedged."""
+def test_inflight_verdict_wedged_when_no_paste_baselines(tmp_path) -> None:
+    """#592: stale live_status, BOTH paste baselines None (legacy meta) → falls back to wedged."""
     ss, _ = _make_session(state=SessionState.CONNECTED)
     head_t = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
     meta = _mk_inflight_meta()
     meta.dispatched_at = head_t
     meta.transcript_mtime_at_paste = None  # unavailable at paste time
+    meta.paste_succeeded_at = None  # legacy meta from before the daemon-clock baseline
     ss._inflight_metas.append(meta)
     ss._head_started_at = head_t
     ss._transcript_recently_grew = lambda now, window: False
@@ -3289,6 +3292,73 @@ def test_inflight_verdict_wedged_when_no_transcript_mtime_at_paste(tmp_path) -> 
     ss._tailer.transcript_path = f
 
     assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
+def test_inflight_verdict_wedged_when_mtime_at_paste_is_stale(tmp_path) -> None:
+    """#592/#595: transcript_mtime_at_paste is a STALE previous-turn write (the JSONL
+    write lagged the tmux paste), and the only write afterward is the paste echo within
+    slack of the ACTUAL paste time. The daemon-clock paste_succeeded_at baseline must
+    anchor the floor to this turn so a real hang-on-paste stays wedged (Murzik #595)."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head_t = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head_t
+    # File mtime sampled at paste was the PREVIOUS turn's write, far in the past —
+    # the JSONL had not been touched for this turn when _deliver_turn sampled it.
+    meta.transcript_mtime_at_paste = head_t - 100.0
+    meta.paste_succeeded_at = head_t  # daemon clock: paste actually happened at head_t
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head_t
+    ss._transcript_recently_grew = lambda now, window: False
+
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head_t - 50.0,
+    }
+
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("{}\n")
+    import os
+
+    # Only the paste echo lands, ~1 s after the real paste — within _TRANSCRIPT_PASTE_SLACK
+    # of paste_succeeded_at. A naive mtime-only baseline (head_t-100) would clear the slack
+    # (head_t+1 > head_t-95) and false-drain; the max(...) baseline keeps it wedged.
+    mtime_paste_echo = head_t + 1.0
+    os.utime(f, (mtime_paste_echo, mtime_paste_echo))
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = f
+
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
+def test_inflight_verdict_idle_via_paste_clock_when_mtime_at_paste_missing(tmp_path) -> None:
+    """#592/#595: mtime-at-paste sampling failed (None) but the daemon-clock
+    paste_succeeded_at baseline still detects a real post-paste response → phantom/idle."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head_t = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head_t
+    meta.transcript_mtime_at_paste = None  # sampling failed at paste time
+    meta.paste_succeeded_at = head_t
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head_t
+    ss._transcript_recently_grew = lambda now, window: False
+
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": head_t - 50.0,
+    }
+
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("{}\n")
+    import os
+
+    mtime_with_response = head_t + 30.0  # real response well past the paste + slack
+    os.utime(f, (mtime_with_response, mtime_with_response))
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = f
+
+    assert ss._inflight_stall_verdict(_time.time()) == "idle"
 
 
 def test_transcript_recently_grew(tmp_path) -> None:


### PR DESCRIPTION
Rebased and scoped to #592 only — the #591 one-shot context fix shipped separately in #600.

## Summary

**Root cause (#592):** When a turn completes but its Stop hook fails to advance `live_status.last_updated` (concurrent-dispatch phantom), the idle-freshness floor check rejects the stale timestamp and returns `"wedged"`, force-restarting a healthy idle REPL.

**Fix:** Secondary verdict path in `_inflight_stall_verdict`. When `live_status.status == "idle"` but the timestamp floor check fails, compare the current transcript `mtime` against `transcript_mtime_at_paste` — sampled right after each successful paste. If the transcript grew by more than `_TRANSCRIPT_PASTE_SLACK` (5 s) after the paste, the REPL was active and the lingering meta is phantom → return `"idle"` and drain without restarting.

## Changes

| File | What changed |
|------|-------------|
| `src/pinky_daemon/tmux_session.py` | `_TRANSCRIPT_PASTE_SLACK` constant; `transcript_mtime_at_paste` field on `_InflightMeta`; mtime capture in `_deliver_turn`; secondary check in `_inflight_stall_verdict` |
| `tests/test_tmux_session.py` | 3 new verdict tests: happy path, paste-echo guard, None-mtime fallback |

## Test plan

- [x] 3 new unit tests: `test_inflight_verdict_idle_via_transcript_mtime`, `test_inflight_verdict_wedged_when_transcript_only_paste_echo`, `test_inflight_verdict_wedged_when_no_transcript_mtime_at_paste`
- [ ] Production: confirm dymok no longer shows repeated `inflight head aged 600s > 600.0s — REPL stuck` events after idle user turns

Closes #592.

https://claude.ai/code/session_01P6FWvEtnMq3Wjyw744L4r8