### PR TITLE
feat(#667): instrument orphan-recovery path + purge unowned ghost sessions

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -143,7 +143,11 @@ from pinky_daemon.session_watchdog import (
     WatchdogConfig,
     compute_mcp_checkable,
 )
-from pinky_daemon.sessions import SessionManager, SessionState
+from pinky_daemon.sessions import (
+    SessionManager,
+    SessionState,
+    is_purgeable_legacy_session,
+)
 from pinky_daemon.shared_mcp import (
     SHARED_MCP_HOST,
     SHARED_MCP_PORT,
@@ -7068,6 +7072,22 @@ npm run build</pre>
         old_resume_handle = ss.resume_handle
         old_turns = ss._stats["turns"]
 
+        # #667 diag: capture pre-restart live-session state so an orphan that's
+        # recovered by this (often EXTERNAL) restart isn't a black box. The
+        # connected/state fields distinguish a connected-but-MCP-wedged orphan
+        # from a disconnected-dead one — the open question from the 2026-06-02
+        # power-loss incident. Fail-safe: never block a restart on diagnostics.
+        try:
+            _st = ss.stats if hasattr(ss, "stats") else {}
+            _log(
+                f"#667 diag: pre-restart state for {name}: "
+                f"transport={type(ss).__name__} state={_st.get('state')!r} "
+                f"connected={_st.get('connected')} turns={_st.get('turns')} "
+                f"resume_handle={'set' if old_resume_handle else 'empty'}"
+            )
+        except Exception:
+            pass
+
         # Disconnect and clear persisted resume handle
         await ss.disconnect()
         agents.set_streaming_session_id(name, "", label="main")
@@ -8641,17 +8661,24 @@ npm run build</pre>
                     _log(f"startup: clearing stale session ID for {agent.name}/main")
                     agents.set_streaming_session_id(agent.name, "", label="main")
 
-        # Clean up legacy sessions for agents that now have streaming sessions.
-        # These ghost sessions were restored by SessionManager._restore_sessions()
-        # but are superseded by the streaming sessions created above.
+        # Clean up restored legacy SDK sessions: those superseded by a live
+        # streaming session, plus unowned ghosts (blank agent_name) that would
+        # otherwise reload every boot and pollute orphan diagnostics with a
+        # stale id (#667). See ``is_purgeable_legacy_session``.
         streaming_agents = set(broker._streaming.keys())
         legacy_purged = 0
+        ghost_purged = 0
         for s in manager.list():
-            if s.agent_name and s.agent_name in streaming_agents:
+            if is_purgeable_legacy_session(s.agent_name, streaming_agents):
+                if not s.agent_name:
+                    ghost_purged += 1
                 manager.delete(s.id)
                 legacy_purged += 1
         if legacy_purged:
-            _log(f"startup: purged {legacy_purged} legacy session(s) superseded by streaming")
+            _log(
+                f"startup: purged {legacy_purged} legacy session(s) "
+                f"({ghost_purged} unowned ghost(s)) (#667)"
+            )
 
         await scheduler.start()
         await autonomy.start()

--- a/src/pinky_daemon/session_watchdog.py
+++ b/src/pinky_daemon/session_watchdog.py
@@ -584,6 +584,16 @@ class SessionWatchdog:
         ):
             return False
         if not snap.connected:
+            if state.mcp_unbound_since:
+                # We were tracking a connected-but-unbound session and it just
+                # went disconnected — torn down (external restart / crash /
+                # warm-wake teardown) before MCP-recover could fire. Surface it
+                # so an orphan recovered by another path isn't invisible (#667).
+                _log(
+                    "mcp-bind: %s was unbound ~%ds then went disconnected before "
+                    "MCP-recover deadline — recovered/torn-down elsewhere (#667)",
+                    snap.agent_name, int(now - state.mcp_unbound_since),
+                )
             state.mcp_unbound_since = 0.0
             return False
 
@@ -606,6 +616,11 @@ class SessionWatchdog:
         # Unbound for the current epoch — track a *sustained* outage.
         if state.mcp_unbound_since == 0.0:
             state.mcp_unbound_since = now
+            _log(
+                "mcp-bind: %s unbound for current gateway epoch — starting "
+                "MCP-recover clock (#667 diag)",
+                snap.agent_name,
+            )
             return False
         unbound_for = now - state.mcp_unbound_since
 

--- a/src/pinky_daemon/sessions.py
+++ b/src/pinky_daemon/sessions.py
@@ -668,6 +668,23 @@ class Session:
         self._persist()
 
 
+def is_purgeable_legacy_session(agent_name: str, streaming_agents: set[str]) -> bool:
+    """At startup, decide whether a restored SDK ``SessionManager`` row should
+    be purged.
+
+    Two cases are purgeable:
+
+    1. **Superseded** — ``agent_name`` is set and that agent now has a live
+       streaming session (the original cleanup case; the SDK row is stale).
+    2. **Unowned ghost** — ``agent_name`` is blank. Such a row can never be
+       reached (no agent binding, never registered in ``broker._streaming``),
+       so it just reloads on every boot. Worse, it pollutes orphan-recovery
+       diagnostics with a stale session id — a 2-month-dead ghost was once
+       blamed for a live MCP-404 orphan (#667). Purge it.
+    """
+    return (not agent_name) or (agent_name in streaming_agents)
+
+
 class SessionManager:
     """Manages multiple concurrent sessions with optional persistence."""
 

--- a/src/pinky_daemon/sessions.py
+++ b/src/pinky_daemon/sessions.py
@@ -681,6 +681,13 @@ def is_purgeable_legacy_session(agent_name: str, streaming_agents: set[str]) -> 
        so it just reloads on every boot. Worse, it pollutes orphan-recovery
        diagnostics with a stale session id — a 2-month-dead ghost was once
        blamed for a live MCP-404 orphan (#667). Purge it.
+
+    Invariant (Pushok review of #668): case 2 is an irreversible DELETE that
+    rests on "blank ``agent_name`` ⇒ unreachable ghost" — true today (id-only
+    lookups; such rows are never registered in ``broker._streaming``, and at
+    cold boot nothing live sits behind them). If SDK session creation ever
+    persists a row and sets ``agent_name`` lazily *after* persist, revisit:
+    this would delete it at boot.
     """
     return (not agent_name) or (agent_name in streaming_agents)
 

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -377,3 +377,20 @@ class TestSessionHistoryPersistence:
         cs.close()
         os.unlink(sp)
         os.unlink(cp)
+
+
+def test_is_purgeable_legacy_session():
+    """Startup purge predicate (#667): unowned ghosts AND superseded sessions
+    are purgeable; an agent-owned session without a streaming session is kept."""
+    from pinky_daemon.sessions import is_purgeable_legacy_session
+
+    streaming = {"barsik", "pushok"}
+    # Unowned ghost (blank agent_name) — always purgeable, regardless of which
+    # agents are streaming. This is the #667 case (2-month-dead pinky-<hex> row).
+    assert is_purgeable_legacy_session("", streaming) is True
+    assert is_purgeable_legacy_session("", set()) is True
+    # Superseded — the owning agent now has a live streaming session.
+    assert is_purgeable_legacy_session("barsik", streaming) is True
+    # Owned by an agent that does NOT have a streaming session — keep it.
+    assert is_purgeable_legacy_session("persik", streaming) is False
+    assert is_purgeable_legacy_session("persik", set()) is False


### PR DESCRIPTION
## Summary
Spun off #663 (track separately, per Brad). **Diagnostics + cleanup — not a recovery-behavior change.** Goal: make the *next* ungraceful-kill orphan diagnosable instead of guessed at, and stop stale ghost rows from polluting recovery notes.

**Context:** on 2026-06-02 barsik hit the exact failure #663 is titled for (resumed session comes up identity-unbound → MCP 404). Root cause of *that* incident was an accidental Mac Mini power unplug (hard kill) — but two things made it hard to diagnose and worth fixing:
1. The #663 watchdog MCP-recover has **never fired** (0 `mcp_epoch_unbound` in api.log + activity DB); recovery came from an external `/streaming/restart`. We can't yet tell if the watchdog was pre-empted (fine) or has a detection gap.
2. The recovery note blamed a session id that's a **2-month-dead ghost** (`pinky-3778b9684a1e`, `last_active` 2026-04-04) — a red herring.

## Changes
- **`sessions.is_purgeable_legacy_session()`** (new, unit-tested) — startup purge predicate now also covers unowned ghosts (blank `agent_name`). The cleanup in `api.py` previously gated on `if s.agent_name`, so a blank-agent-name row reloaded every boot forever and polluted orphan diagnostics with a stale id.
- **`session_watchdog._evaluate_mcp_bind`** — edge-triggered diag logs: (a) when the MCP-recover clock starts (unbound for current epoch), (b) when a connected-but-unbound session goes disconnected before the deadline (recovered/torn-down by another path). These directly answer "why did the watchdog never fire while orphans still got recovered?"
- **`restart_streaming_session`** — log pre-restart live-session state (transport/state/connected/turns/resume_handle), fail-safe, so an externally-driven recovery isn't a black box.

## Not in scope (round 2)
The actual self-heal fix for recovery-after-ungraceful-kill — gated on the diagnostic data this PR collects from the next real event. Same rails as #663 (flag-gate, soak).

## Testing
- `+1` unit test for the purge predicate.
- `test_session_watchdog.py` (52 tests) still green — logging only, no behavior change.
- `py_compile` + ruff clean.

Refs #663, #155. Round 1 of 2 on #667 (does not close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
