### PR TITLE
feat(#149): gated container-runtime activation (provision/exec lifecycle, default-OFF)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2453,6 +2453,18 @@ def create_api(
         if not agent:
             return None
         mode = (getattr(agent, "isolation_mode", "") or "local").strip() or "local"
+        # Container isolation runs the session INSIDE the container via tmux
+        # exec; the SDK/Codex backends don't go through the CommandRunner seam,
+        # so a container agent must use transport="tmux". Surface this as a clear
+        # config error rather than letting it fail obscurely at spawn.
+        if mode == "container":
+            transport = (getattr(agent, "transport", "") or "sdk").strip() or "sdk"
+            if transport != "tmux":
+                return (
+                    400,
+                    f"isolation_mode 'container' for agent '{agent_name}' requires "
+                    f"transport='tmux' (got '{transport}')",
+                )
         try:
             from pinky_daemon.provisioning import get_provisioner
             get_provisioner(mode)
@@ -4933,6 +4945,27 @@ npm run build</pre>
             isolation_mode=req.isolation_mode,
             container_image=req.container_image,
         )
+        # Provision OS-level isolation resources. No-op for local (the default);
+        # gated for container — when the runtime gate is OFF, get_provisioner
+        # raises NotImplementedError and we skip (the start-time guard then
+        # blocks the agent until an operator opts in). On a real provision
+        # failure we roll back the just-registered agent so we never leave a
+        # half-provisioned tenant behind.
+        from pinky_daemon.provisioning import get_provisioner
+
+        try:
+            provisioner = get_provisioner(
+                agent.isolation_mode, signing_key_provider=agents.get_or_create_signing_key
+            )
+        except NotImplementedError:
+            provisioner = None  # dormant mode (e.g. container gate off)
+        if provisioner is not None:
+            result = provisioner.provision(agent)
+            if not result.ok:
+                agents.delete(agent.name)  # roll back the registration
+                raise HTTPException(
+                    500, f"provisioning failed for '{agent.name}': {result.message}"
+                )
         # Write .mcp.json so the agent gets default MCP servers (memory, self, messaging)
         work_dir = Path(agent.working_dir) if agent.working_dir else None
         if work_dir:
@@ -5616,9 +5649,26 @@ npm run build</pre>
     @app.delete("/agents/{name}")
     async def retire_agent(name: str):
         """Retire an agent (soft delete). Preserves all data for restoration."""
+        agent = agents.get(name)  # capture before retire so we can deprovision
         retired = agents.retire(name)
         if not retired:
             raise HTTPException(404, f"Agent '{name}' not found")
+        # Tear down runtime OS resources (no-op for local; gated for container).
+        # Best-effort — failures are logged, never block the retire. The home
+        # VOLUME is intentionally KEPT: retire is a soft delete that "preserves
+        # all data for restoration", and the volume holds the tenant's durable
+        # CLI logins. A full purge belongs to a hard delete, not retire.
+        if agent is not None:
+            try:
+                from pinky_daemon.provisioning import get_provisioner
+
+                get_provisioner(
+                    agent.isolation_mode, signing_key_provider=agents.get_or_create_signing_key
+                ).deprovision(agent)
+            except NotImplementedError:
+                pass  # dormant mode — nothing was provisioned
+            except Exception as e:  # noqa: BLE001 — best-effort cleanup
+                _log(f"api: deprovision on retire of '{name}' failed (ignored): {e}")
         return {"retired": True, "name": name}
 
     @app.post("/agents/{name}/restore")

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -783,6 +783,20 @@ class ContainerProvisioner(AgentProvisioner):
         # until the session connects. A tool-agnostic keep-alive entrypoint lets
         # the daemon `podman exec` tmux into it regardless of the image's own
         # CMD — Pinky asserts nothing about the image beyond "can run sleep".
+        #
+        # HOST-VALIDATION TODOs (deferred — the gate is OFF until a Podman host
+        # exists to verify these end-to-end; the engaged path is incomplete
+        # without them, so they are tracked here rather than left silent):
+        #   1. Bind-mount the agent's host working_dir (data/agents/<name>, which
+        #      the daemon regenerates CLAUDE.md/.mcp.json into) onto the
+        #      in-container workdir, AND make TmuxSession pass an IN-CONTAINER
+        #      cwd to `tmux new-session -c` (today it passes the host path, which
+        #      won't exist inside the container).
+        #   2. Point the in-container .mcp.json at the daemon over the rootless
+        #      network (host.containers.internal) signed with the mounted key
+        #      secret, so the agent's MCP servers reach the daemon.
+        #   3. Seed the container's ~/.claude trust file (the tmux transport
+        #      expects it in HOME) before first connect.
         return [
             self._binary, "create",
             "--name", n.container,
@@ -799,7 +813,8 @@ class ContainerProvisioner(AgentProvisioner):
     def deprovision(self, agent: "Agent", *, remove_volume: bool = False) -> ProvisionResult:
         # Container + secret are cheap and recreatable → always removed. The home
         # VOLUME holds the tenant's persisted CLI logins, so it is KEPT by
-        # default; pass remove_volume=True for a full purge (e.g. on retire).
+        # default; pass remove_volume=True for a full purge (on HARD delete —
+        # NOT on retire, which is a soft delete that preserves data).
         n = self.names(agent)
         removed: list[str] = []
         if self._ops.container_exists(n.container):

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -97,6 +97,11 @@ SECRET_MODE = 0o600
 # by default; ``CONTAINER_BINARY`` is injectable for docker / CI doubles.
 CONTAINER_PREFIX = "pinky-"
 CONTAINER_BINARY = "podman"
+# Opt-in runtime gate. Container isolation stays fail-closed (dormant) until an
+# operator sets this on the daemon host — "" = OFF, "docker" = docker, any other
+# truthy value ("podman"/"1"/...) = podman. Default OFF, so registering/labeling
+# a container agent is allowed but it cannot RUN until the host is set up.
+CONTAINER_RUNTIME_ENV = "PINKY_CONTAINER_RUNTIME"
 # In-container HOME. Everything the tenant persists — including any CLI's OAuth
 # state under ~/.config — lives here and is backed by the per-agent home VOLUME,
 # so a tenant's logins survive container restart/rebuild. Pinky bakes NO tools
@@ -823,6 +828,28 @@ class ContainerProvisioner(AgentProvisioner):
             "PINKY_AGENT_NAME": agent.name,
         }
 
+    def start(self, agent: "Agent") -> None:
+        """Start the agent's (already-provisioned) container. Idempotent —
+        ``podman start`` on a running container is a successful no-op."""
+        self._ops.run([self._binary, "start", self.names(agent).container])
+
+    def stop(self, agent: "Agent") -> None:
+        """Stop the agent's container. The home volume persists its state (incl.
+        CLI OAuth logins), so a later start resumes a fully-configured tenant."""
+        self._ops.run([self._binary, "stop", self.names(agent).container])
+
+    def ensure_started(self, agent: "Agent") -> None:
+        """Idempotently provision (if needed) then start the container, so the
+        daemon can ``podman exec`` the tmux server into it. Raises
+        :class:`ProvisionError` if provisioning fails — a missing/stopped
+        container can't host a session. Called at session cold-start, BEFORE the
+        first ``podman exec``."""
+        if not self.is_provisioned(agent):
+            result = self.provision(agent)
+            if not result.ok:
+                raise ProvisionError(result.message)
+        self.start(agent)
+
     def _rollback(self, created: list[str]) -> list[str]:
         """Undo ``created`` resources in reverse; best-effort, never raises."""
         removed: list[str] = []
@@ -858,18 +885,41 @@ def _agent_container_image(agent: "Agent") -> str:
     return getattr(agent, "container_image", "") or ""
 
 
-def get_provisioner(isolation_mode: str) -> AgentProvisioner:
+def container_runtime_enabled() -> bool:
+    """True iff the operator has opted into the container runtime via
+    ``PINKY_CONTAINER_RUNTIME`` (default OFF → container mode stays fail-closed).
+
+    This is the activation gate: container lifecycle/exec only engages on a host
+    that has actually been set up with a (rootless Podman) runtime. Off by
+    default, so no behavior changes anywhere until an operator flips it.
+    """
+    return bool(os.environ.get(CONTAINER_RUNTIME_ENV, "").strip())
+
+
+def container_runtime_binary() -> str:
+    """The container CLI selected by ``PINKY_CONTAINER_RUNTIME``: ``"docker"``
+    for ``"docker"``, else ``"podman"`` (for ``"podman"``/``"1"``/any other
+    truthy value). Only meaningful when :func:`container_runtime_enabled`."""
+    val = os.environ.get(CONTAINER_RUNTIME_ENV, "").strip().lower()
+    return "docker" if val == "docker" else CONTAINER_BINARY
+
+
+def get_provisioner(
+    isolation_mode: str,
+    *,
+    signing_key_provider: "Callable[[str], str] | None" = None,
+) -> AgentProvisioner:
     """Return the provisioner for ``isolation_mode``.
 
-    ``"local"`` → the no-op :class:`LocalProvisioner`. ``"unix_user"`` is a
-    recognized mode and its provisioner (:class:`UnixUserProvisioner`) now
-    exists, but this factory still **fails closed** for it: activation — wiring
-    the provisioner into the daemon lifecycle together with the
-    ``RunuserCommandRunner`` — is a later increment. Raising here is the
-    dormancy guarantee: the #642 respawn guard blocks a ``unix_user`` agent
-    from launching *because* this raises, so the half-wired path can never run
-    under the daemon uid with none of the requested isolation. Any other value
-    is rejected as unknown.
+    ``"local"`` → the no-op :class:`LocalProvisioner`. ``"unix_user"`` is
+    recognized but still **fails closed** (its lifecycle activation is a
+    separate, Linux/systemd increment). ``"container"`` is **gated**: it returns
+    a real :class:`ContainerProvisioner` only when :func:`container_runtime_enabled`
+    (``PINKY_CONTAINER_RUNTIME`` set), and otherwise fails closed — so the #642
+    respawn guard keeps blocking container agents on any host that hasn't opted
+    into a runtime. ``signing_key_provider`` is threaded into the
+    ContainerProvisioner for provision/deprovision; the runnability check passes
+    none (it only needs the factory to not raise). Any other value is rejected.
     """
     if isolation_mode == LOCAL:
         return LocalProvisioner()
@@ -881,12 +931,16 @@ def get_provisioner(isolation_mode: str) -> AgentProvisioner:
             "the #642 respawn guard keeps blocking unix_user until then."
         )
     if isolation_mode == CONTAINER:
+        if container_runtime_enabled():
+            return ContainerProvisioner(
+                signing_key_provider=signing_key_provider,
+                binary=container_runtime_binary(),
+            )
         raise NotImplementedError(
             "isolation_mode='container' is implemented (ContainerProvisioner) but "
-            "not yet activated: lifecycle wiring (provision-on-register, start/stop "
-            "on session connect/idle, deprovision-on-retire) + ContainerCommandRunner "
-            "injection land in a later increment. get_provisioner stays fail-closed "
-            "so the #642 respawn guard keeps blocking container until then."
+            f"the container runtime is not enabled: set {CONTAINER_RUNTIME_ENV} "
+            "(e.g. 'podman') on the daemon host to activate. get_provisioner stays "
+            "fail-closed so the #642 respawn guard keeps blocking container until then."
         )
     raise ValueError(
         f"unknown isolation_mode {isolation_mode!r}; expected one of {sorted(KNOWN_MODES)}"

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -67,7 +67,11 @@ from collections import deque
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
-from pinky_daemon.command_runner import CommandRunner, LocalCommandRunner
+from pinky_daemon.command_runner import (
+    CommandRunner,
+    ContainerCommandRunner,
+    LocalCommandRunner,
+)
 from pinky_daemon.effort import EFFORT_LEVELS, is_ultracode, resolve_cli_effort
 from pinky_daemon.pricing import compute_cost_from_usage
 from pinky_daemon.sessions import SessionUsage
@@ -768,7 +772,12 @@ class TmuxSession:
 
         # Tmux subprocess control. Injectable for tests (mock the whole
         # ``_TmuxControl`` rather than monkeypatching subprocess primitives).
-        self._tmux = tmux_control or _TmuxControl(self._session_name)
+        # For an isolation_mode="container" agent (runtime gate ON), the tmux
+        # server + REPL run INSIDE its container via a ContainerCommandRunner;
+        # otherwise the default LocalCommandRunner reproduces today's behavior.
+        self._tmux = tmux_control or _TmuxControl(
+            self._session_name, command_runner=self._select_command_runner()
+        )
 
         # Worker queue + task.
         self._message_queue: asyncio.Queue[_QueuedTurn] = asyncio.Queue()
@@ -961,6 +970,53 @@ class TmuxSession:
         """Stable identifier matching StreamingSession's format."""
         label = getattr(self._config, "label", "") or "main"
         return f"{self.agent_name}-{label}"
+
+    def _container_agent(self):
+        """Return this session's Agent iff it should run inside a container —
+        the runtime gate is ON *and* isolation_mode=="container". Returns None
+        (→ default local behavior) otherwise, fail-safe on any lookup error so a
+        registry hiccup can never break a normal (local) session."""
+        from pinky_daemon.provisioning import container_runtime_enabled
+
+        if not container_runtime_enabled() or not self._registry:
+            return None
+        try:
+            agent = self._registry.get(self.agent_name)
+        except Exception:
+            return None
+        if not agent or getattr(agent, "isolation_mode", "") != "container":
+            return None
+        return agent
+
+    def _select_command_runner(self) -> CommandRunner:
+        """LocalCommandRunner by default; a ContainerCommandRunner bound to the
+        agent's container for a gated container agent, so every tmux command
+        execs into the container."""
+        agent = self._container_agent()
+        if agent is None:
+            return LocalCommandRunner()
+        from pinky_daemon.provisioning import ContainerNames, container_runtime_binary
+
+        names = ContainerNames.for_agent(agent.name)
+        return ContainerCommandRunner(
+            names.container, container_binary=container_runtime_binary()
+        )
+
+    async def _ensure_container_started(self) -> None:
+        """For a gated container agent, idempotently provision + start its
+        container BEFORE the first ``podman exec`` (tmux new-session). No-op for
+        local/non-container agents and when the gate is off. Run off-loop since
+        the podman calls are blocking subprocesses."""
+        agent = self._container_agent()
+        if agent is None:
+            return
+        from pinky_daemon.provisioning import get_provisioner
+
+        provisioner = get_provisioner(
+            "container",
+            signing_key_provider=self._registry.get_or_create_signing_key,
+        )
+        await asyncio.to_thread(provisioner.ensure_started, agent)
 
     def _build_session_name(self) -> str:
         """Tmux session name pattern: ``pinky-<agent_name>``.
@@ -1690,6 +1746,10 @@ class TmuxSession:
         env = self._build_repl_env()
 
         async def _spawn():
+            # Container-isolated agents: ensure the container is provisioned +
+            # running before any `podman exec tmux …` (this is the first one).
+            # No-op for local/non-container agents and when the gate is off.
+            await self._ensure_container_started()
             result = await self._tmux.new_session(
                 cwd=cwd,
                 command=claude_cmd,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -653,24 +653,90 @@ class TestAPI:
                 # Unchanged after the rejected update.
                 assert client.get("/agents/tenant").json()["isolation_mode"] == "container"
 
-    def test_container_agent_cannot_start_before_activation(self):
-        """Container isolation is opt-in but DORMANT: an agent labeled
-        isolation_mode='container' registers fine yet REFUSES to start (501)
-        until the activation increment wires the lifecycle — same fail-closed
-        guarantee as unix_user, so it never silently runs under the daemon uid
-        with no container isolation."""
+    def test_container_agent_cannot_start_before_activation(self, monkeypatch):
+        """Container isolation is opt-in but DORMANT by default: with the runtime
+        gate OFF, a container agent registers fine yet REFUSES to start (501) —
+        same fail-closed guarantee as unix_user, so it never silently runs under
+        the daemon uid with no container isolation."""
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                # transport=tmux so we exercise the gate (not the tmux guard).
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet", "transport": "tmux",
+                    "isolated": True, "isolation_mode": "container",
+                })
+                assert r.status_code == 200  # registers (provision skipped, gate off)
+                resp = client.post("/agents/tenant/wake?prompt=Wake")
+                assert resp.status_code == 501
+                assert "not runnable yet" in resp.text
+                assert "container" in resp.text
+
+    def test_container_requires_tmux_transport(self, monkeypatch):
+        """A container agent on a non-tmux transport is blocked at start with a
+        clear 400 — container exec only works through the tmux CommandRunner."""
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             with TestClient(app) as client:
                 client.post("/agents", json={
-                    "name": "tenant", "model": "sonnet",
+                    "name": "tenant", "model": "sonnet",  # default transport=sdk
                     "isolated": True, "isolation_mode": "container",
                 })
                 resp = client.post("/agents/tenant/wake?prompt=Wake")
-                assert resp.status_code == 501
-                assert "not runnable yet" in resp.text
-                assert "container" in resp.text
+                assert resp.status_code == 400
+                assert "transport='tmux'" in resp.text
+
+    def test_register_provisions_and_retire_deprovisions(self, monkeypatch):
+        """Lifecycle wiring: register calls provisioner.provision and retire
+        calls deprovision (best-effort). Uses a fake provisioner so no real
+        podman is needed."""
+        from pinky_daemon import provisioning
+
+        calls = []
+
+        class _FakeProv:
+            def provision(self, agent):
+                calls.append(("provision", agent.name))
+                return provisioning.ProvisionResult(ok=True, mode="container")
+
+            def deprovision(self, agent, **kw):
+                calls.append(("deprovision", agent.name))
+                return provisioning.ProvisionResult(ok=True, mode="container")
+
+        monkeypatch.setattr(provisioning, "get_provisioner", lambda mode, **kw: _FakeProv())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={"name": "tenant", "model": "sonnet"})
+                assert r.status_code == 200
+                assert ("provision", "tenant") in calls
+                d = client.delete("/agents/tenant")
+                assert d.status_code == 200
+                assert ("deprovision", "tenant") in calls
+
+    def test_register_rolls_back_on_provision_failure(self, monkeypatch):
+        """A failed provision rolls back the just-registered agent (hard delete)
+        and surfaces a 500 — no half-provisioned tenant is left behind."""
+        from pinky_daemon import provisioning
+
+        class _FailProv:
+            def provision(self, agent):
+                return provisioning.ProvisionResult(ok=False, mode="container", message="boom")
+
+        monkeypatch.setattr(provisioning, "get_provisioner", lambda mode, **kw: _FailProv())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={"name": "tenant", "model": "sonnet"})
+                assert r.status_code == 500
+                assert "boom" in r.text
+                assert client.get("/agents/tenant").status_code == 404  # rolled back
 
     def test_unix_user_agent_cannot_start_before_provisioner(self):
         """#149 phase-3 (Murzik #642 P1): an agent labeled isolation_mode=

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -82,10 +82,11 @@ class TestGetProvisioner:
             get_provisioner("unix_user")
         assert "fail-closed" in str(exc.value)
 
-    def test_container_stays_fail_closed(self):
-        # Same dormancy guarantee as unix_user: ContainerProvisioner exists but
-        # the factory raises so the #642 respawn guard keeps blocking container
-        # until the activation increment wires the lifecycle.
+    def test_container_stays_fail_closed(self, monkeypatch):
+        # Dormancy guarantee: with the runtime gate OFF (default),
+        # ContainerProvisioner exists but the factory raises so the #642 respawn
+        # guard keeps blocking container until an operator opts in.
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
         with pytest.raises(NotImplementedError) as exc:
             get_provisioner("container")
         assert "fail-closed" in str(exc.value)
@@ -740,6 +741,81 @@ class TestSystemContainerOps:
         assert captured["argv"] == ["podman", "secret", "create", "pinky-x-key", "-"]
         assert captured["input"] == b"s3cret"
         assert "s3cret" not in " ".join(captured["argv"])
+
+
+class TestContainerRuntimeGate:
+    """The PINKY_CONTAINER_RUNTIME opt-in gate: container stays fail-closed by
+    default and only get_provisioner-flips to a real ContainerProvisioner when
+    an operator sets the env on the host."""
+
+    def test_fail_closed_when_gate_off(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with pytest.raises(NotImplementedError) as exc:
+            get_provisioner("container")
+        assert "not enabled" in str(exc.value)
+        assert "PINKY_CONTAINER_RUNTIME" in str(exc.value)
+
+    def test_returns_container_provisioner_when_gate_on(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        p = get_provisioner("container")
+        assert isinstance(p, ContainerProvisioner)
+        assert p.mode == "container"
+        assert p._binary == "podman"
+
+    def test_docker_binary_selected(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "docker")
+        assert get_provisioner("container")._binary == "docker"
+
+    def test_truthy_value_defaults_to_podman(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "1")
+        assert get_provisioner("container")._binary == "podman"
+
+    def test_signing_key_provider_is_threaded(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        p = get_provisioner("container", signing_key_provider=lambda n: f"k-{n}")
+        assert p._signing_key_provider("x") == "k-x"
+
+    def test_local_and_unix_user_unaffected_by_gate(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        assert isinstance(get_provisioner("local"), LocalProvisioner)
+        with pytest.raises(NotImplementedError):
+            get_provisioner("unix_user")  # still fail-closed; its own increment
+
+
+class TestContainerStartStop:
+    def test_start_command_shape(self, container_agent):
+        ops = RecordingContainerOps()
+        _cprov(ops).start(container_agent)
+        assert ops.commands == [["podman", "start", "pinky-tenant"]]
+
+    def test_stop_command_shape(self, container_agent):
+        ops = RecordingContainerOps()
+        _cprov(ops).stop(container_agent)
+        assert ops.commands == [["podman", "stop", "pinky-tenant"]]
+
+    def test_ensure_started_provisions_then_starts_when_absent(self, container_agent):
+        ops = RecordingContainerOps()
+        _cprov(ops).ensure_started(container_agent)
+        assert any(c[:3] == ["podman", "volume", "create"] for c in ops.commands)
+        assert any(len(c) > 3 and c[1] == "create" and c[3] == "pinky-tenant" for c in ops.commands)
+        assert ops.commands[-1] == ["podman", "start", "pinky-tenant"]  # start is last
+
+    def test_ensure_started_only_starts_when_already_provisioned(self, container_agent):
+        ops = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        _cprov(ops).ensure_started(container_agent)
+        assert ops.commands == [["podman", "start", "pinky-tenant"]]  # no re-provision
+
+    def test_ensure_started_raises_on_provision_failure(self, container_agent):
+        ops = RecordingContainerOps()
+        p = ContainerProvisioner(
+            ops=ops, image_provider=lambda a: "", signing_key_provider=lambda n: "k"
+        )
+        with pytest.raises(ProvisionError):
+            p.ensure_started(container_agent)  # no image → provision fails → raises
 
 
 class TestContainerDefaultImageProvider:

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -1,0 +1,116 @@
+"""Container-isolation wiring in TmuxSession (gated runner injection + cold-start
+ensure_started). All gated by PINKY_CONTAINER_RUNTIME and isolation_mode; local
+agents and the gate-off default must behave exactly as before. No real podman —
+the provisioner is faked, runner selection is asserted via wrap() shapes."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import pinky_daemon.provisioning as provisioning
+from pinky_daemon.command_runner import ContainerCommandRunner, LocalCommandRunner
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import TmuxSession
+
+
+class _FakeAgent:
+    def __init__(self, name, isolation_mode="local"):
+        self.name = name
+        self.isolation_mode = isolation_mode
+
+
+class _FakeRegistry:
+    def __init__(self, agent=None, *, raises=False):
+        self._agent = agent
+        self._raises = raises
+
+    def get(self, name):
+        if self._raises:
+            raise RuntimeError("registry boom")
+        return self._agent
+
+    def get_or_create_signing_key(self, name):
+        return f"key-{name}"
+
+
+def _session(agent_name="dymok", registry=None):
+    cfg = StreamingSessionConfig(agent_name=agent_name, working_dir="/tmp/x")
+    # A truthy tmux_control short-circuits the in-__init__ runner selection, so we
+    # can set _registry and call the gated methods directly + deterministically.
+    ss = TmuxSession(cfg, tmux_control=MagicMock())
+    ss._registry = registry
+    return ss
+
+
+class TestSelectCommandRunner:
+    def test_local_by_default_gate_off(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        assert isinstance(ss._select_command_runner(), LocalCommandRunner)
+
+    def test_container_runner_when_gated(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        runner = ss._select_command_runner()
+        assert isinstance(runner, ContainerCommandRunner)
+        assert runner.wrap(["tmux", "ls"]) == ["podman", "exec", "--", "pinky-dymok", "tmux", "ls"]
+
+    def test_docker_binary_honored(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "docker")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        assert ss._select_command_runner().wrap(["tmux"])[0] == "docker"
+
+    def test_local_for_non_container_even_when_gated(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        assert isinstance(ss._select_command_runner(), LocalCommandRunner)
+
+    def test_failsafe_when_registry_missing(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=None)
+        assert isinstance(ss._select_command_runner(), LocalCommandRunner)
+
+    def test_failsafe_when_registry_raises(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(raises=True))
+        assert isinstance(ss._select_command_runner(), LocalCommandRunner)
+
+
+@pytest.mark.asyncio
+class TestEnsureContainerStarted:
+    async def test_noop_for_local_agent(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        called = []
+        monkeypatch.setattr(
+            provisioning, "get_provisioner",
+            lambda *a, **k: called.append(1) or MagicMock(),
+        )
+        await ss._ensure_container_started()
+        assert called == []  # provisioner never consulted for a local agent
+
+    async def test_noop_when_gate_off(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        called = []
+        monkeypatch.setattr(
+            provisioning, "get_provisioner",
+            lambda *a, **k: called.append(1) or MagicMock(),
+        )
+        await ss._ensure_container_started()
+        assert called == []  # gate off → never provisions, even for a container agent
+
+    async def test_calls_ensure_started_when_gated_container(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        seen = {}
+
+        class _FakeProv:
+            def ensure_started(self, agent):
+                seen["agent"] = agent.name
+
+        monkeypatch.setattr(provisioning, "get_provisioner", lambda mode, **kw: _FakeProv())
+        await ss._ensure_container_started()
+        assert seen["agent"] == "dymok"


### PR DESCRIPTION
**Stacked on #657 → #656** — review/merge those first. I'll rebase onto `main` once the parents land.

## What

Wires the full container-isolation runtime **behind a default-OFF gate** (`PINKY_CONTAINER_RUNTIME`). With the gate off — i.e. everywhere today — behavior is **byte-for-byte unchanged** for `local`/`sdk` agents. Only when an operator sets the env on a (rootless-Podman) host does container mode engage.

Three commits:

1. **Gated factory + lifecycle methods** (`provisioning.py`) — `container_runtime_enabled()`/`container_runtime_binary()`; `get_provisioner('container')` flips from fail-closed to a real `ContainerProvisioner(binary=podman|docker)` only when gated (and threads `signing_key_provider` for provision/deprovision). Adds `start`/`stop`/`ensure_started` (idempotent provision-if-needed + `podman start`). `unix_user` untouched (still fail-closed — its own increment).
2. **Lifecycle hooks + transport guard** (`api.py`) — `provision`-on-register (rolls back the agent → 500 on failure), `deprovision`-on-retire (best-effort, **keeps the home volume** since retire preserves data), and a `transport='tmux'` requirement for container agents (the SDK/Codex backends don't go through the CommandRunner seam). No-op for `local`; skipped for dormant modes.
3. **Runner injection + cold-start hook** (`tmux_session.py`) — selects a `ContainerCommandRunner` (tmux + claude run *inside* the container via `podman exec`) and calls `ensure_started()` at the **top of `_spawn()`**, before the first exec. Gated + fail-safe on any registry error.

## Safety / dormancy
- Gate OFF (default) → `get_provisioner('container')` raises → the #642 respawn guard blocks container agents (501), register skips provision, and the tmux runner stays `LocalCommandRunner`. Zero prod behavior change.
- Verified via a 4-way adversarial review (which **caught a critical bug** — an earlier draft wedged the new methods mid-`__init__`, orphaning session init; fixed, and `test_tmux_session`'s 261 tests confirm).

## Deferred to host validation (gate is OFF until then — these are tracked in-code as explicit TODOs, not silent gaps)
The engaged runtime path can't run in CI (no Podman). The following must be finished + validated on the Podman host before flipping the gate in prod:
1. Bind-mount the agent's host `working_dir` → in-container workdir, and pass an **in-container** cwd to `tmux new-session -c` (today it's the host path).
2. In-container `.mcp.json` pointing at the daemon via `host.containers.internal` + the mounted key secret.
3. Seed the container's `~/.claude` trust file before first connect.

## Tests
- Gate on/off/binary-select/key-thread; `start`/`stop`/`ensure_started` shapes; provision-on-register + rollback-500 + deprovision-on-retire + transport-400 + gate-off-501; tmux runner selection + `ensure_started` no-op/gated paths — all via fakes/recording doubles, no real podman.
- Full backend suite green: **2751 passed**.

[Generated with Claude Code]