### PR TITLE
feat(models): add Claude Fable 5 as a selectable model option

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -3698,6 +3698,7 @@ except Exception:
     _MODEL_SEEDS = [
         # Anthropic
         ("anthropic", "claude-opus-4-8", "Claude Opus 4.8", "Newest Opus (2026-05-28). Sharper judgement, more honest progress reporting, longer independent runs. Effort defaults to high; adaptive thinking triggers only when needed.", "opus", 1_000_000, 1, 15.0, 75.0, 1.5, 1, 3),
+        ("anthropic", "claude-fable-5", "Claude Fable 5", "Mythos-class (2026-06-09). Most capable model for the hardest, longest-running work; 1M context. ~2x Opus cost ($10/$50 per Mtok); auto-falls back to Opus 4.8 on cyber/bio/chem queries (<5% of sessions).", "opus", 1_000_000, 1, 10.0, 50.0, 1.0, 1, 4),
         ("anthropic", "claude-opus-4-7", "Claude Opus 4.7", "Stricter instruction-following, xhigh effort, larger vision.", "opus", 1_000_000, 1, 15.0, 75.0, 1.5, 1, 5),
         ("anthropic", "claude-opus-4-6", "Claude Opus 4.6", "Maximum intelligence. Deep reasoning.", "opus", 1_000_000, 1, 15.0, 75.0, 1.5, 1, 10),
         ("anthropic", "claude-sonnet-4-6", "Claude Sonnet 4.6", "Fast + smart. Daily driver.", "sonnet", 1_000_000, 1, 3.0, 15.0, 0.3, 1, 20),
@@ -3712,15 +3713,20 @@ except Exception:
     ]
 
     def _seed_models(self) -> None:
-        """Seed default models if table is empty."""
-        count = self._db.execute("SELECT COUNT(*) FROM models").fetchone()[0]
-        if count > 0:
-            return
+        """Ensure the default model catalog exists.
+
+        Idempotent + additive: ``INSERT OR IGNORE`` keyed on ``id`` so a new
+        release added to ``_MODEL_SEEDS`` propagates to an already-seeded DB on
+        the next startup, without clobbering operator edits to existing rows.
+        (Previously this returned early whenever the table was non-empty, which
+        stranded every newly-added model on already-deployed instances.)
+        """
         now = time.time()
+        inserted = 0
         for (provider, model_id, display, desc, tier, ctx, is_1m,
              inp, out, cached, thinking, sort) in self._MODEL_SEEDS:
             mid = f"{provider}/{model_id}"
-            self._db.execute(
+            cur = self._db.execute(
                 """INSERT OR IGNORE INTO models
                    (id, provider, model_id, display_name, description, tier,
                     context_window, is_1m, input_price, output_price,
@@ -3730,8 +3736,10 @@ except Exception:
                 (mid, provider, model_id, display, desc, tier, ctx, is_1m,
                  inp, out, cached, thinking, sort, now, now),
             )
+            inserted += cur.rowcount
         self._db.commit()
-        _log(f"agent_registry: seeded {len(self._MODEL_SEEDS)} default models")
+        if inserted:
+            _log(f"agent_registry: seeded {inserted} new default model(s)")
 
     def list_models(self, *, provider: str = "", active_only: bool = True) -> list[dict]:
         """List available models, optionally filtered by provider."""

--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -236,9 +236,16 @@ class AnalyticsStore:
             )
 
     def _seed_default_pricing(self, conn) -> None:
-        row = conn.execute("SELECT COUNT(*) AS count FROM analytics_model_pricing").fetchone()
-        if row and row["count"]:
-            return
+        """Seed default per-model pricing — additive + idempotent.
+
+        Each default row is inserted only when that ``(provider, model)`` has
+        no pricing row yet, so a model newly added to ``seed_rows`` propagates
+        to an already-populated analytics DB on the next startup. The previous
+        early-return-when-non-empty stranded every newly-added model on
+        deployed instances — it read $0 on the cost dashboard — because the
+        table was never empty there. Existing rows are never overwritten, so an
+        operator- or ingestion-supplied rate always wins over the seed default.
+        """
         seed_rows = [
             # OpenAI / Codex-family defaults seeded with current official rates.
             ("openai", "gpt-5", "2020-01-01T00:00:00Z", None, 1.25, 10.00, 0.125, "seed"),
@@ -254,6 +261,7 @@ class AnalyticsStore:
             ("openai", "gpt-5.2-chat-latest", "2020-01-01T00:00:00Z", None, 1.75, 14.00, 0.175, "seed"),
             ("openai", "gpt-5.2-codex", "2020-01-01T00:00:00Z", None, 1.75, 14.00, 0.175, "seed"),
             # Anthropic defaults seeded for future provider expansion.
+            ("anthropic", "claude-fable-5", "2020-01-01T00:00:00Z", None, 10.00, 50.00, 1.00, "seed"),
             ("anthropic", "claude-opus-4-8", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),
             ("anthropic", "claude-opus-4-7", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),
             ("anthropic", "claude-opus-4-6", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),
@@ -267,15 +275,22 @@ class AnalyticsStore:
             ("anthropic", "claude-haiku-3.5", "2020-01-01T00:00:00Z", None, 0.80, 4.00, 0.08, "seed"),
             ("anthropic", "claude-haiku-3", "2020-01-01T00:00:00Z", None, 0.25, 1.25, 0.03, "seed"),
         ]
-        conn.executemany(
-            """
-            INSERT INTO analytics_model_pricing (
-              provider, model, effective_from, effective_to,
-              input_usd_per_mtok, output_usd_per_mtok, cached_input_usd_per_mtok, notes
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            seed_rows,
-        )
+        for seed in seed_rows:
+            # No UNIQUE constraint on (provider, model) exists, so INSERT OR
+            # IGNORE cannot dedupe — gate each default insert on absence.
+            conn.execute(
+                """
+                INSERT INTO analytics_model_pricing (
+                  provider, model, effective_from, effective_to,
+                  input_usd_per_mtok, output_usd_per_mtok, cached_input_usd_per_mtok, notes
+                )
+                SELECT ?, ?, ?, ?, ?, ?, ?, ?
+                WHERE NOT EXISTS (
+                  SELECT 1 FROM analytics_model_pricing WHERE provider = ? AND model = ?
+                )
+                """,
+                (*seed, seed[0], seed[1]),
+            )
 
     def ensure_session_fact(
         self,

--- a/src/pinky_daemon/pricing.py
+++ b/src/pinky_daemon/pricing.py
@@ -53,6 +53,16 @@ _OPUS_STD = {
     "cache_write_5m": 6.25,
     "cache_write_1h": 10.00,
 }
+# Fable 5 (Mythos-class, 2026-06-09): the new premium tier. Exactly 2× the
+# standard-Opus per-token price ($10/$50 vs $5/$25), which matches the "~2×
+# faster through your limits" note Claude Code shows for it.
+_FABLE_5 = {
+    "input": 10.00,
+    "output": 50.00,
+    "cache_read": 1.00,
+    "cache_write_5m": 12.50,
+    "cache_write_1h": 20.00,
+}
 # Pre-4.5 Opus (4, 4.1): the old 3×-more-expensive tier. Kept for
 # historical-transcript pricing accuracy.
 _OPUS_LEGACY = {
@@ -92,6 +102,7 @@ RATE_TABLE: dict[str, dict[str, float]] = {
     "claude-opus-4-5": _OPUS_STD,
     "claude-opus-4-1": _OPUS_LEGACY,
     "claude-opus-4": _OPUS_LEGACY,
+    "claude-fable-5": _FABLE_5,
     "claude-sonnet-4-6": _SONNET,
     "claude-sonnet-4-5": _SONNET,
     "claude-sonnet-4": _SONNET,

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -30,7 +30,7 @@ from pinky_daemon.wake_prompt import (
 )
 
 # Models with native 1M context (SDK reports 200k incorrectly)
-_1M_MODELS = {"claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8"}
+_1M_MODELS = {"claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8", "claude-fable-5"}
 
 DEFAULT_STREAMING_ALLOWED_TOOLS = [
     "Read",

--- a/tests/test_analytics_store.py
+++ b/tests/test_analytics_store.py
@@ -341,3 +341,54 @@ class TestTurnClassification:
             store._classify_turn(["mcp__pinky-messaging__send_video"], [])
             == "messaging"
         )
+
+
+class TestFablePricingSeed:
+    """Fable 5 is priced in the Analytics cost path, and the default-pricing
+    seed is additive (propagates new models to an already-populated DB) +
+    idempotent. Guards the bug where a model absent from analytics_model_pricing
+    silently bills $0 across the whole dashboard, and where the old
+    early-return-when-non-empty seed stranded new models on deployed instances.
+    """
+
+    def test_fable_5_priced_not_zero(self, tmp_path):
+        store = _store(tmp_path)
+        pricing = store._lookup_pricing(
+            provider="anthropic", model="claude-fable-5", ts="2026-06-09T12:00:00Z"
+        )
+        assert pricing is not None  # was None -> $0 before Fable was seeded
+        assert pricing["input_usd_per_mtok"] == 10.0
+        assert pricing["output_usd_per_mtok"] == 50.0
+        assert pricing["cached_input_usd_per_mtok"] == 1.0
+
+    def test_seed_propagates_new_model_to_populated_db(self, tmp_path):
+        # Simulate a DB seeded BEFORE Fable existed: delete the Fable row from
+        # an already-populated table, then re-seed. The additive seed must
+        # re-insert exactly that one row. Under the old early-return logic the
+        # non-empty table short-circuited and Fable never reappeared.
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            conn.execute("DELETE FROM analytics_model_pricing WHERE model = 'claude-fable-5'")
+            assert (
+                conn.execute(
+                    "SELECT COUNT(*) FROM analytics_model_pricing WHERE model = 'claude-fable-5'"
+                ).fetchone()[0]
+                == 0
+            )
+            before = conn.execute("SELECT COUNT(*) FROM analytics_model_pricing").fetchone()[0]
+            store._seed_default_pricing(conn)
+            after = conn.execute("SELECT COUNT(*) FROM analytics_model_pricing").fetchone()[0]
+            fable = conn.execute(
+                "SELECT COUNT(*) FROM analytics_model_pricing WHERE model = 'claude-fable-5'"
+            ).fetchone()[0]
+        assert fable == 1
+        assert after == before + 1  # only the missing row added; no other dupes
+
+    def test_seed_is_idempotent(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            before = conn.execute("SELECT COUNT(*) FROM analytics_model_pricing").fetchone()[0]
+            store._seed_default_pricing(conn)
+            store._seed_default_pricing(conn)
+            after = conn.execute("SELECT COUNT(*) FROM analytics_model_pricing").fetchone()[0]
+        assert after == before  # re-seeding never duplicates rows

--- a/tests/test_model_seed_fable.py
+++ b/tests/test_model_seed_fable.py
@@ -1,0 +1,39 @@
+"""Fable 5 lands in the seeded model catalog, and the seed is idempotent.
+
+Guards the additive-seed behavior: a new model added to ``_MODEL_SEEDS`` must
+reach an already-populated DB (the early-return-on-non-empty bug this fixes
+stranded new models on every deployed instance), and re-seeding must never
+duplicate rows.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+from pinky_daemon.agent_registry import AgentRegistry
+
+
+def _by_model_id(reg) -> dict:
+    return {m["model_id"]: m for m in reg.list_models()}
+
+
+def test_fable_5_seeded_with_1m_context_and_price():
+    with tempfile.TemporaryDirectory() as d:
+        reg = AgentRegistry(db_path=f"{d}/agents.db")
+        models = _by_model_id(reg)
+        assert "claude-fable-5" in models
+        fable = models["claude-fable-5"]
+        assert fable["is_1m"] == 1
+        assert fable["context_window"] == 1_000_000
+        assert fable["input_price"] == 10.0
+        assert fable["output_price"] == 50.0
+
+
+def test_seed_is_idempotent_and_additive():
+    with tempfile.TemporaryDirectory() as d:
+        reg = AgentRegistry(db_path=f"{d}/agents.db")
+        before = len(reg.list_models())
+        assert before > 0
+        # Re-running the seed must not duplicate any rows (INSERT OR IGNORE).
+        reg._seed_models()
+        assert len(reg.list_models()) == before

--- a/tests/test_model_seed_fable.py
+++ b/tests/test_model_seed_fable.py
@@ -37,3 +37,27 @@ def test_seed_is_idempotent_and_additive():
         # Re-running the seed must not duplicate any rows (INSERT OR IGNORE).
         reg._seed_models()
         assert len(reg.list_models()) == before
+
+
+def test_seed_propagates_new_model_to_populated_db():
+    # The actual regression this PR fixes: a model added to _MODEL_SEEDS must
+    # reach an ALREADY-seeded DB. Simulate a pre-Fable DB by deleting the row
+    # from a populated table, then re-seed — Fable must reappear with no other
+    # rows duplicated. Reverting to early-return-on-non-empty fails this test.
+    with tempfile.TemporaryDirectory() as d:
+        reg = AgentRegistry(db_path=f"{d}/agents.db")
+        reg._db.execute("DELETE FROM models WHERE model_id = 'claude-fable-5'")
+        reg._db.commit()
+        assert "claude-fable-5" not in _by_model_id(reg)
+        before = len(reg.list_models())
+        reg._seed_models()
+        after = _by_model_id(reg)
+        assert "claude-fable-5" in after
+        assert len(after) == before + 1
+
+
+def test_fable_5_in_1m_models_set():
+    # 1M-context routing (SDK under-reports as 200k) must include Fable.
+    from pinky_daemon.streaming_session import _1M_MODELS
+
+    assert "claude-fable-5" in _1M_MODELS

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -163,3 +163,27 @@ def test_cost_from_usage_tolerates_malformed() -> None:
 
 def test_zero_usage_is_zero_cost() -> None:
     assert compute_cost_from_usage("claude-opus-4-8", {}) == 0.0
+
+
+def test_fable_5_is_double_opus() -> None:
+    # Fable 5 (2026-06-09): $10 input / $50 output per Mtok — exactly 2× the
+    # standard-Opus tier ($5/$25).
+    assert lookup_rate("claude-fable-5") is not None
+    cost = compute_turn_cost_usd(
+        "claude-fable-5",
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        cache_read_tokens=0,
+        cache_creation_5m_tokens=0,
+        cache_creation_1h_tokens=0,
+    )
+    assert cost == pytest.approx(60.0)  # 10 + 50
+    opus = compute_turn_cost_usd(
+        "claude-opus-4-8",
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        cache_read_tokens=0,
+        cache_creation_5m_tokens=0,
+        cache_creation_1h_tokens=0,
+    )
+    assert cost == pytest.approx(2 * opus)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -187,3 +187,13 @@ def test_fable_5_is_double_opus() -> None:
         cache_creation_1h_tokens=0,
     )
     assert cost == pytest.approx(2 * opus)
+
+
+def test_fable_5_cache_rates_are_double_opus() -> None:
+    # Fable 5 is exactly 2x standard Opus across ALL five rate fields, not just
+    # input/output — guards the cache tiers too.
+    fable = lookup_rate("claude-fable-5")
+    opus = lookup_rate("claude-opus-4-8")
+    assert fable is not None and opus is not None
+    for field in ("input", "output", "cache_read", "cache_write_5m", "cache_write_1h"):
+        assert fable[field] == 2 * opus[field], f"{field}: fable={fable[field]} opus={opus[field]}"


### PR DESCRIPTION
## What

Wires up **Claude Fable 5** (`claude-fable-5`) — Anthropic's new Mythos-class model released today (2026-06-09), their most capable generally-available model, with a 1M context window — as a selectable option across the fleet.

## Changes

- **`pricing.py`** — add the Fable 5 rate (`$10` input / `$50` output per Mtok = exactly **2× standard Opus**), so per-turn cost telemetry (#648) prices Fable turns correctly instead of silently costing `$0`.
- **`agent_registry.py`**
  - Add `claude-fable-5` to the `_MODEL_SEEDS` catalog (1M context, `is_1m=1`, sorted just below Opus 4.8).
  - **Make `_seed_models` idempotent + additive.** It previously returned early whenever the `models` table was non-empty, which meant any newly-added model was stranded on every already-deployed instance. Now it `INSERT OR IGNORE`s every startup — new models propagate to existing DBs, operator edits to existing rows are never clobbered, and re-seeding never duplicates.
- **`streaming_session.py`** — add `claude-fable-5` to `_1M_MODELS` (the SDK under-reports its context as 200k).
- **tests** — Fable rate is 2× Opus; the catalog seeds Fable with 1M context + correct price; the seed is idempotent.

## Behavior

- **Default stays Opus 4.8** (half the cost). Fable is opt-in per agent/task (`--model claude-fable-5`).
- ⚠️ Fable auto-falls back to **Opus 4.8** on cyber / bio / chem / distillation queries (triggers in <5% of sessions per Anthropic) — relevant for security-review work.

## Tests

```
$ pytest tests/test_pricing.py tests/test_model_seed_fable.py -q
15 passed
$ pytest tests/test_autonomy.py tests/test_scheduler.py tests/test_ultracode_effort.py -q
73 passed   # AgentRegistry-constructing files — no regression from the seed change
```

ruff clean. No UI change, so the green runs above are the evidence.

🤖 Opened by Barsik