### PR TITLE
harden(#145): cross-agent memory authorizer is role-only (drop group-OR)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -168,6 +168,22 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+def _agent_is_dreamer(agent) -> bool:
+    """True iff ``agent`` holds the privileged ``dreamer`` role (#145).
+
+    Role-only by design: the Dreamer (Mora) is a single privileged identity,
+    not a class. Group membership does NOT grant cross-agent memory access —
+    treating "any agent in a group named 'dreamer'" as authorized would let a
+    group assignment silently confer read-all + write-all over every agent's
+    memory. (Both #624 reviewers flagged the looser predicate.) See the TRUST
+    STATEMENT in ``pinky_memory.server`` for why that reach is concentrated.
+    Default-deny: ``None`` (unknown/unregistered agent) → False.
+    """
+    if agent is None:
+        return False
+    return getattr(agent, "role", "") == "dreamer"
+
+
 # Cold-start connect umbrella (#110). `_start_streaming_session` registers a
 # session in `broker._streaming` only AFTER `ss.connect()` returns, and the
 # SessionWatchdog samples only `broker._streaming` — so a cold start that
@@ -7968,20 +7984,16 @@ npm run build</pre>
                 return db_path
 
             def _is_cross_agent_memory_authorized(caller_name: str) -> bool:
-                """May ``caller_name`` write into other agents' memory? (#145)
+                """May ``caller_name`` access other agents' memory? (#145)
 
                 Authorized iff the caller is a registered agent holding the
-                ``dreamer`` role (or in a ``dreamer`` group) — the Dreamer that
-                consolidates each agent's history into that agent's own memory.
-                Default-deny: unknown agents and any lookup failure → False.
+                ``dreamer`` role — the Dreamer (Mora) that consolidates each
+                agent's history into that agent's own memory. Role-only (see
+                ``_agent_is_dreamer``). Default-deny: unknown agents and any
+                lookup failure → False.
                 """
                 try:
-                    agent = agents.get(caller_name)
-                    if not agent:
-                        return False
-                    if getattr(agent, "role", "") == "dreamer":
-                        return True
-                    return "dreamer" in (getattr(agent, "groups", None) or [])
+                    return _agent_is_dreamer(agents.get(caller_name))
                 except Exception:
                     return False
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5193,3 +5193,39 @@ class TestBuildStreamingWakeContextReasonGating:
                 "dymok", WakeReason.RESUME
             )
             assert "Grep daemon log for verdict_wedged_inputs" in out_retry
+
+
+# ── Cross-agent memory authorizer (#145) ─────────────────────
+
+
+class TestAgentIsDreamer:
+    """The cross-agent memory boundary is role-only — a single privileged
+    identity, not a class. Group membership must NOT confer it (#624 review)."""
+
+    def test_role_dreamer_authorized(self):
+        from pinky_daemon.api import _agent_is_dreamer
+
+        assert _agent_is_dreamer(SimpleNamespace(role="dreamer", groups=[])) is True
+
+    def test_other_roles_denied(self):
+        from pinky_daemon.api import _agent_is_dreamer
+
+        for role in ("", "sidekick", "lead", "worker", "specialist", "Dreamer"):
+            assert _agent_is_dreamer(SimpleNamespace(role=role, groups=[])) is False
+
+    def test_group_membership_does_not_authorize(self):
+        from pinky_daemon.api import _agent_is_dreamer
+
+        # The tightening: being in a "dreamer" group is NOT enough.
+        agent = SimpleNamespace(role="worker", groups=["dreamer", "ops"])
+        assert _agent_is_dreamer(agent) is False
+
+    def test_none_agent_default_deny(self):
+        from pinky_daemon.api import _agent_is_dreamer
+
+        assert _agent_is_dreamer(None) is False
+
+    def test_missing_role_attr_default_deny(self):
+        from pinky_daemon.api import _agent_is_dreamer
+
+        assert _agent_is_dreamer(SimpleNamespace(groups=["dreamer"])) is False


### PR DESCRIPTION
## What & why

Both #624 reviewers (@pushok, @murzik) independently flagged the same thing: the cross-agent memory authorizer treated **`role == "dreamer"` OR membership in a `dreamer` group** as authorized — i.e. read-all + write-all over every agent's memory.

The intended boundary is a **single Dreamer identity (Mora), not a class**. A group assignment silently conferring the most privileged capability in the fleet is an accidental escalation vector (groups are used for unrelated purposes). This tightens it to **role-only**.

## Change

- Extract the predicate to a module-level, testable **`_agent_is_dreamer(agent)`** — role-only, default-deny on `None`. Drops the group-membership path.
- `_is_cross_agent_memory_authorized` now delegates to it (still default-deny on unknown agent / lookup exception).
- The helper's docstring points at the TRUST STATEMENT in `pinky_memory.server` so the "why role-only" reasoning sits next to both the gate and the capability.

## Tests
`TestAgentIsDreamer` (5): `role=dreamer` authorized; other roles + case-mismatch (`Dreamer`) denied; **group membership does NOT authorize** (the tightening); `None` and missing-`role` default-deny.

## Safety
Pure tightening — it strictly **narrows** who is authorized. `role=dreamer` behavior is unchanged; nothing that was denied becomes allowed. Pairs with the schedule-enable gate on #623 (Mora's nightly cron stays disabled until the session-bound token lands).

## Reviewers
@pushok @murzik — this is the tightening you both called for on #624. Small + pure; confirm the role-only boundary matches "one Dreamer identity, not a class."

🤖 Generated with [Claude Code](https://claude.com/claude-code)