### PR TITLE
feat(#149): reject global-secret auth for isolated callers (phase-3 inc2)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3310,7 +3310,17 @@ def create_api(
                 agent_key = agents.get_signing_key(agent_name)
             except Exception:
                 agent_key = None
-        if not secret and not agent_key:
+        # #149 phase-3 inc2: an ISOLATED caller must authenticate with its own
+        # per-agent key. The global secret is dual-accepted for EVERY agent
+        # name, so honoring it for an isolated tenant would stay a forgery path
+        # even after the env gate (#639) stops injecting it into isolated
+        # runtimes. _is_isolated_agent fails CLOSED (registry error → treated
+        # isolated), so a transient lookup failure tightens auth rather than
+        # loosening it; per-agent keys are provisioned fleet-wide (#623) so
+        # non-isolated callers are unaffected.
+        allow_global_secret = not (agent_name and _is_isolated_agent(agent_name))
+        usable_secret = secret if allow_global_secret else ""
+        if not usable_secret and not agent_key:
             return False
         return verify_internal_request(
             secret,
@@ -3320,6 +3330,7 @@ def create_api(
             timestamp=timestamp,
             signature=signature,
             agent_key=agent_key,
+            allow_global_secret=allow_global_secret,
         )
 
     def _internal_isolation_denied(request: Request, caller_name: str) -> bool:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3310,15 +3310,14 @@ def create_api(
                 agent_key = agents.get_signing_key(agent_name)
             except Exception:
                 agent_key = None
-        # #149 phase-3 inc2: an ISOLATED caller must authenticate with its own
-        # per-agent key. The global secret is dual-accepted for EVERY agent
-        # name, so honoring it for an isolated tenant would stay a forgery path
-        # even after the env gate (#639) stops injecting it into isolated
-        # runtimes. _is_isolated_agent fails CLOSED (registry error → treated
-        # isolated), so a transient lookup failure tightens auth rather than
-        # loosening it; per-agent keys are provisioned fleet-wide (#623) so
-        # non-isolated callers are unaffected.
-        allow_global_secret = not (agent_name and _is_isolated_agent(agent_name))
+        # #149 phase-3 inc2: the global secret is a universal bearer credential
+        # (accepted for every name), so it may authenticate ONLY a proven
+        # existing non-isolated agent. Isolated callers must use their own
+        # per-agent key; unknown names and registry errors are denied the global
+        # secret entirely (fail closed) — otherwise a leaked secret authenticates
+        # as any made-up identity (Murzik #640). Per-agent keys are provisioned
+        # fleet-wide (#623) so legitimate callers are unaffected.
+        allow_global_secret = _global_secret_allowed_for(agent_name)
         usable_secret = secret if allow_global_secret else ""
         if not usable_secret and not agent_key:
             return False
@@ -3396,6 +3395,38 @@ def create_api(
             _log(f"isolation-check: registry lookup failed for '{name}': {e} — failing closed")
             return True
         return bool(agent and getattr(agent, "isolated", False))
+
+    def _global_secret_allowed_for(name: str) -> bool:
+        """#149 phase-3 inc2: may the shared global secret authenticate a request
+        claiming ``name``? Only for a PROVEN existing, non-isolated agent.
+
+        The global secret is a universal bearer credential — it is accepted for
+        every name, not bound to an identity. So it must NOT authenticate:
+          * an isolated agent (it must use its own per-agent key), nor
+          * an UNKNOWN / unregistered name (else a leaked secret authenticates as
+            any made-up identity — Murzik's #640 ``ghost`` finding), nor
+          * anything we can't resolve (registry error → fail CLOSED).
+        Distinct from ``_is_isolated_agent`` (which fails closed to *isolated*):
+        here every uncertain case must DENY the global secret, so unknown agents
+        and registry errors both return False. Per-agent keys are provisioned
+        fleet-wide (#623), so legitimate callers are unaffected — every internal
+        signer (hooks, pinky-self/messaging MCP) claims a registered agent name.
+
+        SCOPE (residual, tracked in #638): this still lets a leaked global secret
+        impersonate an *existing non-isolated* agent. Fully closing that needs the
+        fleetwide global-secret drop (#623 inc4) and/or the per-user OS isolation
+        (#638 inc3+) that prevents an isolated tenant from reading the secret.
+        """
+        if not name:
+            return False
+        try:
+            agent = agents.get(name)
+        except Exception as e:
+            _log(f"auth: global-secret check registry lookup failed for '{name}': {e} — denying global")
+            return False
+        if agent is None:
+            return False
+        return not bool(getattr(agent, "isolated", False))
 
     def _deny_isolated_cross_actor(request: Request, body_agent: str) -> None:
         """#149 body-actor guard for /broker/* (and any handler whose acting

--- a/src/pinky_daemon/auth.py
+++ b/src/pinky_daemon/auth.py
@@ -173,6 +173,7 @@ def verify_internal_request(
     timestamp: str,
     signature: str,
     agent_key: str | None = None,
+    allow_global_secret: bool = True,
 ) -> bool:
     """Verify signed local MCP-to-daemon request headers.
 
@@ -182,10 +183,18 @@ def verify_internal_request(
     the global secret remains accepted until the cutover PR provisions
     per-agent keys into agent environments and drops global-secret acceptance.
     At least one of ``secret`` / ``agent_key`` must be present.
+
+    #149 phase-3 inc2: ``allow_global_secret=False`` removes the global secret
+    from the accepted candidates, so the signature must match the per-agent
+    ``agent_key``. Used for ISOLATED callers — the global secret is accepted for
+    EVERY agent name, so honoring it for an isolated tenant would stay a forgery
+    path even after the env gate (#639) stops handing it out. With it False a
+    caller that has no per-agent key cannot authenticate at all (fail closed).
     """
     if not agent_name or not timestamp or not signature:
         return False
-    if not secret and not agent_key:
+    usable_secret = secret if allow_global_secret else ""
+    if not usable_secret and not agent_key:
         return False
     try:
         ts = int(timestamp)
@@ -195,9 +204,9 @@ def verify_internal_request(
         return False
     normalized_path = path.split("?", 1)[0]
     payload = f"{agent_name}\n{method.upper()}\n{normalized_path}\n{ts}".encode("utf-8")
-    # Accept a match against the per-agent key OR the global secret. Each
-    # comparison is constant-time; we only short-circuit on a match.
-    for candidate in (agent_key, secret):
+    # Accept a match against the per-agent key OR (when allowed) the global
+    # secret. Each comparison is constant-time; we only short-circuit on a match.
+    for candidate in (agent_key, usable_secret):
         if candidate and hmac.compare_digest(signature, _sign_bytes(candidate, payload)):
             return True
     return False

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -454,6 +454,11 @@ class TestUIAuthAPI:
 
     def test_internal_headers_bypass_browser_auth(self, monkeypatch):
         client, path = self._make_client(monkeypatch)
+        # #640: global-secret auth now requires a proven-registered, non-isolated
+        # agent name — register the signer (production signers always are).
+        client.app.state.agents.register(
+            "test-agent", model="opus", working_dir="/tmp/test-agent"
+        )
         headers = {
             "Origin": "http://localhost:8888",
             **build_internal_auth_headers(
@@ -538,6 +543,11 @@ class TestAuthMiddlewareDefaultDeny:
         the primary HMAC consumers — explicitly pin one.
         """
         client, path = self._make_client(monkeypatch)
+        # #640: global-secret auth now requires a proven-registered, non-isolated
+        # agent name — register the signer (production signers always are).
+        client.app.state.agents.register(
+            "barsik", model="opus", working_dir="/tmp/barsik"
+        )
         headers = build_internal_auth_headers(
             "test-session-secret",
             agent_name="barsik",
@@ -947,4 +957,17 @@ class TestAgentIsolationScoping:
         )
         resp = client.get("/agents/other", headers=headers)
         assert resp.status_code != 401
+        os.unlink(path)
+
+    def test_unknown_agent_global_secret_rejected(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # Murzik #640: the global secret is a universal bearer credential, so it
+        # must NOT authenticate an UNKNOWN claimed identity — otherwise a leaked
+        # secret signs as any made-up name. 'ghost' is unregistered → 401.
+        headers = build_internal_auth_headers(
+            "test-session-secret", agent_name="ghost",
+            method="GET", path="/agents/tenant",
+        )
+        resp = client.get("/agents/tenant", headers=headers)
+        assert resp.status_code == 401
         os.unlink(path)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -235,6 +235,76 @@ def test_internal_signature_rejected_when_neither_key_matches():
     ) is False
 
 
+# ── #149 phase-3 inc2: isolated callers may not use the global secret ────────
+
+
+def test_verify_rejects_global_secret_signature_when_disallowed():
+    """An isolated caller signs with the global secret: accepted in dual mode,
+    REJECTED once allow_global_secret=False (the daemon-side cutover)."""
+    h = _signed("global-secret", agent_name="sasha", method="POST", path="/agents/sasha/status")
+    common = dict(
+        agent_name="sasha",
+        method="POST",
+        path="/agents/sasha/status",
+        timestamp=h["x-pinky-timestamp"],
+        signature=h["x-pinky-signature"],
+    )
+    # Baseline dual-accept still honors the global secret.
+    assert verify_internal_request("global-secret", agent_key=None, **common) is True
+    # Isolated cutover: the global-secret signature no longer authenticates.
+    assert (
+        verify_internal_request(
+            "global-secret", agent_key=None, allow_global_secret=False, **common
+        )
+        is False
+    )
+    # Even with a per-agent key supplied, a GLOBAL-secret signature is rejected.
+    assert (
+        verify_internal_request(
+            "global-secret", agent_key="sasha-key", allow_global_secret=False, **common
+        )
+        is False
+    )
+
+
+def test_verify_accepts_per_agent_key_when_global_disallowed():
+    """With the global secret disallowed, the agent's OWN per-agent-key
+    signature still authenticates — isolated agents keep working via their key."""
+    h = _signed("sasha-key", agent_name="sasha", method="POST", path="/agents/sasha/status")
+    assert (
+        verify_internal_request(
+            "global-secret",
+            agent_name="sasha",
+            method="POST",
+            path="/agents/sasha/status",
+            timestamp=h["x-pinky-timestamp"],
+            signature=h["x-pinky-signature"],
+            agent_key="sasha-key",
+            allow_global_secret=False,
+        )
+        is True
+    )
+
+
+def test_verify_no_credential_when_global_disallowed_and_no_key():
+    """Fail closed: a keyless isolated caller (global disallowed, agent_key
+    None) cannot authenticate even with an otherwise-valid global signature."""
+    h = _signed("global-secret", agent_name="sasha")
+    assert (
+        verify_internal_request(
+            "global-secret",
+            agent_name="sasha",
+            method="GET",
+            path="/tasks/next",
+            timestamp=h["x-pinky-timestamp"],
+            signature=h["x-pinky-signature"],
+            agent_key=None,
+            allow_global_secret=False,
+        )
+        is False
+    )
+
+
 def test_internal_signature_name_bound_into_payload():
     """A signature minted for agent 'alice' must not verify when presented as
     'bob' — the agent name is part of the signed payload."""
@@ -704,9 +774,16 @@ class TestAgentIsolationScoping:
                      working_dir=str(tmp_path / "other"))
         return TestClient(app), path
 
+    def _signing_key(self, client, agent_name):
+        # #149 phase-3 inc2: isolated callers can no longer authenticate with
+        # the global secret, so sign as each agent with its OWN per-agent key
+        # (provisioned on register, #623) — the realistic post-cutover path.
+        # Falls back to the global secret only if a key is somehow absent.
+        return client.app.state.agents.get_signing_key(agent_name) or "test-session-secret"
+
     def _signed_get(self, client, agent_name, target_path):
         headers = build_internal_auth_headers(
-            "test-session-secret", agent_name=agent_name,
+            self._signing_key(client, agent_name), agent_name=agent_name,
             method="GET", path=target_path,
         )
         return client.get(target_path, headers=headers)
@@ -716,7 +793,7 @@ class TestAgentIsolationScoping:
         # so ``body`` can name any agent (the impersonation vector the
         # body-actor guard defends against).
         headers = build_internal_auth_headers(
-            "test-session-secret", agent_name=agent_name,
+            self._signing_key(client, agent_name), agent_name=agent_name,
             method="POST", path=target_path,
         )
         return client.post(target_path, json=body, headers=headers)
@@ -838,4 +915,36 @@ class TestAgentIsolationScoping:
             {"name": "spawned", "model": "opus", "working_dir": str(tmp_path / "spawned")},
         )
         assert resp.status_code != 403
+        os.unlink(path)
+
+    # ── #149 phase-3 inc2: the global secret no longer authenticates an
+    # isolated caller (daemon-side cutover; dual-accept preserved otherwise) ──
+
+    def test_isolated_agent_global_secret_auth_rejected(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # Isolated 'tenant' signs a SELF request with the forgeable GLOBAL
+        # secret. Post-cutover the daemon refuses to authenticate it at all —
+        # even on its own resource — so auth fails (401) before any route runs.
+        headers = build_internal_auth_headers(
+            "test-session-secret", agent_name="tenant",
+            method="GET", path="/agents/tenant",
+        )
+        resp = client.get("/agents/tenant", headers=headers)
+        assert resp.status_code == 401
+        # Its OWN per-agent key still authenticates (self-access → not 401/403).
+        ok = self._signed_get(client, "tenant", "/agents/tenant")
+        assert ok.status_code not in (401, 403)
+        os.unlink(path)
+
+    def test_non_isolated_agent_global_secret_still_accepted(self, monkeypatch, tmp_path):
+        client, path = self._make_client_with_agents(monkeypatch, tmp_path)
+        # Dual-accept is preserved for full-trust agents: 'other' may still
+        # authenticate with the global secret (until #623 inc4 drops it
+        # fleet-wide). It must not get a 401.
+        headers = build_internal_auth_headers(
+            "test-session-secret", agent_name="other",
+            method="GET", path="/agents/other",
+        )
+        resp = client.get("/agents/other", headers=headers)
+        assert resp.status_code != 401
         os.unlink(path)


### PR DESCRIPTION
## What
Phase-3 isolation, increment 2 — the **daemon-side** complement to #639. The shared global `PINKY_SESSION_SECRET` is a *universal bearer credential* (the daemon accepts it for any name), so the daemon now honors it **only for a proven-registered, non-isolated agent**. Isolated agents, unknown/unregistered names, and registry-lookup errors must authenticate with a per-agent key (#623) — the global secret is rejected for them.

## Why
#639 stopped *injecting* the global secret into isolated runtimes. inc2 stops the daemon from *accepting* it where it shouldn't:
- an isolated tenant that obtained the secret out-of-band can no longer use it under its own name, **and**
- a leaked secret can no longer authenticate as an **unknown/made-up** identity (Murzik's #640 `ghost` finding — previously `ghost + global secret → 200`).

## How
- `verify_internal_request(..., allow_global_secret: bool = True)` — when `False`, the global secret is dropped from the accepted signature candidates; only the per-agent `agent_key` matches.
- `_global_secret_allowed_for(name)` returns `True` **only** for a proven-existing non-isolated agent; isolated / unknown / registry-error all return `False` (fail closed — uncertainty never widens global-secret acceptance). `_has_valid_internal_auth` gates on it.

Per-agent keys are provisioned fleet-wide on register (#623), and every internal signer (hooks, pinky-self/messaging MCP) claims a registered agent name, so legitimate callers are unaffected; dual-accept is preserved for registered non-isolated agents.

## Scope / known limitation (important — Murzik review)
This does **not** fully close "leaked global secret → forgery." A secret leaked to an isolated tenant can still impersonate an **existing non-isolated** agent (sign as that registered name). Closing that completely requires **either**:
- the fleet-wide global-secret drop (#623 inc4 — stop accepting it for all agents), **or**
- the per-user OS isolation (#638 inc3+) that prevents an isolated tenant from reading the secret at all.

inc2's guarantee is narrower and precise: the global secret can no longer authenticate an **isolated-claimed** or **unknown-claimed** identity. Both follow-ups are tracked in #638.

## Tests
- `verify_internal_request` `allow_global_secret` matrix (global rejected when disallowed; per-agent key still accepted; keyless+disallowed fails closed).
- Updated `TestAgentIsolationScoping` to sign as each agent with its **own per-agent key** so the 403 isolation guards still fire post-cutover.
- API-level: isolated-claimed global secret → **401**; **unknown** `ghost` global secret → **401**; registered non-isolated global secret → still accepted.
- Registered the signer in two default-deny fixtures that previously signed unregistered names with the global secret (fixture shorthand, not a production flow).
- Full suite green, ruff clean.

Tracks #638. Builds on #639. @murzik re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)