### PR TITLE
fix(api): require auth on admin/credential/PII API surfaces

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3300,6 +3300,11 @@ def create_api(
         "/api/voice/twiml/", "/api/voice/status/", "/api/voice/amd/",
         # ConversationRelay WebSocket — auth via session-ID-in-path (opaque UUID)
         "/ws/voice/",
+        # Google OAuth callback — Google's redirect arrives cross-site WITHOUT our
+        # SameSite=strict cookie; the route self-authenticates via a one-time state
+        # nonce. Must stay public even though the rest of /calendar is now protected.
+        # (Checked here in gate step 1, BEFORE the _protected_api_prefixes deny.)
+        "/calendar/google/callback",
     )
     _protected_html_paths = {
         "/",
@@ -3337,6 +3342,21 @@ def create_api(
         "/migration",
         "/auth/password",
         "/api/voice",
+        # Admin-control, credential, and PII surfaces — require a session
+        # cookie or signed internal auth like the rest of the list. Legitimate
+        # callers already authenticate: the dashboard via the session cookie
+        # (api.js credentials:'same-origin'), agents/MCP via signed internal
+        # headers (build_internal_auth_headers). Public carve-outs that must
+        # stay reachable live in _public_prefixes above
+        # (/calendar/google/callback) or under a different prefix (the public
+        # app viewer is /a/{share_token}, NOT /apps).
+        "/admin",          # restart / update / channel / watchdog (owner + agent)
+        "/providers",      # LLM provider API keys
+        "/bot-tokens",     # platform bot tokens
+        "/user-profiles",  # owner/contact PII (also assembled into the system prompt)
+        "/calendar",       # CalDAV / Google credentials + config
+        "/apps",           # app management (deploy/share/upload); public viewer is /a/*
+        "/models",         # model registry management
     )
 
     def _session_secret() -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4805,11 +4805,20 @@ class TestGoogleOAuthStateValidation:
 
         app = self._make_app()
         self._seed_credentials(app)
+        from pinky_daemon.auth import SESSION_COOKIE_NAME, create_session_cookie
         with _patch(
             "pinky_calendar.oauth.get_auth_url",
             return_value=("https://accounts.google.com/o/oauth2/auth?state=xyz", "xyz"),
         ):
             with TestClient(app) as client:
+                # /calendar is auth-gated. direct-auth-url is an owner-initiated
+                # action (not Google's cross-site callback), so it requires a
+                # session — unlike the callback tests in this real_auth class.
+                # Mint one.
+                client.cookies.set(
+                    SESSION_COOKIE_NAME,
+                    create_session_cookie(os.environ["PINKY_SESSION_SECRET"]),
+                )
                 resp = client.get("/calendar/google/direct-auth-url")
         assert resp.status_code == 200
         body = resp.json()
@@ -4822,9 +4831,15 @@ class TestGoogleOAuthStateValidation:
     def test_direct_auth_url_requires_credentials(self):
         """Without stored client credentials, direct-auth must 400 — there's
         nothing to build a direct-Google auth URL for."""
+        from pinky_daemon.auth import SESSION_COOKIE_NAME, create_session_cookie
         app = self._make_app()
         # Intentionally skip _seed_credentials().
         with TestClient(app) as client:
+            # /calendar is auth-gated; this owner endpoint needs a session.
+            client.cookies.set(
+                SESSION_COOKIE_NAME,
+                create_session_cookie(os.environ["PINKY_SESSION_SECRET"]),
+            )
             resp = client.get("/calendar/google/direct-auth-url")
         assert resp.status_code == 400
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1108,3 +1108,101 @@ class TestAgentIsolationScoping:
         resp = client.get("/agents/tenant", headers=headers)
         assert resp.status_code == 401
         os.unlink(path)
+
+
+class TestSensitivePrefixesRequireAuth:
+    """Auth-gate coverage for admin-control, credential, and PII API surfaces.
+    /admin, /providers, /bot-tokens, /user-profiles, /calendar, /apps, /models
+    are in ``_protected_api_prefixes`` and require a session cookie or signed
+    internal auth. These tests pin (a) unauth requests get 401, (b) the legit
+    gates still pass — notably HMAC on /admin so agent self-update keeps
+    working, and (c) the public carve-outs are unbroken: the Google OAuth
+    callback stays reachable and the public app viewer (/a/{token}) is not
+    under /apps.
+    """
+
+    _MW_DENY = {"detail": "Unauthorized"}
+
+    def _make_client(self, monkeypatch):
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        monkeypatch.setenv("PINKY_SESSION_SECRET", "test-session-secret")
+        monkeypatch.delenv("PINKY_UI_PASSWORD", raising=False)
+        app = create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
+        return TestClient(app), path
+
+    def test_unauth_sensitive_prefixes_now_401(self, monkeypatch):
+        client, path = self._make_client(monkeypatch)
+        # Non-browser (curl-shape): no Origin, no cookie, no HMAC.
+        for p in (
+            "/admin/restart",
+            "/admin/update",
+            "/providers",
+            "/bot-tokens",
+            "/user-profiles",
+            "/models",
+            "/apps",
+            "/calendar/config",
+            "/calendar/google/credentials",
+        ):
+            resp = client.get(p)
+            assert resp.status_code == 401, (
+                f"{p} must require auth (was an unauth fall-through), got {resp.status_code}"
+            )
+            assert resp.json() == self._MW_DENY, f"{p} should hit the middleware deny"
+        os.unlink(path)
+
+    def test_oauth_callback_carveout_stays_public(self, monkeypatch):
+        """/calendar/google/callback must NOT be blocked by the gate — Google's
+        redirect arrives cross-site with no cookie; the route self-validates a
+        state nonce. It reaches the route (which may 3xx/4xx on a bad state) but
+        is never the middleware default-deny 401."""
+        client, path = self._make_client(monkeypatch)
+        resp = client.get("/calendar/google/callback?state=x&code=y", follow_redirects=False)
+        blocked_by_mw = resp.status_code == 401 and (
+            resp.headers.get("content-type", "").startswith("application/json")
+            and resp.json() == self._MW_DENY
+        )
+        assert not blocked_by_mw, "OAuth callback must stay reachable past the auth gate"
+        os.unlink(path)
+
+    def test_public_app_viewer_not_under_apps_prefix(self, monkeypatch):
+        """Protecting /apps must not break public app viewing — the public
+        viewer lives at /a/{share_token}, a different prefix that still falls
+        through to its route."""
+        client, path = self._make_client(monkeypatch)
+        resp = client.get("/a/some-share-token", follow_redirects=False)
+        blocked_by_mw = resp.status_code == 401 and (
+            resp.headers.get("content-type", "").startswith("application/json")
+            and resp.json() == self._MW_DENY
+        )
+        assert not blocked_by_mw, "/a/{token} public viewer must not be gated by the /apps protection"
+        os.unlink(path)
+
+    def test_session_cookie_passes_sensitive_prefix(self, monkeypatch):
+        client, path = self._make_client(monkeypatch)
+        client.post("/auth/setup", json={"password": "hunter22", "next": "/"})
+        # logged-in browser session → must not be middleware-401 on /providers
+        resp = client.get("/providers")
+        assert resp.status_code != 401, (
+            f"session-authed request blocked at middleware ({resp.status_code})"
+        )
+        os.unlink(path)
+
+    def test_hmac_signed_passes_admin(self, monkeypatch):
+        client, path = self._make_client(monkeypatch)
+        client.app.state.agents.register("barsik", model="opus", working_dir="/tmp/barsik")
+        headers = build_internal_auth_headers(
+            "test-session-secret", agent_name="barsik",
+            method="POST", path="/admin/update/status",
+        )
+        resp = client.post(
+            "/admin/update/status",
+            headers={**headers, "Content-Type": "application/json"},
+            json={},
+        )
+        assert resp.status_code != 401, (
+            f"HMAC-signed admin request blocked at middleware ({resp.status_code}) — "
+            f"would break update_and_restart self-update"
+        )
+        os.unlink(path)


### PR DESCRIPTION
Adds `/admin`, `/providers`, `/bot-tokens`, `/user-profiles`, `/calendar`, `/apps`, `/models` to `_protected_api_prefixes` so they require a session cookie or signed internal auth, consistent with the rest of the protected API surface.

**Carve-outs preserved**
- `/calendar/google/callback` → added to `_public_prefixes` (checked first in the gate). Google's redirect arrives cross-site without our SameSite=strict cookie; the route self-validates a one-time state nonce.
- The public app viewer `/a/{share_token}` is a separate prefix — unaffected by protecting `/apps`.

**Legitimate callers already authenticate** (verified):
- Dashboard via the session cookie (`api.js` `credentials:'same-origin'`).
- Agents/MCP via signed internal headers (`build_internal_auth_headers`), including `update_and_restart` → `/admin/*`, so self-update keeps working.

**Tests**
- New `TestSensitivePrefixesRequireAuth`: unauth → 401; session + HMAC carve-outs (incl. HMAC on `/admin`); OAuth-callback + `/a` viewer stay reachable.
- Two `direct-auth-url` tests updated to authenticate (owner-only endpoint).
- 84 auth/OAuth tests pass locally; ruff clean.

🤖 Opened by Barsik