### PR TITLE
fix(#692): inflight watchdog no longer force-restarts sessions running long background Workflows

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -699,6 +699,20 @@ _WATCHDOG_TICK_SEC = 15.0
 # we want evidence of a *response*, not just the pasted text landing.
 _TRANSCRIPT_PASTE_SLACK = 5.0
 
+# #692 — background-task activity window for the stall verdict. A turn parked
+# on a long-running background task (a Dynamic Workflow, or an ``Agent`` /
+# background tool call) emits nothing to the MAIN transcript — its subagents
+# stream to their own transcripts under ``<session>/subagents`` and
+# ``<session>/workflows``. ``_transcript_recently_grew`` only watches the main
+# transcript, so such a turn looks "quiet" and the watchdog would force_restart
+# it (killing the in-flight work) ~``_TURN_DONE_TIMEOUT_SEC`` in. We treat a
+# subagent/workflow transcript written within this window as positive "still
+# making progress" evidence → ``growing``, not ``wedged``. Tighter than the
+# main-transcript window: a workflow making background progress writes a
+# subagent transcript far more often than this, while a workflow that has been
+# silent this long AND whose main REPL is quiet is genuinely stuck.
+_BACKGROUND_TASK_ACTIVE_WINDOW_SEC = 180.0
+
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
 # ``_session_ready_event`` for turns with ``internal=True and
 # reason.startswith("wake_")`` so the wake prompt's paste doesn't land while
@@ -3721,13 +3735,66 @@ class TmuxSession:
             return False
         return (now - mtime) < window
 
+    def _background_tasks_recently_active(self, now: float, window: float) -> bool:
+        """True if a background task wrote a transcript within ``window`` seconds.
+
+        A blocking turn can be legitimately busy with NO main-transcript output:
+        the REPL is parked on a long-running background task (a Dynamic
+        Workflow, or an ``Agent`` / background tool call) whose subagents stream
+        to their OWN transcript files, not the main one.
+        ``_transcript_recently_grew`` only watches the main transcript, so such
+        a turn looks "quiet" and the watchdog would force_restart it — killing
+        the in-flight background work — ~``_TURN_DONE_TIMEOUT_SEC`` in (#692).
+        This extends the "still producing output" evidence to background-task
+        transcripts.
+
+        Layout: Claude Code writes the main transcript at ``<session>.jsonl``
+        and puts subagent/workflow transcripts under the sibling ``<session>/``
+        directory (``subagents/`` and ``workflows/``). We derive that directory
+        from the tailer's transcript path and look for any entry modified within
+        the window, short-circuiting on the first hit. Absence of evidence →
+        False (same convention as ``_transcript_recently_grew``: fall through to
+        the idle/wedged checks rather than masking a real stall).
+        """
+        tailer = self._tailer
+        path = getattr(tailer, "transcript_path", None) if tailer else None
+        if not path:
+            return False
+        try:
+            path = Path(path)
+        except (TypeError, ValueError):
+            return False
+        name = path.name
+        if not name.endswith(".jsonl"):
+            return False
+        # ``<session>.jsonl`` → sibling ``<session>/`` dir holding background work.
+        session_dir = path.with_name(name[: -len(".jsonl")])
+        cutoff = now - window
+        for sub in ("subagents", "workflows"):
+            root = session_dir / sub
+            try:
+                if not root.is_dir():
+                    continue
+                for entry in root.rglob("*"):
+                    try:
+                        if entry.stat().st_mtime >= cutoff:
+                            return True
+                    except OSError:
+                        continue
+            except OSError:
+                continue
+        return False
+
     def _inflight_stall_verdict(self, now: float) -> str:
         """Classify a possibly-stalled inflight head for the watchdog (#118).
 
         Returns one of:
           - ``"ok"``      — head not (yet) aged past ``_TURN_DONE_TIMEOUT_SEC``.
-          - ``"growing"`` — aged out BUT the transcript is still being written
-                            → a long/streaming turn, not wedged.
+          - ``"growing"`` — aged out BUT the main transcript is still being
+                            written, OR a background task (a Workflow / Agent
+                            tool call) is still writing its own subagent
+                            transcript → a long/streaming or background-busy
+                            turn, not wedged (#692).
           - ``"idle"``    — aged out, transcript quiet, and Claude Code last
                             reported *idle* (Stop hook) at-or-after this head
                             started → the REPL finished and is waiting for
@@ -3752,6 +3819,15 @@ class TmuxSession:
             return "ok"
         # (a) Still producing output? Long/streaming turn — not wedged.
         if self._transcript_recently_grew(now, _TURN_DONE_TIMEOUT_SEC):
+            return "growing"
+        # (a2) Parked on a long-running BACKGROUND task (Workflow / Agent tool)?
+        # Its subagents stream to their own transcripts, leaving the MAIN one
+        # quiet, but the REPL is legitimately busy — not wedged (#692). Checked
+        # BEFORE the idle reconcile so an actively-working background turn is
+        # never drained as a phantom.
+        if self._background_tasks_recently_active(
+            now, _BACKGROUND_TASK_ACTIVE_WINDOW_SEC
+        ):
             return "growing"
         # (b) REPL reported idle? Consult Claude Code's working/idle hook
         # signal (Stop hook → "idle"; PreToolUse/etc → "working"). An idle
@@ -3937,8 +4013,8 @@ class TmuxSession:
                     self._head_started_at = now
                     _log(
                         f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
-                        f"but transcript still growing — not wedged, extending "
-                        f"window (deque depth={depth})"
+                        f"but transcript or background task still active — not "
+                        f"wedged, extending window (deque depth={depth})"
                     )
                     continue
                 if verdict == "idle":

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3477,6 +3477,74 @@ def test_inflight_verdict_wedged_when_no_live_status_fn() -> None:
     assert ss._inflight_stall_verdict(_time.time()) == "wedged"
 
 
+def test_inflight_verdict_growing_when_background_task_active(tmp_path) -> None:
+    """#692: a turn parked on a background Workflow/Agent — main transcript
+    quiet, REPL 'working' — must be ``growing`` (not wedged) while its subagent
+    transcripts are still being written under the sibling session dir."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    _age_out_head(ss)
+    ss._transcript_recently_grew = lambda now, window: False
+    # REPL genuinely busy on the background tool call (would be "wedged" today).
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": _time.time(),
+    }
+    # Main transcript at <session>.jsonl; background work under <session>/.
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}\n")
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = main
+    sub = tmp_path / "session" / "subagents" / "workflows" / "wf_x"
+    sub.mkdir(parents=True)
+    (sub / "agent-1.jsonl").write_text("{}\n")  # fresh mtime = now
+    assert ss._inflight_stall_verdict(_time.time()) == "growing"
+
+
+def test_inflight_verdict_wedged_when_background_task_stale(tmp_path) -> None:
+    """#692 negative: background transcripts exist but were last written long
+    ago (the workflow itself hung) while the main REPL is also quiet → still
+    ``wedged``, preserving genuine stuck-REPL recovery."""
+    import os
+
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    _age_out_head(ss)
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": _time.time(),
+    }
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}\n")
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = main
+    sub = tmp_path / "session" / "subagents" / "wf_x"
+    sub.mkdir(parents=True)
+    f = sub / "agent-1.jsonl"
+    f.write_text("{}\n")
+    stale = _time.time() - (tmux_session._BACKGROUND_TASK_ACTIVE_WINDOW_SEC + 60.0)
+    # Age both the file AND its parent dir past the window (writing the file
+    # had bumped the dir mtime to "now").
+    os.utime(f, (stale, stale))
+    os.utime(sub, (stale, stale))
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
+def test_background_tasks_recently_active_false_without_session_dir(tmp_path) -> None:
+    """Helper returns False when there's no sibling background dir — preserves
+    the wedged/idle fall-through for ordinary (non-background) turns."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}\n")
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = main
+    assert (
+        ss._background_tasks_recently_active(
+            _time.time(), tmux_session._BACKGROUND_TASK_ACTIVE_WINDOW_SEC
+        )
+        is False
+    )
+
+
 def test_inflight_verdict_wedged_when_idle_predates_head() -> None:
     """Hang-on-paste: a turn was pasted (head started) but the REPL's idle
     status is STALE (predates the head) — the REPL never came alive for this


### PR DESCRIPTION
Fixes #692.

## Problem
The tmux session inflight-watchdog (`_inflight_stall_verdict`) force-restarts a session when the in-flight head ages past `_TURN_DONE_TIMEOUT_SEC` (600s) with a quiet **main** transcript. A turn parked on a long-running **background task** — a Dynamic Workflow, or an `Agent`/background tool call — emits nothing to the main transcript (its subagents stream to their own transcript files under `<session>/subagents` and `<session>/workflows`), so the watchdog misclassifies a legitimately-busy session as `wedged` and tears it down, killing the in-flight work and requeuing the turn.

Observed in prod **twice on 2026-06-08**, ~10 min apart, during a 13-target market-research Workflow:
```
inflight head aged 605.1s > 600.0s, transcript quiet + REPL not idle — REPL stuck; scheduling force_restart
```
(`live_status='working'` = REPL genuinely busy. The ASGI `RuntimeError` in the same window is a teardown symptom, not the cause.)

## Fix
Add background-task activity as positive "not wedged" evidence. New helper `_background_tasks_recently_active(now, window)` derives the sibling session dir from the tailer's `<session>.jsonl` path and checks whether any entry under `subagents/` or `workflows/` was written within `_BACKGROUND_TASK_ACTIVE_WINDOW_SEC` (180s, short-circuit on first hit). `_inflight_stall_verdict` consults it right after the main-transcript check and **before** the idle reconcile — so an actively-working background turn returns `growing` (extend the window) and is never drained as a phantom.

A workflow that has made **zero** background progress for the window while the main REPL is also quiet is still correctly declared `wedged`, preserving genuine stuck-REPL recovery. Same fail-safe idiom as `_transcript_recently_grew` (absence of evidence → fall through).

## Testing
- `test_inflight_verdict_growing_when_background_task_active` — fresh subagent transcript → `growing`
- `test_inflight_verdict_wedged_when_background_task_stale` — stale background transcripts + quiet main → still `wedged`
- `test_background_tasks_recently_active_false_without_session_dir` — no sibling dir → helper `False` (ordinary turns unaffected)
- Full `tests/test_tmux_session.py` green (255 passed); ruff clean.

## Risk
Low. Pure additive carve-out in the wedged-verdict path; only reachable after a head has already aged past 600s with a quiet main transcript (rare). No behavior change for sessions without active background tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)