### PR TITLE
feat(security): complete auth-gate route coverage with deny-by-default (#506)

### DIFF
--- a/scripts/audit_route_auth_coverage.py
+++ b/scripts/audit_route_auth_coverage.py
@@ -1,0 +1,124 @@
+"""Audit every registered FastAPI route against the auth allowlists.
+
+Walks ``app.routes`` from a real ``create_api`` instance (post-prefix-resolution)
+and classifies each route as PROTECTED-API / PROTECTED-HTML / PUBLIC-exact /
+PUBLIC-prefix / UNCLASSIFIED.
+
+UNCLASSIFIED is the deny-by-default gap (#506): a path that is neither public
+nor under a protected prefix falls through the auth middleware to the route.
+Under ``PINKY_AUTH_DENY_DEFAULT=enforce`` such a path is 401'd, so every route
+must be classified. This script is the basis for the regression test
+(``tests/test_route_auth_coverage.py``).
+
+The classification sets are read from ``app.state.auth_route_sets`` — the EXACT
+tuples the auth middleware uses — so this audit never drifts from the gate.
+
+Usage:
+    python3 scripts/audit_route_auth_coverage.py
+Exit status is non-zero if any route is UNCLASSIFIED.
+
+Why app.routes (not source-grep): routers under ``APIRouter(prefix="/foo")``
+register decorator strings like ``@router.get("/bar")`` which become ``/foo/bar``
+at runtime. Source-grep misses that. ``app.routes`` is ground truth.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from collections import defaultdict
+
+
+def collect(app) -> tuple[list[tuple[str, str]], dict]:
+    """Return ([(kind, path), ...], auth_route_sets) for ``app``."""
+    from fastapi.routing import APIRoute
+    from starlette.routing import Mount, WebSocketRoute
+
+    routes: list[tuple[str, str]] = []
+    for r in app.routes:
+        if isinstance(r, APIRoute):
+            routes.append(("HTTP", r.path))
+        elif isinstance(r, WebSocketRoute):
+            routes.append(("WS", r.path))
+        elif isinstance(r, Mount):
+            # Mounts (e.g. /assets, /static) serve files at any sub-path; they
+            # are covered by the matching public prefix. The Mount entry itself
+            # is not a callable route, so exclude it.
+            continue
+    return routes, app.state.auth_route_sets
+
+
+def classifier(sets: dict):
+    """Build a classify(path)->label fn from app.state.auth_route_sets."""
+    public_exact = sets["public_exact"]
+    public_prefixes = tuple(sets["public_prefixes"])
+    protected_html = sets["protected_html"]
+    protected_api = tuple(sets["protected_api_prefixes"])
+
+    def classify(path: str) -> str:
+        if path in public_exact:
+            return "PUBLIC-exact"
+        if path.startswith(public_prefixes):
+            return "PUBLIC-prefix"
+        if path in protected_html:
+            return "PROTECTED-HTML"
+        if path.startswith(protected_api):
+            return "PROTECTED-API"
+        return "UNCLASSIFIED"
+
+    return classify
+
+
+def build_app():
+    """Instantiate a real create_api app against a throwaway DB."""
+    os.environ.setdefault(
+        "PINKY_SESSION_SECRET",
+        "test-session-secret-do-not-use-in-prod-32bytes-min",
+    )
+    if "src" not in sys.path:
+        sys.path.insert(0, "src")
+    from pinky_daemon.api import create_api
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    return create_api(max_sessions=10, default_working_dir="/tmp", db_path=db_path)
+
+
+def audit() -> list[tuple[str, str]]:
+    """Return the sorted list of UNCLASSIFIED (kind, path) routes."""
+    app = build_app()
+    routes, sets = collect(app)
+    classify = classifier(sets)
+    unclass = [(k, p) for (k, p) in routes if classify(p) == "UNCLASSIFIED"]
+    return sorted(set(unclass), key=lambda x: x[1])
+
+
+def main() -> int:
+    app = build_app()
+    routes, sets = collect(app)
+    classify = classifier(sets)
+
+    by_class: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for kind, path in routes:
+        by_class[classify(path)].append((kind, path))
+
+    print(f"Total callable routes: {len(routes)}")
+    print(f"Classes: {dict((k, len(v)) for k, v in by_class.items())}")
+
+    unclass = sorted(set(by_class["UNCLASSIFIED"]), key=lambda x: x[1])
+    print(f"\nUNCLASSIFIED ({len(unclass)}):")
+    by_seg: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for kind, p in unclass:
+        seg = "/" + p.lstrip("/").split("/", 1)[0]
+        by_seg[seg].append((kind, p))
+    for seg in sorted(by_seg):
+        print(f"\n  {seg}/  ({len(by_seg[seg])} routes)")
+        for kind, p in sorted(set(by_seg[seg])):
+            print(f"    [{kind:5s}]  {p}")
+
+    return 0 if not unclass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_route_auth_coverage.py
+++ b/scripts/audit_route_auth_coverage.py
@@ -42,10 +42,14 @@ def collect(app) -> tuple[list[tuple[str, str]], dict]:
         elif isinstance(r, WebSocketRoute):
             routes.append(("WS", r.path))
         elif isinstance(r, Mount):
-            # Mounts (e.g. /assets, /static) serve files at any sub-path; they
-            # are covered by the matching public prefix. The Mount entry itself
-            # is not a callable route, so exclude it.
-            continue
+            # A Mount serves an entire subtree (e.g. /assets, /static). The auth
+            # middleware sees the original path BEFORE routing, so the mount's
+            # prefix must be classified too — a future sub-app mounted at an
+            # unclassified prefix would otherwise be reachable while the
+            # zero-unclassified gate stayed green. Represent the mount by its
+            # subtree prefix (trailing slash) so it matches the public/protected
+            # prefix tuples the middleware uses.
+            routes.append(("MOUNT", r.path.rstrip("/") + "/"))
     return routes, app.state.auth_route_sets
 
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3306,6 +3306,11 @@ def create_api(
     }
     _public_prefixes = (
         "/assets/", "/static/", "/p/", "/hooks/",
+        # Public app viewer — a shared app is opened by share token at
+        # /a/{share_token} with no session (the link is the credential). The
+        # management surface (/apps) stays protected; only the /a/ viewer is
+        # public. Listed here so deny-by-default never 401s a valid share link.
+        "/a/",
         # Twilio voice callbacks — authenticated via X-Twilio-Signature, not session
         "/api/voice/twiml/", "/api/voice/status/", "/api/voice/amd/",
         # ConversationRelay WebSocket — auth via session-ID-in-path (opaque UUID)
@@ -3367,7 +3372,53 @@ def create_api(
         "/calendar",       # CalDAV / Google credentials + config
         "/apps",           # app management (deploy/share/upload); public viewer is /a/*
         "/models",         # model registry management
+        # #506 deny-by-default coverage: these surfaces previously fell through
+        # the auth gate (reachable unauthenticated). All are dashboard/agent
+        # management or read surfaces — the dashboard reaches them with the
+        # session cookie, agents via signed internal headers. None is a public
+        # or external-callback route (cross-fleet *delivery* uses the ferry/NATS
+        # transport, not these HTTP routes; /federation + /mesh here are local
+        # peer CRUD + operator diagnostics).
+        "/analytics",      # agent usage/cost analytics (dashboard)
+        "/api/migrate",    # OpenClaw migration (admin)
+        "/comms",          # inter-agent comms inboxes/messages
+        "/dreams",         # dream-runner data
+        "/federation",     # federation peer CRUD (local management)
+        "/mesh",           # mesh operator diagnostics (local)
+        "/milestones",     # project milestones
+        "/plugins",        # plugin registry management
+        "/render",         # server-side PDF/markdown rendering
+        "/schedules",      # cron/wake schedules
+        "/soul-templates", # soul template registry
+        "/sprints",        # sprint management
+        "/triggers",       # webhook/url trigger management
     )
+
+    # Single source of truth for the auth gate's route classification. Exposed
+    # on app.state so the coverage audit (scripts/audit_route_auth_coverage.py)
+    # and its regression test classify against the EXACT sets the middleware
+    # uses — no drifting duplicate lists (#506).
+    app.state.auth_route_sets = {
+        "public_exact": frozenset(_public_exact_paths),
+        "public_prefixes": tuple(_public_prefixes),
+        "protected_html": frozenset(_protected_html_paths),
+        "protected_api_prefixes": tuple(_protected_api_prefixes),
+    }
+
+    # Deny-by-default migration (#506). Modes:
+    #   off     — legacy fall-through: an unauthenticated request to a path that
+    #             is neither public nor under a protected prefix reaches the
+    #             route (the historical gap).
+    #   shadow  — same as off, but log every would-deny so we can soak prod and
+    #             see which unclassified surfaces actually get unauth traffic
+    #             before enforcing.
+    #   enforce — 401 the gap closed.
+    # Default shadow: behaviour-identical to off (still falls through) but emits
+    # the soak signal. Flip to enforce via env once the soak is clean.
+    _auth_deny_mode = os.environ.get("PINKY_AUTH_DENY_DEFAULT", "shadow").strip().lower()
+    if _auth_deny_mode not in ("off", "shadow", "enforce"):
+        _log(f"auth: unknown PINKY_AUTH_DENY_DEFAULT={_auth_deny_mode!r} — defaulting to 'shadow'")
+        _auth_deny_mode = "shadow"
 
     def _session_secret() -> str:
         return os.environ.get("PINKY_SESSION_SECRET", "").strip()
@@ -3713,6 +3764,16 @@ def create_api(
         if path.startswith(_protected_api_prefixes):
             return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
 
+        # 7. Deny-by-default (#506). Anything still here is unauthenticated, not
+        #    public, not a protected-HTML page, and not under a protected API
+        #    prefix — the historical fall-through gap where unmapped/unclassified
+        #    surfaces (e.g. /comms, /federation, /memory, /dreams) were reachable
+        #    without auth. Genuinely-public routes are added to _public_* (e.g.
+        #    the /a/ app viewer) so they pass at step 1 and never reach here.
+        if _auth_deny_mode == "enforce":
+            return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
+        if _auth_deny_mode == "shadow":
+            _log(f"auth: would-deny (shadow) {request.method} {path}")
         return await call_next(request)
 
     # ── Request Timing Middleware ──────────────────────────────

--- a/tests/test_route_auth_coverage.py
+++ b/tests/test_route_auth_coverage.py
@@ -51,6 +51,24 @@ def test_no_unclassified_routes():
     )
 
 
+def test_audit_catches_unclassified_mount():
+    """A future sub-app mounted at an unclassified prefix must be caught by the
+    gate — the middleware sees the path before routing, so mounted subtrees
+    need classification just like HTTP/WS routes (Murzik review, #675)."""
+    from starlette.applications import Starlette
+
+    app = audit_mod.build_app()
+    app.mount("/synthetic-unmapped", Starlette())
+    routes, sets = audit_mod.collect(app)
+    classify = audit_mod.classifier(sets)
+
+    assert ("MOUNT", "/synthetic-unmapped/") in routes, "mount not collected as a subtree"
+    assert classify("/synthetic-unmapped/") == "UNCLASSIFIED"
+    # And the real static mounts still classify cleanly (regression guard).
+    assert classify("/static/") == "PUBLIC-prefix"
+    assert classify("/assets/") == "PUBLIC-prefix"
+
+
 # Surfaces that used to fall through the gate (now protected). A sampling
 # across the prefixes added in #506; an unauthenticated request must 401.
 _NEWLY_PROTECTED = [

--- a/tests/test_route_auth_coverage.py
+++ b/tests/test_route_auth_coverage.py
@@ -1,0 +1,129 @@
+"""Deny-by-default auth coverage (#506).
+
+Two guarantees:
+  1. Every registered route is classified by the auth gate — no route falls
+     through to the app unauthenticated (the audit returns zero UNCLASSIFIED).
+     This is the regression gate: a new route added without a public/protected
+     classification fails CI.
+  2. The previously-leaking surfaces now require auth, the public app viewer
+     stays reachable, and the PINKY_AUTH_DENY_DEFAULT shadow/enforce switch
+     behaves as specified.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pinky_daemon.api import create_api
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import audit_route_auth_coverage as audit_mod  # noqa: E402
+
+
+def _client(mode: str | None = None):
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    old = os.environ.get("PINKY_AUTH_DENY_DEFAULT")
+    if mode is not None:
+        os.environ["PINKY_AUTH_DENY_DEFAULT"] = mode
+    try:
+        app = create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
+    finally:
+        if mode is not None:
+            if old is None:
+                os.environ.pop("PINKY_AUTH_DENY_DEFAULT", None)
+            else:
+                os.environ["PINKY_AUTH_DENY_DEFAULT"] = old
+    return TestClient(app), path
+
+
+def test_no_unclassified_routes():
+    """The whole point of #506: not one registered route is unclassified."""
+    unclassified = audit_mod.audit()
+    assert unclassified == [], (
+        "Routes fall through the auth gate unclassified — add each to a public "
+        f"or protected set in api.py: {unclassified}"
+    )
+
+
+# Surfaces that used to fall through the gate (now protected). A sampling
+# across the prefixes added in #506; an unauthenticated request must 401.
+_NEWLY_PROTECTED = [
+    "/analytics/overview",
+    "/api/migrate/openclaw/status/x",
+    "/comms/messages",
+    "/dreams",
+    "/federation/peers",
+    "/mesh/diagnostics",
+    "/milestones/abc",
+    "/plugins",
+    "/render/pdf",
+    "/schedules",
+    "/soul-templates",
+    "/sprints/abc/burndown",
+    "/triggers",
+]
+
+
+@pytest.mark.real_auth
+def test_previously_leaking_surfaces_require_auth():
+    client, path = _client()
+    try:
+        for route in _NEWLY_PROTECTED:
+            resp = client.get(route)
+            assert resp.status_code == 401, f"{route} should require auth, got {resp.status_code}"
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.real_auth
+def test_public_app_viewer_not_blocked_by_auth():
+    """The /a/{share_token} public viewer must pass the auth gate (it may 404
+    for an unknown token, but it is NOT 401'd)."""
+    client, path = _client()
+    try:
+        resp = client.get("/a/some-unknown-token")
+        assert resp.status_code != 401
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.real_auth
+def test_known_public_routes_reachable():
+    client, path = _client()
+    try:
+        assert client.get("/api").status_code == 200
+        # /login is public (returns the login page or a redirect, never 401).
+        assert client.get("/login", follow_redirects=False).status_code != 401
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.real_auth
+def test_enforce_mode_denies_unmapped_path():
+    """In enforce mode an unauthenticated request to an unmapped, non-public
+    path is 401'd rather than falling through to a 404."""
+    client, path = _client(mode="enforce")
+    try:
+        resp = client.get("/zzz-unmapped-probe")
+        assert resp.status_code == 401
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.real_auth
+def test_off_and_shadow_modes_fall_through_unmapped_path():
+    """off/shadow preserve legacy behaviour: an unmapped path falls through to
+    the app's 404 (shadow additionally logs a would-deny, but does not block)."""
+    for mode in ("off", "shadow"):
+        client, path = _client(mode=mode)
+        try:
+            resp = client.get("/zzz-unmapped-probe")
+            assert resp.status_code == 404, f"mode={mode} should fall through, got {resp.status_code}"
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
## Summary

The auth middleware classified routes against explicit public/protected allow-lists and **fell through to the app for anything unmatched** — leaving 31 management/read surfaces reachable without a session. This closes the gap and adds a deny-by-default safety net for future routes.

## Changes
- **Classify the remaining surfaces as protected**: `/analytics`, `/comms`, `/dreams`, `/federation` (peer CRUD), `/mesh` (operator diagnostics), `/plugins`, `/sprints`, `/milestones`, `/schedules`, `/soul-templates`, `/triggers`, `/render`, `/api/migrate`. The dashboard reaches them via the session cookie, agents via signed internal headers. Cross-fleet *delivery* uses the ferry/NATS transport, not these HTTP routes (`/federation`+`/mesh` here are local peer CRUD + diagnostics).
- **Public app viewer**: add the `/a/` prefix to the public allow-list so a valid `/a/{share_token}` share link is never gated. (`/a/` can't shadow `/agents`/`/admin`/`/apps`/`/api` — those have a non-slash 3rd char.)
- **`PINKY_AUTH_DENY_DEFAULT` (off|shadow|enforce, default shadow)**: catch-all for any *future* unclassified route. `shadow` logs a would-deny then falls through (soak); `enforce` 401s. Flip via env after a clean soak.
- **No drift**: the gate's route sets are exposed on `app.state.auth_route_sets`; the audit + regression test classify against the exact tuples the middleware uses.
- **CI gate**: `tests/test_route_auth_coverage.py::test_no_unclassified_routes` asserts **0 unclassified** — a new unmapped route fails CI. `scripts/audit_route_auth_coverage.py` is the standalone auditor.

## Design note
The 31 surfaces are classified as protected directly (immediate, same class as #671) rather than soaked, because each was code-confirmed internal (no public/external-callback among them). The `shadow`-first switch covers the residual: genuinely-*unknown* future routes, where uncertainty actually warrants a soak.

## Testing
- `tests/test_route_auth_coverage.py` — 0 unclassified; previously-leaking surfaces 401 unauth; `/a/` viewer passes; enforce vs off/shadow on an unmapped path.
- 180 auth-suite tests pass locally; ruff clean.

Part of #164 P1 (task #167); closes #506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)