### PR TITLE
fix(security): silence httpx/httpcore INFO logging that leaked bot tokens

### DIFF
--- a/src/pinky_daemon/__main__.py
+++ b/src/pinky_daemon/__main__.py
@@ -59,9 +59,30 @@ def _load_dotenv() -> None:
                 os.environ[key] = value
 
 
+def _quiet_http_client_loggers() -> None:
+    """Drop httpx/httpcore loggers to WARNING so they never log request URLs.
+
+    httpx logs every request line at INFO, including the full URL. For the
+    Telegram/Discord polling loops that URL embeds the bot token in the path
+    (``api.telegram.org/bot<token>/getUpdates``). The daemon's stdout/stderr is
+    redirected to ``logs/api.log`` (launchd ``StandardOutPath``), so at INFO
+    this wrote live bot tokens to the log in cleartext on every poll — millions
+    of lines. Raising both loggers to WARNING filters the request lines (and any
+    DEBUG-level ``Authorization`` headers) at the logger before they reach a
+    handler, regardless of what uvicorn/root installs. Errors still surface.
+
+    Runs for both api and poll modes, before any HTTP client starts.
+    """
+    import logging
+
+    for name in ("httpx", "httpcore"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
 def main() -> None:
     _install_faulthandler()
     _load_dotenv()
+    _quiet_http_client_loggers()
     parser = argparse.ArgumentParser(description="Pinky — headless Claude Code")
     parser.add_argument(
         "--mode",

--- a/tests/test_http_logger_quiet.py
+++ b/tests/test_http_logger_quiet.py
@@ -1,0 +1,46 @@
+"""httpx/httpcore loggers must be silenced so bot tokens never reach the log.
+
+httpx logs every request line at INFO, including the full URL — and the
+Telegram/Discord poll URLs embed the bot token in the path. With daemon
+stdout redirected to logs/api.log, that leaked live tokens in cleartext on
+every poll. ``_quiet_http_client_loggers`` raises both loggers to WARNING.
+"""
+
+import logging
+
+import pytest
+
+from pinky_daemon.__main__ import _quiet_http_client_loggers
+
+
+@pytest.fixture(autouse=True)
+def _restore_logger_levels():
+    """Loggers are process-global singletons — save/restore around each test."""
+    saved = {name: logging.getLogger(name).level for name in ("httpx", "httpcore")}
+    try:
+        yield
+    finally:
+        for name, level in saved.items():
+            logging.getLogger(name).setLevel(level)
+
+
+def test_sets_both_loggers_to_warning():
+    # Simulate the noisy default that leaked tokens.
+    logging.getLogger("httpx").setLevel(logging.INFO)
+    logging.getLogger("httpcore").setLevel(logging.DEBUG)
+
+    _quiet_http_client_loggers()
+
+    assert logging.getLogger("httpx").level == logging.WARNING
+    assert logging.getLogger("httpcore").level == logging.WARNING
+
+
+def test_info_request_lines_are_filtered():
+    _quiet_http_client_loggers()
+
+    # The leaking record was an INFO "HTTP Request: GET https://.../bot<token>/..."
+    # — it must no longer be emitted; WARNING/ERROR still are.
+    httpx_logger = logging.getLogger("httpx")
+    assert not httpx_logger.isEnabledFor(logging.INFO)
+    assert httpx_logger.isEnabledFor(logging.WARNING)
+    assert logging.getLogger("httpcore").isEnabledFor(logging.WARNING)


### PR DESCRIPTION
## What

httpx logs every request line at **INFO**, including the full URL. The Telegram/Discord polling loops embed the bot token in the path (`api.telegram.org/bot<token>/getUpdates`), and the daemon redirects stdout/stderr → `logs/api.log` (launchd `StandardOutPath`). Result: **every poll wrote a live bot token to the log in cleartext** — ~4.8M of 18.5M lines, 4 Telegram tokens + Discord.

Fix: raise the `httpx` and `httpcore` loggers to `WARNING` in `main()` (both api and poll modes, before any HTTP client starts). Filtering at the *logger* (not a handler) means it holds regardless of what uvicorn/root installs. Errors still log.

## Exposure (for context — not alarming)
- The log is **local + gitignored** → not public. But it was accidentally committed once before (`5f376a6`), so `.gitignore` was the only thing standing between live tokens and the public repo. This closes the source.
- Verified the old committed blob in public history is **clean**: no tokens, no JWTs, no message bodies — no rotation/rewrite needed.

## Scope
A leak sweep flagged a few `str(e)`/`traceback.format_exc()` sites (`broker.py`, `messaging/server.py`, `self/server.py`). Reviewed each: **none log secret values** — `format_exc()` shows code lines not locals, and those urllib URLs point at the internal daemon API (no token). No change there; editing them would be cargo-cult.

Log rotation (the 1.5GB unrotated file) is **tracked separately** — it needs an OS-level mechanism that handles the launchd-held fd, not a code change here.

## Test
`tests/test_http_logger_quiet.py` — asserts both loggers land at WARNING and INFO request lines are filtered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)