### PR TITLE
feat(#104): alert operator on billing/sustained-rate-limit StopFailures

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -983,11 +983,24 @@ def create_api(
     # callback wiring is created in _build_auth_alert_callbacks() below
     # once _broker_send is available; the tracker itself is host-global.
     from pinky_daemon.auth_alerts import (
+        TRANSPORT_FAILURE_POLICIES,
         AuthFailureTracker,
         format_alert_message,
         resolve_operator_chat,
     )
     auth_tracker = AuthFailureTracker()
+    # #104: per-class trackers for non-auth StopFailure classes (billing_error,
+    # rate_limit). Each is an independent sliding-window/cooldown tracker so a
+    # billing failure never counts toward the rate_limit threshold (and vice
+    # versa). Auth stays on its own dedicated `auth_tracker` above.
+    transport_failure_trackers = {
+        et: AuthFailureTracker(
+            fail_window_seconds=pol.fail_window_seconds,
+            fail_threshold=pol.fail_threshold,
+            alert_cooldown_seconds=pol.alert_cooldown_seconds,
+        )
+        for et, pol in TRANSPORT_FAILURE_POLICIES.items()
+    }
 
     # Message broker — routes platform messages through approval checks to agent sessions
     _platform_adapters: dict[tuple[str, str], object] = {}
@@ -1490,6 +1503,7 @@ def create_api(
     app.state.broker = broker
     app.state.agents = agents
     app.state.auth_tracker = auth_tracker
+    app.state.transport_failure_trackers = transport_failure_trackers
     app.state.conversation_store = store
     app.state.session_store = session_store
     app.state.session_event_store = session_event_store
@@ -1975,6 +1989,85 @@ def create_api(
             auth_tracker.record_success(agent_name)
         except Exception as e:
             _log(f"auth_alerts: tracker.record_success raised: {e}")
+
+    async def _on_transport_failure_alert(agent_name: str, error_type: str) -> None:
+        """Record a non-auth transport failure (#104) and alert the operator.
+
+        Mirrors ``_on_auth_failure`` but routes to the per-class tracker and
+        uses class-specific remedy text. Classes without a policy never reach
+        here — the StopFailure endpoint gates on ``TRANSPORT_FAILURE_POLICIES``.
+        Two-phase like the auth path: ``commit_alert`` only after a successful
+        send, so a broker failure preserves the cooldown and retries.
+
+        Per-class failures age out by window eviction (no success-clear hook):
+        a transient rate_limit naturally drops below threshold once the agent
+        recovers, which is exactly the "only alert if sustained" behaviour.
+        """
+        policy = TRANSPORT_FAILURE_POLICIES.get(error_type)
+        tracker = transport_failure_trackers.get(error_type)
+        if policy is None or tracker is None:
+            return
+
+        try:
+            decision = tracker.record_failure(agent_name, error_type)
+        except Exception as e:
+            _log(f"transport_alerts: tracker.record_failure raised: {e}")
+            return
+
+        if not decision.get("should_alert"):
+            return
+
+        try:
+            chat_id, platform = resolve_operator_chat(
+                get_setting=agents.get_setting,
+                list_all_approved_users=agents.list_all_approved_users,
+            )
+        except Exception as e:
+            _log(f"transport_alerts: resolve_operator_chat raised: {e}")
+            return
+
+        if not chat_id:
+            _log(
+                f"transport_alerts: {error_type} alert for {agent_name} "
+                "suppressed — no operator_chat_id and no approved_users fallback"
+            )
+            return
+
+        try:
+            host_label = agents.get_setting("host_label", "") or ""
+        except Exception:
+            host_label = ""
+
+        body = format_alert_message(
+            agent_name=agent_name,
+            decision=decision,
+            error=error_type,
+            host_label=host_label,
+            problem=policy.problem,
+            remedy=policy.remedy,
+        )
+
+        try:
+            await _broker_send(agent_name, platform, chat_id, body)
+        except Exception as e:
+            # Delivery failed — do NOT commit; next failure crossing threshold
+            # retries instead of silencing the alert for the cooldown window.
+            _log(
+                f"transport_alerts: failed to send {error_type} alert via "
+                f"{agent_name} bot to {platform}:{chat_id}: {e} "
+                f"(cooldown not advanced — will retry on next failure)"
+            )
+            return
+
+        try:
+            tracker.commit_alert()
+        except Exception as e:
+            _log(f"transport_alerts: commit_alert raised: {e}")
+        _log(
+            f"transport_alerts: {error_type} operator alert sent to "
+            f"{platform}:{chat_id} for {agent_name} "
+            f"(reason={decision.get('reason')})"
+        )
 
     async def _make_streaming_resume_handle_callback(agent_name: str, label: str):
         """Persist a streaming session's SDK resume handle when captured.
@@ -4596,6 +4689,22 @@ def create_api(
             except Exception as e:
                 _log(f"api: StopFailure auth routing failed for {name}: {e}")
 
+        # #104: non-auth classes with an alert policy (billing_error,
+        # rate_limit) route to their own per-class tracker. Everything else
+        # stays log-only. ``alert_routed`` reflects whether the failure was
+        # sent to any alert tracker (auth or class) — not whether a DM fired
+        # (that's the tracker's threshold/cooldown decision downstream).
+        alert_routed = auth_failure
+        if not auth_failure and error_type in TRANSPORT_FAILURE_POLICIES:
+            alert_routed = True
+            try:
+                await _on_transport_failure_alert(name, error_type)
+            except Exception as e:
+                _log(
+                    f"api: StopFailure transport-alert routing failed "
+                    f"for {name}: {e}"
+                )
+
         # #108 — make the StopFailure POST the authoritative turn-end
         # signal for tmux turns. A terminal API-error turn doesn't
         # reliably emit a ``stop_hook_summary``, so without this the failed
@@ -4624,6 +4733,7 @@ def create_api(
             "agent": name,
             "error_type": error_type,
             "auth_failure": auth_failure,
+            "alert_routed": alert_routed,
             "turn_resolved": turn_resolved,
         }
 
@@ -7927,6 +8037,15 @@ def create_api(
         except Exception as e:
             _log(f"admin/watchdog: auth_tracker.status raised: {e}")
             out["auth_status"] = {"status": "unknown", "error": str(e)}
+        # #104: per-class non-auth alert trackers (billing_error, rate_limit).
+        transport_status: dict[str, dict] = {}
+        for et, tracker in transport_failure_trackers.items():
+            try:
+                transport_status[et] = tracker.status()
+            except Exception as e:
+                _log(f"admin/watchdog: {et} tracker.status raised: {e}")
+                transport_status[et] = {"status": "unknown", "error": str(e)}
+        out["transport_alert_status"] = transport_status
         return out
 
     # ── Admin: Shared MCP Status ─────────────────────────

--- a/src/pinky_daemon/auth_alerts.py
+++ b/src/pinky_daemon/auth_alerts.py
@@ -41,6 +41,79 @@ DEFAULT_FAIL_THRESHOLD = 3               # within window → alert
 DEFAULT_ALERT_COOLDOWN_SECONDS = 1800    # 30 min between alerts
 
 
+# ── Remedy text per failure class ───────────────────────────────────
+#
+# Each operator alert ends with a class-specific remedy. Auth keeps its
+# original "re-auth" instructions verbatim; billing and rate_limit need
+# different actions (re-auth wouldn't fix either).
+
+DEFAULT_AUTH_REMEDY = (
+    "Re-auth needed: SSH to the host, run 'claude' to log back in, "
+    "then 'sudo systemctl restart pinkybot' (or equivalent)."
+)
+BILLING_REMEDY = (
+    "Billing/credits issue — the agent is blocked until it's resolved. "
+    "Check the provider account's payment/credit status "
+    "(e.g. console.anthropic.com) and top up or fix the payment method. "
+    "Re-auth will NOT fix this."
+)
+RATE_LIMIT_REMEDY = (
+    "Sustained rate-limiting — requests are being throttled repeatedly. "
+    "Often transient, but if it persists, check the account's usage/plan "
+    "limits; turns will keep failing until capacity frees up."
+)
+
+
+@dataclass(frozen=True)
+class FailureAlertPolicy:
+    """Alert tuning + messaging for one non-auth StopFailure class (#104).
+
+    Each policy gets its own ``AuthFailureTracker`` instance (the tracker is
+    failure-class-agnostic) so counts never comingle across classes — a
+    billing failure must not count toward the rate_limit threshold.
+    """
+
+    error_type: str
+    problem: str  # headline phrase passed to format_alert_message(problem=...)
+    remedy: str
+    fail_window_seconds: int
+    fail_threshold: int
+    alert_cooldown_seconds: int
+
+
+# Non-auth StopFailure classes that warrant a proactive operator alert (#104).
+# Auth (authentication_failed / oauth_org_not_allowed) has its own dedicated
+# path (AuthFailureTracker + _on_auth_failure) and is intentionally NOT here.
+#
+#   billing_error → persistent + operator-actionable (only a human can fix
+#       payment/credits, and it won't self-resolve). Low threshold so the
+#       operator hears about it fast.
+#   rate_limit    → usually transient. Only alert when SUSTAINED — a higher
+#       threshold + longer window/cooldown so a normal burst never pages
+#       anyone, but a genuine capacity outage still surfaces.
+#
+# server_error / overloaded / invalid_request / unknown are deliberately
+# absent: Anthropic-side or non-actionable, self-resolving — log-only.
+TRANSPORT_FAILURE_POLICIES: dict[str, "FailureAlertPolicy"] = {
+    "billing_error": FailureAlertPolicy(
+        error_type="billing_error",
+        problem="Claude billing blocked",
+        remedy=BILLING_REMEDY,
+        fail_window_seconds=600,        # 10 min
+        fail_threshold=2,               # low — billing won't self-resolve
+        alert_cooldown_seconds=1800,    # 30 min
+    ),
+    "rate_limit": FailureAlertPolicy(
+        error_type="rate_limit",
+        problem="Claude rate-limited",
+        remedy=RATE_LIMIT_REMEDY,
+        fail_window_seconds=600,        # 10 min
+        fail_threshold=5,               # higher — only sustained throttling
+        alert_cooldown_seconds=3600,    # 60 min — quieter; often transient
+    ),
+}
+
+
 @dataclass
 class _AgentFailures:
     """Sliding-window record of recent auth failures for one agent."""
@@ -283,6 +356,8 @@ def format_alert_message(
     decision: dict,
     error: str,
     host_label: str = "",
+    problem: str = "Claude auth broken",
+    remedy: str = DEFAULT_AUTH_REMEDY,
 ) -> str:
     """Render the operator-alert message body.
 
@@ -291,7 +366,11 @@ def format_alert_message(
     without markdown affordances.
 
     Kept human-readable and short; includes enough detail for the operator
-    to know which host to log into and re-auth.
+    to know which host to log into and what to do.
+
+    ``problem`` / ``remedy`` parameterize the message per failure class (#104).
+    The defaults reproduce the original auth-alert wording verbatim so the
+    auth path is unchanged.
     """
     reason = decision.get("reason", "")
     agents_failing = decision.get("agents_failing", 0)
@@ -299,18 +378,14 @@ def format_alert_message(
 
     if reason == "host_wide":
         headline = (
-            f"🚨 Claude auth broken on {host_label or 'this host'}: "
+            f"🚨 {problem} on {host_label or 'this host'}: "
             f"{agents_failing} agent(s) failing"
         )
     else:
         headline = (
-            f"🚨 Claude auth broken for {agent_name}: "
+            f"🚨 {problem} for {agent_name}: "
             f"{count} failures in window"
         )
 
     detail = error.strip()[:200] or "no error detail"
-    instructions = (
-        "Re-auth needed: SSH to the host, run 'claude' to log back in, "
-        "then 'sudo systemctl restart pinkybot' (or equivalent)."
-    )
-    return f"{headline}\n\nLast error: {detail}\n\n{instructions}"
+    return f"{headline}\n\nLast error: {detail}\n\n{remedy}"

--- a/src/pinky_daemon/auth_alerts.py
+++ b/src/pinky_daemon/auth_alerts.py
@@ -94,6 +94,20 @@ class FailureAlertPolicy:
 #
 # server_error / overloaded / invalid_request / unknown are deliberately
 # absent: Anthropic-side or non-actionable, self-resolving — log-only.
+#
+# AGING — why these classes use window-eviction only and have NO
+# clear-on-success hook (intentional asymmetry with the auth path):
+#   The auth tracker clears on a successful turn because auth is BINARY — one
+#   success proves the credential works, so stale failures should drop. These
+#   classes are CONTINUOUS-DEGRADATION signals where intermittent successes
+#   are *expected during the very failure mode we're detecting*:
+#     - rate_limit: a clear-on-success would defeat "only if sustained" — every
+#       200 between two 429s would reset the count, so 5-in-10min could never
+#       accumulate. The semantics require wall-clock window counting.
+#     - billing_error: a success between failures usually means partial
+#       degradation (fallback cred, race against billing-fix propagation), none
+#       of which argue for resetting; a genuine fix is absorbed by the cooldown.
+#   So failures age out purely by sliding-window eviction. (Reviewed: #104/PR599.)
 TRANSPORT_FAILURE_POLICIES: dict[str, "FailureAlertPolicy"] = {
     "billing_error": FailureAlertPolicy(
         error_type="billing_error",

--- a/tests/test_auth_alerts.py
+++ b/tests/test_auth_alerts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from pinky_daemon.auth_alerts import (
+    TRANSPORT_FAILURE_POLICIES,
     AuthFailureTracker,
     format_alert_message,
     resolve_operator_chat,
@@ -404,3 +405,87 @@ def test_admin_watchdog_exposes_auth_status(tmp_path):
     assert auth["agents_failing"] == []
     assert "fail_window_seconds" in auth
     assert "alert_cooldown_seconds" in auth
+
+
+# ── #104: non-auth class alerting (billing / rate_limit) ──────────
+
+
+def test_format_alert_default_problem_remedy_is_auth_verbatim():
+    """The auth path must be byte-for-byte unchanged: defaults reproduce the
+    original "Claude auth broken" + "Re-auth needed" wording."""
+    msg = format_alert_message(
+        agent_name="sasha",
+        decision={"reason": "agent_repeated", "count": 3, "agents_failing": 1},
+        error="authentication_failed",
+        host_label="rpi5",
+    )
+    assert "Claude auth broken for sasha" in msg
+    assert "Re-auth needed" in msg
+
+
+def test_format_alert_billing_problem_and_remedy():
+    pol = TRANSPORT_FAILURE_POLICIES["billing_error"]
+    msg = format_alert_message(
+        agent_name="sasha",
+        decision={"reason": "agent_repeated", "count": 2, "agents_failing": 1},
+        error="billing_error",
+        host_label="rpi5",
+        problem=pol.problem,
+        remedy=pol.remedy,
+    )
+    assert "Claude billing blocked for sasha" in msg
+    assert "billing" in msg.lower()
+    assert "Re-auth needed" not in msg  # billing has a DIFFERENT remedy
+    assert "*" not in msg and "`" not in msg  # still plain text
+
+
+def test_format_alert_rate_limit_problem_and_remedy():
+    pol = TRANSPORT_FAILURE_POLICIES["rate_limit"]
+    msg = format_alert_message(
+        agent_name="sasha",
+        decision={"reason": "host_wide", "count": 1, "agents_failing": 3},
+        error="rate_limit",
+        host_label="rpi5",
+        problem=pol.problem,
+        remedy=pol.remedy,
+    )
+    assert "Claude rate-limited on rpi5" in msg
+    assert "3 agent" in msg
+    assert "rate-limit" in msg.lower()
+
+
+def test_transport_failure_policies_shape():
+    """Policy invariants: billing alerts faster than rate_limit; rate_limit is
+    quieter (longer cooldown); auth is NOT in this map; messaging is set."""
+    assert set(TRANSPORT_FAILURE_POLICIES) == {"billing_error", "rate_limit"}
+    assert "authentication_failed" not in TRANSPORT_FAILURE_POLICIES
+    billing = TRANSPORT_FAILURE_POLICIES["billing_error"]
+    rate = TRANSPORT_FAILURE_POLICIES["rate_limit"]
+    # billing won't self-resolve → lower threshold than transient rate_limit
+    assert billing.fail_threshold < rate.fail_threshold
+    # rate_limit is often transient → quieter (longer cooldown)
+    assert rate.alert_cooldown_seconds >= billing.alert_cooldown_seconds
+    for pol in (billing, rate):
+        assert pol.problem and pol.remedy
+        assert pol.fail_threshold >= 1
+        assert pol.fail_window_seconds > 0
+    assert billing.problem != rate.problem
+
+
+def test_admin_watchdog_exposes_transport_alert_status(tmp_path):
+    """/admin/watchdog includes per-class transport alert trackers (#104)."""
+    from fastapi.testclient import TestClient
+
+    from pinky_daemon.api import create_api
+
+    api = create_api(db_path=str(tmp_path / "memory.db"))
+    with TestClient(api) as client:
+        resp = client.get("/admin/watchdog")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "transport_alert_status" in body
+    tstatus = body["transport_alert_status"]
+    assert set(tstatus) == {"billing_error", "rate_limit"}
+    for et, st in tstatus.items():
+        assert st["status"] == "ok"  # no failures yet
+        assert st["agents_failing"] == []

--- a/tests/test_auth_alerts.py
+++ b/tests/test_auth_alerts.py
@@ -452,6 +452,7 @@ def test_format_alert_rate_limit_problem_and_remedy():
     assert "Claude rate-limited on rpi5" in msg
     assert "3 agent" in msg
     assert "rate-limit" in msg.lower()
+    assert "Re-auth needed" not in msg  # rate_limit has a DIFFERENT remedy
 
 
 def test_transport_failure_policies_shape():

--- a/tests/test_stop_failure_hook.py
+++ b/tests/test_stop_failure_hook.py
@@ -61,7 +61,29 @@ class TestStopFailureEndpoint:
             }
 
         app.state.auth_tracker.record_failure = _spy
+        self._app = app
         return client, calls
+
+    def _spy_transport_tracker(self, error_type: str) -> list:
+        """Spy a per-class transport tracker's record_failure (#104).
+
+        Returns a list that records (agent_name, error) calls and keeps the
+        tracker below threshold (should_alert=False) so no real operator DM is
+        attempted — mirrors the auth spy in ``_client_with_agent``.
+        """
+        calls: list[tuple[str, str]] = []
+
+        def _spy(agent_name, error=""):
+            calls.append((agent_name, error))
+            return {
+                "should_alert": False,
+                "reason": "below_threshold",
+                "count": len(calls),
+                "agents_failing": 1,
+            }
+
+        self._app.state.transport_failure_trackers[error_type].record_failure = _spy
+        return calls
 
     def test_unknown_agent_404(self):
         client, calls = self._client_with_agent()
@@ -95,29 +117,55 @@ class TestStopFailureEndpoint:
         assert r.json()["auth_failure"] is True
         assert calls == [("dymok", "oauth_org_not_allowed")]
 
-    def test_rate_limit_not_routed(self):
-        """Transient class — logged for observability, not routed to the
-        auth tracker, no operator alert."""
-        client, calls = self._client_with_agent()
+    def test_rate_limit_routes_to_rate_limit_tracker_not_auth(self):
+        """#104: rate_limit routes to its OWN per-class tracker (sustained-
+        throttle alert), never the auth tracker."""
+        client, auth_calls = self._client_with_agent()
+        rl_calls = self._spy_transport_tracker("rate_limit")
         r = client.post(
             "/agents/dymok/transport/stop-failure",
             json={"error_type": "rate_limit"},
         )
         assert r.status_code == 200
-        assert r.json()["auth_failure"] is False
-        assert calls == []
+        body = r.json()
+        assert body["auth_failure"] is False
+        assert body["alert_routed"] is True
+        assert auth_calls == []  # NOT the auth tracker
+        assert rl_calls == [("dymok", "rate_limit")]  # its own tracker
 
-    def test_billing_error_not_routed_to_auth(self):
-        """billing_error is a different remedy than re-auth — logged, not
-        routed through the auth tracker."""
-        client, calls = self._client_with_agent()
+    def test_billing_error_routes_to_billing_tracker_not_auth(self):
+        """#104: billing_error routes to its OWN per-class tracker with a
+        billing remedy (re-auth wouldn't help), never the auth tracker."""
+        client, auth_calls = self._client_with_agent()
+        billing_calls = self._spy_transport_tracker("billing_error")
         r = client.post(
             "/agents/dymok/transport/stop-failure",
             json={"error_type": "billing_error"},
         )
         assert r.status_code == 200
-        assert r.json()["auth_failure"] is False
-        assert calls == []
+        body = r.json()
+        assert body["auth_failure"] is False
+        assert body["alert_routed"] is True
+        assert auth_calls == []  # NOT the auth tracker
+        assert billing_calls == [("dymok", "billing_error")]  # its own tracker
+
+    def test_server_error_routed_nowhere(self):
+        """#104: server_error is Anthropic-side / self-resolving → log-only.
+        Not routed to the auth tracker nor any per-class tracker."""
+        client, auth_calls = self._client_with_agent()
+        rl_calls = self._spy_transport_tracker("rate_limit")
+        billing_calls = self._spy_transport_tracker("billing_error")
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={"error_type": "server_error"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["auth_failure"] is False
+        assert body["alert_routed"] is False
+        assert auth_calls == []
+        assert rl_calls == []
+        assert billing_calls == []
 
     def test_missing_error_type_defaults_unknown(self):
         client, calls = self._client_with_agent()


### PR DESCRIPTION
## Problem (#104, fast-follow to #584)

The StopFailure hook forwards Claude Code's typed `error_type`, but only auth-class failures (`authentication_failed` / `oauth_org_not_allowed`) routed into `AuthFailureTracker` and could page the operator. Non-auth classes were **logged only** — so a tmux/CLI agent could go dark for billing or sustained rate-limiting with no alert.

## Policy (confirmed with Brad)

Which classes page the operator:

| Class | Behaviour | Why |
|---|---|---|
| `billing_error` | **Alert** — low threshold (2 in 10min) | Persistent + operator-actionable; only a human can fix payment/credits, won't self-resolve. Re-auth wouldn't help → distinct remedy text. |
| `rate_limit` | **Alert only if sustained** — threshold 5 in 10min, 60min cooldown | Usually transient. A normal burst never pages; a genuine capacity outage still surfaces. |
| `server_error` / `overloaded` / `invalid_request` / `unknown` | **Log-only** | Anthropic-side / non-actionable / self-resolving. |

## Implementation — reuses the proven auth path, zero change to it

- **`auth_alerts.py`**: `FailureAlertPolicy` + `TRANSPORT_FAILURE_POLICIES` registry. `format_alert_message` gains optional `problem`/`remedy` params whose **defaults reproduce the auth wording verbatim** (auth path byte-for-byte unchanged — guarded by a new test).
- **`api.py`**: one independent `AuthFailureTracker` per class (counts never comingle — a billing failure can't count toward the rate_limit threshold). `_on_transport_failure_alert` mirrors `_on_auth_failure`: resolve operator → format → send → **two-phase `commit_alert` only after a successful send** (a broker failure preserves cooldown and retries, the #400 regression guard). The stop-failure endpoint routes policy classes and returns a new `alert_routed` field. `/admin/watchdog` exposes per-class `transport_alert_status`.

Per-class failures age out by **window eviction** (no success-clear hook) — a transient rate_limit naturally drops below threshold once the agent recovers, which is exactly the "only alert if sustained" behaviour.

## Tests

- Updated the two endpoint tests that asserted the old log-only behaviour → now assert per-class routing (and that the auth tracker stays untouched).
- Added: `server_error` routed nowhere; billing/rate_limit message formatting (right problem/remedy, plain-text); policy invariants (billing threshold < rate_limit, rate_limit quieter, auth absent); `/admin/watchdog` `transport_alert_status` shape.
- **Full venv suite: 2743 passed, 1 skipped.** `ruff` clean.

@pushok — tagging you since you reviewed the original auth-alert path (#400/#496); this extends the same machinery.

🤖 Opened by Barsik