### PR TITLE
fix: resolve native ~/.local/bin/claude as a binary fallback

### DIFF
--- a/src/pinky_daemon/claude_runner.py
+++ b/src/pinky_daemon/claude_runner.py
@@ -77,9 +77,17 @@ class ClaudeRunnerConfig:
 
 def _find_claude_binary() -> str:
     """Find the claude CLI binary."""
-    # Check common locations
+    # PATH first (the package-manager install — npm global, etc.), then
+    # known fixed install locations as fallbacks. The native installer
+    # (`claude install`) drops the binary in ~/.local/bin/claude, which is
+    # NOT on the daemon's launchd PATH — so without this fallback, a box
+    # whose only claude is a native build (or one where the npm binary was
+    # removed, e.g. by running `claude install`) would fail to resolve a
+    # binary and the daemon couldn't spawn any agent. PATH still wins when
+    # present, so this never shadows the intended install.
     candidates = [
         shutil.which("claude"),
+        os.path.expanduser("~/.local/bin/claude"),
         os.path.expanduser("~/.claude/local/claude"),
         "/usr/local/bin/claude",
     ]

--- a/tests/test_claude_runner_binary.py
+++ b/tests/test_claude_runner_binary.py
@@ -1,0 +1,57 @@
+"""Tests for claude_runner._find_claude_binary resolution order.
+
+Regression guard for the native-install fallback: `claude install` removes
+the npm-global package and drops the binary in ~/.local/bin/claude, which is
+not on the daemon's launchd PATH. Without the fallback the daemon would fail
+to resolve a binary and couldn't spawn agents (real near-miss, 2026-05-29).
+"""
+
+from __future__ import annotations
+
+from pinky_daemon import claude_runner
+
+
+def _make_executable(path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n")
+
+
+def test_falls_back_to_native_local_bin(monkeypatch, tmp_path) -> None:
+    """PATH has no claude, but the native ~/.local/bin install resolves."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(claude_runner.shutil, "which", lambda _name: None)
+
+    native = tmp_path / ".local" / "bin" / "claude"
+    _make_executable(native)
+
+    assert claude_runner._find_claude_binary() == str(native)
+
+
+def test_path_resolution_wins_over_native(monkeypatch, tmp_path) -> None:
+    """A claude on PATH is preferred over the native fallback."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    on_path = tmp_path / "pathbin" / "claude"
+    _make_executable(on_path)
+    native = tmp_path / ".local" / "bin" / "claude"
+    _make_executable(native)
+
+    monkeypatch.setattr(claude_runner.shutil, "which", lambda _name: str(on_path))
+
+    assert claude_runner._find_claude_binary() == str(on_path)
+
+
+def test_raises_when_no_binary_anywhere(monkeypatch, tmp_path) -> None:
+    """No PATH hit and no fallback files → FileNotFoundError (unchanged)."""
+    monkeypatch.setenv("HOME", str(tmp_path))  # empty home, no ~/.local/bin
+    monkeypatch.setattr(claude_runner.shutil, "which", lambda _name: None)
+    # Neutralize the absolute fallback so the test doesn't depend on whether
+    # /usr/local/bin/claude happens to exist on the runner.
+    monkeypatch.setattr(claude_runner.os.path, "isfile", lambda _p: False)
+
+    try:
+        claude_runner._find_claude_binary()
+    except FileNotFoundError:
+        pass
+    else:  # pragma: no cover - failure path
+        raise AssertionError("expected FileNotFoundError when no binary exists")


### PR DESCRIPTION
## Problem

`_find_claude_binary()` (claude_runner.py) resolves the CLI from: PATH (`shutil.which`), `~/.claude/local/claude`, `/usr/local/bin/claude`. It does **not** include `~/.local/bin/claude` — where the **native installer** (`claude install`) puts the binary.

That location is off the daemon's launchd PATH (`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`). So a box whose only claude is a native build — **or one where the npm binary was removed**, which is exactly what `claude install` does (it uninstalls the npm-global package) — would fail to resolve any binary, and the daemon couldn't spawn agents.

This was a **real near-miss** on the Mac Mini (2026-05-29): running `claude install` to test the native auto-updater removed the npm binary; had the daemon restarted before I reinstalled npm, no agent would have respawned.

## Fix

Add `~/.local/bin/claude` to the fallback candidate list. **PATH still resolves first**, so this never shadows the intended (npm/homebrew) install — it only rescues a box that would otherwise have *no* resolvable binary.

## Tests
`tests/test_claude_runner_binary.py`: native fallback resolves, PATH-wins-over-native, and the no-binary-anywhere `FileNotFoundError` path (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)