### PR TITLE
feat(#623): provision per-agent key into agent env + signers prefer it (increment 2)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -675,7 +675,7 @@ session: None).
 """
 import hashlib, hmac, base64, time, urllib.request, json, os, sys
 
-secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+secret = os.environ.get("PINKY_AGENT_KEY", "").strip() or os.environ.get("PINKY_SESSION_SECRET", "").strip()
 if not secret:
     sys.exit(0)
 
@@ -726,7 +726,7 @@ record analytics + emit live SSE events matching SDK parity.
 """
 import hashlib, hmac, base64, time, urllib.request, json, os, sys
 
-secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+secret = os.environ.get("PINKY_AGENT_KEY", "").strip() or os.environ.get("PINKY_SESSION_SECRET", "").strip()
 if not secret:
     sys.exit(0)
 
@@ -790,7 +790,7 @@ record analytics + emit live SSE events matching SDK parity.
 """
 import hashlib, hmac, base64, time, urllib.request, json, os, sys
 
-secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+secret = os.environ.get("PINKY_AGENT_KEY", "").strip() or os.environ.get("PINKY_SESSION_SECRET", "").strip()
 if not secret:
     sys.exit(0)
 
@@ -873,7 +873,7 @@ failures proactively rather than the agent going silently dark.
 """
 import hashlib, hmac, base64, time, urllib.request, json, os, sys
 
-secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+secret = os.environ.get("PINKY_AGENT_KEY", "").strip() or os.environ.get("PINKY_SESSION_SECRET", "").strip()
 if not secret:
     sys.exit(0)
 
@@ -949,7 +949,7 @@ forwards transcript_path to the daemon.
 """
 import hashlib, hmac, base64, time, urllib.request, json, os, sys
 
-secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+secret = os.environ.get("PINKY_AGENT_KEY", "").strip() or os.environ.get("PINKY_SESSION_SECRET", "").strip()
 if not secret:
     sys.exit(0)
 
@@ -1548,7 +1548,7 @@ class AgentRegistry:
 #!/usr/bin/env python3
 import hashlib, hmac, base64, time, urllib.request, json, os, sys
 
-secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+secret = os.environ.get("PINKY_AGENT_KEY", "").strip() or os.environ.get("PINKY_SESSION_SECRET", "").strip()
 if not secret:
     sys.exit(0)
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -583,6 +583,21 @@ def _write_mcp_json(
         }
 
         # Stdio mode: spawn per-agent processes (original behavior)
+        # #623 increment 2: provision this agent's per-agent signing key into
+        # the per-agent MCP subprocesses so they sign internal requests with a
+        # non-forgeable identity (resolve_signing_secret prefers PINKY_AGENT_KEY
+        # over the inherited global PINKY_SESSION_SECRET). The `env` field is
+        # additive — the subprocess still inherits PINKY_SESSION_SECRET, and the
+        # daemon dual-accepts either, so a missing key degrades gracefully.
+        stdio_env: dict[str, str] = {}
+        if agent_registry:
+            try:
+                agent_key = agent_registry.get_signing_key(agent_name)
+                if agent_key:
+                    stdio_env["PINKY_AGENT_KEY"] = agent_key
+            except Exception:
+                pass
+
         # Pinky-self: heartbeat_ack, schedules, self-management
         tool_gates = _get_agent_tool_gates(agent_name, skill_store)
         self_args = [
@@ -597,6 +612,8 @@ def _write_mcp_json(
             "cwd": pinky_src,
             "alwaysLoad": True,
         }
+        if stdio_env:
+            mcp_config["mcpServers"]["pinky-self"]["env"] = dict(stdio_env)
 
         # Pinky-messaging: outbound messaging through the broker
         mcp_config["mcpServers"]["pinky-messaging"] = {
@@ -608,6 +625,8 @@ def _write_mcp_json(
             "cwd": pinky_src,
             "alwaysLoad": True,
         }
+        if stdio_env:
+            mcp_config["mcpServers"]["pinky-messaging"]["env"] = dict(stdio_env)
 
     # Merge MCP servers from assigned skills
     if skill_store:

--- a/src/pinky_daemon/auth.py
+++ b/src/pinky_daemon/auth.py
@@ -102,6 +102,28 @@ def verify_session_cookie(secret: str, token: str) -> dict[str, Any] | None:
     return payload
 
 
+def resolve_signing_secret() -> str:
+    """Return the secret a per-agent process should sign internal requests with.
+
+    Prefers the agent's per-agent signing key (``PINKY_AGENT_KEY``, provisioned
+    into per-agent environments at #623 increment 2) over the shared global
+    ``PINKY_SESSION_SECRET``. During the dual-accept migration the daemon verifies
+    a signature against EITHER key (see ``verify_internal_request``), so:
+
+    - A process that has its per-agent key (tmux hooks, stdio MCP servers) signs
+      with a non-forgeable identity.
+    - A process that only has the global secret (e.g. the shared-SSE MCP server,
+      whose per-request key binding lands in a later increment, or SDK-agent hooks
+      inheriting daemon env) keeps working unchanged.
+
+    Empty string when neither is set — callers already treat that as "no auth".
+    """
+    return (
+        os.environ.get("PINKY_AGENT_KEY", "").strip()
+        or os.environ.get("PINKY_SESSION_SECRET", "").strip()
+    )
+
+
 def build_internal_auth_headers(secret: str, *, agent_name: str, method: str, path: str, timestamp: int | None = None) -> dict[str, str]:
     """Build signed headers for local MCP-to-daemon requests."""
     if not secret or not agent_name:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1849,6 +1849,20 @@ class TmuxSession:
         secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
         if secret:
             env["PINKY_SESSION_SECRET"] = secret
+        # PINKY_AGENT_KEY (#623 increment 2) — this agent's per-agent signing
+        # key. Provisioned so hook scripts running in this tmux session sign
+        # internal requests with a non-forgeable identity. The daemon dual-
+        # accepts (per-agent key OR global secret), so this is additive: the
+        # global PINKY_SESSION_SECRET above keeps hooks working if the key is
+        # missing (e.g. registry not wired). Lookup guarded like
+        # _restart_threshold_pct — a registry hiccup must not break session env.
+        if self._registry and self.agent_name:
+            try:
+                agent_key = self._registry.get_signing_key(self.agent_name)
+                if agent_key:
+                    env["PINKY_AGENT_KEY"] = agent_key
+            except Exception:
+                pass
         return env
 
     async def disconnect(self) -> None:

--- a/src/pinky_messaging/server.py
+++ b/src/pinky_messaging/server.py
@@ -10,7 +10,7 @@ import urllib.request
 
 from mcp.server.fastmcp import FastMCP
 
-from pinky_daemon.auth import build_internal_auth_headers
+from pinky_daemon.auth import build_internal_auth_headers, resolve_signing_secret
 from pinky_daemon.shared_mcp import LazyAgentName, resolve_lazy
 
 
@@ -50,7 +50,9 @@ def create_server(
         url = f"{api_url}{path}"
         data = json.dumps(resolve_lazy(body)).encode() if body else None
         headers = {"Content-Type": "application/json"} if data else {}
-        secret = os.environ.get("PINKY_SESSION_SECRET", "")
+        # #623: prefer this agent's per-agent signing key when provisioned
+        # (stdio mode), else the shared global secret (shared-SSE / fallback).
+        secret = resolve_signing_secret()
         headers.update(build_internal_auth_headers(
             secret,
             agent_name=str(agent_name),

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -34,7 +34,7 @@ from datetime import datetime, timezone
 
 from mcp.server.fastmcp import FastMCP
 
-from pinky_daemon.auth import build_internal_auth_headers
+from pinky_daemon.auth import build_internal_auth_headers, resolve_signing_secret
 from pinky_daemon.shared_mcp import LazyAgentName, resolve_lazy
 
 
@@ -73,7 +73,9 @@ def create_server(
         url = f"{api_url}{path}"
         data = json.dumps(resolve_lazy(body)).encode() if body else None
         headers = {"Content-Type": "application/json"} if data else {}
-        secret = os.environ.get("PINKY_SESSION_SECRET", "")
+        # #623: prefer this agent's per-agent signing key when provisioned
+        # (stdio mode), else the shared global secret (shared-SSE / fallback).
+        secret = resolve_signing_secret()
         headers.update(build_internal_auth_headers(
             secret,
             agent_name=str(agent_name),

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -53,6 +53,31 @@ class TestSigningKeys:
         agent = registry.register("nova", model="opus")
         assert "signing_key" not in agent.to_dict()
 
+    def test_hook_templates_prefer_per_agent_key(self):
+        """#623 increment 2: every signed tmux hook prefers PINKY_AGENT_KEY
+        over the global PINKY_SESSION_SECRET, so hooks running in an agent's
+        tmux session sign with a non-forgeable identity (daemon dual-accepts).
+        """
+        from pinky_daemon import agent_registry as ar
+
+        prefer_line = (
+            'secret = os.environ.get("PINKY_AGENT_KEY", "").strip() '
+            'or os.environ.get("PINKY_SESSION_SECRET", "").strip()'
+        )
+        sources = [
+            ar._tmux_wake_hook_source("dymok"),
+            ar._tmux_pre_tool_hook_source("dymok"),
+            ar._tmux_post_tool_hook_source("dymok"),
+            ar._tmux_stop_failure_hook_source("dymok"),
+            ar._tmux_session_start_hook_source("dymok"),
+        ]
+        for src in sources:
+            assert prefer_line in src
+            # The old single-source line must be gone (no global-only signer).
+            assert 'secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()\n' not in src
+            # Agent name still bound into the signed request.
+            assert 'x-pinky-agent' in src
+
     def test_backfill_skips_malformed_name_without_bricking(self, registry):
         # A legacy/non-conforming agent name must not brick boot: the per-row
         # get_or_create -> _validate_agent_name raises, but backfill log+skips

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -53,7 +53,7 @@ class TestSigningKeys:
         agent = registry.register("nova", model="opus")
         assert "signing_key" not in agent.to_dict()
 
-    def test_hook_templates_prefer_per_agent_key(self):
+    def test_hook_templates_prefer_per_agent_key(self, tmp_path):
         """#623 increment 2: every signed tmux hook prefers PINKY_AGENT_KEY
         over the global PINKY_SESSION_SECRET, so hooks running in an agent's
         tmux session sign with a non-forgeable identity (daemon dual-accepts).
@@ -64,6 +64,9 @@ class TestSigningKeys:
             'secret = os.environ.get("PINKY_AGENT_KEY", "").strip() '
             'or os.environ.get("PINKY_SESSION_SECRET", "").strip()'
         )
+        old_line = 'secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()\n'
+
+        # The 5 named hook-source templates.
         sources = [
             ar._tmux_wake_hook_source("dymok"),
             ar._tmux_pre_tool_hook_source("dymok"),
@@ -71,10 +74,17 @@ class TestSigningKeys:
             ar._tmux_stop_failure_hook_source("dymok"),
             ar._tmux_session_start_hook_source("dymok"),
         ]
+        # The 6th template is inline in _setup_hooks (status hooks); cover it
+        # through the real write path so a future edit can't silently revert it.
+        AgentRegistry._setup_hooks(tmp_path, "dymok")
+        claude_dir = tmp_path / ".claude"
+        sources.append((claude_dir / "hook_idle.py").read_text())
+        sources.append((claude_dir / "hook_working.py").read_text())
+
         for src in sources:
             assert prefer_line in src
             # The old single-source line must be gone (no global-only signer).
-            assert 'secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()\n' not in src
+            assert old_line not in src
             # Agent name still bound into the signed request.
             assert 'x-pinky-agent' in src
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,6 +15,7 @@ from pinky_daemon.auth import (
     create_session_cookie,
     hash_password,
     password_source,
+    resolve_signing_secret,
     verify_internal_request,
     verify_password,
     verify_session_cookie,
@@ -39,6 +40,51 @@ def test_password_source_prefers_env():
     assert password_source("env-pass", "") == "env"
     assert password_source("", hash_password("stored")) == "settings"
     assert password_source("", "") == "unset"
+
+
+def test_resolve_signing_secret_prefers_agent_key(monkeypatch):
+    # #623 increment 2: per-agent key wins over the global secret.
+    monkeypatch.setenv("PINKY_AGENT_KEY", "per-agent-key")
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+    assert resolve_signing_secret() == "per-agent-key"
+
+
+def test_resolve_signing_secret_falls_back_to_global(monkeypatch):
+    monkeypatch.delenv("PINKY_AGENT_KEY", raising=False)
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+    assert resolve_signing_secret() == "global-secret"
+
+
+def test_resolve_signing_secret_blank_agent_key_falls_back(monkeypatch):
+    # Whitespace-only agent key must not shadow the global secret.
+    monkeypatch.setenv("PINKY_AGENT_KEY", "   ")
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+    assert resolve_signing_secret() == "global-secret"
+
+
+def test_resolve_signing_secret_empty_when_neither_set(monkeypatch):
+    monkeypatch.delenv("PINKY_AGENT_KEY", raising=False)
+    monkeypatch.delenv("PINKY_SESSION_SECRET", raising=False)
+    assert resolve_signing_secret() == ""
+
+
+def test_per_agent_key_signs_request_verifiable_by_daemon(monkeypatch):
+    # End-to-end: a process holding only its per-agent key produces headers
+    # the daemon dual-accepts (agent_key path), with the name bound in.
+    monkeypatch.setenv("PINKY_AGENT_KEY", "alice-key")
+    monkeypatch.delenv("PINKY_SESSION_SECRET", raising=False)
+    headers = build_internal_auth_headers(
+        resolve_signing_secret(), agent_name="alice", method="POST", path="/agents/alice/status",
+    )
+    assert verify_internal_request(
+        "global-secret",  # daemon's global secret — does NOT match the signature
+        agent_name="alice",
+        method="POST",
+        path="/agents/alice/status",
+        timestamp=headers["x-pinky-timestamp"],
+        signature=headers["x-pinky-signature"],
+        agent_key="alice-key",  # ...but the per-agent key does
+    )
 
 
 def test_session_cookie_rejects_tampering():

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -328,6 +328,49 @@ class TestWriteMcpJsonSharedMode:
         finally:
             api_mod.SHARED_MCP_ENABLED = original
 
+    def test_stdio_mode_injects_per_agent_key(self, tmp_path):
+        """#623 increment 2: stdio MCP servers get PINKY_AGENT_KEY in env so
+        they sign with the agent's per-agent key (daemon dual-accepts)."""
+        import json
+        from unittest.mock import MagicMock
+
+        import pinky_daemon.api as api_mod
+
+        registry = MagicMock()
+        registry.get_signing_key.return_value = "barsik-per-agent-key"
+        registry.list_mcp_servers.return_value = []
+
+        original = api_mod.SHARED_MCP_ENABLED
+        api_mod.SHARED_MCP_ENABLED = False
+        try:
+            work_dir = tmp_path / "agent"
+            work_dir.mkdir()
+            api_mod._write_mcp_json(work_dir, "barsik", agent_registry=registry)
+            servers = json.loads((work_dir / ".mcp.json").read_text())["mcpServers"]
+            assert servers["pinky-self"]["env"]["PINKY_AGENT_KEY"] == "barsik-per-agent-key"
+            assert servers["pinky-messaging"]["env"]["PINKY_AGENT_KEY"] == "barsik-per-agent-key"
+        finally:
+            api_mod.SHARED_MCP_ENABLED = original
+
+    def test_stdio_mode_no_env_key_without_registry(self, tmp_path):
+        """No registry → no env block injected (graceful degrade to the
+        inherited global secret, which the daemon still accepts)."""
+        import json
+
+        import pinky_daemon.api as api_mod
+
+        original = api_mod.SHARED_MCP_ENABLED
+        api_mod.SHARED_MCP_ENABLED = False
+        try:
+            work_dir = tmp_path / "agent"
+            work_dir.mkdir()
+            api_mod._write_mcp_json(work_dir, "barsik")
+            servers = json.loads((work_dir / ".mcp.json").read_text())["mcpServers"]
+            assert "env" not in servers["pinky-self"]
+            assert "env" not in servers["pinky-messaging"]
+        finally:
+            api_mod.SHARED_MCP_ENABLED = original
+
     def test_shared_mode_sse(self, tmp_path):
         """With SHARED_MCP_ENABLED, pinky-self and pinky-messaging use SSE."""
         import pinky_daemon.api as api_mod

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -708,6 +708,48 @@ def test_build_repl_env_strips_whitespace_in_pinky_session_secret(
     assert "PINKY_SESSION_SECRET" not in env
 
 
+def test_build_repl_env_provisions_per_agent_key(monkeypatch) -> None:
+    """#623 increment 2: the agent's per-agent signing key is injected as
+    ``PINKY_AGENT_KEY`` so hooks in the tmux session sign with a
+    non-forgeable identity (daemon dual-accepts)."""
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret-xyz")
+    ss, _ = _make_session(agent_name="dymok")
+    ss._registry = MagicMock()
+    ss._registry.get_signing_key.return_value = "dymok-per-agent-key"
+    env = ss._build_repl_env()
+    assert env.get("PINKY_AGENT_KEY") == "dymok-per-agent-key"
+    # Global secret still propagated (dual-accept fallback for other paths).
+    assert env.get("PINKY_SESSION_SECRET") == "global-secret-xyz"
+    ss._registry.get_signing_key.assert_called_once_with("dymok")
+
+
+def test_build_repl_env_omits_agent_key_when_registry_absent() -> None:
+    """No registry wired → no PINKY_AGENT_KEY (graceful degrade to global
+    secret, which the daemon still accepts)."""
+    ss, _ = _make_session()
+    ss._registry = None
+    env = ss._build_repl_env()
+    assert "PINKY_AGENT_KEY" not in env
+
+
+def test_build_repl_env_omits_agent_key_when_lookup_raises() -> None:
+    """A registry hiccup must not break session env construction."""
+    ss, _ = _make_session()
+    ss._registry = MagicMock()
+    ss._registry.get_signing_key.side_effect = RuntimeError("db locked")
+    env = ss._build_repl_env()
+    assert "PINKY_AGENT_KEY" not in env
+
+
+def test_build_repl_env_omits_agent_key_when_none(monkeypatch) -> None:
+    """Agent has no signing key yet (None) → no empty PINKY_AGENT_KEY."""
+    ss, _ = _make_session()
+    ss._registry = MagicMock()
+    ss._registry.get_signing_key.return_value = None
+    env = ss._build_repl_env()
+    assert "PINKY_AGENT_KEY" not in env
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # Concurrent cold-start race (PR6 framework: Case A + Case B)
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Increment 2 of #623 (non-forgeable per-agent identity). Increment 1 (#631, cdc1328) landed the `agent_signing_keys` table + dual-accept verify. This **provisions each agent's key into its per-agent processes** and makes the env-based signers prefer it.

Still **additive / no behavior change**: the daemon dual-accepts a signature matching the per-agent key OR the global secret, so anything not yet cut over keeps working.

## Changes
- **`auth.resolve_signing_secret()`** — single source of truth: `PINKY_AGENT_KEY` if set (non-blank), else `PINKY_SESSION_SECRET`, else `""`.
- **`tmux_session._build_repl_env`** — inject `PINKY_AGENT_KEY` from `registry.get_signing_key(agent_name)` so hooks in the agent's tmux session sign with a non-forgeable identity. Lookup guarded (registry hiccup / missing key → global-secret fallback, never breaks session env).
- **`api._write_mcp_json`** (stdio mode) — inject `PINKY_AGENT_KEY` into the per-agent `pinky-self` / `pinky-messaging` subprocess `env`. Additive — subprocess still inherits `PINKY_SESSION_SECRET`.
- **`pinky_self` / `pinky_messaging` `_api` signers** — use `resolve_signing_secret()`.
- **All 6 signed tmux hook templates** — prefer `PINKY_AGENT_KEY` over the global secret.

## Scope note (for reviewers)
The **shared-SSE MCP server** (the live fleet's mode) signs from one process env that has no `PINKY_AGENT_KEY`, so it still uses the global secret — its per-request name↔key binding is **increment 3**. This increment cuts over the **tmux hook path** + any **stdio-mode** agents. The forgery hole closes at increment 4 (drop global-secret acceptance).

Follow-up still tracked from increment 1: hard-`delete()` doesn't purge `agent_signing_keys` (stale-key-on-recreate) — acceptance criterion for the cutover PR (issue #623 comment).

## Tests
- `resolve_signing_secret` precedence / blank-key fallback / empty + per-agent key signs a daemon-verifiable request
- `_build_repl_env` provisions the key; omits it when registry absent / raises / returns None
- stdio `_write_mcp_json` injects the env block (and omits it without a registry)
- all hook templates carry the prefer-key line and still bind the agent name

164 existing + 17 new assertions green (auth / registry / shared_mcp / tmux); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)