### PR TITLE
feat(#149): persist container_image agent field — container activation prep (slice 1)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -404,6 +404,11 @@ class Agent:
     # Orthogonal to `isolated`: `isolated` is the daemon-authz boundary; this is
     # the runtime sandbox. Only meaningful when `isolated` is True.
     isolation_mode: str = "local"
+    # Operator-supplied container image for isolation_mode="container" (bring-
+    # your-own; Pinky pulls it, never builds it, and bakes in no CLIs). Empty
+    # for every other mode. Consumed by ContainerProvisioner via its default
+    # image_provider; the runtime cutover that uses it is host-gated.
+    container_image: str = ""
     dream_enabled: bool = False  # Enable nightly memory consolidation
     dream_schedule: str = "0 3 * * *"  # Cron for dream runs (default 3 AM)
     dream_timezone: str = "America/Los_Angeles"  # IANA timezone for dream schedule
@@ -475,6 +480,7 @@ class Agent:
             "role": self.role,
             "isolated": self.isolated,
             "isolation_mode": self.isolation_mode,
+            "container_image": self.container_image,
             "dream_enabled": self.dream_enabled,
             "dream_schedule": self.dream_schedule,
             "dream_timezone": self.dream_timezone,
@@ -1387,6 +1393,9 @@ class AgentRegistry:
             # behavior); 'unix_user' = own pinky-<agent> OS user (inc3b, Linux
             # exec only). Orthogonal to `isolated`; only meaningful when isolated.
             ("isolation_mode", "TEXT NOT NULL DEFAULT 'local'"),
+            # Operator-supplied container image for isolation_mode="container".
+            # Empty for other modes; bring-your-own (Pinky never builds it).
+            ("container_image", "TEXT NOT NULL DEFAULT ''"),
         ]
         for col, typedef in migrations:
             if col not in existing:
@@ -1960,7 +1969,7 @@ except Exception:
                         "librarian_enabled", "librarian_schedule",
                         "runtime", "transport", "provider_url", "provider_key", "provider_model", "provider_ref",
                         "thinking_effort", "strict_effort_enforcement", "isolated",
-                        "isolation_mode"):
+                        "isolation_mode", "container_image"):
                 if key in kwargs:
                     updates[key] = kwargs[key]
 
@@ -2041,6 +2050,7 @@ except Exception:
                 role=kwargs.get("role", ""),
                 isolated=kwargs.get("isolated", False),
                 isolation_mode=kwargs.get("isolation_mode", "local"),
+                container_image=kwargs.get("container_image", ""),
                 dream_enabled=kwargs.get("dream_enabled", False),
                 dream_schedule=kwargs.get("dream_schedule", "0 3 * * *"),
                 dream_timezone=kwargs.get("dream_timezone", "America/Los_Angeles"),
@@ -2068,13 +2078,13 @@ except Exception:
                     restart_threshold_pct, context_nudge_threshold_pct, auto_restart, parent, groups,
                     max_sessions, enabled, auto_start, heartbeat_interval, plain_text_fallback,
                     wake_interval, clock_aligned, auto_sleep_hours, voice_config, role, isolated,
-                    isolation_mode,
+                    isolation_mode, container_image,
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
                     librarian_enabled, librarian_schedule,
                     runtime, transport, provider_url, provider_key, provider_model, provider_ref,
                     thinking_effort, strict_effort_enforcement, watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -2086,7 +2096,7 @@ except Exception:
                  int(agent.enabled), int(agent.auto_start), agent.heartbeat_interval, int(agent.plain_text_fallback),
                  agent.wake_interval, int(agent.clock_aligned), agent.auto_sleep_hours,
                  json.dumps(agent.voice_config), agent.role, int(agent.isolated),
-                 agent.isolation_mode,
+                 agent.isolation_mode, agent.container_image,
                  int(agent.dream_enabled), agent.dream_schedule, agent.dream_timezone, agent.dream_model, int(agent.dream_notify),
                  int(agent.librarian_enabled), agent.librarian_schedule,
                  agent.runtime, agent.transport, agent.provider_url, agent.provider_key,
@@ -2126,7 +2136,7 @@ except Exception:
         "runtime, transport, provider_url, provider_key, provider_model, provider_ref, "
         "disallowed_tools, thinking_effort, watchdog_config, last_seen_at, "
         "strict_effort_enforcement, context_nudge_threshold_pct, isolated, "
-        "isolation_mode"
+        "isolation_mode, container_image"
     )
 
     def get(self, name: str) -> Agent | None:
@@ -3919,6 +3929,7 @@ except Exception:
             context_nudge_threshold_pct=row[50] if len(row) > 50 else 0.0,
             isolated=bool(row[51]) if len(row) > 51 else False,
             isolation_mode=row[52] if len(row) > 52 and row[52] else "local",
+            container_image=row[53] if len(row) > 53 and row[53] else "",
         )
 
     # ── Cost Tracking ──────────────────────────────────────

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -4931,6 +4931,7 @@ npm run build</pre>
             watchdog_config=req.watchdog_config or {},
             isolated=req.isolated,
             isolation_mode=req.isolation_mode,
+            container_image=req.container_image,
         )
         # Write .mcp.json so the agent gets default MCP servers (memory, self, messaging)
         work_dir = Path(agent.working_dir) if agent.working_dir else None

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -348,6 +348,10 @@ class RegisterAgentRequest(BaseModel):
     # "unix_user" = own pinky-<agent> OS user + private home/keys (Linux exec,
     # inc3b). Orthogonal to `isolated`; only meaningful when isolated=True.
     isolation_mode: str = "local"
+    # Operator-supplied container image for isolation_mode="container"
+    # (bring-your-own; Pinky pulls it, never builds it, bakes in no CLIs).
+    # Empty for every other mode.
+    container_image: str = ""
 
     @field_validator("isolation_mode")
     @classmethod
@@ -403,6 +407,7 @@ class UpdateAgentRequest(BaseModel):
     # validated value set as the register path. The start-time preflight (api.py)
     # refuses to actually *run* a mode whose provisioner isn't implemented yet.
     isolation_mode: str | None = None
+    container_image: str | None = None  # bring-your-own image for mode=container; None = leave unchanged
 
     @field_validator("isolation_mode")
     @classmethod

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -588,6 +588,35 @@ class TestAPI:
                 # Confirm it survives a re-fetch.
                 assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
 
+    def test_container_image_round_trips(self):
+        """Container isolation: POST/PUT /agents carry the operator-supplied
+        container_image through to the stored agent; default is empty."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                # Default is empty.
+                r = client.post("/agents", json={"name": "plain", "model": "sonnet"})
+                assert r.status_code == 200
+                assert r.json()["container_image"] == ""
+
+                # Registering a container agent persists its image.
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolated": True, "isolation_mode": "container",
+                    "container_image": "myco/agent:1.4",
+                })
+                assert r.status_code == 200
+                assert r.json()["container_image"] == "myco/agent:1.4"
+                assert client.get("/agents/tenant").json()["container_image"] == "myco/agent:1.4"
+
+                # PUT updates the image; an unrelated update leaves it intact.
+                up = client.put("/agents/tenant", json={"container_image": "myco/agent:2.0"})
+                assert up.status_code == 200
+                assert up.json()["container_image"] == "myco/agent:2.0"
+                client.put("/agents/tenant", json={"display_name": "Tenant"})
+                assert client.get("/agents/tenant").json()["container_image"] == "myco/agent:2.0"
+
     def test_register_rejects_unknown_isolation_mode(self):
         """The api_models validator rejects modes outside the known set (422)."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -740,3 +740,26 @@ class TestSystemContainerOps:
         assert captured["argv"] == ["podman", "secret", "create", "pinky-x-key", "-"]
         assert captured["input"] == b"s3cret"
         assert "s3cret" not in " ".join(captured["argv"])
+
+
+class TestContainerDefaultImageProvider:
+    """With no image_provider injected, ContainerProvisioner resolves the image
+    from the agent's persisted ``container_image`` field (activation prep)."""
+
+    def test_reads_agent_container_image(self):
+        ops = RecordingContainerOps()
+        agent = Agent(
+            name="tenant", model="opus", isolated=True,
+            isolation_mode="container", container_image="myco/agent:1",
+        )
+        result = ContainerProvisioner(ops=ops, signing_key_provider=lambda n: "k").provision(agent)
+        assert result.ok is True
+        assert ["podman", "pull", "myco/agent:1"] in ops.commands
+
+    def test_fails_closed_when_container_image_unset(self):
+        ops = RecordingContainerOps()
+        agent = Agent(name="tenant", model="opus", isolation_mode="container")  # no image
+        result = ContainerProvisioner(ops=ops, signing_key_provider=lambda n: "k").provision(agent)
+        assert result.ok is False
+        assert "container_image" in result.message
+        assert ops.commands == []


### PR DESCRIPTION
**Stacked on #656** (`feat/container-isolation-scaffold`) — review/merge that first. I'll rebase this onto `main` once #656 lands.

## What

First activation slice for `isolation_mode="container"`: the operator-supplied, **bring-your-own** container image is now a first-class agent field, wired end-to-end exactly like `isolation_mode`.

- `agent_registry`: `Agent.container_image` + `to_dict` + `_ensure_columns` migration (`TEXT NOT NULL DEFAULT ''`) + update-allowed key set + `register()` INSERT + the shared `SELECT` column list + positional row hydration (`row[53]`, append-at-end and `len(row) > 53`-guarded so pre-migration rows stay safe).
- `api_models`: `container_image` on `RegisterAgentRequest` + `UpdateAgentRequest`.
- `api`: `register_agent` forwards it; the `PUT` path is generic (forwards all non-`None` fields) so update persists it with no extra wiring.
- `ContainerProvisioner`'s default `image_provider` (`_agent_container_image`) now resolves the real persisted field — no injected provider needed.

## Still dormant — no runtime behavior change

`get_provisioner` stays **fail-closed** for `container`. The **atomic runtime cutover** — factory flip + provision/start/stop/deprovision lifecycle + `ContainerCommandRunner` injection into `_TmuxControl` + in-container `~/.claude` trust seed + cold-start budget — lands when the **rootless-Podman Linux host** exists to validate it end-to-end. Flipping it blind (no host, can't exec into a nonexistent container) would break container cold-starts, so it's deliberately the last, host-gated step.

## Tests
- API register/update/refetch round-trip for `container_image` (incl. default-empty + unrelated-update-leaves-intact).
- Provisioner resolves the field via its default provider, and fails closed with a clear `no container_image configured` message when unset.
- Full backend suite green: **2728 passed** (only the pre-existing `nacl`-missing modules excluded locally).

## Remaining activation slices (planned, host-gated for the live flip)
1. Lifecycle hooks — provision-on-register / deprovision-on-retire (testable via the recording `ContainerOps` double).
2. `.mcp.json` generation for container agents — `host.containers.internal` + mounted key secret.
3. `ContainerCommandRunner` injection into `_TmuxControl` + in-container trust seed.
4. The live `get_provisioner` flip + cold-start budget — validated on the Podman host.

[Generated with Claude Code]