### PR TITLE
feat(#623): per-agent signing keys — infra + dual-accept verify (increment 1)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import re
+import secrets
 import sqlite3
 import sys
 import threading
@@ -1261,6 +1262,12 @@ class AgentRegistry:
                 updated_at REAL NOT NULL DEFAULT 0,
                 UNIQUE(provider, model_id)
             );
+
+            CREATE TABLE IF NOT EXISTS agent_signing_keys (
+                agent_name TEXT PRIMARY KEY,
+                signing_key TEXT NOT NULL,
+                created_at REAL NOT NULL DEFAULT 0
+            );
         """)
         self._db.commit()
         self._migrate()
@@ -1323,6 +1330,7 @@ class AgentRegistry:
         self._db.commit()
         self._backfill_runtime_from_provider_url()
         self._warn_codex_runtime_mismatches()
+        self._backfill_signing_keys()
 
         # Migrate agent_schedules table
         sched_existing = {
@@ -2027,6 +2035,10 @@ except Exception:
                 self.set_setting("main_agent", name)
                 _log(f"agents: auto-assigned main_agent={name} (first agent)")
 
+        # Ensure the agent has a per-agent signing key (#623). Idempotent —
+        # returns the existing key on re-registration / update.
+        self.get_or_create_signing_key(name)
+
         return self.get(name)  # type: ignore
 
     _AGENT_COLUMNS = (
@@ -2053,6 +2065,56 @@ except Exception:
         if not row:
             return None
         return self._row_to_agent(row)
+
+    # ── Per-agent signing keys (#623) ──────────────────────────────────
+    # Each agent gets its own 256-bit key for signing internal (MCP->daemon)
+    # requests, replacing the shared global PINKY_SESSION_SECRET. This gives
+    # each agent a NON-FORGEABLE identity — the prerequisite for the
+    # containerized-Counterpart tenant boundary, where one team member's agent
+    # must be unable to impersonate another. Stored in a dedicated table, never
+    # in the agents row / to_dict(), so the secret is never serialized into API
+    # responses. Migration is dual-accept (see auth.verify_internal_request):
+    # the global secret stays valid until the cutover PR provisions per-agent
+    # keys into agent env and drops global-secret acceptance.
+
+    def get_or_create_signing_key(self, agent_name: str) -> str:
+        """Return the agent's per-agent signing key, generating one on first use."""
+        name = _validate_agent_name(agent_name)
+        row = self._db.execute(
+            "SELECT signing_key FROM agent_signing_keys WHERE agent_name=?", (name,)
+        ).fetchone()
+        if row and row[0]:
+            return row[0]
+        key = secrets.token_urlsafe(32)
+        self._db.execute(
+            "INSERT OR REPLACE INTO agent_signing_keys "
+            "(agent_name, signing_key, created_at) VALUES (?, ?, ?)",
+            (name, key, time.time()),
+        )
+        self._db.commit()
+        return key
+
+    def get_signing_key(self, agent_name: str) -> str | None:
+        """Return the agent's signing key if one exists (no generation)."""
+        row = self._db.execute(
+            "SELECT signing_key FROM agent_signing_keys WHERE agent_name=?",
+            (agent_name,),
+        ).fetchone()
+        return row[0] if row and row[0] else None
+
+    def _backfill_signing_keys(self) -> None:
+        """Generate a signing key for any existing agent that lacks one (#623)."""
+        try:
+            rows = self._db.execute("SELECT name FROM agents").fetchall()
+        except Exception:
+            return
+        generated = 0
+        for (name,) in rows:
+            if not self.get_signing_key(name):
+                self.get_or_create_signing_key(name)
+                generated += 1
+        if generated:
+            _log(f"agent_registry: backfilled signing keys for {generated} agent(s)")
 
     def list(self, *, parent: str = "", group: str = "", enabled_only: bool = False,
              include_retired: bool = False) -> list[Agent]:

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2110,9 +2110,14 @@ except Exception:
             return
         generated = 0
         for (name,) in rows:
-            if not self.get_signing_key(name):
-                self.get_or_create_signing_key(name)
-                generated += 1
+            try:
+                if not self.get_signing_key(name):
+                    self.get_or_create_signing_key(name)
+                    generated += 1
+            except Exception as e:
+                # A single non-conforming legacy name must not brick boot
+                # (get_or_create -> _validate_agent_name raises). Log + skip.
+                _log(f"agent_registry: skipped signing-key backfill for {name!r}: {e}")
         if generated:
             _log(f"agent_registry: backfilled signing keys for {generated} agent(s)")
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3225,11 +3225,20 @@ def create_api(
 
     def _has_valid_internal_auth(request: Request) -> bool:
         secret = _session_secret()
-        if not secret:
-            return False
         agent_name = request.headers.get(INTERNAL_AGENT_HEADER, "")
         timestamp = request.headers.get(INTERNAL_TIMESTAMP_HEADER, "")
         signature = request.headers.get(INTERNAL_SIGNATURE_HEADER, "")
+        # Per-agent signing key (#623): dual-accept alongside the global secret.
+        # The agent's own key (if provisioned) is checked first; the global
+        # secret remains valid through the migration window.
+        agent_key = None
+        if agent_name:
+            try:
+                agent_key = agents.get_signing_key(agent_name)
+            except Exception:
+                agent_key = None
+        if not secret and not agent_key:
+            return False
         return verify_internal_request(
             secret,
             agent_name=agent_name,
@@ -3237,6 +3246,7 @@ def create_api(
             path=request.url.path,
             timestamp=timestamp,
             signature=signature,
+            agent_key=agent_key,
         )
 
     def _has_valid_session(request: Request) -> bool:

--- a/src/pinky_daemon/auth.py
+++ b/src/pinky_daemon/auth.py
@@ -116,9 +116,28 @@ def build_internal_auth_headers(secret: str, *, agent_name: str, method: str, pa
     }
 
 
-def verify_internal_request(secret: str, *, agent_name: str, method: str, path: str, timestamp: str, signature: str) -> bool:
-    """Verify signed local MCP-to-daemon request headers."""
-    if not secret or not agent_name or not timestamp or not signature:
+def verify_internal_request(
+    secret: str,
+    *,
+    agent_name: str,
+    method: str,
+    path: str,
+    timestamp: str,
+    signature: str,
+    agent_key: str | None = None,
+) -> bool:
+    """Verify signed local MCP-to-daemon request headers.
+
+    Dual-accept (#623 migration): the signature is accepted if it matches
+    EITHER the agent's per-agent signing key (``agent_key``) OR the shared
+    global ``secret``. Per-agent keys give each agent a non-forgeable identity;
+    the global secret remains accepted until the cutover PR provisions
+    per-agent keys into agent environments and drops global-secret acceptance.
+    At least one of ``secret`` / ``agent_key`` must be present.
+    """
+    if not agent_name or not timestamp or not signature:
+        return False
+    if not secret and not agent_key:
         return False
     try:
         ts = int(timestamp)
@@ -128,8 +147,12 @@ def verify_internal_request(secret: str, *, agent_name: str, method: str, path: 
         return False
     normalized_path = path.split("?", 1)[0]
     payload = f"{agent_name}\n{method.upper()}\n{normalized_path}\n{ts}".encode("utf-8")
-    expected = _sign_bytes(secret, payload)
-    return hmac.compare_digest(signature, expected)
+    # Accept a match against the per-agent key OR the global secret. Each
+    # comparison is constant-time; we only short-circuit on a match.
+    for candidate in (agent_key, secret):
+        if candidate and hmac.compare_digest(signature, _sign_bytes(candidate, payload)):
+            return True
+    return False
 
 
 def password_source(env_password: str, stored_hash: str) -> str:

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -53,6 +53,21 @@ class TestSigningKeys:
         agent = registry.register("nova", model="opus")
         assert "signing_key" not in agent.to_dict()
 
+    def test_backfill_skips_malformed_name_without_bricking(self, registry):
+        # A legacy/non-conforming agent name must not brick boot: the per-row
+        # get_or_create -> _validate_agent_name raises, but backfill log+skips
+        # and still keys the conforming agents.
+        registry.register("good", model="opus")
+        registry._db.execute(
+            "INSERT INTO agents (name, model, created_at, updated_at) VALUES (?,?,?,?)",
+            ("BAD NAME!", "opus", 1.0, 1.0),
+        )
+        registry._db.commit()
+        # Must not raise even though "BAD NAME!" fails validation.
+        registry._backfill_signing_keys()
+        assert registry.get_signing_key("good")
+        assert registry.get_signing_key("BAD NAME!") is None
+
 
 class TestAgentCRUD:
     def test_register(self, registry):

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -20,6 +20,40 @@ def registry():
     os.unlink(path)
 
 
+class TestSigningKeys:
+    """Per-agent signing keys (#623)."""
+
+    def test_register_generates_signing_key(self, registry):
+        registry.register("oleg", model="opus")
+        key = registry.get_signing_key("oleg")
+        assert key
+        assert len(key) >= 32  # 256-bit urlsafe token
+
+    def test_get_or_create_is_idempotent(self, registry):
+        registry.register("leo", model="opus")
+        k1 = registry.get_or_create_signing_key("leo")
+        k2 = registry.get_or_create_signing_key("leo")
+        assert k1 == k2
+
+    def test_get_signing_key_unknown_agent_is_none(self, registry):
+        assert registry.get_signing_key("ghost") is None
+
+    def test_keys_are_distinct_per_agent(self, registry):
+        registry.register("a", model="opus")
+        registry.register("b", model="opus")
+        assert registry.get_signing_key("a") != registry.get_signing_key("b")
+
+    def test_reregister_preserves_signing_key(self, registry):
+        registry.register("kai", model="opus")
+        before = registry.get_signing_key("kai")
+        registry.register("kai", model="sonnet")  # update path
+        assert registry.get_signing_key("kai") == before
+
+    def test_signing_key_not_in_to_dict(self, registry):
+        agent = registry.register("nova", model="opus")
+        assert "signing_key" not in agent.to_dict()
+
+
 class TestAgentCRUD:
     def test_register(self, registry):
         agent = registry.register("oleg", display_name="Oleg", model="opus")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -67,6 +67,87 @@ def test_internal_signature_round_trip():
     ) is True
 
 
+# ── Per-agent signing keys / dual-accept (#623) ─────────────────────────────
+
+
+def _signed(signer_key: str, *, agent_name: str, method: str = "GET", path: str = "/tasks/next"):
+    return build_internal_auth_headers(
+        signer_key, agent_name=agent_name, method=method, path=path, timestamp=int(time.time())
+    )
+
+
+def test_internal_signature_per_agent_key_round_trip():
+    """A request signed with the agent's per-agent key verifies when that key
+    is supplied as agent_key (the #623 per-agent path)."""
+    h = _signed("agent-A-key", agent_name="barsik")
+    assert verify_internal_request(
+        "global-secret",
+        agent_name="barsik",
+        method="GET",
+        path="/tasks/next",
+        timestamp=h["x-pinky-timestamp"],
+        signature=h["x-pinky-signature"],
+        agent_key="agent-A-key",
+    ) is True
+
+
+def test_internal_signature_global_secret_still_accepted_in_dual_mode():
+    """Dual-accept migration: a request signed with the GLOBAL secret still
+    verifies even when a (different) per-agent key is supplied as fallback."""
+    h = _signed("global-secret", agent_name="barsik", method="POST", path="/agents")
+    assert verify_internal_request(
+        "global-secret",
+        agent_name="barsik",
+        method="POST",
+        path="/agents",
+        timestamp=h["x-pinky-timestamp"],
+        signature=h["x-pinky-signature"],
+        agent_key="some-other-agent-key",
+    ) is True
+
+
+def test_internal_signature_rejected_when_neither_key_matches():
+    h = _signed("agent-A-key", agent_name="barsik")
+    assert verify_internal_request(
+        "global-secret",
+        agent_name="barsik",
+        method="GET",
+        path="/tasks/next",
+        timestamp=h["x-pinky-timestamp"],
+        signature=h["x-pinky-signature"],
+        agent_key="wrong-agent-key",
+    ) is False
+
+
+def test_internal_signature_name_bound_into_payload():
+    """A signature minted for agent 'alice' must not verify when presented as
+    'bob' — the agent name is part of the signed payload."""
+    h = _signed("agent-A-key", agent_name="alice")
+    assert verify_internal_request(
+        "global-secret",
+        agent_name="bob",
+        method="GET",
+        path="/tasks/next",
+        timestamp=h["x-pinky-timestamp"],
+        signature=h["x-pinky-signature"],
+        agent_key="agent-A-key",
+    ) is False
+
+
+def test_internal_signature_requires_some_secret():
+    """With neither a global secret nor a per-agent key, verification fails."""
+    h = _signed("agent-A-key", agent_name="barsik")
+    assert verify_internal_request(
+        "",
+        agent_name="barsik",
+        method="GET",
+        path="/tasks/next",
+        timestamp=h["x-pinky-timestamp"],
+        signature=h["x-pinky-signature"],
+        agent_key=None,
+    ) is False
+
+
 class TestUIAuthAPI:
     def _make_client(self, monkeypatch):
         fd, path = tempfile.mkstemp(suffix=".db")


### PR DESCRIPTION
## What & why

First, **safe, additive** increment of #623 — non-forgeable per-agent identity for internal (MCP→daemon) auth, replacing reliance on the shared global `PINKY_SESSION_SECRET`. This is the **prerequisite for the containerized-Counterpart tenant boundary** (task #149): one team member's agent must be unable to impersonate another to the daemon. Today every agent holds the same global secret in its env, so X-Agent-Name is effectively forgeable.

**No behavior change for the running fleet.** This PR is infra + *dual-accept* verification — the global secret keeps working exactly as before. The security win lands at the **cutover** (follow-up PRs), once agents actually sign with their own key.

## Changes
- **New `agent_signing_keys` table** — dedicated, NOT part of the `agents` row or `to_dict()`, so the secret is never serialized into any API response. 256-bit urlsafe key.
- **`AgentRegistry.get_or_create_signing_key` / `get_signing_key`** — key generated at `register()`; existing agents backfilled in `_migrate()`.
- **`auth.verify_internal_request(..., agent_key=None)`** — dual-accept: a signature matching EITHER the per-agent key OR the global secret passes. Agent name remains bound into the signed payload; each comparison is constant-time.
- **`api._has_valid_internal_auth`** — looks up the caller's per-agent key and passes it for dual-accept (global secret stays primary through the migration window).

## Tests
- auth: per-agent-key round-trip, global-secret dual-accept, reject-when-neither-matches, name-binding, requires-some-secret.
- registry: key generation at register, idempotent get_or_create, per-agent distinctness, re-register preserves key, not-in-to_dict, unknown→None.
- **563 passed** across auth/registry/api/self-tools/broker/shared_mcp; ruff clean.

## Follow-ups (separate PRs, sequenced)
1. Provision per-agent key into agent env (`PINKY_AGENT_KEY`) via `_build_repl_env` + .mcp.json + hook templates; cut agents over to signing with it.
2. Shared-MCP `AgentNameMiddleware`: bind X-Agent-Name ↔ per-agent key (the :8890 hop carries no secret today).
3. Drop global-secret acceptance (close the forgery hole) after soak.

## Reviewers
@murzik @pushok — security-sensitive but deliberately non-breaking. Focus: dual-accept logic in `verify_internal_request`, the dedicated-table/no-leak design, and the migration/backfill. The forgery hole is NOT closed by this PR (dual-accept still trusts the global secret) — that's by design; it closes at step 3 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)