### PR TITLE
fix(#682): KG extraction lost ~78% of triples to truncation + brittle parse

### DIFF
--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -984,9 +984,14 @@ class DreamRunner:
         model = "claude-sonnet-4-6"
 
         def call_llm(prompt: str) -> str:
+            # 2048 was too low: reflections with many triples overflowed it, the
+            # JSON array was truncated mid-output, and the whole reflection's
+            # triples were dropped on parse. 8192 leaves ample room for a single
+            # reflection's triples; parse_llm_response also salvages partial
+            # arrays as defense-in-depth if a response still overflows.
             body = json.dumps({
                 "model": model,
-                "max_tokens": 2048,
+                "max_tokens": 8192,
                 "messages": [{"role": "user", "content": prompt}],
             })
             req = urllib.request.Request(

--- a/src/pinky_memory/kg_extractor.py
+++ b/src/pinky_memory/kg_extractor.py
@@ -215,6 +215,33 @@ def validate_triple(t: ExtractedTriple) -> list[str]:
     return issues
 
 
+def _salvage_truncated_json_array(raw: str) -> list:
+    """Recover complete objects from a truncated JSON array.
+
+    When an LLM response is cut off mid-array (e.g. by hitting max_tokens), a
+    single ``json.loads()`` over the whole string fails and would drop every
+    triple from the reflection. This walks the array object-by-object with a
+    raw JSON decoder, collecting each complete top-level object and stopping at
+    the first incomplete (truncated) one — so only the truncated tail is lost,
+    not the whole batch. Returns [] if nothing parseable is found.
+    """
+    start = raw.find("[")
+    if start == -1:
+        return []
+    decoder = json.JSONDecoder()
+    objs: list = []
+    idx = raw.find("{", start)
+    while idx != -1:
+        try:
+            obj, end = decoder.raw_decode(raw, idx)
+        except json.JSONDecodeError:
+            break  # truncated/incomplete trailing object — stop here
+        if isinstance(obj, dict):
+            objs.append(obj)
+        idx = raw.find("{", end)
+    return objs
+
+
 def parse_llm_response(raw: str) -> list[ExtractedTriple]:
     """Parse LLM JSON response into ExtractedTriple objects."""
     # Strip markdown fences if present
@@ -227,8 +254,18 @@ def parse_llm_response(raw: str) -> list[ExtractedTriple]:
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as e:
-        _log(f"kg-extractor: JSON parse error: {e}")
-        return []
+        # Response may be truncated mid-array (max_tokens). Salvage the complete
+        # objects from the valid prefix rather than dropping every triple.
+        salvaged = _salvage_truncated_json_array(raw)
+        if salvaged:
+            _log(
+                f"kg-extractor: JSON parse error ({e}); salvaged "
+                f"{len(salvaged)} complete triple(s) from truncated response"
+            )
+            data = salvaged
+        else:
+            _log(f"kg-extractor: JSON parse error: {e}")
+            return []
 
     if not isinstance(data, list):
         _log(f"kg-extractor: expected list, got {type(data).__name__}")

--- a/tests/test_kg_extractor.py
+++ b/tests/test_kg_extractor.py
@@ -162,6 +162,34 @@ class TestParseLlmResponse:
         triples = parse_llm_response(response)
         assert triples[0].is_negation is True
 
+    def test_salvages_truncated_array(self):
+        # Array cut off mid-object (e.g. hit max_tokens). The whole json.loads
+        # fails, but the complete leading triples must be recovered rather than
+        # the entire reflection dropped (the 78% loss seen on the first live run).
+        raw = (
+            '[{"subject": "Brad", "predicate": "uses", "object": "Python", "confidence": 0.9}, '
+            '{"subject": "Brad", "predicate": "uses", "object": "SQLite", "confidence": 0.9}, '
+            '{"subject": "Brad", "predicate": "uses", "object": "Rus'
+        )
+        triples = parse_llm_response(raw)
+        assert len(triples) == 2
+        assert triples[0].object == "Python"
+        assert triples[1].object == "SQLite"
+
+    def test_salvages_truncated_array_with_open_fence(self):
+        # Truncated AND fenced — the closing fence never arrived.
+        raw = (
+            '```json\n[{"subject": "Brad", "predicate": "uses", "object": "Vim", "confidence": 0.9}, '
+            '{"subject": "Brad", "predicate": "uses", "object": "Em'
+        )
+        triples = parse_llm_response(raw)
+        assert len(triples) == 1
+        assert triples[0].object == "Vim"
+
+    def test_unsalvageable_truncation_returns_empty(self):
+        # Cut off before any complete object — nothing to recover.
+        assert parse_llm_response('[{"subject": "Brad", "predi') == []
+
     def test_skips_non_dict_items(self):
         response = json.dumps(["not a dict", {"subject": "A", "predicate": "b", "object": "C"}])
         triples = parse_llm_response(response)


### PR DESCRIPTION
## What & why

The **first live** per-reflection KG extraction run — the night after #685 re-enabled the path (release 26.06.118) — lost **39 of 50 reflections** to JSON parse errors. Caught on the 3am 2026-06-08 dream while watching the never-soaked path.

Log evidence (`logs/api.log`, 3am run):
- `dream-runner: 'barsik' extracted 94 KG triples` ✅ (path works)
- but **39× `kg-extractor: JSON parse error`** vs only **11 successful** extractions (11 + 39 = 50 = batch limit)

### Root cause — two compounding bugs

1. **Truncation.** `max_tokens=2048` (`dream_runner.py` `_build_kg_llm_caller`) cut off the triple-JSON array mid-output for reflections producing many triples. Parse errors clustered at char ~5900 ≈ 2048 tokens (`Unterminated string`, `Expecting ',' delimiter`...).
2. **All-or-nothing parse.** `parse_llm_response` did a single `json.loads()` and `return []` on **any** `JSONDecodeError` — so a truncated array dropped **every** triple from that reflection, not just the cut-off tail.

## Fix

- Raise extraction `max_tokens` **2048 → 8192** (ample for one reflection's triples).
- **Salvage** complete objects from a truncated JSON array (`raw_decode` object-by-object, stop at the first incomplete one) as defense-in-depth — only the truncated tail is lost.

## Tests

3 new regression tests (truncated-array salvage, truncated + open markdown fence, unsalvageable). **156 KG + dream tests green, ruff clean.**

Non-urgent (next run is 3am tomorrow). Found-and-fixed overnight; flagged to Brad for sign-off before review + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)