### PR TITLE
feat(#151): native /effort ultracode activation for tmux agents

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -68,7 +68,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from pinky_daemon.command_runner import CommandRunner, LocalCommandRunner
-from pinky_daemon.effort import EFFORT_LEVELS, resolve_cli_effort
+from pinky_daemon.effort import EFFORT_LEVELS, is_ultracode, resolve_cli_effort
 from pinky_daemon.pricing import compute_cost_from_usage
 from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.streaming_session import (
@@ -715,6 +715,14 @@ _TRANSCRIPT_PASTE_SLACK = 5.0
 # across the bootstrap window (Murzik #571 review catch).
 _SESSION_READY_GATE_TIMEOUT_SEC = 30.0
 
+# Issue #151 — native ultracode activation settle. After typing the interactive
+# ``/effort ultracode`` into a freshly-ready REPL (see ``_deliver_turn``), pause
+# briefly so the CLI processes the slash command before the wake prompt's
+# bracketed-paste lands. The command is client-side + instant (no model turn),
+# so a short settle is sufficient; it is NOT a correctness gate, just ordering
+# slack between two send paths into the same pane.
+_NATIVE_ULTRACODE_SETTLE_SEC = 0.4
+
 
 class TmuxSession:
     """Agent session backed by an interactive ``claude`` REPL in tmux.
@@ -921,6 +929,18 @@ class TmuxSession:
         # a stale "open" state from the previous session would let
         # wake prompts paste into a still-booting fresh REPL.
         self._session_ready_event: asyncio.Event = asyncio.Event()
+
+        # Issue #151 — native ultracode activation. Armed by
+        # ``_build_claude_cmd`` on a FRESH cold-start launch whose effective
+        # effort is ultracode; consumed exactly once in ``_deliver_turn``,
+        # which types the interactive ``/effort ultracode`` into the
+        # now-ready REPL before the first prompt pastes (upgrading from
+        # "xhigh + ULTRACODE_DIRECTIVE" to the CLI's real ultracode tier —
+        # its own standing dynamic-workflow system-reminder). Default False
+        # so non-ultracode agents — and unit tests that call ``_deliver_turn``
+        # directly without building the launch command — never type the
+        # slash command. Re-armed per launch (see ``_build_claude_cmd``).
+        self._native_ultracode_pending: bool = False
 
         # Test seam: when True, ``connect()`` skips wake-prompt assembly
         # + enqueue. Production callers must NOT flip this; it exists so
@@ -1806,6 +1826,25 @@ class TmuxSession:
         cli_effort = resolve_cli_effort(self.effective_effort)
         if cli_effort and cli_effort not in ("medium", "auto"):
             parts.extend(["--effort", cli_effort])
+
+        # #151 native ultracode activation. ultracode boots at --effort xhigh
+        # (above) because the CLI flag rejects the literal "ultracode". The
+        # real tier — xhigh + the CLI's own standing dynamic-workflow
+        # system-reminder — is reachable ONLY via the interactive
+        # ``/effort ultracode``. Arm a one-shot so ``_deliver_turn`` types it
+        # into the ready REPL BEFORE the first prompt pastes (Brad's ordering:
+        # spawn → change effort → inject wake context). FRESH launches only:
+        # a ``--continue`` reconnect already carries conversation context,
+        # where ``/effort`` trips the mid-session "Change effort level?"
+        # confirmation (the prompt-cache full re-read). On a fresh spawn the
+        # input area is empty, so the CLI sets effort silently. Re-armed every
+        # build so a failed-spawn retry doesn't lose the activation;
+        # ULTRACODE_DIRECTIVE remains the fallback if the keystroke send fails
+        # or on a CLI predating native ultracode.
+        self._native_ultracode_pending = (not use_continue) and is_ultracode(
+            self.effective_effort
+        )
+
         cmd = " ".join(shlex.quote(p) for p in parts)
 
         # Instrumentation: typed launch-mode log so validation tooling
@@ -4214,6 +4253,59 @@ class TmuxSession:
                         f"tmux[{self.agent_name}]: analytics wake_gate "
                         f"emit failed ({gate_subtype}, {gate_latency_ms}ms): {e}"
                     )
+
+        # #151 native ultracode activation. On the FIRST turn after a fresh
+        # cold-start with ultracode effort, type the interactive
+        # ``/effort ultracode`` into the now-ready REPL BEFORE pasting the
+        # prompt — Brad's ordering: spawn → change effort → inject wake
+        # context. The input area is empty at this point (no turn has pasted
+        # yet), so the CLI sets effort silently; the "Change effort level?"
+        # confirmation only fires mid-conversation (the prompt-cache re-read).
+        # One-shot + best-effort: the flag is cleared regardless of outcome,
+        # and a send failure / readiness timeout degrades to the
+        # ULTRACODE_DIRECTIVE fallback rather than blocking delivery.
+        if self._native_ultracode_pending:
+            self._native_ultracode_pending = False
+            # Raw keystrokes typed during the splash/MCP-boot phase get eaten,
+            # so ensure the input area is live first. Wake turns already
+            # awaited this gate above (no-op here); a non-wake first turn
+            # waits here. Timeout → attempt the send anyway (context is still
+            # empty; worst case the directive fallback carries the tier).
+            if not self._session_ready_event.is_set():
+                try:
+                    await asyncio.wait_for(
+                        self._session_ready_event.wait(),
+                        timeout=_SESSION_READY_GATE_TIMEOUT_SEC,
+                    )
+                except asyncio.TimeoutError:
+                    _log(
+                        f"tmux[{self.agent_name}]: native /effort ultracode — "
+                        f"readiness gate timeout; sending anyway"
+                    )
+            try:
+                eff_res = await self._tmux.send_keys(
+                    "/effort ultracode", enter=True
+                )
+                if eff_res.ok:
+                    # Settle so the slash command is processed before the
+                    # prompt's bracketed-paste lands in the same pane.
+                    await asyncio.sleep(_NATIVE_ULTRACODE_SETTLE_SEC)
+                    _log(
+                        f"tmux[{self.agent_name}]: native /effort ultracode "
+                        f"activated (pre-prompt)"
+                    )
+                else:
+                    _log(
+                        f"tmux[{self.agent_name}]: native /effort ultracode "
+                        f"send failed (rc={eff_res.returncode}, "
+                        f"stderr={(eff_res.stderr or '').strip()!r}); "
+                        f"ULTRACODE_DIRECTIVE fallback remains in effect"
+                    )
+            except Exception as e:  # pragma: no cover — defensive
+                _log(
+                    f"tmux[{self.agent_name}]: native /effort ultracode raised "
+                    f"({e}); continuing with prompt + directive fallback"
+                )
 
         # Clear the back-compat ``_turn_done`` event before pasting.
         # Under #560 the worker no longer awaits this between dispatches

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -415,6 +415,51 @@ def test_set_effort_accepts_ultracode() -> None:
     assert ss.effective_effort == "ultracode"
 
 
+# Native ultracode activation arming (#151). A fresh cold-start with ultracode
+# effort arms a one-shot so ``_deliver_turn`` types the interactive
+# ``/effort ultracode`` (the CLI flag can't express it). A ``--continue``
+# reconnect must NOT arm — it carries context where /effort trips the
+# mid-session "Change effort level?" confirmation.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_build_claude_cmd_arms_native_ultracode_on_fresh_ultracode(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    ss._config.thinking_effort = "ultracode"
+    cmd = ss._build_claude_cmd()
+    # Fresh (no prior transcript) → no --continue, and the one-shot is armed.
+    assert "--continue" not in cmd
+    assert ss._native_ultracode_pending is True
+
+
+def test_build_claude_cmd_does_not_arm_native_ultracode_on_continue(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    ss._config.thinking_effort = "ultracode"
+    # Seed a prior transcript at the encoded-cwd path → use_continue=True.
+    project_dir = ss._project_dir()
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "seed.jsonl").write_text("")
+    cmd = ss._build_claude_cmd()
+    assert "--continue" in cmd
+    assert ss._native_ultracode_pending is False
+
+
+def test_build_claude_cmd_does_not_arm_native_ultracode_for_non_ultracode(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ss, _ = _make_session()
+    ss._config.thinking_effort = "xhigh"
+    ss._build_claude_cmd()
+    assert ss._native_ultracode_pending is False
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # capture_pane signature: escapes flag for the read-only pane viewer
 # ──────────────────────────────────────────────────────────────────────────
@@ -762,6 +807,99 @@ async def test_deliver_turn_uses_paste_text_not_send_keys() -> None:
     assert args[0] == "hello dymok" or kwargs.get("text") == "hello dymok"
     # And raw send_keys must NOT have been used for dispatch.
     tmux.send_keys.assert_not_awaited()
+
+
+# Native ultracode activation delivery (#151). When armed, ``_deliver_turn``
+# types ``/effort ultracode`` via send_keys BEFORE the prompt's paste_text, on
+# the still-empty input area (no mid-session confirmation). One-shot +
+# best-effort: fires once, and a send failure still pastes the prompt.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_types_native_effort_before_paste_when_armed(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._NATIVE_ULTRACODE_SETTLE_SEC", 0.0
+    )
+    tmux = _make_mock_tmux()
+    ss, _ = _make_session(tmux=tmux)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._native_ultracode_pending = True
+    ss._session_ready_event.set()  # input area live; skip the readiness wait
+
+    # Record cross-mock call order so we can assert effort precedes prompt.
+    order = MagicMock()
+    order.attach_mock(tmux.send_keys, "send_keys")
+    order.attach_mock(tmux.paste_text, "paste_text")
+
+    turn = _QueuedTurn(
+        prompt="hello dymok",
+        platform="telegram",
+        chat_id="123",
+        message_id="m1",
+    )
+    await ss._deliver_turn(turn)
+
+    tmux.send_keys.assert_awaited_once_with("/effort ultracode", enter=True)
+    tmux.paste_text.assert_awaited_once()
+    names = [c[0] for c in order.mock_calls]
+    assert names.index("send_keys") < names.index("paste_text")
+    # One-shot consumed.
+    assert ss._native_ultracode_pending is False
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_native_effort_is_one_shot(monkeypatch) -> None:
+    """Fires once per session. A second turn must not re-type /effort — by
+    then context exists and it would hit the confirmation prompt."""
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._NATIVE_ULTRACODE_SETTLE_SEC", 0.0
+    )
+    tmux = _make_mock_tmux()
+    ss, _ = _make_session(tmux=tmux)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._native_ultracode_pending = True
+    ss._session_ready_event.set()
+
+    t1 = _QueuedTurn(
+        prompt="first", platform="telegram", chat_id="1", message_id="a"
+    )
+    t2 = _QueuedTurn(
+        prompt="second", platform="telegram", chat_id="1", message_id="b"
+    )
+    await ss._deliver_turn(t1)
+    await ss._deliver_turn(t2)
+
+    assert tmux.send_keys.await_count == 1
+    assert tmux.paste_text.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_native_effort_send_failure_still_pastes(
+    monkeypatch,
+) -> None:
+    """If the /effort keystroke send fails, delivery still pastes the prompt
+    (degrade to the ULTRACODE_DIRECTIVE fallback, never block)."""
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._NATIVE_ULTRACODE_SETTLE_SEC", 0.0
+    )
+    tmux = _make_mock_tmux()
+    tmux.send_keys = AsyncMock(return_value=_fail("boom"))
+    ss, _ = _make_session(tmux=tmux)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._native_ultracode_pending = True
+    ss._session_ready_event.set()
+
+    turn = _QueuedTurn(
+        prompt="hello", platform="telegram", chat_id="1", message_id="m"
+    )
+    await ss._deliver_turn(turn)
+
+    tmux.send_keys.assert_awaited_once()
+    tmux.paste_text.assert_awaited_once()  # prompt still delivered
+    assert ss._native_ultracode_pending is False
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Makes tmux agents get the CLI's **real** ultracode tier — xhigh reasoning + the CLI's own standing dynamic-workflow system-reminder — instead of just our approximation (`--effort xhigh` + the `ULTRACODE_DIRECTIVE` system-prompt injection).

The CLI flag rejects the literal `ultracode` (only low/medium/high/xhigh/max), so the real tier is reachable **only** by typing the interactive `/effort ultracode` into a live REPL. This wires that in so it's enableable straight from pinky-self: `set_thinking_effort('ultracode')` → stashed → applied on next REPL relaunch (the existing path) → native activation fires at spawn.

## How

- **Arm** (`_build_claude_cmd`): a one-shot `_native_ultracode_pending` is set on a **fresh** cold-start launch (`not use_continue`) whose effective effort is ultracode. `--continue` reconnects are excluded — they carry conversation context, where `/effort` trips the mid-session **"Change effort level?"** confirmation (a prompt-cache full re-read).
- **Fire** (`_deliver_turn`): the flag is consumed before the first paste — ensure the input area is live (reusing the #570 readiness gate), `send_keys("/effort ultracode")`, settle, then the prompt pastes. Ordering is exactly **spawn → change effort → inject wake context**. Empty input area at this point = silent set, no confirmation.
- **Fallback preserved**: one-shot (never re-types mid-session), and a send failure / readiness timeout degrades to the still-present `ULTRACODE_DIRECTIVE` rather than blocking delivery. Fully inert for non-ultracode agents.

## The gotcha this sidesteps

`/effort ultracode` mid-conversation pops a confirmation because switching effort busts the prompt cache (full-history re-read next turn). By activating only at **fresh spawn** (empty context) and relying on `set_effort` already deferring to relaunch, the live-toggle/confirmation path is never exercised.

## Verification

- **End-to-end on claude 2.1.159**: the exact one-invocation form `tmux send-keys '/effort ultracode' Enter` activates silently on an empty session — status bar shows `ultracode`, no confirmation dialog, no autocomplete interference.
- **Tests**: 6 new (3 arming: fresh-arms / continue-skips / non-ultracode-skips; 3 delivery: effort-before-paste ordering, one-shot, send-failure-still-pastes). Full `test_tmux_session.py` suite green (252). `ruff` clean.

🤖 Opened by Barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)