### PR TITLE
feat(dreams): tmux transport for dream runs — Max-account billing (#707)

### DIFF
--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -26,6 +26,7 @@ import numpy as np
 
 from pinky_daemon.dream_prompt import DREAM_SYSTEM_PROMPT
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig
+from pinky_daemon.tmux_dream_runner import TmuxDreamConfig, TmuxDreamRunner
 
 
 def _log(msg: str) -> None:
@@ -162,6 +163,30 @@ class DreamRunner:
             )
             self._db.commit()
 
+    def _resolve_dream_transport(self) -> str:
+        """Which transport runs the dream: ``sdk`` (default) or ``tmux`` (#707).
+
+        Resolution: ``PINKY_DREAM_TRANSPORT`` in system_settings (via the
+        injected setting_provider — daemon env does NOT carry settings, same
+        trap as the API key / #685), then process env, then ``sdk``.
+        """
+        import os
+
+        val = ""
+        if self._setting_provider:
+            try:
+                val = (self._setting_provider("PINKY_DREAM_TRANSPORT") or "").strip()
+            except Exception:
+                val = ""
+        if not val:
+            val = os.environ.get("PINKY_DREAM_TRANSPORT", "").strip()
+        val = val.lower()
+        if val not in ("sdk", "tmux"):
+            if val:
+                _log(f"dream-runner: unknown PINKY_DREAM_TRANSPORT={val!r} — using sdk")
+            return "sdk"
+        return val
+
     # ── Public API ────────────────────────────────────────────
 
     def should_dream(self, agent_name: str, agent_config) -> bool:
@@ -232,16 +257,30 @@ class DreamRunner:
         dream_model = getattr(agent_config, "dream_model", "") or ""
         model = dream_model or getattr(agent_config, "model", None) or None
 
-        config = SDKRunnerConfig(
-            working_dir=work_dir,
-            model=model,
-            allowed_tools=_DREAM_ALLOWED_TOOLS,
-            permission_mode="bypassPermissions",
-            system_prompt=system_prompt,
-            max_turns=50,
-        )
-
-        runner = SDKRunner(config, agent_name=agent_name)
+        transport = self._resolve_dream_transport()
+        if transport == "tmux":
+            # #707: interactive tmux session on Max-account billing. The
+            # system prompt travels inside the prompt file, not as an option.
+            runner = TmuxDreamRunner(
+                TmuxDreamConfig(
+                    working_dir=work_dir,
+                    model=model,
+                    system_prompt=system_prompt,
+                ),
+                agent_name=agent_name,
+            )
+            _log(f"dream-runner: transport=tmux for '{agent_name}' "
+                 f"(session pinky-dream-{agent_name})")
+        else:
+            config = SDKRunnerConfig(
+                working_dir=work_dir,
+                model=model,
+                allowed_tools=_DREAM_ALLOWED_TOOLS,
+                permission_mode="bypassPermissions",
+                system_prompt=system_prompt,
+                max_turns=50,
+            )
+            runner = SDKRunner(config, agent_name=agent_name)
 
         # Build the user prompt with conversation history injected
         history_block = "\n".join(history_lines)

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -266,6 +266,8 @@ class DreamRunner:
                     working_dir=work_dir,
                     model=model,
                     system_prompt=system_prompt,
+                    # SDK allowlist + Read/Write for the file-passing protocol
+                    allowed_tools=["Read", "Write", *_DREAM_ALLOWED_TOOLS],
                 ),
                 agent_name=agent_name,
             )

--- a/src/pinky_daemon/tmux_dream_runner.py
+++ b/src/pinky_daemon/tmux_dream_runner.py
@@ -63,8 +63,20 @@ class TmuxDreamConfig:
     # instructions, so file-level delivery is equivalent in practice).
     system_prompt: str = ""
 
-    # Tools the dream session must not use. It only needs Read (prompt file),
-    # Write (result file), ToolSearch + pinky-memory recall/reflect.
+    # PRIMARY tool boundary (Murzik, #708 review): the dream prompt embeds raw
+    # conversation history, so an injection there must not reach a broad
+    # interactive tool surface. Mirror the SDK path's allowlist semantics
+    # (--allowedTools + bypassPermissions), widened only by Read (prompt file)
+    # and Write (result file) which the file-passing protocol requires.
+    allowed_tools: list[str] = field(default_factory=lambda: [
+        "Read",
+        "Write",
+        "ToolSearch",
+        "mcp__pinky-memory__recall",
+        "mcp__pinky-memory__reflect",
+    ])
+
+    # Belt-and-suspenders denylist on top of the allowlist boundary.
     disallowed_tools: list[str] = field(default_factory=lambda: [
         "Bash",
         "mcp__pinky-messaging__*",
@@ -156,6 +168,8 @@ class TmuxDreamRunner:
         if self._config.model:
             cmd += ["--model", self._config.model]
         cmd += ["--permission-mode", "bypassPermissions"]
+        if self._config.allowed_tools:
+            cmd += ["--allowedTools", ",".join(self._config.allowed_tools)]
         if self._config.disallowed_tools:
             cmd += ["--disallowedTools", ",".join(self._config.disallowed_tools)]
 

--- a/src/pinky_daemon/tmux_dream_runner.py
+++ b/src/pinky_daemon/tmux_dream_runner.py
@@ -1,0 +1,266 @@
+"""Tmux-based dream runner — one-shot dream sessions on interactive billing (#707).
+
+Programmatic Claude (SDK / ``-p`` print mode) bills as API usage starting
+June 15, 2026, while interactive sessions draw from the Max account. Dreams
+are one-shot batch jobs with ~200K-char prompts, so this runner drives a
+detached tmux session running the system ``claude`` binary interactively and
+passes the work through FILES: the full prompt is written to a prompt file,
+the REPL receives only a one-line instruction, and the session delivers its
+report by writing a result file the runner polls for. The 200K prompt never
+touches the paste path (readiness-gate paste is the flaky part of the tmux
+rails — see #707).
+
+The session runs in the agent's working dir so the agent's ``.mcp.json``
+(shared MCP gateway + per-agent bearer key) applies and reflect() calls
+attribute to the right agent, same as the SDK path it replaces.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from pinky_daemon.claude_runner import RunResult
+
+# Reuse the rails' first-run gate pre-seed (#112): without it a fresh
+# project dir wedges the REPL at the trust dialog / bypass-permissions
+# acceptance and the typed instruction is silently eaten (observed in the
+# #707 live smoke test). Same-package reuse of tested helpers, on purpose.
+from pinky_daemon.tmux_session import (
+    _resolve_claude_config_path,
+    _seed_claude_trust_file,
+)
+
+_DEFAULT_CLAUDE_BIN = "/opt/homebrew/bin/claude"  # cc_autoupdate.sh manages this path
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+@dataclass
+class TmuxDreamConfig:
+    """Configuration for the tmux-based dream runner."""
+
+    # Working directory (the agent's dir — CLAUDE.md and .mcp.json live here)
+    working_dir: str = "."
+
+    # Model selection (CLI --model). None/empty = binary default.
+    model: str | None = None
+
+    # Claude binary. Empty = $PINKY_CLAUDE_BIN, then which(claude), then
+    # the cc_autoupdate-managed homebrew path.
+    claude_binary: str = ""
+
+    # System prompt — prepended to the prompt file (interactive CC has no
+    # per-session system-prompt override; the dream prompt is self-contained
+    # instructions, so file-level delivery is equivalent in practice).
+    system_prompt: str = ""
+
+    # Tools the dream session must not use. It only needs Read (prompt file),
+    # Write (result file), ToolSearch + pinky-memory recall/reflect.
+    disallowed_tools: list[str] = field(default_factory=lambda: [
+        "Bash",
+        "mcp__pinky-messaging__*",
+        "mcp__pinky-outreach__*",
+        "mcp__pinky-self__*",
+    ])
+
+    # Hard cap on the whole run (spawn -> result file). Dreams currently run
+    # ~15 min; leave generous headroom before declaring the night lost.
+    timeout_s: float = 3600.0
+
+    # How often to poll for the result file.
+    poll_interval_s: float = 5.0
+
+    # How long to wait for the REPL to draw before sending the instruction.
+    ready_timeout_s: float = 60.0
+
+    # Delay before checking the instruction actually submitted (re-Enter guard).
+    submit_check_delay_s: float = 5.0
+
+
+class TmuxDreamRunner:
+    """Runs a one-shot dream in a detached tmux session.
+
+    Mirrors SDKRunner's ``run(prompt) -> RunResult`` surface so
+    dream_runner can swap transports behind a flag.
+    """
+
+    def __init__(self, config: TmuxDreamConfig | None = None, *, agent_name: str = "") -> None:
+        self._config = config or TmuxDreamConfig()
+        self._agent_name = agent_name or "agent"
+
+    @property
+    def session_name(self) -> str:
+        return f"pinky-dream-{self._agent_name}"
+
+    # ── tmux plumbing ─────────────────────────────────────────
+
+    async def _tmux(self, *args: str) -> tuple[int, str]:
+        """Run a tmux command; returns (returncode, combined output)."""
+        proc = await asyncio.create_subprocess_exec(
+            "tmux", *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        out, _ = await proc.communicate()
+        return proc.returncode or 0, out.decode(errors="replace")
+
+    def _resolve_binary(self) -> str:
+        if self._config.claude_binary:
+            return self._config.claude_binary
+        env_bin = os.environ.get("PINKY_CLAUDE_BIN", "").strip()
+        if env_bin:
+            return env_bin
+        return shutil.which("claude") or _DEFAULT_CLAUDE_BIN
+
+    # ── run ───────────────────────────────────────────────────
+
+    async def run(self, prompt: str, *, system_prompt: str = "") -> RunResult:
+        start = time.time()
+        work_dir = Path(self._config.working_dir).resolve()
+        dreams_dir = work_dir / "dreams"
+        dreams_dir.mkdir(parents=True, exist_ok=True)
+
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        prompt_path = dreams_dir / f"prompt-{stamp}.md"
+        result_path = dreams_dir / f"result-{stamp}.md"
+
+        sys_prompt = system_prompt or self._config.system_prompt
+        body = f"{sys_prompt}\n\n---\n\n{prompt}" if sys_prompt else prompt
+        prompt_path.write_text(body, encoding="utf-8")
+        if result_path.exists():  # paranoia: never read a stale result
+            result_path.unlink()
+
+        # Pre-seed trust/bypass acceptance for this dir (#112 mechanism) —
+        # best-effort; agent dirs are normally already trusted by their main
+        # session, but a first dream on a fresh box must not wedge.
+        try:
+            if self._seed_trust(str(work_dir)):
+                _log(f"tmux-dream: seeded claude trust for {work_dir}")
+        except Exception as e:
+            _log(f"tmux-dream: trust seed failed (continuing): {e}")
+
+        # Defensive: a stale session from a crashed run would shadow the new
+        # one (the #704 overlap guard prevents concurrent fires, not leftovers).
+        await self._tmux("kill-session", "-t", self.session_name)
+
+        cmd = [self._resolve_binary()]
+        if self._config.model:
+            cmd += ["--model", self._config.model]
+        cmd += ["--permission-mode", "bypassPermissions"]
+        if self._config.disallowed_tools:
+            cmd += ["--disallowedTools", ",".join(self._config.disallowed_tools)]
+
+        rc, out = await self._tmux(
+            "new-session", "-d", "-s", self.session_name, "-c", str(work_dir), *cmd
+        )
+        if rc != 0:
+            return RunResult(
+                output="",
+                exit_code=1,
+                error=f"tmux new-session failed: {out.strip()}",
+                duration_ms=int((time.time() - start) * 1000),
+            )
+
+        _log(
+            f"tmux-dream: spawned {self.session_name} "
+            f"(model={self._config.model or 'default'}, prompt={prompt_path.name})"
+        )
+
+        try:
+            if not await self._wait_ready():
+                # Proceed anyway: the pty buffers typed input, and CC reads it
+                # once the REPL is up. Logged so a hung binary is diagnosable.
+                _log(f"tmux-dream: {self.session_name} REPL not visibly ready "
+                     f"after {self._config.ready_timeout_s}s — sending anyway")
+
+            instruction = (
+                f"Read the file {prompt_path} and follow ALL instructions in it exactly. "
+                f"When the work is fully complete, write your final report as plain text "
+                f"to {result_path} using the Write tool. Do not create that file until "
+                f"you are done — it is the completion signal."
+            )
+            rc, out = await self._tmux(
+                "send-keys", "-t", self.session_name, "-l", instruction
+            )
+            if rc != 0:
+                return RunResult(
+                    output="",
+                    exit_code=1,
+                    error=f"tmux send-keys failed: {out.strip()}",
+                    duration_ms=int((time.time() - start) * 1000),
+                )
+            await self._tmux("send-keys", "-t", self.session_name, "Enter")
+            await self._ensure_submitted(instruction)
+
+            output = await self._wait_for_result(result_path, deadline=start + self._config.timeout_s)
+            elapsed_ms = int((time.time() - start) * 1000)
+            _log(f"tmux-dream: {self.session_name} done in {elapsed_ms}ms, "
+                 f"report={len(output)} chars")
+            return RunResult(output=output.strip(), exit_code=0, duration_ms=elapsed_ms)
+
+        except TimeoutError:
+            _, pane = await self._tmux("capture-pane", "-p", "-t", self.session_name)
+            tail = pane.strip()[-500:]
+            return RunResult(
+                output="",
+                exit_code=1,
+                error=(
+                    f"dream tmux run timed out after {int(self._config.timeout_s)}s "
+                    f"without a result file; pane tail: {tail}"
+                ),
+                duration_ms=int((time.time() - start) * 1000),
+            )
+        finally:
+            await self._tmux("kill-session", "-t", self.session_name)
+
+    def _seed_trust(self, project_dir: str) -> bool:
+        """Seed first-run trust flags; seam for tests."""
+        return _seed_claude_trust_file(_resolve_claude_config_path(), project_dir)
+
+    # ── waiting ───────────────────────────────────────────────
+
+    async def _ensure_submitted(self, instruction: str) -> None:
+        """Re-send Enter once if the instruction is still parked in the input box.
+
+        Paste-without-submit is a known tmux-rails failure mode; the dream
+        turn is long, so a single cheap recheck beats losing the whole night.
+        """
+        await asyncio.sleep(self._config.submit_check_delay_s)
+        rc, pane = await self._tmux("capture-pane", "-p", "-t", self.session_name)
+        if rc != 0:
+            return
+        marker = instruction[:40]
+        if marker in pane and "esc to interrupt" not in pane:
+            _log(f"tmux-dream: {self.session_name} instruction not submitted — re-sending Enter")
+            await self._tmux("send-keys", "-t", self.session_name, "Enter")
+
+    async def _wait_ready(self) -> bool:
+        """Poll the pane until the Claude REPL has drawn its input UI."""
+        deadline = time.time() + self._config.ready_timeout_s
+        while time.time() < deadline:
+            rc, pane = await self._tmux("capture-pane", "-p", "-t", self.session_name)
+            if rc == 0 and ("shortcuts" in pane or "❯" in pane or "Claude" in pane):
+                return True
+            await asyncio.sleep(1.0)
+        return False
+
+    async def _wait_for_result(self, path: Path, *, deadline: float) -> str:
+        """Poll for the result file; require a stable non-empty size before reading."""
+        last_size = -1
+        while time.time() < deadline:
+            if path.exists():
+                size = path.stat().st_size
+                if size > 0 and size == last_size:
+                    return path.read_text(encoding="utf-8", errors="replace")
+                last_size = size
+            await asyncio.sleep(self._config.poll_interval_s)
+        raise TimeoutError(f"no result file at {path}")

--- a/tests/test_tmux_dream_runner.py
+++ b/tests/test_tmux_dream_runner.py
@@ -1,0 +1,169 @@
+"""Tests for the tmux-based dream runner (#707)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+from pinky_daemon.dream_runner import DreamRunner
+from pinky_daemon.tmux_dream_runner import TmuxDreamConfig, TmuxDreamRunner
+
+
+class _FakeTmux:
+    """Records tmux invocations; pane is 'ready' from the first capture."""
+
+    def __init__(self, *, new_session_rc: int = 0):
+        self.calls: list[tuple[str, ...]] = []
+        self._new_session_rc = new_session_rc
+
+    async def __call__(self, *args: str) -> tuple[int, str]:
+        self.calls.append(args)
+        if args[0] == "new-session":
+            return self._new_session_rc, "" if self._new_session_rc == 0 else "no server"
+        if args[0] == "capture-pane":
+            return 0, "❯ try 'help'  ? for shortcuts"
+        return 0, ""
+
+    def named(self, cmd: str) -> list[tuple[str, ...]]:
+        return [c for c in self.calls if c[0] == cmd]
+
+
+def _runner(tmp: str, fake: _FakeTmux, **overrides) -> TmuxDreamRunner:
+    cfg = TmuxDreamConfig(
+        working_dir=tmp,
+        model="claude-sonnet-4-6",
+        system_prompt="DREAM INSTRUCTIONS",
+        timeout_s=overrides.pop("timeout_s", 5.0),
+        poll_interval_s=0.05,
+        ready_timeout_s=2.0,
+        submit_check_delay_s=0.01,
+        **overrides,
+    )
+    runner = TmuxDreamRunner(cfg, agent_name="ivan")
+    runner._tmux = fake  # type: ignore[method-assign]
+
+    seeded: list[str] = []
+    runner._seeded_dirs = seeded  # type: ignore[attr-defined]
+
+    def _fake_seed(project_dir: str) -> bool:
+        seeded.append(project_dir)
+        return False
+
+    runner._seed_trust = _fake_seed  # type: ignore[method-assign]
+    return runner
+
+
+class TestTmuxDreamRunner:
+    @pytest.mark.asyncio
+    async def test_happy_path_prompt_file_instruction_result(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _FakeTmux()
+            runner = _runner(tmp, fake)
+
+            async def write_result():
+                # Wait until the instruction was sent, then play the dream agent
+                while not fake.named("send-keys"):
+                    await asyncio.sleep(0.01)
+                instruction = fake.named("send-keys")[0][-1]
+                result_path = next(
+                    tok for tok in instruction.split() if "result-" in tok
+                )
+                with open(result_path, "w") as f:
+                    f.write("FINAL DREAM REPORT")
+
+            writer = asyncio.create_task(write_result())
+            result = await runner.run("consolidate the night")
+            await writer
+
+            assert result.ok
+            assert result.output == "FINAL DREAM REPORT"
+
+            # Prompt file holds system prompt + prompt; REPL never saw them
+            dreams = os.listdir(os.path.join(tmp, "dreams"))
+            prompt_file = next(f for f in dreams if f.startswith("prompt-"))
+            content = open(os.path.join(tmp, "dreams", prompt_file)).read()
+            assert "DREAM INSTRUCTIONS" in content
+            assert "consolidate the night" in content
+            instruction = fake.named("send-keys")[0][-1]
+            assert "consolidate the night" not in instruction
+            assert "prompt-" in instruction and "result-" in instruction
+
+            # Spawn used the model + bypassPermissions; session torn down
+            spawn = fake.named("new-session")[0]
+            assert "--model" in spawn and "claude-sonnet-4-6" in spawn
+            assert "--permission-mode" in spawn and "bypassPermissions" in spawn
+            assert "--disallowedTools" in spawn
+            assert fake.named("kill-session")
+
+            # First-run trust gates were pre-seeded for the working dir
+            assert runner._seeded_dirs == [str(os.path.realpath(tmp))]
+
+    @pytest.mark.asyncio
+    async def test_stale_session_killed_before_spawn(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _FakeTmux(new_session_rc=1)
+            runner = _runner(tmp, fake)
+            await runner.run("x")
+            assert fake.calls[0][0] == "kill-session"
+            assert fake.calls[1][0] == "new-session"
+
+    @pytest.mark.asyncio
+    async def test_new_session_failure_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _FakeTmux(new_session_rc=1)
+            runner = _runner(tmp, fake)
+            result = await runner.run("x")
+            assert result.exit_code == 1
+            assert "new-session failed" in result.error
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_session_and_reports(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _FakeTmux()
+            runner = _runner(tmp, fake, timeout_s=0.2)
+            result = await runner.run("x")
+            assert result.exit_code == 1
+            assert "timed out" in result.error
+            assert fake.named("kill-session")
+
+    def test_session_name_is_distinct_from_main_rails(self):
+        runner = TmuxDreamRunner(TmuxDreamConfig(), agent_name="ivan")
+        assert runner.session_name == "pinky-dream-ivan"
+
+
+class TestDreamTransportResolution:
+    def _dr(self, setting_provider=None) -> DreamRunner:
+        import tempfile as tf
+
+        return DreamRunner(
+            db_path=os.path.join(tf.mkdtemp(), "dream_state.db"),
+            setting_provider=setting_provider,
+        )
+
+    def test_default_is_sdk(self, monkeypatch):
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        assert self._dr()._resolve_dream_transport() == "sdk"
+
+    def test_setting_provider_wins(self, monkeypatch):
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        dr = self._dr(setting_provider=lambda k: "tmux" if k == "PINKY_DREAM_TRANSPORT" else "")
+        assert dr._resolve_dream_transport() == "tmux"
+
+    def test_env_fallback(self, monkeypatch):
+        monkeypatch.setenv("PINKY_DREAM_TRANSPORT", "tmux")
+        assert self._dr()._resolve_dream_transport() == "tmux"
+
+    def test_unknown_value_falls_back_to_sdk(self, monkeypatch):
+        monkeypatch.setenv("PINKY_DREAM_TRANSPORT", "carrier-pigeon")
+        assert self._dr()._resolve_dream_transport() == "sdk"
+
+    def test_setting_provider_exception_is_contained(self, monkeypatch):
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+
+        def boom(key):
+            raise RuntimeError("db locked")
+
+        assert self._dr(setting_provider=boom)._resolve_dream_transport() == "sdk"

--- a/tests/test_tmux_dream_runner.py
+++ b/tests/test_tmux_dream_runner.py
@@ -95,6 +95,7 @@ class TestTmuxDreamRunner:
             spawn = fake.named("new-session")[0]
             assert "--model" in spawn and "claude-sonnet-4-6" in spawn
             assert "--permission-mode" in spawn and "bypassPermissions" in spawn
+            assert "--allowedTools" in spawn
             assert "--disallowedTools" in spawn
             assert fake.named("kill-session")
 
@@ -132,6 +133,68 @@ class TestTmuxDreamRunner:
     def test_session_name_is_distinct_from_main_rails(self):
         runner = TmuxDreamRunner(TmuxDreamConfig(), agent_name="ivan")
         assert runner.session_name == "pinky-dream-ivan"
+
+    @pytest.mark.asyncio
+    async def test_allowlist_is_the_primary_tool_boundary(self):
+        """#708 review (Murzik): the dream prompt embeds raw conversation
+        history, so the spawn must pin an explicit --allowedTools allowlist
+        (SDK-path parity + Read/Write), not rely on broad defaults trimmed
+        by a denylist.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _FakeTmux(new_session_rc=1)  # fail fast after spawn
+            runner = _runner(tmp, fake)
+            await runner.run("x")
+            spawn = fake.named("new-session")[0]
+            idx = spawn.index("--allowedTools")
+            allowed = spawn[idx + 1].split(",")
+            assert allowed == [
+                "Read",
+                "Write",
+                "ToolSearch",
+                "mcp__pinky-memory__recall",
+                "mcp__pinky-memory__reflect",
+            ]
+
+    @pytest.mark.asyncio
+    async def test_dream_runner_passes_sdk_parity_allowlist(self, monkeypatch):
+        """The dream_runner tmux branch derives its allowlist from
+        _DREAM_ALLOWED_TOOLS (single source of truth) + Read/Write.
+        """
+        from pinky_daemon import dream_runner as dr_mod
+
+        captured = {}
+        orig_init = dr_mod.TmuxDreamRunner.__init__
+
+        def spy_init(self, config=None, *, agent_name=""):
+            captured["allowed"] = list(config.allowed_tools)
+            orig_init(self, config, agent_name=agent_name)
+
+        monkeypatch.setattr(dr_mod.TmuxDreamRunner, "__init__", spy_init)
+        monkeypatch.setenv("PINKY_DREAM_TRANSPORT", "tmux")
+
+        class _Agent:
+            dream_enabled = True
+            working_dir = ""
+            dream_model = ""
+            model = "claude-sonnet-4-6"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dr = DreamRunner(
+                db_path=os.path.join(tmp, "dream_state.db"),
+                history_provider=lambda *a, **k: [
+                    {"timestamp": 1.0, "role": "user", "content": "hi", "channel": "t"}
+                ],
+            )
+
+            async def fake_run(self, prompt, **kw):
+                from pinky_daemon.claude_runner import RunResult
+                return RunResult(output="dream report", exit_code=0)
+
+            monkeypatch.setattr(dr_mod.TmuxDreamRunner, "run", fake_run)
+            await dr.run_dream("ivan", _Agent())
+
+        assert captured["allowed"] == ["Read", "Write", *dr_mod._DREAM_ALLOWED_TOOLS]
 
 
 class TestDreamTransportResolution:


### PR DESCRIPTION
Closes #707. Deadline-driven: programmatic mode starts billing as API money **June 15** (Brad, msgs 10680/10682).

## What

New `TmuxDreamRunner` (mirrors `SDKRunner.run(prompt) → RunResult`) that runs each dream in a detached tmux session on the **system** claude binary (2.1.170, cc_autoupdate-managed, Max-account auth) instead of the SDK's bundled CLI (2.1.150).

**File-passing, never prompt-pasting:** the full ~200K-char dream prompt (system prompt + history) is written to `dreams/prompt-<ts>.md`; the REPL receives a one-line instruction; the session delivers by writing `dreams/result-<ts>.md` (polled, size-stability check, hard timeout 1h). Runs in the agent's working dir, so the agent's `.mcp.json` + bearer key make `reflect()` attribute correctly — same as the SDK path.

**Gating:** `PINKY_DREAM_TRANSPORT` = `tmux` | `sdk`, resolved system_settings (via `setting_provider`, same chain as the API key / #685 lesson) → env → default **sdk** (no behavior change until flipped).

**Hardenings — both fired in the live smoke test:**
1. First-run trust/bypass pre-seed (reuses the rails' #112 `_seed_claude_trust_file`): without it the REPL wedges at the trust dialog and silently eats the instruction (observed in smoke run 1)
2. `_ensure_submitted`: re-sends Enter once if the instruction is parked in the input box (paste-without-submit — fired in smoke run 2 and saved it)

Failure semantics unchanged: error `RunResult` → dream marked failed, scheduler alert path as today. Stale `pinky-dream-<agent>` sessions are killed before spawn; sessions always torn down in `finally`.

## Evidence (live end-to-end smoke on this Mini)

```
tmux-dream: seeded claude trust for /private/var/folders/.../tmp7ais5ps6
tmux-dream: spawned pinky-dream-smoketest (model=haiku, prompt=prompt-20260610-082148.md)
tmux-dream: pinky-dream-smoketest instruction not submitted — re-sending Enter
tmux-dream: pinky-dream-smoketest done in 10087ms, report=19 chars
exit_code: 0  output: 'TMUX DREAM SMOKE OK'  (0 dream sessions left after)
```

## Tests

10 new (`tests/test_tmux_dream_runner.py`): happy path (prompt file contents, instruction carries only paths, model/flags on spawn, trust seed, teardown), stale-session pre-kill, spawn failure, timeout + teardown, session naming, and 5 transport-resolution tests (default sdk, setting_provider wins, env fallback, unknown value, provider exception contained). 15 passed with `test_dream_runner.py`; ruff clean.

## Deploy plan (needs to land before June 15)

1. Merge **after #704** (scheduler must not block on dreams; tmux dreams are just as long)
2. Cut release, `update_and_restart()`
3. Set `PINKY_DREAM_TRANSPORT=tmux` (daemon .env or system_settings)
4. Soak one 3am night (~June 11–12), verify `transport=tmux` in dream logs + reflections attribute correctly, then it's done with margin before the 15th

Follow-ups (not this PR): per-turn usage capture from the dream session transcript → #648 analytics; `max_turns` has no interactive equivalent (timeout is the backstop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
