### PR TITLE
fix(#682): KG reflection-extraction was dead — resolve API key from settings + fix Sonnet alias

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1725,6 +1725,7 @@ def create_api(
             role=role,
         ),
         owner_provider=lambda: agents.get_owner_profile(),
+        setting_provider=lambda key: agents.get_setting(key, ""),
     )
     app.state.dream_runner = dream_runner
     app.state.agent_history_resolver = _resolve_agent_history

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -80,6 +80,7 @@ class DreamRunner:
         *,
         history_provider: Callable[[str, float, int, str], list[dict]] | None = None,
         owner_provider: Callable[[], dict] | None = None,
+        setting_provider: Callable[[str], str] | None = None,
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
@@ -87,6 +88,10 @@ class DreamRunner:
         # Optional () -> owner-profile dict, used to derive high-value entity
         # names for KG proactive-surfacing materiality. May be None.
         self._owner_provider = owner_provider
+        # Optional (key) -> system_settings value resolver. The daemon process
+        # env does NOT carry ANTHROPIC_API_KEY (it lives in system_settings), so
+        # KG extraction's LLM caller must resolve the key through this. May be None.
+        self._setting_provider = setting_provider
         self._db.execute("PRAGMA journal_mode=WAL")
         self._init_tables()
 
@@ -961,12 +966,22 @@ class DreamRunner:
         import os
         import urllib.request
 
-        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        # Resolve the API key the same way the rest of the daemon does
+        # (cf. voice_routes.py): per-agent provider_key override → system_settings
+        # → process env. The daemon process env does NOT carry ANTHROPIC_API_KEY
+        # (it lives in system_settings), so an os.environ-only read silently
+        # returned None here and skipped KG extraction on every dream run.
+        api_key = (
+            getattr(agent_config, "provider_key", "")
+            or (self._setting_provider("ANTHROPIC_API_KEY") if self._setting_provider else "")
+            or os.environ.get("ANTHROPIC_API_KEY", "")
+        )
         if not api_key:
             return None
 
-        # Use a fast, cheap model for extraction — sonnet is good enough
-        model = "claude-sonnet-4-6-20260217"
+        # Use a fast, cheap model for extraction — sonnet is good enough.
+        # Use the bare alias (no date suffix); dated Sonnet 4.6 snapshots 404.
+        model = "claude-sonnet-4-6"
 
         def call_llm(prompt: str) -> str:
             body = json.dumps({

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -2,11 +2,26 @@
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
+import urllib.request
 from datetime import datetime
 
 from pinky_daemon.dream_runner import DreamRunner
+
+
+class _FakeAgentConfig:
+    """Minimal stand-in exposing the attrs _build_kg_llm_caller reads."""
+
+    def __init__(self, provider_key: str = "") -> None:
+        self.provider_key = provider_key
+
+
+def _new_runner(**kwargs) -> tuple[DreamRunner, str]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    return DreamRunner(db_path=path, **kwargs), path
 
 
 class TestDreamRunner:
@@ -36,5 +51,96 @@ class TestDreamRunner:
                 expected[1],
             ]
             assert watermark == 300.0
+        finally:
+            os.unlink(path)
+
+
+class TestBuildKGLLMCaller:
+    """Regression tests for the KG-extraction LLM caller key resolution.
+
+    The daemon process env does NOT carry ANTHROPIC_API_KEY (it lives in
+    system_settings), so reading os.environ only returned None and silently
+    skipped KG extraction on every dream run. The caller must resolve the key
+    through provider_key -> setting_provider -> env.
+    """
+
+    def test_returns_none_when_no_key_anywhere(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        runner, path = _new_runner()  # no setting_provider
+        try:
+            assert runner._build_kg_llm_caller(_FakeAgentConfig()) is None
+        finally:
+            os.unlink(path)
+
+    def test_resolves_key_from_setting_provider_when_env_missing(self, monkeypatch):
+        # The real-world failure: env lacks the key but system_settings has it.
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        runner, path = _new_runner(
+            setting_provider=lambda key: "sk-from-settings" if key == "ANTHROPIC_API_KEY" else "",
+        )
+        try:
+            assert runner._build_kg_llm_caller(_FakeAgentConfig()) is not None
+        finally:
+            os.unlink(path)
+
+    def test_calls_api_with_alias_model_and_resolved_key(self, monkeypatch):
+        # End-to-end: proves both the key-resolution fix and the corrected
+        # model alias (a dated Sonnet 4.6 snapshot would 404).
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        captured: dict = {}
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return json.dumps({"content": [{"type": "text", "text": "ok"}]}).encode()
+
+        def _fake_urlopen(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            captured["headers"] = {k.lower(): v for k, v in req.headers.items()}
+            return _FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+        runner, path = _new_runner(
+            setting_provider=lambda key: "sk-from-settings" if key == "ANTHROPIC_API_KEY" else "",
+        )
+        try:
+            caller = runner._build_kg_llm_caller(_FakeAgentConfig())
+            assert caller is not None
+            assert caller("extract triples") == "ok"
+            assert captured["body"]["model"] == "claude-sonnet-4-6"
+            assert captured["headers"]["x-api-key"] == "sk-from-settings"
+        finally:
+            os.unlink(path)
+
+    def test_provider_key_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-env")
+        captured: dict = {}
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return json.dumps({"content": [{"type": "text", "text": "ok"}]}).encode()
+
+        def _fake_urlopen(req, timeout=None):
+            captured["headers"] = {k.lower(): v for k, v in req.headers.items()}
+            return _FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+        runner, path = _new_runner(setting_provider=lambda key: "sk-from-settings")
+        try:
+            caller = runner._build_kg_llm_caller(_FakeAgentConfig(provider_key="sk-from-agent"))
+            assert caller is not None
+            caller("extract triples")
+            assert captured["headers"]["x-api-key"] == "sk-from-agent"
         finally:
             os.unlink(path)


### PR DESCRIPTION
## Summary

The dream runner's **per-reflection KG extraction has silently no-op'd on every dream run** — so the #682 KG reasoning layer (read tools, proactive surfacing) has been reasoning over a graph that dreams never populated from reflections. Only manually-added (`kg_add`) and hygiene-pass triples were ever in there.

Two bugs, fixed together:

### Bug 1 (active — fired 53× in one log rotation)
`_build_kg_llm_caller` read `ANTHROPIC_API_KEY` from `os.environ` only. The **daemon process env doesn't carry it** (verified: the key lives in `system_settings`, same as the OpenAI key per `shared_mcp.py:509-510`). So the key resolved empty → caller returned `None` → the whole extraction pass was skipped with `"dream-runner: could not build LLM caller for KG extraction"`. This is the same class of bug as the semantic-recall NoOp-embedder issue (#679): a key read from env instead of resolved from settings.

**Fix:** resolve the key the way the rest of the daemon does (cf. `voice_routes.py:660-662`): per-agent `provider_key` → `system_settings` → env, via a new optional `setting_provider` injected into `DreamRunner` (wired in `api.py` next to `owner_provider`). Most agents have an empty `provider_key` and rely on the shared `system_settings` key, so the settings tier is the one that matters in practice.

### Bug 2 (latent — would surface the moment Bug 1 was fixed)
The extraction model was hardcoded to `claude-sonnet-4-6-20260217`, an **invalid dated snapshot that 404s** (Sonnet 4.6 has no dated snapshot; the canonical id is the bare alias). Never hit before only because the key check failed first.

**Fix:** use the bare alias `claude-sonnet-4-6`.

## Verification
- Confirmed empirically: daemon PID env lacks the key; `system_settings` has it (len 108); error string present in live + rotated logs (53× in one rotation).
- New regression tests (`TestBuildKGLLMCaller`): returns None with no key anywhere; resolves from `setting_provider` when env is missing (the real-world case); end-to-end call asserts model == `claude-sonnet-4-6` and the resolved key; `provider_key` precedence.
- `pytest tests/test_dream_runner.py` → 5 passed. `ruff` clean.

## Risk
Low. Additive optional kwarg (backward-compatible — `__main__` path and existing tests construct `DreamRunner` without it). No behavior change except: KG extraction now actually runs during dreams. Worth watching token spend on the first real dream run after deploy, since the per-reflection extraction pass will execute for the first time (it processes unprocessed reflections in batches of 50).

🤖 Opened by Barsik