### PR TITLE
feat(#614): soft context-watermark nudge for tmux sessions

### DIFF
--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -141,9 +141,11 @@
     let selectedModel = '';
     let selectedEffort = 'medium';
     let contextNudgePct = 80;
+    let softNudgePct = 35;
     let savingModel = false;
     let savingEffort = false;
     let savingNudge = false;
+    let savingSoftNudge = false;
 
     const availableModels = [
         { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6 (1M)' },
@@ -525,6 +527,7 @@
             if (agentData.model && !selectedModel) selectedModel = agentData.model;
             if (agentData.thinking_effort) selectedEffort = agentData.thinking_effort;
             if (agentData.restart_threshold_pct != null) contextNudgePct = agentData.restart_threshold_pct;
+            if (agentData.context_nudge_threshold_pct != null && agentData.context_nudge_threshold_pct > 0) softNudgePct = agentData.context_nudge_threshold_pct;
             if (agentData.model) infoModel = agentData.model;
         } catch { /* non-critical */ }
 
@@ -1033,6 +1036,13 @@
         savingNudge = false;
     }
 
+    async function saveSoftNudge() {
+        if (!activeAgent) return;
+        savingSoftNudge = true;
+        try { await api('PUT', `/agents/${activeAgent}`, { context_nudge_threshold_pct: softNudgePct }); } catch (e) { alert(`Failed to update soft nudge: ${e.message}`); }
+        savingSoftNudge = false;
+    }
+
     async function saveEffort() {
         if (!activeAgent) return;
         savingEffort = true;
@@ -1311,6 +1321,10 @@
                     <label class="setting-item" title={$_('chat.restart_threshold_help')}>
                         <span>{$_('chat.restart_threshold_label')}</span>
                         <input type="number" min="10" max="95" step="5" bind:value={contextNudgePct} on:change={saveNudge} disabled={savingNudge}>
+                    </label>
+                    <label class="setting-item" title="Soft watermark: at this % the agent gets a one-time nudge to checkpoint + context_restart at a natural break. Must be below the hard restart threshold.">
+                        <span>Soft nudge %</span>
+                        <input type="number" min="10" max="90" step="5" bind:value={softNudgePct} on:change={saveSoftNudge} disabled={savingSoftNudge}>
                     </label>
                 </div>
             {/if}

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -331,6 +331,11 @@ class Agent:
     max_turns: int = 0
     timeout: float = 300.0
     restart_threshold_pct: float = 80.0
+    # Soft context-watermark (#614): when usage first crosses this %, the
+    # agent gets a one-time in-REPL nudge to checkpoint + context_restart
+    # at a natural break. 0.0 = use the global default. Must sit below
+    # restart_threshold_pct (the hard safety net).
+    context_nudge_threshold_pct: float = 0.0
     auto_restart: bool = True
     parent: str = ""  # Parent agent name (for hierarchy)
     groups: list[str] = field(default_factory=list)
@@ -406,6 +411,7 @@ class Agent:
             "max_turns": self.max_turns,
             "timeout": self.timeout,
             "restart_threshold_pct": self.restart_threshold_pct,
+            "context_nudge_threshold_pct": self.context_nudge_threshold_pct,
             "auto_restart": self.auto_restart,
             "parent": self.parent,
             "groups": self.groups,
@@ -1015,6 +1021,7 @@ class AgentRegistry:
                 max_turns INTEGER NOT NULL DEFAULT 0,
                 timeout REAL NOT NULL DEFAULT 300.0,
                 restart_threshold_pct REAL NOT NULL DEFAULT 80.0,
+                context_nudge_threshold_pct REAL NOT NULL DEFAULT 0.0,
                 auto_restart INTEGER NOT NULL DEFAULT 1,
                 parent TEXT NOT NULL DEFAULT '',
                 groups TEXT NOT NULL DEFAULT '[]',
@@ -1306,6 +1313,8 @@ class AgentRegistry:
             # gating which targets this agent may publish to via
             # mesh_remote_send. Default-deny (empty list = no outbound).
             ("mesh_outbound_allowlist", "TEXT NOT NULL DEFAULT '[]'"),
+            # Soft context-watermark nudge (#614); 0 = use global default.
+            ("context_nudge_threshold_pct", "REAL NOT NULL DEFAULT 0.0"),
         ]
         for col, typedef in migrations:
             if col not in existing:
@@ -1870,6 +1879,7 @@ except Exception:
             for key in ("display_name", "model", "soul", "users", "boundaries",
                         "system_prompt", "working_dir",
                         "permission_mode", "max_turns", "timeout", "restart_threshold_pct",
+                        "context_nudge_threshold_pct",
                         "auto_restart", "parent", "max_sessions", "enabled",
                         "auto_start", "heartbeat_interval", "wake_interval",
                         "clock_aligned", "auto_sleep_hours", "plain_text_fallback", "voice_config", "role",
@@ -1939,6 +1949,7 @@ except Exception:
                 max_turns=kwargs.get("max_turns", 0),
                 timeout=kwargs.get("timeout", 300.0),
                 restart_threshold_pct=kwargs.get("restart_threshold_pct", 80.0),
+                context_nudge_threshold_pct=kwargs.get("context_nudge_threshold_pct", 0.0),
                 auto_restart=kwargs.get("auto_restart", True),
                 parent=kwargs.get("parent", ""),
                 groups=kwargs.get("groups", []),
@@ -1976,7 +1987,7 @@ except Exception:
                    (name, display_name, model, soul, users, boundaries,
                     system_prompt, working_dir,
                     permission_mode, allowed_tools, disallowed_tools, max_turns, timeout,
-                    restart_threshold_pct, auto_restart, parent, groups,
+                    restart_threshold_pct, context_nudge_threshold_pct, auto_restart, parent, groups,
                     max_sessions, enabled, auto_start, heartbeat_interval, plain_text_fallback,
                     wake_interval, clock_aligned, auto_sleep_hours, voice_config, role,
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
@@ -1984,13 +1995,14 @@ except Exception:
                     runtime, transport, provider_url, provider_key, provider_model, provider_ref,
                     thinking_effort, strict_effort_enforcement, watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
                  json.dumps(agent.allowed_tools), json.dumps(agent.disallowed_tools),
                  agent.max_turns, agent.timeout,
-                 agent.restart_threshold_pct, int(agent.auto_restart),
+                 agent.restart_threshold_pct, agent.context_nudge_threshold_pct,
+                 int(agent.auto_restart),
                  agent.parent, json.dumps(agent.groups), agent.max_sessions,
                  int(agent.enabled), int(agent.auto_start), agent.heartbeat_interval, int(agent.plain_text_fallback),
                  agent.wake_interval, int(agent.clock_aligned), agent.auto_sleep_hours,
@@ -2029,7 +2041,7 @@ except Exception:
         "working_status, working_status_updated_at, "
         "runtime, transport, provider_url, provider_key, provider_model, provider_ref, "
         "disallowed_tools, thinking_effort, watchdog_config, last_seen_at, "
-        "strict_effort_enforcement"
+        "strict_effort_enforcement, context_nudge_threshold_pct"
     )
 
     def get(self, name: str) -> Agent | None:
@@ -3742,6 +3754,7 @@ except Exception:
             watchdog_config=json.loads(row[47]) if len(row) > 47 and row[47] else {},
             last_seen_at=row[48] if len(row) > 48 else 0.0,
             strict_effort_enforcement=bool(row[49]) if len(row) > 49 else False,
+            context_nudge_threshold_pct=row[50] if len(row) > 50 else 0.0,
         )
 
     # ── Cost Tracking ──────────────────────────────────────

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -364,6 +364,7 @@ class UpdateAgentRequest(BaseModel):
     enabled: bool | None = None
     plain_text_fallback: bool | None = None
     restart_threshold_pct: float | None = None
+    context_nudge_threshold_pct: float | None = None  # Soft nudge %; 0=use global default (#614)
     wake_interval: int | None = None  # Seconds (0=disabled, 1800=30m, 3600=1h)
     clock_aligned: bool | None = None  # Align to wall clock boundaries
     auto_sleep_hours: int | None = None  # Auto-sleep after N hours idle (0=disabled)

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -85,9 +85,16 @@ from pinky_daemon.transport_state import (
 from pinky_daemon.wake_prompt import (
     WakePromptInput,
     WakeReason,
+    build_context_nudge_prompt,
     build_idle_sleep_prompt,
     build_wake_prompt,
 )
+
+# Soft context-watermark default (#614) — used when an agent's
+# ``context_nudge_threshold_pct`` is unset (0). Sits well below the
+# hard ``restart_threshold_pct`` (default 80) so the agent gets an
+# early, graceful heads-up to checkpoint before the safety net trips.
+DEFAULT_CONTEXT_NUDGE_THRESHOLD_PCT = 35.0
 
 # ──────────────────────────────────────────────────────────────────────────
 # Tmux subprocess control
@@ -782,6 +789,14 @@ class TmuxSession:
         # post-/compact). Per-turn token accumulation lives in
         # ``self.usage`` (a SessionUsage dataclass).
         self._restart_nudge_fired = False
+
+        # Soft context-watermark latch (#614). Distinct from
+        # ``_restart_nudge_fired`` (which gates the SSE-to-UI restart_nudge
+        # at the hard threshold): this gates the one-shot in-REPL nudge
+        # injected when usage first crosses the agent's *soft* threshold.
+        # Re-arms when usage drops back below the soft line (e.g. after a
+        # context_restart), so it can fire once per window.
+        self._soft_nudge_fired = False
 
         # Effort knob. tmux's claude REPL doesn't currently honor a
         # per-session effort override (CLAUDE_EFFORT env is set at
@@ -2397,6 +2412,25 @@ class TmuxSession:
         cap_pct = self._RESTART_TOKENS_CAP_1M / max_tokens * 100.0
         return min(pct_threshold, cap_pct)
 
+    def _soft_nudge_threshold_pct(self) -> float:
+        """Pull the agent's soft context-watermark from the registry (#614).
+
+        Returns the per-agent ``context_nudge_threshold_pct`` when set to a
+        positive value; otherwise falls back to the global
+        ``DEFAULT_CONTEXT_NUDGE_THRESHOLD_PCT`` (35%). A value of 0 means
+        "unset → use global default", matching AgentRegistry's column default.
+        """
+        if not self._registry:
+            return DEFAULT_CONTEXT_NUDGE_THRESHOLD_PCT
+        try:
+            agent = self._registry.get(self.agent_name)
+            raw = getattr(agent, "context_nudge_threshold_pct", 0.0) if agent else 0.0
+            if raw and float(raw) > 0:
+                return float(raw)
+        except Exception:
+            pass
+        return DEFAULT_CONTEXT_NUDGE_THRESHOLD_PCT
+
     def _record_turn_usage(self, response: TurnResponse) -> None:
         """Fold a turn's usage block into ``self.usage`` (SessionUsage).
 
@@ -2586,6 +2620,44 @@ class TmuxSession:
             # Re-arm the latch once context drops back below threshold
             # (e.g. /compact ran). Next crossing will fire a fresh nudge.
             self._restart_nudge_fired = False
+
+        # Soft context-watermark nudge (#614). Unlike the restart_nudge
+        # above (SSE-to-UI only), this injects a one-time reminder INTO the
+        # agent's REPL telling it to checkpoint + context_restart at a
+        # natural break. It sits strictly below the hard threshold: if usage
+        # is already at/above the hard line, that path owns the response and
+        # we don't double-act (issue #614 "hard wins"). Fires once per
+        # crossing; re-arms when usage drops back below the soft line.
+        #
+        # ``threshold`` here is the EFFECTIVE hard threshold
+        # (``_effective_restart_threshold_pct``, post-#618), not the raw 80%.
+        # That matters on 1M-context models where the hard line drops to
+        # ~41% (the 400k cap): the soft band must follow it down to
+        # [soft, ~41%) so the nudge never fires ABOVE the real restart point
+        # (which would invert the escalation — soft after hard). Gating on
+        # the effective threshold keeps "soft strictly below hard" true on
+        # both 200k and 1M windows. (Dymok #614/#618 integration.)
+        soft_threshold = self._soft_nudge_threshold_pct()
+        if 0 < soft_threshold < threshold:
+            if soft_threshold <= pct < threshold and not self._soft_nudge_fired:
+                self._soft_nudge_fired = True
+                await self._emit_stream_event(
+                    {
+                        "type": "context_nudge_soft",
+                        "agent_name": self.agent_name,
+                        "percentage": pct,
+                        "threshold_pct": soft_threshold,
+                        "total_tokens": info["totalTokens"],
+                        "max_tokens": info["maxTokens"],
+                    }
+                )
+                await self._enqueue_internal_prompt(
+                    build_context_nudge_prompt(pct, soft_threshold),
+                    reason="context_nudge_soft",
+                    wait_for_completion=False,
+                )
+            elif pct < soft_threshold and self._soft_nudge_fired:
+                self._soft_nudge_fired = False
 
     async def _enqueue_autorestart_nudge(
         self, *, total: int, max_tokens: int, pct: float

--- a/src/pinky_daemon/wake_prompt.py
+++ b/src/pinky_daemon/wake_prompt.py
@@ -61,9 +61,12 @@ def build_context_nudge_prompt(pct: float, threshold: float) -> str:
         f"[SYSTEM] Context usage is at {pct:.0f}% "
         f"(soft watermark {threshold:.0f}%).\n\n"
         "When you reach a natural break — between tasks, not mid-step — "
-        "save your context (use reflect() to persist key state) and call "
-        "context_restart to continue with a fresh window. No rush: finish "
-        "what you're doing first. This is a heads-up, not an interruption."
+        "call save_my_context with a concrete wake_action capturing what to "
+        "resume, then call context_restart to continue with a fresh window. "
+        "save_my_context is what lets the restart proceed (the restart guard "
+        "requires it); reflect() is optional — use it only for a durable "
+        "insight worth keeping long-term. No rush: finish what you're doing "
+        "first. This is a heads-up, not an interruption."
     )
 
 

--- a/src/pinky_daemon/wake_prompt.py
+++ b/src/pinky_daemon/wake_prompt.py
@@ -42,8 +42,29 @@ __all__ = [
     "build_wake_prompt",
     "wake_reason_from_runtime",
     "build_idle_sleep_prompt",
+    "build_context_nudge_prompt",
     "DEFAULT_TIMEZONE",
 ]
+
+
+def build_context_nudge_prompt(pct: float, threshold: float) -> str:
+    """Soft context-watermark nudge injected into the agent's stream (#614).
+
+    A one-time, in-REPL reminder fired the first time context usage
+    crosses the agent's soft threshold. Unlike the hard auto-restart,
+    this asks the agent to checkpoint and ``context_restart`` *at a
+    natural break* — between tasks, not mid-step — so work isn't cut
+    off. Delivered via the same internal-prompt path as wake / pre-sleep
+    prompts (``_enqueue_internal_prompt``).
+    """
+    return (
+        f"[SYSTEM] Context usage is at {pct:.0f}% "
+        f"(soft watermark {threshold:.0f}%).\n\n"
+        "When you reach a natural break — between tasks, not mid-step — "
+        "save your context (use reflect() to persist key state) and call "
+        "context_restart to continue with a fresh window. No rush: finish "
+        "what you're doing first. This is a heads-up, not an interruption."
+    )
 
 
 def build_idle_sleep_prompt() -> str:

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -4382,6 +4382,184 @@ async def test_restart_nudge_rearms_after_drop_below_threshold() -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# Soft context-watermark nudge (#614). Distinct from the restart_nudge
+# above: when usage first crosses the agent's *soft* threshold (well below
+# the hard restart_threshold_pct), inject a one-time reminder INTO the
+# agent's REPL telling it to checkpoint + context_restart at a natural
+# break. Fires once per crossing; never fires at/above the hard line.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _drain_queue(ss) -> list:
+    drained = []
+    while not ss._message_queue.empty():
+        drained.append(ss._message_queue.get_nowait())
+    return drained
+
+
+@pytest.mark.asyncio
+async def test_soft_nudge_fires_and_injects_when_crossing_soft_threshold() -> None:
+    """Crossing the soft threshold (but staying below the hard one) fires a
+    ``context_nudge_soft`` SSE event AND enqueues an internal prompt into the
+    REPL via the wake/internal-prompt path."""
+    events: list[dict] = []
+
+    async def stream_cb(evt):
+        events.append(evt)
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._restart_threshold_pct = lambda: 50.0
+    ss._soft_nudge_threshold_pct = lambda: 20.0
+
+    # Below soft: nothing. (5k / 167k ~ 3%.)
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_turn_response(input_tokens=5_000))
+    assert not [e for e in events if e["type"] == "context_nudge_soft"]
+    assert _drain_queue(ss) == []
+
+    # Cross soft, stay below hard. (50k / 167k ~ 30%.)
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_turn_response(input_tokens=50_000))
+
+    soft_events = [e for e in events if e["type"] == "context_nudge_soft"]
+    assert len(soft_events) == 1
+    assert soft_events[0]["threshold_pct"] == 20.0
+    assert soft_events[0]["percentage"] >= 20.0
+    assert ss._soft_nudge_fired is True
+    # The hard restart_nudge must NOT have fired (we're below 50%).
+    assert not [e for e in events if e["type"] == "restart_nudge"]
+
+    # Exactly one internal prompt was enqueued for the REPL.
+    queued = _drain_queue(ss)
+    assert len(queued) == 1
+    assert queued[0].internal is True
+    assert queued[0].reason == "context_nudge_soft"
+    assert "context_restart" in queued[0].prompt
+
+
+@pytest.mark.asyncio
+async def test_soft_nudge_does_not_fire_at_or_above_hard_threshold() -> None:
+    """If usage is already at/above the hard threshold, the hard path owns
+    the response — the soft nudge must not also fire or inject."""
+    events: list[dict] = []
+
+    async def stream_cb(evt):
+        events.append(evt)
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._restart_threshold_pct = lambda: 50.0
+    ss._soft_nudge_threshold_pct = lambda: 20.0
+
+    # Straight past both thresholds. (100k / 167k ~ 60%.)
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_turn_response(input_tokens=100_000))
+
+    assert [e for e in events if e["type"] == "restart_nudge"]
+    assert not [e for e in events if e["type"] == "context_nudge_soft"]
+    assert ss._soft_nudge_fired is False
+    # Post-#618: crossing the hard line ALSO enqueues the autorestart nudge
+    # (reason="context_autorestart_nudge"), so the queue is no longer empty
+    # here. The #614 invariant being pinned is narrower — "hard wins, soft
+    # does not also act" — so assert specifically that no SOFT nudge turn was
+    # injected, while tolerating the expected autorestart turn.
+    queued = _drain_queue(ss)
+    assert not [t for t in queued if t.reason == "context_nudge_soft"]
+
+
+@pytest.mark.asyncio
+async def test_soft_nudge_does_not_refire_while_above_soft() -> None:
+    """One signal per crossing — staying above the soft line on later turns
+    must not re-inject."""
+    events: list[dict] = []
+
+    async def stream_cb(evt):
+        events.append(evt)
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._restart_threshold_pct = lambda: 80.0
+    ss._soft_nudge_threshold_pct = lambda: 20.0
+
+    for tokens in (50_000, 60_000, 70_000):  # all in [20%, 80%)
+        _seed_inflight(ss)
+        await ss._handle_turn_complete(_turn_response(input_tokens=tokens))
+
+    assert len([e for e in events if e["type"] == "context_nudge_soft"]) == 1
+    assert len([t for t in _drain_queue(ss) if t.reason == "context_nudge_soft"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_soft_nudge_rearms_after_drop_below_soft() -> None:
+    """After a context_restart drops usage below the soft line, the latch
+    re-arms and the next crossing injects a fresh nudge."""
+    events: list[dict] = []
+
+    async def stream_cb(evt):
+        events.append(evt)
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._restart_threshold_pct = lambda: 80.0
+    ss._soft_nudge_threshold_pct = lambda: 20.0
+
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_turn_response(input_tokens=50_000))
+    assert ss._soft_nudge_fired is True
+
+    # Post-restart: usage drops below soft → re-arm.
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_turn_response(input_tokens=5_000))
+    assert ss._soft_nudge_fired is False
+
+    # Cross again → fresh injection.
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_turn_response(input_tokens=50_000))
+    assert len([e for e in events if e["type"] == "context_nudge_soft"]) == 2
+    assert len([t for t in _drain_queue(ss) if t.reason == "context_nudge_soft"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_soft_nudge_skipped_when_soft_not_below_hard() -> None:
+    """A misconfigured soft threshold that is not strictly below the hard one
+    is inert — the gate requires ``soft < hard``."""
+    events: list[dict] = []
+
+    async def stream_cb(evt):
+        events.append(evt)
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._restart_threshold_pct = lambda: 50.0
+    ss._soft_nudge_threshold_pct = lambda: 50.0  # == hard, not below
+
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_turn_response(input_tokens=60_000))  # ~36%
+    assert not [e for e in events if e["type"] == "context_nudge_soft"]
+    assert _drain_queue(ss) == []
+
+
+def test_soft_nudge_threshold_resolves_global_default_when_unset() -> None:
+    """The resolver returns the per-agent value when positive, else the
+    global ``DEFAULT_CONTEXT_NUDGE_THRESHOLD_PCT``."""
+    ss, _ = _make_session_with_response_cb()
+
+    # No registry → global default.
+    ss._registry = None
+    assert ss._soft_nudge_threshold_pct() == tmux_session.DEFAULT_CONTEXT_NUDGE_THRESHOLD_PCT
+
+    # Registry agent with 0 (unset) → global default.
+    ss._registry = MagicMock()
+    ss._registry.get.return_value = MagicMock(context_nudge_threshold_pct=0.0)
+    assert ss._soft_nudge_threshold_pct() == tmux_session.DEFAULT_CONTEXT_NUDGE_THRESHOLD_PCT
+
+    # Registry agent with a positive override → that value.
+    ss._registry.get.return_value = MagicMock(context_nudge_threshold_pct=42.0)
+    assert ss._soft_nudge_threshold_pct() == 42.0
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # Wake-prompt / internal-prompt path (PR for #543)
 # ──────────────────────────────────────────────────────────────────────────
 

--- a/tests/test_wake_prompt.py
+++ b/tests/test_wake_prompt.py
@@ -229,6 +229,18 @@ class TestContextNudgePrompt:
         assert "context_restart" in out
         assert "natural break" in out
 
+    def test_instructs_save_my_context_not_reflect_for_restart(self) -> None:
+        """The restart guard requires ``save_my_context`` (with a wake_action),
+        NOT ``reflect`` — reflect() is long-term semantic memory and does not
+        satisfy the guard. An agent following the nudge literally must call
+        save_my_context, else context_restart is blocked with no saved state.
+        Pin the wording so the reflect()-only regression can't return."""
+        out = build_context_nudge_prompt(36.4, 35.0)
+        # The save instruction that actually unblocks the restart.
+        assert "save_my_context" in out
+        # It must precede the restart call in the prose ordering.
+        assert out.index("save_my_context") < out.index("context_restart")
+
     def test_rounds_percentages_to_whole_numbers(self) -> None:
         out = build_context_nudge_prompt(50.0, 20.0)
         assert "50%" in out and "20%" in out

--- a/tests/test_wake_prompt.py
+++ b/tests/test_wake_prompt.py
@@ -17,6 +17,7 @@ from pinky_daemon.wake_prompt import (
     DEFAULT_TIMEZONE,
     WakePromptInput,
     WakeReason,
+    build_context_nudge_prompt,
     build_wake_prompt,
 )
 
@@ -214,3 +215,21 @@ class TestContractRegression:
         idx_saved_close = out.index("──────────────────")
         idx_lead = out.index("Fresh context — pick up from saved state")
         assert idx_header < idx_saved_open < idx_body < idx_saved_close < idx_lead
+
+
+class TestContextNudgePrompt:
+    """The soft context-watermark nudge (#614) is a system-reminder asking
+    the agent to checkpoint + context_restart at a natural break."""
+
+    def test_carries_pct_threshold_and_restart_instruction(self) -> None:
+        out = build_context_nudge_prompt(36.4, 35.0)
+        assert out.startswith("[SYSTEM]")
+        assert "36%" in out  # rounded, no decimals
+        assert "35%" in out
+        assert "context_restart" in out
+        assert "natural break" in out
+
+    def test_rounds_percentages_to_whole_numbers(self) -> None:
+        out = build_context_nudge_prompt(50.0, 20.0)
+        assert "50%" in out and "20%" in out
+        assert "50.0%" not in out


### PR DESCRIPTION
Closes #614.

## What

A **soft**, earlier sibling of the hard context auto-restart (#618). When a tmux agent's context usage first crosses a per-agent **soft watermark** (default 35%), it gets a one-time `[SYSTEM]` nudge injected into its own REPL: *"at a natural break, save your context and `context_restart`."* It's a gentle heads-up to checkpoint at a clean seam — not the hard safety net.

Two-tier model, both on the production tmux path:
- **Soft (this PR, #614):** fires once in the band `[soft, hard)`, cooperative, "no rush, finish what you're doing."
- **Hard (#618, already on main):** fires at the effective restart threshold, drives an immediate save + restart.

## Design

- **Per-agent threshold, UI-editable + persisted.** New `context_nudge_threshold_pct` column on the agent (DB migration via the `_migrate`/`_ensure_columns` pattern), `0.0` = use the global default (`DEFAULT_CONTEXT_NUDGE_THRESHOLD_PCT = 35.0`). Wired end-to-end: dataclass → registry register/read → API `UpdateAgentRequest` → Svelte settings control in Chat.svelte.
- **One-shot latch with re-arm.** Separate `_soft_nudge_fired` latch (distinct from the hard `_restart_nudge_fired`). Fires exactly once per crossing; re-arms when usage drops back below the soft line (e.g. after a restart). Naturally re-arms post-`context_restart` since fresh-context pct < soft.
- **Hard always wins.** The soft block gates on `0 < soft_threshold < threshold` and only fires in `[soft, hard)`. At/above the hard line the restart path owns the response and the soft nudge stays silent.

## #618 integration (the important bit)

This is rebased on top of #618. Both touch `_emit_context_usage_event`. The key interaction: #618 made `threshold` bind to `_effective_restart_threshold_pct()`, which on **1M-context models** drops the hard fire point to ~41% (the 400k-token cap). Because the soft band gates on that same `threshold`, it **automatically tracks the hard line down** to `[soft, ~41%)` on 1M windows — the nudge can never fire *above* the real restart point (which would invert the escalation). No special-casing needed; documented inline at the soft block.

## Testing

- 6 soft-nudge tests in `test_tmux_session.py` (fire-on-cross + inject, no-fire at/above hard, no-refire while above, re-arm after drop, inert when `soft >= hard`, resolver default).
- `test_soft_nudge_does_not_fire_at_or_above_hard_threshold` asserts the narrow invariant ("hard wins → soft doesn't *also* fire") while tolerating #618's expected autorestart-nudge turn.
- Builder tests in `test_wake_prompt.py` for `build_context_nudge_prompt`.
- Targeted suites green (tmux_session / tmux_context_autorestart / wake_prompt / agent_registry), ruff clean. CI runs the full suite.

🤖 Opened by Dymok