### PR TITLE
feat(#153): write-time KG ephemeral-entity guard + shared detector

### DIFF
--- a/scripts/kg_ephemeral_sweep.py
+++ b/scripts/kg_ephemeral_sweep.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Recurring ephemeral-node sweep for an agent's KG (#153 phase-2, step 1).
+
+The mitigation half of the #153 plan: the dream/extraction write-path keeps
+minting *pure-identifier* "entities" (bare PR/issue/task/release IDs, version
+stamps, owner/repo#NNN) that are point-in-time events, not durable graph
+nodes. Pass-1 (scripts/kg_hygiene.py) removed a hardcoded list of them once;
+this script generalizes that pass to PATTERNS so it can be cron'd to catch
+regrowth, and doubles as the instrument that measures the regrowth rate.
+
+The durable fix is the write-path GUARD (a separate, reviewed pinky-memory
+PR). This sweep is intentionally conservative and reversible — it is NOT the
+guard, and it does NOT attempt the judgment-heavy work (descriptive-ephemeral
+demotion, concept retyping, fuzzy dedup).
+
+Safety design (per Dymok's reliability review):
+  * Anchored, full-name patterns only — must match the ENTIRE entity name.
+    Misses (e.g. "PR #124 period foundation") are intentional: descriptive
+    nodes carry context and are out of scope. Miss-and-recatch > false-delete.
+  * Auto-backup of the DB file before any --apply that actually deletes.
+  * Every deleted entity AND every deleted edge is logged to a JSONL regrowth
+    log, so false positives are auditable and the rate is measurable.
+  * Dry-run by default (prints plan, rolls back). --apply commits.
+  * Fails safe: on a locked/busy DB it backs off and exits non-zero without
+    partial writes (single transaction).
+
+Usage:
+    python3 scripts/kg_ephemeral_sweep.py <memory.db> [--apply] [--log PATH]
+"""
+import json
+import os
+import shutil
+import sqlite3
+import sys
+from datetime import datetime, timezone
+
+# Detection logic lives in the package so the write-time guard
+# (src/pinky_memory/ephemeral_guard.py) and this sweep share ONE source of
+# truth and can never drift. Requires the pinky_memory package importable
+# (editable install / installed wheel), which is the case wherever the daemon
+# runs this cron.
+from pinky_memory.ephemeral_guard import is_ephemeral
+
+
+def find_candidates(conn):
+    rows = conn.execute("SELECT id, name, type FROM kg_entities").fetchall()
+    return [(eid, name, etype) for eid, name, etype in rows if is_ephemeral(name)]
+
+
+def edges_for(conn, name):
+    return conn.execute(
+        "SELECT id, subject, predicate, object, valid_to FROM kg_triples "
+        "WHERE subject = ? OR object = ?",
+        (name, name),
+    ).fetchall()
+
+
+def backup_db(db_path):
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H%M%S")
+    base = os.path.basename(db_path).replace(".db", "")
+    dest_dir = os.path.join("data", "backups", "kg", f"{ts}_sweep")
+    os.makedirs(dest_dir, exist_ok=True)
+    dest = os.path.join(dest_dir, f"{base}.db")
+    shutil.copy2(db_path, dest)
+    # WAL/SHM too, if present, so the copy is consistent on restore.
+    for ext in ("-wal", "-shm"):
+        if os.path.exists(db_path + ext):
+            shutil.copy2(db_path + ext, dest + ext)
+    return dest
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print(__doc__)
+        sys.exit(0 if len(sys.argv) >= 2 else 1)
+
+    db = sys.argv[1]
+    args = sys.argv[2:]
+    apply = "--apply" in args
+    log_path = "data/backups/kg/ephemeral_sweep_log.jsonl"
+    if "--log" in args:
+        log_path = args[args.index("--log") + 1]
+
+    if not os.path.exists(db):
+        print(f"ERROR: db not found: {db}")
+        sys.exit(2)
+
+    conn = sqlite3.connect(db, timeout=10)
+    conn.execute("PRAGMA busy_timeout = 8000")
+
+    candidates = find_candidates(conn)
+    deleted_edges = []
+    for _eid, name, _etype in candidates:
+        for tid, s, p, o, vt in edges_for(conn, name):
+            deleted_edges.append(
+                {"triple_id": tid, "subject": s, "predicate": p, "object": o,
+                 "active": vt is None, "via": name}
+            )
+
+    n_ent = len(candidates)
+    n_active_edges = sum(1 for e in deleted_edges if e["active"])
+    n_total_edges = len(deleted_edges)
+
+    print(f"db: {db}")
+    print(f"ephemeral pure-ID candidates: {n_ent}")
+    for _eid, name, etype in candidates:
+        ec = sum(1 for e in deleted_edges if e["via"] == name)
+        print(f"  - {name!r} (type={etype}, edges={ec})")
+    print(f"edges to remove: {n_total_edges} ({n_active_edges} active)")
+
+    backup_path = None
+    applied = False
+    if apply and n_ent:
+        backup_path = backup_db(db)
+        print(f"backup: {backup_path}")
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            for _eid, name, _etype in candidates:
+                conn.execute("DELETE FROM kg_triples WHERE subject = ? OR object = ?", (name, name))
+                conn.execute("DELETE FROM kg_entities WHERE name = ?", (name,))
+            conn.commit()
+            applied = True
+            print("APPLIED + committed.")
+        except sqlite3.OperationalError as e:
+            conn.rollback()
+            print(f"ABORTED (db busy/locked): {e}")
+            conn.close()
+            sys.exit(3)
+    elif apply:
+        print("nothing to apply (0 candidates).")
+    else:
+        print("DRY RUN — no changes.")
+
+    conn.close()
+
+    # Regrowth log: one JSONL record per run. n_candidates per run = regrowth
+    # since the previous sweep (the measurement Dymok asked for).
+    record = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "db": db,
+        "n_candidates": n_ent,
+        "candidates": [name for _e, name, _t in candidates],
+        "n_edges": n_total_edges,
+        "n_active_edges": n_active_edges,
+        "deleted_edges": deleted_edges if applied else [],
+        "applied": applied,
+        "backup": backup_path,
+    }
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    with open(log_path, "a") as f:
+        f.write(json.dumps(record) + "\n")
+    print(f"logged -> {log_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -551,7 +551,7 @@ class DreamRunner:
                 extractor._resolve_functional_conflict(t, result)
 
             try:
-                store.kg_add(
+                added = store.kg_add(
                     subject=t.subject,
                     predicate=t.predicate,
                     obj=t.object,
@@ -564,7 +564,15 @@ class DreamRunner:
                     temporal_granularity=t.temporal_granularity,
                     evidence_span=t.evidence_span,
                 )
-                count += 1
+                # Write-time guard (#153) may reject a pure-ID ephemeral; don't
+                # count a rejected triple as consolidated.
+                if added.get("rejected"):
+                    _log(
+                        f"dream-runner: KG insert skipped (ephemeral): "
+                        f"({t.subject}) --[{t.predicate}]--> ({t.object})"
+                    )
+                else:
+                    count += 1
             except Exception as e:
                 _log(
                     f"dream-runner: KG insert failed for "

--- a/src/pinky_memory/ephemeral_guard.py
+++ b/src/pinky_memory/ephemeral_guard.py
@@ -1,0 +1,108 @@
+"""Write-time ephemeral-entity guard for the knowledge graph (#153 phase-2).
+
+Single source of truth for detecting PURE-IDENTIFIER "entities" — bare tracker
+IDs and version stamps (``PR #635``, ``issue #501``, ``release 26.05.094``,
+``26.05.070``, ``bradbrok/PinkyBot#336``) that are point-in-time events, not
+durable graph nodes. The detection logic lifted here was soak-validated against
+barsik's live ~392-entity graph by ``scripts/kg_ephemeral_sweep.py``: 49 true
+positives, ZERO false positives.
+
+This module is the ROOT-CAUSE half of the #153 plan: ``store.kg_add`` calls
+``is_ephemeral_entity`` to reject these names at write time so they never enter
+the graph. The recurring sweep (``scripts/kg_ephemeral_sweep.py``) imports the
+SAME ``is_ephemeral`` from here, so the regex lives in exactly one place and the
+two halves can never drift.
+
+Design principles (hard constraints):
+  * Anchored FULL-NAME match only (``re.fullmatch``). "PR #124 period
+    foundation" is a DESCRIPTIVE node and MUST be kept — misses are intentional
+    (miss-and-recatch by the sweep beats a false-block at write time).
+  * Reversible + flag-gated: ``PINKY_KG_EPHEMERAL_GUARD`` env kill-switch,
+    read per-call so a daemon restart flips it with no code change.
+  * Every rejection is logged to JSONL (mirrors the sweep's regrowth log), and
+    a log-write failure must NEVER break a memory write.
+"""
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+# Verbatim from scripts/kg_ephemeral_sweep.py — each must match the WHOLE
+# normalized entity name. Deliberately tight: tracker IDs and release stamps
+# with no descriptive payload.
+EPHEMERAL_PATTERNS = [
+    r"PR\s*#\s*\d+",                       # PR #635
+    r"(?:issue|task)\s*#\s*\d+",           # issue #501, Task #70
+    r"release\s+\d[\w.]*",                 # release 26.05.094, Release 26.05.089
+    r"\d{2}\.\d{2}\.\d{3}",                # 26.05.070  (PinkyBot YY.MM.NNN stamp)
+    r"[\w.-]+/[\w.-]+#\d+",                # bradbrok/PinkyBot#336
+    r"[\w.-]+\s+(?:issue|PR)\s*#\s*\d+",   # tod-dashboard Issue #66, GitHub issue #567
+    r"PinkyBot\s+#\d+(?:-\d+)?",           # PinkyBot #472-479
+    r"PinkyBot\s+\d{2}\.\d{2}\.\d{3}",     # PinkyBot 26.05.093
+]
+_RX = re.compile(
+    "(?:%s)" % "|".join(f"(?:{p})" for p in EPHEMERAL_PATTERNS),
+    re.IGNORECASE,
+)
+
+# Default ON: the patterns are production-soak-validated (49 TP / 0 FP). Shipping
+# off-by-default would just let the sweep keep deleting regrowth the guard could
+# have stopped at the door. The env kill-switch gives instant reversibility.
+EPHEMERAL_GUARD_DEFAULT = True
+
+
+def _normalize(name: str) -> str:
+    """Canonicalize a name the same way kg_extractor.normalize_entity_name does:
+    strip + collapse internal whitespace. Inlined (not imported) to keep this
+    module dependency-free and avoid a store -> kg_extractor import edge."""
+    return re.sub(r"\s+", " ", (name or "").strip())
+
+
+def is_ephemeral_entity(name: str) -> bool:
+    """True iff the entire normalized name is a pure-ID / version-stamp ephemeral."""
+    return bool(_RX.fullmatch(_normalize(name)))
+
+
+# Back-compat alias so scripts/kg_ephemeral_sweep.py's import is a drop-in.
+is_ephemeral = is_ephemeral_entity
+
+
+def guard_enabled() -> bool:
+    """Whether the write-time guard is active. Read per-call so flipping the env
+    var + restarting the MCP reverts behavior with no code change."""
+    v = os.environ.get("PINKY_KG_EPHEMERAL_GUARD")
+    if v is None:
+        return EPHEMERAL_GUARD_DEFAULT
+    return v.strip().lower() not in ("0", "false", "off", "no")
+
+
+def log_rejection(db_path, *, role, name, subject, predicate, obj, source):
+    """Append one JSONL record per write-time rejection. Mirrors the sweep's log
+    so the write-time counterpart and the regrowth log together measure
+    before/after. A log-write failure degrades to a warning — it must never
+    break the memory write that triggered it."""
+    rec = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": "write_rejected",
+        "db": db_path,
+        "role": role,
+        "name": name,
+        "subject": subject,
+        "predicate": predicate,
+        "object": obj,
+        "source": source,
+        "reason": "ephemeral_entity",
+    }
+    path = os.environ.get("PINKY_KG_EPHEMERAL_GUARD_LOG") or os.path.join(
+        os.path.dirname(db_path) or ".", "ephemeral_guard_log.jsonl"
+    )
+    try:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "a") as f:
+            f.write(json.dumps(rec) + "\n")
+    except Exception as e:  # pragma: no cover - defensive; log path may be unwritable
+        logger.warning("ephemeral guard log write failed (%s); rejection still applied", e)
+    logger.info("kg_add rejected ephemeral entity %r (role=%s, source=%s)", name, role, source)

--- a/src/pinky_memory/kg_extractor.py
+++ b/src/pinky_memory/kg_extractor.py
@@ -392,7 +392,17 @@ class KGExtractor:
                     temporal_granularity=t.temporal_granularity,
                     evidence_span=t.evidence_span,
                 )
-                result.triples_added.append(added)
+                # Write-time guard (#153) may reject a pure-ID ephemeral; route
+                # it to skipped (with evidence_span) rather than counting it added.
+                if added.get("rejected"):
+                    result.triples_skipped.append({
+                        "subject": t.subject, "predicate": t.predicate,
+                        "object": t.object,
+                        "reason": f"ephemeral entity ({added.get('reason')})",
+                        "evidence_span": t.evidence_span,
+                    })
+                else:
+                    result.triples_added.append(added)
             except Exception as e:
                 result.errors.append(
                     f"insert failed for ({t.subject}, {t.predicate}, {t.object}): {e}"

--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -421,8 +421,9 @@ def create_server(
                 object_type=object_type, confidence=confidence,
                 source_reflection_id=source_reflection_id,
             )
+            _rej = " REJECTED (ephemeral)" if isinstance(result, dict) and result.get("rejected") else ""
             _log(
-                f"kg_add_for: caller={caller} -> target={target_agent} "
+                f"kg_add_for{_rej}: caller={caller} -> target={target_agent} "
                 f"({subject}) --[{predicate}]--> ({object})"
             )
             if isinstance(result, dict):
@@ -657,7 +658,10 @@ def create_server(
             object_type=object_type, confidence=confidence,
             source_reflection_id=source_reflection_id,
         )
-        _log(f"kg_add: ({subject}) --[{predicate}]--> ({object})")
+        if isinstance(result, dict) and result.get("rejected"):
+            _log(f"kg_add REJECTED (ephemeral): ({subject}) --[{predicate}]--> ({object})")
+        else:
+            _log(f"kg_add: ({subject}) --[{predicate}]--> ({object})")
         return json.dumps(result)
 
     @mcp.tool()

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -13,6 +13,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from pinky_memory.ephemeral_guard import (
+    guard_enabled,
+    is_ephemeral_entity,
+    log_rejection,
+)
 from pinky_memory.types import (
     MemoryQueryFilters,
     Reflection,
@@ -2431,8 +2436,34 @@ class ReflectionStore:
         temporal_granularity: str = "none",
         evidence_span: str = "",
     ) -> dict:
-        """Add a triple to the knowledge graph. Auto-creates entities."""
+        """Add a triple to the knowledge graph. Auto-creates entities.
+
+        Write-time ephemeral guard (#153): if either endpoint is a pure-ID /
+        version-stamp ephemeral (PR/issue/release/task IDs, YY.MM.NNN stamps),
+        the whole triple is rejected before either entity is minted — no orphan
+        entity row, no orphan edge. Returns a rejection sentinel (same key shape
+        as success, with ``rejected=True``) so callers never KeyError. Gated by
+        ``PINKY_KG_EPHEMERAL_GUARD`` (default on, read per-call).
+        """
         import time
+        if guard_enabled():
+            bad_role = (
+                "subject" if is_ephemeral_entity(subject)
+                else "object" if is_ephemeral_entity(obj)
+                else None
+            )
+            if bad_role:
+                name = subject if bad_role == "subject" else obj
+                log_rejection(
+                    self._db_path, role=bad_role, name=name,
+                    subject=subject, predicate=predicate, obj=obj, source="kg_add",
+                )
+                return {
+                    "id": None, "subject": subject, "predicate": predicate,
+                    "object": obj, "valid_from": None,
+                    "extraction_method": "rejected",
+                    "rejected": True, "reason": "ephemeral_entity",
+                }
         self._ensure_entity(subject, subject_type)
         self._ensure_entity(obj, object_type)
         tid = _generate_id()

--- a/tests/test_kg_ephemeral_guard.py
+++ b/tests/test_kg_ephemeral_guard.py
@@ -1,0 +1,204 @@
+"""Tests for the write-time KG ephemeral-entity guard (#153 step-2).
+
+Covers the shared detector (pure), the store choke-point, the MCP tool path,
+the extractor rejection-routing, the flag kill-switch, and rejection logging.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pinky_memory.embeddings import NoOpEmbeddingClient
+from pinky_memory.ephemeral_guard import (
+    guard_enabled,
+    is_ephemeral,
+    is_ephemeral_entity,
+)
+from pinky_memory.kg_extractor import KGExtractor
+from pinky_memory.server import create_server
+from pinky_memory.store import ReflectionStore
+
+
+def _tools(srv):
+    return {t.name: t.fn for t in srv._tool_manager.list_tools()}
+
+
+def _entity_exists(store, name) -> bool:
+    row = store._conn.execute(
+        "SELECT 1 FROM kg_entities WHERE name = ?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+@pytest.fixture(autouse=True)
+def _clean_guard_env(monkeypatch):
+    """Start every test with the guard at its default (ON) and the default log
+    path (next to the temp db), so ambient env can't leak between tests."""
+    monkeypatch.delenv("PINKY_KG_EPHEMERAL_GUARD", raising=False)
+    monkeypatch.delenv("PINKY_KG_EPHEMERAL_GUARD_LOG", raising=False)
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = ReflectionStore(db_path=str(tmp_path / "mem.db"))
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def srv(store):
+    return create_server(store, NoOpEmbeddingClient())
+
+
+# Pure-ID / version-stamp ephemerals — MUST be caught.
+EPHEMERAL_POSITIVES = [
+    "PR #635", "issue #501", "task #70", "release 26.05.094", "26.05.070",
+    "bradbrok/PinkyBot#336", "tod-dashboard Issue #66", "PinkyBot #472-479",
+    "PinkyBot 26.05.093", "Release 26.05.089",
+]
+# Legit named/descriptive entities — MUST pass (intentional misses).
+LEGIT_NEGATIVES = [
+    "PR #124 period foundation", "Codex CLI 0.125.0", "Claude Code", "PinkyBot",
+    "tod-dashboard Issue #66 follow-up", "Brad", "SQLite", "Python 3.12",
+    "Postgres 13.0",
+]
+
+
+class TestIsEphemeralEntity:
+    @pytest.mark.parametrize("name", EPHEMERAL_POSITIVES)
+    def test_positives(self, name):
+        assert is_ephemeral_entity(name) is True
+
+    @pytest.mark.parametrize("name", LEGIT_NEGATIVES)
+    def test_false_positive_guards(self, name):
+        assert is_ephemeral_entity(name) is False
+
+    @pytest.mark.parametrize("name", ["  PR #635  ", "pr #635", "PR#635", "Release 26.05.089"])
+    def test_whitespace_and_case(self, name):
+        assert is_ephemeral_entity(name) is True
+
+    def test_empty_and_none(self):
+        assert is_ephemeral_entity("") is False
+        assert is_ephemeral_entity(None) is False
+
+    def test_sweep_import_parity(self):
+        # scripts/kg_ephemeral_sweep.py imports `is_ephemeral`; it MUST be the
+        # exact same object so the guard and sweep can never drift.
+        assert is_ephemeral is is_ephemeral_entity
+
+
+class TestGuardEnabled:
+    @pytest.mark.parametrize("val", ["0", "false", "off", "no", "FALSE", "Off"])
+    def test_disabled(self, val, monkeypatch):
+        monkeypatch.setenv("PINKY_KG_EPHEMERAL_GUARD", val)
+        assert guard_enabled() is False
+
+    @pytest.mark.parametrize("val", ["1", "true", "on", "yes"])
+    def test_enabled(self, val, monkeypatch):
+        monkeypatch.setenv("PINKY_KG_EPHEMERAL_GUARD", val)
+        assert guard_enabled() is True
+
+    def test_default_enabled(self):
+        assert guard_enabled() is True
+
+
+class TestStoreGuard:
+    def test_rejects_ephemeral_subject(self, store):
+        result = store.kg_add(subject="PR #635", predicate="relates_to", obj="feature")
+        assert result["rejected"] is True
+        assert result["id"] is None
+        # No triple and no orphan entity for either endpoint.
+        assert store.kg_query(entity="PR #635") == []
+        assert store.kg_query(entity="feature") == []
+        assert not _entity_exists(store, "PR #635")
+        assert not _entity_exists(store, "feature")
+
+    def test_rejects_ephemeral_object(self, store):
+        result = store.kg_add(subject="Brad", predicate="filed", obj="issue #501")
+        assert result["rejected"] is True
+        # Guard returns before _ensure_entity, so the legit subject is also
+        # never minted — the whole triple is rejected atomically.
+        assert not _entity_exists(store, "issue #501")
+        assert not _entity_exists(store, "Brad")
+
+    def test_allows_legit(self, store):
+        result = store.kg_add(subject="Brad", predicate="uses", obj="SQLite")
+        assert result.get("rejected") is not True
+        assert result["id"] is not None
+        assert len(store.kg_query(entity="Brad")) == 1
+
+    def test_allows_descriptive(self, store):
+        # Anchored fullmatch: any descriptive payload defeats the pattern.
+        result = store.kg_add(
+            subject="PR #124 period foundation", predicate="status", obj="merged"
+        )
+        assert result.get("rejected") is not True
+        assert len(store.kg_query(entity="PR #124 period foundation")) == 1
+
+    def test_rejection_dict_shape(self, store):
+        result = store.kg_add(subject="PR #635", predicate="x", obj="y")
+        for key in ("id", "subject", "predicate", "object", "valid_from", "extraction_method"):
+            assert key in result, f"missing success-shape key: {key}"
+        assert result["rejected"] is True
+        assert result["reason"] == "ephemeral_entity"
+        assert result["extraction_method"] == "rejected"
+
+    def test_flag_off_allows(self, store, monkeypatch):
+        monkeypatch.setenv("PINKY_KG_EPHEMERAL_GUARD", "0")
+        result = store.kg_add(subject="PR #635", predicate="relates_to", obj="feature")
+        assert result.get("rejected") is not True
+        assert result["id"] is not None
+        assert len(store.kg_query(entity="PR #635")) == 1
+
+
+class TestMcpKgAddGuard:
+    def test_mcp_kg_add_rejects(self, srv):
+        result = json.loads(_tools(srv)["kg_add"](subject="PR #635", predicate="x", object="y"))
+        assert result["rejected"] is True
+
+    def test_mcp_kg_add_allows(self, srv):
+        result = json.loads(
+            _tools(srv)["kg_add"](subject="Brad", predicate="uses", object="SQLite")
+        )
+        assert result.get("rejected") is not True
+        assert result["id"] is not None
+
+
+class TestExtractorGuard:
+    def test_ephemeral_routed_to_skipped(self, store):
+        llm_response = json.dumps([{
+            "subject": "PR #700", "predicate": "relates_to", "object": "feature x",
+            "confidence": 0.9, "evidence_span": "PR #700 relates to feature x",
+        }])
+        extractor = KGExtractor(store=store, llm_caller=lambda p: llm_response)
+        result = extractor.extract_from_reflection("ref1", "PR #700 relates to feature x")
+        assert result.total_added == 0
+        assert any("ephemeral" in s.get("reason", "") for s in result.triples_skipped)
+        # Nothing reached the real store.
+        assert store.kg_query(entity="PR #700") == []
+        assert not _entity_exists(store, "PR #700")
+
+
+class TestRejectionLogging:
+    def test_rejection_logged(self, store, tmp_path, monkeypatch):
+        log_path = tmp_path / "guard.jsonl"
+        monkeypatch.setenv("PINKY_KG_EPHEMERAL_GUARD_LOG", str(log_path))
+        store.kg_add(subject="PR #635", predicate="relates_to", obj="feature")
+        lines = log_path.read_text().strip().splitlines()
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["event"] == "write_rejected"
+        assert rec["role"] == "subject"
+        assert rec["name"] == "PR #635"
+        assert rec["source"] == "kg_add"
+        assert rec["reason"] == "ephemeral_entity"
+
+    def test_log_failure_does_not_break_write(self, store, tmp_path, monkeypatch):
+        # Parent of the log dir is a regular file -> makedirs/open raise; the
+        # rejection must still apply and kg_add must not propagate the error.
+        a_file = tmp_path / "afile"
+        a_file.write_text("x")
+        monkeypatch.setenv("PINKY_KG_EPHEMERAL_GUARD_LOG", str(a_file / "sub" / "g.jsonl"))
+        result = store.kg_add(subject="PR #635", predicate="x", obj="y")
+        assert result["rejected"] is True


### PR DESCRIPTION
## What & why

Root-cause half of **#153 step-2** (KG data hygiene). The dream/extraction write-path keeps minting pure-identifier "entities" — bare tracker IDs and version stamps (`PR #635`, `issue #501`, `release 26.05.094`, `26.05.070`, `bradbrok/PinkyBot#336`) that are point-in-time *events*, not durable graph nodes. The cron'd sweep (`scripts/kg_ephemeral_sweep.py`) deletes regrowth as a band-aid. **This guard stops them at write time**, so the sweep eventually catches nothing.

## Approach

- **New `src/pinky_memory/ephemeral_guard.py`** — single source of truth for detection: anchored `re.fullmatch` over 8 patterns soak-validated against the live graph (**49 true positives / 0 false positives**), plus `guard_enabled()` (env kill-switch) and `log_rejection()` (JSONL).
- **`store.kg_add`** rejects an ephemeral endpoint *before* `_ensure_entity` — the single atomic choke-point every write funnels through, so a rejection leaves **no orphan entity row and no orphan edge**. Returns a rejection sentinel in the **success-key shape** (`id=None, …, rejected=True`) so no caller `KeyError`s.
- **All four `kg_add` callers** handle the sentinel: `kg_extractor` → `triples_skipped`; `dream_runner` → don't count as consolidated; `server.kg_add` + `kg_add_for` → log as rejected, not success.
  - ⚠️ The `dream_runner` caller (`src/pinky_daemon/dream_runner.py`) was **missed by the initial design** (a reviewer flagged it but searched the wrong package and it was wrongly dismissed as a phantom file). Caught during implementation by grepping every caller in `src/`.
- **`scripts/kg_ephemeral_sweep.py`** now imports `is_ephemeral` from the shared module — the regex lives in exactly one place and the guard/sweep can't drift. (Brought under version control here; it's the recurring mitigation that pairs with the guard.)

## Safety / reversibility

- Flag-gated `PINKY_KG_EPHEMERAL_GUARD` (default **on**), read **per-call** → flip to `0` + restart the MCP fully reverts with no code change. Log path override: `PINKY_KG_EPHEMERAL_GUARD_LOG`.
- **Write-time only** — never deletes or mutates existing data. Worst case a bad pattern blocks a *new* write; observable within minutes via the rejection JSONL, instantly reversible via the kill-switch.
- Anchored `fullmatch` makes false-blocks structurally hard: any descriptive payload defeats the match (`PR #124 period foundation`, `Codex CLI 0.125.0`, `Claude Code` all pass).
- Log writes are defensively wrapped — a log-write failure can never break a memory write.
- Intentionally **uncovered**: raw SQL backfill/restore (bypasses `kg_add`); the cron sweep remains the standing net there.

## Current regrowth data

Measured against the live graph just now: **0 ephemeral regrowth** in the ~16h since pass-1 hygiene (entity count 335 → 338; the +3 are legit, not pure-ID). So there's **no fire** — this is a *preventive* root-cause fix justified by the historical accumulation (49 ephemerals had built up over time), not an emergency.

## Tests

`tests/test_kg_ephemeral_guard.py` — **47 tests**: detector positives/negatives + whitespace/case, `guard_enabled` matrix, store choke-point (reject subject/object with no-orphan assertions, allow legit, allow descriptive, rejection-dict shape, flag-off), MCP tool path, extractor rejection-routing, logging + log-failure resilience, and sweep import parity (`is_ephemeral is is_ephemeral_entity`). Full memory/dream surface: **301 passed, 0 regressions**. `ruff` clean.

## Not merging unilaterally

This touches the live memory write path, so it's up for review rather than a solo merge. Default-on means a release deploys the guard active; happy to ship behind `PINKY_KG_EPHEMERAL_GUARD=0` for a soak first if you'd prefer.

🤖 Opened by Barsik · Generated with [Claude Code](https://claude.com/claude-code)
