### PR TITLE
feat(models): register Claude Fable 5 + Mythos 5

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -3737,6 +3737,8 @@ except Exception:
 
     _MODEL_SEEDS = [
         # Anthropic
+        ("anthropic", "claude-fable-5", "Claude Fable 5", "Anthropic's most capable widely-released model (2026-06-09). Demanding reasoning + long-horizon agentic work. 1M context; adaptive thinking always on (use effort to control depth).", "fable", 1_000_000, 1, 10.0, 50.0, 1.0, 1, 1),
+        ("anthropic", "claude-mythos-5", "Claude Mythos 5", "Claude Fable 5 capabilities without the safety classifiers. Limited availability via Project Glasswing (approved customers only).", "fable", 1_000_000, 1, 10.0, 50.0, 1.0, 1, 2),
         ("anthropic", "claude-opus-4-8", "Claude Opus 4.8", "Newest Opus (2026-05-28). Sharper judgement, more honest progress reporting, longer independent runs. Effort defaults to high; adaptive thinking triggers only when needed.", "opus", 1_000_000, 1, 15.0, 75.0, 1.5, 1, 3),
         ("anthropic", "claude-opus-4-7", "Claude Opus 4.7", "Stricter instruction-following, xhigh effort, larger vision.", "opus", 1_000_000, 1, 15.0, 75.0, 1.5, 1, 5),
         ("anthropic", "claude-opus-4-6", "Claude Opus 4.6", "Maximum intelligence. Deep reasoning.", "opus", 1_000_000, 1, 15.0, 75.0, 1.5, 1, 10),
@@ -3752,15 +3754,20 @@ except Exception:
     ]
 
     def _seed_models(self) -> None:
-        """Seed default models if table is empty."""
-        count = self._db.execute("SELECT COUNT(*) FROM models").fetchone()[0]
-        if count > 0:
-            return
+        """Ensure default models exist (idempotent).
+
+        Per-row ``INSERT OR IGNORE`` adds any missing model and never
+        overwrites an existing row, so new entries in ``_MODEL_SEEDS``
+        propagate to existing installs on the next startup — not only to a
+        fresh DB. (Previously this early-returned when the table was
+        non-empty, so a newly-added model never reached running deployments.)
+        """
         now = time.time()
+        added = 0
         for (provider, model_id, display, desc, tier, ctx, is_1m,
              inp, out, cached, thinking, sort) in self._MODEL_SEEDS:
             mid = f"{provider}/{model_id}"
-            self._db.execute(
+            cur = self._db.execute(
                 """INSERT OR IGNORE INTO models
                    (id, provider, model_id, display_name, description, tier,
                     context_window, is_1m, input_price, output_price,
@@ -3770,8 +3777,10 @@ except Exception:
                 (mid, provider, model_id, display, desc, tier, ctx, is_1m,
                  inp, out, cached, thinking, sort, now, now),
             )
+            added += cur.rowcount
         self._db.commit()
-        _log(f"agent_registry: seeded {len(self._MODEL_SEEDS)} default models")
+        if added:
+            _log(f"agent_registry: seeded {added} model(s)")
 
     def list_models(self, *, provider: str = "", active_only: bool = True) -> list[dict]:
         """List available models, optionally filtered by provider."""

--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -254,6 +254,8 @@ class AnalyticsStore:
             ("openai", "gpt-5.2-chat-latest", "2020-01-01T00:00:00Z", None, 1.75, 14.00, 0.175, "seed"),
             ("openai", "gpt-5.2-codex", "2020-01-01T00:00:00Z", None, 1.75, 14.00, 0.175, "seed"),
             # Anthropic defaults seeded for future provider expansion.
+            ("anthropic", "claude-fable-5", "2020-01-01T00:00:00Z", None, 10.00, 50.00, 1.00, "seed"),
+            ("anthropic", "claude-mythos-5", "2020-01-01T00:00:00Z", None, 10.00, 50.00, 1.00, "seed"),
             ("anthropic", "claude-opus-4-8", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),
             ("anthropic", "claude-opus-4-7", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),
             ("anthropic", "claude-opus-4-6", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),

--- a/src/pinky_daemon/pricing.py
+++ b/src/pinky_daemon/pricing.py
@@ -53,6 +53,16 @@ _OPUS_STD = {
     "cache_write_5m": 6.25,
     "cache_write_1h": 10.00,
 }
+# Fable / Mythos 5 (2026-06-09): the new flagship family. 1M context,
+# priced at $10 in / $50 out per Mtok; same cache ratios as Opus
+# (read 0.1×, write-5m 1.25×, write-1h 2×). Mythos shares Fable's pricing.
+_FABLE = {
+    "input": 10.00,
+    "output": 50.00,
+    "cache_read": 1.00,
+    "cache_write_5m": 12.50,
+    "cache_write_1h": 20.00,
+}
 # Pre-4.5 Opus (4, 4.1): the old 3×-more-expensive tier. Kept for
 # historical-transcript pricing accuracy.
 _OPUS_LEGACY = {
@@ -86,6 +96,8 @@ _HAIKU_35 = {
 
 # Bare-model-id → rate dict. Add new model ids here on each release.
 RATE_TABLE: dict[str, dict[str, float]] = {
+    "claude-fable-5": _FABLE,
+    "claude-mythos-5": _FABLE,
     "claude-opus-4-8": _OPUS_STD,
     "claude-opus-4-7": _OPUS_STD,
     "claude-opus-4-6": _OPUS_STD,

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -30,7 +30,14 @@ from pinky_daemon.wake_prompt import (
 )
 
 # Models with native 1M context (SDK reports 200k incorrectly)
-_1M_MODELS = {"claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8"}
+_1M_MODELS = {
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+}
 
 DEFAULT_STREAMING_ALLOWED_TOOLS = [
     "Read",

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -846,3 +846,42 @@ class TestAgentContextToPrompt:
         empty = AgentContext(agent_name="dymok")
         assert empty.to_prompt() == ""
         assert empty.to_prompt(resume_mode=True) == ""
+
+
+class TestModelSeeds:
+    """Model registry seeding — Claude Fable 5 / Mythos 5 + idempotency."""
+
+    def test_fable_and_mythos_seeded(self, registry):
+        models = {
+            m["model_id"]: m
+            for m in registry.list_models(provider="anthropic", active_only=False)
+        }
+        assert "claude-fable-5" in models
+        assert "claude-mythos-5" in models
+        fable = models["claude-fable-5"]
+        assert fable["input_price"] == 10.0
+        assert fable["output_price"] == 50.0
+        assert fable["context_window"] == 1_000_000
+        assert fable["is_1m"] == 1
+        assert fable["supports_thinking"] == 1
+
+    def test_seed_idempotent_and_propagates(self, registry):
+        n = len(registry.list_models(active_only=False))
+        # Re-seeding a populated DB must not duplicate.
+        registry._seed_models()
+        assert len(registry.list_models(active_only=False)) == n
+        # A model missing from an existing DB is (re-)added on the next seed —
+        # the mechanism by which a newly-added model reaches running installs
+        # rather than only fresh databases.
+        registry._db.execute("DELETE FROM models WHERE model_id='claude-fable-5'")
+        registry._db.commit()
+        assert all(
+            m["model_id"] != "claude-fable-5"
+            for m in registry.list_models(active_only=False)
+        )
+        registry._seed_models()
+        assert any(
+            m["model_id"] == "claude-fable-5"
+            for m in registry.list_models(active_only=False)
+        )
+        assert len(registry.list_models(active_only=False)) == n

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -107,6 +107,26 @@ def test_tier_suffix_is_stripped() -> None:
     assert cost == pytest.approx(5.0)
 
 
+def test_fable_and_mythos_5_rates() -> None:
+    # Claude Fable 5 / Mythos 5 (2026-06-09): $10 in / $50 out per Mtok.
+    for model in ("claude-fable-5", "claude-mythos-5"):
+        cost = compute_turn_cost_usd(
+            model,
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+            cache_read_tokens=0,
+            cache_creation_5m_tokens=0,
+            cache_creation_1h_tokens=0,
+        )
+        assert cost == pytest.approx(60.0), model
+    rate = lookup_rate("claude-fable-5")
+    assert rate["input"] == 10.0
+    assert rate["output"] == 50.0
+    assert rate["cache_read"] == 1.0  # 0.1x input
+    assert rate["cache_write_5m"] == 12.5  # 1.25x input
+    assert rate["cache_write_1h"] == 20.0  # 2x input
+
+
 def test_cost_from_usage_with_transcript_split() -> None:
     """Transcript-shape usage with the nested 5m/1h breakdown."""
     usage = {


### PR DESCRIPTION
## What

Registers the new Anthropic flagship family — **Claude Fable 5** and **Claude Mythos 5** (GA 2026-06-09) — across the daemon's model config, so an agent running on Fable 5 is priced and window-sized correctly.

| | Fable 5 / Mythos 5 |
|---|---|
| API id | `claude-fable-5` / `claude-mythos-5` |
| Context | 1M tokens · 128k max output |
| Price | $10 / M input, $50 / M output |

## Changes
- **`pricing.py`** — `_FABLE` rate ($10/$50, Opus cache ratios: read 0.1×, write-5m 1.25×, write-1h 2×); `RATE_TABLE` entries for both. → live per-turn cost is correct.
- **`streaming_session.py`** — add both to `_1M_MODELS` (the SDK reports 200k incorrectly for native-1M models). → context-% + the model-switch restart logic detect 1M.
- **`agent_registry.py`** — seed both into the model registry (1M ctx, $10/$50, adaptive thinking). **Made `_seed_models` idempotent** (per-row `INSERT OR IGNORE`, dropped the `if count>0: return` early-return) so a newly-added model propagates to existing installs on the next startup — previously a new seed only reached *fresh* DBs, so adding a model was a no-op for running deployments.
- **`analytics_store.py`** — seed both into `analytics_model_pricing`.

Mythos 5 is limited-access (Project Glasswing); seeded for completeness/consistency.

## Verification
- New tests: fable/mythos rate + cost (1M+1M = \$60), registry seed values, and `_seed_models` idempotency + propagation (delete a model → re-seed re-adds it, no dupes).
- **Full suite: 3467 passed, 1 skipped.** ruff clean.
- Backend config change — no UI; the green suite + cost assertions are the evidence.

## Note
The `_seed_models` idempotency change will, on next startup, re-add any *default* model a user had manually deleted from their registry (seeds are defaults). Considered acceptable; flagging explicitly.

🤖 Opened by Barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)