### PR TITLE
feat(#145): cross-agent memory tools (reflect_for / kg_add_for) for the Dreamer

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7967,9 +7967,28 @@ npm run build</pre>
                 Path(db_path).parent.mkdir(parents=True, exist_ok=True)
                 return db_path
 
+            def _is_cross_agent_memory_authorized(caller_name: str) -> bool:
+                """May ``caller_name`` write into other agents' memory? (#145)
+
+                Authorized iff the caller is a registered agent holding the
+                ``dreamer`` role (or in a ``dreamer`` group) — the Dreamer that
+                consolidates each agent's history into that agent's own memory.
+                Default-deny: unknown agents and any lookup failure → False.
+                """
+                try:
+                    agent = agents.get(caller_name)
+                    if not agent:
+                        return False
+                    if getattr(agent, "role", "") == "dreamer":
+                        return True
+                    return "dreamer" in (getattr(agent, "groups", None) or [])
+                except Exception:
+                    return False
+
             shared_mcp_manager = SharedMcpManager(
                 api_url="http://localhost:8888",
                 memory_db_resolver=_resolve_memory_db,
+                cross_agent_authorizer=_is_cross_agent_memory_authorized,
             )
             await shared_mcp_manager.start()
             _log(f"startup: shared MCP server started on {shared_mcp_manager.url}")

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -307,11 +307,13 @@ class SharedMcpManager:
         port: int = SHARED_MCP_PORT,
         api_url: str = "http://localhost:8888",
         memory_db_resolver: "Callable[[str], str] | None" = None,
+        cross_agent_authorizer: "Callable[[str], bool] | None" = None,
     ):
         self._host = host
         self._port = port
         self._api_url = api_url
         self._memory_db_resolver = memory_db_resolver
+        self._cross_agent_authorizer = cross_agent_authorizer
         self._memory_pool: MemoryStorePool | None = None
         self._server = None  # uvicorn.Server instance
         self._thread: threading.Thread | None = None
@@ -370,6 +372,7 @@ class SharedMcpManager:
             memory_mcp = create_memory_server(
                 store_factory=self._memory_pool.get_store,
                 embedder=embedder,
+                cross_agent_authorizer=self._cross_agent_authorizer,
             )
             mcp_servers["memory"] = memory_mcp
             _log("[shared-mcp] pinky-memory included (per-agent store pool)")

--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -177,6 +177,11 @@ def create_server(
         )
         ref = s.insert(ref)
         if input_data.supersedes:
+            # Supersession deactivates the prior reflection in ``s``. On the
+            # cross-agent path this is a write *into the target store*, so a
+            # consolidating dreamer can deactivate a stale reflection it is
+            # replacing — intended for consolidation, but it means these tools
+            # are not strictly insert-only.
             s.deactivate_superseded(input_data.supersedes, superseded_by=ref.id)
         return {
             "id": ref.id,
@@ -226,9 +231,14 @@ def create_server(
     # ── Cross-agent memory (dreamer-only, #145) ──────────────────────────
     # Registered ONLY when a cross_agent_authorizer is wired (shared mode).
     # These let the Dreamer consolidate each agent's history into that
-    # agent's own memory namespace. The authorizer is the real security
-    # boundary (caller must hold the dreamer role); the slug + registry
-    # checks are defense in depth.
+    # agent's own memory namespace. The authorizer gates MCP-client-mediated
+    # calls: caller identity is the X-Agent-Name header, so the role check
+    # holds only while that header is trustworthy. It is NOT a defense against
+    # a shell-capable agent spoofing the header on the tokenless local SSE
+    # endpoint — but that path is pre-existing (plain reflect/recall resolve
+    # the store from the same caller context), so these tools don't widen it.
+    # Real transport auth for the shared MCP is tracked in #623. The slug +
+    # registry checks are defense in depth.
     if cross_agent_authorizer is not None:
 
         @mcp.tool()

--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -28,6 +29,13 @@ if TYPE_CHECKING:
 def _log(msg: str) -> None:
     """Log to stderr (stdout is MCP protocol)."""
     print(msg, file=sys.stderr, flush=True)
+
+
+# Strict agent-name slug for cross-agent memory targets (#614/#145). Mirrors
+# the trust-boundary slug discipline tracked in #105 — defends the
+# store-factory path resolution against traversal / injection even though the
+# resolver also validates against the registry (defense in depth).
+_AGENT_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
 
 def _safe_embed(
@@ -90,6 +98,7 @@ def create_server(
     embedder: EmbeddingClient | NoOpEmbeddingClient | None = None,
     *,
     store_factory: Callable[[str], ReflectionStore] | None = None,
+    cross_agent_authorizer: Callable[[str], bool] | None = None,
     host: str = "127.0.0.1",
     port: int = 8000,
 ) -> FastMCP:
@@ -99,20 +108,83 @@ def create_server(
     - **stdio** (per-agent): pass ``store`` and ``embedder`` directly.
     - **shared SSE**: pass ``store_factory`` (agent_name -> store) and ``embedder``.
       Each tool call resolves the agent from ContextVar and gets the right store.
+
+    ``cross_agent_authorizer`` (shared mode only): a predicate
+    ``(caller_agent_name) -> bool`` answering "may this caller write into
+    *other* agents' memory?". When provided, the privileged ``reflect_for`` /
+    ``kg_add_for`` tools are registered — these let an authorized agent (the
+    Dreamer, role=dreamer) consolidate each agent's history into *that agent's*
+    memory namespace (#145). When ``None`` (or in stdio mode) the cross-agent
+    tools are NOT registered at all — the capability simply doesn't exist.
     """
     if store is None and store_factory is None:
         raise ValueError("Either store or store_factory must be provided")
+
+    def _current_caller() -> str:
+        """Resolve the calling agent from the shared-mode ContextVar."""
+        from pinky_daemon.shared_mcp import get_current_agent
+        agent = get_current_agent()
+        if not agent:
+            raise ValueError("No agent identified in shared mode — missing X-Agent-Name header?")
+        return agent
 
     def _get_store() -> "ReflectionStore":
         """Resolve the correct store for the current request."""
         if store is not None:
             return store
         # Shared mode: resolve agent from ContextVar
-        from pinky_daemon.shared_mcp import get_current_agent
-        agent = get_current_agent()
-        if not agent:
-            raise ValueError("No agent identified in shared mode — missing X-Agent-Name header?")
-        return store_factory(agent)  # type: ignore[misc]
+        return store_factory(_current_caller())  # type: ignore[misc]
+
+    def _resolve_target_store(target_agent: str) -> "ReflectionStore":
+        """Resolve + validate another agent's store for a cross-agent write.
+
+        Two guards: a strict slug (defends path resolution) and the
+        store_factory's own registry check (raises ValueError for unknown
+        agents). Cross-agent writes require shared mode.
+        """
+        if store_factory is None:
+            raise ValueError("cross-agent memory writes require shared mode")
+        if not isinstance(target_agent, str) or not _AGENT_SLUG_RE.match(target_agent):
+            raise ValueError(f"invalid target agent name: {target_agent!r}")
+        return store_factory(target_agent)
+
+    def _authorize_cross_agent(caller: str) -> None:
+        """Raise PermissionError unless the caller may write to other agents."""
+        if cross_agent_authorizer is None or not cross_agent_authorizer(caller):
+            raise PermissionError(
+                f"agent '{caller}' is not authorized for cross-agent memory writes"
+            )
+
+    def _embed_build_insert(s: "ReflectionStore", input_data: "ReflectInput") -> dict:
+        """Embed + build + insert a Reflection into ``s``; handle supersession.
+
+        Shared by ``reflect`` (own store) and ``reflect_for`` (target store)
+        so the storage path is identical regardless of destination.
+        """
+        embedding = _safe_embed(embedder, input_data.content, "reflect")
+        ref = Reflection(
+            type=input_data.type,
+            content=input_data.content,
+            context=input_data.context,
+            project=input_data.project,
+            salience=input_data.salience,
+            supersedes=input_data.supersedes,
+            entities=input_data.entities,
+            source_session_id=input_data.source_session_id,
+            source_channel=input_data.source_channel,
+            source_message_ids=input_data.source_message_ids,
+            embedding=embedding,
+        )
+        ref = s.insert(ref)
+        if input_data.supersedes:
+            s.deactivate_superseded(input_data.supersedes, superseded_by=ref.id)
+        return {
+            "id": ref.id,
+            "type": ref.type.value,
+            "salience": ref.salience,
+            "stored": True,
+            "embedded": bool(embedding),
+        }
 
     mcp = FastMCP("pinky-memory", host=host, port=port)
 
@@ -147,41 +219,98 @@ def create_server(
             source_message_ids=source_message_ids or [],
         )
 
-        # Generate embedding (tolerant: empty / raised embeddings downgrade
-        # to keyword-only search rather than aborting storage).
-        embedding = _safe_embed(embedder, input_data.content, "reflect")
+        result = _embed_build_insert(_get_store(), input_data)
+        _log(f"reflect: stored {result['id']} type={result['type']}")
+        return json.dumps(result)
 
-        # Build reflection
-        ref = Reflection(
-            type=input_data.type,
-            content=input_data.content,
-            context=input_data.context,
-            project=input_data.project,
-            salience=input_data.salience,
-            supersedes=input_data.supersedes,
-            entities=input_data.entities,
-            source_session_id=input_data.source_session_id,
-            source_channel=input_data.source_channel,
-            source_message_ids=input_data.source_message_ids,
-            embedding=embedding,
-        )
+    # ── Cross-agent memory (dreamer-only, #145) ──────────────────────────
+    # Registered ONLY when a cross_agent_authorizer is wired (shared mode).
+    # These let the Dreamer consolidate each agent's history into that
+    # agent's own memory namespace. The authorizer is the real security
+    # boundary (caller must hold the dreamer role); the slug + registry
+    # checks are defense in depth.
+    if cross_agent_authorizer is not None:
 
-        # Insert
-        s = _get_store()
-        ref = s.insert(ref)
+        @mcp.tool()
+        def reflect_for(
+            target_agent: str,
+            content: str,
+            type: str = "fact",
+            context: str = "",
+            project: str = "",
+            salience: int = 3,
+            supersedes: str = "",
+            entities: list[str] | None = None,
+            source_session_id: str | None = None,
+            source_channel: str | None = None,
+            source_message_ids: list[str] | None = None,
+        ) -> str:
+            """Store a memory into ANOTHER agent's long-term memory (dreamer-only).
 
-        # Handle supersession (after insert so we have ref.id)
-        if input_data.supersedes:
-            s.deactivate_superseded(input_data.supersedes, superseded_by=ref.id)
-        _log(f"reflect: stored {ref.id} type={ref.type.value}")
+            For the Dreamer to consolidate an agent's recent history into that
+            agent's own memory. ``target_agent`` must be a registered agent and
+            the caller must hold the dreamer role; otherwise this errors. Every
+            write is audited. Same fields as ``reflect``, plus ``target_agent``.
+            """
+            caller = _current_caller()
+            _authorize_cross_agent(caller)
+            s = _resolve_target_store(target_agent)
+            input_data = ReflectInput(
+                content=content,
+                type=ReflectionType(type),
+                context=context,
+                project=project,
+                salience=salience,
+                supersedes=supersedes,
+                entities=[e.lower() for e in entities] if entities else [],
+                source_session_id=source_session_id,
+                source_channel=source_channel,
+                source_message_ids=source_message_ids or [],
+            )
+            result = _embed_build_insert(s, input_data)
+            # Audit: who wrote what into whom.
+            _log(
+                f"reflect_for: caller={caller} -> target={target_agent} "
+                f"stored {result['id']} type={result['type']}"
+            )
+            result["target_agent"] = target_agent
+            result["written_by"] = caller
+            return json.dumps(result)
 
-        return json.dumps({
-            "id": ref.id,
-            "type": ref.type.value,
-            "salience": ref.salience,
-            "stored": True,
-            "embedded": bool(embedding),
-        })
+        @mcp.tool()
+        def kg_add_for(
+            target_agent: str,
+            subject: str,
+            predicate: str,
+            object: str,
+            valid_from: str = "",
+            subject_type: str = "unknown",
+            object_type: str = "unknown",
+            confidence: float = 1.0,
+            source_reflection_id: str = "",
+        ) -> str:
+            """Add a knowledge-graph fact to ANOTHER agent's memory (dreamer-only).
+
+            Cross-agent counterpart to ``kg_add`` for Dreamer consolidation.
+            ``target_agent`` must be a registered agent and the caller must hold
+            the dreamer role. Audited.
+            """
+            caller = _current_caller()
+            _authorize_cross_agent(caller)
+            s = _resolve_target_store(target_agent)
+            result = s.kg_add(
+                subject=subject, predicate=predicate, obj=object,
+                valid_from=valid_from, subject_type=subject_type,
+                object_type=object_type, confidence=confidence,
+                source_reflection_id=source_reflection_id,
+            )
+            _log(
+                f"kg_add_for: caller={caller} -> target={target_agent} "
+                f"({subject}) --[{predicate}]--> ({object})"
+            )
+            if isinstance(result, dict):
+                result = {**result, "target_agent": target_agent, "written_by": caller}
+            return json.dumps(result)
 
     @mcp.tool()
     def recall(

--- a/tests/test_memory_cross_agent.py
+++ b/tests/test_memory_cross_agent.py
@@ -1,0 +1,162 @@
+"""Tests for cross-agent memory writes (reflect_for / kg_add_for) — #145.
+
+These privileged tools let the Dreamer (role=dreamer) consolidate each
+agent's history into THAT agent's own memory namespace. Security model:
+- registered ONLY when a cross_agent_authorizer is wired (shared mode);
+- the authorizer (caller must be authorized) is the real boundary;
+- target must be a strict slug AND a known agent (store_factory raises).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from pinky_memory.embeddings import NoOpEmbeddingClient
+from pinky_memory.server import create_server
+from pinky_memory.store import ReflectionStore
+
+_KNOWN_AGENTS = {"dreamer", "barsik", "pushok"}
+
+
+def _tools(srv) -> dict:
+    return {t.name: t.fn for t in srv._tool_manager.list_tools()}
+
+
+@pytest.fixture
+def shared(tmp_path):
+    """Shared-mode server: per-agent store factory + dreamer-only authorizer."""
+    stores: dict[str, ReflectionStore] = {}
+
+    def factory(name: str) -> ReflectionStore:
+        # Mirror _resolve_memory_db: unknown agents raise ValueError.
+        if name not in _KNOWN_AGENTS:
+            raise ValueError(f"Unknown agent: {name}")
+        if name not in stores:
+            stores[name] = ReflectionStore(db_path=str(tmp_path / f"{name}.db"))
+        return stores[name]
+
+    def authorizer(caller: str) -> bool:
+        return caller == "dreamer"
+
+    srv = create_server(
+        store_factory=factory,
+        embedder=NoOpEmbeddingClient(),
+        cross_agent_authorizer=authorizer,
+    )
+    yield srv, stores
+    for s in stores.values():
+        s.close()
+
+
+def _count(store: ReflectionStore) -> int:
+    return len(
+        store.search_by_keyword(
+            query="", limit=100, active_only=True,
+            type_filter=None, project_filter="", min_weight=0.0, entity_filter="",
+        )
+    )
+
+
+# ── Registration gating ──────────────────────────────────────────────────────
+
+
+def test_cross_agent_tools_absent_without_authorizer(tmp_path):
+    """No authorizer → the capability simply doesn't exist."""
+    store = ReflectionStore(db_path=str(tmp_path / "m.db"))
+    try:
+        srv = create_server(store, NoOpEmbeddingClient())
+        names = set(_tools(srv))
+        assert "reflect_for" not in names
+        assert "kg_add_for" not in names
+    finally:
+        store.close()
+
+
+def test_cross_agent_tools_present_with_authorizer(shared):
+    srv, _ = shared
+    names = set(_tools(srv))
+    assert "reflect_for" in names
+    assert "kg_add_for" in names
+
+
+# ── reflect_for ───────────────────────────────────────────────────────────────
+
+
+def test_reflect_for_writes_into_target_not_caller(shared):
+    srv, stores = shared
+    reflect_for = _tools(srv)["reflect_for"]
+
+    with patch("pinky_daemon.shared_mcp.get_current_agent", return_value="dreamer"):
+        out = json.loads(reflect_for(target_agent="barsik", content="Barsik prefers X"))
+
+    assert out["stored"] is True
+    assert out["target_agent"] == "barsik"
+    assert out["written_by"] == "dreamer"
+    # Landed in barsik's store, NOT the dreamer's.
+    assert _count(stores["barsik"]) == 1
+    assert "dreamer" not in stores or _count(stores["dreamer"]) == 0
+
+
+def test_reflect_for_rejects_unauthorized_caller(shared):
+    srv, stores = shared
+    reflect_for = _tools(srv)["reflect_for"]
+
+    with patch("pinky_daemon.shared_mcp.get_current_agent", return_value="pushok"):
+        with pytest.raises(PermissionError):
+            reflect_for(target_agent="barsik", content="should not land")
+
+    # Authorization is checked BEFORE the target store is resolved, so the
+    # rejected write never even opened barsik's store (lazy factory).
+    assert "barsik" not in stores
+
+
+def test_reflect_for_rejects_invalid_target_slug(shared):
+    srv, _ = shared
+    reflect_for = _tools(srv)["reflect_for"]
+
+    with patch("pinky_daemon.shared_mcp.get_current_agent", return_value="dreamer"):
+        for bad in ("../evil", "Barsik", "a/b", "x" * 65, ""):
+            with pytest.raises(ValueError):
+                reflect_for(target_agent=bad, content="x")
+
+
+def test_reflect_for_rejects_unknown_agent(shared):
+    srv, _ = shared
+    reflect_for = _tools(srv)["reflect_for"]
+
+    with patch("pinky_daemon.shared_mcp.get_current_agent", return_value="dreamer"):
+        with pytest.raises(ValueError):
+            reflect_for(target_agent="ghost", content="x")  # valid slug, not registered
+
+
+# ── kg_add_for ──────────────────────────────────────────────────────────────────
+
+
+def test_kg_add_for_authorized_writes_to_target(shared):
+    srv, stores = shared
+    kg_add_for = _tools(srv)["kg_add_for"]
+
+    with patch("pinky_daemon.shared_mcp.get_current_agent", return_value="dreamer"):
+        out = json.loads(
+            kg_add_for(
+                target_agent="barsik",
+                subject="Barsik", predicate="uses", object="SQLite",
+            )
+        )
+    assert out.get("target_agent") == "barsik"
+    assert out.get("written_by") == "dreamer"
+
+
+def test_kg_add_for_rejects_unauthorized_caller(shared):
+    srv, _ = shared
+    kg_add_for = _tools(srv)["kg_add_for"]
+
+    with patch("pinky_daemon.shared_mcp.get_current_agent", return_value="barsik"):
+        with pytest.raises(PermissionError):
+            kg_add_for(
+                target_agent="pushok",
+                subject="x", predicate="y", object="z",
+            )


### PR DESCRIPTION
## What & why

First gating piece of the **Dreamer-as-agent** build (#145, [design doc](docs/plans/task-145-dreamer-agent.md)). The Dreamer is a first-class agent whose job is to consolidate each agent's recent history into **that agent's own memory**. That requires the one net-new capability everything else hangs on: an authorized agent writing into *another* agent's memory namespace. This PR adds exactly that — `reflect_for` and `kg_add_for` — and nothing else.

## Security model (this is a trust-boundary expansion — please review as such)

- **Registered only when wired.** The tools exist only when a `cross_agent_authorizer` is passed to `create_server` (shared SSE mode). In stdio / no-authorizer mode they're not registered at all.
- **Authorizer gates MCP-client-mediated calls.** `_is_cross_agent_memory_authorized` (api.py) returns True only for a registered agent with `role == "dreamer"` (or in a `dreamer` group). **Default-deny** on unknown agent or any lookup exception. It's checked **before** the target store is resolved — a rejected write never even opens the target DB (test asserts this). Caveat: caller identity is the `X-Agent-Name` header, so this gate holds against MCP-client calls but **not** against a shell-capable agent spoofing the header on the tokenless local SSE endpoint. That spoof path is **pre-existing** (plain `reflect`/`recall` already resolve the store from the same caller context) — these tools don't widen it. Real transport auth for the shared MCP is tracked in #623.
- **Defense-in-depth on the target.** Strict slug `_AGENT_SLUG_RE` (mirrors the #105 trust-boundary slug discipline) + the store_factory's existing registry validation (raises `ValueError` for unknown agents; the DB path is derived from the *registered* `working_dir`, so no traversal).
- **No standalone delete/invalidate.** The only deactivation path is supersession: passing `supersedes` deactivates the reflection being replaced in the target store (intended for consolidation). So these tools are insert + supersede, not strictly insert-only.
- **Audited.** Every cross-agent write logs `caller -> target`.

## Wiring
`create_server` gains `cross_agent_authorizer`; `SharedMcpManager` passes it through; `api.py` defines the dreamer predicate. `reflect`'s embed+insert path is extracted into `_embed_build_insert` so own-store and cross-agent writes are byte-identical in behavior.

## Tests
`tests/test_memory_cross_agent.py` (8): registration gating (absent w/o authorizer), authorized write lands in **target** store not caller's, unauthorized rejected before store resolution, invalid-slug + unknown-agent rejected, `kg_add_for` auth. Existing memory + shared_mcp suites green (95).

## Explicitly out of scope (follow-ups)
- **#623** — transport auth for the shared MCP (per-agent session-bound bearer token). The actual fix for the X-Agent-Name spoof surface; hardens these tools AND pre-existing store routing.
- `SKILL_TO_GATES` list-filtering to *hide* these from non-dreamers (the authorizer already blocks them — this is just tool-list hygiene).
- The Dreamer agent registration, nightly schedule, and `dream_runner.py` shrink — subsequent PRs per the design doc.

## Reviewer
@pushok — flagging you given the trust-boundary nature (you caught the user-modeling trust issue before). Want eyes on the authorizer + default-deny semantics specifically. Not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)