### PR TITLE
feat(#98): codex app-server path for CodexSession (Tier 2, flag-gated)

### DIFF
--- a/src/pinky_daemon/codex_app_server.py
+++ b/src/pinky_daemon/codex_app_server.py
@@ -1,0 +1,250 @@
+"""Async JSON-RPC client for ``codex app-server``.
+
+Transport layer only. Speaks the newline-delimited JSON dialect that
+``codex app-server`` exposes over stdio. Higher layers (CodexSession) build
+on this to host long-lived *Threads* instead of spawning ``codex exec`` once
+per user message — avoiding per-turn cold-start cost and gaining native
+reconnect (Tier 2 of the Codex modernisation, task #98).
+
+Wire protocol (observed against codex-cli 0.125, ``--listen stdio://``):
+
+  * One JSON object per line (NDJSON). No ``Content-Length`` framing and no
+    ``"jsonrpc"`` version field — the server neither emits nor requires it.
+  * Client request:   ``{"id": <int>, "method": "<m>", "params": {...}}``
+  * Server response:  ``{"id": <int>, "result": {...}}``
+                  or  ``{"id": <int>, "error": {"code", "message", ...}}``
+  * Server notification (no id): ``{"method": "<m>", "params": {...}}``
+  * Server->client request (has id + method, expects a response):
+    e.g. approval prompts (``item/commandExecution/requestApproval``). Routed
+    to ``server_request_handler``; unhandled requests get a JSON-RPC error
+    response so the server is never left waiting.
+
+Methods use slash notation (``initialize``, ``thread/start``, ``turn/start``,
+``item/completed`` ...) — distinct from the dot notation of the legacy
+``codex exec --json`` stream. Mapping app-server notifications back onto the
+existing event shapes is the integration layer's job, not this module's.
+
+This module is pure transport: it does not know about agents, turns, or
+PinkyBot session state. That keeps it unit-testable against an in-memory
+stream pair with no real subprocess.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+
+from pinky_daemon.streaming_session import _log
+
+DEFAULT_COMMAND = ("codex", "app-server")
+# Generous default: a single turn can run for minutes under heavy tool use.
+DEFAULT_REQUEST_TIMEOUT = 600.0
+# Match codex_session's subprocess read limit — large tool-result frames can
+# exceed asyncio's default 64KiB line buffer and raise LimitOverrunError.
+_STREAM_LIMIT = 10 * 1024 * 1024
+
+# async fn(method: str, params: dict) -> None
+NotificationHandler = Callable[[str, dict], Awaitable[None]]
+# async fn(method: str, params: dict) -> dict (the result payload)
+ServerRequestHandler = Callable[[str, dict], Awaitable[dict | None]]
+
+
+class CodexAppServerError(Exception):
+    """A JSON-RPC error frame, or a transport failure (EOF / closed)."""
+
+    def __init__(self, message: str, *, code: int | None = None, data: object = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.data = data
+
+    @classmethod
+    def from_frame(cls, err: object) -> CodexAppServerError:
+        if isinstance(err, dict):
+            return cls(
+                str(err.get("message", "unknown error")),
+                code=err.get("code"),
+                data=err.get("data"),
+            )
+        return cls(str(err))
+
+
+class CodexAppServerClient:
+    """JSON-RPC client over a duplex byte stream.
+
+    Constructed from an ``asyncio.StreamReader``/``StreamWriter`` pair so it can
+    be driven by a real subprocess (see :func:`spawn_app_server`) or by an
+    in-memory stream in tests. Call :meth:`start` to begin reading, then
+    :meth:`request` / :meth:`notify`. Always :meth:`close` when done.
+    """
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        *,
+        notification_handler: NotificationHandler | None = None,
+        server_request_handler: ServerRequestHandler | None = None,
+        log: Callable[[str], None] = _log,
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+        self._notification_handler = notification_handler
+        self._server_request_handler = server_request_handler
+        self._log = log
+        self._next_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        self._read_task: asyncio.Task | None = None
+        self._closed = False
+
+    def start(self) -> None:
+        """Begin consuming the read stream. Idempotent."""
+        if self._read_task is None:
+            self._read_task = asyncio.create_task(self._read_loop())
+
+    async def request(
+        self,
+        method: str,
+        params: dict | None = None,
+        *,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT,
+    ) -> object:
+        """Send a request and await its result. Raises CodexAppServerError on
+        an error frame, transport close, or timeout."""
+        if self._closed:
+            raise CodexAppServerError("client is closed")
+        self._next_id += 1
+        rid = self._next_id
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[rid] = fut
+        try:
+            await self._send({"id": rid, "method": method, "params": params or {}})
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except asyncio.TimeoutError as exc:
+            raise CodexAppServerError(f"request {method!r} timed out after {timeout}s") from exc
+        finally:
+            self._pending.pop(rid, None)
+
+    async def notify(self, method: str, params: dict | None = None) -> None:
+        """Send a notification (no id, no response expected)."""
+        await self._send({"method": method, "params": params or {}})
+
+    async def initialize(self, *, name: str = "pinkybot", version: str = "1") -> object:
+        """Perform the required ``initialize`` handshake."""
+        return await self.request("initialize", {"clientInfo": {"name": name, "version": version}})
+
+    async def _send(self, msg: dict) -> None:
+        if self._closed:
+            raise CodexAppServerError("client is closed")
+        self._writer.write((json.dumps(msg) + "\n").encode())
+        await self._writer.drain()
+
+    async def _read_loop(self) -> None:
+        try:
+            while True:
+                line = await self._reader.readline()
+                if not line:
+                    break  # EOF — server closed stdout
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    msg = json.loads(stripped)
+                except json.JSONDecodeError:
+                    self._log(f"codex-app-server: skipping non-JSON line: {stripped[:200]!r}")
+                    continue
+                await self._dispatch(msg)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — read loop must not die silently
+            self._log(f"codex-app-server: read loop error: {exc}")
+        finally:
+            self._fail_pending(CodexAppServerError("connection closed"))
+
+    async def _dispatch(self, msg: dict) -> None:
+        mid = msg.get("id")
+        method = msg.get("method")
+        if method is not None and mid is not None:
+            await self._handle_server_request(mid, method, msg.get("params") or {})
+        elif method is not None:
+            if self._notification_handler is not None:
+                await self._notification_handler(method, msg.get("params") or {})
+        elif mid is not None:
+            fut = self._pending.get(mid)
+            if fut is not None and not fut.done():
+                if "error" in msg:
+                    fut.set_exception(CodexAppServerError.from_frame(msg["error"]))
+                else:
+                    fut.set_result(msg.get("result"))
+        else:
+            self._log(f"codex-app-server: unrecognized message: {msg}")
+
+    async def _handle_server_request(self, mid: object, method: str, params: dict) -> None:
+        if self._server_request_handler is None:
+            await self._send(
+                {"id": mid, "error": {"code": -32601, "message": f"no handler for {method!r}"}}
+            )
+            return
+        try:
+            result = await self._server_request_handler(method, params)
+            await self._send({"id": mid, "result": result if result is not None else {}})
+        except Exception as exc:  # noqa: BLE001 — surface handler failure as an error frame
+            await self._send({"id": mid, "error": {"code": -32000, "message": str(exc)}})
+
+    def _fail_pending(self, exc: CodexAppServerError) -> None:
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.set_exception(exc)
+        self._pending.clear()
+
+    async def close(self) -> None:
+        """Stop reading and close the write side. Idempotent."""
+        self._closed = True
+        if self._read_task is not None:
+            self._read_task.cancel()
+            try:
+                await self._read_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._read_task = None
+        self._fail_pending(CodexAppServerError("client is closed"))
+        try:
+            self._writer.close()
+        except Exception:  # noqa: BLE001 — best-effort close
+            pass
+
+
+async def spawn_app_server(
+    *,
+    command: tuple[str, ...] | list[str] | None = None,
+    cwd: str | None = None,
+    env: dict | None = None,
+    notification_handler: NotificationHandler | None = None,
+    server_request_handler: ServerRequestHandler | None = None,
+    log: Callable[[str], None] = _log,
+) -> tuple[CodexAppServerClient, asyncio.subprocess.Process]:
+    """Launch ``codex app-server`` and return a started client plus its process.
+
+    The caller owns the process lifecycle: call ``client.close()`` then
+    terminate/kill ``proc`` on shutdown.
+    """
+    cmd = list(command or DEFAULT_COMMAND)
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+        env=env,
+        limit=_STREAM_LIMIT,
+    )
+    assert proc.stdout is not None and proc.stdin is not None
+    client = CodexAppServerClient(
+        proc.stdout,
+        proc.stdin,
+        notification_handler=notification_handler,
+        server_request_handler=server_request_handler,
+        log=log,
+    )
+    client.start()
+    return client, proc

--- a/src/pinky_daemon/codex_app_server.py
+++ b/src/pinky_daemon/codex_app_server.py
@@ -83,24 +83,31 @@ class CodexAppServerClient:
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
         *,
+        stderr: asyncio.StreamReader | None = None,
         notification_handler: NotificationHandler | None = None,
         server_request_handler: ServerRequestHandler | None = None,
         log: Callable[[str], None] = _log,
     ) -> None:
         self._reader = reader
         self._writer = writer
+        self._stderr = stderr
         self._notification_handler = notification_handler
         self._server_request_handler = server_request_handler
         self._log = log
         self._next_id = 0
         self._pending: dict[int, asyncio.Future] = {}
         self._read_task: asyncio.Task | None = None
+        self._stderr_task: asyncio.Task | None = None
         self._closed = False
 
     def start(self) -> None:
         """Begin consuming the read stream. Idempotent."""
         if self._read_task is None:
             self._read_task = asyncio.create_task(self._read_loop())
+        # Drain stderr continuously: an undrained PIPE on a long-lived process
+        # blocks the child once the OS buffer (~64KiB) fills, wedging every turn.
+        if self._stderr is not None and self._stderr_task is None:
+            self._stderr_task = asyncio.create_task(self._drain_stderr())
 
     async def request(
         self,
@@ -179,6 +186,26 @@ class CodexAppServerClient:
         else:
             self._log(f"codex-app-server: unrecognized message: {msg}")
 
+    async def _drain_stderr(self) -> None:
+        """Consume the subprocess stderr stream so it can never block the child.
+
+        Logs non-empty lines (truncated) for diagnostics; ends on EOF when the
+        process exits or is killed.
+        """
+        assert self._stderr is not None
+        try:
+            while True:
+                line = await self._stderr.readline()
+                if not line:
+                    break  # EOF — process closed stderr
+                text = line.decode(errors="replace").rstrip()
+                if text:
+                    self._log(f"codex-app-server[stderr]: {text[:500]}")
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — drain must not crash the client
+            self._log(f"codex-app-server: stderr drain error: {exc}")
+
     async def _handle_server_request(self, mid: object, method: str, params: dict) -> None:
         if self._server_request_handler is None:
             await self._send(
@@ -207,6 +234,13 @@ class CodexAppServerClient:
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
             self._read_task = None
+        if self._stderr_task is not None:
+            self._stderr_task.cancel()
+            try:
+                await self._stderr_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._stderr_task = None
         self._fail_pending(CodexAppServerError("client is closed"))
         try:
             self._writer.close()
@@ -242,6 +276,7 @@ async def spawn_app_server(
     client = CodexAppServerClient(
         proc.stdout,
         proc.stdin,
+        stderr=proc.stderr,
         notification_handler=notification_handler,
         server_request_handler=server_request_handler,
         log=log,

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -23,6 +23,11 @@ import os
 import time
 from dataclasses import dataclass, field
 
+from pinky_daemon.codex_app_server import (
+    CodexAppServerClient,
+    CodexAppServerError,
+    spawn_app_server,
+)
 from pinky_daemon.context_estimator import ContextTextEstimator
 from pinky_daemon.sessions import MODEL_CONTEXT_SIZES, SessionUsage
 from pinky_daemon.streaming_session import (
@@ -126,6 +131,24 @@ class CodexSession:
         # MCP server config for Codex CLI (injected via -c flags)
         # Uses the shared MCP server's streamable HTTP transport
         self._mcp_servers = config.mcp_servers or {}
+
+        # Tier 2 (#98): when PINKY_CODEX_APP_SERVER=1, route turns through a
+        # long-lived ``codex app-server`` JSON-RPC connection instead of
+        # spawning ``codex exec`` per message. Legacy exec stays the default
+        # and the fallback until the soak proves the app-server path. One
+        # app-server process + one thread per session here (chunk 2); a shared
+        # supervisor lands in chunk 3.
+        self._use_app_server = os.environ.get("PINKY_CODEX_APP_SERVER") == "1"
+        self._app_client: CodexAppServerClient | None = None
+        self._app_proc: asyncio.subprocess.Process | None = None
+        # Active turn correlation: the read loop dispatches notifications onto
+        # a single handler, but turns are processed sequentially by the worker,
+        # so a single in-flight result + completion future is sufficient.
+        self._active_turn_result: CodexTurnResult | None = None
+        self._turn_done: asyncio.Future | None = None
+        # Latest per-turn token breakdown from thread/tokenUsage/updated —
+        # app-server reports usage out-of-band, not inside turn/completed.
+        self._appserver_last_usage: dict = {}
 
     async def connect(self) -> None:
         """Start the session. Sends wake prompt via codex exec."""
@@ -542,6 +565,9 @@ class CodexSession:
 
         Streams stdout line-by-line for real-time activity tracking.
         """
+        if self._use_app_server:
+            return await self._exec_codex_app_server(prompt)
+
         result = CodexTurnResult()
 
         cmd = self._build_codex_cmd()
@@ -673,6 +699,331 @@ class CodexSession:
             self._current_proc = None
 
         return result
+
+    # ── Codex app-server path (#98 Tier 2) ────────────────────────────────
+    #
+    # The app-server hosts a long-lived Thread; each user message is a
+    # ``turn/start`` against it. The wire protocol is JSON-RPC over stdio,
+    # handled by CodexAppServerClient. The slash-notation notifications it
+    # emits are translated back onto the legacy dot-notation event shapes
+    # so ``_handle_event`` — and all its activity/analytics/stream-event
+    # bookkeeping — is reused verbatim.
+
+    _APPROVAL_POLICY = "never"  # AskForApproval — full-auto, never prompt
+    _SANDBOX_MODE = "danger-full-access"  # SandboxMode — parity with the exec yolo flag
+
+    async def _ensure_app_server(self) -> None:
+        """Spawn + initialise the app-server connection if not already live."""
+        if self._app_client is not None and self._app_proc is not None:
+            if self._app_proc.returncode is None:
+                return  # still running
+            # Process died under us — drop the stale client and respawn.
+            await self._teardown_app_server()
+
+        env = {**os.environ}
+        if self._openai_api_key:
+            env["OPENAI_API_KEY"] = self._openai_api_key
+
+        self._app_client, self._app_proc = await spawn_app_server(
+            cwd=self._working_dir,
+            env=env,
+            notification_handler=self._on_appserver_notification,
+            server_request_handler=self._on_appserver_request,
+            log=_log,
+        )
+        await self._app_client.initialize(name="pinkybot", version="1")
+        _log(f"codex[{self.agent_name}]: app-server connected (pid={self._app_proc.pid})")
+
+    async def _teardown_app_server(self) -> None:
+        """Close the client and kill the process. Idempotent."""
+        if self._app_client is not None:
+            try:
+                await self._app_client.close()
+            except Exception:
+                pass
+            self._app_client = None
+        if self._app_proc is not None:
+            try:
+                if self._app_proc.returncode is None:
+                    self._app_proc.kill()
+                    await asyncio.wait_for(self._app_proc.wait(), timeout=5)
+            except Exception:
+                pass
+            self._app_proc = None
+
+    def _appserver_config(self) -> dict:
+        """Build the per-thread ``config`` override for MCP servers.
+
+        Mirrors _build_codex_cmd's ``-c mcp_servers.<name>.url=...`` injection,
+        expressed as the nested config object app-server's thread/start accepts.
+        """
+        mcp: dict = {}
+        for name, server_config in self._mcp_servers.items():
+            url = server_config.get("url", "")
+            if not url:
+                continue
+            entry: dict = {"url": url}
+            headers = server_config.get("headers", {})
+            if headers:
+                entry["http_headers"] = dict(headers)
+            mcp[name] = entry
+        return {"mcp_servers": mcp} if mcp else {}
+
+    def _appserver_effort(self) -> str | None:
+        """Map the configured thinking_effort onto a ReasoningEffort value."""
+        effort = self._reasoning_effort or ""
+        if not effort:
+            return None
+        if effort == "max":
+            return "high"  # parity with legacy: Codex has no "max"
+        if effort in ("none", "minimal", "low", "medium", "high", "xhigh"):
+            return effort
+        return None
+
+    async def _exec_codex_app_server(self, prompt: str) -> CodexTurnResult:
+        """Run a single turn over the long-lived app-server connection."""
+        result = CodexTurnResult()
+        try:
+            await self._ensure_app_server()
+        except Exception as e:  # noqa: BLE001 — surface as a failed turn, keep session alive
+            result.failed = True
+            result.errors.append(f"app-server connect failed: {e}")
+            _log(f"codex[{self.agent_name}]: app-server connect failed: {e}")
+            await self._emit_stream_event({
+                "type": "turn_failed", "agent": self.agent_name,
+                "session_id": self.id, "error": str(e),
+            })
+            return result
+
+        client = self._app_client
+        assert client is not None
+        loop = asyncio.get_running_loop()
+        self._active_turn_result = result
+        self._turn_done = loop.create_future()
+        self._appserver_last_usage = {}
+
+        config = self._appserver_config()
+        _log(
+            f"codex[{self.agent_name}]: app-server turn "
+            f"{'resume ' + self.codex_session_id[:12] + ' ' if self.codex_session_id else 'new '}"
+            f"(prompt: {len(prompt)} chars)"
+        )
+
+        try:
+            if self.codex_session_id:
+                params: dict = {
+                    "threadId": self.codex_session_id,
+                    "approvalPolicy": self._APPROVAL_POLICY,
+                    "sandbox": self._SANDBOX_MODE,
+                }
+                if self._codex_model:
+                    params["model"] = self._codex_model
+                if config:
+                    params["config"] = config
+                resp = await client.request("thread/resume", params)
+            else:
+                params = {
+                    "cwd": self._working_dir,
+                    "approvalPolicy": self._APPROVAL_POLICY,
+                    "sandbox": self._SANDBOX_MODE,
+                }
+                if self._codex_model:
+                    params["model"] = self._codex_model
+                if config:
+                    params["config"] = config
+                resp = await client.request("thread/start", params)
+
+            # The thread/started notification normally sets codex_session_id via
+            # _handle_event; cover the case where only the response carries it.
+            thread_id = ""
+            if isinstance(resp, dict):
+                thread_id = (resp.get("thread") or {}).get("id", "")
+            if thread_id and thread_id != self.codex_session_id:
+                self.codex_session_id = thread_id
+                self.resume_handle = thread_id
+                result.thread_id = thread_id
+                self._pending_resume_handle_update = thread_id
+
+            turn_params: dict = {
+                "threadId": self.codex_session_id,
+                "input": [{"type": "text", "text": prompt}],
+            }
+            effort = self._appserver_effort()
+            if effort:
+                turn_params["effort"] = effort
+            await client.request("turn/start", turn_params)
+
+            # turn/start returns immediately; notifications drive the turn.
+            # _on_appserver_notification resolves _turn_done on turn/completed.
+            await asyncio.wait_for(self._turn_done, timeout=600)
+
+        except asyncio.TimeoutError:
+            result.failed = True
+            result.errors.append("codex app-server turn timed out after 600s")
+            _log(f"codex[{self.agent_name}]: app-server turn timed out")
+            await self._emit_stream_event({
+                "type": "turn_failed", "agent": self.agent_name,
+                "session_id": self.id, "error": "codex app-server turn timed out after 600s",
+            })
+            # A wedged thread is unrecoverable — drop the connection so the next
+            # turn respawns and resumes cleanly.
+            await self._teardown_app_server()
+        except CodexAppServerError as e:
+            result.failed = True
+            result.errors.append(str(e))
+            _log(f"codex[{self.agent_name}]: app-server error: {e}")
+            await self._emit_stream_event({
+                "type": "turn_failed", "agent": self.agent_name,
+                "session_id": self.id, "error": str(e),
+            })
+            await self._teardown_app_server()
+        except Exception as e:  # noqa: BLE001 — keep the session alive across turn failures
+            result.failed = True
+            result.errors.append(str(e))
+            _log(f"codex[{self.agent_name}]: app-server turn exception: {e}")
+            await self._emit_stream_event({
+                "type": "turn_failed", "agent": self.agent_name,
+                "session_id": self.id, "error": str(e),
+            })
+            await self._teardown_app_server()
+        finally:
+            self._active_turn_result = None
+            self._turn_done = None
+
+        return result
+
+    async def _on_appserver_notification(self, method: str, params: dict) -> None:
+        """Translate an app-server notification onto the legacy event path."""
+        # Incremental streaming text — UI only; full text arrives via the
+        # final item/completed agentMessage (matches the legacy non-delta path).
+        if method == "item/agentMessage/delta":
+            delta = params.get("delta", "")
+            if delta:
+                await self._emit_stream_event({
+                    "type": "assistant_delta", "agent": self.agent_name,
+                    "session_id": self.id, "delta": delta,
+                })
+            return
+
+        if method == "thread/tokenUsage/updated":
+            token_usage = params.get("tokenUsage") or {}
+            self._appserver_last_usage = (
+                token_usage.get("last") or token_usage.get("total") or {}
+            )
+            return
+
+        event = self._appserver_to_event(method, params)
+        if event is not None and self._active_turn_result is not None:
+            await self._handle_event(event, self._active_turn_result)
+
+        if method == "turn/completed" and self._turn_done is not None:
+            if not self._turn_done.done():
+                self._turn_done.set_result(None)
+
+    async def _on_appserver_request(self, method: str, params: dict) -> dict:
+        """Auto-approve server->client requests (full-auto).
+
+        With approvalPolicy=never + danger-full-access these should not fire,
+        but the handler is a defensive net: an unanswered approval request
+        would otherwise cancel the underlying tool call (cf. #351).
+        """
+        if method in ("execCommandApproval", "applyPatchApproval"):
+            return {"decision": "approved"}
+        if method in (
+            "item/commandExecution/requestApproval",
+            "item/fileChange/requestApproval",
+        ):
+            return {"decision": "accept"}
+        if method == "item/permissions/requestApproval":
+            return {"permissions": {}, "scope": "session"}
+        # Elicitations / tool-call / user-input requests: nothing useful to add
+        # under full-auto; an empty result lets the server proceed.
+        return {}
+
+    def _appserver_to_event(self, method: str, params: dict) -> dict | None:
+        """Map a slash-notation notification onto a legacy dot-notation event."""
+        if method == "thread/started":
+            return {
+                "type": "thread.started",
+                "thread_id": (params.get("thread") or {}).get("id", ""),
+            }
+        if method == "turn/started":
+            return {"type": "turn.started"}
+        if method == "item/started":
+            return {
+                "type": "item.started",
+                "item": self._appserver_item_to_legacy(params.get("item") or {}),
+            }
+        if method == "item/completed":
+            return {
+                "type": "item.completed",
+                "item": self._appserver_item_to_legacy(params.get("item") or {}),
+            }
+        if method == "turn/completed":
+            turn = params.get("turn") or {}
+            if turn.get("status") == "failed":
+                return {"type": "turn.failed", "error": turn.get("error") or {}}
+            return {"type": "turn.completed", "usage": self._appserver_usage_to_legacy()}
+        if method == "error":
+            err = params.get("error")
+            msg = err.get("message", "unknown error") if isinstance(err, dict) else str(err)
+            return {"type": "error", "message": msg}
+        return None
+
+    def _appserver_usage_to_legacy(self) -> dict:
+        """Convert the captured camelCase token breakdown to legacy snake_case."""
+        u = self._appserver_last_usage or {}
+        return {
+            "input_tokens": u.get("inputTokens", 0),
+            "output_tokens": u.get("outputTokens", 0),
+            "cached_input_tokens": u.get("cachedInputTokens", 0),
+            "reasoning_output_tokens": u.get("reasoningOutputTokens", 0),
+        }
+
+    @staticmethod
+    def _appserver_item_to_legacy(item: dict) -> dict:
+        """Translate an app-server ThreadItem onto the legacy item shape.
+
+        App-server uses camelCase types/fields (``agentMessage``, ``exitCode``);
+        the legacy ``codex exec --json`` stream — which _handle_event parses —
+        uses snake_case (``agent_message``, ``exit_code``). Unknown types pass
+        through with their type so _handle_event logs them benignly.
+        """
+        item_type = item.get("type", "")
+        item_id = item.get("id", "")
+        if item_type == "agentMessage":
+            return {"type": "agent_message", "text": item.get("text", ""), "id": item_id}
+        if item_type == "commandExecution":
+            return {
+                "type": "command_execution",
+                "command": item.get("command", ""),
+                "exit_code": item.get("exitCode"),
+                "aggregated_output": item.get("aggregatedOutput", ""),
+                "id": item_id,
+            }
+        if item_type == "fileChange":
+            changes = item.get("changes") or []
+            filepath = ""
+            if isinstance(changes, list) and changes and isinstance(changes[0], dict):
+                filepath = changes[0].get("path", "")
+            return {"type": "file_edit", "filepath": filepath, "id": item_id}
+        if item_type == "mcpToolCall":
+            return {
+                "type": "mcp_tool_call",
+                "tool_name": item.get("tool", ""),
+                "input": item.get("arguments") or {},
+                "id": item_id,
+            }
+        if item_type == "dynamicToolCall":
+            return {
+                "type": "function_call",
+                "tool_name": item.get("tool", ""),
+                "input": item.get("arguments") or {},
+                "id": item_id,
+            }
+        if item_type == "error":
+            return {"type": "error", "message": item.get("message", "unknown error"), "id": item_id}
+        return {"type": item_type, "id": item_id}
 
     async def _emit_stream_event(self, event: dict) -> None:
         """Best-effort incremental stream event forwarding for UI consumers."""
@@ -1080,7 +1431,7 @@ class CodexSession:
         self._analytics_log_activity("session_end")
         self._analytics_session_ended()
 
-        # Kill any in-flight codex subprocess
+        # Kill any in-flight codex subprocess (legacy exec path)
         if self._current_proc:
             try:
                 self._current_proc.kill()
@@ -1088,6 +1439,11 @@ class CodexSession:
             except Exception:
                 pass
             self._current_proc = None
+
+        # Unblock an in-flight app-server turn, then tear down the connection.
+        if self._turn_done is not None and not self._turn_done.done():
+            self._turn_done.set_exception(CodexAppServerError("session disconnected"))
+        await self._teardown_app_server()
 
         if self._worker_task and not self._worker_task.done():
             self._worker_task.cancel()

--- a/tests/test_codex_app_server.py
+++ b/tests/test_codex_app_server.py
@@ -255,3 +255,52 @@ class TestFramingAndLifecycle:
         await client.close()
         await client.close()  # must not raise
         assert writer.closed
+
+
+class TestStderrDrain:
+    @pytest.mark.asyncio
+    async def test_stderr_is_drained_and_logged(self):
+        """stderr lines must be consumed so a long-lived child never blocks."""
+        logged: list[str] = []
+        reader = asyncio.StreamReader()
+        stderr = asyncio.StreamReader()
+        writer = FakeWriter()
+        client = CodexAppServerClient(
+            reader, writer, stderr=stderr, log=logged.append
+        )
+        client.start()
+
+        stderr.feed_data(b"warning: something\n")
+        stderr.feed_data(b"\n")  # blank line ignored
+        stderr.feed_data(b"another line\n")
+        await _settle()
+
+        drained = [m for m in logged if "[stderr]" in m]
+        assert any("warning: something" in m for m in drained)
+        assert any("another line" in m for m in drained)
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_stderr_task_stops_on_eof(self):
+        reader = asyncio.StreamReader()
+        stderr = asyncio.StreamReader()
+        client = CodexAppServerClient(reader, FakeWriter(), stderr=stderr)
+        client.start()
+        assert client._stderr_task is not None
+
+        stderr.feed_eof()
+        await _settle()
+        assert client._stderr_task.done()
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_close_cancels_stderr_task(self):
+        reader = asyncio.StreamReader()
+        stderr = asyncio.StreamReader()  # never fed → drain stays blocked
+        client = CodexAppServerClient(reader, FakeWriter(), stderr=stderr)
+        client.start()
+        task = client._stderr_task
+        assert task is not None
+        await client.close()
+        assert task.done()
+        assert client._stderr_task is None

--- a/tests/test_codex_app_server.py
+++ b/tests/test_codex_app_server.py
@@ -1,0 +1,257 @@
+"""Unit tests for the codex app-server JSON-RPC transport client.
+
+Drives CodexAppServerClient against an in-memory stream pair (a real
+asyncio.StreamReader the test feeds server frames into, plus a fake writer
+capturing client output) so no real ``codex app-server`` subprocess is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from pinky_daemon.codex_app_server import CodexAppServerClient, CodexAppServerError
+
+
+class FakeWriter:
+    """Minimal asyncio.StreamWriter stand-in capturing written bytes."""
+
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+    def frames(self) -> list[dict]:
+        return [json.loads(ln) for ln in self.buffer.split(b"\n") if ln.strip()]
+
+
+def make_client(**kwargs) -> tuple[CodexAppServerClient, asyncio.StreamReader, FakeWriter]:
+    reader = asyncio.StreamReader()
+    writer = FakeWriter()
+    client = CodexAppServerClient(reader, writer, **kwargs)
+    client.start()
+    return client, reader, writer
+
+
+async def _settle() -> None:
+    """Yield enough times for the read loop / request coroutine to advance."""
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+
+def _feed(reader: asyncio.StreamReader, msg: dict) -> None:
+    reader.feed_data((json.dumps(msg) + "\n").encode())
+
+
+class TestRequestResponse:
+    @pytest.mark.asyncio
+    async def test_request_response_correlation(self):
+        client, reader, writer = make_client()
+        task = asyncio.create_task(client.request("ping", {"x": 1}))
+        await _settle()
+
+        frames = writer.frames()
+        assert len(frames) == 1
+        assert frames[0]["method"] == "ping"
+        assert frames[0]["params"] == {"x": 1}
+        rid = frames[0]["id"]
+
+        _feed(reader, {"id": rid, "result": {"pong": True}})
+        result = await asyncio.wait_for(task, timeout=1)
+        assert result == {"pong": True}
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_resolve_out_of_order(self):
+        client, reader, writer = make_client()
+        t1 = asyncio.create_task(client.request("a"))
+        t2 = asyncio.create_task(client.request("b"))
+        await _settle()
+
+        frames = writer.frames()
+        assert len(frames) == 2
+        ids = {f["method"]: f["id"] for f in frames}
+        assert ids["a"] != ids["b"]
+
+        # Respond to the second request first.
+        _feed(reader, {"id": ids["b"], "result": "B"})
+        _feed(reader, {"id": ids["a"], "result": "A"})
+        assert await asyncio.wait_for(t1, timeout=1) == "A"
+        assert await asyncio.wait_for(t2, timeout=1) == "B"
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_error_frame_raises(self):
+        client, reader, writer = make_client()
+        task = asyncio.create_task(client.request("boom"))
+        await _settle()
+        rid = writer.frames()[0]["id"]
+
+        _feed(reader, {"id": rid, "error": {"code": -32000, "message": "kaboom"}})
+        with pytest.raises(CodexAppServerError, match="kaboom") as exc:
+            await asyncio.wait_for(task, timeout=1)
+        assert exc.value.code == -32000
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_request_timeout(self):
+        client, _reader, _writer = make_client()
+        with pytest.raises(CodexAppServerError, match="timed out"):
+            await client.request("slow", timeout=0.05)
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_request_on_closed_client_raises(self):
+        client, _reader, _writer = make_client()
+        await client.close()
+        with pytest.raises(CodexAppServerError, match="closed"):
+            await client.request("nope")
+
+    @pytest.mark.asyncio
+    async def test_initialize_sends_client_info(self):
+        client, reader, writer = make_client()
+        task = asyncio.create_task(client.initialize(name="pinkybot", version="9"))
+        await _settle()
+        frame = writer.frames()[0]
+        assert frame["method"] == "initialize"
+        assert frame["params"] == {"clientInfo": {"name": "pinkybot", "version": "9"}}
+
+        _feed(reader, {"id": frame["id"], "result": {"codexHome": "/x"}})
+        assert await asyncio.wait_for(task, timeout=1) == {"codexHome": "/x"}
+        await client.close()
+
+
+class TestNotifications:
+    @pytest.mark.asyncio
+    async def test_notification_dispatched_to_handler(self):
+        seen: list[tuple[str, dict]] = []
+
+        async def handler(method: str, params: dict) -> None:
+            seen.append((method, params))
+
+        client, reader, _writer = make_client(notification_handler=handler)
+        _feed(reader, {"method": "turn/started", "params": {"thread_id": "t1"}})
+        await _settle()
+        assert seen == [("turn/started", {"thread_id": "t1"})]
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_notification_without_handler_is_ignored(self):
+        client, reader, _writer = make_client()
+        _feed(reader, {"method": "turn/started", "params": {}})
+        await _settle()  # must not raise
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_outbound_notify_has_no_id(self):
+        client, _reader, writer = make_client()
+        await client.notify("client/event", {"k": "v"})
+        frame = writer.frames()[0]
+        assert "id" not in frame
+        assert frame == {"method": "client/event", "params": {"k": "v"}}
+        await client.close()
+
+
+class TestServerRequests:
+    @pytest.mark.asyncio
+    async def test_server_request_routed_to_handler_and_answered(self):
+        async def handler(method: str, params: dict) -> dict:
+            assert method == "execCommandApproval"
+            return {"decision": "approved"}
+
+        client, reader, writer = make_client(server_request_handler=handler)
+        _feed(reader, {"id": 42, "method": "execCommandApproval", "params": {"cmd": "ls"}})
+        await _settle()
+
+        responses = [f for f in writer.frames() if f.get("id") == 42]
+        assert responses == [{"id": 42, "result": {"decision": "approved"}}]
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_unhandled_server_request_gets_error_response(self):
+        client, reader, writer = make_client()  # no server_request_handler
+        _feed(reader, {"id": 7, "method": "execCommandApproval", "params": {}})
+        await _settle()
+
+        resp = [f for f in writer.frames() if f.get("id") == 7][0]
+        assert "error" in resp
+        assert resp["error"]["code"] == -32601
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_becomes_error_frame(self):
+        async def handler(method: str, params: dict) -> dict:
+            raise RuntimeError("handler blew up")
+
+        client, reader, writer = make_client(server_request_handler=handler)
+        _feed(reader, {"id": 9, "method": "execCommandApproval", "params": {}})
+        await _settle()
+
+        resp = [f for f in writer.frames() if f.get("id") == 9][0]
+        assert resp["error"]["code"] == -32000
+        assert "handler blew up" in resp["error"]["message"]
+        await client.close()
+
+
+class TestFramingAndLifecycle:
+    @pytest.mark.asyncio
+    async def test_multiple_frames_in_one_chunk(self):
+        seen: list[str] = []
+
+        async def handler(method: str, params: dict) -> None:
+            seen.append(method)
+
+        client, reader, _writer = make_client(notification_handler=handler)
+        chunk = (
+            json.dumps({"method": "a", "params": {}})
+            + "\n"
+            + json.dumps({"method": "b", "params": {}})
+            + "\n"
+        ).encode()
+        reader.feed_data(chunk)
+        await _settle()
+        assert seen == ["a", "b"]
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_non_json_line_is_skipped(self):
+        seen: list[str] = []
+
+        async def handler(method: str, params: dict) -> None:
+            seen.append(method)
+
+        client, reader, _writer = make_client(notification_handler=handler)
+        reader.feed_data(b"not json at all\n")
+        _feed(reader, {"method": "ok", "params": {}})
+        await _settle()
+        assert seen == ["ok"]  # bad line skipped, good one still dispatched
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_eof_fails_pending_requests(self):
+        client, reader, writer = make_client()
+        task = asyncio.create_task(client.request("hang"))
+        await _settle()
+        assert writer.frames()  # request was sent
+
+        reader.feed_eof()
+        with pytest.raises(CodexAppServerError, match="connection closed"):
+            await asyncio.wait_for(task, timeout=1)
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self):
+        client, _reader, writer = make_client()
+        await client.close()
+        await client.close()  # must not raise
+        assert writer.closed

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -868,3 +868,355 @@ class TestCodexPendingWakeCallback:
         # But the field IS cleared so a recovery turn doesn't replay
         # the (now-stale) callback against a turn it wasn't paired with.
         assert s._pending_wake_callback is None
+
+
+# ── #98 Tier 2: codex app-server path ────────────────────────────────────
+
+
+def _appserver_session(monkeypatch=None, **overrides):
+    """Build a CodexSession with the app-server flag forced on."""
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        label="main",
+        model=overrides.pop("model", ""),
+        working_dir=overrides.pop("working_dir", "/tmp"),
+        provider_url="codex_cli",
+        provider_key="test-key",
+        **overrides,
+    )
+    s = CodexSession(config)
+    s._use_app_server = True
+    return s
+
+
+class _FakeAppClient:
+    """Stand-in for CodexAppServerClient driven from notifications.
+
+    On ``turn/start`` it replays a scripted notification sequence through the
+    session's notification handler (which is exactly how the real read loop
+    feeds the session), so the full translate→_handle_event path is exercised.
+    """
+
+    def __init__(self, session, notifications, *, thread_id="thr-1", fire_on_start=None):
+        self._session = session
+        self._notifications = notifications
+        self._thread_id = thread_id
+        self._fire_on_start = fire_on_start or []
+        self.requests = []
+        self.closed = False
+
+    async def initialize(self, **kw):
+        return {}
+
+    async def request(self, method, params=None, *, timeout=600.0):
+        self.requests.append((method, params or {}))
+        if method == "thread/start":
+            for m, p in self._fire_on_start:
+                await self._session._on_appserver_notification(m, p)
+            return {"thread": {"id": self._thread_id}}
+        if method == "thread/resume":
+            return {"thread": {"id": (params or {}).get("threadId", self._thread_id)}}
+        if method == "turn/start":
+            for m, p in self._notifications:
+                await self._session._on_appserver_notification(m, p)
+            return {"turn": {"id": "t1", "status": "completed"}}
+        return {}
+
+    async def close(self):
+        self.closed = True
+
+
+def _patch_ensure(session, fake):
+    async def _ensure():
+        session._app_client = fake
+    session._ensure_app_server = _ensure
+
+
+class TestCodexAppServerFlag:
+    def test_flag_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CODEX_APP_SERVER", raising=False)
+        config = StreamingSessionConfig(
+            agent_name="a", working_dir="/tmp", provider_url="codex_cli",
+        )
+        assert CodexSession(config)._use_app_server is False
+
+    def test_flag_on_when_set(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CODEX_APP_SERVER", "1")
+        config = StreamingSessionConfig(
+            agent_name="a", working_dir="/tmp", provider_url="codex_cli",
+        )
+        assert CodexSession(config)._use_app_server is True
+
+    @pytest.mark.asyncio
+    async def test_exec_dispatches_to_app_server_when_flagged(self):
+        s = _appserver_session()
+        sentinel = CodexTurnResult(thread_id="sentinel")
+
+        async def _fake_app(prompt):
+            return sentinel
+
+        s._exec_codex_app_server = _fake_app
+        out = await s._exec_codex("hi")
+        assert out is sentinel
+
+
+class TestCodexAppServerTranslation:
+    """Unit tests for the slash→dot notification/item shim."""
+
+    def _s(self):
+        return _appserver_session()
+
+    def test_thread_started(self):
+        ev = self._s()._appserver_to_event("thread/started", {"thread": {"id": "abc"}})
+        assert ev == {"type": "thread.started", "thread_id": "abc"}
+
+    def test_turn_started(self):
+        assert self._s()._appserver_to_event("turn/started", {}) == {"type": "turn.started"}
+
+    def test_item_completed_agent_message(self):
+        ev = self._s()._appserver_to_event(
+            "item/completed", {"item": {"id": "0", "type": "agentMessage", "text": "hi"}}
+        )
+        assert ev["type"] == "item.completed"
+        assert ev["item"] == {"type": "agent_message", "text": "hi", "id": "0"}
+
+    def test_item_command_execution(self):
+        item = {"id": "1", "type": "commandExecution", "command": "ls",
+                "exitCode": 0, "aggregatedOutput": "out"}
+        ev = self._s()._appserver_to_event("item/completed", {"item": item})
+        assert ev["item"] == {
+            "type": "command_execution", "command": "ls",
+            "exit_code": 0, "aggregated_output": "out", "id": "1",
+        }
+
+    def test_item_file_change(self):
+        item = {"id": "2", "type": "fileChange",
+                "changes": [{"path": "/x/y.py", "kind": "update", "diff": "..."}]}
+        ev = self._s()._appserver_to_event("item/completed", {"item": item})
+        assert ev["item"] == {"type": "file_edit", "filepath": "/x/y.py", "id": "2"}
+
+    def test_item_mcp_tool_call(self):
+        item = {"id": "3", "type": "mcpToolCall", "tool": "send", "arguments": {"text": "hi"}}
+        ev = self._s()._appserver_to_event("item/completed", {"item": item})
+        assert ev["item"] == {
+            "type": "mcp_tool_call", "tool_name": "send",
+            "input": {"text": "hi"}, "id": "3",
+        }
+
+    def test_item_dynamic_tool_call(self):
+        item = {"id": "4", "type": "dynamicToolCall", "tool": "Grep", "arguments": {"q": "x"}}
+        ev = self._s()._appserver_to_event("item/completed", {"item": item})
+        assert ev["item"]["type"] == "function_call"
+        assert ev["item"]["tool_name"] == "Grep"
+
+    def test_turn_completed_maps_usage(self):
+        s = self._s()
+        s._appserver_last_usage = {
+            "inputTokens": 12, "outputTokens": 3,
+            "cachedInputTokens": 4, "reasoningOutputTokens": 1,
+        }
+        ev = s._appserver_to_event("turn/completed", {"turn": {"status": "completed"}})
+        assert ev == {"type": "turn.completed", "usage": {
+            "input_tokens": 12, "output_tokens": 3,
+            "cached_input_tokens": 4, "reasoning_output_tokens": 1,
+        }}
+
+    def test_turn_completed_failed_maps_to_turn_failed(self):
+        ev = self._s()._appserver_to_event(
+            "turn/completed", {"turn": {"status": "failed", "error": {"message": "boom"}}}
+        )
+        assert ev == {"type": "turn.failed", "error": {"message": "boom"}}
+
+    def test_error_notification(self):
+        ev = self._s()._appserver_to_event("error", {"error": {"message": "rate limited"}})
+        assert ev == {"type": "error", "message": "rate limited"}
+
+    def test_unknown_method_returns_none(self):
+        assert self._s()._appserver_to_event("thread/status/changed", {}) is None
+
+
+class TestCodexAppServerApprovals:
+    def _s(self):
+        return _appserver_session()
+
+    @pytest.mark.asyncio
+    async def test_exec_command_approval(self):
+        assert await self._s()._on_appserver_request("execCommandApproval", {}) == {
+            "decision": "approved"}
+
+    @pytest.mark.asyncio
+    async def test_apply_patch_approval(self):
+        assert await self._s()._on_appserver_request("applyPatchApproval", {}) == {
+            "decision": "approved"}
+
+    @pytest.mark.asyncio
+    async def test_command_execution_request_approval(self):
+        out = await self._s()._on_appserver_request(
+            "item/commandExecution/requestApproval", {})
+        assert out == {"decision": "accept"}
+
+    @pytest.mark.asyncio
+    async def test_file_change_request_approval(self):
+        out = await self._s()._on_appserver_request("item/fileChange/requestApproval", {})
+        assert out == {"decision": "accept"}
+
+    @pytest.mark.asyncio
+    async def test_permissions_request_approval(self):
+        out = await self._s()._on_appserver_request("item/permissions/requestApproval", {})
+        assert out == {"permissions": {}, "scope": "session"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_request_returns_empty(self):
+        assert await self._s()._on_appserver_request("mcpServer/elicitation/request", {}) == {}
+
+
+class TestCodexAppServerEffortAndConfig:
+    def test_effort_passthrough(self):
+        s = _appserver_session()
+        s._reasoning_effort = "high"
+        assert s._appserver_effort() == "high"
+
+    def test_effort_max_maps_to_high(self):
+        s = _appserver_session()
+        s._reasoning_effort = "max"
+        assert s._appserver_effort() == "high"
+
+    def test_effort_invalid_returns_none(self):
+        s = _appserver_session()
+        s._reasoning_effort = "bananas"
+        assert s._appserver_effort() is None
+
+    def test_config_builds_mcp_servers(self):
+        s = _appserver_session()
+        s._mcp_servers = {
+            "pinky": {"url": "http://x/mcp", "headers": {"X-Agent-Name": "test-agent"}},
+            "empty": {"url": ""},
+        }
+        cfg = s._appserver_config()
+        assert cfg == {"mcp_servers": {
+            "pinky": {"url": "http://x/mcp", "http_headers": {"X-Agent-Name": "test-agent"}},
+        }}
+
+    def test_config_empty_when_no_servers(self):
+        s = _appserver_session()
+        s._mcp_servers = {}
+        assert s._appserver_config() == {}
+
+
+class TestCodexAppServerTurn:
+    """Full-turn integration via a fake app-server client."""
+
+    @pytest.mark.asyncio
+    async def test_simple_turn_accumulates_text_and_usage(self):
+        s = _appserver_session()
+        notifications = [
+            ("thread/started", {"thread": {"id": "thr-1"}}),
+            ("turn/started", {}),
+            ("item/agentMessage/delta", {"delta": "hel"}),
+            ("item/completed", {"item": {"id": "0", "type": "agentMessage", "text": "hello"}}),
+            ("thread/tokenUsage/updated", {"tokenUsage": {"last": {
+                "inputTokens": 100, "outputTokens": 10,
+                "cachedInputTokens": 5, "reasoningOutputTokens": 2,
+            }}}),
+            ("turn/completed", {"threadId": "thr-1", "turn": {"id": "t1", "status": "completed"}}),
+        ]
+        fake = _FakeAppClient(s, notifications)
+        _patch_ensure(s, fake)
+
+        result = await s._exec_codex_app_server("hi there")
+
+        assert not result.failed
+        assert result.text_parts == ["hello"]
+        assert result.input_tokens == 100
+        assert result.output_tokens == 10
+        assert result.cached_input_tokens == 5
+        assert result.reasoning_output_tokens == 2
+        # thread id captured + queued for resume-handle persistence
+        assert s.codex_session_id == "thr-1"
+        assert s.resume_handle == "thr-1"
+        assert s._pending_resume_handle_update == "thr-1"
+        # request sequence: fresh thread/start then turn/start
+        methods = [m for m, _ in fake.requests]
+        assert methods == ["thread/start", "turn/start"]
+
+    @pytest.mark.asyncio
+    async def test_thread_id_from_response_when_no_notification(self):
+        s = _appserver_session()
+        # No thread/started notification — rely on the thread/start response.
+        notifications = [
+            ("turn/started", {}),
+            ("item/completed", {"item": {"id": "0", "type": "agentMessage", "text": "ok"}}),
+            ("turn/completed", {"turn": {"status": "completed"}}),
+        ]
+        fake = _FakeAppClient(s, notifications, thread_id="resp-thread")
+        _patch_ensure(s, fake)
+
+        result = await s._exec_codex_app_server("hi")
+        assert not result.failed
+        assert s.codex_session_id == "resp-thread"
+
+    @pytest.mark.asyncio
+    async def test_resume_uses_existing_thread_id(self):
+        s = _appserver_session()
+        s.codex_session_id = "existing-thread"
+        notifications = [
+            ("item/completed", {"item": {"id": "0", "type": "agentMessage", "text": "hi"}}),
+            ("turn/completed", {"turn": {"status": "completed"}}),
+        ]
+        fake = _FakeAppClient(s, notifications)
+        _patch_ensure(s, fake)
+
+        await s._exec_codex_app_server("again")
+        methods = [m for m, _ in fake.requests]
+        assert methods == ["thread/resume", "turn/start"]
+        # turn/start targets the existing thread
+        turn_params = dict(fake.requests)["turn/start"]
+        assert turn_params["threadId"] == "existing-thread"
+        assert turn_params["input"] == [{"type": "text", "text": "again"}]
+
+    @pytest.mark.asyncio
+    async def test_command_execution_recorded(self):
+        s = _appserver_session()
+        notifications = [
+            ("thread/started", {"thread": {"id": "thr-1"}}),
+            ("item/completed", {"item": {
+                "id": "0", "type": "commandExecution",
+                "command": "ls -la", "exitCode": 0, "aggregatedOutput": "total 8",
+            }}),
+            ("item/completed", {"item": {"id": "1", "type": "agentMessage", "text": "done"}}),
+            ("turn/completed", {"turn": {"status": "completed"}}),
+        ]
+        fake = _FakeAppClient(s, notifications)
+        _patch_ensure(s, fake)
+
+        result = await s._exec_codex_app_server("run ls")
+        assert len(result.tool_uses) == 1
+        assert result.tool_uses[0]["tool"] == "Bash"
+        assert result.tool_uses[0]["input"]["command"] == "ls -la"
+        assert result.text_parts == ["done"]
+
+    @pytest.mark.asyncio
+    async def test_failed_turn(self):
+        s = _appserver_session()
+        notifications = [
+            ("thread/started", {"thread": {"id": "thr-1"}}),
+            ("turn/completed", {"turn": {"status": "failed", "error": {"message": "rate limited"}}}),
+        ]
+        fake = _FakeAppClient(s, notifications)
+        _patch_ensure(s, fake)
+
+        result = await s._exec_codex_app_server("boom")
+        assert result.failed
+        assert "rate limited" in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_connect_failure_returns_failed_result(self):
+        s = _appserver_session()
+
+        async def _boom():
+            raise RuntimeError("spawn failed")
+
+        s._ensure_app_server = _boom
+        result = await s._exec_codex_app_server("hi")
+        assert result.failed
+        assert "spawn failed" in result.errors[0]


### PR DESCRIPTION
## What

**#98 (Codex Tier 2):** move `CodexSession` off spawn-per-message `codex exec` onto a long-lived `codex app-server` JSON-RPC connection. Gated behind `PINKY_CODEX_APP_SERVER=1`; **legacy `codex exec` stays the default + fallback** until proven.

### Chunk 1 — transport layer (`codex_app_server.py`)
- Async NDJSON JSON-RPC client over stdio. No `Content-Length` framing, no `jsonrpc` field (matches codex-cli 0.125 `--listen stdio://`).
- Request/response correlation by id; concurrent in-flight requests.
- Server notifications → injectable handler; server→client requests (approvals) → injectable handler; unhandled ones get a JSON-RPC error so the server never hangs.
- Background **stderr drain** so a long-lived process can't wedge on a full PIPE buffer.
- `spawn_app_server()` launches the binary; client is transport-agnostic (testable on in-memory streams).

### Chunk 2 — session integration (`codex_session.py`)
- `_exec_codex` branches to the app-server path when the flag is on; per-session app-server process + one thread (shared supervisor is chunk 3).
- `thread/start` (new) / `thread/resume` (existing `codex_session_id`) → `turn/start`; awaits `turn/completed`.
- Slash→dot notification shim + camelCase→snake_case ThreadItem translation feeds the existing `_handle_event` verbatim (activity/analytics/stream events reused).
- Auto-approves server requests (full-auto parity with the old yolo flag).
- Token usage captured from `thread/tokenUsage/updated` (app-server reports out-of-band).
- Timeout/error → teardown so the next turn respawns + resumes. `disconnect()` fails the in-flight turn and tears down.

## Not in this PR (follow-up chunks of #98)
- Chunk 3: shared-server supervisor — one process across all codex agents, one thread/agent, respawn + resume-all on death.
- Chunk 4: Murzik soak before flipping the default.

## Verification
- `ruff check` clean.
- `pytest tests/test_codex_app_server.py tests/test_codex_session.py` → 90 passed.
- Live `initialize` handshake against a real `codex app-server` confirmed.
- Flag defaults **off** → zero behavior change on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)