### PR TITLE
fix(memory): resolve OPENAI_API_KEY from settings so semantic recall works (#630)

### DIFF
--- a/scripts/backfill_embeddings.py
+++ b/scripts/backfill_embeddings.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""One-time backfill of missing reflection embeddings (issue #630).
+
+Background: the pinky-memory embedder only ever read OPENAI_API_KEY from the
+process env, while the key actually lives in system_settings. So it ran NoOp
+and stored empty embeddings (``'[]'``) fleet-wide — semantic recall() silently
+degraded to keyword-only (found 2026-06-05). After the embedder fix
+(get_setting -> env) deploys, NEW reflects embed correctly; this script
+re-embeds the historical rows that were written empty.
+
+Safety:
+  * DRY-RUN by default. Pass --apply to write.
+  * Idempotent: only touches rows whose embedding is empty (``length<=2``,
+    i.e. the ``'[]'`` default) AND have non-empty content. Never overwrites an
+    existing real embedding, never touches content.
+  * Per-batch transactions with a busy timeout so it cooperates with the live
+    daemon's WAL connections.
+  * The OpenAI key is read from system_settings (same source the fix uses);
+    nothing is printed.
+
+Usage:
+    python scripts/backfill_embeddings.py                 # dry-run, all agents
+    python scripts/backfill_embeddings.py --apply         # write
+    python scripts/backfill_embeddings.py --apply --agent barsik
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sqlite3
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO, "src"))
+
+SETTINGS_DB = os.path.join(REPO, "data", "conversations_agents.db")
+BATCH = 100
+
+
+def resolve_openai_key() -> str:
+    """Read OPENAI_API_KEY from system_settings, else env. No printing."""
+    try:
+        conn = sqlite3.connect(SETTINGS_DB)
+        row = conn.execute(
+            "SELECT value FROM system_settings WHERE key='OPENAI_API_KEY'"
+        ).fetchone()
+        conn.close()
+        if row and row[0]:
+            return row[0]
+    except Exception as exc:  # noqa: BLE001
+        print(f"  (settings lookup failed: {type(exc).__name__}: {exc})")
+    return os.environ.get("OPENAI_API_KEY", "")
+
+
+def discover_dbs(agent: str = "") -> list[str]:
+    pat = (
+        os.path.join(REPO, "data", "agents", agent, "data", "memory.db")
+        if agent
+        else os.path.join(REPO, "data", "agents", "*", "data", "memory.db")
+    )
+    dbs = []
+    for p in sorted(glob.glob(pat)):
+        try:
+            c = sqlite3.connect(p)
+            has = c.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='reflections'"
+            ).fetchone()
+            c.close()
+            if has:
+                dbs.append(p)
+        except Exception:  # noqa: BLE001
+            continue
+    return dbs
+
+
+def backfill_db(path: str, embedder, apply: bool) -> tuple[int, int]:
+    """Returns (rows_needing_backfill, rows_written)."""
+    conn = sqlite3.connect(path, timeout=30.0)
+    conn.execute("PRAGMA busy_timeout=30000")
+    rows = conn.execute(
+        "SELECT id, content FROM reflections "
+        "WHERE length(embedding)<=2 AND length(trim(content))>0 "
+        "ORDER BY created_at"
+    ).fetchall()
+    need = len(rows)
+    if not apply or need == 0:
+        conn.close()
+        return need, 0
+
+    written = 0
+    for i in range(0, need, BATCH):
+        chunk = rows[i : i + BATCH]
+        vectors = embedder.embed_batch([c for _, c in chunk])
+        cur = conn.cursor()
+        for (rid, _), vec in zip(chunk, vectors):
+            if not vec:  # embed failed for this item — leave it for a re-run
+                continue
+            cur.execute(
+                "UPDATE reflections SET embedding=? WHERE id=?",
+                (json.dumps(vec), rid),
+            )
+            written += 1
+        conn.commit()
+        print(f"    {path.split('/agents/')[-1]}: {min(i + BATCH, need)}/{need}")
+    conn.close()
+    return need, written
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="write (default: dry-run)")
+    ap.add_argument("--agent", default="", help="limit to one agent")
+    args = ap.parse_args()
+
+    key = resolve_openai_key()
+    if not key:
+        print("FATAL: no OPENAI_API_KEY in system_settings or env — cannot embed.")
+        return 1
+
+    from pinky_memory.embeddings import EmbeddingClient
+
+    embedder = EmbeddingClient(api_key=key) if args.apply else None
+    dbs = discover_dbs(args.agent)
+    print(f"{'APPLY' if args.apply else 'DRY-RUN'} — {len(dbs)} memory DB(s)\n")
+
+    total_need = total_written = 0
+    for db in dbs:
+        need, written = backfill_db(db, embedder, args.apply)
+        total_need += need
+        total_written += written
+        tag = db.split("/agents/")[-1]
+        print(f"  {tag}: {need} need embedding" + (f", {written} written" if args.apply else ""))
+
+    print(
+        f"\nTOTAL: {total_need} rows need embedding"
+        + (f", {total_written} written." if args.apply else " (dry-run; pass --apply to write).")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8640,11 +8640,25 @@ npm run build</pre>
                 except Exception:
                     return None
 
+            # Resolve the OpenAI key for the shared pinky-memory embedder.
+            # It lives in system_settings (where TTS/broker read it via
+            # get_setting), NOT the daemon process env — so the embedder, which
+            # only consulted os.environ, silently ran NoOp and disabled semantic
+            # recall fleet-wide until 2026-06-05. Prefer settings, fall back to
+            # env. Empty -> NoOp embedder (logged at WARNING).
+            try:
+                _memory_openai_key = agents.get_setting("OPENAI_API_KEY") or os.environ.get(
+                    "OPENAI_API_KEY", ""
+                )
+            except Exception:
+                _memory_openai_key = os.environ.get("OPENAI_API_KEY", "")
+
             shared_mcp_manager = SharedMcpManager(
                 api_url="http://localhost:8888",
                 memory_db_resolver=_resolve_memory_db,
                 cross_agent_authorizer=_is_cross_agent_memory_authorized,
                 signing_key_resolver=_resolve_signing_key,
+                openai_api_key=_memory_openai_key,
             )
             await shared_mcp_manager.start()
             _log(f"startup: shared MCP server started on {shared_mcp_manager.url}")

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -499,12 +499,18 @@ class SharedMcpManager:
         memory_db_resolver: "Callable[[str], str] | None" = None,
         cross_agent_authorizer: "Callable[[str], bool] | None" = None,
         signing_key_resolver: "Callable[[str], str | None] | None" = None,
+        openai_api_key: str = "",
     ):
         self._host = host
         self._port = port
         self._api_url = api_url
         self._memory_db_resolver = memory_db_resolver
         self._cross_agent_authorizer = cross_agent_authorizer
+        # OPENAI_API_KEY for the shared pinky-memory embedder. The daemon
+        # process env does NOT carry it (the key lives in system_settings), so
+        # the daemon resolves it and passes it in here. Empty -> NoOp embedder
+        # (keyword-only recall). See semantic-recall regression 2026-06-05.
+        self._openai_api_key = openai_api_key
         # #623: agent_name -> per-agent signing key, so the shared self/messaging
         # servers sign each request with the resolved agent's key (the shared
         # process has no PINKY_AGENT_KEY env). None falls back to global secret.
@@ -564,7 +570,7 @@ class SharedMcpManager:
             from pinky_memory.server import create_server as create_memory_server
 
             self._memory_pool = MemoryStorePool(self._memory_db_resolver)
-            embedder = build_embedding_client()
+            embedder = build_embedding_client(api_key=self._openai_api_key)
 
             memory_mcp = create_memory_server(
                 store_factory=self._memory_pool.get_store,

--- a/src/pinky_memory/embeddings.py
+++ b/src/pinky_memory/embeddings.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 
 class EmbeddingClient:
@@ -52,8 +55,26 @@ class NoOpEmbeddingClient:
         return [[] for _ in texts]
 
 
-def build_embedding_client() -> EmbeddingClient | NoOpEmbeddingClient:
-    api_key = os.environ.get("OPENAI_API_KEY", "")
-    if not api_key:
+def build_embedding_client(api_key: str = "") -> EmbeddingClient | NoOpEmbeddingClient:
+    """Build the embedding client, resolving the OpenAI key in priority order.
+
+    1. ``api_key`` argument — for callers that resolve it from a settings
+       store the process env doesn't carry (e.g. the daemon reading the
+       ``OPENAI_API_KEY`` row in ``system_settings``).
+    2. ``OPENAI_API_KEY`` environment variable.
+
+    Falls back to the NoOp client (empty embeddings → keyword-only recall)
+    only when no key is found anywhere. That downgrade is logged at WARNING:
+    a missing key silently disabled semantic recall fleet-wide before
+    2026-06-05 because the embedder only ever consulted the env, while the
+    key lived in ``system_settings``. Loud failure prevents a repeat.
+    """
+    resolved = api_key or os.environ.get("OPENAI_API_KEY", "")
+    if not resolved:
+        logger.warning(
+            "pinky-memory: no OPENAI_API_KEY (passed arg or environment) — "
+            "using NoOp embedder; semantic recall() is DISABLED (keyword-only) "
+            "until a key is configured"
+        )
         return NoOpEmbeddingClient()
-    return EmbeddingClient(api_key=api_key)
+    return EmbeddingClient(api_key=resolved)

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -131,6 +131,34 @@ class TestBuildEmbeddingClient:
                 client = build_embedding_client()
                 assert isinstance(client, EmbeddingClient)
 
+    def test_passed_api_key_used_without_env(self):
+        # The daemon resolves the key from system_settings (process env lacks
+        # it) and passes it in — that path must build a real client.
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("OPENAI_API_KEY", None)
+            with patch("openai.OpenAI"):
+                client = build_embedding_client(api_key="sk-passed")
+                assert isinstance(client, EmbeddingClient)
+                assert client._api_key == "sk-passed"
+
+    def test_passed_api_key_overrides_env(self):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-env"}):
+            with patch("openai.OpenAI"):
+                client = build_embedding_client(api_key="sk-passed")
+                assert isinstance(client, EmbeddingClient)
+                assert client._api_key == "sk-passed"
+
+    def test_noop_downgrade_logs_warning(self, caplog):
+        # Silent NoOp is what hid the fleet-wide recall outage; the downgrade
+        # must now be loud.
+        import logging
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("OPENAI_API_KEY", None)
+            with caplog.at_level(logging.WARNING, logger="pinky_memory.embeddings"):
+                client = build_embedding_client()
+            assert isinstance(client, NoOpEmbeddingClient)
+            assert any("NoOp embedder" in r.message for r in caplog.records)
+
 
 # ── reflect tool ───────────────────────────────────────────────────────────────
 

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -250,6 +250,38 @@ class TestSharedMcpManager:
         assert captured["self"] is resolver
         assert captured["messaging"] is resolver
 
+    def test_threads_openai_api_key_into_embedder(self, monkeypatch):
+        """The manager passes its openai_api_key into the pinky-memory embedder.
+
+        The daemon process env does NOT carry OPENAI_API_KEY (it lives in
+        system_settings), so the daemon resolves it and hands it to the
+        manager. If this regresses, the embedder falls back to NoOp and
+        semantic recall silently dies fleet-wide (regression 2026-06-05).
+        """
+        import pinky_daemon.shared_mcp as sm
+
+        captured = {}
+
+        monkeypatch.setattr("pinky_self.server.create_server", lambda **kw: object())
+        monkeypatch.setattr("pinky_messaging.server.create_server", lambda **kw: object())
+
+        def fake_build_embedder(api_key=""):
+            captured["api_key"] = api_key
+            return object()
+
+        monkeypatch.setattr(
+            "pinky_memory.embeddings.build_embedding_client", fake_build_embedder
+        )
+        monkeypatch.setattr("pinky_memory.server.create_server", lambda **kw: object())
+        monkeypatch.setattr(sm, "create_shared_app", lambda servers: servers)
+
+        mgr = SharedMcpManager(
+            memory_db_resolver=lambda name: ":memory:",
+            openai_api_key="sk-from-settings",
+        )
+        mgr._create_app()
+        assert captured["api_key"] == "sk-from-settings"
+
 
 class TestGateToolNames:
     """GATE_TOOL_NAMES and _get_shared_mode_disallowed_tools."""


### PR DESCRIPTION
## Problem

Semantic `recall()` has been **dead fleet-wide** — silently running keyword-only.

The pinky-memory embedder (`build_embedding_client`) only ever read `OPENAI_API_KEY` from the **process env**. But the key lives in `system_settings` (where TTS/broker read it via `registry.get_setting`). The daemon env doesn't carry it → the embedder fell back to `NoOpEmbeddingClient` → every `reflect()` stored an empty embedding (`'[]'`) and every `recall()` query embedded to `[]`, skipping semantic search entirely and falling back to keyword (`server.py` `_search_and_format`).

The NoOp downgrade was **silent by design**, so this went unnoticed. Keyword fallback masked it.

### Evidence (real embeddings / total)
`barsik 9/1187 · pushok 0/102 · murzik 0/50 · dymok 1/30 · persik 0/4 · ryzhik 0/1`

Reproduced live: a query paraphrasing "wall one teammate's agent off from another's data/credentials" returned an unrelated RPi auth note (keyword hit on "credentials"), **not** the near-paraphrase containerization memory that exists.

## Fix

- `build_embedding_client(api_key="")` — prefers a passed key, then env; logs the NoOp downgrade at **WARNING** so this can't silently rot again.
- `SharedMcpManager` threads an `openai_api_key` through to the embedder.
- The daemon resolves it via `agents.get_setting("OPENAI_API_KEY")` → env and passes it in. Clean layering: `pinky_memory` never imports the daemon registry.
- `scripts/backfill_embeddings.py` — one-time, **idempotent**, **dry-run-by-default** re-embed of the historical rows written empty (~1364 across 8 agent DBs). Run **after** this deploys. (issue #630)

Live fleet uses SSE-only memory (`:8890/mcp/memory/sse`), so the shared-SSE path is the whole live fix; the stdio entrypoint keeps reading env (standalone use).

## Tests
`tests/test_memory_server.py` — passed-key builds a real client without env; passed key overrides env; NoOp downgrade logs a warning.
`tests/test_shared_mcp.py` — manager threads `openai_api_key` into the embedder (regression guard).

All affected suites green locally (124 passed: memory_server + shared_mcp + sqlite_concurrency).

## Rollout
1. Merge → release → `update_and_restart` (restores go-forward embedding).
2. Run `python scripts/backfill_embeddings.py --apply` (re-embeds history; ≈ $0.015 OpenAI).
3. Verify: `recall()` semantic match + `introspect` embedding coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)