### PR TITLE
feat(#144): tmux context auto-management — restart at threshold (1M→400k)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2616,6 +2616,13 @@ class TmuxSession:
             f"context_restart to continue in a fresh session. Do this now — don't "
             f"pick up new work first. A clean restart keeps your reasoning sharp."
         )
+        # MUST stay fire-and-forget (wait_for_completion=False). This runs
+        # inside the tailer's _handle_turn_complete callback — the very code
+        # that SETS turn completion events. Waiting here for THIS nudge's
+        # completion would block the single tailer task on an event only a
+        # future stop-hook (drained by that same task) can set: a self-
+        # deadlock, bounded only by timeout_sec. Do not "improve" this to
+        # wait_for_completion=True. (Dymok #618 review.)
         await self._enqueue_internal_prompt(prompt, reason="context_autorestart_nudge")
 
     async def _handle_turn_complete(self, response: TurnResponse) -> None:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2295,6 +2295,17 @@ class TmuxSession:
     # buffer.
     _AUTOCOMPACT_BUFFER_TOKENS = 33_000
 
+    # Absolute token ceiling for the restart-for-sanity nudge on
+    # 1M-context models. Brad's preference (2026-05-29): on a 1M window,
+    # restart around 400k tokens for a clean slate rather than riding the
+    # context up toward the autocompact buffer. Expressed as an absolute
+    # token count (not a %) because "restart around 400k" is how the
+    # budget is reasoned about, and 40-ish % means very different real
+    # headroom on a 1M vs a 200k window. Only bites when it is *below*
+    # the percentage-based threshold (always true on 1M, never on 200k
+    # since 400k exceeds that window entirely).
+    _RESTART_TOKENS_CAP_1M = 400_000
+
     def _raw_max_tokens_for_model(self) -> int:
         """Return the model's **raw** context-window cap (no buffer).
 
@@ -2361,6 +2372,30 @@ class TmuxSession:
         except Exception:
             pass
         return 80.0
+
+    def _effective_restart_threshold_pct(self) -> float:
+        """Restart threshold as a percentage, with the 1M absolute cap applied.
+
+        Combines the per-agent percentage threshold
+        (``_restart_threshold_pct``) with the absolute
+        ``_RESTART_TOKENS_CAP_1M`` ceiling, returning whichever fires
+        *earlier* (the lower percentage). The cap is expressed against
+        the **effective** max tokens so it lines up with the percentage
+        the gauge reports — i.e. crossing the returned percentage means
+        the real token total has reached ``min(pct·max, 400k)``.
+
+        On a 200k window the 400k cap exceeds the whole window, so the
+        ``min`` is always the configured percentage and behaviour is
+        unchanged. On a 1M window 400k ≈ 41% of the ~967k effective cap,
+        so the threshold drops from the default 80% to ~41% — Brad's
+        restart-around-400k-for-sanity preference.
+        """
+        pct_threshold = self._restart_threshold_pct()
+        max_tokens = self._max_tokens_for_model()
+        if max_tokens <= 0:
+            return pct_threshold
+        cap_pct = self._RESTART_TOKENS_CAP_1M / max_tokens * 100.0
+        return min(pct_threshold, cap_pct)
 
     def _record_turn_usage(self, response: TurnResponse) -> None:
         """Fold a turn's usage block into ``self.usage`` (SessionUsage).
@@ -2521,7 +2556,7 @@ class TmuxSession:
             }
         )
 
-        threshold = self._restart_threshold_pct()
+        threshold = self._effective_restart_threshold_pct()
         pct = info.get("percentage", 0.0) or 0.0
         if pct >= threshold and not self._restart_nudge_fired:
             self._restart_nudge_fired = True
@@ -2535,10 +2570,53 @@ class TmuxSession:
                     "max_tokens": info["maxTokens"],
                 }
             )
+            # Drive the action, not just the notification. The SSE event
+            # above informs the UI / observers; this delivers the restart
+            # directive INTO the agent's own next turn so something
+            # actually happens. Gated by PINKY_CONTEXT_AUTORESTART_NUDGE
+            # (default on; set "0" to fall back to notify-only for soak /
+            # kill-switch). Latch above guarantees one nudge per crossing.
+            if os.environ.get("PINKY_CONTEXT_AUTORESTART_NUDGE", "1") != "0":
+                await self._enqueue_autorestart_nudge(
+                    total=info["totalTokens"],
+                    max_tokens=info["maxTokens"],
+                    pct=pct,
+                )
         elif pct < threshold and self._restart_nudge_fired:
             # Re-arm the latch once context drops back below threshold
             # (e.g. /compact ran). Next crossing will fire a fresh nudge.
             self._restart_nudge_fired = False
+
+    async def _enqueue_autorestart_nudge(
+        self, *, total: int, max_tokens: int, pct: float
+    ) -> None:
+        """Deliver the restart-for-sanity directive into the agent's own turn.
+
+        The companion ``restart_nudge`` SSE event tells the UI / observers;
+        this tells the *agent*. Routed through ``_enqueue_internal_prompt``
+        so it rides the normal turn queue without polluting the
+        user-visible conversation (no conversation_store append, no chat
+        routing). The agent is asked to author its own continuation via
+        ``save_my_context`` *before* ``context_restart`` — the daemon
+        can't write a meaningful wake_action, which is exactly why a clean
+        restart (fresh slate + agent-authored handoff) beats an in-place
+        ``/compact`` at this depth.
+
+        Tail-enqueued (not ``front``): any user turns already queued are
+        answered first, then the restart. The alternative — jumping the
+        restart ahead of pending user work — trades responsiveness for a
+        slightly tighter context bound; left as a follow-up call for
+        review. One nudge per crossing (caller latched).
+        """
+        prompt = (
+            f"⚠️ Context budget check — you're at {total:,} / {max_tokens:,} tokens "
+            f"({pct:.0f}%), past your restart-for-sanity threshold. Finish the "
+            f"thought you're on, then: (1) call save_my_context with a concrete "
+            f"wake_action capturing exactly what to resume, and (2) call "
+            f"context_restart to continue in a fresh session. Do this now — don't "
+            f"pick up new work first. A clean restart keeps your reasoning sharp."
+        )
+        await self._enqueue_internal_prompt(prompt, reason="context_autorestart_nudge")
 
     async def _handle_turn_complete(self, response: TurnResponse) -> None:
         """Tailer callback — fired once per ``stop_hook_summary`` entry.

--- a/tests/test_tmux_context_autorestart.py
+++ b/tests/test_tmux_context_autorestart.py
@@ -1,0 +1,152 @@
+"""Tests for the tmux context-autorestart nudge (task #144).
+
+Covers the two halves of the feature:
+
+1. ``_effective_restart_threshold_pct`` — the percentage threshold with
+   the absolute ``_RESTART_TOKENS_CAP_1M`` (400k) ceiling folded in.
+   Bites on 1M-context models (drops 80%→~41%), no-ops on 200k.
+2. ``_emit_context_usage_event`` — on crossing it must now ALSO drive the
+   agent via ``_enqueue_internal_prompt`` (the "dead wire" the SSE-only
+   ``restart_nudge`` left disconnected), one-shot per crossing, re-arming
+   after the total drops, and honouring the
+   ``PINKY_CONTEXT_AUTORESTART_NUDGE`` kill-switch.
+
+Mirrors test_tmux_session.py's mock strategy — never shells out to tmux.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import TmuxSession, _TmuxControl
+
+# A 1M-context model and a 200k one (membership in streaming_session._1M_MODELS).
+_MODEL_1M = "claude-opus-4-8"
+_MODEL_200K = "claude-haiku-4-5"
+
+
+def _make_mock_tmux() -> MagicMock:
+    tmux = MagicMock(spec=_TmuxControl)
+    tmux.session_name = "pinky-test"
+    tmux.has_session = AsyncMock(return_value=False)
+    tmux.new_session = AsyncMock()
+    tmux.kill_session = AsyncMock()
+    tmux.send_keys = AsyncMock()
+    tmux.paste_text = AsyncMock()
+    tmux.capture_pane = AsyncMock()
+    return tmux
+
+
+def _make_session(*, model: str) -> TmuxSession:
+    cfg = StreamingSessionConfig(
+        agent_name="dreamer",
+        working_dir="/tmp/tmux-autorestart-test",
+        model=model,
+    )
+    ss = TmuxSession(cfg, tmux_control=_make_mock_tmux())
+    ss._skip_wake_prompt_for_tests = True
+    # Isolate the unit: patch the two awaited side-effect sinks so the
+    # crossing logic runs without an SSE bus or a live turn queue.
+    ss._emit_stream_event = AsyncMock()
+    ss._enqueue_internal_prompt = AsyncMock()
+    return ss
+
+
+def _set_total_tokens(ss: TmuxSession, total: int) -> None:
+    """Pin the session's current-window total via last_usage."""
+    ss.usage.last_usage = {"input_tokens": total}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _effective_restart_threshold_pct
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_effective_threshold_caps_at_400k_on_1m_model() -> None:
+    ss = _make_session(model=_MODEL_1M)
+    # Effective max = 1_000_000 - 33_000 buffer = 967_000.
+    # cap_pct = 400_000 / 967_000 * 100 ≈ 41.36, below the 80% default.
+    assert ss._effective_restart_threshold_pct() == pytest.approx(
+        400_000 / 967_000 * 100.0, rel=1e-3
+    )
+
+
+def test_effective_threshold_unchanged_on_200k_model() -> None:
+    ss = _make_session(model=_MODEL_200K)
+    # 400k cap exceeds the whole 200k window, so min() yields the
+    # configured 80% default — behaviour identical to pre-feature.
+    assert ss._effective_restart_threshold_pct() == pytest.approx(80.0)
+
+
+def test_400k_cap_fires_well_before_the_old_80pct_point() -> None:
+    """Regression intent: the cap must trigger earlier than 80% on 1M."""
+    ss = _make_session(model=_MODEL_1M)
+    assert ss._effective_restart_threshold_pct() < 80.0
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _emit_context_usage_event → autorestart nudge
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crossing_enqueues_nudge_once() -> None:
+    ss = _make_session(model=_MODEL_1M)
+    # 450k tokens ≈ 46.5% on a 967k window — past the ~41% cap.
+    _set_total_tokens(ss, 450_000)
+
+    await ss._emit_context_usage_event()
+    await ss._emit_context_usage_event()  # still above; latch must hold
+
+    assert ss._enqueue_internal_prompt.await_count == 1
+    _, kwargs = ss._enqueue_internal_prompt.call_args
+    assert kwargs.get("reason") == "context_autorestart_nudge"
+
+
+@pytest.mark.asyncio
+async def test_no_nudge_below_threshold() -> None:
+    ss = _make_session(model=_MODEL_1M)
+    _set_total_tokens(ss, 100_000)  # ~10% — well below
+
+    await ss._emit_context_usage_event()
+
+    ss._enqueue_internal_prompt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_latch_rearms_after_total_drops() -> None:
+    ss = _make_session(model=_MODEL_1M)
+
+    _set_total_tokens(ss, 450_000)
+    await ss._emit_context_usage_event()  # fire #1
+
+    _set_total_tokens(ss, 80_000)
+    await ss._emit_context_usage_event()  # drop below → re-arm
+    assert ss._restart_nudge_fired is False
+
+    _set_total_tokens(ss, 450_000)
+    await ss._emit_context_usage_event()  # fire #2
+
+    assert ss._enqueue_internal_prompt.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_keeps_sse_but_suppresses_nudge(monkeypatch) -> None:
+    monkeypatch.setenv("PINKY_CONTEXT_AUTORESTART_NUDGE", "0")
+    ss = _make_session(model=_MODEL_1M)
+    _set_total_tokens(ss, 450_000)
+
+    await ss._emit_context_usage_event()
+
+    # Notify-only: the restart_nudge SSE still fires for the UI...
+    nudge_events = [
+        c.args[0]
+        for c in ss._emit_stream_event.call_args_list
+        if c.args and c.args[0].get("type") == "restart_nudge"
+    ]
+    assert len(nudge_events) == 1
+    # ...but the agent-facing directive is suppressed.
+    ss._enqueue_internal_prompt.assert_not_called()

--- a/tests/test_tmux_context_autorestart.py
+++ b/tests/test_tmux_context_autorestart.py
@@ -107,6 +107,24 @@ async def test_crossing_enqueues_nudge_once() -> None:
 
 
 @pytest.mark.asyncio
+async def test_nudge_is_tail_enqueued_not_front() -> None:
+    """Lock the tail-vs-front decision (Dymok #618 review, Q1).
+
+    Front-enqueue would jump the restart ahead of queued user turns,
+    making them depend on replay surviving an agent-initiated
+    context_restart. Tail-enqueue answers users first, then restarts.
+    """
+    ss = _make_session(model=_MODEL_1M)
+    _set_total_tokens(ss, 450_000)
+
+    await ss._emit_context_usage_event()
+
+    ss._enqueue_internal_prompt.assert_awaited_once()
+    _, kwargs = ss._enqueue_internal_prompt.call_args
+    assert kwargs.get("front", False) is False
+
+
+@pytest.mark.asyncio
 async def test_no_nudge_below_threshold() -> None:
     ss = _make_session(model=_MODEL_1M)
     _set_total_tokens(ss, 100_000)  # ~10% — well below


### PR DESCRIPTION
## What

Connects the tmux context watchdog's **dead wire**. Since #533/#535 tmux agents can *see* their context usage and a `restart_nudge` SSE fires at the threshold — but **nothing consumed it**, so at high context nothing actually happened. This makes the threshold crossing *act*.

Two parts:

### 1. Drive the action, not just the notification
On crossing, `_emit_context_usage_event` now also enqueues an internal turn (`_enqueue_internal_prompt`) telling the agent to `save_my_context` (with a real `wake_action`) then `context_restart`.

- **Why restart, not `/compact`:** the agent authoring its own continuation note beats a lossy in-place summary — and the daemon can't write a meaningful `wake_action` itself. Clean slate + agent handoff.
- **Why this is safe to build on:** the tmux `context_restart` path was fixed in #543 (`force_fresh_context_once` → genuine fresh session, no silent `--continue` resume).
- One-shot per crossing (reuses the existing `_restart_nudge_fired` latch); re-arms once the total drops back under threshold.
- **Kill-switch:** `PINKY_CONTEXT_AUTORESTART_NUDGE=0` falls back to notify-only (SSE still fires). Default on. Lets us soak on one agent first.

### 2. Restart-for-sanity at ~400k on 1M models
`_effective_restart_threshold_pct` folds an absolute `_RESTART_TOKENS_CAP_1M = 400_000` ceiling into the percentage threshold. On a 1M window that's ≈41% of the 967k effective cap, so 1M agents restart at ~400k instead of riding to 80%. No-ops on 200k windows (400k exceeds the window). Brad's explicit preference.

## Tests
`tests/test_tmux_context_autorestart.py` (7): threshold cap on 1M vs 200k, one-shot crossing, re-arm after drop, kill-switch keeps SSE but suppresses the agent nudge. Existing tmux/context/watchdog suites green (252 passed).

## Open calls for review (@dymok — your transport)
1. **Tail vs front enqueue:** the nudge is tail-enqueued, so any queued user turns are answered before the restart. Front-enqueue would bound context tighter but reorder ahead of waiting users. Went with tail for v1 — flagging for your call.
2. **No escalation if ignored:** one nudge per crossing; if the agent doesn't act, CC's own autocompact remains the ultimate backstop. Acceptable for v1?
3. **Per-agent absolute threshold** (`restart_threshold_tokens` DB field) deferred as a follow-up — v1 hardcodes the 400k cap for 1M.

Draft until @dymok reviews. Not for self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)