### PR TITLE
feat(#145): agent-facing register_agent tool (admin-gated)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -456,6 +456,7 @@ GATE_TOOL_NAMES: dict[str, list[str]] = {
     ],
     "admin": [
         "check_for_updates", "update_and_restart", "restart_daemon",
+        "register_agent",
     ],
     "triggers": [
         "create_trigger", "list_triggers", "delete_trigger", "test_trigger",

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -2079,6 +2079,22 @@ def create_server(
                     f"grants cross-agent memory read+write over the entire fleet "
                     f"— pass confirm_privileged_role=True to proceed deliberately."
                 )
+            # Create-only guard. POST /agents is an UPSERT — register() merges
+            # the provided fields and UPDATEs when the name already exists. Since
+            # this tool always sends soul/model/role/groups/transport, calling it
+            # with an existing name would silently overwrite that agent (blank its
+            # soul, reset role, empty groups) and still return 200. Refuse on
+            # collision instead; existing agents are modified via the dashboard /
+            # update path, which keeps the upsert semantics intact there.
+            existing = _api("GET", f"/agents/{name}")
+            if isinstance(existing, dict) and "error" not in existing:
+                return (
+                    f"Refusing to register '{name}': an agent with that name "
+                    f"already exists. register_agent is create-only — to change "
+                    f"an existing agent, use the dashboard or update path (POST "
+                    f"/agents is an upsert and would overwrite its soul, model, "
+                    f"role, and groups)."
+                )
             caller = str(agent_name)
             create = _api("POST", "/agents", {
                 "name": name,

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -2047,6 +2047,78 @@ def create_server(
                 return f"Restart failed: {result['error']}"
             return f"Daemon is restarting (was at {result.get('git_hash', '?')}). Your session will resume automatically."
 
+        @mcp.tool()
+        def register_agent(
+            name: str,
+            display_name: str = "",
+            model: str = "opus",
+            role: str = "",
+            soul: str = "",
+            skills: list[str] | None = None,
+            groups: list[str] | None = None,
+            transport: str = "tmux",
+            confirm_privileged_role: bool = False,
+        ) -> str:
+            """Register a new agent in the fleet, then assign its skills.
+
+            Admin-tier capability (same trust level as update_and_restart).
+            Creates the agent record, then assigns each skill in `skills` —
+            skills determine the agent's tools; omit/empty = core tools only.
+
+            role: free-form (sidekick/lead/worker/dreamer/...). The "dreamer"
+            role grants cross-agent memory: read-all AND write-all over EVERY
+            agent's memory. Creating a privileged role requires
+            confirm_privileged_role=True — a deliberate, audited act.
+            transport: "tmux" (modern rails) or "sdk".
+            """
+            privileged_roles = {"dreamer"}
+            if role in privileged_roles and not confirm_privileged_role:
+                return (
+                    f"Refusing to create agent '{name}' with privileged role "
+                    f"'{role}' without confirm_privileged_role=True. This role "
+                    f"grants cross-agent memory read+write over the entire fleet "
+                    f"— pass confirm_privileged_role=True to proceed deliberately."
+                )
+            caller = str(agent_name)
+            create = _api("POST", "/agents", {
+                "name": name,
+                "display_name": display_name or name.capitalize(),
+                "model": model,
+                "role": role,
+                "soul": soul,
+                "groups": groups or [],
+                "transport": transport,
+            })
+            if isinstance(create, dict) and "error" in create:
+                return f"Failed to register agent '{name}': {create['error']}"
+
+            assigned, failed = [], []
+            for sk in (skills or []):
+                r = _api("POST", f"/agents/{name}/skills/{sk}", {"assigned_by": caller})
+                if isinstance(r, dict) and "error" in r:
+                    failed.append(f"{sk} ({r['error']})")
+                else:
+                    assigned.append(sk)
+
+            parts = [
+                f"Registered agent '{name}' "
+                f"(display={create.get('display_name', name)}, "
+                f"model={create.get('model', model)}, role={role or '(none)'}) "
+                f"by {caller}."
+            ]
+            if assigned:
+                parts.append(f"Skills assigned: {', '.join(assigned)}.")
+            if failed:
+                parts.append(f"Skills FAILED (assign manually): {', '.join(failed)}.")
+            if not skills:
+                parts.append("No skills assigned — core tools only.")
+            if role in privileged_roles:
+                parts.append(
+                    f"NOTE: '{role}' is a privileged role with fleet-wide "
+                    f"cross-agent memory access."
+                )
+            return " ".join(parts)
+
 
     def _register_triggers_tools():
         # ── Trigger Tools ──────────────────────────────────────────

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -2047,9 +2047,13 @@ class TestToolGates:
 
 class TestRegisterAgent:
     def test_creates_and_assigns_skills(self, srv):
-        # /skills/ must come before /agents so the skill-assign URL matches first.
+        # Mock ordering (matched in insertion order, method-blind):
+        #   /skills/      → skill-assign POSTs
+        #   /agents/mora  → the create-only GET pre-check; "error" body = not found
+        #   /agents       → the POST create
         with _mock_api({
             "/skills/": {"assigned": True},
+            "/agents/mora": {"error": "not found", "status": 404},
             "/agents": {"name": "mora", "display_name": "Mora", "model": "opus"},
             "*": {},
         }):
@@ -2071,6 +2075,7 @@ class TestRegisterAgent:
     def test_privileged_role_with_confirm_proceeds(self, srv):
         with _mock_api({
             "/skills/": {"assigned": True},
+            "/agents/mora": {"error": "not found", "status": 404},
             "/agents": {"name": "mora", "display_name": "Mora", "model": "opus"},
             "*": {},
         }):
@@ -2082,13 +2087,39 @@ class TestRegisterAgent:
         assert "privileged role" in out.lower()
 
     def test_create_error_surfaces(self, srv):
-        with _mock_api({"/agents": {"error": "name taken"}, "*": {}}):
+        # POST /agents genuinely fails on e.g. an invalid name
+        # (_validate_agent_name → 400). The create-only GET pre-check returns
+        # not-found so we reach the create call, whose error must surface.
+        # (Previously this mocked a "name taken" error that the upsert endpoint
+        # never returns; collisions are now handled by the create-only guard —
+        # see test_existing_name_refused.)
+        with _mock_api({
+            "/agents/mora": {"error": "not found", "status": 404},
+            "/agents": {"error": "invalid agent name", "status": 400},
+            "*": {},
+        }):
             out = _tools(srv)["register_agent"](name="mora", role="worker")
         assert "Failed to register" in out
+
+    def test_existing_name_refused(self, srv):
+        # Create-only guard: an existing name is refused, not silently upserted.
+        # The GET pre-check returns an agent dict (no "error") → refuse before
+        # any POST, so register_agent('barsik') can't blank Barsik's soul/role.
+        with _mock_api({
+            "/agents/barsik": {"name": "barsik", "role": "sidekick", "soul": "x"},
+            "*": {},
+        }):
+            out = _tools(srv)["register_agent"](
+                name="barsik", role="worker", soul="would-overwrite",
+            )
+        assert "Refusing to register 'barsik'" in out
+        assert "already exists" in out
+        assert "Registered agent" not in out
 
     def test_skill_failure_reported(self, srv):
         with _mock_api({
             "/skills/": {"error": "no such skill"},
+            "/agents/mora": {"error": "not found", "status": 404},
             "/agents": {"name": "mora"},
             "*": {},
         }):

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -2013,10 +2013,11 @@ class TestToolGates:
         tools = {t.name for t in srv._tool_manager.list_tools()}
         assert tools == CORE_TOOLS
 
-    def test_all_gates_has_68_tools(self):
+    def test_all_gates_has_69_tools(self):
         """All gates → full tool set.
 
-        Drop from 69 in #552 with the removal of ``request_sleep``.
+        Was 68; +1 in #145 with ``register_agent`` (admin gate).
+        (Had dropped from 69 to 68 in #552 with the removal of ``request_sleep``.)
         """
         all_gates = [
             "extras", "kb", "research", "presentations", "triggers",
@@ -2024,7 +2025,7 @@ class TestToolGates:
         ]
         srv = create_server(agent_name="test", tool_gates=all_gates)
         tools = srv._tool_manager.list_tools()
-        assert len(tools) == 68
+        assert len(tools) == 69
 
     def test_extras_gate_adds_extras_tools(self):
         """Enabling 'extras' gate adds get_attribution, render_pdf, etc."""
@@ -2040,3 +2041,65 @@ class TestToolGates:
                      "kb_run_librarian", "kb_save_wiki", "kb_delete_wiki",
                      "kb_delete_raw", "kb_update_raw"}
         assert tools == CORE_TOOLS | kb_tools
+
+
+# ── register_agent (#145, admin gate) ───────────────────────────────────────────
+
+class TestRegisterAgent:
+    def test_creates_and_assigns_skills(self, srv):
+        # /skills/ must come before /agents so the skill-assign URL matches first.
+        with _mock_api({
+            "/skills/": {"assigned": True},
+            "/agents": {"name": "mora", "display_name": "Mora", "model": "opus"},
+            "*": {},
+        }):
+            out = _tools(srv)["register_agent"](
+                name="mora", display_name="Mora", model="opus", role="worker",
+                skills=["pinky-memory", "file-access"],
+            )
+        assert "Registered agent 'mora'" in out
+        assert "pinky-memory" in out and "file-access" in out
+        assert "by barsik" in out  # audit: caller recorded
+
+    def test_privileged_role_requires_confirm(self, srv):
+        # Guard fires BEFORE any API call — no agent should be created.
+        with _ok({"name": "mora"}):
+            out = _tools(srv)["register_agent"](name="mora", role="dreamer")
+        assert "Refusing" in out
+        assert "confirm_privileged_role" in out
+
+    def test_privileged_role_with_confirm_proceeds(self, srv):
+        with _mock_api({
+            "/skills/": {"assigned": True},
+            "/agents": {"name": "mora", "display_name": "Mora", "model": "opus"},
+            "*": {},
+        }):
+            out = _tools(srv)["register_agent"](
+                name="mora", role="dreamer", confirm_privileged_role=True,
+                skills=["pinky-memory"],
+            )
+        assert "Registered agent 'mora'" in out
+        assert "privileged role" in out.lower()
+
+    def test_create_error_surfaces(self, srv):
+        with _mock_api({"/agents": {"error": "name taken"}, "*": {}}):
+            out = _tools(srv)["register_agent"](name="mora", role="worker")
+        assert "Failed to register" in out
+
+    def test_skill_failure_reported(self, srv):
+        with _mock_api({
+            "/skills/": {"error": "no such skill"},
+            "/agents": {"name": "mora"},
+            "*": {},
+        }):
+            out = _tools(srv)["register_agent"](name="mora", skills=["bogus-skill"])
+        assert "FAILED" in out
+
+    def test_gated_to_admin(self):
+        from pinky_self.server import create_server
+        with_admin = {t.name for t in create_server(
+            agent_name="x", tool_gates=["admin"])._tool_manager.list_tools()}
+        without = {t.name for t in create_server(
+            agent_name="x", tool_gates=[])._tool_manager.list_tools()}
+        assert "register_agent" in with_admin
+        assert "register_agent" not in without


### PR DESCRIPTION
> **🔑 Owner design decision (2026-05-29) resolves the gating question below — see pinned comment. TL;DR: full-trust inner fleet is the default, admin-tier gating is intentional, dreamer-creation-by-agent is authorized, isolation is a separate opt-in track. Re-review on correctness, not inter-agent isolation.**

---

## What & why

Brad wants trusted agents able to register new agents directly, not only via the dashboard. There was no agent-facing path: no MCP tool, `POST /agents` requires owner/internal auth, and no CLI command. This adds **`register_agent`** to pinky-self.

## Trust model / gating (please review as such)

Placed under the existing **`admin` gate** — the same trust tier as `update_and_restart` / `restart_daemon`. Rationale: any agent that can replace the daemon's code (update_and_restart) can already do anything, so "create an agent" sits naturally in that tier rather than inventing a new one. Open question for reviewers: **should agent-creation be gated *more* tightly than the other admin tools?** (e.g. a dedicated `fleet-admin` gate assigned to fewer agents.) I lean "admin is fine given update_and_restart is already there," but flagging it explicitly since it's a real expansion.

Defense against the specific crown-jewel risk:
- **Privileged-role guard.** Creating `role="dreamer"` (which grants cross-agent memory **read-all + write-all** over the whole fleet, via #622/#624) requires `confirm_privileged_role=True`. It can't happen by accident; the act is deliberate and the result records the caller.
- Registered in `GATE_TOOL_NAMES["admin"]` so shared-MCP **client-side gating keeps it admin-only** — without this it would leak to every agent (the filter only hides tools it knows are gated).

## How it works
- `register_agent(name, display_name, model, role, soul, skills, groups, transport, confirm_privileged_role)`.
- Authenticates via the internal HMAC headers pinky-self already uses (`build_internal_auth_headers`).
- `POST /agents` to create, then `POST /agents/{name}/skills/{skill}` per skill (skills determine the new agent's tools; omit = core only).
- Returns a summary incl. assigned/failed skills, the caller (audit), and a privileged-role note.

## Tests
`TestRegisterAgent`: create + skill assignment, privileged-role guard (blocks without confirm; proceeds with), create-error + skill-failure surfacing, and admin-gating (present under `admin`, absent without). Updated all-gates tool count 68→69. `TestAgentIsDreamer` still green.

## Known limitations (follow-ups, not blockers)
- `dream_enabled` / fine-grained dream config aren't settable at creation (not in `RegisterAgentRequest`); set via update post-creation. Low-stakes for a dreamer (no schedule).
- Audit is in the tool result; richer server-side audit (caller→created in the daemon log) is a nice follow-up.

## Dogfood
Once released, I'll register **Mora** (the Dreamer) through this tool — `register_agent(name="mora", role="dreamer", confirm_privileged_role=True, model="opus", skills=["pinky-memory","file-access","pinky-self"], ...)`.

## Reviewers
@pushok @murzik — trust-boundary: an agent minting agents. Want eyes on (1) the admin-gate placement vs. a tighter gate, (2) the privileged-role guard being sufficient, (3) the GATE_TOOL_NAMES registration (so it doesn't leak un-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)