### PR TITLE
fix(sweep): api - cold-start race lock, fail-closed tool gates, unblock event loop

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -5960,8 +5960,14 @@ npm run build</pre>
         updates = {}
         if "provider_url" in req:
             updates["provider_url"] = (req["provider_url"] or "").strip()
-        if "provider_key" in req:
-            updates["provider_key"] = (req["provider_key"] or "").strip()
+        if req.get("provider_key") is not None:
+            # Secret: JSON null (like omitting the field) means "unchanged";
+            # an explicit "" clears the stored key.
+            key = req["provider_key"].strip()
+            if key:
+                updates["provider_key"] = key
+            else:
+                updates["clear_provider_key"] = True
         if "provider_model" in req:
             updates["provider_model"] = (req["provider_model"] or "").strip()
         if "provider_ref" in req:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -159,6 +159,7 @@ from pinky_daemon.shared_mcp import (
 )
 from pinky_daemon.skill_loader import discover_all_skills, register_discovered_skills
 from pinky_daemon.skill_store import SkillStore
+from pinky_daemon.streaming_session import _1M_MODELS
 from pinky_daemon.task_store import TaskStore
 
 # Alias: pinky_daemon.sessions.SessionState (imported above) is the
@@ -522,13 +523,14 @@ def _get_agent_tool_gates(agent_name: str, skill_store=None) -> list[str]:
     core tools only (no gates). They can always load_skill() to get more.
     """
     if not skill_store:
-        # No skill store available — fall back to all gates for safety
-        return list(ALL_TOOL_GATES)
+        # No skill store available: fail closed (core tools only)
+        return []
 
     try:
         agent_skills = skill_store.get_agent_skills(agent_name, enabled_only=True)
     except Exception:
-        return list(ALL_TOOL_GATES)
+        # Skill lookup failed: fail closed rather than granting every gate
+        return []
 
     if not agent_skills:
         return []  # No skills → core tools only
@@ -1303,6 +1305,15 @@ def create_api(
         silent: bool = False,
     ) -> SimpleNamespace:
         """Send a text message and return SimpleNamespace(message_id=...)."""
+        # iMessage has its own adapter factory; the generic lookup below
+        # never constructs one and would 503 before this branch could run.
+        if platform == "imessage":
+            im = _get_imessage_adapter(agent_name)
+            if not im:
+                raise HTTPException(503, "iMessage not enabled for this agent")
+            result = im.send_message(chat_id, content)
+            return SimpleNamespace(message_id=_extract_message_id(result))
+
         adapter = _get_platform_adapter(agent_name, platform)
         if not adapter:
             raise HTTPException(503, f"No {platform} adapter for {agent_name}")
@@ -1344,13 +1355,6 @@ def create_api(
 
         if platform == "slack":
             result = adapter.send_message(chat_id, content, thread_ts=reply_to or None)
-            return SimpleNamespace(message_id=_extract_message_id(result))
-
-        if platform == "imessage":
-            im = _get_imessage_adapter(agent_name)
-            if not im:
-                raise HTTPException(503, "iMessage not enabled for this agent")
-            result = im.send_message(chat_id, content)
             return SimpleNamespace(message_id=_extract_message_id(result))
 
         raise HTTPException(400, f"Unsupported platform: {platform}")
@@ -1738,6 +1742,11 @@ def create_api(
             sessions_map = broker._streaming.get(agent_name, {})
             total_session_cost = sum(ss.usage.total_cost_usd for ss in sessions_map.values())
             fired = _agent_cost_milestones.setdefault(agent_name, set())
+            # Session restarts reset the live cost baseline to ~0; drop fired
+            # thresholds above the current total so they can fire again.
+            fired.intersection_update(
+                {m for m in _COST_MILESTONES if m <= total_session_cost}
+            )
             for milestone in _COST_MILESTONES:
                 if total_session_cost >= milestone and milestone not in fired:
                     fired.add(milestone)
@@ -2505,6 +2514,15 @@ def create_api(
     _CONTEXT_CACHE_TTL = 30.0  # noqa: N806 — seconds
     _context_fetch_in_progress: set[str] = set()
 
+    def _context_cache_put(sid: str, info: dict, now: float) -> None:
+        _context_cache[sid] = (now, info)
+        # Keys are resume handles, which churn on every context restart; keep
+        # stale entries a few TTLs as fallback but drop them after that so the
+        # cache stays bounded over the daemon's lifetime.
+        stale_after = 10 * _CONTEXT_CACHE_TTL
+        for key in [k for k, (ts, _) in _context_cache.items() if now - ts > stale_after]:
+            del _context_cache[key]
+
     async def _streaming_context_info(ss, *, force: bool = False) -> dict:
         """Best-effort context usage details for a streaming session.
 
@@ -2525,7 +2543,7 @@ def create_api(
                 except Exception:
                     info = {}
                 if info:
-                    _context_cache[sid] = (now, info)
+                    _context_cache_put(sid, info, now)
                 return info
             return {}
 
@@ -2561,7 +2579,7 @@ def create_api(
                 "categories": ctx.get("categories", []),
                 "mcp_tools": ctx.get("mcpTools", []),
             }
-            _context_cache[sid] = (now, info)
+            _context_cache_put(sid, info, now)
             return info
         except Exception:
             # Return stale cache on timeout rather than empty
@@ -2756,7 +2774,24 @@ def create_api(
         codex_mcp_servers = {}
         if is_codex and SHARED_MCP_ENABLED:
             shared_base = f"http://{_mcp_connect_host()}:{SHARED_MCP_PORT}"
+            # #623: codex agents need the derived bearer too (see _sse_headers
+            # in _write_mcp_json) or any config requiring bearer auth (exposed
+            # bind / PINKY_SHARED_MCP_REQUIRE_AUTH=1) rejects their MCP calls.
             agent_headers = {"X-Agent-Name": agent_name}
+            try:
+                agent_key = (agents.get_or_create_signing_key(agent_name) or "").strip()
+            except Exception:
+                agent_key = ""
+            if agent_key:
+                from pinky_daemon.shared_mcp import derive_mcp_bearer
+
+                agent_headers["Authorization"] = f"Bearer {derive_mcp_bearer(agent_key)}"
+            else:
+                _log(
+                    f"api: WARNING no signing key for codex agent '{agent_name}' "
+                    f"-- its shared-MCP requests will be rejected wherever "
+                    f"bearer auth is required"
+                )
             for srv_name in ("self", "memory", "messaging"):
                 codex_mcp_servers[f"pinky-{srv_name}"] = {
                     "url": f"{shared_base}/mcp/{srv_name}/http/mcp",
@@ -2866,9 +2901,9 @@ def create_api(
                         agent_name=agent_name,
                         platform="telegram",
                         chat_id=str(owner_chat),
-                        text=(
-                            f"⚠️ {agent_name} cold-start connect timed out after "
-                            f"{COLD_START_CONNECT_TIMEOUT_SEC:.0f}s ({label}) — "
+                        content=(
+                            f"WARNING: {agent_name} cold-start connect timed out after "
+                            f"{COLD_START_CONNECT_TIMEOUT_SEC:.0f}s ({label}) -- "
                             f"session not started."
                         ),
                     )
@@ -2914,6 +2949,13 @@ def create_api(
 
         return ss
 
+    # Per-(agent,label) locks so concurrent triggers (inbound platform
+    # message, scheduler wake, HTTP chat/wake endpoints) cannot all observe
+    # "no session" and each launch a full cold start. The loser of such a
+    # race would be silently dropped from the broker registry while its
+    # subprocess kept running, invisible to the watchdog.
+    _streaming_ensure_locks: dict[tuple[str, str], asyncio.Lock] = {}
+
     async def _ensure_streaming_session(agent_name: str, *, label: str = "main"):
         """Return a connected streaming session for an agent label.
 
@@ -2928,37 +2970,51 @@ def create_api(
                               "not running" fallback shape downstream)
           - DEAD / UNINITIALIZED → connect() (this is the auto-start /
                               resurrection path; explicit and intentional)
+
+        Cold starts / reconnects are serialized per (agent, label); the
+        connected fast path stays lock-free.
         """
         sessions = broker._streaming.get(agent_name, {})
         ss = sessions.get(label)
-        if ss:
-            state = ss.state
-            if state == TransportSessionState.CONNECTED:
-                return ss
-            if state == TransportSessionState.RECONNECTING:
-                # Wait for the in-flight reconnect to land. Use the same
-                # bounded poll the broker uses on the inbound path so the
-                # waits stay consistent.
-                from pinky_daemon.broker import (
-                    _INBOUND_RECONNECT_POLL_SEC,
-                    _INBOUND_RECONNECT_WAIT_SEC,
-                )
-                deadline = time.monotonic() + _INBOUND_RECONNECT_WAIT_SEC
-                while time.monotonic() < deadline:
-                    await asyncio.sleep(_INBOUND_RECONNECT_POLL_SEC)
-                    if ss.state == TransportSessionState.CONNECTED:
-                        break
-                return ss
-            # IDLE_SLEEPING / DEAD / UNINITIALIZED → explicit connect().
-            # #149 P1: this relaunches the transport for an existing session
-            # object — guard it too, else a local→unix_user update could wake
-            # the old local session under the daemon uid (Murzik #642 review).
-            _enforce_isolation_runnable(agent_name)
-            await ss.connect()
+        if ss and ss.state == TransportSessionState.CONNECTED:
             return ss
 
-        resume_id = agents.get_streaming_session_id(agent_name, label=label)
-        return await _start_streaming_session(agent_name, label=label, resume_id=resume_id)
+        lock = _streaming_ensure_locks.setdefault((agent_name, label), asyncio.Lock())
+        async with lock:
+            # Re-check under the lock: a concurrent caller may have started
+            # or reconnected the session while we waited.
+            sessions = broker._streaming.get(agent_name, {})
+            ss = sessions.get(label)
+            if ss:
+                state = ss.state
+                if state == TransportSessionState.CONNECTED:
+                    return ss
+                if state == TransportSessionState.RECONNECTING:
+                    # Wait for the in-flight reconnect to land. Use the same
+                    # bounded poll the broker uses on the inbound path so the
+                    # waits stay consistent.
+                    from pinky_daemon.broker import (
+                        _INBOUND_RECONNECT_POLL_SEC,
+                        _INBOUND_RECONNECT_WAIT_SEC,
+                    )
+                    deadline = time.monotonic() + _INBOUND_RECONNECT_WAIT_SEC
+                    while time.monotonic() < deadline:
+                        await asyncio.sleep(_INBOUND_RECONNECT_POLL_SEC)
+                        if ss.state == TransportSessionState.CONNECTED:
+                            break
+                    return ss
+                # IDLE_SLEEPING / DEAD / UNINITIALIZED → explicit connect().
+                # #149 P1: this relaunches the transport for an existing session
+                # object — guard it too, else a local→unix_user update could wake
+                # the old local session under the daemon uid (Murzik #642 review).
+                _enforce_isolation_runnable(agent_name)
+                await ss.connect()
+                return ss
+
+            resume_id = agents.get_streaming_session_id(agent_name, label=label)
+            return await _start_streaming_session(
+                agent_name, label=label, resume_id=resume_id
+            )
 
     # Wire the broker's cold-wake path so inbound platform messages
     # (Telegram, Discord, etc.) can start a fresh streaming session for a
@@ -4037,21 +4093,27 @@ npm run build</pre>
 
     # ── Auth Rate Limiting ─────────────────────────────────
     # In-memory per-IP rate limiter for auth endpoints. No external deps.
+    # Keyed by the socket peer address: X-Forwarded-For is client-controlled
+    # (no trusted-proxy config exists), so honoring it would hand attackers a
+    # fresh budget per spoofed value plus an unbounded dict entry each.
     _auth_attempts: dict[str, list[float]] = {}  # IP -> list of attempt timestamps
     _AUTH_MAX_ATTEMPTS = 5  # noqa: N806 — max attempts per window
     _AUTH_WINDOW_SECONDS = 300  # noqa: N806 — 5-minute window
 
     def _check_auth_rate_limit(request: Request) -> None:
         """Raise 429 if IP has exceeded auth attempt limit."""
-        ip = request.headers.get("x-forwarded-for", "").split(",")[0].strip() or (request.client.host if request.client else "unknown")
+        ip = request.client.host if request.client else "unknown"
         now = time.time()
         cutoff = now - _AUTH_WINDOW_SECONDS
 
-        # Clean old entries
+        # Evict IPs whose attempts have all expired so the dict stays bounded
+        for stale_ip in [k for k, ts in _auth_attempts.items() if not ts or ts[-1] <= cutoff]:
+            del _auth_attempts[stale_ip]
+
         attempts = [t for t in _auth_attempts.get(ip, []) if t > cutoff]
-        _auth_attempts[ip] = attempts
 
         if len(attempts) >= _AUTH_MAX_ATTEMPTS:
+            _auth_attempts[ip] = attempts
             _log(f"auth: rate limited {ip} ({len(attempts)} attempts in {_AUTH_WINDOW_SECONDS}s)")
             raise HTTPException(429, "Too many authentication attempts. Try again later.")
 
@@ -5094,7 +5156,7 @@ npm run build</pre>
         }
         if key_name not in allowed:
             raise HTTPException(400, f"Unknown key: {key_name}. Allowed: {', '.join(sorted(allowed))}")
-        value = req.get("value", "").strip()
+        value = (req.get("value") or "").strip()
         if not value:
             raise HTTPException(400, "value is required")
         agents.set_setting(key_name, value)
@@ -5897,13 +5959,13 @@ npm run build</pre>
             raise HTTPException(404, f"Agent '{name}' not found")
         updates = {}
         if "provider_url" in req:
-            updates["provider_url"] = req["provider_url"].strip()
+            updates["provider_url"] = (req["provider_url"] or "").strip()
         if "provider_key" in req:
-            updates["provider_key"] = req["provider_key"].strip()
+            updates["provider_key"] = (req["provider_key"] or "").strip()
         if "provider_model" in req:
-            updates["provider_model"] = req["provider_model"].strip()
+            updates["provider_model"] = (req["provider_model"] or "").strip()
         if "provider_ref" in req:
-            updates["provider_ref"] = req["provider_ref"].strip()
+            updates["provider_ref"] = (req["provider_ref"] or "").strip()
         if updates:
             agents.register(name, **updates)
         return {"saved": True, **updates}
@@ -6078,6 +6140,12 @@ npm run build</pre>
             enabled=req.enabled, settings=req.settings, token_ref=req.token_ref,
         )
 
+        # Evict the cached outbound adapter so sends pick up the new token
+        # immediately (adapters bind the token at construction).
+        _platform_adapters.pop((name, platform), None)
+        if platform == "imessage":
+            _platform_adapters.pop(("__global__", "imessage"), None)
+
         # Dynamically start/restart a broker poller for Telegram tokens
         raw_token = agents.get_raw_token(name, platform)
         if platform == "telegram" and raw_token:
@@ -6159,6 +6227,11 @@ npm run build</pre>
         """Remove a bot token for an agent."""
         if not agents.remove_token(name, platform):
             raise HTTPException(404, "Token not found")
+
+        # Evict the cached outbound adapter so sends stop using the removed token
+        _platform_adapters.pop((name, platform), None)
+        if platform == "imessage":
+            _platform_adapters.pop(("__global__", "imessage"), None)
 
         # Stop broker poller if removing a Telegram token
         if platform == "telegram":
@@ -6826,6 +6899,11 @@ npm run build</pre>
             raise HTTPException(409, f"Session '{new_label}' already exists for {name}")
         # Move in broker registry
         sessions[new_label] = sessions.pop(label)
+        # Retarget the live session: its id derives from _config.label and the
+        # resume-handle callback closed over the old label, so without this the
+        # session keeps persisting turns and resume handles under the old name.
+        ss._config.label = new_label
+        ss._on_resume_handle = await _make_streaming_resume_handle_callback(name, new_label)
         # Update stored session ID mapping
         old_sid = agents.get_streaming_session_id(name, label=label)
         if old_sid:
@@ -7495,12 +7573,14 @@ npm run build</pre>
             pass
 
         new_is_1m = req.model in _1M_MODELS
-        old_is_1m = old_max > 500_000  # Current window is 1M-class
+        if old_max > 0:
+            old_is_1m = old_max > 500_000  # Current window is 1M-class
+        else:
+            # Usage fetch failed: fall back to the configured model class so a
+            # 1M -> 200k switch still forces the context-window restart.
+            old_is_1m = (ss._config.model or "") in _1M_MODELS
 
         needs_restart = new_is_1m != old_is_1m
-
-        # Update agent config first
-        agents.register(name, model=req.model)
 
         if needs_restart:
             # Context window changes — need full restart
@@ -7508,6 +7588,10 @@ npm run build</pre>
             guard = _get_streaming_restart_guard(name, ss)
             if not guard["restart_safe"]:
                 raise HTTPException(409, _guard_message("restart", guard))
+
+            # Persist only once the restart is actually going ahead, so a 409
+            # above leaves the DB matching the still-running session.
+            agents.register(name, model=req.model)
 
             # Ask agent to save state
             try:
@@ -7553,6 +7637,8 @@ npm run build</pre>
             except Exception as e:
                 raise HTTPException(500, f"Failed to set model: {e}")
 
+            # Persist only after the live session actually switched
+            agents.register(name, model=req.model)
             return {"updated": True, "agent": name, "model": req.model, "restarted": False}
 
     @app.post("/agents/{name}/streaming/compact")
@@ -8095,11 +8181,13 @@ npm run build</pre>
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
-        file_path = Path(agent.working_dir).resolve() / filename
+        work_dir = Path(agent.working_dir).resolve()
+        file_path = work_dir / filename
         if not file_path.exists() or not file_path.is_file():
             raise HTTPException(404, f"File '{filename}' not found")
-        # Safety: don't serve files outside the working dir
-        if not str(file_path).startswith(str(Path(agent.working_dir).resolve())):
+        # Safety: don't serve files outside the working dir. Resolve first so
+        # a symlink inside the dir pointing elsewhere is rejected too.
+        if not str(file_path.resolve()).startswith(str(work_dir)):
             raise HTTPException(403, "Access denied")
         return {"name": filename, "content": file_path.read_text(errors="replace")}
 
@@ -8707,7 +8795,7 @@ npm run build</pre>
                         agent_name=agent_name,
                         platform="telegram",
                         chat_id=str(owner_chat),
-                        text=message,
+                        content=message,
                     )
         except Exception as exc:
             _log(f"watchdog: alert delivery failed for {agent_name}: {exc}")
@@ -8957,14 +9045,14 @@ npm run build</pre>
                 )
                 if existing:
                     _log(f"startup: telegram poller already exists for {agent.name}, skipping")
-                    continue
-                adapter = TelegramAdapter(token, timeout=45.0)  # > poll_timeout (30s) to avoid racing
-                poller = BrokerTelegramPoller(
-                    adapter, agent.name, broker, registry=agents,
-                )
-                _broker_pollers.append(poller)
-                asyncio.create_task(poller.start())
-                _log(f"startup: broker poller started for {agent.name}")
+                else:
+                    adapter = TelegramAdapter(token, timeout=45.0)  # > poll_timeout (30s) to avoid racing
+                    poller = BrokerTelegramPoller(
+                        adapter, agent.name, broker, registry=agents,
+                    )
+                    _broker_pollers.append(poller)
+                    asyncio.create_task(poller.start())
+                    _log(f"startup: broker poller started for {agent.name}")
 
             # Discord poller — REST polling (Gateway/WebSocket is a future v0.2)
             discord_token = agents.get_raw_token(agent.name, "discord")
@@ -9113,18 +9201,23 @@ npm run build</pre>
         }
         for name in list(broker._streaming.keys()):
             sessions = broker._streaming.get(name, {})
-            for label, ss in list(sessions.items()):
-                try:
-                    s = ss.stats
-                    manifest["agents"][name] = {
-                        "label": label,
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
-                        "in_progress": s.get("current_activity", ""),
-                        "activity_log": s.get("activity_log", []),
-                        "pending_responses": s.get("pending_responses", 0),
-                    }
-                except Exception:
-                    pass
+            if not sessions:
+                continue
+            # One entry per agent; prefer the main session's state so a
+            # multi-label agent does not overwrite it with a sub-session's.
+            label = "main" if "main" in sessions else next(iter(sessions))
+            ss = sessions[label]
+            try:
+                s = ss.stats
+                manifest["agents"][name] = {
+                    "label": label,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "in_progress": s.get("current_activity", ""),
+                    "activity_log": s.get("activity_log", []),
+                    "pending_responses": s.get("pending_responses", 0),
+                }
+            except Exception:
+                pass
         try:
             manifest_path.write_text(_json.dumps(manifest, indent=2))
             _log(f"shutdown: restart manifest written for {len(manifest['agents'])} agent(s)")
@@ -9142,6 +9235,7 @@ npm run build</pre>
             broker.unregister_streaming(name)
         for poller in _broker_pollers:
             poller.stop()
+        _broker_pollers.clear()
         await autonomy.stop()
         await scheduler.stop()
         await watchdog.stop()
@@ -9322,259 +9416,271 @@ npm run build</pre>
         branch = "main"
         repo_dir = str(Path(__file__).resolve().parent.parent.parent)
 
-        # Current state
-        try:
-            before_hash = sp.check_output(
-                ["git", "rev-parse", "--short", "HEAD"],
-                cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
-            ).decode().strip()
-        except Exception:
-            before_hash = "unknown"
-
-        # Current tag (if any)
-        try:
-            current_tag = sp.check_output(
-                ["git", "describe", "--tags", "--exact-match", "HEAD"],
-                cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
-            ).decode().strip()
-        except Exception:
-            current_tag = None
-
-        # Fetch tags + branch
-        try:
-            sp.check_output(
-                ["git", "fetch", "origin", "--tags", branch],
-                cwd=repo_dir, stderr=sp.STDOUT, timeout=30,
-            )
-        except sp.CalledProcessError as e:
-            return {"error": f"git fetch failed: {e.output.decode()[:500]}"}
-
-        # Unshallow if needed (install.sh uses --depth 1) so tag/commit
-        # resolution and verification see full history.
-        try:
-            is_shallow = sp.check_output(
-                ["git", "rev-parse", "--is-shallow-repository"],
-                cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
-            ).decode().strip()
-            if is_shallow == "true":
-                sp.check_output(
-                    ["git", "fetch", "--unshallow", "origin"],
-                    cwd=repo_dir, stderr=sp.STDOUT, timeout=60,
-                )
-        except Exception:
-            pass  # Non-fatal — shallow log may still miss commits
-
-        # Resolve + verify the deploy target. Empty target = latest published
-        # release; a tag = that release (verified against the GitHub Releases
-        # API over TLS unless force); a commit SHA = an explicit operator pin.
-        from pinky_daemon import self_update
-        decision = self_update.resolve_and_verify(
-            repo_dir, target, force=force, log=_log,
-        )
-        target_tag = self_update.latest_release_tag(repo_dir)
-
-        # Preview mode — report the planned deploy without mutating anything.
-        if dry_run:
+        # The whole update pipeline (git fetch/checkout, release
+        # verification over TLS, pip install, npm build) is blocking and can
+        # take minutes; run it off the event loop so the daemon keeps
+        # routing messages while the update proceeds.
+        def _run_update() -> dict:
+            # Current state
             try:
-                pending = sp.check_output(
-                    ["git", "log", "--oneline", f"HEAD..origin/{branch}"],
+                before_hash = sp.check_output(
+                    ["git", "rev-parse", "--short", "HEAD"],
                     cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
                 ).decode().strip()
             except Exception:
-                pending = ""
-            commits = [line for line in pending.splitlines() if line.strip()] if pending else []
-            result = {
-                "dry_run": True,
-                "current_hash": before_hash,
-                "current_release": current_tag,
-                "branch": branch,
-                "pending_commits": len(commits),
-                "commits": commits,
-                "up_to_date": len(commits) == 0,
-                "deploy_ref": decision.ref or None,
-                "deploy_kind": decision.kind or None,
-                "verified": decision.verified,
-            }
-            if target_tag:
-                result["latest_release"] = target_tag
+                before_hash = "unknown"
+
+            # Current tag (if any)
+            try:
+                current_tag = sp.check_output(
+                    ["git", "describe", "--tags", "--exact-match", "HEAD"],
+                    cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
+                ).decode().strip()
+            except Exception:
+                current_tag = None
+
+            # Fetch tags + branch
+            try:
+                sp.check_output(
+                    ["git", "fetch", "origin", "--tags", branch],
+                    cwd=repo_dir, stderr=sp.STDOUT, timeout=30,
+                )
+            except sp.CalledProcessError as e:
+                return {"error": f"git fetch failed: {e.output.decode()[:500]}"}
+
+            # Unshallow if needed (install.sh uses --depth 1) so tag/commit
+            # resolution and verification see full history.
+            try:
+                is_shallow = sp.check_output(
+                    ["git", "rev-parse", "--is-shallow-repository"],
+                    cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
+                ).decode().strip()
+                if is_shallow == "true":
+                    sp.check_output(
+                        ["git", "fetch", "--unshallow", "origin"],
+                        cwd=repo_dir, stderr=sp.STDOUT, timeout=60,
+                    )
+            except Exception:
+                pass  # Non-fatal — shallow log may still miss commits
+
+            # Resolve + verify the deploy target. Empty target = latest published
+            # release; a tag = that release (verified against the GitHub Releases
+            # API over TLS unless force); a commit SHA = an explicit operator pin.
+            from pinky_daemon import self_update
+            decision = self_update.resolve_and_verify(
+                repo_dir, target, force=force, log=_log,
+            )
+            target_tag = self_update.latest_release_tag(repo_dir)
+
+            # Preview mode — report the planned deploy without mutating anything.
+            if dry_run:
+                try:
+                    pending = sp.check_output(
+                        ["git", "log", "--oneline", f"HEAD..origin/{branch}"],
+                        cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
+                    ).decode().strip()
+                except Exception:
+                    pending = ""
+                commits = [line for line in pending.splitlines() if line.strip()] if pending else []
+                result = {
+                    "dry_run": True,
+                    "current_hash": before_hash,
+                    "current_release": current_tag,
+                    "branch": branch,
+                    "pending_commits": len(commits),
+                    "commits": commits,
+                    "up_to_date": len(commits) == 0,
+                    "deploy_ref": decision.ref or None,
+                    "deploy_kind": decision.kind or None,
+                    "verified": decision.verified,
+                }
+                if target_tag:
+                    result["latest_release"] = target_tag
+                if decision.error:
+                    result["verify_error"] = decision.error
+                return result
+
+            # Refuse before touching the working tree if verification failed.
             if decision.error:
-                result["verify_error"] = decision.error
+                return {
+                    "error": decision.error,
+                    "current_release": current_tag,
+                    "staying_on_version": before_hash,
+                }
+
+            # Force mode: discard local mods to TRACKED files before checkout.
+            # Untracked files (e.g. .env, local notes) are NOT touched.
+            forced_reset = False
+            forced_files: list[str] = []
+            if force:
+                try:
+                    dirty = sp.check_output(
+                        ["git", "diff", "--name-only", "HEAD"],
+                        cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
+                    ).decode().strip()
+                    if dirty:
+                        forced_files = [f for f in dirty.splitlines() if f.strip()]
+                        # checkout HEAD (not the index) so staged changes are
+                        # discarded too; plain `checkout -- .` restores from the
+                        # index and leaves staged mods to break the deploy checkout
+                        sp.check_output(
+                            ["git", "checkout", "HEAD", "--", "."],
+                            cwd=repo_dir, stderr=sp.STDOUT, timeout=30,
+                        )
+                        forced_reset = True
+                        _log(f"admin: force=True reset {len(forced_files)} tracked file(s): {forced_files[:10]}")
+                except sp.CalledProcessError as e:
+                    return {"error": f"force reset failed: {e.output.decode()[:500]}"}
+                except Exception as e:
+                    _log(f"admin: force reset warning: {e}")
+
+            # Check out the resolved + verified ref (detached HEAD at the tag, or
+            # the pinned commit). Replaces `git pull origin main` so production
+            # runs exactly the verified ref, not whatever is at branch HEAD.
+            try:
+                sp.check_output(
+                    ["git", "checkout", decision.ref],
+                    cwd=repo_dir, stderr=sp.STDOUT, timeout=60,
+                )
+                _log(f"admin: checked out {decision.kind} {decision.ref} (verified={decision.verified})")
+            except sp.CalledProcessError as e:
+                return {"error": f"git checkout {decision.ref} failed: {e.output.decode()[:500]}"}
+
+            # After hash + commit summary
+            try:
+                after_hash = sp.check_output(
+                    ["git", "rev-parse", "--short", "HEAD"],
+                    cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
+                ).decode().strip()
+            except Exception:
+                after_hash = "unknown"
+
+            try:
+                summary = sp.check_output(
+                    ["git", "log", "--oneline", f"{before_hash}..{after_hash}"],
+                    cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
+                ).decode().strip()
+            except Exception:
+                summary = ""
+
+            # Detect dependency changes — rebuild whenever pyproject.toml or uv.lock
+            # changed in the pull, when force_deps=True is passed, or when the
+            # installed package versions have drifted from the pyproject pins
+            # (e.g., pyproject was bumped on an earlier pull that skipped reinstall).
+            deps_rebuilt = False
+            deps_error = ""
+            deps_drift: list[dict] = []
+            try:
+                if before_hash != after_hash:
+                    changed = sp.check_output(
+                        ["git", "diff", "--name-only", before_hash, after_hash, "--",
+                         "pyproject.toml", "uv.lock"],
+                        cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
+                    ).decode().strip()
+                else:
+                    changed = ""
+
+                # Auto-deps drift check: compare installed versions to pyproject pins
+                # independently of git diff. Catches the "pyproject bumped earlier,
+                # routine restart skipped reinstall" case that force_deps used to
+                # paper over manually.
+                try:
+                    deps_drift = _check_installed_deps_drift(repo_dir)
+                except Exception as drift_exc:
+                    _log(f"admin: deps drift check failed (non-fatal): {drift_exc}")
+                    deps_drift = []
+
+                if changed or force_deps or deps_drift:
+                    # Prefer project venv pip if present, else use the running daemon's
+                    # interpreter (sys.executable). This works for both venv and
+                    # system-python deployments — the prior `.venv/bin/pip`-only path
+                    # silently skipped rebuilds on system-python hosts.
+                    venv_pip = Path(repo_dir) / ".venv" / "bin" / "pip"
+                    if venv_pip.exists():
+                        pip_cmd = [str(venv_pip), "install", "-e", ".[all]", "--quiet"]
+                    else:
+                        # PEP 668: system pythons (Homebrew, Debian) mark themselves
+                        # externally-managed. --break-system-packages lets us install
+                        # into the same env the daemon imports from.
+                        pip_cmd = [
+                            sys.executable, "-m", "pip", "install",
+                            "-e", ".[all]", "--quiet", "--break-system-packages",
+                        ]
+                    sp.check_output(pip_cmd, cwd=repo_dir, stderr=sp.STDOUT, timeout=180)
+                    deps_rebuilt = True
+            except sp.CalledProcessError as e:
+                deps_error = f"pip install failed: {e.output.decode()[:500] if e.output else e}"
+                _log(f"admin: {deps_error}")
+            except Exception as e:
+                deps_error = f"deps rebuild failed: {e}"
+                _log(f"admin: {deps_error}")
+
+            # Always rebuild frontend on update to keep compiled assets fresh
+            frontend_rebuilt = False
+            frontend_error = ""
+            frontend_manifest: dict | None = None
+            try:
+                fe_dir = str(Path(repo_dir) / "frontend-svelte")
+                npm_path = shutil.which("npm")
+                if npm_path and Path(fe_dir).exists():
+                    _log("admin: rebuilding frontend...")
+                    sp.check_output(
+                        [npm_path, "install", "--silent"], cwd=fe_dir, stderr=sp.STDOUT, timeout=120
+                    )
+                    sp.check_output(
+                        [npm_path, "run", "build"], cwd=fe_dir, stderr=sp.STDOUT, timeout=120
+                    )
+                    frontend_rebuilt = True
+                elif not npm_path:
+                    frontend_error = "npm not found — install Node.js 18+ to enable auto frontend builds"
+                    _log(f"admin: {frontend_error}")
+            except Exception as e:
+                frontend_error = f"Frontend build failed: {e}"
+                _log(f"admin: {frontend_error}")
+
+            if frontend_rebuilt:
+                try:
+                    frontend_manifest = _write_frontend_build_manifest(
+                        repo_dir, git_hash=after_hash,
+                    )
+                except Exception as e:
+                    frontend_error = f"Frontend build manifest failed: {e}"
+                    _log(f"admin: {frontend_error}")
+
+            frontend_status = _frontend_build_status(repo_dir, current_git_hash=after_hash)
+            app.state.frontend_build_status = frontend_status
+
+            result = {
+                "updated": True,
+                "before_hash": before_hash,
+                "after_hash": after_hash,
+                # The release actually deployed (the resolved ref when it's a tag);
+                # None for an operator-pinned commit. latest_release reports the
+                # newest tag regardless, for context.
+                "release": decision.ref if decision.kind == "release" else None,
+                "latest_release": target_tag,
+                "deploy_ref": decision.ref,
+                "deploy_kind": decision.kind,
+                "verified": decision.verified,
+                "commits": summary.splitlines() if summary else [],
+                "deps_rebuilt": deps_rebuilt,
+                "deps_error": deps_error or None,
+                "deps_drift": deps_drift,
+                "frontend_rebuilt": frontend_rebuilt,
+                "frontend_error": frontend_error or None,
+                "frontend_manifest": frontend_manifest,
+                "frontend_status": frontend_status,
+                "forced_reset": forced_reset,
+                "forced_files": forced_files,
+                "restarting": before_hash != after_hash or deps_rebuilt,
+            }
+
             return result
 
-        # Refuse before touching the working tree if verification failed.
-        if decision.error:
-            return {
-                "error": decision.error,
-                "current_release": current_tag,
-                "staying_on_version": before_hash,
-            }
-
-        # Force mode: discard local mods to TRACKED files before checkout.
-        # Untracked files (e.g. .env, local notes) are NOT touched.
-        forced_reset = False
-        forced_files: list[str] = []
-        if force:
-            try:
-                dirty = sp.check_output(
-                    ["git", "diff", "--name-only", "HEAD"],
-                    cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
-                ).decode().strip()
-                if dirty:
-                    forced_files = [f for f in dirty.splitlines() if f.strip()]
-                    sp.check_output(
-                        ["git", "checkout", "--", "."],
-                        cwd=repo_dir, stderr=sp.STDOUT, timeout=30,
-                    )
-                    forced_reset = True
-                    _log(f"admin: force=True reset {len(forced_files)} tracked file(s): {forced_files[:10]}")
-            except sp.CalledProcessError as e:
-                return {"error": f"force reset failed: {e.output.decode()[:500]}"}
-            except Exception as e:
-                _log(f"admin: force reset warning: {e}")
-
-        # Check out the resolved + verified ref (detached HEAD at the tag, or
-        # the pinned commit). Replaces `git pull origin main` so production
-        # runs exactly the verified ref, not whatever is at branch HEAD.
-        try:
-            sp.check_output(
-                ["git", "checkout", decision.ref],
-                cwd=repo_dir, stderr=sp.STDOUT, timeout=60,
-            )
-            _log(f"admin: checked out {decision.kind} {decision.ref} (verified={decision.verified})")
-        except sp.CalledProcessError as e:
-            return {"error": f"git checkout {decision.ref} failed: {e.output.decode()[:500]}"}
-
-        # After hash + commit summary
-        try:
-            after_hash = sp.check_output(
-                ["git", "rev-parse", "--short", "HEAD"],
-                cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
-            ).decode().strip()
-        except Exception:
-            after_hash = "unknown"
-
-        try:
-            summary = sp.check_output(
-                ["git", "log", "--oneline", f"{before_hash}..{after_hash}"],
-                cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
-            ).decode().strip()
-        except Exception:
-            summary = ""
-
-        # Detect dependency changes — rebuild whenever pyproject.toml or uv.lock
-        # changed in the pull, when force_deps=True is passed, or when the
-        # installed package versions have drifted from the pyproject pins
-        # (e.g., pyproject was bumped on an earlier pull that skipped reinstall).
-        deps_rebuilt = False
-        deps_error = ""
-        deps_drift: list[dict] = []
-        try:
-            if before_hash != after_hash:
-                changed = sp.check_output(
-                    ["git", "diff", "--name-only", before_hash, after_hash, "--",
-                     "pyproject.toml", "uv.lock"],
-                    cwd=repo_dir, stderr=sp.DEVNULL, timeout=10,
-                ).decode().strip()
-            else:
-                changed = ""
-
-            # Auto-deps drift check: compare installed versions to pyproject pins
-            # independently of git diff. Catches the "pyproject bumped earlier,
-            # routine restart skipped reinstall" case that force_deps used to
-            # paper over manually.
-            try:
-                deps_drift = _check_installed_deps_drift(repo_dir)
-            except Exception as drift_exc:
-                _log(f"admin: deps drift check failed (non-fatal): {drift_exc}")
-                deps_drift = []
-
-            if changed or force_deps or deps_drift:
-                # Prefer project venv pip if present, else use the running daemon's
-                # interpreter (sys.executable). This works for both venv and
-                # system-python deployments — the prior `.venv/bin/pip`-only path
-                # silently skipped rebuilds on system-python hosts.
-                venv_pip = Path(repo_dir) / ".venv" / "bin" / "pip"
-                if venv_pip.exists():
-                    pip_cmd = [str(venv_pip), "install", "-e", ".[all]", "--quiet"]
-                else:
-                    # PEP 668: system pythons (Homebrew, Debian) mark themselves
-                    # externally-managed. --break-system-packages lets us install
-                    # into the same env the daemon imports from.
-                    pip_cmd = [
-                        sys.executable, "-m", "pip", "install",
-                        "-e", ".[all]", "--quiet", "--break-system-packages",
-                    ]
-                sp.check_output(pip_cmd, cwd=repo_dir, stderr=sp.STDOUT, timeout=180)
-                deps_rebuilt = True
-        except sp.CalledProcessError as e:
-            deps_error = f"pip install failed: {e.output.decode()[:500] if e.output else e}"
-            _log(f"admin: {deps_error}")
-        except Exception as e:
-            deps_error = f"deps rebuild failed: {e}"
-            _log(f"admin: {deps_error}")
-
-        # Always rebuild frontend on update to keep compiled assets fresh
-        frontend_rebuilt = False
-        frontend_error = ""
-        frontend_manifest: dict | None = None
-        try:
-            fe_dir = str(Path(repo_dir) / "frontend-svelte")
-            npm_path = shutil.which("npm")
-            if npm_path and Path(fe_dir).exists():
-                _log("admin: rebuilding frontend...")
-                sp.check_output(
-                    [npm_path, "install", "--silent"], cwd=fe_dir, stderr=sp.STDOUT, timeout=120
-                )
-                sp.check_output(
-                    [npm_path, "run", "build"], cwd=fe_dir, stderr=sp.STDOUT, timeout=120
-                )
-                frontend_rebuilt = True
-            elif not npm_path:
-                frontend_error = "npm not found — install Node.js 18+ to enable auto frontend builds"
-                _log(f"admin: {frontend_error}")
-        except Exception as e:
-            frontend_error = f"Frontend build failed: {e}"
-            _log(f"admin: {frontend_error}")
-
-        if frontend_rebuilt:
-            try:
-                frontend_manifest = _write_frontend_build_manifest(
-                    repo_dir, git_hash=after_hash,
-                )
-            except Exception as e:
-                frontend_error = f"Frontend build manifest failed: {e}"
-                _log(f"admin: {frontend_error}")
-
-        frontend_status = _frontend_build_status(repo_dir, current_git_hash=after_hash)
-        app.state.frontend_build_status = frontend_status
-
-        result = {
-            "updated": True,
-            "before_hash": before_hash,
-            "after_hash": after_hash,
-            # The release actually deployed (the resolved ref when it's a tag);
-            # None for an operator-pinned commit. latest_release reports the
-            # newest tag regardless, for context.
-            "release": decision.ref if decision.kind == "release" else None,
-            "latest_release": target_tag,
-            "deploy_ref": decision.ref,
-            "deploy_kind": decision.kind,
-            "verified": decision.verified,
-            "commits": summary.splitlines() if summary else [],
-            "deps_rebuilt": deps_rebuilt,
-            "deps_error": deps_error or None,
-            "deps_drift": deps_drift,
-            "frontend_rebuilt": frontend_rebuilt,
-            "frontend_error": frontend_error or None,
-            "frontend_manifest": frontend_manifest,
-            "frontend_status": frontend_status,
-            "forced_reset": forced_reset,
-            "forced_files": forced_files,
-            "restarting": before_hash != after_hash or deps_rebuilt,
-        }
+        result = await asyncio.to_thread(_run_update)
 
         # Schedule graceful restart if anything changed
-        if result["restarting"]:
+        if result.get("restarting"):
             import signal
 
             async def _delayed_exit():
@@ -9905,7 +10011,8 @@ npm run build</pre>
             result["setup_message"] = "Claude Code CLI not found. Install it first: npm install -g @anthropic-ai/claude-code"
         else:
             try:
-                proc = subprocess.run(
+                proc = await asyncio.to_thread(
+                    subprocess.run,
                     ["claude", "auth", "status"],
                     capture_output=True, text=True, timeout=10,
                 )
@@ -9922,7 +10029,8 @@ npm run build</pre>
         # ── Codex CLI auth ──
         if result["codex_installed"]:
             try:
-                proc = subprocess.run(
+                proc = await asyncio.to_thread(
+                    subprocess.run,
                     ["codex", "login", "status"],
                     capture_output=True, text=True, timeout=10,
                 )

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8183,12 +8183,14 @@ npm run build</pre>
             raise HTTPException(404, f"Agent '{name}' not found")
         work_dir = Path(agent.working_dir).resolve()
         file_path = work_dir / filename
+        # Safety: don't serve files outside the working dir. Resolve first so
+        # a symlink inside the dir pointing elsewhere is rejected too, and
+        # check containment before existence so outside paths 403, not 404.
+        # is_relative_to avoids the '/dir' vs '/dir-evil' prefix pitfall.
+        if not file_path.resolve().is_relative_to(work_dir):
+            raise HTTPException(403, "Access denied")
         if not file_path.exists() or not file_path.is_file():
             raise HTTPException(404, f"File '{filename}' not found")
-        # Safety: don't serve files outside the working dir. Resolve first so
-        # a symlink inside the dir pointing elsewhere is rejected too.
-        if not str(file_path.resolve()).startswith(str(work_dir)):
-            raise HTTPException(403, "Access denied")
         return {"name": filename, "content": file_path.read_text(errors="replace")}
 
     @app.put("/agents/{name}/files/{filename}")
@@ -8203,8 +8205,8 @@ npm run build</pre>
         work_dir = Path(agent.working_dir).resolve()
         work_dir.mkdir(parents=True, exist_ok=True)
         file_path = work_dir / filename
-        # Safety check
-        if not str(file_path.resolve()).startswith(str(work_dir)):
+        # Safety check (resolve first; is_relative_to avoids prefix pitfalls)
+        if not file_path.resolve().is_relative_to(work_dir):
             raise HTTPException(403, "Access denied")
         file_path.write_text(req.content)
         if filename == "CLAUDE.md":
@@ -9216,8 +9218,8 @@ npm run build</pre>
                     "activity_log": s.get("activity_log", []),
                     "pending_responses": s.get("pending_responses", 0),
                 }
-            except Exception:
-                pass
+            except Exception as e:
+                _log(f"shutdown: could not snapshot {name} for restart manifest: {e}")
         try:
             manifest_path.write_text(_json.dumps(manifest, indent=2))
             _log(f"shutdown: restart manifest written for {len(manifest['agents'])} agent(s)")

--- a/tests/test_admin_update.py
+++ b/tests/test_admin_update.py
@@ -94,8 +94,8 @@ class _GitMock:
                 joined += "\n"
             return joined.encode()
 
-        # git checkout -- .  (force reset of tracked files)
-        if cmd[:3] == ["git", "checkout", "--"]:
+        # git checkout HEAD -- .  (force reset of tracked files, incl. staged)
+        if cmd[:4] == ["git", "checkout", "HEAD", "--"]:
             return b""
 
         # git checkout <branch>  (used when on detached HEAD / wrong branch)
@@ -117,7 +117,7 @@ class _GitMock:
         return b""
 
     def did_force_reset(self) -> bool:
-        return any(c[:4] == ["git", "checkout", "--", "."] for c in self.calls)
+        return any(c[:5] == ["git", "checkout", "HEAD", "--", "."] for c in self.calls)
 
     def did_pull(self) -> bool:
         return any(c[:3] == ["git", "pull", "origin"] for c in self.calls)
@@ -171,7 +171,8 @@ class TestAdminUpdateForce:
 
         # Critical ordering: reset must happen BEFORE the deploy checkout
         reset_idx = next(
-            i for i, c in enumerate(gm.calls) if c[:4] == ["git", "checkout", "--", "."]
+            i for i, c in enumerate(gm.calls)
+            if c[:5] == ["git", "checkout", "HEAD", "--", "."]
         )
         deploy_idx = next(
             i for i, c in enumerate(gm.calls)

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -885,12 +885,27 @@ class TestGateToolNames:
             assert name.startswith("mcp__pinky-self__")
 
     def test_no_skills_disallows_everything(self):
-        """Agent with no skills gets all gated tools disallowed."""
-        from pinky_daemon.api import _get_shared_mode_disallowed_tools
+        """Agent with no skill store fails closed: all gated tools disallowed."""
+        from pinky_daemon.api import ALL_GATED_TOOL_NAMES, _get_shared_mode_disallowed_tools
         disallowed = _get_shared_mode_disallowed_tools("no-skills-agent", skill_store=None)
-        # No skill_store → _get_agent_tool_gates returns ALL gates → nothing disallowed
-        # (safety fallback: all gates open when no skill store)
-        assert disallowed == []
+        # No skill_store -> _get_agent_tool_gates fails closed -> no gates open
+        assert set(disallowed) == ALL_GATED_TOOL_NAMES
+
+    def test_broken_skill_store_fails_closed(self):
+        """A skill-store error must not grant every gate (incl. admin)."""
+        from pinky_daemon.api import (
+            ALL_GATED_TOOL_NAMES,
+            _get_agent_tool_gates,
+            _get_shared_mode_disallowed_tools,
+        )
+
+        class BrokenSkillStore:
+            def get_agent_skills(self, name, enabled_only=True):
+                raise RuntimeError("database is locked")
+
+        assert _get_agent_tool_gates("agent", BrokenSkillStore()) == []
+        disallowed = _get_shared_mode_disallowed_tools("agent", skill_store=BrokenSkillStore())
+        assert set(disallowed) == ALL_GATED_TOOL_NAMES
 
     def test_with_mock_skill_store_no_skills(self):
         """Agent with skill store but no skills → all gated tools disallowed."""

--- a/tests/test_sweep_api_fixes.py
+++ b/tests/test_sweep_api_fixes.py
@@ -1,0 +1,419 @@
+"""Regression tests for the api sweep fixes (cold-start race, broker send
+kwargs, iMessage outbound, adapter cache eviction, fail-closed tool gates,
+auth rate limiting, streaming-session rename, model-change persistence)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+def _make_app(db_path: str):
+    from pinky_daemon.api import create_api
+    return create_api(max_sessions=10, default_working_dir="/tmp", db_path=db_path)
+
+
+class _FakeContextClient:
+    def __init__(self, total_tokens=0, max_tokens=200_000):
+        self.total_tokens = total_tokens
+        self.max_tokens = max_tokens
+        self.queries: list[str] = []
+
+    async def get_context_usage(self):
+        return {"totalTokens": self.total_tokens, "maxTokens": self.max_tokens}
+
+    async def query(self, prompt: str):
+        self.queries.append(prompt)
+
+
+class _FakeStreamingSession:
+    def __init__(self, agent_name: str, label: str = "main", *, max_tokens: int = 200_000):
+        from pinky_daemon.transport_state import SessionState
+        self._TS = SessionState
+        self.agent_name = agent_name
+        self.label = label
+        self.resume_handle = f"{agent_name}-{label}-sdk"
+        self.created_at = time.time()
+        self.last_active = self.created_at
+        self._state = SessionState.CONNECTED
+        self._stats = {
+            "messages_sent": 2, "turns": 3, "errors": 0,
+            "reconnects": 0, "auto_restarts": 0,
+        }
+        self._config = SimpleNamespace(
+            model="sonnet", label=label, context_restart_pct=80,
+            permission_mode="bypassPermissions",
+        )
+        self.usage = SimpleNamespace(total_cost_usd=0.0, input_tokens=0, output_tokens=0)
+        self._client = _FakeContextClient(max_tokens=max_tokens)
+        self.disconnect_calls = 0
+        self.connect_calls = 0
+
+    @property
+    def state(self):
+        return self._state
+
+    @property
+    def id(self) -> str:
+        return f"{self.agent_name}-{self._config.label}"
+
+    @property
+    def stats(self) -> dict:
+        return {
+            **self._stats,
+            "connected": self._state == self._TS.CONNECTED,
+            "pending_responses": 0, "cost_usd": 0.0, "account": {},
+        }
+
+    async def disconnect(self):
+        self.disconnect_calls += 1
+        self._state = self._TS.DEAD
+
+    async def connect(self):
+        self.connect_calls += 1
+        self._state = self._TS.CONNECTED
+
+
+class TestColdStartRace:
+    def test_concurrent_cold_starts_share_one_session(self):
+        """Concurrent _ensure_streaming_session calls for the same (agent,
+        label) must serialize: one cold start, every caller gets the same
+        session object, no orphaned loser subprocess."""
+        import pinky_daemon.streaming_session as ss_mod
+
+        connect_count = {"n": 0}
+
+        async def fake_connect(self):
+            from pinky_daemon.transport_state import SessionState
+            connect_count["n"] += 1
+            await asyncio.sleep(0.05)  # widen the race window
+            self._state_machine._state = SessionState.CONNECTED
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch.object(ss_mod.StreamingSession, "connect", new=fake_connect):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "race-agent", "model": "sonnet"})
+                ensure = app.state.broker._ensure_session_callback
+
+                async def run():
+                    return await asyncio.gather(
+                        ensure("race-agent"), ensure("race-agent"), ensure("race-agent")
+                    )
+
+                s1, s2, s3 = asyncio.run(run())
+                assert s1 is not None
+                assert s1 is s2 is s3
+                assert connect_count["n"] == 1, (
+                    f"expected exactly one cold start, got {connect_count['n']} "
+                    f"(concurrent triggers each launched their own session)"
+                )
+
+
+class TestColdStartTimeoutAlert:
+    def test_timeout_alert_uses_content_kwarg(self):
+        """The cold-start-timeout owner alert must actually reach the broker
+        send callback (it used to pass text= and TypeError every time)."""
+        import pytest
+
+        import pinky_daemon.api as api_mod
+        import pinky_daemon.streaming_session as ss_mod
+
+        async def hang_connect(self):
+            await asyncio.sleep(30)
+
+        sent: list[str] = []
+
+        async def recorder(agent_name, platform, chat_id, content, *,
+                           reply_to="", parse_mode="", silent=False):
+            sent.append(content)
+            return {"sent": True}
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch.object(ss_mod.StreamingSession, "connect", new=hang_connect), \
+                patch.object(api_mod, "COLD_START_CONNECT_TIMEOUT_SEC", 0.05):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "slow-agent", "model": "sonnet"})
+                app.state.agents.get_owner_profile = lambda: {"chat_id": "777"}
+                broker = app.state.broker
+                broker._send_callback = recorder
+                ensure = broker._ensure_session_callback
+
+                with pytest.raises(asyncio.TimeoutError):
+                    asyncio.run(ensure("slow-agent"))
+
+                assert sent, "owner alert never reached the broker send callback"
+                assert "cold-start" in sent[0]
+
+
+class TestIMessageOutbound:
+    def test_broker_send_imessage_reaches_adapter(self):
+        """platform=imessage must route to the iMessage adapter instead of
+        503ing on the generic adapter lookup."""
+        sent = []
+
+        class FakeIM:
+            def __init__(self):
+                pass
+
+            def send_message(self, chat_id, content):
+                sent.append((chat_id, content))
+                return {"message_id": "im-1"}
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_outreach.imessage.iMessageAdapter", FakeIM):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "im-agent", "model": "sonnet"})
+                r = client.put(
+                    "/agents/im-agent/tokens/imessage", json={"token": "enabled"}
+                )
+                assert r.status_code == 200, r.text
+
+                r = client.post("/broker/send", json={
+                    "agent_name": "im-agent",
+                    "platform": "imessage",
+                    "chat_id": "+15551234567",
+                    "content": "hello",
+                })
+                assert r.status_code == 200, r.text
+                assert sent == [("+15551234567", "hello")]
+
+
+class TestAdapterCacheEviction:
+    def test_token_rotation_evicts_cached_outbound_adapter(self):
+        """After PUT /tokens/{platform}, outbound sends must use the new
+        token instead of the stale cached adapter."""
+
+        class FakeTG:
+            instances: list = []
+
+            def __init__(self, token, timeout=None, **kwargs):
+                self.token = token
+                self.sent: list = []
+                FakeTG.instances.append(self)
+
+            def send_message(self, chat_id, content, **kwargs):
+                self.sent.append((chat_id, content))
+                return {"message_id": "1"}
+
+        class FakePoller:
+            def __init__(self, adapter, agent_name, broker, registry=None, **kwargs):
+                self._agent_name = agent_name
+
+            async def start(self):
+                pass
+
+            def stop(self):
+                pass
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_outreach.telegram.TelegramAdapter", FakeTG), \
+                patch("pinky_daemon.pollers.BrokerTelegramPoller", FakePoller):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "tg-agent", "model": "sonnet"})
+                client.put("/agents/tg-agent/tokens/telegram", json={"token": "tok-A"})
+                r = client.post("/broker/send", json={
+                    "agent_name": "tg-agent", "platform": "telegram",
+                    "chat_id": "1", "content": "first",
+                })
+                assert r.status_code == 200, r.text
+
+                client.put("/agents/tg-agent/tokens/telegram", json={"token": "tok-B"})
+                r = client.post("/broker/send", json={
+                    "agent_name": "tg-agent", "platform": "telegram",
+                    "chat_id": "1", "content": "second",
+                })
+                assert r.status_code == 200, r.text
+
+                tokens_used = [i.token for i in FakeTG.instances if i.sent]
+                assert "tok-B" in tokens_used, (
+                    f"send after rotation still used stale adapter "
+                    f"(tokens used: {tokens_used})"
+                )
+
+
+class TestAuthRateLimit:
+    def test_spoofed_x_forwarded_for_does_not_reset_budget(self):
+        """The limiter must key on the socket peer, not the client-controlled
+        X-Forwarded-For header (which also grew the dict without bound)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                for i in range(5):
+                    r = client.post(
+                        "/auth/login",
+                        json={"password": "wrong"},
+                        headers={"X-Forwarded-For": f"10.0.0.{i}"},
+                    )
+                    assert r.status_code != 429
+                r = client.post(
+                    "/auth/login",
+                    json={"password": "wrong"},
+                    headers={"X-Forwarded-For": "10.99.99.99"},
+                )
+                assert r.status_code == 429, (
+                    "a fresh spoofed X-Forwarded-For value reset the rate budget"
+                )
+
+
+class TestRenameStreamingSession:
+    def test_rename_retargets_live_session(self):
+        """Renaming must update the live session's label and rebind its
+        resume-handle persistence to the new label."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "ren-agent", "model": "sonnet"})
+                fake = _FakeStreamingSession("ren-agent", "side")
+                app.state.broker.register_streaming("ren-agent", fake, label="side")
+                agents = app.state.agents
+                agents.set_streaming_session_id("ren-agent", "old-sid", label="side")
+
+                r = client.patch(
+                    "/agents/ren-agent/streaming-sessions/side",
+                    json={"label": "worker"},
+                )
+                assert r.status_code == 200, r.text
+
+                assert fake._config.label == "worker"
+                assert fake.id == "ren-agent-worker"
+                assert agents.get_streaming_session_id("ren-agent", label="worker") == "old-sid"
+
+                # New resume handles must persist under the NEW label
+                asyncio.run(fake._on_resume_handle("ren-agent", "fresh-handle"))
+                assert (
+                    agents.get_streaming_session_id("ren-agent", label="worker")
+                    == "fresh-handle"
+                )
+                assert agents.get_streaming_session_id("ren-agent", label="side") == ""
+
+
+class TestSetStreamingModelPersistence:
+    def test_guard_409_leaves_model_unchanged(self):
+        """A 409 from the restart guard must not have already persisted the
+        new model to the agents DB."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "mod-agent", "model": "sonnet"})
+                fake = _FakeStreamingSession("mod-agent", "main", max_tokens=200_000)
+                app.state.broker.register_streaming("mod-agent", fake, label="main")
+                # No recent context save -> restart guard refuses the restart.
+                r = client.post(
+                    "/agents/mod-agent/streaming/model",
+                    json={"model": "claude-opus-4-7"},  # 1M model -> needs restart
+                )
+                assert r.status_code == 409, r.text
+                assert app.state.agents.get("mod-agent").model == "sonnet"
+
+    def test_hot_swap_failure_leaves_model_unchanged(self):
+        """A failed hot swap (500) must not have persisted the new model."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "mod-agent", "model": "sonnet"})
+                fake = _FakeStreamingSession("mod-agent", "main", max_tokens=200_000)
+                # _FakeContextClient has no set_model -> hot swap raises -> 500
+                app.state.broker.register_streaming("mod-agent", fake, label="main")
+                r = client.post(
+                    "/agents/mod-agent/streaming/model",
+                    json={"model": "claude-haiku-4-5"},  # 200k class -> hot swap
+                )
+                assert r.status_code == 500, r.text
+                assert app.state.agents.get("mod-agent").model == "sonnet"
+
+
+class TestProviderNullFields:
+    def test_provider_null_value_is_treated_as_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "prov-agent", "model": "sonnet"})
+                r = client.put(
+                    "/agents/prov-agent/provider", json={"provider_url": None}
+                )
+                assert r.status_code == 200, r.text
+                assert r.json()["provider_url"] == ""
+
+    def test_api_key_null_value_is_400_not_500(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                r = client.put(
+                    "/system/api-keys/OPENAI_API_KEY", json={"value": None}
+                )
+                assert r.status_code == 400, r.text
+
+
+class TestCodexSharedMcpBearer:
+    def test_codex_mcp_headers_include_derived_bearer(self):
+        """Codex agents must carry the derived bearer so shared-MCP configs
+        that require auth do not silently reject all their tool calls."""
+        import pinky_daemon.api as api_mod
+        import pinky_daemon.codex_session as codex_mod
+        from pinky_daemon.shared_mcp import derive_mcp_bearer
+        from pinky_daemon.transport_state import SessionState
+
+        class FakeCodexSession:
+            last_config = None
+
+            def __init__(self, config, **kwargs):
+                FakeCodexSession.last_config = config
+                self._config = config
+                self.agent_name = config.agent_name
+                self.resume_handle = ""
+                self._state = SessionState.UNINITIALIZED
+
+            @property
+            def state(self):
+                return self._state
+
+            @property
+            def id(self):
+                return f"{self.agent_name}-{self._config.label}"
+
+            async def connect(self):
+                self._state = SessionState.CONNECTED
+
+            async def disconnect(self):
+                self._state = SessionState.DEAD
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch.object(api_mod, "SHARED_MCP_ENABLED", True), \
+                patch.object(codex_mod, "CodexSession", FakeCodexSession):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = _make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "codex-agent", "model": "gpt-5"})
+                agents = app.state.agents
+                agents.register("codex-agent", runtime="codex_cli")
+                ensure = app.state.broker._ensure_session_callback
+
+                ss = asyncio.run(ensure("codex-agent"))
+                assert ss is not None
+                cfg = FakeCodexSession.last_config
+                assert cfg is not None
+                for srv in ("pinky-self", "pinky-memory", "pinky-messaging"):
+                    headers = cfg.mcp_servers[srv]["headers"]
+                    assert headers["X-Agent-Name"] == "codex-agent"
+                    key = agents.get_signing_key("codex-agent")
+                    assert headers["Authorization"] == f"Bearer {derive_mcp_bearer(key)}"


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **high** No lock around streaming-session cold start (high, race) (`src/pinky_daemon/api.py:2932`)
  - Per-(agent,label) asyncio.Lock serializes cold starts/reconnects with re-check under the lock; connected fast path stays lock-free; broker.py untouched per group_note.
- **medium** Cold-start timeout owner alert crashes on wrong kwarg text= (`src/pinky_daemon/api.py:2865`)
  - broker.send_callback now called with content= at both the cold-start alert and the identical watchdog-alert call; alert text de-emojified to ASCII.
- **n/a** iMessage outbound unreachable in _send_text_message (`src/pinky_daemon/api.py`)
  - imessage branch moved before the generic adapter 503 check so sends route through _get_imessage_adapter.
- **medium** Platform adapter cache never invalidated on token rotation (`src/pinky_daemon/api.py:1219`)
  - set_agent_token and remove_agent_token pop (name, platform) plus the (__global__, imessage) cache key so outbound sends pick up the new token immediately.
- **medium** _get_agent_tool_gates fails open on skill-store error (`src/pinky_daemon/api.py:530`)
  - Both the no-skill-store and exception branches now return [] (core tools only) instead of ALL_TOOL_GATES; test_shared_mcp.py updated and a fail-closed regression test added.
- **medium** Codex shared-MCP config omits the derived bearer (`src/pinky_daemon/api.py:2759`)
  - Codex MCP headers now include Authorization: Bearer derive_mcp_bearer(signing_key) via agents.get_or_create_signing_key, with a logged warning if no key.
- **n/a** rename_streaming_session leaves live session label stale (`src/pinky_daemon/api.py`)
  - Rename now sets ss._config.label = new_label and rebinds ss._on_resume_handle to a callback for the new label so turns/analytics/resume handles persist under it.
- **n/a** _auth_attempts unbounded and keyed by spoofable X-Forwarded-For (`src/pinky_daemon/api.py`)
  - Limiter keys on request.client.host only and sweeps fully-expired IP entries on each check so the dict stays bounded.
- **n/a** /admin/update blocks the event loop for minutes (`src/pinky_daemon/api.py`)
  - Entire git/verify/pip/npm pipeline moved into a sync _run_update helper awaited via asyncio.to_thread (dry_run included); restart scheduling stays on the loop.
- **n/a** GET /system/auth blocks the loop up to ~20s (`src/pinky_daemon/api.py`)
  - Both claude/codex CLI subprocess.run checks wrapped in await asyncio.to_thread.
- **medium** set_streaming_model persists model before guard/swap can fail (`src/pinky_daemon/api.py:7503`)
  - agents.register(model=...) moved to after the restart-guard 409 (restart branch) and after a successful set_model (hot-swap branch); old_is_1m falls back to ss._config.model in _1M_MODELS when usage fetch fails.
- **low** _1M_MODELS has no module-level definition (`src/pinky_daemon/api.py:344`)
  - Top-level 'from pinky_daemon.streaming_session import _1M_MODELS' so the name is always bound; _refresh_1m_models rebinds it from the DB.
- **low** _context_cache grows without eviction (`src/pinky_daemon/api.py:2564`)
  - All writes go through _context_cache_put which prunes entries older than 10x the TTL.
- **low** Cost milestones never reset after session restart (`src/pinky_daemon/api.py:1741`)
  - _record_cost prunes fired thresholds above the current live total via intersection_update so milestones can re-fire per session.
- **n/a** PUT /agents/{name}/provider 500s on JSON null fields (`src/pinky_daemon/api.py`)
  - All provider fields and the api-key value use (value or '').strip() so null is treated as empty (400/empty-string instead of AttributeError 500).
- **n/a** Startup telegram-poller dedupe continue-skips the rest of agent setup (`src/pinky_daemon/api.py`)
  - continue replaced with an else block matching the Discord dedupe, and on_shutdown clears _broker_pollers after stopping them.
- **n/a** Shutdown restart manifest last-label-wins for multi-label agents (`src/pinky_daemon/api.py`)
  - Manifest writes one entry per agent preferring the 'main' label instead of overwriting inside the per-label loop.
- **n/a** read_agent_file containment check is dead code / misses symlink escape (`src/pinky_daemon/api.py`)
  - GET handler resolves file_path before the startswith containment check, mirroring the PUT handler, so symlinks escaping the work dir get 403.
- **n/a** /admin/update force-reset restores from the index not HEAD (`src/pinky_daemon/api.py`)
  - force=True now runs git checkout HEAD -- . so staged changes are discarded too; tests/test_admin_update.py mock and assertions updated to the new command.

## Testing
**api**: All from worktree root /Users/bradbrok/Documents/Devs/PinkyBot/.claude/worktrees/wf_85885bcd-cae-1: python3 -m pytest tests/test_sweep_api_fixes.py -q -> 11 passed; python3 -m pytest tests/test_admin_update.py tests/test_shared_mcp.py tests/test_shared_mcp_integration.py tests/test_apps_mcp_tools.py -q -> 157 passed; python3 -m pytest tests/test_api.py tests/test_auth.py tests/test_auth_alerts.py tests/test_broker.py tests/test_daemon.py -q -> 525 passed; python3 -m pytest tests/test_codex_session.py tests/test_session_watchdog.py tests/test_scheduler.py tests/test_discord_poller.py tests/test_discord.py tests/test_stop_failure_hook.py -q -> 259 passed; python3 -m pytest tests/test_tmux_session.py tests/test_pinky_self_tools.py tests/test_outreach_server.py tests/test_messaging_server.py tests/test_agent_status.py -q -> 543 passed; full suite python3 -m pytest tests/ -q -x -> 3510 passed, 2 skipped; python3 -m ruff check src/pinky_daemon/api.py tests/test_sweep_api_fixes.py tests/test_admin_update.py tests/test_shared_mcp.py -> all checks passed (one isort autofix applied to the new test file).

Generated with [Claude Code](https://claude.com/claude-code)