### PR TITLE
fix(#638): Host normalization for bearer-authed shared-MCP + container autoupdater off

### DIFF
--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -913,6 +913,11 @@ class ContainerProvisioner(AgentProvisioner):
             "-e", f"HOME={n.home}",
             "-e", f"CLAUDE_CONFIG_DIR={config_dir}",
             "-e", f"PINKY_AGENT_NAME={agent.name}",
+            # The image's claude is root-installed (npm prefix) while the
+            # tenant runs as the keep-id user — self-update can never succeed
+            # and just spams "Auto-update failed" in the REPL. The image is
+            # the upgrade unit; updates ship by changing container_image.
+            "-e", "DISABLE_AUTOUPDATER=1",
             "--entrypoint", "sleep",
             image, "infinity",
         ]
@@ -950,6 +955,7 @@ class ContainerProvisioner(AgentProvisioner):
             "HOME": n.home,
             "CLAUDE_CONFIG_DIR": self._config_dir_for(agent, n),
             "PINKY_AGENT_NAME": agent.name,
+            "DISABLE_AUTOUPDATER": "1",
         }
 
     def start(self, agent: "Agent") -> None:

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -456,6 +456,23 @@ class AgentNameMiddleware:
             if not expected or not hmac.compare_digest(bearer, expected):
                 await _send_401(send, "invalid agent credentials")
                 return
+            # Bearer-authenticated request: normalize the Host header to
+            # loopback before the MCP SDK sees it. The SDK's SSE/HTTP
+            # transports carry DNS-rebinding protection that 421s any
+            # non-localhost Host — which rejects every container client
+            # (Host: host.containers.internal:8890) before tools ever load
+            # (live-caught on the Pi #638 rollout). That protection guards
+            # browser-context attacks on unauthenticated localhost servers;
+            # for a request that just proved possession of the per-agent
+            # bearer it is redundant — while the legacy no-bearer loopback
+            # path below keeps its Host untouched, so rebinding protection
+            # stays fully intact exactly where it still matters.
+            server = scope.get("server") or ("127.0.0.1", SHARED_MCP_PORT)
+            loop_host = f"127.0.0.1:{server[1]}".encode()
+            scope = dict(scope)
+            scope["headers"] = [
+                (k, v) for (k, v) in scope.get("headers", []) if k != b"host"
+            ] + [(b"host", loop_host)]
         elif auth_required:
             await _send_401(send, "agent bearer token required")
             return

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -915,6 +915,17 @@ class TestContainerResourceCaps:
         assert _flag_value(cc, "--memory") == "2g"
         assert _flag_value(cc, "--pids-limit") == "2048"
 
+    def test_autoupdater_disabled_in_container(self, container_agent):
+        # Root-installed claude vs keep-id user: self-update can never work in
+        # the bring-your-own image; without this the REPL spams update errors.
+        # The image is the upgrade unit (ship updates via container_image).
+        ops = RecordingContainerOps()
+        prov = _cprov(ops)
+        prov.provision(container_agent)
+        cc = _create_cmd(ops)
+        assert "DISABLE_AUTOUPDATER=1" in cc
+        assert prov.runtime_env(container_agent)["DISABLE_AUTOUPDATER"] == "1"
+
     def test_env_overrides_cap_values(self, container_agent, monkeypatch):
         monkeypatch.setenv("PINKY_CONTAINER_MEMORY", "512m")
         monkeypatch.setenv("PINKY_CONTAINER_PIDS_LIMIT", "256")

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -335,6 +335,55 @@ class TestAgentNameMiddlewareAuth:
         assert calls == ["barsik"]
         assert messages == []
 
+    async def test_valid_bearer_normalizes_host_header(self):
+        """#638 Pi live-catch: the MCP SDK's DNS-rebinding protection 421s any
+        non-localhost Host (e.g. host.containers.internal:8890 from container
+        clients) before tools load. A bearer-AUTHENTICATED request gets its
+        Host rewritten to loopback so the SDK accepts it; the rebinding guard
+        stays intact for the legacy no-bearer loopback path."""
+        seen = {}
+
+        async def inner_app(scope, receive, send):
+            seen["headers"] = dict(scope["headers"])
+            seen["agent"] = get_current_agent()
+
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(
+            self.REMOTE,
+            [
+                (b"host", b"host.containers.internal:8890"),
+                (b"x-agent-name", b"barsik"),
+                (b"authorization", _bearer_header("barsik-key")),
+            ],
+        )
+        scope["server"] = ("0.0.0.0", 8890)
+        await middleware(scope, None, send)
+        assert seen["agent"] == "barsik"
+        assert seen["headers"][b"host"] == b"127.0.0.1:8890"
+        assert messages == []
+
+    async def test_legacy_loopback_keeps_original_host(self):
+        """No bearer (legacy loopback trust) -> Host passes through untouched,
+        so the SDK's DNS-rebinding protection still guards that path."""
+        seen = {}
+
+        async def inner_app(scope, receive, send):
+            seen["headers"] = dict(scope["headers"])
+
+        send, messages = _recording_send()
+        middleware = AgentNameMiddleware(inner_app, signing_key_resolver=self._resolver)
+        scope = _http_scope(
+            self.LOOPBACK,
+            [
+                (b"host", b"evil.example:8890"),
+                (b"x-agent-name", b"barsik"),
+            ],
+        )
+        await middleware(scope, None, send)
+        assert seen["headers"][b"host"] == b"evil.example:8890"
+        assert messages == []
+
     @pytest.mark.asyncio
     async def test_invalid_bearer_rejected_even_from_loopback(self):
         """A wrong token is rejected REGARDLESS of peer — presenting a bearer


### PR DESCRIPTION
Third live-validation catch from the sasha container rollout: sasha itself reported its pinky-* MCP tools were not loaded. Probe with its exact .mcp.json headers returned **421 Misdirected Request / Invalid Host header** from the MCP SDK's DNS-rebinding protection — `Host: host.containers.internal:8890` is rejected before our bearer is evaluated, on both the SSE and streamable-HTTP mounts.

Fix: AgentNameMiddleware rewrites Host to `127.0.0.1:<bound port>` ONLY after the per-agent bearer validates (proof-of-key makes the rebinding guard redundant); legacy no-bearer loopback requests keep their original Host so the SDK protection still covers the unauthenticated path. Plus `DISABLE_AUTOUPDATER=1` in container env — root-installed claude vs keep-id user means self-update can never succeed (the image is the upgrade unit), and it spams the REPL otherwise.

Tests: Host-rewrite + Host-passthrough middleware tests, argv/runtime_env autoupdater assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)