### PR TITLE
feat(#149): container isolation_mode scaffold — ContainerProvisioner + ContainerCommandRunner (dormant)

### DIFF
--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -352,7 +352,7 @@ class RegisterAgentRequest(BaseModel):
     @field_validator("isolation_mode")
     @classmethod
     def _isolation_mode_known(cls, v: str) -> str:
-        allowed = {"local", "unix_user"}
+        allowed = {"local", "unix_user", "container"}
         if v not in allowed:
             raise ValueError(
                 f"isolation_mode must be one of {sorted(allowed)} (got {v!r})"
@@ -409,7 +409,7 @@ class UpdateAgentRequest(BaseModel):
     def _isolation_mode_known(cls, v: str | None) -> str | None:
         if v is None:
             return v
-        allowed = {"local", "unix_user"}
+        allowed = {"local", "unix_user", "container"}
         if v not in allowed:
             raise ValueError(
                 f"isolation_mode must be one of {sorted(allowed)} (got {v!r})"

--- a/src/pinky_daemon/command_runner.py
+++ b/src/pinky_daemon/command_runner.py
@@ -12,6 +12,11 @@ sites that build the command:
     ="unix_user"`` tenant's tmux server + REPL get launched under their own
     ``pinky-<agent>`` uid, so the agent's process cannot read the daemon's
     files or other tenants' homes.
+  - :class:`ContainerCommandRunner` runs argv INSIDE an agent's container via
+    ``podman exec <container> --`` (rootless Podman). This is how an
+    ``isolation_mode="container"`` tenant's tmux server + REPL run inside their
+    own container — own filesystem, own CLIs, own credentials — while the
+    daemon drives them from the host. Same wrap-and-delegate shape as runuser.
 
 The seam lives behind ``_TmuxControl`` (tmux_session.py): that class builds
 ``tmux …`` argvs and delegates the actual exec to its injected runner. A
@@ -138,6 +143,67 @@ class RunuserCommandRunner(CommandRunner):
     def wrap(self, argv: list[str]) -> list[str]:
         """Return ``argv`` prefixed with the runuser invocation."""
         return [self.runuser_binary, "-u", self.username, "--", *argv]
+
+    async def run(
+        self,
+        argv: list[str],
+        *,
+        timeout: float | None = None,
+        stdin: bytes | None = None,
+    ) -> CommandResult:
+        return await self._inner.run(self.wrap(argv), timeout=timeout, stdin=stdin)
+
+
+class ContainerCommandRunner(CommandRunner):
+    """Run argv INSIDE an agent's container via ``podman exec`` (or docker).
+
+    This is how an ``isolation_mode="container"`` tenant's tmux server + claude
+    REPL get driven: the daemon stays on the host, and every tmux control
+    command (``new-session``, ``send-keys``, ``capture-pane`` …) is exec'd into
+    the agent's already-running container. So the whole interactive session —
+    tmux, claude, and whatever CLIs the operator's image provides — lives inside
+    the container, while the daemon orchestrates it from outside. Exactly the
+    shape of :class:`RunuserCommandRunner`, with ``podman exec <container>``
+    standing in for ``runuser -u <user>``.
+
+    The container must already be running (the ``ContainerProvisioner`` creates
+    it; the activation increment starts it on session connect). The actual exec
+    is delegated to an inner runner — :class:`LocalCommandRunner` by default —
+    so timeout/kill semantics are shared with the local path and tests can
+    inject a recording double.
+
+    The ``--`` terminator after the flags is deliberate: it stops the container
+    CLI from interpreting the container name or any wrapped arg (e.g. a leading
+    ``-l`` on ``tmux send-keys``) as one of its own options. The wrapped argv is
+    passed as separate args, never shell-joined, so there is no quoting surface.
+    """
+
+    def __init__(
+        self,
+        container: str,
+        *,
+        user: str | None = None,
+        workdir: str | None = None,
+        container_binary: str = "podman",
+        inner: CommandRunner | None = None,
+    ) -> None:
+        if not container:
+            raise ValueError("ContainerCommandRunner requires a non-empty container")
+        self.container = container
+        self.user = user
+        self.workdir = workdir
+        self.container_binary = container_binary
+        self._inner = inner or LocalCommandRunner()
+
+    def wrap(self, argv: list[str]) -> list[str]:
+        """Return ``argv`` prefixed with the ``podman exec`` invocation."""
+        cmd = [self.container_binary, "exec"]
+        if self.user is not None:
+            cmd += ["-u", self.user]
+        if self.workdir is not None:
+            cmd += ["-w", self.workdir]
+        cmd += ["--", self.container, *argv]
+        return cmd
 
     async def run(
         self,

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -19,6 +19,15 @@ process is actually sandboxed at the operating-system level.
                       :class:`UnixUserProvisioner` + the systemd unit
                       template — but **dormant**: ``get_provisioner`` still
                       fails closed for ``unix_user`` (see below).
+  - ``"container"`` — the agent runs inside its own (rootless Podman)
+                      container: own filesystem, own home VOLUME (persists CLI
+                      OAuth state for a durable per-employee login), own
+                      signing-key secret. Pinky owns isolation + lifecycle only
+                      and is tool-agnostic — the image is operator-supplied
+                      (bring-your-own; Pinky bakes in no CLIs). Ships the real
+                      :class:`ContainerProvisioner` + ``ContainerCommandRunner``
+                      but **dormant**: ``get_provisioner`` fails closed for
+                      ``container`` until lifecycle activation. Strictly opt-in.
 
 A ``AgentProvisioner`` owns the lifecycle of those OS resources
 (provision / deprovision / introspect) and contributes any extra process
@@ -64,7 +73,8 @@ if TYPE_CHECKING:  # pragma: no cover — typing only, avoids a runtime import c
 # of the request layer.
 LOCAL = "local"
 UNIX_USER = "unix_user"
-KNOWN_MODES = frozenset({LOCAL, UNIX_USER})
+CONTAINER = "container"
+KNOWN_MODES = frozenset({LOCAL, UNIX_USER, CONTAINER})
 
 # OS-user naming + filesystem layout for unix_user tenants. The username is
 # ``pinky-<agent>`` so every managed account shares a greppable prefix and can
@@ -80,6 +90,18 @@ UNIX_USER_SHELL = "/usr/sbin/nologin"
 # so even another managed tenant on the same host can't read across.
 DIR_MODE = 0o700
 SECRET_MODE = 0o600
+
+# Container naming + in-container layout for the ``container`` isolation mode.
+# One container, one home volume, and one signing-key secret per agent, all
+# sharing the greppable ``pinky-<agent>`` prefix. Runtime is Podman (rootless)
+# by default; ``CONTAINER_BINARY`` is injectable for docker / CI doubles.
+CONTAINER_PREFIX = "pinky-"
+CONTAINER_BINARY = "podman"
+# In-container HOME. Everything the tenant persists — including any CLI's OAuth
+# state under ~/.config — lives here and is backed by the per-agent home VOLUME,
+# so a tenant's logins survive container restart/rebuild. Pinky bakes NO tools
+# into the image: which CLIs exist inside is entirely the operator's image.
+CONTAINER_HOME = "/home/agent"
 
 
 @dataclass
@@ -500,6 +522,342 @@ def _default_mcp_json(agent: "Agent", paths: UnixUserPaths) -> str:
     return json.dumps({"mcpServers": {}}, indent=2)
 
 
+# --------------------------------------------------------------------------- #
+# container provisioning (#149 / container isolation_mode)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ContainerNames:
+    """Resolved Podman object names + in-container paths for one tenant.
+
+    Centralizing derivation keeps provision / deprovision / is_provisioned /
+    runtime_env in agreement and gives tests one place to assert the layout
+    (mirrors :class:`UnixUserPaths`). One container, one home volume, one
+    signing-key secret per agent, all under the ``pinky-<agent>`` prefix.
+    """
+
+    container: str
+    volume: str
+    secret: str
+    home: str
+    workdir: str
+    config_dir: str
+
+    @classmethod
+    def for_agent(
+        cls,
+        agent_name: str,
+        *,
+        prefix: str = CONTAINER_PREFIX,
+        home: str = CONTAINER_HOME,
+    ) -> "ContainerNames":
+        base = f"{prefix}{agent_name}"
+        return cls(
+            container=base,
+            volume=f"{base}-home",
+            secret=f"{base}-key",
+            home=home,
+            workdir=str(Path(home) / "workdir"),
+            config_dir=str(Path(home) / ".claude"),
+        )
+
+
+@runtime_checkable
+class ContainerOps(Protocol):
+    """The privileged container-runtime seam (mirrors :class:`ProvisionOps`).
+
+    Every Podman mutation a :class:`ContainerProvisioner` performs goes through
+    this protocol so the whole provisioner is testable on macOS — and without a
+    real container runtime — by injecting a recording double. ``run`` is the
+    single command channel (matches the CommandRunner seam's "assert command
+    shapes" contract); the signing-key secret gets its own ``write_secret``
+    because its *content* must never be passed on an argv (process-list leak).
+    """
+
+    def run(self, argv: list[str]) -> None:
+        """Run a podman command; raise on non-zero exit."""
+
+    def image_exists(self, ref: str) -> bool: ...
+
+    def volume_exists(self, name: str) -> bool: ...
+
+    def secret_exists(self, name: str) -> bool: ...
+
+    def container_exists(self, name: str) -> bool: ...
+
+    def write_secret(self, name: str, content: str) -> None:
+        """Create a Podman secret ``name`` from ``content`` via stdin (no argv leak)."""
+
+
+class SystemContainerOps:
+    """Real :class:`ContainerOps` — drives the ``podman`` CLI via subprocess.
+
+    Runs only on the container host that actually owns the tenants. Never
+    exercised in unit tests; correctness here is by inspection, while the
+    provisioner *logic* is covered via a recording double.
+    """
+
+    def __init__(self, binary: str = CONTAINER_BINARY) -> None:
+        self._bin = binary
+
+    def run(self, argv: list[str]) -> None:
+        proc = subprocess.run(argv, capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise ProvisionError(
+                f"command failed ({proc.returncode}): {' '.join(argv)}\n{proc.stderr.strip()}"
+            )
+
+    def _exists(self, kind: str, name: str) -> bool:
+        # `podman <kind> inspect NAME` exits 0 iff the object exists; absence is
+        # a non-zero exit, not an error. Uniform across image/volume/secret/
+        # container, so one helper covers them all.
+        return (
+            subprocess.run([self._bin, kind, "inspect", name], capture_output=True).returncode
+            == 0
+        )
+
+    def image_exists(self, ref: str) -> bool:
+        return self._exists("image", ref)
+
+    def volume_exists(self, name: str) -> bool:
+        return self._exists("volume", name)
+
+    def secret_exists(self, name: str) -> bool:
+        return self._exists("secret", name)
+
+    def container_exists(self, name: str) -> bool:
+        return self._exists("container", name)
+
+    def write_secret(self, name: str, content: str) -> None:
+        # `podman secret create NAME -` reads the secret from stdin, so the key
+        # never appears on an argv / in the host process list.
+        proc = subprocess.run(
+            [self._bin, "secret", "create", name, "-"],
+            input=content.encode("utf-8"),
+            capture_output=True,
+        )
+        if proc.returncode != 0:
+            raise ProvisionError(
+                f"podman secret create {name} failed ({proc.returncode}): "
+                f"{proc.stderr.decode('utf-8', 'replace').strip()}"
+            )
+
+
+class ContainerProvisioner(AgentProvisioner):
+    """Provision a dedicated Podman container + home volume + key secret for an
+    ``isolation_mode="container"`` tenant.
+
+    Pinky owns ISOLATION + LIFECYCLE only and is deliberately TOOL-AGNOSTIC.
+    The image is OPERATOR-SUPPLIED (bring-your-own via ``image_provider``):
+    Pinky pulls it, never builds it, and bakes in no CLIs — whatever tooling
+    (gcloud / gh / kubectl / nothing) lives inside is entirely the operator's
+    image. Per agent this creates:
+
+      - a home VOLUME (``pinky-<agent>-home``) mounted at the in-container HOME,
+        so the tenant's CLI OAuth state (e.g. ``~/.config/<cli>``) persists
+        across restart/rebuild — the basis for a durable per-employee login;
+      - a signing-key SECRET (``pinky-<agent>-key``) created from stdin so the
+        key never hits an argv (same intent as the unix_user keystore);
+      - the CONTAINER itself (``pinky-<agent>``), created **stopped** via
+        ``podman create``. Starting/stopping it on session connect/idle and
+        injecting a :class:`ContainerCommandRunner` (so the tmux server + claude
+        REPL run *inside* it) is the activation increment's job.
+
+    Container isolation is strictly OPT-IN. ``get_provisioner`` stays
+    **fail-closed** for ``"container"`` (like ``"unix_user"``), so the #642
+    respawn guard blocks a container-labeled agent from launching until
+    activation wires the lifecycle. Construct this class directly; tests inject
+    a recording :class:`ContainerOps`, so none of this needs a real Podman.
+
+    **Idempotent** + **rollback**: identical contract to
+    :class:`UnixUserProvisioner` — a re-provision of a ready tenant is a no-op,
+    and a mid-provision failure tears down (in reverse) only what this call
+    built.
+    """
+
+    mode = CONTAINER
+
+    def __init__(
+        self,
+        *,
+        ops: ContainerOps | None = None,
+        image_provider: Callable[["Agent"], str] | None = None,
+        signing_key_provider: Callable[[str], str] | None = None,
+        prefix: str = CONTAINER_PREFIX,
+        home: str = CONTAINER_HOME,
+        binary: str = CONTAINER_BINARY,
+    ) -> None:
+        self._ops: ContainerOps = ops or SystemContainerOps(binary)
+        # Where the operator's image reference comes from. The persisted
+        # ``container_image`` agent field + register/update wiring land with the
+        # activation increment (mirrors _default_mcp_json); until then the
+        # default reads a forward-compatible attribute, so tests inject directly.
+        self._image_provider = image_provider or _agent_container_image
+        self._signing_key_provider = signing_key_provider or _no_signing_key
+        self._prefix = prefix
+        self._home = home
+        self._binary = binary
+
+    def names(self, agent: "Agent") -> ContainerNames:
+        return ContainerNames.for_agent(agent.name, prefix=self._prefix, home=self._home)
+
+    def is_provisioned(self, agent: "Agent") -> bool:
+        # The static per-agent resources the runtime depends on: the home
+        # volume, the key secret, and the (created, possibly-stopped) container.
+        # The image is implied — `podman create` could not have built the
+        # container without it. Starting it is a separate runtime concern.
+        n = self.names(agent)
+        return (
+            self._ops.volume_exists(n.volume)
+            and self._ops.secret_exists(n.secret)
+            and self._ops.container_exists(n.container)
+        )
+
+    def provision(self, agent: "Agent") -> ProvisionResult:
+        n = self.names(agent)
+        if self.is_provisioned(agent):
+            return ProvisionResult(
+                ok=True, mode=CONTAINER, message=f"container: {n.container} already provisioned"
+            )
+
+        image = self._image_provider(agent)
+        if not image:
+            return ProvisionResult(
+                ok=False,
+                mode=CONTAINER,
+                message=(
+                    f"container provision of {n.container} failed: no container_image "
+                    f"configured for {agent.name!r} (bring-your-own image is required)"
+                ),
+            )
+
+        # Reconcile, not all-or-nothing: skip resources that already exist so
+        # provision() repairs a partial tenant, and track only what THIS call
+        # built so rollback never tears down a pre-existing resource.
+        created: list[str] = []
+        try:
+            # 1. Home volume — persistent CLI/OAuth state.
+            if not self._ops.volume_exists(n.volume):
+                self._ops.run([self._binary, "volume", "create", n.volume])
+                created.append(f"volume:{n.volume}")
+            # 2. Signing-key secret (content via stdin, never an argv).
+            if not self._ops.secret_exists(n.secret):
+                key = self._signing_key_provider(agent.name)
+                if not key:
+                    raise ProvisionError(f"no signing key available for {agent.name!r}")
+                self._ops.write_secret(n.secret, key)
+                created.append(f"secret:{n.secret}")
+            # 3. Ensure the operator's image is present (pull if missing). Images
+            #    are shared infra, so this is NOT tracked as a per-agent resource
+            #    to tear down on rollback/deprovision.
+            if not self._ops.image_exists(image):
+                self._ops.run([self._binary, "pull", image])
+            # 4. The container — created STOPPED. Start/stop on session
+            #    connect/idle is the activation increment's responsibility.
+            if not self._ops.container_exists(n.container):
+                self._ops.run(self._create_argv(agent, n, image))
+                created.append(f"container:{n.container}")
+        except Exception as e:
+            removed = self._rollback(created)
+            return ProvisionResult(
+                ok=False,
+                mode=CONTAINER,
+                created=created,
+                removed=removed,
+                message=f"container provision of {n.container} failed: {e}",
+            )
+
+        return ProvisionResult(
+            ok=True, mode=CONTAINER, created=created,
+            message=f"container: provisioned {n.container}",
+        )
+
+    def _create_argv(self, agent: "Agent", n: ContainerNames, image: str) -> list[str]:
+        # `podman create` (not `run`): the container exists but stays stopped
+        # until the session connects. A tool-agnostic keep-alive entrypoint lets
+        # the daemon `podman exec` tmux into it regardless of the image's own
+        # CMD — Pinky asserts nothing about the image beyond "can run sleep".
+        return [
+            self._binary, "create",
+            "--name", n.container,
+            "--restart", "no",
+            "-v", f"{n.volume}:{n.home}",
+            "--secret", f"{n.secret},type=mount",
+            "-e", f"HOME={n.home}",
+            "-e", f"CLAUDE_CONFIG_DIR={n.config_dir}",
+            "-e", f"PINKY_AGENT_NAME={agent.name}",
+            "--entrypoint", "sleep",
+            image, "infinity",
+        ]
+
+    def deprovision(self, agent: "Agent", *, remove_volume: bool = False) -> ProvisionResult:
+        # Container + secret are cheap and recreatable → always removed. The home
+        # VOLUME holds the tenant's persisted CLI logins, so it is KEPT by
+        # default; pass remove_volume=True for a full purge (e.g. on retire).
+        n = self.names(agent)
+        removed: list[str] = []
+        if self._ops.container_exists(n.container):
+            self._ops.run([self._binary, "rm", "-f", n.container])
+            removed.append(f"container:{n.container}")
+        if self._ops.secret_exists(n.secret):
+            self._ops.run([self._binary, "secret", "rm", n.secret])
+            removed.append(f"secret:{n.secret}")
+        if remove_volume and self._ops.volume_exists(n.volume):
+            self._ops.run([self._binary, "volume", "rm", n.volume])
+            removed.append(f"volume:{n.volume}")
+        suffix = "" if remove_volume else " (home volume preserved)"
+        return ProvisionResult(
+            ok=True, mode=CONTAINER, removed=removed,
+            message=f"container: deprovisioned {n.container}{suffix}",
+        )
+
+    def runtime_env(self, agent: "Agent") -> dict[str, str]:
+        """Process env for the tenant's in-container runtime. ``HOME``/
+        ``CLAUDE_CONFIG_DIR`` confine config + Claude trust to the home volume;
+        the signing key is delivered via the mounted secret, not env."""
+        n = self.names(agent)
+        return {
+            "HOME": n.home,
+            "CLAUDE_CONFIG_DIR": n.config_dir,
+            "PINKY_AGENT_NAME": agent.name,
+        }
+
+    def _rollback(self, created: list[str]) -> list[str]:
+        """Undo ``created`` resources in reverse; best-effort, never raises."""
+        removed: list[str] = []
+        for token in reversed(created):
+            kind, _, value = token.partition(":")
+            try:
+                if kind == "container":
+                    if self._ops.container_exists(value):
+                        self._ops.run([self._binary, "rm", "-f", value])
+                elif kind == "secret":
+                    if self._ops.secret_exists(value):
+                        self._ops.run([self._binary, "secret", "rm", value])
+                elif kind == "volume":
+                    if self._ops.volume_exists(value):
+                        self._ops.run([self._binary, "volume", "rm", value])
+                removed.append(token)
+            except Exception:
+                # Best-effort — a stuck resource is surfaced via the returned
+                # ProvisionResult, not raised.
+                continue
+        return removed
+
+
+def _agent_container_image(agent: "Agent") -> str:
+    """Default image provider: read the agent's configured image.
+
+    The persisted ``container_image`` field + register/update wiring land with
+    the activation increment (this mirrors how ``_default_mcp_json`` is a
+    placeholder until real per-tenant MCP wiring lands). Until then this reads a
+    forward-compatible attribute — so the moment the column exists it just
+    works — and tests inject ``image_provider`` directly.
+    """
+    return getattr(agent, "container_image", "") or ""
+
+
 def get_provisioner(isolation_mode: str) -> AgentProvisioner:
     """Return the provisioner for ``isolation_mode``.
 
@@ -521,6 +879,14 @@ def get_provisioner(isolation_mode: str) -> AgentProvisioner:
             "not yet activated: lifecycle wiring + RunuserCommandRunner injection "
             "land in a later #149 increment. get_provisioner stays fail-closed so "
             "the #642 respawn guard keeps blocking unix_user until then."
+        )
+    if isolation_mode == CONTAINER:
+        raise NotImplementedError(
+            "isolation_mode='container' is implemented (ContainerProvisioner) but "
+            "not yet activated: lifecycle wiring (provision-on-register, start/stop "
+            "on session connect/idle, deprovision-on-retire) + ContainerCommandRunner "
+            "injection land in a later increment. get_provisioner stays fail-closed "
+            "so the #642 respawn guard keeps blocking container until then."
         )
     raise ValueError(
         f"unknown isolation_mode {isolation_mode!r}; expected one of {sorted(KNOWN_MODES)}"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -595,7 +595,7 @@ class TestAPI:
             app = self._make_app(db_path)
             with TestClient(app) as client:
                 r = client.post("/agents", json={
-                    "name": "bad", "model": "sonnet", "isolation_mode": "container",
+                    "name": "bad", "model": "sonnet", "isolation_mode": "qemu_vm",
                 })
                 assert r.status_code == 422
 
@@ -614,11 +614,34 @@ class TestAPI:
                 assert r.json()["isolation_mode"] == "unix_user"
                 assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
 
-                # Unknown value rejected by the validator.
-                bad = client.put("/agents/tenant", json={"isolation_mode": "container"})
+                # A known mode (container) is accepted by the validator...
+                ok = client.put("/agents/tenant", json={"isolation_mode": "container"})
+                assert ok.status_code == 200
+                assert ok.json()["isolation_mode"] == "container"
+                # ...while a truly-unknown value is still rejected.
+                bad = client.put("/agents/tenant", json={"isolation_mode": "qemu_vm"})
                 assert bad.status_code == 422
                 # Unchanged after the rejected update.
-                assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
+                assert client.get("/agents/tenant").json()["isolation_mode"] == "container"
+
+    def test_container_agent_cannot_start_before_activation(self):
+        """Container isolation is opt-in but DORMANT: an agent labeled
+        isolation_mode='container' registers fine yet REFUSES to start (501)
+        until the activation increment wires the lifecycle — same fail-closed
+        guarantee as unix_user, so it never silently runs under the daemon uid
+        with no container isolation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolated": True, "isolation_mode": "container",
+                })
+                resp = client.post("/agents/tenant/wake?prompt=Wake")
+                assert resp.status_code == 501
+                assert "not runnable yet" in resp.text
+                assert "container" in resp.text
 
     def test_unix_user_agent_cannot_start_before_provisioner(self):
         """#149 phase-3 (Murzik #642 P1): an agent labeled isolation_mode=

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -15,6 +15,7 @@ import pytest
 
 from pinky_daemon.command_runner import (
     CommandResult,
+    ContainerCommandRunner,
     LocalCommandRunner,
     RunuserCommandRunner,
 )
@@ -103,3 +104,45 @@ class TestRunuserCommandRunner:
     async def test_empty_username_rejected(self):
         with pytest.raises(ValueError):
             RunuserCommandRunner("")
+
+
+@pytest.mark.asyncio
+class TestContainerCommandRunner:
+    async def test_wrap_shape_minimal(self):
+        r = ContainerCommandRunner("pinky-mora")
+        assert r.wrap(["tmux", "has-session", "-t", "x"]) == [
+            "podman", "exec", "--", "pinky-mora", "tmux", "has-session", "-t", "x",
+        ]
+
+    async def test_wrap_includes_user_and_workdir(self):
+        r = ContainerCommandRunner("pinky-mora", user="agent", workdir="/home/agent/workdir")
+        assert r.wrap(["tmux"]) == [
+            "podman", "exec", "-u", "agent", "-w", "/home/agent/workdir",
+            "--", "pinky-mora", "tmux",
+        ]
+
+    async def test_custom_container_binary(self):
+        r = ContainerCommandRunner("pinky-mora", container_binary="docker")
+        assert r.wrap(["tmux"])[0] == "docker"
+
+    async def test_terminator_isolates_wrapped_options(self):
+        # A wrapped arg that looks like an exec option must sit AFTER ``--``.
+        r = ContainerCommandRunner("pinky-mora")
+        wrapped = r.wrap(["send-keys", "-l", "hi"])
+        assert wrapped.index("--") < wrapped.index("-l")
+        # the container name comes right after the terminator
+        assert wrapped[wrapped.index("--") + 1] == "pinky-mora"
+
+    async def test_run_delegates_wrapped_argv_to_inner(self):
+        inner = _RecordingRunner()
+        r = ContainerCommandRunner("pinky-mora", user="agent", inner=inner)
+        await r.run(["tmux", "kill-session"], timeout=5.0, stdin=b"x")
+        assert len(inner.calls) == 1
+        argv, timeout, stdin = inner.calls[0]
+        assert argv == ["podman", "exec", "-u", "agent", "--", "pinky-mora", "tmux", "kill-session"]
+        assert timeout == 5.0  # timeout/stdin pass through unchanged
+        assert stdin == b"x"
+
+    async def test_empty_container_rejected(self):
+        with pytest.raises(ValueError):
+            ContainerCommandRunner("")

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -15,9 +15,12 @@ from pinky_daemon.provisioning import (
     KNOWN_MODES,
     SECRET_MODE,
     AgentProvisioner,
+    ContainerNames,
+    ContainerProvisioner,
     LocalProvisioner,
     ProvisionError,
     ProvisionResult,
+    SystemContainerOps,
     SystemProvisionOps,
     UnixUserPaths,
     UnixUserProvisioner,
@@ -79,12 +82,20 @@ class TestGetProvisioner:
             get_provisioner("unix_user")
         assert "fail-closed" in str(exc.value)
 
+    def test_container_stays_fail_closed(self):
+        # Same dormancy guarantee as unix_user: ContainerProvisioner exists but
+        # the factory raises so the #642 respawn guard keeps blocking container
+        # until the activation increment wires the lifecycle.
+        with pytest.raises(NotImplementedError) as exc:
+            get_provisioner("container")
+        assert "fail-closed" in str(exc.value)
+
     def test_unknown_mode_rejected(self):
         with pytest.raises(ValueError):
-            get_provisioner("container")
+            get_provisioner("qemu_vm")
 
     def test_known_modes_constant(self):
-        assert KNOWN_MODES == frozenset({"local", "unix_user"})
+        assert KNOWN_MODES == frozenset({"local", "unix_user", "container"})
 
 
 class TestProvisionResult:
@@ -428,3 +439,304 @@ class TestSystemProvisionOps:
         resolve = make_db_signing_key_resolver(str(target))
         assert resolve("tenant") == "sekret"
         assert resolve("someone-else") is None
+
+
+# --------------------------------------------------------------------------- #
+# container provisioning (container isolation_mode)
+# --------------------------------------------------------------------------- #
+
+
+class RecordingContainerOps:
+    """In-memory ContainerOps double: records every podman command + tracks
+    image/volume/secret/container state so idempotency + rollback paths are
+    exercised without a real container runtime.
+
+    ``fail_predicate(argv) -> bool`` injects a mid-provision command failure.
+    """
+
+    def __init__(
+        self, *, images=None, volumes=None, secrets=None, containers=None, fail_predicate=None
+    ):
+        self.commands: list[list[str]] = []
+        self.secrets_written: list[tuple[str, str]] = []
+        self._images = set(images or [])
+        self._volumes = set(volumes or [])
+        self._secrets = set(secrets or [])
+        self._containers = set(containers or [])
+        self._fail = fail_predicate
+
+    def run(self, argv):
+        self.commands.append(list(argv))
+        if self._fail and self._fail(list(argv)):
+            raise ProvisionError(f"injected failure: {' '.join(argv)}")
+        # Reflect state mutations (argv[0] is the podman binary).
+        if len(argv) >= 4 and argv[1] == "volume" and argv[2] == "create":
+            self._volumes.add(argv[3])
+        elif len(argv) >= 3 and argv[1] == "pull":
+            self._images.add(argv[2])
+        elif len(argv) >= 4 and argv[1] == "create" and argv[2] == "--name":
+            self._containers.add(argv[3])
+        elif len(argv) >= 4 and argv[1] == "rm" and argv[2] == "-f":
+            self._containers.discard(argv[3])
+        elif len(argv) >= 4 and argv[1] == "secret" and argv[2] == "rm":
+            self._secrets.discard(argv[3])
+        elif len(argv) >= 4 and argv[1] == "volume" and argv[2] == "rm":
+            self._volumes.discard(argv[3])
+
+    def image_exists(self, ref):
+        return ref in self._images
+
+    def volume_exists(self, name):
+        return name in self._volumes
+
+    def secret_exists(self, name):
+        return name in self._secrets
+
+    def container_exists(self, name):
+        return name in self._containers
+
+    def write_secret(self, name, content):
+        self.secrets_written.append((name, content))
+        self._secrets.add(name)
+
+
+@pytest.fixture
+def container_agent():
+    return Agent(name="tenant", model="opus", isolated=True, isolation_mode="container")
+
+
+def _cprov(ops, **kw):
+    kw.setdefault("image_provider", lambda a: "myco/agent:1")
+    kw.setdefault("signing_key_provider", lambda n: f"key-{n}")
+    return ContainerProvisioner(ops=ops, **kw)
+
+
+class TestContainerNames:
+    def test_layout(self):
+        n = ContainerNames.for_agent("tenant")
+        assert n.container == "pinky-tenant"
+        assert n.volume == "pinky-tenant-home"
+        assert n.secret == "pinky-tenant-key"
+        assert n.home == "/home/agent"
+        assert n.workdir == "/home/agent/workdir"
+        assert n.config_dir == "/home/agent/.claude"
+
+    def test_custom_prefix_and_home(self):
+        n = ContainerNames.for_agent("x", prefix="bot-", home="/srv/x")
+        assert n.container == "bot-x"
+        assert n.volume == "bot-x-home"
+        assert n.secret == "bot-x-key"
+        assert n.home == "/srv/x"
+        assert n.config_dir == "/srv/x/.claude"
+
+
+class TestContainerProvisionerContract:
+    def test_is_an_agent_provisioner(self):
+        assert isinstance(_cprov(RecordingContainerOps()), AgentProvisioner)
+        assert _cprov(RecordingContainerOps()).mode == "container"
+
+
+class TestContainerProvision:
+    def test_command_shapes(self, container_agent):
+        ops = RecordingContainerOps()
+        result = _cprov(ops).provision(container_agent)
+        assert result.ok is True
+        assert result.mode == "container"
+        assert ["podman", "volume", "create", "pinky-tenant-home"] in ops.commands
+        assert ["podman", "pull", "myco/agent:1"] in ops.commands
+        # the container is CREATED (stopped), never `run` — start is activation's job
+        creates = [c for c in ops.commands if len(c) > 1 and c[1] == "create"]
+        assert len(creates) == 1
+        cc = creates[0]
+        assert cc[:4] == ["podman", "create", "--name", "pinky-tenant"]
+        assert "pinky-tenant-home:/home/agent" in cc  # home volume mount
+        assert "pinky-tenant-key,type=mount" in cc  # key secret mount
+        assert "HOME=/home/agent" in cc
+        assert cc[-4:] == ["--entrypoint", "sleep", "myco/agent:1", "infinity"]
+
+    def test_signing_key_never_on_an_argv(self, container_agent):
+        ops = RecordingContainerOps()
+        _cprov(ops).provision(container_agent)
+        # the key VALUE went via write_secret (stdin), not any podman argv
+        assert ops.secrets_written == [("pinky-tenant-key", "key-tenant")]
+        assert not any("key-tenant" in tok for c in ops.commands for tok in c)
+
+    def test_created_tokens_recorded_in_order(self, container_agent):
+        ops = RecordingContainerOps()
+        result = _cprov(ops).provision(container_agent)
+        # image pull is shared infra → NOT a tracked per-agent resource
+        assert result.created == [
+            "volume:pinky-tenant-home",
+            "secret:pinky-tenant-key",
+            "container:pinky-tenant",
+        ]
+
+    def test_no_image_fails_closed_before_touching_anything(self, container_agent):
+        ops = RecordingContainerOps()
+        p = ContainerProvisioner(
+            ops=ops, image_provider=lambda a: "", signing_key_provider=lambda n: "k"
+        )
+        result = p.provision(container_agent)
+        assert result.ok is False
+        assert "container_image" in result.message
+        assert ops.commands == []  # nothing created without an image
+
+    def test_missing_signing_key_fails_and_rolls_back(self, container_agent):
+        ops = RecordingContainerOps()
+        p = ContainerProvisioner(
+            ops=ops, image_provider=lambda a: "img:1", signing_key_provider=lambda n: ""
+        )
+        result = p.provision(container_agent)
+        assert result.ok is False
+        assert "signing key" in result.message.lower()
+        # the volume created before the failure was rolled back
+        assert not ops.volume_exists("pinky-tenant-home")
+        assert any(c[:3] == ["podman", "volume", "rm"] for c in ops.commands)
+
+    def test_idempotent_when_fully_provisioned(self, container_agent):
+        ops = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        result = _cprov(ops).provision(container_agent)
+        assert result.ok is True
+        assert "already provisioned" in result.message
+        assert ops.commands == []
+
+    def test_reconciles_partial_tenant(self, container_agent):
+        # volume exists; secret + container missing → build only the gaps,
+        # don't recreate the volume, and track only this call's work.
+        ops = RecordingContainerOps(volumes={"pinky-tenant-home"})
+        result = _cprov(ops).provision(container_agent)
+        assert result.ok is True
+        assert not any(c[:3] == ["podman", "volume", "create"] for c in ops.commands)
+        assert ops.secrets_written == [("pinky-tenant-key", "key-tenant")]
+        assert any(len(c) > 3 and c[1] == "create" and c[3] == "pinky-tenant" for c in ops.commands)
+        assert result.created == ["secret:pinky-tenant-key", "container:pinky-tenant"]
+
+    def test_present_image_is_not_pulled(self, container_agent):
+        ops = RecordingContainerOps(images={"myco/agent:1"})
+        _cprov(ops).provision(container_agent)
+        assert not any(len(c) > 1 and c[1] == "pull" for c in ops.commands)
+
+
+class TestContainerRollback:
+    def test_failure_on_container_create_undoes_in_reverse(self, container_agent):
+        # Fail the container `create`; volume + secret were built first.
+        ops = RecordingContainerOps(fail_predicate=lambda a: len(a) > 1 and a[1] == "create")
+        result = _cprov(ops).provision(container_agent)
+        assert result.ok is False
+        assert result.created == ["volume:pinky-tenant-home", "secret:pinky-tenant-key"]
+        # undone in reverse: secret rm'd, then volume rm'd
+        assert result.removed == ["secret:pinky-tenant-key", "volume:pinky-tenant-home"]
+        assert not ops.secret_exists("pinky-tenant-key")
+        assert not ops.volume_exists("pinky-tenant-home")
+
+
+class TestContainerDeprovision:
+    def test_default_keeps_home_volume(self, container_agent):
+        ops = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        result = _cprov(ops).deprovision(container_agent)
+        assert result.ok is True
+        assert result.removed == ["container:pinky-tenant", "secret:pinky-tenant-key"]
+        assert "preserved" in result.message
+        assert ops.volume_exists("pinky-tenant-home")  # the durable login survives
+        assert not ops.container_exists("pinky-tenant")
+        assert not ops.secret_exists("pinky-tenant-key")
+
+    def test_remove_volume_purges_everything(self, container_agent):
+        ops = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        result = _cprov(ops).deprovision(container_agent, remove_volume=True)
+        assert result.removed == [
+            "container:pinky-tenant",
+            "secret:pinky-tenant-key",
+            "volume:pinky-tenant-home",
+        ]
+        assert not ops.volume_exists("pinky-tenant-home")
+
+    def test_absent_is_noop(self, container_agent):
+        ops = RecordingContainerOps()
+        result = _cprov(ops).deprovision(container_agent)
+        assert result.ok is True
+        assert result.removed == []
+        assert ops.commands == []
+
+
+class TestContainerIsProvisioned:
+    def test_requires_volume_secret_and_container(self, container_agent):
+        full = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        assert _cprov(full).is_provisioned(container_agent) is True
+        no_container = RecordingContainerOps(
+            volumes={"pinky-tenant-home"}, secrets={"pinky-tenant-key"}
+        )
+        assert _cprov(no_container).is_provisioned(container_agent) is False
+        no_secret = RecordingContainerOps(
+            volumes={"pinky-tenant-home"}, containers={"pinky-tenant"}
+        )
+        assert _cprov(no_secret).is_provisioned(container_agent) is False
+
+
+class TestContainerRuntimeEnv:
+    def test_in_container_paths(self, container_agent):
+        env = _cprov(RecordingContainerOps()).runtime_env(container_agent)
+        assert env["HOME"] == "/home/agent"
+        assert env["CLAUDE_CONFIG_DIR"] == "/home/agent/.claude"
+        assert env["PINKY_AGENT_NAME"] == "tenant"
+
+
+class TestSystemContainerOps:
+    """The real ops shell out to podman, so they can't run in CI — but their
+    argv shapes (and the no-argv-leak secret guarantee) are worth pinning via a
+    monkeypatched subprocess.run."""
+
+    def test_exists_uses_inspect(self, monkeypatch):
+        import subprocess
+
+        calls: list[list[str]] = []
+
+        class _R:
+            returncode = 0
+
+        monkeypatch.setattr(subprocess, "run", lambda argv, **kw: calls.append(argv) or _R())
+        ops = SystemContainerOps()
+        assert ops.image_exists("img:1") is True
+        assert calls[-1] == ["podman", "image", "inspect", "img:1"]
+        ops.container_exists("c")
+        assert calls[-1] == ["podman", "container", "inspect", "c"]
+        ops.volume_exists("v")
+        assert calls[-1] == ["podman", "volume", "inspect", "v"]
+        ops.secret_exists("s")
+        assert calls[-1] == ["podman", "secret", "inspect", "s"]
+
+    def test_write_secret_feeds_stdin_never_argv(self, monkeypatch):
+        import subprocess
+
+        captured: dict = {}
+
+        class _R:
+            returncode = 0
+            stderr = b""
+
+        def fake_run(argv, **kw):
+            captured["argv"] = argv
+            captured["input"] = kw.get("input")
+            return _R()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        SystemContainerOps().write_secret("pinky-x-key", "s3cret")
+        assert captured["argv"] == ["podman", "secret", "create", "pinky-x-key", "-"]
+        assert captured["input"] == b"s3cret"
+        assert "s3cret" not in " ".join(captured["argv"])


### PR DESCRIPTION
## What

First increment toward container-per-agent isolation: a third **opt-in** `isolation_mode="container"` alongside `local` and `unix_user`. Shipped **dormant** in the exact `#149 inc3c` style — real code + full tests, with `get_provisioner` still fail-closed so nothing runs in prod yet.

This is the **isolation + lifecycle mechanism only**. Pinky stays **tool-agnostic**: the container image is operator-supplied (bring-your-own), Pinky pulls it and never builds it, and bakes in **no** CLIs (gcloud/gh/kubectl/etc. are the image's concern).

## Pieces

- **`ContainerProvisioner(AgentProvisioner)`** — per-agent rootless-Podman lifecycle:
  - home **VOLUME** (`pinky-<agent>-home`) — persists the tenant's `~/.config/<cli>` OAuth state across restart/rebuild → the basis for a durable per-employee login;
  - signing-key **SECRET** (`pinky-<agent>-key`) — created from **stdin**, so the key never appears on an argv / in the process list;
  - the **CONTAINER** (`pinky-<agent>`) — created **stopped** via `podman create`; start/stop on session connect/idle is the activation increment's job.
  - Idempotent + partial-failure rollback (undo in reverse), identical contract to `UnixUserProvisioner`. `deprovision` **keeps the home volume by default** (`remove_volume=True` to purge).
- **`ContainerOps` protocol + `SystemContainerOps`** (podman CLI) — the privileged seam, so the whole provisioner is unit-testable on macOS via a recording double (no real Podman in CI).
- **`ContainerCommandRunner(CommandRunner)`** — wraps argv as `podman exec [flags] -- <container> …`, so an agent's tmux server + claude REPL run **inside** its container while the daemon drives them from the host. Same wrap-and-delegate shape as `RunuserCommandRunner`; the `--` terminator is load-bearing (keeps `tmux send-keys -l/-t` args out of podman's flag parser).
- **`api_models`** — `"container"` accepted by both `isolation_mode` validators (label-now / can't-run-yet, mirroring `unix_user`).
- **`get_provisioner`** — stays **fail-closed** for `container`: the #642 respawn guard blocks a container-labeled agent from launching until activation. **Zero prod behavior change.**

## Deferred to the activation increment (intentionally)

- Persisted `container_image` agent field + register/update wiring (the provisioner takes the image via an injected provider for now — mirrors how `unix_user` deferred its real MCP/key providers).
- Lifecycle call sites (provision-on-register, start/stop on connect/idle, deprovision-on-retire), `ContainerCommandRunner` injection into `_TmuxControl`, in-container `~/.claude` trust seed, cold-start budget.
- The Linux/rootless-Podman host (only needed once container mode is actually used).

Interactive CLI logins (e.g. `gcloud auth login --no-launch-browser`) need **no Pinky feature** — a container agent has its own shell, so it runs the login itself and surfaces the URL via existing messaging.

## Tests
- Full container provision / deprovision / rollback / idempotency / reconcile / `runtime_env` coverage via a recording `ContainerOps` double.
- `ContainerCommandRunner` wrap + delegation + `--` isolation.
- `SystemContainerOps` argv shapes via monkeypatched `subprocess` (incl. the no-argv-leak secret guarantee).
- A container-can't-start-before-activation API test mirroring `unix_user`.
- Full backend suite green: **2725 passed** (only pre-existing `nacl`-missing modules excluded locally).

[Generated with Claude Code]