### PR TITLE
feat(#623): shared-SSE per-request agent key binding (increment 3)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8027,10 +8027,24 @@ npm run build</pre>
                 except Exception:
                     return False
 
+            def _resolve_signing_key(agent_name: str) -> str | None:
+                """Resolve agent_name -> per-agent signing key (#623).
+
+                Lets the shared self/messaging MCP servers sign each request
+                with the resolved agent's own key instead of the global secret.
+                Guarded: unknown agent / lookup failure -> None -> the signer
+                falls back to the global secret (dual-accept still works).
+                """
+                try:
+                    return agents.get_signing_key(agent_name)
+                except Exception:
+                    return None
+
             shared_mcp_manager = SharedMcpManager(
                 api_url="http://localhost:8888",
                 memory_db_resolver=_resolve_memory_db,
                 cross_agent_authorizer=_is_cross_agent_memory_authorized,
+                signing_key_resolver=_resolve_signing_key,
             )
             await shared_mcp_manager.start()
             _log(f"startup: shared MCP server started on {shared_mcp_manager.url}")

--- a/src/pinky_daemon/auth.py
+++ b/src/pinky_daemon/auth.py
@@ -124,6 +124,27 @@ def resolve_signing_secret() -> str:
     )
 
 
+def resolve_request_signing_secret(agent_name, signing_key_resolver=None) -> str:
+    """Per-request signing secret for the shared MCP servers (#623 increment 3).
+
+    Shared-SSE serves many agents from one process, so the per-agent key can't
+    come from the process env. The daemon passes ``signing_key_resolver``
+    (``agent_name -> key | None``); this prefers that resolved key, else falls
+    back to ``resolve_signing_secret()`` (the env-based PINKY_AGENT_KEY / global
+    secret used by stdio-mode and hooks). Resolver errors degrade to the
+    fallback — never raise into the request path. The daemon dual-accepts, so a
+    None resolution keeps working via the global secret.
+    """
+    if signing_key_resolver:
+        try:
+            key = signing_key_resolver(agent_name)
+            if key:
+                return key
+        except Exception:
+            pass
+    return resolve_signing_secret()
+
+
 def build_internal_auth_headers(secret: str, *, agent_name: str, method: str, path: str, timestamp: int | None = None) -> dict[str, str]:
     """Build signed headers for local MCP-to-daemon requests."""
     if not secret or not agent_name:

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -308,12 +308,17 @@ class SharedMcpManager:
         api_url: str = "http://localhost:8888",
         memory_db_resolver: "Callable[[str], str] | None" = None,
         cross_agent_authorizer: "Callable[[str], bool] | None" = None,
+        signing_key_resolver: "Callable[[str], str | None] | None" = None,
     ):
         self._host = host
         self._port = port
         self._api_url = api_url
         self._memory_db_resolver = memory_db_resolver
         self._cross_agent_authorizer = cross_agent_authorizer
+        # #623: agent_name -> per-agent signing key, so the shared self/messaging
+        # servers sign each request with the resolved agent's key (the shared
+        # process has no PINKY_AGENT_KEY env). None falls back to global secret.
+        self._signing_key_resolver = signing_key_resolver
         self._memory_pool: MemoryStorePool | None = None
         self._server = None  # uvicorn.Server instance
         self._thread: threading.Thread | None = None
@@ -348,12 +353,14 @@ class SharedMcpManager:
             agent_name="",
             api_url=self._api_url,
             tool_gates=all_gates,
+            signing_key_resolver=self._signing_key_resolver,
         )
 
         # Shared pinky-messaging: agent_name="" (resolved via ContextVar)
         messaging_mcp = create_messaging_server(
             agent_name="",
             api_url=self._api_url,
+            signing_key_resolver=self._signing_key_resolver,
         )
 
         mcp_servers = {

--- a/src/pinky_messaging/server.py
+++ b/src/pinky_messaging/server.py
@@ -7,10 +7,11 @@ import os
 import sys
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 
 from mcp.server.fastmcp import FastMCP
 
-from pinky_daemon.auth import build_internal_auth_headers, resolve_signing_secret
+from pinky_daemon.auth import build_internal_auth_headers, resolve_request_signing_secret
 from pinky_daemon.shared_mcp import LazyAgentName, resolve_lazy
 
 
@@ -39,8 +40,16 @@ def create_server(
     api_url: str = "http://localhost:8888",
     host: str = "127.0.0.1",
     port: int = 8102,
+    signing_key_resolver: Callable[[str], str | None] | None = None,
 ) -> FastMCP:
-    """Create the pinky-messaging MCP server."""
+    """Create the pinky-messaging MCP server.
+
+    ``signing_key_resolver`` (#623 shared-SSE per-request key binding):
+    ``agent_name -> per-agent signing key | None``. In shared mode the daemon
+    passes this to look up the request's resolved agent's key (the process has
+    no PINKY_AGENT_KEY env); stdio mode passes None and uses the env key
+    (increment 2). Both fall back to the global secret (dual-accept).
+    """
 
     agent_name = LazyAgentName(agent_name)
     mcp = FastMCP("pinky-messaging", host=host, port=port)
@@ -50,12 +59,10 @@ def create_server(
         url = f"{api_url}{path}"
         data = json.dumps(resolve_lazy(body)).encode() if body else None
         headers = {"Content-Type": "application/json"} if data else {}
-        # #623: prefer this agent's per-agent signing key when provisioned
-        # (stdio mode), else the shared global secret (shared-SSE / fallback).
-        secret = resolve_signing_secret()
+        agent = str(agent_name)
         headers.update(build_internal_auth_headers(
-            secret,
-            agent_name=str(agent_name),
+            resolve_request_signing_secret(agent, signing_key_resolver),
+            agent_name=agent,
             method=method,
             path=path,
         ))

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -30,11 +30,12 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Callable
 from datetime import datetime, timezone
 
 from mcp.server.fastmcp import FastMCP
 
-from pinky_daemon.auth import build_internal_auth_headers, resolve_signing_secret
+from pinky_daemon.auth import build_internal_auth_headers, resolve_request_signing_secret
 from pinky_daemon.shared_mcp import LazyAgentName, resolve_lazy
 
 
@@ -49,6 +50,7 @@ def create_server(
     host: str = "127.0.0.1",
     port: int = 8010,
     tool_gates: list[str] | None = None,
+    signing_key_resolver: Callable[[str], str | None] | None = None,
 ) -> FastMCP:
     """Create the pinky-self MCP server.
 
@@ -57,6 +59,13 @@ def create_server(
         api_url: PinkyBot API URL.
         tool_gates: List of gate names to activate (e.g. ["kb", "research"]).
                     Empty list = core tools only.
+        signing_key_resolver: #623 shared-SSE per-request key binding —
+            ``agent_name -> per-agent signing key | None``. In shared mode the
+            server process has no PINKY_AGENT_KEY env (one process, many agents),
+            so the daemon passes this resolver to look up the request's resolved
+            agent's key. Stdio mode passes None and relies on PINKY_AGENT_KEY in
+            the process env (increment 2). Either way falls back to the global
+            secret so dual-accept keeps working.
     """
     if tool_gates is None:
         tool_gates = []
@@ -73,12 +82,10 @@ def create_server(
         url = f"{api_url}{path}"
         data = json.dumps(resolve_lazy(body)).encode() if body else None
         headers = {"Content-Type": "application/json"} if data else {}
-        # #623: prefer this agent's per-agent signing key when provisioned
-        # (stdio mode), else the shared global secret (shared-SSE / fallback).
-        secret = resolve_signing_secret()
+        agent = str(agent_name)
         headers.update(build_internal_auth_headers(
-            secret,
-            agent_name=str(agent_name),
+            resolve_request_signing_secret(agent, signing_key_resolver),
+            agent_name=agent,
             method=method,
             path=path,
         ))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,6 +15,7 @@ from pinky_daemon.auth import (
     create_session_cookie,
     hash_password,
     password_source,
+    resolve_request_signing_secret,
     resolve_signing_secret,
     verify_internal_request,
     verify_password,
@@ -66,6 +67,60 @@ def test_resolve_signing_secret_empty_when_neither_set(monkeypatch):
     monkeypatch.delenv("PINKY_AGENT_KEY", raising=False)
     monkeypatch.delenv("PINKY_SESSION_SECRET", raising=False)
     assert resolve_signing_secret() == ""
+
+
+def test_resolve_request_signing_secret_prefers_resolver_key(monkeypatch):
+    # #623 increment 3 (shared-SSE): the per-request resolver wins.
+    monkeypatch.delenv("PINKY_AGENT_KEY", raising=False)
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+    got = resolve_request_signing_secret("alice", lambda name: f"{name}-key")
+    assert got == "alice-key"
+
+
+def test_resolve_request_signing_secret_none_falls_back(monkeypatch):
+    # Resolver returns None (unknown agent) → fall back to env/global secret.
+    monkeypatch.delenv("PINKY_AGENT_KEY", raising=False)
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+    assert resolve_request_signing_secret("ghost", lambda name: None) == "global-secret"
+
+
+def test_resolve_request_signing_secret_resolver_raises_falls_back(monkeypatch):
+    # A resolver hiccup must never raise into the request path.
+    monkeypatch.delenv("PINKY_AGENT_KEY", raising=False)
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+
+    def boom(name):
+        raise RuntimeError("db locked")
+
+    assert resolve_request_signing_secret("alice", boom) == "global-secret"
+
+
+def test_resolve_request_signing_secret_no_resolver_uses_env(monkeypatch):
+    # Stdio mode: no resolver, PINKY_AGENT_KEY in env (increment 2) wins.
+    monkeypatch.setenv("PINKY_AGENT_KEY", "env-agent-key")
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+    assert resolve_request_signing_secret("alice", None) == "env-agent-key"
+
+
+def test_resolve_request_signing_secret_resolver_signature_dual_accepted(monkeypatch):
+    # End-to-end: a shared-server request signed via the resolver's per-agent
+    # key verifies on the daemon through the agent_key path (dual-accept), with
+    # the resolved agent name bound in.
+    monkeypatch.delenv("PINKY_AGENT_KEY", raising=False)
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+    secret = resolve_request_signing_secret("alice", lambda name: "alice-key")
+    headers = build_internal_auth_headers(
+        secret, agent_name="alice", method="POST", path="/agents/alice/status",
+    )
+    assert verify_internal_request(
+        "global-secret",  # daemon global secret does NOT match the signature
+        agent_name="alice",
+        method="POST",
+        path="/agents/alice/status",
+        timestamp=headers["x-pinky-timestamp"],
+        signature=headers["x-pinky-signature"],
+        agent_key="alice-key",  # ...but the per-agent key does
+    )
 
 
 def test_per_agent_key_signs_request_verifiable_by_daemon(monkeypatch):

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -213,6 +213,36 @@ class TestSharedMcpManager:
         assert mgr._port == 9999
         assert mgr._api_url == "http://example.com"
 
+    def test_threads_signing_key_resolver_into_servers(self, monkeypatch):
+        """#623 increment 3: the manager passes its signing_key_resolver into
+        both the shared self and messaging servers so they sign each request
+        with the resolved agent's per-agent key."""
+        import pinky_daemon.shared_mcp as sm
+
+        captured = {}
+
+        def fake_self_server(**kwargs):
+            captured["self"] = kwargs.get("signing_key_resolver")
+            return object()
+
+        def fake_messaging_server(**kwargs):
+            captured["messaging"] = kwargs.get("signing_key_resolver")
+            return object()
+
+        # _create_app imports create_server lazily from these modules.
+        monkeypatch.setattr("pinky_self.server.create_server", fake_self_server)
+        monkeypatch.setattr("pinky_messaging.server.create_server", fake_messaging_server)
+        # Avoid building the real combined ASGI app over our dummy objects.
+        monkeypatch.setattr(sm, "create_shared_app", lambda servers: servers)
+
+        def resolver(name):
+            return f"{name}-key"
+
+        mgr = SharedMcpManager(signing_key_resolver=resolver)
+        mgr._create_app()
+        assert captured["self"] is resolver
+        assert captured["messaging"] is resolver
+
 
 class TestGateToolNames:
     """GATE_TOOL_NAMES and _get_shared_mode_disallowed_tools."""


### PR DESCRIPTION
## What & why

Increment 3 of #623 (non-forgeable per-agent identity). Increments 1 (#631) + 2 (#632) gave each agent a signing key and cut over the per-agent-process signers (tmux hooks, stdio MCP). **This cuts over the live fleet's path**: the shared-SSE MCP server, which serves every agent from **one process** and so can't get a per-agent key from the process env.

Still **additive** — the daemon dual-accepts (per-agent key OR global secret), so a `None` resolution falls back to the global secret unchanged.

## Changes
- **`auth.resolve_request_signing_secret(agent_name, resolver)`** — per-request secret = `resolver(agent)` if it yields a key, else `resolve_signing_secret()` (env/global). Resolver errors degrade to the fallback, never raise into the request path. Single source of truth for precedence.
- **`pinky_self` / `pinky_messaging` `create_server`** gain a `signing_key_resolver` param; `_api` signs each request with the resolved agent's key. The resolved agent comes from the `AgentNameMiddleware` ContextVar (`str(LazyAgentName)`) — so each request signs with **its own** agent's key, no cross-agent contamination.
- **`SharedMcpManager`** threads `signing_key_resolver` into both servers (mirrors the existing `memory_db_resolver` pattern).
- **`api` on_startup** wires the resolver to `agents.get_signing_key` (guarded: unknown agent / failure → `None` → global-secret fallback).

## Result
Both transports now prefer the per-agent key: **stdio** via the env (increment 2), **shared-SSE** via the resolver (here). The global secret is now only a fallback.

## Next (increment 4)
Drop global-secret acceptance to close the forgery hole — gated on the **three cutover criteria** tracked on #623: stale-key on hard `delete()`, on-disk `.mcp.json` plaintext key, and the `mcp-servers` endpoint echoing the key. Plus #149 fs-isolation.

## Tests
- `resolve_request_signing_secret`: prefers resolver key / None falls back / resolver-raises falls back / no-resolver uses env + resolver-keyed signature dual-accepted with the agent name bound in
- `SharedMcpManager` threads the resolver into both shared servers

300 passed across auth / shared_mcp / shared_mcp_integration / pinky_self_tools / broker; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)