### PR TITLE
feat(#149): CommandRunner execution seam under _TmuxControl (phase-3 inc3b)

### DIFF
--- a/src/pinky_daemon/command_runner.py
+++ b/src/pinky_daemon/command_runner.py
@@ -1,0 +1,149 @@
+"""CommandRunner — the subprocess-execution seam for #149 phase-3.
+
+A ``CommandRunner`` runs an argv and returns its result. It exists so the
+*identity* a subprocess runs under can be swapped without touching the call
+sites that build the command:
+
+  - :class:`LocalCommandRunner` runs argv verbatim under the daemon's own
+    OS user. This is the default everywhere and reproduces the exact
+    pre-#149-phase-3 behavior (a plain ``asyncio.create_subprocess_exec``).
+  - :class:`RunuserCommandRunner` runs argv as another OS user via
+    ``runuser -u <user> --`` (Linux only). This is how an ``isolation_mode
+    ="unix_user"`` tenant's tmux server + REPL get launched under their own
+    ``pinky-<agent>`` uid, so the agent's process cannot read the daemon's
+    files or other tenants' homes.
+
+The seam lives behind ``_TmuxControl`` (tmux_session.py): that class builds
+``tmux …`` argvs and delegates the actual exec to its injected runner. A
+local agent gets a LocalCommandRunner (no change); a unix_user agent gets a
+RunuserCommandRunner bound to its OS user. The provisioner that creates that
+OS user, and the systemd supervision unit, land in inc3c — this module is
+only the execution half and is fully testable on macOS via the argv-wrapping
+contract (no Linux/root needed to assert command shapes).
+
+Design note — why timeout+kill lives in the runner: callers want one
+consistent "run argv, bound the wait, kill on timeout" primitive regardless
+of which identity it runs under. Centralizing it here means the runuser
+wrapper inherits the exact same timeout semantics as the local path for free.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class CommandResult:
+    """Outcome of one subprocess invocation. ``stdout``/``stderr`` are raw
+    bytes — the caller decides how to decode (``_TmuxControl`` decodes utf-8
+    with ``errors='replace'``)."""
+
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+class CommandRunner(ABC):
+    """Runs an argv under some OS identity and returns its result."""
+
+    @abstractmethod
+    async def run(
+        self,
+        argv: list[str],
+        *,
+        timeout: float | None = None,
+        stdin: bytes | None = None,
+    ) -> CommandResult:
+        """Execute ``argv``, optionally feeding ``stdin``.
+
+        ``timeout`` (seconds) bounds the wait; on expiry the child is killed
+        and ``asyncio.TimeoutError`` propagates, matching the prior inline
+        behavior in ``_TmuxControl._run``.
+        """
+
+
+class LocalCommandRunner(CommandRunner):
+    """Run argv verbatim under the daemon's own user — the default.
+
+    Byte-for-byte the behavior ``_TmuxControl._run`` had inline before the
+    seam existed: ``create_subprocess_exec`` with piped stdout/stderr, a
+    bounded wait, and a kill-on-timeout that re-raises ``TimeoutError``.
+    """
+
+    async def run(
+        self,
+        argv: list[str],
+        *,
+        timeout: float | None = None,
+        stdin: bytes | None = None,
+    ) -> CommandResult:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=stdin), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            raise
+        return CommandResult(
+            returncode=proc.returncode or 0,
+            stdout=stdout or b"",
+            stderr=stderr or b"",
+        )
+
+
+class RunuserCommandRunner(CommandRunner):
+    """Run argv as another OS user via ``runuser`` (Linux only).
+
+    ``runuser -u <user> -- <argv...>`` switches uid/gid to ``username``
+    without a PAM session or password prompt (it requires the caller to be
+    root, which the daemon is when managing unix_user tenants). The actual
+    exec is delegated to an inner runner — :class:`LocalCommandRunner` by
+    default — so timeout/kill semantics are shared with the local path and
+    tests can inject a recording double.
+
+    The ``--`` terminator is mandatory: it stops ``runuser`` from
+    interpreting any of the wrapped argv (e.g. a leading ``-x``) as its own
+    option. The wrapped argv is passed as separate args, never shell-joined,
+    so there is no quoting/injection surface.
+    """
+
+    def __init__(
+        self,
+        username: str,
+        *,
+        runuser_binary: str = "runuser",
+        inner: CommandRunner | None = None,
+    ) -> None:
+        if not username:
+            raise ValueError("RunuserCommandRunner requires a non-empty username")
+        self.username = username
+        self.runuser_binary = runuser_binary
+        self._inner = inner or LocalCommandRunner()
+
+    def wrap(self, argv: list[str]) -> list[str]:
+        """Return ``argv`` prefixed with the runuser invocation."""
+        return [self.runuser_binary, "-u", self.username, "--", *argv]
+
+    async def run(
+        self,
+        argv: list[str],
+        *,
+        timeout: float | None = None,
+        stdin: bytes | None = None,
+    ) -> CommandResult:
+        return await self._inner.run(self.wrap(argv), timeout=timeout, stdin=stdin)

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -67,6 +67,7 @@ from collections import deque
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
+from pinky_daemon.command_runner import CommandRunner, LocalCommandRunner
 from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.streaming_session import (
     StreamingSessionConfig,
@@ -285,12 +286,19 @@ class _TmuxControl:
         *,
         tmux_binary: str = "tmux",
         socket_name: str = "",
+        command_runner: CommandRunner | None = None,
     ) -> None:
         self.session_name = session_name
         self.tmux_binary = tmux_binary
         # An explicit socket isolates Pinky's tmux sessions from the
         # operator's own. Empty = use tmux's default socket.
         self.socket_name = socket_name
+        # #149 phase-3 execution seam: who runs the tmux subprocess. Default
+        # LocalCommandRunner reproduces the prior inline create_subprocess_exec
+        # verbatim (daemon's own user). An isolation_mode='unix_user' tenant is
+        # wired with a RunuserCommandRunner so its tmux server + REPL run under
+        # the agent's own pinky-<agent> uid. See command_runner.py.
+        self._runner: CommandRunner = command_runner or LocalCommandRunner()
 
     def _base_cmd(self) -> list[str]:
         cmd = [self.tmux_binary]
@@ -314,23 +322,17 @@ class _TmuxControl:
         # 5s here defends a hung tmux server; 60s up there defends a hung
         # REPL bootstrap (auth flow, CLAUDE.md load, etc.).
         cmd = self._base_cmd() + list(args)
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except asyncio.TimeoutError:
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
-            raise
+        # Delegate the actual exec to the injected CommandRunner. For local
+        # agents this is LocalCommandRunner — identical to the prior inline
+        # create_subprocess_exec. For unix_user tenants the runner wraps the
+        # argv in ``runuser -u pinky-<agent> --`` so tmux runs under the
+        # agent's uid. Timeout/kill semantics live in the runner; a timeout
+        # still raises asyncio.TimeoutError for the caller to handle.
+        result = await self._runner.run(cmd, timeout=timeout)
         return TmuxCommandResult(
-            returncode=proc.returncode or 0,
-            stdout=stdout.decode("utf-8", errors="replace"),
-            stderr=stderr.decode("utf-8", errors="replace"),
+            returncode=result.returncode,
+            stdout=result.stdout.decode("utf-8", errors="replace"),
+            stderr=result.stderr.decode("utf-8", errors="replace"),
         )
 
     async def has_session(self) -> bool:

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -1,0 +1,105 @@
+"""Tests for the #149 phase-3 CommandRunner execution seam.
+
+LocalCommandRunner is exercised against real short-lived subprocesses (it IS
+the subprocess primitive, so mocking it would test nothing). RunuserCommandRunner
+is tested via its argv-wrapping contract + a recording inner runner — no Linux,
+root, or real ``runuser`` needed to assert the command shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+from pinky_daemon.command_runner import (
+    CommandResult,
+    LocalCommandRunner,
+    RunuserCommandRunner,
+)
+
+
+class TestCommandResult:
+    def test_ok_true_on_zero(self):
+        assert CommandResult(0, b"", b"").ok is True
+
+    def test_ok_false_on_nonzero(self):
+        assert CommandResult(1, b"", b"").ok is False
+
+
+@pytest.mark.asyncio
+class TestLocalCommandRunner:
+    async def test_captures_stdout_and_returncode(self):
+        r = await LocalCommandRunner().run(
+            [sys.executable, "-c", "import sys; sys.stdout.write('hi'); sys.exit(3)"]
+        )
+        assert r.returncode == 3
+        assert r.stdout == b"hi"
+        assert r.ok is False
+
+    async def test_captures_stderr(self):
+        r = await LocalCommandRunner().run(
+            [sys.executable, "-c", "import sys; sys.stderr.write('boom')"]
+        )
+        assert r.returncode == 0
+        assert b"boom" in r.stderr
+
+    async def test_feeds_stdin(self):
+        r = await LocalCommandRunner().run(
+            [sys.executable, "-c", "import sys; sys.stdout.write(sys.stdin.read())"],
+            stdin=b"piped",
+        )
+        assert r.stdout == b"piped"
+
+    async def test_timeout_raises_and_kills(self):
+        # A 30s sleep with a 0.2s ceiling must raise rather than hang.
+        with pytest.raises(asyncio.TimeoutError):
+            await LocalCommandRunner().run(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+                timeout=0.2,
+            )
+
+
+class _RecordingRunner(LocalCommandRunner):
+    """Inner runner double that records argv instead of executing."""
+
+    def __init__(self):
+        self.calls: list[tuple[list[str], float | None, bytes | None]] = []
+
+    async def run(self, argv, *, timeout=None, stdin=None):
+        self.calls.append((argv, timeout, stdin))
+        return CommandResult(0, b"", b"")
+
+
+@pytest.mark.asyncio
+class TestRunuserCommandRunner:
+    async def test_wrap_shape(self):
+        r = RunuserCommandRunner("pinky-mora")
+        assert r.wrap(["tmux", "has-session", "-t", "x"]) == [
+            "runuser", "-u", "pinky-mora", "--", "tmux", "has-session", "-t", "x",
+        ]
+
+    async def test_custom_runuser_binary(self):
+        r = RunuserCommandRunner("pinky-mora", runuser_binary="/usr/sbin/runuser")
+        assert r.wrap(["tmux"])[0] == "/usr/sbin/runuser"
+
+    async def test_run_delegates_wrapped_argv_to_inner(self):
+        inner = _RecordingRunner()
+        r = RunuserCommandRunner("pinky-mora", inner=inner)
+        await r.run(["tmux", "kill-session"], timeout=5.0, stdin=b"x")
+        assert len(inner.calls) == 1
+        argv, timeout, stdin = inner.calls[0]
+        assert argv == ["runuser", "-u", "pinky-mora", "--", "tmux", "kill-session"]
+        assert timeout == 5.0  # timeout/stdin pass through unchanged
+        assert stdin == b"x"
+
+    async def test_terminator_isolates_wrapped_options(self):
+        # A wrapped arg that looks like a runuser option must sit AFTER ``--``.
+        r = RunuserCommandRunner("pinky-mora")
+        wrapped = r.wrap(["-l"])
+        assert wrapped.index("--") < wrapped.index("-l")
+
+    async def test_empty_username_rejected(self):
+        with pytest.raises(ValueError):
+            RunuserCommandRunner("")

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -409,6 +409,65 @@ async def test_capture_pane_with_escapes_adds_e_flag() -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# CommandRunner seam (#149 phase-3): _run delegates exec to its runner
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_defaults_to_local_command_runner() -> None:
+    """A _TmuxControl built without an explicit runner uses LocalCommandRunner
+    — i.e. the prior verbatim behavior (daemon's own user)."""
+    from pinky_daemon.command_runner import LocalCommandRunner
+
+    tmux = _TmuxControl("pinky-test")
+    assert isinstance(tmux._runner, LocalCommandRunner)
+
+
+@pytest.mark.asyncio
+async def test_run_delegates_built_argv_to_injected_runner() -> None:
+    """_run hands the fully-built ``tmux …`` argv to its CommandRunner and
+    decodes the bytes result into a TmuxCommandResult. This is the swap point
+    a unix_user tenant uses (RunuserCommandRunner wraps the same argv)."""
+    from pinky_daemon.command_runner import CommandResult, CommandRunner
+
+    class _Recording(CommandRunner):
+        def __init__(self):
+            self.argv = None
+            self.timeout = None
+
+        async def run(self, argv, *, timeout=None, stdin=None):
+            self.argv = argv
+            self.timeout = timeout
+            return CommandResult(0, b"out", b"err")
+
+    rec = _Recording()
+    tmux = _TmuxControl("pinky-test", socket_name="pinkysock", command_runner=rec)
+    result = await tmux._run("has-session", "-t", "pinky-test", timeout=5.0)
+
+    # Built argv includes the base cmd (binary + socket flag) then the args.
+    assert rec.argv == ["tmux", "-L", "pinkysock", "has-session", "-t", "pinky-test"]
+    assert rec.timeout == 5.0
+    assert result.returncode == 0
+    assert result.stdout == "out"  # bytes decoded
+    assert result.stderr == "err"
+
+
+@pytest.mark.asyncio
+async def test_run_propagates_runner_timeout() -> None:
+    """A runner that times out surfaces asyncio.TimeoutError to the caller,
+    same as the prior inline behavior."""
+    from pinky_daemon.command_runner import CommandRunner
+
+    class _TimingOut(CommandRunner):
+        async def run(self, argv, *, timeout=None, stdin=None):
+            raise asyncio.TimeoutError
+
+    tmux = _TmuxControl("pinky-test", command_runner=_TimingOut())
+    with pytest.raises(asyncio.TimeoutError):
+        await tmux._run("has-session")
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # resize_window / resize_pane: viewer reshapes tmux pane to fit the modal
 # ──────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Phase-3 inc3b: introduces the `CommandRunner` execution seam under `_TmuxControl` so isolated-tenant command execution can later be routed through a `runuser`-based runner without touching call sites.

- `LocalCommandRunner` — verbatim current behavior (default; full-trust inner-fleet agents)
- `RunuserCommandRunner` — placeholder seam for unix_user tenants (dormant; not wired into provisioning yet)
- `_TmuxControl` now executes via the injected runner instead of calling subprocess directly

Pure refactor + seam — no behavior change for existing agents. inc3a (#642) landed first; this was rebased onto main after #642's squash-merge (the original #643 auto-closed when its stacked base branch was deleted). Same commit Murzik approved, replayed cleanly onto main with zero conflicts.

Tests: `test_command_runner.py` (new) + `test_tmux_session.py` — 244 passed locally against current main.

Supersedes the auto-closed #643. Part of #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)