### PR TITLE
fix(scheduler): run dream/librarian callbacks as background tasks (#702)

### DIFF
--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -216,7 +216,11 @@ class AgentScheduler:
         # so a long dream (~1h with KG extraction) can't freeze the tick loop —
         # a blocked tick silently skips every cron minute in the window.
         self._dream_tasks: dict[str, asyncio.Task] = {}  # agent_name -> running dream
-        self._librarian_tasks: dict[str, asyncio.Task] = {}  # agent_name -> running librarian
+        # The librarian curates ONE shared project-level KBStore (api.py wires a
+        # single LibrarianRunner guarded by a global _librarian_state.running
+        # lock on the ingest-debounce path), so scheduled runs must not execute
+        # concurrently across agents either: single global slot, not per-agent.
+        self._librarian_tasks: dict[str, asyncio.Task] = {}  # LIBRARIAN_GLOBAL_KEY -> running librarian
         # Resurrection rate-limit: agent_name -> list[timestamp] of recent attempts.
         # Used by _check_heartbeats to cap how often we ping the heartbeat_callback
         # for a stuck agent (avoid thrashing on a persistently-broken session).
@@ -693,17 +697,26 @@ class AgentScheduler:
                         except Exception as e:
                             _log(f"scheduler: auto-sleep idle_sleep failed for {agent.name}/{label}: {e}")
 
-    def _spawn_agent_callback(self, task_map: dict, callback, agent, *, kind: str, fired_msg: str) -> None:
+    LIBRARIAN_GLOBAL_KEY = "__shared_kb__"
+
+    def _spawn_agent_callback(
+        self, task_map: dict, callback, agent, *, kind: str, fired_msg: str, key: str = ""
+    ) -> None:
         """Fire a dream/librarian callback as a background task (#702).
 
         The tick loop must never await these inline: a dream can run for an
         hour (KG extraction over dozens of reflections), and a blocked tick
         skips every cron schedule, heartbeat check, and wake in the window —
         `_check_schedules` matches the current minute only, with no catch-up.
+
+        ``key`` is the overlap-guard slot: agent name for dreams (independent
+        per-agent state), LIBRARIAN_GLOBAL_KEY for librarian runs (shared KB —
+        at most one run in flight fleet-wide).
         """
-        existing = task_map.get(agent.name)
+        key = key or agent.name
+        existing = task_map.get(key)
         if existing and not existing.done():
-            _log(f"scheduler: {kind} for '{agent.name}' still running — skipping refire")
+            _log(f"scheduler: {kind} run already in flight — skipping fire for '{agent.name}'")
             return
         _log(fired_msg)
 
@@ -713,7 +726,7 @@ class AgentScheduler:
             except Exception as e:
                 _log(f"scheduler: {kind} callback failed for '{agent.name}': {e}")
 
-        task_map[agent.name] = asyncio.create_task(_run())
+        task_map[key] = asyncio.create_task(_run())
 
     async def _check_dreams(self, now: float) -> None:
         """Check dream schedules for all dream-enabled agents and fire if due."""
@@ -786,6 +799,7 @@ class AgentScheduler:
                     self._librarian_tasks, self._librarian_callback, agent, kind="librarian",
                     fired_msg=f"scheduler: librarian schedule fired for '{agent.name}' "
                               f"(cron={cron_expr})",
+                    key=self.LIBRARIAN_GLOBAL_KEY,
                 )
 
     async def _check_url_watchers(self, now: float) -> None:

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -212,6 +212,11 @@ class AgentScheduler:
         self._task: asyncio.Task | None = None
         self._last_clock_slot: dict[str, int] = {}  # agent_name -> last fired clock slot (minutes since midnight)
         self._last_dream_check: dict[str, tuple] = {}  # agent_name -> (date_str, cron-minute) dedup key
+        # In-flight dream/librarian runs (#702). These run as background tasks
+        # so a long dream (~1h with KG extraction) can't freeze the tick loop —
+        # a blocked tick silently skips every cron minute in the window.
+        self._dream_tasks: dict[str, asyncio.Task] = {}  # agent_name -> running dream
+        self._librarian_tasks: dict[str, asyncio.Task] = {}  # agent_name -> running librarian
         # Resurrection rate-limit: agent_name -> list[timestamp] of recent attempts.
         # Used by _check_heartbeats to cap how often we ping the heartbeat_callback
         # for a stuck agent (avoid thrashing on a persistently-broken session).
@@ -235,6 +240,17 @@ class AgentScheduler:
             except asyncio.CancelledError:
                 pass
             self._task = None
+        # Cancel in-flight dream/librarian runs. Before #702 these ran inside
+        # the loop task, so stop() cancelled them implicitly — keep that contract.
+        for task_map in (self._dream_tasks, self._librarian_tasks):
+            for task in task_map.values():
+                if not task.done():
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+            task_map.clear()
         _log("scheduler: stopped")
 
     async def _loop(self) -> None:
@@ -677,6 +693,28 @@ class AgentScheduler:
                         except Exception as e:
                             _log(f"scheduler: auto-sleep idle_sleep failed for {agent.name}/{label}: {e}")
 
+    def _spawn_agent_callback(self, task_map: dict, callback, agent, *, kind: str, fired_msg: str) -> None:
+        """Fire a dream/librarian callback as a background task (#702).
+
+        The tick loop must never await these inline: a dream can run for an
+        hour (KG extraction over dozens of reflections), and a blocked tick
+        skips every cron schedule, heartbeat check, and wake in the window —
+        `_check_schedules` matches the current minute only, with no catch-up.
+        """
+        existing = task_map.get(agent.name)
+        if existing and not existing.done():
+            _log(f"scheduler: {kind} for '{agent.name}' still running — skipping refire")
+            return
+        _log(fired_msg)
+
+        async def _run() -> None:
+            try:
+                await callback(agent.name, agent)
+            except Exception as e:
+                _log(f"scheduler: {kind} callback failed for '{agent.name}': {e}")
+
+        task_map[agent.name] = asyncio.create_task(_run())
+
     async def _check_dreams(self, now: float) -> None:
         """Check dream schedules for all dream-enabled agents and fire if due."""
         if not self._dream_callback:
@@ -706,11 +744,10 @@ class AgentScheduler:
 
             if cron_matches(cron_expr, dt):
                 self._last_dream_check[agent.name] = dedup_key
-                _log(f"scheduler: dream schedule fired for '{agent.name}' (cron={cron_expr})")
-                try:
-                    await self._dream_callback(agent.name, agent)
-                except Exception as e:
-                    _log(f"scheduler: dream callback failed for '{agent.name}': {e}")
+                self._spawn_agent_callback(
+                    self._dream_tasks, self._dream_callback, agent, kind="dream",
+                    fired_msg=f"scheduler: dream schedule fired for '{agent.name}' (cron={cron_expr})",
+                )
 
     async def _check_librarian(self, now: float) -> None:
         """Check if the KB librarian should run.
@@ -745,12 +782,11 @@ class AgentScheduler:
 
             if cron_matches(cron_expr, dt):
                 self._last_librarian_check[agent.name] = dedup_key
-                _log(f"scheduler: librarian schedule fired for '{agent.name}' "
-                     f"(cron={cron_expr})")
-                try:
-                    await self._librarian_callback(agent.name, agent)
-                except Exception as e:
-                    _log(f"scheduler: librarian callback failed for '{agent.name}': {e}")
+                self._spawn_agent_callback(
+                    self._librarian_tasks, self._librarian_callback, agent, kind="librarian",
+                    fired_msg=f"scheduler: librarian schedule fired for '{agent.name}' "
+                              f"(cron={cron_expr})",
+                )
 
     async def _check_url_watchers(self, now: float) -> None:
         """Poll enabled url-type triggers whose interval has elapsed."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -802,4 +802,57 @@ class TestDreamNonBlocking:
         await asyncio.wait_for(scheduler._check_librarian(time.time()), timeout=2)
         await asyncio.wait_for(started.wait(), timeout=2)
         release.set()
-        await asyncio.wait_for(scheduler._librarian_tasks["ivan"], timeout=2)
+        await asyncio.wait_for(
+            scheduler._librarian_tasks[AgentScheduler.LIBRARIAN_GLOBAL_KEY], timeout=2
+        )
+
+    @pytest.mark.asyncio
+    async def test_librarian_guard_is_global_across_agents(self, registry):
+        """The librarian curates one shared KBStore: two librarian-enabled
+        agents due in the same minute must NOT run concurrently — the second
+        fire is skipped while the first is in flight (global slot, not
+        per-agent). The old inline await serialized these; per-agent tasks
+        would race the shared raw/wiki store.
+        """
+        registry.register(
+            "ivan",
+            model="opus",
+            librarian_enabled=True,
+            librarian_schedule="* * * * *",
+        )
+        registry.register(
+            "petr",
+            model="opus",
+            librarian_enabled=True,
+            librarian_schedule="* * * * *",
+        )
+        starts = []
+        release = asyncio.Event()
+
+        async def lib_cb(agent_name, agent):
+            starts.append(agent_name)
+            await release.wait()
+
+        scheduler = AgentScheduler(registry, librarian_callback=lib_cb)
+        # Both agents match the same cron minute in one check pass
+        await asyncio.wait_for(scheduler._check_librarian(time.time()), timeout=2)
+        await asyncio.sleep(0)  # let the background task start
+        # Bypass the (date, minute) dedup to simulate later cron minutes too
+        scheduler._last_librarian_check.clear()
+        await asyncio.wait_for(scheduler._check_librarian(time.time()), timeout=2)
+        await asyncio.sleep(0)
+        # Only ONE shared-KB run started, fleet-wide
+        assert len(starts) == 1
+        release.set()
+        await asyncio.wait_for(
+            scheduler._librarian_tasks[AgentScheduler.LIBRARIAN_GLOBAL_KEY], timeout=2
+        )
+        # Once the in-flight run finishes, a later fire can start again
+        scheduler._last_librarian_check.clear()
+        await asyncio.wait_for(scheduler._check_librarian(time.time()), timeout=2)
+        await asyncio.sleep(0)
+        assert len(starts) == 2
+        release.set()
+        await asyncio.wait_for(
+            scheduler._librarian_tasks[AgentScheduler.LIBRARIAN_GLOBAL_KEY], timeout=2
+        )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import tempfile
 import time
@@ -666,3 +667,139 @@ class TestHeartbeatResurrection:
         assert latest.metadata["source"] == "server_presence"
         assert latest.metadata["reason"] == "fresh_last_seen"
         assert latest.metadata["last_seen_at"] == pytest.approx(now - 10)
+
+
+# ── Non-blocking dream/librarian fires (issue #702) ────────────────────────
+
+
+class TestDreamNonBlocking:
+    """Dream/librarian callbacks must run as background tasks. The old inline
+    await froze the tick loop for the dream's full duration (~1h with KG
+    extraction), silently skipping every cron schedule in the window (#702).
+    """
+
+    @pytest.mark.asyncio
+    async def test_dream_fire_does_not_block_check(self, registry):
+        registry.register(
+            "ivan", model="opus", dream_enabled=True, dream_schedule="* * * * *"
+        )
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def dream_cb(agent_name, agent):
+            started.set()
+            await release.wait()
+
+        scheduler = AgentScheduler(registry, dream_callback=dream_cb)
+        # Before #702 this await would hang until the dream finished
+        await asyncio.wait_for(scheduler._check_dreams(time.time()), timeout=2)
+        await asyncio.wait_for(started.wait(), timeout=2)
+        task = scheduler._dream_tasks["ivan"]
+        assert not task.done()
+        release.set()
+        await asyncio.wait_for(task, timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_schedules_fire_while_dream_runs(self, registry):
+        """The #702 regression: a cron schedule due mid-dream must still fire."""
+        registry.register(
+            "ivan", model="opus", dream_enabled=True, dream_schedule="* * * * *"
+        )
+        registry.add_schedule("ivan", "* * * * *", name="mid-dream", prompt="hi")
+        release = asyncio.Event()
+        fired = []
+
+        async def dream_cb(agent_name, agent):
+            await release.wait()
+
+        async def wake_cb(agent_name, session_id, prompt):
+            fired.append(agent_name)
+
+        scheduler = AgentScheduler(
+            registry, dream_callback=dream_cb, wake_callback=wake_cb
+        )
+        now = time.time()
+        await asyncio.wait_for(scheduler._check_dreams(now), timeout=2)
+        await asyncio.wait_for(scheduler._check_schedules(now), timeout=2)
+        assert fired == ["ivan"]
+        release.set()
+        await asyncio.wait_for(scheduler._dream_tasks["ivan"], timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_overlap_guard_skips_refire(self, registry):
+        registry.register(
+            "ivan", model="opus", dream_enabled=True, dream_schedule="* * * * *"
+        )
+        starts = []
+        release = asyncio.Event()
+
+        async def dream_cb(agent_name, agent):
+            starts.append(agent_name)
+            await release.wait()
+
+        scheduler = AgentScheduler(registry, dream_callback=dream_cb)
+        await scheduler._check_dreams(time.time())
+        await asyncio.sleep(0)  # let the background task start
+        # Bypass the (date, minute) dedup to simulate the next cron minute
+        scheduler._last_dream_check.clear()
+        await scheduler._check_dreams(time.time())
+        await asyncio.sleep(0)
+        assert starts == ["ivan"]
+        release.set()
+        await asyncio.wait_for(scheduler._dream_tasks["ivan"], timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_callback_exception_is_contained(self, registry):
+        registry.register(
+            "ivan", model="opus", dream_enabled=True, dream_schedule="* * * * *"
+        )
+
+        async def dream_cb(agent_name, agent):
+            raise RuntimeError("boom")
+
+        scheduler = AgentScheduler(registry, dream_callback=dream_cb)
+        await scheduler._check_dreams(time.time())
+        # Must not raise out of the task wrapper
+        await asyncio.wait_for(scheduler._dream_tasks["ivan"], timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_inflight_dream(self, registry):
+        registry.register(
+            "ivan", model="opus", dream_enabled=True, dream_schedule="* * * * *"
+        )
+        cancelled = asyncio.Event()
+
+        async def dream_cb(agent_name, agent):
+            try:
+                await asyncio.Event().wait()  # blocks until cancelled
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        scheduler = AgentScheduler(registry, dream_callback=dream_cb)
+        await scheduler._check_dreams(time.time())
+        await asyncio.sleep(0)
+        await scheduler.stop()
+        assert cancelled.is_set()
+        assert scheduler._dream_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_librarian_fire_does_not_block_check(self, registry):
+        registry.register(
+            "ivan",
+            model="opus",
+            librarian_enabled=True,
+            librarian_schedule="* * * * *",
+        )
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def lib_cb(agent_name, agent):
+            started.set()
+            await release.wait()
+
+        scheduler = AgentScheduler(registry, librarian_callback=lib_cb)
+        await asyncio.wait_for(scheduler._check_librarian(time.time()), timeout=2)
+        await asyncio.wait_for(started.wait(), timeout=2)
+        release.set()
+        await asyncio.wait_for(scheduler._librarian_tasks["ivan"], timeout=2)


### PR DESCRIPTION
Fixes #702.

## Problem

`_tick()` → `_check_dreams()` awaited the dream callback **inline**, so the scheduler loop froze for the dream's entire duration — ~58 minutes on 2026-06-10 (857s core dream + ~45 min sequential KG extraction over 50 reflections). `_check_schedules` matches the current minute only, with no catch-up, so every cron minute inside the window was lost: schedules, clock-aligned wakes, heartbeat watchdog/resurrection, auto-sleep, idle checks, URL watchers — frozen fleet-wide, nightly. A 3:20am schedule was silently skipped tonight (log evidence in #702). `_check_librarian` had the identical pattern.

This worsens once #695 lands (KG timeout 30→90s + retries lengthens dreams), so it should merge before/with it.

## Fix

- New `_spawn_agent_callback()`: fires dream/librarian callbacks via `asyncio.create_task`, keeps per-agent task refs (`_dream_tasks` / `_librarian_tasks`)
- Overlap guard: refire is skipped (logged) while the previous run for that agent is in-flight
- Exceptions logged in the wrapper — same log lines as before
- `stop()` cancels in-flight runs — same semantics as before, when cancelling the loop task killed a mid-flight dream

No API/schema changes; `api.py` callbacks untouched.

## Evidence (instead of a screenshot — backend-only change)

Tonight's blackout, `logs/api.log`:
```
scheduler: dream schedule fired for 'barsik' (cron=0 3 * * *)    <- 3:00
dream-runner: 'barsik' dream complete in 857.3s
dream-runner: extracting KG triples from 50 reflections ...
dream-runner: 'barsik' KG insights digest ready (475 chars)
scheduler: firing schedule 'cc-autoupdate' ...                   <- 4:00, next scheduler line
```
Schedule #47 (`20 3 * * *`, active) never fired — `last_ran: never`.

## Tests

6 new in `tests/test_scheduler.py` (`TestDreamNonBlocking`): non-blocking fire, **schedule-fires-mid-dream regression test**, overlap guard, exception containment, stop()-cancels-in-flight, librarian non-blocking. `tests/test_scheduler.py`: 59 passed; `test_dream_runner.py`: 5 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)