### PR TITLE
fix(#110): bound cold-start connect so BOOTING wedges can't hang the start path

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -167,6 +167,56 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+# Cold-start connect umbrella (#110). `_start_streaming_session` registers a
+# session in `broker._streaming` only AFTER `ss.connect()` returns, and the
+# SessionWatchdog samples only `broker._streaming` — so a cold start that
+# wedges *inside* connect() (BOOTING, before registration) is invisible to the
+# watchdog and would hang the start path indefinitely. This bound caps that
+# wedge at the start site. It sits above tmux's 60s spawn bound
+# (`tmux_session._COLD_START_TIMEOUT_SEC`) and well below the 4/6-min
+# transition watchdog, so a legitimately slow SDK handshake isn't force-killed
+# mid-flight. Scope is the *cold start* in `_start_streaming_session` only —
+# `_ensure_streaming_session`'s reconnect path acts on an already-registered
+# session, which the transition watchdog can already observe.
+COLD_START_CONNECT_TIMEOUT_SEC = float(
+    os.environ.get("PINKY_COLD_START_CONNECT_TIMEOUT_SEC", "120")
+)
+
+
+async def _bounded_cold_start_connect(
+    ss,
+    *,
+    agent_name: str,
+    label: str,
+    timeout: float = COLD_START_CONNECT_TIMEOUT_SEC,
+) -> None:
+    """Run ``ss.connect()`` under a cold-start umbrella timeout (#110).
+
+    On timeout, ``asyncio.wait_for`` cancels the in-flight ``connect()``. For a
+    wedge still in BOOTING, ``connect()``'s own ``BaseException`` handler drives
+    BOOT_FAILED → DEAD. But a cancel can also land *after* BOOT_COMPLETE (state
+    already CONNECTED) yet *before* the caller registers the session —
+    bypassing that handler and leaving an unregistered-but-connected client. So
+    we always best-effort ``disconnect()`` before re-raising; the caller must
+    treat any raise as "do NOT register this session".
+    """
+    try:
+        await asyncio.wait_for(ss.connect(), timeout=timeout)
+    except asyncio.TimeoutError:
+        _log(
+            f"streaming-start: cold start timed out for {agent_name}/{label} "
+            f"after {timeout:.0f}s — discarding unregistered session"
+        )
+        try:
+            await ss.disconnect()
+        except Exception as de:  # best-effort cleanup; never mask the timeout
+            _log(
+                f"streaming-start: post-timeout disconnect failed for "
+                f"{agent_name}/{label}: {de}"
+            )
+        raise
+
+
 # ── Request/Response Models ──────────────────────────────────
 
 
@@ -2238,7 +2288,47 @@ def create_api(
 
         ss = SessionClass(config, **init_kwargs)
         ss._on_resume_handle = sid_callback
-        await ss.connect()
+        try:
+            await _bounded_cold_start_connect(
+                ss,
+                agent_name=agent_name,
+                label=label,
+                timeout=COLD_START_CONNECT_TIMEOUT_SEC,
+            )
+        except asyncio.TimeoutError:
+            # Cold-start wedged past the umbrella (#110). The session was NOT
+            # registered and was best-effort disconnected by the helper. Alert
+            # the owner + audit, then propagate so callers (boot loop /
+            # _ensure_streaming_session) surface the failure normally.
+            try:
+                activity.log(
+                    agent_name=agent_name,
+                    event_type="cold_start_timeout",
+                    title=(
+                        f"Cold-start connect timed out after "
+                        f"{COLD_START_CONNECT_TIMEOUT_SEC:.0f}s ({label})"
+                    ),
+                    metadata={"label": label, "resume_id": resume_id or ""},
+                )
+                owner = agents.get_owner_profile()
+                owner_chat = owner.get("chat_id", "") if owner else ""
+                if owner_chat:
+                    await broker.send_callback(
+                        agent_name=agent_name,
+                        platform="telegram",
+                        chat_id=str(owner_chat),
+                        text=(
+                            f"⚠️ {agent_name} cold-start connect timed out after "
+                            f"{COLD_START_CONNECT_TIMEOUT_SEC:.0f}s ({label}) — "
+                            f"session not started."
+                        ),
+                    )
+            except Exception as ae:
+                _log(
+                    f"streaming-start: cold-start timeout alert failed for "
+                    f"{agent_name}: {ae}"
+                )
+            raise
         broker.register_streaming(agent_name, ss, label=label)
 
         # Log session lifecycle event

--- a/tests/test_cold_start_umbrella.py
+++ b/tests/test_cold_start_umbrella.py
@@ -1,0 +1,129 @@
+"""Cold-start connect umbrella (#110).
+
+`_start_streaming_session` registers a session in `broker._streaming` only
+AFTER `ss.connect()` returns, and the SessionWatchdog samples only
+`broker._streaming` — so a cold start that wedges *inside* connect() (BOOTING,
+before registration) is invisible to the watchdog and would hang the start
+path indefinitely. `_bounded_cold_start_connect` caps that wedge at the start
+site and guarantees best-effort cleanup so the caller never registers a
+half-started session.
+
+These tests exercise the extracted helper directly (the start site itself is a
+deep closure inside the app factory). The fake session mirrors the real
+`connect()` cancellation contract:
+  - cancel while BOOTING  → connect()'s BaseException handler drives DEAD
+  - cancel after CONNECTED → handler is bypassed (state stays CONNECTED);
+                             only the start-site disconnect() cleans up
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pinky_daemon.api import (
+    COLD_START_CONNECT_TIMEOUT_SEC,
+    _bounded_cold_start_connect,
+)
+from pinky_daemon.transport_state import SessionState
+
+
+class _FakeColdStartSession:
+    """Fake session whose connect() can wedge in BOOTING or post-CONNECTED."""
+
+    def __init__(
+        self,
+        *,
+        mode: str = "wedge_booting",
+        disconnect_raises: bool = False,
+    ) -> None:
+        # mode: "wedge_booting" | "wedge_after_connected" | "fast"
+        self._mode = mode
+        self._disconnect_raises = disconnect_raises
+        self.state = SessionState.UNINITIALIZED
+        self.connect_started = False
+        self.disconnect_called = False
+
+    async def connect(self) -> None:
+        self.connect_started = True
+        if self._mode == "fast":
+            self.state = SessionState.CONNECTED
+            return
+        if self._mode == "wedge_after_connected":
+            # Mimic BOOT_COMPLETE → CONNECTED, then hang before returning.
+            self.state = SessionState.CONNECTED
+            await asyncio.sleep(3600)  # cancelled by wait_for; state stays CONNECTED
+            return
+        # Default: enter BOOTING and wedge. On cancellation, mimic connect()'s
+        # BaseException → BOOT_FAILED → DEAD completion.
+        self.state = SessionState.BOOTING
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            self.state = SessionState.DEAD
+            raise
+
+    async def disconnect(self) -> None:
+        self.disconnect_called = True
+        if self._disconnect_raises:
+            raise RuntimeError("disconnect boom")
+
+
+@pytest.mark.asyncio
+async def test_cold_start_timeout_wedged_in_booting():
+    """connect() wedges in BOOTING → TimeoutError, cleanup ran, lands DEAD."""
+    ss = _FakeColdStartSession(mode="wedge_booting")
+    with pytest.raises(asyncio.TimeoutError):
+        await _bounded_cold_start_connect(
+            ss, agent_name="a", label="main", timeout=0.05
+        )
+    assert ss.connect_started
+    assert ss.disconnect_called, "start-site cleanup must run on timeout"
+    # connect()'s own BOOT_FAILED handler drove the lifecycle to DEAD.
+    assert ss.state == SessionState.DEAD
+
+
+@pytest.mark.asyncio
+async def test_cold_start_timeout_after_boot_complete_pre_register():
+    """connect() reached CONNECTED then hung pre-return → defensive disconnect.
+
+    This is the non-obvious window: cancellation lands after BOOT_COMPLETE, so
+    connect()'s BaseException→DEAD handler is bypassed (state stays CONNECTED).
+    Without the start-site disconnect() we'd discard an unregistered-but-
+    connected client.
+    """
+    ss = _FakeColdStartSession(mode="wedge_after_connected")
+    with pytest.raises(asyncio.TimeoutError):
+        await _bounded_cold_start_connect(
+            ss, agent_name="a", label="main", timeout=0.05
+        )
+    assert ss.state == SessionState.CONNECTED  # past the BOOT_FAILED catch
+    assert ss.disconnect_called, "defensive cleanup must run even when CONNECTED"
+
+
+@pytest.mark.asyncio
+async def test_cold_start_connect_success_no_cleanup():
+    """A connect() that completes in time returns cleanly, no disconnect()."""
+    ss = _FakeColdStartSession(mode="fast")
+    await _bounded_cold_start_connect(
+        ss, agent_name="a", label="main", timeout=5
+    )
+    assert ss.state == SessionState.CONNECTED
+    assert not ss.disconnect_called
+
+
+@pytest.mark.asyncio
+async def test_cold_start_timeout_disconnect_error_does_not_mask_timeout():
+    """A failing cleanup disconnect() must not swallow/replace the TimeoutError."""
+    ss = _FakeColdStartSession(mode="wedge_booting", disconnect_raises=True)
+    with pytest.raises(asyncio.TimeoutError):
+        await _bounded_cold_start_connect(
+            ss, agent_name="a", label="main", timeout=0.05
+        )
+    assert ss.disconnect_called
+
+
+def test_cold_start_timeout_default_is_sane():
+    """Umbrella sits above tmux's 60s spawn bound, below the 4min transition warn."""
+    assert COLD_START_CONNECT_TIMEOUT_SEC > 60.0
+    assert COLD_START_CONNECT_TIMEOUT_SEC < 240.0


### PR DESCRIPTION
## Problem (#110, follow-up to #109/PR#586)

`_start_streaming_session` (api.py) registers a session in `broker._streaming` **only after** `ss.connect()` returns:

```python
await ss.connect()                       # can wedge here, in BOOTING
broker.register_streaming(...)           # registers only after connect() returns
```

`SessionWatchdog` samples **only** `broker._streaming`. So a cold start that wedges *inside* `connect()` (BOOTING, pre-registration) is never registered → invisible to the watchdog → hangs the start path indefinitely. #109's transition branch covers RECONNECTING and transitions on already-registered sessions; fresh cold-start BOOTING was the remaining gap. Confirmed `StreamingSession.connect()` has no umbrella timeout (tmux bounds only its *spawn* via `_COLD_START_TIMEOUT_SEC=60`).

## Fix — option (a): bound at the start site

Chose the start-site umbrella over "register before connect" (option b) after design review with @murzik. (b) would expose registered-but-not-connected objects to every broker/routing/status path and lean on the 4/6-min transition watchdog for cold-start recovery — too much surface for a start-site timeout.

- New `_bounded_cold_start_connect(ss, …, timeout)`: wraps `connect()` in `asyncio.wait_for`.
- `COLD_START_CONNECT_TIMEOUT_SEC` — default **120s**, env-overridable (`PINKY_COLD_START_CONNECT_TIMEOUT_SEC`). Above tmux's 60s spawn bound, well below the 4/6-min transition watchdog.
- On timeout: cancellation propagates into `connect()`. A still-BOOTING wedge hits `connect()`'s `BaseException → BOOT_FAILED → DEAD` handler. **The non-obvious window** (@murzik's catch): a cancel landing *after* `BOOT_COMPLETE` (state already CONNECTED) but before registration bypasses that handler — so the helper **always** best-effort `disconnect()`s before re-raising.
- Caller treats any raise as "do NOT register", alerts the owner, and audit-logs (`cold_start_timeout`).
- Scope is the **cold start** only — `_ensure_streaming_session`'s reconnect path acts on an already-registered session the transition watchdog can already observe.

## Tests (`tests/test_cold_start_umbrella.py`)

1. `connect()` wedges in BOOTING → `TimeoutError`, `disconnect()` ran, lands DEAD.
2. `connect()` reached CONNECTED then hung pre-return → defensive `disconnect()` ran (pins the post-BOOT_COMPLETE window).
3. Happy path completes in time → no `disconnect()`.
4. Failing cleanup `disconnect()` does not mask the `TimeoutError`.
5. Default timeout sanity (60s < default < 240s).

## Verification

- `tests/test_cold_start_umbrella.py` → 5 passed
- `test_api.py` + `test_streaming_session.py` + `test_tmux_session.py` → 536 passed
- `ruff check` clean

🤖 Opened by Barsik