### PR TITLE
fix(#641): resolve agent signing key at request time to end stale-key 401 lockouts

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1001,6 +1001,10 @@ class AgentRegistry:
 
     def __init__(self, db_path: str = "data/agents.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        # Absolute path retained so callers (e.g. _write_mcp_json) can hand
+        # stdio MCP subprocesses an explicit DB location for request-time
+        # signing-key lookup (#641) rather than relying on their cwd.
+        self._db_path = str(Path(db_path).resolve())
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         self._db.execute("PRAGMA journal_mode=WAL")
         self._db.execute("PRAGMA foreign_keys=ON")

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -651,6 +651,17 @@ def _write_mcp_json(
                     stdio_env["PINKY_AGENT_KEY"] = agent_key
             except Exception:
                 pass
+            # #641: hand self/messaging the explicit agents-DB path so they can
+            # look up the CURRENT signing key at request time (via a resolver in
+            # their entrypoints) instead of trusting the baked PINKY_AGENT_KEY
+            # above, which goes stale when the daemon restarts but the long-lived
+            # stdio servers (children of the persistent tmux REPL) don't. Explicit
+            # path — these run with cwd=pinky_src, so a relative DB path would
+            # resolve wrong. Regenerated on every daemon startup (see _start), so
+            # existing agents pick this up on the next REPL relaunch.
+            db_path = getattr(agent_registry, "_db_path", "")
+            if isinstance(db_path, str) and db_path:
+                stdio_env["PINKY_AGENTS_DB"] = db_path
 
         # Pinky-self: heartbeat_ack, schedules, self-management
         tool_gates = _get_agent_tool_gates(agent_name, skill_store)

--- a/src/pinky_daemon/auth.py
+++ b/src/pinky_daemon/auth.py
@@ -150,6 +150,54 @@ def resolve_request_signing_secret(agent_name, signing_key_resolver=None) -> str
     return resolve_signing_secret()
 
 
+def make_db_signing_key_resolver(db_path: str):
+    """Build a request-time signing-key resolver backed by the agents DB (#641).
+
+    Returns ``agent_name -> current signing key | None``. Each call opens the
+    agents DB **read-only** and SELECTs the agent's current per-agent key, so a
+    stale ``PINKY_AGENT_KEY`` captured into a long-lived stdio MCP server's env
+    at spawn can never shadow the key the DB actually holds. That env-vs-DB
+    desync is the root cause of the post-daemon-restart 401 lockout (#641):
+    ``.mcp.json`` bakes the key statically, ``resolve_signing_secret`` prefers
+    it, and the daemon rejects once it drifts.
+
+    Pair with :func:`resolve_request_signing_secret`: when a resolver is present
+    it ignores process-env ``PINKY_AGENT_KEY`` entirely and falls back to the
+    GLOBAL secret only — so the stale env key is dead, exactly as in shared-SSE
+    mode. The daemon stays the policy authority (dual-accept for non-isolated,
+    fail-closed for isolated per #640); this only changes what the *signer*
+    presents, never what the verifier accepts.
+
+    Fails soft: any error (missing file, missing table, locked DB) returns
+    None, so signing degrades to the global secret rather than raising into the
+    request path.
+
+    NOTE (#149 inc3c): a unix_user-isolated tenant must NOT read the fleet DB —
+    it holds every agent's signing key. This DB-backed resolver is the
+    local-mode repair only; an isolated tenant gets a single-agent,
+    provisioner-placed key source swapped in behind this same resolver seam.
+    """
+    import sqlite3
+
+    def _resolve(agent_name: str) -> str | None:
+        if not agent_name or not db_path:
+            return None
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
+            try:
+                row = conn.execute(
+                    "SELECT signing_key FROM agent_signing_keys WHERE agent_name=?",
+                    (agent_name,),
+                ).fetchone()
+            finally:
+                conn.close()
+            return row[0] if row and row[0] else None
+        except Exception:
+            return None
+
+    return _resolve
+
+
 def build_internal_auth_headers(secret: str, *, agent_name: str, method: str, path: str, timestamp: int | None = None) -> dict[str, str]:
     """Build signed headers for local MCP-to-daemon requests."""
     if not secret or not agent_name:

--- a/src/pinky_daemon/auth.py
+++ b/src/pinky_daemon/auth.py
@@ -177,10 +177,17 @@ def make_db_signing_key_resolver(db_path: str):
     local-mode repair only; an isolated tenant gets a single-agent,
     provisioner-placed key source swapped in behind this same resolver seam.
     """
+    import re
     import sqlite3
 
+    # Same allowlist the registry/API enforce on agent names. Parameter binding
+    # already neutralizes SQL injection, but validating here keeps the resolver
+    # inside the agent-name trust boundary (@murzik #644 hardening): a malformed
+    # name can never reach the query and simply resolves to None → global fallback.
+    _name_re = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
     def _resolve(agent_name: str) -> str | None:
-        if not agent_name or not db_path:
+        if not agent_name or not db_path or not _name_re.fullmatch(agent_name):
             return None
         try:
             conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)

--- a/src/pinky_messaging/__main__.py
+++ b/src/pinky_messaging/__main__.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from pathlib import Path
+
+
+def _default_agents_db() -> str:
+    """Canonical agents DB path, used when PINKY_AGENTS_DB isn't set. Repo root
+    is two parents up from ``src/pinky_messaging/__main__.py``; the daemon's
+    default agents DB is ``data/conversations_agents.db`` under it."""
+    return str(Path(__file__).resolve().parents[2] / "data" / "conversations_agents.db")
 
 
 def main() -> None:
@@ -19,15 +27,29 @@ def main() -> None:
         default=os.environ.get("PINKY_API_URL", "http://localhost:8888"),
         help="PinkyBot API URL (or set PINKY_API_URL env var)",
     )
+    parser.add_argument(
+        "--db-path", default="",
+        help="Agents DB path for request-time signing-key lookup (#641); "
+             "defaults to $PINKY_AGENTS_DB or the canonical data path.",
+    )
     args = parser.parse_args()
 
     if not args.agent:
         print("Error: --agent is required", file=sys.stderr)
         sys.exit(1)
 
+    from pinky_daemon.auth import make_db_signing_key_resolver
     from pinky_messaging.server import create_server
 
-    server = create_server(agent_name=args.agent, api_url=args.api_url)
+    # #641: look up the current signing key from the agents DB at request time
+    # so a stale baked PINKY_AGENT_KEY can't lock this stdio server out after a
+    # daemon restart. Resolver present → env key ignored, global-secret fallback.
+    db_path = args.db_path or os.environ.get("PINKY_AGENTS_DB", "") or _default_agents_db()
+    resolver = make_db_signing_key_resolver(db_path)
+
+    server = create_server(
+        agent_name=args.agent, api_url=args.api_url, signing_key_resolver=resolver,
+    )
     print(f"[pinky-messaging] {args.agent} -> {args.api_url}", file=sys.stderr)
     server.run(transport="stdio")
 

--- a/src/pinky_self/__main__.py
+++ b/src/pinky_self/__main__.py
@@ -1,9 +1,23 @@
 """Run pinky-self MCP server standalone."""
 
 import argparse
+import os
 import sys
+from pathlib import Path
 
+from pinky_daemon.auth import make_db_signing_key_resolver
 from pinky_self.server import create_server
+
+
+def _default_agents_db() -> str:
+    """Canonical agents DB path, used when PINKY_AGENTS_DB isn't set.
+
+    This file lives at ``src/pinky_self/__main__.py``; the repo root is two
+    parents up and the daemon's default agents DB is
+    ``data/conversations_agents.db`` under it. PINKY_AGENTS_DB (injected via
+    .mcp.json) overrides this.
+    """
+    return str(Path(__file__).resolve().parents[2] / "data" / "conversations_agents.db")
 
 
 def main():
@@ -13,6 +27,11 @@ def main():
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8010)
     parser.add_argument(
+        "--db-path", default="",
+        help="Agents DB path for request-time signing-key lookup (#641); "
+             "defaults to $PINKY_AGENTS_DB or the canonical data path.",
+    )
+    parser.add_argument(
         "--tool-gates", default="",
         help="Comma-separated tool gates to activate "
              "(e.g. kb,research,presentations,triggers,schedule,skill-admin,admin,tasks-admin)",
@@ -21,12 +40,20 @@ def main():
 
     gates = [g.strip() for g in args.tool_gates.split(",") if g.strip()] if args.tool_gates else []
 
+    # #641: resolve the signing key from the agents DB at request time so a
+    # stale baked PINKY_AGENT_KEY can't lock this stdio server out after a
+    # daemon restart. With a resolver present, the server ignores the env key
+    # and falls back to the global secret only.
+    db_path = args.db_path or os.environ.get("PINKY_AGENTS_DB", "") or _default_agents_db()
+    resolver = make_db_signing_key_resolver(db_path)
+
     server = create_server(
         agent_name=args.agent,
         api_url=args.api_url,
         host=args.host,
         port=args.port,
         tool_gates=gates,
+        signing_key_resolver=resolver,
     )
 
     print(f"[pinky-self] Starting for agent '{args.agent}'", file=sys.stderr)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -192,6 +192,18 @@ def test_db_resolver_unknown_agent_returns_none(tmp_path):
     assert resolver("ghost") is None
 
 
+def test_db_resolver_rejects_malformed_agent_name(tmp_path):
+    # @murzik #644 hardening: a name outside the agent allowlist never reaches
+    # the query — resolves to None (→ global fallback), staying inside the
+    # agent-name trust boundary.
+    db = str(tmp_path / "agents.db")
+    _seed_signing_key(db, "alice", "current-key")
+    resolver = make_db_signing_key_resolver(db)
+    for bad in ("../../etc/passwd", "Alice", "a b", "a'; DROP TABLE x;--", "-leading"):
+        assert resolver(bad) is None
+    assert resolver("alice") == "current-key"  # valid name still works
+
+
 def test_db_resolver_missing_db_fails_soft(tmp_path):
     # Missing file / unreadable DB must degrade to None (→ global-secret
     # fallback), never raise into the request path.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,6 +14,7 @@ from pinky_daemon.auth import (
     build_internal_auth_headers,
     create_session_cookie,
     hash_password,
+    make_db_signing_key_resolver,
     password_source,
     resolve_request_signing_secret,
     resolve_signing_secret,
@@ -154,6 +155,130 @@ def test_per_agent_key_signs_request_verifiable_by_daemon(monkeypatch):
         timestamp=headers["x-pinky-timestamp"],
         signature=headers["x-pinky-signature"],
         agent_key="alice-key",  # ...but the per-agent key does
+    )
+
+
+# ── #641: request-time signing-key resolver (stale-env-key lockout fix) ──────
+
+
+def _seed_signing_key(db_path: str, agent_name: str, key: str) -> None:
+    """Create the agent_signing_keys table + row, mirroring AgentRegistry."""
+    import sqlite3
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS agent_signing_keys "
+        "(agent_name TEXT PRIMARY KEY, signing_key TEXT NOT NULL, created_at REAL)"
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO agent_signing_keys (agent_name, signing_key, created_at) "
+        "VALUES (?, ?, 0)",
+        (agent_name, key),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_db_resolver_returns_current_key(tmp_path):
+    db = str(tmp_path / "agents.db")
+    _seed_signing_key(db, "alice", "current-key")
+    resolver = make_db_signing_key_resolver(db)
+    assert resolver("alice") == "current-key"
+
+
+def test_db_resolver_unknown_agent_returns_none(tmp_path):
+    db = str(tmp_path / "agents.db")
+    _seed_signing_key(db, "alice", "current-key")
+    resolver = make_db_signing_key_resolver(db)
+    assert resolver("ghost") is None
+
+
+def test_db_resolver_missing_db_fails_soft(tmp_path):
+    # Missing file / unreadable DB must degrade to None (→ global-secret
+    # fallback), never raise into the request path.
+    resolver = make_db_signing_key_resolver(str(tmp_path / "does-not-exist.db"))
+    assert resolver("alice") is None
+    assert make_db_signing_key_resolver("")("alice") is None
+
+
+def test_db_resolver_sees_key_rotation(tmp_path):
+    # Each call reads fresh — a key changed in the DB after the resolver was
+    # built is picked up on the very next request (the #641 property).
+    db = str(tmp_path / "agents.db")
+    _seed_signing_key(db, "alice", "old-key")
+    resolver = make_db_signing_key_resolver(db)
+    assert resolver("alice") == "old-key"
+    _seed_signing_key(db, "alice", "new-key")
+    assert resolver("alice") == "new-key"
+
+
+def test_641_resolver_signs_with_current_key_ignoring_stale_env(tmp_path, monkeypatch):
+    """The core #641 scenario: a stdio server's env carries a STALE
+    PINKY_AGENT_KEY (baked at spawn), but the DB now holds a different current
+    key. With the DB resolver wired, signing uses the CURRENT key — so the
+    daemon (verifying against the current agent_key) accepts it, and the stale
+    key is dead. Pre-fix, signing preferred the stale env key → 401."""
+    db = str(tmp_path / "agents.db")
+    _seed_signing_key(db, "alice", "current-key")
+    monkeypatch.setenv("PINKY_AGENT_KEY", "STALE-baked-key")
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+
+    resolver = make_db_signing_key_resolver(db)
+    secret = resolve_request_signing_secret("alice", resolver)
+    assert secret == "current-key"  # NOT the stale env key
+
+    headers = build_internal_auth_headers(
+        secret, agent_name="alice", method="POST", path="/agents/alice/status",
+    )
+    # Daemon verifies against the CURRENT per-agent key → accepted.
+    assert verify_internal_request(
+        "global-secret", agent_name="alice", method="POST",
+        path="/agents/alice/status",
+        timestamp=headers["x-pinky-timestamp"],
+        signature=headers["x-pinky-signature"],
+        agent_key="current-key",
+    )
+    # And the same signature does NOT verify against the stale key — proving
+    # we did not sign with it.
+    assert not verify_internal_request(
+        "global-secret", agent_name="alice", method="POST",
+        path="/agents/alice/status",
+        timestamp=headers["x-pinky-timestamp"],
+        signature=headers["x-pinky-signature"],
+        agent_key="STALE-baked-key", allow_global_secret=False,
+    )
+
+
+def test_641_resolver_none_falls_back_to_global_not_stale_env(tmp_path, monkeypatch):
+    """If the resolver can't find a key (unknown agent / DB error), signing
+    falls back to the GLOBAL secret — never the stale process env key."""
+    db = str(tmp_path / "agents.db")
+    _seed_signing_key(db, "alice", "current-key")
+    monkeypatch.setenv("PINKY_AGENT_KEY", "STALE-baked-key")
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+    resolver = make_db_signing_key_resolver(db)
+    # 'ghost' has no DB key → resolver None → global secret, not stale env.
+    assert resolve_request_signing_secret("ghost", resolver) == "global-secret"
+
+
+def test_641_isolated_invariant_preserved(tmp_path, monkeypatch):
+    """#640 invariant unchanged: a global-secret signature is rejected when
+    allow_global_secret=False (isolated caller) even if the signer fell back to
+    it. The fix changes only what the signer presents, never verifier policy."""
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret")
+    # Signer falls back to global (no per-agent key resolvable).
+    secret = resolve_request_signing_secret("iso", lambda name: None)
+    assert secret == "global-secret"
+    headers = build_internal_auth_headers(
+        secret, agent_name="iso", method="POST", path="/agents/iso/status",
+    )
+    # Isolated verification (allow_global_secret=False) with no per-agent key
+    # → fail closed, regardless of the global-secret signature.
+    assert not verify_internal_request(
+        "global-secret", agent_name="iso", method="POST",
+        path="/agents/iso/status",
+        timestamp=headers["x-pinky-timestamp"],
+        signature=headers["x-pinky-signature"],
+        agent_key=None, allow_global_secret=False,
     )
 
 

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -369,6 +369,7 @@ class TestWriteMcpJsonSharedMode:
         registry = MagicMock()
         registry.get_signing_key.return_value = "barsik-per-agent-key"
         registry.list_mcp_servers.return_value = []
+        registry._db_path = "/abs/data/conversations_agents.db"  # #641
 
         original = api_mod.SHARED_MCP_ENABLED
         api_mod.SHARED_MCP_ENABLED = False
@@ -379,6 +380,10 @@ class TestWriteMcpJsonSharedMode:
             servers = json.loads((work_dir / ".mcp.json").read_text())["mcpServers"]
             assert servers["pinky-self"]["env"]["PINKY_AGENT_KEY"] == "barsik-per-agent-key"
             assert servers["pinky-messaging"]["env"]["PINKY_AGENT_KEY"] == "barsik-per-agent-key"
+            # #641: explicit agents-DB path injected so the stdio servers can
+            # look up the CURRENT signing key at request time.
+            assert servers["pinky-self"]["env"]["PINKY_AGENTS_DB"] == "/abs/data/conversations_agents.db"
+            assert servers["pinky-messaging"]["env"]["PINKY_AGENTS_DB"] == "/abs/data/conversations_agents.db"
         finally:
             api_mod.SHARED_MCP_ENABLED = original
 


### PR DESCRIPTION
## #641 — stale agent-key 401 lockout

### Root cause
`_write_mcp_json` bakes the agent's **current** `PINKY_AGENT_KEY` statically into `.mcp.json` at write time. The stdio `pinky-self` / `pinky-messaging` servers are long-lived **children of the persistent tmux REPL, which survives daemon restarts** — so they keep signing every daemon request with that frozen key forever (`resolve_signing_secret` prefers it). The moment the daemon's DB key no longer matches the baked one, **every daemon-backed tool 401s** (messaging, tasks, agent comms) until a manual `launchctl kickstart`. This recurred repeatedly tonight.

### Fix (per @murzik design review)
Route the stdio self/messaging servers through the **same request-time resolver seam** that shared-SSE already uses, so a stale env key is *dead* once a resolver is present:

- **`auth.make_db_signing_key_resolver(db_path)`** — opens the agents DB **read-only** and SELECTs the agent's *current* signing key per call; fails soft to `None`. With a resolver present, `resolve_request_signing_secret` ignores process-env `PINKY_AGENT_KEY` and falls back to the **global secret only**.
- **`pinky_self` / `pinky_messaging` `__main__`** — build the resolver from `PINKY_AGENTS_DB` (explicit, injected via `.mcp.json`) or a canonical default path, and pass it to `create_server`.
- **`_write_mcp_json`** — inject `PINKY_AGENTS_DB` (absolute, from `registry._db_path`) for the stdio servers. `.mcp.json` is regenerated on **every daemon startup**, so existing agents pick this up on their next REPL relaunch.
- `AgentRegistry` retains an absolute `_db_path` for that injection.

### Security: no verifier changes
The daemon stays the policy authority — **dual-accept for non-isolated agents, fail-closed for isolated callers (#640)** is fully preserved. This changes only what the *signer* presents, never what the verifier accepts. No stale/old-key acceptance is added on the daemon side. unix_user tenants (#149 inc3c) will get a provisioner-placed single-agent key source behind this same resolver seam — never the fleet DB.

### Tests
`make_db_signing_key_resolver`: current key / unknown→None / bad-path fail-soft / sees rotation. Core #641 e2e: stale env key ignored, signs with current key, daemon accepts current + rejects stale. `None`→global-not-stale fallback. #640 isolated invariant unchanged. `PINKY_AGENTS_DB` injected into `.mcp.json`. 602 passed across affected suites; ruff clean.

### Deploy note
Code deploy + daemon restart refreshes `.mcp.json` (PINKY_AGENTS_DB). The MCP servers are children of the persistent tmux REPL, so **fully activating the fix requires a REPL relaunch** (context_restart) after deploy — bouncing the daemon alone doesn't replace the running stdio servers. I'll sequence that on deploy and verify auth holds across a subsequent daemon restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)