### PR TITLE
feat(#682): KG proactive surfacing — nightly material contradiction/change digest (PR2)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1724,6 +1724,7 @@ def create_api(
             limit=limit,
             role=role,
         ),
+        owner_provider=lambda: agents.get_owner_profile(),
     )
     app.state.dream_runner = dream_runner
     app.state.agent_history_resolver = _resolve_agent_history
@@ -1998,6 +1999,13 @@ def create_api(
             if morning_summary:
                 dream_ctx = f"Dream summary from last night:\n{morning_summary}"
                 wake_ctx = f"{wake_ctx}\n\n{dream_ctx}" if wake_ctx else dream_ctx
+
+            # Inject proactive KG insights digest (flag-gated PINKY_KG_PROACTIVE,
+            # OFF by default; computed during the nightly dream). Advisory only —
+            # the agent reviews it and decides whether to surface to the owner.
+            kg_insights = dream_runner.get_kg_insights(agent_name)
+            if kg_insights:
+                wake_ctx = f"{wake_ctx}\n\n{kg_insights}" if wake_ctx else kg_insights
 
         # Inject unread inbox messages from other agents
         inbox_messages = comms.get_inbox(agent_name, unread_only=True, limit=10)

--- a/src/pinky_daemon/dream_prompt.py
+++ b/src/pinky_daemon/dream_prompt.py
@@ -203,7 +203,28 @@ Rules:
 - The description should be specific enough that an agent knows when to activate it
 - Use kebab-case names under 30 characters
 
-## Phase 8 — Report
+## Phase 8 — Keep the knowledge graph contradiction-free
+
+The system now reasons over your temporal knowledge graph. A deterministic
+post-dream pass detects functional contradictions (one subject+predicate with
+two live values — e.g. two current timezones, two employers, two deploy
+targets) and recent changes, then surfaces the material ones into tomorrow's
+wake context for review.
+
+Your job in this phase is to keep the graph clean so that reasoning stays sharp:
+- When consolidation reveals a fact has CHANGED (someone moved, switched jobs,
+  a project was renamed, a service moved hosts), make sure the OLD fact is
+  properly superseded — don't leave it sitting alongside the new one as a
+  second live value.
+- Prefer correcting a stale fact over piling on a contradicting one.
+- You do NOT need to hand-list every contradiction in your report; the
+  deterministic pass handles surfacing. Focus on accurate extraction: the
+  right predicate, the right entities, and a real `valid_from` date.
+
+No auto-fixes are ever applied to the graph on your behalf — surfacing is
+advisory.
+
+## Phase 9 — Report
 
 Output a plain summary of what you did. Cover:
 - What time range you processed and how many messages

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -67,10 +67,14 @@ class DreamRunner:
         db_path: str = "data/dream_state.db",
         *,
         history_provider: Callable[[str, float, int, str], list[dict]] | None = None,
+        owner_provider: Callable[[], dict] | None = None,
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         self._history_provider = history_provider
+        # Optional () -> owner-profile dict, used to derive high-value entity
+        # names for KG proactive-surfacing materiality. May be None.
+        self._owner_provider = owner_provider
         self._db.execute("PRAGMA journal_mode=WAL")
         self._init_tables()
 
@@ -82,6 +86,12 @@ class DreamRunner:
                 last_summary TEXT,
                 sessions_processed INT DEFAULT 0,
                 memories_stored INT DEFAULT 0
+            );
+            CREATE TABLE IF NOT EXISTS kg_surfaced (
+                agent_name TEXT NOT NULL,
+                fingerprint TEXT NOT NULL,
+                surfaced_at REAL,
+                PRIMARY KEY (agent_name, fingerprint)
             );
         """)
         self._db.commit()
@@ -121,6 +131,17 @@ class DreamRunner:
         if "last_message_ts" not in cols:
             self._db.execute(
                 "ALTER TABLE dream_state ADD COLUMN last_message_ts REAL DEFAULT 0"
+            )
+            self._db.commit()
+        # Migration: add KG proactive-surfacing columns (#682 PR2)
+        if "kg_insights" not in cols:
+            self._db.execute(
+                "ALTER TABLE dream_state ADD COLUMN kg_insights TEXT"
+            )
+            self._db.commit()
+        if "kg_insights_notified_at" not in cols:
+            self._db.execute(
+                "ALTER TABLE dream_state ADD COLUMN kg_insights_notified_at REAL"
             )
             self._db.commit()
 
@@ -260,6 +281,21 @@ class DreamRunner:
         if kg_count:
             _log(f"dream-runner: '{agent_name}' extracted {kg_count} KG triples")
 
+        # Post-dream: surface MATERIAL, not-yet-seen KG contradictions/changes
+        # into the agent's morning wake context. Flag-gated (PINKY_KG_PROACTIVE,
+        # OFF by default), read-only over the KG, deduped + top-5 capped. It
+        # never auto-messages the owner — the agent reviews the digest on wake
+        # and decides. ``last_dream_at`` here is the PRIOR dream time (captured
+        # before _save_state above), so changes are scoped to this cycle.
+        kg_digest = self._surface_kg_insights(
+            agent_name, agent_config, since_ts=last_dream_at
+        )
+        if kg_digest:
+            _log(
+                f"dream-runner: '{agent_name}' KG insights digest ready "
+                f"({len(kg_digest)} chars)"
+            )
+
         return summary
 
     def get_morning_summary(self, agent_name: str) -> str | None:
@@ -301,6 +337,147 @@ class DreamRunner:
         self._db.commit()
 
         return last_summary
+
+    # ── KG proactive surfacing (#682 PR2) ───────────────────────
+
+    def get_kg_insights(self, agent_name: str) -> str | None:
+        """Return the pending KG-insights digest once per dream cycle.
+
+        Mirrors :meth:`get_morning_summary`: delivers the digest only when a
+        dream ran within the morning window and it has not yet been delivered
+        for this cycle (``kg_insights_notified_at`` is NULL or predates
+        ``last_dream_at``). Returns None otherwise.
+        """
+        row = self._db.execute(
+            "SELECT last_dream_at, kg_insights, kg_insights_notified_at"
+            " FROM dream_state WHERE agent_name=?",
+            (agent_name,),
+        ).fetchone()
+        if not row or not row[0] or not row[1]:
+            return None
+
+        last_dream_at, digest, notified_at = row
+        if time.time() - last_dream_at > _MORNING_WINDOW_S:
+            return None
+        if notified_at is not None and notified_at >= last_dream_at:
+            return None
+
+        self._db.execute(
+            "UPDATE dream_state SET kg_insights_notified_at=? WHERE agent_name=?",
+            (time.time(), agent_name),
+        )
+        self._db.commit()
+        return digest
+
+    def _high_value_entities(self) -> set[str]:
+        """Case-folded owner name aliases used to boost insight materiality.
+
+        Derived from the owner profile (if an ``owner_provider`` was wired);
+        empty set otherwise. With an empty set, materiality rests entirely on
+        the high-value predicate domains, which is conservative and correct.
+        """
+        if self._owner_provider is None:
+            return set()
+        try:
+            owner = self._owner_provider() or {}
+        except Exception:  # noqa: BLE001 — never let surfacing break the dream
+            return set()
+        names: set[str] = set()
+        full = str(owner.get("name", "") or "").strip()
+        if full:
+            names.add(full)
+            names.update(full.split())
+        return {n.strip().casefold() for n in names if n.strip()}
+
+    def _load_surfaced_fingerprints(self, agent_name: str) -> set[str]:
+        rows = self._db.execute(
+            "SELECT fingerprint FROM kg_surfaced WHERE agent_name=?",
+            (agent_name,),
+        ).fetchall()
+        return {r[0] for r in rows}
+
+    def _record_surfaced_fingerprints(
+        self, agent_name: str, fingerprints: list[str]
+    ) -> None:
+        if not fingerprints:
+            return
+        now = time.time()
+        self._db.executemany(
+            "INSERT OR IGNORE INTO kg_surfaced(agent_name, fingerprint, surfaced_at)"
+            " VALUES (?,?,?)",
+            [(agent_name, fp, now) for fp in fingerprints],
+        )
+        self._db.commit()
+
+    def _surface_kg_insights(
+        self, agent_name: str, agent_config, *, since_ts: float | None = None
+    ) -> str:
+        """Compute a digest of material, unseen KG contradictions/changes.
+
+        Flag-gated by ``PINKY_KG_PROACTIVE`` (default OFF). Reads the agent's
+        KG (never writes), applies the materiality policy in
+        :mod:`pinky_memory.kg_reason`, suppresses repeats by fingerprint, caps
+        the volume, and stores the digest for once-per-cycle delivery via
+        :meth:`get_kg_insights`. Returns the digest text ("" if nothing).
+
+        Any failure is swallowed (logged) so surfacing can never break a dream.
+        """
+        import os
+
+        if os.environ.get("PINKY_KG_PROACTIVE", "0").strip() != "1":
+            return ""
+
+        try:
+            from pinky_memory import kg_reason
+            from pinky_memory.store import ReflectionStore
+        except ImportError:
+            _log("dream-runner: kg_reason/store unavailable — skipping surfacing")
+            return ""
+
+        work_dir = getattr(agent_config, "working_dir", "") or "."
+        db_path = str(Path(work_dir).resolve() / "data" / "memory.db")
+        if not Path(db_path).exists():
+            return ""
+
+        try:
+            store = ReflectionStore(db_path=db_path)
+            contradictions = store.kg_find_contradictions()
+            if since_ts is None:
+                since_ts = time.time() - 48 * 3600
+            changes = store.kg_what_changed(since=str(since_ts))
+        except Exception as e:  # noqa: BLE001 — surfacing must never crash dream
+            _log(f"dream-runner: KG surfacing query failed for '{agent_name}': {e}")
+            return ""
+
+        high_value = self._high_value_entities()
+        seen = self._load_surfaced_fingerprints(agent_name)
+        selected = kg_reason.select_insights(
+            contradictions, changes, seen, high_value, cap=5
+        )
+        digest = kg_reason.format_digest(selected)
+
+        if not digest:
+            # Nothing new/material this cycle — clear any stale pending digest.
+            self._db.execute(
+                "UPDATE dream_state SET kg_insights=NULL WHERE agent_name=?",
+                (agent_name,),
+            )
+            self._db.commit()
+            return ""
+
+        self._record_surfaced_fingerprints(agent_name, selected["fingerprints"])
+        self._db.execute(
+            "UPDATE dream_state SET kg_insights=?, kg_insights_notified_at=NULL"
+            " WHERE agent_name=?",
+            (digest, agent_name),
+        )
+        self._db.commit()
+        _log(
+            f"dream-runner: '{agent_name}' surfaced "
+            f"{len(selected['contradictions'])} contradiction(s) + "
+            f"{len(selected['changes'])} change(s)"
+        )
+        return digest
 
     def get_state(self, agent_name: str) -> dict:
         """Return the full dream_state row for an agent as a dict."""

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -32,6 +32,18 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+def _kg_proactive_enabled() -> bool:
+    """Master switch for KG proactive surfacing (``PINKY_KG_PROACTIVE``).
+
+    Default OFF. Gates BOTH the nightly compute and the morning delivery, so
+    flipping it off fully suppresses surfacing — including any digest that was
+    already computed while it was on.
+    """
+    import os
+
+    return os.environ.get("PINKY_KG_PROACTIVE", "0").strip() == "1"
+
+
 # How long between dream runs (seconds). Default: 20 hours so nightly cron
 # won't double-fire if the scheduler ticks slightly early.
 _DREAM_COOLDOWN_S = 20 * 3600
@@ -347,7 +359,14 @@ class DreamRunner:
         dream ran within the morning window and it has not yet been delivered
         for this cycle (``kg_insights_notified_at`` is NULL or predates
         ``last_dream_at``). Returns None otherwise.
+
+        Also gated by the ``PINKY_KG_PROACTIVE`` master switch: if surfacing is
+        disabled at wake time, no digest is delivered even if one was computed
+        while it was enabled.
         """
+        if not _kg_proactive_enabled():
+            return None
+
         row = self._db.execute(
             "SELECT last_dream_at, kg_insights, kg_insights_notified_at"
             " FROM dream_state WHERE agent_name=?",
@@ -422,9 +441,7 @@ class DreamRunner:
 
         Any failure is swallowed (logged) so surfacing can never break a dream.
         """
-        import os
-
-        if os.environ.get("PINKY_KG_PROACTIVE", "0").strip() != "1":
+        if not _kg_proactive_enabled():
             return ""
 
         try:

--- a/src/pinky_memory/kg_reason.py
+++ b/src/pinky_memory/kg_reason.py
@@ -1,0 +1,210 @@
+"""Pure reasoning helpers for proactive KG surfacing (#682, PR2).
+
+Given the raw, read-only outputs of ``ReflectionStore.kg_find_contradictions()``
+and ``ReflectionStore.kg_what_changed()``, decide which insights are MATERIAL
+(worth a human's attention), suppress repeats by a stable fingerprint, cap the
+volume, and format a short advisory digest.
+
+Everything here is a PURE function: no DB, no I/O, no globals, no clock. That
+keeps the materiality policy unit-testable in isolation and lets the dream
+runner own all the side effects (querying the store, persisting fingerprints,
+delivering the digest).
+
+Materiality policy (designed with Murzik):
+- A functional CONTRADICTION (one subject+predicate with >1 live value) is
+  material if its predicate is in a high-value domain (location, timezone,
+  employment, ownership, deploy target) OR it touches a high-value entity.
+- A CHANGE that ENDED/superseded is material if it is a high-value domain or
+  touches a high-value entity (a fact ending is inherently notable).
+- A CHANGE that was ADDED (still live) is material only if it touches a
+  high-value entity AND its confidence is >= 0.7 (ignore low-confidence noise).
+- Surfacing is advisory only — no auto-fix is ever applied to the graph.
+"""
+
+from __future__ import annotations
+
+# Functional predicates whose contradiction/change is ALWAYS material — the
+# domains where a stale value would actively mislead the agent. A subset of
+# kg_extractor.FUNCTIONAL_PREDICATES plus ownership variants. The softer
+# functional predicates (primary_language/editor/model, married_to, dating)
+# are material only when they touch a high-value entity.
+MATERIAL_PREDICATES = frozenset({
+    "lives_in", "located_in", "timezone",
+    "works_at", "employed_by", "current_role", "current_title",
+    "reports_to", "managed_by", "owns", "owned_by",
+    "runs_on", "hosted_on", "deployed_to",
+})
+
+# Additions below this confidence are treated as noise unless they touch a
+# high-value entity at or above it.
+LOW_CONF = 0.7
+
+# Default cap on insights surfaced in a single digest.
+DEFAULT_CAP = 5
+
+
+def _norm(s: object) -> str:
+    """Case-folded, stripped string for stable comparison/fingerprinting."""
+    return str(s or "").strip().casefold()
+
+
+# ── Fingerprints (repeat-suppression keys) ──────────────────────────────────
+
+def contradiction_fingerprint(c: dict) -> str:
+    """Stable key for a contradiction: subject|predicate|sorted-live-values.
+
+    Independent of value ordering and of the advisory winner, so the same
+    standing contradiction is suppressed across nights until it actually
+    changes (a value is added/removed/resolved).
+    """
+    subj = _norm(c.get("subject"))
+    pred = _norm(c.get("predicate"))
+    vals = "|".join(sorted(_norm(v) for v in c.get("active_values", [])))
+    return f"contradiction:{subj}|{pred}|{vals}"
+
+
+def change_fingerprint(change: dict, bucket: str) -> str:
+    """Stable key for a change: bucket + triple id.
+
+    A given triple can legitimately surface once as ``added`` and later once as
+    ``ended``; the bucket keeps those distinct while preventing the same
+    triple/bucket from re-surfacing every night.
+    """
+    return f"change:{bucket}:{change.get('id')}"
+
+
+# ── Materiality ─────────────────────────────────────────────────────────────
+
+def is_material_contradiction(c: dict, high_value: set[str]) -> bool:
+    pred = _norm(c.get("predicate"))
+    if pred in MATERIAL_PREDICATES:
+        return True
+    ents = {_norm(c.get("subject"))}
+    ents |= {_norm(v) for v in c.get("active_values", [])}
+    return bool(ents & high_value)
+
+
+def is_material_change(change: dict, bucket: str, high_value: set[str]) -> bool:
+    pred = _norm(change.get("predicate"))
+    touches_hv = (
+        _norm(change.get("subject")) in high_value
+        or _norm(change.get("object")) in high_value
+    )
+    if bucket == "ended":
+        return pred in MATERIAL_PREDICATES or touches_hv
+    # bucket == "added": still-live fact. Ignore low-confidence noise; only
+    # surface when it touches a high-value entity.
+    try:
+        conf = float(change.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        conf = 0.0
+    if conf < LOW_CONF:
+        return False
+    return touches_hv
+
+
+# ── Selection (filter + dedup + cap) ────────────────────────────────────────
+
+def select_insights(
+    contradictions: list[dict] | None,
+    changes: dict | None,
+    seen_fingerprints,
+    high_value,
+    cap: int = DEFAULT_CAP,
+) -> dict:
+    """Pick material, not-yet-seen insights up to ``cap`` total.
+
+    Contradictions are considered first (highest signal), then ENDED changes,
+    then ADDED changes. Returns a dict with the selected contradictions, the
+    selected changes (each tagged with ``_bucket``), and the list of NEW
+    fingerprints to persist for repeat-suppression.
+    """
+    seen = set(seen_fingerprints or ())
+    hv = {_norm(e) for e in (high_value or ()) if _norm(e)}
+    cap = max(0, int(cap))
+
+    sel_contra: list[dict] = []
+    sel_changes: list[dict] = []
+    new_fps: list[str] = []
+
+    def _full() -> bool:
+        return (len(sel_contra) + len(sel_changes)) >= cap
+
+    for c in contradictions or []:
+        if _full():
+            break
+        fp = contradiction_fingerprint(c)
+        if fp in seen or fp in new_fps:
+            continue
+        if not is_material_contradiction(c, hv):
+            continue
+        sel_contra.append(c)
+        new_fps.append(fp)
+
+    changes = changes or {}
+    for bucket in ("ended", "added"):
+        for ch in changes.get(bucket, []) or []:
+            if _full():
+                break
+            fp = change_fingerprint(ch, bucket)
+            if fp in seen or fp in new_fps:
+                continue
+            if not is_material_change(ch, bucket, hv):
+                continue
+            sel_changes.append({**ch, "_bucket": bucket})
+            new_fps.append(fp)
+        if _full():
+            break
+
+    return {
+        "contradictions": sel_contra,
+        "changes": sel_changes,
+        "fingerprints": new_fps,
+    }
+
+
+# ── Formatting ──────────────────────────────────────────────────────────────
+
+def format_digest(selected: dict, *, min_items: int = 1) -> str:
+    """Render the selected insights as a short advisory digest.
+
+    Returns "" when there is nothing material (fewer than ``min_items``),
+    which the caller treats as "surface nothing this cycle".
+    """
+    contra = selected.get("contradictions", []) if selected else []
+    changes = selected.get("changes", []) if selected else []
+    if (len(contra) + len(changes)) < max(1, min_items):
+        return ""
+
+    lines = [
+        "🧠 KG insights from last night's consolidation "
+        "(read-only — no auto-fix applied):",
+    ]
+
+    if contra:
+        lines.append("")
+        lines.append(f"Live contradictions ({len(contra)}):")
+        for c in contra:
+            vals = " vs ".join(str(v) for v in c.get("active_values", []))
+            winner = (c.get("suggested_winner") or {}).get("object", "")
+            line = f"  • {c.get('subject')} — {c.get('predicate')}: {vals}"
+            if winner:
+                line += f"  (advisory winner: {winner})"
+            lines.append(line)
+
+    if changes:
+        lines.append("")
+        lines.append(f"Recent changes ({len(changes)}):")
+        for ch in changes:
+            verb = "ended" if ch.get("_bucket") == "ended" else "added"
+            obj = ch.get("object", "")
+            lines.append(
+                f"  • [{verb}] {ch.get('subject')} {ch.get('predicate')} {obj}".rstrip()
+            )
+
+    lines.append("")
+    lines.append(
+        "If any of these matter to Brad or an active project, surface it; "
+        "otherwise note and move on."
+    )
+    return "\n".join(lines)

--- a/tests/test_kg_proactive.py
+++ b/tests/test_kg_proactive.py
@@ -1,0 +1,284 @@
+"""Tests for proactive KG surfacing (#682, PR2).
+
+Two layers:
+  * ``pinky_memory.kg_reason`` pure functions — materiality policy,
+    fingerprints, selection (filter/dedup/cap), and digest formatting.
+  * ``DreamRunner._surface_kg_insights`` + ``get_kg_insights`` — the
+    flag-gated, read-only, deduped, once-per-cycle delivery wiring.
+
+Invariants (designed with Murzik):
+  * Flag OFF (default) ⇒ surfacing is completely inert.
+  * Contradictions on high-value predicate domains are always material;
+    softer predicates need a high-value entity.
+  * Changes: ended/superseded are material on high-value domain/entity;
+    additions only when high-value AND confidence >= 0.7.
+  * Fingerprints suppress repeats across nights; top-5 cap bounds volume.
+  * Nothing is ever written to the KG; the owner is never auto-messaged.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+
+from pinky_daemon.dream_runner import DreamRunner
+from pinky_memory import kg_reason
+from pinky_memory.store import ReflectionStore
+
+# ── Builders ────────────────────────────────────────────────────────────────
+
+def _contradiction(subject, predicate, values, winner=None):
+    return {
+        "subject": subject,
+        "predicate": predicate,
+        "active_values": list(values),
+        "conflicting": [
+            {"id": i, "object": v, "valid_from": "", "confidence": 1.0,
+             "source_reflection_id": ""}
+            for i, v in enumerate(values)
+        ],
+        "suggested_winner": {"object": winner or values[-1], "reason": "advisory"},
+    }
+
+
+def _change(_id, subject, predicate, obj, *, confidence=1.0, status="active",
+            valid_to=None):
+    return {
+        "id": _id, "subject": subject, "predicate": predicate, "object": obj,
+        "valid_from": "2026-06-01", "valid_to": valid_to,
+        "confidence": confidence, "status": status, "source_reflection_id": "",
+    }
+
+
+# ── Fingerprints ────────────────────────────────────────────────────────────
+
+class TestFingerprints:
+    def test_contradiction_fp_order_independent(self):
+        a = _contradiction("Brad", "timezone", ["PST", "EST"])
+        b = _contradiction("Brad", "timezone", ["EST", "PST"])
+        assert kg_reason.contradiction_fingerprint(a) == \
+            kg_reason.contradiction_fingerprint(b)
+
+    def test_contradiction_fp_casefolded(self):
+        a = _contradiction("brad", "TimeZone", ["pst", "est"])
+        b = _contradiction("Brad", "timezone", ["PST", "EST"])
+        assert kg_reason.contradiction_fingerprint(a) == \
+            kg_reason.contradiction_fingerprint(b)
+
+    def test_contradiction_fp_changes_with_values(self):
+        a = _contradiction("Brad", "timezone", ["PST", "EST"])
+        b = _contradiction("Brad", "timezone", ["PST", "EST", "CST"])
+        assert kg_reason.contradiction_fingerprint(a) != \
+            kg_reason.contradiction_fingerprint(b)
+
+    def test_change_fp_distinct_by_bucket(self):
+        ch = _change(7, "Brad", "lives_in", "Denver")
+        assert kg_reason.change_fingerprint(ch, "added") != \
+            kg_reason.change_fingerprint(ch, "ended")
+
+    def test_change_fp_stable_by_id(self):
+        ch = _change(7, "Brad", "lives_in", "Denver")
+        assert kg_reason.change_fingerprint(ch, "added") == "change:added:7"
+
+
+# ── Materiality ─────────────────────────────────────────────────────────────
+
+class TestMateriality:
+    def test_contradiction_material_predicate_always(self):
+        c = _contradiction("SomeRandomPerson", "timezone", ["PST", "EST"])
+        assert kg_reason.is_material_contradiction(c, set()) is True
+
+    def test_contradiction_soft_predicate_needs_high_value(self):
+        c = _contradiction("Stranger", "primary_editor", ["vim", "emacs"])
+        assert kg_reason.is_material_contradiction(c, set()) is False
+        assert kg_reason.is_material_contradiction(c, {"stranger"}) is True
+
+    def test_change_ended_material_on_material_predicate(self):
+        ch = _change(1, "TOD", "deployed_to", "Contabo", valid_to="2026-06-05",
+                     status="ended")
+        assert kg_reason.is_material_change(ch, "ended", set()) is True
+
+    def test_change_added_low_conf_ignored(self):
+        ch = _change(2, "Brad", "lives_in", "Denver", confidence=0.5)
+        assert kg_reason.is_material_change(ch, "added", {"brad"}) is False
+
+    def test_change_added_high_conf_high_value(self):
+        ch = _change(3, "Brad", "lives_in", "Denver", confidence=0.9)
+        assert kg_reason.is_material_change(ch, "added", {"brad"}) is True
+
+    def test_change_added_high_conf_but_not_high_value(self):
+        ch = _change(4, "Nobody", "lives_in", "Denver", confidence=0.9)
+        assert kg_reason.is_material_change(ch, "added", {"brad"}) is False
+
+
+# ── Selection ───────────────────────────────────────────────────────────────
+
+class TestSelectInsights:
+    def test_dedup_against_seen(self):
+        c = _contradiction("Brad", "timezone", ["PST", "EST"])
+        fp = kg_reason.contradiction_fingerprint(c)
+        sel = kg_reason.select_insights([c], {}, {fp}, set())
+        assert sel["contradictions"] == []
+        assert sel["fingerprints"] == []
+
+    def test_contradictions_first_then_cap(self):
+        contras = [
+            _contradiction(f"Person{i}", "timezone", ["PST", "EST"])
+            for i in range(7)
+        ]
+        sel = kg_reason.select_insights(contras, {}, set(), set(), cap=5)
+        assert len(sel["contradictions"]) == 5
+        assert len(sel["changes"]) == 0
+        assert len(sel["fingerprints"]) == 5
+
+    def test_changes_fill_remaining_capacity(self):
+        contras = [_contradiction("Brad", "timezone", ["PST", "EST"])]
+        changes = {
+            "ended": [
+                _change(i, "TOD", "deployed_to", f"Host{i}", valid_to="2026-06-05",
+                        status="ended")
+                for i in range(10)
+            ],
+            "added": [],
+        }
+        sel = kg_reason.select_insights(contras, changes, set(), set(), cap=5)
+        assert len(sel["contradictions"]) == 1
+        assert len(sel["changes"]) == 4  # filled to the cap of 5
+        assert all(ch["_bucket"] == "ended" for ch in sel["changes"])
+
+    def test_immaterial_filtered_out(self):
+        contras = [_contradiction("Stranger", "primary_editor", ["vim", "emacs"])]
+        sel = kg_reason.select_insights(contras, {}, set(), set())
+        assert sel["contradictions"] == []
+
+    def test_within_run_dedup(self):
+        c = _contradiction("Brad", "timezone", ["PST", "EST"])
+        sel = kg_reason.select_insights([c, c], {}, set(), set())
+        assert len(sel["contradictions"]) == 1
+
+
+# ── Formatting ──────────────────────────────────────────────────────────────
+
+class TestFormatDigest:
+    def test_empty_when_nothing(self):
+        assert kg_reason.format_digest(
+            {"contradictions": [], "changes": []}) == ""
+
+    def test_min_items_threshold(self):
+        sel = {"contradictions": [_contradiction("Brad", "timezone", ["PST", "EST"])],
+               "changes": []}
+        assert kg_reason.format_digest(sel, min_items=2) == ""
+        assert kg_reason.format_digest(sel, min_items=1) != ""
+
+    def test_renders_contradiction_and_change(self):
+        sel = {
+            "contradictions": [
+                _contradiction("Brad", "timezone", ["PST", "EST"], winner="PST")],
+            "changes": [
+                {**_change(9, "TOD", "deployed_to", "Contabo",
+                           valid_to="2026-06-05", status="ended"),
+                 "_bucket": "ended"}],
+        }
+        out = kg_reason.format_digest(sel)
+        assert "no auto-fix applied" in out.lower()
+        assert "Brad" in out and "timezone" in out
+        assert "PST vs EST" in out or "EST vs PST" in out
+        assert "advisory winner: PST" in out
+        assert "[ended] TOD deployed_to Contabo" in out
+
+
+# ── DreamRunner integration ─────────────────────────────────────────────────
+
+@pytest.fixture
+def dream_env(tmp_path, monkeypatch):
+    """A DreamRunner with a temp dream_state.db and an agent KG seeded with a
+    live functional contradiction (Brad timezone PST vs EST)."""
+    dream_db = str(tmp_path / "dream_state.db")
+    work_dir = tmp_path / "agent"
+    (work_dir / "data").mkdir(parents=True)
+    mem_db = str(work_dir / "data" / "memory.db")
+
+    store = ReflectionStore(db_path=mem_db)
+    store.kg_add("Brad", "timezone", "PST", valid_from="2026-01-01")
+    store.kg_add("Brad", "timezone", "EST", valid_from="2026-06-01")
+
+    runner = DreamRunner(
+        db_path=dream_db,
+        owner_provider=lambda: {"name": "Bradley Brockman"},
+    )
+    agent_config = SimpleNamespace(working_dir=str(work_dir))
+    # A dream row must exist for the digest UPDATE to land + the window check.
+    runner._save_state("barsik", "test dream summary")
+    return runner, agent_config
+
+
+class TestSurfaceKGInsights:
+    def test_flag_off_is_inert(self, dream_env, monkeypatch):
+        runner, cfg = dream_env
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        assert runner._surface_kg_insights("barsik", cfg) == ""
+        assert runner.get_kg_insights("barsik") is None
+
+    def test_flag_on_surfaces_contradiction(self, dream_env, monkeypatch):
+        runner, cfg = dream_env
+        monkeypatch.setenv("PINKY_KG_PROACTIVE", "1")
+        digest = runner._surface_kg_insights("barsik", cfg)
+        assert digest
+        assert "timezone" in digest
+        assert "PST" in digest and "EST" in digest
+
+    def test_repeat_suppressed_second_run(self, dream_env, monkeypatch):
+        runner, cfg = dream_env
+        monkeypatch.setenv("PINKY_KG_PROACTIVE", "1")
+        first = runner._surface_kg_insights("barsik", cfg)
+        assert first
+        second = runner._surface_kg_insights("barsik", cfg)
+        assert second == ""  # same contradiction fingerprint already surfaced
+
+    def test_get_kg_insights_once_only(self, dream_env, monkeypatch):
+        runner, cfg = dream_env
+        monkeypatch.setenv("PINKY_KG_PROACTIVE", "1")
+        runner._surface_kg_insights("barsik", cfg)
+        first = runner.get_kg_insights("barsik")
+        assert first and "timezone" in first
+        # Second read in the same cycle returns nothing (already delivered).
+        assert runner.get_kg_insights("barsik") is None
+
+    def test_surfacing_never_writes_kg(self, dream_env, monkeypatch):
+        runner, cfg = dream_env
+        monkeypatch.setenv("PINKY_KG_PROACTIVE", "1")
+        mem_db = str(cfg.working_dir + "/data/memory.db")
+        before = ReflectionStore(db_path=mem_db).kg_find_contradictions()
+        runner._surface_kg_insights("barsik", cfg)
+        after = ReflectionStore(db_path=mem_db).kg_find_contradictions()
+        assert len(before) == len(after) == 1  # unchanged — read-only
+
+    def test_missing_memory_db_is_safe(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PINKY_KG_PROACTIVE", "1")
+        runner = DreamRunner(db_path=str(tmp_path / "ds.db"))
+        cfg = SimpleNamespace(working_dir=str(tmp_path / "no_such_agent"))
+        runner._save_state("ghost", "summary")
+        assert runner._surface_kg_insights("ghost", cfg) == ""
+
+
+def test_high_value_entities_from_owner(tmp_path):
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        runner = DreamRunner(
+            db_path=path,
+            owner_provider=lambda: {"name": "Bradley Brockman"},
+        )
+        hv = runner._high_value_entities()
+        assert "bradley brockman" in hv
+        assert "bradley" in hv and "brockman" in hv
+    finally:
+        os.unlink(path)
+
+
+def test_high_value_entities_empty_without_provider(tmp_path):
+    runner = DreamRunner(db_path=str(tmp_path / "ds.db"))
+    assert runner._high_value_entities() == set()

--- a/tests/test_kg_proactive.py
+++ b/tests/test_kg_proactive.py
@@ -247,6 +247,15 @@ class TestSurfaceKGInsights:
         # Second read in the same cycle returns nothing (already delivered).
         assert runner.get_kg_insights("barsik") is None
 
+    def test_flag_off_suppresses_pending_delivery(self, dream_env, monkeypatch):
+        """Master switch: a digest computed while ON is NOT delivered if the
+        flag is flipped OFF before the morning wake (per Murzik's review)."""
+        runner, cfg = dream_env
+        monkeypatch.setenv("PINKY_KG_PROACTIVE", "1")
+        assert runner._surface_kg_insights("barsik", cfg)  # digest stored
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        assert runner.get_kg_insights("barsik") is None
+
     def test_surfacing_never_writes_kg(self, dream_env, monkeypatch):
         runner, cfg = dream_env
         monkeypatch.setenv("PINKY_KG_PROACTIVE", "1")


### PR DESCRIPTION
## What

PR2 of the **make-the-KG-reason** headline (#682). Builds on PR1 (#683) read-side tools. After each nightly dream, a deterministic post-extraction pass surfaces **material, not-yet-seen** KG contradictions and changes into the agent's **morning wake context** for review.

This is the "proactive surfacing" half: PR1 gave us the *ability* to detect contradictions/changes on demand; PR2 makes the system *notice and raise* the ones that matter, on its own, every night.

## Delivery model — wake-context injection (not a direct owner DM)

The digest is injected into the agent's morning wake context, exactly like the existing dream summary (`get_morning_summary` → `get_kg_insights`). It is **never** auto-sent to Brad. The agent reads it on wake and applies judgment before anything reaches the owner.

This is a deliberate refinement of the original "nightly push" framing: it makes the **"soak before it can ever message Brad"** rail *structural* rather than flag-dependent — there is no code path in this PR that DMs the owner. A direct push can be a small, separately-gated follow-up once we've watched the digests for quality. **@Murzik — flagging this delivery-model choice for your review; it diverges from a direct-push design but strengthens the rail.**

## Rails (all enforced)

- **Flag `PINKY_KG_PROACTIVE`, default OFF** → completely inert in prod until explicitly enabled.
- **Read-only** over the KG — never writes `kg_triples` (test asserts contradiction count unchanged before/after).
- **Repeat-suppression** by stable fingerprint (`kg_surfaced` table) so a standing contradiction isn't re-raised every night.
- **Top-5 cap**, contradictions first.
- **Never crashes the dream** — every failure path is swallowed + logged.
- Materiality policy designed with Murzik (see below).

## Materiality policy (pure, in `kg_reason.py`)

- **Contradiction** material if its predicate is a high-value domain (location, timezone, employment, ownership, deploy target) OR it touches a high-value entity (owner aliases). Softer functional predicates (primary_editor, married_to, …) need the entity match.
- **Change / ended-superseded** material on a high-value domain or entity (a fact ending is inherently notable).
- **Change / added** material only when it touches a high-value entity **and** confidence ≥ 0.7 (ignore low-confidence noise).

## Files

| File | Change |
|------|--------|
| `src/pinky_memory/kg_reason.py` | **new** — pure policy fns: materiality, fingerprints, `select_insights`, `format_digest` |
| `src/pinky_daemon/dream_runner.py` | `_surface_kg_insights()` + `get_kg_insights()` + `kg_surfaced` table / `kg_insights*` columns + `owner_provider` |
| `src/pinky_daemon/api.py` | wire `owner_provider`; inject digest into wake context (same `dream_notify` gate as morning summary) |
| `src/pinky_daemon/dream_prompt.py` | new Phase 8 (keep the graph contradiction-free); Report → Phase 9 |
| `tests/test_kg_proactive.py` | **new** — 27 tests |

## Tests

`tests/test_kg_proactive.py` — 27 tests: pure policy (fingerprints, materiality, selection/cap/dedup, formatting) + runner wiring (flag-off inert, flag-on surfaces, repeat-suppressed, once-only delivery, read-only, missing-db-safe). Full suite green locally (`test_kg_proactive` + `test_kg_reasoning` + `test_dream_runner` + `test_broker` = 77 passed); ruff clean.

## Follow-ups (not in this PR)
- Optional direct-to-owner push, behind its own default-OFF flag, after soak.
- Possible polish: suppress an `added` change that is already represented in a surfaced contradiction (currently both can appear — mildly redundant but informative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)