### PR TITLE
feat(#151): ultracode effort tier (xhigh + workflow-by-default)

### DIFF
--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -1800,7 +1800,7 @@
             </SectionHeader>
             <div style="padding:1rem 1.5rem;background:var(--surface-2);border-radius:var(--radius-lg);margin-top:0.5rem">
                 <div style="display:flex;gap:0.5rem;flex-wrap:wrap">
-                    {#each [['low','Low'],['medium','Medium'],['high','High'],['max','Max']] as [val, label]}
+                    {#each [['low','Low'],['medium','Medium'],['high','High'],['xhigh','XHigh'],['max','Max'],['ultracode','Ultracode ⚡']] as [val, label]}
                         <button class="btn btn-sm" class:btn-primary={thinkingEffort === val}
                             on:click={() => { thinkingEffort = val; thinkingEffortDirty = true; }}>
                             {label}
@@ -1809,6 +1809,8 @@
                 </div>
                 <div style="font-size:0.75rem;color:var(--gray-mid);margin-top:0.5rem">
                     Controls how deeply the model reasons. Higher = slower but more thorough.
+                    <strong>Ultracode</strong> = xhigh reasoning + workflow-by-default orchestration
+                    (best for heavy, multi-step jobs; needs an xhigh-capable model).
                 </div>
             </div>
             {/if}<!-- end model tab -->

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -32,6 +32,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.effort import is_ultracode
+
 # Agent names appear in filesystem paths (data/agents/{name}/, hook scripts
 # under .claude/, settings.json, .mcp.json) and database queries. Restrict
 # to a safe character class to prevent path-traversal and arbitrary-write
@@ -277,6 +279,34 @@ def _cron_next_run(cron: str, timezone: str = "UTC") -> float | None:
         return None
 
 
+# Injected into the system prompt when an agent's effective effort is the
+# ``ultracode`` tier (#151). Replicates Claude Code's native ultracode
+# semantics — "xhigh effort plus standing dynamic-workflow orchestration" —
+# as an explicit operating directive so the behavior holds on every CLI
+# version, including ones predating native ultracode support. The effort knob
+# itself is set to xhigh by the transports (see ``effort.resolve_cli_effort``);
+# this section carries the workflow-by-default half.
+ULTRACODE_DIRECTIVE = """## ⚡ Ultracode Mode (active)
+
+This session runs in **ultracode**: maximum reasoning effort plus standing \
+dynamic-workflow orchestration. Operate accordingly:
+
+- **Author and run a Workflow for every substantive task by default.** \
+Decompose the work, fan out parallel subagents, adversarially verify findings \
+before committing, then synthesize. For multi-phase work (understand → design \
+→ implement → review), run several workflows in sequence and stay in the loop \
+between them.
+- **Token cost is not the constraint — correctness and thoroughness are.** \
+Favor exhaustive coverage and independent verification over a single fast pass.
+- **Reserve solo, inline execution for trivial or conversational turns** (a \
+quick answer, a one-line edit, acking a message). Everything non-trivial gets a \
+workflow.
+- If the Workflow tool is unavailable this session, fall back to spawning \
+parallel subagents and adversarially verifying their output.
+
+This mode is deliberate and owner-enabled. It stays on until the effort level \
+is changed off ultracode."""
+
 DEFAULT_HEARTBEAT_PROMPT = (
     "Heartbeat — your autonomy loop. This is your chance to act, not just report.\n\n"
     "1. Call send_heartbeat(status, context_pct, notes) first "
@@ -392,7 +422,11 @@ class Agent:
     provider_key: str = ""   # API key override, empty = use ANTHROPIC_API_KEY env var
     provider_model: str = ""  # model name override (e.g. "llama3.2"), empty = use agent.model
     provider_ref: str = ""   # ID of a global provider from the providers table
-    thinking_effort: str = "medium"  # low, medium, high, xhigh, max — default thinking depth
+    thinking_effort: str = "medium"  # low, medium, high, xhigh, max, ultracode — default thinking depth
+    # ``ultracode`` (#151): xhigh reasoning + standing workflow orchestration.
+    # Resolves to xhigh for the actual effort knob (the CLI flag rejects the
+    # literal "ultracode"); the workflow-by-default behavior is injected via
+    # ULTRACODE_DIRECTIVE in build_system_prompt.
     # When True, the verify_effort CLI hook blocks tool calls if the runtime
     # effort drifts from thinking_effort. Default False (warn-only): drift is
     # surfaced to /agents/{name}/effort-drift + heartbeat but does not block.
@@ -2312,12 +2346,20 @@ except Exception:
         self._db.commit()
         return cursor.rowcount > 0
 
-    def build_system_prompt(self, agent_name: str, skill_store=None) -> str:
+    def build_system_prompt(
+        self, agent_name: str, skill_store=None, effort: str | None = None
+    ) -> str:
         """Build a complete system prompt from agent config + directives + skill directives.
 
         Combines the agent's base system_prompt with all active directives,
         ordered by priority, plus any directives from assigned skills.
         This is what gets passed to Claude Code.
+
+        ``effort`` is the effective thinking-effort level for the session
+        being built (session override if any, else the agent default). When
+        it is the ``ultracode`` tier (#151), the ULTRACODE_DIRECTIVE section
+        is injected so workflow-by-default orchestration holds regardless of
+        CLI version. Defaults to the agent's persistent ``thinking_effort``.
 
         All content is scanned for prompt injection / exfiltration threats
         before inclusion. Threats are logged and the offending section is
@@ -2349,6 +2391,13 @@ except Exception:
             safe_sp = _safe(agent.system_prompt, f"system_prompt:{agent_name}")
             if safe_sp:
                 parts.append(safe_sp)
+
+        # Ultracode operating mode (#151). Injected high (right after identity)
+        # so it reads as a standing directive. Keyed off the effective effort:
+        # the session override if one was passed, else the agent default.
+        effective_effort = effort if effort is not None else agent.thinking_effort
+        if is_ultracode(effective_effort):
+            parts.append(ULTRACODE_DIRECTIVE)
 
         # Boundaries
         if agent.boundaries:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -119,6 +119,7 @@ from pinky_daemon.autonomy import AgentEvent, AutonomyEngine, EventType
 from pinky_daemon.broker import BrokerMessage, MessageBroker
 from pinky_daemon.conversation_store import ConversationStore
 from pinky_daemon.dream_runner import DreamRunner
+from pinky_daemon.effort import CLI_EFFORT_LEVELS, EFFORT_LEVELS
 from pinky_daemon.hooks import (
     AuditStore,
     HookEvent,
@@ -5424,7 +5425,9 @@ npm run build</pre>
     async def set_agent_effort(name: str, req: dict):
         """Set an agent's default thinking effort level."""
         level = req.get("effort", "medium")
-        if level not in ("low", "medium", "high", "xhigh", "max"):
+        # Persistent default accepts the CLI levels plus the ultracode tier
+        # (#151); "auto" is a session-only override, not a stored default.
+        if level not in (*CLI_EFFORT_LEVELS, "ultracode"):
             raise HTTPException(400, f"Invalid effort level: {level}")
         agent = agents.get(name)
         if not agent:
@@ -5436,7 +5439,7 @@ npm run build</pre>
     async def set_session_effort(name: str, session_label: str, req: dict):
         """Set session-level thinking effort override (label-aware)."""
         level = req.get("effort", "medium")
-        if level not in ("low", "medium", "high", "xhigh", "max", "auto"):
+        if level not in EFFORT_LEVELS:
             raise HTTPException(400, f"Invalid effort level: {level}")
         agent = agents.get(name)
         if not agent:

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -339,7 +339,7 @@ class RegisterAgentRequest(BaseModel):
     provider_key: str = ""  # ANTHROPIC_API_KEY override
     provider_model: str = ""  # Model name override for this provider
     provider_ref: str = ""  # ID of a global provider from the providers table
-    thinking_effort: str = "medium"  # low/medium/high/xhigh/max
+    thinking_effort: str = "medium"  # low/medium/high/xhigh/max/ultracode
     strict_effort_enforcement: bool = False  # PR #429 — block tool calls when effort drifts
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
     isolated: bool = False  # #149 — hard-isolated tenant (Counterpart); daemon denies cross-agent actions
@@ -396,7 +396,7 @@ class UpdateAgentRequest(BaseModel):
     provider_key: str | None = None  # ANTHROPIC_API_KEY override
     provider_model: str | None = None  # Model name override for this provider
     provider_ref: str | None = None  # ID of a global provider from the providers table
-    thinking_effort: str | None = None  # low/medium/high/xhigh/max
+    thinking_effort: str | None = None  # low/medium/high/xhigh/max/ultracode
     strict_effort_enforcement: bool | None = None  # PR #429 — block tool calls when effort drifts
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
     # #149 phase-3 — OS-level runtime sandbox; None = leave unchanged. Same

--- a/src/pinky_daemon/effort.py
+++ b/src/pinky_daemon/effort.py
@@ -1,0 +1,54 @@
+"""Thinking-effort vocabulary + ``ultracode`` resolution (#151).
+
+Single source of truth for the effort levels shared across the transports
+(SDK + tmux), the API validators, the ``set_thinking_effort`` MCP tool, and
+the effort-drift hook.
+
+``ultracode`` is a PinkyBot-native effort tier modeled on Claude Code's
+``/effort ultracode`` — "xhigh effort plus standing dynamic-workflow
+orchestration." Two facts about the CLI shape the implementation:
+
+  1. The ``--effort`` startup flag (and SDK ``options.effort``) REJECT
+     ``ultracode`` — they accept only low/medium/high/xhigh/max. ultracode
+     is activatable only via the interactive ``/effort`` command, and the
+     CLI never persists it.
+  2. ultracode's reasoning level *is* xhigh.
+
+So PinkyBot RESOLVES ultracode to ``xhigh`` for the actual effort knob
+(``--effort`` / ``options.effort`` / the drift-hook expectation) and layers
+the workflow-orchestration behavior in via a system-prompt directive
+(see ``agent_registry.build_system_prompt``). This keeps ultracode working
+on every CLI version — including ones predating native support — without
+ever feeding the CLI a value its flag parser rejects.
+"""
+
+from __future__ import annotations
+
+# Levels the CLI ``--effort`` flag / SDK ``options.effort`` accept natively.
+CLI_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
+
+# Full set the set_thinking_effort tool / session-override endpoint accept:
+# the CLI levels plus "auto" (adaptive — clears the override) and the
+# PinkyBot-native "ultracode" tier.
+EFFORT_LEVELS: tuple[str, ...] = (*CLI_EFFORT_LEVELS, "auto", "ultracode")
+
+# The reasoning level ultracode resolves to for the real effort knob.
+ULTRACODE_BASE_EFFORT = "xhigh"
+
+
+def is_ultracode(level: str | None) -> bool:
+    """True when ``level`` is the ultracode tier (case/space tolerant)."""
+    return (level or "").strip().lower() == "ultracode"
+
+
+def resolve_cli_effort(level: str | None) -> str | None:
+    """Map a Pinky effort level to a value the CLI/SDK effort knob accepts.
+
+    ``ultracode`` → ``xhigh`` (the CLI flag rejects "ultracode"). Every other
+    value — including ``None``, ``""``, and ``"auto"`` — passes through
+    unchanged; callers already treat those as "leave effort adaptive / don't
+    set the flag."
+    """
+    if is_ultracode(level):
+        return ULTRACODE_BASE_EFFORT
+    return level

--- a/src/pinky_daemon/sdk_runner.py
+++ b/src/pinky_daemon/sdk_runner.py
@@ -14,6 +14,7 @@ import time
 from dataclasses import dataclass, field
 
 from pinky_daemon.claude_runner import RunResult
+from pinky_daemon.effort import resolve_cli_effort
 from pinky_daemon.hooks import HookContext, HookEvent, HookManager
 
 
@@ -59,7 +60,8 @@ class SDKRunnerConfig:
     # Explicitly blocked tools (complement to allowed_tools)
     disallowed_tools: list[str] = field(default_factory=list)
 
-    # Thinking effort: low, medium, high, max
+    # Thinking effort: low, medium, high, xhigh, max, ultracode (#151).
+    # ultracode resolves to xhigh for the SDK effort knob.
     thinking_effort: str = "medium"
 
     # When True, the verify_effort CLI hook blocks tool calls if the runtime
@@ -148,8 +150,10 @@ class SDKRunner:
         if self._config.agents:
             options.agents = self._config.agents
 
-        # Apply thinking effort
-        effort = self._config.thinking_effort or "medium"
+        # Apply thinking effort. ultracode resolves to xhigh (#151) — the SDK
+        # forwards options.effort straight to the CLI's --effort flag, which
+        # rejects the literal "ultracode".
+        effort = resolve_cli_effort(self._config.thinking_effort or "medium")
         if effort != "medium":
             options.effort = effort
 

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -18,6 +18,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.effort import CLI_EFFORT_LEVELS, resolve_cli_effort
 from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.transport_state import SessionState, StateMachine, Trigger
 from pinky_daemon.turn_response import TurnResponse
@@ -81,7 +82,7 @@ class StreamingSessionConfig:
     subagents: dict = field(default_factory=dict)  # name -> AgentDefinition
     provider_url: str = ""   # ANTHROPIC_BASE_URL override (e.g. "http://localhost:11434" for Ollama)
     provider_key: str = ""   # ANTHROPIC_API_KEY override (empty = use env var)
-    thinking_effort: str = "medium"  # low, medium, high, xhigh, max — default thinking depth
+    thinking_effort: str = "medium"  # low, medium, high, xhigh, max, ultracode — default thinking depth
     # When True, the verify_effort CLI hook blocks tool calls if the runtime
     # effort drifts from thinking_effort. Default False (warn-only). See #429.
     strict_effort_enforcement: bool = False
@@ -419,8 +420,10 @@ class StreamingSession:
         if self._config.subagents:
             options.agents = self._config.subagents
 
-        # Apply thinking effort
-        effort = self.effective_effort
+        # Apply thinking effort. ultracode resolves to xhigh (#151) — the SDK
+        # forwards options.effort to the CLI's --effort flag, which rejects
+        # the literal "ultracode".
+        effort = resolve_cli_effort(self.effective_effort)
         if effort and effort != "medium":
             options.effort = effort
 
@@ -1527,7 +1530,7 @@ class StreamingSession:
 
     def set_effort(self, level: str) -> None:
         """Set session-level thinking effort override."""
-        if level not in ("low", "medium", "high", "xhigh", "max"):
+        if level not in (*CLI_EFFORT_LEVELS, "ultracode"):
             raise ValueError(f"Invalid effort level: {level}")
         self._effort_override = level
         _log(f"streaming[{self.agent_name}]: effort set to {level}")

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -68,6 +68,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from pinky_daemon.command_runner import CommandRunner, LocalCommandRunner
+from pinky_daemon.effort import EFFORT_LEVELS, resolve_cli_effort
 from pinky_daemon.pricing import compute_cost_from_usage
 from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.streaming_session import (
@@ -1232,7 +1233,7 @@ class TmuxSession:
         """Accept the call for protocol parity. tmux's claude REPL doesn't
         honor mid-session effort changes — log a warning and stash the
         value. A force_restart picks it up on the relaunched REPL."""
-        valid = {"low", "medium", "high", "xhigh", "max", "auto"}
+        valid = set(EFFORT_LEVELS)
         if level not in valid:
             raise ValueError(
                 f"invalid effort {level!r}; expected one of {sorted(valid)}"
@@ -1795,6 +1796,16 @@ class TmuxSession:
         # Optional model override.
         if self._config.model:
             parts.extend(["--model", self._config.model])
+        # Thinking effort (#151). tmux historically never passed --effort, so a
+        # configured effort was only hook-detected, never actually applied.
+        # Mirror the SDK contract — set --effort for any explicit non-medium
+        # level. ultracode resolves to xhigh because the CLI flag rejects the
+        # literal "ultracode" (it's only reachable via interactive /effort);
+        # the workflow-orchestration half is carried by ULTRACODE_DIRECTIVE in
+        # the system prompt.
+        cli_effort = resolve_cli_effort(self.effective_effort)
+        if cli_effort and cli_effort not in ("medium", "auto"):
+            parts.extend(["--effort", cli_effort])
         cmd = " ".join(shlex.quote(p) for p in parts)
 
         # Instrumentation: typed launch-mode log so validation tooling
@@ -1839,7 +1850,10 @@ class TmuxSession:
             env["ANTHROPIC_AUTH_TOKEN"] = self._config.provider_key
         if self.agent_name:
             env["PINKY_AGENT_NAME"] = self.agent_name
-        effort = self.effective_effort
+        # Surface the RESOLVED effort (#151): the drift hook compares this to
+        # the runtime $CLAUDE_EFFORT, which reports xhigh under ultracode — so
+        # expect xhigh, not the literal "ultracode", to avoid false drift.
+        effort = resolve_cli_effort(self.effective_effort)
         if effort:
             env["PINKY_EXPECTED_EFFORT"] = effort
         if self._config.strict_effort_enforcement:

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -1144,12 +1144,17 @@ def create_server(
     @mcp.tool()
     def set_thinking_effort(level: str) -> str:
         """Set thinking effort for this session. Match depth to task complexity.
-        level: low | medium | high | xhigh | max | auto (clears override).
+        level: low | medium | high | xhigh | max | ultracode | auto (clears override).
+
+        ultracode = xhigh reasoning + workflow-by-default orchestration. Set as
+        the agent's DEFAULT effort (owner / effort selector) for the full mode,
+        including the workflow directive; as a session override it engages the
+        xhigh reasoning knob on the next REPL relaunch.
         """
-        if level not in ("low", "medium", "high", "xhigh", "max", "auto"):
+        if level not in ("low", "medium", "high", "xhigh", "max", "ultracode", "auto"):
             return (
                 f"Invalid level: {level}. "
-                "Use low, medium, high, xhigh, max, or auto."
+                "Use low, medium, high, xhigh, max, ultracode, or auto."
             )
         result = _api("POST", f"/agents/{agent_name}/sessions/main/effort", {
             "effort": level,
@@ -1159,6 +1164,11 @@ def create_server(
         effective = result.get("effective", level)
         if level == "auto":
             return f"Effort override cleared. Using default: {effective}"
+        if level == "ultracode":
+            return (
+                "Thinking effort set to ultracode (xhigh + workflow orchestration). "
+                "Takes effect on next REPL relaunch."
+            )
         return f"Thinking effort set to {level}"
 
     def _register_research_tools():

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -369,6 +369,53 @@ def test_build_claude_cmd_includes_dangerously_skip_when_no_transcript(
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# Thinking effort → --effort wiring (#151). tmux historically never passed
+# --effort; ultracode resolves to xhigh because the flag rejects "ultracode".
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_build_claude_cmd_omits_effort_for_medium(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    ss._config.thinking_effort = "medium"
+    assert "--effort" not in ss._build_claude_cmd()
+
+
+def test_build_claude_cmd_passes_effort_for_xhigh(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    ss._config.thinking_effort = "xhigh"
+    assert "--effort xhigh" in ss._build_claude_cmd()
+
+
+def test_build_claude_cmd_resolves_ultracode_to_xhigh(tmp_path, monkeypatch) -> None:
+    """The CLI flag rejects "ultracode" — it must never reach --effort.
+    ultracode resolves to xhigh."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    ss._config.thinking_effort = "ultracode"
+    cmd = ss._build_claude_cmd()
+    assert "--effort xhigh" in cmd
+    assert "ultracode" not in cmd
+
+
+def test_build_repl_env_expects_resolved_effort_for_ultracode() -> None:
+    """PINKY_EXPECTED_EFFORT must be the resolved level (xhigh) so the drift
+    hook matches the runtime $CLAUDE_EFFORT and doesn't false-positive."""
+    ss, _ = _make_session()
+    ss._config.thinking_effort = "ultracode"
+    env = ss._build_repl_env()
+    assert env["PINKY_EXPECTED_EFFORT"] == "xhigh"
+
+
+def test_set_effort_accepts_ultracode() -> None:
+    ss, _ = _make_session()
+    ss.set_effort("ultracode")
+    assert ss._effort_override == "ultracode"
+    assert ss.effective_effort == "ultracode"
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # capture_pane signature: escapes flag for the read-only pane viewer
 # ──────────────────────────────────────────────────────────────────────────
 

--- a/tests/test_ultracode_effort.py
+++ b/tests/test_ultracode_effort.py
@@ -1,0 +1,99 @@
+"""ultracode effort tier (#151).
+
+ultracode = xhigh reasoning + standing workflow orchestration. The CLI's
+``--effort`` flag rejects the literal "ultracode" (only low/medium/high/
+xhigh/max), so PinkyBot resolves it to xhigh for the effort knob and layers
+the workflow-by-default behavior in via a system-prompt directive.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from pinky_daemon.agent_registry import ULTRACODE_DIRECTIVE, AgentRegistry
+from pinky_daemon.effort import (
+    CLI_EFFORT_LEVELS,
+    EFFORT_LEVELS,
+    ULTRACODE_BASE_EFFORT,
+    is_ultracode,
+    resolve_cli_effort,
+)
+
+# ── effort.py vocabulary + resolution ──────────────────────────────────────
+
+
+def test_ultracode_is_pinky_native_not_cli_native():
+    """The CLI flag rejects 'ultracode'; it must NOT be in the CLI set, but
+    must be in the full Pinky effort vocabulary."""
+    assert "ultracode" in EFFORT_LEVELS
+    assert "ultracode" not in CLI_EFFORT_LEVELS
+
+
+def test_resolve_ultracode_maps_to_xhigh():
+    assert resolve_cli_effort("ultracode") == ULTRACODE_BASE_EFFORT == "xhigh"
+
+
+def test_resolve_is_case_and_space_tolerant():
+    assert resolve_cli_effort("  UltraCode ") == "xhigh"
+    assert is_ultracode(" ULTRACODE ")
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh", "max", "auto"])
+def test_resolve_passes_through_non_ultracode(level):
+    assert resolve_cli_effort(level) == level
+
+
+def test_resolve_none_passes_through():
+    assert resolve_cli_effort(None) is None
+
+
+def test_is_ultracode_negatives():
+    for v in (None, "", "max", "xhigh", "ultra", "code"):
+        assert not is_ultracode(v)
+
+
+# ── build_system_prompt directive injection ────────────────────────────────
+
+
+@pytest.fixture
+def registry():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    r = AgentRegistry(db_path=path)
+    yield r
+    r.close()
+    os.unlink(path)
+
+
+def test_directive_injected_when_default_effort_is_ultracode(registry):
+    registry.register("nova", model="opus", soul="I am Nova.", thinking_effort="ultracode")
+    prompt = registry.build_system_prompt("nova")
+    assert ULTRACODE_DIRECTIVE in prompt
+    assert "Ultracode Mode" in prompt
+
+
+def test_directive_absent_for_non_ultracode_default(registry):
+    registry.register("nova", model="opus", soul="I am Nova.", thinking_effort="max")
+    prompt = registry.build_system_prompt("nova")
+    assert ULTRACODE_DIRECTIVE not in prompt
+    assert "Ultracode Mode" not in prompt
+
+
+def test_explicit_effort_param_overrides_default(registry):
+    """A session-override effort passed by the caller drives the directive,
+    independent of the stored default."""
+    registry.register("nova", model="opus", soul="I am Nova.", thinking_effort="medium")
+    # Session running ultracode even though default is medium.
+    prompt = registry.build_system_prompt("nova", effort="ultracode")
+    assert ULTRACODE_DIRECTIVE in prompt
+
+
+def test_explicit_non_ultracode_param_suppresses_ultracode_default(registry):
+    """Passing a concrete non-ultracode effort suppresses the directive even
+    when the stored default is ultracode (session dialed back down)."""
+    registry.register("nova", model="opus", soul="I am Nova.", thinking_effort="ultracode")
+    prompt = registry.build_system_prompt("nova", effort="high")
+    assert ULTRACODE_DIRECTIVE not in prompt


### PR DESCRIPTION
Closes #151.

Adds a Pinky-native **`ultracode`** thinking-effort tier modeled on Claude Code's `/effort ultracode` — *"xhigh effort plus standing dynamic-workflow orchestration."*

## Why it's built this way
Two CLI facts (verified against the 2.1.158 binary) drive the design:
1. The `--effort` startup flag and SDK `options.effort` **reject** the literal `ultracode` — they accept only `low/medium/high/xhigh/max`. ultracode is reachable only via the interactive `/effort` command, and the CLI never persists it.
2. ultracode's reasoning level *is* xhigh.

So ultracode **resolves to `xhigh`** for the actual effort knob (`effort.resolve_cli_effort`), and the workflow-by-default behavior is layered in as a **system-prompt directive** (`ULTRACODE_DIRECTIVE`) injected by `build_system_prompt`. This keeps ultracode working on **every CLI version** — including prod's older build — and never feeds the flag parser a value it rejects.

## ⚠️ Behavior change (flagged)
The tmux transport **never passed `--effort` to the CLI at all** — a configured `thinking_effort` was only drift-*detected* by the hook, never *applied*. tmux now mirrors the SDK contract and sets `--effort` for any explicit non-medium level. So **tmux agents configured above medium will now actually run at that effort** (this also resolves the drift the hook was nagging about).

## Changes
- **`effort.py`** (new): single source of truth for the effort vocabulary + `resolve_cli_effort` / `is_ultracode`.
- **`agent_registry`**: `ULTRACODE_DIRECTIVE` + injection in `build_system_prompt` (new optional `effort` param = effective session effort).
- **`tmux_session`**: wire `--effort <resolved>` into the launch cmd; surface the resolved level as `PINKY_EXPECTED_EFFORT` so the drift hook matches xhigh (no false positives).
- **`sdk_runner` / `streaming_session`**: resolve effort before `options.effort` + drift expectation; accept ultracode in `set_effort`.
- **`api`**: PUT default-effort accepts ultracode; session-override accepts the full `EFFORT_LEVELS` set.
- **`pinky_self` `set_thinking_effort`** tool + **frontend effort selector**: ultracode option (selector also gains the previously-missing `xhigh`).
- **tests**: effort resolution, directive injection, tmux cmd/env wiring (`test_ultracode_effort.py` + additions to `test_tmux_session.py`).

## How to use
Set an agent's **default** effort to `ultracode` (frontend effort selector or `PUT /agents/{name}/effort`) for the full mode — xhigh reasoning + the workflow directive. Turn off by setting effort back. `set_thinking_effort("ultracode")` works as a session override (engages the xhigh knob on next REPL relaunch).

## Known limitations / follow-ups
- ultracode needs an **xhigh-capable model** (opus). Setting it on a haiku/sonnet agent resolves to `--effort xhigh`, which the model may reject at runtime — not guarded here.
- The **pure-native `/effort ultracode` auto-paste** (so tmux gets the CLI's own standing workflow system-reminder, not just our directive) is deferred to a fast-follow — xhigh + directive captures the value without the spawn-sequence fragility.

## Test plan
- [x] `test_ultracode_effort.py` (15) + tmux effort tests (5) pass
- [x] Related suites green: 600 passed (registry, tmux, effort-verification, transport, pinky_self_tools)
- [x] ruff clean; full daemon import smoke OK
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)