### PR TITLE
feat(#149): isolation_mode field + provisioning seam (phase-3 inc3a)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -365,6 +365,15 @@ class Agent:
     # ITSELF only. Daemon denies it cross-agent actions + admin/register_agent.
     # Default False = full-trust inner-fleet agent (no behavior change).
     isolated: bool = False
+    # #149 phase-3 OS isolation: HOW an isolated tenant is run at the OS level.
+    #   "local"     = in-process, shares the daemon's OS user (default; current
+    #                 behavior, no isolation beyond the daemon-authz `isolated` flag).
+    #   "unix_user" = provisioned its own `pinky-<agent>` OS user + private
+    #                 home/workdir/keys, run under that uid (inc3b). EXEC path is
+    #                 Linux/systemd-only; macOS builds it but cannot run it.
+    # Orthogonal to `isolated`: `isolated` is the daemon-authz boundary; this is
+    # the runtime sandbox. Only meaningful when `isolated` is True.
+    isolation_mode: str = "local"
     dream_enabled: bool = False  # Enable nightly memory consolidation
     dream_schedule: str = "0 3 * * *"  # Cron for dream runs (default 3 AM)
     dream_timezone: str = "America/Los_Angeles"  # IANA timezone for dream schedule
@@ -431,6 +440,7 @@ class Agent:
             "voice_config": self.voice_config,
             "role": self.role,
             "isolated": self.isolated,
+            "isolation_mode": self.isolation_mode,
             "dream_enabled": self.dream_enabled,
             "dream_schedule": self.dream_schedule,
             "dream_timezone": self.dream_timezone,
@@ -1334,6 +1344,11 @@ class AgentRegistry:
             # (no behavior change). Enforcement keys off the #623 per-agent-key
             # authenticated identity.
             ("isolated", "INTEGER NOT NULL DEFAULT 0"),
+            # #149 phase-3: OS-level runtime sandbox for an isolated tenant.
+            # 'local' = in-process under the daemon's user (default, current
+            # behavior); 'unix_user' = own pinky-<agent> OS user (inc3b, Linux
+            # exec only). Orthogonal to `isolated`; only meaningful when isolated.
+            ("isolation_mode", "TEXT NOT NULL DEFAULT 'local'"),
         ]
         for col, typedef in migrations:
             if col not in existing:
@@ -1906,7 +1921,8 @@ except Exception:
                         "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
                         "librarian_enabled", "librarian_schedule",
                         "runtime", "transport", "provider_url", "provider_key", "provider_model", "provider_ref",
-                        "thinking_effort", "strict_effort_enforcement", "isolated"):
+                        "thinking_effort", "strict_effort_enforcement", "isolated",
+                        "isolation_mode"):
                 if key in kwargs:
                     updates[key] = kwargs[key]
 
@@ -1986,6 +2002,7 @@ except Exception:
                 voice_config=kwargs.get("voice_config", {}),
                 role=kwargs.get("role", ""),
                 isolated=kwargs.get("isolated", False),
+                isolation_mode=kwargs.get("isolation_mode", "local"),
                 dream_enabled=kwargs.get("dream_enabled", False),
                 dream_schedule=kwargs.get("dream_schedule", "0 3 * * *"),
                 dream_timezone=kwargs.get("dream_timezone", "America/Los_Angeles"),
@@ -2013,12 +2030,13 @@ except Exception:
                     restart_threshold_pct, context_nudge_threshold_pct, auto_restart, parent, groups,
                     max_sessions, enabled, auto_start, heartbeat_interval, plain_text_fallback,
                     wake_interval, clock_aligned, auto_sleep_hours, voice_config, role, isolated,
+                    isolation_mode,
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
                     librarian_enabled, librarian_schedule,
                     runtime, transport, provider_url, provider_key, provider_model, provider_ref,
                     thinking_effort, strict_effort_enforcement, watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -2030,6 +2048,7 @@ except Exception:
                  int(agent.enabled), int(agent.auto_start), agent.heartbeat_interval, int(agent.plain_text_fallback),
                  agent.wake_interval, int(agent.clock_aligned), agent.auto_sleep_hours,
                  json.dumps(agent.voice_config), agent.role, int(agent.isolated),
+                 agent.isolation_mode,
                  int(agent.dream_enabled), agent.dream_schedule, agent.dream_timezone, agent.dream_model, int(agent.dream_notify),
                  int(agent.librarian_enabled), agent.librarian_schedule,
                  agent.runtime, agent.transport, agent.provider_url, agent.provider_key,
@@ -2068,7 +2087,8 @@ except Exception:
         "working_status, working_status_updated_at, "
         "runtime, transport, provider_url, provider_key, provider_model, provider_ref, "
         "disallowed_tools, thinking_effort, watchdog_config, last_seen_at, "
-        "strict_effort_enforcement, context_nudge_threshold_pct, isolated"
+        "strict_effort_enforcement, context_nudge_threshold_pct, isolated, "
+        "isolation_mode"
     )
 
     def get(self, name: str) -> Agent | None:
@@ -3845,6 +3865,7 @@ except Exception:
             strict_effort_enforcement=bool(row[49]) if len(row) > 49 else False,
             context_nudge_threshold_pct=row[50] if len(row) > 50 else 0.0,
             isolated=bool(row[51]) if len(row) > 51 else False,
+            isolation_mode=row[52] if len(row) > 52 and row[52] else "local",
         )
 
     # ── Cost Tracking ──────────────────────────────────────

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2422,6 +2422,43 @@ def create_api(
             "sdk_session_id": ss.resume_handle[:12] if ss.resume_handle else "",
         }
 
+    def _isolation_block_reason(agent_name: str) -> tuple[int, str] | None:
+        """#149 phase-3 respawn guard (single source of truth).
+
+        If ``agent_name``'s ``isolation_mode`` has no runnable provisioner,
+        return ``(http_status, detail)``; else ``None``. Non-raising so HTTP
+        callers and the broker (which has no HTTP context) share one check.
+
+        The field is accepted + persisted at registration (forward-compatible),
+        but ``get_provisioner`` fails closed on unimplemented modes. Consulting
+        this before EVERY transport (re)spawn — cold start, reconnect, restart,
+        idle auto-wake — makes that guarantee operational: a unix_user-labeled
+        agent (incl. one updated from local) can never relaunch under the
+        daemon uid with none of the requested OS isolation. inc3c+ lifts it for
+        unix_user once the provisioner + lifecycle wiring land. (Murzik #642 P1.)
+        """
+        agent = agents.get(agent_name)
+        if not agent:
+            return None
+        mode = (getattr(agent, "isolation_mode", "") or "local").strip() or "local"
+        try:
+            from pinky_daemon.provisioning import get_provisioner
+            get_provisioner(mode)
+            return None
+        except NotImplementedError as e:
+            return (501, f"isolation_mode '{mode}' for agent '{agent_name}' is not runnable yet: {e}")
+        except ValueError as e:
+            return (400, f"invalid isolation_mode for agent '{agent_name}': {e}")
+
+    def _enforce_isolation_runnable(agent_name: str) -> None:
+        """Raise HTTPException if ``agent_name`` can't be (re)spawned under its
+        isolation_mode. The HTTP-context wrapper around _isolation_block_reason."""
+        blocked = _isolation_block_reason(agent_name)
+        if blocked:
+            status, detail = blocked
+            _log(f"api: refusing to start {agent_name}: {detail}")
+            raise HTTPException(status, detail)
+
     async def _start_streaming_session(
         agent_name: str,
         *,
@@ -2523,29 +2560,8 @@ def create_api(
             _log(f"api: {msg}")
             raise HTTPException(400, msg)
 
-        # #149 phase-3 preflight: refuse to START an agent whose isolation_mode
-        # has no implemented provisioner yet. The field is accepted + persisted
-        # at registration (forward-compatible), but get_provisioner() fails closed
-        # on unimplemented modes — surfacing it HERE makes that guarantee
-        # operational. Without this, a unix_user-labeled agent would auto-start
-        # under the local runner as the daemon's uid, silently getting NONE of
-        # the OS isolation the operator asked for. inc3c wires the real
-        # provisioner + lifts this for unix_user. (Murzik #642 review, P1.)
-        isolation_mode = (getattr(agent, "isolation_mode", "") or "local").strip() or "local"
-        try:
-            from pinky_daemon.provisioning import get_provisioner
-            get_provisioner(isolation_mode)
-        except NotImplementedError as e:
-            msg = (
-                f"isolation_mode '{isolation_mode}' for agent '{agent_name}' is "
-                f"not runnable yet: {e}"
-            )
-            _log(f"api: refusing to start {agent_name}: {msg}")
-            raise HTTPException(501, msg)
-        except ValueError as e:
-            msg = f"invalid isolation_mode for agent '{agent_name}': {e}"
-            _log(f"api: refusing to start {agent_name}: {msg}")
-            raise HTTPException(400, msg)
+        # #149 phase-3 cold-start guard (see _enforce_isolation_runnable).
+        _enforce_isolation_runnable(agent_name)
 
         is_codex = runtime == "codex_cli"
         is_tmux = runtime == "claude_sdk" and transport == "tmux"
@@ -2751,7 +2767,11 @@ def create_api(
                     if ss.state == TransportSessionState.CONNECTED:
                         break
                 return ss
-            # IDLE_SLEEPING / DEAD / UNINITIALIZED → explicit connect()
+            # IDLE_SLEEPING / DEAD / UNINITIALIZED → explicit connect().
+            # #149 P1: this relaunches the transport for an existing session
+            # object — guard it too, else a local→unix_user update could wake
+            # the old local session under the daemon uid (Murzik #642 review).
+            _enforce_isolation_runnable(agent_name)
             await ss.connect()
             return ss
 
@@ -2765,6 +2785,10 @@ def create_api(
     # exists but disconnected" case and fall through to "not running" for
     # any sibling that hasn't been touched via the web admin chat path.
     broker.set_ensure_session_callback(_ensure_streaming_session)
+    # #149 P1: guard the broker's idle auto-wake respawn path too (it calls
+    # connect() directly, bypassing _ensure_streaming_session). Shares the same
+    # block-reason check; the broker logs+skips rather than raising HTTP.
+    broker.set_isolation_guard(_isolation_block_reason)
 
     async def _disconnect_streaming_sessions(agent_name: str) -> int:
         """Disconnect and unregister all streaming sessions for an agent."""
@@ -6949,6 +6973,11 @@ npm run build</pre>
         ss = broker._get_streaming_session(name)
         if not ss:
             raise HTTPException(404, f"No streaming session for '{name}'")
+
+        # #149 P1: restart relaunches the transport — guard before we disconnect,
+        # so a blocked (e.g. relabeled unix_user) agent isn't torn down then left
+        # down. An unrunnable isolation_mode means "do not (re)spawn".
+        _enforce_isolation_runnable(name)
 
         guard = _get_streaming_restart_guard(name, ss)
         if not guard["restart_safe"]:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -4870,6 +4870,7 @@ npm run build</pre>
             strict_effort_enforcement=req.strict_effort_enforcement,
             watchdog_config=req.watchdog_config or {},
             isolated=req.isolated,
+            isolation_mode=req.isolation_mode,
         )
         # Write .mcp.json so the agent gets default MCP servers (memory, self, messaging)
         work_dir = Path(agent.working_dir) if agent.working_dir else None

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2523,6 +2523,30 @@ def create_api(
             _log(f"api: {msg}")
             raise HTTPException(400, msg)
 
+        # #149 phase-3 preflight: refuse to START an agent whose isolation_mode
+        # has no implemented provisioner yet. The field is accepted + persisted
+        # at registration (forward-compatible), but get_provisioner() fails closed
+        # on unimplemented modes — surfacing it HERE makes that guarantee
+        # operational. Without this, a unix_user-labeled agent would auto-start
+        # under the local runner as the daemon's uid, silently getting NONE of
+        # the OS isolation the operator asked for. inc3c wires the real
+        # provisioner + lifts this for unix_user. (Murzik #642 review, P1.)
+        isolation_mode = (getattr(agent, "isolation_mode", "") or "local").strip() or "local"
+        try:
+            from pinky_daemon.provisioning import get_provisioner
+            get_provisioner(isolation_mode)
+        except NotImplementedError as e:
+            msg = (
+                f"isolation_mode '{isolation_mode}' for agent '{agent_name}' is "
+                f"not runnable yet: {e}"
+            )
+            _log(f"api: refusing to start {agent_name}: {msg}")
+            raise HTTPException(501, msg)
+        except ValueError as e:
+            msg = f"invalid isolation_mode for agent '{agent_name}': {e}"
+            _log(f"api: refusing to start {agent_name}: {msg}")
+            raise HTTPException(400, msg)
+
         is_codex = runtime == "codex_cli"
         is_tmux = runtime == "claude_sdk" and transport == "tmux"
         resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -343,6 +343,21 @@ class RegisterAgentRequest(BaseModel):
     strict_effort_enforcement: bool = False  # PR #429 — block tool calls when effort drifts
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
     isolated: bool = False  # #149 — hard-isolated tenant (Counterpart); daemon denies cross-agent actions
+    # #149 phase-3 — OS-level runtime sandbox for an isolated tenant.
+    # "local" = in-process under the daemon's user (default, current behavior);
+    # "unix_user" = own pinky-<agent> OS user + private home/keys (Linux exec,
+    # inc3b). Orthogonal to `isolated`; only meaningful when isolated=True.
+    isolation_mode: str = "local"
+
+    @field_validator("isolation_mode")
+    @classmethod
+    def _isolation_mode_known(cls, v: str) -> str:
+        allowed = {"local", "unix_user"}
+        if v not in allowed:
+            raise ValueError(
+                f"isolation_mode must be one of {sorted(allowed)} (got {v!r})"
+            )
+        return v
 
 
 class UpdateAgentRequest(BaseModel):

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -399,6 +399,22 @@ class UpdateAgentRequest(BaseModel):
     thinking_effort: str | None = None  # low/medium/high/xhigh/max
     strict_effort_enforcement: bool | None = None  # PR #429 — block tool calls when effort drifts
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
+    # #149 phase-3 — OS-level runtime sandbox; None = leave unchanged. Same
+    # validated value set as the register path. The start-time preflight (api.py)
+    # refuses to actually *run* a mode whose provisioner isn't implemented yet.
+    isolation_mode: str | None = None
+
+    @field_validator("isolation_mode")
+    @classmethod
+    def _isolation_mode_known(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        allowed = {"local", "unix_user"}
+        if v not in allowed:
+            raise ValueError(
+                f"isolation_mode must be one of {sorted(allowed)} (got {v!r})"
+            )
+        return v
 
 
 class AddDirectiveRequest(BaseModel):

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -219,6 +219,13 @@ class MessageBroker:
         # cold-wake path that uses this.
         self._ensure_session_callback = None
 
+        # Optional #149 isolation-mode respawn guard. Wired by api.py.
+        # Signature: ``fn(agent_name) -> (status:int, detail:str) | None``.
+        # A non-None return means the agent's isolation_mode has no runnable
+        # provisioner, so idle auto-wake must NOT relaunch its transport under
+        # the daemon uid. None = no guard wired (tests). (Murzik #642 P1.)
+        self._isolation_guard = None
+
         # Streaming sessions — persistent ClaudeSDKClient connections per agent
         # agent_name -> {label -> StreamingSession}
         self._streaming: dict[str, dict[str, object]] = {}
@@ -250,6 +257,18 @@ class MessageBroker:
         Signature: ``async fn(agent_name, *, label) -> StreamingSession | None``.
         """
         self._ensure_session_callback = callback
+
+    def set_isolation_guard(self, callback) -> None:
+        """Register the #149 isolation-mode respawn guard.
+
+        ``callback(agent_name) -> (status, detail) | None``. Consulted before
+        idle auto-wake relaunches a transport via ``connect()``; a non-None
+        return means the agent's ``isolation_mode`` isn't runnable yet (no
+        implemented provisioner), so the wake is skipped — logged, not raised,
+        since the broker has no HTTP context. Cold-start through the ensure
+        callback is guarded separately on the api side. (Murzik #642 P1.)
+        """
+        self._isolation_guard = callback
 
     async def _typing_loop(
         self,
@@ -1012,13 +1031,22 @@ class MessageBroker:
             and streaming.state == SessionState.IDLE_SLEEPING
             and streaming.resume_handle
         ):
-            _log(f"broker: {agent_name} is idle-sleeping — auto-waking for inbound message")
-            try:
-                await streaming.connect()
-                _log(f"broker: {agent_name} auto-woke successfully")
-            except Exception as e:
-                _log(f"broker: {agent_name} auto-wake failed: {e}")
+            # #149 P1: don't relaunch the transport for an agent whose
+            # isolation_mode has no runnable provisioner (e.g. a local session
+            # later relabeled unix_user) — that would wake it under the daemon
+            # uid with none of the requested OS isolation. Skip + log.
+            blocked = self._isolation_guard(agent_name) if self._isolation_guard else None
+            if blocked:
+                _log(f"broker: {agent_name} auto-wake blocked — {blocked[1]}")
                 streaming = None
+            else:
+                _log(f"broker: {agent_name} is idle-sleeping — auto-waking for inbound message")
+                try:
+                    await streaming.connect()
+                    _log(f"broker: {agent_name} auto-woke successfully")
+                except Exception as e:
+                    _log(f"broker: {agent_name} auto-wake failed: {e}")
+                    streaming = None
 
         # Cold-start path (PR #460): no session object yet → use the on-demand
         # ensurer if wired (api.py registers it post-init). This matches the

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -1,0 +1,143 @@
+"""Agent OS-level provisioning — the runtime-sandbox seam for #149 phase 3.
+
+An *isolated* agent (the daemon-authz ``isolated`` flag, #635) is denied
+cross-agent actions inside the daemon. That is the authorization half of
+isolation. This module is the *runtime* half: how an isolated tenant's
+process is actually sandboxed at the operating-system level.
+
+``isolation_mode`` on the Agent selects the strategy:
+
+  - ``"local"``     — in-process under the daemon's own OS user. No OS
+                      sandbox; the only boundary is the daemon-authz
+                      ``isolated`` flag. This is the default and the
+                      current (pre-#149-phase-3) behavior for every agent.
+  - ``"unix_user"`` — the agent gets its own ``pinky-<agent>`` OS user with
+                      a private home, working dir, signing key, and MCP
+                      config, and its runtime runs under that uid. EXEC of
+                      this path is Linux/systemd-only and lands in inc3b;
+                      this module ships only the interface + the no-op
+                      ``LocalProvisioner`` in inc3a.
+
+A ``AgentProvisioner`` owns the lifecycle of those OS resources
+(provision / deprovision / introspect) and contributes any extra process
+environment the runtime needs (``runtime_env``). The companion seam — how
+the runtime *command* is launched under the right uid — lives behind the
+CommandRunner in ``tmux_session`` (inc3b); a provisioner never spawns the
+agent itself, it only prepares the ground.
+
+Design constraints (why this exists now, before any real impl):
+  - Additive and inert: nothing in the daemon lifecycle calls a provisioner
+    in inc3a. Wiring provisioning into registration/start/retire is inc3b.
+  - Fail-closed on the unimplemented path: ``get_provisioner("unix_user")``
+    raises rather than silently degrading to local — an operator who asks
+    for OS isolation must not get a no-op by accident.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover — typing only, avoids a runtime import cycle
+    from .agent_registry import Agent
+
+
+# Canonical set of recognized isolation modes. Mirrors the validator on
+# ``RegisterAgentRequest.isolation_mode`` (api_models.py) — duplicated here so
+# in-process callers of ``get_provisioner`` get the same guarantee independent
+# of the request layer.
+LOCAL = "local"
+UNIX_USER = "unix_user"
+KNOWN_MODES = frozenset({LOCAL, UNIX_USER})
+
+
+@dataclass
+class ProvisionResult:
+    """Outcome of a provision / deprovision call.
+
+    ``created``/``removed`` enumerate the OS resources touched, in the order
+    they were touched, so inc3b's UnixUserProvisioner can drive partial-
+    failure rollback (undo in reverse) and so callers can audit exactly what
+    changed. For the no-op LocalProvisioner both lists are always empty.
+    """
+
+    ok: bool = True
+    mode: str = LOCAL
+    created: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+    message: str = ""
+
+
+class AgentProvisioner(ABC):
+    """Owns the OS-level resources backing one isolation strategy.
+
+    Implementations must be **idempotent**: ``provision`` on an already-
+    provisioned agent is a successful no-op, and ``deprovision`` on an
+    already-clean agent is likewise. This keeps daemon restarts and retry
+    loops safe — the daemon may call these on every startup.
+    """
+
+    #: Stable identifier matching the agent's ``isolation_mode`` value.
+    mode: str = LOCAL
+
+    @abstractmethod
+    def provision(self, agent: "Agent") -> ProvisionResult:
+        """Idempotently create the OS resources this agent needs to run."""
+
+    @abstractmethod
+    def deprovision(self, agent: "Agent") -> ProvisionResult:
+        """Idempotently tear down OS resources created by ``provision``."""
+
+    @abstractmethod
+    def is_provisioned(self, agent: "Agent") -> bool:
+        """True iff the agent's OS resources currently exist."""
+
+    @abstractmethod
+    def runtime_env(self, agent: "Agent") -> dict[str, str]:
+        """Extra process env to merge into the agent's runtime (e.g. HOME)."""
+
+
+class LocalProvisioner(AgentProvisioner):
+    """Default strategy: no OS sandbox — runs under the daemon's user.
+
+    Every method is an intentional no-op. This is the behavior every agent
+    has today; ``isolation_mode="local"`` simply names it explicitly. An
+    agent is always considered "provisioned" because there is nothing to set
+    up, and it contributes no extra environment.
+    """
+
+    mode = LOCAL
+
+    def provision(self, agent: "Agent") -> ProvisionResult:
+        return ProvisionResult(ok=True, mode=LOCAL, message="local: no OS resources to provision")
+
+    def deprovision(self, agent: "Agent") -> ProvisionResult:
+        return ProvisionResult(ok=True, mode=LOCAL, message="local: no OS resources to deprovision")
+
+    def is_provisioned(self, agent: "Agent") -> bool:
+        return True
+
+    def runtime_env(self, agent: "Agent") -> dict[str, str]:
+        return {}
+
+
+def get_provisioner(isolation_mode: str) -> AgentProvisioner:
+    """Return the provisioner for ``isolation_mode``.
+
+    ``"local"`` → the no-op :class:`LocalProvisioner`. ``"unix_user"`` is a
+    recognized mode but its provisioner lands in #149 inc3b, so it raises
+    :class:`NotImplementedError` rather than silently degrading to local —
+    an operator asking for OS isolation must never get a no-op by accident.
+    Any other value is rejected as unknown.
+    """
+    if isolation_mode == LOCAL:
+        return LocalProvisioner()
+    if isolation_mode == UNIX_USER:
+        raise NotImplementedError(
+            "isolation_mode='unix_user' provisioning lands in #149 inc3b "
+            "(Linux/systemd OS-user sandbox); not available yet"
+        )
+    raise ValueError(
+        f"unknown isolation_mode {isolation_mode!r}; expected one of {sorted(KNOWN_MODES)}"
+    )

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -2068,6 +2068,7 @@ def create_server(
             transport: str = "tmux",
             confirm_privileged_role: bool = False,
             isolated: bool = False,
+            isolation_mode: str = "local",
         ) -> str:
             """Register a new agent in the fleet, then assign its skills.
 
@@ -2085,6 +2086,11 @@ def create_server(
             (acting on a different agent's resources). Default False = full-trust
             inner-fleet agent. (fs/container isolation is a later phase; this
             flag is the daemon-authz half.)
+            isolation_mode: #149 phase-3 — OS-level runtime sandbox for an
+            isolated tenant. "local" (default) runs in-process under the
+            daemon's user (current behavior). "unix_user" provisions the agent
+            its own pinky-<agent> OS user + private home/keys (Linux/systemd
+            exec only; inc3b). Only meaningful together with isolated=True.
             """
             privileged_roles = {"dreamer"}
             if role in privileged_roles and not confirm_privileged_role:
@@ -2126,6 +2132,7 @@ def create_server(
                 "groups": groups or [],
                 "transport": transport,
                 "isolated": isolated,
+                "isolation_mode": isolation_mode,
             })
             if isinstance(create, dict) and "error" in create:
                 return f"Failed to register agent '{name}': {create['error']}"

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -153,6 +153,30 @@ class TestAgentCRUD:
         registry.register("plain", isolated=True)
         assert registry.get("plain").isolated is True
 
+    def test_isolation_mode_round_trip(self, registry):
+        """#149 phase-3: isolation_mode persists through insert/get/to_dict,
+        defaults to 'local', and is settable via the update path."""
+        # Default 'local'.
+        plain = registry.register("plain", model="opus")
+        assert plain.isolation_mode == "local"
+        assert registry.get("plain").isolation_mode == "local"
+        assert registry.get("plain").to_dict()["isolation_mode"] == "local"
+
+        # Insert with an explicit mode.
+        iso = registry.register("tenant", model="opus", isolated=True,
+                                isolation_mode="unix_user")
+        assert iso.isolation_mode == "unix_user"
+        assert registry.get("tenant").isolation_mode == "unix_user"
+        assert registry.get("tenant").to_dict()["isolation_mode"] == "unix_user"
+
+        # Update path changes it for an existing agent.
+        registry.register("plain", isolation_mode="unix_user")
+        assert registry.get("plain").isolation_mode == "unix_user"
+
+        # isolation_mode is orthogonal to the isolated flag.
+        assert registry.get("tenant").isolated is True
+        assert registry.get("plain").isolated is False
+
     def test_register_with_full_config(self, registry, tmp_path):
         agent = registry.register(
             "leo",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -599,6 +599,46 @@ class TestAPI:
                 })
                 assert r.status_code == 422
 
+    def test_update_isolation_mode_round_trips(self):
+        """#149 phase-3 (Murzik #642 P2): PUT /agents/{name} can change
+        isolation_mode; the validator rejects unknown values."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "tenant", "model": "sonnet"})
+                assert client.get("/agents/tenant").json()["isolation_mode"] == "local"
+
+                r = client.put("/agents/tenant", json={"isolation_mode": "unix_user"})
+                assert r.status_code == 200
+                assert r.json()["isolation_mode"] == "unix_user"
+                assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
+
+                # Unknown value rejected by the validator.
+                bad = client.put("/agents/tenant", json={"isolation_mode": "container"})
+                assert bad.status_code == 422
+                # Unchanged after the rejected update.
+                assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
+
+    def test_unix_user_agent_cannot_start_before_provisioner(self):
+        """#149 phase-3 (Murzik #642 P1): an agent labeled isolation_mode=
+        'unix_user' is accepted at registration but REFUSES to start (501)
+        until inc3c wires the provisioner — it must never silently run under
+        the local runner with no OS isolation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolated": True, "isolation_mode": "unix_user",
+                })
+                # Wake triggers _start_streaming_session → isolation preflight.
+                resp = client.post("/agents/tenant/wake?prompt=Wake")
+                assert resp.status_code == 501
+                assert "not runnable yet" in resp.text
+                assert "unix_user" in resp.text
+
     # Note: `test_sleep_disconnects_streaming_main` and
     # `test_sleep_requires_recent_explicit_context_save` were removed
     # in #552 along with the `POST /agents/{name}/sleep` endpoint

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -624,7 +624,8 @@ class TestAPI:
         """#149 phase-3 (Murzik #642 P1): an agent labeled isolation_mode=
         'unix_user' is accepted at registration but REFUSES to start (501)
         until inc3c wires the provisioner — it must never silently run under
-        the local runner with no OS isolation."""
+        the local runner with no OS isolation. Covers the COLD-start path
+        (_start_streaming_session)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
@@ -638,6 +639,63 @@ class TestAPI:
                 assert resp.status_code == 501
                 assert "not runnable yet" in resp.text
                 assert "unix_user" in resp.text
+
+    def test_unix_user_reconnect_refused(self):
+        """#149 P1 re-review (Murzik): the RECONNECT path
+        (_ensure_streaming_session) must also hit the guard. An existing
+        local session relabeled unix_user must not relaunch via connect()
+        under the daemon uid. /chat auto-wakes a non-connected session."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolated": True, "isolation_mode": "unix_user",
+                })
+                # Existing session object in a non-connected (DEAD) state.
+                fake = self._FakeStreamingSession("tenant", "main", connected=False)
+                app.state.broker.register_streaming("tenant", fake, label="main")
+
+                resp = client.post("/agents/tenant/chat", json={"content": "hi"})
+                assert resp.status_code == 501
+                assert "not runnable yet" in resp.text
+                assert fake.connect_calls == 0  # never relaunched
+
+    def test_unix_user_restart_refused_without_teardown(self):
+        """#149 P1 re-review (Murzik): the RESTART endpoint must hit the guard
+        BEFORE disconnecting — a relabeled unix_user agent is refused (501)
+        and not torn down then left down."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolated": True, "isolation_mode": "unix_user",
+                })
+                fake = self._FakeStreamingSession("tenant", "main")  # CONNECTED
+                app.state.broker.register_streaming("tenant", fake, label="main")
+
+                resp = client.post("/agents/tenant/streaming/restart")
+                assert resp.status_code == 501
+                assert "not runnable yet" in resp.text
+                assert fake.disconnect_calls == 0  # guard fired before teardown
+
+    def test_local_agent_unaffected_by_isolation_guard(self):
+        """Control: a normal local agent passes the guard on every path —
+        the guard only blocks unimplemented modes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "plain", "model": "sonnet"})
+                fake = self._FakeStreamingSession("plain", "main")  # CONNECTED
+                app.state.broker.register_streaming("plain", fake, label="main")
+                # Restart reaches the save-safety guard (409), NOT a 501 —
+                # proving the isolation guard let a local agent through.
+                resp = client.post("/agents/plain/streaming/restart")
+                assert resp.status_code != 501
 
     # Note: `test_sleep_disconnects_streaming_main` and
     # `test_sleep_requires_recent_explicit_context_save` were removed

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -566,6 +566,39 @@ class TestAPI:
                 assert len(data) == 1
                 assert data[0]["id"] == "adhoc"
 
+    def test_register_isolation_mode_round_trips(self):
+        """#149 phase-3: POST /agents carries isolation_mode through to the
+        stored agent; default is 'local'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                # Default.
+                r = client.post("/agents", json={"name": "plain", "model": "sonnet"})
+                assert r.status_code == 200
+                assert r.json()["isolation_mode"] == "local"
+
+                # Explicit unix_user persists.
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolated": True, "isolation_mode": "unix_user",
+                })
+                assert r.status_code == 200
+                assert r.json()["isolation_mode"] == "unix_user"
+                # Confirm it survives a re-fetch.
+                assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
+
+    def test_register_rejects_unknown_isolation_mode(self):
+        """The api_models validator rejects modes outside the known set (422)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={
+                    "name": "bad", "model": "sonnet", "isolation_mode": "container",
+                })
+                assert r.status_code == 422
+
     # Note: `test_sleep_disconnects_streaming_main` and
     # `test_sleep_requires_recent_explicit_context_save` were removed
     # in #552 along with the `POST /agents/{name}/sleep` endpoint

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -423,6 +423,89 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
+    async def test_idle_autowake_blocked_by_isolation_guard(self):
+        """#149 P1 re-review (Murzik #642): the broker's idle auto-wake calls
+        connect() directly, bypassing _ensure_streaming_session. It must
+        consult the isolation guard first — a blocked agent (e.g. a local
+        session relabeled unix_user) is NOT relaunched under the daemon uid."""
+        from pinky_daemon.transport_state import SessionState
+
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            class _SleepingSession:
+                resume_handle = "sdk-resume"
+
+                def __init__(self):
+                    self.state = SessionState.IDLE_SLEEPING
+                    self.connect_calls = 0
+                    self.sent: list[str] = []
+
+                async def connect(self):
+                    self.connect_calls += 1
+                    self.state = SessionState.CONNECTED
+
+                async def send(self, prompt, **kwargs):
+                    self.sent.append(prompt)
+
+            ss = _SleepingSession()
+            broker.register_streaming("barsik", ss, label="main")
+            # Guard returns a block reason → wake must be skipped.
+            broker.set_isolation_guard(
+                lambda name: (501, "isolation_mode 'unix_user' is not runnable yet")
+            )
+
+            msg = BrokerMessage(
+                platform="telegram", chat_id="6770805286",
+                sender_name="Brad", sender_id="u-1",
+                content="ping while asleep", agent_name="barsik",
+            )
+            await broker._route_streaming("barsik", msg)
+
+            assert ss.connect_calls == 0, "blocked agent must not be auto-woken"
+            assert ss.state == SessionState.IDLE_SLEEPING, "session left untouched"
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_idle_autowake_proceeds_when_guard_allows(self):
+        """Control for the guard-block test: a guard returning None (mode
+        runnable) leaves the existing auto-wake behavior intact."""
+        from pinky_daemon.transport_state import SessionState
+
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            class _SleepingSession:
+                resume_handle = "sdk-resume"
+
+                def __init__(self):
+                    self.state = SessionState.IDLE_SLEEPING
+                    self.connect_calls = 0
+                    self.sent: list[str] = []
+
+                async def connect(self):
+                    self.connect_calls += 1
+                    self.state = SessionState.CONNECTED
+
+                async def send(self, prompt, **kwargs):
+                    self.sent.append(prompt)
+
+            ss = _SleepingSession()
+            broker.register_streaming("barsik", ss, label="main")
+            broker.set_isolation_guard(lambda name: None)  # mode runnable
+
+            msg = BrokerMessage(
+                platform="telegram", chat_id="6770805286",
+                sender_name="Brad", sender_id="u-1",
+                content="ping while asleep", agent_name="barsik",
+            )
+            await broker._route_streaming("barsik", msg)
+
+            assert ss.connect_calls == 1, "runnable agent auto-wakes as before"
+            assert ss.sent, "message should deliver after auto-wake"
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
     async def test_stop_typing_cancels_active_task(self):
         """_stop_typing must cancel a running typing-loop task."""
         import asyncio

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -2144,3 +2144,33 @@ class TestRegisterAgent:
             agent_name="x", tool_gates=[])._tool_manager.list_tools()}
         assert "register_agent" in with_admin
         assert "register_agent" not in without
+
+    def test_isolation_mode_flows_into_payload(self, srv):
+        """#149 phase-3: the isolation_mode arg is forwarded in the POST body;
+        default is 'local'."""
+        bodies: list[dict] = []
+
+        def _urlopen(req, timeout=30):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            # Record the POST /agents create body (has a data payload).
+            if url.endswith("/agents") and getattr(req, "data", None):
+                bodies.append(json.loads(req.data.decode()))
+            data = {"error": "not found", "status": 404} if url.endswith("/agents/mora") \
+                else {"name": "mora", "model": "opus"}
+            resp = MagicMock()
+            resp.read.return_value = json.dumps(data).encode()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=_urlopen):
+            _tools(srv)["register_agent"](
+                name="mora", isolated=True, isolation_mode="unix_user",
+            )
+        assert bodies and bodies[0]["isolation_mode"] == "unix_user"
+        assert bodies[0]["isolated"] is True
+
+        bodies.clear()
+        with patch("urllib.request.urlopen", side_effect=_urlopen):
+            _tools(srv)["register_agent"](name="mora")
+        assert bodies and bodies[0]["isolation_mode"] == "local"

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -1,0 +1,97 @@
+"""Tests for the #149 phase-3 agent OS-provisioning seam.
+
+inc3a ships only the interface + the no-op LocalProvisioner + the factory.
+These tests pin that contract: the no-op is genuinely inert, the factory
+maps modes correctly, and the unimplemented unix_user path fails closed
+(raises) rather than silently degrading to local.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_daemon.agent_registry import Agent
+from pinky_daemon.provisioning import (
+    KNOWN_MODES,
+    AgentProvisioner,
+    LocalProvisioner,
+    ProvisionResult,
+    get_provisioner,
+)
+
+
+@pytest.fixture
+def local_agent():
+    return Agent(name="tenant", model="opus", isolated=True, isolation_mode="local")
+
+
+class TestLocalProvisioner:
+    def test_is_an_agent_provisioner(self):
+        assert isinstance(LocalProvisioner(), AgentProvisioner)
+        assert LocalProvisioner().mode == "local"
+
+    def test_provision_is_a_successful_noop(self, local_agent):
+        result = LocalProvisioner().provision(local_agent)
+        assert isinstance(result, ProvisionResult)
+        assert result.ok is True
+        assert result.mode == "local"
+        assert result.created == []  # nothing created
+        assert result.removed == []
+
+    def test_deprovision_is_a_successful_noop(self, local_agent):
+        result = LocalProvisioner().deprovision(local_agent)
+        assert result.ok is True
+        assert result.created == []
+        assert result.removed == []
+
+    def test_always_provisioned(self, local_agent):
+        # No OS resources to set up → always considered ready.
+        assert LocalProvisioner().is_provisioned(local_agent) is True
+
+    def test_contributes_no_runtime_env(self, local_agent):
+        assert LocalProvisioner().runtime_env(local_agent) == {}
+
+    def test_idempotent(self, local_agent):
+        p = LocalProvisioner()
+        # Repeated calls stay successful no-ops.
+        assert p.provision(local_agent).ok
+        assert p.provision(local_agent).ok
+        assert p.deprovision(local_agent).ok
+        assert p.deprovision(local_agent).ok
+
+
+class TestGetProvisioner:
+    def test_local_returns_local_provisioner(self):
+        p = get_provisioner("local")
+        assert isinstance(p, LocalProvisioner)
+        assert p.mode == "local"
+
+    def test_unix_user_not_yet_implemented(self):
+        # Fail-closed: the recognized-but-unbuilt path raises rather than
+        # silently handing back a no-op LocalProvisioner.
+        with pytest.raises(NotImplementedError) as exc:
+            get_provisioner("unix_user")
+        assert "inc3b" in str(exc.value)
+
+    def test_unknown_mode_rejected(self):
+        with pytest.raises(ValueError):
+            get_provisioner("container")
+
+    def test_known_modes_constant(self):
+        assert KNOWN_MODES == frozenset({"local", "unix_user"})
+
+
+class TestProvisionResult:
+    def test_defaults(self):
+        r = ProvisionResult()
+        assert r.ok is True
+        assert r.mode == "local"
+        assert r.created == []
+        assert r.removed == []
+        assert r.message == ""
+
+    def test_created_lists_are_independent(self):
+        # default_factory must not share a single list across instances.
+        a, b = ProvisionResult(), ProvisionResult()
+        a.created.append("user:pinky-x")
+        assert b.created == []


### PR DESCRIPTION
## #149 phase-3 inc3a — OS-isolation scaffolding

First of two PRs for phase-3 OS-level agent isolation. **Additive and inert**: nothing in the daemon lifecycle invokes a provisioner yet, and the default path is unchanged. Everything is gated behind a new `isolation_mode` field that defaults to `'local'` (current in-process behavior). **Zero isolated agents in the fleet**, so even a daemon restart onto this WIP leaves every agent on the untouched default path.

### What's here
- **`Agent.isolation_mode`** (`'local'` | `'unix_user'`), wired end-to-end: dataclass + `to_dict`, `_ensure_columns` migration (`TEXT NOT NULL DEFAULT 'local'`), `register()` create/update paths, `_AGENT_COLUMNS` SELECT, and `_row_to_agent` (appended as `row[52]` so existing positions are untouched).
- **`RegisterAgentRequest.isolation_mode`** with a fail-closed validator (rejects modes outside `{local, unix_user}` → 422); `POST /agents` passthrough.
- **pinky_self `register_agent` tool**: new param + payload passthrough.
- **New `provisioning.py`**: `AgentProvisioner` ABC + no-op `LocalProvisioner` + `get_provisioner()` factory. `unix_user` raises `NotImplementedError` (lands in inc3b) rather than silently degrading to a no-op — an operator asking for OS isolation must never get a no-op by accident.

### What's NOT here (inc3b)
`UnixUserProvisioner` (real `pinky-<agent>` OS user + home/keys/perms), the CommandRunner seam under `_TmuxControl` (runuser/systemd-run swap), and the `pinky-agent@.service` template. Real OS-user/systemd exec is Linux-only and validates on the Pi, not macOS.

### Tests
- Column round-trip (insert/get/to_dict/update), defaults to `'local'`, orthogonal to `isolated`.
- API round-trip + validator rejection of unknown modes.
- Tool payload passthrough (default `'local'`, explicit `'unix_user'`).
- Provisioner contract: no-op inertness, idempotency, factory mapping, fail-closed `unix_user`.

Full suite green (run in chunks; ~2800 passed, 1 skipped). Ruff clean.

### Review focus (per Murzik)
Provisioning boundary, key/secret placement (deferred to inc3b), migration/backfill of existing agents (column defaults `'local'` for all), and the fail-closed unix_user path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)