### PR TITLE
fix(sweep): sessions - voice-reply self-deadlock, reconnect races, typing-indicator leak

### DIFF
--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -238,6 +238,10 @@ class MessageBroker:
         # Active typing indicator tasks: (agent_name, chat_id) -> asyncio.Task
         self._typing_tasks: dict[tuple[str, str], asyncio.Task] = {}
 
+        # Strong refs to background cleanup tasks (e.g. disconnecting a
+        # displaced streaming session) so the GC can't collect them mid-flight.
+        self._background_tasks: set[asyncio.Task] = set()
+
     @property
     def send_callback(self):
         """Expose the send callback for direct use by scheduler etc."""
@@ -990,7 +994,10 @@ class MessageBroker:
         if chat_id:
             label = self._registry.get_channel_session(agent_name, chat_id)
             session = sessions.get(label)
-            if session and session.state == SessionState.CONNECTED:
+            # Return the mapped session in ANY state so _route_streaming's
+            # auto-wake / wait-for-reconnect logic operates on the assigned
+            # session instead of leaking the message into 'main'.
+            if session is not None:
                 return session
         # Fall back to main
         return sessions.get("main")
@@ -1266,7 +1273,11 @@ class MessageBroker:
 
         for att in downloadable:
             try:
-                local_path = adapter.download_file(att["file_id"], dest_dir=dest_dir)
+                # download_file is sync (blocking httpx GET) -- offload so a
+                # multi-MB download doesn't freeze the daemon event loop.
+                local_path = await asyncio.to_thread(
+                    adapter.download_file, att["file_id"], dest_dir=dest_dir,
+                )
                 local_path = os.path.abspath(local_path)
                 att["local_path"] = local_path
                 _log(f"broker: downloaded {att['type']} for {agent_name}: {local_path}")
@@ -1274,7 +1285,8 @@ class MessageBroker:
                 _is_anim_ext = local_path.lower().endswith((".gif", ".mp4", ".webm", ".mov"))
                 if att.get("type") in {"animation", "video"} or _is_anim_ext:
                     try:
-                        preview = _make_gif_preview(local_path)
+                        # ffprobe/ffmpeg subprocesses + PIL resize -- offload too
+                        preview = await asyncio.to_thread(_make_gif_preview, local_path)
                         if preview:
                             att["local_path"] = preview
                             att["original_path"] = local_path
@@ -1317,7 +1329,10 @@ class MessageBroker:
                 _log(f"broker: no telegram token for {agent_name}, can't download voice")
                 return ""
             adapter = TelegramAdapter(raw_token)
-            local_path = adapter.download_file(file_id, dest_dir=tempfile.mkdtemp(prefix="pinky_voice_"))
+            # Sync download -- offload so it doesn't block the event loop
+            local_path = await asyncio.to_thread(
+                adapter.download_file, file_id, dest_dir=tempfile.mkdtemp(prefix="pinky_voice_"),
+            )
             file_size = os.path.getsize(local_path) if os.path.exists(local_path) else -1
             _log(f"broker: downloaded voice file for {agent_name}: {local_path} ({file_size} bytes)")
             if file_size <= 0:
@@ -1414,8 +1429,6 @@ class MessageBroker:
                     _log(f"broker: deepgram detected language: {detected_lang}")
 
             elif provider == "whisper_local":
-                import asyncio
-
                 from faster_whisper import WhisperModel
                 model_size = voice_cfg.get("whisper_model", "base")
                 lang = voice_cfg.get("whisper_lang", None)  # None = auto-detect
@@ -1499,14 +1512,22 @@ class MessageBroker:
                 "voice": voice,
                 "model": model,
             }).encode()
+            base_url = os.environ.get("PINKY_DAEMON_URL", "http://localhost:8888").rstrip("/")
             req = urllib.request.Request(
-                "http://localhost:8888/broker/send-voice",
+                f"{base_url}/broker/send-voice",
                 data=body,
                 method="POST",
                 headers={"Content-Type": "application/json"},
             )
-            with urllib.request.urlopen(req, timeout=60) as resp:
-                result = json.loads(resp.read())
+
+            # The endpoint is served by THIS process on the same event loop.
+            # A sync urlopen here would block the loop and deadlock against
+            # our own request until the socket timeout -- run it in a thread.
+            def _post() -> dict:
+                with urllib.request.urlopen(req, timeout=60) as resp:
+                    return json.loads(resp.read())
+
+            result = await asyncio.to_thread(_post)
             if result.get("sent"):
                 _log(f"broker: voice reply sent for {agent_name} ({provider}/{voice})")
                 # Also send text version for accessibility
@@ -1581,11 +1602,48 @@ class MessageBroker:
         ]
 
     def register_streaming(self, agent_name: str, session, label: str = "main") -> None:
-        """Register a StreamingSession for an agent under a label."""
+        """Register a StreamingSession for an agent under a label.
+
+        Defense-in-depth: if a still-connected session is already registered
+        under this label, overwriting it would orphan a live SDK subprocess
+        that keeps processing messages. Log loudly and schedule a disconnect
+        of the displaced session.
+        """
         if agent_name not in self._streaming:
             self._streaming[agent_name] = {}
+        displaced = self._streaming[agent_name].get(label)
+        if (
+            displaced is not None
+            and displaced is not session
+            and getattr(displaced, "state", None) == SessionState.CONNECTED
+        ):
+            _log(
+                f"broker: WARNING overwriting still-connected streaming session "
+                f"for {agent_name}/{label} -- scheduling disconnect of displaced session"
+            )
+            try:
+                task = asyncio.get_running_loop().create_task(
+                    self._disconnect_displaced(agent_name, label, displaced)
+                )
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+            except RuntimeError:
+                _log(
+                    f"broker: no running event loop -- displaced session for "
+                    f"{agent_name}/{label} left connected"
+                )
         self._streaming[agent_name][label] = session
         _log(f"broker: registered streaming session for {agent_name}/{label}")
+
+    async def _disconnect_displaced(self, agent_name: str, label: str, displaced) -> None:
+        try:
+            await displaced.disconnect()
+            _log(f"broker: displaced streaming session for {agent_name}/{label} disconnected")
+        except Exception as e:
+            _log(
+                f"broker: failed to disconnect displaced session for "
+                f"{agent_name}/{label}: {e}"
+            )
 
     def unregister_streaming(self, agent_name: str, label: str = "") -> None:
         """Unregister a streaming session. If no label, remove all for the agent."""

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1608,6 +1608,12 @@ class MessageBroker:
         under this label, overwriting it would orphan a live SDK subprocess
         that keeps processing messages. Log loudly and schedule a disconnect
         of the displaced session.
+
+        Exception: when displaced and replacement share the same transport
+        resource (equal non-empty resume_handle -- tmux names its OS session
+        ``pinky-{agent}`` with no per-instance component, so both objects
+        drive ONE tmux session), disconnecting the displaced object would
+        ``kill-session`` the replacement's live transport. Skip it.
         """
         if agent_name not in self._streaming:
             self._streaming[agent_name] = {}
@@ -1617,21 +1623,30 @@ class MessageBroker:
             and displaced is not session
             and getattr(displaced, "state", None) == SessionState.CONNECTED
         ):
-            _log(
-                f"broker: WARNING overwriting still-connected streaming session "
-                f"for {agent_name}/{label} -- scheduling disconnect of displaced session"
-            )
-            try:
-                task = asyncio.get_running_loop().create_task(
-                    self._disconnect_displaced(agent_name, label, displaced)
-                )
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-            except RuntimeError:
+            displaced_handle = getattr(displaced, "resume_handle", "") or ""
+            new_handle = getattr(session, "resume_handle", "") or ""
+            if displaced_handle and displaced_handle == new_handle:
                 _log(
-                    f"broker: no running event loop -- displaced session for "
-                    f"{agent_name}/{label} left connected"
+                    f"broker: displaced streaming session for {agent_name}/{label} "
+                    f"shares its transport resource with the replacement -- "
+                    f"skipping disconnect"
                 )
+            else:
+                _log(
+                    f"broker: WARNING overwriting still-connected streaming session "
+                    f"for {agent_name}/{label} -- scheduling disconnect of displaced session"
+                )
+                try:
+                    task = asyncio.get_running_loop().create_task(
+                        self._disconnect_displaced(agent_name, label, displaced)
+                    )
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+                except RuntimeError:
+                    _log(
+                        f"broker: no running event loop -- displaced session for "
+                        f"{agent_name}/{label} left connected"
+                    )
         self._streaming[agent_name][label] = session
         _log(f"broker: registered streaming session for {agent_name}/{label}")
 

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -221,6 +221,11 @@ class AgentScheduler:
         # lock on the ingest-debounce path), so scheduled runs must not execute
         # concurrently across agents either: single global slot, not per-agent.
         self._librarian_tasks: dict[str, asyncio.Task] = {}  # LIBRARIAN_GLOBAL_KEY -> running librarian
+        # In-flight idle/auto-sleep runs. idle_sleep() waits up to a minute
+        # for the pre-sleep memory-save turn, so it must never be awaited
+        # inline in the tick (same #702 class as dreams): one slot per
+        # (agent_name, label) so a sleep spanning several ticks isn't refired.
+        self._sleep_tasks: dict[tuple[str, str], asyncio.Task] = {}
         # Resurrection rate-limit: agent_name -> list[timestamp] of recent attempts.
         # Used by _check_heartbeats to cap how often we ping the heartbeat_callback
         # for a stuck agent (avoid thrashing on a persistently-broken session).
@@ -244,9 +249,10 @@ class AgentScheduler:
             except asyncio.CancelledError:
                 pass
             self._task = None
-        # Cancel in-flight dream/librarian runs. Before #702 these ran inside
-        # the loop task, so stop() cancelled them implicitly — keep that contract.
-        for task_map in (self._dream_tasks, self._librarian_tasks):
+        # Cancel in-flight dream/librarian/sleep runs. Before #702 these ran
+        # inside the loop task, so stop() cancelled them implicitly — keep
+        # that contract.
+        for task_map in (self._dream_tasks, self._librarian_tasks, self._sleep_tasks):
             for task in task_map.values():
                 if not task.done():
                     task.cancel()
@@ -570,10 +576,28 @@ class AgentScheduler:
                             self._activity.log(name, "agent_sleep", f"{name} auto-slept (idle timeout)")
                         except Exception:
                             pass
-                    try:
-                        await ss.idle_sleep()
-                    except Exception as e:
-                        _log(f"scheduler: idle sleep failed for {name}/{label}: {e}")
+                    self._spawn_idle_sleep(name, label, ss)
+
+    def _spawn_idle_sleep(self, name: str, label: str, ss) -> None:
+        """Fire idle_sleep as a background task — never inline in the tick.
+
+        idle_sleep() gives the pre-sleep memory-save turn up to a minute to
+        complete; N idle agents awaited serially would stall the tick loop
+        N minutes, skipping every cron minute / heartbeat / wake in the
+        window (#702 class). Mirrors ``_spawn_agent_callback``.
+        """
+        key = (name, label)
+        existing = self._sleep_tasks.get(key)
+        if existing and not existing.done():
+            return
+
+        async def _run() -> None:
+            try:
+                await ss.idle_sleep()
+            except Exception as e:
+                _log(f"scheduler: idle sleep failed for {name}/{label}: {e}")
+
+        self._sleep_tasks[key] = asyncio.create_task(_run())
 
     def _cleanup_expired_messages(self) -> None:
         """Remove expired inbox entries via the comms cleanup callback."""
@@ -692,10 +716,7 @@ class AgentScheduler:
                             _log(f"scheduler: auto-sleep callback failed for {agent.name}: {e}")
                     else:
                         # Fallback: use idle_sleep on the session directly
-                        try:
-                            await ss.idle_sleep()
-                        except Exception as e:
-                            _log(f"scheduler: auto-sleep idle_sleep failed for {agent.name}/{label}: {e}")
+                        self._spawn_idle_sleep(agent.name, label, ss)
 
     LIBRARIAN_GLOBAL_KEY = "__shared_kb__"
 

--- a/src/pinky_daemon/session_store.py
+++ b/src/pinky_daemon/session_store.py
@@ -48,6 +48,10 @@ class SessionRecord:
     agent_name: str = ""
     disallowed_tools: list[str] = field(default_factory=list)
     provider_url: str = ""
+    # Stored as plaintext, like the other secrets in the data/ SQLite stores.
+    # At-rest protection is the owner-only 0600 file mode applied by the
+    # startup permission sweep (db_security.sweep_db_permissions, #673).
+    # Never log or echo this field.
     provider_key: str = ""
 
 

--- a/src/pinky_daemon/session_store.py
+++ b/src/pinky_daemon/session_store.py
@@ -16,7 +16,7 @@ import json
 import sqlite3
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -46,6 +46,9 @@ class SessionRecord:
     sdk_session_id: str
     session_type: str = "chat"
     agent_name: str = ""
+    disallowed_tools: list[str] = field(default_factory=list)
+    provider_url: str = ""
+    provider_key: str = ""
 
 
 class SessionStore:
@@ -77,7 +80,10 @@ class SessionStore:
                 restart_count INTEGER NOT NULL DEFAULT 0,
                 sdk_session_id TEXT NOT NULL DEFAULT '',
                 session_type TEXT NOT NULL DEFAULT 'chat',
-                agent_name TEXT NOT NULL DEFAULT ''
+                agent_name TEXT NOT NULL DEFAULT '',
+                disallowed_tools TEXT NOT NULL DEFAULT '[]',
+                provider_url TEXT NOT NULL DEFAULT '',
+                provider_key TEXT NOT NULL DEFAULT ''
             );
 
         """)
@@ -94,7 +100,7 @@ class SessionStore:
         "id, model, soul, working_dir, allowed_tools, max_turns, timeout, "
         "system_prompt, restart_threshold_pct, auto_restart, permission_mode, "
         "state, created_at, last_active, restart_count, sdk_session_id, "
-        "session_type, agent_name"
+        "session_type, agent_name, disallowed_tools, provider_url, provider_key"
     )
 
     def _migrate(self) -> None:
@@ -105,6 +111,9 @@ class SessionStore:
         migrations = [
             ("session_type", "TEXT NOT NULL DEFAULT 'chat'"),
             ("agent_name", "TEXT NOT NULL DEFAULT ''"),
+            ("disallowed_tools", "TEXT NOT NULL DEFAULT '[]'"),
+            ("provider_url", "TEXT NOT NULL DEFAULT ''"),
+            ("provider_key", "TEXT NOT NULL DEFAULT ''"),
         ]
         for col, typedef in migrations:
             if col not in existing:
@@ -116,7 +125,7 @@ class SessionStore:
         """Save or update a session record."""
         self._db.execute(
             f"""INSERT INTO sessions ({self._COLUMNS})
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT (id) DO UPDATE SET
                 model=excluded.model, soul=excluded.soul, working_dir=excluded.working_dir,
                 allowed_tools=excluded.allowed_tools, max_turns=excluded.max_turns,
@@ -125,7 +134,9 @@ class SessionStore:
                 auto_restart=excluded.auto_restart, permission_mode=excluded.permission_mode,
                 state=excluded.state, last_active=excluded.last_active,
                 restart_count=excluded.restart_count, sdk_session_id=excluded.sdk_session_id,
-                session_type=excluded.session_type, agent_name=excluded.agent_name""",
+                session_type=excluded.session_type, agent_name=excluded.agent_name,
+                disallowed_tools=excluded.disallowed_tools,
+                provider_url=excluded.provider_url, provider_key=excluded.provider_key""",
             (
                 record.id, record.model, record.soul, record.working_dir,
                 json.dumps(record.allowed_tools), record.max_turns, record.timeout,
@@ -134,6 +145,8 @@ class SessionStore:
                 record.state, record.created_at, record.last_active,
                 record.restart_count, record.sdk_session_id,
                 record.session_type, record.agent_name,
+                json.dumps(record.disallowed_tools),
+                record.provider_url, record.provider_key,
             ),
         )
         self._db.commit()
@@ -253,6 +266,9 @@ class SessionStore:
             sdk_session_id=row[15],
             session_type=row[16] if len(row) > 16 else "chat",
             agent_name=row[17] if len(row) > 17 else "",
+            disallowed_tools=json.loads(row[18]) if len(row) > 18 and row[18] else [],
+            provider_url=row[19] if len(row) > 19 else "",
+            provider_key=row[20] if len(row) > 20 else "",
         )
 
     def close(self) -> None:

--- a/src/pinky_daemon/sessions.py
+++ b/src/pinky_daemon/sessions.py
@@ -368,67 +368,76 @@ class Session:
             self.state = SessionState.running
             self.last_active = time.time()
 
-            # Record user message
-            user_msg = SessionMessage(role="user", content=content)
-            self.history.append(user_msg)
+            try:
+                # Record user message
+                user_msg = SessionMessage(role="user", content=content)
+                self.history.append(user_msg)
 
-            # Determine if this is a fresh start or continuation
-            active = self._active_history()
-            is_first = len(active) <= 1  # Only the message we just added
+                # Determine if this is a fresh start or continuation
+                active = self._active_history()
+                is_first = len(active) <= 1  # Only the message we just added
 
-            # Build system prompt for fresh starts
-            system_prompt = ""
-            if is_first:
-                system_prompt = self._build_restart_prompt()
+                # Build system prompt for fresh starts
+                system_prompt = ""
+                if is_first:
+                    system_prompt = self._build_restart_prompt()
 
-            start = time.time()
+                start = time.time()
 
-            can_resume = not is_first
-            resume_id = ""
-            if can_resume and self._runner_type == "sdk" and self._sdk_session_id:
-                # SDK sessions should prefer the real Claude session ID when we have it.
-                resume_id = self._sdk_session_id
+                can_resume = not is_first
+                resume_id = ""
+                if can_resume and self._runner_type == "sdk" and self._sdk_session_id:
+                    # SDK sessions should prefer the real Claude session ID when we have it.
+                    resume_id = self._sdk_session_id
 
-            result = await self._runner.run(
-                content,
-                session_id=resume_id,
-                resume=can_resume,
-                system_prompt=system_prompt if not can_resume else "",
-            )
-
-            # If resume failed, retry as fresh conversation
-            if not result.ok and can_resume:
-                _log(f"session {self.id}: resume failed, retrying as fresh conversation")
-                self._sdk_session_id = ""
-                system_prompt = self._build_restart_prompt()
                 result = await self._runner.run(
                     content,
-                    session_id="",
-                    resume=False,
-                    system_prompt=system_prompt,
+                    session_id=resume_id,
+                    resume=can_resume,
+                    system_prompt=system_prompt if not can_resume else "",
                 )
 
-            elapsed_ms = int((time.time() - start) * 1000)
+                # If resume failed, retry as fresh conversation
+                if not result.ok and can_resume:
+                    _log(f"session {self.id}: resume failed, retrying as fresh conversation")
+                    self._sdk_session_id = ""
+                    system_prompt = self._build_restart_prompt()
+                    result = await self._runner.run(
+                        content,
+                        session_id="",
+                        resume=False,
+                        system_prompt=system_prompt,
+                    )
 
-            # Capture real session ID from SDK
-            if result.session_id:
-                self._sdk_session_id = result.session_id
+                elapsed_ms = int((time.time() - start) * 1000)
 
-            # Record usage stats
-            self.usage.record(result)
+                # Capture real session ID from SDK
+                if result.session_id:
+                    self._sdk_session_id = result.session_id
 
-            # Record assistant response
-            assistant_msg = SessionMessage(
-                role="assistant",
-                content=result.output,
-                duration_ms=elapsed_ms,
-                error=result.error if not result.ok else "",
-            )
-            self.history.append(assistant_msg)
+                # Record usage stats
+                self.usage.record(result)
 
-            self.state = SessionState.idle if result.ok else SessionState.error
-            self._persist()
-            return assistant_msg
+                # Record assistant response
+                assistant_msg = SessionMessage(
+                    role="assistant",
+                    content=result.output,
+                    duration_ms=elapsed_ms,
+                    error=result.error if not result.ok else "",
+                )
+                self.history.append(assistant_msg)
+
+                self.state = SessionState.idle if result.ok else SessionState.error
+                self._persist()
+                return assistant_msg
+            except BaseException:
+                # CancelledError (caller request timed out) or a runner bug
+                # must not strand the session in 'running' forever -- a
+                # stuck-running session is unevictable and rejects all
+                # future sends as busy.
+                self.state = SessionState.error
+                self._persist()
+                raise
 
     async def restart(self) -> Checkpoint:
         """Manually restart the session with a checkpoint.
@@ -633,6 +642,9 @@ class Session:
             sdk_session_id=self._sdk_session_id,
             session_type=self.session_type.value,
             agent_name=self.agent_name,
+            disallowed_tools=self.disallowed_tools,
+            provider_url=self._provider_url,
+            provider_key=self._provider_key,
         )
         self._store.save(record)
 
@@ -730,6 +742,7 @@ class SessionManager:
                 soul=rec.soul,
                 working_dir=rec.working_dir,
                 allowed_tools=rec.allowed_tools,
+                disallowed_tools=rec.disallowed_tools,
                 max_turns=rec.max_turns,
                 timeout=rec.timeout,
                 system_prompt=rec.system_prompt,
@@ -738,6 +751,8 @@ class SessionManager:
                 permission_mode=rec.permission_mode,
                 session_type=rec.session_type,
                 agent_name=rec.agent_name,
+                provider_url=rec.provider_url,
+                provider_key=rec.provider_key,
             )
             # Restore metadata
             session.created_at = rec.created_at

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -282,6 +282,14 @@ class StreamingSession:
         )
         self._last_response = ""
         self._pending_chats: list[tuple[str, str, str]] = []  # Queue of (platform, chat_id, message_id)
+        # Set by the reader loop at every turn boundary (ResultMessage).
+        # idle_sleep() awaits it so the save-state turn can finish before
+        # the transport is torn down.
+        self._turn_done = asyncio.Event()
+        # In-flight warm reconnect, if any. attempt_reconnect() coalesces
+        # concurrent callers onto this single task so two reconnects never
+        # interleave disconnect/connect (which would orphan an SDK client).
+        self._reconnect_task: asyncio.Task | None = None
 
         self.agent_name = config.agent_name
         self.resume_handle = config.resume_handle  # SDK resume token (persisted across restarts)
@@ -569,19 +577,22 @@ class StreamingSession:
         # same fields via ``_emit_stream_event`` because it has that
         # surface; SDK lacks a stream-event callback today (deferred
         # follow-up — would unify observability across transports).
-        _ctx_chars = len(self._config.wake_context or "")
+        _ctx_chars = len(wake_context_body or "")
         _prompt_hash = hashlib.sha256(wake_prompt.encode("utf-8")).hexdigest()[:12]
         _log(
             f"streaming[{self.agent_name}]: wake_prompt_sent "
             f"reason={wake_reason.value} "
             f"context_chars={_ctx_chars} "
-            f"context_present={bool(self._config.wake_context)} "
+            f"context_present={bool(wake_context_body)} "
             f"prompt_hash={_prompt_hash}"
         )
 
         async def _send_wake_prompt() -> None:
             try:
                 await self._client.query(wake_prompt)
+                # Keep ResultMessage pops 1:1 with queries: the wake turn
+                # has no routing target, so enqueue an unrouted sentinel.
+                self._pending_chats.append(("", "", ""))
                 _log(
                     f"streaming[{self.agent_name}]: sent wake prompt "
                     f"(reason={wake_reason.value})"
@@ -654,8 +665,10 @@ class StreamingSession:
                 metadata={"platform": platform, "chat_id": chat_id},
             )
             await self._client.query(prompt + agent_hint)
-            if chat_id:
-                self._pending_chats.append((platform, chat_id, message_id))
+            # Always enqueue one routing entry per query -- even with no
+            # chat_id -- so ResultMessage pops stay 1:1 with queries and a
+            # system/internal turn can't consume a user turn's routing.
+            self._pending_chats.append((platform, chat_id, message_id))
             _log(f"streaming[{self.agent_name}]: sent message (chat={chat_id})")
         except Exception as e:
             self._stats["errors"] += 1
@@ -894,6 +907,30 @@ class StreamingSession:
                             },
                         )
                         self._stamp_last_seen()
+                        # Fire the response callback with EMPTY text for routed
+                        # turns so downstream bookkeeping (typing indicator
+                        # stop in broker.route_response) still runs. The
+                        # suppressed content is never forwarded -- route_response
+                        # no-ops on empty text.
+                        if self._response_callback and resp_chat_id:
+                            try:
+                                await self._response_callback(TurnResponse(
+                                    agent_name=self.agent_name,
+                                    session_id=self.id,
+                                    platform=resp_platform,
+                                    chat_id=resp_chat_id,
+                                    message_id=resp_message_id,
+                                    text="",
+                                    tool_uses=list(turn_tool_uses),
+                                    used_outreach_tools=any(
+                                        _is_outreach_tool(tool_use.get("tool", ""))
+                                        for tool_use in turn_tool_uses
+                                    ),
+                                    usage=msg.usage or {},
+                                    num_turns=msg.num_turns or 0,
+                                ))
+                            except Exception as e:
+                                _log(f"streaming[{self.agent_name}]: callback error: {e}")
                         self._last_response = ""
                         self._current_activity = ""
                         self._activity_log = []
@@ -902,6 +939,7 @@ class StreamingSession:
                         turn_thinking = []
                         self._stats["turns"] += 1
                         self.last_active = time.time()
+                        self._turn_done.set()
                         # Reset per-turn auth dedupe — turn boundary
                         auth_reported_this_turn = False
                         continue
@@ -925,7 +963,12 @@ class StreamingSession:
                         model_usage=msg.model_usage or {},
                     )
 
-                    if self._response_callback and (turn_result.response_text or turn_result.tool_uses):
+                    # Fire whenever there's content OR a routing target: a
+                    # routed turn with no text/tools must still reach
+                    # broker.route_response so the typing indicator stops.
+                    if self._response_callback and (
+                        turn_result.response_text or turn_result.tool_uses or resp_chat_id
+                    ):
                         try:
                             await self._response_callback(turn_result)
                         except Exception as e:
@@ -1056,6 +1099,7 @@ class StreamingSession:
                     turn_thinking = []  # Reset for next turn
                     self._stats["turns"] += 1
                     self.last_active = time.time()
+                    self._turn_done.set()
                     # Reset per-turn auth dedupe — turn boundary. Successful
                     # turns rarely set this flag (no auth error fired), but
                     # reset unconditionally to keep the invariant simple.
@@ -1106,6 +1150,8 @@ class StreamingSession:
                 )
                 try:
                     await self._client.query(warn_msg)
+                    # Unrouted system turn -- keep ResultMessage pops 1:1
+                    self._pending_chats.append(("", "", ""))
                     self._context_warned = True
                     _log(f"streaming[{self.agent_name}]: warned agent at {pct}% context")
                 except Exception as e:
@@ -1146,6 +1192,8 @@ class StreamingSession:
         )
         try:
             await self._client.query(warn_msg)
+            # Unrouted system turn -- keep ResultMessage pops 1:1
+            self._pending_chats.append(("", "", ""))
         except Exception:
             pass
 
@@ -1237,8 +1285,28 @@ class StreamingSession:
         # via its internal-prompt mechanism with explicit
         # wait_for_completion semantics.
         try:
+            self._turn_done.clear()
             await self._client.query(build_idle_sleep_prompt())
+            # Unrouted system turn -- keep ResultMessage pops 1:1
+            self._pending_chats.append(("", "", ""))
             _log(f"streaming[{self.agent_name}]: memory save prompt sent before idle sleep")
+            # query() returns as soon as the prompt hits the transport; it
+            # does NOT wait for the turn. Give the save turn a bounded
+            # window to complete before tearing the session down --
+            # mirrors tmux_session's wait_for_completion semantics.
+            if self._reader_task and not self._reader_task.done():
+                try:
+                    await asyncio.wait_for(
+                        self._turn_done.wait(),
+                        timeout=self._IDLE_SLEEP_SAVE_TIMEOUT_SEC,
+                    )
+                    _log(f"streaming[{self.agent_name}]: memory save turn completed")
+                except asyncio.TimeoutError:
+                    _log(
+                        f"streaming[{self.agent_name}]: memory save turn did not "
+                        f"complete within {self._IDLE_SLEEP_SAVE_TIMEOUT_SEC:g}s -- "
+                        f"sleeping anyway"
+                    )
         except Exception as e:
             _log(f"streaming[{self.agent_name}]: memory save failed before idle sleep: {e}")
 
@@ -1261,6 +1329,10 @@ class StreamingSession:
     # First attempt waits 2s (preserves prior behavior), then escalates to 8s and 30s.
     _RECONNECT_BACKOFF = (2, 8, 30)
 
+    # Bounded wait for the memory-save turn to complete before idle_sleep()
+    # tears the transport down. See idle_sleep().
+    _IDLE_SLEEP_SAVE_TIMEOUT_SEC = 60.0
+
     async def attempt_reconnect(self) -> None:
         """Attempt to reconnect after a failure with bounded retries.
 
@@ -1272,7 +1344,35 @@ class StreamingSession:
         api.py (BROKER / SCHEDULER triggers drive DEAD → RECONNECTING).
         Public method: callable from inside the reader loop (transient
         transport failure) and from the watchdog callback.
+
+        Concurrent callers (a transport drop typically surfaces in send()
+        AND the reader loop, plus the watchdog can fire during the backoff
+        window) are coalesced onto a single in-flight reconnect task. Two
+        interleaved disconnect/connect cycles would each construct an SDK
+        client and reader task, with the later assignment orphaning the
+        first live subprocess. Running the cycle in its own task also keeps
+        it alive when the initiating caller (e.g. the old reader task,
+        cancelled by disconnect()) dies mid-reconnect.
         """
+        existing = self._reconnect_task
+        if existing and not existing.done():
+            _log(
+                f"streaming[{self.agent_name}]: reconnect already in flight -- "
+                f"awaiting the existing attempt"
+            )
+            await existing
+            return
+        task = asyncio.create_task(self._reconnect_with_backoff())
+        self._reconnect_task = task
+        task.add_done_callback(self._clear_reconnect_task)
+        await task
+
+    def _clear_reconnect_task(self, task: asyncio.Task) -> None:
+        if self._reconnect_task is task:
+            self._reconnect_task = None
+
+    async def _reconnect_with_backoff(self) -> None:
+        """Single warm-reconnect cycle: disconnect, then bounded retries."""
         # Settle the macro state: RECONNECTING for the duration of all retry
         # attempts (transport_state.py §5 — no flicker DEAD ↔ RECONNECTING
         # between attempts). The reader-loop exception path already drove us
@@ -1369,6 +1469,10 @@ class StreamingSession:
             except Exception:
                 pass
             self._client = None
+        # Routing entries for turns that will never complete are stale; a
+        # reconnected session must not deliver its first responses (e.g. the
+        # wake-prompt turn) to a leftover chat_id from before the teardown.
+        self._pending_chats.clear()
         _log(f"streaming[{self.agent_name}]: disconnected")
 
     # ── Analytics helpers ─────────────────────────────────

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -1284,6 +1284,7 @@ class StreamingSession:
         # #543 / idle-sleep parity) so tmux can use the same instruction
         # via its internal-prompt mechanism with explicit
         # wait_for_completion semantics.
+        sends_before = self._stats["messages_sent"]
         try:
             self._turn_done.clear()
             await self._client.query(build_idle_sleep_prompt())
@@ -1309,6 +1310,18 @@ class StreamingSession:
                     )
         except Exception as e:
             _log(f"streaming[{self.agent_name}]: memory save failed before idle sleep: {e}")
+
+        # A message accepted during the save window would have its query
+        # killed by the disconnect below. Abort the sleep instead and let
+        # the new traffic run. The send counter is the signal -- last_active
+        # also advances when the save turn itself completes, so it can't
+        # distinguish new inbound messages from the save finishing.
+        if self._stats["messages_sent"] != sends_before:
+            _log(
+                f"streaming[{self.agent_name}]: new message arrived during "
+                f"pre-sleep save window -- aborting idle sleep"
+            )
+            return False
 
         # Set IDLE_SLEEPING state BEFORE the disconnect side effect, so
         # ``disconnect()``'s "from CONNECTED → DEAD" fallback (for callers
@@ -1354,18 +1367,17 @@ class StreamingSession:
         it alive when the initiating caller (e.g. the old reader task,
         cancelled by disconnect()) dies mid-reconnect.
         """
-        existing = self._reconnect_task
-        if existing and not existing.done():
+        task = self._reconnect_task
+        if task is not None and not task.done():
             _log(
                 f"streaming[{self.agent_name}]: reconnect already in flight -- "
                 f"awaiting the existing attempt"
             )
-            await existing
-            return
-        task = asyncio.create_task(self._reconnect_with_backoff())
-        self._reconnect_task = task
-        task.add_done_callback(self._clear_reconnect_task)
-        await task
+        else:
+            task = asyncio.create_task(self._reconnect_with_backoff())
+            self._reconnect_task = task
+            task.add_done_callback(self._clear_reconnect_task)
+        await asyncio.wait_for(task, timeout=None)
 
     def _clear_reconnect_task(self, task: asyncio.Task) -> None:
         if self._reconnect_task is task:
@@ -1472,7 +1484,25 @@ class StreamingSession:
         # Routing entries for turns that will never complete are stale; a
         # reconnected session must not deliver its first responses (e.g. the
         # wake-prompt turn) to a leftover chat_id from before the teardown.
+        # Fire the response callback with empty text for each routed entry
+        # first: broker.route_response is the only place the typing
+        # indicator stops, and a turn that dies in this teardown would
+        # otherwise leave the typing task spinning against the platform API.
+        stale_routes = [entry for entry in self._pending_chats if entry[1]]
         self._pending_chats.clear()
+        if self._response_callback:
+            for platform, chat_id, message_id in stale_routes:
+                try:
+                    await self._response_callback(TurnResponse(
+                        agent_name=self.agent_name,
+                        session_id=self.id,
+                        platform=platform,
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        text="",
+                    ))
+                except Exception as e:
+                    _log(f"streaming[{self.agent_name}]: stale-route callback error: {e}")
         _log(f"streaming[{self.agent_name}]: disconnected")
 
     # ── Analytics helpers ─────────────────────────────────

--- a/src/pinky_daemon/wake_prompt.py
+++ b/src/pinky_daemon/wake_prompt.py
@@ -76,11 +76,13 @@ def build_idle_sleep_prompt() -> str:
     Separate text contract from the wake prompts: this is a save-state
     instruction telling the agent to commit memory + note its task
     before the session goes dormant. Both transports use the same text
-    but DIFFERENT delivery primitives — SDK does a synchronous
-    ``client.query`` (implicitly wait-for-completion), tmux must
-    enqueue via ``_enqueue_internal_prompt(wait_for_completion=True,
-    timeout_sec=...)``. Without the wait, tmux would paste the
-    instruction and kill the pane before the agent could honor it
+    but DIFFERENT delivery primitives: SDK ``client.query`` returns as
+    soon as the prompt hits the transport (NOT wait-for-completion), so
+    ``StreamingSession.idle_sleep`` waits on a turn-boundary event with
+    a bounded timeout before disconnecting; tmux must enqueue via
+    ``_enqueue_internal_prompt(wait_for_completion=True,
+    timeout_sec=...)``. Without the wait, either transport would tear
+    down the session before the agent could honor the instruction
     (the footgun Murzik flagged in the internal-prompt API review).
 
     Currently a static string for parity with SDK behavior. Future

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1054,6 +1054,52 @@ class TestStreamingSessionRegistry:
         finally:
             tmpdir.cleanup()
 
+    @pytest.mark.asyncio
+    async def test_register_streaming_skips_disconnect_when_transport_shared(self):
+        """Tmux names its OS session pinky-{agent} (no per-instance component),
+        so a displaced and a replacement session object drive the SAME tmux
+        session -- resume_handle is that name on both. Disconnecting the
+        displaced object would kill-session the replacement's live transport."""
+        import asyncio
+
+        from pinky_daemon.transport_state import SessionState
+
+        tmpdir, _, broker = self._make_broker()
+        try:
+            class _TmuxLike:
+                def __init__(self, handle):
+                    self.state = SessionState.CONNECTED
+                    self.resume_handle = handle
+                    self.disconnect_calls = 0
+
+                async def disconnect(self):
+                    self.disconnect_calls += 1
+
+            old = _TmuxLike("pinky-barsik")
+            new = _TmuxLike("pinky-barsik")
+            broker.register_streaming("barsik", old, label="main")
+            broker.register_streaming("barsik", new, label="main")
+            for _ in range(5):
+                await asyncio.sleep(0)
+
+            assert old.disconnect_calls == 0, (
+                "displaced session sharing the transport resource must NOT be "
+                "disconnected -- that would kill the replacement's tmux session"
+            )
+            assert new.disconnect_calls == 0
+            assert broker._streaming["barsik"]["main"] is new
+
+            # Distinct resources (e.g. two SDK sessions with their own
+            # subprocesses) still get the displaced-disconnect treatment.
+            third = _TmuxLike("other-handle")
+            broker.register_streaming("barsik", third, label="main")
+            for _ in range(5):
+                await asyncio.sleep(0)
+            assert new.disconnect_calls == 1
+            assert third.disconnect_calls == 0
+        finally:
+            tmpdir.cleanup()
+
 
 class TestEventLoopOffload:
     """Blocking platform I/O must run off the event loop (asyncio.to_thread)."""

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -951,3 +951,214 @@ class TestOutboundDedupe:
             assert dup["deduped"] is True
         finally:
             tmpdir.cleanup()
+
+
+class TestStreamingSessionRegistry:
+    """_get_streaming_session mapping + register_streaming displacement."""
+
+    def _make_broker(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        registry = AgentRegistry(db_path=f"{tmpdir.name}/agents.db")
+        registry.register("barsik", model="sonnet", working_dir=tmpdir.name)
+        broker = MessageBroker(registry, SessionManager())
+        return tmpdir, registry, broker
+
+    def test_mapped_session_returned_even_when_not_connected(self):
+        """A channel mapped to a non-main label must get THAT session back in
+        any state, so _route_streaming's auto-wake targets the assigned
+        session instead of leaking the message into main's context."""
+        from pinky_daemon.transport_state import SessionState
+
+        tmpdir, registry, broker = self._make_broker()
+        try:
+            class _Session:
+                def __init__(self, state):
+                    self.state = state
+
+            main = _Session(SessionState.CONNECTED)
+            research = _Session(SessionState.IDLE_SLEEPING)
+            broker.register_streaming("barsik", main, label="main")
+            broker.register_streaming("barsik", research, label="research")
+            registry.set_channel_session("barsik", "chat-1", "research")
+
+            got = broker._get_streaming_session("barsik", "chat-1")
+            assert got is research, (
+                "mapped session must be returned in ANY state -- falling back "
+                "to main delivers the message into the wrong session context"
+            )
+            # Unmapped chat still falls back to main.
+            assert broker._get_streaming_session("barsik", "chat-2") is main
+            # Mapped label with no session object falls back to main.
+            registry.set_channel_session("barsik", "chat-3", "ghost")
+            assert broker._get_streaming_session("barsik", "chat-3") is main
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_register_streaming_disconnects_displaced_connected_session(self):
+        """Overwriting a still-connected session must schedule a disconnect of
+        the displaced one instead of orphaning a live SDK subprocess."""
+        import asyncio
+
+        from pinky_daemon.transport_state import SessionState
+
+        tmpdir, _, broker = self._make_broker()
+        try:
+            class _Session:
+                def __init__(self, state):
+                    self.state = state
+                    self.disconnect_calls = 0
+
+                async def disconnect(self):
+                    self.disconnect_calls += 1
+
+            old = _Session(SessionState.CONNECTED)
+            new = _Session(SessionState.CONNECTED)
+            broker.register_streaming("barsik", old, label="main")
+            broker.register_streaming("barsik", new, label="main")
+
+            # Let the scheduled disconnect task run.
+            for _ in range(5):
+                await asyncio.sleep(0)
+
+            assert old.disconnect_calls == 1, "displaced session must be disconnected"
+            assert new.disconnect_calls == 0
+            assert broker._streaming["barsik"]["main"] is new
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_register_streaming_leaves_disconnected_displaced_alone(self):
+        import asyncio
+
+        from pinky_daemon.transport_state import SessionState
+
+        tmpdir, _, broker = self._make_broker()
+        try:
+            class _Session:
+                def __init__(self, state):
+                    self.state = state
+                    self.disconnect_calls = 0
+
+                async def disconnect(self):
+                    self.disconnect_calls += 1
+
+            old = _Session(SessionState.DEAD)
+            new = _Session(SessionState.CONNECTED)
+            broker.register_streaming("barsik", old, label="main")
+            broker.register_streaming("barsik", new, label="main")
+            for _ in range(5):
+                await asyncio.sleep(0)
+
+            assert old.disconnect_calls == 0, "non-connected displaced session is left alone"
+        finally:
+            tmpdir.cleanup()
+
+
+class TestEventLoopOffload:
+    """Blocking platform I/O must run off the event loop (asyncio.to_thread)."""
+
+    def _make_broker(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        registry = AgentRegistry(db_path=f"{tmpdir.name}/agents.db")
+        registry.register("barsik", model="sonnet", working_dir=tmpdir.name)
+
+        sent_messages: list[tuple[str, str, str, str]] = []
+
+        async def send_callback(agent_name, platform, chat_id, content):
+            sent_messages.append((agent_name, platform, chat_id, content))
+
+        broker = MessageBroker(registry, SessionManager(), send_callback=send_callback)
+        return tmpdir, registry, broker, sent_messages
+
+    @pytest.mark.asyncio
+    async def test_download_photo_attachments_offloads_sync_download(self, monkeypatch):
+        """TelegramAdapter.download_file is fully synchronous (blocking httpx
+        GET + file write). It must run in a worker thread, not on the loop."""
+        import os
+        import threading
+
+        from pinky_outreach.telegram import TelegramAdapter
+
+        tmpdir, registry, broker, _ = self._make_broker()
+        try:
+            registry.set_token("barsik", "telegram", "123:abc")
+            loop_thread = threading.get_ident()
+            download_threads: list[int] = []
+
+            def fake_download(self, file_id, dest_dir=""):
+                download_threads.append(threading.get_ident())
+                return os.path.join(dest_dir, "photo.jpg")
+
+            monkeypatch.setattr(TelegramAdapter, "download_file", fake_download)
+
+            msg = BrokerMessage(
+                platform="telegram",
+                chat_id="6770805286",
+                sender_name="Brad",
+                sender_id="u-1",
+                content="look at this",
+                agent_name="barsik",
+                attachments=[{"type": "photo", "file_id": "f-1"}],
+            )
+            await broker._download_photo_attachments("barsik", msg)
+
+            assert download_threads, "download_file was never called"
+            assert download_threads[0] != loop_thread, (
+                "download_file ran on the event-loop thread -- a multi-MB "
+                "download would freeze the entire daemon"
+            )
+            assert msg.attachments[0]["local_path"].endswith("photo.jpg")
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_try_voice_reply_uses_daemon_url_and_offloads(self, monkeypatch):
+        """The voice-reply HTTP loopback targets THIS process: a sync urlopen
+        on the event loop self-deadlocks until the 60s socket timeout. It must
+        run in a worker thread and honor PINKY_DAEMON_URL."""
+        import threading
+        import urllib.request
+
+        tmpdir, registry, broker, sent_messages = self._make_broker()
+        try:
+            registry.register("barsik", voice_config={"voice_reply": True})
+            monkeypatch.setenv("PINKY_DAEMON_URL", "http://127.0.0.1:9111")
+
+            loop_thread = threading.get_ident()
+            captured: list[tuple[str, int]] = []
+
+            class _FakeResp:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    return False
+
+                def read(self):
+                    return b'{"sent": true}'
+
+            def fake_urlopen(req, timeout=0):
+                captured.append((req.full_url, threading.get_ident()))
+                return _FakeResp()
+
+            monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+            sent = await broker._try_voice_reply(
+                "barsik", "telegram", "6770805286", "hello in voice",
+            )
+
+            assert sent is True
+            assert captured, "urlopen never called"
+            url, thread_id = captured[0]
+            assert url == "http://127.0.0.1:9111/broker/send-voice", (
+                f"voice reply must honor PINKY_DAEMON_URL, got {url}"
+            )
+            assert thread_id != loop_thread, (
+                "urlopen ran on the event-loop thread -- guaranteed deadlock "
+                "against our own /broker/send-voice endpoint"
+            )
+            # Accessibility text companion still goes out.
+            assert ("barsik", "telegram", "6770805286", "hello in voice") in sent_messages
+        finally:
+            tmpdir.cleanup()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -669,6 +669,94 @@ class TestHeartbeatResurrection:
         assert latest.metadata["last_seen_at"] == pytest.approx(now - 10)
 
 
+# ── Non-blocking idle/auto-sleep fires (#702 class) ────────────────────────
+
+
+class _FakeIdleSession:
+    """Streaming-session stand-in for idle/auto-sleep scheduling tests."""
+
+    def __init__(self, *, idle_timeout: int = 60) -> None:
+        from types import SimpleNamespace
+
+        from pinky_daemon.transport_state import SessionState
+
+        self.state = SessionState.CONNECTED
+        self.last_active = 0.0
+        self._config = SimpleNamespace(idle_timeout=idle_timeout)
+        self.sleep_calls = 0
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def idle_sleep(self) -> bool:
+        self.sleep_calls += 1
+        self.started.set()
+        await self.release.wait()
+        return True
+
+
+class TestIdleSleepNonBlocking:
+    """idle_sleep() waits up to a minute for the pre-sleep memory-save turn,
+    so the tick must spawn it as a background task. N idle agents awaited
+    serially would stall every cron minute, heartbeat, and wake in the
+    window — the same class of freeze #702 fixed for dreams.
+    """
+
+    @pytest.mark.asyncio
+    async def test_idle_check_does_not_block_on_slow_idle_sleep(self, registry):
+        ss = _FakeIdleSession()
+        scheduler = AgentScheduler(
+            registry, streaming_sessions_fn=lambda: {"ivan": {"main": ss}}
+        )
+        # Before the fix this await would hang until idle_sleep finished.
+        await asyncio.wait_for(scheduler._check_idle_sessions(time.time()), timeout=2)
+        await asyncio.wait_for(ss.started.wait(), timeout=2)
+        task = scheduler._sleep_tasks[("ivan", "main")]
+        assert not task.done()
+        ss.release.set()
+        await asyncio.wait_for(task, timeout=2)
+        assert ss.sleep_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_idle_sleep_overlap_guard_skips_refire(self, registry):
+        ss = _FakeIdleSession()
+        scheduler = AgentScheduler(
+            registry, streaming_sessions_fn=lambda: {"ivan": {"main": ss}}
+        )
+        await scheduler._check_idle_sessions(time.time())
+        await asyncio.sleep(0)
+        # Session still CONNECTED mid-save: the next tick must not fire a
+        # second idle_sleep (second save prompt) for the same (agent, label).
+        await scheduler._check_idle_sessions(time.time())
+        await asyncio.sleep(0)
+        assert ss.sleep_calls == 1
+        ss.release.set()
+        await asyncio.wait_for(scheduler._sleep_tasks[("ivan", "main")], timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_auto_sleep_fallback_does_not_block_tick(self, registry):
+        registry.register("ivan", model="opus", auto_sleep_hours=1)
+        ss = _FakeIdleSession(idle_timeout=0)
+        scheduler = AgentScheduler(
+            registry, streaming_sessions_fn=lambda: {"ivan": {"main": ss}}
+        )
+        await asyncio.wait_for(scheduler._check_auto_sleep(time.time()), timeout=2)
+        await asyncio.wait_for(ss.started.wait(), timeout=2)
+        assert ss.sleep_calls == 1
+        ss.release.set()
+        await asyncio.wait_for(scheduler._sleep_tasks[("ivan", "main")], timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_inflight_idle_sleep(self, registry):
+        ss = _FakeIdleSession()
+        scheduler = AgentScheduler(
+            registry, streaming_sessions_fn=lambda: {"ivan": {"main": ss}}
+        )
+        await scheduler._check_idle_sessions(time.time())
+        await asyncio.sleep(0)
+        await scheduler.stop()
+        assert scheduler._sleep_tasks == {}
+
+
 # ── Non-blocking dream/librarian fires (issue #702) ────────────────────────
 
 

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -394,3 +394,156 @@ def test_is_purgeable_legacy_session():
     # Owned by an agent that does NOT have a streaming session — keep it.
     assert is_purgeable_legacy_session("persik", streaming) is False
     assert is_purgeable_legacy_session("persik", set()) is False
+
+
+class TestGuardrailPersistence:
+    """disallowed_tools and provider overrides must survive a restart --
+    a restored session silently losing its tool restrictions or reverting
+    to the default Anthropic endpoint is config drift with no error."""
+
+    def test_record_roundtrips_disallowed_tools_and_provider(self, store):
+        store.save(_make_record(
+            disallowed_tools=["Bash", "Write"],
+            provider_url="http://localhost:11434",
+            provider_key="sk-local",
+        ))
+        got = store.get("test-session")
+        assert got.disallowed_tools == ["Bash", "Write"]
+        assert got.provider_url == "http://localhost:11434"
+        assert got.provider_key == "sk-local"
+
+    def test_record_defaults_when_fields_omitted(self, store):
+        store.save(_make_record())
+        got = store.get("test-session")
+        assert got.disallowed_tools == []
+        assert got.provider_url == ""
+        assert got.provider_key == ""
+
+    def test_migration_adds_columns_to_old_database(self):
+        """Opening a pre-existing DB without the new columns must migrate it
+        in place and read old rows with safe defaults."""
+        import sqlite3
+
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        try:
+            conn = sqlite3.connect(path)
+            conn.execute("""
+                CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    model TEXT NOT NULL DEFAULT '',
+                    soul TEXT NOT NULL DEFAULT '',
+                    working_dir TEXT NOT NULL DEFAULT '.',
+                    allowed_tools TEXT NOT NULL DEFAULT '[]',
+                    max_turns INTEGER NOT NULL DEFAULT 0,
+                    timeout REAL NOT NULL DEFAULT 300.0,
+                    system_prompt TEXT NOT NULL DEFAULT '',
+                    restart_threshold_pct REAL NOT NULL DEFAULT 80.0,
+                    auto_restart INTEGER NOT NULL DEFAULT 1,
+                    permission_mode TEXT NOT NULL DEFAULT '',
+                    state TEXT NOT NULL DEFAULT 'idle',
+                    created_at REAL NOT NULL,
+                    last_active REAL NOT NULL,
+                    restart_count INTEGER NOT NULL DEFAULT 0,
+                    sdk_session_id TEXT NOT NULL DEFAULT '',
+                    session_type TEXT NOT NULL DEFAULT 'chat',
+                    agent_name TEXT NOT NULL DEFAULT ''
+                )
+            """)
+            conn.execute(
+                "INSERT INTO sessions (id, created_at, last_active) VALUES (?, ?, ?)",
+                ("legacy", 1000.0, 1000.0),
+            )
+            conn.commit()
+            conn.close()
+
+            s = SessionStore(db_path=path)
+            got = s.get("legacy")
+            assert got is not None
+            assert got.disallowed_tools == []
+            assert got.provider_url == ""
+            assert got.provider_key == ""
+            # New fields persist on the migrated DB too.
+            s.save(_make_record(id="legacy", disallowed_tools=["Bash"]))
+            assert s.get("legacy").disallowed_tools == ["Bash"]
+            s.close()
+        finally:
+            os.unlink(path)
+
+    def test_manager_restore_passes_guardrails_to_session(self):
+        from pinky_daemon.sessions import SessionManager
+
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        try:
+            st1 = SessionStore(db_path=path)
+            mgr1 = SessionManager(store=st1)
+            mgr1.create(
+                session_id="locked",
+                model="sonnet",
+                disallowed_tools=["Bash", "Write"],
+                provider_url="http://localhost:11434",
+                provider_key="sk-local",
+            )
+            st1.close()
+
+            st2 = SessionStore(db_path=path)
+            mgr2 = SessionManager(store=st2)
+            session = mgr2.get("locked")
+            assert session is not None
+            assert session.disallowed_tools == ["Bash", "Write"], (
+                "restored session silently lost its tool restrictions"
+            )
+            assert session._provider_url == "http://localhost:11434"
+            assert session._provider_key == "sk-local"
+            st2.close()
+        finally:
+            os.unlink(path)
+
+
+class TestSendStateRecovery:
+    """Session.send must not strand the session in 'running' when the runner
+    raises or the caller is cancelled -- a stuck-running session is
+    unevictable and rejects all future sends as busy."""
+
+    @pytest.mark.asyncio
+    async def test_send_resets_state_when_runner_cancelled(self):
+        import asyncio
+
+        from pinky_daemon.sessions import SessionManager, SessionState
+
+        mgr = SessionManager()
+        session = mgr.create(session_id="cancel-me")
+
+        class _CancelledRunner:
+            async def run(self, content, **kwargs):
+                raise asyncio.CancelledError()
+
+        session._runner = _CancelledRunner()
+        session._runner_type = "sdk"
+
+        with pytest.raises(asyncio.CancelledError):
+            await session.send("hello")
+
+        assert session.state == SessionState.error, (
+            f"state must not stay 'running' after cancellation, got {session.state}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_resets_state_when_runner_raises(self):
+        from pinky_daemon.sessions import SessionManager, SessionState
+
+        mgr = SessionManager()
+        session = mgr.create(session_id="boom")
+
+        class _BoomRunner:
+            async def run(self, content, **kwargs):
+                raise RuntimeError("runner exploded")
+
+        session._runner = _BoomRunner()
+        session._runner_type = "sdk"
+
+        with pytest.raises(RuntimeError, match="runner exploded"):
+            await session.send("hello")
+
+        assert session.state == SessionState.error

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -942,3 +942,231 @@ async def test_billing_error_assistant_does_not_block_subsequent_auth_alert() ->
     assert callback.await_count == 1
     args, _ = callback.await_args
     assert args == (ss.agent_name, "authentication_failed")
+
+
+# -- _pending_chats routing-queue 1:1 invariant -------------------------------
+#
+# Response routing relies on FIFO correlation: one _pending_chats entry per
+# query, one pop per ResultMessage. System-initiated queries (wake prompt,
+# context warn, restart-blocked notice, idle-sleep save prompt) used to skip
+# the enqueue, so their ResultMessages consumed USER routing tuples and the
+# real user turn popped ("", "", "") -- silently dropping the reply (or
+# delivering a system turn's text to the user's chat). The queue also
+# survived disconnect(), leaking stale chat_ids into a resumed session.
+
+
+@pytest.mark.asyncio
+async def test_send_enqueues_routing_entry_even_without_chat_id() -> None:
+    """Every query through send() must enqueue exactly one routing entry,
+    including internal sends with no chat_id (e.g. inject_agent_message)."""
+    ss = _make_session()
+    await ss.send("internal prompt")
+    assert ss._pending_chats == [("", "", "")]
+
+    await ss.send("user prompt", platform="telegram", chat_id="123", message_id="9")
+    assert ss._pending_chats == [("", "", ""), ("telegram", "123", "9")]
+
+
+@pytest.mark.asyncio
+async def test_context_warn_enqueues_unrouted_sentinel() -> None:
+    """The [SYSTEM] context warning triggers an agent turn whose ResultMessage
+    pops a routing tuple -- a sentinel must be enqueued for it."""
+    ss = _make_session(warn_pct=40, restart_pct=80)
+    _stub_ctx(ss, pct=50)
+    await ss._check_context()
+    assert ss._pending_chats == [("", "", "")]
+
+
+@pytest.mark.asyncio
+async def test_restart_blocked_notice_enqueues_unrouted_sentinel() -> None:
+    ss = _make_session()
+    await ss._notify_restart_blocked({"message": "save first"})
+    assert ss._pending_chats == [("", "", "")]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_clears_pending_chats() -> None:
+    """Stale routing entries must not survive a teardown -- a reconnected
+    session's first turns would otherwise be routed to an old chat_id."""
+    ss = _make_session()
+    ss._pending_chats.append(("telegram", "123", "9"))
+    await ss.disconnect()
+    assert ss._pending_chats == []
+
+
+@pytest.mark.asyncio
+async def test_system_turn_does_not_consume_user_routing() -> None:
+    """A system turn (sentinel entry) completing before a user turn must pop
+    its own sentinel, leaving the user tuple for the user turn."""
+    ss = _make_session()
+    routed: list[tuple[str, str]] = []
+
+    async def capture(turn_result):
+        routed.append((turn_result.platform, turn_result.chat_id))
+
+    ss._response_callback = capture
+    # System turn queued first (e.g. wake prompt), then a user message.
+    ss._pending_chats.append(("", "", ""))
+    ss._pending_chats.append(("telegram", "123", "9"))
+
+    await _run_reader_against_stream(
+        ss,
+        [
+            _make_result_message(),  # system turn -- pops the sentinel
+            _make_result_message(),  # user turn -- pops the user tuple
+        ],
+    )
+
+    assert routed == [("telegram", "123")], (
+        f"user turn must route to the user's chat, got {routed}"
+    )
+
+
+# -- Typing-indicator leak: callback must fire for every routed turn ----------
+#
+# broker.route_response is the only place the Telegram typing loop is
+# cancelled. The reader loop used to skip the response callback for errored
+# turns and for turns with no text/tool uses, leaving the typing task
+# hammering the Telegram API forever.
+
+
+@pytest.mark.asyncio
+async def test_error_result_fires_callback_with_empty_text_for_routed_turn() -> None:
+    ss = _make_session()
+    routed: list[tuple[str, str]] = []
+
+    async def capture(turn_result):
+        routed.append((turn_result.chat_id, turn_result.response_text))
+
+    ss._response_callback = capture
+    ss._pending_chats.append(("telegram", "123", "9"))
+
+    await _run_reader_against_stream(
+        ss,
+        [_make_result_message(is_error=True, api_error_status=429)],
+    )
+
+    assert routed == [("123", "")], (
+        "errored routed turn must still fire the callback (empty text) so "
+        "the broker can stop the typing indicator"
+    )
+
+
+@pytest.mark.asyncio
+async def test_routed_turn_with_no_text_or_tools_still_fires_callback() -> None:
+    ss = _make_session()
+    routed: list[str] = []
+
+    async def capture(turn_result):
+        routed.append(turn_result.chat_id)
+
+    ss._response_callback = capture
+    ss._pending_chats.append(("telegram", "123", "9"))
+
+    await _run_reader_against_stream(ss, [_make_result_message()])
+
+    assert routed == ["123"]
+
+
+@pytest.mark.asyncio
+async def test_unrouted_empty_turn_does_not_fire_callback() -> None:
+    """Sentinel turns with no content stay silent -- no routing target."""
+    ss = _make_session()
+    routed: list[str] = []
+
+    async def capture(turn_result):
+        routed.append(turn_result.chat_id)
+
+    ss._response_callback = capture
+    ss._pending_chats.append(("", "", ""))
+
+    await _run_reader_against_stream(ss, [_make_result_message()])
+
+    assert routed == []
+
+
+# -- idle_sleep must let the memory-save turn finish before teardown ----------
+#
+# query() returns as soon as the prompt hits the transport. idle_sleep()
+# used to disconnect() immediately after, killing the CLI subprocess before
+# the save-memories turn ever ran -- the "save state before sleeping"
+# contract was a no-op.
+
+
+@pytest.mark.asyncio
+async def test_idle_sleep_waits_for_save_turn_completion() -> None:
+    ss = _make_session()
+    order: list[str] = []
+
+    async def fake_reader() -> None:
+        await asyncio.sleep(0.05)
+        order.append("save_turn_done")
+        ss._turn_done.set()
+
+    ss._reader_task = asyncio.create_task(fake_reader())
+
+    orig_disconnect = ss.disconnect
+
+    async def tracking_disconnect() -> None:
+        order.append("disconnect")
+        await orig_disconnect()
+
+    ss.disconnect = tracking_disconnect  # type: ignore[assignment]
+
+    result = await ss.idle_sleep()
+
+    assert result is True
+    assert order == ["save_turn_done", "disconnect"], (
+        f"disconnect must happen AFTER the save turn completes, got {order}"
+    )
+    assert ss.state == SessionState.IDLE_SLEEPING
+
+
+@pytest.mark.asyncio
+async def test_idle_sleep_proceeds_after_save_timeout() -> None:
+    """The wait is bounded -- a wedged save turn must not block sleep forever."""
+    ss = _make_session()
+    ss._IDLE_SLEEP_SAVE_TIMEOUT_SEC = 0.05  # type: ignore[assignment]
+
+    async def never_finishes() -> None:
+        await asyncio.sleep(60)
+
+    ss._reader_task = asyncio.create_task(never_finishes())
+
+    result = await ss.idle_sleep()
+
+    assert result is True
+    assert ss.state == SessionState.IDLE_SLEEPING
+
+
+# -- Warm-reconnect coalescing -------------------------------------------------
+#
+# A transport drop surfaces in send() AND the reader loop (and the watchdog
+# can fire during the backoff window). Unguarded, two concurrent
+# attempt_reconnect calls interleave disconnect/sleep/connect: each connect()
+# builds its own SDK client + reader task and the later assignment orphans
+# the first live subprocess.
+
+
+@pytest.mark.asyncio
+async def test_concurrent_attempt_reconnect_coalesces_to_single_cycle() -> None:
+    ss = _make_session()
+    ss._RECONNECT_BACKOFF = (0.01,)  # type: ignore[assignment]
+    connect_calls = 0
+
+    async def fake_connect() -> None:
+        nonlocal connect_calls
+        connect_calls += 1
+        await asyncio.sleep(0.05)
+        ss._state_machine._state = SessionState.CONNECTED
+
+    ss.connect = fake_connect  # type: ignore[assignment]
+
+    await asyncio.gather(ss.attempt_reconnect(), ss.attempt_reconnect())
+
+    assert connect_calls == 1, (
+        f"concurrent attempt_reconnect must coalesce onto one cycle; "
+        f"connect() ran {connect_calls}x"
+    )
+    assert ss.state == SessionState.CONNECTED
+    assert ss._reconnect_task is None, "in-flight marker must clear when done"

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -995,6 +995,30 @@ async def test_disconnect_clears_pending_chats() -> None:
 
 
 @pytest.mark.asyncio
+async def test_disconnect_fires_empty_callback_for_routed_pending_entries() -> None:
+    """A routed turn that dies in a teardown (e.g. the disconnect inside a
+    warm reconnect) never reaches broker.route_response -- the only place the
+    typing indicator stops. disconnect() must fire the callback with empty
+    text for each routed entry; sentinels stay silent."""
+    ss = _make_session()
+    routed: list[tuple[str, str, str]] = []
+
+    async def capture(turn_result):
+        routed.append((turn_result.platform, turn_result.chat_id, turn_result.text))
+
+    ss._response_callback = capture
+    ss._pending_chats.append(("telegram", "123", "9"))
+    ss._pending_chats.append(("", "", ""))
+
+    await ss.disconnect()
+
+    assert routed == [("telegram", "123", "")], (
+        f"routed entries must fire an empty-text callback on teardown, got {routed}"
+    )
+    assert ss._pending_chats == []
+
+
+@pytest.mark.asyncio
 async def test_system_turn_does_not_consume_user_routing() -> None:
     """A system turn (sentinel entry) completing before a user turn must pop
     its own sentinel, leaving the user tuple for the user turn."""
@@ -1137,6 +1161,27 @@ async def test_idle_sleep_proceeds_after_save_timeout() -> None:
 
     assert result is True
     assert ss.state == SessionState.IDLE_SLEEPING
+
+
+@pytest.mark.asyncio
+async def test_idle_sleep_aborts_when_message_arrives_during_save_window() -> None:
+    """A send() accepted during the save window would have its query killed
+    by the teardown -- the sleep must abort and leave the session connected."""
+    ss = _make_session()
+
+    async def reader_with_traffic() -> None:
+        await ss.send("hi there", platform="telegram", chat_id="123")
+        ss._turn_done.set()
+
+    ss._reader_task = asyncio.create_task(reader_with_traffic())
+
+    result = await ss.idle_sleep()
+
+    assert result is False
+    assert ss.state == SessionState.CONNECTED, (
+        "idle sleep must abort when new traffic arrives mid-save"
+    )
+    assert ss._client is not None, "transport must not be torn down on abort"
 
 
 # -- Warm-reconnect coalescing -------------------------------------------------


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **high** Voice reply makes blocking HTTP call to its own server from the event loop (`src/pinky_daemon/broker.py:1508`)
  - Run the urlopen loopback in asyncio.to_thread and build the URL from PINKY_DAEMON_URL instead of hardcoded localhost:8888 (inherited from interrupted agent, verified; regression test asserts off-loop thread + URL).
- **medium** _pending_chats routing queue desyncs on system queries and survives restarts (`src/pinky_daemon/streaming_session.py:823`)
  - Enqueue an unrouted ("","","") sentinel for every system query (wake prompt, context warn, restart-blocked, idle-sleep save), always enqueue in send(), and clear _pending_chats in disconnect() (inherited, verified; tests cover sentinel ordering and queue clearing).
- **n/a** Synchronous downloads and ffmpeg subprocesses block the event loop on inbound media (`src/pinky_daemon/broker.py`)
  - Wrap adapter.download_file (both photo and voice paths) and _make_gif_preview in asyncio.to_thread (inherited, verified; test asserts download runs off the loop thread).
- **medium** idle_sleep sends the memory-save prompt and disconnects immediately (`src/pinky_daemon/streaming_session.py:1240`)
  - idle_sleep now waits (bounded, 60s) on a turn-boundary event set by the reader loop before disconnect (inherited, verified); I additionally corrected the factually wrong 'implicitly wait-for-completion' docstring in wake_prompt.py per the fix_hint.
- **medium** Typing-indicator task leaks and runs forever on errored or unroutable turns (`src/pinky_daemon/broker.py:288`)
  - Fire the response callback (empty text, never the suppressed content) for routed errored turns and routed turns with no text/tools so broker.route_response stops the typing loop (inherited, verified; tests cover error, empty, and unrouted cases).
- **medium** disallowed_tools and provider overrides not persisted -- restored sessions lose guardrails (`src/pinky_daemon/session_store.py:28`)
  - Added disallowed_tools/provider_url/provider_key to SessionRecord, schema, migration, save and row mapping; Session._persist and SessionManager._restore_sessions pass them through (inherited, verified; tests cover roundtrip, old-DB migration, manager restore).
- **medium** Channel-to-session mapping silently bypassed when assigned session is not CONNECTED (`src/pinky_daemon/broker.py:993`)
  - _get_streaming_session returns the mapped session in any state so _route_streaming auto-wake/wait logic targets the assigned session; falls back to main only when no object exists for the label (inherited, verified; test covers mapped-sleeping, unmapped, ghost-label cases).
- **n/a** Concurrent warm reconnects unguarded -- orphaned SDK subprocess and duplicate reader loops (`src/pinky_daemon/streaming_session.py`)
  - attempt_reconnect coalesces concurrent callers onto a single in-flight _reconnect_with_backoff task; running it as its own task also survives the initiating reader task being cancelled by disconnect (inherited, verified; test proves one connect() for two concurrent callers).
- **n/a** Session stuck in 'running' forever if runner.run is cancelled or raises (`src/pinky_daemon/sessions.py`)
  - Session.send wraps the post-state-set body in try/except BaseException that sets state=error, persists, and re-raises (inherited, verified; tests cover CancelledError and RuntimeError).
- **n/a** wake_prompt_sent log reports stale config wake_context instead of delivered body (`src/pinky_daemon/streaming_session.py`)
  - context_chars/context_present now computed from the freshly rebuilt wake_context_body actually delivered; marker kept at enqueue time matching the tmux transport convention (inherited, verified).
- **n/a** Group note: register_streaming defense-in-depth for displaced connected sessions (`src/pinky_daemon/broker.py`)
  - Overwriting a still-CONNECTED session under the same label logs a WARNING and schedules a background disconnect of the displaced session (strong task refs kept in _background_tasks); no-op when no loop or session not connected (inherited, verified; tests cover both branches).

## Deferred (not fixed here, with reasons)
- Make _heartbeat_resurrect skip state == RECONNECTING (reconnect-race fix_hint, second half): Lives in api.py, which the group_note explicitly forbids touching (a lock is being added there on another branch). The coalescing guard in attempt_reconnect already neutralizes the watchdog case: a watchdog call during the backoff window awaits the in-flight reconnect task instead of starting a second cycle.
- Replace voice-reply HTTP loopback with a direct in-process TTS/send callback: The deeper refactor in the fix_hint requires wiring a broker callback from api.py (out of scope per group_note). The implemented minimal fix (to_thread + PINKY_DAEMON_URL) is the alternative the fix_hint explicitly sanctioned and removes both the deadlock and the hardcoded port.

## Testing
**sessions**: From worktree root: (1) python3 -m pytest tests/test_streaming_session.py tests/test_session_store.py tests/test_broker.py -q -> 106 passed; (2) python3 -m pytest on the 12 other test files referencing changed symbols (test_agent_status, test_api, test_codex_session, test_scheduler, test_session_watchdog, test_shared_mcp, test_shared_mcp_integration, test_tmux_session, test_tmux_transcript, test_transport, test_transport_state, test_wake_prompt) -> 1072 passed; (3) python3 -m pytest tests/test_wake_prompt.py -q after my wake_prompt.py edit -> 28 passed; (4) python3 -m pytest tests/ -q on all remaining files -> 2342 passed, 2 skipped. Full suite effectively green: 3548 passed, 2 skipped, 0 failed. ruff check on all 8 changed files: All checks passed.

Generated with [Claude Code](https://claude.com/claude-code)