### PR TITLE
feat(memory): enable sqlite-vec for indexed vector search (#630 follow-up)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ dependencies = [
     "pyyaml>=6.0",
     "numpy>=2.2",
     "openai>=2.30",
+    # Indexed vector search for pinky-memory (vec0 virtual table). Without it
+    # the store falls back to an O(n) numpy cosine scan — correct but slower.
+    # The store loads it via sqlite3 load_extension and degrades gracefully if
+    # absent, so this is a performance dependency, not a hard requirement.
+    "sqlite-vec>=0.1.9",
     "httpx>=0.28",
     "fastapi>=0.135",
     "uvicorn>=0.44",

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -305,6 +305,24 @@ class TestEmbeddingSearch:
         with pytest.raises(InvalidQueryEmbeddingError):
             store.search_by_embedding_scored([])
 
+    def test_sqlite_vec_activates_when_loadable(self, tmp_path):
+        """When sqlite-vec is installed (declared dep) AND the runtime allows
+        loadable extensions, the store must use the indexed vec path — not
+        silently fall back to numpy. Guards the dependency wiring so a dropped
+        dep or a load-extension regression surfaces loudly (#630 follow-up)."""
+        import sqlite3
+
+        pytest.importorskip("sqlite_vec")
+        probe = sqlite3.connect(":memory:")
+        try:
+            probe.enable_load_extension(True)
+        except (AttributeError, sqlite3.OperationalError):
+            pytest.skip("runtime sqlite3 cannot load extensions")
+        finally:
+            probe.close()
+        store = _store(tmp_path)
+        assert store._vec_available is True
+
     def test_vec_fallback_logs_and_counts(self, tmp_path, caplog, monkeypatch):
         """Regression for #290: sqlite-vec failures must log + bump fallback counter.
 


### PR DESCRIPTION
## Why

Follow-up to #679 (which restored fleet-wide embeddings). The store has always *supported* sqlite-vec's `vec0` indexed search — loads it via `sqlite3.load_extension`, backfills from the `embedding` column, and falls back to an O(n) numpy cosine scan when absent. But `sqlite-vec` was never a declared dependency, so prod logged `No module named 'sqlite_vec'` and ran the numpy fallback. With embeddings now populated everywhere, turn on the indexed path.

"No half measures" — Brad.

## Change
- `pyproject.toml`: add `sqlite-vec>=0.1.9` (performance dep; the store degrades gracefully if a runtime can't load extensions, so it's not load-bearing).
- `tests/test_memory_store.py`: guard test — when sqlite-vec is installed **and** the runtime allows loadable extensions, the store must set `_vec_available=True`. Catches a dropped dep or a load-extension regression instead of silently reverting to numpy.

## Verification (on a copy of the live store)
- `_vec_available=True`, `_vec_dimensions=1536`
- `vec0` table auto-backfilled from existing embeddings (`vec_backfill_complete inserted=1110`)
- indexed `search_by_embedding` returns results
- runtime `enable_load_extension` confirmed available (macOS arm64; CI linux)
- full memory suite green **with** the extension installed (memory_server + store + cross_agent + shared_mcp)

## Rollout
Merge → release → `update_and_restart`. On daemon start each agent's store loads the extension and builds `reflections_vec` from its embeddings (one-time, idempotent). Post-deploy check: `introspect` shows `vec_available: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)