### PR TITLE
fix(broker): reply hint names real pinky-messaging tools

### DIFF
--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1117,9 +1117,14 @@ class MessageBroker:
         _no_hint_platforms = {"web", "api", ""}
         if message.platform and message.platform not in _no_hint_platforms:
             hint = (
-                f"\n💬 Reply on {message.platform} using send_message() or reply() "
-                f"(chat_id: {message.chat_id})"
+                f"\n💬 Reply on {message.platform} using pinky-messaging: "
+                f'send(chat_id="{message.chat_id}", platform="{message.platform}", text=...)'
             )
+            if message.message_id:
+                hint += (
+                    f' — or thread(message_id="{message.message_id}", text=...) '
+                    f"to quote-reply to this message"
+                )
         await streaming.send(
             prompt,
             platform=message.platform,

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -547,6 +547,48 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
+    async def test_route_streaming_reply_hint_names_pinky_messaging_tools(self):
+        """The agent reply hint must reference real pinky-messaging tools
+        (send/thread), not the non-existent send_message()/reply() that the
+        old hint named. Regression for Brad's 2026-05-29 report."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            from pinky_daemon.transport_state import SessionState
+
+            class _CapturingStreaming:
+                state = SessionState.CONNECTED
+                resume_handle = "live"
+                captured: dict = {}
+
+                async def send(self, prompt, **kwargs) -> None:
+                    _CapturingStreaming.captured = kwargs
+
+            broker.register_streaming("barsik", _CapturingStreaming(), label="main")
+
+            msg = BrokerMessage(
+                platform="telegram",
+                chat_id="6770805286",
+                sender_name="Brad",
+                sender_id="u-1",
+                content="hi barsik",
+                agent_name="barsik",
+                message_id="9999",
+            )
+            await broker._route_streaming("barsik", msg)
+
+            hint = _CapturingStreaming.captured.get("agent_hint", "")
+            assert hint, "no agent_hint passed to streaming.send()"
+            # The bogus tool names must be gone.
+            assert "send_message()" not in hint
+            assert "reply()" not in hint
+            # Real pinky-messaging tools, with the live chat_id/platform/message_id.
+            assert 'send(chat_id="6770805286"' in hint
+            assert 'platform="telegram"' in hint
+            assert 'thread(message_id="9999"' in hint
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
     async def test_route_streaming_falls_back_when_no_ensurer_wired(self):
         """If no ensurer is wired (e.g. in tests/embedded scenarios), the
         broker must preserve the pre-fix behavior and surface the


### PR DESCRIPTION
## What

The inbound-message reply-hint footer told agents to reply with `send_message()` or `reply()` — **neither tool exists**. Agents reply via pinky-messaging's `send()` / `thread()`. This pointed every agent at phantom tools.

## Change

- `broker.py`: hint now names the real tools, pre-filled with the live `chat_id`/`platform`, and appends `thread(message_id=...)` when a message_id is present so quote-replies are discoverable.
- The `💬 Reply on` prefix is preserved, so the hint-stripping in `streaming_session.py` / `codex_session.py` still removes it from stored chat history.
- Added a broker regression test asserting the new tool names + absence of the bogus ones.

## Test

`pytest tests/test_broker.py` → 31 passed.

Reported by Brad 2026-05-29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)