### PR TITLE
fix(sweep): sched - dream watermark data loss, malformed-cron tick abort, blocking IO

### DIFF
--- a/src/pinky_daemon/autonomy.py
+++ b/src/pinky_daemon/autonomy.py
@@ -23,6 +23,7 @@ Architecture:
 from __future__ import annotations
 
 import asyncio
+import itertools
 import sys
 import time
 from dataclasses import dataclass, field
@@ -75,6 +76,10 @@ class EventQueue:
 
     def __init__(self) -> None:
         self._queues: dict[str, asyncio.PriorityQueue] = {}
+        # Monotonic tiebreaker: AgentEvent has no ordering, so two events with
+        # equal priority and timestamp would make heapq compare the events
+        # themselves and raise TypeError, losing the event.
+        self._seq = itertools.count()
 
     def ensure_queue(self, agent_name: str) -> None:
         if agent_name not in self._queues:
@@ -85,7 +90,7 @@ class EventQueue:
         self.ensure_queue(event.agent_name)
         # Priority queue: lower number = higher priority, negate for urgency
         await self._queues[event.agent_name].put(
-            (-event.priority, event.timestamp, event)
+            (-event.priority, event.timestamp, next(self._seq), event)
         )
 
     async def pop(self, agent_name: str, timeout: float = 0) -> AgentEvent | None:
@@ -93,11 +98,11 @@ class EventQueue:
         self.ensure_queue(agent_name)
         try:
             if timeout > 0:
-                _, _, event = await asyncio.wait_for(
+                _, _, _, event = await asyncio.wait_for(
                     self._queues[agent_name].get(), timeout=timeout
                 )
             else:
-                _, _, event = self._queues[agent_name].get_nowait()
+                _, _, _, event = self._queues[agent_name].get_nowait()
             return event
         except (asyncio.QueueEmpty, asyncio.TimeoutError):
             return None

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -13,6 +13,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 import sqlite3
@@ -231,7 +232,9 @@ class DreamRunner:
 
         if not history_lines:
             summary = "No new conversation history to process."
-            self._save_state(agent_name, summary)
+            # Preserve the existing watermark; saving the default 0.0 would
+            # make the next dream re-fetch and re-consolidate all history.
+            self._save_state(agent_name, summary, last_message_ts=last_message_ts)
             return summary
 
         # Build system prompt
@@ -304,6 +307,7 @@ class DreamRunner:
         elapsed = time.time() - start
 
         summary = result.output.strip() if result.output else ""
+        run_failed = not summary or result.exit_code != 0
         if not summary:
             summary = f"Dream run failed or produced no output (exit={result.exit_code})"
             if result.error:
@@ -311,31 +315,51 @@ class DreamRunner:
 
         _log(f"dream-runner: '{agent_name}' dream complete in {elapsed:.1f}s — {summary[:120]}")
 
-        self._save_state(agent_name, summary, last_message_ts=new_watermark)
+        # Only advance the watermark on success: a failed run must leave this
+        # cycle's history unprocessed so the next dream re-fetches it.
+        self._save_state(
+            agent_name,
+            summary,
+            last_message_ts=last_message_ts if run_failed else new_watermark,
+        )
+
+        # The post-dream pipeline below is synchronous (blocking urllib calls
+        # with retries, numpy over all embeddings). It runs on the daemon's
+        # single shared event loop, so each step is offloaded to a worker
+        # thread; otherwise the whole daemon (API, pollers, broker, scheduler)
+        # freezes for the duration of the pipeline.
 
         # Post-dream: build memory graph links for new reflections
-        self._build_memory_links(agent_name, agent_config, since=dream_start)
+        await asyncio.to_thread(
+            self._build_memory_links, agent_name, agent_config, since=dream_start
+        )
 
         # Post-dream: extract and store user profiles + relationships from dream output
-        profile_count = self._extract_user_profiles(summary)
+        profile_count = await asyncio.to_thread(self._extract_user_profiles, summary)
         if profile_count:
             _log(f"dream-runner: '{agent_name}' extracted {profile_count} user profile entries")
-        rel_count = self._extract_user_relationships(summary)
+        rel_count = await asyncio.to_thread(self._extract_user_relationships, summary)
         if rel_count:
             _log(f"dream-runner: '{agent_name}' extracted {rel_count} user relationships")
 
-        # Post-dream: extract and create proposed skills
-        skills_created = self._extract_proposed_skills(summary, agent_name)
+        # Post-dream: extract and create proposed skills. Must run off-loop:
+        # it POSTs to the daemon's own API, which can only be served while the
+        # event loop is free.
+        skills_created = await asyncio.to_thread(
+            self._extract_proposed_skills, summary, agent_name
+        )
         if skills_created:
             _log(f"dream-runner: '{agent_name}' created {skills_created} skill draft(s)")
 
         # Post-dream: extract KG triples from dream output (inline extraction)
-        kg_dream_count = self._extract_kg_from_dream_output(summary, agent_config)
+        kg_dream_count = await asyncio.to_thread(
+            self._extract_kg_from_dream_output, summary, agent_config
+        )
         if kg_dream_count:
             _log(f"dream-runner: '{agent_name}' extracted {kg_dream_count} KG triples from dream")
 
         # Post-dream: extract KG triples from new reflections (per-reflection LLM pass)
-        kg_count = self._extract_kg_triples(agent_name, agent_config)
+        kg_count = await asyncio.to_thread(self._extract_kg_triples, agent_name, agent_config)
         if kg_count:
             _log(f"dream-runner: '{agent_name}' extracted {kg_count} KG triples")
 
@@ -345,8 +369,8 @@ class DreamRunner:
         # never auto-messages the owner — the agent reviews the digest on wake
         # and decides. ``last_dream_at`` here is the PRIOR dream time (captured
         # before _save_state above), so changes are scoped to this cycle.
-        kg_digest = self._surface_kg_insights(
-            agent_name, agent_config, since_ts=last_dream_at
+        kg_digest = await asyncio.to_thread(
+            self._surface_kg_insights, agent_name, agent_config, since_ts=last_dream_at
         )
         if kg_digest:
             _log(

--- a/src/pinky_daemon/librarian_runner.py
+++ b/src/pinky_daemon/librarian_runner.py
@@ -182,7 +182,18 @@ class LibrarianRunner:
         start = time.time()
 
         last_run = self._get_last_run_at(agent_name)
-        new_sources = self._kb.list_raw(since=last_run, limit=100)
+        # list_raw returns newest-first; page through so a >100-source backlog
+        # is not silently dropped, then process oldest-first so the watermark
+        # can advance to exactly the newest source actually handled.
+        new_sources = []
+        offset = 0
+        while True:
+            page = self._kb.list_raw(since=last_run, limit=100, offset=offset)
+            new_sources.extend(page)
+            if len(page) < 100 or offset >= 4900:
+                break
+            offset += 100
+        new_sources.sort(key=lambda s: s.filed_at)
 
         if not new_sources:
             _log("librarian: no new sources — skipping")
@@ -203,6 +214,9 @@ class LibrarianRunner:
 
         if not changed_sources:
             _log("librarian: all sources unchanged (hash match) — skipping")
+            # Hash-matched content is already curated; move the watermark past
+            # it so these sources are not re-listed on every subsequent run.
+            self._advance_watermark(agent_name, new_sources[-1].filed_at)
             return {"sources_processed": 0, "skipped": True}
 
         new_sources = [src for src, _ in changed_sources]
@@ -211,12 +225,17 @@ class LibrarianRunner:
         since_str = last_run or "beginning"
         _log(f"librarian: found {len(new_sources)} changed source(s) since {since_str}")
 
-        # Build source content block for the prompt
+        # Build source content block for the prompt. Sources are oldest-first,
+        # so when the budget truncates the list the dropped sources are the
+        # newest ones and stay beyond the watermark for the next run.
         source_blocks = []
+        included_ids = []
         total_chars = 0
+        processed_through = None
         for src in new_sources:
             content = self._kb.get_raw_content(src.id)
             if not content:
+                processed_through = src.filed_at
                 continue
             block = (
                 f"### Source: {src.title} (ID: {src.id})\n"
@@ -225,11 +244,17 @@ class LibrarianRunner:
                 f"{content}\n\n---\n"
             )
             if total_chars + len(block) > _MAX_SOURCE_CHARS:
-                _log(f"librarian: truncating sources at {len(source_blocks)} "
-                     f"(budget: {_MAX_SOURCE_CHARS})")
-                break
+                if source_blocks:
+                    _log(f"librarian: truncating sources at {len(source_blocks)} "
+                         f"(budget: {_MAX_SOURCE_CHARS})")
+                    break
+                # A single source larger than the whole budget: include it
+                # truncated so the run still makes progress past it.
+                block = block[:_MAX_SOURCE_CHARS] + "\n...(truncated)\n\n---\n"
             source_blocks.append(block)
+            included_ids.append(src.id)
             total_chars += len(block)
+            processed_through = src.filed_at
 
         # Build wiki manifest (slug + title + sources — not full content)
         wiki_pages = self._kb.list_wiki(limit=200)
@@ -277,6 +302,7 @@ class LibrarianRunner:
         elapsed = time.time() - start
 
         summary = result.output.strip() if result.output else ""
+        run_failed = not summary or result.exit_code != 0
         if not summary:
             summary = f"Librarian run failed (exit={result.exit_code})"
             if result.error:
@@ -285,17 +311,25 @@ class LibrarianRunner:
         _log(f"librarian: curation complete in {elapsed:.1f}s — {summary[:200]}")
 
         # Parse stats from summary (best-effort)
-        source_ids = [s.id for s in new_sources[:len(source_blocks)]]
-        stats = self._parse_stats(summary, source_ids)
+        stats = self._parse_stats(summary, included_ids)
         stats["duration_s"] = round(elapsed, 1)
         stats["summary"] = summary
 
-        # Save state
-        self._save_state(agent_name, stats)
         self._save_run_log(agent_name, stats)
 
+        if run_failed:
+            # Keep the watermark and processed hashes untouched so these
+            # sources are re-fetched and curated on the next run.
+            _log("librarian: run failed; not advancing last_run_at")
+            stats["failed"] = True
+            return stats
+
+        # Save state: advance the watermark only to the newest source actually
+        # included in this run, never to "now".
+        self._save_state(agent_name, stats, last_run_at=processed_through)
+
         # Record processed body hashes so unchanged sources are skipped next run
-        hash_entries = [(sid, body_hashes[sid]) for sid in source_ids if sid in body_hashes]
+        hash_entries = [(sid, body_hashes[sid]) for sid in included_ids if sid in body_hashes]
         self._save_processed_hashes(hash_entries)
 
         return stats
@@ -309,9 +343,15 @@ class LibrarianRunner:
             "pages_updated": [],  # TODO: parse from summary
         }
 
-    def _save_state(self, agent_name: str, stats: dict) -> None:
-        """Update the persistent state after a run."""
-        now = datetime.now(timezone.utc).isoformat()
+    def _save_state(
+        self, agent_name: str, stats: dict, last_run_at: str | None = None
+    ) -> None:
+        """Update the persistent state after a successful run.
+
+        ``last_run_at`` is the filed_at watermark of the newest source actually
+        processed; defaults to "now" when no finer-grained marker is available.
+        """
+        watermark = last_run_at or datetime.now(timezone.utc).isoformat()
         conn = self._conn()
         try:
             conn.execute(
@@ -328,12 +368,27 @@ class LibrarianRunner:
                 """,
                 (
                     agent_name,
-                    now,
+                    watermark,
                     stats.get("sources_processed", 0),
                     len(stats.get("pages_created", [])),
                     len(stats.get("pages_updated", [])),
                     stats.get("summary", ""),
                 ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _advance_watermark(self, agent_name: str, last_run_at: str) -> None:
+        """Move last_run_at forward without touching the last-run stats."""
+        conn = self._conn()
+        try:
+            conn.execute(
+                """INSERT INTO librarian_state (agent_name, last_run_at)
+                   VALUES (?, ?)
+                   ON CONFLICT(agent_name) DO UPDATE SET
+                       last_run_at = excluded.last_run_at""",
+                (agent_name, last_run_at),
             )
             conn.commit()
         finally:

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -22,6 +22,28 @@ from pinky_outreach.telegram import TelegramAdapter, TelegramError
 # window before discovery sweeps, we still want to deliver it.
 _PRIME_FRESH_WINDOW_SECONDS = 30.0
 
+# Strong references to in-flight delivery tasks: the event loop keeps only
+# weak references, so a bare fire-and-forget create_task can be garbage
+# collected mid-flight and its exception silently dropped.
+_DELIVERY_TASKS: set["asyncio.Task"] = set()
+
+
+def _deliver_in_background(coro, log_prefix: str) -> "asyncio.Task":
+    """Schedule an inbound delivery coroutine, surfacing failures in the log."""
+    task = asyncio.create_task(coro)
+    _DELIVERY_TASKS.add(task)
+
+    def _on_done(t: "asyncio.Task") -> None:
+        _DELIVERY_TASKS.discard(t)
+        if t.cancelled():
+            return
+        exc = t.exception()
+        if exc is not None:
+            _log(f"{log_prefix}: broker delivery failed: {exc!r}")
+
+    task.add_done_callback(_on_done)
+    return task
+
 if TYPE_CHECKING:
     from pinky_outreach.types import Chat
 
@@ -113,7 +135,7 @@ class TelegramPoller:
             )
 
             # Fire and forget — handler manages concurrency
-            asyncio.create_task(self._handler.handle(inbound))
+            _deliver_in_background(self._handler.handle(inbound), "telegram-poller")
 
             # Push event to autonomy engine
             if self._event_callback:
@@ -247,7 +269,10 @@ class BrokerTelegramPoller:
             )
 
             # Route through broker (fire and forget)
-            asyncio.create_task(self._broker.handle_inbound(broker_msg))
+            _deliver_in_background(
+                self._broker.handle_inbound(broker_msg),
+                f"broker-poller[{self._agent_name}]",
+            )
 
             # Push event to autonomy engine
             if self._event_callback:
@@ -368,7 +393,10 @@ class BrokeriMessagePoller:
                 f"in {msg.chat_id}: {msg.content[:50]}..."
             )
 
-            asyncio.create_task(self._broker.handle_inbound(broker_msg))
+            _deliver_in_background(
+                self._broker.handle_inbound(broker_msg),
+                f"imessage-poller[{self._agent_name}]",
+            )
 
             if self._event_callback:
                 try:
@@ -641,27 +669,18 @@ class BrokerDiscordPoller:
         self._channel_info_cache[channel_id] = chat_info
         return chat_info
 
-    def _attach_broker_failure_logger(self, task: "asyncio.Task") -> None:
-        """Surface unhandled broker delivery exceptions as poller log lines."""
-        def _log_failure(t: "asyncio.Task") -> None:
-            if t.cancelled():
-                return
-            exc = t.exception()
-            if exc is None:
-                return
-            _log(
-                f"discord-poller[{self._agent_name}]: "
-                f"broker delivery failed: {exc!r}"
-            )
-        task.add_done_callback(_log_failure)
-
     async def _poll_once(self) -> None:
         """Single sweep across all watched channels."""
         loop = asyncio.get_running_loop()
         self._poll_count += 1
 
         for channel_id in list(self._channels):
-            after = self._last_id.get(channel_id, "")
+            after = self._last_id.get(channel_id)
+            if after is None:
+                # Priming failed during discovery; polling with no floor would
+                # replay up to 50 historical messages. Skip until the next
+                # discovery re-primes it (`added` is computed from _last_id).
+                continue
             if after == "0":
                 # Empty-channel sentinel — drop the after filter so the first real
                 # message is picked up regardless of snowflake ordering.
@@ -738,10 +757,10 @@ class BrokerDiscordPoller:
                     f"{msg.sender} in {channel_id}: {msg.content[:50]}..."
                 )
 
-                delivery = asyncio.create_task(
-                    self._broker.handle_inbound(broker_msg)
+                _deliver_in_background(
+                    self._broker.handle_inbound(broker_msg),
+                    f"discord-poller[{self._agent_name}]",
                 )
-                self._attach_broker_failure_logger(delivery)
 
                 if self._event_callback:
                     try:

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -85,8 +85,9 @@ def cron_matches(cron_expr: str, dt: datetime) -> bool:
     """Check if a datetime matches a 5-field cron expression.
 
     Fields: minute hour day-of-month month day-of-week
-    Supports: * (any), */N (step), N-M (range), N,M (list)
-    Day-of-week: 0=Monday ... 6=Sunday (ISO)
+    Supports: * (any), */N (step), N-M (range), N-M/S (range step),
+    N,M (list), and 3-letter day/month names (mon, jan, ...)
+    Day-of-week: 0=Sunday ... 6=Saturday
     """
     fields = cron_expr.strip().split()
     if len(fields) != 5:
@@ -95,9 +96,15 @@ def cron_matches(cron_expr: str, dt: datetime) -> bool:
     values = [dt.minute, dt.hour, dt.day, dt.month, dt.isoweekday() % 7]
     limits = [(0, 59), (0, 23), (1, 31), (1, 12), (0, 6)]
 
-    for field, value, (lo, hi) in zip(fields, values, limits):
-        if not _field_matches(field, value, lo, hi):
-            return False
+    try:
+        for field, value, (lo, hi) in zip(fields, values, limits):
+            if not _field_matches(field, value, lo, hi):
+                return False
+    except ValueError:
+        # Schedules are stored unvalidated; a single malformed expression
+        # must never abort the scheduler tick for everyone else.
+        _log(f"scheduler: invalid cron expression {cron_expr!r}; treating as no match")
+        return False
     return True
 
 
@@ -109,24 +116,47 @@ def _field_matches(field: str, value: int, lo: int, hi: int) -> bool:
     return False
 
 
+# Standard cron name tokens. Day-of-week values match isoweekday() % 7
+# (0=Sunday ... 6=Saturday); month names map to 1-12.
+_CRON_NAMES = {
+    "sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6,
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+    "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+
+def _cron_int(token: str) -> int:
+    """Parse a cron token: a plain integer or a 3-letter day/month name."""
+    token = token.strip().lower()
+    if token in _CRON_NAMES:
+        return _CRON_NAMES[token]
+    return int(token)
+
+
 def _part_matches(part: str, value: int, lo: int, hi: int) -> bool:
-    """Match a single part of a cron field (e.g., '*/5', '1-3', '7')."""
+    """Match a single part of a cron field (e.g., '*/5', '1-3', 'mon-fri/2', '7')."""
     if part == "*":
         return True
 
+    step = 1
     if "/" in part:
-        base, step_str = part.split("/", 1)
+        part, step_str = part.split("/", 1)
         step = int(step_str)
-        if base == "*":
+        if step <= 0:
+            raise ValueError(f"invalid cron step: {step_str!r}")
+        if part == "*":
             return value % step == 0
-        start = int(base)
-        return value >= start and (value - start) % step == 0
+        if "-" not in part:
+            start = _cron_int(part)
+            return value >= start and (value - start) % step == 0
 
     if "-" in part:
-        start, end = part.split("-", 1)
-        return int(start) <= value <= int(end)
+        start_str, end_str = part.split("-", 1)
+        start = _cron_int(start_str)
+        end = _cron_int(end_str)
+        return start <= value <= end and (value - start) % step == 0
 
-    return value == int(part)
+    return value == _cron_int(part)
 
 
 def next_cron_description(cron_expr: str) -> str:
@@ -826,14 +856,18 @@ class AgentScheduler:
         import urllib.error
         import urllib.request
 
-        try:
+        def _fetch() -> tuple[int, str]:
             req = urllib.request.Request(
                 trigger.url, method=trigger.method or "GET",
             )
             with urllib.request.urlopen(req, timeout=5) as resp:
-                status_code = resp.status
                 body_bytes = resp.read(65536)  # cap at 64KB
-                body_text = body_bytes.decode(errors="replace")
+                return resp.status, body_bytes.decode(errors="replace")
+
+        try:
+            # Off-loop: a slow watched URL must not stall the shared event loop
+            # (cf. the run_in_executor pattern in pollers.py).
+            status_code, body_text = await asyncio.to_thread(_fetch)
         except urllib.error.HTTPError as e:
             status_code = e.code
             body_text = ""

--- a/tests/test_autonomy.py
+++ b/tests/test_autonomy.py
@@ -154,3 +154,39 @@ class TestPushEventWakeGate:
             assert popped.data == {"text": "hello"}
         finally:
             await engine.stop()
+
+
+class TestEventQueueTieBreak:
+    """Two events with equal priority and timestamp must not make heapq
+    compare AgentEvent objects (no ordering defined) and raise TypeError,
+    losing the event."""
+
+    @pytest.mark.asyncio
+    async def test_identical_priority_and_timestamp_events_both_queue(self):
+        from pinky_daemon.autonomy import EventQueue
+
+        queue = EventQueue()
+        ts = 1717000000.0
+        first = AgentEvent(
+            type=EventType.message_received,
+            agent_name="ivan",
+            data={"n": 1},
+            timestamp=ts,
+            priority=1,
+        )
+        second = AgentEvent(
+            type=EventType.message_received,
+            agent_name="ivan",
+            data={"n": 2},
+            timestamp=ts,
+            priority=1,
+        )
+
+        await queue.push(first)
+        await queue.push(second)  # ties with first on (priority, timestamp)
+
+        popped = [
+            (await queue.pop("ivan")).data["n"],
+            (await queue.pop("ivan")).data["n"],
+        ]
+        assert popped == [1, 2]  # FIFO within equal priority

--- a/tests/test_discord_poller.py
+++ b/tests/test_discord_poller.py
@@ -86,6 +86,47 @@ class TestBrokerDiscordPoller:
         mock_broker.handle_inbound.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_priming_failure_does_not_replay_history(self, mock_adapter, mock_broker):
+        """A channel whose priming fetch failed must not be polled floorless.
+
+        Polling with no after-filter would replay the latest 50 historical
+        messages as fresh inbound. The channel stays parked until the next
+        discovery re-primes it.
+        """
+        history = [
+            _msg(msg_id=str(200 - i), content=f"old-{i}", author_id="user-9")
+            for i in range(3)
+        ]
+        mock_adapter.get_messages.side_effect = [
+            DiscordError("transient", status_code=502),  # priming fails
+        ]
+
+        poller = self._make_poller(mock_adapter, mock_broker)
+        await poller._refresh_channels(verbose=True)
+        assert poller.watched_channels == ["chan-A"]
+        assert "chan-A" not in poller._last_id
+
+        # The channel is in the watch set, but the poll must skip it
+        mock_adapter.get_messages.side_effect = [history]
+        await poller._poll_once()
+        await asyncio.sleep(0)
+        mock_broker.handle_inbound.assert_not_called()
+
+        # Next discovery re-primes it and polling resumes with a floor
+        latest = _msg(msg_id="200", content="latest")
+        new_msg = _msg(msg_id="201", content="fresh", author_id="user-9")
+        mock_adapter.get_messages.side_effect = [
+            [latest],    # re-prime
+            [new_msg],   # poll
+        ]
+        await poller._refresh_channels(verbose=False)
+        await poller._poll_once()
+        await asyncio.sleep(0)
+
+        assert mock_broker.handle_inbound.await_count == 1
+        assert mock_broker.handle_inbound.await_args.args[0].message_id == "201"
+
+    @pytest.mark.asyncio
     async def test_new_message_routed_through_broker(self, mock_adapter, mock_broker):
         """Real inbound user message should produce a BrokerMessage with platform=discord."""
         baseline = _msg(msg_id="100", content="baseline")

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -259,3 +259,84 @@ class TestKGCallerRetry:
             assert calls["n"] == 2  # 529 is transient — retried
         finally:
             os.unlink(path)
+
+
+class _StubSDKRunner:
+    """Stands in for SDKRunner inside run_dream; returns a canned RunResult."""
+
+    result = None
+
+    def __init__(self, config, agent_name=""):
+        self.config = config
+        self.agent_name = agent_name
+
+    async def run(self, prompt):
+        return type(self).result
+
+
+class _DreamAgentConfig:
+    def __init__(self, working_dir: str) -> None:
+        self.working_dir = working_dir
+        self.model = "sonnet"
+        self.dream_model = ""
+        self.provider_key = ""
+
+
+class TestRunDreamWatermark:
+    """run_dream must never lose the last_message_ts watermark: an idle night
+    must not reset it to 0 (full-history reprocess), and a failed run must not
+    advance it (that night's history silently skipped forever)."""
+
+    def _runner(self, tmp_path, messages):
+        return DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            history_provider=lambda agent, after_ts, limit, role: messages,
+        )
+
+    @pytest.mark.asyncio
+    async def test_idle_night_preserves_watermark(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        runner = self._runner(tmp_path, [])
+        runner._save_state("pinky", "seed", last_message_ts=123.0)
+
+        summary = await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        assert "No new conversation history" in summary
+        assert runner._get_last_message_ts("pinky") == 123.0
+
+    @pytest.mark.asyncio
+    async def test_failed_run_does_not_advance_watermark(self, tmp_path, monkeypatch):
+        from pinky_daemon.claude_runner import RunResult
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        monkeypatch.setattr("pinky_daemon.dream_runner.SDKRunner", _StubSDKRunner)
+        _StubSDKRunner.result = RunResult(output="", exit_code=1, error="boom")
+
+        messages = [{"timestamp": 200.0, "role": "user", "content": "hello"}]
+        runner = self._runner(tmp_path, messages)
+        runner._save_state("pinky", "seed", last_message_ts=100.0)
+
+        summary = await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        assert "Dream run failed" in summary
+        # Failed run: the night's history stays unprocessed for the next cycle
+        assert runner._get_last_message_ts("pinky") == 100.0
+
+    @pytest.mark.asyncio
+    async def test_successful_run_advances_watermark(self, tmp_path, monkeypatch):
+        from pinky_daemon.claude_runner import RunResult
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        monkeypatch.setattr("pinky_daemon.dream_runner.SDKRunner", _StubSDKRunner)
+        _StubSDKRunner.result = RunResult(output="Consolidated.", exit_code=0)
+
+        messages = [{"timestamp": 200.0, "role": "user", "content": "hello"}]
+        runner = self._runner(tmp_path, messages)
+        runner._save_state("pinky", "seed", last_message_ts=100.0)
+
+        summary = await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        assert summary == "Consolidated."
+        assert runner._get_last_message_ts("pinky") == 200.0

--- a/tests/test_librarian_runner.py
+++ b/tests/test_librarian_runner.py
@@ -1,0 +1,143 @@
+"""Tests for LibrarianRunner watermark and failure handling.
+
+The librarian must never advance last_run_at past sources it did not
+actually process: a failed SDK run keeps the watermark (and records no
+body hashes), and budget truncation only advances the watermark to the
+newest source actually included in the prompt.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from pinky_daemon.claude_runner import RunResult
+from pinky_daemon.kb_store import KBStore
+from pinky_daemon.librarian_runner import LibrarianRunner
+
+
+class _StubSDKRunner:
+    """Stands in for SDKRunner inside LibrarianRunner.run."""
+
+    result = None
+    prompts: list = []
+
+    def __init__(self, config, agent_name=""):
+        self.config = config
+        self.agent_name = agent_name
+
+    async def run(self, prompt):
+        type(self).prompts.append(prompt)
+        return type(self).result
+
+
+class _AgentConfig:
+    def __init__(self, working_dir: str) -> None:
+        self.working_dir = working_dir
+        self.model = "sonnet"
+
+
+@pytest.fixture
+def kb(tmp_path):
+    return KBStore(data_dir=tmp_path)
+
+
+@pytest.fixture
+def runner(kb, tmp_path):
+    return LibrarianRunner(kb, db_path=tmp_path / "librarian_state.db")
+
+
+@pytest.fixture
+def stub_sdk(monkeypatch):
+    _StubSDKRunner.prompts = []
+    monkeypatch.setattr("pinky_daemon.librarian_runner.SDKRunner", _StubSDKRunner)
+    return _StubSDKRunner
+
+
+class TestLibrarianFailureHandling:
+    @pytest.mark.asyncio
+    async def test_failed_run_keeps_watermark_and_hashes(
+        self, kb, runner, tmp_path, stub_sdk
+    ):
+        src = kb.ingest(title="Note", content="hello world", filed_by="brad")
+        cfg = _AgentConfig(str(tmp_path))
+
+        stub_sdk.result = RunResult(output="", exit_code=1, error="boom")
+        stats = await runner.run("ivan", cfg)
+
+        assert stats.get("failed") is True
+        assert "Librarian run failed" in stats["summary"]
+        # Watermark untouched: the source is re-fetched on the next run
+        assert runner._get_last_run_at("ivan") is None
+        assert runner.has_new_sources("ivan") is True
+        # Body hash not recorded: the retry is not hash-skipped
+        assert runner._get_processed_hash(src.id) is None
+
+        # A later successful run processes the same source
+        stub_sdk.result = RunResult(output="Curated 1 source.", exit_code=0)
+        stats2 = await runner.run("ivan", cfg)
+
+        assert stats2["source_ids"] == [src.id]
+        assert runner.has_new_sources("ivan") is False
+        assert runner._get_processed_hash(src.id) is not None
+
+
+class TestLibrarianAllUnchanged:
+    @pytest.mark.asyncio
+    async def test_all_unchanged_advances_watermark(self, kb, runner, tmp_path, stub_sdk):
+        """Sources whose body hash is already recorded are skipped without an
+        SDK run, and the watermark moves past them so they are not re-listed
+        (and re-hashed) on every subsequent run."""
+        src = kb.ingest(title="Note", content="hello world", filed_by="brad")
+        content = kb.get_raw_content(src.id)
+        runner._save_processed_hashes([(src.id, runner._body_hash(content))])
+        cfg = _AgentConfig(str(tmp_path))
+        stub_sdk.result = RunResult(output="Curated.", exit_code=0)
+
+        stats = await runner.run("ivan", cfg)
+
+        assert stats == {"sources_processed": 0, "skipped": True}
+        assert stub_sdk.prompts == []  # no SDK run for unchanged content
+        assert runner._get_last_run_at("ivan") == src.filed_at
+        assert runner.has_new_sources("ivan") is False
+
+
+class TestLibrarianTruncationWatermark:
+    @pytest.mark.asyncio
+    async def test_truncated_sources_survive_to_next_run(
+        self, kb, runner, tmp_path, stub_sdk, monkeypatch
+    ):
+        monkeypatch.setattr("pinky_daemon.librarian_runner._MAX_SOURCE_CHARS", 800)
+        old = kb.ingest(title="Old", content="x" * 100, filed_by="brad")
+        time.sleep(0.005)  # distinct filed_at for a strict > watermark
+        new = kb.ingest(title="New", content="y" * 2000, filed_by="brad")
+        cfg = _AgentConfig(str(tmp_path))
+        stub_sdk.result = RunResult(output="Curated.", exit_code=0)
+
+        stats = await runner.run("ivan", cfg)
+
+        # Oldest-first: only the old source fit the budget
+        assert stats["source_ids"] == [old.id]
+        assert runner._get_last_run_at("ivan") == old.filed_at
+
+        # The truncated source is picked up by the next run
+        stats2 = await runner.run("ivan", cfg)
+        assert stats2["source_ids"] == [new.id]
+        assert runner._get_last_run_at("ivan") == new.filed_at
+
+    @pytest.mark.asyncio
+    async def test_single_oversized_source_still_progresses(
+        self, kb, runner, tmp_path, stub_sdk, monkeypatch
+    ):
+        monkeypatch.setattr("pinky_daemon.librarian_runner._MAX_SOURCE_CHARS", 800)
+        big = kb.ingest(title="Big", content="z" * 5000, filed_by="brad")
+        cfg = _AgentConfig(str(tmp_path))
+        stub_sdk.result = RunResult(output="Curated.", exit_code=0)
+
+        stats = await runner.run("ivan", cfg)
+
+        # Included truncated, watermark moved past it: no livelock
+        assert stats["source_ids"] == [big.id]
+        assert runner._get_last_run_at("ivan") == big.filed_at
+        assert runner.has_new_sources("ivan") is False

--- a/tests/test_poller_delivery.py
+++ b/tests/test_poller_delivery.py
@@ -1,0 +1,49 @@
+"""Tests for the shared poller delivery-task helper.
+
+Fire-and-forget create_task calls keep only a weak reference (the task can
+be GC'd mid-flight) and swallow exceptions until garbage collection. The
+helper must hold a strong reference until done and surface failures in the
+poller log immediately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pinky_daemon.pollers import _DELIVERY_TASKS, _deliver_in_background
+
+
+class TestDeliverInBackground:
+    @pytest.mark.asyncio
+    async def test_failure_is_logged_with_prefix(self, capsys):
+        async def _boom():
+            raise RuntimeError("broker exploded")
+
+        task = _deliver_in_background(_boom(), "broker-poller[ivan]")
+        assert task in _DELIVERY_TASKS
+
+        with pytest.raises(RuntimeError):
+            await task
+        await asyncio.sleep(0)  # let the done callback run
+
+        captured = capsys.readouterr()
+        assert "broker-poller[ivan]: broker delivery failed" in captured.err
+        assert "broker exploded" in captured.err
+        assert task not in _DELIVERY_TASKS
+
+    @pytest.mark.asyncio
+    async def test_success_logs_nothing_and_releases_reference(self, capsys):
+        async def _ok():
+            return 42
+
+        task = _deliver_in_background(_ok(), "telegram-poller")
+        assert task in _DELIVERY_TASKS
+
+        assert await task == 42
+        await asyncio.sleep(0)
+
+        captured = capsys.readouterr()
+        assert "delivery failed" not in captured.err
+        assert task not in _DELIVERY_TASKS

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -78,6 +78,35 @@ class TestCronParser:
         assert cron_matches("0 9 * * 1-5", dt_saturday) is False
 
 
+class TestCronRobustness:
+    """Malformed crons must never raise (one bad schedule would abort the
+    whole scheduler tick), and standard name/range-step tokens must parse."""
+
+    def test_day_name_token(self):
+        dt_monday = datetime(2026, 3, 23, 9, 0)  # Monday
+        dt_tuesday = datetime(2026, 3, 24, 9, 0)  # Tuesday
+        assert cron_matches("0 9 * * mon", dt_monday) is True
+        assert cron_matches("0 9 * * mon", dt_tuesday) is False
+        assert cron_matches("0 9 * * mon-fri", dt_monday) is True
+
+    def test_month_name_token(self):
+        dt = datetime(2026, 3, 27, 8, 0)
+        assert cron_matches("0 8 * mar *", dt) is True
+        assert cron_matches("0 8 * apr *", dt) is False
+
+    def test_range_with_step(self):
+        assert cron_matches("1-5/2 * * * *", datetime(2026, 3, 23, 9, 3)) is True
+        assert cron_matches("1-5/2 * * * *", datetime(2026, 3, 23, 9, 4)) is False
+        assert cron_matches("1-5/2 * * * *", datetime(2026, 3, 23, 9, 7)) is False
+
+    def test_malformed_cron_returns_false_instead_of_raising(self):
+        dt = datetime(2026, 3, 23, 9, 0)
+        assert cron_matches("0 9 * * funky", dt) is False
+        assert cron_matches("*/x * * * *", dt) is False
+        assert cron_matches("0 9 * * 1-x", dt) is False
+        assert cron_matches("*/0 * * * *", dt) is False
+
+
 class TestCronDescription:
     def test_hourly(self):
         desc = next_cron_description("0 8 * * *")
@@ -856,3 +885,75 @@ class TestDreamNonBlocking:
         await asyncio.wait_for(
             scheduler._librarian_tasks[AgentScheduler.LIBRARIAN_GLOBAL_KEY], timeout=2
         )
+
+
+# -- URL Watcher Tests ---------------------------------------
+
+
+class _StubTrigger:
+    def __init__(self) -> None:
+        self.id = 1
+        self.name = "watch"
+        self.agent_name = "ivan"
+        self.url = "http://example.invalid/status"
+        self.method = "GET"
+        self.condition = "status_is"
+        self.condition_value = "200"
+        self.last_value = ""
+        self.prompt_template = ""
+
+
+class _StubTriggerStore:
+    def __init__(self) -> None:
+        self.checks: list = []
+        self.fires: list = []
+
+    def record_check(self, trigger_id, value):
+        self.checks.append((trigger_id, value))
+
+    def record_fire(self, trigger_id):
+        self.fires.append(trigger_id)
+
+
+class TestUrlWatcherOffLoop:
+    @pytest.mark.asyncio
+    async def test_fetch_runs_off_event_loop(self, registry, monkeypatch):
+        """The urlopen+read must run in a worker thread, not block the shared
+        event loop (which also serves the API, pollers, and broker)."""
+        import threading
+        import urllib.request
+
+        loop_thread = threading.current_thread()
+        seen = {}
+
+        class _Resp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self, n=-1):
+                return b"ok"
+
+        def _fake_urlopen(req, timeout=None):
+            seen["thread"] = threading.current_thread()
+            return _Resp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+        store = _StubTriggerStore()
+        fired = []
+
+        async def wake_cb(agent_name, session_id, prompt):
+            fired.append(agent_name)
+
+        scheduler = AgentScheduler(registry, wake_callback=wake_cb, trigger_store=store)
+        await scheduler._poll_url_trigger(_StubTrigger(), time.time())
+
+        assert seen["thread"] is not loop_thread
+        assert fired == ["ivan"]
+        assert store.fires == [1]
+        assert store.checks == [(1, "200")]


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **high** Dream watermark reset to 0 on idle night (`src/pinky_daemon/dream_runner.py:234`)
  - Idle-night branch now passes the existing last_message_ts to _save_state instead of the 0.0 default, so a quiet day no longer triggers full-history reprocessing (regression test in tests/test_dream_runner.py).
- **high** Dream watermark advanced even when the dream run failed (`src/pinky_daemon/dream_runner.py:314`)
  - run_dream computes run_failed from empty output / non-zero exit and keeps the prior watermark on failure, so that night's history is re-fetched next cycle (regression tests for failed and successful runs).
- **n/a** Synchronous KG extraction blocks the entire daemon event loop (`src/pinky_daemon/dream_runner.py`)
  - The whole sync post-dream pipeline (_build_memory_links, profile/relationship extraction, _extract_kg_from_dream_output, _extract_kg_triples, _surface_kg_insights) is now offloaded via asyncio.to_thread; self._db already uses check_same_thread=False and steps are awaited sequentially.
- **high** One malformed cron expression aborts every scheduler tick (`src/pinky_daemon/scheduler.py:323`)
  - cron_matches catches ValueError (logs and treats the expression as no-match, protecting all call sites: schedules, dreams, librarian) and _part_matches now supports 3-letter day/month names and range/step tokens; corrected the stale day-of-week docstring (code has always been 0=Sunday).
- **n/a** _extract_proposed_skills blocking HTTP call to the daemon's own API (`src/pinky_daemon/dream_runner.py`)
  - Runs via asyncio.to_thread, so the loop stays free to serve the POST to /skills/from-md instead of self-deadlocking; this is the minimal option from the fix_hint (in-process call would require out-of-scope routes/skills.py wiring).
- **medium** URL watcher polling uses blocking urllib in the async scheduler tick (`src/pinky_daemon/scheduler.py:833`)
  - _poll_url_trigger moves urlopen+read into a sync helper run via asyncio.to_thread; test asserts the fetch executes off the loop thread and the trigger still fires/records.
- **n/a** Discord channel with failed priming polled with no last_id floor (`src/pinky_daemon/pollers.py`)
  - _poll_once skips channels missing from _last_id (parked until the next discovery re-primes them, since added is computed from _last_id membership); test covers fail -> skip -> re-prime -> deliver-only-new.
- **medium** Librarian advances last_run_at past truncated/failed sources (`src/pinky_daemon/librarian_runner.py:294`)
  - Failed runs keep the watermark and record no hashes; successful runs page past the 100-row limit, process oldest-first, and advance last_run_at only to the newest source actually included; single oversized sources are truncated-included to avoid livelock; I additionally added _advance_watermark on the all-unchanged (hash-match) early return so already-curated sources stop being re-listed every run (new tests/test_librarian_runner.py).
- **low** Telegram/iMessage pollers fire-and-forget broker tasks swallow exceptions (`src/pinky_daemon/pollers.py:250`)
  - New module-level _deliver_in_background helper keeps strong task references and logs delivery failures with a per-poller prefix; applied to Telegram, broker-Telegram, iMessage, and Discord (replacing the Discord-only logger) with tests in tests/test_poller_delivery.py.
- **n/a** EventQueue priority tuples raise TypeError on (priority, timestamp) ties (`src/pinky_daemon/autonomy.py`)
  - itertools.count() sequence number added as a heap tiebreaker (4-tuples unpacked in pop), preserving FIFO within equal priority; regression test in tests/test_autonomy.py.

## Deferred (not fixed here, with reasons)
- Validate cron expressions in add_schedule / agent updates (part of finding 4 fix_hint): Requires editing api.py / agent_registry.py, which are not cited in the findings file (hard scope rule). The core defect (one bad cron aborting every tick) is fully fixed in scheduler.py: malformed crons now log and no-match instead of raising.
- Stop storing the dream failure string as last_summary / morning summary (optional part of finding 2): Product decision: the failure string doubling as the delivered morning summary may be intentional surfacing of failures to the agent, and changing get_morning_summary semantics is beyond the verified defect. The watermark data-loss core of the finding is fixed.

## Testing
**sched**: From the worktree root: python3 -m pytest tests/test_autonomy.py tests/test_discord_poller.py tests/test_dream_runner.py tests/test_kg_proactive.py tests/test_librarian_runner.py tests/test_poller_delivery.py tests/test_scheduler.py tests/test_tmux_dream_runner.py -q -> 151 passed. Full suite: python3 -m pytest tests/ -q -> 3514 passed, 2 skipped (7m12s). ruff check on all 11 changed files -> All checks passed. Test files were selected by grepping tests/ for every changed symbol (cron_matches, EventQueue, _deliver_in_background, run_dream, DreamRunner, LibrarianRunner, _poll_url_trigger, pollers, _save_state, push_event).

Generated with [Claude Code](https://claude.com/claude-code)