### PR TITLE
fix(#638): seed claude credentials into the container HOME volume

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1218,6 +1218,50 @@ class TmuxSession:
                 f"(non-fatal): {e}"
             )
 
+    async def _seed_container_home_creds(self) -> None:
+        """Copy the seeded Claude credentials from the (bind-mounted, host-
+        seeded) CLAUDE_CONFIG_DIR into the home VOLUME's ``~/.claude/`` —
+        INSIDE the container, after it is running.
+
+        Live-validated on the Pi (#638 rollout): claude reads OAuth
+        credentials from ``$HOME/.claude/.credentials.json``, NOT from
+        CLAUDE_CONFIG_DIR — with creds only in the config dir it sits at the
+        OAuth login screen forever (trust flags in CLAUDE_CONFIG_DIR *are*
+        honored; credentials are not). Idempotent: skips when the volume
+        already has credentials, so an agent's own later ``claude login`` (or
+        a token refresh) is never clobbered. Best-effort: a failure must not
+        block the spawn (worst case is the login prompt, not a regression)."""
+        runner = self._select_command_runner()
+        if not isinstance(runner, ContainerCommandRunner):
+            return
+        seed_sh = (
+            'test -f "$HOME/.claude/.credentials.json" || { '
+            'test -f "$CLAUDE_CONFIG_DIR/.credentials.json" && '
+            'mkdir -p "$HOME/.claude" && '
+            'cp "$CLAUDE_CONFIG_DIR/.credentials.json" '
+            '"$HOME/.claude/.credentials.json" && '
+            'chmod 600 "$HOME/.claude/.credentials.json"; }'
+        )
+        try:
+            res = await runner.run(["sh", "-c", seed_sh], timeout=15)
+            if res.ok:
+                _log(
+                    f"tmux[{self.agent_name}]: ensured claude credentials in "
+                    f"container home volume"
+                )
+            else:
+                _log(
+                    f"tmux[{self.agent_name}]: in-container creds seed "
+                    f"rc={res.returncode} "
+                    f"stderr={res.stderr.decode('utf-8', 'replace').strip()[:200]!r} "
+                    f"(non-fatal)"
+                )
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: in-container creds seed failed "
+                f"(non-fatal): {e}"
+            )
+
     async def _seed_container_trust(self, project_dir: str) -> None:
         """Seed Claude Code's first-run trust/bypass flags INSIDE a container
         agent's home volume — its ``.claude.json`` lives there, not on a host
@@ -2026,9 +2070,10 @@ class TmuxSession:
 
         async def _spawn():
             # Container is up (started above, outside this umbrella): seed its
-            # trust file (via `podman exec`) before the REPL launches. No-op
-            # for local agents.
+            # trust file and home-volume credentials (via `podman exec`)
+            # before the REPL launches. No-ops for local agents.
             await self._seed_container_trust(cwd)
+            await self._seed_container_home_creds()
             result = await self._tmux.new_session(
                 cwd=cwd,
                 command=claude_cmd,

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -245,6 +245,52 @@ class TestSeedContainerTrust:
         assert "CLAUDE_CONFIG_DIR" in seed  # resolves the in-container config dir
 
 
+@pytest.mark.asyncio
+class TestSeedContainerHomeCreds:
+    """#638 live-validation fix: claude reads OAuth creds from $HOME/.claude
+    (the home VOLUME), not CLAUDE_CONFIG_DIR — the in-container seed copies
+    the host-seeded config-dir creds into the volume, idempotently."""
+
+    async def test_noop_for_local_agent(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        await ss._seed_container_home_creds()  # must not raise / not exec
+
+    async def test_execs_idempotent_copy_in_container(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(
+            _FakeAgent("dymok", "container", working_dir="/srv/agents/dymok")
+        ))
+        inner = _RecordingInner()
+        runner = ContainerCommandRunner(
+            "pinky-dymok", workdir="/srv/agents/dymok", inner=inner
+        )
+        monkeypatch.setattr(ss, "_select_command_runner", lambda: runner)
+        await ss._seed_container_home_creds()
+        assert len(inner.calls) == 1
+        cmd = inner.calls[0]
+        assert cmd[:2] == ["podman", "exec"]
+        assert "pinky-dymok" in cmd and "sh" in cmd and "-c" in cmd
+        seed = cmd[cmd.index("-c") + 1]
+        # Skip-if-present FIRST (an agent's own claude login is never
+        # clobbered), then copy config-dir creds into $HOME/.claude at 0600.
+        assert seed.startswith('test -f "$HOME/.claude/.credentials.json" ||')
+        assert '"$CLAUDE_CONFIG_DIR/.credentials.json"' in seed
+        assert 'chmod 600 "$HOME/.claude/.credentials.json"' in seed
+
+    async def test_runner_failure_is_nonfatal(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(
+            _FakeAgent("dymok", "container", working_dir="/srv/agents/dymok")
+        ))
+        inner = _StubInner(exc=RuntimeError("podman gone"))
+        runner = ContainerCommandRunner(
+            "pinky-dymok", workdir="/srv/agents/dymok", inner=inner
+        )
+        monkeypatch.setattr(ss, "_select_command_runner", lambda: runner)
+        await ss._seed_container_home_creds()  # swallowed, never blocks spawn
+
+
 def _claude_slug(path: str) -> str:
     """Claude Code's project-dir encoder: every non-alphanumeric char of the
     RESOLVED cwd becomes '-' (mirrors _project_dir's re.sub)."""


### PR DESCRIPTION
Live-validation fix from the sasha container rollout on the Pi: claude reads OAuth credentials from `$HOME/.claude/.credentials.json` (home volume), not `CLAUDE_CONFIG_DIR` — so the in-container REPL sat at the OAuth login screen despite the host-side seed. Trust flags in the config dir ARE honored; credentials are not.

Adds an idempotent in-container post-start seed (next to the trust seed): copy config-dir creds into `$HOME/.claude` at 0600, skip-if-present so a tenant's own `claude login`/refresh is never clobbered. Best-effort, never blocks the spawn. 3 new tests.

Validation evidence: `podman exec pinky-sasha tmux capture-pane` showed the OAuth URL prompt with `.credentials.json` present in the config dir; container/tmux/transcript plumbing all healthy otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)