### PR TITLE
fix(sweep): memory - BM25 score inversion, consolidation guard, FTS5 fallbacks

### DIFF
--- a/src/pinky_memory/kg_extractor.py
+++ b/src/pinky_memory/kg_extractor.py
@@ -397,16 +397,7 @@ class KGExtractor:
                     continue  # Older than existing — skip
 
             # Dedupe: skip if an identical active triple already exists
-            existing_dupes = self._store.kg_query(
-                entity=t.subject, predicate=t.predicate,
-                include_expired=False, limit=10,
-            )
-            is_dupe = any(
-                e["subject"].lower() == t.subject.lower()
-                and e["object"].lower() == t.object.lower()
-                for e in existing_dupes
-            )
-            if is_dupe:
+            if self._store.kg_has_active_triple(t.subject, t.predicate, t.object):
                 result.triples_skipped.append({
                     "subject": t.subject, "predicate": t.predicate,
                     "object": t.object, "reason": "duplicate active triple",

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -1573,13 +1573,23 @@ class ReflectionStore:
                 # Find k-NN candidates from the FULL store (excluding self)
                 candidates = self._knn_for_consolidation(ref, k=5, exclude_ids=deactivated_ids)
 
+                # Rank by affinity with salience as tie-break so ref's fate is
+                # decided by its strongest candidate first. kNN backends order
+                # float ties differently (vec0 quantizes to float32), and if a
+                # weaker candidate were processed first, ref could archive it
+                # and then lose to the canonical row, leaving a supersession
+                # chain through an inactive reflection.
+                scored = []
                 for sim, candidate in candidates:
-                    if candidate.id in deactivated_ids or candidate.id == ref.id:
+                    if candidate.id == ref.id:
                         continue
-
-                    # Compute temporal proximity
                     temporal = self._temporal_proximity(ref.created_at, candidate.created_at)
-                    affinity = 0.7 * sim + 0.3 * temporal
+                    scored.append((0.7 * sim + 0.3 * temporal, candidate))
+                scored.sort(key=lambda t: (t[0], t[1].salience), reverse=True)
+
+                for affinity, candidate in scored:
+                    if candidate.id in deactivated_ids:
+                        continue
 
                     if affinity >= merge_threshold:
                         # Auto-dedup: keep higher salience, or longer content on tie

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -104,7 +104,10 @@ CREATE TRIGGER IF NOT EXISTS reflections_ad AFTER DELETE ON reflections BEGIN
     VALUES ('delete', old.rowid, old.id, old.content, old.context, old.project);
 END;
 
-CREATE TRIGGER IF NOT EXISTS reflections_au AFTER UPDATE ON reflections BEGIN
+-- Drop+recreate migrates older DBs where the trigger fired on every UPDATE
+-- (access tracking churned the FTS index); only indexed columns matter here.
+DROP TRIGGER IF EXISTS reflections_au;
+CREATE TRIGGER reflections_au AFTER UPDATE OF id, content, context, project ON reflections BEGIN
     INSERT INTO reflections_fts(reflections_fts, rowid, id, content, context, project)
     VALUES ('delete', old.rowid, old.id, old.content, old.context, old.project);
     INSERT INTO reflections_fts(rowid, id, content, context, project)
@@ -991,10 +994,12 @@ class ReflectionStore:
             [*params, limit],
         ).fetchall()
         results = []
+        touch_ids = []
         for row in rows:
             ref = self._row_to_reflection(row)
-            self._touch(ref.id)
+            touch_ids.append(ref.id)
             results.append((1.0, ref))
+        self._touch_many(touch_ids)
         return results
 
     def _search_by_fts5(
@@ -1064,6 +1069,7 @@ class ReflectionStore:
             logger.debug("FTS5 query failed, falling back to LIKE: %s", e)
             return self._search_by_like(
                 query, limit, active_only, type_filter, project_filter, min_weight, entity_filter,
+                type_exclude,
             )
 
         if not rows:
@@ -1076,18 +1082,20 @@ class ReflectionStore:
             return []
 
         raw_scores = [row["rank"] for row in valid_rows]
-        worst = min(raw_scores)  # most negative = worst match
-        best = max(raw_scores)   # closest to 0 = best match
-        score_range = best - worst if best != worst else 1.0
+        best = min(raw_scores)   # most negative = best match
+        worst = max(raw_scores)  # closest to 0 = worst match
+        score_range = worst - best
 
         results = []
+        touch_ids = []
         for row in valid_rows:
             ref = self._row_to_reflection(row)
-            self._touch(ref.id)
-            # Normalise: best match → 1.0, worst → 0.0
-            normalised = (row["rank"] - worst) / score_range if score_range else 1.0
+            touch_ids.append(ref.id)
+            # Normalise: best match -> 1.0, worst -> 0.0
+            normalised = (worst - row["rank"]) / score_range if score_range else 1.0
             results.append((normalised, ref))
 
+        self._touch_many(touch_ids)
         return results
 
     def _search_by_like(
@@ -1143,14 +1151,16 @@ class ReflectionStore:
 
         num_tokens = len(tokens) if tokens else 1
         results = []
+        touch_ids = []
         for row in rows:
             ref = self._row_to_reflection(row)
-            self._touch(ref.id)
+            touch_ids.append(ref.id)
             combined = (ref.content + " " + ref.context).lower()
             hits = sum(1 for t in tokens if t in combined) if tokens else 0
             score = hits / num_tokens
             results.append((score, ref))
 
+        self._touch_many(touch_ids)
         return results
 
     def search_by_keyword(
@@ -1173,10 +1183,14 @@ class ReflectionStore:
 
     # ── Access tracking ──
 
-    def _touch(self, reflection_id: str) -> None:
-        self._conn.execute(
+    def _touch_many(self, reflection_ids: list[str]) -> None:
+        """Batch access tracking: one UPDATE per id, a single commit."""
+        if not reflection_ids:
+            return
+        now = _now_iso()
+        self._conn.executemany(
             "UPDATE reflections SET accessed_at = ?, access_count = access_count + 1 WHERE id = ?",
-            (_now_iso(), reflection_id),
+            [(now, rid) for rid in reflection_ids],
         )
         self._conn.commit()
 
@@ -1576,6 +1590,10 @@ class ReflectionStore:
                         )
                         deactivated_ids.add(loser.id)
                         merged += 1
+                        if loser.id == ref.id:
+                            # ref itself was deactivated; it must not win
+                            # against remaining candidates
+                            break
 
                     elif affinity >= review_band and llm_classify is not None:
                         # LLM review band
@@ -1595,6 +1613,8 @@ class ReflectionStore:
                             )
                             deactivated_ids.add(loser.id)
                             merged += 1
+                            if loser.id == ref.id:
+                                break
                         elif verdict == "updated":
                             # New supersedes old
                             self._conn.execute(
@@ -1847,9 +1867,10 @@ class ReflectionStore:
     def revert_memory_event(self, event_id: int) -> bool:
         """Revert a memory hygiene event.
 
-        - decay: restore prior salience/weight and reactivate if archived
+        - decay: restore prior weight (metadata prior_weight) and reactivate if archived
         - dedup_merge: restore merged reflection content and reactivate
         - promotion: delete promoted insight and clear promoted_to from sources
+        - archive: reactivate the archived reflection(s)
 
         Returns True if reverted, False if event not found or already reversed.
         """
@@ -1864,15 +1885,15 @@ class ReflectionStore:
 
         with self._lock:
             if event_type == "decay":
-                # Restore prior salience and reactivate
-                prior_salience = event.get("prior_salience")
+                # Restore prior weight and reactivate
+                prior_weight = meta.get("prior_weight")
                 was_archived = meta.get("archived", False)
                 for sid in source_ids:
                     updates = []
                     params: list = []
-                    if prior_salience is not None:
+                    if prior_weight is not None:
                         updates.append("weight = ?")
-                        params.append(prior_salience)
+                        params.append(prior_weight)
                     if was_archived:
                         updates.append("active = 1")
                     if updates:
@@ -1915,6 +1936,14 @@ class ReflectionStore:
                             )
                         except (json.JSONDecodeError, AttributeError):
                             pass
+
+            elif event_type == "archive":
+                # Reactivate the archived reflection(s)
+                for sid in source_ids:
+                    self._conn.execute(
+                        "UPDATE reflections SET active = 1 WHERE id = ?",
+                        (sid,),
+                    )
 
             else:
                 return False
@@ -2558,6 +2587,16 @@ class ReflectionStore:
             for r in rows
         ]
 
+    def kg_has_active_triple(self, subject: str, predicate: str, obj: str) -> bool:
+        """True if an identical active triple exists (columns are COLLATE NOCASE)."""
+        row = self._conn.execute(
+            "SELECT 1 FROM kg_triples "
+            "WHERE subject = ? AND predicate = ? AND object = ? AND valid_to IS NULL "
+            "LIMIT 1",
+            (subject, predicate, obj),
+        ).fetchone()
+        return row is not None
+
     def kg_invalidate(
         self,
         subject: str,
@@ -2719,7 +2758,9 @@ class ReflectionStore:
 
         s = (since or "").strip()
         try:
-            if s and s.replace(".", "", 1).isdigit():  # raw epoch
+            is_numeric = bool(s) and s.replace(".", "", 1).isdigit()
+            # A bare 4-digit number is a year ("2026"), not epoch seconds
+            if is_numeric and ("." in s or len(s) > 4):  # raw epoch
                 since_epoch = float(s)
                 since_date = _dt.fromtimestamp(
                     since_epoch, _tz.utc

--- a/tests/test_kg_extractor.py
+++ b/tests/test_kg_extractor.py
@@ -257,6 +257,14 @@ class TestKGExtractorWithMockLLM:
             def kg_query(self, entity="", predicate="", include_expired=False, limit=10):
                 return self.queries  # Pre-populated for conflict tests
 
+            def kg_has_active_triple(self, subject, predicate, obj):
+                return any(
+                    q["subject"].lower() == subject.lower()
+                    and q["predicate"].lower() == predicate.lower()
+                    and q["object"].lower() == obj.lower()
+                    for q in self.queries
+                )
+
         return MockStore()
 
     def test_basic_extraction(self):
@@ -360,6 +368,29 @@ class TestKGExtractorWithMockLLM:
         extractor = KGExtractor(store=store, llm_caller=lambda p: llm_response)
 
         result = extractor.extract_from_reflection("ref1", "Brad uses Python for all his projects")
+        assert result.total_added == 0
+        assert len(result.triples_skipped) == 1
+        assert "duplicate" in result.triples_skipped[0]["reason"]
+
+    def test_dedupe_sees_triples_beyond_recent_window(self, tmp_path):
+        """Dedupe must be an exact-match existence check, not a scan of the 10
+        most recent triples; busy subjects regrow duplicates otherwise."""
+        from pinky_memory.store import ReflectionStore
+
+        store = ReflectionStore(str(tmp_path / "kg.db"))
+        store.kg_add("Brad", "uses", "Python")
+        # Bury the original well past any recency window
+        for i in range(12):
+            store.kg_add("Brad", "uses", f"Tool{i}")
+
+        llm_response = json.dumps([{
+            "subject": "Brad",
+            "predicate": "uses",
+            "object": "Python",
+            "confidence": 0.9,
+        }])
+        extractor = KGExtractor(store=store, llm_caller=lambda p: llm_response)
+        result = extractor.extract_from_reflection("ref1", "Brad uses Python for everything")
         assert result.total_added == 0
         assert len(result.triples_skipped) == 1
         assert "duplicate" in result.triples_skipped[0]["reason"]

--- a/tests/test_kg_reasoning.py
+++ b/tests/test_kg_reasoning.py
@@ -103,6 +103,19 @@ class TestKGWhatChanged:
             result = store.kg_what_changed(since=since)
             assert result["counts"]["added"] >= 1
 
+    def test_bare_year_is_year_not_epoch(self, store):
+        """since='2099' means the year 2099, not 2099 epoch seconds (1970)."""
+        store.kg_add("Brad", "uses", "Python")
+        result = store.kg_what_changed(since="2099")
+        assert result["counts"]["added"] == 0
+
+    def test_epoch_since_still_parses(self, store):
+        store.kg_add("Brad", "uses", "Python")
+        # Float epoch and a >4-digit integer epoch both stay epoch-parsed
+        for since in ("946684800.0", "946684800"):  # 2000-01-01 UTC
+            result = store.kg_what_changed(since=since)
+            assert result["counts"]["added"] >= 1
+
     def test_malformed_since_safe(self, store):
         store.kg_add("Brad", "uses", "Python")
         # garbage falls back to "everything changed", never raises

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -231,6 +231,67 @@ class TestKeywordSearch:
         assert isinstance(score, float)
         assert "vector" in reflection.content
 
+    def test_scored_best_match_gets_highest_score(self, tmp_path):
+        """BM25 normalisation: best match -> 1.0, worst -> 0.0 (not inverted)."""
+        store = _store(tmp_path)
+        if not store._fts5_available:
+            pytest.skip("FTS5 not available")
+        both = store.insert(_fact("alpha beta gamma"))
+        one = store.insert(_fact("alpha unrelated filler"))
+        scored = dict(
+            (ref.id, score)
+            for score, ref in store.search_by_keyword_scored("alpha beta")
+        )
+        assert scored[both.id] > scored[one.id]
+        assert scored[both.id] == 1.0
+        assert scored[one.id] == 0.0
+
+    def test_fts5_fallback_preserves_type_exclude(self, tmp_path):
+        """A query that breaks FTS5 syntax falls back to LIKE; the fallback
+        must still honour type_exclude."""
+        store = _store(tmp_path)
+        # Double quote in the token breaks the manually built MATCH expression
+        query = 'cool"stuff'
+        store.insert(Reflection(
+            type=ReflectionType.insight, content='cool"stuff should be excluded',
+        ))
+        store.insert(_fact('cool"stuff should remain'))
+        results = store.search_by_keyword_scored(
+            query, type_exclude=[ReflectionType.insight],
+        )
+        assert results, "fallback should still match by LIKE"
+        assert all(ref.type != ReflectionType.insight for _, ref in results)
+
+    def test_search_batches_access_tracking(self, tmp_path):
+        store = _store(tmp_path)
+        r = store.insert(_fact("touch tracking sample"))
+        store.search_by_keyword("touch tracking")
+        assert store.get(r.id).access_count == 1
+
+    def test_fts_update_trigger_is_column_scoped(self, tmp_path):
+        """Access-tracking UPDATEs must not churn the FTS index; the update
+        trigger only fires for indexed columns and still reindexes content."""
+        store = _store(tmp_path)
+        if not store._fts5_available:
+            pytest.skip("FTS5 not available")
+        sql = store._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'reflections_au'"
+        ).fetchone()[0]
+        assert "AFTER UPDATE OF" in sql
+        # Content changes still propagate to the index
+        r = store.insert(_fact("original searchable phrase"))
+        store._conn.execute(
+            "UPDATE reflections SET content = ? WHERE id = ?",
+            ("replacement findable text", r.id),
+        )
+        store._conn.commit()
+        assert any(
+            x.id == r.id for x in store.search_by_keyword("replacement findable")
+        )
+        assert all(
+            x.id != r.id for x in store.search_by_keyword("original searchable")
+        )
+
     def test_search_respects_active_filter(self, tmp_path):
         store = _store(tmp_path)
         r = store.insert(_fact("inactive keyword test"))
@@ -666,6 +727,55 @@ class TestMemoryEvents:
         # Source should be reactivated
         assert store.get(r.id).active is True
 
+    def test_revert_decay_restores_weight_not_salience(self, tmp_path):
+        """Decay revert must restore the 0-1 weight from metadata, never write
+        the 1-5 salience integer into the weight column."""
+        store = _store(tmp_path)
+        r = store.insert(_fact("decayed", salience=5))
+        store._conn.execute(
+            "UPDATE reflections SET weight = 0.05, active = 0 WHERE id = ?", (r.id,)
+        )
+        store._conn.commit()
+        event_id = store.log_memory_event(
+            "decay",
+            source_ids=[r.id],
+            prior_salience=5,
+            metadata={"prior_weight": 0.8, "archived": True},
+        )
+        assert store.revert_memory_event(event_id) is True
+        fetched = store.get(r.id)
+        assert fetched.active is True
+        assert abs(fetched.weight - 0.8) < 0.001
+
+    def test_revert_decay_without_prior_weight_keeps_weight(self, tmp_path):
+        """Old-style decay events (no prior_weight metadata) must not corrupt
+        weight with the salience integer."""
+        store = _store(tmp_path)
+        r = store.insert(_fact("decayed", salience=4))
+        store._conn.execute(
+            "UPDATE reflections SET weight = 0.4, active = 0 WHERE id = ?", (r.id,)
+        )
+        store._conn.commit()
+        event_id = store.log_memory_event(
+            "decay", source_ids=[r.id], prior_salience=4, metadata={"archived": True},
+        )
+        assert store.revert_memory_event(event_id) is True
+        fetched = store.get(r.id)
+        assert fetched.active is True
+        assert fetched.weight <= 1.0
+
+    def test_revert_archive_event_reactivates(self, tmp_path):
+        store = _store(tmp_path)
+        r = store.insert(_fact("archived memory"))
+        store.archive_reflection(r.id, reason="cleanup")
+        assert store.get(r.id).active is False
+        event = store._conn.execute(
+            "SELECT id FROM memory_events WHERE event_type = 'archive' "
+            "ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        assert store.revert_memory_event(event["id"]) is True
+        assert store.get(r.id).active is True
+
     def test_revert_unknown_event_type_returns_false(self, tmp_path):
         store = _store(tmp_path)
         r = store.insert(_fact("x"))
@@ -1073,3 +1183,24 @@ class TestConsolidateBatch:
         # One should be deactivated as duplicate
         active_count = sum(1 for rid in [r1.id, r2.id] if store.get(rid).active)
         assert active_count <= 2  # at most kept one
+
+    def test_consolidate_deactivated_ref_cannot_win(self, tmp_path):
+        """Once a batch reflection loses a merge, it must stop consuming
+        candidates: an inactive reflection must never archive active memories
+        (that would leave a supersession chain pointing at an inactive row)."""
+        store = _store(tmp_path)
+        emb = _emb()
+        winner = store.insert(_fact("canonical version", embedding=emb, salience=5))
+        perturbed = [x + 0.001 for x in emb]
+        mag = sum(x * x for x in perturbed) ** 0.5
+        perturbed = [x / mag for x in perturbed]
+        weak = store.insert(_fact("weak near duplicate", embedding=perturbed, salience=1))
+        ref = store.insert(_fact("new near duplicate", embedding=emb, salience=2))
+
+        store.consolidate_batch([ref.id], merge_threshold=0.85)
+
+        # ref lost to the high-salience canonical version...
+        assert store.get(ref.id).active is False
+        assert store.get(ref.id).superseded_by == winner.id
+        # ...and must not have gone on to archive the weaker active memory
+        assert store.get(weak.id).active is True


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **medium** consolidate_batch lets an already-deactivated reflection go on to 'win' and archive other active memories (`src/pinky_memory/store.py:1572`)
  - break out of the candidate loop when ref itself loses a merge (both the auto-merge and LLM 'same' branches), so an inactive ref can never win against later candidates or hit the 'updated' branch; the existing outer-loop deactivated_ids guard covers cross-iteration cases
- **low** BM25 relevance scores are inverted in _search_by_fts5 (`src/pinky_memory/store.py:1079`)
  - swap best/worst semantics (best = min(raw_scores), most negative) and normalise as (worst - rank) / range so best match scores 1.0, worst 0.0; tied scores now yield 1.0
- **low** revert_memory_event('decay') writes prior salience into the weight column (`src/pinky_memory/store.py:1874`)
  - decay revert now restores weight from metadata['prior_weight'] (and skips weight restore when absent) instead of writing the 1-5 salience integer into the 0-1 weight column
- **low** kg_what_changed parses a bare year as epoch seconds (`src/pinky_memory/store.py:2722`)
  - epoch shortcut only taken when the numeric string contains a dot or has more than 4 digits, so since='2026' falls through to the existing YYYY-01-01 year handling
- **low** _search_by_fts5 error fallback drops the type_exclude filter (`src/pinky_memory/store.py:1065`)
  - forward type_exclude to the _search_by_like fallback in the OperationalError branch (verified it matches the 8th positional parameter of _search_by_like)
- **low** KG extractor dedupe window (kg_query limit=10) lets duplicate triples regrow (`src/pinky_memory/kg_extractor.py:400`)
  - replace the 10-row recency-window scan with a new ReflectionStore.kg_has_active_triple exact-match existence query (subject/predicate/object =, valid_to IS NULL; columns are COLLATE NOCASE so matching stays case-insensitive)
- **low** Keyword/browse search commits per returned row and fires FTS5 reindex triggers on every read (`src/pinky_memory/store.py:1176`)
  - replace per-row _touch with _touch_many (one executemany + single commit per search) in _browse_all/_search_by_fts5/_search_by_like, and scope reflections_au to AFTER UPDATE OF id, content, context, project with a DROP+CREATE migration that runs at store init and on the FTS rebuild path
- **low** memory_events revert system cannot revert the only event type actually produced ('archive') (`src/pinky_memory/store.py:1919`)
  - add an 'archive' branch to revert_memory_event that reactivates the archived reflection(s) and marks the event reversed (the minimum option from the fix_hint)

## Deferred (not fixed here, with reasons)
- Wiring the memory hygiene pipeline (decay/dedup_merge event logging, scheduled apply_decay/consolidate_batch/gc_inactive): The second half of the dead-code finding asks for apply_decay/consolidate_batch/gc_inactive to run on a scheduled job with log_memory_event calls. That requires daemon-side wiring in files outside the findings scope (scheduler, MCP server) and a product decision about hygiene cadence; the fix_hint's minimum option (make 'archive' revertable) was implemented instead. gc_inactive therefore remains unreachable in production.

## Testing
**memory**: All work was already committed by the interrupted agent (commit 9024120); I verified it rather than re-fixing. Commands run from the worktree root: (1) python3 -m pytest tests/test_memory_store.py tests/test_kg_extractor.py tests/test_kg_reasoning.py tests/test_kg_phase2_store.py tests/test_kg_ephemeral_guard.py tests/test_memory_server.py tests/test_memory_cross_agent.py tests/test_content_scanner.py -q -> 355 passed, 1 skipped. (2) python3 -m pytest tests/test_kg_proactive.py tests/test_sdk_runner.py tests/test_shared_mcp.py tests/test_ferry_host_pinky.py -q -> 197 passed. (3) Full suite: python3 -m pytest tests/ -q -x --ignore=tests/test_ferry_host_pinky.py -> 3451 passed, 2 skipped (8m22s; ferry file covered by run 2). (4) Negative verification: temporarily checked out main's src/pinky_memory/{store.py,kg_extractor.py} and ran the 9 new regression tests -> all 9 FAILED pre-fix, then restored HEAD source where they pass. (5) ruff check on all 5 changed files -> All checks passed. (6) Added-line diff scanned for non-ASCII -> clean.

Generated with [Claude Code](https://claude.com/claude-code)