### PR TITLE
fix(#638): seed hasCompletedOnboarding for container agents

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1285,6 +1285,13 @@ class TmuxSession:
             "    except Exception: d={}\n"
             "if not isinstance(d,dict): d={}\n"
             "d['bypassPermissionsModeAccepted']=True\n"
+            # Live-validated on the Pi (#638): without the GLOBAL onboarding
+            # flag, a fresh container config dir triggers claude's first-run
+            # wizard, whose first step is the OAuth sign-in screen — even with
+            # VALID credentials in place (claude had already written
+            # oauthAccount/userID from them). Local agents inherit the
+            # operator's onboarded ~/.claude.json so they never hit this.
+            "d['hasCompletedOnboarding']=True\n"
             "pr=d.setdefault('projects',{})\n"
             "pr.setdefault(proj,{})\n"
             "pr[proj]['hasTrustDialogAccepted']=True\n"

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -242,6 +242,10 @@ class TestSeedContainerTrust:
         seed = cmd[cmd.index("-c") + 1]
         assert "bypassPermissionsModeAccepted" in seed
         assert "hasTrustDialogAccepted" in seed
+        # #638 Pi live-validation: the GLOBAL onboarding flag must be seeded or
+        # a fresh container config dir wedges on the first-run wizard's OAuth
+        # sign-in step even with valid credentials present.
+        assert "d['hasCompletedOnboarding']=True" in seed
         assert "CLAUDE_CONFIG_DIR" in seed  # resolves the in-container config dir
 
 


### PR DESCRIPTION
Second live-validation catch from the sasha rollout: valid creds were accepted (claude wrote oauthAccount/userID into the container .claude.json) but the REPL still parked on the OAuth screen — it is the first-run onboarding wizard, gated by the GLOBAL `hasCompletedOnboarding` flag, which a fresh container config dir lacks. Local agents inherit the operator's onboarded ~/.claude.json so only container tenants hit it. One-key addition to the in-container trust seed + test assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)