### PR TITLE
fix(#172): make KG per-reflection extraction resilient to transient timeouts

### DIFF
--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -964,6 +964,9 @@ class DreamRunner:
         a full SDK session for each reflection's extraction prompt.
         """
         import os
+        import socket
+        import time
+        import urllib.error
         import urllib.request
 
         # Resolve the API key the same way the rest of the daemon does
@@ -982,6 +985,14 @@ class DreamRunner:
         # Use a fast, cheap model for extraction — sonnet is good enough.
         # Use the bare alias (no date suffix); dated Sonnet 4.6 snapshots 404.
         model = "claude-sonnet-4-6"
+
+        # 30s was too short once #686 raised max_tokens 2048->8192: the heaviest
+        # reflections now generate longer responses that blew past it, losing
+        # ~34% of a rotation to "read operation timed out" (#172). 90s
+        # comfortably covers a heavy single reflection's output; transient
+        # failures are retried below with a short backoff.
+        read_timeout = 90
+        max_attempts = 3  # 1 initial try + 2 retries
 
         def call_llm(prompt: str) -> str:
             # 2048 was too low: reflections with many triples overflowed it, the
@@ -1003,17 +1014,38 @@ class DreamRunner:
                     "anthropic-version": "2023-06-01",
                 },
             )
-            try:
-                with urllib.request.urlopen(req, timeout=30) as resp:
-                    data = json.loads(resp.read().decode())
-                    # Extract text from content blocks
-                    for block in data.get("content", []):
-                        if block.get("type") == "text":
-                            return block["text"]
-                    return ""
-            except Exception as e:
-                _log(f"dream-runner: KG LLM call failed: {e}")
-                raise
+            for attempt in range(max_attempts):
+                try:
+                    with urllib.request.urlopen(req, timeout=read_timeout) as resp:
+                        data = json.loads(resp.read().decode())
+                        # Extract text from content blocks
+                        for block in data.get("content", []):
+                            if block.get("type") == "text":
+                                return block["text"]
+                        return ""
+                except urllib.error.HTTPError as e:
+                    # Retry transient server-side / rate-limit statuses; fail
+                    # fast on 4xx client errors (bad key, malformed request).
+                    if e.code in (429, 500, 502, 503, 529) and attempt < max_attempts - 1:
+                        time.sleep(2 ** attempt)
+                        continue
+                    _log(f"dream-runner: KG LLM call failed (HTTP {e.code}): {e}")
+                    raise
+                except (TimeoutError, socket.timeout, urllib.error.URLError) as e:
+                    # Network-level transient: read timeout, connection reset.
+                    # Exactly the failures #172 saw — retry with backoff.
+                    if attempt < max_attempts - 1:
+                        time.sleep(2 ** attempt)
+                        continue
+                    _log(
+                        f"dream-runner: KG LLM call failed after "
+                        f"{max_attempts} attempts: {e}"
+                    )
+                    raise
+                except Exception as e:
+                    _log(f"dream-runner: KG LLM call failed: {e}")
+                    raise
+            return ""  # unreachable: the loop always returns or raises
 
         return call_llm
 

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -2391,7 +2391,11 @@ class ReflectionStore:
                     "kg_triples column %s add skipped: %s", col_name, e
                 )
 
-        # Extraction log: tracks which reflections have been KG-processed
+        # Extraction log: tracks which reflections have been KG-processed.
+        # `attempts` counts consecutive failed (errored, zero-triple) passes at
+        # the current extractor_version so the self-heal retry in
+        # kg_get_unprocessed_reflections can give up on a reflection that fails
+        # every run instead of retrying it forever (#172).
         self._conn.executescript("""
             CREATE TABLE IF NOT EXISTS kg_extraction_log (
                 reflection_id TEXT PRIMARY KEY,
@@ -2399,10 +2403,21 @@ class ReflectionStore:
                 triples_extracted INTEGER DEFAULT 0,
                 triples_superseded INTEGER DEFAULT 0,
                 errors TEXT DEFAULT '',
+                attempts INTEGER NOT NULL DEFAULT 0,
                 processed_at REAL NOT NULL
             );
         """)
         self._conn.commit()
+        # Idempotent migration for DBs created before `attempts` existed.
+        try:
+            self._conn.execute(
+                "ALTER TABLE kg_extraction_log ADD COLUMN attempts "
+                "INTEGER NOT NULL DEFAULT 0"
+            )
+            self._conn.commit()
+        except sqlite3.OperationalError as e:
+            # Column already exists (idempotent migration).
+            logger.debug("kg_extraction_log column attempts add skipped: %s", e)
 
     def _ensure_entity(self, name: str, entity_type: str = "unknown") -> str:
         """Get or create an entity by name. Returns the entity ID."""
@@ -2878,36 +2893,53 @@ class ReflectionStore:
         self,
         extractor_version: str = "",
         limit: int = 50,
+        retry_failed_max_attempts: int = 3,
     ) -> list[dict]:
-        """Get reflections that haven't been KG-processed yet.
+        """Get reflections that need KG extraction.
 
-        If extractor_version is provided, also returns reflections processed
-        by an older version (for reprocessing on prompt/validator changes).
+        A reflection is returned when:
+        - it has never been KG-processed, OR
+        - it was processed by an older extractor_version (reprocess on
+          prompt/validator changes — only when extractor_version is given), OR
+        - its last pass *failed* (recorded an error and produced no triples)
+          and it has been retried fewer than `retry_failed_max_attempts`
+          times. This self-heals transient failures (e.g. an LLM read
+          timeout, #172) on a later run, while the attempts bound stops a
+          reflection that fails every run from churning forever. Pass
+          `retry_failed_max_attempts=0` to disable the failed-pass retry.
         """
+        # A failed pass is retriable while attempts is still under budget.
+        # COALESCE guards rows written before the `attempts` column existed.
+        retry_failed = (
+            "(l.triples_extracted = 0 AND l.errors != '' "
+            "AND COALESCE(l.attempts, 0) < ?)"
+        )
         if extractor_version:
-            # Unprocessed OR processed by older version
+            # Unprocessed OR processed by older version OR a retriable failure.
             rows = self._conn.execute(
-                """SELECT r.id, r.content, r.context, r.project, r.type,
+                f"""SELECT r.id, r.content, r.context, r.project, r.type,
                           r.salience, r.created_at
                    FROM reflections r
                    LEFT JOIN kg_extraction_log l ON r.id = l.reflection_id
                    WHERE r.active = 1
                      AND (l.reflection_id IS NULL
-                          OR l.extractor_version != ?)
+                          OR l.extractor_version != ?
+                          OR {retry_failed})
                    ORDER BY r.created_at DESC
                    LIMIT ?""",
-                (extractor_version, limit),
+                (extractor_version, retry_failed_max_attempts, limit),
             ).fetchall()
         else:
             rows = self._conn.execute(
-                """SELECT r.id, r.content, r.context, r.project, r.type,
+                f"""SELECT r.id, r.content, r.context, r.project, r.type,
                           r.salience, r.created_at
                    FROM reflections r
                    LEFT JOIN kg_extraction_log l ON r.id = l.reflection_id
-                   WHERE r.active = 1 AND l.reflection_id IS NULL
+                   WHERE r.active = 1
+                     AND (l.reflection_id IS NULL OR {retry_failed})
                    ORDER BY r.created_at DESC
                    LIMIT ?""",
-                (limit,),
+                (retry_failed_max_attempts, limit),
             ).fetchall()
 
         return [
@@ -2928,22 +2960,40 @@ class ReflectionStore:
         triples_superseded: int = 0,
         errors: str = "",
     ) -> None:
-        """Record that a reflection has been KG-processed."""
+        """Record that a reflection has been KG-processed.
+
+        A pass that produced no triples but recorded an error (e.g. an LLM
+        read timeout) is a *failed* pass: it increments `attempts` so the
+        self-heal retry in kg_get_unprocessed_reflections can bound how many
+        times a perpetually-failing reflection is retried. Any pass that adds
+        triples — or completes without error — resets `attempts` to 0, and a
+        change of extractor_version restarts the budget (the new extractor
+        deserves a fresh set of attempts).
+        """
         import time
+        failed = triples_extracted == 0 and bool(errors)
         with self._lock:
             self._conn.execute(
                 """INSERT INTO kg_extraction_log
                    (reflection_id, extractor_version, triples_extracted,
-                    triples_superseded, errors, processed_at)
-                   VALUES (?, ?, ?, ?, ?, ?)
+                    triples_superseded, errors, attempts, processed_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(reflection_id) DO UPDATE SET
                     extractor_version=excluded.extractor_version,
                     triples_extracted=excluded.triples_extracted,
                     triples_superseded=excluded.triples_superseded,
                     errors=excluded.errors,
+                    attempts=CASE
+                        WHEN excluded.triples_extracted != 0 OR excluded.errors = ''
+                            THEN 0
+                        WHEN excluded.extractor_version
+                             != kg_extraction_log.extractor_version
+                            THEN 1
+                        ELSE kg_extraction_log.attempts + 1
+                    END,
                     processed_at=excluded.processed_at""",
                 (reflection_id, extractor_version, triples_extracted,
-                 triples_superseded, errors, time.time()),
+                 triples_superseded, errors, 1 if failed else 0, time.time()),
             )
             self._conn.commit()
 

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import time
+import urllib.error
 import urllib.request
 from datetime import datetime
+
+import pytest
 
 from pinky_daemon.dream_runner import DreamRunner
 
@@ -142,5 +146,116 @@ class TestBuildKGLLMCaller:
             assert caller is not None
             caller("extract triples")
             assert captured["headers"]["x-api-key"] == "sk-from-agent"
+        finally:
+            os.unlink(path)
+
+
+class _FakeResp:
+    def __init__(self, text="ok"):
+        self._text = text
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return json.dumps({"content": [{"type": "text", "text": self._text}]}).encode()
+
+
+class TestKGCallerRetry:
+    """The KG caller retries transient failures (read timeouts, 5xx/429) with
+    backoff and fails fast on client errors. Regression for #172: once #686
+    raised max_tokens to 8192, the heaviest reflections blew past the old fixed
+    30s read timeout and were lost with no retry (~34% of a rotation)."""
+
+    def _caller(self, monkeypatch):
+        # No real backoff sleeps — call_llm's `time` is the global module.
+        monkeypatch.setattr(time, "sleep", lambda *_a: None)
+        runner, path = _new_runner(
+            setting_provider=lambda key: "sk" if key == "ANTHROPIC_API_KEY" else "",
+        )
+        return runner._build_kg_llm_caller(_FakeAgentConfig()), path
+
+    def test_retries_timeout_then_succeeds(self, monkeypatch):
+        calls = {"n": 0}
+
+        def _urlopen(req, timeout=None):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise TimeoutError("The read operation timed out")
+            return _FakeResp("recovered")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+        caller, path = self._caller(monkeypatch)
+        try:
+            assert caller("prompt") == "recovered"
+            assert calls["n"] == 3  # 2 timeouts + 1 success
+        finally:
+            os.unlink(path)
+
+    def test_raises_after_exhausting_retries(self, monkeypatch):
+        calls = {"n": 0}
+
+        def _urlopen(req, timeout=None):
+            calls["n"] += 1
+            raise TimeoutError("The read operation timed out")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+        caller, path = self._caller(monkeypatch)
+        try:
+            with pytest.raises(TimeoutError):
+                caller("prompt")
+            assert calls["n"] == 3  # bounded: 1 initial + 2 retries
+        finally:
+            os.unlink(path)
+
+    def test_uses_widened_read_timeout(self, monkeypatch):
+        # Regression: the old fixed 30s timeout is what #172 blew past.
+        seen = {}
+
+        def _urlopen(req, timeout=None):
+            seen["timeout"] = timeout
+            return _FakeResp("ok")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+        caller, path = self._caller(monkeypatch)
+        try:
+            caller("prompt")
+            assert seen["timeout"] >= 90
+        finally:
+            os.unlink(path)
+
+    def test_no_retry_on_client_error(self, monkeypatch):
+        calls = {"n": 0}
+
+        def _urlopen(req, timeout=None):
+            calls["n"] += 1
+            raise urllib.error.HTTPError("http://x", 400, "Bad Request", {}, None)
+
+        monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+        caller, path = self._caller(monkeypatch)
+        try:
+            with pytest.raises(urllib.error.HTTPError):
+                caller("prompt")
+            assert calls["n"] == 1  # fail fast on 4xx — no retry
+        finally:
+            os.unlink(path)
+
+    def test_retries_on_overloaded_529(self, monkeypatch):
+        calls = {"n": 0}
+
+        def _urlopen(req, timeout=None):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise urllib.error.HTTPError("http://x", 529, "Overloaded", {}, None)
+            return _FakeResp("ok")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+        caller, path = self._caller(monkeypatch)
+        try:
+            assert caller("prompt") == "ok"
+            assert calls["n"] == 2  # 529 is transient — retried
         finally:
             os.unlink(path)

--- a/tests/test_kg_phase2_store.py
+++ b/tests/test_kg_phase2_store.py
@@ -186,3 +186,96 @@ class TestKGExtractionStats:
         assert stats["unprocessed"] == 1
         assert stats["total_triples_extracted"] == 3
         assert stats["extraction_errors"] == 1
+
+
+class TestKGSelfHealRetry:
+    """Self-heal: a failed extraction pass (error + 0 triples) is re-offered on
+    a later run so transient failures (e.g. an LLM read timeout, #172) recover,
+    bounded by `attempts` so a perpetually-failing reflection gives up instead
+    of churning forever."""
+
+    def _insert_reflection(self, store, ref_id, content="Brad uses Python daily"):
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        store._conn.execute(
+            """INSERT INTO reflections
+               (id, type, content, context, project, salience, active,
+                embedding, created_at, accessed_at, access_count, weight)
+               VALUES (?, 'fact', ?, '', '', 3, 1, '[]', ?, ?, 0, 1.0)""",
+            (ref_id, content, now, now),
+        )
+        store._conn.commit()
+
+    def _attempts(self, store, ref_id):
+        row = store._conn.execute(
+            "SELECT attempts FROM kg_extraction_log WHERE reflection_id = ?",
+            (ref_id,),
+        ).fetchone()
+        return row["attempts"]
+
+    def test_failed_pass_is_reoffered(self, store):
+        self._insert_reflection(store, "r1")
+        store.kg_log_extraction("r1", "1.0", triples_extracted=0, errors="timeout")
+        # Same version -> not the version-mismatch path; self-heal must re-offer.
+        unprocessed = store.kg_get_unprocessed_reflections(extractor_version="1.0")
+        assert [r["id"] for r in unprocessed] == ["r1"]
+
+    def test_no_version_branch_also_self_heals(self, store):
+        self._insert_reflection(store, "r1")
+        store.kg_log_extraction("r1", "1.0", triples_extracted=0, errors="timeout")
+        # No extractor_version passed -> exercises the second SQL branch.
+        assert [r["id"] for r in store.kg_get_unprocessed_reflections()] == ["r1"]
+
+    def test_successful_pass_not_reoffered(self, store):
+        self._insert_reflection(store, "r1")
+        store.kg_log_extraction("r1", "1.0", triples_extracted=5)
+        assert store.kg_get_unprocessed_reflections(extractor_version="1.0") == []
+
+    def test_error_with_triples_not_reoffered(self, store):
+        # A pass that still added triples is a partial success, not a failure —
+        # re-running would only re-dedupe, so it must not be re-offered.
+        self._insert_reflection(store, "r1")
+        store.kg_log_extraction(
+            "r1", "1.0", triples_extracted=3, errors="1 triple failed validation"
+        )
+        assert self._attempts(store, "r1") == 0
+        assert store.kg_get_unprocessed_reflections(extractor_version="1.0") == []
+
+    def test_attempts_increment_then_bound(self, store):
+        self._insert_reflection(store, "r1")
+        for expected in (1, 2, 3):
+            store.kg_log_extraction("r1", "1.0", triples_extracted=0, errors="timeout")
+            assert self._attempts(store, "r1") == expected
+        # attempts == 3, default budget is 3 -> 3 < 3 false -> no longer offered.
+        assert store.kg_get_unprocessed_reflections(extractor_version="1.0") == []
+        # ...but a higher budget would still pick it up.
+        again = store.kg_get_unprocessed_reflections(
+            extractor_version="1.0", retry_failed_max_attempts=5
+        )
+        assert [r["id"] for r in again] == ["r1"]
+
+    def test_attempts_reset_on_success(self, store):
+        self._insert_reflection(store, "r1")
+        store.kg_log_extraction("r1", "1.0", triples_extracted=0, errors="timeout")
+        store.kg_log_extraction("r1", "1.0", triples_extracted=0, errors="timeout")
+        assert self._attempts(store, "r1") == 2
+        store.kg_log_extraction("r1", "1.0", triples_extracted=4)  # recovers
+        assert self._attempts(store, "r1") == 0
+        assert store.kg_get_unprocessed_reflections(extractor_version="1.0") == []
+
+    def test_version_change_resets_attempts(self, store):
+        self._insert_reflection(store, "r1")
+        for _ in range(3):
+            store.kg_log_extraction("r1", "1.0", triples_extracted=0, errors="timeout")
+        assert self._attempts(store, "r1") == 3
+        # New extractor version, still failing -> budget restarts at 1.
+        store.kg_log_extraction("r1", "2.0", triples_extracted=0, errors="timeout")
+        assert self._attempts(store, "r1") == 1
+
+    def test_retry_disabled_with_zero_budget(self, store):
+        self._insert_reflection(store, "r1")
+        store.kg_log_extraction("r1", "1.0", triples_extracted=0, errors="timeout")
+        # attempts=1, budget 0 -> 1 < 0 false -> not re-offered.
+        assert store.kg_get_unprocessed_reflections(
+            extractor_version="1.0", retry_failed_max_attempts=0
+        ) == []


### PR DESCRIPTION
## Problem

Tonight's **first live per-reflection KG-extraction run** (#682) worked — but #172's reconciliation (Pushok) and an independent dig surfaced a new failure mode that #686 indirectly created.

#686 raised the KG-extraction `max_tokens` 2048→8192 to stop truncation loss (**correct** — parse errors 39→0, yield ~90→449 triples, salvage canary dormant). But the longer responses then blew past the **fixed 30s read timeout**:

```
dream-runner: extracting KG triples from 50 reflections for 'barsik'
dream-runner: KG LLM call failed: The read operation timed out   ← ×17
...
dream-runner: 'barsik' extracted 449 KG triples
```

**Reconciliation: 50 = 33 winners + 0 salvaged + 0 parse-errors + 17 timeouts (34% lost).** The KG call (`dream_runner.py:1007`) was `urllib.urlopen(req, timeout=30)` with **no retry**.

Worse — counting one layer deeper: a timed-out reflection is logged via `kg_log_extraction` at the *current* `extractor_version`, and `kg_get_unprocessed_reflections` only re-offered rows that were **unlogged or version-mismatched** — it never checked `errors`. So a failed reflection was marked **done-forever** and never retried. Not lost-for-tonight — **stranded permanently**.

## Fix

A resilience layer on top of #686 (which stays as-is — not reverted).

**PREVENT** — `dream_runner._build_kg_llm_caller`:
- read timeout **30s → 90s** (comfortably covers a heavy single reflection's output)
- **bounded transient-only retry** (1 initial + 2 with backoff): read timeouts / conn resets / 429 / 5xx / 529 retried; **4xx client errors fail fast**.

**SELF-HEAL** — `store.kg_get_unprocessed_reflections` + `kg_log_extraction`:
- a **failed pass** (error + 0 triples) is re-offered on a later run → a straggler that exhausts in-run retries recovers next night, and **tonight's 17 heal automatically**.
- bounded by a new **`attempts`** counter (additive `kg_extraction_log` column + idempotent migration): UPSERT increments on consecutive failures, resets to 0 on any success, restarts the budget on `extractor_version` change. `retry_failed_max_attempts` (default 3) caps retries so a perpetually-too-heavy reflection **deterministic-skips after 3 nights** instead of churning ~3 LLM calls/night forever (`=0` disables).

Closes the **stranded-forever / churn-forever** pair — both sides of the same `errors`-column blind spot. Lifetime ceiling on a pathological reflection: ~9 LLM calls (3 nights × 3 in-run), then clean give-up.

## Tests

13 new tests (`TestKGSelfHealRetry` ×8, `TestKGCallerRetry` ×5) — retry-then-succeed, exhaustion bound, 4xx fail-fast, 529 retry, 90s timeout, attempts increment/bound/reset, version-change reset, zero-budget disable, both SQL branches.

```
tests/test_kg_phase2_store.py tests/test_dream_runner.py .............................. 30 passed
broader KG/memory/dream suite ............................................. 333 passed
ruff: All checks passed!
```

## Blast radius

Only `dream_runner` calls these in production, via the **version form** — so the change is contained to the nightly dream pipeline (fleet-wide). The no-version self-heal branch is test-only.

## Credit

Diagnosis + the symmetric churn-forever edge caught with **Pushok** (#172 reconciliation, both-ways flagging).

🤖 Opened by Barsik