### PR TITLE
harden(#623): pre-cutover key-leak/lifecycle fixes (3 of 4 increment-4 criteria)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2198,6 +2198,13 @@ except Exception:
     def delete(self, name: str) -> bool:
         """Permanently delete an agent and all its directives/tokens (cascade)."""
         cursor = self._db.execute("DELETE FROM agents WHERE name=?", (name,))
+        # #623: purge the per-agent signing key too. Without this, a hard-
+        # deleted name keeps its key in agent_signing_keys, so re-registering
+        # that name inherits a STALE signing credential. Harmless under dual-
+        # accept, but once the per-agent key is the sole credential (increment
+        # 4) a recreated agent must mint a fresh identity, not resurrect the
+        # old one. No FK/cascade on the table, so delete explicitly.
+        self._db.execute("DELETE FROM agent_signing_keys WHERE agent_name=?", (name,))
         self._db.commit()
         if cursor.rowcount > 0:
             _log(f"agents: deleted {name}")

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -526,6 +526,30 @@ def _get_agent_tool_gates(agent_name: str, skill_store=None) -> list[str]:
     return sorted(gates)
 
 
+# #623: env var names whose VALUES must never be returned over the API. The
+# /agents/{name}/mcp-servers endpoint echoes the .mcp.json / DB `env` block,
+# which now carries PINKY_AGENT_KEY (the per-agent signing credential) for
+# stdio agents. The substring set also redacts custom-server secrets as
+# defense-in-depth. Keys stay visible (so the UI shows which vars are set);
+# only values are masked.
+_SENSITIVE_ENV_SUBSTRINGS = (
+    "KEY", "SECRET", "TOKEN", "PASSWORD", "PASSWD", "CREDENTIAL", "AUTH",
+)
+
+
+def _redact_env_secrets(env: dict) -> dict:
+    """Mask values of sensitive env vars before returning an env dict via API."""
+    if not isinstance(env, dict):
+        return env
+    out = {}
+    for k, v in env.items():
+        if isinstance(k, str) and any(s in k.upper() for s in _SENSITIVE_ENV_SUBSTRINGS):
+            out[k] = "***redacted***"
+        else:
+            out[k] = v
+    return out
+
+
 def _write_mcp_json(
     work_dir: Path,
     agent_name: str,
@@ -5554,7 +5578,7 @@ npm run build</pre>
                 entry["server_type"] = "http"
                 entry["url"] = cfg.get("url", "")
             if "env" in cfg:
-                entry["env"] = cfg["env"]
+                entry["env"] = _redact_env_secrets(cfg["env"])
             servers.append(entry)
 
         # Emit custom DB servers
@@ -5566,7 +5590,7 @@ npm run build</pre>
                 "command": srv["command"],
                 "args": json.loads(srv["args"]),
                 "url": srv["url"],
-                "env": json.loads(srv["env"]),
+                "env": _redact_env_secrets(json.loads(srv["env"])),
                 "enabled": srv["enabled"],
             })
 

--- a/src/pinky_daemon/auth.py
+++ b/src/pinky_daemon/auth.py
@@ -142,6 +142,11 @@ def resolve_request_signing_secret(agent_name, signing_key_resolver=None) -> str
                 return key
         except Exception:
             pass
+        # Shared-mode fallback: GLOBAL secret only. A resolver means we're the
+        # multi-agent shared process — a process-level PINKY_AGENT_KEY (if one
+        # ever leaked into this env) would be a single WRONG identity for every
+        # agent, so never honor it here. Use the global secret (dual-accept).
+        return os.environ.get("PINKY_SESSION_SECRET", "").strip()
     return resolve_signing_secret()
 
 

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -53,6 +53,23 @@ class TestSigningKeys:
         agent = registry.register("nova", model="opus")
         assert "signing_key" not in agent.to_dict()
 
+    def test_delete_purges_signing_key_no_stale_on_recreate(self, registry):
+        """#623 pre-cutover hardening: hard delete() purges agent_signing_keys
+        so a re-registered name mints a FRESH key, not the stale one."""
+        registry.register("alice", model="opus")
+        first_key = registry.get_signing_key("alice")
+        assert first_key
+
+        assert registry.delete("alice") is True
+        # Key is gone — not orphaned in agent_signing_keys.
+        assert registry.get_signing_key("alice") is None
+
+        # Re-register the same name → brand-new key, not the old one.
+        registry.register("alice", model="opus")
+        second_key = registry.get_signing_key("alice")
+        assert second_key
+        assert second_key != first_key
+
     def test_hook_templates_prefer_per_agent_key(self, tmp_path):
         """#623 increment 2: every signed tmux hook prefers PINKY_AGENT_KEY
         over the global PINKY_SESSION_SECRET, so hooks running in an agent's

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -60,7 +60,10 @@ class TestSigningKeys:
         first_key = registry.get_signing_key("alice")
         assert first_key
 
-        assert registry.delete("alice") is True
+        # Split the side-effecting call out of the assert (CodeQL: asserts are
+        # stripped under python -O, which would skip the delete).
+        deleted = registry.delete("alice")
+        assert deleted is True
         # Key is gone — not orphaned in agent_signing_keys.
         assert registry.get_signing_key("alice") is None
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,35 @@ from pinky_daemon.sessions import (
 # ── SessionMessage ───────────────────────────────────────────
 
 
+class TestRedactEnvSecrets:
+    """#623 pre-cutover hardening: /mcp-servers must not echo secret env values."""
+
+    def test_redacts_pinky_agent_key(self):
+        from pinky_daemon.api import _redact_env_secrets
+
+        out = _redact_env_secrets({"PINKY_AGENT_KEY": "supersecret", "FOO": "bar"})
+        assert out["PINKY_AGENT_KEY"] == "***redacted***"
+        assert out["FOO"] == "bar"  # non-sensitive value preserved
+        assert "PINKY_AGENT_KEY" in out  # key stays visible, only value masked
+
+    def test_redacts_common_secret_patterns(self):
+        from pinky_daemon.api import _redact_env_secrets
+
+        env = {
+            "API_TOKEN": "t", "DB_PASSWORD": "p", "X_SECRET": "s",
+            "AUTH_HEADER": "a", "MY_CREDENTIAL": "c", "PLAIN": "ok",
+        }
+        out = _redact_env_secrets(env)
+        for k in ("API_TOKEN", "DB_PASSWORD", "X_SECRET", "AUTH_HEADER", "MY_CREDENTIAL"):
+            assert out[k] == "***redacted***"
+        assert out["PLAIN"] == "ok"
+
+    def test_non_dict_passthrough(self):
+        from pinky_daemon.api import _redact_env_secrets
+
+        assert _redact_env_secrets(None) is None
+
+
 class TestSessionMessage:
     def test_create(self):
         msg = SessionMessage(role="user", content="Hello")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -102,6 +102,21 @@ def test_resolve_request_signing_secret_no_resolver_uses_env(monkeypatch):
     assert resolve_request_signing_secret("alice", None) == "env-agent-key"
 
 
+def test_resolve_request_signing_secret_shared_fallback_ignores_process_env_key(monkeypatch):
+    # Pre-cutover hardening (#623): with a resolver present (shared multi-agent
+    # process), a resolver-None must fall back to the GLOBAL secret only — never
+    # a stray process-level PINKY_AGENT_KEY, which would be one wrong identity
+    # for every agent.
+    monkeypatch.setenv("PINKY_AGENT_KEY", "stray-process-key")
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+    assert resolve_request_signing_secret("alice", lambda name: None) == "global-secret"
+
+    def boom(name):
+        raise RuntimeError("db locked")
+
+    assert resolve_request_signing_secret("alice", boom) == "global-secret"
+
+
 def test_resolve_request_signing_secret_resolver_signature_dual_accepted(monkeypatch):
     # End-to-end: a shared-server request signed via the resolver's per-agent
     # key verifies on the daemon through the agent_key path (dual-accept), with


### PR DESCRIPTION
## What & why

Safe, **additive** hardening that closes **three of the four** increment-4 acceptance criteria surfaced in the #631 / #632 / #633 reviews. **No global-secret drop here** — dual-accept stays. This just removes ways the per-agent key could leak or go stale *before* it becomes the sole credential at increment 4. The 4th criterion (on-disk plaintext `.mcp.json` key) needs #149 fs-isolation and stays parked.

## Fixes
1. **Stale-key-on-recreate** (Murzik, inc 1): `AgentRegistry.delete()` now purges `agent_signing_keys` (no FK/cascade, so explicit). A re-registered name mints a fresh key instead of resurrecting the deleted agent's identity.
2. **API key echo** (Murzik, inc 2): `GET /agents/{name}/mcp-servers` echoed the `.mcp.json` / DB `env` block, which carries `PINKY_AGENT_KEY` for stdio agents. New `_redact_env_secrets()` masks values of sensitive env vars (`KEY`/`SECRET`/`TOKEN`/`PASSWORD`/`CREDENTIAL`/`AUTH` substrings) at both echo sites — keys stay visible, only values masked. Defense-in-depth for custom-server secrets too.
3. **Shared-mode fallback** (Murzik, inc 3): `resolve_request_signing_secret`, when a resolver is present (multi-agent shared process), now falls back to the **global secret only** — never a stray process-level `PINKY_AGENT_KEY` (which would be one wrong identity for every agent).

## Still gating increment 4 (not in this PR)
- Criterion 2: on-disk plaintext key in `.mcp.json` on a shared fs → needs **#149 container/fs-isolation** (or off-disk provisioning) + `chmod 600`.
- The hard sequencing rule stands: don't drop global-secret acceptance until that's resolved.

## Tests
- `delete()` purges the key + fresh-key-on-recreate
- `_redact_env_secrets` masks `PINKY_AGENT_KEY` + common secret patterns, preserves non-sensitive values, non-dict passthrough
- shared-mode fallback ignores a process-env `PINKY_AGENT_KEY` on resolver None / raise

167 passed (registry / auth / api-CRUD / redaction); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)