### PR TITLE
fix(#638): wildcard shared-MCP bind must not leak into connect URLs

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -597,6 +597,23 @@ def _redact_env_secrets(env: dict) -> dict:
     return out
 
 
+def _mcp_connect_host() -> str:
+    """Connect-host for loopback (non-container) MCP clients.
+
+    PINKY_SHARED_MCP_HOST is a *bind* address: operators set it to 0.0.0.0
+    (or ::) so container-isolated agents can reach the shared MCP over the
+    rootless network. But a wildcard bind is not a valid *connect* target —
+    a client that dials http://0.0.0.0:PORT sends `Host: 0.0.0.0`, which the
+    SSE server rejects with "Invalid Host header", silently dropping every
+    pinky tool for the agent. Non-container agents always talk to the daemon
+    over loopback, so normalize a wildcard bind to 127.0.0.1 here. Container
+    agents don't use this — they get host.containers.internal explicitly.
+    """
+    if SHARED_MCP_HOST in ("0.0.0.0", "::", ""):
+        return "127.0.0.1"
+    return SHARED_MCP_HOST
+
+
 def _write_mcp_json(
     work_dir: Path,
     agent_name: str,
@@ -686,7 +703,7 @@ def _write_mcp_json(
             }
     elif SHARED_MCP_ENABLED:
         # Shared SSE mode: point at the shared HTTP server with agent identity header
-        shared_base = f"http://{SHARED_MCP_HOST}:{SHARED_MCP_PORT}"
+        shared_base = f"http://{_mcp_connect_host()}:{SHARED_MCP_PORT}"
         agent_headers = _sse_headers()
 
         # Memory: per-agent SQLite via shared SSE server (store pool)
@@ -2738,7 +2755,7 @@ def create_api(
         # Build MCP server config for Codex agents (injected via -c flags)
         codex_mcp_servers = {}
         if is_codex and SHARED_MCP_ENABLED:
-            shared_base = f"http://{SHARED_MCP_HOST}:{SHARED_MCP_PORT}"
+            shared_base = f"http://{_mcp_connect_host()}:{SHARED_MCP_PORT}"
             agent_headers = {"X-Agent-Name": agent_name}
             for srv_name in ("self", "memory", "messaging"):
                 codex_mcp_servers[f"pinky-{srv_name}"] = {

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -1087,6 +1087,34 @@ class TestWriteMcpJsonSharedMode:
         finally:
             api_mod.SHARED_MCP_ENABLED = original
 
+    def test_shared_mode_wildcard_bind_normalized_to_loopback(self, tmp_path):
+        """Regression: PINKY_SHARED_MCP_HOST=0.0.0.0 is a *bind* address. A
+        non-container agent must NOT get http://0.0.0.0:PORT as its connect URL
+        — the SSE client would send `Host: 0.0.0.0` and the server rejects it
+        with 'Invalid Host header', silently dropping every pinky tool. The
+        wildcard bind must be normalized to 127.0.0.1 for loopback agents."""
+        import json
+
+        import pinky_daemon.api as api_mod
+
+        orig_enabled = api_mod.SHARED_MCP_ENABLED
+        orig_host = api_mod.SHARED_MCP_HOST
+        api_mod.SHARED_MCP_ENABLED = True
+        try:
+            for bind in ("0.0.0.0", "::", ""):
+                api_mod.SHARED_MCP_HOST = bind
+                work_dir = tmp_path / f"agent-{bind or 'empty'}"
+                work_dir.mkdir()
+                api_mod._write_mcp_json(work_dir, "barsik")
+                servers = json.loads((work_dir / ".mcp.json").read_text())["mcpServers"]
+                for name in ("pinky-memory", "pinky-self", "pinky-messaging"):
+                    url = servers[name]["url"]
+                    assert url.startswith("http://127.0.0.1:"), (bind, name, url)
+                    assert "0.0.0.0" not in url and "://:" not in url, (bind, name, url)
+        finally:
+            api_mod.SHARED_MCP_ENABLED = orig_enabled
+            api_mod.SHARED_MCP_HOST = orig_host
+
 
 class TestMemoryStorePool:
     """Tests for the MemoryStorePool used in shared SSE mode."""


### PR DESCRIPTION
Ports the live Pi hotfix (made directly in the prod working tree during the sasha rollout — preserved rather than discarded, like ec82055 before it): with `PINKY_SHARED_MCP_HOST=0.0.0.0`, local agents' `.mcp.json` got `http://0.0.0.0:8890` connect URLs → `Host: 0.0.0.0` → MCP SDK "Invalid Host header" → all pinky tools silently dropped for every NON-container agent. Wildcard binds (`0.0.0.0`/`::`/empty) now normalize to `127.0.0.1` in the loopback branch; container agents keep `host.containers.internal` (covered by #699's bearer-authed Host normalization). Includes the hotfix's regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)