### PR TITLE
feat(#648): live token/cost analytics for tmux transport

### DIFF
--- a/src/pinky_daemon/pricing.py
+++ b/src/pinky_daemon/pricing.py
@@ -1,0 +1,204 @@
+"""Per-turn token-cost pricing for the daemon.
+
+The SDK transport gets ``total_cost_usd`` for free on each
+``ResultMessage``. The tmux transport does not — Claude Code runs under
+a subscription and the transcript carries only token *counts*, never a
+dollar figure. To reach Analytics / lifetime-cost parity (issue #648)
+we have to compute the cost ourselves from the token counts and a rate
+table.
+
+This module is the version-controlled twin of the rate table that
+``scripts/burn_cost_report.py`` reads from
+``~/.pinkybot/burn/rates/*.jsonl`` for the post-hoc snapshot overlay.
+The post-hoc tool keeps its rates out-of-tree so historical snapshots
+can be repriced without a code change; the *live* daemon path needs the
+rates compiled in so a fresh deploy prices turns correctly with no
+external file dependency. The two must agree on the math — the cost
+breakdown here mirrors ``compute_row_cost`` exactly (split 5m/1h
+cache-write billing, 1h fallback when the split is absent).
+
+All prices are USD per million tokens (``usd_per_mtok``). Cache-creation
+("write") tokens are billed at one of two rates depending on the
+ephemeral TTL the API chose for that prompt prefix:
+
+* 5-minute ephemeral cache → ``cache_write_5m`` (1.25× base input)
+* 1-hour   ephemeral cache → ``cache_write_1h`` (2× base input)
+
+Cache-*read* tokens are billed at the cheap ``cache_read`` rate.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Strip a trailing context-window tier from a model id
+# ("claude-opus-4-8[1m]" → "claude-opus-4-8"). The live transcript model
+# field is bare, but be defensive in case a tiered id reaches us.
+_TIER_RE = re.compile(r"\[[^\]]+\]\s*$")
+
+_M = 1_000_000
+
+# --------------------------------------------------------------------- #
+# Rate table — keep in sync with ~/.pinkybot/burn/rates/anthropic_*.jsonl
+# (the snapshot overlay's out-of-tree copy). All values usd_per_mtok.
+# --------------------------------------------------------------------- #
+
+# Standard Opus tier (4.5 and newer): the price has been flat across
+# 4.5 → 4.6 → 4.7 → 4.8. 1M context is sold at the same per-token price
+# as 200K, so no tier split is needed here.
+_OPUS_STD = {
+    "input": 5.00,
+    "output": 25.00,
+    "cache_read": 0.50,
+    "cache_write_5m": 6.25,
+    "cache_write_1h": 10.00,
+}
+# Pre-4.5 Opus (4, 4.1): the old 3×-more-expensive tier. Kept for
+# historical-transcript pricing accuracy.
+_OPUS_LEGACY = {
+    "input": 15.00,
+    "output": 75.00,
+    "cache_read": 1.50,
+    "cache_write_5m": 18.75,
+    "cache_write_1h": 30.00,
+}
+_SONNET = {
+    "input": 3.00,
+    "output": 15.00,
+    "cache_read": 0.30,
+    "cache_write_5m": 3.75,
+    "cache_write_1h": 6.00,
+}
+_HAIKU_45 = {
+    "input": 1.00,
+    "output": 5.00,
+    "cache_read": 0.10,
+    "cache_write_5m": 1.25,
+    "cache_write_1h": 2.00,
+}
+_HAIKU_35 = {
+    "input": 0.80,
+    "output": 4.00,
+    "cache_read": 0.08,
+    "cache_write_5m": 1.00,
+    "cache_write_1h": 1.60,
+}
+
+# Bare-model-id → rate dict. Add new model ids here on each release.
+RATE_TABLE: dict[str, dict[str, float]] = {
+    "claude-opus-4-8": _OPUS_STD,
+    "claude-opus-4-7": _OPUS_STD,
+    "claude-opus-4-6": _OPUS_STD,
+    "claude-opus-4-5": _OPUS_STD,
+    "claude-opus-4-1": _OPUS_LEGACY,
+    "claude-opus-4": _OPUS_LEGACY,
+    "claude-sonnet-4-6": _SONNET,
+    "claude-sonnet-4-5": _SONNET,
+    "claude-sonnet-4": _SONNET,
+    "claude-haiku-4-5": _HAIKU_45,
+    "claude-haiku-3-5": _HAIKU_35,
+}
+
+
+def _strip_tier(model_id: str) -> str:
+    return _TIER_RE.sub("", (model_id or "").strip())
+
+
+def lookup_rate(model_id: str) -> dict[str, float] | None:
+    """Resolve a (possibly tiered) model id to its rate dict, or None."""
+    return RATE_TABLE.get(_strip_tier(model_id))
+
+
+def compute_turn_cost_usd(
+    model: str,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_creation_5m_tokens: int,
+    cache_creation_1h_tokens: int,
+) -> float:
+    """Cost (USD) for one turn's token counts under ``model``'s rates.
+
+    Returns ``0.0`` when the model is unknown (no rate row) — mirrors
+    ``burn_cost_report``'s "missing rate ⇒ skip" behaviour rather than
+    guessing. The caller may log the miss so a new model id gets added
+    to ``RATE_TABLE``.
+
+    The 5m/1h split mirrors ``scripts/burn_cost_report.compute_row_cost``
+    exactly so the live figure agrees with the post-hoc snapshot overlay.
+    """
+    rate = lookup_rate(model)
+    if rate is None:
+        return 0.0
+    inp = int(input_tokens or 0)
+    out = int(output_tokens or 0)
+    cr = int(cache_read_tokens or 0)
+    cc_5m = int(cache_creation_5m_tokens or 0)
+    cc_1h = int(cache_creation_1h_tokens or 0)
+    return (
+        inp / _M * rate["input"]
+        + out / _M * rate["output"]
+        + cr / _M * rate["cache_read"]
+        + cc_5m / _M * rate["cache_write_5m"]
+        + cc_1h / _M * rate["cache_write_1h"]
+    )
+
+
+def _split_cache_creation(usage: dict) -> tuple[int, int]:
+    """Extract (5m, 1h) cache-creation token counts from a usage block.
+
+    Claude transcripts carry the split under
+    ``usage.cache_creation.{ephemeral_5m_input_tokens,
+    ephemeral_1h_input_tokens}``. When that nested breakdown is absent we
+    fall back to billing the entire ``cache_creation_input_tokens``
+    aggregate at the 1h rate — the conservative (over-estimating) choice
+    that ``burn_cost_report`` makes for pre-split snapshots.
+    """
+    split = usage.get("cache_creation")
+    if isinstance(split, dict):
+        cc_5m = split.get("ephemeral_5m_input_tokens")
+        cc_1h = split.get("ephemeral_1h_input_tokens")
+        if cc_5m is not None or cc_1h is not None:
+            return int(cc_5m or 0), int(cc_1h or 0)
+    # No split present — bill all cache-creation at 1h (worst case).
+    total = usage.get("cache_creation_input_tokens") or usage.get(
+        "cache_write_tokens"
+    ) or 0
+    try:
+        return 0, int(total or 0)
+    except (TypeError, ValueError):
+        return 0, 0
+
+
+def compute_cost_from_usage(model: str, usage: dict) -> float:
+    """Cost (USD) for a raw transcript/SDK usage dict under ``model``.
+
+    Tolerant of both the Claude transcript key shape
+    (``cache_creation_input_tokens`` / ``cache_read_input_tokens``) and
+    the SDK's shortened forms (``cache_write_tokens`` /
+    ``cache_read_tokens``). Malformed values are treated as zero rather
+    than raising — pricing is best-effort telemetry, never a hard
+    dependency of the turn pipeline.
+    """
+    if not isinstance(usage, dict):
+        return 0.0
+    try:
+        inp = int(usage.get("input_tokens") or 0)
+        out = int(usage.get("output_tokens") or 0)
+        cr = int(
+            usage.get("cache_read_input_tokens")
+            or usage.get("cache_read_tokens")
+            or 0
+        )
+    except (TypeError, ValueError):
+        return 0.0
+    cc_5m, cc_1h = _split_cache_creation(usage)
+    return compute_turn_cost_usd(
+        model,
+        input_tokens=inp,
+        output_tokens=out,
+        cache_read_tokens=cr,
+        cache_creation_5m_tokens=cc_5m,
+        cache_creation_1h_tokens=cc_1h,
+    )

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -68,6 +68,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from pinky_daemon.command_runner import CommandRunner, LocalCommandRunner
+from pinky_daemon.pricing import compute_cost_from_usage
 from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.streaming_session import (
     StreamingSessionConfig,
@@ -2542,6 +2543,103 @@ class TmuxSession:
         if u:
             self.usage.last_usage = dict(u)
 
+    def _log_turn_cost_and_analytics(self, response: TurnResponse) -> None:
+        """Forward a completed turn's usage to analytics + cost tracking.
+
+        The SDK path (``StreamingSession``) gets ``total_cost_usd`` on
+        every ``ResultMessage`` and fires ``cost_callback`` +
+        ``analytics_store.log_turn_usage`` per turn — that's what powers
+        the live Analytics page and lifetime-cost rollups. The tmux path
+        runs Claude Code under a subscription, so the transcript carries
+        only token *counts*, never a dollar figure. Without this, tmux
+        agents are dark on live Analytics and lifetime cost; only the
+        post-hoc ``burn_snapshot`` scrape catches them (#648).
+
+        We close that gap here: compute the per-turn cost from the token
+        counts via the in-tree rate table (``pricing.py``, the live twin
+        of ``burn_cost_report``'s rate file) and fire both callbacks with
+        the SDK's signatures.
+
+        Must run AFTER ``_record_turn_usage`` so ``self.usage.total_turns``
+        is the current turn's 1-based sequence — the tmux analog of the
+        SDK's ``self._turn_seq``. Both reset to 0 per session and share a
+        stable ``self.id``, so the ``log_turn_usage`` upsert
+        (``ON CONFLICT(session_id, turn_seq)``) behaves identically across
+        the two transports.
+
+        Defensive throughout: pricing/analytics are side telemetry, never
+        a correctness dependency of the turn pipeline. A failure here must
+        not crash the tailer or break reply delivery.
+        """
+        if not self._analytics_store and not self._cost_callback:
+            return
+        turn_seq = self.usage.total_turns
+        if turn_seq <= 0:
+            return
+
+        u = response.usage if isinstance(response.usage, dict) else {}
+        # Prefer the transcript's own model field (authoritative for the
+        # turn that actually ran); fall back to the configured model.
+        model = (response.model or self._config.model or "").strip()
+
+        try:
+            input_tokens = int(u.get("input_tokens", 0) or 0)
+            output_tokens = int(u.get("output_tokens", 0) or 0)
+            # Analytics ``cached_input_tokens`` is cache-READ only (matches
+            # the SDK path + the column's meaning).
+            cached_input_tokens = int(
+                u.get("cache_read_input_tokens", 0)
+                or u.get("cache_read_tokens", 0)
+                or 0
+            )
+        except (TypeError, ValueError):
+            input_tokens = output_tokens = cached_input_tokens = 0
+
+        cost_usd = 0.0
+        try:
+            cost_usd = compute_cost_from_usage(model, u)
+        except Exception as e:  # pragma: no cover - defensive
+            _log(f"tmux[{self.agent_name}]: turn cost compute failed: {e}")
+        if model and cost_usd == 0.0 and (input_tokens or output_tokens):
+            # Non-empty turn but zero cost ⇒ no rate row for this model.
+            # Surface once so a new model id gets added to the table.
+            _log(
+                f"tmux[{self.agent_name}]: no pricing rate for model "
+                f"{model!r}; turn cost recorded as $0"
+            )
+
+        if cost_usd:
+            self.usage.total_cost_usd += cost_usd
+        if self._cost_callback:
+            try:
+                self._cost_callback(
+                    self.agent_name,
+                    cost_usd,
+                    input_tokens,
+                    output_tokens,
+                    self.resume_handle or "",
+                )
+            except Exception as e:
+                _log(f"tmux[{self.agent_name}]: cost callback error: {e}")
+
+        if self._analytics_store and (
+            input_tokens or output_tokens or cached_input_tokens
+        ):
+            try:
+                self._analytics_store.log_turn_usage(
+                    session_id=self.id,
+                    agent_name=self.agent_name,
+                    turn_seq=turn_seq,
+                    provider="anthropic",
+                    model=model,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cached_input_tokens=cached_input_tokens,
+                    error=False,
+                )
+            except Exception as e:
+                _log(f"tmux[{self.agent_name}]: analytics usage failed: {e}")
+
     def _current_total_tokens(self) -> int:
         """Token count for the current *context window* (not cumulative).
 
@@ -2888,6 +2986,11 @@ class TmuxSession:
         # entry's ``usage`` block; we just need to fold it into the
         # session-level dataclass and emit it.
         self._record_turn_usage(response)
+        # #648 — forward per-turn usage to analytics + cost tracking so
+        # tmux agents reach live Analytics / lifetime-cost parity with the
+        # SDK path. Must follow ``_record_turn_usage`` (it bumps
+        # ``total_turns``, used as the analytics turn_seq).
+        self._log_turn_cost_and_analytics(response)
         await self._emit_context_usage_event()
 
         # Stream event for analytics (usage / duration). Named

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -105,6 +105,7 @@ class _TurnBuffer:
         self._tool_uses: list[dict] = []
         self._last_stop_reason: str = ""
         self._last_usage: dict = {}
+        self._last_model: str = ""
         self._assistant_count: int = 0
         self._turn_started_at: float | None = None  # epoch seconds
         self._turn_ended_at: float | None = None
@@ -165,6 +166,15 @@ class _TurnBuffer:
         usage = msg.get("usage")
         if isinstance(usage, dict):
             self._last_usage = usage
+        # Capture the model that produced this turn. The configured model
+        # (``config.model``) can be empty when the agent relies on Claude
+        # Code's default, so the transcript's own ``model`` field is the
+        # authoritative per-turn source for cost pricing (#648). Synthetic
+        # placeholder rows ("<synthetic>") carry no real usage, so prefer
+        # the last entry that actually reported usage.
+        model = msg.get("model")
+        if model and model != "<synthetic>":
+            self._last_model = model
 
     def drain(self, prevented_continuation: bool = False) -> TurnResponse:
         """Snapshot + reset for the next turn."""
@@ -178,6 +188,7 @@ class _TurnBuffer:
             tool_uses=list(self._tool_uses),
             stop_reason=self._last_stop_reason,
             usage=dict(self._last_usage),
+            model=self._last_model,
             prevented_continuation=prevented_continuation,
             duration_ms=duration_ms,
             assistant_entry_count=self._assistant_count,
@@ -188,6 +199,7 @@ class _TurnBuffer:
         self._tool_uses.clear()
         self._last_stop_reason = ""
         self._last_usage = {}
+        self._last_model = ""
         self._assistant_count = 0
         self._turn_started_at = None
         self._turn_ended_at = None

--- a/src/pinky_daemon/turn_response.py
+++ b/src/pinky_daemon/turn_response.py
@@ -26,6 +26,7 @@ class TurnResponse:
     used_outreach_tools: bool = False
     stop_reason: str = ""
     usage: dict = field(default_factory=dict)
+    model: str = ""
     model_usage: dict = field(default_factory=dict)
     total_cost_usd: float = 0.0
     num_turns: int = 0
@@ -48,6 +49,7 @@ class TurnResponse:
         used_outreach_tools: bool = False,
         stop_reason: str = "",
         usage: dict | None = None,
+        model: str = "",
         model_usage: dict | None = None,
         total_cost_usd: float = 0.0,
         num_turns: int = 0,
@@ -66,6 +68,7 @@ class TurnResponse:
         self.used_outreach_tools = used_outreach_tools
         self.stop_reason = stop_reason
         self.usage = dict(usage or {})
+        self.model = model
         self.model_usage = dict(model_usage or {})
         self.total_cost_usd = total_cost_usd
         self.num_turns = num_turns

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,165 @@
+"""Unit tests for ``pinky_daemon.pricing`` (issue #648).
+
+The expected dollar figures are hand-computed from the in-tree rate
+table, which mirrors ``scripts/burn_cost_report.compute_row_cost`` (split
+5m/1h cache-write billing, 1h fallback when the split is absent). All
+rates are USD per million tokens.
+
+Standard Opus tier (4.5+): input 5.00, output 25.00, cache_read 0.50,
+cache_write_5m 6.25, cache_write_1h 10.00.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_daemon.pricing import (
+    compute_cost_from_usage,
+    compute_turn_cost_usd,
+    lookup_rate,
+)
+
+
+def test_pure_input_output_opus() -> None:
+    # 1M input @ $5 + 1M output @ $25 = $30.00
+    cost = compute_turn_cost_usd(
+        "claude-opus-4-8",
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        cache_read_tokens=0,
+        cache_creation_5m_tokens=0,
+        cache_creation_1h_tokens=0,
+    )
+    assert cost == pytest.approx(30.0)
+
+
+def test_split_cache_write_rates_opus() -> None:
+    # cache_read 1M @ $0.50 + cw5m 1M @ $6.25 + cw1h 1M @ $10 = $16.75
+    cost = compute_turn_cost_usd(
+        "claude-opus-4-8",
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=1_000_000,
+        cache_creation_5m_tokens=1_000_000,
+        cache_creation_1h_tokens=1_000_000,
+    )
+    assert cost == pytest.approx(16.75)
+
+
+def test_sonnet_rates() -> None:
+    # 2M input @ $3 + 1M output @ $15 = $21.00
+    cost = compute_turn_cost_usd(
+        "claude-sonnet-4-6",
+        input_tokens=2_000_000,
+        output_tokens=1_000_000,
+        cache_read_tokens=0,
+        cache_creation_5m_tokens=0,
+        cache_creation_1h_tokens=0,
+    )
+    assert cost == pytest.approx(21.0)
+
+
+def test_haiku_rates() -> None:
+    cost = compute_turn_cost_usd(
+        "claude-haiku-4-5",
+        input_tokens=1_000_000,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_creation_5m_tokens=0,
+        cache_creation_1h_tokens=0,
+    )
+    assert cost == pytest.approx(1.0)
+
+
+def test_legacy_opus_is_three_x() -> None:
+    # Pre-4.5 Opus billed at the 3x tier: 1M input @ $15.
+    cost = compute_turn_cost_usd(
+        "claude-opus-4-1",
+        input_tokens=1_000_000,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_creation_5m_tokens=0,
+        cache_creation_1h_tokens=0,
+    )
+    assert cost == pytest.approx(15.0)
+
+
+def test_unknown_model_costs_zero() -> None:
+    assert lookup_rate("gpt-5-turbo") is None
+    cost = compute_turn_cost_usd(
+        "gpt-5-turbo",
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        cache_read_tokens=0,
+        cache_creation_5m_tokens=0,
+        cache_creation_1h_tokens=0,
+    )
+    assert cost == 0.0
+
+
+def test_tier_suffix_is_stripped() -> None:
+    # A tiered id ("...[1m]") must resolve to the same rate as the bare id.
+    assert lookup_rate("claude-opus-4-8[1m]") is lookup_rate("claude-opus-4-8")
+    cost = compute_cost_from_usage(
+        "claude-opus-4-8[1m]",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+    )
+    assert cost == pytest.approx(5.0)
+
+
+def test_cost_from_usage_with_transcript_split() -> None:
+    """Transcript-shape usage with the nested 5m/1h breakdown."""
+    usage = {
+        "input_tokens": 10_000,
+        "output_tokens": 500,
+        "cache_read_input_tokens": 2_000,
+        "cache_creation_input_tokens": 3_000,
+        "cache_creation": {
+            "ephemeral_5m_input_tokens": 1_000,
+            "ephemeral_1h_input_tokens": 2_000,
+        },
+    }
+    # 10000*5 + 500*25 + 2000*0.5 + 1000*6.25 + 2000*10, all /1e6
+    expected = (
+        10_000 / 1e6 * 5
+        + 500 / 1e6 * 25
+        + 2_000 / 1e6 * 0.5
+        + 1_000 / 1e6 * 6.25
+        + 2_000 / 1e6 * 10
+    )
+    assert compute_cost_from_usage("claude-opus-4-8", usage) == pytest.approx(expected)
+
+
+def test_cost_from_usage_falls_back_to_1h_without_split() -> None:
+    """No nested split ⇒ bill the whole cache_creation aggregate at 1h."""
+    usage = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 1_000_000,
+    }
+    # All 1M cache-creation tokens at the 1h rate ($10).
+    assert compute_cost_from_usage("claude-opus-4-8", usage) == pytest.approx(10.0)
+
+
+def test_cost_from_usage_accepts_sdk_short_keys() -> None:
+    """SDK shortened key shape (cache_write_tokens / cache_read_tokens)."""
+    usage = {
+        "input_tokens": 1_000_000,
+        "output_tokens": 0,
+        "cache_read_tokens": 1_000_000,
+        "cache_write_tokens": 1_000_000,
+    }
+    # input 1M@5 + cache_read 1M@0.5 + cache_write(all 1h) 1M@10 = 15.5
+    assert compute_cost_from_usage("claude-opus-4-8", usage) == pytest.approx(15.5)
+
+
+def test_cost_from_usage_tolerates_malformed() -> None:
+    """Garbage values must yield 0.0, never raise."""
+    assert compute_cost_from_usage("claude-opus-4-8", {"input_tokens": "abc"}) == 0.0
+    assert compute_cost_from_usage("claude-opus-4-8", None) == 0.0
+    assert compute_cost_from_usage("claude-opus-4-8", {"input_tokens": None}) == 0.0
+
+
+def test_zero_usage_is_zero_cost() -> None:
+    assert compute_cost_from_usage("claude-opus-4-8", {}) == 0.0

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -4256,6 +4256,186 @@ async def test_record_turn_usage_tolerates_schema_drift() -> None:
     assert ss.usage.last_stop_reason == "end_turn"
 
 
+# ──────────────────────────────────────────────────────────────────────────
+# #648 — per-turn analytics + cost forwarding (parity with SDK path)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _make_usage_session(
+    *, analytics=None, cost_cb=None, model: str = "claude-opus-4-8"
+) -> TmuxSession:
+    """Build a CONNECTED TmuxSession wired with the callbacks #648 forwards.
+
+    Self-contained (uses only the ctor + the mock-tmux primitive) so it
+    doesn't depend on the optional kwargs of other test helpers.
+    """
+    cfg = StreamingSessionConfig(
+        agent_name="dymok",
+        working_dir="/tmp/tmux-session-test",
+        model=model,
+    )
+    ss = TmuxSession(
+        cfg,
+        tmux_control=_make_mock_tmux(),
+        analytics_store=analytics,
+        cost_callback=cost_cb,
+    )
+    ss._skip_wake_prompt_for_tests = True
+    ss._state_machine._state = SessionState.CONNECTED
+    return ss
+
+
+def _usage_turn_response(
+    *,
+    model: str = "claude-opus-4-8",
+    input_tokens: int = 10_000,
+    output_tokens: int = 500,
+    cache_read: int = 2_000,
+    cache_write: int = 0,
+    text: str = "ok",
+) -> TurnResponse:
+    return TurnResponse(
+        text=text,
+        stop_reason="end_turn",
+        model=model,
+        usage={
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_creation_input_tokens": cache_write,
+            "cache_read_input_tokens": cache_read,
+        },
+        duration_ms=100,
+        assistant_entry_count=1,
+        tool_uses=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_complete_logs_analytics_row() -> None:
+    """A completed turn must upsert an ``analytics_turn_usage`` row with
+    the SDK-shaped kwargs so tmux agents show up on the live Analytics
+    page (#648). ``cached_input_tokens`` is cache-READ only."""
+    analytics = MagicMock()
+    ss = _make_usage_session(analytics=analytics)
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_usage_turn_response())
+
+    analytics.log_turn_usage.assert_called_once()
+    kwargs = analytics.log_turn_usage.call_args.kwargs
+    assert kwargs["session_id"] == ss.id
+    assert kwargs["agent_name"] == "dymok"
+    assert kwargs["turn_seq"] == 1
+    assert kwargs["provider"] == "anthropic"
+    assert kwargs["model"] == "claude-opus-4-8"
+    assert kwargs["input_tokens"] == 10_000
+    assert kwargs["output_tokens"] == 500
+    assert kwargs["cached_input_tokens"] == 2_000
+    assert kwargs["error"] is False
+
+
+@pytest.mark.asyncio
+async def test_turn_complete_fires_cost_callback_with_computed_cost() -> None:
+    """tmux has no per-turn dollar figure from the transcript, so the
+    cost must be COMPUTED from token counts and forwarded via
+    ``cost_callback`` (signature: agent, cost, input, output, handle)."""
+    cost_cb = MagicMock()
+    ss = _make_usage_session(cost_cb=cost_cb)
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_usage_turn_response())
+
+    cost_cb.assert_called_once()
+    args = cost_cb.call_args.args
+    assert args[0] == "dymok"
+    # 10000*5 + 500*25 + 2000*0.5 (all /1e6) = 0.0635 (no cache-write).
+    expected = 10_000 / 1e6 * 5 + 500 / 1e6 * 25 + 2_000 / 1e6 * 0.5
+    assert args[1] == pytest.approx(expected)
+    assert args[2] == 10_000  # input_tokens
+    assert args[3] == 500  # output_tokens
+    assert args[4] == ss.resume_handle
+    # Lifetime cost accumulates onto session usage.
+    assert ss.usage.total_cost_usd == pytest.approx(expected)
+
+
+@pytest.mark.asyncio
+async def test_turn_seq_increments_across_turns() -> None:
+    """Each turn upserts under a monotonic turn_seq (the tmux analog of
+    the SDK's ``_turn_seq``) so rows don't clobber each other."""
+    analytics = MagicMock()
+    ss = _make_usage_session(analytics=analytics)
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_usage_turn_response())
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_usage_turn_response())
+    seqs = [c.kwargs["turn_seq"] for c in analytics.log_turn_usage.call_args_list]
+    assert seqs == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_model_falls_back_to_config_when_transcript_blank() -> None:
+    """If the transcript carried no model field, price under the
+    configured model rather than dropping the cost to zero."""
+    cost_cb = MagicMock()
+    analytics = MagicMock()
+    ss = _make_usage_session(
+        cost_cb=cost_cb, analytics=analytics, model="claude-sonnet-4-6"
+    )
+    _seed_inflight(ss)
+    # response.model empty → fall back to config.model.
+    await ss._handle_turn_complete(_usage_turn_response(model=""))
+    assert analytics.log_turn_usage.call_args.kwargs["model"] == "claude-sonnet-4-6"
+    # Sonnet input rate $3: 10000/1e6*3 + 500/1e6*15 + 2000/1e6*0.3
+    expected = 10_000 / 1e6 * 3 + 500 / 1e6 * 15 + 2_000 / 1e6 * 0.3
+    assert cost_cb.call_args.args[1] == pytest.approx(expected)
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_costs_zero_but_still_logs_usage() -> None:
+    """An unpriced model records $0 cost but STILL logs the token row —
+    analytics visibility must not depend on having a rate."""
+    cost_cb = MagicMock()
+    analytics = MagicMock()
+    ss = _make_usage_session(cost_cb=cost_cb, analytics=analytics)
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_usage_turn_response(model="some-future-model"))
+    assert cost_cb.call_args.args[1] == 0.0
+    analytics.log_turn_usage.assert_called_once()
+    assert analytics.log_turn_usage.call_args.kwargs["input_tokens"] == 10_000
+
+
+@pytest.mark.asyncio
+async def test_no_callbacks_is_safe() -> None:
+    """A session with neither analytics_store nor cost_callback must
+    complete turns without error (the common pre-#648 wiring)."""
+    ss = _make_usage_session()
+    _seed_inflight(ss)
+    # Must not raise.
+    await ss._handle_turn_complete(_usage_turn_response())
+    assert ss.usage.total_turns == 1
+
+
+@pytest.mark.asyncio
+async def test_analytics_failure_is_swallowed() -> None:
+    """A flaky analytics_store must not break turn completion / delivery —
+    cost/analytics are side telemetry, not correctness."""
+    analytics = MagicMock()
+    analytics.log_turn_usage = MagicMock(side_effect=RuntimeError("db locked"))
+    ss = _make_usage_session(analytics=analytics)
+    _seed_inflight(ss)
+    # Must not raise.
+    await ss._handle_turn_complete(_usage_turn_response())
+    assert ss.usage.total_turns == 1
+
+
+@pytest.mark.asyncio
+async def test_cost_callback_failure_is_swallowed() -> None:
+    """A raising cost_callback must not crash the tailer."""
+    cost_cb = MagicMock(side_effect=RuntimeError("boom"))
+    ss = _make_usage_session(cost_cb=cost_cb)
+    _seed_inflight(ss)
+    await ss._handle_turn_complete(_usage_turn_response())
+    assert ss.usage.total_turns == 1
+
+
 @pytest.mark.asyncio
 async def test_emits_context_usage_event_with_sdk_shape() -> None:
     """``context_usage`` SSE event must carry the SDK-compatible fields


### PR DESCRIPTION
## What & why

Closes #648.

The SDK transport gets per-turn `total_cost_usd` for free on each `ResultMessage` and fires `cost_callback` + `analytics_store.log_turn_usage` every turn — that's what powers the **live Analytics page** and **lifetime-cost** rollups. The tmux transport already captured per-turn token counts (folded into `SessionUsage` by `_record_turn_usage`) but never forwarded them. So tmux agents were **dark** on live Analytics + lifetime cost; only the post-hoc `burn_snapshot` scrape caught them.

This brings tmux to parity with the SDK path.

## How

- **NEW `src/pinky_daemon/pricing.py`** — in-tree per-model rate table, the live twin of `burn_cost_report`'s gitignored `~/.pinkybot/burn/rates/*.jsonl`. The daemon needs rates compiled in so a fresh deploy prices turns with no external-file dependency (the home-dir file is also stale — it predates opus-4-8). Split 5m/1h cache-write billing + 1h fallback mirror `burn_cost_report.compute_row_cost` exactly so the live figure agrees with the snapshot overlay. Unknown model → `$0` (logged once, never guesses).
- **`TurnResponse` gains a `model` field**; the transcript tailer (`_TurnBuffer`) captures the per-turn `model` (skipping `<synthetic>` rows) and returns it on `drain()`. Cost is then priced under the model that *actually ran*, falling back to the configured model when the transcript field is blank.
- **`_log_turn_cost_and_analytics`** (tmux_session) computes the per-turn cost and fires `cost_callback(agent, cost, input, output, handle)` + `analytics_store.log_turn_usage(...)` with the SDK's signatures. It runs right after `_record_turn_usage`, using `self.usage.total_turns` as the analytics `turn_seq` — the tmux analog of the SDK's `self._turn_seq` — so the `ON CONFLICT(session_id, turn_seq)` upsert behaves identically across transports. `cached_input_tokens` is cache-**read** only, matching the column's meaning + the SDK path. Fully defensive: pricing/analytics are side telemetry and never crash the tailer or block reply delivery.

## Tests

- `tests/test_pricing.py` — rate math hand-checked against `burn_cost_report` (split caches, 1h fallback, SDK short keys, tier-suffix stripping, unknown model, malformed input).
- 8 new tmux wiring tests — analytics-row shape, computed-cost callback, `turn_seq` monotonicity, config-model fallback, unknown-model `$0` still logs usage, no-callback safety, and both failure paths swallowed.
- Full suite: **310 passed**, ruff clean.

🤖 Opened by Barsik