### PR TITLE
fix(#591): skip continuation manifest on warm-resume wakes

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -615,11 +615,23 @@ class AgentContext:
             "updated_by": self.updated_by,
         }
 
-    def to_prompt(self) -> str:
-        """Format as a system prompt section for injection on restart."""
+    def to_prompt(self, resume_mode: bool = False) -> str:
+        """Format as a system prompt section for injection on restart.
+
+        ``resume_mode=True`` is for warm-resume wakes (``claude --continue``
+        succeeded, prior conversation already in context). In that mode
+        only the wake_action directive is rendered — the rest of the
+        manifest (task/context/notes/blockers/priority) is redundant
+        with what the resumed conversation already carries, and replaying
+        it caused #591. The wake_action is preserved because it is a
+        directive ("do this FIRST"), not history; dropping it would
+        silently lose intent set by the prior session.
+        """
         parts = []
         if self.wake_action:
             parts.append(f"## ⚡ Wake Action (do this FIRST)\n{self.wake_action}")
+        if resume_mode:
+            return "\n\n".join(parts) if parts else ""
         if self.task:
             parts.append(f"## Continuation\nYou were working on: {self.task}")
         if self.context:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -151,6 +151,7 @@ from pinky_daemon.task_store import TaskStore
 # while keeping both enums accessible.
 from pinky_daemon.transport_state import SessionState as TransportSessionState
 from pinky_daemon.trigger_store import TriggerStore
+from pinky_daemon.wake_prompt import WakeReason
 
 # Feature flag: shared MCP mode uses a single HTTP/SSE server instead of per-agent stdio
 SHARED_MCP_ENABLED = os.environ.get("PINKY_SHARED_MCP", "0") == "1"
@@ -1749,22 +1750,101 @@ def create_api(
         guard["message"] = _guard_message("restart", guard)
         return guard
 
-    def _build_streaming_wake_context(agent_name: str) -> str:
-        """Build wake context for a streaming session."""
+    def _get_previous_wake_timestamp(agent_name: str) -> float | None:
+        """Return the timestamp of the previous ``agent_wake`` event for the
+        agent, or ``None`` if no prior wake exists.
+
+        Used by :func:`_build_streaming_wake_context` to decide whether a
+        saved-context ``wake_action`` is fresh-for-this-cycle on a
+        ``RESUME`` wake — the directive is "fresh" iff it was written
+        AFTER the previous wake (i.e. set during the current awake
+        period, not replayed from a prior cycle). #591 fix.
+
+        Safe to call from ``_build_streaming_wake_context`` because the
+        CURRENT wake's ``agent_wake`` event is logged AFTER this function
+        returns (see api.py:2449 and api.py:7557 — wake events are
+        logged post-connect, while wake-context is built pre-connect).
+        So ``list(..., limit=1)`` returns the PREVIOUS wake's timestamp.
+        """
+        try:
+            events = activity.list(
+                agent_name=agent_name, event_type="agent_wake", limit=1
+            )
+        except Exception:
+            return None
+        if not events:
+            return None
+        ts = events[0].get("created_at")
+        try:
+            return float(ts) if ts is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    def _build_streaming_wake_context(
+        agent_name: str, reason: WakeReason = WakeReason.NEW_SESSION
+    ) -> str:
+        """Build wake context for a streaming session.
+
+        ``reason`` gates how the saved-context manifest is rendered (#591).
+        On ``WakeReason.RESUME`` the agent is warm-resuming via
+        ``claude --continue`` and the prior conversation is already in
+        context, so the bulk manifest (task/context/notes/blockers/
+        priority_items) is redundant and replaying it caused the
+        stale-continuation bug. Only a *fresh-this-cycle* ``wake_action``
+        is preserved on RESUME (directive, not history).
+
+        For ``CONTEXT_RESTART`` / ``AUTO_RESTART`` / ``NEW_SESSION`` /
+        ``IDLE_WAKE``, the agent is launching fresh (or near-fresh) with
+        no prior conversation, so the full manifest is rendered as
+        before. The default value preserves pre-#591 behavior for the
+        ``wake_context_builder(name)`` 1-arg callers.
+        """
         wake_ctx = ""
+        emitted_manifest = False  # Whether saved-context contributed to wake_ctx
         saved = agents.get_context(agent_name)
         if saved:
-            ctx_prompt = saved.to_prompt()
-            if ctx_prompt:
-                wake_ctx = ctx_prompt
+            if reason == WakeReason.RESUME:
+                # Warm --continue resume: drop the bulk manifest. Emit
+                # wake_action only if it was set during the current
+                # awake period (manifest written after the previous
+                # wake). This blocks replay of stale directives from
+                # prior sleep cycles (the original #591 symptom).
+                #
+                # Deliberately do NOT set ``emitted_manifest = True``
+                # here. The stale-warning that gates on that flag is
+                # about the BULK manifest's absolute age (>12h); this
+                # branch already validated freshness via the tighter
+                # cycle-bound check, and we never emitted the bulk to
+                # begin with. Firing the warning on a wake_action that
+                # was JUST certified fresh-this-cycle would be a
+                # contradiction (Barsik branch review).
+                if saved.wake_action:
+                    prev_wake_ts = _get_previous_wake_timestamp(agent_name)
+                    fresh_this_cycle = (
+                        prev_wake_ts is None or saved.updated_at > prev_wake_ts
+                    )
+                    if fresh_this_cycle:
+                        directive = saved.to_prompt(resume_mode=True)
+                        if directive:
+                            wake_ctx = directive
+            else:
+                ctx_prompt = saved.to_prompt()
+                if ctx_prompt:
+                    wake_ctx = ctx_prompt
+                    emitted_manifest = True
 
-        freshness = _get_saved_context_freshness(agent_name)
-        if freshness.get("stale_warning"):
-            warning = (
-                f"WARNING: Saved continuation context is {freshness.get('age_human', 'stale')} old. "
-                "Verify it against recent work before relying on it."
-            )
-            wake_ctx = f"{warning}\n\n{wake_ctx}" if wake_ctx else warning
+        # Freshness warning only meaningful when we emitted the manifest —
+        # for RESUME with wake_action_only the cycle-bound gate already
+        # validated freshness, and for empty wake_ctx the warning is
+        # misleading (warns about state we're not actually showing).
+        if emitted_manifest:
+            freshness = _get_saved_context_freshness(agent_name)
+            if freshness.get("stale_warning"):
+                warning = (
+                    f"WARNING: Saved continuation context is {freshness.get('age_human', 'stale')} old. "
+                    "Verify it against recent work before relying on it."
+                )
+                wake_ctx = f"{warning}\n\n{wake_ctx}" if wake_ctx else warning
 
         channel_ctx = broker.build_channel_context(agent_name)
         if channel_ctx:
@@ -1863,6 +1943,10 @@ def create_api(
                 _log(f"wake_context: failed to read restart manifest for {agent_name}: {e}")
 
         return wake_ctx
+
+    # Exposed for unit-test reach-in (#591 reason-gating verification).
+    # Not part of the public API; harness should not depend on it.
+    app.state._build_streaming_wake_context = _build_streaming_wake_context
 
     _stream_event_subscribers: dict[str, set[asyncio.Queue]] = {}
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1455,6 +1455,9 @@ def create_api(
 
     activity = ActivityStore(db_path=db_path.replace(".db", "_activity.db"))
     app.state.activity = activity
+    # Exposed for unit-test reach-in (#591 P1#1 — verifying commit=False
+    # preserves inbox state). Not part of the public API.
+    app.state.comms = comms
 
     async def _broker_stop_agent(agent_name: str) -> dict:
         """Stop callback for broker command interception."""
@@ -1781,7 +1784,10 @@ def create_api(
             return None
 
     def _build_streaming_wake_context(
-        agent_name: str, reason: WakeReason = WakeReason.NEW_SESSION
+        agent_name: str,
+        reason: WakeReason = WakeReason.NEW_SESSION,
+        *,
+        commit: bool = True,
     ) -> str:
         """Build wake context for a streaming session.
 
@@ -1798,6 +1804,17 @@ def create_api(
         no prior conversation, so the full manifest is rendered as
         before. The default value preserves pre-#591 behavior for the
         ``wake_context_builder(name)`` 1-arg callers.
+
+        ``commit`` gates the side-effecting consumption steps embedded in
+        the build (inbox ``mark_read`` and restart-manifest deletion).
+        When ``False``, the function renders the *current* state without
+        consuming — used by the eager pre-build at session-config creation
+        time, which would otherwise consume inbox + manifest BEFORE the
+        delivered connect-time rebuild runs (Murzik P1#1: production saw
+        unread agent messages and restart-manifest content silently
+        vanish from real wake prompts). ``True`` (the default) preserves
+        pre-#591 behavior for legacy callers and is what the connect-time
+        rebuild uses.
         """
         wake_ctx = ""
         emitted_manifest = False  # Whether saved-context contributed to wake_ctx
@@ -1870,7 +1887,8 @@ def create_api(
                 + "\nReply via send_to_agent, not by messaging the owner."
             )
             wake_ctx = f"{wake_ctx}\n\n{inbox_ctx}" if wake_ctx else inbox_ctx
-            comms.mark_read(agent_name, [m.id for m in inbox_messages])
+            if commit:
+                comms.mark_read(agent_name, [m.id for m in inbox_messages])
 
         # Inject open task summary
         try:
@@ -1933,12 +1951,16 @@ def create_api(
                         restart_ctx = "── Restart Manifest ──\n" + "\n".join(restart_lines) + "\n──────────────────"
                         wake_ctx = f"{restart_ctx}\n\n{wake_ctx}" if wake_ctx else restart_ctx
 
-                    # Consume this agent's entry so it doesn't repeat on next wake
-                    del manifest["agents"][agent_name]
-                    if manifest["agents"]:
-                        manifest_path.write_text(_json.dumps(manifest, indent=2))
-                    else:
-                        manifest_path.unlink(missing_ok=True)
+                    # Consume this agent's entry so it doesn't repeat on next wake.
+                    # Gated by ``commit`` — preview builds (eager pre-build at
+                    # config-create time) must NOT delete or the delivered
+                    # rebuild loses the manifest content.
+                    if commit:
+                        del manifest["agents"][agent_name]
+                        if manifest["agents"]:
+                            manifest_path.write_text(_json.dumps(manifest, indent=2))
+                        else:
+                            manifest_path.unlink(missing_ok=True)
             except Exception as e:
                 _log(f"wake_context: failed to read restart manifest for {agent_name}: {e}")
 
@@ -1947,6 +1969,37 @@ def create_api(
     # Exposed for unit-test reach-in (#591 reason-gating verification).
     # Not part of the public API; harness should not depend on it.
     app.state._build_streaming_wake_context = _build_streaming_wake_context
+
+    def _log_agent_wake_event(agent_name: str, reason: WakeReason) -> None:
+        """Fires from SDK / tmux / codex sessions after a wake prompt is
+        successfully delivered.
+
+        Centralizes the ``agent_wake`` activity event so the #591
+        cycle-gate boundary advances on EVERY delivered warm wake — not
+        just cold-start + scheduler (the prior coverage that missed the
+        ``_ensure_streaming_session`` reconnect and broker auto-wake
+        paths, leaving directives to replay forever on warm wakes —
+        Murzik P1#2).
+
+        Failure-tolerant: callbacks raise, so wrap in try/except. Don't
+        let a logging hiccup wedge the wake delivery.
+        """
+        try:
+            activity.log(
+                agent_name=agent_name,
+                event_type="agent_wake",
+                title=f"{agent_name} woke up",
+                metadata={"reason": reason.value},
+            )
+        except Exception as e:
+            _log(
+                f"api: agent_wake log failed for {agent_name} "
+                f"(reason={reason.value}): {e}"
+            )
+
+    # Exposed for unit-test reach-in (verifying centralized wake logging
+    # advances the cycle-gate boundary). Not part of the public API.
+    app.state._log_agent_wake_event = _log_agent_wake_event
 
     _stream_event_subscribers: dict[str, set[asyncio.Queue]] = {}
 
@@ -2418,8 +2471,15 @@ def create_api(
             max_turns=agent.max_turns,
             system_prompt=agents.build_system_prompt(agent_name, skill_store=skills),
             resume_handle=resume_id,
-            wake_context=_build_streaming_wake_context(agent_name),
+            # commit=False here: the connect-time rebuild via
+            # ``wake_context_builder`` is the delivered (committed) build
+            # that consumes inbox + restart_manifest. An eager committed
+            # build here would consume both before the delivered one
+            # runs, leaving the actual wake prompt without unread inbox
+            # or restart-manifest content (Murzik P1#1).
+            wake_context=_build_streaming_wake_context(agent_name, commit=False),
             wake_context_builder=_build_streaming_wake_context,
+            on_wake_delivered=_log_agent_wake_event,
             restart_guard=lambda session, _agent_name=agent_name: _get_streaming_restart_guard(_agent_name, session),
             live_status_fn=lambda _agent_name=agent_name: _agent_live_status.get(_agent_name),
             context_warn_pct=warn_pct,
@@ -2530,12 +2590,13 @@ def create_api(
                 event_type=event_type,
                 metadata={"label": label, "resume_id": resume_id or ""},
             )
-            activity.log(
-                agent_name=agent_name,
-                event_type="agent_wake",
-                title=f"{agent_name} {'resumed' if resume_id else 'started'} session",
-                metadata={"label": label, "session_id": ss.id, "event": event_type},
-            )
+            # ``agent_wake`` is logged centrally via ``on_wake_delivered``
+            # (api._log_agent_wake_event) which fires from the session's
+            # connect-time wake-prompt delivery. Logging it here would
+            # double-count and undercut the #591 cycle-gate (Murzik P1#2):
+            # the boundary would advance BEFORE the actual wake prompt
+            # lands, so a delivery-failure could eat the directive while
+            # the gate thinks the wake "happened."
         except Exception as _e:
             _log(f"api: failed to log session start event for {agent_name}: {_e}")
 
@@ -6576,7 +6637,7 @@ def create_api(
         agents.set_streaming_session_id(name, "", label="main")
 
         # Refresh wake context and reconnect fresh
-        ss._config.wake_context = _build_streaming_wake_context(name)
+        ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
         ss._config.resume_handle = ""
         ss._config.restart_reason = "context_restart"
         # PR for #543: explicit launch-behavior contract — the next
@@ -6749,7 +6810,7 @@ def create_api(
         await ss.disconnect()
         agents.set_streaming_session_id(name, "", label="main")
 
-        ss._config.wake_context = _build_streaming_wake_context(name)
+        ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
         ss._config.resume_handle = ""
         ss.resume_handle = ""
         if hasattr(ss, "codex_session_id"):
@@ -7638,7 +7699,12 @@ def create_api(
             return
         await ss.send(prompt)
         _log(f"scheduler: woke {agent_name} via streaming main")
-        activity.log(agent_name, "agent_wake", f"{agent_name} woke up")
+        # ``agent_wake`` is logged centrally via ``on_wake_delivered``
+        # when the session's connect-time wake prompt lands. Logging
+        # here would double-count for scheduled wakes that triggered
+        # a cold-start (the connect already fired the callback) and
+        # would mismark scheduled re-prompts (which aren't really new
+        # wake events — the session was already awake). See Murzik P1#2.
 
     async def _dream_callback(agent_name: str, agent_config) -> None:
         """Callback for the scheduler to run nightly dream consolidation."""
@@ -8645,7 +8711,7 @@ def create_api(
         await ss.disconnect()
         agents.set_streaming_session_id(name, "", label="main")
 
-        ss._config.wake_context = _build_streaming_wake_context(name)
+        ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
         ss._config.resume_handle = ""
         ss._config.restart_reason = "force_restart"
         ss._config.force_fresh_context_once = True

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -32,6 +32,7 @@ from pinky_daemon.streaming_session import (
 )
 from pinky_daemon.transport_state import SessionState
 from pinky_daemon.turn_response import TurnResponse
+from pinky_daemon.wake_prompt import WakeReason
 
 
 @dataclass
@@ -144,9 +145,31 @@ class CodexSession:
 
         # Send wake prompt
         is_resume = bool(self.codex_session_id)
+        wake_reason = WakeReason.RESUME if is_resume else WakeReason.NEW_SESSION
+        # #591 — rebuild wake-context body with the now-known reason so
+        # the builder can gate the saved-state manifest (RESUME drops
+        # the bulk; NEW_SESSION emits it). The static
+        # ``self._config.wake_context`` set at config-create time was
+        # built without reason context and is now a commit=False preview
+        # only — relying on it here would re-emit a stale manifest on
+        # warm Codex resumes. TypeError fallback keeps legacy 1-arg
+        # builders working.
+        wake_context_body = self._config.wake_context or ""
+        if self._config.wake_context_builder:
+            try:
+                wake_context_body = self._config.wake_context_builder(
+                    self.agent_name, wake_reason
+                )
+            except TypeError:
+                pass
+            except Exception as e:
+                _log(
+                    f"codex[{self.agent_name}]: wake context rebuild failed: {e} "
+                    "— using stored body"
+                )
         ctx_block = ""
-        if self._config.wake_context:
-            ctx_block = f"\n\n── Saved State ──\n{self._config.wake_context}\n──────────────────"
+        if wake_context_body:
+            ctx_block = f"\n\n── Saved State ──\n{wake_context_body}\n──────────────────"
 
         tools_hint = (
             "You have explicit pinky-messaging outreach tools: "
@@ -171,6 +194,19 @@ class CodexSession:
         # Queue wake prompt (no chat routing — internal)
         self._record_internal_context_text(wake_prompt)
         await self._message_queue.put((wake_prompt, "", "", ""))
+
+        # Wake prompt queued for delivery. Fire the post-delivery
+        # callback so ``agent_wake`` is logged on every warm wake
+        # (advances the #591 cycle-gate boundary for Codex sessions
+        # too — Murzik P1#2).
+        if self._config.on_wake_delivered:
+            try:
+                self._config.on_wake_delivered(self.agent_name, wake_reason)
+            except Exception as _cb_e:
+                _log(
+                    f"codex[{self.agent_name}]: on_wake_delivered "
+                    f"callback failed: {_cb_e}"
+                )
 
     async def send(
         self,

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -85,6 +85,13 @@ class CodexSession:
         self._message_queue: asyncio.Queue[tuple[str, str, str, str]] = asyncio.Queue()
         self._worker_task: asyncio.Task | None = None
         self._current_proc: asyncio.subprocess.Process | None = None  # For cleanup on disconnect
+        # #591 P1#2 (Murzik round-2): callback fired after the NEXT
+        # codex-exec succeeds. ``connect()`` sets it when on_wake_delivered
+        # is wired, so the cycle-gate boundary advances only on confirmed
+        # wake-prompt delivery (post-exec), not at queue.put time. Single-
+        # pending semantics — wake prompts only come from connect(),
+        # which is mutually exclusive with another in-flight wake.
+        self._pending_wake_callback: object = None  # Callable() -> None
 
         self.agent_name = config.agent_name
         self.resume_handle = ""  # Codex thread_id used to resume (opaque resume token)
@@ -191,22 +198,25 @@ class CodexSession:
             "plain-text delivery based on agent settings."
         )
 
+        # #591 P1#2 (Murzik round-2): arm the post-delivery callback
+        # BEFORE the put so the worker can fire it after _exec_codex
+        # actually runs the wake prompt. Firing at queue.put time would
+        # advance the cycle-gate boundary against a wake that may
+        # never reach the model (exec failure, subprocess crash, etc.),
+        # eating the directive on the next RESUME.
+        if self._config.on_wake_delivered:
+            _config_cb = self._config.on_wake_delivered
+            _agent_name = self.agent_name
+            _wake_reason = wake_reason
+
+            def _wake_delivered_cb() -> None:
+                _config_cb(_agent_name, _wake_reason)
+
+            self._pending_wake_callback = _wake_delivered_cb
+
         # Queue wake prompt (no chat routing — internal)
         self._record_internal_context_text(wake_prompt)
         await self._message_queue.put((wake_prompt, "", "", ""))
-
-        # Wake prompt queued for delivery. Fire the post-delivery
-        # callback so ``agent_wake`` is logged on every warm wake
-        # (advances the #591 cycle-gate boundary for Codex sessions
-        # too — Murzik P1#2).
-        if self._config.on_wake_delivered:
-            try:
-                self._config.on_wake_delivered(self.agent_name, wake_reason)
-            except Exception as _cb_e:
-                _log(
-                    f"codex[{self.agent_name}]: on_wake_delivered "
-                    f"callback failed: {_cb_e}"
-                )
 
     async def send(
         self,
@@ -268,6 +278,25 @@ class CodexSession:
                     self._processing = True
                     self._current_turn_seq = self._stats["turns"] + 1
                     result = await self._exec_codex(prompt)
+
+                    # #591 P1#2 (Murzik round-2): fire the pending wake
+                    # callback after exec confirms delivery. Only on
+                    # success — failed execs leave the boundary intact
+                    # so the next attempt re-emits the directive. The
+                    # callback is one-shot per arm; cleared whether
+                    # fired or skipped so a subsequent non-wake turn
+                    # doesn't fire it spuriously.
+                    if self._pending_wake_callback is not None:
+                        cb = self._pending_wake_callback
+                        self._pending_wake_callback = None
+                        if not result.failed:
+                            try:
+                                cb()
+                            except Exception as _cb_e:
+                                _log(
+                                    f"codex[{self.agent_name}]: "
+                                    f"on_wake_delivered callback failed: {_cb_e}"
+                                )
 
                     # Fire async resume-handle callback (set by sync _handle_event)
                     if self._pending_resume_handle_update and self._on_resume_handle:
@@ -952,12 +981,12 @@ class CodexSession:
 
         await self.disconnect()
 
-        # Refresh wake context
-        if self._config.wake_context_builder:
-            try:
-                self._config.wake_context = self._config.wake_context_builder(self.agent_name)
-            except Exception as e:
-                _log(f"codex[{self.agent_name}]: failed to refresh wake context: {e}")
+        # #591 P1#1 (Murzik round-2): the prior eager refresh here ran
+        # the builder 1-arg (commit=True), consuming inbox + restart-
+        # manifest BEFORE connect() ran its own reason-aware committed
+        # rebuild — same double-consume pattern as the API-layer sites.
+        # Removed: connect() is the single source-of-truth for both the
+        # wake_context body and side-effect consumption.
 
         self.codex_session_id = ""
         self.resume_handle = ""

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -514,10 +514,32 @@ class StreamingSession:
             resume_handle=self.resume_handle,
             restart_reason=self._config.restart_reason,
         )
+        # #591 — rebuild wake-context body with the freshly-computed
+        # wake_reason so the builder can gate the saved-state manifest
+        # against the actual wake type (RESUME drops the bulk manifest;
+        # CONTEXT_RESTART/AUTO_RESTART/NEW_SESSION emit it). The static
+        # ``self._config.wake_context`` set at config-create time
+        # predates this signal — kept as a fallback for tests / paths
+        # without a builder. Trailing positional kwarg keeps 1-arg
+        # callers of older builders working.
+        wake_context_body = self._config.wake_context or ""
+        if self._config.wake_context_builder:
+            try:
+                wake_context_body = self._config.wake_context_builder(
+                    self.agent_name, wake_reason
+                )
+            except TypeError:
+                # Legacy 1-arg builder — fall back to the pre-built body.
+                pass
+            except Exception as e:
+                _log(
+                    f"streaming[{self.agent_name}]: wake context rebuild failed: {e} "
+                    "— using stored body"
+                )
         wake_prompt = build_wake_prompt(
             WakePromptInput(
                 reason=wake_reason,
-                context_body=self._config.wake_context or "",
+                context_body=wake_context_body,
                 timezone=self._config.timezone or "America/Los_Angeles",
             )
         )

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -1180,12 +1180,12 @@ class StreamingSession:
         # wake-context refresh and at connect() entry.
         self._state_machine._state = SessionState.RECONNECTING
 
-        # Refresh wake context from DB before reconnecting
-        if self._config.wake_context_builder:
-            try:
-                self._config.wake_context = self._config.wake_context_builder(self.agent_name)
-            except Exception as e:
-                _log(f"streaming[{self.agent_name}]: failed to refresh wake context: {e}")
+        # #591 P1#1 (Murzik round-2): the prior eager refresh here ran
+        # the builder 1-arg (commit=True), consuming inbox + restart-
+        # manifest BEFORE connect() ran its own reason-aware committed
+        # rebuild — same double-consume pattern as the API-layer sites.
+        # Removed entirely: connect() is now the single source-of-truth
+        # for both the wake_context body and side-effect consumption.
 
         # Reconnect fresh with wake context
         self._config.resume_handle = ""

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -63,6 +63,14 @@ class StreamingSessionConfig:
     resume_handle: str = ""  # SDK resume token (opaque session-continuation handle) from previous run
     wake_context: str = ""  # Saved continuation context to inject on wake
     wake_context_builder: object = None  # Callable(agent_name) -> str; refreshes wake_context on restart
+    # Fires AFTER successful wake-prompt delivery (paste/query landed).
+    # Callers (api.py) wire it to log ``agent_wake`` so the previous-wake
+    # timestamp the #591 cycle-bound gate reads is advanced on EVERY
+    # delivered wake — not just cold-start + scheduler (Murzik P1#2).
+    # Failure-tolerant: delivery failures must NOT fire the callback or
+    # the boundary advances against a wake that never reached the model
+    # → the directive would be eaten by a wedged paste.
+    on_wake_delivered: object = None  # Callable(agent_name, WakeReason) -> None
     restart_guard: object = None  # Callable(session) -> dict; blocks restart if persistence is stale
     live_status_fn: object = None  # Callable() -> dict|None; agent's live REPL status {"status","last_updated"} from Claude Code working/idle hooks. Tmux inflight watchdog uses it to avoid force-restarting an idle (not wedged) REPL (#118).
     context_warn_pct: int = 40  # Warn agent to save state at this %
@@ -569,6 +577,19 @@ class StreamingSession:
                 )
             except Exception as e:
                 _log(f"streaming[{self.agent_name}]: wake prompt failed: {e}")
+                return  # delivery failed → DO NOT fire on_wake_delivered (#591 P1#2)
+            # Wake prompt delivered. Fire the post-delivery callback so
+            # the agent_wake activity event is logged (advances the
+            # #591 cycle-gate boundary on every successful warm wake,
+            # not just cold-start + scheduler — Murzik P1#2).
+            if self._config.on_wake_delivered:
+                try:
+                    self._config.on_wake_delivered(self.agent_name, wake_reason)
+                except Exception as _cb_e:
+                    _log(
+                        f"streaming[{self.agent_name}]: on_wake_delivered "
+                        f"callback failed: {_cb_e}"
+                    )
 
         # Do not block daemon startup on the agent's first turn. Wake prompts
         # may immediately use MCP tools that depend on the API listener.

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -545,6 +545,16 @@ class _QueuedTurn:
     # they don't progress (e.g. disconnect) before the agent honors the
     # prompt. Ignored when ``None``.
     completion_event: asyncio.Event | None = None
+    # #591 P1#2 (Murzik round-2): for wake prompts, the
+    # ``on_wake_delivered`` callback must fire ONLY after the actual
+    # paste lands — enqueue-time firing advances the cycle-gate
+    # boundary even when the paste later fails (context-lock deferral
+    # or REPL not-ready), eating the directive on the next RESUME.
+    # ``_deliver_turn`` invokes this after ``result.ok`` so the boundary
+    # tracks confirmed delivery, not just intent. ``None`` for
+    # non-wake turns and for any internal turn whose enqueuer doesn't
+    # care about post-delivery hooks.
+    on_delivered: object = None  # Callable() -> None — fires on paste-success
 
 
 @dataclass
@@ -1516,34 +1526,38 @@ class TmuxSession:
                 timezone=self._config.timezone or "America/Los_Angeles",
             )
         )
+        # #591 P1#2 (Murzik round-2): defer the on_wake_delivered fire
+        # to AFTER the actual paste lands, not at enqueue success. The
+        # paste happens later in ``_deliver_turn``; if it fails (context
+        # lock deferral, paste_text returning not-ok) the prompt is
+        # never shown to the agent, and firing the callback at enqueue
+        # would advance the #591 cycle-gate boundary against a wake
+        # that never reached the model — eating the directive on the
+        # next RESUME. The closure carries the agent name + reason so
+        # ``_deliver_turn`` can fire on paste-success without re-reading
+        # them. ``None`` when no callback is wired (tests).
+        _wake_delivered_cb: object = None
+        if self._config.on_wake_delivered:
+            _config_cb = self._config.on_wake_delivered
+            _agent_name = self.agent_name
+            _reason = reason
+
+            def _wake_delivered_cb() -> None:  # type: ignore[no-redef]
+                _config_cb(_agent_name, _reason)
+
         try:
             await self._enqueue_internal_prompt(
                 wake_prompt,
                 reason=f"wake_{reason.value}",
                 wait_for_completion=False,
                 front=front,
+                on_delivered=_wake_delivered_cb,
             )
         except Exception as e:
             _log(
                 f"tmux[{self.agent_name}]: wake prompt enqueue failed: {e} "
                 f"(reason={reason.value}) — session remains CONNECTED"
             )
-            return  # enqueue failed → DO NOT fire on_wake_delivered (#591 P1#2)
-        # Wake prompt enqueued for delivery. Fire the post-delivery
-        # callback so ``agent_wake`` is logged on every warm wake (not
-        # just cold-start + scheduler — Murzik P1#2). For tmux, "delivery"
-        # means enqueued — actual paste happens asynchronously when the
-        # worker pulls it. The pre-existing wake_prompt_sent log line and
-        # SSE event use the same enqueue-success semantics, so the
-        # boundary advances in lock-step with existing instrumentation.
-        if self._config.on_wake_delivered:
-            try:
-                self._config.on_wake_delivered(self.agent_name, reason)
-            except Exception as _cb_e:
-                _log(
-                    f"tmux[{self.agent_name}]: on_wake_delivered "
-                    f"callback failed: {_cb_e}"
-                )
 
     async def _spawn_tmux_repl(self) -> None:
         """Spawn the tmux session and the in-pane claude REPL, then start
@@ -1942,6 +1956,7 @@ class TmuxSession:
         wait_for_completion: bool = False,
         timeout_sec: float | None = None,
         front: bool = False,
+        on_delivered: object = None,
     ) -> None:
         """Queue a daemon-internal prompt with no external-side-effects.
 
@@ -2051,6 +2066,7 @@ class TmuxSession:
             internal=True,
             reason=reason,
             completion_event=completion,
+            on_delivered=on_delivered,
         )
         if front:
             # Prepend ahead of existing queue contents. Synchronous
@@ -3844,6 +3860,25 @@ class TmuxSession:
                 f"tmux paste-buffer / send-keys failed: rc={result.returncode} "
                 f"stderr={result.stderr.strip()!r}"
             )
+
+        # #591 P1#2 (Murzik round-2): paste landed. Fire the optional
+        # post-delivery callback (set on wake turns by
+        # ``_enqueue_wake_prompt`` so ``agent_wake`` is logged AFTER the
+        # prompt actually reached the REPL — not at enqueue time). This
+        # guarantees the cycle-gate boundary advances only on confirmed
+        # delivery: paste-failure (the ``if not result.ok`` branch above)
+        # raises BEFORE this point, so a wedged paste leaves the
+        # boundary intact and the next attempt re-emits the directive.
+        # Failure-tolerant: a misbehaving callback must not strand the
+        # delivery, so wrap in try/except.
+        if turn.on_delivered is not None:
+            try:
+                turn.on_delivered()
+            except Exception as _cb_e:
+                _log(
+                    f"tmux[{self.agent_name}]: on_delivered callback "
+                    f"failed (reason={turn.reason}): {_cb_e}"
+                )
 
         # Paste succeeded — append routing metadata to the deque so
         # ``_handle_turn_complete`` can popleft it when this turn's

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1528,6 +1528,22 @@ class TmuxSession:
                 f"tmux[{self.agent_name}]: wake prompt enqueue failed: {e} "
                 f"(reason={reason.value}) — session remains CONNECTED"
             )
+            return  # enqueue failed → DO NOT fire on_wake_delivered (#591 P1#2)
+        # Wake prompt enqueued for delivery. Fire the post-delivery
+        # callback so ``agent_wake`` is logged on every warm wake (not
+        # just cold-start + scheduler — Murzik P1#2). For tmux, "delivery"
+        # means enqueued — actual paste happens asynchronously when the
+        # worker pulls it. The pre-existing wake_prompt_sent log line and
+        # SSE event use the same enqueue-success semantics, so the
+        # boundary advances in lock-step with existing instrumentation.
+        if self._config.on_wake_delivered:
+            try:
+                self._config.on_wake_delivered(self.agent_name, reason)
+            except Exception as _cb_e:
+                _log(
+                    f"tmux[{self.agent_name}]: on_wake_delivered "
+                    f"callback failed: {_cb_e}"
+                )
 
     async def _spawn_tmux_repl(self) -> None:
         """Spawn the tmux session and the in-pane claude REPL, then start

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1485,10 +1485,34 @@ class TmuxSession:
         """
         if self._skip_wake_prompt_for_tests:
             return
+        # #591 — rebuild wake-context body with the freshly-computed
+        # ``reason`` so the builder can gate the saved-state manifest
+        # against the actual wake type (RESUME drops the bulk manifest
+        # since ``claude --continue`` already loaded the conversation;
+        # CONTEXT_RESTART/AUTO_RESTART/NEW_SESSION emit it). The static
+        # ``self._config.wake_context`` was set at config-create time
+        # (BEFORE the warm-vs-fresh decision is made) so reading it here
+        # without rebuilding would re-emit a stale manifest on RESUME —
+        # the exact symptom #591 was filed for. Falls back to the stored
+        # body when no builder is wired (tests). Trailing positional
+        # kwarg keeps legacy 1-arg builders working.
+        wake_context_body = self._config.wake_context or ""
+        if self._config.wake_context_builder:
+            try:
+                wake_context_body = self._config.wake_context_builder(
+                    self.agent_name, reason
+                )
+            except TypeError:
+                pass
+            except Exception as e:
+                _log(
+                    f"tmux[{self.agent_name}]: wake context rebuild failed: {e} "
+                    "— using stored body"
+                )
         wake_prompt = build_wake_prompt(
             WakePromptInput(
                 reason=reason,
-                context_body=self._config.wake_context or "",
+                context_body=wake_context_body,
                 timezone=self._config.timezone or "America/Los_Angeles",
             )
         )

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -7,7 +7,7 @@ import tempfile
 
 import pytest
 
-from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.agent_registry import AgentContext, AgentRegistry
 
 
 @pytest.fixture
@@ -504,3 +504,86 @@ class TestOwnerProfile:
         # Let's just check the structure is sensible
         assert "# Oleg" in prompt
         assert "## Memory" in prompt
+
+
+class TestAgentContextToPrompt:
+    """#591 — ``to_prompt(resume_mode=True)`` gates manifest rendering for
+    warm ``--continue`` resumes. The bulk manifest is redundant when the
+    prior conversation is already loaded; only the ``wake_action``
+    directive must survive because it represents intent set by the prior
+    session ("do this FIRST"), not history.
+    """
+
+    def _full_ctx(self) -> AgentContext:
+        return AgentContext(
+            agent_name="dymok",
+            task="Phase 2 of tmux watchdog fix",
+            context="Detailed context body",
+            notes="Some scratch notes",
+            blockers=["upstream PR pending"],
+            priority_items=["check daemon log", "ping barsik"],
+            wake_action="Grep daemon log for verdict_wedged_inputs lines",
+            updated_at=1_700_000_000.0,
+        )
+
+    def test_default_emits_full_manifest(self):
+        """Pins pre-#591 behavior for non-resume wakes (CONTEXT_RESTART /
+        AUTO_RESTART / NEW_SESSION / IDLE_WAKE). All sections render."""
+        out = self._full_ctx().to_prompt()
+        assert "## ⚡ Wake Action (do this FIRST)" in out
+        assert "Grep daemon log for verdict_wedged_inputs lines" in out
+        assert "## Continuation" in out
+        assert "Phase 2 of tmux watchdog fix" in out
+        assert "### Context" in out
+        assert "Detailed context body" in out
+        assert "### Notes" in out
+        assert "Some scratch notes" in out
+        assert "### Blockers" in out
+        assert "upstream PR pending" in out
+        assert "### Priority Items" in out
+        assert "check daemon log" in out
+
+    def test_resume_mode_emits_only_wake_action(self):
+        """RESUME mode (warm ``--continue``): only the directive renders.
+        Continuation/Context/Notes/Blockers/Priority are dropped because
+        the resumed conversation already carries that history."""
+        out = self._full_ctx().to_prompt(resume_mode=True)
+        # Directive survives.
+        assert "## ⚡ Wake Action (do this FIRST)" in out
+        assert "Grep daemon log for verdict_wedged_inputs lines" in out
+        # Bulk does NOT.
+        assert "## Continuation" not in out
+        assert "Phase 2 of tmux watchdog fix" not in out
+        assert "### Context" not in out
+        assert "Detailed context body" not in out
+        assert "### Notes" not in out
+        assert "Some scratch notes" not in out
+        assert "### Blockers" not in out
+        assert "upstream PR pending" not in out
+        assert "### Priority Items" not in out
+
+    def test_resume_mode_returns_empty_when_no_wake_action(self):
+        """RESUME mode with manifest set but no wake_action: nothing to
+        render. Caller (``_build_streaming_wake_context``) treats empty
+        return as "no saved-state contribution to wake prompt."""
+        ctx = self._full_ctx()
+        ctx.wake_action = ""
+        out = ctx.to_prompt(resume_mode=True)
+        assert out == ""
+
+    def test_resume_mode_empty_when_wake_action_only_field_empty(self):
+        """RESUME mode with ONLY wake_action set (no other fields): the
+        directive renders by itself. Confirms the gate doesn't require
+        the bulk fields to be populated."""
+        ctx = AgentContext(
+            agent_name="dymok",
+            wake_action="Ping Barsik with verdict data",
+        )
+        out = ctx.to_prompt(resume_mode=True)
+        assert out == "## ⚡ Wake Action (do this FIRST)\nPing Barsik with verdict data"
+
+    def test_default_empty_context_returns_empty_string(self):
+        """Regression: empty manifest → empty string, both modes."""
+        empty = AgentContext(agent_name="dymok")
+        assert empty.to_prompt() == ""
+        assert empty.to_prompt(resume_mode=True) == ""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5014,3 +5014,182 @@ class TestBuildStreamingWakeContextReasonGating:
             # Manifest sections must NOT appear.
             assert "## ⚡ Wake Action" not in out
             assert "## Continuation" not in out
+
+    def test_commit_false_does_not_consume_inbox(self):
+        """#591 P1#1 (Murzik): the eager pre-build at session-config
+        creation time must NOT consume inbox messages — that would
+        leave the delivered (connect-time) rebuild with an empty
+        inbox and a wake prompt missing the new agent messages.
+        """
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+            app.state.agents.register("barsik", model="sonnet")
+            # barsik sends dymok a message — appears in dymok's inbox.
+            app.state.comms.send(
+                from_session="barsik",
+                to_session="dymok",
+                content="Phase 2 plan looks right — ship it",
+            )
+            unread_before = len(
+                app.state.comms.get_inbox("dymok", unread_only=True)
+            )
+            assert unread_before == 1
+
+            # Eager pre-build (commit=False): must NOT mark inbox read.
+            out_preview = app.state._build_streaming_wake_context(
+                "dymok", WakeReason.NEW_SESSION, commit=False
+            )
+            assert "Phase 2 plan looks right" in out_preview  # content rendered
+            unread_after_preview = len(
+                app.state.comms.get_inbox("dymok", unread_only=True)
+            )
+            assert unread_after_preview == 1  # NOT marked read
+
+            # Delivered build (commit=True): marks inbox read.
+            out_delivered = app.state._build_streaming_wake_context(
+                "dymok", WakeReason.NEW_SESSION, commit=True
+            )
+            assert "Phase 2 plan looks right" in out_delivered
+            unread_after_delivered = len(
+                app.state.comms.get_inbox("dymok", unread_only=True)
+            )
+            assert unread_after_delivered == 0  # NOW marked read
+
+    def test_commit_false_does_not_consume_restart_manifest(self):
+        """#591 P1#1 (Murzik): the eager pre-build must NOT delete
+        the agent's entry from restart_manifest.json — the delivered
+        rebuild would then find nothing and the wake prompt would
+        miss the restart manifest content.
+        """
+        import json
+        from datetime import datetime
+        from datetime import timezone as _utc
+        from pathlib import Path
+
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+            manifest_path = Path(db_path).parent / "restart_manifest.json"
+            manifest = {
+                "restart_time": datetime.now(_utc.utc).isoformat(),
+                "agents": {
+                    "dymok": {
+                        "in_progress": "Phase 2 of tmux watchdog",
+                        "activity_log": ["build", "test"],
+                        "pending_responses": 0,
+                    },
+                },
+            }
+            manifest_path.write_text(json.dumps(manifest))
+
+            # Eager pre-build (commit=False): renders content, no delete.
+            out_preview = app.state._build_streaming_wake_context(
+                "dymok", WakeReason.NEW_SESSION, commit=False
+            )
+            assert "Phase 2 of tmux watchdog" in out_preview
+            assert manifest_path.exists()  # NOT deleted
+            persisted = json.loads(manifest_path.read_text())
+            assert "dymok" in persisted["agents"]  # entry still present
+
+            # Delivered build (commit=True): deletes the entry.
+            out_delivered = app.state._build_streaming_wake_context(
+                "dymok", WakeReason.NEW_SESSION, commit=True
+            )
+            assert "Phase 2 of tmux watchdog" in out_delivered
+            # Last entry was for dymok — manifest file should now be gone.
+            assert not manifest_path.exists()
+
+    def test_central_wake_log_advances_cycle_gate_on_warm_wakes(self):
+        """#591 P1#2 (Murzik): the cycle-bound gate's source-of-truth is
+        the most-recent ``agent_wake`` event. Before the centralized
+        callback, warm-wake paths (broker auto-wake, reconnect) didn't
+        log ``agent_wake``, so a directive set once would replay on
+        every subsequent warm wake forever. With the central callback,
+        every successful delivery advances the boundary.
+
+        Concrete replay shape:
+          T0 cold-start log → save wake_action T1 → warm-wake T2 emits
+          directive + LOGS T2 → T3 warm-wake reads prev_wake=T2 →
+          manifest.updated_at(T1) < T2 → directive does NOT replay.
+        """
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+
+            # T0: seed prior cold-start wake event.
+            t0 = time.time() - 7200
+            self._seed_previous_wake(app, "dymok", t0)
+            # T1: save_my_context — wake_action set just before sleep.
+            t1 = t0 + 3600
+            self._seed_manifest_at(
+                app, "dymok",
+                task="Working on tmux watchdog",
+                wake_action="Grep daemon log for verdict_wedged_inputs",
+                when=t1,
+            )
+
+            # T2: warm wake fires. Directive should emit (manifest.t1 > t0).
+            out_t2 = app.state._build_streaming_wake_context(
+                "dymok", WakeReason.RESUME
+            )
+            assert "Grep daemon log for verdict_wedged_inputs" in out_t2
+
+            # Central callback advances the boundary to T2.
+            app.state._log_agent_wake_event("dymok", WakeReason.RESUME)
+
+            # T3: another warm wake. prev_wake is now T2, AFTER manifest.
+            # The cycle gate must REJECT — directive must not replay.
+            out_t3 = app.state._build_streaming_wake_context(
+                "dymok", WakeReason.RESUME
+            )
+            assert "Grep daemon log for verdict_wedged_inputs" not in out_t3
+
+    def test_central_wake_log_failure_does_not_advance_gate(self):
+        """#591 P1#2 (Barsik refinement): the callback fires ONLY on
+        successful delivery. If the wake prompt's paste/query fails,
+        the boundary must NOT advance — otherwise a wedged delivery
+        would eat the directive permanently (next attempt finds the
+        boundary already past the manifest and skips emission).
+
+        We can't directly simulate a paste failure in this unit test,
+        but we CAN verify the invariant: without firing the callback,
+        the manifest stays fresh-this-cycle on the retry.
+        """
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+
+            t0 = time.time() - 7200
+            self._seed_previous_wake(app, "dymok", t0)
+            t1 = t0 + 3600
+            self._seed_manifest_at(
+                app, "dymok",
+                task="Working on tmux watchdog",
+                wake_action="Grep daemon log for verdict_wedged_inputs",
+                when=t1,
+            )
+
+            # First warm-wake attempt emits the directive.
+            out_first = app.state._build_streaming_wake_context(
+                "dymok", WakeReason.RESUME
+            )
+            assert "Grep daemon log for verdict_wedged_inputs" in out_first
+
+            # Delivery fails: callback NOT fired. Boundary stays at T0.
+
+            # Retry attempt MUST still emit — manifest is still fresh
+            # against T0. (Contrast with the prior test where the
+            # callback fired and advanced the boundary.)
+            out_retry = app.state._build_streaming_wake_context(
+                "dymok", WakeReason.RESUME
+            )
+            assert "Grep daemon log for verdict_wedged_inputs" in out_retry

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4761,3 +4761,256 @@ class TestGoogleOAuthStateValidation:
         assert "corrupt state" in resp.text.lower()
         # Still purged, even though it was malformed — can't be retried.
         assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_naive-nonce") == ""
+
+
+class TestBuildStreamingWakeContextReasonGating:
+    """#591 — ``_build_streaming_wake_context`` gates the saved-context
+    manifest by wake reason.
+
+    On ``WakeReason.RESUME`` (warm ``claude --continue``) the prior
+    conversation is already in context, so the bulk manifest is dropped.
+    Only a *fresh-this-cycle* ``wake_action`` survives — gated by
+    comparison against the previous ``agent_wake`` event's timestamp.
+
+    On any other reason (CONTEXT_RESTART / AUTO_RESTART / NEW_SESSION /
+    IDLE_WAKE) the full manifest is emitted as before.
+
+    Transient context (inbox, tasks, channels, dreams, restart manifest)
+    is fresh per-wake and continues to fire on RESUME — only the saved
+    manifest is gated.
+    """
+
+    def _make_app(self, path: str):
+        from pinky_daemon.api import create_api
+        return create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
+
+    def _seed_previous_wake(self, app, agent_name: str, when: float) -> None:
+        """Insert an ``agent_wake`` activity event with a specific
+        created_at so the cycle-bound freshness check has a baseline.
+        Uses raw SQL because ``activity.log`` stamps NOW unconditionally.
+        """
+        with app.state.activity._db:
+            app.state.activity._db.execute(
+                "INSERT INTO activity_log (agent_name, event_type, title, "
+                "description, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (agent_name, "agent_wake", "prev wake", "", "{}", when),
+            )
+
+    def _seed_manifest_at(
+        self, app, agent_name: str, *, task: str, wake_action: str, when: float
+    ) -> None:
+        app.state.agents.set_context(
+            agent_name,
+            task=task,
+            wake_action=wake_action,
+            metadata={"source": "save_my_context"},
+        )
+        with app.state.agents._db:
+            app.state.agents._db.execute(
+                "UPDATE agent_contexts SET updated_at=? WHERE agent_name=?",
+                (when, agent_name),
+            )
+
+    def test_resume_with_fresh_wake_action_emits_directive_only(self):
+        """RESUME + manifest written AFTER previous wake → only
+        wake_action renders. Bulk fields stay out of the wake prompt."""
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+            prev_wake = time.time() - 3600
+            self._seed_previous_wake(app, "dymok", prev_wake)
+            self._seed_manifest_at(
+                app, "dymok",
+                task="Phase 2 of tmux watchdog fix",
+                wake_action="Grep daemon log for verdict_wedged_inputs",
+                when=prev_wake + 1800,  # 30 min after previous wake — fresh this cycle
+            )
+
+            out = app.state._build_streaming_wake_context("dymok", WakeReason.RESUME)
+            assert "## ⚡ Wake Action (do this FIRST)" in out
+            assert "Grep daemon log for verdict_wedged_inputs" in out
+            # Bulk fields must NOT appear.
+            assert "## Continuation" not in out
+            assert "Phase 2 of tmux watchdog fix" not in out
+
+    def test_resume_with_stale_wake_action_drops_directive(self):
+        """RESUME + manifest written BEFORE previous wake → cycle-bound
+        gate rejects, no manifest contribution. Pins the #591 repro:
+        14h-old directive must not replay on a new wake."""
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+            prev_wake = time.time() - 3600
+            # Manifest written 14h before the previous wake — stale.
+            self._seed_manifest_at(
+                app, "dymok",
+                task="Old task from prior cycle",
+                wake_action="Old directive from prior cycle",
+                when=prev_wake - 14 * 3600,
+            )
+            self._seed_previous_wake(app, "dymok", prev_wake)
+
+            out = app.state._build_streaming_wake_context("dymok", WakeReason.RESUME)
+            assert "Old directive from prior cycle" not in out
+            assert "Old task from prior cycle" not in out
+            # Bulk fields ALSO not emitted on RESUME regardless of staleness.
+            assert "## Continuation" not in out
+
+    def test_resume_with_no_wake_action_drops_manifest(self):
+        """RESUME + fresh manifest but wake_action empty → no manifest
+        contribution. The bulk-only manifest is redundant on warm
+        resume."""
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+            prev_wake = time.time() - 3600
+            self._seed_previous_wake(app, "dymok", prev_wake)
+            self._seed_manifest_at(
+                app, "dymok",
+                task="Working on something",
+                wake_action="",  # No directive
+                when=prev_wake + 1800,
+            )
+
+            out = app.state._build_streaming_wake_context("dymok", WakeReason.RESUME)
+            assert "## ⚡ Wake Action" not in out
+            assert "Working on something" not in out
+            assert "## Continuation" not in out
+
+    def test_resume_with_no_previous_wake_emits_directive(self):
+        """RESUME with no prior ``agent_wake`` event → fall through to
+        emit (first-ever resume edge case). The manifest must be fresh
+        in some absolute sense too, but if no prior wake exists we
+        treat the directive as fresh-by-default."""
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+            self._seed_manifest_at(
+                app, "dymok",
+                task="First-ever task",
+                wake_action="Do the first-ever thing",
+                when=time.time() - 60,
+            )
+
+            out = app.state._build_streaming_wake_context("dymok", WakeReason.RESUME)
+            assert "Do the first-ever thing" in out
+            # Still drops the bulk on RESUME.
+            assert "## Continuation" not in out
+
+    def test_context_restart_emits_full_manifest(self):
+        """CONTEXT_RESTART = fresh ``claude`` launch (no --continue).
+        The bulk manifest is needed because the new session has no
+        prior conversation to anchor against. Regression guard."""
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+            self._seed_manifest_at(
+                app, "dymok",
+                task="Phase 2 of tmux watchdog fix",
+                wake_action="Grep daemon log",
+                when=time.time() - 600,
+            )
+
+            out = app.state._build_streaming_wake_context(
+                "dymok", WakeReason.CONTEXT_RESTART
+            )
+            assert "## ⚡ Wake Action (do this FIRST)" in out
+            assert "Grep daemon log" in out
+            assert "## Continuation" in out
+            assert "Phase 2 of tmux watchdog fix" in out
+
+    def test_default_reason_emits_full_manifest(self):
+        """Backwards compat: legacy 1-arg callers (``builder(name)``)
+        get the default ``WakeReason.NEW_SESSION`` which emits the full
+        manifest — same as pre-#591 behavior. Protects external callers
+        that haven't been updated to pass a reason."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+            self._seed_manifest_at(
+                app, "dymok",
+                task="Legacy task",
+                wake_action="Legacy directive",
+                when=time.time() - 600,
+            )
+
+            # One-arg call (no reason) — pre-#591 caller shape.
+            out = app.state._build_streaming_wake_context("dymok")
+            assert "Legacy directive" in out
+            assert "## Continuation" in out
+            assert "Legacy task" in out
+
+    def test_resume_with_fresh_directive_but_absolute_age_no_warning(self):
+        """RESUME + cycle-fresh wake_action that is ALSO >12h old in
+        absolute terms (no agent_wake between save and now) → no stale
+        warning. The stale-warning is about the BULK manifest's
+        absolute age; this branch already validated cycle freshness
+        via the tighter previous-wake comparison, and we never emit
+        the bulk on RESUME. Firing the warning here would contradict
+        the cycle-bound gate that just certified the directive.
+
+        Repro shape (Barsik branch review): agent awake continuously
+        with the only prior agent_wake event >12h old, fresh save
+        within the current awake period, current RESUME wake.
+        """
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+            # Previous agent_wake fired 15h ago (e.g., daemon-restart
+            # wake at the start of a long awake period).
+            prev_wake = time.time() - 15 * 3600
+            self._seed_previous_wake(app, "dymok", prev_wake)
+            # Manifest saved 13h ago — AFTER the prior wake (cycle-
+            # fresh) but >12h absolute (would trip the stale-warning
+            # constant if we let it).
+            self._seed_manifest_at(
+                app, "dymok",
+                task="Working through a long shift",
+                wake_action="Ping Barsik with status when you wake",
+                when=time.time() - 13 * 3600,
+            )
+
+            out = app.state._build_streaming_wake_context(
+                "dymok", WakeReason.RESUME
+            )
+            # Directive survives (cycle-fresh).
+            assert "Ping Barsik with status when you wake" in out
+            # The stale-continuation warning MUST NOT appear — the
+            # cycle-bound gate already validated freshness and we
+            # didn't emit the bulk to which the warning refers.
+            assert "WARNING: Saved continuation context" not in out
+
+    def test_resume_preserves_channel_context(self):
+        """Transient context (channel preamble, inbox, tasks, dreams,
+        restart manifest) is fresh per wake and continues to fire on
+        RESUME — only the saved-context manifest is gated by reason.
+        The model wouldn't otherwise know about active channels or
+        new inbox messages received while asleep.
+        """
+        from pinky_daemon.wake_prompt import WakeReason
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register("dymok", model="sonnet")
+            # No saved manifest. Broker still emits default channel
+            # context — the transient layer must not be gated by reason.
+
+            out = app.state._build_streaming_wake_context("dymok", WakeReason.RESUME)
+            assert "## Active Channels" in out
+            assert "## Messaging Tools" in out
+            # Manifest sections must NOT appear.
+            assert "## ⚡ Wake Action" not in out
+            assert "## Continuation" not in out

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -774,3 +774,97 @@ class TestCodexIsHealthy:
         s._message_queue.put_nowait(("p2", "tg", "1", "2"))
         h = s.is_healthy()
         assert h["queue_depth"] == 2
+
+
+class TestCodexPendingWakeCallback:
+    """#591 P1#2 (Murzik round-2): the codex worker fires the pending
+    wake-callback AFTER _exec_codex succeeds, not at queue.put time.
+    Failed execs leave the boundary intact so the next attempt re-emits
+    the directive.
+    """
+
+    @pytest.mark.asyncio
+    async def test_worker_fires_pending_callback_after_exec_success(self):
+        """Happy path: exec succeeds → pending callback fires once, then
+        is cleared so a subsequent non-wake turn doesn't re-fire it."""
+        config = StreamingSessionConfig(
+            agent_name="dymok",
+            working_dir="/tmp",
+            provider_url="codex_cli",
+        )
+        s = CodexSession(config)
+        s._connected = True
+        s._connect_attempted = True
+
+        fires: list[str] = []
+        s._pending_wake_callback = lambda: fires.append("delivered")
+
+        async def fake_exec(prompt: str) -> CodexTurnResult:
+            return CodexTurnResult()  # failed=False by default
+
+        s._exec_codex = fake_exec  # type: ignore[assignment]
+        s._message_queue.put_nowait(("wake prompt body", "", "", ""))
+
+        worker = asyncio.create_task(s._message_worker())
+        # Let worker process one turn, then stop the loop.
+        await asyncio.sleep(0.05)
+        s._connected = False
+        s._message_queue.put_nowait(("noop", "", "", ""))  # unblock get()
+        try:
+            await asyncio.wait_for(worker, timeout=2.0)
+        except asyncio.TimeoutError:
+            worker.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await worker
+
+        assert fires == ["delivered"], (
+            "pending_wake_callback must fire exactly once on exec-success"
+        )
+        # And cleared so it doesn't re-fire on a subsequent non-wake turn.
+        assert s._pending_wake_callback is None
+
+    @pytest.mark.asyncio
+    async def test_worker_skips_pending_callback_on_exec_failure(self):
+        """Failure path: exec fails → callback does NOT fire. Boundary
+        stays put so the next attempt re-emits the directive. Pending
+        callback is still cleared so a subsequent non-wake turn doesn't
+        spuriously fire it once exec recovers.
+        """
+        config = StreamingSessionConfig(
+            agent_name="dymok",
+            working_dir="/tmp",
+            provider_url="codex_cli",
+        )
+        s = CodexSession(config)
+        s._connected = True
+        s._connect_attempted = True
+
+        fires: list[str] = []
+        s._pending_wake_callback = lambda: fires.append("delivered")
+
+        async def fake_exec_fail(prompt: str) -> CodexTurnResult:
+            result = CodexTurnResult()
+            result.failed = True
+            return result
+
+        s._exec_codex = fake_exec_fail  # type: ignore[assignment]
+        s._message_queue.put_nowait(("wake prompt body", "", "", ""))
+
+        worker = asyncio.create_task(s._message_worker())
+        await asyncio.sleep(0.05)
+        s._connected = False
+        s._message_queue.put_nowait(("noop", "", "", ""))
+        try:
+            await asyncio.wait_for(worker, timeout=2.0)
+        except asyncio.TimeoutError:
+            worker.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await worker
+
+        assert fires == [], (
+            "pending_wake_callback MUST NOT fire on exec-failure — "
+            "boundary stays put so retry re-emits"
+        )
+        # But the field IS cleared so a recovery turn doesn't replay
+        # the (now-stale) callback against a turn it wasn't paired with.
+        assert s._pending_wake_callback is None

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -1129,7 +1129,13 @@ async def test_force_restart_enqueues_resume_wake_prompt() -> None:
     enqueued: list[tuple[str, bool]] = []
 
     async def _record(
-        prompt, *, reason, wait_for_completion=False, timeout_sec=None, front=False
+        prompt,
+        *,
+        reason,
+        wait_for_completion=False,
+        timeout_sec=None,
+        front=False,
+        on_delivered=None,
     ):
         enqueued.append((reason, front))
         return None
@@ -1160,7 +1166,13 @@ async def test_force_restart_skips_wake_prompt_under_test_seam() -> None:
     enqueued: list[str] = []
 
     async def _record(
-        prompt, *, reason, wait_for_completion=False, timeout_sec=None, front=False
+        prompt,
+        *,
+        reason,
+        wait_for_completion=False,
+        timeout_sec=None,
+        front=False,
+        on_delivered=None,
     ):
         enqueued.append(reason)
         return None
@@ -6415,3 +6427,89 @@ class TestHandleStopFailure:
         assert len(ss._inflight_metas) == 1
         assert ss._inflight_metas[0].meta["chat_id"] == "B"
         assert not b_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_fires_on_delivered_after_paste_success() -> None:
+    """#591 P1#2 (Murzik round-2): for wake turns, the
+    ``on_delivered`` callback (carried on the _QueuedTurn) must fire
+    AFTER paste_text succeeds — not at enqueue time. This pins the
+    "boundary advances on confirmed delivery" invariant; enqueue-time
+    fire would let context-lock deferrals or stuck pastes advance
+    the #591 cycle-gate against a wake that never reached the model.
+    """
+    tmux = _make_mock_tmux()
+    tmux.paste_text = AsyncMock(return_value=_ok())
+    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+
+    fires: list[str] = []
+    turn = _QueuedTurn(
+        prompt="wake prompt body",
+        platform="",
+        chat_id="",
+        message_id="",
+        internal=True,
+        reason="wake_resume",
+        on_delivered=lambda: fires.append("delivered"),
+    )
+
+    await ss._deliver_turn(turn)
+
+    tmux.paste_text.assert_awaited_once()
+    assert fires == ["delivered"], (
+        "on_delivered must fire exactly once after paste-success"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_skips_on_delivered_on_paste_failure() -> None:
+    """#591 P1#2 (Murzik round-2): on paste_text failure, _deliver_turn
+    raises BEFORE the on_delivered fire site. This pins the
+    failure-doesn't-advance-boundary invariant — a wedged paste leaves
+    the cycle-gate boundary intact so the next attempt re-emits the
+    directive.
+    """
+    tmux = _make_mock_tmux()
+    tmux.paste_text = AsyncMock(return_value=_fail("rc=1"))
+    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+
+    fires: list[str] = []
+    turn = _QueuedTurn(
+        prompt="wake prompt body",
+        platform="",
+        chat_id="",
+        message_id="",
+        internal=True,
+        reason="wake_resume",
+        on_delivered=lambda: fires.append("delivered"),
+    )
+
+    with pytest.raises(RuntimeError):
+        await ss._deliver_turn(turn)
+
+    assert fires == [], (
+        "on_delivered MUST NOT fire on paste-failure — boundary stays put "
+        "so next attempt re-emits the directive"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_no_on_delivered_is_safe() -> None:
+    """#591 P1#2: external (non-wake) turns have no on_delivered set;
+    _deliver_turn must handle the None gracefully without firing
+    anything. Regression guard for the external-message path.
+    """
+    tmux = _make_mock_tmux()
+    tmux.paste_text = AsyncMock(return_value=_ok())
+    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+
+    # External turn — no on_delivered (default None).
+    turn = _QueuedTurn(
+        prompt="hi dymok",
+        platform="telegram",
+        chat_id="123",
+        message_id="m1",
+    )
+
+    await ss._deliver_turn(turn)
+    tmux.paste_text.assert_awaited_once()  # delivered cleanly, no crash


### PR DESCRIPTION
## Summary

- On `claude --continue` resumes the prior conversation is already in context, so re-injecting the saved-state manifest is redundant noise. This PR drops the bulk manifest from RESUME wake prompts; only a *current-cycle* `wake_action` directive survives.
- Cycle-bound freshness gate: `updated_at > previous_wake_ts` (most recent prior `agent_wake` event from `activity_log`). No schema bump.
- Other wake reasons (`CONTEXT_RESTART` / `AUTO_RESTART` / `NEW_SESSION` / `IDLE_WAKE`) emit the full manifest as before — fresh-launch wakes need it because the new session has no prior conversation to anchor against.
- Transient context (inbox / tasks / channels / dreams / restart manifest) is fresh per-wake and continues to fire on RESUME — only the saved-context manifest is gated by reason.

This is the back-half of the (b) split agreed with @bradbrok in chat: #595 keeps the #592 transcript-mtime phantom-drain fix, and this PR owns #591 via reason-gated Design 2 (vs. #595's earlier destructive `clear_context()` approach, which only stopped repeats — the FIRST RESUME post-presave still emitted the bulky block, contradicting "wake up like nothing happened").

Co-designed with @barsik (cycle-bound freshness gate). See https://github.com/bradbrok/PinkyBot/issues/591#issuecomment-4551961465 for the framing discussion that led to this shape, and https://github.com/bradbrok/PinkyBot/pull/595#issuecomment-4552079289 for the removal footprint on #595.

## What changed

| File | What |
|------|------|
| `src/pinky_daemon/agent_registry.py` | `AgentContext.to_prompt(resume_mode=False)` — emit only the `wake_action` section when `resume_mode=True` |
| `src/pinky_daemon/api.py` | `_get_previous_wake_timestamp` helper + reason-aware `_build_streaming_wake_context(name, reason=NEW_SESSION)` |
| `src/pinky_daemon/streaming_session.py` | `connect()` rebuilds wake-context body via builder with the just-computed `wake_reason`; TypeError-safe for legacy 1-arg builders |
| `src/pinky_daemon/tmux_session.py` | `_enqueue_wake_prompt` uses the same builder-rebuild pattern with the connect-time reason |
| `tests/test_agent_registry.py` | 5 unit tests for `to_prompt(resume_mode=...)` |
| `tests/test_api.py` | 8 integration tests for `_build_streaming_wake_context` reason-gating |

## Test plan

- [x] 5 unit tests pass (full manifest default / wake_action-only on resume / empty without wake_action / wake_action standalone / regression empty manifest)
- [x] 8 integration tests pass (fresh wake_action / stale wake_action drop / no wake_action drop / no-prior-wake edge / CONTEXT_RESTART full / default-arg backwards compat / channel transient preserved / cycle-fresh-but-absolute-stale no-warning regression)
- [x] Full suite green: 2755 passed + 1 skipped
- [x] `ruff check` clean on all touched files
- [ ] Production: confirm warm-wake-from-idle-sleeping no longer injects the `── Saved State ──` block when the agent had no pending wake_action
- [ ] Production: confirm a `save_my_context` call immediately before idle-sleep with `wake_action="..."` set DOES emit the directive (and only the directive) on the next warm wake

🤖 Generated with [Claude Code](https://claude.com/claude-code)