### PR TITLE
fix(#139): timeout-bound iMessageAdapter chat.db init

### DIFF
--- a/src/pinky_outreach/imessage.py
+++ b/src/pinky_outreach/imessage.py
@@ -71,6 +71,7 @@ class iMessageAdapter:  # noqa: N801
             return
 
         result: dict = {}
+        timed_out = threading.Event()
 
         def _open() -> None:
             try:
@@ -82,6 +83,12 @@ class iMessageAdapter:  # noqa: N801
                 # Test read access + seed last_rowid so we only get new messages.
                 db.execute("SELECT COUNT(*) FROM message").fetchone()
                 row = db.execute("SELECT MAX(ROWID) FROM message").fetchone()
+                if timed_out.is_set():
+                    # Parent already gave up; the handle would never be installed
+                    # on the adapter, so close it here rather than leaking it until
+                    # GC collects the orphaned thread's frame.
+                    db.close()
+                    return
                 result["db"] = db
                 result["last_rowid"] = row[0] or 0
             except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
@@ -92,6 +99,7 @@ class iMessageAdapter:  # noqa: N801
         opener.join(timeout=self._init_timeout)
 
         if opener.is_alive():
+            timed_out.set()
             _log(
                 f"imessage: chat.db open timed out after {self._init_timeout}s — "
                 "disabling receive (open() blocked, likely macOS Full Disk Access / "

--- a/src/pinky_outreach/imessage.py
+++ b/src/pinky_outreach/imessage.py
@@ -14,10 +14,16 @@ import os
 import sqlite3
 import subprocess
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 
 from pinky_outreach.types import Chat, Message, Platform
+
+# chat.db open() is a C-level syscall that can block indefinitely under some
+# macOS TCC / file-lock states instead of raising. Bound it so a hung open
+# can never wedge daemon startup (see _init_db).
+_DB_OPEN_TIMEOUT_SEC = 10.0
 
 
 def _log(msg: str) -> None:
@@ -36,8 +42,11 @@ class iMessageAdapter:  # noqa: N801
     # Apple's epoch: 2001-01-01 00:00:00 UTC
     APPLE_EPOCH_OFFSET = 978307200
 
-    def __init__(self, *, db_path: str = "") -> None:
+    def __init__(
+        self, *, db_path: str = "", init_timeout: float = _DB_OPEN_TIMEOUT_SEC
+    ) -> None:
         self._db_path = db_path or self.CHAT_DB
+        self._init_timeout = init_timeout
         self._last_rowid: int = 0
         self._db: sqlite3.Connection | None = None
         self._db_available = False
@@ -46,29 +55,62 @@ class iMessageAdapter:  # noqa: N801
         self._init_db()
 
     def _init_db(self) -> None:
-        """Initialize read-only connection to chat.db."""
+        """Open a read-only connection to chat.db, bounded by a timeout.
+
+        ``sqlite3.connect``'s open() is a C-level syscall that, under some macOS
+        TCC / file-lock states, blocks indefinitely instead of raising
+        ``OperationalError``. A blocking syscall cannot be cancelled and the
+        ``except`` below cannot catch it, so running it inline wedged the whole
+        daemon startup (2026-05-28 incident). We run the open in a daemon thread
+        and ``join`` with a timeout; if it doesn't return in time we give up,
+        mark receive unavailable, and leave the stuck opener thread orphaned
+        (daemon=True, so it never blocks process exit).
+        """
         if not os.path.exists(self._db_path):
             _log(f"imessage: chat.db not found at {self._db_path}")
             return
 
-        try:
-            self._db = sqlite3.connect(
-                f"file:{self._db_path}?mode=ro",
-                uri=True,
-                check_same_thread=False,
-            )
-            # Test read access
-            self._db.execute("SELECT COUNT(*) FROM message").fetchone()
-            self._db_available = True
+        result: dict = {}
 
-            # Set last_rowid to current max so we only get new messages
-            row = self._db.execute("SELECT MAX(ROWID) FROM message").fetchone()
-            self._last_rowid = row[0] or 0
-            _log(f"imessage: chat.db connected, last_rowid={self._last_rowid}")
-        except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
-            _log(f"imessage: chat.db not accessible (need Full Disk Access): {e}")
+        def _open() -> None:
+            try:
+                db = sqlite3.connect(
+                    f"file:{self._db_path}?mode=ro",
+                    uri=True,
+                    check_same_thread=False,
+                )
+                # Test read access + seed last_rowid so we only get new messages.
+                db.execute("SELECT COUNT(*) FROM message").fetchone()
+                row = db.execute("SELECT MAX(ROWID) FROM message").fetchone()
+                result["db"] = db
+                result["last_rowid"] = row[0] or 0
+            except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
+                result["error"] = e
+
+        opener = threading.Thread(target=_open, name="imessage-chatdb-open", daemon=True)
+        opener.start()
+        opener.join(timeout=self._init_timeout)
+
+        if opener.is_alive():
+            _log(
+                f"imessage: chat.db open timed out after {self._init_timeout}s — "
+                "disabling receive (open() blocked, likely macOS Full Disk Access / "
+                "TCC). Leaving the opener thread orphaned so startup is not wedged."
+            )
             self._db = None
             self._db_available = False
+            return
+
+        if "error" in result:
+            _log(f"imessage: chat.db not accessible (need Full Disk Access): {result['error']}")
+            self._db = None
+            self._db_available = False
+            return
+
+        self._db = result["db"]
+        self._last_rowid = result["last_rowid"]
+        self._db_available = True
+        _log(f"imessage: chat.db connected, last_rowid={self._last_rowid}")
 
     def close(self) -> None:
         if self._db:

--- a/tests/test_imessage_adapter.py
+++ b/tests/test_imessage_adapter.py
@@ -1,0 +1,76 @@
+"""Tests for iMessageAdapter chat.db init — focused on the timeout guard.
+
+Regression for the 2026-05-28 daemon wedge: ``sqlite3.connect``'s open() on
+~/Library/Messages/chat.db blocked indefinitely (macOS TCC drift) instead of
+raising, and since it ran inline in the startup path it wedged the whole
+daemon. The adapter now bounds the open with a daemon-thread join timeout.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+
+from pinky_outreach.imessage import iMessageAdapter
+
+
+def _make_chat_db(path: str) -> None:
+    db = sqlite3.connect(path)
+    db.execute("CREATE TABLE message (ROWID INTEGER PRIMARY KEY)")
+    db.execute("INSERT INTO message DEFAULT VALUES")
+    db.commit()
+    db.close()
+
+
+class TestInitDbTimeout:
+    def test_blocking_open_times_out_without_wedging(self, tmp_path, monkeypatch):
+        """A hung open() must bound out near init_timeout, not block forever."""
+        db_path = tmp_path / "chat.db"
+        db_path.write_text("")  # exists so the file check passes; connect is patched
+
+        release = threading.Event()
+
+        def _hanging_connect(*_a, **_k):
+            release.wait()  # block past init_timeout
+            raise sqlite3.OperationalError("released")  # caught in the orphaned thread
+
+        monkeypatch.setattr(
+            "pinky_outreach.imessage.sqlite3.connect", _hanging_connect
+        )
+
+        start = time.monotonic()
+        adapter = iMessageAdapter(db_path=str(db_path), init_timeout=0.2)
+        elapsed = time.monotonic() - start
+
+        assert adapter.can_receive is False
+        assert adapter._db is None
+        assert elapsed < 2.0  # returned ~init_timeout, did NOT block on the open
+        release.set()  # let the orphaned opener thread unwind cleanly
+
+    def test_successful_open_seeds_last_rowid(self, tmp_path):
+        db_path = tmp_path / "chat.db"
+        _make_chat_db(str(db_path))
+        adapter = iMessageAdapter(db_path=str(db_path), init_timeout=5)
+        assert adapter.can_receive is True
+        assert adapter._last_rowid == 1
+        adapter.close()
+
+    def test_operational_error_disables_receive(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "chat.db"
+        db_path.write_text("")
+
+        def _raising_connect(*_a, **_k):
+            raise sqlite3.OperationalError("unable to open database file")
+
+        monkeypatch.setattr(
+            "pinky_outreach.imessage.sqlite3.connect", _raising_connect
+        )
+        adapter = iMessageAdapter(db_path=str(db_path), init_timeout=5)
+        assert adapter.can_receive is False
+        assert adapter._db is None
+
+    def test_missing_db_file_disables_receive(self, tmp_path):
+        adapter = iMessageAdapter(db_path=str(tmp_path / "nope.db"), init_timeout=5)
+        assert adapter.can_receive is False
+        assert adapter._db is None

--- a/tests/test_imessage_adapter.py
+++ b/tests/test_imessage_adapter.py
@@ -48,6 +48,39 @@ class TestInitDbTimeout:
         assert elapsed < 2.0  # returned ~init_timeout, did NOT block on the open
         release.set()  # let the orphaned opener thread unwind cleanly
 
+    def test_late_success_after_timeout_closes_handle(self, tmp_path, monkeypatch):
+        """If the orphaned opener unblocks after timeout, it must close its own
+        handle rather than leak it (the adapter never installs it)."""
+        db_path = tmp_path / "chat.db"
+        db_path.write_text("")
+
+        release = threading.Event()
+        closed = threading.Event()
+
+        class _FakeConn:
+            def execute(self, *_a, **_k):
+                release.wait()  # block past init_timeout, then "succeed"
+                return self
+
+            def fetchone(self):
+                return [7]
+
+            def close(self):
+                closed.set()
+
+        monkeypatch.setattr(
+            "pinky_outreach.imessage.sqlite3.connect",
+            lambda *_a, **_k: _FakeConn(),
+        )
+
+        adapter = iMessageAdapter(db_path=str(db_path), init_timeout=0.2)
+        assert adapter.can_receive is False
+        assert adapter._db is None
+
+        release.set()  # let the orphaned opener finish the open after timeout
+        assert closed.wait(timeout=2.0)  # it must close the handle it opened
+        assert adapter._db is None  # and never install it on the adapter
+
     def test_successful_open_seeds_last_rowid(self, tmp_path):
         db_path = tmp_path / "chat.db"
         _make_chat_db(str(db_path))


### PR DESCRIPTION
## Summary
- `iMessageAdapter._init_db()` opened `~/Library/Messages/chat.db` via `sqlite3.connect(..., mode=ro)` inline in the per-agent startup loop. That `open()` is a C-level syscall that, under some macOS TCC / file-lock states, **blocks indefinitely instead of raising `OperationalError`** — wedging the entire daemon boot (2026-05-28 incident; launchd KeepAlive masked it as a 5s crash loop).
- The existing try/except can't catch a blocking syscall, and async cancellation can't unblock it. This is the **second** occurrence of the pattern after ca605ae/#110.
- Fix: run the open in a daemon thread and `join(timeout=init_timeout)`. On timeout, mark receive unavailable and **orphan** the stuck thread (`daemon=True`, never blocks process exit). Defense lives next to the open in `imessage.py`, not at the `api.py` call site.

## Changes
- `src/pinky_outreach/imessage.py`: `init_timeout` ctor param (default 10s), `_init_db()` rewritten to bound the open in a daemon thread.
- `tests/test_imessage_adapter.py`: 4 regression tests (`TestInitDbTimeout`) — hung-open bounds out near `init_timeout`, successful open seeds `last_rowid`, `OperationalError` disables receive, missing file disables receive. CI-safe (tmp_path, no real chat.db).

## Test plan
- [x] `ruff check` clean
- [x] `pytest tests/test_imessage_adapter.py` — 4 passed
- [ ] Murzik review

## Follow-up (not in this PR)
- After deploy, restore barsik's imessage token (Misha's emergency unwedge cleared it): `UPDATE agent_tokens SET token='enabled' WHERE agent_name='barsik' AND platform='imessage'`
- Task #140: sweep boot path for other unbounded/uncancellable OS-resource calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)