### PR TITLE
feat(#682): KG reasoning tools — multi-hop, what-changed, contradiction detection (PR1)

### DIFF
--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -709,15 +709,46 @@ def create_server(
         return json.dumps({"entity": entity, "count": len(results), "timeline": results})
 
     @mcp.tool()
-    def kg_connections(entity: str) -> str:
-        """Find all entities connected to a given entity.
-        Returns outgoing (entity → X) and incoming (X → entity) relationships.
+    def kg_connections(entity: str, depth: int = 1) -> str:
+        """Find entities connected to a given entity.
+        depth=1 (default): direct outgoing (entity → X) + incoming (X → entity)
+        relationships. depth>1 (capped at 3): also returns "reachable" — a
+        bounded, cycle-guarded multi-hop neighbourhood (each entity once, at its
+        shortest distance). Use for "how is X connected to Y?" reasoning chains.
         """
         s = _get_store()
-        result = s.kg_connections(entity=entity)
+        result = s.kg_connections(entity=entity, depth=depth)
         total = len(result["outgoing"]) + len(result["incoming"])
-        _log(f"kg_connections: {entity} → {total} connections")
+        reached = len(result.get("reachable", []))
+        _log(f"kg_connections: {entity} depth={depth} → {total} direct, {reached} multi-hop")
         return json.dumps({"entity": entity, **result})
+
+    @mcp.tool()
+    def kg_what_changed(since: str, limit: int = 100) -> str:
+        """Summarise what changed in the knowledge graph since a point in time.
+        since: ISO date/datetime (e.g. "2026-06-01") or epoch seconds.
+        Returns facts ADDED since then and facts ENDED/superseded since then,
+        with counts. Answers "what changed about this customer/project lately?".
+        """
+        s = _get_store()
+        result = s.kg_what_changed(since=since, limit=limit)
+        c = result["counts"]
+        _log(f"kg_what_changed: since={since} → +{c['added']} added, -{c['ended']} ended")
+        return json.dumps(result)
+
+    @mcp.tool()
+    def kg_find_contradictions() -> str:
+        """Detect live contradictions in the knowledge graph.
+        Finds functional predicates (single-value-expected, e.g. lives_in,
+        timezone, current_role) that have more than one ACTIVE value for the
+        same subject. Read-only diagnosis: returns the conflicting facts plus an
+        ADVISORY suggested winner — it never edits the graph. Resolve with
+        kg_invalidate after reviewing.
+        """
+        s = _get_store()
+        result = s.kg_find_contradictions()
+        _log(f"kg_find_contradictions: {len(result)} live contradiction(s)")
+        return json.dumps({"count": len(result), "contradictions": result})
 
     @mcp.tool()
     def kg_stats() -> str:

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -2554,8 +2554,21 @@ class ReflectionStore:
             for r in rows
         ]
 
+    # Multi-hop traversal is bounded so "reasoning" queries stay cheap and
+    # cycle-safe. depth=1 returns the exact legacy shape (no extra keys) so
+    # existing callers/tests are byte-compatible.
+    _KG_MAX_DEPTH = 3
+    _KG_MAX_NODES = 200
+
     def kg_connections(self, entity: str, depth: int = 1) -> dict:
-        """Find all entities connected to a given entity (1 hop by default)."""
+        """Find entities connected to an entity.
+
+        depth=1 (default) returns the direct 1-hop neighbours in the legacy
+        shape: ``{"outgoing": [...], "incoming": [...]}``. depth>1 additionally
+        returns a bounded, cycle-guarded BFS of entities reachable within
+        ``depth`` hops under ``reachable`` (each entity once, at its shortest
+        distance >= 2) plus ``depth``. Active triples only; deterministic order.
+        """
         result: dict[str, list[dict]] = {"outgoing": [], "incoming": []}
 
         out_rows = self._conn.execute(
@@ -2582,7 +2595,212 @@ class ReflectionStore:
                 "valid_from": r["valid_from"],
             })
 
+        depth = max(1, min(int(depth), self._KG_MAX_DEPTH))
+        if depth == 1:
+            return result
+
+        # ── Bounded multi-hop BFS (records entities at distance >= 2) ──
+        # Seed visited with the root + all distance-1 neighbours so a node is
+        # only ever recorded at its shortest distance (no duplicate edges).
+        visited = {entity.casefold()}
+        level: list[str] = []
+        for edge in result["outgoing"]:
+            k = edge["target"].casefold()
+            if k not in visited:
+                visited.add(k)
+                level.append(edge["target"])
+        for edge in result["incoming"]:
+            k = edge["source"].casefold()
+            if k not in visited:
+                visited.add(k)
+                level.append(edge["source"])
+
+        reachable: list[dict] = []
+        truncated = False
+        for dist in range(2, depth + 1):
+            next_level: list[str] = []
+            for node in sorted(level, key=str.casefold):
+                for predicate, nbr, direction in self._kg_neighbors(node):
+                    k = nbr.casefold()
+                    if k in visited:
+                        continue
+                    visited.add(k)
+                    reachable.append({
+                        "entity": nbr, "distance": dist, "via": node,
+                        "predicate": predicate, "direction": direction,
+                    })
+                    next_level.append(nbr)
+                    if len(visited) >= self._KG_MAX_NODES:
+                        truncated = True
+                        break
+                if truncated:
+                    break
+            level = next_level
+            if not level or truncated:
+                break
+
+        reachable.sort(key=lambda r: (r["distance"], r["entity"].casefold()))
+        result["depth"] = depth
+        result["reachable"] = reachable
+        if truncated:
+            result["truncated"] = True
         return result
+
+    def _kg_neighbors(self, node: str) -> list[tuple]:
+        """Active 1-hop neighbours of a node, both directions, deterministic."""
+        rows = self._conn.execute(
+            """SELECT predicate, object AS nbr, 'outgoing' AS direction
+               FROM kg_triples WHERE subject = ? AND valid_to IS NULL
+               UNION
+               SELECT predicate, subject AS nbr, 'incoming' AS direction
+               FROM kg_triples WHERE object = ? AND valid_to IS NULL
+               ORDER BY predicate, nbr""",
+            (node, node),
+        ).fetchall()
+        return [(r["predicate"], r["nbr"], r["direction"]) for r in rows]
+
+    def kg_what_changed(self, since: str, limit: int = 100) -> dict:
+        """Summarise KG changes since a point in time.
+
+        Returns facts ADDED since ``since`` (by ``extracted_at``) and facts
+        ENDED/superseded since ``since`` (by ``valid_to``). ``since`` is an ISO
+        date/datetime (or epoch); ``extracted_at`` is epoch REAL and
+        ``valid_to`` is ISO text, so each bucket is compared in its OWN native
+        type — never a mixed string/float comparison.
+        """
+        from datetime import datetime as _dt
+        from datetime import timezone as _tz
+
+        s = (since or "").strip()
+        try:
+            if s and s.replace(".", "", 1).isdigit():  # raw epoch
+                since_epoch = float(s)
+                since_date = _dt.fromtimestamp(
+                    since_epoch, _tz.utc
+                ).strftime("%Y-%m-%d")
+            else:
+                parts = s.split("T")[0].split("-")
+                if len(parts) == 1 and parts[0]:
+                    iso = f"{parts[0]}-01-01"
+                elif len(parts) == 2:
+                    iso = f"{parts[0]}-{parts[1]}-01"
+                else:
+                    iso = s
+                dtv = _dt.fromisoformat(iso)
+                if dtv.tzinfo is None:
+                    dtv = dtv.replace(tzinfo=_tz.utc)
+                since_epoch = dtv.timestamp()
+                since_date = iso[:10]
+        except (ValueError, OverflowError, IndexError):
+            since_epoch, since_date = 0.0, "0000-01-01"
+
+        def _row(r):
+            return {
+                "id": r["id"], "subject": r["subject"],
+                "predicate": r["predicate"], "object": r["object"],
+                "valid_from": r["valid_from"], "valid_to": r["valid_to"],
+                "confidence": r["confidence"], "status": r["status"],
+                "source_reflection_id": r["source_reflection_id"],
+            }
+
+        added = [
+            _row(r) for r in self._conn.execute(
+                """SELECT id, subject, predicate, object, valid_from, valid_to,
+                          confidence, status, source_reflection_id, extracted_at
+                   FROM kg_triples
+                   WHERE extracted_at > ?
+                   ORDER BY extracted_at DESC
+                   LIMIT ?""",
+                (since_epoch, limit),
+            ).fetchall()
+        ]
+        ended = [
+            _row(r) for r in self._conn.execute(
+                """SELECT id, subject, predicate, object, valid_from, valid_to,
+                          confidence, status, source_reflection_id, extracted_at
+                   FROM kg_triples
+                   WHERE valid_to IS NOT NULL AND valid_to >= ?
+                   ORDER BY valid_to DESC
+                   LIMIT ?""",
+                (since_date, limit),
+            ).fetchall()
+        ]
+        return {
+            "since": since,
+            "added": added,
+            "ended": ended,
+            "counts": {
+                "added": len(added),
+                "ended": len(ended),
+                "superseded": sum(1 for e in ended if e["status"] == "superseded"),
+            },
+        }
+
+    def kg_find_contradictions(self) -> list[dict]:
+        """Detect live contradictions: functional predicates with >1 active value.
+
+        Read-side DIAGNOSIS only — never writes. For each (subject, predicate)
+        among FUNCTIONAL_PREDICATES with more than one distinct active object,
+        returns the conflicting triples plus an ADVISORY suggested winner
+        (newer valid_from > higher confidence > newer extracted_at). Multi-valued
+        and event predicates are excluded by design (legit N active values).
+        """
+        from collections import defaultdict
+
+        from .kg_extractor import FUNCTIONAL_PREDICATES
+
+        preds = sorted(FUNCTIONAL_PREDICATES)
+        if not preds:
+            return []
+        placeholders = ",".join("?" * len(preds))
+        rows = self._conn.execute(
+            f"""SELECT id, subject, predicate, object, valid_from,
+                       confidence, extracted_at, source_reflection_id
+                FROM kg_triples
+                WHERE valid_to IS NULL AND predicate IN ({placeholders})
+                ORDER BY subject, predicate""",
+            preds,
+        ).fetchall()
+
+        groups: dict = defaultdict(list)
+        for r in rows:
+            groups[(r["subject"].casefold(), r["predicate"].casefold())].append(r)
+
+        contradictions: list[dict] = []
+        for members in groups.values():
+            if len({m["object"].casefold() for m in members}) <= 1:
+                continue
+            ranked = sorted(
+                members,
+                key=lambda m: (m["valid_from"] or "", m["confidence"], m["extracted_at"]),
+                reverse=True,
+            )
+            winner = ranked[0]
+            contradictions.append({
+                "subject": members[0]["subject"],
+                "predicate": members[0]["predicate"],
+                "active_values": sorted(
+                    {m["object"] for m in members}, key=str.casefold
+                ),
+                "conflicting": [
+                    {
+                        "id": m["id"], "object": m["object"],
+                        "valid_from": m["valid_from"],
+                        "confidence": m["confidence"],
+                        "source_reflection_id": m["source_reflection_id"],
+                    }
+                    for m in ranked
+                ],
+                "suggested_winner": {
+                    "object": winner["object"],
+                    "reason": "newer valid_from, then higher confidence, then "
+                              "newer extracted_at (advisory — no change applied)",
+                },
+            })
+        contradictions.sort(
+            key=lambda c: (c["subject"].casefold(), c["predicate"].casefold())
+        )
+        return contradictions
 
     def kg_entities_list(self, entity_type: str = "", limit: int = 100) -> list[dict]:
         """List all entities, optionally filtered by type."""

--- a/tests/test_kg_reasoning.py
+++ b/tests/test_kg_reasoning.py
@@ -1,0 +1,145 @@
+"""Tests for the KG reasoning layer — multi-hop connections, what-changed
+diff, and functional-predicate contradiction detection (steal-roadmap headline).
+
+Invariants under test (agreed with Murzik on design review):
+  * depth=1 kg_connections stays shape-compatible (no new keys).
+  * depth>1 is bounded, active-only, cycle-guarded, deterministic.
+  * kg_what_changed buckets added (extracted_at) vs ended/superseded (valid_to)
+    in their own native types — no mixed string/float comparison.
+  * kg_find_contradictions flags FUNCTIONAL predicates only; multi-valued stay
+    out; the suggested winner is advisory and nothing is written.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_memory.store import ReflectionStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    db_path = str(tmp_path / "test_memory.db")
+    return ReflectionStore(db_path=db_path)
+
+
+class TestKGConnectionsMultiHop:
+    def test_depth1_shape_unchanged(self, store):
+        """depth=1 returns exactly outgoing/incoming — no extra keys (back-compat)."""
+        store.kg_add("Brad", "works_on", "TOD")
+        result = store.kg_connections("Brad")  # default depth=1
+        assert set(result.keys()) == {"outgoing", "incoming"}
+        assert result["outgoing"][0]["target"] == "TOD"
+        assert result["outgoing"][0]["predicate"] == "works_on"
+
+    def test_depth2_reaches_two_hops(self, store):
+        store.kg_add("Brad", "works_on", "TOD")
+        store.kg_add("TOD", "uses", "Postgres")
+        result = store.kg_connections("Brad", depth=2)
+        assert result["depth"] == 2
+        reached = {r["entity"] for r in result["reachable"]}
+        assert "Postgres" in reached
+        # Postgres is distance 2 via TOD
+        pg = next(r for r in result["reachable"] if r["entity"] == "Postgres")
+        assert pg["distance"] == 2
+        assert pg["via"] == "TOD"
+
+    def test_distance1_not_duplicated_in_reachable(self, store):
+        """Direct neighbours stay in outgoing/incoming, not re-listed in reachable."""
+        store.kg_add("Brad", "works_on", "TOD")
+        store.kg_add("TOD", "uses", "Postgres")
+        result = store.kg_connections("Brad", depth=2)
+        reached = {r["entity"] for r in result["reachable"]}
+        assert "TOD" not in reached  # TOD is a distance-1 direct edge
+
+    def test_cycle_guarded(self, store):
+        """A↔B mutual edges must not loop or re-add the root."""
+        store.kg_add("Brad", "knows", "Yulia")
+        store.kg_add("Yulia", "knows", "Brad")
+        result = store.kg_connections("Brad", depth=3)
+        reached = {r["entity"] for r in result["reachable"]}
+        assert "Brad" not in reached  # root never re-recorded
+
+    def test_depth_clamped(self, store):
+        store.kg_add("A", "x", "B")
+        result = store.kg_connections("A", depth=99)
+        assert result["depth"] == store._KG_MAX_DEPTH  # capped, not 99
+
+    def test_active_only_traversal(self, store):
+        """Expired (valid_to set) edges are not traversed."""
+        store.kg_add("Brad", "works_on", "TOD")
+        store.kg_add("TOD", "uses", "OldDB")
+        store.kg_invalidate("TOD", "uses", "OldDB")  # ends that edge
+        result = store.kg_connections("Brad", depth=2)
+        reached = {r["entity"] for r in result["reachable"]}
+        assert "OldDB" not in reached
+
+
+class TestKGWhatChanged:
+    def test_added_bucket(self, store):
+        store.kg_add("Brad", "uses", "Python")
+        result = store.kg_what_changed(since="2000-01-01")
+        objs = {a["object"] for a in result["added"]}
+        assert "Python" in objs
+        assert result["counts"]["added"] >= 1
+
+    def test_future_since_excludes(self, store):
+        store.kg_add("Brad", "uses", "Python")
+        result = store.kg_what_changed(since="2099-01-01")
+        assert result["counts"]["added"] == 0
+
+    def test_ended_and_superseded_buckets(self, store):
+        store.kg_add("Brad", "lives_in", "Denver")
+        store.kg_invalidate("Brad", "lives_in", "Denver")  # sets valid_to + status=superseded
+        result = store.kg_what_changed(since="2000-01-01")
+        ended_objs = {e["object"] for e in result["ended"]}
+        assert "Denver" in ended_objs
+        assert result["counts"]["superseded"] >= 1
+
+    def test_partial_date_parses(self, store):
+        """A partial 'since' (year, or year-month) must not raise."""
+        store.kg_add("Brad", "uses", "Python")
+        for since in ("2000", "2000-06", "2000-06-01"):
+            result = store.kg_what_changed(since=since)
+            assert result["counts"]["added"] >= 1
+
+    def test_malformed_since_safe(self, store):
+        store.kg_add("Brad", "uses", "Python")
+        # garbage falls back to "everything changed", never raises
+        result = store.kg_what_changed(since="not-a-date")
+        assert "added" in result
+
+
+class TestKGFindContradictions:
+    def test_functional_conflict_detected(self, store):
+        store.kg_add("Brad", "lives_in", "Denver", valid_from="2026-01")
+        store.kg_add("Brad", "lives_in", "Austin", valid_from="2026-05")
+        result = store.kg_find_contradictions()
+        assert len(result) == 1
+        c = result[0]
+        assert c["predicate"] == "lives_in"
+        assert set(c["active_values"]) == {"Denver", "Austin"}
+
+    def test_suggested_winner_is_newest_valid_from(self, store):
+        store.kg_add("Brad", "lives_in", "Denver", valid_from="2026-01")
+        store.kg_add("Brad", "lives_in", "Austin", valid_from="2026-05")
+        c = store.kg_find_contradictions()[0]
+        assert c["suggested_winner"]["object"] == "Austin"  # newer valid_from wins
+
+    def test_multivalued_not_flagged(self, store):
+        """'uses' is multi-valued — two active values is NOT a contradiction."""
+        store.kg_add("Brad", "uses", "Python")
+        store.kg_add("Brad", "uses", "Rust")
+        assert store.kg_find_contradictions() == []
+
+    def test_single_value_not_flagged(self, store):
+        store.kg_add("Brad", "lives_in", "Denver")
+        assert store.kg_find_contradictions() == []
+
+    def test_read_only_no_mutation(self, store):
+        """Detection must not write — the conflicting triples stay active."""
+        store.kg_add("Brad", "timezone", "America/Los_Angeles", valid_from="2026-01")
+        store.kg_add("Brad", "timezone", "America/New_York", valid_from="2026-05")
+        store.kg_find_contradictions()
+        active = store.kg_query(entity="Brad", predicate="timezone")
+        assert len(active) == 2  # both still active — nothing was invalidated


### PR DESCRIPTION
Closes part of #682 (PR1 of 2 — read-side reasoning tools; PR2 = proactive surfacing).

Makes the temporal KG **reason**, not just store/recall. Read-side diagnosis only — no schema change, no writes. Designed collaboratively with @murzik.

## What's in this PR
- **Multi-hop `kg_connections(depth=N)`** — `depth=1` (default) returns the exact legacy `{outgoing, incoming}` shape. `depth>1` (clamped to 3) adds `reachable`: a bounded, cycle-guarded BFS of entities at shortest distance ≥2, active-only, deterministic order, with a `truncated` flag past the node cap (200).
- **`kg_what_changed(since)`** — `added` (by `extracted_at` epoch) and `ended`/superseded (by `valid_to` ISO) buckets + counts. `since` is parsed deliberately into epoch *and* ISO date so each bucket compares in its own native type — no mixed string/float comparison. Tolerates partial dates and garbage.
- **`kg_find_contradictions()`** — FUNCTIONAL_PREDICATES with >1 distinct active value per subject. Returns conflicting triples + provenance + an **advisory** suggested winner (newer `valid_from` → higher `confidence` → newer `extracted_at`). Never writes. Multi-valued/event predicates excluded by design.

All three are store methods reading `kg_triples` directly, because `kg_query` selects but drops `extracted_at` and never returns `status`/`evidence_span`.

## Review invariants (per @murzik's design review)
- [x] `depth=1` response stays shape-compatible (no new keys) — existing `kg_phase2` tests still green
- [x] `depth>1` bounded, active-only, cycle-guarded, deterministic, no duplicate edges (root + distance-1 seeded into `visited`)
- [x] `kg_what_changed` parses `since` into epoch for `extracted_at`; treats `valid_to`/`status` as separate ended/superseded signals; no mixed-type compares
- [x] contradictions FUNCTIONAL-only, grouped by normalized subject/predicate/object, return original rows + provenance
- [x] suggested winner is explicitly advisory; no write path

## Tests / lint
- `tests/test_kg_reasoning.py` — 18 new tests (multi-hop reach/cycle/clamp/active-only, what-changed buckets + date parsing, contradictions functional-only + advisory winner + read-only no-mutation).
- 28 passed (18 new + 10 existing KG store tests, back-compat). `ruff check` clean.

@murzik — tagging you for review per your invariants above. PR2 (nightly proactive surfacing, `PINKY_KG_PROACTIVE` off-by-default + soak) lands after this.

🤖 Opened by Barsik
