### PR TITLE
fix(tmux): pre-seed .claude.json trust/bypass flags on fresh launch (#112)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -124,6 +124,15 @@ _TRANSPORT_LOCK_DIR = Path("data/transport-locks")
 # Serializes read-modify-write of the shared ``.claude.json`` across the
 # daemon's concurrent agent launches so two simultaneous seeds can't drop
 # each other's ``projects[...]`` entry (last-write-wins clobber).
+#
+# NOTE (cross-process race, accepted): this lock only serializes seeds
+# WITHIN the daemon process. On a box where many agents' ``claude``
+# processes share one ``.claude.json``, an already-running claude could
+# write its own per-session keys (``numStartups``, ``lastCost``, ...)
+# between our read and our ``os.replace`` — silently dropping that write.
+# Window is tiny and severity low (those keys are non-load-bearing
+# telemetry), so we accept it for now. A file lock (``fcntl.flock``)
+# around the read-modify-write is the proper fix if this ever matters.
 _CLAUDE_JSON_SEED_LOCK = threading.Lock()
 
 

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -57,9 +57,11 @@ session stays alive.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import re
 import shlex
+import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field, replace
@@ -101,6 +103,98 @@ from pinky_daemon.wake_prompt import (
 # and not per-agent because the lock signals daemon-wide intent, not
 # agent-internal state.
 _TRANSPORT_LOCK_DIR = Path("data/transport-locks")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Claude Code first-run trust pre-seed (#112)
+# ──────────────────────────────────────────────────────────────────────────
+#
+# A fresh ``claude`` REPL on a box that has never run Claude Code in this
+# agent-home wedges at two interactive first-run gates:
+#   1. "Do you trust the files in this folder?"
+#   2. "Bypass Permissions mode" acceptance
+# ``claude --dangerously-skip-permissions`` does NOT auto-accept either —
+# the pane parks at the prompt, no transcript is ever written, and the
+# session sits CONNECTED-but-mute with ``pending_responses=true`` forever
+# (the symptom that wedged Angel on a fresh box). Claude Code persists the
+# "already accepted" state in its global ``.claude.json``; pre-seeding the
+# relevant flags before launch makes every new tmux agent boot clean on
+# any box without an operator manually clearing the prompts.
+
+# Serializes read-modify-write of the shared ``.claude.json`` across the
+# daemon's concurrent agent launches so two simultaneous seeds can't drop
+# each other's ``projects[...]`` entry (last-write-wins clobber).
+_CLAUDE_JSON_SEED_LOCK = threading.Lock()
+
+
+def _resolve_claude_config_path(env: dict[str, str] | None = None) -> Path:
+    """Resolve the path to Claude Code's global ``.claude.json``.
+
+    Mirrors the CLI's resolution: ``$CLAUDE_CONFIG_DIR/.claude.json`` when
+    ``CLAUDE_CONFIG_DIR`` is set, else ``$HOME/.claude.json``. ``env``
+    defaults to the daemon process environment, which the tmux REPL
+    inherits (``_build_repl_env`` only adds ``-e`` overrides on top, so
+    the effective HOME/CLAUDE_CONFIG_DIR the launched ``claude`` sees is
+    the daemon's unless explicitly overridden). Injectable for tests.
+    """
+    e = env if env is not None else os.environ
+    cfg_dir = (e.get("CLAUDE_CONFIG_DIR") or "").strip()
+    base = Path(cfg_dir) if cfg_dir else Path(e.get("HOME") or Path.home())
+    return base / ".claude.json"
+
+
+def _seed_claude_trust_file(config_path: Path, project_dir: str) -> bool:
+    """Idempotently pre-seed first-run trust/bypass flags in
+    ``config_path`` (Claude Code's ``.claude.json``) for ``project_dir``.
+
+    Sets top-level ``bypassPermissionsModeAccepted`` and, under
+    ``projects[<resolved project_dir>]``, ``hasTrustDialogAccepted`` +
+    ``hasCompletedProjectOnboarding`` — all to ``True``. Preserves every
+    other key (the file also holds oauth creds + per-project history).
+
+    Returns ``True`` if the file was modified, ``False`` if every flag was
+    already set (no write). Raises on a corrupt/non-object file rather than
+    clobbering it — callers treat seeding as best-effort and swallow.
+
+    Atomic: writes a sibling temp file and ``os.replace``s it in, so a
+    concurrent reader never sees a half-written config. Serialized
+    process-wide via ``_CLAUDE_JSON_SEED_LOCK``.
+    """
+    proj_key = str(Path(project_dir).resolve())
+    with _CLAUDE_JSON_SEED_LOCK:
+        data: dict = {}
+        if config_path.exists():
+            with config_path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                raise ValueError(
+                    f"{config_path} root is not a JSON object "
+                    f"(got {type(data).__name__}) — refusing to overwrite"
+                )
+
+        changed = False
+        if data.get("bypassPermissionsModeAccepted") is not True:
+            data["bypassPermissionsModeAccepted"] = True
+            changed = True
+
+        projects = data.setdefault("projects", {})
+        if not isinstance(projects, dict):
+            raise ValueError(f"{config_path} 'projects' is not an object")
+        proj = projects.setdefault(proj_key, {})
+        if not isinstance(proj, dict):
+            raise ValueError(f"{config_path} projects[{proj_key!r}] is not an object")
+        for flag in ("hasTrustDialogAccepted", "hasCompletedProjectOnboarding"):
+            if proj.get(flag) is not True:
+                proj[flag] = True
+                changed = True
+
+        if changed:
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = config_path.parent / f".claude.json.pinky-seed.{os.getpid()}.tmp"
+            with tmp.open("w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            os.replace(tmp, config_path)
+        return changed
 
 # Transient-failure retry cadence for the worker loop. Fixed (not
 # exponential) — mirrors pulse-v2's poll cadence and keeps the
@@ -1421,6 +1515,27 @@ class TmuxSession:
         cwd = self._config.working_dir or "."
         # Ensure cwd exists — claude --continue needs it.
         Path(cwd).mkdir(parents=True, exist_ok=True)
+
+        # Pre-seed Claude Code's first-run trust/bypass flags (#112) so a
+        # FRESH REPL doesn't wedge on the "trust this folder?" / "Bypass
+        # Permissions mode" gates that --dangerously-skip-permissions does
+        # NOT auto-accept. Idempotent + best-effort: a failure here must
+        # never block the spawn (worst case is the pre-existing wedge, not
+        # a regression). Resolve the config path against the effective env
+        # the launched claude inherits (daemon env + our -e overrides).
+        try:
+            effective_env = {**os.environ, **self._build_repl_env()}
+            cfg_path = _resolve_claude_config_path(effective_env)
+            if _seed_claude_trust_file(cfg_path, cwd):
+                _log(
+                    f"tmux[{self.agent_name}]: pre-seeded claude trust flags "
+                    f"in {cfg_path} for project {cwd}"
+                )
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: claude trust pre-seed failed "
+                f"(non-fatal): {e}"
+            )
 
         # Pulse-v2 idle-prompt gate (task #92) re-arms on every fresh
         # spawn. The new REPL hasn't responded to anything yet, so the

--- a/tests/test_tmux_trust_seed.py
+++ b/tests/test_tmux_trust_seed.py
@@ -1,0 +1,143 @@
+"""Tests for the Claude Code first-run trust pre-seed (#112).
+
+Covers the two pure helpers wired into ``_spawn_tmux_repl``:
+- ``_resolve_claude_config_path`` — CLI-matching config-path resolution.
+- ``_seed_claude_trust_file`` — idempotent, atomic, non-clobbering seed of
+  the trust/bypass flags that ``--dangerously-skip-permissions`` does NOT
+  auto-accept (the wedge a fresh tmux agent hit on a cold box).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pinky_daemon.tmux_session import (
+    _resolve_claude_config_path,
+    _seed_claude_trust_file,
+)
+
+# ── _resolve_claude_config_path ──────────────────────────────────────────
+
+
+def test_resolve_honors_claude_config_dir():
+    p = _resolve_claude_config_path({"CLAUDE_CONFIG_DIR": "/tmp/cfg", "HOME": "/home/x"})
+    assert p == Path("/tmp/cfg/.claude.json")
+
+
+def test_resolve_falls_back_to_home_when_no_config_dir():
+    p = _resolve_claude_config_path({"HOME": "/home/x"})
+    assert p == Path("/home/x/.claude.json")
+
+
+def test_resolve_blank_config_dir_falls_back_to_home():
+    p = _resolve_claude_config_path({"CLAUDE_CONFIG_DIR": "  ", "HOME": "/home/x"})
+    assert p == Path("/home/x/.claude.json")
+
+
+# ── _seed_claude_trust_file ──────────────────────────────────────────────
+
+
+def test_seed_creates_missing_file(tmp_path: Path):
+    cfg = tmp_path / ".claude.json"
+    proj = tmp_path / "agents" / "angel"
+    proj.mkdir(parents=True)
+
+    wrote = _seed_claude_trust_file(cfg, str(proj))
+
+    assert wrote is True
+    assert cfg.exists()
+    data = json.loads(cfg.read_text())
+    assert data["bypassPermissionsModeAccepted"] is True
+    entry = data["projects"][str(proj.resolve())]
+    assert entry["hasTrustDialogAccepted"] is True
+    assert entry["hasCompletedProjectOnboarding"] is True
+
+
+def test_seed_is_idempotent(tmp_path: Path):
+    cfg = tmp_path / ".claude.json"
+    proj = tmp_path / "proj"
+    proj.mkdir()
+
+    assert _seed_claude_trust_file(cfg, str(proj)) is True
+    # Second call: every flag already set → no write, returns False.
+    assert _seed_claude_trust_file(cfg, str(proj)) is False
+
+
+def test_seed_preserves_existing_keys_and_other_projects(tmp_path: Path):
+    cfg = tmp_path / ".claude.json"
+    other = "/some/other/project"
+    cfg.write_text(
+        json.dumps(
+            {
+                "oauthAccount": {"token": "SECRET-DO-NOT-LOSE"},
+                "numStartups": 7,
+                "projects": {
+                    other: {"hasTrustDialogAccepted": True, "lastCost": 0.42},
+                },
+            }
+        )
+    )
+    proj = tmp_path / "proj"
+    proj.mkdir()
+
+    wrote = _seed_claude_trust_file(cfg, str(proj))
+
+    assert wrote is True
+    data = json.loads(cfg.read_text())
+    # Untouched pre-existing data survives.
+    assert data["oauthAccount"] == {"token": "SECRET-DO-NOT-LOSE"}
+    assert data["numStartups"] == 7
+    assert data["projects"][other] == {"hasTrustDialogAccepted": True, "lastCost": 0.42}
+    # New project seeded alongside.
+    assert data["bypassPermissionsModeAccepted"] is True
+    assert data["projects"][str(proj.resolve())]["hasTrustDialogAccepted"] is True
+
+
+def test_seed_completes_partial_flags(tmp_path: Path):
+    cfg = tmp_path / ".claude.json"
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    # Top-level bypass already accepted, but this project never trusted.
+    cfg.write_text(json.dumps({"bypassPermissionsModeAccepted": True, "projects": {}}))
+
+    wrote = _seed_claude_trust_file(cfg, str(proj))
+
+    assert wrote is True  # project flags were missing
+    data = json.loads(cfg.read_text())
+    entry = data["projects"][str(proj.resolve())]
+    assert entry["hasTrustDialogAccepted"] is True
+    assert entry["hasCompletedProjectOnboarding"] is True
+
+
+def test_seed_corrupt_file_raises_and_does_not_overwrite(tmp_path: Path):
+    cfg = tmp_path / ".claude.json"
+    cfg.write_text("{ this is not valid json ")
+
+    with pytest.raises(json.JSONDecodeError):
+        _seed_claude_trust_file(cfg, str(tmp_path / "proj"))
+
+    # The corrupt file is left exactly as-is — we never clobber a file
+    # that might hold (unparseable but recoverable) oauth creds.
+    assert cfg.read_text() == "{ this is not valid json "
+
+
+def test_seed_non_object_root_raises(tmp_path: Path):
+    cfg = tmp_path / ".claude.json"
+    cfg.write_text(json.dumps(["unexpected", "array"]))
+
+    with pytest.raises(ValueError):
+        _seed_claude_trust_file(cfg, str(tmp_path / "proj"))
+
+
+def test_seed_no_temp_file_left_behind(tmp_path: Path):
+    cfg = tmp_path / ".claude.json"
+    proj = tmp_path / "proj"
+    proj.mkdir()
+
+    _seed_claude_trust_file(cfg, str(proj))
+
+    leftovers = list(tmp_path.glob(".claude.json.pinky-seed*"))
+    assert leftovers == []


### PR DESCRIPTION
Closes #112.

## Problem

Bringing a new tmux agent up on a fresh box (Angel) wedged: her in-pane `claude` process parked at the first-run **"Do you trust the files in this folder?"** + **"Bypass Permissions mode"** prompts. `claude --dangerously-skip-permissions` does **not** auto-accept these — so the process stays alive, writes zero transcript, and the session sits CONNECTED-but-mute with `pending_responses=true` forever. The daemon's tmux launcher had no logic to pre-seed trust, so this required a manual `.claude.json` seed + `nsenter send-keys` to clear the live prompts (the workaround applied on the TOD box).

## Fix

Pre-seed the flags Claude Code persists for the "already accepted" state into the global `.claude.json` **before** launching the REPL, idempotently in the launch path, so every new tmux agent boots clean on any box:

- top-level `bypassPermissionsModeAccepted = true`
- `projects[<resolved working_dir>].hasTrustDialogAccepted = true`
- `projects[<resolved working_dir>].hasCompletedProjectOnboarding = true`

### Implementation (`tmux_session.py`)
- **`_resolve_claude_config_path(env)`** — mirrors the CLI's resolution (`$CLAUDE_CONFIG_DIR/.claude.json` else `$HOME/.claude.json`), resolved against the effective env the launched `claude` inherits (daemon env + the `-e` overrides from `_build_repl_env`).
- **`_seed_claude_trust_file(path, project_dir)`** — idempotent (returns whether it wrote), **atomic** (sibling temp + `os.replace`), **preserves all other keys** (oauth creds + per-project history), and **raises rather than clobbering** a corrupt / non-object file. Serialized process-wide via a lock so concurrent agent launches can't drop each other's `projects[...]` entry (last-write-wins).
- Wired into `_spawn_tmux_repl` right after the cwd `mkdir`. **Best-effort** — any failure is logged and never blocks the spawn (worst case is the pre-existing wedge, not a new regression).

### Related
- #110 (BOOTING watchdog gap) — wedged-before-registration detection would *also* catch this class; complementary, not a substitute.

## Testing
- `tests/test_tmux_trust_seed.py` — **10 tests**: path resolution (CLAUDE_CONFIG_DIR / HOME / blank), create-missing, idempotency, preservation of existing keys + other projects, partial-flag completion, corrupt-file & non-object refusal, no temp-file leak.
- Existing `tests/test_tmux_session.py` — **209 pass** (no regression).
- `ruff check` clean.

🤖 Opened by Barsik