### PR TITLE
feat(#149): withhold global secret from isolated agents' tmux env (phase-3 inc1)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1859,33 +1859,43 @@ class TmuxSession:
         # FastAPI middleware read it from the same env var. Empty/missing is
         # tolerated: hooks already handle that gracefully (silent no-op).
         #
-        # #149 phase-3 security gate: an ISOLATED agent that carries its own
-        # per-agent key must NOT receive the global secret. With both present a
-        # tenant could sign internal requests AS ANY OTHER AGENT (the daemon
-        # dual-accepts the global secret for every name), defeating the whole
-        # point of per-agent identity. Scrubbing it here scopes the isolated
-        # tenant to a single non-forgeable identity. Fail-SAFE rather than
-        # fail-closed for the degenerate "isolated but no key yet" case: a
-        # keyless isolated agent keeps the global secret (with a loud warning)
-        # so its hooks/MCP don't brick on a provisioning gap — isolation is
-        # incomplete but the agent stays alive. All currently-isolated agents
-        # carry keys (#623 inc2/3), so the warning path is defensive only.
+        # #149 phase-3 security gate (fail CLOSED — Murzik #639 review): the
+        # global secret is the fleet-wide signing key; the daemon dual-accepts
+        # it for EVERY agent name, so any child that holds it can sign internal
+        # requests AS ANY OTHER AGENT. Inject it ONLY when the agent is *proven*
+        # non-isolated. Withhold it whenever:
+        #   - the agent is isolated — with a per-agent key it signs as itself;
+        #     WITHOUT one it is a provisioning failure, so omit BOTH and let
+        #     hooks/MCP no-op rather than hand a sandbox the forgeable secret
+        #     (fail closed, not degraded-available); or
+        #   - isolation can't be proven (registry unwired/errored) AND a
+        #     per-agent key is present — the key already gives a working
+        #     identity, and registry uncertainty must not cause secret exposure
+        #     (same fail-open class as #635).
+        # The only paths that still receive the global secret are proven
+        # non-isolated agents and the legacy/dev "unknown + no key" case (an
+        # agent with no key genuinely needs the shared secret to sign at all).
         secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
-        isolated = self._is_isolated()
-        if secret:
-            if isolated and agent_key:
+        status = self._isolation_status()
+        if status == "isolated":
+            if agent_key:
                 _log(
-                    f"tmux[{self.agent_name}]: isolated agent — withholding global "
-                    f"PINKY_SESSION_SECRET from child env (per-agent key only)"
+                    f"tmux[{self.agent_name}]: isolated — per-agent key only, "
+                    f"global secret withheld"
                 )
             else:
-                if isolated and not agent_key:
-                    _log(
-                        f"tmux[{self.agent_name}]: WARNING isolated agent has no "
-                        f"per-agent signing key — retaining global secret so hooks "
-                        f"don't break; isolation is INCOMPLETE until a key is provisioned"
-                    )
-                env["PINKY_SESSION_SECRET"] = secret
+                _log(
+                    f"tmux[{self.agent_name}]: ERROR isolated agent has no per-agent "
+                    f"signing key — withholding global secret too (hooks/MCP will "
+                    f"no-op); provision a key to restore signing"
+                )
+        elif status == "unknown" and agent_key and secret:
+            _log(
+                f"tmux[{self.agent_name}]: isolation status unknown but per-agent "
+                f"key present — withholding global secret (fail closed)"
+            )
+        elif secret:
+            env["PINKY_SESSION_SECRET"] = secret
         return env
 
     async def disconnect(self) -> None:
@@ -2408,23 +2418,29 @@ class TmuxSession:
                 )
         return max(1, raw - self._AUTOCOMPACT_BUFFER_TOKENS)
 
-    def _is_isolated(self) -> bool:
-        """True iff this agent carries the #149 ``isolated`` tenant flag.
+    def _isolation_status(self) -> str:
+        """Tri-state isolation lookup for the env secret gate (#149 phase-3).
 
-        Read through the registry like the other per-agent getters. Fails
-        SAFE (returns False) when the registry isn't wired or errors — the
-        caller (``_build_repl_env``'s secret gate) then preserves the
-        pre-#149 behavior rather than risk bricking an agent's hooks on a
-        transient registry hiccup. Defense-in-depth against forgery lives in
-        the daemon authz layer (#635) regardless of this hint.
+        Returns ``"isolated"``, ``"not_isolated"``, or ``"unknown"`` (registry
+        unwired, agent not found, or lookup raised). A bare bool would conflate
+        "proven non-isolated" (safe to inject the global secret) with "can't
+        tell" — and Murzik's #639 review caught that conflation as a fail-OPEN:
+        if ``get_signing_key`` returns a key but ``registry.get`` raises, a bool
+        helper falls to False and the env builder would inject BOTH the per-agent
+        key AND the forgeable global secret (the same fail-open class fixed in
+        #635). The caller withholds the global secret whenever isolation can't
+        be *proven* false and a per-agent key already provides a working
+        identity, so registry uncertainty never causes global-secret exposure.
         """
         if not self._registry or not self.agent_name:
-            return False
+            return "unknown"
         try:
             agent = self._registry.get(self.agent_name)
-            return bool(agent and getattr(agent, "isolated", False))
         except Exception:
-            return False
+            return "unknown"
+        if agent is None:
+            return "unknown"
+        return "isolated" if getattr(agent, "isolated", False) else "not_isolated"
 
     def _restart_threshold_pct(self) -> float:
         """Pull the agent's restart threshold from the registry.

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1841,28 +1841,51 @@ class TmuxSession:
             env["PINKY_EXPECTED_EFFORT"] = effort
         if self._config.strict_effort_enforcement:
             env["PINKY_STRICT_EFFORT"] = "1"
-        # PINKY_SESSION_SECRET — see docstring. Read from os.environ
-        # rather than a config field because it's a daemon-wide secret
-        # (the daemon's own SDK clients and FastAPI middleware read it
-        # from the same env var). Empty/missing is tolerated: hooks
-        # already handle that gracefully (silent no-op).
-        secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
-        if secret:
-            env["PINKY_SESSION_SECRET"] = secret
         # PINKY_AGENT_KEY (#623 increment 2) — this agent's per-agent signing
         # key. Provisioned so hook scripts running in this tmux session sign
-        # internal requests with a non-forgeable identity. The daemon dual-
-        # accepts (per-agent key OR global secret), so this is additive: the
-        # global PINKY_SESSION_SECRET above keeps hooks working if the key is
-        # missing (e.g. registry not wired). Lookup guarded like
+        # internal requests with a non-forgeable identity. Lookup guarded like
         # _restart_threshold_pct — a registry hiccup must not break session env.
+        agent_key = ""
         if self._registry and self.agent_name:
             try:
-                agent_key = self._registry.get_signing_key(self.agent_name)
-                if agent_key:
-                    env["PINKY_AGENT_KEY"] = agent_key
+                agent_key = (self._registry.get_signing_key(self.agent_name) or "").strip()
             except Exception:
-                pass
+                agent_key = ""
+        if agent_key:
+            env["PINKY_AGENT_KEY"] = agent_key
+
+        # PINKY_SESSION_SECRET — the daemon-wide secret. Read from os.environ
+        # rather than a config field because the daemon's own SDK clients and
+        # FastAPI middleware read it from the same env var. Empty/missing is
+        # tolerated: hooks already handle that gracefully (silent no-op).
+        #
+        # #149 phase-3 security gate: an ISOLATED agent that carries its own
+        # per-agent key must NOT receive the global secret. With both present a
+        # tenant could sign internal requests AS ANY OTHER AGENT (the daemon
+        # dual-accepts the global secret for every name), defeating the whole
+        # point of per-agent identity. Scrubbing it here scopes the isolated
+        # tenant to a single non-forgeable identity. Fail-SAFE rather than
+        # fail-closed for the degenerate "isolated but no key yet" case: a
+        # keyless isolated agent keeps the global secret (with a loud warning)
+        # so its hooks/MCP don't brick on a provisioning gap — isolation is
+        # incomplete but the agent stays alive. All currently-isolated agents
+        # carry keys (#623 inc2/3), so the warning path is defensive only.
+        secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+        isolated = self._is_isolated()
+        if secret:
+            if isolated and agent_key:
+                _log(
+                    f"tmux[{self.agent_name}]: isolated agent — withholding global "
+                    f"PINKY_SESSION_SECRET from child env (per-agent key only)"
+                )
+            else:
+                if isolated and not agent_key:
+                    _log(
+                        f"tmux[{self.agent_name}]: WARNING isolated agent has no "
+                        f"per-agent signing key — retaining global secret so hooks "
+                        f"don't break; isolation is INCOMPLETE until a key is provisioned"
+                    )
+                env["PINKY_SESSION_SECRET"] = secret
         return env
 
     async def disconnect(self) -> None:
@@ -2384,6 +2407,24 @@ class TmuxSession:
                     f"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE={override!r}"
                 )
         return max(1, raw - self._AUTOCOMPACT_BUFFER_TOKENS)
+
+    def _is_isolated(self) -> bool:
+        """True iff this agent carries the #149 ``isolated`` tenant flag.
+
+        Read through the registry like the other per-agent getters. Fails
+        SAFE (returns False) when the registry isn't wired or errors — the
+        caller (``_build_repl_env``'s secret gate) then preserves the
+        pre-#149 behavior rather than risk bricking an agent's hooks on a
+        transient registry hiccup. Defense-in-depth against forgery lives in
+        the daemon authz layer (#635) regardless of this hint.
+        """
+        if not self._registry or not self.agent_name:
+            return False
+        try:
+            agent = self._registry.get(self.agent_name)
+            return bool(agent and getattr(agent, "isolated", False))
+        except Exception:
+            return False
 
     def _restart_threshold_pct(self) -> float:
         """Pull the agent's restart threshold from the registry.

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -716,11 +716,41 @@ def test_build_repl_env_provisions_per_agent_key(monkeypatch) -> None:
     ss, _ = _make_session(agent_name="dymok")
     ss._registry = MagicMock()
     ss._registry.get_signing_key.return_value = "dymok-per-agent-key"
+    # Non-isolated agent: dual-accept fallback retains the global secret.
+    ss._registry.get.return_value.isolated = False
     env = ss._build_repl_env()
     assert env.get("PINKY_AGENT_KEY") == "dymok-per-agent-key"
     # Global secret still propagated (dual-accept fallback for other paths).
     assert env.get("PINKY_SESSION_SECRET") == "global-secret-xyz"
     ss._registry.get_signing_key.assert_called_once_with("dymok")
+
+
+def test_build_repl_env_isolated_withholds_global_secret(monkeypatch) -> None:
+    """#149 phase-3 gate: an isolated agent that carries its own per-agent key
+    must NOT receive the global PINKY_SESSION_SECRET (which the daemon accepts
+    for any name → a forgery vector). It gets PINKY_AGENT_KEY only."""
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret-xyz")
+    ss, _ = _make_session(agent_name="dymok")
+    ss._registry = MagicMock()
+    ss._registry.get_signing_key.return_value = "dymok-per-agent-key"
+    ss._registry.get.return_value.isolated = True
+    env = ss._build_repl_env()
+    assert env.get("PINKY_AGENT_KEY") == "dymok-per-agent-key"
+    assert "PINKY_SESSION_SECRET" not in env
+
+
+def test_build_repl_env_isolated_without_key_retains_secret(monkeypatch) -> None:
+    """Fail-safe: an isolated agent with NO per-agent key keeps the global
+    secret so its hooks/MCP don't brick on a provisioning gap. Isolation is
+    incomplete (logged) but the agent stays alive."""
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret-xyz")
+    ss, _ = _make_session(agent_name="dymok")
+    ss._registry = MagicMock()
+    ss._registry.get_signing_key.return_value = None
+    ss._registry.get.return_value.isolated = True
+    env = ss._build_repl_env()
+    assert "PINKY_AGENT_KEY" not in env
+    assert env.get("PINKY_SESSION_SECRET") == "global-secret-xyz"
 
 
 def test_build_repl_env_omits_agent_key_when_registry_absent() -> None:

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -739,10 +739,11 @@ def test_build_repl_env_isolated_withholds_global_secret(monkeypatch) -> None:
     assert "PINKY_SESSION_SECRET" not in env
 
 
-def test_build_repl_env_isolated_without_key_retains_secret(monkeypatch) -> None:
-    """Fail-safe: an isolated agent with NO per-agent key keeps the global
-    secret so its hooks/MCP don't brick on a provisioning gap. Isolation is
-    incomplete (logged) but the agent stays alive."""
+def test_build_repl_env_isolated_without_key_withholds_secret(monkeypatch) -> None:
+    """Fail CLOSED (Murzik #639 review): an isolated agent with NO per-agent
+    key is a provisioning failure, not an availability case — withhold the
+    global secret too (hooks/MCP no-op) rather than hand a sandbox the
+    forgeable fleet-wide signing secret for the very window this gate closes."""
     monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret-xyz")
     ss, _ = _make_session(agent_name="dymok")
     ss._registry = MagicMock()
@@ -750,7 +751,24 @@ def test_build_repl_env_isolated_without_key_retains_secret(monkeypatch) -> None
     ss._registry.get.return_value.isolated = True
     env = ss._build_repl_env()
     assert "PINKY_AGENT_KEY" not in env
-    assert env.get("PINKY_SESSION_SECRET") == "global-secret-xyz"
+    assert "PINKY_SESSION_SECRET" not in env
+
+
+def test_build_repl_env_withholds_secret_when_isolation_unknown_but_key_present(
+    monkeypatch,
+) -> None:
+    """Fail-open guard (Murzik #639 review): if a per-agent key resolves but the
+    isolation lookup RAISES (status unknown), the global secret must still be
+    withheld — registry uncertainty must not expose the forgeable fleet secret
+    (same fail-open class as #635). The key already gives a working identity."""
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret-xyz")
+    ss, _ = _make_session(agent_name="dymok")
+    ss._registry = MagicMock()
+    ss._registry.get_signing_key.return_value = "dymok-per-agent-key"
+    ss._registry.get.side_effect = RuntimeError("db locked")
+    env = ss._build_repl_env()
+    assert env.get("PINKY_AGENT_KEY") == "dymok-per-agent-key"
+    assert "PINKY_SESSION_SECRET" not in env
 
 
 def test_build_repl_env_omits_agent_key_when_registry_absent() -> None:


### PR DESCRIPTION
## What
Phase-3 isolation, increment 1 (the security gate). Stop injecting the global `PINKY_SESSION_SECRET` into an **isolated** agent's tmux child env. Isolated agents sign internal requests with their own per-agent key (#623) only.

## Why
The global secret is the fleet-wide signing key — the daemon dual-accepts it for **every** agent name (`verify_internal_request`). So any sandboxed child that holds it can sign internal requests **as any other agent**, making per-agent identity forgeable from inside the sandbox. This is the first item on the #638 phase-3 merge gate, and closes the env-injection forgery vector even before per-user filesystem isolation lands.

## How
`_build_repl_env()` resolves the per-agent key first, then injects the global secret **only when the agent is proven non-isolated** (fail-closed — Murzik #639 review). Behavior matrix:

| isolation status | per-agent key | `PINKY_AGENT_KEY` | `PINKY_SESSION_SECRET` |
|---|---|---|---|
| isolated | yes | ✅ | ❌ withheld (gate) |
| isolated | no | ❌ | ❌ withheld (fail-closed; hooks/MCP no-op, ERROR-logged) |
| unknown (registry unwired/errored) | yes | ✅ | ❌ withheld (can't prove non-isolated) |
| unknown | no | ❌ | ✅ retained (legacy/dev path with no other way to sign) |
| non-isolated | yes | ✅ | ✅ unchanged |
| non-isolated | no | ❌ | ✅ unchanged |

New tri-state `_isolation_status()` helper returns `isolated` / `not_isolated` / `unknown`. A bare bool conflated "proven non-isolated" with "can't tell" — and that conflation was a **fail-open**: if `get_signing_key()` returned a key but `registry.get()` raised, the env builder would inject both the key and the global secret (the same fail-open class fixed in #635). The tri-state withholds the global secret whenever isolation can't be proven false and a key already provides a working identity.

## Tests
- `test_build_repl_env_isolated_withholds_global_secret` — isolated+key → key only.
- `test_build_repl_env_isolated_without_key_withholds_secret` — fail-closed, both withheld.
- `test_build_repl_env_withholds_secret_when_isolation_unknown_but_key_present` — registry-error fail-open guard.
- Updated `test_build_repl_env_provisions_per_agent_key` to pin the non-isolated case explicitly.
- Full `tests/test_tmux_session.py` (230) green, ruff clean.

## Scope / follow-ups (tracked in #638)
- Env-side only. Daemon-side **stops accepting** global-secret auth for isolated callers (#623 inc4 for isolated) is the next PR.
- `isolation_mode` column, `AgentProvisioner`, `CommandRunner` seam, and `unix_user` provisioning are subsequent increments.

Tracks #638. Reviewed by @murzik (fail-closed hardening applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)