### PR TITLE
fix(#142): remove onboarding dead-ends for non-technical setup

### DIFF
--- a/frontend-svelte/src/pages/Onboarding.svelte
+++ b/frontend-svelte/src/pages/Onboarding.svelte
@@ -308,15 +308,29 @@
 
     // Navigation
     function prev() { if (step > 0) { step--; loadStepData(); } }
-    let authSkipWarned = false;
+
+    // The auth step (2) is the one non-technical users get stuck on: without
+    // Claude auth the agent silently never works. Hard-gate it — the primary
+    // Next button is disabled until auth is detected, so the happy path can't
+    // skip past it by accident (the old double-Next warning was too easy to
+    // click through). Skipping is still possible, but only via a deliberate,
+    // separately-labeled action that confirms first.
+    $: authReady = !!(authStatus?.logged_in || authStatus?.has_api_key);
+    $: authGateBlocking = step === 2 && !authReady;
+
     function next() {
-        // Warn once if skipping auth step without Claude being authenticated
-        if (step === 2 && !authStatus?.logged_in && !authSkipWarned) {
-            authSkipWarned = true;
-            toast('Claude is not authenticated — your agent won\'t work without it. Click Next again to skip anyway.', 'error');
-            return;
-        }
+        if (authGateBlocking) return; // gated — use skipAuthStep() to bypass
         if (step < totalSteps - 1) { step++; loadStepData(); }
+    }
+
+    function skipAuthStep() {
+        const ok = window.confirm(
+            'Claude is NOT authenticated.\n\n' +
+            'Your agent will not be able to respond until you run `claude login` ' +
+            '(or set ANTHROPIC_API_KEY) and restart the server.\n\n' +
+            'Skip this step anyway?'
+        );
+        if (ok && step < totalSteps - 1) { step++; loadStepData(); }
     }
 
     function keyLabel(k) {
@@ -662,7 +676,9 @@
 
         <div class="wizard-footer">
             <button class="wizard-btn" on:click={prev} style="visibility:{step === 0 ? 'hidden' : 'visible'}">{$_('common.back')}</button>
-            {#if step > 0 && step < totalSteps - 1}
+            {#if authGateBlocking}
+                <button class="wizard-btn" on:click={skipAuthStep} style="color:var(--text-error, #c44);font-size:0.7rem">{$_('onboarding.skip')} →</button>
+            {:else if step > 0 && step < totalSteps - 1}
                 <button class="wizard-btn" on:click={next} style="color:var(--text-muted);font-size:0.7rem">{$_('onboarding.skip')}</button>
             {:else}
                 <div></div>
@@ -674,7 +690,7 @@
             {:else if step === 0}
                 <button class="wizard-btn wizard-btn-primary" on:click={next}>{$_('onboarding.lets_go')}</button>
             {:else}
-                <button class="wizard-btn wizard-btn-primary" on:click={next}>{$_('common.next')}</button>
+                <button class="wizard-btn wizard-btn-primary" on:click={next} disabled={authGateBlocking} title={authGateBlocking ? 'Authenticate Claude to continue, or use Skip' : ''}>{$_('common.next')}</button>
             {/if}
         </div>
     </div>

--- a/install.sh
+++ b/install.sh
@@ -147,15 +147,48 @@ pip install --quiet -e ".[all]"
 ok "Dependencies installed"
 
 # ── 8. Build frontend ─────────────────────────────────────────────────────────
+# The daemon serves the compiled SPA from frontend-dist/. If this build is
+# skipped or fails, the dashboard 503s with manual build instructions — but
+# that's a bad first impression, so try hard to build here and fail loudly
+# (not silently) if it breaks. We don't `err`/exit on failure: the daemon can
+# still run headless and the user can rebuild later, so a build hiccup
+# shouldn't trap them in a reinstall loop.
+FRONTEND_OK=0
 step "Building frontend..."
-if command -v npm &>/dev/null && [ -d "frontend-svelte" ]; then
-  cd frontend-svelte
-  npm install --silent 2>&1 | tail -1
-  npm run build 2>&1 | tail -1
-  cd "$INSTALL_DIR"
-  ok "Frontend built"
+if [ ! -d "frontend-svelte" ]; then
+  echo -e "  ${YELLOW}No frontend-svelte/ directory — skipping frontend build.${RESET}"
+elif ! command -v npm &>/dev/null; then
+  echo -e "  ${YELLOW}npm not found — skipping frontend build.${RESET}"
+  echo -e "  ${DIM}Install Node.js 18+ then build manually:${RESET}"
+  echo -e "  ${DIM}  cd $INSTALL_DIR/frontend-svelte && npm install && npm run build${RESET}"
 else
-  echo -e "  ${YELLOW}Skipping frontend build (npm not available)${RESET}"
+  cd frontend-svelte
+  BUILD_FAILED=0
+  echo -e "  ${DIM}Installing frontend dependencies (npm install)...${RESET}"
+  if ! npm install --no-audit --no-fund >/tmp/pinky-npm-install.log 2>&1; then
+    BUILD_FAILED=1
+    echo -e "  ${RED}npm install failed.${RESET} Last lines:"
+    tail -5 /tmp/pinky-npm-install.log | sed 's/^/    /'
+  fi
+  if [ "$BUILD_FAILED" -eq 0 ]; then
+    echo -e "  ${DIM}Compiling frontend (npm run build)...${RESET}"
+    if ! npm run build >/tmp/pinky-npm-build.log 2>&1; then
+      BUILD_FAILED=1
+      echo -e "  ${RED}npm run build failed.${RESET} Last lines:"
+      tail -5 /tmp/pinky-npm-build.log | sed 's/^/    /'
+    fi
+  fi
+  cd "$INSTALL_DIR"
+  # Verify the build actually produced a servable SPA, regardless of exit code.
+  if [ "$BUILD_FAILED" -eq 0 ] && [ -f "frontend-dist/index.html" ]; then
+    FRONTEND_OK=1
+    ok "Frontend built"
+  else
+    echo -e "  ${YELLOW}⚠  Frontend build did not produce frontend-dist/index.html.${RESET}"
+    echo -e "  ${DIM}The server will still start, but the dashboard won't load until you build it:${RESET}"
+    echo -e "  ${DIM}  cd $INSTALL_DIR/frontend-svelte && npm install && npm run build${RESET}"
+    echo -e "  ${DIM}Build logs: /tmp/pinky-npm-install.log, /tmp/pinky-npm-build.log${RESET}"
+  fi
 fi
 
 # ── 9. Create wrapper script ───────────────────────────────────────────────────

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1370,14 +1370,19 @@ class AgentRegistry:
             )
             _log("agent_registry: migrated — added wake_action to agent_contexts")
 
-        # Seed main_agent default
+        # Seed main_agent default: if unset, adopt the oldest enabled agent.
+        # New installs get their main agent auto-assigned at create time (see
+        # ``register``); this migration covers pre-existing installs whose
+        # main_agent was never set (e.g. agents created via the API before
+        # auto-assignment landed). Name-agnostic — no hardcoded agent name.
         if not self.get_setting("main_agent"):
             row = self._db.execute(
-                "SELECT name FROM agents WHERE name='barsik' AND enabled=1",
+                "SELECT name FROM agents WHERE enabled=1 "
+                "ORDER BY created_at ASC, name ASC LIMIT 1",
             ).fetchone()
             if row:
-                self.set_setting("main_agent", "barsik")
-                _log("agent_registry: seeded main_agent=barsik")
+                self.set_setting("main_agent", row[0])
+                _log(f"agent_registry: seeded main_agent={row[0]}")
 
         self._db.commit()
 
@@ -2000,6 +2005,15 @@ except Exception:
             )
             self._db.commit()
             _log(f"agents: registered {name}")
+
+            # First-run convenience: if no main agent is designated yet, adopt
+            # this newly created agent. Without a main agent the daemon starts
+            # no autonomy loop and the agent never auto-wakes — a silent
+            # dead-end for fresh installs. Only fires on creation of an enabled
+            # agent when main is unset, so it never overrides an existing choice.
+            if agent.enabled and not self.get_setting("main_agent"):
+                self.set_setting("main_agent", name)
+                _log(f"agents: auto-assigned main_agent={name} (first agent)")
 
         return self.get(name)  # type: ignore
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3407,7 +3407,39 @@ def create_api(
         html_path = frontend_dir / filename if frontend_dir.exists() else None
         if html_path and html_path.exists():
             return FileResponse(str(html_path))
-        return HTMLResponse("<h1>Frontend not found</h1>", status_code=404)
+        # No built SPA and no vanilla HTML. New installs that skipped the
+        # frontend build (npm unavailable at install time, manual install, or a
+        # self-update that pulled source without rebuilding) land here. Surface
+        # the exact build command instead of a bare "not found".
+        repo_root = frontend_dist.parent
+        return HTMLResponse(
+            f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PinkyBot — frontend not built</title>
+    <style>
+      body {{ font-family: system-ui, sans-serif; background: #111318; color: #f3f5f7; margin: 0; }}
+      main {{ max-width: 40rem; margin: 10vh auto; padding: 2rem; background: #1a1f28; border: 1px solid #2a3140; border-radius: 0.5rem; }}
+      h1 {{ margin: 0 0 1rem 0; font-size: 1.4rem; }}
+      p {{ color: #c6ced8; line-height: 1.5; }}
+      pre {{ background: #0c1016; padding: 1rem; border-radius: 0.4rem; overflow-x: auto; color: #9ad; }}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>The PinkyBot web UI hasn't been built yet</h1>
+      <p>The daemon is running, but the frontend assets are missing. Build them once, then reload this page:</p>
+      <pre>cd {repo_root}/frontend-svelte
+npm install
+npm run build</pre>
+      <p>This needs Node.js 18+ and npm. The installer (<code>install.sh</code>) normally does this automatically; you only see this page if that step was skipped.</p>
+    </main>
+  </body>
+</html>""",
+            status_code=503,
+        )
 
     def _auth_page(title: str, message: str, detail: str) -> HTMLResponse:
         return HTMLResponse(

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -754,8 +754,26 @@ class MessageBroker:
             return
 
         if status is None or status == "pending":
-            # Auto-approve primary user
             primary = self._registry.get_primary_user()
+            # First-run ownership claim: if no primary user has ever been
+            # configured, the first person to message the bot is treated as the
+            # owner — set them as primary (which also auto-approves them across
+            # all agents). This removes the confusing "waiting for approval"
+            # message a fresh owner would otherwise get from their own bot.
+            # Tradeoff: whoever messages first claims ownership, so the owner
+            # should connect before sharing the bot. Only fires when primary is
+            # completely unset.
+            if not primary.get("chat_id"):
+                self._registry.set_primary_user(
+                    user_id,
+                    display_name=message.sender_name or "",
+                )
+                _log(
+                    f"broker: no primary user configured — claimed {user_id} "
+                    f"({message.sender_name}) as primary/owner for {agent_name}"
+                )
+                primary = self._registry.get_primary_user()
+            # Auto-approve primary user
             if primary.get("chat_id") and user_id == primary["chat_id"]:
                 self._registry.approve_user(
                     agent_name, user_id,

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -255,6 +255,40 @@ class TestAgentCRUD:
         registry.stamp_last_seen("ghost", ts=42.0)
 
 
+class TestMainAgentAutoAssign:
+    """First-run convenience: a fresh install must not silently end up with no
+    main agent (no main_agent ⇒ daemon starts no autonomy loop ⇒ created agent
+    never wakes). Creating the first enabled agent adopts it as main."""
+
+    def test_first_agent_becomes_main(self, registry):
+        assert registry.get_main_agent() == ""
+        registry.register("alpha")
+        assert registry.get_main_agent() == "alpha"
+
+    def test_second_agent_does_not_override_main(self, registry):
+        registry.register("alpha")
+        registry.register("beta")
+        assert registry.get_main_agent() == "alpha"
+
+    def test_explicit_main_is_not_overridden(self, registry):
+        registry.register("alpha")
+        registry.set_main_agent("alpha")
+        registry.register("beta")
+        assert registry.get_main_agent() == "alpha"
+
+    def test_disabled_first_agent_not_auto_assigned(self, registry):
+        registry.register("alpha", enabled=False)
+        assert registry.get_main_agent() == ""
+
+    def test_updating_existing_agent_does_not_assign_main(self, registry):
+        # Seed main, clear it, then re-register (update path) — update must not
+        # auto-assign; only creation does.
+        registry.register("alpha")
+        registry.set_setting("main_agent", "")
+        registry.register("alpha", model="opus")
+        assert registry.get_main_agent() == ""
+
+
 class TestAgentNameValidation:
     """Path-traversal defense: agent names must match the safe-char allowlist.
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -129,6 +129,70 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
+    async def test_first_inbound_claims_primary_on_fresh_install(self, monkeypatch):
+        """Fresh install: no primary user configured. The first person to
+        message the bot should be claimed as primary/owner and auto-approved,
+        instead of getting the confusing 'waiting for approval' reply from
+        their own bot."""
+        tmpdir, registry, broker, sent_messages, _ = self._make_broker()
+        try:
+            routed: list[str] = []
+
+            async def _fake_route(agent_name, message):
+                routed.append(message.sender_id)
+
+            monkeypatch.setattr(broker, "_route_streaming", _fake_route)
+            assert registry.get_primary_user().get("chat_id") in (None, "")
+
+            msg = BrokerMessage(
+                platform="telegram",
+                chat_id="6770805286",
+                sender_name="Brad",
+                sender_id="6770805286",
+                content="hey",
+                agent_name="barsik",
+            )
+            await broker.handle_inbound(msg)
+
+            assert registry.get_primary_user().get("chat_id") == "6770805286"
+            assert registry.get_user_status("barsik", "6770805286") == "approved"
+            assert routed == ["6770805286"]  # routed, not queued as pending
+            assert not any("Waiting for approval" in m[3] for m in sent_messages)
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_stranger_not_claimed_when_primary_already_set(self, monkeypatch):
+        """Once a primary owner exists, a new sender must NOT hijack ownership —
+        they go through the normal pending-approval flow."""
+        tmpdir, registry, broker, sent_messages, _ = self._make_broker()
+        try:
+            routed: list[str] = []
+
+            async def _fake_route(agent_name, message):
+                routed.append(message.sender_id)
+
+            monkeypatch.setattr(broker, "_route_streaming", _fake_route)
+            registry.set_primary_user("6770805286", display_name="Brad")
+
+            msg = BrokerMessage(
+                platform="telegram",
+                chat_id="999",
+                sender_name="Stranger",
+                sender_id="999",
+                content="let me in",
+                agent_name="barsik",
+            )
+            await broker.handle_inbound(msg)
+
+            assert registry.get_primary_user().get("chat_id") == "6770805286"
+            assert registry.get_user_status("barsik", "999") == "pending"
+            assert routed == []  # not routed — queued pending approval
+            assert any("Waiting for approval" in m[3] for m in sent_messages)
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
     async def test_route_streaming_waits_for_in_flight_reconnect(self, monkeypatch):
         """Regression: messages arriving during ``context_restart`` (where the
         streaming session object exists but ``state`` is briefly != CONNECTED


### PR DESCRIPTION
## Summary

Brad: *"PinkyBot is way too difficult for someone non-technical to set up — it gets stuck at various parts of setup, especially outside the Anthropic config. Don't forget the front end — new installs don't build it by default either."*

This removes the silent dead-ends a fresh, non-technical install hits:

1. **No main agent auto-assigned.** Creating the first agent left `main_agent` unset → daemon started no autonomy loop → the agent never woke (silent dead-end). `register()` now adopts the first *enabled* agent as main; a name-agnostic migration seeds `main_agent` for pre-existing installs (drops the hardcoded `"barsik"` seed). Subsequent agents and explicit choices are never overridden.
2. **Owner treated as a stranger.** With no primary user configured, the owner messaging their own bot got *"Request sent! Waiting for approval."* The broker now claims the **first inbound sender** as primary/owner (auto-approved) — but only when primary is *completely unset*.
3. **Frontend never built / built-but-broken.** `install.sh` swallowed npm's exit code via `| tail -1`, printing "Frontend built" even on failure. Now captures real exit codes, verifies `frontend-dist/index.html` exists, and **fails loudly** with the manual build command (warns, doesn't `exit` — daemon can still run headless).
4. **Bare 404** `<h1>Frontend not found</h1>` → styled **503** page showing the exact `cd … && npm install && npm run build` commands.
5. **Auth step hard-gate.** Wizard step 2 `Next` is disabled until Claude auth is detected; skipping now requires a deliberate confirm dialog instead of an accidental double-click.

## ⚠️ Security tradeoff to review

Fix #2 means **whoever messages the bot first claims ownership.** Gated tightly to fire only when primary is *completely unset*, so it's a one-time first-run claim — but an operator who shares the bot URL/token before connecting themselves could have a stranger claim owner. Acceptable for first-run UX vs. the alternative (owner locked out of their own bot), but flagging explicitly. Open to a narrower gate if preferred.

## Test plan

- [x] `test_agent_registry.py` — 5 new tests: first agent → main, second doesn't override, explicit choice preserved, disabled agent skipped, update-path doesn't assign
- [x] `test_broker.py` — 2 new tests: first inbound claims primary + auto-approves; stranger NOT claimed when primary already set
- [x] `tests/test_agent_registry.py + test_broker.py + test_onboarding.py` → 116 passed
- [x] ruff clean on all edited files
- [x] `npm run build` compiles; produces `frontend-dist/index.html`
- [x] `bash -n install.sh` syntax OK
- [ ] Manual: fresh-install walkthrough (recommend before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)