### PR TITLE
feat(ops): rotate the daemon console log (daily + size-capped, gzip, 0600, redacted)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8583,6 +8583,20 @@ npm run build</pre>
         except Exception as exc:  # never let hardening abort startup
             _log(f"startup: db permission sweep skipped ({exc})")
 
+        # Rotate the daemon console log (logs/api.log): daily + size-capped,
+        # gzipped 0600 archives with Telegram tokens redacted, pruned past the
+        # retention window. copytruncate keeps launchd's open fd valid (it does
+        # not reopen StandardOutPath after a move). Best-effort background task,
+        # behind a kill-switch (PINKY_LOG_ROTATION=off + restart to disable).
+        if os.environ.get("PINKY_LOG_ROTATION", "on").strip().lower() not in ("off", "0", "false"):
+            try:
+                from pinky_daemon.log_rotation import run_rotation_loop
+                _api_log = Path("logs") / "api.log"
+                if _api_log.exists():
+                    asyncio.create_task(run_rotation_loop(_api_log))
+            except Exception as exc:  # never let log rotation abort startup
+                _log(f"startup: log rotation not started ({exc})")
+
         # Start shared MCP server BEFORE agent sessions so SSE URLs are ready
         if SHARED_MCP_ENABLED:
             def _resolve_memory_db(agent_name: str) -> str:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8593,7 +8593,11 @@ npm run build</pre>
                 from pinky_daemon.log_rotation import run_rotation_loop
                 _api_log = Path("logs") / "api.log"
                 if _api_log.exists():
-                    asyncio.create_task(run_rotation_loop(_api_log))
+                    # Keep a strong ref on app.state so the task isn't GC'd
+                    # mid-flight (asyncio.create_task only holds a weak ref).
+                    app.state.log_rotation_task = asyncio.create_task(
+                        run_rotation_loop(_api_log)
+                    )
             except Exception as exc:  # never let log rotation abort startup
                 _log(f"startup: log rotation not started ({exc})")
 

--- a/src/pinky_daemon/log_rotation.py
+++ b/src/pinky_daemon/log_rotation.py
@@ -24,8 +24,12 @@ have Telegram bot tokens redacted as they are written, and are pruned past a
 retention window.
 
 copytruncate caveat: a log line written in the narrow window between the copy
-reaching EOF and the truncate is lost from the archive. For a daemon console
-log this is an acceptable trade for never dropping launchd's file descriptor.
+reaching EOF and the truncate is lost entirely — it is appended after the copy
+observes EOF and then removed by the truncate. The copy reads to EOF rather than
+a fixed byte snapshot, which keeps that window minimal at the cost of chasing a
+writer that appends faster than gzip/redaction consumes; that is acceptable for
+this low-rate console log (httpx request logging was silenced in #676). For a
+daemon console log this is a fair trade for never dropping launchd's fd.
 """
 
 from __future__ import annotations

--- a/src/pinky_daemon/log_rotation.py
+++ b/src/pinky_daemon/log_rotation.py
@@ -1,0 +1,195 @@
+"""Daily, size-bounded rotation for the daemon's console log.
+
+The daemon's console output (every ``_log()`` helper is a plain ``print()``)
+is captured by launchd's ``StandardOutPath`` / ``StandardErrorPath`` into a
+single ``logs/api.log``. Left unmanaged it grows without bound — in production
+it reached ~1.5 GB — and, before #676 silenced httpx INFO request logging, it
+accumulated cleartext Telegram bot-token poll URLs.
+
+This module rotates that file **in place using copytruncate**: the live file is
+copied to a gzipped, token-redacted archive and then truncated to zero *without*
+changing its inode, so launchd's open file descriptor keeps appending to the
+same file with no reopen needed. This matters because launchd does **not**
+reopen ``StandardOutPath`` after a rename — a move-based rotation (newsyslog /
+``TimedRotatingFileHandler``) would leave launchd writing to the renamed
+archive while ``api.log`` stayed empty. Truncating in place sidesteps that
+entirely and needs no plist change.
+
+Rotation runs from a background task on the daemon event loop
+(:func:`run_rotation_loop`); the blocking copy/gzip work is offloaded to a
+thread so it never stalls the loop. It triggers when the UTC day rolls over or
+the live file crosses a size cap (whichever comes first), so a single runaway
+day cannot reproduce the 1.5 GB file. Archives are created ``0600``, gzipped,
+have Telegram bot tokens redacted as they are written, and are pruned past a
+retention window.
+
+copytruncate caveat: a log line written in the narrow window between the copy
+reaching EOF and the truncate is lost from the archive. For a daemon console
+log this is an acceptable trade for never dropping launchd's file descriptor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import logging
+import os
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger("pinky.log_rotation")
+
+_ARCHIVE_FILE_MODE = 0o600
+_DEFAULT_MAX_BYTES = 500 * 1024 * 1024  # 500 MB — size-roll guard
+_DEFAULT_BACKUP_DAYS = 14
+_CHECK_INTERVAL_S = 300  # how often the loop checks whether a roll is due
+
+# Redact Telegram bot tokens in archived lines. The token in
+# ``api.telegram.org/bot<id>:<secret>/...`` is the secret after the colon; the
+# numeric bot id is not sensitive and is kept so the archive stays diagnosable.
+_TELEGRAM_TOKEN_RE = re.compile(rb"(bot\d{6,}:)[A-Za-z0-9_-]{20,}")
+
+__all__ = [
+    "LogRotator",
+    "run_rotation_loop",
+]
+
+
+def _redact(line: bytes) -> bytes:
+    return _TELEGRAM_TOKEN_RE.sub(rb"\1REDACTED", line)
+
+
+def _archive_path(log_path: Path, stamp: str) -> Path:
+    """``logs/api.log`` + stamp -> a non-colliding ``logs/api.log.<stamp>.gz``."""
+    base = log_path.name
+    candidate = log_path.with_name(f"{base}.{stamp}.gz")
+    n = 1
+    while candidate.exists():
+        candidate = log_path.with_name(f"{base}.{stamp}.{n}.gz")
+        n += 1
+    return candidate
+
+
+def _copytruncate(log_path: Path, archive: Path) -> int:
+    """Copy ``log_path`` into ``archive`` (gzip + redact), then truncate in place.
+
+    Returns the number of source bytes archived. The live file's inode is
+    preserved (``truncate`` rather than ``unlink``) so launchd's append-mode fd
+    keeps writing to the same file after the roll.
+    """
+    tmp = archive.with_name(archive.name + ".part")
+    if tmp.exists():
+        tmp.unlink()
+    written = 0
+    # O_EXCL + 0600 from creation: the archive is never briefly world-readable.
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, _ARCHIVE_FILE_MODE)
+    with open(log_path, "rb") as src, gzip.GzipFile(
+        fileobj=os.fdopen(fd, "wb"), mode="wb"
+    ) as dst:
+        for line in src:
+            dst.write(_redact(line))
+            written += len(line)
+    os.replace(tmp, archive)
+    # Truncate the live file in place — preserves inode + perms for launchd's fd.
+    with open(log_path, "r+b") as f:
+        f.truncate(0)
+    return written
+
+
+class LogRotator:
+    """Stateful copytruncate rotator for a single console log file.
+
+    Holds the UTC day the live file is currently accumulating so a day-roll
+    archive is named for the day it actually covers. Methods are synchronous
+    and intended to be called from a thread (see :func:`run_rotation_loop`).
+    """
+
+    def __init__(
+        self,
+        log_path: str | Path,
+        *,
+        max_bytes: int = _DEFAULT_MAX_BYTES,
+        backup_days: int = _DEFAULT_BACKUP_DAYS,
+    ) -> None:
+        self.log_path = Path(log_path)
+        self.max_bytes = max_bytes
+        self.backup_days = backup_days
+        self._current_day = self._today()
+
+    @staticmethod
+    def _today() -> str:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    def check_and_rotate(self) -> Path | None:
+        """Rotate if the day rolled over or the file exceeds the size cap.
+
+        Returns the archive path if a rotation happened, else ``None``.
+        Best-effort: any failure is logged and swallowed (returns ``None``).
+        """
+        try:
+            size = self.log_path.stat().st_size
+        except FileNotFoundError:
+            return None
+        today = self._today()
+        size_roll = size >= self.max_bytes
+        day_roll = today != self._current_day and size > 0
+        if not (size_roll or day_roll):
+            return None
+
+        # Day-roll archives are named for the day that just closed; a same-day
+        # size-roll gets a time suffix so multiple rolls per day never collide.
+        if day_roll and not size_roll:
+            stamp = self._current_day
+        else:
+            stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+        archive = _archive_path(self.log_path, stamp)
+
+        try:
+            _copytruncate(self.log_path, archive)
+        except Exception:
+            logger.exception("log_rotation: copytruncate failed")
+            return None
+
+        if day_roll:
+            self._current_day = today
+        self._prune()
+        logger.info("log_rotation: rotated console log and pruned old archives")
+        return archive
+
+    def _prune(self) -> None:
+        """Delete archives older than the retention window. Best-effort."""
+        cutoff = time.time() - self.backup_days * 86400
+        for p in self.log_path.parent.glob(f"{self.log_path.name}.*.gz"):
+            try:
+                if p.stat().st_mtime < cutoff:
+                    p.unlink()
+            except OSError:
+                pass
+
+
+async def run_rotation_loop(
+    log_path: str | Path,
+    *,
+    max_bytes: int = _DEFAULT_MAX_BYTES,
+    backup_days: int = _DEFAULT_BACKUP_DAYS,
+    interval_s: int = _CHECK_INTERVAL_S,
+) -> None:
+    """Background task: rotate ``log_path`` on day-roll or size cap, forever.
+
+    An oversized pre-existing file (e.g. the legacy 1.5 GB ``api.log``) is
+    rolled promptly on the first check. Blocking copy/gzip runs in a thread.
+    """
+    rotator = LogRotator(log_path, max_bytes=max_bytes, backup_days=backup_days)
+    first = True
+    while True:
+        if not first:
+            await asyncio.sleep(interval_s)
+        first = False
+        try:
+            await asyncio.to_thread(rotator.check_and_rotate)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("log_rotation: periodic check failed")

--- a/tests/test_log_rotation.py
+++ b/tests/test_log_rotation.py
@@ -1,0 +1,142 @@
+"""Tests for the console-log copytruncate rotator (log rotation, task #169).
+
+Covers redaction, the copytruncate invariants (inode preserved, live file
+truncated, archive gzipped + 0600), day-roll vs size-roll naming, the no-op
+case, retention pruning, and the background loop's first-pass rotation.
+"""
+import gzip
+import os
+import stat
+import time
+from pathlib import Path
+
+from pinky_daemon.log_rotation import LogRotator, _redact, run_rotation_loop
+
+_TOKEN_LINE = (
+    b"INFO httpx HTTP Request: GET "
+    b"https://api.telegram.org/bot8123456789:AAGZxQ_realish-token-MATERIAL12345/getUpdates\n"
+)
+
+
+def _gunzip(path: Path) -> bytes:
+    with gzip.open(path, "rb") as f:
+        return f.read()
+
+
+def test_redact_strips_token_secret_keeps_id():
+    out = _redact(_TOKEN_LINE)
+    assert b"bot8123456789:REDACTED" in out
+    assert b"AAGZxQ_realish-token-MATERIAL12345" not in out
+
+
+def test_redact_leaves_normal_lines_untouched():
+    line = b"INFO startup: db permission sweep ok\n"
+    assert _redact(line) == line
+
+
+def test_size_roll_copytruncate_invariants(tmp_path):
+    log = tmp_path / "api.log"
+    body = _TOKEN_LINE + b"a normal line\n" + b"another line\n"
+    log.write_bytes(body)
+    ino_before = log.stat().st_ino
+
+    rot = LogRotator(log, max_bytes=1, backup_days=14)  # any non-empty file rolls
+    archive = rot.check_and_rotate()
+
+    assert archive is not None and archive.exists()
+    assert archive.suffix == ".gz"
+    # Archive is owner-only.
+    assert stat.S_IMODE(archive.stat().st_mode) == 0o600
+    # Archive content: token redacted, normal lines intact.
+    restored = _gunzip(archive)
+    assert b"bot8123456789:REDACTED" in restored
+    assert b"AAGZxQ_realish-token-MATERIAL12345" not in restored
+    assert b"a normal line\n" in restored and b"another line\n" in restored
+    # Live file truncated in place, same inode (launchd's fd stays valid).
+    assert log.exists() and log.stat().st_size == 0
+    assert log.stat().st_ino == ino_before
+
+
+def test_day_roll_names_archive_for_closed_day(tmp_path):
+    log = tmp_path / "api.log"
+    log.write_bytes(b"yesterday content\n")
+    rot = LogRotator(log, max_bytes=10**9, backup_days=14)  # huge cap → not a size roll
+    rot._current_day = "2020-01-01"  # pretend the live file accumulated that day
+
+    archive = rot.check_and_rotate()
+
+    assert archive is not None
+    assert archive.name == "api.log.2020-01-01.gz"  # named for the day that closed
+    assert _gunzip(archive) == b"yesterday content\n"
+    assert log.stat().st_size == 0
+    assert rot._current_day != "2020-01-01"  # advanced to today
+
+
+def test_no_roll_when_small_and_same_day(tmp_path):
+    log = tmp_path / "api.log"
+    log.write_bytes(b"small\n")
+    rot = LogRotator(log, max_bytes=10**9, backup_days=14)
+
+    assert rot.check_and_rotate() is None
+    assert log.read_bytes() == b"small\n"  # untouched
+    assert not list(tmp_path.glob("api.log.*.gz"))
+
+
+def test_missing_file_is_noop(tmp_path):
+    rot = LogRotator(tmp_path / "api.log", max_bytes=1)
+    assert rot.check_and_rotate() is None
+
+
+def test_prune_removes_archives_past_retention(tmp_path):
+    log = tmp_path / "api.log"
+    log.write_bytes(b"x\n")
+    old = tmp_path / "api.log.2020-01-01.gz"
+    recent = tmp_path / "api.log.2020-02-02.gz"
+    old.write_bytes(b"old")
+    recent.write_bytes(b"recent")
+    old_time = time.time() - 30 * 86400
+    os.utime(old, (old_time, old_time))  # 30 days old
+    # recent keeps its fresh mtime
+
+    rot = LogRotator(log, backup_days=14)
+    rot._prune()
+
+    assert not old.exists()  # 30d > 14d retention → pruned
+    assert recent.exists()  # within window → kept
+
+
+def test_size_roll_suffixed_to_avoid_collision(tmp_path):
+    log = tmp_path / "api.log"
+    rot = LogRotator(log, max_bytes=1, backup_days=14)
+    log.write_bytes(b"first\n")
+    a1 = rot.check_and_rotate()
+    log.write_bytes(b"second\n")
+    a2 = rot.check_and_rotate()
+    # Two size-rolls; archives must not collide even within the same second.
+    assert a1 != a2
+    assert a1.exists() and a2.exists()
+
+
+async def test_run_rotation_loop_rolls_oversized_file_on_first_pass(tmp_path):
+    log = tmp_path / "api.log"
+    log.write_bytes(_TOKEN_LINE + b"data\n")
+    # interval far in the future so only the immediate first-pass check runs.
+    import asyncio
+
+    task = asyncio.create_task(
+        run_rotation_loop(log, max_bytes=1, backup_days=14, interval_s=3600)
+    )
+    # Yield until the first-pass rotation lands (thread offload).
+    for _ in range(50):
+        await asyncio.sleep(0.02)
+        if list(tmp_path.glob("api.log.*.gz")):
+            break
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    archives = list(tmp_path.glob("api.log.*.gz"))
+    assert archives, "loop should have rotated the oversized file on first pass"
+    assert log.stat().st_size == 0


### PR DESCRIPTION
## What

Adds daily, size-bounded rotation for the daemon's console log (`logs/api.log`). That file is launchd's `StandardOutPath` capture of the daemon's stdout/stderr — every `_log()` helper is a plain `print()` — and was growing unbounded (it reached ~1.5 GB in prod). This closes the "add log rotation" half of #169 (the httpx token-silencing half shipped in #676).

## How — copytruncate

The rotator copies the live file to a gzipped archive, then **truncates it in place** rather than renaming it:

- launchd does **not** reopen `StandardOutPath` after a move, so a rename-based approach (newsyslog / `TimedRotatingFileHandler`) would leave launchd writing to the renamed archive while `api.log` stayed empty.
- Truncating in place preserves the inode, so launchd's append-mode fd keeps writing to the same file with no reopen — and **no plist change / `launchctl` reload** is needed.

Behaviour:
- **Triggers** on UTC day change or a size cap (`500 MB`, whichever first) so one runaway day can't reproduce the 1.5 GB file.
- **Archives** are gzipped, created `0600` (O_EXCL — never briefly world-readable), and named for the day they cover (`api.log.2026-06-05.gz`); same-day size-rolls get a time suffix.
- **Token redaction**: Telegram bot tokens in archived lines are redacted as they're written (defense-in-depth for the pre-#676 history that's still on disk).
- **Retention**: archives older than 14 days are pruned.
- Runs as a best-effort background task from `on_startup`, behind a `PINKY_LOG_ROTATION` kill-switch (default `on`; set `off` + restart to disable). The blocking copy/gzip runs in a thread, so it never stalls the event loop. An oversized pre-existing file is rolled on the first pass.

## copytruncate caveat

A log line written in the narrow window between the copy reaching EOF and the truncate is lost from the archive — the standard copytruncate trade-off, acceptable for a console log in exchange for never dropping launchd's fd.

## Tests

`tests/test_log_rotation.py` (9 tests): redaction, copytruncate invariants (inode preserved, live file truncated to 0, archive gzipped + `0600`), day-roll vs size-roll naming, no-op when small/same-day, missing-file no-op, retention pruning, collision-suffixing, and the background loop rotating an oversized file on its first pass. `ruff` clean.

## Deploy notes

- No launchd/plist changes. On the first restart with this code, the existing large `api.log` rotates to a redacted `.gz` archive and the live file starts fresh.
- Kill-switch: `PINKY_LOG_ROTATION=off` in `.env` + restart fully disables it.

🤖 Opened by Barsik
