### PR TITLE
feat(#149): isolation flag + daemon authz scoping (phase 2)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -361,6 +361,10 @@ class Agent:
     #   }
     # }
     role: str = ""  # Agent role: sidekick, lead, worker, specialist
+    # #149 tenant isolation: True = hard-isolated tenant (Counterpart), scoped to
+    # ITSELF only. Daemon denies it cross-agent actions + admin/register_agent.
+    # Default False = full-trust inner-fleet agent (no behavior change).
+    isolated: bool = False
     dream_enabled: bool = False  # Enable nightly memory consolidation
     dream_schedule: str = "0 3 * * *"  # Cron for dream runs (default 3 AM)
     dream_timezone: str = "America/Los_Angeles"  # IANA timezone for dream schedule
@@ -426,6 +430,7 @@ class Agent:
             "plain_text_fallback": self.plain_text_fallback,
             "voice_config": self.voice_config,
             "role": self.role,
+            "isolated": self.isolated,
             "dream_enabled": self.dream_enabled,
             "dream_schedule": self.dream_schedule,
             "dream_timezone": self.dream_timezone,
@@ -1322,6 +1327,13 @@ class AgentRegistry:
             ("mesh_outbound_allowlist", "TEXT NOT NULL DEFAULT '[]'"),
             # Soft context-watermark nudge (#614); 0 = use global default.
             ("context_nudge_threshold_pct", "REAL NOT NULL DEFAULT 0.0"),
+            # #149 tenant isolation: when 1, this agent is a hard-isolated
+            # tenant (Counterpart) — scoped to ITSELF only. The daemon denies
+            # it cross-agent actions (acting on a different agent's resources)
+            # and admin/register_agent. Default 0 = full-trust inner-fleet agent
+            # (no behavior change). Enforcement keys off the #623 per-agent-key
+            # authenticated identity.
+            ("isolated", "INTEGER NOT NULL DEFAULT 0"),
         ]
         for col, typedef in migrations:
             if col not in existing:
@@ -1894,7 +1906,7 @@ except Exception:
                         "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
                         "librarian_enabled", "librarian_schedule",
                         "runtime", "transport", "provider_url", "provider_key", "provider_model", "provider_ref",
-                        "thinking_effort", "strict_effort_enforcement"):
+                        "thinking_effort", "strict_effort_enforcement", "isolated"):
                 if key in kwargs:
                     updates[key] = kwargs[key]
 
@@ -1926,6 +1938,8 @@ except Exception:
                 updates["librarian_enabled"] = int(updates["librarian_enabled"])
             if "strict_effort_enforcement" in updates:
                 updates["strict_effort_enforcement"] = int(updates["strict_effort_enforcement"])
+            if "isolated" in updates:
+                updates["isolated"] = int(updates["isolated"])
 
             if updates:
                 updates["updated_at"] = now
@@ -1971,6 +1985,7 @@ except Exception:
                 plain_text_fallback=kwargs.get("plain_text_fallback", False),
                 voice_config=kwargs.get("voice_config", {}),
                 role=kwargs.get("role", ""),
+                isolated=kwargs.get("isolated", False),
                 dream_enabled=kwargs.get("dream_enabled", False),
                 dream_schedule=kwargs.get("dream_schedule", "0 3 * * *"),
                 dream_timezone=kwargs.get("dream_timezone", "America/Los_Angeles"),
@@ -1997,13 +2012,13 @@ except Exception:
                     permission_mode, allowed_tools, disallowed_tools, max_turns, timeout,
                     restart_threshold_pct, context_nudge_threshold_pct, auto_restart, parent, groups,
                     max_sessions, enabled, auto_start, heartbeat_interval, plain_text_fallback,
-                    wake_interval, clock_aligned, auto_sleep_hours, voice_config, role,
+                    wake_interval, clock_aligned, auto_sleep_hours, voice_config, role, isolated,
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
                     librarian_enabled, librarian_schedule,
                     runtime, transport, provider_url, provider_key, provider_model, provider_ref,
                     thinking_effort, strict_effort_enforcement, watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -2014,7 +2029,7 @@ except Exception:
                  agent.parent, json.dumps(agent.groups), agent.max_sessions,
                  int(agent.enabled), int(agent.auto_start), agent.heartbeat_interval, int(agent.plain_text_fallback),
                  agent.wake_interval, int(agent.clock_aligned), agent.auto_sleep_hours,
-                 json.dumps(agent.voice_config), agent.role,
+                 json.dumps(agent.voice_config), agent.role, int(agent.isolated),
                  int(agent.dream_enabled), agent.dream_schedule, agent.dream_timezone, agent.dream_model, int(agent.dream_notify),
                  int(agent.librarian_enabled), agent.librarian_schedule,
                  agent.runtime, agent.transport, agent.provider_url, agent.provider_key,
@@ -2053,7 +2068,7 @@ except Exception:
         "working_status, working_status_updated_at, "
         "runtime, transport, provider_url, provider_key, provider_model, provider_ref, "
         "disallowed_tools, thinking_effort, watchdog_config, last_seen_at, "
-        "strict_effort_enforcement, context_nudge_threshold_pct"
+        "strict_effort_enforcement, context_nudge_threshold_pct, isolated"
     )
 
     def get(self, name: str) -> Agent | None:
@@ -3829,6 +3844,7 @@ except Exception:
             last_seen_at=row[48] if len(row) > 48 else 0.0,
             strict_effort_enforcement=bool(row[49]) if len(row) > 49 else False,
             context_nudge_threshold_pct=row[50] if len(row) > 50 else 0.0,
+            isolated=bool(row[51]) if len(row) > 51 else False,
         )
 
     # ── Cost Tracking ──────────────────────────────────────

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -537,6 +537,11 @@ _SENSITIVE_ENV_SUBSTRINGS = (
 )
 
 
+# #149: matches /agents/{name} and /agents/{name}/... — captures the target
+# agent name so the isolation guard can compare it to the authenticated caller.
+_AGENTS_RESOURCE_PATH_RE = re.compile(r"^/agents/([^/]+)(?:/.*)?$")
+
+
 def _redact_env_secrets(env: dict) -> dict:
     """Mask values of sensitive env vars before returning an env dict via API."""
     if not isinstance(env, dict):
@@ -3292,6 +3297,36 @@ def create_api(
             agent_key=agent_key,
         )
 
+    def _internal_isolation_denied(request: Request, caller_name: str) -> bool:
+        """#149 tenant isolation: an authenticated *isolated* agent may only
+        act on its OWN ``/agents/{name}/*`` resources. Returns True (deny) when
+        the caller is isolated and the request targets a DIFFERENT agent.
+
+        Only reached after _has_valid_internal_auth succeeds, so ``caller_name``
+        is the verified signed identity (the signature binds the name). The
+        cheap path checks (no /agents/{target} match, or target == caller) short-
+        circuit BEFORE any registry lookup, so the hot path (self-calls, non-
+        /agents endpoints) pays no extra DB read — only a genuine cross-agent
+        target triggers the isolated-flag lookup.
+
+        Defense-in-depth on top of tool-gating: isolated agents are provisioned
+        without admin/register gates, but this enforces the tenant boundary at
+        the daemon regardless of what tools the agent manages to invoke.
+        """
+        if not caller_name:
+            return False
+        m = _AGENTS_RESOURCE_PATH_RE.match(request.url.path)
+        if not m:
+            return False  # not an /agents/{target}/* surface
+        target = m.group(1)
+        if target == caller_name:
+            return False  # acting on self — always allowed, no lookup
+        try:
+            caller = agents.get(caller_name)
+        except Exception:
+            return False
+        return bool(caller and getattr(caller, "isolated", False))
+
     def _has_valid_session(request: Request) -> bool:
         secret = _session_secret()
         if not secret:
@@ -3339,6 +3374,17 @@ def create_api(
 
         # 2. HMAC-signed internal request (agent-to-daemon, hook scripts).
         if _has_valid_internal_auth(request):
+            # #149: an isolated agent is scoped to its OWN resources. Deny any
+            # cross-agent /agents/{other}/* access even with a valid signature.
+            caller = request.headers.get(INTERNAL_AGENT_HEADER, "")
+            if _internal_isolation_denied(request, caller):
+                return JSONResponse(
+                    status_code=403,
+                    content={
+                        "error": "isolated agent may only access its own resources",
+                        "agent": caller,
+                    },
+                )
             return await call_next(request)
 
         # 3. Valid session cookie → through. Pulled up from the per-path
@@ -4680,6 +4726,7 @@ npm run build</pre>
             thinking_effort=req.thinking_effort,
             strict_effort_enforcement=req.strict_effort_enforcement,
             watchdog_config=req.watchdog_config or {},
+            isolated=req.isolated,
         )
         # Write .mcp.json so the agent gets default MCP servers (memory, self, messaging)
         work_dir = Path(agent.working_dir) if agent.working_dir else None

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -4780,8 +4780,25 @@ npm run build</pre>
     # ── Agent Registry Endpoints ────────────────────────────
 
     @app.post("/agents")
-    async def register_agent(req: RegisterAgentRequest):
+    async def register_agent(req: RegisterAgentRequest, request: Request):
         """Register a new agent or update an existing one."""
+        # #149: registering/upserting agents is an ADMIN capability. This is the
+        # agent-mint/upsert collection route — it has no target agent in the
+        # PATH, so the middleware's path-based isolation guard can't see it
+        # (target is None → flows through). An isolated tenant reaching here with
+        # a valid signature could mint a new full-trust agent OR upsert an
+        # existing record (including dropping its OWN isolated flag — a direct
+        # escape). Deny the whole route for isolated callers; agents are minted
+        # by an operator/admin, never self-served by a tenant. (Murzik #635
+        # re-review catch.) Operator/browser sessions carry no internal-agent
+        # header → caller "" → not isolated → unaffected.
+        caller = request.headers.get(INTERNAL_AGENT_HEADER, "")
+        if _is_isolated_agent(caller):
+            _log(
+                f"isolation: denied isolated agent '{caller}' from POST /agents "
+                f"(admin mint/upsert, body name='{req.name}')"
+            )
+            raise HTTPException(403, "isolated agent may not register or modify agents")
         agent = agents.register(
             req.name,
             display_name=req.display_name,

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -537,9 +537,34 @@ _SENSITIVE_ENV_SUBSTRINGS = (
 )
 
 
-# #149: matches /agents/{name} and /agents/{name}/... — captures the target
-# agent name so the isolation guard can compare it to the authenticated caller.
-_AGENTS_RESOURCE_PATH_RE = re.compile(r"^/agents/([^/]+)(?:/.*)?$")
+# #149: path surfaces that embed a TARGET agent name in the URL. The isolation
+# guard extracts that target and compares it to the authenticated caller so an
+# isolated agent can only act on its OWN resources.
+#   /agents/{name}, /agents/{name}/...   — agent record + all sub-resources
+#   /autonomy/{name}/...                 — start/stop/event (NOT /autonomy/status,
+#                                          which is target-less and so excluded by
+#                                          the required trailing sub-segment)
+_ISOLATION_PATH_RES = (
+    re.compile(r"^/agents/([^/]+)(?:/.*)?$"),
+    re.compile(r"^/autonomy/([^/]+)/.+$"),
+)
+
+# #149: body-actor surfaces (/broker/*) are NOT matched here. Their acting
+# agent comes from the request BODY (field ``agent_name``), not the path, so
+# path matching can't catch impersonation (e.g. an isolated agent POSTing to
+# /broker/send with a forged agent_name — Pushok's review catch). Those are
+# guarded in the handlers via _deny_isolated_cross_actor(), where the body is
+# already parsed (reading the body in BaseHTTPMiddleware is fragile).
+
+
+def _isolation_path_target(path: str) -> str | None:
+    """Return the target agent name embedded in an isolation-relevant path, or
+    None if the path doesn't name a specific agent."""
+    for rx in _ISOLATION_PATH_RES:
+        m = rx.match(path)
+        if m:
+            return m.group(1)
+    return None
 
 
 def _redact_env_secrets(env: dict) -> dict:
@@ -3298,16 +3323,23 @@ def create_api(
         )
 
     def _internal_isolation_denied(request: Request, caller_name: str) -> bool:
-        """#149 tenant isolation: an authenticated *isolated* agent may only
-        act on its OWN ``/agents/{name}/*`` resources. Returns True (deny) when
-        the caller is isolated and the request targets a DIFFERENT agent.
+        """#149 tenant isolation (PATH-target surfaces): an authenticated
+        *isolated* agent may only act on its OWN resources. Returns True (deny)
+        when the caller is isolated and the request path targets a DIFFERENT
+        agent (``/agents/{other}/*`` or ``/autonomy/{other}/*``).
 
         Only reached after _has_valid_internal_auth succeeds, so ``caller_name``
         is the verified signed identity (the signature binds the name). The
-        cheap path checks (no /agents/{target} match, or target == caller) short-
+        cheap path checks (no agent-target match, or target == caller) short-
         circuit BEFORE any registry lookup, so the hot path (self-calls, non-
-        /agents endpoints) pays no extra DB read — only a genuine cross-agent
+        targeted endpoints) pays no extra DB read — only a genuine cross-agent
         target triggers the isolated-flag lookup.
+
+        Body-actor surfaces (/broker/*, where the sender is named in the request
+        body, not the path) are NOT covered here — they're enforced in the
+        handlers via _deny_isolated_cross_actor(). Reading the request body in
+        BaseHTTPMiddleware is fragile, so the body check lives where the body is
+        already parsed.
 
         Defense-in-depth on top of tool-gating: isolated agents are provisioned
         without admin/register gates, but this enforces the tenant boundary at
@@ -3315,17 +3347,69 @@ def create_api(
         """
         if not caller_name:
             return False
-        m = _AGENTS_RESOURCE_PATH_RE.match(request.url.path)
-        if not m:
-            return False  # not an /agents/{target}/* surface
-        target = m.group(1)
+        target = _isolation_path_target(request.url.path)
+        if target is None:
+            return False  # path does not name a specific agent
         if target == caller_name:
             return False  # acting on self — always allowed, no lookup
+        # Genuine cross-agent target. Resolve the caller's isolation flag.
+        # Fail CLOSED: a registry error means we cannot prove the caller is
+        # non-isolated, so deny this (already cross-agent shaped) request rather
+        # than risk a tenant escape.
         try:
             caller = agents.get(caller_name)
-        except Exception:
+        except Exception as e:
+            _log(
+                f"isolation-check: registry lookup failed for '{caller_name}' "
+                f"on {request.url.path}: {e} — failing closed (deny)"
+            )
+            return True
+        if caller and getattr(caller, "isolated", False):
+            _log(
+                f"isolation: denied isolated agent '{caller_name}' cross-agent "
+                f"access to {request.url.path}"
+            )
+            return True
+        return False
+
+    def _is_isolated_agent(name: str) -> bool:
+        """True iff ``name`` resolves to an agent with the #149 isolated flag.
+        Fails CLOSED (returns True) on registry error so a body-actor guard
+        denies rather than risks a tenant escape when isolation can't be
+        verified."""
+        if not name:
             return False
-        return bool(caller and getattr(caller, "isolated", False))
+        try:
+            agent = agents.get(name)
+        except Exception as e:
+            _log(f"isolation-check: registry lookup failed for '{name}': {e} — failing closed")
+            return True
+        return bool(agent and getattr(agent, "isolated", False))
+
+    def _deny_isolated_cross_actor(request: Request, body_agent: str) -> None:
+        """#149 body-actor guard for /broker/* (and any handler whose acting
+        agent comes from the request body). Raises 403 when an *isolated*
+        caller's body names a DIFFERENT agent — i.e. an attempt to send/act AS
+        another agent. No-op for non-isolated callers (full-trust inner-fleet
+        agents may act broadly) and for non-internal callers (operator/browser
+        sessions don't carry a verified internal-agent header).
+
+        The caller identity is the signature-verified internal header, set only
+        after _has_valid_internal_auth succeeds in the middleware; a session/
+        browser request has no such header and is left untouched here.
+        """
+        caller = request.headers.get(INTERNAL_AGENT_HEADER, "")
+        if not caller or not body_agent or body_agent == caller:
+            return
+        if _is_isolated_agent(caller):
+            _log(
+                f"isolation: denied isolated agent '{caller}' from acting as "
+                f"'{body_agent}' on {request.url.path}"
+            )
+            raise HTTPException(
+                status_code=403,
+                detail="isolated agent may only act as itself",
+            )
 
     def _has_valid_session(request: Request) -> bool:
         secret = _session_secret()
@@ -6239,7 +6323,7 @@ npm run build</pre>
         }
 
     @app.post("/broker/send")
-    async def broker_send_message(req: dict):
+    async def broker_send_message(req: dict, request: Request):
         """Send an outbound message through the broker on behalf of an agent."""
         agent_name = req.get("agent_name", "")
         platform = req.get("platform", "telegram")
@@ -6249,6 +6333,7 @@ npm run build</pre>
         parse_mode = req.get("parse_mode", "")
         if not agent_name or not chat_id or not content:
             raise HTTPException(400, "agent_name, chat_id, and content are required")
+        _deny_isolated_cross_actor(request, agent_name)
         try:
             result = await _broker_send(
                 agent_name,
@@ -6277,7 +6362,7 @@ npm run build</pre>
         return result
 
     @app.post("/broker/thread")
-    async def broker_thread(req: dict):
+    async def broker_thread(req: dict, request: Request):
         """Send a threaded/quoted reply to an inbound message using stored broker context."""
         agent_name = req.get("agent_name", "")
         source_message_id = req.get("message_id", "")
@@ -6285,6 +6370,7 @@ npm run build</pre>
         parse_mode = req.get("parse_mode", "")
         if not agent_name or not source_message_id or not content:
             raise HTTPException(400, "agent_name, message_id, and content are required")
+        _deny_isolated_cross_actor(request, agent_name)
 
         ctx = _resolve_message_context(agent_name, source_message_id)
         voice_settings = _get_voice_reply_settings(agent_name, ctx.platform)
@@ -6337,12 +6423,13 @@ npm run build</pre>
         return result
 
     @app.post("/broker/broadcast")
-    async def broker_broadcast(req: dict):
+    async def broker_broadcast(req: dict, request: Request):
         """Broadcast a message to all active channels for an agent."""
         agent_name = req.get("agent_name", "")
         content = req.get("content", "").strip()
         if not agent_name or not content:
             raise HTTPException(400, "agent_name and content are required")
+        _deny_isolated_cross_actor(request, agent_name)
 
         deliveries: list[dict] = []
         errors: list[str] = []
@@ -6420,6 +6507,7 @@ npm run build</pre>
 
     async def _broker_send_file_route(
         req: dict,
+        request: Request,
         *,
         kind: str,  # "photo" or "document"
         method: str,  # "send_photo" or "send_document"
@@ -6432,6 +6520,7 @@ npm run build</pre>
         in `finally` so a failed send doesn't leave the chat showing "typing…" forever.
         """
         agent_name = req.get("agent_name", "")
+        _deny_isolated_cross_actor(request, agent_name)  # #149 body-actor guard
         source_message_id = req.get("message_id", "")
         platform = req.get("platform", "telegram")
         chat_id = req.get("chat_id", "")
@@ -6525,17 +6614,17 @@ npm run build</pre>
         return result
 
     @app.post("/broker/send-photo")
-    async def broker_send_photo(req: dict):
+    async def broker_send_photo(req: dict, request: Request):
         """Send a photo through the broker on behalf of an agent."""
-        return await _broker_send_file_route(req, kind="photo", method="send_photo")
+        return await _broker_send_file_route(req, request, kind="photo", method="send_photo")
 
     @app.post("/broker/send-document")
-    async def broker_send_document(req: dict):
+    async def broker_send_document(req: dict, request: Request):
         """Send a document through the broker on behalf of an agent."""
-        return await _broker_send_file_route(req, kind="document", method="send_document")
+        return await _broker_send_file_route(req, request, kind="document", method="send_document")
 
     @app.post("/broker/send-gif")
-    async def broker_send_gif(req: dict):
+    async def broker_send_gif(req: dict, request: Request):
         """Search Giphy and send the result as an animation through the broker.
 
         API key is resolved from system settings, then env var, then a public
@@ -6548,6 +6637,7 @@ npm run build</pre>
         giphy_public_key = "dc6zaTOxFJmzC"
 
         agent_name_req = req.get("agent_name", "")
+        _deny_isolated_cross_actor(request, agent_name_req)  # #149 body-actor guard
         source_message_id = req.get("message_id", "")
         platform = req.get("platform", "telegram")
         chat_id = req.get("chat_id", "")
@@ -6686,23 +6776,24 @@ npm run build</pre>
         return result
 
     @app.post("/broker/send-animation")
-    async def broker_send_animation(req: dict):
+    async def broker_send_animation(req: dict, request: Request):
         """Send an animation (GIF) through the broker on behalf of an agent.
 
         Issue #395 follow-up: routed through the shared _broker_send_file_route
         helper so failures surface as structured 502 and the typing indicator
         is always torn down in `finally`.
         """
-        return await _broker_send_file_route(req, kind="animation", method="send_animation")
+        return await _broker_send_file_route(req, request, kind="animation", method="send_animation")
 
     @app.post("/broker/send-voice")
-    async def broker_send_voice(req: dict):
+    async def broker_send_voice(req: dict, request: Request):
         """Generate TTS audio and send as a voice message through the broker.
 
         Supports ElevenLabs, OpenAI TTS, and Deepgram Aura. API keys are
         read from system settings (settings panel) or env vars.
         """
         agent_name_req = req.get("agent_name", "")
+        _deny_isolated_cross_actor(request, agent_name_req)  # #149 body-actor guard
         source_message_id = req.get("message_id", "")
         platform = req.get("platform", "telegram")
         chat_id = req.get("chat_id", "")
@@ -6741,9 +6832,10 @@ npm run build</pre>
         return result
 
     @app.post("/broker/react")
-    async def broker_react(req: dict):
+    async def broker_react(req: dict, request: Request):
         """Add a reaction through the broker on behalf of an agent."""
         agent_name = req.get("agent_name", "")
+        _deny_isolated_cross_actor(request, agent_name)  # #149 body-actor guard
         platform = req.get("platform", "telegram")
         chat_id = req.get("chat_id", "")
         message_id = req.get("message_id", "")

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -342,6 +342,7 @@ class RegisterAgentRequest(BaseModel):
     thinking_effort: str = "medium"  # low/medium/high/xhigh/max
     strict_effort_enforcement: bool = False  # PR #429 — block tool calls when effort drifts
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
+    isolated: bool = False  # #149 — hard-isolated tenant (Counterpart); daemon denies cross-agent actions
 
 
 class UpdateAgentRequest(BaseModel):

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -2067,6 +2067,7 @@ def create_server(
             groups: list[str] | None = None,
             transport: str = "tmux",
             confirm_privileged_role: bool = False,
+            isolated: bool = False,
         ) -> str:
             """Register a new agent in the fleet, then assign its skills.
 
@@ -2079,6 +2080,11 @@ def create_server(
             agent's memory. Creating a privileged role requires
             confirm_privileged_role=True — a deliberate, audited act.
             transport: "tmux" (modern rails) or "sdk".
+            isolated: #149 — True creates a HARD-ISOLATED tenant (Counterpart),
+            scoped to itself only. The daemon denies it any cross-agent action
+            (acting on a different agent's resources). Default False = full-trust
+            inner-fleet agent. (fs/container isolation is a later phase; this
+            flag is the daemon-authz half.)
             """
             privileged_roles = {"dreamer"}
             if role in privileged_roles and not confirm_privileged_role:
@@ -2119,6 +2125,7 @@ def create_server(
                 "soul": soul,
                 "groups": groups or [],
                 "transport": transport,
+                "isolated": isolated,
             })
             if isinstance(create, dict) and "error" in create:
                 return f"Failed to register agent '{name}': {create['error']}"

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -135,6 +135,24 @@ class TestAgentCRUD:
         assert agent.enabled is True
         assert agent.created_at > 0
 
+    def test_isolated_flag_round_trip(self, registry):
+        """#149: the isolated flag persists through insert/get/to_dict, defaults
+        off, and is settable via the update path."""
+        # Default off.
+        plain = registry.register("plain", model="opus")
+        assert plain.isolated is False
+        assert registry.get("plain").isolated is False
+        assert registry.get("plain").to_dict()["isolated"] is False
+
+        # Insert with isolated=True.
+        iso = registry.register("tenant", model="opus", isolated=True)
+        assert iso.isolated is True
+        assert registry.get("tenant").isolated is True
+
+        # Update path flips it on for an existing agent.
+        registry.register("plain", isolated=True)
+        assert registry.get("plain").isolated is True
+
     def test_register_with_full_config(self, registry, tmp_path):
         agent = registry.register(
             "leo",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -798,3 +798,44 @@ class TestAgentIsolationScoping:
         )
         assert resp.status_code != 403
         os.unlink(path)
+
+    # ── ADMIN collection route: POST /agents (no path target) ─────────────
+    # Murzik #635 catch: the agent-mint/upsert route has no agent name in the
+    # path, so the middleware can't see it. An isolated tenant must not reach it.
+
+    def test_isolated_agent_denied_register_new_agent(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # Isolated 'tenant' signs with its own identity and tries to MINT a new
+        # full-trust agent via the collection route.
+        resp = self._signed_post(
+            client, "tenant", "/agents",
+            {"name": "spawned", "model": "opus"},
+        )
+        assert resp.status_code == 403
+        assert "isolated" in str(resp.json()).lower()
+        # And the agent must NOT have been created.
+        assert client.app.state.agents.get("spawned") is None
+        os.unlink(path)
+
+    def test_isolated_agent_denied_self_upsert_register(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # Even a self-named upsert is denied — it would let the tenant drop its
+        # OWN isolated flag (escape).
+        resp = self._signed_post(
+            client, "tenant", "/agents",
+            {"name": "tenant", "model": "opus", "isolated": False},
+        )
+        assert resp.status_code == 403
+        # Flag unchanged — tenant is still isolated.
+        assert client.app.state.agents.get("tenant").isolated is True
+        os.unlink(path)
+
+    def test_non_isolated_agent_register_not_denied(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # Full-trust 'other' may still register agents (route works as before).
+        resp = self._signed_post(
+            client, "other", "/agents",
+            {"name": "spawned", "model": "opus", "working_dir": str(tmp_path / "spawned")},
+        )
+        assert resp.status_code != 403
+        os.unlink(path)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -679,8 +679,14 @@ class TestAuthMiddlewareDefaultDeny:
 
 class TestAgentIsolationScoping:
     """#149: an authenticated *isolated* agent may only act on its OWN
-    /agents/{name}/* resources; cross-agent access is denied 403 even with a
-    valid signature. Full-trust (non-isolated) agents are unaffected.
+    resources; cross-agent access is denied 403 even with a valid signature.
+    Two enforcement layers are covered here:
+
+      * PATH-target surfaces (middleware): /agents/{other}/*, /autonomy/{other}/*
+      * BODY-actor surfaces (handler): /broker/* where the acting agent is named
+        in the request body (forgeable — the signature does NOT cover the body).
+
+    Full-trust (non-isolated) agents are unaffected by either layer.
     """
 
     def _make_client_with_agents(self, monkeypatch, tmp_path):
@@ -705,6 +711,16 @@ class TestAgentIsolationScoping:
         )
         return client.get(target_path, headers=headers)
 
+    def _signed_post(self, client, agent_name, target_path, body):
+        # The signature binds the CALLER name + method + path, NOT the body —
+        # so ``body`` can name any agent (the impersonation vector the
+        # body-actor guard defends against).
+        headers = build_internal_auth_headers(
+            "test-session-secret", agent_name=agent_name,
+            method="POST", path=target_path,
+        )
+        return client.post(target_path, json=body, headers=headers)
+
     def test_isolated_agent_denied_cross_agent_access(self, monkeypatch, tmp_path):
         client, path = self._make_client_with_agents(monkeypatch, tmp_path)
         resp = self._signed_get(client, "tenant", "/agents/other")
@@ -723,5 +739,62 @@ class TestAgentIsolationScoping:
         client, path = self._make_client_with_agents(monkeypatch, tmp_path)
         # 'other' is full-trust — cross-agent access is NOT isolation-denied.
         resp = self._signed_get(client, "other", "/agents/tenant")
+        assert resp.status_code != 403
+        os.unlink(path)
+
+    # ── PATH-target: /autonomy/{name}/* (middleware) ──────────────────────
+
+    def test_isolated_agent_denied_cross_agent_autonomy(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        resp = self._signed_post(client, "tenant", "/autonomy/other/start", {})
+        assert resp.status_code == 403
+        assert "isolated" in resp.json().get("error", "").lower()
+        os.unlink(path)
+
+    def test_isolated_agent_allowed_self_autonomy(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        resp = self._signed_post(client, "tenant", "/autonomy/tenant/start", {})
+        # Acting on self → not isolation-denied (handler may still 4xx/5xx).
+        assert resp.status_code != 403
+        os.unlink(path)
+
+    def test_isolated_agent_allowed_targetless_autonomy_status(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # /autonomy/status names no agent → not an isolation-relevant surface.
+        resp = self._signed_get(client, "tenant", "/autonomy/status")
+        assert resp.status_code != 403
+        os.unlink(path)
+
+    # ── BODY-actor: /broker/* (handler) ───────────────────────────────────
+
+    def test_isolated_agent_denied_broker_send_as_other(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # Valid signature as 'tenant', but body forges agent_name='other'.
+        resp = self._signed_post(
+            client, "tenant", "/broker/send",
+            {"agent_name": "other", "chat_id": "123", "content": "hi"},
+        )
+        assert resp.status_code == 403
+        assert "isolated" in str(resp.json()).lower()
+        os.unlink(path)
+
+    def test_isolated_agent_allowed_broker_send_as_self(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # body agent_name == caller → guard is a no-op; handler runs (may 5xx
+        # since no real platform is wired up, but it is NOT isolation-denied).
+        resp = self._signed_post(
+            client, "tenant", "/broker/send",
+            {"agent_name": "tenant", "chat_id": "123", "content": "hi"},
+        )
+        assert resp.status_code != 403
+        os.unlink(path)
+
+    def test_non_isolated_agent_broker_send_as_other_not_denied(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # 'other' is full-trust — the body-actor guard does not restrict it.
+        resp = self._signed_post(
+            client, "other", "/broker/send",
+            {"agent_name": "tenant", "chat_id": "123", "content": "hi"},
+        )
         assert resp.status_code != 403
         os.unlink(path)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -675,3 +675,53 @@ class TestAuthMiddlewareDefaultDeny:
                 f"PINKY_SESSION_SECRET is unset, got {resp.status_code}"
             )
         os.unlink(path)
+
+
+class TestAgentIsolationScoping:
+    """#149: an authenticated *isolated* agent may only act on its OWN
+    /agents/{name}/* resources; cross-agent access is denied 403 even with a
+    valid signature. Full-trust (non-isolated) agents are unaffected.
+    """
+
+    def _make_client_with_agents(self, monkeypatch, tmp_path):
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        monkeypatch.setenv("PINKY_SESSION_SECRET", "test-session-secret")
+        monkeypatch.delenv("PINKY_UI_PASSWORD", raising=False)
+        app = create_api(max_sessions=10, default_working_dir=str(tmp_path), db_path=path)
+        # Seed via the app's OWN registry instance (app.state.agents) so the
+        # middleware's isolation lookup sees the same rows.
+        reg = app.state.agents
+        reg.register("tenant", model="opus", isolated=True,
+                     working_dir=str(tmp_path / "tenant"))
+        reg.register("other", model="opus",
+                     working_dir=str(tmp_path / "other"))
+        return TestClient(app), path
+
+    def _signed_get(self, client, agent_name, target_path):
+        headers = build_internal_auth_headers(
+            "test-session-secret", agent_name=agent_name,
+            method="GET", path=target_path,
+        )
+        return client.get(target_path, headers=headers)
+
+    def test_isolated_agent_denied_cross_agent_access(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        resp = self._signed_get(client, "tenant", "/agents/other")
+        assert resp.status_code == 403
+        assert "isolated" in resp.json().get("error", "").lower()
+        os.unlink(path)
+
+    def test_isolated_agent_allowed_self_access(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        resp = self._signed_get(client, "tenant", "/agents/tenant")
+        # Acting on self → isolation guard allows; route handles it (not 403).
+        assert resp.status_code != 403
+        os.unlink(path)
+
+    def test_non_isolated_agent_not_restricted(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # 'other' is full-trust — cross-agent access is NOT isolation-denied.
+        resp = self._signed_get(client, "other", "/agents/tenant")
+        assert resp.status_code != 403
+        os.unlink(path)


### PR DESCRIPTION
## What & why

Phase 2 of the containerized-isolated-agent (Counterpart) work — the **daemon-side tenant-isolation policy**. Pure daemon work, **no Docker** (the container boundary is phase 3). The `isolated` flag defaults **OFF**, so this is additive: **zero behavior change for the existing full-trust fleet** (no agent is isolated yet).

Builds on #623 (merged): the per-agent-key identity is what makes the authz check trustworthy.

## Changes
- **`isolated` flag** on Agent (BOOL, default 0): migration via `_ensure_columns`, dataclass field, `to_dict`, `_AGENT_COLUMNS`, `_row_to_agent`, and `register()` insert + update paths.
- **opt-in**: `register_agent` MCP tool + `RegisterAgentRequest` gain an `isolated` param.
- **Daemon authz — two enforcement layers.** The caller identity is the #623-verified signed name, so the checks are trustworthy. An isolated caller may only act on its **own** resources:

| Cross-agent vector | Where | Guard |
|---|---|---|
| `/agents/{other}/*` (agent record + sub-resources) | `auth_middleware` | path-target → 403 |
| `POST /agents` (admin mint/upsert — incl. self-upsert flag-drop) | `register_agent` handler | admin-deny → 403 |
| `/autonomy/{other}/*` (start/stop/event) | `auth_middleware` | path-target → 403 |
| `/broker/*` (sender named in request **body**, signature doesn't cover it) | broker handlers | body-actor → 403 |

  - **Path-target layer** (`_internal_isolation_denied` + `_isolation_path_target`): matches `/agents/{other}/*` **and** `/autonomy/{other}/*` (`/autonomy/status` is target-less → reachable). Cheap path-regex + self-name compare short-circuit *before* any registry lookup. **Fails CLOSED + logs** on registry error (an unverifiable isolation state denies rather than risks a tenant escape).
  - **Body-actor layer** (`_deny_isolated_cross_actor`): `/broker/*` take the sending `agent_name` from the request body, which the path matcher can't see. Guards all 9 broker senders (send/thread/broadcast/photo/document/gif/animation/voice/react). An isolated caller may only act **as itself**.
  - **Admin collection route** (`POST /agents`): no agent name in the path → middleware can't see it; an isolated caller could otherwise mint a full-trust agent **or self-upsert to drop its own `isolated` flag**. Denied outright for isolated callers. (Operator/browser sessions carry no internal-agent header → unaffected.)
  - Defense-in-depth on top of tool-gating (isolated agents are provisioned without admin/register gates).

## Scope (precise — closes agent-name-keyed cross-agent vectors only)
This is the **authz half**, daemon/process-level. The four vectors above are **keyed on an agent name** (path or body) and are closed.

**Explicitly deferred to the inc4 gate** — surfaces NOT keyed on a path agent name (`session_id` ≠ agent name), so the path matcher can't see them: `/sessions/{id}/*`, `/comms/messages` + `/comms/inboxes`, `GET /schedules`, `/federation/peers/*`. These must be closed via a **daemon default-deny allowlist OR phase-3 container network-isolation** before any real isolated tenant is minted.

**`isolated=True` must NOT be used to mint a real tenant** until: (a) the deferred surfaces above are closed, **and** (b) #623 increment 4 drops global-secret dual-accept (otherwise an isolated agent that learns the global secret could sign as another agent and bypass the body-actor guard). Phase 3 (container + per-agent secret mounts) delivers fs/network isolation and **unblocks #623 inc4**.

## Tests
- registry round-trip: `isolated` defaults off, persists insert/get/to_dict, settable via update
- `TestAgentIsolationScoping` (12 cases): cross-agent `/agents/*`, `/autonomy/*`, `POST /agents` (mint + self-upsert), `/broker/*` body-actor — all **denied 403**; self-access + non-isolated callers **allowed**; `/autonomy/status` target-less **reachable**
- `test_auth.py` + `test_agent_registry.py`: **147 passed**; ruff clean

## Reviews
Both reviewers signed off on HEAD `7979bcd`: **Pushok** (verified soundness chain + swept the collection-route sibling-gap class) and **Murzik** (caught the `POST /agents` escape on the prior commit, confirmed fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)