### PR TITLE
feat(#638): per-agent container isolation — engaged runtime, fleet-deploy ready (consolidates #656/#657/#658)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Personal AI companion framework powered by Claude Code. Manages persistent AI ag
 - **Streaming Session** — Long-lived Claude Agent SDK session per agent; messages routed through broker
 - **Skills** — SKILL.md-based capability plugins assigned per agent; contribute directives and MCP servers
 - **Directives** — Priority-ordered instructions injected into system prompt
+- **Container isolation** — Opt-in per-agent rootless Podman sandbox (`isolation_mode="container"` + `container_image`, gated by `PINKY_CONTAINER_RUNTIME` on the host); see `specs/container-isolation.md`
 
 ## Running
 

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -205,6 +205,7 @@
     let wizTransportUserSet = false;  // tracks whether user manually changed the toggle (suppresses auto-default)
     let wizIsolation = 'local';       // 'local' | 'container' — agent isolation mode
     let wizContainerImage = '';       // OCI image ref, required when isolation is 'container'
+    let wizIsolationHint = '';        // transient notice when isolation/transport are auto-reconciled
     let wizCustomSoul = '';
     let wizTelegramToken = '';
     let wizDiscordToken = '';
@@ -427,9 +428,18 @@
      * Persist an agent's isolation settings ('local' | 'container').
      * Saved immediately (same pattern as the transport toggle); like
      * transport, the agent must be stopped and re-started to take effect.
-     * Container mode requires a container image ref.
+     * Container mode requires a container image ref, and the daemon rejects
+     * container + non-tmux spawns, so container mode also requires transport=tmux.
      */
     async function saveAgentIsolation(agentName, mode, image) {
+        if (mode === 'container') {
+            const agent = agentList.find(a => a.name === agentName);
+            if (((agent && agent.transport) || 'sdk').toLowerCase() !== 'tmux') {
+                toast('Container isolation requires the tmux transport. Switch transport to tmux first.', 'error');
+                detailIsolationMode = 'local'; // snap the select back; nothing was saved
+                return;
+            }
+        }
         const img = (image || '').trim();
         if (mode === 'container' && !img) {
             toast('Container image is required for container isolation', 'error');
@@ -986,7 +996,7 @@
 
     // Wizard
     let wizPronouns = '';
-    function openWizard() { wizStep = -1; importMode = false; importStep = 1; importFiles = { workspace: null, config: null, lock: null }; importDirPath = ''; importParseId = null; importPreview = null; importLoading = false; importTaskId = null; importProgress = { total: 0, imported: 0, failed: 0, done: false }; importDragover = false; importError = null; importAgentName = null; if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizName = ''; wizDisplayName = ''; wizPronouns = ''; wizModel = 'claude-opus-4-6'; wizProviderRef = ''; wizCustomProvider = false; wizProviderPreset = 'anthropic'; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; wizMode = 'bypassPermissions'; wizHeart = 'sidekick'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizThinkingEffort = 'medium'; wizShowAdvanced = false; wizMaxTurns = 0; wizTimeout = 300; wizMaxSessions = 5; wizPlainTextFallback = false; wizTransport = 'tmux'; wizTransportUserSet = false; wizIsolation = 'local'; wizContainerImage = ''; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; globalProviders = []; api('GET', '/providers').then(d => { globalProviders = d || []; }).catch(() => { globalProviders = []; }); wizardOpen = true; }
+    function openWizard() { wizStep = -1; importMode = false; importStep = 1; importFiles = { workspace: null, config: null, lock: null }; importDirPath = ''; importParseId = null; importPreview = null; importLoading = false; importTaskId = null; importProgress = { total: 0, imported: 0, failed: 0, done: false }; importDragover = false; importError = null; importAgentName = null; if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizName = ''; wizDisplayName = ''; wizPronouns = ''; wizModel = 'claude-opus-4-6'; wizProviderRef = ''; wizCustomProvider = false; wizProviderPreset = 'anthropic'; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; wizMode = 'bypassPermissions'; wizHeart = 'sidekick'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizThinkingEffort = 'medium'; wizShowAdvanced = false; wizMaxTurns = 0; wizTimeout = 300; wizMaxSessions = 5; wizPlainTextFallback = false; wizTransport = 'tmux'; wizTransportUserSet = false; wizIsolation = 'local'; wizContainerImage = ''; wizIsolationHint = ''; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; globalProviders = []; api('GET', '/providers').then(d => { globalProviders = d || []; }).catch(() => { globalProviders = []; }); wizardOpen = true; }
     function closeWizard() { if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizardOpen = false; }
 
     // Import (OpenClaw migration) helpers
@@ -1157,6 +1167,15 @@
         // tmux default — otherwise the override would be sticky across provider flips.
         wizTransport = 'sdk';
         wizTransportUserSet = false;
+    }
+
+    // Container isolation only runs through the tmux transport (the daemon rejects
+    // container + non-tmux spawns with a 400). If the effective transport stops being
+    // tmux while container is selected (SDK clicked, or provider flipped non-Anthropic),
+    // snap isolation back to local so the POST payload can never be container+non-tmux.
+    $: if (wizIsolation === 'container' && (wizIsAnthropic ? wizTransport : 'sdk') !== 'tmux') {
+        wizIsolation = 'local';
+        wizIsolationHint = 'Container isolation requires the tmux transport - switched back to local.';
     }
 
     async function loadModels() {
@@ -2667,11 +2686,23 @@
                                 </div>
                                 <div>
                                     <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">Isolation</div>
-                                    <select class="wizard-input" style="margin:0" bind:value={wizIsolation}>
+                                    <select class="wizard-input" style="margin:0" bind:value={wizIsolation}
+                                            on:change={() => {
+                                                if (wizIsolation === 'container' && wizTransport !== 'tmux') {
+                                                    wizTransport = 'tmux';
+                                                    wizTransportUserSet = true;
+                                                    wizIsolationHint = 'Container isolation requires the tmux transport - switched automatically.';
+                                                } else {
+                                                    wizIsolationHint = '';
+                                                }
+                                            }}>
                                         <option value="local">Local (runs on daemon host)</option>
-                                        <option value="container">Container (per-agent container)</option>
+                                        <option value="container" disabled={!wizIsAnthropic}>Container (per-agent container)</option>
                                     </select>
                                     <div style="font-size:0.7rem;color:var(--gray-mid);margin-top:0.3rem">Container mode requires the container runtime enabled on the daemon host (PINKY_CONTAINER_RUNTIME); the image must provide tmux, claude, python3.</div>
+                                    {#if wizIsolationHint}
+                                        <div style="font-size:0.7rem;color:var(--yellow);margin-top:0.3rem">{wizIsolationHint}</div>
+                                    {/if}
                                     {#if wizIsolation === 'container'}
                                         <input type="text" class="wizard-input" style="margin:0.5rem 0 0" bind:value={wizContainerImage} placeholder="registry/image:tag" autocomplete="off" spellcheck="false">
                                     {/if}

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -104,6 +104,8 @@
     let providerDirty = false;
     let thinkingEffort = 'medium';
     let thinkingEffortDirty = false;
+    let detailIsolationMode = 'local';   // 'local' | 'container' — detail Runtime tab editor state
+    let detailContainerImage = '';       // OCI image ref shown/edited in the detail Runtime tab
     let globalProviders = [];
     let modelRegistry = [];
     $: anthropicModels = modelRegistry.filter(m => m.provider === 'anthropic');
@@ -201,6 +203,8 @@
     let wizPlainTextFallback = false;
     let wizTransport = 'tmux';        // 'tmux' | 'sdk' — defaults to tmux for Anthropic, sdk for others
     let wizTransportUserSet = false;  // tracks whether user manually changed the toggle (suppresses auto-default)
+    let wizIsolation = 'local';       // 'local' | 'container' — agent isolation mode
+    let wizContainerImage = '';       // OCI image ref, required when isolation is 'container'
     let wizCustomSoul = '';
     let wizTelegramToken = '';
     let wizDiscordToken = '';
@@ -419,6 +423,30 @@
         }
     }
 
+    /**
+     * Persist an agent's isolation settings ('local' | 'container').
+     * Saved immediately (same pattern as the transport toggle); like
+     * transport, the agent must be stopped and re-started to take effect.
+     * Container mode requires a container image ref.
+     */
+    async function saveAgentIsolation(agentName, mode, image) {
+        const img = (image || '').trim();
+        if (mode === 'container' && !img) {
+            toast('Container image is required for container isolation', 'error');
+            return;
+        }
+        try {
+            const payload = mode === 'container'
+                ? { isolation_mode: 'container', container_image: img }
+                : { isolation_mode: 'local' };
+            await api('PUT', `/agents/${agentName}`, payload);
+            toast(`Isolation → ${mode.toUpperCase()} (stop and restart agent to apply)`);
+            refreshAgents();
+        } catch (e) {
+            toast('Failed to update isolation: ' + (e?.message || e), 'error');
+        }
+    }
+
     function openChat(id) {
         window.location.hash = `/chat#${id}`;
     }
@@ -529,6 +557,8 @@
             providerDirty = false;
             thinkingEffort = agent.thinking_effort || 'medium';
             thinkingEffortDirty = false;
+            detailIsolationMode = (agent.isolation_mode || 'local').toLowerCase();
+            detailContainerImage = agent.container_image || '';
             globalProviders = await api('GET', '/providers').catch(() => []);
             globalBotTokens = await api('GET', '/bot-tokens').catch(() => []);
             if (req !== openDetailSeq) return;
@@ -956,7 +986,7 @@
 
     // Wizard
     let wizPronouns = '';
-    function openWizard() { wizStep = -1; importMode = false; importStep = 1; importFiles = { workspace: null, config: null, lock: null }; importDirPath = ''; importParseId = null; importPreview = null; importLoading = false; importTaskId = null; importProgress = { total: 0, imported: 0, failed: 0, done: false }; importDragover = false; importError = null; importAgentName = null; if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizName = ''; wizDisplayName = ''; wizPronouns = ''; wizModel = 'claude-opus-4-6'; wizProviderRef = ''; wizCustomProvider = false; wizProviderPreset = 'anthropic'; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; wizMode = 'bypassPermissions'; wizHeart = 'sidekick'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizThinkingEffort = 'medium'; wizShowAdvanced = false; wizMaxTurns = 0; wizTimeout = 300; wizMaxSessions = 5; wizPlainTextFallback = false; wizTransport = 'tmux'; wizTransportUserSet = false; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; globalProviders = []; api('GET', '/providers').then(d => { globalProviders = d || []; }).catch(() => { globalProviders = []; }); wizardOpen = true; }
+    function openWizard() { wizStep = -1; importMode = false; importStep = 1; importFiles = { workspace: null, config: null, lock: null }; importDirPath = ''; importParseId = null; importPreview = null; importLoading = false; importTaskId = null; importProgress = { total: 0, imported: 0, failed: 0, done: false }; importDragover = false; importError = null; importAgentName = null; if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizName = ''; wizDisplayName = ''; wizPronouns = ''; wizModel = 'claude-opus-4-6'; wizProviderRef = ''; wizCustomProvider = false; wizProviderPreset = 'anthropic'; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; wizMode = 'bypassPermissions'; wizHeart = 'sidekick'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizThinkingEffort = 'medium'; wizShowAdvanced = false; wizMaxTurns = 0; wizTimeout = 300; wizMaxSessions = 5; wizPlainTextFallback = false; wizTransport = 'tmux'; wizTransportUserSet = false; wizIsolation = 'local'; wizContainerImage = ''; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; globalProviders = []; api('GET', '/providers').then(d => { globalProviders = d || []; }).catch(() => { globalProviders = []; }); wizardOpen = true; }
     function closeWizard() { if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizardOpen = false; }
 
     // Import (OpenClaw migration) helpers
@@ -1058,6 +1088,7 @@
         }
         if (wizStep < wizTotalSteps - 1) { wizStep++; return; }
         // Summon!
+        if (wizIsolation === 'container' && !wizContainerImage.trim()) { toast('Container image is required for container isolation', 'error'); return; }
         if (summoning) return;
         summoning = true;
         try {
@@ -1078,7 +1109,7 @@
             // Runtime selection: codex_cli runtime when Codex is picked, else claude_sdk.
             // Custom Anthropic-compatible providers still use claude_sdk (provider_url overrides at SDK level).
             const registerRuntime = wizProviderUrl === 'codex_cli' ? 'codex_cli' : 'claude_sdk';
-            await api('POST', '/agents', { name: wizName, display_name: wizDisplayName, model: registerModel, permission_mode: wizMode, soul, role: wizRole, auto_start: wizAutoStart, heartbeat_interval: wizHeartbeatInterval, thinking_effort: wizThinkingEffort, max_turns: wizMaxTurns, timeout: wizTimeout, max_sessions: wizMaxSessions, plain_text_fallback: wizPlainTextFallback, runtime: registerRuntime, transport: wizIsAnthropic ? wizTransport : 'sdk' });
+            await api('POST', '/agents', { name: wizName, display_name: wizDisplayName, model: registerModel, permission_mode: wizMode, soul, role: wizRole, auto_start: wizAutoStart, heartbeat_interval: wizHeartbeatInterval, thinking_effort: wizThinkingEffort, max_turns: wizMaxTurns, timeout: wizTimeout, max_sessions: wizMaxSessions, plain_text_fallback: wizPlainTextFallback, runtime: registerRuntime, transport: wizIsAnthropic ? wizTransport : 'sdk', isolation_mode: wizIsolation, container_image: wizIsolation === 'container' ? wizContainerImage.trim() : '' });
             // Apply provider config if a global provider, custom endpoint, or Codex was selected
             if (wizProviderRef || wizCustomProvider || wizProviderUrl === 'codex_cli') {
                 await api('PUT', `/agents/${wizName}/provider`, {
@@ -2120,6 +2151,27 @@
                 </button>
             </div>
 
+            <!-- Isolation -->
+            <SectionHeader title="Isolation" variant="detail" style="margin-top:0.5rem" />
+            <div class="token-item">
+                <select class="form-select" bind:value={detailIsolationMode}
+                        title="Where the agent's Claude process runs"
+                        on:change={() => { if (detailIsolationMode === 'local' || detailContainerImage.trim()) saveAgentIsolation(currentAgent, detailIsolationMode, detailContainerImage); }}>
+                    <option value="local">LOCAL</option>
+                    <option value="container">CONTAINER</option>
+                </select>
+                {#if detailIsolationMode === 'container'}
+                    <input type="text" class="form-input" style="flex:1;min-width:180px"
+                           bind:value={detailContainerImage} placeholder="registry/image:tag"
+                           autocomplete="off" spellcheck="false"
+                           on:change={() => { if (detailContainerImage.trim()) saveAgentIsolation(currentAgent, 'container', detailContainerImage); }}>
+                {:else}
+                    <span style="flex:1"></span>
+                {/if}
+                <span style="font-size:0.7rem;color:var(--gray-mid)">stop &amp; restart agent to apply</span>
+            </div>
+            <div style="font-size:0.7rem;color:var(--gray-mid);margin:0.3rem 0 0.5rem">Container mode requires the container runtime enabled on the daemon host (PINKY_CONTAINER_RUNTIME); the image must provide tmux, claude, python3.</div>
+
             <!-- Live Sessions (formerly Streaming Sessions) -->
             <SectionHeader title={$_('agents.live_sessions')} variant="detail" style="margin-top:0.5rem">
                 <button slot="actions" class="btn btn-sm btn-primary" on:click={createStreamingSession}>+ {$_('agents.session')}</button>
@@ -2613,6 +2665,17 @@
                                         <div style="font-size:0.7rem;color:var(--gray-mid);margin-top:0.3rem">Tmux is only available with Anthropic models (claude_sdk runtime).</div>
                                     {/if}
                                 </div>
+                                <div>
+                                    <div style="font-family:var(--font-grotesk);font-size:0.7rem;color:var(--gray-mid);text-transform:uppercase;margin-bottom:0.3rem">Isolation</div>
+                                    <select class="wizard-input" style="margin:0" bind:value={wizIsolation}>
+                                        <option value="local">Local (runs on daemon host)</option>
+                                        <option value="container">Container (per-agent container)</option>
+                                    </select>
+                                    <div style="font-size:0.7rem;color:var(--gray-mid);margin-top:0.3rem">Container mode requires the container runtime enabled on the daemon host (PINKY_CONTAINER_RUNTIME); the image must provide tmux, claude, python3.</div>
+                                    {#if wizIsolation === 'container'}
+                                        <input type="text" class="wizard-input" style="margin:0.5rem 0 0" bind:value={wizContainerImage} placeholder="registry/image:tag" autocomplete="off" spellcheck="false">
+                                    {/if}
+                                </div>
                             </div>
                             {/if}
                         </div>
@@ -2670,6 +2733,9 @@
                             Heartbeat: <span class="val">{wizHeartbeatInterval ? wizHeartbeatInterval + 's' : 'Disabled'}</span><br>
                             Outreach: <span class="val">{wizSummaryPlatforms.length ? wizSummaryPlatforms.join(', ') : 'None (local only)'}</span>
                             <br>Transport: <span class="val">{(wizIsAnthropic ? wizTransport : 'sdk').toUpperCase()}</span>
+                            {#if wizIsolation === 'container'}
+                            <br>Isolation: <span class="val">CONTAINER ({wizContainerImage || 'no image'})</span>
+                            {/if}
                             {#if wizThinkingEffort !== 'medium'}
                             <br>Effort: <span class="val">{wizThinkingEffort.toUpperCase()}</span>
                             {/if}

--- a/specs/container-isolation.md
+++ b/specs/container-isolation.md
@@ -1,0 +1,127 @@
+# Container isolation (per-agent rootless Podman)
+
+Phase-3 of #149 / #638: each opted-in agent runs its tmux server + `claude`
+REPL inside its own rootless Podman container. The daemon orchestrates the
+full lifecycle (provision on register, start on session connect, recreate on
+image change, deprovision on retire) — no manual sysadmin per agent.
+
+What the boundary buys: per-agent filesystem namespace (no sibling
+`.mcp.json` / signing-key theft), private network namespace, cgroup
+memory/pids caps, and no fleet-wide `PINKY_SESSION_SECRET` inside the
+sandbox (per-agent key only).
+
+## Host setup (one-time, per host)
+
+1. Install rootless Podman (validated: Podman 5.4.2, Debian 13, aarch64).
+   Docker also works (`PINKY_CONTAINER_RUNTIME=docker`).
+2. Daemon env (`.env`):
+   - `PINKY_CONTAINER_RUNTIME=podman` — the opt-in gate. Unset = container
+     agents register but refuse to start (fail-closed).
+   - `PINKY_SHARED_MCP=1` and `PINKY_SHARED_MCP_HOST=0.0.0.0` — container
+     agents reach MCP via SSE at `host.containers.internal:8890`. Binding
+     beyond loopback is safe because non-loopback shared-MCP requests now
+     REQUIRE the per-agent bearer token (see Security below).
+   - Optional: `PINKY_CONTAINER_MEMORY` (default `2g`), 
+     `PINKY_CONTAINER_PIDS_LIMIT` (default `2048`) — `0` disables a cap.
+   - Optional: `PINKY_CONTAINER_DAEMON_URL` (default
+     `http://host.containers.internal:8888`) if the daemon API listens on a
+     non-default port.
+   - Optional: `PINKY_CONTAINER_SEED_CREDS=0` to disable the automatic
+     Claude-credentials bootstrap (see Credentials below).
+3. The daemon API must listen on a container-reachable interface (default
+   `0.0.0.0:8888` — already the case).
+
+## Bring-your-own image
+
+Pinky pulls the image, never builds it, and bakes in no tools. Contract
+(checked at cold start, clear BOOT_FAILED message if missing):
+
+- `tmux`, `claude` (Claude Code CLI), `python3`, `sh`, `sleep`
+
+A minimal Debian-slim + python3 + tmux + Claude Code image is enough. The
+image must match the host arch (aarch64 on the Pi).
+
+## Per-agent activation
+
+Register (or update) with `isolation_mode="container"` and
+`container_image="registry/image:tag"` (required — 422 without it).
+`isolated=true` is implied/coerced for any non-local mode. Transport must
+be `tmux` (enforced). The UI exposes both fields (wizard advanced block +
+agent detail Runtime tab).
+
+What the daemon creates per agent (all prefixed `pinky-<agent>`):
+
+- container `pinky-<agent>` — created stopped, `sleep infinity` entrypoint,
+  started on session connect; every tmux command is `podman exec`ed in
+- volume `pinky-<agent>-home` — in-container HOME (`/home/agent`); persists
+  any CLI state; preserved on retire, removed only on hard purge
+- secret `pinky-<agent>-key` — the per-agent signing key (stdin-created,
+  never on argv)
+
+Key create flags: `--userns=keep-id` (claude refuses
+`--dangerously-skip-permissions` as root; keeps bind-mounted files
+writable), `--add-host=host.containers.internal:host-gateway`,
+working_dir bind-mounted at the SAME absolute path, memory/pids caps.
+
+## How the response pipeline works (CLAUDE_CONFIG_DIR)
+
+The container runs with `CLAUDE_CONFIG_DIR=<working_dir>/.claude-container`.
+Because the working_dir is same-path bind-mounted, transcripts, trust
+flags, and credentials are visible to the host daemon at the identical
+absolute path — the host-side transcript tailer, `--continue` detection,
+and watchdog evidence work unchanged. Changing this breaks message
+delivery; don't.
+
+Hook scripts inside the container POST to the daemon via
+`PINKY_DAEMON_URL=http://host.containers.internal:8888` (injected into the
+session env automatically).
+
+## Credentials
+
+By default the daemon seeds its own `~/.claude/.credentials.json` into the
+agent's config dir once (first spawn, skipped if present, 0600) — the
+whole fleet shares the operator's Claude identity, matching current
+non-container behavior. The copy lives on the host working_dir, so it
+survives container recreates, and an in-container token refresh or
+`claude login` persists.
+
+For a per-tenant identity instead: `PINKY_CONTAINER_SEED_CREDS=0`, then
+once per agent: `podman exec -it pinky-<agent> claude login`.
+
+## Security model
+
+- Shared MCP (`:8890`): identity = `X-Agent-Name` header + `Authorization:
+  Bearer <per-agent signing key>`. Non-loopback peers (i.e. containers) are
+  rejected without a valid bearer; the bearer is validated constant-time
+  against the live registry key. Loopback callers keep legacy header trust
+  until `PINKY_SHARED_MCP_REQUIRE_AUTH=1` is set (the eventual flip once
+  every local agent carries a key — #623 increment 4).
+- Isolated agents never receive `PINKY_SESSION_SECRET`; they sign internal
+  requests with `PINKY_AGENT_KEY` only, and the daemon refuses
+  global-secret auth for isolated callers.
+- `.mcp.json` is 0600 and sits in the agent's own working_dir.
+
+## Failure behavior
+
+- Container dies while idle: the next message's paste fails with a podman
+  "not running" error -> the session schedules disconnect -> the next
+  inbound message auto-wakes, `ensure_started` restarts the container.
+- Image changed on the agent record: next cold start recreates the
+  container (home volume + key secret preserved).
+- Missing podman binary / gate off / bad image: clear, actionable errors
+  at register or BOOT_FAILED at start — never a silent local fallback.
+
+## Known limits / follow-ups
+
+- macOS hosts (Mac Mini): podman runs inside a `podman machine` VM —
+  same-path bind mounts and host-gateway semantics need separate
+  validation. Pi/Linux first; container agents on macOS unsupported until
+  validated (#638).
+- No per-agent egress allowlist yet (network namespace only) — #638
+  increment 4 carries the nftables/pasta prototype.
+- Containers stay running while the agent idles (`sleep infinity` is
+  near-free); stop-on-idle-sleep is wired in the provisioner but not yet
+  called.
+- First `podman pull` of a large image can exceed the 60s cold-start
+  budget; provision-on-register pre-pulls (gate on), so this only bites
+  when the image was manually removed.

--- a/specs/container-isolation.md
+++ b/specs/container-isolation.md
@@ -91,15 +91,28 @@ once per agent: `podman exec -it pinky-<agent> claude login`.
 ## Security model
 
 - Shared MCP (`:8890`): identity = `X-Agent-Name` header + `Authorization:
-  Bearer <per-agent signing key>`. Non-loopback peers (i.e. containers) are
-  rejected without a valid bearer; the bearer is validated constant-time
-  against the live registry key. Loopback callers keep legacy header trust
-  until `PINKY_SHARED_MCP_REQUIRE_AUTH=1` is set (the eventual flip once
-  every local agent carries a key — #623 increment 4).
+  Bearer <token>`. The token is a one-way DERIVATION of the per-agent
+  signing key (`derive_mcp_bearer`) — capturing it on the wire never
+  yields the signing credential itself. Every SSE agent's `.mcp.json`
+  carries it (container and local alike).
+- Enforcement: whenever the shared MCP is BOUND beyond loopback
+  (`PINKY_SHARED_MCP_HOST`), bearer auth is required for EVERY request —
+  per-request peer-address classification is deliberately not trusted
+  there, because rootless Podman (pasta/slirp) can present container
+  traffic with a loopback source address. On a loopback bind, loopback
+  callers keep legacy header trust unless
+  `PINKY_SHARED_MCP_REQUIRE_AUTH=1` (values 0/false/no = off). A bearer,
+  when present, is always validated (constant-time, resolved from the
+  live registry) — there is no downgrade path.
 - Isolated agents never receive `PINKY_SESSION_SECRET`; they sign internal
   requests with `PINKY_AGENT_KEY` only, and the daemon refuses
-  global-secret auth for isolated callers.
+  global-secret auth for isolated callers. Any non-local isolation_mode
+  implies `isolated=true` (coerced at register/update and enforced again
+  at the runtime secret gate).
 - `.mcp.json` is 0600 and sits in the agent's own working_dir.
+- The execution seam (local vs podman-exec) is re-selected from the live
+  registry row on EVERY spawn, and a registry failure at spawn fails
+  closed (BOOT_FAILED) — never a silent fallback to host execution.
 
 ## Failure behavior
 
@@ -122,6 +135,15 @@ once per agent: `podman exec -it pinky-<agent> claude login`.
 - Containers stay running while the agent idles (`sleep infinity` is
   near-free); stop-on-idle-sleep is wired in the provisioner but not yet
   called.
-- First `podman pull` of a large image can exceed the 60s cold-start
-  budget; provision-on-register pre-pulls (gate on), so this only bites
-  when the image was manually removed.
+- Container provision/start at spawn runs under its own budget
+  (`PINKY_CONTAINER_START_TIMEOUT_SEC`, default 600s) so a legitimate
+  multi-minute image pull cannot trip the 60s REPL cold-start timeout.
+- Docker (`PINKY_CONTAINER_RUNTIME=docker`) is wired but UNVALIDATED —
+  in particular rootless Docker's in-container uid is 0 and claude
+  refuses `--dangerously-skip-permissions` as root. Podman is the
+  supported runtime; treat docker as experimental.
+- Flipping an agent back to `local` keeps `isolated=true` (the flag also
+  gates daemon API scoping, so it is never auto-cleared); clear it
+  explicitly via `PUT /agents/{name} {"isolated": false}` if intended.
+  The downgrade deprovisions the container + key secret; the home volume
+  is kept.

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -742,7 +742,7 @@ digest = hmac.new(secret.encode(), payload, hashlib.sha256).digest()
 sig = base64.urlsafe_b64encode(digest).decode().rstrip("=")
 
 req = urllib.request.Request(
-    f"http://localhost:8888{{path}}",
+    os.environ.get("PINKY_DAEMON_URL", "http://localhost:8888").rstrip("/") + path,
     data=json.dumps({{"event": "stop_hook_summary"}}).encode(),
     method="POST",
 )
@@ -810,7 +810,7 @@ body = {{
 }}
 
 req = urllib.request.Request(
-    f"http://localhost:8888{{path}}",
+    os.environ.get("PINKY_DAEMON_URL", "http://localhost:8888").rstrip("/") + path,
     data=json.dumps(body).encode(),
     method="POST",
 )
@@ -888,7 +888,7 @@ body = {{
 }}
 
 req = urllib.request.Request(
-    f"http://localhost:8888{{path}}",
+    os.environ.get("PINKY_DAEMON_URL", "http://localhost:8888").rstrip("/") + path,
     data=json.dumps(body, default=str).encode(),
     method="POST",
 )
@@ -967,7 +967,7 @@ body = {{
 }}
 
 req = urllib.request.Request(
-    f"http://localhost:8888{{path}}",
+    os.environ.get("PINKY_DAEMON_URL", "http://localhost:8888").rstrip("/") + path,
     data=json.dumps(body).encode(),
     method="POST",
 )
@@ -1028,7 +1028,7 @@ digest = hmac.new(secret.encode(), payload_sig, hashlib.sha256).digest()
 sig = base64.urlsafe_b64encode(digest).decode().rstrip("=")
 
 req = urllib.request.Request(
-    f"http://localhost:8888{{path}}",
+    os.environ.get("PINKY_DAEMON_URL", "http://localhost:8888").rstrip("/") + path,
     data=json.dumps({{
         "transcript_path": transcript_path,
         "session_id": session_id,
@@ -1634,7 +1634,7 @@ digest = hmac.new(secret.encode(), payload, hashlib.sha256).digest()
 sig = base64.urlsafe_b64encode(digest).decode().rstrip("=")
 
 req = urllib.request.Request(
-    f"http://localhost:8888{{path}}",
+    os.environ.get("PINKY_DAEMON_URL", "http://localhost:8888").rstrip("/") + path,
     data=json.dumps({{"status": "{status}"}}).encode(),
     method="POST",
 )

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1656,17 +1656,23 @@ except Exception:
         tmux_post_tool_path = claude_dir / "hook_tmux_post_tool.py"
         tmux_stop_failure_path = claude_dir / "hook_tmux_stop_failure.py"
 
-        if not working_path.exists():
-            working_path.write_text(
-                hook_template.format(agent_name=agent_name, status="working")
-            )
-            _log(f"agent_registry: created hook_working.py for {agent_name}")
-
-        if not idle_path.exists():
-            idle_path.write_text(
-                hook_template.format(agent_name=agent_name, status="idle")
-            )
-            _log(f"agent_registry: created hook_idle.py for {agent_name}")
+        # #638: these two were historically written once and left alone, which
+        # stranded fleet agents on stale sources (e.g. the hardcoded
+        # http://localhost:8888 that is dead inside a container netns). They
+        # are fully PinkyBot-managed, so keep them current like the five
+        # always-rewritten hooks below.
+        AgentRegistry._write_hook_if_changed(
+            hook_path=working_path,
+            new_source=hook_template.format(agent_name=agent_name, status="working"),
+            hook_filename="hook_working.py",
+            agent_name=agent_name,
+        )
+        AgentRegistry._write_hook_if_changed(
+            hook_path=idle_path,
+            new_source=hook_template.format(agent_name=agent_name, status="idle"),
+            hook_filename="hook_idle.py",
+            agent_name=agent_name,
+        )
 
         # #429: verify_effort hook — compares $CLAUDE_EFFORT (v2.1.133+) to
         # PINKY_EXPECTED_EFFORT (set by daemon at session start). On drift,

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -404,6 +404,11 @@ class Agent:
     # Orthogonal to `isolated`: `isolated` is the daemon-authz boundary; this is
     # the runtime sandbox. Only meaningful when `isolated` is True.
     isolation_mode: str = "local"
+    # Operator-supplied container image for isolation_mode="container" (bring-
+    # your-own; Pinky pulls it, never builds it, and bakes in no CLIs). Empty
+    # for every other mode. Consumed by ContainerProvisioner via its default
+    # image_provider; the runtime cutover that uses it is host-gated.
+    container_image: str = ""
     dream_enabled: bool = False  # Enable nightly memory consolidation
     dream_schedule: str = "0 3 * * *"  # Cron for dream runs (default 3 AM)
     dream_timezone: str = "America/Los_Angeles"  # IANA timezone for dream schedule
@@ -475,6 +480,7 @@ class Agent:
             "role": self.role,
             "isolated": self.isolated,
             "isolation_mode": self.isolation_mode,
+            "container_image": self.container_image,
             "dream_enabled": self.dream_enabled,
             "dream_schedule": self.dream_schedule,
             "dream_timezone": self.dream_timezone,
@@ -1387,6 +1393,9 @@ class AgentRegistry:
             # behavior); 'unix_user' = own pinky-<agent> OS user (inc3b, Linux
             # exec only). Orthogonal to `isolated`; only meaningful when isolated.
             ("isolation_mode", "TEXT NOT NULL DEFAULT 'local'"),
+            # Operator-supplied container image for isolation_mode="container".
+            # Empty for other modes; bring-your-own (Pinky never builds it).
+            ("container_image", "TEXT NOT NULL DEFAULT ''"),
         ]
         for col, typedef in migrations:
             if col not in existing:
@@ -1960,7 +1969,7 @@ except Exception:
                         "librarian_enabled", "librarian_schedule",
                         "runtime", "transport", "provider_url", "provider_key", "provider_model", "provider_ref",
                         "thinking_effort", "strict_effort_enforcement", "isolated",
-                        "isolation_mode"):
+                        "isolation_mode", "container_image"):
                 if key in kwargs:
                     updates[key] = kwargs[key]
 
@@ -2041,6 +2050,7 @@ except Exception:
                 role=kwargs.get("role", ""),
                 isolated=kwargs.get("isolated", False),
                 isolation_mode=kwargs.get("isolation_mode", "local"),
+                container_image=kwargs.get("container_image", ""),
                 dream_enabled=kwargs.get("dream_enabled", False),
                 dream_schedule=kwargs.get("dream_schedule", "0 3 * * *"),
                 dream_timezone=kwargs.get("dream_timezone", "America/Los_Angeles"),
@@ -2068,13 +2078,13 @@ except Exception:
                     restart_threshold_pct, context_nudge_threshold_pct, auto_restart, parent, groups,
                     max_sessions, enabled, auto_start, heartbeat_interval, plain_text_fallback,
                     wake_interval, clock_aligned, auto_sleep_hours, voice_config, role, isolated,
-                    isolation_mode,
+                    isolation_mode, container_image,
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
                     librarian_enabled, librarian_schedule,
                     runtime, transport, provider_url, provider_key, provider_model, provider_ref,
                     thinking_effort, strict_effort_enforcement, watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -2086,7 +2096,7 @@ except Exception:
                  int(agent.enabled), int(agent.auto_start), agent.heartbeat_interval, int(agent.plain_text_fallback),
                  agent.wake_interval, int(agent.clock_aligned), agent.auto_sleep_hours,
                  json.dumps(agent.voice_config), agent.role, int(agent.isolated),
-                 agent.isolation_mode,
+                 agent.isolation_mode, agent.container_image,
                  int(agent.dream_enabled), agent.dream_schedule, agent.dream_timezone, agent.dream_model, int(agent.dream_notify),
                  int(agent.librarian_enabled), agent.librarian_schedule,
                  agent.runtime, agent.transport, agent.provider_url, agent.provider_key,
@@ -2126,7 +2136,7 @@ except Exception:
         "runtime, transport, provider_url, provider_key, provider_model, provider_ref, "
         "disallowed_tools, thinking_effort, watchdog_config, last_seen_at, "
         "strict_effort_enforcement, context_nudge_threshold_pct, isolated, "
-        "isolation_mode"
+        "isolation_mode, container_image"
     )
 
     def get(self, name: str) -> Agent | None:
@@ -3926,6 +3936,7 @@ except Exception:
             context_nudge_threshold_pct=row[50] if len(row) > 50 else 0.0,
             isolated=bool(row[51]) if len(row) > 51 else False,
             isolation_mode=row[52] if len(row) > 52 and row[52] else "local",
+            container_image=row[53] if len(row) > 53 and row[53] else "",
         )
 
     # ── Cost Tracking ──────────────────────────────────────

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -113,6 +113,10 @@ SET_EFFORT_ACCEPTED = ("low", "medium", "high", "xhigh", "max", "auto")
 
 def _post_drift(agent: str, expected: str, actual: str, tool_name: str,
                 strict: bool, daemon_url: str) -> None:
+    import base64
+    import hashlib
+    import hmac
+    import time
     import urllib.request
 
     path = f"/agents/{agent}/effort-drift"
@@ -127,6 +131,26 @@ def _post_drift(agent: str, expected: str, actual: str, tool_name: str,
     )
     req.add_header("Content-Type", "application/json")
     req.add_header("x-pinky-agent", agent)
+    # HMAC-sign exactly like the daemon's verify_internal_request expects:
+    # SHA256 over the newline-joined agent / METHOD / path / ts, base64url,
+    # padding stripped. Prefer the per-agent key — an isolated agent has the
+    # global secret both withheld from its env (#639) and rejected by the
+    # daemon (#640), so an unsigned (or global-secret-signed) effort-drift
+    # POST 401s. With no secret at all there is nothing the daemon would
+    # accept, so send unsigned and let the endpoint decide (legacy/dev).
+    # (Ported from the Pi-only hotfix ec82055, which never landed on main.)
+    secret = (
+        os.environ.get("PINKY_AGENT_KEY", "").strip()
+        or os.environ.get("PINKY_SESSION_SECRET", "").strip()
+    )
+    if secret:
+        ts = int(time.time())
+        sig_payload = f"{agent}\\nPOST\\n{path}\\n{ts}".encode()
+        sig = base64.urlsafe_b64encode(
+            hmac.new(secret.encode(), sig_payload, hashlib.sha256).digest()
+        ).decode().rstrip("=")
+        req.add_header("x-pinky-timestamp", str(ts))
+        req.add_header("x-pinky-signature", sig)
     try:
         urllib.request.urlopen(req, timeout=2)
     except Exception:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -5086,6 +5086,7 @@ npm run build</pre>
             watchdog_config=req.watchdog_config or {},
             isolated=req.isolated,
             isolation_mode=req.isolation_mode,
+            container_image=req.container_image,
         )
         # Write .mcp.json so the agent gets default MCP servers (memory, self, messaging)
         work_dir = Path(agent.working_dir) if agent.working_dir else None

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -635,21 +635,14 @@ def _write_mcp_json(
         except Exception:
             is_container_agent = False
 
-    if is_container_agent:
-        if not SHARED_MCP_ENABLED:
-            _log(
-                f"api: WARNING container agent '{agent_name}' gets SSE MCP config "
-                f"but the shared MCP server is disabled (PINKY_SHARED_MCP unset) — "
-                f"its MCP tools will not connect until it is enabled"
-            )
-        shared_base = f"http://host.containers.internal:{SHARED_MCP_PORT}"
-        agent_headers = {"X-Agent-Name": agent_name}
-        # #623/#638: a container reaches the shared MCP over a non-loopback
-        # bind, where the spoofable X-Agent-Name header alone must NOT grant
-        # identity. Send the per-agent signing key as a static bearer token —
-        # AgentNameMiddleware requires + validates it for non-loopback peers.
-        # The .mcp.json sits inside the agent's own working_dir (container-
-        # private at runtime), the same place stdio mode keeps this key.
+    # #623/#638: SSE callers authenticate with the per-agent bearer (a one-way
+    # derivation of the signing key — see shared_mcp.derive_mcp_bearer; the raw
+    # key never travels as a header). EVERY SSE agent gets it, not just
+    # container ones, so an exposed bind / PINKY_SHARED_MCP_REQUIRE_AUTH=1
+    # works for a mixed fleet. The .mcp.json is 0600 in the agent's own
+    # working_dir — the same exposure class as the stdio-mode key env.
+    def _sse_headers() -> dict:
+        headers = {"X-Agent-Name": agent_name}
         agent_key = ""
         if agent_registry:
             try:
@@ -660,12 +653,26 @@ def _write_mcp_json(
             except Exception:
                 agent_key = ""
         if agent_key:
-            agent_headers["Authorization"] = f"Bearer {agent_key}"
+            from pinky_daemon.shared_mcp import derive_mcp_bearer
+
+            headers["Authorization"] = f"Bearer {derive_mcp_bearer(agent_key)}"
         else:
             _log(
-                f"api: WARNING no signing key for container agent '{agent_name}' — "
-                f"its shared-MCP requests will be rejected on non-loopback binds"
+                f"api: WARNING no signing key for SSE agent '{agent_name}' — "
+                f"its shared-MCP requests will be rejected wherever bearer "
+                f"auth is required (non-loopback binds / REQUIRE_AUTH)"
             )
+        return headers
+
+    if is_container_agent:
+        if not SHARED_MCP_ENABLED:
+            _log(
+                f"api: WARNING container agent '{agent_name}' gets SSE MCP config "
+                f"but the shared MCP server is disabled (PINKY_SHARED_MCP unset) — "
+                f"its MCP tools will not connect until it is enabled"
+            )
+        shared_base = f"http://host.containers.internal:{SHARED_MCP_PORT}"
+        agent_headers = _sse_headers()
         for _name, _path in (
             ("pinky-memory", "memory"),
             ("pinky-self", "self"),
@@ -680,7 +687,7 @@ def _write_mcp_json(
     elif SHARED_MCP_ENABLED:
         # Shared SSE mode: point at the shared HTTP server with agent identity header
         shared_base = f"http://{SHARED_MCP_HOST}:{SHARED_MCP_PORT}"
-        agent_headers = {"X-Agent-Name": agent_name}
+        agent_headers = _sse_headers()
 
         # Memory: per-agent SQLite via shared SSE server (store pool)
         mcp_config["mcpServers"]["pinky-memory"] = {
@@ -5171,7 +5178,7 @@ npm run build</pre>
         # blocks the agent until an operator opts in). On a real provision
         # failure we roll back the just-registered agent so we never leave a
         # half-provisioned tenant behind.
-        from pinky_daemon.provisioning import get_provisioner
+        from pinky_daemon.provisioning import ProvisionResult, get_provisioner
 
         try:
             provisioner = get_provisioner(
@@ -5180,7 +5187,20 @@ npm run build</pre>
         except NotImplementedError:
             provisioner = None  # dormant mode (e.g. container gate off)
         if provisioner is not None:
-            result = provisioner.provision(agent)
+            # to_thread: provision drives blocking podman subprocesses (incl.
+            # a possible multi-minute image pull) — inline it would freeze the
+            # entire event loop (every poller + hook POST + UI request).
+            # provision() is an idempotent reconcile, so the (rare) overlap
+            # with a cold-start ensure_started in another thread converges:
+            # the loser errors on a name conflict and the next attempt heals.
+            try:
+                result = await asyncio.to_thread(provisioner.provision, agent)
+            except Exception as e:  # belt-and-braces: the ABC contract is
+                # "return ok=False", but a provisioner that raises instead
+                # must hit the same rollback logic, not skip it.
+                result = ProvisionResult(
+                    ok=False, mode=agent.isolation_mode, message=str(e)
+                )
             if not result.ok:
                 if not agent_existed_before:
                     agents.delete(agent.name)  # roll back the NEW registration
@@ -5529,9 +5549,24 @@ npm run build</pre>
         path = Path(req.transcript_path)
         if not path.is_absolute():
             raise HTTPException(400, "transcript_path must be absolute")
-        # Restrict to ``~/.claude/projects/``. Resolve symlinks before
-        # the prefix check so a symlinked attack path is normalised.
-        projects_root = (Path.home() / ".claude" / "projects").resolve()
+        # Restrict to the agent's legitimate transcript roots. Resolve
+        # symlinks before the prefix check so a symlinked attack path is
+        # normalised. Local agents: ``~/.claude/projects/``. Container
+        # agents (#638): claude runs with CLAUDE_CONFIG_DIR =
+        # <working_dir>/.claude-container, so its SessionStart hook
+        # legitimately reports <working_dir>/.claude-container/projects/...
+        # — without this root the report 403s and the tailer never repoints
+        # off its cold-start guess.
+        allowed_roots = [(Path.home() / ".claude" / "projects").resolve()]
+        if getattr(agent, "isolation_mode", "local") == "container":
+            wd = (agent.working_dir or "").strip()
+            if wd and Path(wd).is_absolute():
+                from pinky_daemon.provisioning import container_config_dir
+
+                allowed_roots.append(
+                    (Path(container_config_dir(str(Path(wd).resolve()))) / "projects")
+                    .resolve()
+                )
         try:
             normalised = path.resolve(strict=False)
         except (OSError, RuntimeError) as e:
@@ -5540,10 +5575,11 @@ npm run build</pre>
         # is recognized by CodeQL's path-traversal taint analysis — the
         # equivalent ``parents``-membership check tripped a false-positive
         # CodeQL alert in round-2 even though it had the same semantics.
-        if not normalised.is_relative_to(projects_root):
+        if not any(normalised.is_relative_to(root) for root in allowed_roots):
             raise HTTPException(
                 403,
-                f"transcript_path must be under {projects_root}",
+                f"transcript_path must be under one of "
+                f"{', '.join(str(r) for r in allowed_roots)}",
             )
 
         session = broker.get_streaming_session(name, label=req.label)
@@ -5781,7 +5817,55 @@ npm run build</pre>
         # receive the fleet-wide forgeable secret inside its sandbox.
         if kwargs.get("isolation_mode") not in (None, "local"):
             kwargs["isolated"] = True
+        # Final-state validation (mirrors the register-path 422): the MERGED
+        # record must not be container-mode without an image — that includes
+        # PUT {isolation_mode: container} with no image on file, and PUT
+        # {container_image: ""} clearing the image of a container agent.
+        final_mode = kwargs.get(
+            "isolation_mode", getattr(existing, "isolation_mode", "local")
+        )
+        final_image = kwargs.get(
+            "container_image", getattr(existing, "container_image", "") or ""
+        )
+        if final_mode == "container" and not (final_image or "").strip():
+            raise HTTPException(
+                422,
+                "isolation_mode='container' requires a non-empty container_image "
+                "(bring-your-own image, e.g. 'registry/image:tag')",
+            )
+        was_container = getattr(existing, "isolation_mode", "local") == "container"
         agent = agents.register(name, **kwargs)
+
+        isolation_touched = "isolation_mode" in kwargs or "container_image" in kwargs
+        if isolation_touched:
+            # Regenerate .mcp.json NOW — the documented flow is "flip via PUT,
+            # then restart the agent", and the restart path does NOT rewrite
+            # it. Without this a flipped-to-container agent boots reading its
+            # stale stdio config (host python, absent in the image) and a
+            # flipped-to-local one keeps pointing at host.containers.internal.
+            work_dir = Path(agent.working_dir) if agent.working_dir else None
+            if work_dir:
+                _write_mcp_json(work_dir, name, agent_registry=agents, skill_store=skills)
+
+        if was_container and final_mode != "container":
+            # Downgrade away from container: tear down the container + key
+            # secret so they don't orphan forever (retire was previously the
+            # only deprovision site). The home VOLUME is kept — same
+            # data-preserving contract as retire. Best-effort, off-loop.
+            try:
+                from pinky_daemon.provisioning import get_provisioner
+
+                provisioner = get_provisioner(
+                    "container", signing_key_provider=agents.get_or_create_signing_key
+                )
+                await asyncio.to_thread(provisioner.deprovision, existing)
+            except NotImplementedError:
+                pass  # gate off — nothing was provisioned on this host
+            except Exception as e:  # noqa: BLE001 — best-effort cleanup
+                _log(
+                    f"api: deprovision on isolation downgrade of '{name}' "
+                    f"failed (ignored): {e}"
+                )
 
         # CLAUDE.md is agent-owned after spawn — don't overwrite on soul field updates.
         # The file is written once at spawn; agents edit it directly after that.
@@ -5913,9 +5997,12 @@ npm run build</pre>
             try:
                 from pinky_daemon.provisioning import get_provisioner
 
-                get_provisioner(
+                provisioner = get_provisioner(
                     agent.isolation_mode, signing_key_provider=agents.get_or_create_signing_key
-                ).deprovision(agent)
+                )
+                # to_thread: deprovision runs blocking podman subprocesses
+                # (rm -f waits for container teardown) — keep the loop free.
+                await asyncio.to_thread(provisioner.deprovision, agent)
             except NotImplementedError:
                 pass  # dormant mode — nothing was provisioned
             except Exception as e:  # noqa: BLE001 — best-effort cleanup

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2527,6 +2527,18 @@ def create_api(
         if not agent:
             return None
         mode = (getattr(agent, "isolation_mode", "") or "local").strip() or "local"
+        # Container isolation runs the session INSIDE the container via tmux
+        # exec; the SDK/Codex backends don't go through the CommandRunner seam,
+        # so a container agent must use transport="tmux". Surface this as a clear
+        # config error rather than letting it fail obscurely at spawn.
+        if mode == "container":
+            transport = (getattr(agent, "transport", "") or "sdk").strip() or "sdk"
+            if transport != "tmux":
+                return (
+                    400,
+                    f"isolation_mode 'container' for agent '{agent_name}' requires "
+                    f"transport='tmux' (got '{transport}')",
+                )
         try:
             from pinky_daemon.provisioning import get_provisioner
             get_provisioner(mode)
@@ -5088,6 +5100,27 @@ npm run build</pre>
             isolation_mode=req.isolation_mode,
             container_image=req.container_image,
         )
+        # Provision OS-level isolation resources. No-op for local (the default);
+        # gated for container — when the runtime gate is OFF, get_provisioner
+        # raises NotImplementedError and we skip (the start-time guard then
+        # blocks the agent until an operator opts in). On a real provision
+        # failure we roll back the just-registered agent so we never leave a
+        # half-provisioned tenant behind.
+        from pinky_daemon.provisioning import get_provisioner
+
+        try:
+            provisioner = get_provisioner(
+                agent.isolation_mode, signing_key_provider=agents.get_or_create_signing_key
+            )
+        except NotImplementedError:
+            provisioner = None  # dormant mode (e.g. container gate off)
+        if provisioner is not None:
+            result = provisioner.provision(agent)
+            if not result.ok:
+                agents.delete(agent.name)  # roll back the registration
+                raise HTTPException(
+                    500, f"provisioning failed for '{agent.name}': {result.message}"
+                )
         # Write .mcp.json so the agent gets default MCP servers (memory, self, messaging)
         work_dir = Path(agent.working_dir) if agent.working_dir else None
         if work_dir:
@@ -5786,9 +5819,26 @@ npm run build</pre>
     @app.delete("/agents/{name}")
     async def retire_agent(name: str):
         """Retire an agent (soft delete). Preserves all data for restoration."""
+        agent = agents.get(name)  # capture before retire so we can deprovision
         retired = agents.retire(name)
         if not retired:
             raise HTTPException(404, f"Agent '{name}' not found")
+        # Tear down runtime OS resources (no-op for local; gated for container).
+        # Best-effort — failures are logged, never block the retire. The home
+        # VOLUME is intentionally KEPT: retire is a soft delete that "preserves
+        # all data for restoration", and the volume holds the tenant's durable
+        # CLI logins. A full purge belongs to a hard delete, not retire.
+        if agent is not None:
+            try:
+                from pinky_daemon.provisioning import get_provisioner
+
+                get_provisioner(
+                    agent.isolation_mode, signing_key_provider=agents.get_or_create_signing_key
+                ).deprovision(agent)
+            except NotImplementedError:
+                pass  # dormant mode — nothing was provisioned
+            except Exception as e:  # noqa: BLE001 — best-effort cleanup
+                _log(f"api: deprovision on retire of '{name}' failed (ignored): {e}")
         return {"retired": True, "name": name}
 
     @app.post("/agents/{name}/restore")

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -617,7 +617,39 @@ def _write_mcp_json(
     pinky_src = str(Path(__file__).resolve().parent.parent)
     mcp_config: dict = {"mcpServers": {}}
 
-    if SHARED_MCP_ENABLED:
+    # A container-isolated agent (#149) can't run the stdio MCP servers: they
+    # spawn `sys.executable -m pinky_self`, i.e. the HOST python + PinkyBot src,
+    # which don't exist in the operator's bring-your-own image. It must reach the
+    # daemon's shared MCP over the rootless network instead. host.containers.internal
+    # is wired via `--add-host` at container create (ContainerProvisioner). This
+    # requires the shared MCP server running (PINKY_SHARED_MCP=1) and bound so
+    # containers can reach it (PINKY_SHARED_MCP_HOST, e.g. 0.0.0.0) — a deploy
+    # concern; the daemon emits the right per-agent config regardless.
+    is_container_agent = False
+    if agent_registry:
+        try:
+            _a = agent_registry.get(agent_name)
+            is_container_agent = bool(
+                _a and getattr(_a, "isolation_mode", "") == "container"
+            )
+        except Exception:
+            is_container_agent = False
+
+    if is_container_agent:
+        shared_base = f"http://host.containers.internal:{SHARED_MCP_PORT}"
+        agent_headers = {"X-Agent-Name": agent_name}
+        for _name, _path in (
+            ("pinky-memory", "memory"),
+            ("pinky-self", "self"),
+            ("pinky-messaging", "messaging"),
+        ):
+            mcp_config["mcpServers"][_name] = {
+                "type": "sse",
+                "url": f"{shared_base}/mcp/{_path}/sse",
+                "headers": agent_headers,
+                "alwaysLoad": True,
+            }
+    elif SHARED_MCP_ENABLED:
         # Shared SSE mode: point at the shared HTTP server with agent identity header
         shared_base = f"http://{SHARED_MCP_HOST}:{SHARED_MCP_PORT}"
         agent_headers = {"X-Agent-Name": agent_name}

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -636,8 +636,36 @@ def _write_mcp_json(
             is_container_agent = False
 
     if is_container_agent:
+        if not SHARED_MCP_ENABLED:
+            _log(
+                f"api: WARNING container agent '{agent_name}' gets SSE MCP config "
+                f"but the shared MCP server is disabled (PINKY_SHARED_MCP unset) — "
+                f"its MCP tools will not connect until it is enabled"
+            )
         shared_base = f"http://host.containers.internal:{SHARED_MCP_PORT}"
         agent_headers = {"X-Agent-Name": agent_name}
+        # #623/#638: a container reaches the shared MCP over a non-loopback
+        # bind, where the spoofable X-Agent-Name header alone must NOT grant
+        # identity. Send the per-agent signing key as a static bearer token —
+        # AgentNameMiddleware requires + validates it for non-loopback peers.
+        # The .mcp.json sits inside the agent's own working_dir (container-
+        # private at runtime), the same place stdio mode keeps this key.
+        agent_key = ""
+        if agent_registry:
+            try:
+                getter = getattr(
+                    agent_registry, "get_or_create_signing_key", None
+                ) or agent_registry.get_signing_key
+                agent_key = (getter(agent_name) or "").strip()
+            except Exception:
+                agent_key = ""
+        if agent_key:
+            agent_headers["Authorization"] = f"Bearer {agent_key}"
+        else:
+            _log(
+                f"api: WARNING no signing key for container agent '{agent_name}' — "
+                f"its shared-MCP requests will be rejected on non-loopback binds"
+            )
         for _name, _path in (
             ("pinky-memory", "memory"),
             ("pinky-self", "self"),
@@ -5100,6 +5128,11 @@ npm run build</pre>
                 f"(admin mint/upsert, body name='{req.name}')"
             )
             raise HTTPException(403, "isolated agent may not register or modify agents")
+        # POST /agents is an UPSERT — remember whether this name already
+        # existed so a provisioning failure below rolls back only a NEWLY
+        # created agent. Hard-deleting a pre-existing agent (row + signing
+        # key) over a transient podman error would destroy a live tenant.
+        agent_existed_before = agents.get(req.name) is not None
         agent = agents.register(
             req.name,
             display_name=req.display_name,
@@ -5149,9 +5182,19 @@ npm run build</pre>
         if provisioner is not None:
             result = provisioner.provision(agent)
             if not result.ok:
-                agents.delete(agent.name)  # roll back the registration
+                if not agent_existed_before:
+                    agents.delete(agent.name)  # roll back the NEW registration
+                    raise HTTPException(
+                        500, f"provisioning failed for '{agent.name}': {result.message}"
+                    )
+                # Pre-existing agent: keep the (updated) record — the cold-start
+                # ensure_started path re-provisions lazily once the cause is
+                # fixed. Deleting here would destroy a live tenant over a
+                # transient runtime error.
                 raise HTTPException(
-                    500, f"provisioning failed for '{agent.name}': {result.message}"
+                    500,
+                    f"provisioning failed for '{agent.name}': {result.message} "
+                    f"(existing agent kept; it will re-provision at next start)",
                 )
         # Write .mcp.json so the agent gets default MCP servers (memory, self, messaging)
         work_dir = Path(agent.working_dir) if agent.working_dir else None
@@ -5732,6 +5775,12 @@ npm run build</pre>
             raise HTTPException(404, f"Agent '{name}' not found")
 
         kwargs = {k: v for k, v in req.model_dump().items() if v is not None}
+        # #638: flipping an agent to a non-local isolation_mode implies
+        # isolated=True (same coupling RegisterAgentRequest enforces) — without
+        # it a container tenant updated via PUT would keep isolated=False and
+        # receive the fleet-wide forgeable secret inside its sandbox.
+        if kwargs.get("isolation_mode") not in (None, "local"):
+            kwargs["isolated"] = True
         agent = agents.register(name, **kwargs)
 
         # CLAUDE.md is agent-owned after spawn — don't overwrite on soul field updates.

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Agent names appear in filesystem paths (data/agents/{name}/, hook scripts,
 # settings.json, .mcp.json) and database queries. Restrict to a safe character
@@ -362,6 +362,24 @@ class RegisterAgentRequest(BaseModel):
                 f"isolation_mode must be one of {sorted(allowed)} (got {v!r})"
             )
         return v
+
+    @model_validator(mode="after")
+    def _couple_isolation(self) -> "RegisterAgentRequest":
+        # #638: a non-local isolation_mode IS isolation — a container/unix_user
+        # tenant registered with isolated=False would still receive the
+        # fleet-wide forgeable PINKY_SESSION_SECRET inside its sandbox,
+        # defeating the OS boundary. Coerce rather than reject (the bool is an
+        # implementation detail callers shouldn't have to know to set).
+        if self.isolation_mode != "local":
+            self.isolated = True
+        # Container mode is unrunnable without an image; fail at registration
+        # with a clear message instead of at first provision.
+        if self.isolation_mode == "container" and not self.container_image.strip():
+            raise ValueError(
+                "isolation_mode='container' requires container_image "
+                "(bring-your-own image, e.g. 'registry/image:tag')"
+            )
+        return self
 
 
 class UpdateAgentRequest(BaseModel):

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -352,7 +352,7 @@ class RegisterAgentRequest(BaseModel):
     @field_validator("isolation_mode")
     @classmethod
     def _isolation_mode_known(cls, v: str) -> str:
-        allowed = {"local", "unix_user"}
+        allowed = {"local", "unix_user", "container"}
         if v not in allowed:
             raise ValueError(
                 f"isolation_mode must be one of {sorted(allowed)} (got {v!r})"
@@ -409,7 +409,7 @@ class UpdateAgentRequest(BaseModel):
     def _isolation_mode_known(cls, v: str | None) -> str | None:
         if v is None:
             return v
-        allowed = {"local", "unix_user"}
+        allowed = {"local", "unix_user", "container"}
         if v not in allowed:
             raise ValueError(
                 f"isolation_mode must be one of {sorted(allowed)} (got {v!r})"

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -348,6 +348,10 @@ class RegisterAgentRequest(BaseModel):
     # "unix_user" = own pinky-<agent> OS user + private home/keys (Linux exec,
     # inc3b). Orthogonal to `isolated`; only meaningful when isolated=True.
     isolation_mode: str = "local"
+    # Operator-supplied container image for isolation_mode="container"
+    # (bring-your-own; Pinky pulls it, never builds it, bakes in no CLIs).
+    # Empty for every other mode.
+    container_image: str = ""
 
     @field_validator("isolation_mode")
     @classmethod
@@ -403,6 +407,7 @@ class UpdateAgentRequest(BaseModel):
     # validated value set as the register path. The start-time preflight (api.py)
     # refuses to actually *run* a mode whose provisioner isn't implemented yet.
     isolation_mode: str | None = None
+    container_image: str | None = None  # bring-your-own image for mode=container; None = leave unchanged
 
     @field_validator("isolation_mode")
     @classmethod

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -421,6 +421,10 @@ class UpdateAgentRequest(BaseModel):
     thinking_effort: str | None = None  # low/medium/high/xhigh/max/ultracode
     strict_effort_enforcement: bool | None = None  # PR #429 — block tool calls when effort drifts
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
+    # #149 — hard-isolation flag; None = leave unchanged. Settable so a
+    # container→local round trip can explicitly lift the (auto-coerced)
+    # isolation; note the handler re-coerces True for any non-local mode.
+    isolated: bool | None = None
     # #149 phase-3 — OS-level runtime sandbox; None = leave unchanged. Same
     # validated value set as the register path. The start-time preflight (api.py)
     # refuses to actually *run* a mode whose provisioner isn't implemented yet.

--- a/src/pinky_daemon/command_runner.py
+++ b/src/pinky_daemon/command_runner.py
@@ -12,6 +12,11 @@ sites that build the command:
     ="unix_user"`` tenant's tmux server + REPL get launched under their own
     ``pinky-<agent>`` uid, so the agent's process cannot read the daemon's
     files or other tenants' homes.
+  - :class:`ContainerCommandRunner` runs argv INSIDE an agent's container via
+    ``podman exec <container> --`` (rootless Podman). This is how an
+    ``isolation_mode="container"`` tenant's tmux server + REPL run inside their
+    own container — own filesystem, own CLIs, own credentials — while the
+    daemon drives them from the host. Same wrap-and-delegate shape as runuser.
 
 The seam lives behind ``_TmuxControl`` (tmux_session.py): that class builds
 ``tmux …`` argvs and delegates the actual exec to its injected runner. A
@@ -138,6 +143,67 @@ class RunuserCommandRunner(CommandRunner):
     def wrap(self, argv: list[str]) -> list[str]:
         """Return ``argv`` prefixed with the runuser invocation."""
         return [self.runuser_binary, "-u", self.username, "--", *argv]
+
+    async def run(
+        self,
+        argv: list[str],
+        *,
+        timeout: float | None = None,
+        stdin: bytes | None = None,
+    ) -> CommandResult:
+        return await self._inner.run(self.wrap(argv), timeout=timeout, stdin=stdin)
+
+
+class ContainerCommandRunner(CommandRunner):
+    """Run argv INSIDE an agent's container via ``podman exec`` (or docker).
+
+    This is how an ``isolation_mode="container"`` tenant's tmux server + claude
+    REPL get driven: the daemon stays on the host, and every tmux control
+    command (``new-session``, ``send-keys``, ``capture-pane`` …) is exec'd into
+    the agent's already-running container. So the whole interactive session —
+    tmux, claude, and whatever CLIs the operator's image provides — lives inside
+    the container, while the daemon orchestrates it from outside. Exactly the
+    shape of :class:`RunuserCommandRunner`, with ``podman exec <container>``
+    standing in for ``runuser -u <user>``.
+
+    The container must already be running (the ``ContainerProvisioner`` creates
+    it; the activation increment starts it on session connect). The actual exec
+    is delegated to an inner runner — :class:`LocalCommandRunner` by default —
+    so timeout/kill semantics are shared with the local path and tests can
+    inject a recording double.
+
+    The ``--`` terminator after the flags is deliberate: it stops the container
+    CLI from interpreting the container name or any wrapped arg (e.g. a leading
+    ``-l`` on ``tmux send-keys``) as one of its own options. The wrapped argv is
+    passed as separate args, never shell-joined, so there is no quoting surface.
+    """
+
+    def __init__(
+        self,
+        container: str,
+        *,
+        user: str | None = None,
+        workdir: str | None = None,
+        container_binary: str = "podman",
+        inner: CommandRunner | None = None,
+    ) -> None:
+        if not container:
+            raise ValueError("ContainerCommandRunner requires a non-empty container")
+        self.container = container
+        self.user = user
+        self.workdir = workdir
+        self.container_binary = container_binary
+        self._inner = inner or LocalCommandRunner()
+
+    def wrap(self, argv: list[str]) -> list[str]:
+        """Return ``argv`` prefixed with the ``podman exec`` invocation."""
+        cmd = [self.container_binary, "exec"]
+        if self.user is not None:
+            cmd += ["-u", self.user]
+        if self.workdir is not None:
+            cmd += ["-w", self.workdir]
+        cmd += ["--", self.container, *argv]
+        return cmd
 
     async def run(
         self,

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -783,6 +783,20 @@ class ContainerProvisioner(AgentProvisioner):
         # until the session connects. A tool-agnostic keep-alive entrypoint lets
         # the daemon `podman exec` tmux into it regardless of the image's own
         # CMD — Pinky asserts nothing about the image beyond "can run sleep".
+        #
+        # HOST-VALIDATION TODOs (deferred — the gate is OFF until a Podman host
+        # exists to verify these end-to-end; the engaged path is incomplete
+        # without them, so they are tracked here rather than left silent):
+        #   1. Bind-mount the agent's host working_dir (data/agents/<name>, which
+        #      the daemon regenerates CLAUDE.md/.mcp.json into) onto the
+        #      in-container workdir, AND make TmuxSession pass an IN-CONTAINER
+        #      cwd to `tmux new-session -c` (today it passes the host path, which
+        #      won't exist inside the container).
+        #   2. Point the in-container .mcp.json at the daemon over the rootless
+        #      network (host.containers.internal) signed with the mounted key
+        #      secret, so the agent's MCP servers reach the daemon.
+        #   3. Seed the container's ~/.claude trust file (the tmux transport
+        #      expects it in HOME) before first connect.
         return [
             self._binary, "create",
             "--name", n.container,
@@ -799,7 +813,8 @@ class ContainerProvisioner(AgentProvisioner):
     def deprovision(self, agent: "Agent", *, remove_volume: bool = False) -> ProvisionResult:
         # Container + secret are cheap and recreatable → always removed. The home
         # VOLUME holds the tenant's persisted CLI logins, so it is KEPT by
-        # default; pass remove_volume=True for a full purge (e.g. on retire).
+        # default; pass remove_volume=True for a full purge (on HARD delete —
+        # NOT on retire, which is a soft delete that preserves data).
         n = self.names(agent)
         removed: list[str] = []
         if self._ops.container_exists(n.container):

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -784,24 +784,32 @@ class ContainerProvisioner(AgentProvisioner):
         # the daemon `podman exec` tmux into it regardless of the image's own
         # CMD — Pinky asserts nothing about the image beyond "can run sleep".
         #
-        # HOST-VALIDATION TODOs (deferred — the gate is OFF until a Podman host
-        # exists to verify these end-to-end; the engaged path is incomplete
-        # without them, so they are tracked here rather than left silent):
-        #   1. Bind-mount the agent's host working_dir (data/agents/<name>, which
-        #      the daemon regenerates CLAUDE.md/.mcp.json into) onto the
-        #      in-container workdir, AND make TmuxSession pass an IN-CONTAINER
-        #      cwd to `tmux new-session -c` (today it passes the host path, which
-        #      won't exist inside the container).
-        #   2. Point the in-container .mcp.json at the daemon over the rootless
-        #      network (host.containers.internal) signed with the mounted key
-        #      secret, so the agent's MCP servers reach the daemon.
-        #   3. Seed the container's ~/.claude trust file (the tmux transport
-        #      expects it in HOME) before first connect.
-        return [
-            self._binary, "create",
-            "--name", n.container,
-            "--restart", "no",
-            "-v", f"{n.volume}:{n.home}",
+        # Engaged-path wiring (host-validated 2026-06-02 on rootless Podman):
+        #   - Bind the agent's host working_dir at the SAME absolute path inside
+        #     the container. The daemon regenerates CLAUDE.md/.mcp.json/.claude
+        #     hooks there, and settings.json wires hook scripts by ABSOLUTE host
+        #     path — mounting them anywhere else would silently no-op every hook.
+        #     Same-path means `tmux new-session -c <working_dir>` resolves
+        #     identically on host and in-container (no cwd translation needed).
+        #   - `--userns=keep-id` (Podman): runs the tenant as the host daemon's
+        #     own uid, so (a) claude accepts --dangerously-skip-permissions (it
+        #     refuses to run as root) and (b) the bind-mounted, daemon-owned files
+        #     stay readable+writable from inside the container.
+        #   - `--add-host=host.containers.internal:host-gateway`: lets the
+        #     rootless container reach the daemon API + shared MCP on the host.
+        # The in-container .mcp.json (SSE → host.containers.internal) and the
+        # ~/.claude trust seed are handled by the daemon (api._write_mcp_json /
+        # TmuxSession), not here.
+        host_workdir = (agent.working_dir or "").strip()
+        argv = [self._binary, "create", "--name", n.container, "--restart", "no"]
+        # keep-id is Podman-specific; rootless Docker maps to the host user already.
+        if "podman" in self._binary:
+            argv += ["--userns=keep-id"]
+        argv += ["--add-host=host.containers.internal:host-gateway"]
+        argv += ["-v", f"{n.volume}:{n.home}"]
+        if host_workdir:
+            argv += ["-v", f"{host_workdir}:{host_workdir}"]
+        argv += [
             "--secret", f"{n.secret},type=mount",
             "-e", f"HOME={n.home}",
             "-e", f"CLAUDE_CONFIG_DIR={n.config_dir}",
@@ -809,6 +817,7 @@ class ContainerProvisioner(AgentProvisioner):
             "--entrypoint", "sleep",
             image, "infinity",
         ]
+        return argv
 
     def deprovision(self, agent: "Agent", *, remove_volume: bool = False) -> ProvisionResult:
         # Container + secret are cheap and recreatable → always removed. The home

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -765,12 +765,23 @@ class ContainerProvisioner(AgentProvisioner):
     def names(self, agent: "Agent") -> ContainerNames:
         return ContainerNames.for_agent(agent.name, prefix=self._prefix, home=self._home)
 
+    def _host_workdir(self, agent: "Agent") -> str:
+        """The agent's working_dir as the SESSION will see it: absolute paths
+        are symlink-resolved to match the api factory's
+        ``str(Path(working_dir).resolve())`` — the mount, ``exec -w``,
+        CLAUDE_CONFIG_DIR, trust seed, and tailer slug must all agree on ONE
+        canonical path or hooks/transcripts silently miss."""
+        wd = (agent.working_dir or "").strip()
+        if wd and Path(wd).is_absolute():
+            return str(Path(wd).resolve())
+        return wd
+
     def _config_dir_for(self, agent: "Agent", n: ContainerNames) -> str:
         """CLAUDE_CONFIG_DIR for this tenant: inside the same-path-mounted
         working_dir when one is configured (host-visible — transcripts, trust,
         creds), else the home-volume fallback. Only an ABSOLUTE working_dir
         qualifies — a relative one can't be same-path bind-mounted."""
-        wd = (agent.working_dir or "").strip()
+        wd = self._host_workdir(agent)
         if wd and Path(wd).is_absolute():
             return container_config_dir(wd)
         return n.config_dir
@@ -873,7 +884,7 @@ class ContainerProvisioner(AgentProvisioner):
         # The in-container .mcp.json (SSE → host.containers.internal) and the
         # ~/.claude trust seed are handled by the daemon (api._write_mcp_json /
         # TmuxSession), not here.
-        host_workdir = (agent.working_dir or "").strip()
+        host_workdir = self._host_workdir(agent)
         argv = [self._binary, "create", "--name", n.container, "--restart", "no"]
         # keep-id is Podman-specific; rootless Docker maps to the host user already.
         if "podman" in self._binary:
@@ -888,7 +899,9 @@ class ContainerProvisioner(AgentProvisioner):
         if pids and pids != "0":
             argv += ["--pids-limit", pids]
         argv += ["-v", f"{n.volume}:{n.home}"]
-        if host_workdir:
+        # Only an absolute working_dir can be same-path bind-mounted (registry
+        # rows are absolute in practice; a relative one would mount garbage).
+        if host_workdir and Path(host_workdir).is_absolute():
             argv += ["-v", f"{host_workdir}:{host_workdir}"]
         # CLAUDE_CONFIG_DIR lives INSIDE the same-path-mounted working_dir (not
         # the home volume) so transcripts/config/creds are host-visible at the
@@ -983,6 +996,11 @@ class ContainerProvisioner(AgentProvisioner):
             return
         if not current or current == desired:
             return
+        # Pull the NEW image BEFORE destroying the working container — a
+        # typo'd ref or registry outage must leave the agent running on the
+        # old image (with a raised, actionable error), not container-less.
+        if not self._ops.image_exists(desired):
+            self._ops.run([self._binary, "pull", desired])
         self._ops.run([self._binary, "rm", "-f", n.container])
         result = self.provision(agent)
         if not result.ok:

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -19,6 +19,15 @@ process is actually sandboxed at the operating-system level.
                       :class:`UnixUserProvisioner` + the systemd unit
                       template — but **dormant**: ``get_provisioner`` still
                       fails closed for ``unix_user`` (see below).
+  - ``"container"`` — the agent runs inside its own (rootless Podman)
+                      container: own filesystem, own home VOLUME (persists CLI
+                      OAuth state for a durable per-employee login), own
+                      signing-key secret. Pinky owns isolation + lifecycle only
+                      and is tool-agnostic — the image is operator-supplied
+                      (bring-your-own; Pinky bakes in no CLIs). Ships the real
+                      :class:`ContainerProvisioner` + ``ContainerCommandRunner``
+                      but **dormant**: ``get_provisioner`` fails closed for
+                      ``container`` until lifecycle activation. Strictly opt-in.
 
 A ``AgentProvisioner`` owns the lifecycle of those OS resources
 (provision / deprovision / introspect) and contributes any extra process
@@ -64,7 +73,8 @@ if TYPE_CHECKING:  # pragma: no cover — typing only, avoids a runtime import c
 # of the request layer.
 LOCAL = "local"
 UNIX_USER = "unix_user"
-KNOWN_MODES = frozenset({LOCAL, UNIX_USER})
+CONTAINER = "container"
+KNOWN_MODES = frozenset({LOCAL, UNIX_USER, CONTAINER})
 
 # OS-user naming + filesystem layout for unix_user tenants. The username is
 # ``pinky-<agent>`` so every managed account shares a greppable prefix and can
@@ -80,6 +90,18 @@ UNIX_USER_SHELL = "/usr/sbin/nologin"
 # so even another managed tenant on the same host can't read across.
 DIR_MODE = 0o700
 SECRET_MODE = 0o600
+
+# Container naming + in-container layout for the ``container`` isolation mode.
+# One container, one home volume, and one signing-key secret per agent, all
+# sharing the greppable ``pinky-<agent>`` prefix. Runtime is Podman (rootless)
+# by default; ``CONTAINER_BINARY`` is injectable for docker / CI doubles.
+CONTAINER_PREFIX = "pinky-"
+CONTAINER_BINARY = "podman"
+# In-container HOME. Everything the tenant persists — including any CLI's OAuth
+# state under ~/.config — lives here and is backed by the per-agent home VOLUME,
+# so a tenant's logins survive container restart/rebuild. Pinky bakes NO tools
+# into the image: which CLIs exist inside is entirely the operator's image.
+CONTAINER_HOME = "/home/agent"
 
 
 @dataclass
@@ -500,6 +522,342 @@ def _default_mcp_json(agent: "Agent", paths: UnixUserPaths) -> str:
     return json.dumps({"mcpServers": {}}, indent=2)
 
 
+# --------------------------------------------------------------------------- #
+# container provisioning (#149 / container isolation_mode)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ContainerNames:
+    """Resolved Podman object names + in-container paths for one tenant.
+
+    Centralizing derivation keeps provision / deprovision / is_provisioned /
+    runtime_env in agreement and gives tests one place to assert the layout
+    (mirrors :class:`UnixUserPaths`). One container, one home volume, one
+    signing-key secret per agent, all under the ``pinky-<agent>`` prefix.
+    """
+
+    container: str
+    volume: str
+    secret: str
+    home: str
+    workdir: str
+    config_dir: str
+
+    @classmethod
+    def for_agent(
+        cls,
+        agent_name: str,
+        *,
+        prefix: str = CONTAINER_PREFIX,
+        home: str = CONTAINER_HOME,
+    ) -> "ContainerNames":
+        base = f"{prefix}{agent_name}"
+        return cls(
+            container=base,
+            volume=f"{base}-home",
+            secret=f"{base}-key",
+            home=home,
+            workdir=str(Path(home) / "workdir"),
+            config_dir=str(Path(home) / ".claude"),
+        )
+
+
+@runtime_checkable
+class ContainerOps(Protocol):
+    """The privileged container-runtime seam (mirrors :class:`ProvisionOps`).
+
+    Every Podman mutation a :class:`ContainerProvisioner` performs goes through
+    this protocol so the whole provisioner is testable on macOS — and without a
+    real container runtime — by injecting a recording double. ``run`` is the
+    single command channel (matches the CommandRunner seam's "assert command
+    shapes" contract); the signing-key secret gets its own ``write_secret``
+    because its *content* must never be passed on an argv (process-list leak).
+    """
+
+    def run(self, argv: list[str]) -> None:
+        """Run a podman command; raise on non-zero exit."""
+
+    def image_exists(self, ref: str) -> bool: ...
+
+    def volume_exists(self, name: str) -> bool: ...
+
+    def secret_exists(self, name: str) -> bool: ...
+
+    def container_exists(self, name: str) -> bool: ...
+
+    def write_secret(self, name: str, content: str) -> None:
+        """Create a Podman secret ``name`` from ``content`` via stdin (no argv leak)."""
+
+
+class SystemContainerOps:
+    """Real :class:`ContainerOps` — drives the ``podman`` CLI via subprocess.
+
+    Runs only on the container host that actually owns the tenants. Never
+    exercised in unit tests; correctness here is by inspection, while the
+    provisioner *logic* is covered via a recording double.
+    """
+
+    def __init__(self, binary: str = CONTAINER_BINARY) -> None:
+        self._bin = binary
+
+    def run(self, argv: list[str]) -> None:
+        proc = subprocess.run(argv, capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise ProvisionError(
+                f"command failed ({proc.returncode}): {' '.join(argv)}\n{proc.stderr.strip()}"
+            )
+
+    def _exists(self, kind: str, name: str) -> bool:
+        # `podman <kind> inspect NAME` exits 0 iff the object exists; absence is
+        # a non-zero exit, not an error. Uniform across image/volume/secret/
+        # container, so one helper covers them all.
+        return (
+            subprocess.run([self._bin, kind, "inspect", name], capture_output=True).returncode
+            == 0
+        )
+
+    def image_exists(self, ref: str) -> bool:
+        return self._exists("image", ref)
+
+    def volume_exists(self, name: str) -> bool:
+        return self._exists("volume", name)
+
+    def secret_exists(self, name: str) -> bool:
+        return self._exists("secret", name)
+
+    def container_exists(self, name: str) -> bool:
+        return self._exists("container", name)
+
+    def write_secret(self, name: str, content: str) -> None:
+        # `podman secret create NAME -` reads the secret from stdin, so the key
+        # never appears on an argv / in the host process list.
+        proc = subprocess.run(
+            [self._bin, "secret", "create", name, "-"],
+            input=content.encode("utf-8"),
+            capture_output=True,
+        )
+        if proc.returncode != 0:
+            raise ProvisionError(
+                f"podman secret create {name} failed ({proc.returncode}): "
+                f"{proc.stderr.decode('utf-8', 'replace').strip()}"
+            )
+
+
+class ContainerProvisioner(AgentProvisioner):
+    """Provision a dedicated Podman container + home volume + key secret for an
+    ``isolation_mode="container"`` tenant.
+
+    Pinky owns ISOLATION + LIFECYCLE only and is deliberately TOOL-AGNOSTIC.
+    The image is OPERATOR-SUPPLIED (bring-your-own via ``image_provider``):
+    Pinky pulls it, never builds it, and bakes in no CLIs — whatever tooling
+    (gcloud / gh / kubectl / nothing) lives inside is entirely the operator's
+    image. Per agent this creates:
+
+      - a home VOLUME (``pinky-<agent>-home``) mounted at the in-container HOME,
+        so the tenant's CLI OAuth state (e.g. ``~/.config/<cli>``) persists
+        across restart/rebuild — the basis for a durable per-employee login;
+      - a signing-key SECRET (``pinky-<agent>-key``) created from stdin so the
+        key never hits an argv (same intent as the unix_user keystore);
+      - the CONTAINER itself (``pinky-<agent>``), created **stopped** via
+        ``podman create``. Starting/stopping it on session connect/idle and
+        injecting a :class:`ContainerCommandRunner` (so the tmux server + claude
+        REPL run *inside* it) is the activation increment's job.
+
+    Container isolation is strictly OPT-IN. ``get_provisioner`` stays
+    **fail-closed** for ``"container"`` (like ``"unix_user"``), so the #642
+    respawn guard blocks a container-labeled agent from launching until
+    activation wires the lifecycle. Construct this class directly; tests inject
+    a recording :class:`ContainerOps`, so none of this needs a real Podman.
+
+    **Idempotent** + **rollback**: identical contract to
+    :class:`UnixUserProvisioner` — a re-provision of a ready tenant is a no-op,
+    and a mid-provision failure tears down (in reverse) only what this call
+    built.
+    """
+
+    mode = CONTAINER
+
+    def __init__(
+        self,
+        *,
+        ops: ContainerOps | None = None,
+        image_provider: Callable[["Agent"], str] | None = None,
+        signing_key_provider: Callable[[str], str] | None = None,
+        prefix: str = CONTAINER_PREFIX,
+        home: str = CONTAINER_HOME,
+        binary: str = CONTAINER_BINARY,
+    ) -> None:
+        self._ops: ContainerOps = ops or SystemContainerOps(binary)
+        # Where the operator's image reference comes from. The persisted
+        # ``container_image`` agent field + register/update wiring land with the
+        # activation increment (mirrors _default_mcp_json); until then the
+        # default reads a forward-compatible attribute, so tests inject directly.
+        self._image_provider = image_provider or _agent_container_image
+        self._signing_key_provider = signing_key_provider or _no_signing_key
+        self._prefix = prefix
+        self._home = home
+        self._binary = binary
+
+    def names(self, agent: "Agent") -> ContainerNames:
+        return ContainerNames.for_agent(agent.name, prefix=self._prefix, home=self._home)
+
+    def is_provisioned(self, agent: "Agent") -> bool:
+        # The static per-agent resources the runtime depends on: the home
+        # volume, the key secret, and the (created, possibly-stopped) container.
+        # The image is implied — `podman create` could not have built the
+        # container without it. Starting it is a separate runtime concern.
+        n = self.names(agent)
+        return (
+            self._ops.volume_exists(n.volume)
+            and self._ops.secret_exists(n.secret)
+            and self._ops.container_exists(n.container)
+        )
+
+    def provision(self, agent: "Agent") -> ProvisionResult:
+        n = self.names(agent)
+        if self.is_provisioned(agent):
+            return ProvisionResult(
+                ok=True, mode=CONTAINER, message=f"container: {n.container} already provisioned"
+            )
+
+        image = self._image_provider(agent)
+        if not image:
+            return ProvisionResult(
+                ok=False,
+                mode=CONTAINER,
+                message=(
+                    f"container provision of {n.container} failed: no container_image "
+                    f"configured for {agent.name!r} (bring-your-own image is required)"
+                ),
+            )
+
+        # Reconcile, not all-or-nothing: skip resources that already exist so
+        # provision() repairs a partial tenant, and track only what THIS call
+        # built so rollback never tears down a pre-existing resource.
+        created: list[str] = []
+        try:
+            # 1. Home volume — persistent CLI/OAuth state.
+            if not self._ops.volume_exists(n.volume):
+                self._ops.run([self._binary, "volume", "create", n.volume])
+                created.append(f"volume:{n.volume}")
+            # 2. Signing-key secret (content via stdin, never an argv).
+            if not self._ops.secret_exists(n.secret):
+                key = self._signing_key_provider(agent.name)
+                if not key:
+                    raise ProvisionError(f"no signing key available for {agent.name!r}")
+                self._ops.write_secret(n.secret, key)
+                created.append(f"secret:{n.secret}")
+            # 3. Ensure the operator's image is present (pull if missing). Images
+            #    are shared infra, so this is NOT tracked as a per-agent resource
+            #    to tear down on rollback/deprovision.
+            if not self._ops.image_exists(image):
+                self._ops.run([self._binary, "pull", image])
+            # 4. The container — created STOPPED. Start/stop on session
+            #    connect/idle is the activation increment's responsibility.
+            if not self._ops.container_exists(n.container):
+                self._ops.run(self._create_argv(agent, n, image))
+                created.append(f"container:{n.container}")
+        except Exception as e:
+            removed = self._rollback(created)
+            return ProvisionResult(
+                ok=False,
+                mode=CONTAINER,
+                created=created,
+                removed=removed,
+                message=f"container provision of {n.container} failed: {e}",
+            )
+
+        return ProvisionResult(
+            ok=True, mode=CONTAINER, created=created,
+            message=f"container: provisioned {n.container}",
+        )
+
+    def _create_argv(self, agent: "Agent", n: ContainerNames, image: str) -> list[str]:
+        # `podman create` (not `run`): the container exists but stays stopped
+        # until the session connects. A tool-agnostic keep-alive entrypoint lets
+        # the daemon `podman exec` tmux into it regardless of the image's own
+        # CMD — Pinky asserts nothing about the image beyond "can run sleep".
+        return [
+            self._binary, "create",
+            "--name", n.container,
+            "--restart", "no",
+            "-v", f"{n.volume}:{n.home}",
+            "--secret", f"{n.secret},type=mount",
+            "-e", f"HOME={n.home}",
+            "-e", f"CLAUDE_CONFIG_DIR={n.config_dir}",
+            "-e", f"PINKY_AGENT_NAME={agent.name}",
+            "--entrypoint", "sleep",
+            image, "infinity",
+        ]
+
+    def deprovision(self, agent: "Agent", *, remove_volume: bool = False) -> ProvisionResult:
+        # Container + secret are cheap and recreatable → always removed. The home
+        # VOLUME holds the tenant's persisted CLI logins, so it is KEPT by
+        # default; pass remove_volume=True for a full purge (e.g. on retire).
+        n = self.names(agent)
+        removed: list[str] = []
+        if self._ops.container_exists(n.container):
+            self._ops.run([self._binary, "rm", "-f", n.container])
+            removed.append(f"container:{n.container}")
+        if self._ops.secret_exists(n.secret):
+            self._ops.run([self._binary, "secret", "rm", n.secret])
+            removed.append(f"secret:{n.secret}")
+        if remove_volume and self._ops.volume_exists(n.volume):
+            self._ops.run([self._binary, "volume", "rm", n.volume])
+            removed.append(f"volume:{n.volume}")
+        suffix = "" if remove_volume else " (home volume preserved)"
+        return ProvisionResult(
+            ok=True, mode=CONTAINER, removed=removed,
+            message=f"container: deprovisioned {n.container}{suffix}",
+        )
+
+    def runtime_env(self, agent: "Agent") -> dict[str, str]:
+        """Process env for the tenant's in-container runtime. ``HOME``/
+        ``CLAUDE_CONFIG_DIR`` confine config + Claude trust to the home volume;
+        the signing key is delivered via the mounted secret, not env."""
+        n = self.names(agent)
+        return {
+            "HOME": n.home,
+            "CLAUDE_CONFIG_DIR": n.config_dir,
+            "PINKY_AGENT_NAME": agent.name,
+        }
+
+    def _rollback(self, created: list[str]) -> list[str]:
+        """Undo ``created`` resources in reverse; best-effort, never raises."""
+        removed: list[str] = []
+        for token in reversed(created):
+            kind, _, value = token.partition(":")
+            try:
+                if kind == "container":
+                    if self._ops.container_exists(value):
+                        self._ops.run([self._binary, "rm", "-f", value])
+                elif kind == "secret":
+                    if self._ops.secret_exists(value):
+                        self._ops.run([self._binary, "secret", "rm", value])
+                elif kind == "volume":
+                    if self._ops.volume_exists(value):
+                        self._ops.run([self._binary, "volume", "rm", value])
+                removed.append(token)
+            except Exception:
+                # Best-effort — a stuck resource is surfaced via the returned
+                # ProvisionResult, not raised.
+                continue
+        return removed
+
+
+def _agent_container_image(agent: "Agent") -> str:
+    """Default image provider: read the agent's configured image.
+
+    The persisted ``container_image`` field + register/update wiring land with
+    the activation increment (this mirrors how ``_default_mcp_json`` is a
+    placeholder until real per-tenant MCP wiring lands). Until then this reads a
+    forward-compatible attribute — so the moment the column exists it just
+    works — and tests inject ``image_provider`` directly.
+    """
+    return getattr(agent, "container_image", "") or ""
+
+
 def get_provisioner(isolation_mode: str) -> AgentProvisioner:
     """Return the provisioner for ``isolation_mode``.
 
@@ -521,6 +879,14 @@ def get_provisioner(isolation_mode: str) -> AgentProvisioner:
             "not yet activated: lifecycle wiring + RunuserCommandRunner injection "
             "land in a later #149 increment. get_provisioner stays fail-closed so "
             "the #642 respawn guard keeps blocking unix_user until then."
+        )
+    if isolation_mode == CONTAINER:
+        raise NotImplementedError(
+            "isolation_mode='container' is implemented (ContainerProvisioner) but "
+            "not yet activated: lifecycle wiring (provision-on-register, start/stop "
+            "on session connect/idle, deprovision-on-retire) + ContainerCommandRunner "
+            "injection land in a later increment. get_provisioner stays fail-closed "
+            "so the #642 respawn guard keeps blocking container until then."
         )
     raise ValueError(
         f"unknown isolation_mode {isolation_mode!r}; expected one of {sorted(KNOWN_MODES)}"

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -97,6 +97,11 @@ SECRET_MODE = 0o600
 # by default; ``CONTAINER_BINARY`` is injectable for docker / CI doubles.
 CONTAINER_PREFIX = "pinky-"
 CONTAINER_BINARY = "podman"
+# Opt-in runtime gate. Container isolation stays fail-closed (dormant) until an
+# operator sets this on the daemon host — "" = OFF, "docker" = docker, any other
+# truthy value ("podman"/"1"/...) = podman. Default OFF, so registering/labeling
+# a container agent is allowed but it cannot RUN until the host is set up.
+CONTAINER_RUNTIME_ENV = "PINKY_CONTAINER_RUNTIME"
 # In-container HOME. Everything the tenant persists — including any CLI's OAuth
 # state under ~/.config — lives here and is backed by the per-agent home VOLUME,
 # so a tenant's logins survive container restart/rebuild. Pinky bakes NO tools
@@ -823,6 +828,28 @@ class ContainerProvisioner(AgentProvisioner):
             "PINKY_AGENT_NAME": agent.name,
         }
 
+    def start(self, agent: "Agent") -> None:
+        """Start the agent's (already-provisioned) container. Idempotent —
+        ``podman start`` on a running container is a successful no-op."""
+        self._ops.run([self._binary, "start", self.names(agent).container])
+
+    def stop(self, agent: "Agent") -> None:
+        """Stop the agent's container. The home volume persists its state (incl.
+        CLI OAuth logins), so a later start resumes a fully-configured tenant."""
+        self._ops.run([self._binary, "stop", self.names(agent).container])
+
+    def ensure_started(self, agent: "Agent") -> None:
+        """Idempotently provision (if needed) then start the container, so the
+        daemon can ``podman exec`` the tmux server into it. Raises
+        :class:`ProvisionError` if provisioning fails — a missing/stopped
+        container can't host a session. Called at session cold-start, BEFORE the
+        first ``podman exec``."""
+        if not self.is_provisioned(agent):
+            result = self.provision(agent)
+            if not result.ok:
+                raise ProvisionError(result.message)
+        self.start(agent)
+
     def _rollback(self, created: list[str]) -> list[str]:
         """Undo ``created`` resources in reverse; best-effort, never raises."""
         removed: list[str] = []
@@ -858,18 +885,41 @@ def _agent_container_image(agent: "Agent") -> str:
     return getattr(agent, "container_image", "") or ""
 
 
-def get_provisioner(isolation_mode: str) -> AgentProvisioner:
+def container_runtime_enabled() -> bool:
+    """True iff the operator has opted into the container runtime via
+    ``PINKY_CONTAINER_RUNTIME`` (default OFF → container mode stays fail-closed).
+
+    This is the activation gate: container lifecycle/exec only engages on a host
+    that has actually been set up with a (rootless Podman) runtime. Off by
+    default, so no behavior changes anywhere until an operator flips it.
+    """
+    return bool(os.environ.get(CONTAINER_RUNTIME_ENV, "").strip())
+
+
+def container_runtime_binary() -> str:
+    """The container CLI selected by ``PINKY_CONTAINER_RUNTIME``: ``"docker"``
+    for ``"docker"``, else ``"podman"`` (for ``"podman"``/``"1"``/any other
+    truthy value). Only meaningful when :func:`container_runtime_enabled`."""
+    val = os.environ.get(CONTAINER_RUNTIME_ENV, "").strip().lower()
+    return "docker" if val == "docker" else CONTAINER_BINARY
+
+
+def get_provisioner(
+    isolation_mode: str,
+    *,
+    signing_key_provider: "Callable[[str], str] | None" = None,
+) -> AgentProvisioner:
     """Return the provisioner for ``isolation_mode``.
 
-    ``"local"`` → the no-op :class:`LocalProvisioner`. ``"unix_user"`` is a
-    recognized mode and its provisioner (:class:`UnixUserProvisioner`) now
-    exists, but this factory still **fails closed** for it: activation — wiring
-    the provisioner into the daemon lifecycle together with the
-    ``RunuserCommandRunner`` — is a later increment. Raising here is the
-    dormancy guarantee: the #642 respawn guard blocks a ``unix_user`` agent
-    from launching *because* this raises, so the half-wired path can never run
-    under the daemon uid with none of the requested isolation. Any other value
-    is rejected as unknown.
+    ``"local"`` → the no-op :class:`LocalProvisioner`. ``"unix_user"`` is
+    recognized but still **fails closed** (its lifecycle activation is a
+    separate, Linux/systemd increment). ``"container"`` is **gated**: it returns
+    a real :class:`ContainerProvisioner` only when :func:`container_runtime_enabled`
+    (``PINKY_CONTAINER_RUNTIME`` set), and otherwise fails closed — so the #642
+    respawn guard keeps blocking container agents on any host that hasn't opted
+    into a runtime. ``signing_key_provider`` is threaded into the
+    ContainerProvisioner for provision/deprovision; the runnability check passes
+    none (it only needs the factory to not raise). Any other value is rejected.
     """
     if isolation_mode == LOCAL:
         return LocalProvisioner()
@@ -881,12 +931,16 @@ def get_provisioner(isolation_mode: str) -> AgentProvisioner:
             "the #642 respawn guard keeps blocking unix_user until then."
         )
     if isolation_mode == CONTAINER:
+        if container_runtime_enabled():
+            return ContainerProvisioner(
+                signing_key_provider=signing_key_provider,
+                binary=container_runtime_binary(),
+            )
         raise NotImplementedError(
             "isolation_mode='container' is implemented (ContainerProvisioner) but "
-            "not yet activated: lifecycle wiring (provision-on-register, start/stop "
-            "on session connect/idle, deprovision-on-retire) + ContainerCommandRunner "
-            "injection land in a later increment. get_provisioner stays fail-closed "
-            "so the #642 respawn guard keeps blocking container until then."
+            f"the container runtime is not enabled: set {CONTAINER_RUNTIME_ENV} "
+            "(e.g. 'podman') on the daemon host to activate. get_provisioner stays "
+            "fail-closed so the #642 respawn guard keeps blocking container until then."
         )
     raise ValueError(
         f"unknown isolation_mode {isolation_mode!r}; expected one of {sorted(KNOWN_MODES)}"

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -107,6 +107,26 @@ CONTAINER_RUNTIME_ENV = "PINKY_CONTAINER_RUNTIME"
 # so a tenant's logins survive container restart/rebuild. Pinky bakes NO tools
 # into the image: which CLIs exist inside is entirely the operator's image.
 CONTAINER_HOME = "/home/agent"
+# Claude Code config dir for container agents, placed INSIDE the bind-mounted
+# working_dir so it resolves to the SAME absolute path on host and in-container.
+# This is what makes the host-side transcript tailer (response pipeline), the
+# `--continue` prior-transcript check, and `claude login` credential durability
+# work for container agents: transcripts/config/creds land on the host disk via
+# the existing same-path workdir mount — no extra mount, no path translation.
+# The home VOLUME still backs ~/.config etc. for any other CLIs in the image.
+CONTAINER_CONFIG_DIRNAME = ".claude-container"
+# Conservative default resource caps for container tenants (the Pi 5 shares
+# 8GB with a POS stack). Operator-overridable per host; set to "0" to disable.
+CONTAINER_MEMORY_ENV = "PINKY_CONTAINER_MEMORY"
+CONTAINER_MEMORY_DEFAULT = "2g"
+CONTAINER_PIDS_ENV = "PINKY_CONTAINER_PIDS_LIMIT"
+CONTAINER_PIDS_DEFAULT = "2048"
+
+
+def container_config_dir(working_dir: str) -> str:
+    """The CLAUDE_CONFIG_DIR used inside a container agent's runtime — a
+    host-visible path inside the (same-path bind-mounted) working_dir."""
+    return str(Path(working_dir) / CONTAINER_CONFIG_DIRNAME)
 
 
 @dataclass
@@ -591,6 +611,9 @@ class ContainerOps(Protocol):
 
     def container_exists(self, name: str) -> bool: ...
 
+    def container_image(self, name: str) -> str:
+        """The image ref container ``name`` was created from ("" if unknown)."""
+
     def write_secret(self, name: str, content: str) -> None:
         """Create a Podman secret ``name`` from ``content`` via stdin (no argv leak)."""
 
@@ -606,8 +629,20 @@ class SystemContainerOps:
     def __init__(self, binary: str = CONTAINER_BINARY) -> None:
         self._bin = binary
 
+    def _missing_binary(self) -> ProvisionError:
+        # FileNotFoundError from subprocess means the container CLI itself is
+        # absent — translate to a clean ProvisionError so provision()/register
+        # return an actionable message instead of an unrolled 500.
+        return ProvisionError(
+            f"container binary {self._bin!r} not found on this host — install it "
+            f"(rootless podman) or unset {CONTAINER_RUNTIME_ENV}"
+        )
+
     def run(self, argv: list[str]) -> None:
-        proc = subprocess.run(argv, capture_output=True, text=True)
+        try:
+            proc = subprocess.run(argv, capture_output=True, text=True)
+        except FileNotFoundError:
+            raise self._missing_binary() from None
         if proc.returncode != 0:
             raise ProvisionError(
                 f"command failed ({proc.returncode}): {' '.join(argv)}\n{proc.stderr.strip()}"
@@ -617,10 +652,30 @@ class SystemContainerOps:
         # `podman <kind> inspect NAME` exits 0 iff the object exists; absence is
         # a non-zero exit, not an error. Uniform across image/volume/secret/
         # container, so one helper covers them all.
-        return (
-            subprocess.run([self._bin, kind, "inspect", name], capture_output=True).returncode
-            == 0
-        )
+        try:
+            return (
+                subprocess.run(
+                    [self._bin, kind, "inspect", name], capture_output=True
+                ).returncode
+                == 0
+            )
+        except FileNotFoundError:
+            raise self._missing_binary() from None
+
+    def container_image(self, name: str) -> str:
+        # `.Config.Image` is the create-time image REFERENCE on both Podman and
+        # Docker (`.ImageName` is Podman-only); used for image-drift detection.
+        try:
+            proc = subprocess.run(
+                [self._bin, "container", "inspect", "--format", "{{.Config.Image}}", name],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            raise self._missing_binary() from None
+        if proc.returncode != 0:
+            return ""
+        return proc.stdout.strip()
 
     def image_exists(self, ref: str) -> bool:
         return self._exists("image", ref)
@@ -637,11 +692,14 @@ class SystemContainerOps:
     def write_secret(self, name: str, content: str) -> None:
         # `podman secret create NAME -` reads the secret from stdin, so the key
         # never appears on an argv / in the host process list.
-        proc = subprocess.run(
-            [self._bin, "secret", "create", name, "-"],
-            input=content.encode("utf-8"),
-            capture_output=True,
-        )
+        try:
+            proc = subprocess.run(
+                [self._bin, "secret", "create", name, "-"],
+                input=content.encode("utf-8"),
+                capture_output=True,
+            )
+        except FileNotFoundError:
+            raise self._missing_binary() from None
         if proc.returncode != 0:
             raise ProvisionError(
                 f"podman secret create {name} failed ({proc.returncode}): "
@@ -707,6 +765,16 @@ class ContainerProvisioner(AgentProvisioner):
     def names(self, agent: "Agent") -> ContainerNames:
         return ContainerNames.for_agent(agent.name, prefix=self._prefix, home=self._home)
 
+    def _config_dir_for(self, agent: "Agent", n: ContainerNames) -> str:
+        """CLAUDE_CONFIG_DIR for this tenant: inside the same-path-mounted
+        working_dir when one is configured (host-visible — transcripts, trust,
+        creds), else the home-volume fallback. Only an ABSOLUTE working_dir
+        qualifies — a relative one can't be same-path bind-mounted."""
+        wd = (agent.working_dir or "").strip()
+        if wd and Path(wd).is_absolute():
+            return container_config_dir(wd)
+        return n.config_dir
+
     def is_provisioned(self, agent: "Agent") -> bool:
         # The static per-agent resources the runtime depends on: the home
         # volume, the key secret, and the (created, possibly-stopped) container.
@@ -721,27 +789,32 @@ class ContainerProvisioner(AgentProvisioner):
 
     def provision(self, agent: "Agent") -> ProvisionResult:
         n = self.names(agent)
-        if self.is_provisioned(agent):
-            return ProvisionResult(
-                ok=True, mode=CONTAINER, message=f"container: {n.container} already provisioned"
-            )
-
-        image = self._image_provider(agent)
-        if not image:
-            return ProvisionResult(
-                ok=False,
-                mode=CONTAINER,
-                message=(
-                    f"container provision of {n.container} failed: no container_image "
-                    f"configured for {agent.name!r} (bring-your-own image is required)"
-                ),
-            )
-
         # Reconcile, not all-or-nothing: skip resources that already exist so
         # provision() repairs a partial tenant, and track only what THIS call
-        # built so rollback never tears down a pre-existing resource.
+        # built so rollback never tears down a pre-existing resource. The
+        # is_provisioned probe sits INSIDE the try: a missing/broken container
+        # binary surfaces as a clean ok=False result, not an unrolled 500
+        # bubbling out of the register endpoint.
         created: list[str] = []
         try:
+            if self.is_provisioned(agent):
+                return ProvisionResult(
+                    ok=True,
+                    mode=CONTAINER,
+                    message=f"container: {n.container} already provisioned",
+                )
+
+            image = self._image_provider(agent)
+            if not image:
+                return ProvisionResult(
+                    ok=False,
+                    mode=CONTAINER,
+                    message=(
+                        f"container provision of {n.container} failed: no container_image "
+                        f"configured for {agent.name!r} (bring-your-own image is required)"
+                    ),
+                )
+
             # 1. Home volume — persistent CLI/OAuth state.
             if not self._ops.volume_exists(n.volume):
                 self._ops.run([self._binary, "volume", "create", n.volume])
@@ -806,13 +879,26 @@ class ContainerProvisioner(AgentProvisioner):
         if "podman" in self._binary:
             argv += ["--userns=keep-id"]
         argv += ["--add-host=host.containers.internal:host-gateway"]
+        # Resource caps — an unbounded tenant could starve the host (the Pi 5
+        # shares 8GB with a POS stack). Env-overridable; "0" disables a cap.
+        memory = os.environ.get(CONTAINER_MEMORY_ENV, CONTAINER_MEMORY_DEFAULT).strip()
+        if memory and memory != "0":
+            argv += ["--memory", memory]
+        pids = os.environ.get(CONTAINER_PIDS_ENV, CONTAINER_PIDS_DEFAULT).strip()
+        if pids and pids != "0":
+            argv += ["--pids-limit", pids]
         argv += ["-v", f"{n.volume}:{n.home}"]
         if host_workdir:
             argv += ["-v", f"{host_workdir}:{host_workdir}"]
+        # CLAUDE_CONFIG_DIR lives INSIDE the same-path-mounted working_dir (not
+        # the home volume) so transcripts/config/creds are host-visible at the
+        # identical absolute path — the host-side transcript tailer, the
+        # --continue check, and `claude login` durability all depend on this.
+        config_dir = self._config_dir_for(agent, n)
         argv += [
             "--secret", f"{n.secret},type=mount",
             "-e", f"HOME={n.home}",
-            "-e", f"CLAUDE_CONFIG_DIR={n.config_dir}",
+            "-e", f"CLAUDE_CONFIG_DIR={config_dir}",
             "-e", f"PINKY_AGENT_NAME={agent.name}",
             "--entrypoint", "sleep",
             image, "infinity",
@@ -842,13 +928,14 @@ class ContainerProvisioner(AgentProvisioner):
         )
 
     def runtime_env(self, agent: "Agent") -> dict[str, str]:
-        """Process env for the tenant's in-container runtime. ``HOME``/
-        ``CLAUDE_CONFIG_DIR`` confine config + Claude trust to the home volume;
+        """Process env for the tenant's in-container runtime. ``HOME`` confines
+        shell/CLI state to the home volume; ``CLAUDE_CONFIG_DIR`` points inside
+        the same-path-mounted working_dir (host-visible — see ``_create_argv``);
         the signing key is delivered via the mounted secret, not env."""
         n = self.names(agent)
         return {
             "HOME": n.home,
-            "CLAUDE_CONFIG_DIR": n.config_dir,
+            "CLAUDE_CONFIG_DIR": self._config_dir_for(agent, n),
             "PINKY_AGENT_NAME": agent.name,
         }
 
@@ -872,7 +959,34 @@ class ContainerProvisioner(AgentProvisioner):
             result = self.provision(agent)
             if not result.ok:
                 raise ProvisionError(result.message)
+        else:
+            self._recreate_if_image_changed(agent)
         self.start(agent)
+
+    def _recreate_if_image_changed(self, agent: "Agent") -> None:
+        """Recreate the container when the agent's configured ``container_image``
+        no longer matches what the existing container was created from —
+        otherwise an image change on a provisioned agent silently never applies.
+        The home volume and key secret survive (only the container is replaced).
+        Probe failures are tolerated (older ops doubles / inspect hiccups → keep
+        the existing container); an actual recreate failure raises."""
+        probe = getattr(self._ops, "container_image", None)
+        if probe is None:
+            return
+        desired = (self._image_provider(agent) or "").strip()
+        if not desired:
+            return
+        n = self.names(agent)
+        try:
+            current = (probe(n.container) or "").strip()
+        except Exception:
+            return
+        if not current or current == desired:
+            return
+        self._ops.run([self._binary, "rm", "-f", n.container])
+        result = self.provision(agent)
+        if not result.ok:
+            raise ProvisionError(result.message)
 
     def _rollback(self, created: list[str]) -> list[str]:
         """Undo ``created`` resources in reverse; best-effort, never raises."""

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -12,6 +12,9 @@ ContextVar that tools read instead.
 
 from __future__ import annotations
 
+import hmac
+import ipaddress
+import json
 import os
 import re
 import sys
@@ -324,28 +327,105 @@ def get_probe_status(agent_name: str) -> dict:
 
 # ── ASGI Middleware ───────────────────────────────────────────
 
-class AgentNameMiddleware:
-    """ASGI middleware that extracts X-Agent-Name header into ContextVar.
+def _is_loopback_peer(scope: dict) -> bool:
+    """True when the ASGI client address is loopback (or an in-process client
+    with no real socket, e.g. starlette's TestClient / a None client). Only a
+    genuinely non-loopback IP counts as remote — real remote sockets always
+    carry a real peer IP, so unparseable hosts stay in the legacy-trust class
+    instead of breaking in-process callers."""
+    client = scope.get("client")
+    if not client:
+        return True
+    host = client[0] or ""
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return True
 
-    Wrap the combined Starlette app with this so all MCP tool calls
-    within a request can read the agent name via get_current_agent()
-    or make_agent_name_resolver().
+
+async def _send_401(send, detail: str) -> None:
+    body = json.dumps({"detail": detail}).encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+class AgentNameMiddleware:
+    """ASGI middleware that authenticates the caller and exposes the agent
+    name to MCP tools via ContextVar.
+
+    Identity model (#623 / #638): historically the shared MCP trusted the
+    ``X-Agent-Name`` header alone — acceptable only on a loopback bind. To
+    serve container-isolated agents the server must bind beyond loopback
+    (PINKY_SHARED_MCP_HOST), where a bare header would let ANY network peer
+    act as ANY agent. So:
+
+      - a request carrying ``Authorization: Bearer <token>`` is validated
+        against the agent's per-agent signing key (constant-time compare)
+        REGARDLESS of peer — a wrong/unknown token is rejected even from
+        loopback (no downgrade path);
+      - a request from a NON-loopback peer MUST carry a valid bearer;
+      - a loopback request without a bearer keeps the legacy header-trust
+        (existing local agents / sessions keep working unchanged), unless
+        ``PINKY_SHARED_MCP_REQUIRE_AUTH`` is set (the future flip to
+        bearer-only once every fleet agent carries a key).
+
+    The bearer token IS the per-agent signing key (#623) — minted at
+    provision, delivered via the agent's own ``.mcp.json``, resolved here
+    at request time via ``signing_key_resolver`` so daemon-side rotation
+    takes effect immediately. Resolver errors fail CLOSED for bearer
+    validation (reject) — never open.
     """
 
-    def __init__(self, app):
+    def __init__(self, app, signing_key_resolver: "Callable[[str], str | None] | None" = None):
         self.app = app
+        self._signing_key_resolver = signing_key_resolver
+
+    def _resolve_key(self, agent_name: str) -> str:
+        if not self._signing_key_resolver:
+            return ""
+        try:
+            return (self._signing_key_resolver(agent_name) or "").strip()
+        except Exception:
+            return ""
 
     async def __call__(self, scope, receive, send):
-        if scope["type"] == "http":
-            headers = dict(scope.get("headers", []))
-            agent_name = headers.get(b"x-agent-name", b"").decode()
-            if agent_name and _AGENT_NAME_RE.match(agent_name):
-                token = _current_agent.set(agent_name)
-                try:
-                    await self.app(scope, receive, send)
-                finally:
-                    _current_agent.reset(token)
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = dict(scope.get("headers", []))
+        agent_name = headers.get(b"x-agent-name", b"").decode()
+        valid_name = bool(agent_name and _AGENT_NAME_RE.match(agent_name))
+        auth = headers.get(b"authorization", b"").decode()
+        bearer = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
+        auth_required = bool(
+            os.environ.get("PINKY_SHARED_MCP_REQUIRE_AUTH", "").strip()
+        ) or not _is_loopback_peer(scope)
+
+        if bearer:
+            key = self._resolve_key(agent_name) if valid_name else ""
+            if not key or not hmac.compare_digest(bearer, key):
+                await _send_401(send, "invalid agent credentials")
                 return
+        elif auth_required:
+            await _send_401(send, "agent bearer token required")
+            return
+
+        if valid_name:
+            token = _current_agent.set(agent_name)
+            try:
+                await self.app(scope, receive, send)
+            finally:
+                _current_agent.reset(token)
+            return
         await self.app(scope, receive, send)
 
 
@@ -353,12 +433,16 @@ class AgentNameMiddleware:
 
 def create_shared_app(
     mcp_servers: dict,
+    signing_key_resolver: "Callable[[str], str | None] | None" = None,
 ) -> object:
     """Create a combined Starlette app mounting multiple MCP servers.
 
     Args:
         mcp_servers: Dict of mount_name -> FastMCP instance.
                      e.g. {"memory": memory_mcp, "self": self_mcp, "messaging": msg_mcp}
+        signing_key_resolver: agent_name -> per-agent signing key, used by
+                     AgentNameMiddleware to validate inbound bearer tokens
+                     (required for any non-loopback bind — see the middleware).
 
     Returns:
         ASGI app ready for uvicorn.
@@ -407,7 +491,7 @@ def create_shared_app(
             yield
 
     inner_app = Starlette(routes=routes, lifespan=_combined_lifespan)
-    app = AgentNameMiddleware(inner_app)
+    app = AgentNameMiddleware(inner_app, signing_key_resolver=signing_key_resolver)
 
     transports = ", ".join(f"/mcp/{n} (sse+http)" for n in mcp_servers)
     _log(f"[shared-mcp] Mounting {len(mcp_servers)} servers: {transports}")
@@ -587,7 +671,9 @@ class SharedMcpManager:
             mcp_servers["memory"] = memory_mcp
             _log("[shared-mcp] pinky-memory included (per-agent store pool)")
 
-        return create_shared_app(mcp_servers)
+        return create_shared_app(
+            mcp_servers, signing_key_resolver=self._signing_key_resolver
+        )
 
     def _run_in_thread(self) -> None:
         """Run the shared MCP server in a dedicated thread with supervisor loop."""

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -12,6 +12,7 @@ ContextVar that tools read instead.
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 import threading
@@ -417,7 +418,13 @@ def create_shared_app(
 # ── Shared Server Manager ─────────────────────────────────────
 
 SHARED_MCP_PORT = 8890
-SHARED_MCP_HOST = "127.0.0.1"
+# Bind address for the shared MCP server. Default loopback (host-only). Set
+# PINKY_SHARED_MCP_HOST (e.g. "0.0.0.0") to expose it to container-isolated
+# agents that reach it via host.containers.internal. NOTE: the shared MCP
+# authenticates callers by the X-Agent-Name header alone, so binding beyond
+# loopback widens the trust surface — only do so on a trusted network / behind
+# a firewall until that path carries a signature.
+SHARED_MCP_HOST = os.environ.get("PINKY_SHARED_MCP_HOST", "127.0.0.1")
 
 
 class MemoryStorePool:

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -327,6 +327,30 @@ def get_probe_status(agent_name: str) -> dict:
 
 # ── ASGI Middleware ───────────────────────────────────────────
 
+def derive_mcp_bearer(signing_key: str) -> str:
+    """Derive the shared-MCP bearer token from an agent's signing key.
+
+    The bearer travels as a static plaintext header on every MCP call (HTTP,
+    possibly across the container bridge), so it must NOT be the signing key
+    itself — a captured bearer would otherwise also forge HMAC-signed daemon
+    API requests. A one-way derivation scopes the exposure: leaking the bearer
+    leaks MCP identity only, never the signing credential."""
+    if not signing_key:
+        return ""
+    return hmac.new(
+        signing_key.encode("utf-8"), b"pinky-shared-mcp-bearer-v1", "sha256"
+    ).hexdigest()
+
+
+def _require_auth_env() -> bool:
+    """PINKY_SHARED_MCP_REQUIRE_AUTH parsed like the other operator toggles:
+    unset/empty/"0"/"false"/"no" = off, anything else = on (a bare
+    ``bool(value)`` would treat an operator's ``=0`` as ENABLED)."""
+    return os.environ.get("PINKY_SHARED_MCP_REQUIRE_AUTH", "").strip().lower() not in (
+        "", "0", "false", "no",
+    )
+
+
 def _is_loopback_peer(scope: dict) -> bool:
     """True when the ASGI client address is loopback (or an in-process client
     with no real socket, e.g. starlette's TestClient / a None client). Only a
@@ -378,24 +402,39 @@ class AgentNameMiddleware:
         ``PINKY_SHARED_MCP_REQUIRE_AUTH`` is set (the future flip to
         bearer-only once every fleet agent carries a key).
 
-    The bearer token IS the per-agent signing key (#623) — minted at
-    provision, delivered via the agent's own ``.mcp.json``, resolved here
-    at request time via ``signing_key_resolver`` so daemon-side rotation
-    takes effect immediately. Resolver errors fail CLOSED for bearer
-    validation (reject) — never open.
+    The bearer token is DERIVED from the per-agent signing key (#623, see
+    :func:`derive_mcp_bearer` — the raw key never travels as a header) —
+    minted at provision, delivered via the agent's own ``.mcp.json``,
+    resolved here at request time via ``signing_key_resolver`` so
+    daemon-side rotation takes effect immediately. Resolver errors fail
+    CLOSED for bearer validation (reject) — never open.
+
+    ``require_auth=True`` (set by the manager whenever the server is BOUND
+    beyond loopback) removes the loopback escape hatch entirely. This is
+    the load-bearing defense for containers: with rootless Podman
+    (pasta/slirp), container→host traffic can arrive with a 127.0.0.1
+    SOURCE address, so per-request peer classification alone cannot be
+    trusted on an exposed bind — the bind itself is the decision point.
     """
 
-    def __init__(self, app, signing_key_resolver: "Callable[[str], str | None] | None" = None):
+    def __init__(
+        self,
+        app,
+        signing_key_resolver: "Callable[[str], str | None] | None" = None,
+        require_auth: bool = False,
+    ):
         self.app = app
         self._signing_key_resolver = signing_key_resolver
+        self._require_auth = require_auth
 
-    def _resolve_key(self, agent_name: str) -> str:
+    def _resolve_bearer(self, agent_name: str) -> str:
         if not self._signing_key_resolver:
             return ""
         try:
-            return (self._signing_key_resolver(agent_name) or "").strip()
+            key = (self._signing_key_resolver(agent_name) or "").strip()
         except Exception:
             return ""
+        return derive_mcp_bearer(key)
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http":
@@ -406,13 +445,15 @@ class AgentNameMiddleware:
         valid_name = bool(agent_name and _AGENT_NAME_RE.match(agent_name))
         auth = headers.get(b"authorization", b"").decode()
         bearer = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
-        auth_required = bool(
-            os.environ.get("PINKY_SHARED_MCP_REQUIRE_AUTH", "").strip()
-        ) or not _is_loopback_peer(scope)
+        auth_required = (
+            self._require_auth
+            or _require_auth_env()
+            or not _is_loopback_peer(scope)
+        )
 
         if bearer:
-            key = self._resolve_key(agent_name) if valid_name else ""
-            if not key or not hmac.compare_digest(bearer, key):
+            expected = self._resolve_bearer(agent_name) if valid_name else ""
+            if not expected or not hmac.compare_digest(bearer, expected):
                 await _send_401(send, "invalid agent credentials")
                 return
         elif auth_required:
@@ -434,6 +475,7 @@ class AgentNameMiddleware:
 def create_shared_app(
     mcp_servers: dict,
     signing_key_resolver: "Callable[[str], str | None] | None" = None,
+    require_auth: bool = False,
 ) -> object:
     """Create a combined Starlette app mounting multiple MCP servers.
 
@@ -443,6 +485,8 @@ def create_shared_app(
         signing_key_resolver: agent_name -> per-agent signing key, used by
                      AgentNameMiddleware to validate inbound bearer tokens
                      (required for any non-loopback bind — see the middleware).
+        require_auth: force bearer-only auth for every request (set whenever
+                     the server is bound beyond loopback).
 
     Returns:
         ASGI app ready for uvicorn.
@@ -491,7 +535,11 @@ def create_shared_app(
             yield
 
     inner_app = Starlette(routes=routes, lifespan=_combined_lifespan)
-    app = AgentNameMiddleware(inner_app, signing_key_resolver=signing_key_resolver)
+    app = AgentNameMiddleware(
+        inner_app,
+        signing_key_resolver=signing_key_resolver,
+        require_auth=require_auth,
+    )
 
     transports = ", ".join(f"/mcp/{n} (sse+http)" for n in mcp_servers)
     _log(f"[shared-mcp] Mounting {len(mcp_servers)} servers: {transports}")
@@ -671,8 +719,19 @@ class SharedMcpManager:
             mcp_servers["memory"] = memory_mcp
             _log("[shared-mcp] pinky-memory included (per-agent store pool)")
 
+        # A non-loopback BIND forces bearer-only auth for all requests: with
+        # rootless Podman the container->host source address can appear as
+        # 127.0.0.1, so peer classification alone cannot gate an exposed bind.
+        bind_exposed = self._host not in ("127.0.0.1", "::1", "localhost")
+        if bind_exposed:
+            _log(
+                f"[shared-mcp] non-loopback bind {self._host!r} — bearer auth "
+                f"REQUIRED for every request"
+            )
         return create_shared_app(
-            mcp_servers, signing_key_resolver=self._signing_key_resolver
+            mcp_servers,
+            signing_key_resolver=self._signing_key_resolver,
+            require_auth=bind_exposed,
         )
 
     def _run_in_thread(self) -> None:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -166,6 +166,27 @@ def _resolve_claude_config_path(env: dict[str, str] | None = None) -> Path:
     return base / ".claude.json"
 
 
+def _is_dead_runtime_stderr(stderr: str) -> bool:
+    """True when a tmux command's stderr says the execution substrate is gone —
+    either the tmux pane itself, or (for container agents, #638) the container
+    that ``podman exec`` needs. Both mean the same thing for the session state
+    machine: no future paste can succeed, so the worker must schedule disconnect
+    instead of silently eating every subsequent message against a zombie."""
+    low = (stderr or "").lower()
+    return any(
+        needle in low
+        for needle in (
+            "can't find pane",
+            # podman exec into a stopped container
+            "can only create exec sessions on running containers",
+            # docker exec into a stopped container
+            "container is not running",
+            # podman/docker: container was removed entirely
+            "no such container",
+        )
+    )
+
+
 def _seed_claude_trust_file(config_path: Path, project_dir: str) -> bool:
     """Idempotently pre-seed first-run trust/bypass flags in
     ``config_path`` (Claude Code's ``.claude.json``) for ``project_dir``.
@@ -1037,6 +1058,87 @@ class TmuxSession:
             signing_key_provider=self._registry.get_or_create_signing_key,
         )
         await asyncio.to_thread(provisioner.ensure_started, agent)
+        await self._check_container_image_contract()
+
+    async def _check_container_image_contract(self) -> None:
+        """Fail fast (clear message → BOOT_FAILED) when the operator's
+        bring-your-own image is missing a binary the daemon's runtime depends
+        on: ``tmux`` (every session command is ``podman exec … tmux``),
+        ``claude`` (the REPL itself), ``python3`` (in-container trust seed +
+        hook scripts). Without this, a bad image surfaces as an opaque
+        tmux-spawn stderr minutes later. Probe failures other than a clean
+        "missing" verdict are tolerated (the spawn will surface them)."""
+        runner = self._select_command_runner()
+        if not isinstance(runner, ContainerCommandRunner):
+            return
+        probe = "for c in tmux claude python3; do command -v $c >/dev/null || echo $c; done"
+        try:
+            res = await runner.run(["sh", "-c", probe], timeout=15)
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: image-contract probe errored "
+                f"(non-fatal, spawn will surface real failures): {e}"
+            )
+            return
+        missing = res.stdout.decode("utf-8", "replace").split() if res.ok else []
+        if missing:
+            raise RuntimeError(
+                f"container image for {self.agent_name!r} is missing required "
+                f"binaries: {', '.join(missing)} — the bring-your-own image must "
+                f"provide tmux, claude (Claude Code CLI), and python3"
+            )
+
+    def _seed_container_claude_creds(self) -> None:
+        """One-time host-side seed of the daemon user's Claude OAuth credentials
+        into a container agent's (host-visible) CLAUDE_CONFIG_DIR, so the
+        in-container ``claude`` starts authenticated instead of sitting at a
+        login prompt (#638 creds story).
+
+        The durable design: CLAUDE_CONFIG_DIR lives inside the same-path-mounted
+        working_dir, so a subsequent in-container ``claude login`` (or a token
+        refresh) persists across container restarts AND recreates. This seed is
+        only the bootstrap — skipped when creds already exist there. First-party
+        trusted agents sharing the operator's Claude identity is the accepted
+        model on both fleets today; set PINKY_CONTAINER_SEED_CREDS=0 to disable
+        and log each tenant in manually (podman exec -it pinky-<agent> claude
+        login). Best-effort: failure must never block the spawn."""
+        if self._container_agent() is None:
+            return
+        if os.environ.get("PINKY_CONTAINER_SEED_CREDS", "1").strip().lower() in (
+            "0", "false", "no",
+        ):
+            return
+        wd = (self._config.working_dir or "").strip()
+        if not wd or not Path(wd).is_absolute():
+            return
+        from pinky_daemon.provisioning import container_config_dir
+
+        dst_dir = Path(container_config_dir(wd))
+        dst = dst_dir / ".credentials.json"
+        if dst.exists():
+            return
+        host_cfg = (os.environ.get("CLAUDE_CONFIG_DIR") or "").strip()
+        src = (Path(host_cfg) if host_cfg else Path.home() / ".claude") / ".credentials.json"
+        try:
+            if not src.exists():
+                _log(
+                    f"tmux[{self.agent_name}]: no host claude credentials at "
+                    f"{src} to seed — in-container claude will need a manual "
+                    f"login (non-fatal)"
+                )
+                return
+            dst_dir.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(src.read_bytes())
+            os.chmod(dst, 0o600)
+            _log(
+                f"tmux[{self.agent_name}]: seeded claude credentials into "
+                f"container config dir {dst_dir}"
+            )
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: container creds seed failed "
+                f"(non-fatal): {e}"
+            )
 
     async def _seed_container_trust(self, project_dir: str) -> None:
         """Seed Claude Code's first-run trust/bypass flags INSIDE a container
@@ -1797,6 +1899,12 @@ class TmuxSession:
                     f"tmux[{self.agent_name}]: claude trust pre-seed failed "
                     f"(non-fatal): {e}"
                 )
+        else:
+            # Container agent: bootstrap Claude credentials into its
+            # host-visible CLAUDE_CONFIG_DIR (one-time, best-effort) so the
+            # in-container REPL starts authenticated. Host-side file copy —
+            # no container required, so it runs before ensure_started.
+            self._seed_container_claude_creds()
 
         # Pulse-v2 idle-prompt gate (task #92) re-arms on every fresh
         # spawn. The new REPL hasn't responded to anything yet, so the
@@ -2049,6 +2157,18 @@ class TmuxSession:
                 agent_key = ""
         if agent_key:
             env["PINKY_AGENT_KEY"] = agent_key
+
+        # Container agents (#638): every PinkyBot hook script POSTs to the
+        # daemon at PINKY_DAEMON_URL (default http://localhost:8888) — but
+        # inside the container netns, localhost is the CONTAINER, so without
+        # this the whole hook fleet (Stop-hook wakes, SessionStart transcript
+        # reporting, live status, tool telemetry) silently no-ops and the
+        # response pipeline never fires. host.containers.internal is wired
+        # via --add-host at container create (ContainerProvisioner).
+        if self._container_agent() is not None:
+            env["PINKY_DAEMON_URL"] = os.environ.get(
+                "PINKY_CONTAINER_DAEMON_URL", "http://host.containers.internal:8888"
+            )
 
         # PINKY_SESSION_SECRET — the daemon-wide secret. Read from os.environ
         # rather than a config field because the daemon's own SDK clients and
@@ -2636,6 +2756,13 @@ class TmuxSession:
             return "unknown"
         if agent is None:
             return "unknown"
+        # A non-local isolation_mode IS isolation, regardless of the `isolated`
+        # bool: a container/unix_user tenant holding the fleet-wide forgeable
+        # PINKY_SESSION_SECRET would defeat the entire OS boundary (#638 gap —
+        # the register/update models coerce isolated=True for non-local modes,
+        # but legacy rows / direct DB writes must not bypass the secret gate).
+        if getattr(agent, "isolation_mode", "local") not in ("", "local"):
+            return "isolated"
         return "isolated" if getattr(agent, "isolated", False) else "not_isolated"
 
     def _restart_threshold_pct(self) -> float:
@@ -3672,6 +3799,21 @@ class TmuxSession:
         # → '-'. For an absolute path the leading '/' yields the leading
         # '-' on its own; do NOT prepend an extra dash (that was the bug).
         encoded = re.sub(r"[^a-zA-Z0-9]", "-", str(cwd))
+        # Container agents (#638): claude runs with CLAUDE_CONFIG_DIR set to
+        # <working_dir>/.claude-container INSIDE the container — and because
+        # the working_dir is bind-mounted at the SAME absolute path, that
+        # config dir (and the transcripts under its projects/) is visible to
+        # this host-side daemon at the identical path. Without this branch
+        # the tailer looks in the daemon user's ~/.claude, finds nothing,
+        # and the whole response pipeline is dead for container agents.
+        # NOTE: the slug still encodes the agent's cwd — identical in- and
+        # out-of-container because of the same-path mount.
+        if self._container_agent() is not None:
+            wd = (self._config.working_dir or "").strip()
+            if wd and Path(wd).is_absolute():
+                from pinky_daemon.provisioning import container_config_dir
+
+                return Path(container_config_dir(wd)) / "projects" / encoded
         return Path.home() / ".claude" / "projects" / encoded
 
     def _has_prior_transcript(self) -> bool:
@@ -3829,11 +3971,11 @@ class TmuxSession:
                     ):
                         turn.completion_event.set()
                     self._inflight_turn = None
-                    # Task #90: dead-pane already scheduled disconnect from
-                    # inside _deliver_turn. Exit the worker cleanly so we
-                    # don't retry into the now-being-torn-down pane. The
-                    # watchdog also exits when CONNECTED → DEAD.
-                    if "can't find pane" in str(e):
+                    # Task #90: dead-pane/dead-container already scheduled
+                    # disconnect from inside _deliver_turn. Exit the worker
+                    # cleanly so we don't retry into the now-being-torn-down
+                    # pane. The watchdog also exits when CONNECTED → DEAD.
+                    if _is_dead_runtime_stderr(str(e)):
                         return
                 finally:
                     self._processing = False
@@ -4541,9 +4683,9 @@ class TmuxSession:
             # via the default-disconnect path; the next inbound
             # send_to_agent triggers the normal auto-wake cold-start
             # path (validated in production by #517/#518/#519).
-            if "can't find pane" in (result.stderr or ""):
+            if _is_dead_runtime_stderr(result.stderr or ""):
                 _log(
-                    f"tmux[{self.agent_name}]: pane vanished "
+                    f"tmux[{self.agent_name}]: pane/container vanished "
                     f"(stderr={result.stderr.strip()!r}); scheduling disconnect"
                 )
                 # create_task — must not await disconnect from inside

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -67,7 +67,11 @@ from collections import deque
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
-from pinky_daemon.command_runner import CommandRunner, LocalCommandRunner
+from pinky_daemon.command_runner import (
+    CommandRunner,
+    ContainerCommandRunner,
+    LocalCommandRunner,
+)
 from pinky_daemon.effort import EFFORT_LEVELS, is_ultracode, resolve_cli_effort
 from pinky_daemon.pricing import compute_cost_from_usage
 from pinky_daemon.sessions import SessionUsage
@@ -782,7 +786,12 @@ class TmuxSession:
 
         # Tmux subprocess control. Injectable for tests (mock the whole
         # ``_TmuxControl`` rather than monkeypatching subprocess primitives).
-        self._tmux = tmux_control or _TmuxControl(self._session_name)
+        # For an isolation_mode="container" agent (runtime gate ON), the tmux
+        # server + REPL run INSIDE its container via a ContainerCommandRunner;
+        # otherwise the default LocalCommandRunner reproduces today's behavior.
+        self._tmux = tmux_control or _TmuxControl(
+            self._session_name, command_runner=self._select_command_runner()
+        )
 
         # Worker queue + task.
         self._message_queue: asyncio.Queue[_QueuedTurn] = asyncio.Queue()
@@ -975,6 +984,53 @@ class TmuxSession:
         """Stable identifier matching StreamingSession's format."""
         label = getattr(self._config, "label", "") or "main"
         return f"{self.agent_name}-{label}"
+
+    def _container_agent(self):
+        """Return this session's Agent iff it should run inside a container —
+        the runtime gate is ON *and* isolation_mode=="container". Returns None
+        (→ default local behavior) otherwise, fail-safe on any lookup error so a
+        registry hiccup can never break a normal (local) session."""
+        from pinky_daemon.provisioning import container_runtime_enabled
+
+        if not container_runtime_enabled() or not self._registry:
+            return None
+        try:
+            agent = self._registry.get(self.agent_name)
+        except Exception:
+            return None
+        if not agent or getattr(agent, "isolation_mode", "") != "container":
+            return None
+        return agent
+
+    def _select_command_runner(self) -> CommandRunner:
+        """LocalCommandRunner by default; a ContainerCommandRunner bound to the
+        agent's container for a gated container agent, so every tmux command
+        execs into the container."""
+        agent = self._container_agent()
+        if agent is None:
+            return LocalCommandRunner()
+        from pinky_daemon.provisioning import ContainerNames, container_runtime_binary
+
+        names = ContainerNames.for_agent(agent.name)
+        return ContainerCommandRunner(
+            names.container, container_binary=container_runtime_binary()
+        )
+
+    async def _ensure_container_started(self) -> None:
+        """For a gated container agent, idempotently provision + start its
+        container BEFORE the first ``podman exec`` (tmux new-session). No-op for
+        local/non-container agents and when the gate is off. Run off-loop since
+        the podman calls are blocking subprocesses."""
+        agent = self._container_agent()
+        if agent is None:
+            return
+        from pinky_daemon.provisioning import get_provisioner
+
+        provisioner = get_provisioner(
+            "container",
+            signing_key_provider=self._registry.get_or_create_signing_key,
+        )
+        await asyncio.to_thread(provisioner.ensure_started, agent)
 
     def _build_session_name(self) -> str:
         """Tmux session name pattern: ``pinky-<agent_name>``.
@@ -1704,6 +1760,10 @@ class TmuxSession:
         env = self._build_repl_env()
 
         async def _spawn():
+            # Container-isolated agents: ensure the container is provisioned +
+            # running before any `podman exec tmux …` (this is the first one).
+            # No-op for local/non-container agents and when the gate is off.
+            await self._ensure_container_started()
             result = await self._tmux.new_session(
                 cwd=cwd,
                 command=claude_cmd,

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -166,6 +166,23 @@ def _resolve_claude_config_path(env: dict[str, str] | None = None) -> Path:
     return base / ".claude.json"
 
 
+# Sentinel distinguishing "caller passed no agent" from "caller passed None
+# (= local)" in the container-aware helpers below.
+_UNSET = object()
+
+
+def _container_start_timeout_sec() -> float:
+    """Budget for provision+start of a container at spawn (#638). Separate from
+    (and much larger than) the 60s cold-start umbrella because it can include a
+    legitimate multi-minute ``podman pull`` on slow links. Env-overridable."""
+    raw = os.environ.get("PINKY_CONTAINER_START_TIMEOUT_SEC", "").strip()
+    try:
+        val = float(raw) if raw else 600.0
+    except (TypeError, ValueError):
+        val = 600.0
+    return max(val, 1.0)
+
+
 def _is_dead_runtime_stderr(stderr: str) -> bool:
     """True when a tmux command's stderr says the execution substrate is gone —
     either the tmux pane itself, or (for container agents, #638) the container
@@ -173,18 +190,21 @@ def _is_dead_runtime_stderr(stderr: str) -> bool:
     machine: no future paste can succeed, so the worker must schedule disconnect
     instead of silently eating every subsequent message against a zombie."""
     low = (stderr or "").lower()
-    return any(
+    if any(
         needle in low
         for needle in (
             "can't find pane",
             # podman exec into a stopped container
             "can only create exec sessions on running containers",
-            # docker exec into a stopped container
-            "container is not running",
             # podman/docker: container was removed entirely
             "no such container",
         )
-    )
+    ):
+        return True
+    # docker exec into a stopped container: "Error response from daemon:
+    # container <id> is not running" — the id sits between the words, so a
+    # contiguous-substring needle can never match. Require both fragments.
+    return "container" in low and "is not running" in low
 
 
 def _seed_claude_trust_file(config_path: Path, project_dir: str) -> bool:
@@ -326,6 +346,18 @@ class _TmuxControl:
         # wired with a RunuserCommandRunner so its tmux server + REPL run under
         # the agent's own pinky-<agent> uid. See command_runner.py.
         self._runner: CommandRunner = command_runner or LocalCommandRunner()
+
+    def set_command_runner(self, runner: CommandRunner) -> None:
+        """Swap the execution seam. #638: the runner must be RE-SELECTED at
+        every spawn (TmuxSession._spawn_tmux_repl), not fixed at construction —
+        session objects survive isolation_mode changes (PUT /agents flips the
+        registry row with no session teardown, and reconnect/restart reuse the
+        SAME object), and a stale runner is a silent isolation bypass: a
+        flipped-to-container agent would keep launching claude on the HOST
+        through a construction-time LocalCommandRunner while every other
+        container decision (provision, seeds, tailer path, hook env) reads the
+        live row and pretends isolation is in force."""
+        self._runner = runner
 
     def _base_cmd(self) -> list[str]:
         cmd = [self.tmux_binary]
@@ -1006,28 +1038,43 @@ class TmuxSession:
         label = getattr(self._config, "label", "") or "main"
         return f"{self.agent_name}-{label}"
 
-    def _container_agent(self):
+    def _container_agent(self, strict: bool = False):
         """Return this session's Agent iff it should run inside a container —
         the runtime gate is ON *and* isolation_mode=="container". Returns None
-        (→ default local behavior) otherwise, fail-safe on any lookup error so a
-        registry hiccup can never break a normal (local) session."""
+        (→ default local behavior) otherwise.
+
+        ``strict`` (#638, used by the SPAWN path): a registry lookup FAILURE
+        raises instead of returning None. The default fail-safe is right for
+        read-side consumers (a hiccup must not break a local session's env or
+        tailer), but at spawn time silently falling back to a
+        LocalCommandRunner would launch a container-labeled agent UNISOLATED
+        on the host — fail closed there."""
         from pinky_daemon.provisioning import container_runtime_enabled
 
         if not container_runtime_enabled() or not self._registry:
             return None
         try:
             agent = self._registry.get(self.agent_name)
-        except Exception:
+        except Exception as e:
+            if strict:
+                raise RuntimeError(
+                    f"registry lookup failed while resolving isolation for "
+                    f"{self.agent_name!r} — refusing to spawn (a fallback to "
+                    f"local execution would silently bypass container "
+                    f"isolation): {e}"
+                ) from e
             return None
         if not agent or getattr(agent, "isolation_mode", "") != "container":
             return None
         return agent
 
-    def _select_command_runner(self) -> CommandRunner:
+    def _select_command_runner(self, agent=_UNSET) -> CommandRunner:
         """LocalCommandRunner by default; a ContainerCommandRunner bound to the
         agent's container for a gated container agent, so every tmux command
-        execs into the container."""
-        agent = self._container_agent()
+        execs into the container. ``agent`` lets the spawn path pass its own
+        registry snapshot so the runner and the rest of the spawn agree."""
+        if agent is _UNSET:
+            agent = self._container_agent()
         if agent is None:
             return LocalCommandRunner()
         from pinky_daemon.provisioning import ContainerNames, container_runtime_binary
@@ -1035,20 +1082,31 @@ class TmuxSession:
         names = ContainerNames.for_agent(agent.name)
         # The agent's host working_dir is bind-mounted into the container at the
         # SAME absolute path (ContainerProvisioner._create_argv), so it's a valid
-        # in-container cwd. Pass it as the `podman exec -w` so every tmux command
-        # (and the claude REPL tmux launches) runs in the agent's project dir.
+        # in-container cwd. Use the SESSION's (api-resolved) working_dir so the
+        # `podman exec -w`, `tmux new-session -c`, trust seed, and tailer slug
+        # all agree on one path (the registry row may hold a symlinked variant).
+        workdir = (self._config.working_dir or "").strip() or (
+            (getattr(agent, "working_dir", "") or "").strip()
+        )
         return ContainerCommandRunner(
             names.container,
             container_binary=container_runtime_binary(),
-            workdir=(getattr(agent, "working_dir", "") or "").strip() or None,
+            workdir=workdir or None,
         )
 
-    async def _ensure_container_started(self) -> None:
+    async def _ensure_container_started(self, agent=_UNSET) -> None:
         """For a gated container agent, idempotently provision + start its
         container BEFORE the first ``podman exec`` (tmux new-session). No-op for
         local/non-container agents and when the gate is off. Run off-loop since
-        the podman calls are blocking subprocesses."""
-        agent = self._container_agent()
+        the podman calls are blocking subprocesses.
+
+        #638: runs OUTSIDE the 60s cold-start umbrella with its own (much
+        larger) budget — ensure_started can legitimately include a multi-minute
+        ``podman pull`` (image evicted, container_image changed), and a
+        wait_for cancellation can't stop a to_thread anyway (it would leak a
+        zombie provisioning thread that races the retry's provision)."""
+        if agent is _UNSET:
+            agent = self._container_agent()
         if agent is None:
             return
         from pinky_daemon.provisioning import get_provisioner
@@ -1057,7 +1115,20 @@ class TmuxSession:
             "container",
             signing_key_provider=self._registry.get_or_create_signing_key,
         )
-        await asyncio.to_thread(provisioner.ensure_started, agent)
+        timeout = _container_start_timeout_sec()
+        try:
+            await asyncio.wait_for(
+                asyncio.to_thread(provisioner.ensure_started, agent),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            raise RuntimeError(
+                f"container start for {self.agent_name!r} exceeded "
+                f"{timeout:.0f}s (PINKY_CONTAINER_START_TIMEOUT_SEC) — likely a "
+                f"slow/wedged image pull; NOTE the underlying provisioning "
+                f"thread cannot be cancelled and may still complete in the "
+                f"background, in which case the next start attempt is fast"
+            ) from None
         await self._check_container_image_contract()
 
     async def _check_container_image_contract(self) -> None:
@@ -1128,8 +1199,15 @@ class TmuxSession:
                 )
                 return
             dst_dir.mkdir(parents=True, exist_ok=True)
-            dst.write_bytes(src.read_bytes())
-            os.chmod(dst, 0o600)
+            # Create 0600 from the first byte (no write→chmod gap in a
+            # bind-mounted dir): open with mode via os.open, then write.
+            fd = os.open(str(dst), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            try:
+                with os.fdopen(fd, "wb") as fh:
+                    fh.write(src.read_bytes())
+            except Exception:
+                dst.unlink(missing_ok=True)
+                raise
             _log(
                 f"tmux[{self.agent_name}]: seeded claude credentials into "
                 f"container config dir {dst_dir}"
@@ -1874,6 +1952,23 @@ class TmuxSession:
         # Ensure cwd exists — claude --continue needs it.
         Path(cwd).mkdir(parents=True, exist_ok=True)
 
+        # #638 (review-confirmed critical): take ONE strict registry snapshot
+        # and RE-SELECT the execution seam from it on EVERY spawn. Session
+        # objects survive isolation_mode flips (PUT /agents tears nothing
+        # down; reconnect/restart/auto-wake reuse this object), so a runner
+        # fixed at construction silently launches a flipped-to-container
+        # agent UNISOLATED on the host (or podman-wraps a flipped-to-local
+        # one into a stopped container). strict=True: a registry failure
+        # raises → BOOT_FAILED, never a quiet local fallback.
+        container_agent = self._container_agent(strict=True)
+        self._tmux.set_command_runner(self._select_command_runner(container_agent))
+
+        # Container agents: provision + start the container BEFORE any
+        # `podman exec tmux …`. Deliberately OUTSIDE the 60s cold-start
+        # umbrella below — this can include a multi-minute image pull and
+        # runs under its own budget (see _ensure_container_started).
+        await self._ensure_container_started(container_agent)
+
         # Pre-seed Claude Code's first-run trust/bypass flags (#112) so a
         # FRESH REPL doesn't wedge on the "trust this folder?" / "Bypass
         # Permissions mode" gates that --dangerously-skip-permissions does
@@ -1881,11 +1976,10 @@ class TmuxSession:
         # never block the spawn (worst case is the pre-existing wedge, not
         # a regression). Resolve the config path against the effective env
         # the launched claude inherits (daemon env + our -e overrides).
-        # Local agents seed the host's ~/.claude.json here. A container agent's
-        # trust file lives in its home VOLUME (not a host path the daemon can
-        # resolve), so it is seeded in-container via `podman exec` inside
-        # ``_spawn()`` below — once the container is actually running.
-        if self._container_agent() is None:
+        # Local agents seed the host's ~/.claude.json here. A container
+        # agent's trust file is seeded in-container via `podman exec` inside
+        # ``_spawn()`` below (the container is running by now).
+        if container_agent is None:
             try:
                 effective_env = {**os.environ, **self._build_repl_env()}
                 cfg_path = _resolve_claude_config_path(effective_env)
@@ -1931,12 +2025,9 @@ class TmuxSession:
         env = self._build_repl_env()
 
         async def _spawn():
-            # Container-isolated agents: ensure the container is provisioned +
-            # running before any `podman exec tmux …` (this is the first one).
-            # No-op for local/non-container agents and when the gate is off.
-            await self._ensure_container_started()
-            # Container is up now: seed its trust file in the home volume (via
-            # `podman exec`) before the REPL launches. No-op for local agents.
+            # Container is up (started above, outside this umbrella): seed its
+            # trust file (via `podman exec`) before the REPL launches. No-op
+            # for local agents.
             await self._seed_container_trust(cwd)
             result = await self._tmux.new_session(
                 cwd=cwd,

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1012,8 +1012,14 @@ class TmuxSession:
         from pinky_daemon.provisioning import ContainerNames, container_runtime_binary
 
         names = ContainerNames.for_agent(agent.name)
+        # The agent's host working_dir is bind-mounted into the container at the
+        # SAME absolute path (ContainerProvisioner._create_argv), so it's a valid
+        # in-container cwd. Pass it as the `podman exec -w` so every tmux command
+        # (and the claude REPL tmux launches) runs in the agent's project dir.
         return ContainerCommandRunner(
-            names.container, container_binary=container_runtime_binary()
+            names.container,
+            container_binary=container_runtime_binary(),
+            workdir=(getattr(agent, "working_dir", "") or "").strip() or None,
         )
 
     async def _ensure_container_started(self) -> None:
@@ -1031,6 +1037,58 @@ class TmuxSession:
             signing_key_provider=self._registry.get_or_create_signing_key,
         )
         await asyncio.to_thread(provisioner.ensure_started, agent)
+
+    async def _seed_container_trust(self, project_dir: str) -> None:
+        """Seed Claude Code's first-run trust/bypass flags INSIDE a container
+        agent's home volume — its ``.claude.json`` lives there, not on a host
+        path the daemon can resolve, so we ``podman exec`` the seed now that the
+        container is running. No-op for local/non-container agents. Best-effort:
+        a failure must never block the spawn (worst case is the pre-existing
+        trust-gate wedge, not a regression). Mirrors ``_seed_claude_trust_file``
+        but runs in-container and reads CLAUDE_CONFIG_DIR from the container env."""
+        runner = self._select_command_runner()
+        if not isinstance(runner, ContainerCommandRunner):
+            return
+        seed_py = (
+            "import json,os,sys,pathlib\n"
+            "cfg=(os.environ.get('CLAUDE_CONFIG_DIR') or '').strip()\n"
+            "base=pathlib.Path(cfg) if cfg else pathlib.Path(os.environ.get('HOME') or '/')\n"
+            "p=base/'.claude.json'\n"
+            "proj=os.path.realpath(sys.argv[1])\n"
+            "d={}\n"
+            "if p.exists():\n"
+            "    try: d=json.loads(p.read_text())\n"
+            "    except Exception: d={}\n"
+            "if not isinstance(d,dict): d={}\n"
+            "d['bypassPermissionsModeAccepted']=True\n"
+            "pr=d.setdefault('projects',{})\n"
+            "pr.setdefault(proj,{})\n"
+            "pr[proj]['hasTrustDialogAccepted']=True\n"
+            "pr[proj]['hasCompletedProjectOnboarding']=True\n"
+            "p.parent.mkdir(parents=True,exist_ok=True)\n"
+            "p.write_text(json.dumps(d,indent=2))\n"
+        )
+        try:
+            res = await runner.run(
+                ["python3", "-c", seed_py, project_dir], timeout=20
+            )
+            if res.ok:
+                _log(
+                    f"tmux[{self.agent_name}]: seeded in-container claude trust "
+                    f"for project {project_dir}"
+                )
+            else:
+                _log(
+                    f"tmux[{self.agent_name}]: in-container trust seed "
+                    f"rc={res.returncode} "
+                    f"stderr={res.stderr.decode('utf-8', 'replace').strip()[:200]!r} "
+                    f"(non-fatal)"
+                )
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: in-container trust seed failed "
+                f"(non-fatal): {e}"
+            )
 
     def _build_session_name(self) -> str:
         """Tmux session name pattern: ``pinky-<agent_name>``.
@@ -1721,19 +1779,24 @@ class TmuxSession:
         # never block the spawn (worst case is the pre-existing wedge, not
         # a regression). Resolve the config path against the effective env
         # the launched claude inherits (daemon env + our -e overrides).
-        try:
-            effective_env = {**os.environ, **self._build_repl_env()}
-            cfg_path = _resolve_claude_config_path(effective_env)
-            if _seed_claude_trust_file(cfg_path, cwd):
+        # Local agents seed the host's ~/.claude.json here. A container agent's
+        # trust file lives in its home VOLUME (not a host path the daemon can
+        # resolve), so it is seeded in-container via `podman exec` inside
+        # ``_spawn()`` below — once the container is actually running.
+        if self._container_agent() is None:
+            try:
+                effective_env = {**os.environ, **self._build_repl_env()}
+                cfg_path = _resolve_claude_config_path(effective_env)
+                if _seed_claude_trust_file(cfg_path, cwd):
+                    _log(
+                        f"tmux[{self.agent_name}]: pre-seeded claude trust flags "
+                        f"in {cfg_path} for project {cwd}"
+                    )
+            except Exception as e:
                 _log(
-                    f"tmux[{self.agent_name}]: pre-seeded claude trust flags "
-                    f"in {cfg_path} for project {cwd}"
+                    f"tmux[{self.agent_name}]: claude trust pre-seed failed "
+                    f"(non-fatal): {e}"
                 )
-        except Exception as e:
-            _log(
-                f"tmux[{self.agent_name}]: claude trust pre-seed failed "
-                f"(non-fatal): {e}"
-            )
 
         # Pulse-v2 idle-prompt gate (task #92) re-arms on every fresh
         # spawn. The new REPL hasn't responded to anything yet, so the
@@ -1764,6 +1827,9 @@ class TmuxSession:
             # running before any `podman exec tmux …` (this is the first one).
             # No-op for local/non-container agents and when the gate is off.
             await self._ensure_container_started()
+            # Container is up now: seed its trust file in the home volume (via
+            # `podman exec`) before the REPL launches. No-op for local agents.
+            await self._seed_container_trust(cwd)
             result = await self._tmux.new_session(
                 cwd=cwd,
                 command=claude_cmd,

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -108,6 +108,38 @@ class TestSigningKeys:
             # Agent name still bound into the signed request.
             assert 'x-pinky-agent' in src
 
+    def test_hook_templates_honor_daemon_url_env(self, tmp_path):
+        """#638: every generated tmux hook script resolves the daemon URL from
+        PINKY_DAEMON_URL (default http://localhost:8888) instead of hardcoding
+        it inline — a hardcoded localhost is dead inside a container netns;
+        container sessions inject PINKY_DAEMON_URL=http://host.containers.internal:8888.
+        """
+        from pinky_daemon import agent_registry as ar
+
+        env_line = 'os.environ.get("PINKY_DAEMON_URL", "http://localhost:8888")'
+
+        # The 5 named hook-source templates.
+        sources = [
+            ar._tmux_wake_hook_source("dymok"),
+            ar._tmux_pre_tool_hook_source("dymok"),
+            ar._tmux_post_tool_hook_source("dymok"),
+            ar._tmux_stop_failure_hook_source("dymok"),
+            ar._tmux_session_start_hook_source("dymok"),
+        ]
+        # The 6th template is inline in _setup_hooks (status hooks); cover it
+        # through the real write path so a future edit can't silently revert it.
+        AgentRegistry._setup_hooks(tmp_path, "dymok")
+        claude_dir = tmp_path / ".claude"
+        sources.append((claude_dir / "hook_idle.py").read_text())
+        sources.append((claude_dir / "hook_working.py").read_text())
+
+        for src in sources:
+            # Env-resolved URL with the loopback default still present.
+            assert env_line in src
+            # The old inline f-string shape (f"http://localhost:8888{path}")
+            # must be gone — that URL can never be overridden at runtime.
+            assert 'f"http://localhost:8888' not in src
+
     def test_backfill_skips_malformed_name_without_bricking(self, registry):
         # A legacy/non-conforming agent name must not brick boot: the per-row
         # get_or_create -> _validate_agent_name raises, but backfill log+skips

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -140,6 +140,53 @@ class TestSigningKeys:
             # must be gone — that URL can never be overridden at runtime.
             assert 'f"http://localhost:8888' not in src
 
+    def test_stale_status_hooks_rewritten_in_place(self, tmp_path):
+        """#638 review fix: hook_working.py / hook_idle.py were historically
+        write-once, stranding fleet agents on stale sources (e.g. the
+        hardcoded f"http://localhost:8888" that is dead inside a container
+        netns). They are fully PinkyBot-managed, so _setup_hooks now rewrites
+        them via _write_hook_if_changed whenever the on-disk content drifted
+        from the current template."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        stale = (
+            "#!/usr/bin/env python3\n"
+            "import urllib.request\n"
+            'path = "/agents/dymok/status"\n'
+            'req = urllib.request.Request(f"http://localhost:8888{path}")\n'
+        )
+        (claude_dir / "hook_working.py").write_text(stale)
+        (claude_dir / "hook_idle.py").write_text(stale)
+
+        AgentRegistry._setup_hooks(tmp_path, "dymok")
+
+        for fname in ("hook_working.py", "hook_idle.py"):
+            src = (claude_dir / fname).read_text()
+            assert src != stale  # rewritten, not left alone
+            # Current template: env-resolved daemon URL, no hardcoded inline
+            # f-string that a container session could never override.
+            assert "PINKY_DAEMON_URL" in src
+            assert 'f"http://localhost:8888' not in src
+        # The pair stays distinct — each posts its own status payload.
+        assert '"status": "working"' in (claude_dir / "hook_working.py").read_text()
+        assert '"status": "idle"' in (claude_dir / "hook_idle.py").read_text()
+
+    def test_current_status_hooks_left_untouched(self, tmp_path):
+        """The rewrite is content-gated: a second _setup_hooks run over
+        already-current sources must not touch the files (no churn on every
+        registration / workspace sync)."""
+        AgentRegistry._setup_hooks(tmp_path, "dymok")
+        claude_dir = tmp_path / ".claude"
+        working = claude_dir / "hook_working.py"
+        idle = claude_dir / "hook_idle.py"
+        before = (working.read_text(), idle.read_text())
+        before_mtimes = (working.stat().st_mtime_ns, idle.stat().st_mtime_ns)
+
+        AgentRegistry._setup_hooks(tmp_path, "dymok")
+
+        assert (working.read_text(), idle.read_text()) == before
+        assert (working.stat().st_mtime_ns, idle.stat().st_mtime_ns) == before_mtimes
+
     def test_backfill_skips_malformed_name_without_bricking(self, registry):
         # A legacy/non-conforming agent name must not brick boot: the per-row
         # get_or_create -> _validate_agent_name raises, but backfill log+skips

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -677,6 +677,7 @@ class TestAPI:
                 r = client.post("/agents", json={
                     "name": "tenant", "model": "sonnet", "transport": "tmux",
                     "isolated": True, "isolation_mode": "container",
+                    "container_image": "myco/agent:1",
                 })
                 assert r.status_code == 200  # registers (provision skipped, gate off)
                 resp = client.post("/agents/tenant/wake?prompt=Wake")
@@ -695,6 +696,7 @@ class TestAPI:
                 client.post("/agents", json={
                     "name": "tenant", "model": "sonnet",  # default transport=sdk
                     "isolated": True, "isolation_mode": "container",
+                    "container_image": "myco/agent:1",
                 })
                 resp = client.post("/agents/tenant/wake?prompt=Wake")
                 assert resp.status_code == 400

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -605,7 +605,7 @@ class TestAPI:
             app = self._make_app(db_path)
             with TestClient(app) as client:
                 r = client.post("/agents", json={
-                    "name": "bad", "model": "sonnet", "isolation_mode": "container",
+                    "name": "bad", "model": "sonnet", "isolation_mode": "qemu_vm",
                 })
                 assert r.status_code == 422
 
@@ -624,11 +624,34 @@ class TestAPI:
                 assert r.json()["isolation_mode"] == "unix_user"
                 assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
 
-                # Unknown value rejected by the validator.
-                bad = client.put("/agents/tenant", json={"isolation_mode": "container"})
+                # A known mode (container) is accepted by the validator...
+                ok = client.put("/agents/tenant", json={"isolation_mode": "container"})
+                assert ok.status_code == 200
+                assert ok.json()["isolation_mode"] == "container"
+                # ...while a truly-unknown value is still rejected.
+                bad = client.put("/agents/tenant", json={"isolation_mode": "qemu_vm"})
                 assert bad.status_code == 422
                 # Unchanged after the rejected update.
-                assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
+                assert client.get("/agents/tenant").json()["isolation_mode"] == "container"
+
+    def test_container_agent_cannot_start_before_activation(self):
+        """Container isolation is opt-in but DORMANT: an agent labeled
+        isolation_mode='container' registers fine yet REFUSES to start (501)
+        until the activation increment wires the lifecycle — same fail-closed
+        guarantee as unix_user, so it never silently runs under the daemon uid
+        with no container isolation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolated": True, "isolation_mode": "container",
+                })
+                resp = client.post("/agents/tenant/wake?prompt=Wake")
+                assert resp.status_code == 501
+                assert "not runnable yet" in resp.text
+                assert "container" in resp.text
 
     def test_unix_user_agent_cannot_start_before_provisioner(self):
         """#149 phase-3 (Murzik #642 P1): an agent labeled isolation_mode=

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -598,9 +598,12 @@ class TestAPI:
                 # Confirm it survives a re-fetch.
                 assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
 
-    def test_container_image_round_trips(self):
+    def test_container_image_round_trips(self, monkeypatch):
         """Container isolation: POST/PUT /agents carry the operator-supplied
         container_image through to the stored agent; default is empty."""
+        # Hermetic: with the gate env set on the dev host this would invoke
+        # the REAL get_provisioner('container') (SystemContainerOps → podman).
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
@@ -653,8 +656,14 @@ class TestAPI:
                 assert r.json()["isolation_mode"] == "unix_user"
                 assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
 
-                # A known mode (container) is accepted by the validator...
-                ok = client.put("/agents/tenant", json={"isolation_mode": "container"})
+                # A known mode (container) is accepted by the validator —
+                # with an image, per the #638 final-state check (the
+                # imageless flip is pinned to 422 in
+                # test_update_container_mode_requires_image_on_file).
+                ok = client.put("/agents/tenant", json={
+                    "isolation_mode": "container",
+                    "container_image": "myco/agent:1",
+                })
                 assert ok.status_code == 200
                 assert ok.json()["isolation_mode"] == "container"
                 # ...while a truly-unknown value is still rejected.
@@ -800,12 +809,12 @@ class TestAPI:
 
     def test_container_agent_mcp_json_carries_bearer_auth(self, monkeypatch):
         """#638/#623: a container agent's .mcp.json points every pinky-* server
-        at the shared MCP via host.containers.internal and carries the agent's
-        per-agent signing key as an Authorization bearer (required for
-        non-loopback peers) plus the X-Agent-Name identity header."""
+        at the shared MCP via host.containers.internal and carries the DERIVED
+        bearer of its per-agent signing key (required for non-loopback peers;
+        the raw key never travels as a header) plus X-Agent-Name."""
         from pathlib import Path
 
-        from pinky_daemon.shared_mcp import SHARED_MCP_PORT
+        from pinky_daemon.shared_mcp import SHARED_MCP_PORT, derive_mcp_bearer
 
         monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -835,7 +844,9 @@ class TestAPI:
                         f"http://host.containers.internal:{SHARED_MCP_PORT}/mcp/"
                     )
                     assert cfg["headers"]["X-Agent-Name"] == "tenant"
-                    assert cfg["headers"]["Authorization"] == f"Bearer {key}"
+                    assert cfg["headers"]["Authorization"] == (
+                        f"Bearer {derive_mcp_bearer(key)}"
+                    )
 
     def test_register_container_mode_coerces_isolated(self, monkeypatch):
         """#638: a non-local isolation_mode IS isolation — POST with
@@ -891,6 +902,234 @@ class TestAPI:
                 })
                 assert r.status_code == 422
                 assert "container_image" in r.text
+
+    def test_update_container_mode_requires_image_on_file(self, monkeypatch):
+        """#638 review fix: PUT validates the MERGED record — flipping to
+        isolation_mode='container' with no image on file is rejected (422)
+        instead of producing an unrunnable tenant at first provision."""
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "tenant", "model": "sonnet"})
+
+                r = client.put("/agents/tenant", json={"isolation_mode": "container"})
+                assert r.status_code == 422
+                assert "container_image" in r.text
+                # The record is unchanged by the rejected update.
+                assert client.get("/agents/tenant").json()["isolation_mode"] == "local"
+
+    def test_update_cannot_clear_image_of_container_agent(self, monkeypatch):
+        """#638 review fix: the other half of the merged-record check — PUT
+        {container_image: ""} on a container agent would leave the final state
+        container-mode-without-an-image, so it is rejected (422)."""
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolated": True, "isolation_mode": "container",
+                    "container_image": "myco/agent:1",
+                })
+                assert r.status_code == 200
+
+                r = client.put("/agents/tenant", json={"container_image": ""})
+                assert r.status_code == 422
+                assert "container_image" in r.text
+                # Image (and mode) survive the rejected update.
+                got = client.get("/agents/tenant").json()
+                assert got["container_image"] == "myco/agent:1"
+                assert got["isolation_mode"] == "container"
+
+    def test_update_to_container_rewrites_mcp_json_to_sse(self, monkeypatch):
+        """#638 review fix: the documented flow is "flip via PUT, then restart
+        the agent" and the restart path does NOT rewrite .mcp.json — so the
+        PUT itself must regenerate it. Before: stdio (host-python "command"
+        servers). After: SSE via host.containers.internal."""
+        from pathlib import Path
+
+        import pinky_daemon.api as api_mod
+
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        # Hermetic: stdio is the local-agent shape only while shared mode is off.
+        monkeypatch.setattr(api_mod, "SHARED_MCP_ENABLED", False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            work_dir = os.path.join(tmpdir, "agents", "tenant")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet", "working_dir": work_dir,
+                })
+                assert r.status_code == 200
+                before = (Path(work_dir) / ".mcp.json").read_text()
+                assert "command" in before  # stdio servers (host python)
+                assert "host.containers.internal" not in before
+
+                r = client.put("/agents/tenant", json={
+                    "isolation_mode": "container",
+                    "container_image": "myco/agent:1",
+                })
+                assert r.status_code == 200
+
+                after = json.loads(
+                    (Path(work_dir) / ".mcp.json").read_text()
+                )["mcpServers"]
+                for server in ("pinky-memory", "pinky-self", "pinky-messaging"):
+                    assert after[server]["type"] == "sse"
+                    assert after[server]["url"].startswith(
+                        "http://host.containers.internal:"
+                    )
+                    assert "command" not in after[server]
+
+    def test_update_downgrade_container_to_local_deprovisions(self, monkeypatch):
+        """#638 review fix: PUT flipping container -> local tears down the
+        container + key secret (deprovision) so they don't orphan forever —
+        retire was previously the only deprovision site."""
+        from pinky_daemon import provisioning
+
+        calls = []
+
+        class _FakeProv:
+            def provision(self, agent):
+                calls.append(("provision", agent.name))
+                return provisioning.ProvisionResult(ok=True, mode="container")
+
+            def deprovision(self, agent, **kw):
+                calls.append(("deprovision", agent.name))
+                return provisioning.ProvisionResult(ok=True, mode="container")
+
+        monkeypatch.setattr(
+            provisioning, "get_provisioner", lambda mode, **kw: _FakeProv()
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolated": True, "isolation_mode": "container",
+                    "container_image": "myco/agent:1",
+                })
+                assert r.status_code == 200
+
+                r = client.put("/agents/tenant", json={"isolation_mode": "local"})
+                assert r.status_code == 200
+                assert r.json()["isolation_mode"] == "local"
+                # Deprovision fired exactly once, for this tenant.
+                assert [c for c in calls if c[0] == "deprovision"] == [
+                    ("deprovision", "tenant")
+                ]
+                assert client.get("/agents/tenant").json()["isolation_mode"] == "local"
+
+    def test_update_isolated_false_clears_flag_on_local_agent(self):
+        """UpdateAgentRequest.isolated (#638): settable so a container->local
+        round trip can explicitly lift the auto-coerced isolation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet", "isolated": True,
+                })
+                assert client.get("/agents/tenant").json()["isolated"] is True
+
+                r = client.put("/agents/tenant", json={"isolated": False})
+                assert r.status_code == 200
+                assert r.json()["isolated"] is False
+                assert client.get("/agents/tenant").json()["isolated"] is False
+
+    def test_update_isolated_false_recoerced_for_container_mode(self, monkeypatch):
+        """#638: the handler re-coerces isolated=True for any non-local mode —
+        an explicit {"isolated": false} alongside a container flip must NOT
+        hand the tenant the fleet-wide forgeable secret."""
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "tenant", "model": "sonnet"})
+
+                r = client.put("/agents/tenant", json={
+                    "isolated": False,
+                    "isolation_mode": "container",
+                    "container_image": "myco/agent:1",
+                })
+                assert r.status_code == 200
+                assert r.json()["isolated"] is True
+                assert client.get("/agents/tenant").json()["isolated"] is True
+
+    def test_transcript_path_allows_container_config_root(self, monkeypatch):
+        """#638: a container agent's claude runs with CLAUDE_CONFIG_DIR=
+        <working_dir>/.claude-container, so its SessionStart hook legitimately
+        reports a transcript under <wd>/.claude-container/projects/... — the
+        endpoint must accept that root (without it the report 403s and the
+        tailer never repoints off its cold-start guess)."""
+        from pathlib import Path
+
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            work_dir = os.path.join(tmpdir, "agents", "tenant")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet", "transport": "tmux",
+                    "isolated": True, "isolation_mode": "container",
+                    "container_image": "myco/agent:1",
+                    "working_dir": work_dir,
+                })
+                assert r.status_code == 200
+
+                candidate = (
+                    Path(work_dir) / ".claude-container" / "projects"
+                    / "-srv-agents-tenant" / "session.jsonl"
+                )
+                resp = client.post(
+                    "/agents/tenant/transport/transcript-path",
+                    json={"transcript_path": str(candidate)},
+                )
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["ok"] is True
+                # No live session registered — the path VALIDATION passing is
+                # what this test pins.
+                assert body.get("session") is None
+
+                # The perimeter still holds for the same container agent.
+                resp = client.post(
+                    "/agents/tenant/transport/transcript-path",
+                    json={"transcript_path": "/etc/passwd"},
+                )
+                assert resp.status_code == 403
+
+    def test_transcript_path_container_root_denied_for_local_agent(self, monkeypatch):
+        """The container-config root exists ONLY for isolation_mode='container'
+        rows — a local agent reporting the container-style path is still
+        403'd (its only legitimate root is ~/.claude/projects/)."""
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            work_dir = os.path.join(tmpdir, "agents", "plain")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={
+                    "name": "plain", "model": "sonnet", "working_dir": work_dir,
+                })
+                assert r.status_code == 200
+
+                candidate = os.path.join(
+                    work_dir, ".claude-container", "projects", "x", "s.jsonl"
+                )
+                resp = client.post(
+                    "/agents/plain/transport/transcript-path",
+                    json={"transcript_path": candidate},
+                )
+                assert resp.status_code == 403
+                assert "projects" in resp.json()["detail"].lower()
 
     def test_unix_user_agent_cannot_start_before_provisioner(self):
         """#149 phase-3 (Murzik #642 P1): an agent labeled isolation_mode=

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -598,6 +598,35 @@ class TestAPI:
                 # Confirm it survives a re-fetch.
                 assert client.get("/agents/tenant").json()["isolation_mode"] == "unix_user"
 
+    def test_container_image_round_trips(self):
+        """Container isolation: POST/PUT /agents carry the operator-supplied
+        container_image through to the stored agent; default is empty."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                # Default is empty.
+                r = client.post("/agents", json={"name": "plain", "model": "sonnet"})
+                assert r.status_code == 200
+                assert r.json()["container_image"] == ""
+
+                # Registering a container agent persists its image.
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolated": True, "isolation_mode": "container",
+                    "container_image": "myco/agent:1.4",
+                })
+                assert r.status_code == 200
+                assert r.json()["container_image"] == "myco/agent:1.4"
+                assert client.get("/agents/tenant").json()["container_image"] == "myco/agent:1.4"
+
+                # PUT updates the image; an unrelated update leaves it intact.
+                up = client.put("/agents/tenant", json={"container_image": "myco/agent:2.0"})
+                assert up.status_code == 200
+                assert up.json()["container_image"] == "myco/agent:2.0"
+                client.put("/agents/tenant", json={"display_name": "Tenant"})
+                assert client.get("/agents/tenant").json()["container_image"] == "myco/agent:2.0"
+
     def test_register_rejects_unknown_isolation_mode(self):
         """The api_models validator rejects modes outside the known set (422)."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -663,24 +663,90 @@ class TestAPI:
                 # Unchanged after the rejected update.
                 assert client.get("/agents/tenant").json()["isolation_mode"] == "container"
 
-    def test_container_agent_cannot_start_before_activation(self):
-        """Container isolation is opt-in but DORMANT: an agent labeled
-        isolation_mode='container' registers fine yet REFUSES to start (501)
-        until the activation increment wires the lifecycle — same fail-closed
-        guarantee as unix_user, so it never silently runs under the daemon uid
-        with no container isolation."""
+    def test_container_agent_cannot_start_before_activation(self, monkeypatch):
+        """Container isolation is opt-in but DORMANT by default: with the runtime
+        gate OFF, a container agent registers fine yet REFUSES to start (501) —
+        same fail-closed guarantee as unix_user, so it never silently runs under
+        the daemon uid with no container isolation."""
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                # transport=tmux so we exercise the gate (not the tmux guard).
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet", "transport": "tmux",
+                    "isolated": True, "isolation_mode": "container",
+                })
+                assert r.status_code == 200  # registers (provision skipped, gate off)
+                resp = client.post("/agents/tenant/wake?prompt=Wake")
+                assert resp.status_code == 501
+                assert "not runnable yet" in resp.text
+                assert "container" in resp.text
+
+    def test_container_requires_tmux_transport(self, monkeypatch):
+        """A container agent on a non-tmux transport is blocked at start with a
+        clear 400 — container exec only works through the tmux CommandRunner."""
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             with TestClient(app) as client:
                 client.post("/agents", json={
-                    "name": "tenant", "model": "sonnet",
+                    "name": "tenant", "model": "sonnet",  # default transport=sdk
                     "isolated": True, "isolation_mode": "container",
                 })
                 resp = client.post("/agents/tenant/wake?prompt=Wake")
-                assert resp.status_code == 501
-                assert "not runnable yet" in resp.text
-                assert "container" in resp.text
+                assert resp.status_code == 400
+                assert "transport='tmux'" in resp.text
+
+    def test_register_provisions_and_retire_deprovisions(self, monkeypatch):
+        """Lifecycle wiring: register calls provisioner.provision and retire
+        calls deprovision (best-effort). Uses a fake provisioner so no real
+        podman is needed."""
+        from pinky_daemon import provisioning
+
+        calls = []
+
+        class _FakeProv:
+            def provision(self, agent):
+                calls.append(("provision", agent.name))
+                return provisioning.ProvisionResult(ok=True, mode="container")
+
+            def deprovision(self, agent, **kw):
+                calls.append(("deprovision", agent.name))
+                return provisioning.ProvisionResult(ok=True, mode="container")
+
+        monkeypatch.setattr(provisioning, "get_provisioner", lambda mode, **kw: _FakeProv())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={"name": "tenant", "model": "sonnet"})
+                assert r.status_code == 200
+                assert ("provision", "tenant") in calls
+                d = client.delete("/agents/tenant")
+                assert d.status_code == 200
+                assert ("deprovision", "tenant") in calls
+
+    def test_register_rolls_back_on_provision_failure(self, monkeypatch):
+        """A failed provision rolls back the just-registered agent (hard delete)
+        and surfaces a 500 — no half-provisioned tenant is left behind."""
+        from pinky_daemon import provisioning
+
+        class _FailProv:
+            def provision(self, agent):
+                return provisioning.ProvisionResult(ok=False, mode="container", message="boom")
+
+        monkeypatch.setattr(provisioning, "get_provisioner", lambda mode, **kw: _FailProv())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={"name": "tenant", "model": "sonnet"})
+                assert r.status_code == 500
+                assert "boom" in r.text
+                assert client.get("/agents/tenant").status_code == 404  # rolled back
 
     def test_unix_user_agent_cannot_start_before_provisioner(self):
         """#149 phase-3 (Murzik #642 P1): an agent labeled isolation_mode=

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -750,6 +750,148 @@ class TestAPI:
                 assert "boom" in r.text
                 assert client.get("/agents/tenant").status_code == 404  # rolled back
 
+    def test_register_upsert_keeps_existing_agent_on_provision_failure(self, monkeypatch):
+        """#638: POST /agents is an UPSERT — a provision failure must only roll
+        back a NEWLY created agent. A pre-existing agent re-POSTed through a
+        failing provisioner is KEPT (500 says so explicitly): hard-deleting it
+        over a transient podman error would destroy a live tenant."""
+        from pinky_daemon import provisioning
+
+        fail = {"on": False}
+
+        class _TogglableProv:
+            def provision(self, agent):
+                if fail["on"]:
+                    return provisioning.ProvisionResult(
+                        ok=False, mode="container", message="podman flaked"
+                    )
+                return provisioning.ProvisionResult(ok=True, mode="container")
+
+            def deprovision(self, agent, **kw):
+                return provisioning.ProvisionResult(ok=True, mode="container")
+
+        monkeypatch.setattr(
+            provisioning, "get_provisioner", lambda mode, **kw: _TogglableProv()
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                # Case A: brand-new agent + failing provision -> 500, rolled back.
+                fail["on"] = True
+                r = client.post("/agents", json={"name": "newbie", "model": "sonnet"})
+                assert r.status_code == 500
+                assert "podman flaked" in r.text
+                assert "existing agent kept" not in r.text  # new-agent branch
+                assert client.get("/agents/newbie").status_code == 404
+
+                # Case B: agent exists (provision succeeded), then a re-POST
+                # hits a failing provisioner -> 500 but the agent SURVIVES.
+                fail["on"] = False
+                r = client.post("/agents", json={"name": "tenant", "model": "sonnet"})
+                assert r.status_code == 200
+
+                fail["on"] = True
+                r = client.post("/agents", json={"name": "tenant", "model": "sonnet"})
+                assert r.status_code == 500
+                assert "podman flaked" in r.text
+                assert "existing agent kept" in r.text
+                assert client.get("/agents/tenant").status_code == 200  # NOT deleted
+
+    def test_container_agent_mcp_json_carries_bearer_auth(self, monkeypatch):
+        """#638/#623: a container agent's .mcp.json points every pinky-* server
+        at the shared MCP via host.containers.internal and carries the agent's
+        per-agent signing key as an Authorization bearer (required for
+        non-loopback peers) plus the X-Agent-Name identity header."""
+        from pathlib import Path
+
+        from pinky_daemon.shared_mcp import SHARED_MCP_PORT
+
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            work_dir = os.path.join(tmpdir, "agents", "tenant")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet", "transport": "tmux",
+                    "isolated": True, "isolation_mode": "container",
+                    "container_image": "myco/agent:1",
+                    "working_dir": work_dir,
+                })
+                assert r.status_code == 200
+
+                key = app.state.agents.get_signing_key("tenant")
+                assert key  # minted at registration
+
+                mcp = json.loads(
+                    (Path(work_dir) / ".mcp.json").read_text()
+                )["mcpServers"]
+                for server in ("pinky-memory", "pinky-self", "pinky-messaging"):
+                    cfg = mcp[server]
+                    assert cfg["type"] == "sse"
+                    # Reaches the daemon over the rootless network, not loopback.
+                    assert cfg["url"].startswith(
+                        f"http://host.containers.internal:{SHARED_MCP_PORT}/mcp/"
+                    )
+                    assert cfg["headers"]["X-Agent-Name"] == "tenant"
+                    assert cfg["headers"]["Authorization"] == f"Bearer {key}"
+
+    def test_register_container_mode_coerces_isolated(self, monkeypatch):
+        """#638: a non-local isolation_mode IS isolation — POST with
+        isolation_mode='container' and `isolated` OMITTED still yields
+        isolated=true, so a container tenant can never receive the forgeable
+        global secret just because a caller forgot the bool."""
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolation_mode": "container",
+                    "container_image": "myco/agent:1",
+                    # isolated deliberately omitted (defaults False)
+                })
+                assert r.status_code == 200
+                assert r.json()["isolated"] is True
+                assert client.get("/agents/tenant").json()["isolated"] is True
+
+    def test_update_container_mode_coerces_isolated(self, monkeypatch):
+        """#638: the PUT path enforces the same coupling — flipping an existing
+        isolated=false agent to isolation_mode='container' implies
+        isolated=true (without it the updated tenant would keep the fleet-wide
+        PINKY_SESSION_SECRET inside its sandbox)."""
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "tenant", "model": "sonnet"})
+                assert client.get("/agents/tenant").json()["isolated"] is False
+
+                r = client.put("/agents/tenant", json={
+                    "isolation_mode": "container", "container_image": "myco/agent:1",
+                })
+                assert r.status_code == 200
+                assert r.json()["isolated"] is True
+                assert client.get("/agents/tenant").json()["isolated"] is True
+
+    def test_register_container_mode_requires_image(self):
+        """#638: container mode is unrunnable without an image — POST with
+        isolation_mode='container' and no container_image fails at registration
+        (422) instead of at first provision."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                r = client.post("/agents", json={
+                    "name": "tenant", "model": "sonnet",
+                    "isolation_mode": "container",
+                })
+                assert r.status_code == 422
+                assert "container_image" in r.text
+
     def test_unix_user_agent_cannot_start_before_provisioner(self):
         """#149 phase-3 (Murzik #642 P1): an agent labeled isolation_mode=
         'unix_user' is accepted at registration but REFUSES to start (501)

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -15,6 +15,7 @@ import pytest
 
 from pinky_daemon.command_runner import (
     CommandResult,
+    ContainerCommandRunner,
     LocalCommandRunner,
     RunuserCommandRunner,
 )
@@ -103,3 +104,45 @@ class TestRunuserCommandRunner:
     async def test_empty_username_rejected(self):
         with pytest.raises(ValueError):
             RunuserCommandRunner("")
+
+
+@pytest.mark.asyncio
+class TestContainerCommandRunner:
+    async def test_wrap_shape_minimal(self):
+        r = ContainerCommandRunner("pinky-mora")
+        assert r.wrap(["tmux", "has-session", "-t", "x"]) == [
+            "podman", "exec", "--", "pinky-mora", "tmux", "has-session", "-t", "x",
+        ]
+
+    async def test_wrap_includes_user_and_workdir(self):
+        r = ContainerCommandRunner("pinky-mora", user="agent", workdir="/home/agent/workdir")
+        assert r.wrap(["tmux"]) == [
+            "podman", "exec", "-u", "agent", "-w", "/home/agent/workdir",
+            "--", "pinky-mora", "tmux",
+        ]
+
+    async def test_custom_container_binary(self):
+        r = ContainerCommandRunner("pinky-mora", container_binary="docker")
+        assert r.wrap(["tmux"])[0] == "docker"
+
+    async def test_terminator_isolates_wrapped_options(self):
+        # A wrapped arg that looks like an exec option must sit AFTER ``--``.
+        r = ContainerCommandRunner("pinky-mora")
+        wrapped = r.wrap(["send-keys", "-l", "hi"])
+        assert wrapped.index("--") < wrapped.index("-l")
+        # the container name comes right after the terminator
+        assert wrapped[wrapped.index("--") + 1] == "pinky-mora"
+
+    async def test_run_delegates_wrapped_argv_to_inner(self):
+        inner = _RecordingRunner()
+        r = ContainerCommandRunner("pinky-mora", user="agent", inner=inner)
+        await r.run(["tmux", "kill-session"], timeout=5.0, stdin=b"x")
+        assert len(inner.calls) == 1
+        argv, timeout, stdin = inner.calls[0]
+        assert argv == ["podman", "exec", "-u", "agent", "--", "pinky-mora", "tmux", "kill-session"]
+        assert timeout == 5.0  # timeout/stdin pass through unchanged
+        assert stdin == b"x"
+
+    async def test_empty_container_rejected(self):
+        with pytest.raises(ValueError):
+            ContainerCommandRunner("")

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -740,3 +740,26 @@ class TestSystemContainerOps:
         assert captured["argv"] == ["podman", "secret", "create", "pinky-x-key", "-"]
         assert captured["input"] == b"s3cret"
         assert "s3cret" not in " ".join(captured["argv"])
+
+
+class TestContainerDefaultImageProvider:
+    """With no image_provider injected, ContainerProvisioner resolves the image
+    from the agent's persisted ``container_image`` field (activation prep)."""
+
+    def test_reads_agent_container_image(self):
+        ops = RecordingContainerOps()
+        agent = Agent(
+            name="tenant", model="opus", isolated=True,
+            isolation_mode="container", container_image="myco/agent:1",
+        )
+        result = ContainerProvisioner(ops=ops, signing_key_provider=lambda n: "k").provision(agent)
+        assert result.ok is True
+        assert ["podman", "pull", "myco/agent:1"] in ops.commands
+
+    def test_fails_closed_when_container_image_unset(self):
+        ops = RecordingContainerOps()
+        agent = Agent(name="tenant", model="opus", isolation_mode="container")  # no image
+        result = ContainerProvisioner(ops=ops, signing_key_provider=lambda n: "k").provision(agent)
+        assert result.ok is False
+        assert "container_image" in result.message
+        assert ops.commands == []

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -8,6 +8,8 @@ maps modes correctly, and the unimplemented unix_user path fails closed
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from pinky_daemon.agent_registry import Agent
@@ -1078,6 +1080,122 @@ class TestContainerImageDriftRecreate:
         ops = self._full_ops(current_image="myco/agent:1")
         _cprov(ops, image_provider=lambda a: "").ensure_started(container_agent)
         assert ops.commands == [["podman", "start", "pinky-tenant"]]
+
+
+class TestImageDriftPullBeforeRm:
+    """#638 review fix: on image drift, the NEW image is pulled BEFORE the
+    working container is ``rm -f``'d — a typo'd ref or a registry outage must
+    leave the agent running on the old image (with a raised, actionable
+    error), never container-less."""
+
+    def _full_ops(self, **kw):
+        return DriftAwareContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+            **kw,
+        )
+
+    def test_missing_new_image_pulled_before_rm(self, container_agent):
+        # Desired myco/agent:2 is NOT present locally → pull must precede rm.
+        ops = self._full_ops(current_image="myco/agent:1")
+        _cprov(ops, image_provider=lambda a: "myco/agent:2").ensure_started(container_agent)
+        pull = ops.commands.index(["podman", "pull", "myco/agent:2"])
+        rm = ops.commands.index(["podman", "rm", "-f", "pinky-tenant"])
+        assert pull < rm
+        # Exactly one pull — the re-provision after rm sees the image present.
+        assert [c for c in ops.commands if len(c) > 1 and c[1] == "pull"] == [
+            ["podman", "pull", "myco/agent:2"]
+        ]
+        # The recreate still completed and the tenant is up.
+        assert ops.container_exists("pinky-tenant")
+        assert "myco/agent:2" in _create_cmd(ops)
+        assert ops.commands[-1] == ["podman", "start", "pinky-tenant"]
+
+    def test_present_new_image_not_pulled(self, container_agent):
+        # Image already local → no pull at all; drift still recreates.
+        ops = self._full_ops(current_image="myco/agent:1", images={"myco/agent:2"})
+        _cprov(ops, image_provider=lambda a: "myco/agent:2").ensure_started(container_agent)
+        assert not any(len(c) > 1 and c[1] == "pull" for c in ops.commands)
+        assert ["podman", "rm", "-f", "pinky-tenant"] in ops.commands
+        assert "myco/agent:2" in _create_cmd(ops)
+
+    def test_failed_pull_keeps_old_container(self, container_agent):
+        # The load-bearing property of the ordering: a failing pull raises
+        # BEFORE rm, so the existing container survives untouched.
+        ops = self._full_ops(
+            current_image="myco/agent:1",
+            fail_predicate=lambda a: len(a) > 1 and a[1] == "pull",
+        )
+        with pytest.raises(ProvisionError):
+            _cprov(ops, image_provider=lambda a: "myco/agent:9").ensure_started(
+                container_agent
+            )
+        assert ops.container_exists("pinky-tenant")  # never rm'd
+        assert ["podman", "rm", "-f", "pinky-tenant"] not in ops.commands
+
+
+class TestHostWorkdirResolution:
+    """``_host_workdir`` (#638 review fix): an ABSOLUTE working_dir is
+    symlink-resolved to match the api factory's ``Path(...).resolve()`` — the
+    mount, the in-container cwd, and CLAUDE_CONFIG_DIR must all agree on ONE
+    canonical path or hooks/transcripts silently miss. A relative working_dir
+    is returned as-is (it can't be same-path bind-mounted) and keeps the
+    home-volume config-dir fallback."""
+
+    def _agent(self, working_dir):
+        return Agent(
+            name="tenant", model="opus", isolated=True,
+            isolation_mode="container", working_dir=working_dir,
+        )
+
+    def test_absolute_symlinked_workdir_resolved_in_create_argv(self, tmp_path):
+        real = tmp_path / "real-wd"
+        real.mkdir()
+        link = tmp_path / "link-wd"
+        os.symlink(real, link)
+        resolved = str(link.resolve())
+        assert resolved != str(link)  # the symlink genuinely diverges
+
+        ops = RecordingContainerOps()
+        p = _cprov(ops)
+        agent = self._agent(str(link))
+        assert p._host_workdir(agent) == resolved
+
+        p.provision(agent)
+        cc = _create_cmd(ops)
+        # Same-path bind mount and CLAUDE_CONFIG_DIR both use the RESOLVED path.
+        assert f"{resolved}:{resolved}" in cc
+        assert f"CLAUDE_CONFIG_DIR={resolved}/.claude-container" in cc
+        # No token still carries the raw symlinked variant.
+        assert not any(str(link) in tok for tok in cc)
+        # runtime_env agrees with the create argv.
+        env = p.runtime_env(agent)
+        assert env["CLAUDE_CONFIG_DIR"] == f"{resolved}/.claude-container"
+
+    def test_already_canonical_absolute_path_unchanged(self, tmp_path):
+        real = tmp_path / "wd"
+        real.mkdir()
+        canonical = str(real.resolve())
+        p = _cprov(RecordingContainerOps())
+        assert p._host_workdir(self._agent(canonical)) == canonical
+
+    def test_relative_workdir_returned_as_is_with_home_volume_fallback(self):
+        ops = RecordingContainerOps()
+        p = _cprov(ops)
+        agent = self._agent("data/agents/tenant")
+        # Never resolved against the daemon's CWD — returned verbatim.
+        assert p._host_workdir(agent) == "data/agents/tenant"
+        p.provision(agent)
+        # The config dir falls back to the home volume (a relative path can't
+        # be same-path bind-mounted).
+        assert "CLAUDE_CONFIG_DIR=/home/agent/.claude" in _create_cmd(ops)
+        assert p.runtime_env(agent)["CLAUDE_CONFIG_DIR"] == "/home/agent/.claude"
+
+    def test_blank_workdir_returned_empty(self):
+        p = _cprov(RecordingContainerOps())
+        assert p._host_workdir(self._agent("   ")) == ""
+        assert p._host_workdir(self._agent("")) == ""
 
 
 class TestSystemContainerOpsMissingBinary:

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -15,9 +15,12 @@ from pinky_daemon.provisioning import (
     KNOWN_MODES,
     SECRET_MODE,
     AgentProvisioner,
+    ContainerNames,
+    ContainerProvisioner,
     LocalProvisioner,
     ProvisionError,
     ProvisionResult,
+    SystemContainerOps,
     SystemProvisionOps,
     UnixUserPaths,
     UnixUserProvisioner,
@@ -79,12 +82,20 @@ class TestGetProvisioner:
             get_provisioner("unix_user")
         assert "fail-closed" in str(exc.value)
 
+    def test_container_stays_fail_closed(self):
+        # Same dormancy guarantee as unix_user: ContainerProvisioner exists but
+        # the factory raises so the #642 respawn guard keeps blocking container
+        # until the activation increment wires the lifecycle.
+        with pytest.raises(NotImplementedError) as exc:
+            get_provisioner("container")
+        assert "fail-closed" in str(exc.value)
+
     def test_unknown_mode_rejected(self):
         with pytest.raises(ValueError):
-            get_provisioner("container")
+            get_provisioner("qemu_vm")
 
     def test_known_modes_constant(self):
-        assert KNOWN_MODES == frozenset({"local", "unix_user"})
+        assert KNOWN_MODES == frozenset({"local", "unix_user", "container"})
 
 
 class TestProvisionResult:
@@ -428,3 +439,304 @@ class TestSystemProvisionOps:
         resolve = make_db_signing_key_resolver(str(target))
         assert resolve("tenant") == "sekret"
         assert resolve("someone-else") is None
+
+
+# --------------------------------------------------------------------------- #
+# container provisioning (container isolation_mode)
+# --------------------------------------------------------------------------- #
+
+
+class RecordingContainerOps:
+    """In-memory ContainerOps double: records every podman command + tracks
+    image/volume/secret/container state so idempotency + rollback paths are
+    exercised without a real container runtime.
+
+    ``fail_predicate(argv) -> bool`` injects a mid-provision command failure.
+    """
+
+    def __init__(
+        self, *, images=None, volumes=None, secrets=None, containers=None, fail_predicate=None
+    ):
+        self.commands: list[list[str]] = []
+        self.secrets_written: list[tuple[str, str]] = []
+        self._images = set(images or [])
+        self._volumes = set(volumes or [])
+        self._secrets = set(secrets or [])
+        self._containers = set(containers or [])
+        self._fail = fail_predicate
+
+    def run(self, argv):
+        self.commands.append(list(argv))
+        if self._fail and self._fail(list(argv)):
+            raise ProvisionError(f"injected failure: {' '.join(argv)}")
+        # Reflect state mutations (argv[0] is the podman binary).
+        if len(argv) >= 4 and argv[1] == "volume" and argv[2] == "create":
+            self._volumes.add(argv[3])
+        elif len(argv) >= 3 and argv[1] == "pull":
+            self._images.add(argv[2])
+        elif len(argv) >= 4 and argv[1] == "create" and argv[2] == "--name":
+            self._containers.add(argv[3])
+        elif len(argv) >= 4 and argv[1] == "rm" and argv[2] == "-f":
+            self._containers.discard(argv[3])
+        elif len(argv) >= 4 and argv[1] == "secret" and argv[2] == "rm":
+            self._secrets.discard(argv[3])
+        elif len(argv) >= 4 and argv[1] == "volume" and argv[2] == "rm":
+            self._volumes.discard(argv[3])
+
+    def image_exists(self, ref):
+        return ref in self._images
+
+    def volume_exists(self, name):
+        return name in self._volumes
+
+    def secret_exists(self, name):
+        return name in self._secrets
+
+    def container_exists(self, name):
+        return name in self._containers
+
+    def write_secret(self, name, content):
+        self.secrets_written.append((name, content))
+        self._secrets.add(name)
+
+
+@pytest.fixture
+def container_agent():
+    return Agent(name="tenant", model="opus", isolated=True, isolation_mode="container")
+
+
+def _cprov(ops, **kw):
+    kw.setdefault("image_provider", lambda a: "myco/agent:1")
+    kw.setdefault("signing_key_provider", lambda n: f"key-{n}")
+    return ContainerProvisioner(ops=ops, **kw)
+
+
+class TestContainerNames:
+    def test_layout(self):
+        n = ContainerNames.for_agent("tenant")
+        assert n.container == "pinky-tenant"
+        assert n.volume == "pinky-tenant-home"
+        assert n.secret == "pinky-tenant-key"
+        assert n.home == "/home/agent"
+        assert n.workdir == "/home/agent/workdir"
+        assert n.config_dir == "/home/agent/.claude"
+
+    def test_custom_prefix_and_home(self):
+        n = ContainerNames.for_agent("x", prefix="bot-", home="/srv/x")
+        assert n.container == "bot-x"
+        assert n.volume == "bot-x-home"
+        assert n.secret == "bot-x-key"
+        assert n.home == "/srv/x"
+        assert n.config_dir == "/srv/x/.claude"
+
+
+class TestContainerProvisionerContract:
+    def test_is_an_agent_provisioner(self):
+        assert isinstance(_cprov(RecordingContainerOps()), AgentProvisioner)
+        assert _cprov(RecordingContainerOps()).mode == "container"
+
+
+class TestContainerProvision:
+    def test_command_shapes(self, container_agent):
+        ops = RecordingContainerOps()
+        result = _cprov(ops).provision(container_agent)
+        assert result.ok is True
+        assert result.mode == "container"
+        assert ["podman", "volume", "create", "pinky-tenant-home"] in ops.commands
+        assert ["podman", "pull", "myco/agent:1"] in ops.commands
+        # the container is CREATED (stopped), never `run` — start is activation's job
+        creates = [c for c in ops.commands if len(c) > 1 and c[1] == "create"]
+        assert len(creates) == 1
+        cc = creates[0]
+        assert cc[:4] == ["podman", "create", "--name", "pinky-tenant"]
+        assert "pinky-tenant-home:/home/agent" in cc  # home volume mount
+        assert "pinky-tenant-key,type=mount" in cc  # key secret mount
+        assert "HOME=/home/agent" in cc
+        assert cc[-4:] == ["--entrypoint", "sleep", "myco/agent:1", "infinity"]
+
+    def test_signing_key_never_on_an_argv(self, container_agent):
+        ops = RecordingContainerOps()
+        _cprov(ops).provision(container_agent)
+        # the key VALUE went via write_secret (stdin), not any podman argv
+        assert ops.secrets_written == [("pinky-tenant-key", "key-tenant")]
+        assert not any("key-tenant" in tok for c in ops.commands for tok in c)
+
+    def test_created_tokens_recorded_in_order(self, container_agent):
+        ops = RecordingContainerOps()
+        result = _cprov(ops).provision(container_agent)
+        # image pull is shared infra → NOT a tracked per-agent resource
+        assert result.created == [
+            "volume:pinky-tenant-home",
+            "secret:pinky-tenant-key",
+            "container:pinky-tenant",
+        ]
+
+    def test_no_image_fails_closed_before_touching_anything(self, container_agent):
+        ops = RecordingContainerOps()
+        p = ContainerProvisioner(
+            ops=ops, image_provider=lambda a: "", signing_key_provider=lambda n: "k"
+        )
+        result = p.provision(container_agent)
+        assert result.ok is False
+        assert "container_image" in result.message
+        assert ops.commands == []  # nothing created without an image
+
+    def test_missing_signing_key_fails_and_rolls_back(self, container_agent):
+        ops = RecordingContainerOps()
+        p = ContainerProvisioner(
+            ops=ops, image_provider=lambda a: "img:1", signing_key_provider=lambda n: ""
+        )
+        result = p.provision(container_agent)
+        assert result.ok is False
+        assert "signing key" in result.message.lower()
+        # the volume created before the failure was rolled back
+        assert not ops.volume_exists("pinky-tenant-home")
+        assert any(c[:3] == ["podman", "volume", "rm"] for c in ops.commands)
+
+    def test_idempotent_when_fully_provisioned(self, container_agent):
+        ops = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        result = _cprov(ops).provision(container_agent)
+        assert result.ok is True
+        assert "already provisioned" in result.message
+        assert ops.commands == []
+
+    def test_reconciles_partial_tenant(self, container_agent):
+        # volume exists; secret + container missing → build only the gaps,
+        # don't recreate the volume, and track only this call's work.
+        ops = RecordingContainerOps(volumes={"pinky-tenant-home"})
+        result = _cprov(ops).provision(container_agent)
+        assert result.ok is True
+        assert not any(c[:3] == ["podman", "volume", "create"] for c in ops.commands)
+        assert ops.secrets_written == [("pinky-tenant-key", "key-tenant")]
+        assert any(len(c) > 3 and c[1] == "create" and c[3] == "pinky-tenant" for c in ops.commands)
+        assert result.created == ["secret:pinky-tenant-key", "container:pinky-tenant"]
+
+    def test_present_image_is_not_pulled(self, container_agent):
+        ops = RecordingContainerOps(images={"myco/agent:1"})
+        _cprov(ops).provision(container_agent)
+        assert not any(len(c) > 1 and c[1] == "pull" for c in ops.commands)
+
+
+class TestContainerRollback:
+    def test_failure_on_container_create_undoes_in_reverse(self, container_agent):
+        # Fail the container `create`; volume + secret were built first.
+        ops = RecordingContainerOps(fail_predicate=lambda a: len(a) > 1 and a[1] == "create")
+        result = _cprov(ops).provision(container_agent)
+        assert result.ok is False
+        assert result.created == ["volume:pinky-tenant-home", "secret:pinky-tenant-key"]
+        # undone in reverse: secret rm'd, then volume rm'd
+        assert result.removed == ["secret:pinky-tenant-key", "volume:pinky-tenant-home"]
+        assert not ops.secret_exists("pinky-tenant-key")
+        assert not ops.volume_exists("pinky-tenant-home")
+
+
+class TestContainerDeprovision:
+    def test_default_keeps_home_volume(self, container_agent):
+        ops = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        result = _cprov(ops).deprovision(container_agent)
+        assert result.ok is True
+        assert result.removed == ["container:pinky-tenant", "secret:pinky-tenant-key"]
+        assert "preserved" in result.message
+        assert ops.volume_exists("pinky-tenant-home")  # the durable login survives
+        assert not ops.container_exists("pinky-tenant")
+        assert not ops.secret_exists("pinky-tenant-key")
+
+    def test_remove_volume_purges_everything(self, container_agent):
+        ops = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        result = _cprov(ops).deprovision(container_agent, remove_volume=True)
+        assert result.removed == [
+            "container:pinky-tenant",
+            "secret:pinky-tenant-key",
+            "volume:pinky-tenant-home",
+        ]
+        assert not ops.volume_exists("pinky-tenant-home")
+
+    def test_absent_is_noop(self, container_agent):
+        ops = RecordingContainerOps()
+        result = _cprov(ops).deprovision(container_agent)
+        assert result.ok is True
+        assert result.removed == []
+        assert ops.commands == []
+
+
+class TestContainerIsProvisioned:
+    def test_requires_volume_secret_and_container(self, container_agent):
+        full = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        assert _cprov(full).is_provisioned(container_agent) is True
+        no_container = RecordingContainerOps(
+            volumes={"pinky-tenant-home"}, secrets={"pinky-tenant-key"}
+        )
+        assert _cprov(no_container).is_provisioned(container_agent) is False
+        no_secret = RecordingContainerOps(
+            volumes={"pinky-tenant-home"}, containers={"pinky-tenant"}
+        )
+        assert _cprov(no_secret).is_provisioned(container_agent) is False
+
+
+class TestContainerRuntimeEnv:
+    def test_in_container_paths(self, container_agent):
+        env = _cprov(RecordingContainerOps()).runtime_env(container_agent)
+        assert env["HOME"] == "/home/agent"
+        assert env["CLAUDE_CONFIG_DIR"] == "/home/agent/.claude"
+        assert env["PINKY_AGENT_NAME"] == "tenant"
+
+
+class TestSystemContainerOps:
+    """The real ops shell out to podman, so they can't run in CI — but their
+    argv shapes (and the no-argv-leak secret guarantee) are worth pinning via a
+    monkeypatched subprocess.run."""
+
+    def test_exists_uses_inspect(self, monkeypatch):
+        import subprocess
+
+        calls: list[list[str]] = []
+
+        class _R:
+            returncode = 0
+
+        monkeypatch.setattr(subprocess, "run", lambda argv, **kw: calls.append(argv) or _R())
+        ops = SystemContainerOps()
+        assert ops.image_exists("img:1") is True
+        assert calls[-1] == ["podman", "image", "inspect", "img:1"]
+        ops.container_exists("c")
+        assert calls[-1] == ["podman", "container", "inspect", "c"]
+        ops.volume_exists("v")
+        assert calls[-1] == ["podman", "volume", "inspect", "v"]
+        ops.secret_exists("s")
+        assert calls[-1] == ["podman", "secret", "inspect", "s"]
+
+    def test_write_secret_feeds_stdin_never_argv(self, monkeypatch):
+        import subprocess
+
+        captured: dict = {}
+
+        class _R:
+            returncode = 0
+            stderr = b""
+
+        def fake_run(argv, **kw):
+            captured["argv"] = argv
+            captured["input"] = kw.get("input")
+            return _R()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        SystemContainerOps().write_secret("pinky-x-key", "s3cret")
+        assert captured["argv"] == ["podman", "secret", "create", "pinky-x-key", "-"]
+        assert captured["input"] == b"s3cret"
+        assert "s3cret" not in " ".join(captured["argv"])

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -24,6 +24,7 @@ from pinky_daemon.provisioning import (
     SystemProvisionOps,
     UnixUserPaths,
     UnixUserProvisioner,
+    container_config_dir,
     get_provisioner,
 )
 
@@ -877,3 +878,280 @@ class TestContainerDefaultImageProvider:
         assert result.ok is False
         assert "container_image" in result.message
         assert ops.commands == []
+
+
+# --------------------------------------------------------------------------- #
+# engaged-path gaps (#638): resource caps, host-visible CLAUDE_CONFIG_DIR,
+# image-drift recreate, missing-binary translation, provision() resilience
+# --------------------------------------------------------------------------- #
+
+
+def _flag_value(argv, flag):
+    """The value following ``flag`` in ``argv`` ("" if the flag is absent)."""
+    for i, tok in enumerate(argv):
+        if tok == flag:
+            return argv[i + 1]
+    return ""
+
+
+def _create_cmd(ops):
+    """The single `<binary> create ...` argv recorded by an ops double."""
+    return next(c for c in ops.commands if len(c) > 1 and c[1] == "create")
+
+
+class TestContainerResourceCaps:
+    """Resource caps on the create argv (#638): an unbounded tenant could
+    starve the host (the Pi 5 shares 8GB with a POS stack). Conservative
+    defaults, env-overridable per host, and "0" disables a cap entirely."""
+
+    def test_default_caps_injected(self, container_agent, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_MEMORY", raising=False)
+        monkeypatch.delenv("PINKY_CONTAINER_PIDS_LIMIT", raising=False)
+        ops = RecordingContainerOps()
+        _cprov(ops).provision(container_agent)
+        cc = _create_cmd(ops)
+        assert _flag_value(cc, "--memory") == "2g"
+        assert _flag_value(cc, "--pids-limit") == "2048"
+
+    def test_env_overrides_cap_values(self, container_agent, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_MEMORY", "512m")
+        monkeypatch.setenv("PINKY_CONTAINER_PIDS_LIMIT", "256")
+        ops = RecordingContainerOps()
+        _cprov(ops).provision(container_agent)
+        cc = _create_cmd(ops)
+        assert _flag_value(cc, "--memory") == "512m"
+        assert _flag_value(cc, "--pids-limit") == "256"
+
+    def test_zero_disables_both_caps(self, container_agent, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_MEMORY", "0")
+        monkeypatch.setenv("PINKY_CONTAINER_PIDS_LIMIT", "0")
+        ops = RecordingContainerOps()
+        _cprov(ops).provision(container_agent)
+        cc = _create_cmd(ops)
+        assert "--memory" not in cc
+        assert "--pids-limit" not in cc
+
+    def test_zero_disables_each_cap_independently(self, container_agent, monkeypatch):
+        # Disable only memory; the pids cap keeps its default.
+        monkeypatch.setenv("PINKY_CONTAINER_MEMORY", "0")
+        monkeypatch.delenv("PINKY_CONTAINER_PIDS_LIMIT", raising=False)
+        ops = RecordingContainerOps()
+        _cprov(ops).provision(container_agent)
+        cc = _create_cmd(ops)
+        assert "--memory" not in cc
+        assert _flag_value(cc, "--pids-limit") == "2048"
+
+
+class TestContainerClaudeConfigDir:
+    """CLAUDE_CONFIG_DIR placement (#638): for an agent with an ABSOLUTE
+    working_dir it lives at <working_dir>/.claude-container INSIDE the
+    same-path bind mount, so transcripts/config/creds are host-visible at the
+    identical absolute path (the host-side tailer, --continue detection, and
+    `claude login` durability depend on this). Empty or relative working_dirs
+    fall back to the home volume — test_in_container_paths pins the fallback."""
+
+    def _agent(self, working_dir):
+        return Agent(
+            name="tenant", model="opus", isolated=True,
+            isolation_mode="container", working_dir=working_dir,
+        )
+
+    def test_absolute_working_dir_places_config_inside_it(self):
+        ops = RecordingContainerOps()
+        _cprov(ops).provision(self._agent("/srv/data/agents/tenant"))
+        cc = _create_cmd(ops)
+        token = "CLAUDE_CONFIG_DIR=/srv/data/agents/tenant/.claude-container"
+        assert token in cc
+        assert cc[cc.index(token) - 1] == "-e"  # injected as an env pair
+        # the home-volume fallback is NOT used when the workdir qualifies
+        assert "CLAUDE_CONFIG_DIR=/home/agent/.claude" not in cc
+
+    def test_runtime_env_matches_create_argv(self):
+        env = _cprov(RecordingContainerOps()).runtime_env(self._agent("/srv/data/agents/tenant"))
+        assert env["CLAUDE_CONFIG_DIR"] == "/srv/data/agents/tenant/.claude-container"
+        assert env["HOME"] == "/home/agent"  # home stays on the volume
+
+    def test_relative_working_dir_falls_back_to_home_volume(self):
+        # A relative workdir can't be same-path bind-mounted → fallback.
+        ops = RecordingContainerOps()
+        p = _cprov(ops)
+        agent = self._agent("data/agents/tenant")
+        p.provision(agent)
+        assert "CLAUDE_CONFIG_DIR=/home/agent/.claude" in _create_cmd(ops)
+        assert p.runtime_env(agent)["CLAUDE_CONFIG_DIR"] == "/home/agent/.claude"
+
+    def test_blank_working_dir_falls_back_to_home_volume(self):
+        # Whitespace-only is treated as unset (the .strip() path).
+        ops = RecordingContainerOps()
+        p = _cprov(ops)
+        agent = self._agent("   ")
+        p.provision(agent)
+        assert "CLAUDE_CONFIG_DIR=/home/agent/.claude" in _create_cmd(ops)
+        assert p.runtime_env(agent)["CLAUDE_CONFIG_DIR"] == "/home/agent/.claude"
+
+    def test_container_config_dir_helper(self):
+        # The shared helper the daemon uses to find the same path host-side.
+        assert container_config_dir("/srv/x") == "/srv/x/.claude-container"
+
+
+class DriftAwareContainerOps(RecordingContainerOps):
+    """RecordingContainerOps + the ``container_image`` probe (#638): reports the
+    image ref the existing container was created from, so the image-drift
+    recreate path in ensure_started is exercisable. ``probe_error`` makes the
+    probe raise (inspect hiccup) to pin the tolerated-failure path."""
+
+    def __init__(self, *, current_image="", probe_error=None, **kw):
+        super().__init__(**kw)
+        self.probes: list[str] = []
+        self._current_image = current_image
+        self._probe_error = probe_error
+
+    def container_image(self, name):
+        self.probes.append(name)
+        if self._probe_error is not None:
+            raise self._probe_error
+        return self._current_image
+
+
+class TestContainerImageDriftRecreate:
+    """ensure_started on an already-provisioned tenant recreates the container
+    when the agent's configured image no longer matches what the existing
+    container was created from (#638) — otherwise an image change on a
+    provisioned agent would silently never apply."""
+
+    def _full_ops(self, **kw):
+        return DriftAwareContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+            **kw,
+        )
+
+    def test_drift_recreates_container_only(self, container_agent):
+        ops = self._full_ops(current_image="myco/agent:1", images={"myco/agent:2"})
+        _cprov(ops, image_provider=lambda a: "myco/agent:2").ensure_started(container_agent)
+        assert ops.probes == ["pinky-tenant"]
+        # rm -f the stale container, re-provision with the NEW image, then start
+        rm = ops.commands.index(["podman", "rm", "-f", "pinky-tenant"])
+        create = ops.commands.index(_create_cmd(ops))
+        assert rm < create
+        assert "myco/agent:2" in _create_cmd(ops)
+        assert ops.commands[-1] == ["podman", "start", "pinky-tenant"]
+        # volume + secret still exist → re-provision rebuilt ONLY the container
+        assert not any(c[:3] == ["podman", "volume", "create"] for c in ops.commands)
+        assert ops.secrets_written == []
+        assert ops.container_exists("pinky-tenant")
+
+    def test_matching_image_starts_without_recreate(self, container_agent):
+        # _cprov's provider says myco/agent:1 — same as the probe → no rm.
+        ops = self._full_ops(current_image="myco/agent:1")
+        _cprov(ops).ensure_started(container_agent)
+        assert ops.probes == ["pinky-tenant"]
+        assert ops.commands == [["podman", "start", "pinky-tenant"]]
+
+    def test_old_double_without_probe_skips_drift_check(self, container_agent):
+        # An ops double with NO container_image method (the pre-#638 shape):
+        # the probe is skipped entirely — no rm, even with a drifted image.
+        ops = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        _cprov(ops, image_provider=lambda a: "myco/agent:2").ensure_started(container_agent)
+        assert ops.commands == [["podman", "start", "pinky-tenant"]]
+
+    def test_probe_failure_keeps_existing_container(self, container_agent):
+        # An inspect hiccup is tolerated: keep the existing container, no rm.
+        ops = self._full_ops(probe_error=RuntimeError("inspect hiccup"))
+        _cprov(ops, image_provider=lambda a: "myco/agent:2").ensure_started(container_agent)
+        assert ops.probes == ["pinky-tenant"]
+        assert ops.commands == [["podman", "start", "pinky-tenant"]]
+
+    def test_unknown_current_image_keeps_existing_container(self, container_agent):
+        # Probe returns "" (unknown) → no evidence of drift → no rm.
+        ops = self._full_ops(current_image="")
+        _cprov(ops, image_provider=lambda a: "myco/agent:2").ensure_started(container_agent)
+        assert ops.commands == [["podman", "start", "pinky-tenant"]]
+
+    def test_no_desired_image_keeps_existing_container(self, container_agent):
+        # No configured image to compare against → nothing to enforce, no rm.
+        ops = self._full_ops(current_image="myco/agent:1")
+        _cprov(ops, image_provider=lambda a: "").ensure_started(container_agent)
+        assert ops.commands == [["podman", "start", "pinky-tenant"]]
+
+
+class TestSystemContainerOpsMissingBinary:
+    """A missing container CLI (#638): subprocess.run raises FileNotFoundError,
+    which every SystemContainerOps method must translate into a clean,
+    actionable ProvisionError naming the binary and the PINKY_CONTAINER_RUNTIME
+    gate — never a raw FileNotFoundError unrolling into a 500."""
+
+    @pytest.fixture
+    def no_binary(self, monkeypatch):
+        import subprocess
+
+        def raise_fnf(*args, **kwargs):
+            raise FileNotFoundError("No such file or directory")
+
+        monkeypatch.setattr(subprocess, "run", raise_fnf)
+
+    def _assert_actionable(self, exc_info, binary="podman"):
+        msg = str(exc_info.value)
+        assert binary in msg
+        assert "PINKY_CONTAINER_RUNTIME" in msg
+
+    def test_run_raises_provision_error(self, no_binary):
+        with pytest.raises(ProvisionError) as exc:
+            SystemContainerOps().run(["podman", "volume", "create", "v"])
+        self._assert_actionable(exc)
+
+    def test_exists_probes_raise_provision_error(self, no_binary):
+        ops = SystemContainerOps()
+        for probe, arg in (
+            (ops.image_exists, "img:1"),
+            (ops.volume_exists, "v"),
+            (ops.secret_exists, "s"),
+            (ops.container_exists, "c"),
+        ):
+            with pytest.raises(ProvisionError) as exc:
+                probe(arg)
+            self._assert_actionable(exc)
+
+    def test_container_image_probe_raises_provision_error(self, no_binary):
+        with pytest.raises(ProvisionError) as exc:
+            SystemContainerOps().container_image("pinky-x")
+        self._assert_actionable(exc)
+
+    def test_write_secret_raises_provision_error(self, no_binary):
+        with pytest.raises(ProvisionError) as exc:
+            SystemContainerOps().write_secret("pinky-x-key", "s3cret")
+        self._assert_actionable(exc)
+
+    def test_custom_binary_named_in_message(self, no_binary):
+        with pytest.raises(ProvisionError) as exc:
+            SystemContainerOps("docker").run(["docker", "ps"])
+        self._assert_actionable(exc, binary="docker")
+
+
+class BrokenProbeContainerOps(RecordingContainerOps):
+    """Double whose volume_exists raises a ProvisionError — the shape a missing
+    binary takes once SystemContainerOps translates it, surfacing INSIDE the
+    is_provisioned probe at the top of provision()."""
+
+    def volume_exists(self, name):
+        raise ProvisionError("container binary 'podman' not found on this host")
+
+
+class TestContainerProvisionResilience:
+    def test_probe_failure_yields_failed_result_not_exception(self, container_agent):
+        # The is_provisioned probe sits INSIDE provision()'s try (#638): a
+        # missing/broken binary must come back as a clean ok=False result the
+        # register endpoint can report, not an exception escaping provision().
+        ops = BrokenProbeContainerOps()
+        result = _cprov(ops).provision(container_agent)
+        assert isinstance(result, ProvisionResult)
+        assert result.ok is False
+        assert result.mode == "container"
+        assert "not found" in result.message
+        assert result.created == []  # nothing was built before the probe blew up
+        assert result.removed == []

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -555,6 +555,44 @@ class TestContainerProvision:
         assert "HOME=/home/agent" in cc
         assert cc[-4:] == ["--entrypoint", "sleep", "myco/agent:1", "infinity"]
 
+    def test_create_includes_engaged_path_flags(self, container_agent):
+        # Rootless uid mapping (so claude runs non-root + bind files stay
+        # writable) and host reachability for the daemon API + shared MCP.
+        ops = RecordingContainerOps()
+        _cprov(ops).provision(container_agent)
+        cc = next(c for c in ops.commands if len(c) > 1 and c[1] == "create")
+        assert "--userns=keep-id" in cc
+        assert "--add-host=host.containers.internal:host-gateway" in cc
+
+    def test_create_binds_working_dir_at_same_absolute_path(self):
+        # The host working_dir must be mounted at the SAME absolute path so the
+        # absolute hook commands in .claude/settings.json resolve in-container.
+        ops = RecordingContainerOps()
+        agent = Agent(
+            name="tenant", model="opus", isolated=True,
+            isolation_mode="container", working_dir="/srv/data/agents/tenant",
+        )
+        _cprov(ops).provision(agent)
+        cc = next(c for c in ops.commands if len(c) > 1 and c[1] == "create")
+        assert "/srv/data/agents/tenant:/srv/data/agents/tenant" in cc
+
+    def test_no_working_dir_omits_bind(self, container_agent):
+        # container_agent fixture has no working_dir → no workdir bind emitted.
+        ops = RecordingContainerOps()
+        _cprov(ops).provision(container_agent)
+        cc = next(c for c in ops.commands if len(c) > 1 and c[1] == "create")
+        assert not any(tok.count(":") and tok.split(":")[0] == tok.split(":")[1]
+                       for tok in cc if "/" in tok and tok != "pinky-tenant-home:/home/agent")
+
+    def test_docker_runtime_omits_keep_id(self, container_agent):
+        # keep-id is Podman-specific; rootless Docker maps to the host user already.
+        ops = RecordingContainerOps()
+        _cprov(ops, binary="docker").provision(container_agent)
+        cc = next(c for c in ops.commands if len(c) > 1 and c[1] == "create")
+        assert cc[0] == "docker"
+        assert "--userns=keep-id" not in cc
+        assert "--add-host=host.containers.internal:host-gateway" in cc
+
     def test_signing_key_never_on_an_argv(self, container_agent):
         ops = RecordingContainerOps()
         _cprov(ops).provision(container_agent)

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -82,10 +82,11 @@ class TestGetProvisioner:
             get_provisioner("unix_user")
         assert "fail-closed" in str(exc.value)
 
-    def test_container_stays_fail_closed(self):
-        # Same dormancy guarantee as unix_user: ContainerProvisioner exists but
-        # the factory raises so the #642 respawn guard keeps blocking container
-        # until the activation increment wires the lifecycle.
+    def test_container_stays_fail_closed(self, monkeypatch):
+        # Dormancy guarantee: with the runtime gate OFF (default),
+        # ContainerProvisioner exists but the factory raises so the #642 respawn
+        # guard keeps blocking container until an operator opts in.
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
         with pytest.raises(NotImplementedError) as exc:
             get_provisioner("container")
         assert "fail-closed" in str(exc.value)
@@ -740,6 +741,81 @@ class TestSystemContainerOps:
         assert captured["argv"] == ["podman", "secret", "create", "pinky-x-key", "-"]
         assert captured["input"] == b"s3cret"
         assert "s3cret" not in " ".join(captured["argv"])
+
+
+class TestContainerRuntimeGate:
+    """The PINKY_CONTAINER_RUNTIME opt-in gate: container stays fail-closed by
+    default and only get_provisioner-flips to a real ContainerProvisioner when
+    an operator sets the env on the host."""
+
+    def test_fail_closed_when_gate_off(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        with pytest.raises(NotImplementedError) as exc:
+            get_provisioner("container")
+        assert "not enabled" in str(exc.value)
+        assert "PINKY_CONTAINER_RUNTIME" in str(exc.value)
+
+    def test_returns_container_provisioner_when_gate_on(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        p = get_provisioner("container")
+        assert isinstance(p, ContainerProvisioner)
+        assert p.mode == "container"
+        assert p._binary == "podman"
+
+    def test_docker_binary_selected(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "docker")
+        assert get_provisioner("container")._binary == "docker"
+
+    def test_truthy_value_defaults_to_podman(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "1")
+        assert get_provisioner("container")._binary == "podman"
+
+    def test_signing_key_provider_is_threaded(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        p = get_provisioner("container", signing_key_provider=lambda n: f"k-{n}")
+        assert p._signing_key_provider("x") == "k-x"
+
+    def test_local_and_unix_user_unaffected_by_gate(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        assert isinstance(get_provisioner("local"), LocalProvisioner)
+        with pytest.raises(NotImplementedError):
+            get_provisioner("unix_user")  # still fail-closed; its own increment
+
+
+class TestContainerStartStop:
+    def test_start_command_shape(self, container_agent):
+        ops = RecordingContainerOps()
+        _cprov(ops).start(container_agent)
+        assert ops.commands == [["podman", "start", "pinky-tenant"]]
+
+    def test_stop_command_shape(self, container_agent):
+        ops = RecordingContainerOps()
+        _cprov(ops).stop(container_agent)
+        assert ops.commands == [["podman", "stop", "pinky-tenant"]]
+
+    def test_ensure_started_provisions_then_starts_when_absent(self, container_agent):
+        ops = RecordingContainerOps()
+        _cprov(ops).ensure_started(container_agent)
+        assert any(c[:3] == ["podman", "volume", "create"] for c in ops.commands)
+        assert any(len(c) > 3 and c[1] == "create" and c[3] == "pinky-tenant" for c in ops.commands)
+        assert ops.commands[-1] == ["podman", "start", "pinky-tenant"]  # start is last
+
+    def test_ensure_started_only_starts_when_already_provisioned(self, container_agent):
+        ops = RecordingContainerOps(
+            volumes={"pinky-tenant-home"},
+            secrets={"pinky-tenant-key"},
+            containers={"pinky-tenant"},
+        )
+        _cprov(ops).ensure_started(container_agent)
+        assert ops.commands == [["podman", "start", "pinky-tenant"]]  # no re-provision
+
+    def test_ensure_started_raises_on_provision_failure(self, container_agent):
+        ops = RecordingContainerOps()
+        p = ContainerProvisioner(
+            ops=ops, image_provider=lambda a: "", signing_key_provider=lambda n: "k"
+        )
+        with pytest.raises(ProvisionError):
+            p.ensure_started(container_agent)  # no image → provision fails → raises
 
 
 class TestContainerDefaultImageProvider:

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -445,6 +445,39 @@ class TestWriteMcpJsonSharedMode:
         finally:
             api_mod.SHARED_MCP_ENABLED = original
 
+    def test_container_agent_uses_host_containers_internal_sse(self, tmp_path):
+        """#149: a container-isolated agent gets SSE MCP pointed at the daemon
+        over host.containers.internal — independent of the global shared flag
+        (stdio would spawn the HOST python + PinkyBot src, absent in the
+        operator's bring-your-own image)."""
+        import json
+        from unittest.mock import MagicMock
+
+        import pinky_daemon.api as api_mod
+
+        registry = MagicMock()
+        registry.get.return_value = type("A", (), {"isolation_mode": "container"})()
+        registry.list_mcp_servers.return_value = []
+        registry._db_path = "/x.db"
+
+        original = api_mod.SHARED_MCP_ENABLED
+        api_mod.SHARED_MCP_ENABLED = False  # global shared OFF — container still SSE
+        try:
+            work_dir = tmp_path / "agent"
+            work_dir.mkdir()
+            api_mod._write_mcp_json(work_dir, "barsik", agent_registry=registry)
+            servers = json.loads((work_dir / ".mcp.json").read_text())["mcpServers"]
+            for name in ("pinky-memory", "pinky-self", "pinky-messaging"):
+                assert servers[name]["type"] == "sse"
+                assert servers[name]["url"].startswith(
+                    "http://host.containers.internal:"
+                )
+                assert servers[name]["url"].endswith("/sse")
+                assert servers[name]["headers"]["X-Agent-Name"] == "barsik"
+                assert "command" not in servers[name]  # no host-python stdio
+        finally:
+            api_mod.SHARED_MCP_ENABLED = original
+
     def test_shared_mode_sse(self, tmp_path):
         """With SHARED_MCP_ENABLED, pinky-self and pinky-messaging use SSE."""
         import pinky_daemon.api as api_mod

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -13,6 +13,7 @@ from pinky_daemon.shared_mcp import (
     SharedMcpManager,
     _current_agent,
     bump_gateway_epoch,
+    create_shared_app,
     get_current_agent,
     get_gateway_epoch,
     get_probe_request,
@@ -204,6 +205,348 @@ class TestAgentNameMiddleware:
         scope = {"type": "websocket"}
         await middleware(scope, None, None)
         assert called == [True]
+
+
+def _http_scope(client, headers):
+    """Build a minimal ASGI http scope. ``client`` is an (host, port) tuple,
+    None (in-process caller), or "absent" to omit the key entirely."""
+    scope = {"type": "http", "headers": headers}
+    if client != "absent":
+        scope["client"] = client
+    return scope
+
+
+def _recording_app():
+    """Inner ASGI app that records each call's resolved agent name."""
+    calls = []
+
+    async def inner_app(scope, receive, send):
+        calls.append(get_current_agent())
+
+    return inner_app, calls
+
+
+def _recording_send():
+    """ASGI send callable that records messages, plus status/detail helpers."""
+    messages = []
+
+    async def send(message):
+        messages.append(message)
+
+    return send, messages
+
+
+def _response_status(messages):
+    return next(
+        (m["status"] for m in messages if m["type"] == "http.response.start"), None
+    )
+
+
+def _response_detail(messages):
+    import json
+
+    body = b"".join(
+        m.get("body", b"") for m in messages if m["type"] == "http.response.body"
+    )
+    return json.loads(body)["detail"] if body else None
+
+
+class TestAgentNameMiddlewareAuth:
+    """#623 / #638 — inbound bearer auth on the shared MCP gateway.
+
+    The bearer token IS the per-agent signing key, resolved at request time
+    via signing_key_resolver. Non-loopback peers (the container path via
+    PINKY_SHARED_MCP_HOST) MUST present a valid bearer; loopback keeps the
+    legacy X-Agent-Name header trust until PINKY_SHARED_MCP_REQUIRE_AUTH
+    flips the fleet to bearer-only. A bearer, when present, is validated
+    regardless of peer — there is no loopback downgrade path.
+    """
+
+    LOOPBACK = ("127.0.0.1", 54321)
+    REMOTE = ("10.0.0.50", 54321)
+
+    @pytest.fixture(autouse=True)
+    def _clear_require_auth_env(self, monkeypatch):
+        """Keep tests hermetic: the strict-mode flag is read per-request."""
+        monkeypatch.delenv("PINKY_SHARED_MCP_REQUIRE_AUTH", raising=False)
+
+    @staticmethod
+    def _resolver(name):
+        return f"{name}-key"
+
+    @pytest.mark.asyncio
+    async def test_loopback_header_without_bearer_keeps_legacy_trust(self):
+        """Loopback + X-Agent-Name + no bearer passes through (existing local
+        agents keep working unchanged); the ContextVar carries the name."""
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(self.LOOPBACK, [(b"x-agent-name", b"barsik")])
+        await middleware(scope, None, send)
+        assert calls == ["barsik"]
+        assert messages == []  # no 401 emitted
+
+    @pytest.mark.asyncio
+    async def test_ipv6_loopback_without_bearer_keeps_legacy_trust(self):
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(("::1", 54321), [(b"x-agent-name", b"barsik")])
+        await middleware(scope, None, send)
+        assert calls == ["barsik"]
+        assert messages == []
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_without_bearer_rejected(self):
+        """A network peer presenting only X-Agent-Name gets 401 — a bare
+        header would let ANY peer act as ANY agent beyond loopback."""
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(self.REMOTE, [(b"x-agent-name", b"barsik")])
+        await middleware(scope, None, send)
+        assert calls == []  # inner app never reached
+        assert _response_status(messages) == 401
+        assert _response_detail(messages) == "agent bearer token required"
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_with_valid_bearer_passes(self):
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(
+            self.REMOTE,
+            [
+                (b"x-agent-name", b"barsik"),
+                (b"authorization", b"Bearer barsik-key"),
+            ],
+        )
+        await middleware(scope, None, send)
+        assert calls == ["barsik"]
+        assert messages == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_bearer_rejected_even_from_loopback(self):
+        """A wrong token is rejected REGARDLESS of peer — presenting a bearer
+        opts into validation; there is no loopback downgrade path."""
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(
+            self.LOOPBACK,
+            [
+                (b"x-agent-name", b"barsik"),
+                (b"authorization", b"Bearer wrong-key"),
+            ],
+        )
+        await middleware(scope, None, send)
+        assert calls == []
+        assert _response_status(messages) == 401
+        assert _response_detail(messages) == "invalid agent credentials"
+
+    @pytest.mark.asyncio
+    async def test_bearer_without_resolver_rejected(self):
+        """No signing_key_resolver configured -> any bearer fails closed."""
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app)  # resolver=None
+        scope = _http_scope(
+            self.LOOPBACK,
+            [
+                (b"x-agent-name", b"barsik"),
+                (b"authorization", b"Bearer barsik-key"),
+            ],
+        )
+        await middleware(scope, None, send)
+        assert calls == []
+        assert _response_status(messages) == 401
+
+    @pytest.mark.asyncio
+    async def test_resolver_error_fails_closed(self):
+        """Resolver errors fail CLOSED for bearer validation — never open."""
+        def boom(name):
+            raise RuntimeError("db unavailable")
+
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=boom)
+        scope = _http_scope(
+            self.REMOTE,
+            [
+                (b"x-agent-name", b"barsik"),
+                (b"authorization", b"Bearer barsik-key"),
+            ],
+        )
+        await middleware(scope, None, send)
+        assert calls == []
+        assert _response_status(messages) == 401
+
+    @pytest.mark.asyncio
+    async def test_require_auth_env_rejects_loopback_without_bearer(self, monkeypatch):
+        """PINKY_SHARED_MCP_REQUIRE_AUTH flips strict mode: even loopback must
+        carry a bearer (the future bearer-only fleet posture)."""
+        monkeypatch.setenv("PINKY_SHARED_MCP_REQUIRE_AUTH", "1")
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(self.LOOPBACK, [(b"x-agent-name", b"barsik")])
+        await middleware(scope, None, send)
+        assert calls == []
+        assert _response_status(messages) == 401
+        assert _response_detail(messages) == "agent bearer token required"
+
+    @pytest.mark.asyncio
+    async def test_require_auth_env_with_valid_bearer_passes(self, monkeypatch):
+        monkeypatch.setenv("PINKY_SHARED_MCP_REQUIRE_AUTH", "1")
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(
+            self.LOOPBACK,
+            [
+                (b"x-agent-name", b"barsik"),
+                (b"authorization", b"Bearer barsik-key"),
+            ],
+        )
+        await middleware(scope, None, send)
+        assert calls == ["barsik"]
+        assert messages == []
+
+    @pytest.mark.asyncio
+    async def test_missing_client_treated_as_loopback(self):
+        """No ASGI client (in-process caller, e.g. TestClient with no socket)
+        stays in the legacy-trust class — passes without a bearer."""
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        # client key present but None
+        scope = _http_scope(None, [(b"x-agent-name", b"barsik")])
+        await middleware(scope, None, send)
+        # client key absent entirely
+        scope2 = _http_scope("absent", [(b"x-agent-name", b"pushok")])
+        await middleware(scope2, None, send)
+        assert calls == ["barsik", "pushok"]
+        assert messages == []
+
+    @pytest.mark.asyncio
+    async def test_unparseable_client_host_treated_as_loopback(self):
+        """Hosts that aren't IPs (starlette TestClient uses "testclient") stay
+        in the legacy-trust class — real remote sockets always carry a real
+        peer IP, so this can't be reached from the network."""
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(("testclient", 50000), [(b"x-agent-name", b"barsik")])
+        await middleware(scope, None, send)
+        assert calls == ["barsik"]
+        assert messages == []
+
+    @pytest.mark.asyncio
+    async def test_non_http_scope_passes_through_untouched(self):
+        """Lifespan (and any non-http) scope bypasses auth entirely."""
+        seen = []
+
+        async def inner_app(scope, receive, send):
+            seen.append(scope)
+
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = {"type": "lifespan"}
+        await middleware(scope, None, send)
+        assert seen == [{"type": "lifespan"}]
+        assert messages == []
+
+    @pytest.mark.asyncio
+    async def test_bearer_with_missing_agent_name_rejected(self):
+        """A bearer cannot validate without an agent name to resolve a key
+        for — no name, no key, 401."""
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(self.REMOTE, [(b"authorization", b"Bearer some-key")])
+        await middleware(scope, None, send)
+        assert calls == []
+        assert _response_status(messages) == 401
+        assert _response_detail(messages) == "invalid agent credentials"
+
+    @pytest.mark.asyncio
+    async def test_bearer_with_invalid_agent_name_rejected(self):
+        """An invalid (non [a-z0-9_-]) name never reaches the resolver — the
+        bearer is rejected even if the token would otherwise match."""
+        resolved = []
+
+        def resolver(name):
+            resolved.append(name)
+            return "some-key"
+
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=resolver)
+        scope = _http_scope(
+            self.REMOTE,
+            [
+                (b"x-agent-name", b"../../../etc/passwd"),
+                (b"authorization", b"Bearer some-key"),
+            ],
+        )
+        await middleware(scope, None, send)
+        assert calls == []
+        assert resolved == []  # resolver never consulted for an invalid name
+        assert _response_status(messages) == 401
+
+    @pytest.mark.asyncio
+    async def test_empty_resolved_key_rejected(self):
+        """Resolver returning None/empty (unknown agent, no key minted) means
+        the bearer cannot match — fail closed."""
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=lambda n: None)
+        scope = _http_scope(
+            self.REMOTE,
+            [
+                (b"x-agent-name", b"barsik"),
+                (b"authorization", b"Bearer barsik-key"),
+            ],
+        )
+        await middleware(scope, None, send)
+        assert calls == []
+        assert _response_status(messages) == 401
+
+    @pytest.mark.asyncio
+    async def test_contextvar_reset_after_authed_request(self):
+        async def inner_app(scope, receive, send):
+            pass
+
+        send, _messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(
+            self.REMOTE,
+            [
+                (b"x-agent-name", b"barsik"),
+                (b"authorization", b"Bearer barsik-key"),
+            ],
+        )
+        await middleware(scope, None, send)
+        assert get_current_agent() == ""
+
+
+class TestCreateSharedAppWiring:
+    """create_shared_app must thread signing_key_resolver into the middleware."""
+
+    def test_threads_signing_key_resolver_into_middleware(self):
+        """#623/#638: without this wiring, every inbound bearer fails closed
+        (resolver None) and container agents can never authenticate."""
+        def resolver(name):
+            return f"{name}-key"
+
+        app = create_shared_app({}, signing_key_resolver=resolver)
+        assert isinstance(app, AgentNameMiddleware)
+        assert app._signing_key_resolver is resolver
+
+    def test_default_resolver_is_none(self):
+        app = create_shared_app({})
+        assert isinstance(app, AgentNameMiddleware)
+        assert app._signing_key_resolver is None
 
 
 class TestSharedMcpManager:

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -240,7 +240,7 @@ class TestSharedMcpManager:
         monkeypatch.setattr("pinky_self.server.create_server", fake_self_server)
         monkeypatch.setattr("pinky_messaging.server.create_server", fake_messaging_server)
         # Avoid building the real combined ASGI app over our dummy objects.
-        monkeypatch.setattr(sm, "create_shared_app", lambda servers: servers)
+        monkeypatch.setattr(sm, "create_shared_app", lambda servers, **kw: servers)
 
         def resolver(name):
             return f"{name}-key"
@@ -273,7 +273,7 @@ class TestSharedMcpManager:
             "pinky_memory.embeddings.build_embedding_client", fake_build_embedder
         )
         monkeypatch.setattr("pinky_memory.server.create_server", lambda **kw: object())
-        monkeypatch.setattr(sm, "create_shared_app", lambda servers: servers)
+        monkeypatch.setattr(sm, "create_shared_app", lambda servers, **kw: servers)
 
         mgr = SharedMcpManager(
             memory_db_resolver=lambda name: ":memory:",

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from pinky_daemon.shared_mcp import (
@@ -12,8 +14,10 @@ from pinky_daemon.shared_mcp import (
     MemoryStorePool,
     SharedMcpManager,
     _current_agent,
+    _require_auth_env,
     bump_gateway_epoch,
     create_shared_app,
+    derive_mcp_bearer,
     get_current_agent,
     get_gateway_epoch,
     get_probe_request,
@@ -216,6 +220,12 @@ def _http_scope(client, headers):
     return scope
 
 
+def _bearer_header(signing_key: str) -> bytes:
+    """Authorization header value an agent's .mcp.json carries: the DERIVED
+    bearer (#638 — the raw signing key never travels on the wire)."""
+    return f"Bearer {derive_mcp_bearer(signing_key)}".encode()
+
+
 def _recording_app():
     """Inner ASGI app that records each call's resolved agent name."""
     calls = []
@@ -318,7 +328,7 @@ class TestAgentNameMiddlewareAuth:
             self.REMOTE,
             [
                 (b"x-agent-name", b"barsik"),
-                (b"authorization", b"Bearer barsik-key"),
+                (b"authorization", _bearer_header("barsik-key")),
             ],
         )
         await middleware(scope, None, send)
@@ -354,7 +364,7 @@ class TestAgentNameMiddlewareAuth:
             self.LOOPBACK,
             [
                 (b"x-agent-name", b"barsik"),
-                (b"authorization", b"Bearer barsik-key"),
+                (b"authorization", _bearer_header("barsik-key")),
             ],
         )
         await middleware(scope, None, send)
@@ -374,7 +384,7 @@ class TestAgentNameMiddlewareAuth:
             self.REMOTE,
             [
                 (b"x-agent-name", b"barsik"),
-                (b"authorization", b"Bearer barsik-key"),
+                (b"authorization", _bearer_header("barsik-key")),
             ],
         )
         await middleware(scope, None, send)
@@ -405,7 +415,7 @@ class TestAgentNameMiddlewareAuth:
             self.LOOPBACK,
             [
                 (b"x-agent-name", b"barsik"),
-                (b"authorization", b"Bearer barsik-key"),
+                (b"authorization", _bearer_header("barsik-key")),
             ],
         )
         await middleware(scope, None, send)
@@ -505,7 +515,7 @@ class TestAgentNameMiddlewareAuth:
             self.REMOTE,
             [
                 (b"x-agent-name", b"barsik"),
-                (b"authorization", b"Bearer barsik-key"),
+                (b"authorization", _bearer_header("barsik-key")),
             ],
         )
         await middleware(scope, None, send)
@@ -523,11 +533,106 @@ class TestAgentNameMiddlewareAuth:
             self.REMOTE,
             [
                 (b"x-agent-name", b"barsik"),
-                (b"authorization", b"Bearer barsik-key"),
+                (b"authorization", _bearer_header("barsik-key")),
             ],
         )
         await middleware(scope, None, send)
         assert get_current_agent() == ""
+
+
+class TestDeriveMcpBearer:
+    """#638 — the shared-MCP bearer is a one-way derivation of the signing
+    key: leaking the bearer leaks MCP identity only, never the HMAC-signing
+    credential itself."""
+
+    def test_deterministic(self):
+        assert derive_mcp_bearer("barsik-key") == derive_mcp_bearer("barsik-key")
+
+    def test_distinct_keys_yield_distinct_bearers(self):
+        assert derive_mcp_bearer("barsik-key") != derive_mcp_bearer("pushok-key")
+
+    def test_hex_shape(self):
+        token = derive_mcp_bearer("barsik-key")
+        assert re.fullmatch(r"[0-9a-f]{64}", token)  # sha256 hexdigest
+
+    def test_never_the_signing_key_itself(self):
+        key = "some-signing-key"
+        token = derive_mcp_bearer(key)
+        assert token != key
+        assert key not in token
+
+    def test_empty_key_yields_empty_bearer(self):
+        assert derive_mcp_bearer("") == ""
+
+
+class TestRequireAuthEnv:
+    """PINKY_SHARED_MCP_REQUIRE_AUTH parses like the other operator toggles:
+    unset/empty/"0"/"false"/"no" (any case) = off, anything else = on — a bare
+    ``bool(value)`` would treat an operator's ``=0`` as ENABLED."""
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "FALSE", "No", " 0 "])
+    def test_off_values(self, monkeypatch, value):
+        monkeypatch.setenv("PINKY_SHARED_MCP_REQUIRE_AUTH", value)
+        assert _require_auth_env() is False
+
+    def test_unset_is_off(self, monkeypatch):
+        monkeypatch.delenv("PINKY_SHARED_MCP_REQUIRE_AUTH", raising=False)
+        assert _require_auth_env() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", "Yes", "on"])
+    def test_on_values(self, monkeypatch, value):
+        monkeypatch.setenv("PINKY_SHARED_MCP_REQUIRE_AUTH", value)
+        assert _require_auth_env() is True
+
+
+class TestAgentNameMiddlewareRequireAuthParam:
+    """``require_auth=True`` (#638) — the bind-level enforcement set by the
+    manager on any non-loopback bind. With rootless Podman (pasta/slirp),
+    container->host traffic can arrive with a 127.0.0.1 SOURCE address, so the
+    loopback escape hatch must be removed entirely on an exposed bind: even a
+    loopback peer must present a valid derived bearer."""
+
+    LOOPBACK = ("127.0.0.1", 54321)
+
+    @pytest.fixture(autouse=True)
+    def _clear_require_auth_env(self, monkeypatch):
+        """Hermetic: the param must do the enforcing, not the env flag."""
+        monkeypatch.delenv("PINKY_SHARED_MCP_REQUIRE_AUTH", raising=False)
+
+    @staticmethod
+    def _resolver(name):
+        return f"{name}-key"
+
+    @pytest.mark.asyncio
+    async def test_loopback_header_without_bearer_rejected(self):
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(
+            inner_app, signing_key_resolver=self._resolver, require_auth=True
+        )
+        scope = _http_scope(self.LOOPBACK, [(b"x-agent-name", b"barsik")])
+        await middleware(scope, None, send)
+        assert calls == []  # inner app never reached
+        assert _response_status(messages) == 401
+        assert _response_detail(messages) == "agent bearer token required"
+
+    @pytest.mark.asyncio
+    async def test_loopback_with_valid_derived_bearer_passes(self):
+        inner_app, calls = _recording_app()
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(
+            inner_app, signing_key_resolver=self._resolver, require_auth=True
+        )
+        scope = _http_scope(
+            self.LOOPBACK,
+            [
+                (b"x-agent-name", b"barsik"),
+                (b"authorization", _bearer_header("barsik-key")),
+            ],
+        )
+        await middleware(scope, None, send)
+        assert calls == ["barsik"]
+        assert messages == []  # no 401 emitted
 
 
 class TestCreateSharedAppWiring:
@@ -624,6 +729,61 @@ class TestSharedMcpManager:
         )
         mgr._create_app()
         assert captured["api_key"] == "sk-from-settings"
+
+
+class _FakeMcpServer:
+    """Minimal FastMCP double: just enough surface for the REAL
+    create_shared_app to mount routes over it (streamable HTTP + SSE)."""
+
+    _session_manager = None
+
+    @staticmethod
+    async def _asgi(scope, receive, send):
+        return None
+
+    def streamable_http_app(self):
+        return self._asgi
+
+    def sse_app(self, mount_path="/"):
+        return self._asgi
+
+
+class TestSharedMcpManagerRequireAuthWiring:
+    """#638: _create_app derives require_auth from the BIND (the decision
+    point for containers — peer classification can't be trusted on an exposed
+    bind) and threads it through the REAL create_shared_app. Only the server
+    factories are stubbed; the returned middleware object is introspected."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_server_factories(self, monkeypatch):
+        monkeypatch.setattr(
+            "pinky_self.server.create_server", lambda **kw: _FakeMcpServer()
+        )
+        monkeypatch.setattr(
+            "pinky_messaging.server.create_server", lambda **kw: _FakeMcpServer()
+        )
+
+    def test_exposed_bind_forces_bearer_auth(self):
+        def resolver(name):
+            return f"{name}-key"
+
+        mgr = SharedMcpManager(host="0.0.0.0", signing_key_resolver=resolver)
+        app = mgr._create_app()
+        assert isinstance(app, AgentNameMiddleware)
+        assert app._require_auth is True
+        # The resolver rides along so inbound bearers can actually validate.
+        assert app._signing_key_resolver is resolver
+
+    def test_loopback_bind_keeps_legacy_trust(self):
+        mgr = SharedMcpManager(host="127.0.0.1")
+        app = mgr._create_app()
+        assert isinstance(app, AgentNameMiddleware)
+        assert app._require_auth is False
+
+    @pytest.mark.parametrize("host", ["::1", "localhost"])
+    def test_other_loopback_spellings_not_exposed(self, host):
+        app = SharedMcpManager(host=host)._create_app()
+        assert app._require_auth is False
 
 
 class TestGateToolNames:
@@ -802,6 +962,10 @@ class TestWriteMcpJsonSharedMode:
         registry.get.return_value = type("A", (), {"isolation_mode": "container"})()
         registry.list_mcp_servers.return_value = []
         registry._db_path = "/x.db"
+        # Real (non-Mock) key getter: the bearer header must be the DERIVED
+        # token of the actual signing key — a bare MagicMock here would
+        # serialize garbage ('Bearer <MagicMock ...>') that nothing asserts.
+        registry.get_or_create_signing_key = lambda name: f"{name}-signing-key"
 
         original = api_mod.SHARED_MCP_ENABLED
         api_mod.SHARED_MCP_ENABLED = False  # global shared OFF — container still SSE
@@ -810,6 +974,7 @@ class TestWriteMcpJsonSharedMode:
             work_dir.mkdir()
             api_mod._write_mcp_json(work_dir, "barsik", agent_registry=registry)
             servers = json.loads((work_dir / ".mcp.json").read_text())["mcpServers"]
+            expected_bearer = f"Bearer {derive_mcp_bearer('barsik-signing-key')}"
             for name in ("pinky-memory", "pinky-self", "pinky-messaging"):
                 assert servers[name]["type"] == "sse"
                 assert servers[name]["url"].startswith(
@@ -817,6 +982,7 @@ class TestWriteMcpJsonSharedMode:
                 )
                 assert servers[name]["url"].endswith("/sse")
                 assert servers[name]["headers"]["X-Agent-Name"] == "barsik"
+                assert servers[name]["headers"]["Authorization"] == expected_bearer
                 assert "command" not in servers[name]  # no host-python stdio
         finally:
             api_mod.SHARED_MCP_ENABLED = original

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -1,25 +1,36 @@
 """Container-isolation wiring in TmuxSession (gated runner injection + cold-start
-ensure_started). All gated by PINKY_CONTAINER_RUNTIME and isolation_mode; local
-agents and the gate-off default must behave exactly as before. No real podman —
-the provisioner is faked, runner selection is asserted via wrap() shapes."""
+ensure_started), plus the engaged-path gaps closed for #638: in-workdir
+CLAUDE_CONFIG_DIR for the host-side tailer, PINKY_DAEMON_URL for in-container
+hooks, the isolation_mode-implies-isolated secret gate, dead-container stderr
+detection, host-side creds seeding, and the image-contract probe. All gated by
+PINKY_CONTAINER_RUNTIME and isolation_mode; local agents and the gate-off
+default must behave exactly as before. No real podman — the provisioner is
+faked, runner selection is asserted via wrap() shapes."""
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 import pinky_daemon.provisioning as provisioning
-from pinky_daemon.command_runner import ContainerCommandRunner, LocalCommandRunner
+from pinky_daemon.command_runner import (
+    CommandResult,
+    ContainerCommandRunner,
+    LocalCommandRunner,
+)
 from pinky_daemon.streaming_session import StreamingSessionConfig
-from pinky_daemon.tmux_session import TmuxSession
+from pinky_daemon.tmux_session import TmuxSession, _is_dead_runtime_stderr
 
 
 class _FakeAgent:
-    def __init__(self, name, isolation_mode="local", working_dir=""):
+    def __init__(self, name, isolation_mode="local", working_dir="", isolated=False):
         self.name = name
         self.isolation_mode = isolation_mode
         self.working_dir = working_dir
+        self.isolated = isolated
 
 
 class _RecordingInner:
@@ -33,6 +44,22 @@ class _RecordingInner:
 
         self.calls.append(list(argv))
         return CommandResult(returncode=0, stdout=b"", stderr=b"")
+
+
+class _StubInner:
+    """Inner CommandRunner double with a scripted result — never spawns."""
+
+    def __init__(self, *, stdout=b"", returncode=0, exc=None):
+        self.stdout = stdout
+        self.returncode = returncode
+        self.exc = exc
+        self.calls: list[list[str]] = []
+
+    async def run(self, argv, *, timeout=None, stdin=None):
+        self.calls.append(list(argv))
+        if self.exc is not None:
+            raise self.exc
+        return CommandResult(returncode=self.returncode, stdout=self.stdout, stderr=b"")
 
 
 class _FakeRegistry:
@@ -49,8 +76,8 @@ class _FakeRegistry:
         return f"key-{name}"
 
 
-def _session(agent_name="dymok", registry=None):
-    cfg = StreamingSessionConfig(agent_name=agent_name, working_dir="/tmp/x")
+def _session(agent_name="dymok", registry=None, working_dir="/tmp/x"):
+    cfg = StreamingSessionConfig(agent_name=agent_name, working_dir=working_dir)
     # A truthy tmux_control short-circuits the in-__init__ runner selection, so we
     # can set _registry and call the gated methods directly + deterministically.
     ss = TmuxSession(cfg, tmux_control=MagicMock())
@@ -174,3 +201,191 @@ class TestSeedContainerTrust:
         assert "bypassPermissionsModeAccepted" in seed
         assert "hasTrustDialogAccepted" in seed
         assert "CLAUDE_CONFIG_DIR" in seed  # resolves the in-container config dir
+
+
+def _claude_slug(path: str) -> str:
+    """Claude Code's project-dir encoder: every non-alphanumeric char of the
+    RESOLVED cwd becomes '-' (mirrors _project_dir's re.sub)."""
+    return re.sub(r"[^a-zA-Z0-9]", "-", str(Path(path).resolve()))
+
+
+class TestProjectDir:
+    """#638 response pipeline: a container agent's claude runs with
+    CLAUDE_CONFIG_DIR=<working_dir>/.claude-container inside the same-path bind
+    mount, so the host-side tailer must look for transcripts there — and local
+    agents must keep the unchanged ~/.claude/projects/<slug> path."""
+
+    def test_container_agent_projects_under_in_workdir_config_dir(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        wd = str(tmp_path / "proj")
+        ss = _session(
+            registry=_FakeRegistry(_FakeAgent("dymok", "container", working_dir=wd)),
+            working_dir=wd,
+        )
+        expected = Path(wd) / ".claude-container" / "projects" / _claude_slug(wd)
+        assert ss._project_dir() == expected
+
+    def test_local_agent_unchanged(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        wd = str(tmp_path / "proj")
+        ss = _session(
+            registry=_FakeRegistry(_FakeAgent("dymok", "local", working_dir=wd)),
+            working_dir=wd,
+        )
+        assert ss._project_dir() == Path.home() / ".claude" / "projects" / _claude_slug(wd)
+
+
+class TestBuildReplEnv:
+    """#638 hooks: inside the container netns, localhost is the container, so
+    container sessions must point the hook fleet at the host gateway via
+    PINKY_DAEMON_URL (operator override: PINKY_CONTAINER_DAEMON_URL)."""
+
+    def test_container_agent_gets_host_gateway_daemon_url(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        monkeypatch.delenv("PINKY_CONTAINER_DAEMON_URL", raising=False)
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        env = ss._build_repl_env()
+        assert env["PINKY_DAEMON_URL"] == "http://host.containers.internal:8888"
+
+    def test_container_daemon_url_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        monkeypatch.setenv("PINKY_CONTAINER_DAEMON_URL", "http://10.0.2.2:9999")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        assert ss._build_repl_env()["PINKY_DAEMON_URL"] == "http://10.0.2.2:9999"
+
+    def test_local_agent_has_no_daemon_url(self, monkeypatch):
+        # Local hooks keep their localhost:8888 default — no key at all.
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        assert "PINKY_DAEMON_URL" not in ss._build_repl_env()
+
+
+class TestIsolationStatus:
+    """#638 secret-gate hardening: a non-local isolation_mode IS isolation,
+    regardless of the `isolated` bool — legacy rows / direct DB writes must
+    never hand a container tenant the forgeable fleet-wide secret."""
+
+    def test_container_mode_isolated_despite_false_flag(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        monkeypatch.setenv("PINKY_SESSION_SECRET", "fleet-secret")
+        ss = _session(registry=_FakeRegistry(
+            _FakeAgent("dymok", "container", isolated=False)
+        ))
+        assert ss._isolation_status() == "isolated"
+        # And the env builder withholds the global secret accordingly.
+        assert "PINKY_SESSION_SECRET" not in ss._build_repl_env()
+
+    def test_local_mode_not_isolated_gets_secret(self, monkeypatch):
+        monkeypatch.setenv("PINKY_SESSION_SECRET", "fleet-secret")
+        ss = _session(registry=_FakeRegistry(
+            _FakeAgent("dymok", "local", isolated=False)
+        ))
+        assert ss._isolation_status() == "not_isolated"
+        assert ss._build_repl_env()["PINKY_SESSION_SECRET"] == "fleet-secret"
+
+
+class TestIsDeadRuntimeStderr:
+    """#638: a stopped/removed container is the same terminal condition as a
+    vanished tmux pane — the worker must schedule disconnect, not silently eat
+    every subsequent paste against a zombie."""
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "can't find pane",
+            "Error: can only create exec sessions on running containers: "
+            "container state improper",
+            "Error: no such container pinky-x",
+            "container is not running",
+            "Container Is Not Running",  # match is case-insensitive
+        ],
+    )
+    def test_dead_runtime_detected(self, stderr):
+        assert _is_dead_runtime_stderr(stderr) is True
+
+    @pytest.mark.parametrize("stderr", ["", "some other error"])
+    def test_other_stderr_not_dead(self, stderr):
+        assert _is_dead_runtime_stderr(stderr) is False
+
+
+class TestSeedContainerClaudeCreds:
+    """#638 creds story: one-time host-side bootstrap of the daemon user's
+    Claude OAuth creds into the container agent's host-visible
+    <working_dir>/.claude-container, so the in-container claude starts
+    authenticated. Best-effort, idempotent, opt-out via env."""
+
+    def _creds_session(self, monkeypatch, tmp_path, *, host_creds=b'{"oauth": "tok"}'):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        monkeypatch.delenv("PINKY_CONTAINER_SEED_CREDS", raising=False)
+        host_cfg = tmp_path / "host-claude"
+        host_cfg.mkdir()
+        if host_creds is not None:
+            (host_cfg / ".credentials.json").write_bytes(host_creds)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(host_cfg))
+        wd = tmp_path / "agent-wd"
+        wd.mkdir()
+        ss = _session(
+            registry=_FakeRegistry(_FakeAgent("dymok", "container", working_dir=str(wd))),
+            working_dir=str(wd),
+        )
+        return ss, host_cfg, wd
+
+    def test_copies_host_creds_with_0600(self, monkeypatch, tmp_path):
+        ss, _host_cfg, wd = self._creds_session(monkeypatch, tmp_path)
+        ss._seed_container_claude_creds()
+        dst = wd / ".claude-container" / ".credentials.json"
+        assert dst.read_bytes() == b'{"oauth": "tok"}'
+        assert dst.stat().st_mode & 0o777 == 0o600
+
+    def test_second_call_noops_when_dst_exists(self, monkeypatch, tmp_path):
+        # The in-workdir copy is the durable one (a later in-container login /
+        # token refresh writes there) — a re-seed must never clobber it.
+        ss, host_cfg, wd = self._creds_session(monkeypatch, tmp_path)
+        ss._seed_container_claude_creds()
+        (host_cfg / ".credentials.json").write_bytes(b'{"oauth": "rotated"}')
+        ss._seed_container_claude_creds()
+        dst = wd / ".claude-container" / ".credentials.json"
+        assert dst.read_bytes() == b'{"oauth": "tok"}'
+
+    def test_disabled_via_env(self, monkeypatch, tmp_path):
+        ss, _host_cfg, wd = self._creds_session(monkeypatch, tmp_path)
+        monkeypatch.setenv("PINKY_CONTAINER_SEED_CREDS", "0")
+        ss._seed_container_claude_creds()
+        assert not (wd / ".claude-container" / ".credentials.json").exists()
+
+    def test_missing_host_creds_nonfatal(self, monkeypatch, tmp_path):
+        ss, _host_cfg, wd = self._creds_session(monkeypatch, tmp_path, host_creds=None)
+        ss._seed_container_claude_creds()  # must not raise
+        assert not (wd / ".claude-container" / ".credentials.json").exists()
+
+
+@pytest.mark.asyncio
+class TestCheckContainerImageContract:
+    """#638 fail-fast: the bring-your-own image must provide tmux, claude, and
+    python3 — a missing binary raises a clear RuntimeError instead of an opaque
+    tmux-spawn stderr minutes later. Probe errors themselves are tolerated."""
+
+    def _contract_session(self, monkeypatch, inner):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        runner = ContainerCommandRunner("pinky-dymok", inner=inner)
+        monkeypatch.setattr(ss, "_select_command_runner", lambda: runner)
+        return ss
+
+    async def test_missing_binary_raises_naming_it(self, monkeypatch):
+        ss = self._contract_session(monkeypatch, _StubInner(stdout=b"claude\n"))
+        with pytest.raises(RuntimeError, match="claude"):
+            await ss._check_container_image_contract()
+
+    async def test_all_binaries_present_no_raise(self, monkeypatch):
+        inner = _StubInner(stdout=b"")
+        ss = self._contract_session(monkeypatch, inner)
+        await ss._check_container_image_contract()
+        assert len(inner.calls) == 1  # exactly one sh -c probe, exec'd in-container
+        assert inner.calls[0][:2] == ["podman", "exec"]
+
+    async def test_probe_error_tolerated(self, monkeypatch):
+        ss = self._contract_session(
+            monkeypatch, _StubInner(exc=RuntimeError("podman exploded"))
+        )
+        await ss._check_container_image_contract()  # must not raise (logged only)

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -16,9 +16,23 @@ from pinky_daemon.tmux_session import TmuxSession
 
 
 class _FakeAgent:
-    def __init__(self, name, isolation_mode="local"):
+    def __init__(self, name, isolation_mode="local", working_dir=""):
         self.name = name
         self.isolation_mode = isolation_mode
+        self.working_dir = working_dir
+
+
+class _RecordingInner:
+    """Inner CommandRunner double — records wrapped argvs, never spawns."""
+
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    async def run(self, argv, *, timeout=None, stdin=None):
+        from pinky_daemon.command_runner import CommandResult
+
+        self.calls.append(list(argv))
+        return CommandResult(returncode=0, stdout=b"", stderr=b"")
 
 
 class _FakeRegistry:
@@ -56,6 +70,20 @@ class TestSelectCommandRunner:
         runner = ss._select_command_runner()
         assert isinstance(runner, ContainerCommandRunner)
         assert runner.wrap(["tmux", "ls"]) == ["podman", "exec", "--", "pinky-dymok", "tmux", "ls"]
+
+    def test_container_runner_passes_in_container_cwd(self, monkeypatch):
+        # The agent's working_dir (bind-mounted at the same path) becomes the
+        # `podman exec -w` so tmux + claude run in the project dir in-container.
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(
+            _FakeAgent("dymok", "container", working_dir="/srv/agents/dymok")
+        ))
+        runner = ss._select_command_runner()
+        assert isinstance(runner, ContainerCommandRunner)
+        assert runner.wrap(["tmux", "ls"]) == [
+            "podman", "exec", "-w", "/srv/agents/dymok", "--",
+            "pinky-dymok", "tmux", "ls",
+        ]
 
     def test_docker_binary_honored(self, monkeypatch):
         monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "docker")
@@ -114,3 +142,35 @@ class TestEnsureContainerStarted:
         monkeypatch.setattr(provisioning, "get_provisioner", lambda mode, **kw: _FakeProv())
         await ss._ensure_container_started()
         assert seen["agent"] == "dymok"
+
+
+@pytest.mark.asyncio
+class TestSeedContainerTrust:
+    async def test_noop_for_local_agent(self, monkeypatch):
+        # Local agents seed trust on the host path; the in-container seeder is a
+        # no-op for them (runner isn't a ContainerCommandRunner) — never execs.
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        await ss._seed_container_trust("/tmp/x")  # must not raise / not exec
+
+    async def test_execs_seed_in_container(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(
+            _FakeAgent("dymok", "container", working_dir="/srv/agents/dymok")
+        ))
+        inner = _RecordingInner()
+        runner = ContainerCommandRunner(
+            "pinky-dymok", workdir="/srv/agents/dymok", inner=inner
+        )
+        monkeypatch.setattr(ss, "_select_command_runner", lambda: runner)
+        await ss._seed_container_trust("/srv/agents/dymok")
+        assert len(inner.calls) == 1
+        cmd = inner.calls[0]
+        # podman exec -w <wd> -- pinky-dymok python3 -c <seed> <project_dir>
+        assert cmd[:2] == ["podman", "exec"]
+        assert "pinky-dymok" in cmd and "python3" in cmd and "-c" in cmd
+        assert cmd[-1] == "/srv/agents/dymok"  # project dir is the script arg
+        seed = cmd[cmd.index("-c") + 1]
+        assert "bypassPermissionsModeAccepted" in seed
+        assert "hasTrustDialogAccepted" in seed
+        assert "CLAUDE_CONFIG_DIR" in seed  # resolves the in-container config dir

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -1,0 +1,116 @@
+"""Container-isolation wiring in TmuxSession (gated runner injection + cold-start
+ensure_started). All gated by PINKY_CONTAINER_RUNTIME and isolation_mode; local
+agents and the gate-off default must behave exactly as before. No real podman —
+the provisioner is faked, runner selection is asserted via wrap() shapes."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import pinky_daemon.provisioning as provisioning
+from pinky_daemon.command_runner import ContainerCommandRunner, LocalCommandRunner
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import TmuxSession
+
+
+class _FakeAgent:
+    def __init__(self, name, isolation_mode="local"):
+        self.name = name
+        self.isolation_mode = isolation_mode
+
+
+class _FakeRegistry:
+    def __init__(self, agent=None, *, raises=False):
+        self._agent = agent
+        self._raises = raises
+
+    def get(self, name):
+        if self._raises:
+            raise RuntimeError("registry boom")
+        return self._agent
+
+    def get_or_create_signing_key(self, name):
+        return f"key-{name}"
+
+
+def _session(agent_name="dymok", registry=None):
+    cfg = StreamingSessionConfig(agent_name=agent_name, working_dir="/tmp/x")
+    # A truthy tmux_control short-circuits the in-__init__ runner selection, so we
+    # can set _registry and call the gated methods directly + deterministically.
+    ss = TmuxSession(cfg, tmux_control=MagicMock())
+    ss._registry = registry
+    return ss
+
+
+class TestSelectCommandRunner:
+    def test_local_by_default_gate_off(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        assert isinstance(ss._select_command_runner(), LocalCommandRunner)
+
+    def test_container_runner_when_gated(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        runner = ss._select_command_runner()
+        assert isinstance(runner, ContainerCommandRunner)
+        assert runner.wrap(["tmux", "ls"]) == ["podman", "exec", "--", "pinky-dymok", "tmux", "ls"]
+
+    def test_docker_binary_honored(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "docker")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        assert ss._select_command_runner().wrap(["tmux"])[0] == "docker"
+
+    def test_local_for_non_container_even_when_gated(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        assert isinstance(ss._select_command_runner(), LocalCommandRunner)
+
+    def test_failsafe_when_registry_missing(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=None)
+        assert isinstance(ss._select_command_runner(), LocalCommandRunner)
+
+    def test_failsafe_when_registry_raises(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(raises=True))
+        assert isinstance(ss._select_command_runner(), LocalCommandRunner)
+
+
+@pytest.mark.asyncio
+class TestEnsureContainerStarted:
+    async def test_noop_for_local_agent(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        called = []
+        monkeypatch.setattr(
+            provisioning, "get_provisioner",
+            lambda *a, **k: called.append(1) or MagicMock(),
+        )
+        await ss._ensure_container_started()
+        assert called == []  # provisioner never consulted for a local agent
+
+    async def test_noop_when_gate_off(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        called = []
+        monkeypatch.setattr(
+            provisioning, "get_provisioner",
+            lambda *a, **k: called.append(1) or MagicMock(),
+        )
+        await ss._ensure_container_started()
+        assert called == []  # gate off → never provisions, even for a container agent
+
+    async def test_calls_ensure_started_when_gated_container(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        seen = {}
+
+        class _FakeProv:
+            def ensure_started(self, agent):
+                seen["agent"] = agent.name
+
+        monkeypatch.setattr(provisioning, "get_provisioner", lambda mode, **kw: _FakeProv())
+        await ss._ensure_container_started()
+        assert seen["agent"] == "dymok"

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -22,7 +22,13 @@ from pinky_daemon.command_runner import (
     LocalCommandRunner,
 )
 from pinky_daemon.streaming_session import StreamingSessionConfig
-from pinky_daemon.tmux_session import TmuxSession, _is_dead_runtime_stderr
+from pinky_daemon.tmux_session import (
+    TmuxCommandResult,
+    TmuxSession,
+    _container_start_timeout_sec,
+    _is_dead_runtime_stderr,
+    _TmuxControl,
+)
 
 
 class _FakeAgent:
@@ -96,15 +102,41 @@ class TestSelectCommandRunner:
         ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
         runner = ss._select_command_runner()
         assert isinstance(runner, ContainerCommandRunner)
-        assert runner.wrap(["tmux", "ls"]) == ["podman", "exec", "--", "pinky-dymok", "tmux", "ls"]
+        # #638: the SESSION's working_dir ("/tmp/x" in the fixture) is the
+        # canonical cwd — it is what tmux new-session -c gets, so podman exec
+        # -w must agree with it (the registry row may hold a symlinked or
+        # stale variant).
+        assert runner.wrap(["tmux", "ls"]) == [
+            "podman", "exec", "-w", "/tmp/x", "--", "pinky-dymok", "tmux", "ls",
+        ]
 
     def test_container_runner_passes_in_container_cwd(self, monkeypatch):
-        # The agent's working_dir (bind-mounted at the same path) becomes the
+        # The session's working_dir (bind-mounted at the same path) becomes the
         # `podman exec -w` so tmux + claude run in the project dir in-container.
+        # The agent ROW's working_dir is only the fallback when the session
+        # config carries none (#638 raw-vs-resolved divergence fix).
         monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
-        ss = _session(registry=_FakeRegistry(
-            _FakeAgent("dymok", "container", working_dir="/srv/agents/dymok")
-        ))
+        ss = _session(
+            registry=_FakeRegistry(
+                _FakeAgent("dymok", "container", working_dir="/srv/agents/dymok")
+            ),
+            working_dir="/srv/agents/dymok",
+        )
+        runner = ss._select_command_runner()
+        assert isinstance(runner, ContainerCommandRunner)
+        assert runner.wrap(["tmux", "ls"]) == [
+            "podman", "exec", "-w", "/srv/agents/dymok", "--",
+            "pinky-dymok", "tmux", "ls",
+        ]
+
+    def test_container_runner_falls_back_to_agent_row_workdir(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(
+            registry=_FakeRegistry(
+                _FakeAgent("dymok", "container", working_dir="/srv/agents/dymok")
+            ),
+            working_dir="",
+        )
         runner = ss._select_command_runner()
         assert isinstance(runner, ContainerCommandRunner)
         assert runner.wrap(["tmux", "ls"]) == [
@@ -167,8 +199,18 @@ class TestEnsureContainerStarted:
                 seen["agent"] = agent.name
 
         monkeypatch.setattr(provisioning, "get_provisioner", lambda mode, **kw: _FakeProv())
+        # Stub the post-start image probe — otherwise it would exec a REAL
+        # `podman exec ... sh -c` subprocess on the test host (passing only
+        # because the probe tolerates errors).
+        probe_calls = []
+
+        async def _fake_probe():
+            probe_calls.append(True)
+
+        monkeypatch.setattr(ss, "_check_container_image_contract", _fake_probe)
         await ss._ensure_container_started()
         assert seen["agent"] == "dymok"
+        assert probe_calls == [True]  # contract probe runs after start
 
 
 @pytest.mark.asyncio
@@ -389,3 +431,175 @@ class TestCheckContainerImageContract:
             monkeypatch, _StubInner(exc=RuntimeError("podman exploded"))
         )
         await ss._check_container_image_contract()  # must not raise (logged only)
+
+
+class TestContainerAgentStrict:
+    """#638 review fix: ``strict=True`` (the SPAWN path) fails CLOSED on a
+    registry lookup failure — silently falling back to a LocalCommandRunner
+    would launch a container-labeled agent UNISOLATED on the host. The default
+    (read-side) fail-safe keeps returning None for the same failure."""
+
+    def test_strict_raises_refusing_to_spawn_when_registry_fails(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(raises=True))
+        with pytest.raises(RuntimeError, match="refusing to spawn"):
+            ss._container_agent(strict=True)
+
+    def test_non_strict_returns_none_for_same_failing_registry(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(raises=True))
+        assert ss._container_agent() is None  # read-side consumers stay fail-safe
+
+    def test_strict_gate_off_short_circuits_before_registry(self, monkeypatch):
+        # The gate check precedes the lookup, so even strict mode never raises
+        # (and never consults the broken registry) when the runtime is off.
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        ss = _session(registry=_FakeRegistry(raises=True))
+        assert ss._container_agent(strict=True) is None
+
+
+@pytest.mark.asyncio
+class TestTmuxControlSetCommandRunner:
+    """#638: set_command_runner swaps the execution seam on a LIVE _TmuxControl
+    — the runner is re-selected at every spawn, so a session that survives an
+    isolation_mode flip must start exec'ing through the new runner."""
+
+    async def test_swap_wraps_subsequent_commands_in_podman_exec(self):
+        inner = _RecordingInner()
+        # The recording inner stands in for the LocalCommandRunner: argv runs
+        # verbatim (no wrap) until the seam is swapped.
+        control = _TmuxControl("pinky-dymok-main", command_runner=inner)
+        await control.has_session()
+        assert inner.calls[-1] == ["tmux", "has-session", "-t", "pinky-dymok-main"]
+
+        control.set_command_runner(
+            ContainerCommandRunner(
+                "pinky-dymok", workdir="/srv/agents/dymok", inner=inner
+            )
+        )
+        await control.has_session()
+        assert inner.calls[-1] == [
+            "podman", "exec", "-w", "/srv/agents/dymok", "--", "pinky-dymok",
+            "tmux", "has-session", "-t", "pinky-dymok-main",
+        ]
+
+    async def test_swap_back_to_local_unwraps(self):
+        # The reverse flip (container -> local) must stop podman-wrapping.
+        inner = _RecordingInner()
+        control = _TmuxControl(
+            "pinky-dymok-main",
+            command_runner=ContainerCommandRunner("pinky-dymok", inner=inner),
+        )
+        await control.has_session()
+        assert inner.calls[-1][:2] == ["podman", "exec"]
+
+        control.set_command_runner(inner)
+        await control.has_session()
+        assert inner.calls[-1] == ["tmux", "has-session", "-t", "pinky-dymok-main"]
+
+
+class TestContainerStartTimeoutSec:
+    """#638: the provision+start budget at spawn — env-overridable, with a
+    600s default (a legitimate podman pull can take minutes) and a 1s floor."""
+
+    def test_default_600(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_START_TIMEOUT_SEC", raising=False)
+        assert _container_start_timeout_sec() == 600.0
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_START_TIMEOUT_SEC", "42")
+        assert _container_start_timeout_sec() == 42.0
+
+    def test_garbage_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_START_TIMEOUT_SEC", "soon-ish")
+        assert _container_start_timeout_sec() == 600.0
+
+    def test_floor_at_one_second(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_START_TIMEOUT_SEC", "0.05")
+        assert _container_start_timeout_sec() == 1.0
+
+    def test_blank_value_is_default(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_START_TIMEOUT_SEC", "   ")
+        assert _container_start_timeout_sec() == 600.0
+
+
+@pytest.mark.asyncio
+class TestSpawnRebindsCommandRunner:
+    """#638 (review-confirmed critical): _spawn_tmux_repl re-selects the
+    execution seam from a fresh strict registry snapshot on EVERY spawn.
+    Session objects survive isolation_mode flips (PUT /agents tears nothing
+    down), so a runner fixed at construction would silently launch a
+    flipped-to-container agent on the HOST."""
+
+    def _spawnable_session(self, monkeypatch, tmp_path, agent):
+        registry = _FakeRegistry(agent)
+        ss = _session(registry=registry, working_dir=str(tmp_path))
+        # Stub every spawn collaborator with side effects beyond the seam.
+        seen = {"ensure_started": []}
+
+        async def fake_ensure(agent=None):
+            seen["ensure_started"].append(agent)
+
+        async def fake_seed_trust(project_dir):
+            return None
+
+        async def fake_start_tailer():
+            return None
+
+        monkeypatch.setattr(ss, "_ensure_container_started", fake_ensure)
+        monkeypatch.setattr(ss, "_seed_container_claude_creds", lambda: None)
+        monkeypatch.setattr(ss, "_seed_container_trust", fake_seed_trust)
+        monkeypatch.setattr(ss, "_build_claude_cmd", lambda: "claude")
+        monkeypatch.setattr(ss, "_start_tailer", fake_start_tailer)
+        ss._tmux.has_session = AsyncMock(return_value=False)
+        ss._tmux.kill_session = AsyncMock()
+        ss._tmux.new_session = AsyncMock(
+            return_value=TmuxCommandResult(returncode=0, stdout="", stderr="")
+        )
+        return ss, seen
+
+    async def test_spawn_after_container_flip_binds_container_runner(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        # The row starts LOCAL — the session was constructed for a local agent.
+        agent = _FakeAgent("dymok", "local", working_dir=str(tmp_path))
+        ss, seen = self._spawnable_session(monkeypatch, tmp_path, agent)
+        # PUT /agents flips the registry row with no session teardown.
+        agent.isolation_mode = "container"
+
+        await ss._spawn_tmux_repl()
+
+        ss._tmux.set_command_runner.assert_called_once()
+        runner = ss._tmux.set_command_runner.call_args[0][0]
+        assert isinstance(runner, ContainerCommandRunner)
+        # Bound to THIS agent's container, exec'ing in the session's cwd.
+        assert runner.wrap(["tmux"]) == [
+            "podman", "exec", "-w", str(tmp_path), "--", "pinky-dymok", "tmux",
+        ]
+        # And the same strict snapshot drove the container start.
+        assert seen["ensure_started"] == [agent]
+
+    async def test_spawn_for_local_row_binds_local_runner(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        agent = _FakeAgent("dymok", "local", working_dir=str(tmp_path))
+        ss, seen = self._spawnable_session(monkeypatch, tmp_path, agent)
+
+        await ss._spawn_tmux_repl()
+
+        runner = ss._tmux.set_command_runner.call_args[0][0]
+        assert isinstance(runner, LocalCommandRunner)
+        assert seen["ensure_started"] == [None]  # no container agent snapshot
+
+    async def test_spawn_fails_closed_when_registry_breaks(self, monkeypatch, tmp_path):
+        # A registry failure at spawn raises (-> BOOT_FAILED) instead of
+        # quietly re-binding a LocalCommandRunner.
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        agent = _FakeAgent("dymok", "container", working_dir=str(tmp_path))
+        ss, _seen = self._spawnable_session(monkeypatch, tmp_path, agent)
+        ss._registry = _FakeRegistry(raises=True)
+
+        with pytest.raises(RuntimeError, match="refusing to spawn"):
+            await ss._spawn_tmux_repl()
+        ss._tmux.set_command_runner.assert_not_called()
+        ss._tmux.new_session.assert_not_called()

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -962,6 +962,9 @@ def test_build_repl_env_provisions_per_agent_key(monkeypatch) -> None:
     ss._registry.get_signing_key.return_value = "dymok-per-agent-key"
     # Non-isolated agent: dual-accept fallback retains the global secret.
     ss._registry.get.return_value.isolated = False
+    # #638: a bare MagicMock auto-generates a truthy Mock for isolation_mode,
+    # which the non-local coupling rightly treats as isolated — declare local.
+    ss._registry.get.return_value.isolation_mode = "local"
     env = ss._build_repl_env()
     assert env.get("PINKY_AGENT_KEY") == "dymok-per-agent-key"
     # Global secret still propagated (dual-accept fallback for other paths).


### PR DESCRIPTION
Consolidates the full #638 phase-3 container-isolation stack (#656 scaffold, #657 container_image field, #658 gated runtime, and the engaged-runtime work) onto latest main as ONE reviewable PR, then closes every gap that blocked fleet deploy. The stacked PRs #656/#657/#658 are superseded by this and closed.

## What ships

**The stack (rebased clean onto main, no conflicts):** ContainerProvisioner (idempotent reconcile: home volume, stdin-created key secret, pull-if-missing, podman create with --userns=keep-id + host-gateway + same-path workdir mount), ContainerCommandRunner (every tmux command podman-exec'd), provision-on-register / deprovision-on-retire, tmux-transport guard, default-OFF gate (PINKY_CONTAINER_RUNTIME).

**Gap closure (the response pipeline was dead before this):**
- CLAUDE_CONFIG_DIR moved to `<working_dir>/.claude-container` inside the same-path mount: transcripts/trust/creds are host-visible at the identical absolute path, so the host-side tailer, `--continue`, watchdog evidence, and SessionStart path reporting all work unchanged
- All 7 hook scripts honor PINKY_DAEMON_URL; container sessions inject `http://host.containers.internal:8888` (hooks no longer POST into the container's own dead localhost); stale hook_working/hook_idle are rewritten
- Shared-MCP inbound auth (#623): derived per-agent bearer (one-way from the signing key) in every SSE agent's .mcp.json; non-loopback BINDS require it on every request (peer-address classification is not trusted on exposed binds — rootless podman can present loopback sources); loopback binds keep legacy header trust until PINKY_SHARED_MCP_REQUIRE_AUTH
- isolation coupling: non-local isolation_mode implies isolated=true at register/PUT/runtime — a container tenant can never receive the forgeable global secret
- Claude creds bootstrap: one-time host-side seed of the operator's OAuth creds into the agent's config dir (durable across recreates; PINKY_CONTAINER_SEED_CREDS=0 for manual per-tenant login)
- Resource caps (--memory 2g, --pids-limit 2048, env-overridable), image-contract preflight (tmux/claude/python3), image-drift recreate (pull-before-rm), dead-container stderr detection -> auto-recovery, missing-binary -> clean ProvisionError, register-upsert no longer hard-deletes pre-existing agents on provision failure
- Event loop kept free: provision/deprovision via to_thread; container start has its own 600s budget outside the 60s REPL cold-start timeout
- Frontend: isolation_mode + container_image in wizard and detail Runtime tab, with container<->tmux transport coupling enforced on both surfaces
- Operator runbook: `specs/container-isolation.md`

## Review
Two multi-agent passes: a 7-reader gap map, then a 5-dimension adversarial review (42 agents; every finding independently verified by attempted refutation). 34 confirmed findings fixed in `ac5b2e8` — including a critical: the CommandRunner was bound once at construction, so flipping isolation_mode on a live session ran claude unisolated on the host; the seam is now re-selected per spawn from a strict registry snapshot, failing closed.

## Tests
~105 new tests across provisioning / shared-MCP auth / tmux container wiring / API semantics / hook sources, including a spawn-rebinding regression test. Full suite: **3456 passed, 2 skipped**; ruff clean; frontend builds.

## Deploy plan (per Brad)
RPi fleet ONLY for testing (gate stays off everywhere else; Mac Mini untouched — podman-machine semantics unvalidated, documented as out of scope). After merge: cut a Release, deploy to the Pi, validate with a throwaway container agent end-to-end (register -> message -> reply -> restart -> reply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)