### PR TITLE
fix(sweep): mcp-servers - empty outreach tool descriptions, pinky-self export/auth fixes

### DIFF
--- a/src/pinky_outreach/imessage.py
+++ b/src/pinky_outreach/imessage.py
@@ -54,7 +54,7 @@ class iMessageAdapter:  # noqa: N801
         # Try to connect to chat.db
         self._init_db()
 
-    def _init_db(self) -> None:
+    def _init_db(self, *, reseed: bool = True) -> None:
         """Open a read-only connection to chat.db, bounded by a timeout.
 
         ``sqlite3.connect``'s open() is a C-level syscall that, under some macOS
@@ -65,7 +65,19 @@ class iMessageAdapter:  # noqa: N801
         and ``join`` with a timeout; if it doesn't return in time we give up,
         mark receive unavailable, and leave the stuck opener thread orphaned
         (daemon=True, so it never blocks process exit).
+
+        ``reseed=False`` (reconnect path) keeps the existing ``_last_rowid``
+        high-water mark so messages that arrived during a transient query
+        failure are replayed on the next poll instead of being skipped.
         """
+        if self._db is not None:
+            try:
+                self._db.close()
+            except sqlite3.Error:
+                pass
+            self._db = None
+        self._db_available = False
+
         if not os.path.exists(self._db_path):
             _log(f"imessage: chat.db not found at {self._db_path}")
             return
@@ -116,7 +128,8 @@ class iMessageAdapter:  # noqa: N801
             return
 
         self._db = result["db"]
-        self._last_rowid = result["last_rowid"]
+        if reseed:
+            self._last_rowid = result["last_rowid"]
         self._db_available = True
         _log(f"imessage: chat.db connected, last_rowid={self._last_rowid}")
 
@@ -258,8 +271,9 @@ end tell
             ).fetchall()
         except sqlite3.OperationalError as e:
             _log(f"imessage: chat.db query error: {e}")
-            # Try reconnecting
-            self._init_db()
+            # Reconnect without reseeding _last_rowid so the rows we failed
+            # to read here are replayed on the next poll.
+            self._init_db(reseed=False)
             return []
 
         messages = []

--- a/src/pinky_outreach/server.py
+++ b/src/pinky_outreach/server.py
@@ -109,16 +109,10 @@ def create_server(
         """List configured messaging platforms."""
         return json.dumps({"platforms": active_platforms})
 
-    @mcp.tool()
-    def send_message(
-        content: str,
-        chat_id: str,
-        platform: str = default_platform,
-        reply_to: str = "",
-        parse_mode: str = "",
-        silent: bool = False,
-    ) -> str:
-        f"""Send a message to a chat on any configured platform.
+    # Tool docs are interpolated with the active platform list, so they are
+    # passed as decorator descriptions: an f-string first statement is an
+    # expression, not a docstring, and would register an empty description.
+    @mcp.tool(description=f"""Send a message to a chat on any configured platform.
 
         Available platforms: {platform_list}
 
@@ -129,7 +123,15 @@ def create_server(
             reply_to: Message ID to reply to (optional). For Slack, this is a thread_ts.
             parse_mode: Text formatting: HTML or Markdown (Telegram only).
             silent: Send without notification sound (Telegram only).
-        """
+        """)
+    def send_message(
+        content: str,
+        chat_id: str,
+        platform: str = default_platform,
+        reply_to: str = "",
+        parse_mode: str = "",
+        silent: bool = False,
+    ) -> str:
         if platform not in active_platforms:
             return _err(f"Platform '{platform}' not available. Configured: {platform_list}")
 
@@ -200,15 +202,7 @@ def create_server(
         else:
             return _err(f"Platform '{platform}' not supported. Available: {platform_list}")
 
-    @mcp.tool()
-    def check_messages(
-        chat_id: str = "",
-        platform: str = default_platform,
-        timeout: int = 0,
-        limit: int = 20,
-        after: str = "",
-    ) -> str:
-        f"""Poll for new inbound messages.
+    @mcp.tool(description=f"""Poll for new inbound messages.
 
         Telegram: uses long polling (chat_id not required, returns all new messages).
         Discord/Slack: fetches recent messages from a channel (chat_id required).
@@ -219,10 +213,17 @@ def create_server(
         Args:
             chat_id: Channel ID (required for Discord/Slack, ignored for Telegram/WhatsApp).
             platform: Platform to check ({platform_list}).
-            timeout: Long poll timeout in seconds (Telegram only, 0 = instant, max 50).
+            timeout: Long poll timeout in seconds (Telegram only, 0 = instant, max 25).
             limit: Max messages to return (1-100).
             after: Only messages after this ID/timestamp (Discord/Slack).
-        """
+        """)
+    def check_messages(
+        chat_id: str = "",
+        platform: str = default_platform,
+        timeout: int = 0,
+        limit: int = 20,
+        after: str = "",
+    ) -> str:
         if platform not in active_platforms:
             return _err(f"Platform '{platform}' not available. Configured: {platform_list}")
 
@@ -230,7 +231,9 @@ def create_server(
             if not telegram:
                 return _not_configured("telegram")
             try:
-                messages = telegram.get_updates(timeout=min(timeout, 50), limit=limit)
+                # Cap below the adapter's 30s httpx client timeout: a longer
+                # long-poll would hit the transport read timeout first.
+                messages = telegram.get_updates(timeout=min(timeout, 25), limit=limit)
                 _log(f"outreach: checked telegram, {len(messages)} new messages")
                 return json.dumps({
                     "platform": "telegram",
@@ -296,14 +299,7 @@ def create_server(
         else:
             return _err(f"Platform '{platform}' not supported.")
 
-    @mcp.tool()
-    def send_photo(
-        chat_id: str,
-        file_path: str,
-        caption: str = "",
-        platform: str = default_platform,
-    ) -> str:
-        f"""Send a photo/image to a chat.
+    @mcp.tool(description=f"""Send a photo/image to a chat.
 
         Available platforms: {platform_list}
 
@@ -312,7 +308,13 @@ def create_server(
             file_path: Absolute path to the image file.
             caption: Optional caption text.
             platform: Platform ({platform_list}).
-        """
+        """)
+    def send_photo(
+        chat_id: str,
+        file_path: str,
+        caption: str = "",
+        platform: str = default_platform,
+    ) -> str:
         if platform not in active_platforms:
             return _err(f"Platform '{platform}' not available. Configured: {platform_list}")
 
@@ -359,14 +361,7 @@ def create_server(
         else:
             return _err(f"Platform '{platform}' not supported.")
 
-    @mcp.tool()
-    def send_document(
-        chat_id: str,
-        file_path: str,
-        caption: str = "",
-        platform: str = default_platform,
-    ) -> str:
-        f"""Send a file/document to a chat.
+    @mcp.tool(description=f"""Send a file/document to a chat.
 
         Available platforms: {platform_list}
 
@@ -375,7 +370,13 @@ def create_server(
             file_path: Absolute path to the file.
             caption: Optional caption text.
             platform: Platform ({platform_list}).
-        """
+        """)
+    def send_document(
+        chat_id: str,
+        file_path: str,
+        caption: str = "",
+        platform: str = default_platform,
+    ) -> str:
         if platform not in active_platforms:
             return _err(f"Platform '{platform}' not available. Configured: {platform_list}")
 
@@ -422,14 +423,7 @@ def create_server(
         else:
             return _err(f"Platform '{platform}' not supported.")
 
-    @mcp.tool()
-    def send_video(
-        chat_id: str,
-        file_path: str,
-        caption: str = "",
-        platform: str = default_platform,
-    ) -> str:
-        f"""Send a video that plays inline (not a file download) to a chat.
+    @mcp.tool(description=f"""Send a video that plays inline (not a file download) to a chat.
 
         On Telegram this uses sendVideo with streaming enabled so the clip plays
         in-place instead of arriving as a downloadable attachment. Other platforms
@@ -442,7 +436,13 @@ def create_server(
             file_path: Absolute path to the video file (.mp4 recommended).
             caption: Optional caption text.
             platform: Platform ({platform_list}).
-        """
+        """)
+    def send_video(
+        chat_id: str,
+        file_path: str,
+        caption: str = "",
+        platform: str = default_platform,
+    ) -> str:
         if platform not in active_platforms:
             return _err(f"Platform '{platform}' not available. Configured: {platform_list}")
 
@@ -489,19 +489,18 @@ def create_server(
         else:
             return _err(f"Platform '{platform}' not supported.")
 
-    @mcp.tool()
-    def get_chat_info(
-        chat_id: str,
-        platform: str = default_platform,
-    ) -> str:
-        f"""Get information about a chat/channel.
+    @mcp.tool(description=f"""Get information about a chat/channel.
 
         Available platforms: {platform_list}
 
         Args:
             chat_id: Chat/channel ID to look up.
             platform: Platform ({platform_list}).
-        """
+        """)
+    def get_chat_info(
+        chat_id: str,
+        platform: str = default_platform,
+    ) -> str:
         if platform not in active_platforms:
             return _err(f"Platform '{platform}' not available. Configured: {platform_list}")
 
@@ -558,14 +557,7 @@ def create_server(
         else:
             return _err(f"Platform '{platform}' not supported.")
 
-    @mcp.tool()
-    def add_reaction(
-        chat_id: str,
-        message_id: str,
-        emoji: str,
-        platform: str = default_platform,
-    ) -> str:
-        f"""React to a message with an emoji.
+    @mcp.tool(description=f"""React to a message with an emoji.
 
         Available platforms: {platform_list}
 
@@ -574,7 +566,13 @@ def create_server(
             message_id: Message to react to. For Slack, this is the message timestamp (ts).
             emoji: Emoji to react with. For Slack, use name without colons (e.g. "thumbsup").
             platform: Platform ({platform_list}).
-        """
+        """)
+    def add_reaction(
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+        platform: str = default_platform,
+    ) -> str:
         if platform not in active_platforms:
             return _err(f"Platform '{platform}' not available. Configured: {platform_list}")
 
@@ -621,14 +619,7 @@ def create_server(
         else:
             return _err(f"Platform '{platform}' not supported.")
 
-    @mcp.tool()
-    def download_file(
-        file_id: str,
-        platform: str = default_platform,
-        url: str = "",
-        dest_dir: str = "/tmp/pinky_files",
-    ) -> str:
-        f"""Download a file attachment from any platform.
+    @mcp.tool(description=f"""Download a file attachment from any platform.
 
         Available platforms: {platform_list}
 
@@ -637,7 +628,13 @@ def create_server(
             platform: Platform the file is from ({platform_list}).
             url: Direct download URL (required for Discord/Slack).
             dest_dir: Local directory to save files to.
-        """
+        """)
+    def download_file(
+        file_id: str,
+        platform: str = default_platform,
+        url: str = "",
+        dest_dir: str = "/tmp/pinky_files",
+    ) -> str:
         import os
 
         if platform not in active_platforms:
@@ -694,15 +691,14 @@ def create_server(
         else:
             return _err(f"Platform '{platform}' not supported.")
 
-    @mcp.tool()
-    def bot_info(platform: str = default_platform) -> str:
-        f"""Get info about the configured bot.
+    @mcp.tool(description=f"""Get info about the configured bot.
 
         Available platforms: {platform_list}
 
         Args:
             platform: Platform ({platform_list}).
-        """
+        """)
+    def bot_info(platform: str = default_platform) -> str:
         if platform not in active_platforms:
             return _err(f"Platform '{platform}' not available. Configured: {platform_list}")
 

--- a/src/pinky_outreach/slack.py
+++ b/src/pinky_outreach/slack.py
@@ -138,9 +138,13 @@ class SlackAdapter:
         upload_url = url_data["upload_url"]
         file_id = url_data["file_id"]
 
-        # Step 2: Upload the file
+        # Step 2: Upload the file (stream from disk; match the client's 30s
+        # timeout instead of httpx's 5s module-level default)
         with open(file_path, "rb") as f:
-            upload_resp = httpx.post(upload_url, content=f.read())
+            try:
+                upload_resp = httpx.post(upload_url, content=f, timeout=30.0)
+            except httpx.HTTPError as e:
+                raise SlackError(f"File upload failed: {e}") from e
             if upload_resp.status_code >= 400:
                 raise SlackError(f"File upload failed: {upload_resp.status_code}")
 

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -24,6 +24,7 @@ inbound message can warm-wake the agent.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
@@ -108,6 +109,15 @@ def create_server(
         except Exception as e:
             return {"error": str(e)}
 
+    async def _api_async(method: str, path: str, body: dict | None = None) -> dict:
+        """Call the PinkyBot API off the event loop.
+
+        Async tools run directly on the server's event loop; the blocking
+        urlopen in _api would otherwise stall every session sharing the loop
+        for up to its 30s timeout.
+        """
+        return await asyncio.to_thread(_api, method, path, body)
+
     def _format_age(seconds: float | int | None) -> str:
         """Render compact age text for saved context metadata."""
         if seconds is None:
@@ -168,6 +178,8 @@ def create_server(
         def list_my_schedules() -> str:
             """List all your cron schedules with status and last run time."""
             result = _api("GET", f"/agents/{agent_name}/schedules?enabled_only=false")
+            if "error" in result:
+                return f"Failed to list schedules: {result['error']}"
             schedules = result.get("schedules", [])
             if not schedules:
                 return "No schedules set."
@@ -251,6 +263,11 @@ def create_server(
     def load_my_context() -> str:
         """Restore working state from before last restart/sleep. Call on wake-up to pick up where you left off."""
         result = _api("GET", f"/agents/{agent_name}/context")
+        if "error" in result:
+            return (
+                f"Failed to load context: {result['error']} "
+                "(do not assume a fresh start - retry before overwriting saved state)"
+            )
         if result.get("context") is None:
             return "No saved context. This is a fresh start."
         ctx = result
@@ -283,6 +300,8 @@ def create_server(
         """Get your highest-priority unblocked task. Respects blocked_by dependencies."""
         target = agent_name_override or agent_name
         result = _api("GET", f"/tasks?assigned_agent={target}&status=pending&limit=50")
+        if isinstance(result, dict) and "error" in result:
+            return f"Failed to get tasks: {result['error']}"
         tasks = result if isinstance(result, list) else result.get("tasks", [])
         if not tasks:
             return "No unblocked tasks available."
@@ -1413,22 +1432,33 @@ def create_server(
             """Export a research brief as a formatted PDF. Returns a file path for send_document."""
             import urllib.error as _ue
             import urllib.request as _ur
-            url = f"{api_url}/research/{topic_id}/export?format=pdf"
+            from pathlib import Path
+            request_path = f"/research/{topic_id}/export"
+            url = f"{api_url}{request_path}?format=pdf"
+            agent = str(agent_name)
+            headers = build_internal_auth_headers(
+                resolve_request_signing_secret(agent, signing_key_resolver),
+                agent_name=agent,
+                method="GET",
+                path=request_path,
+            )
             try:
-                req = _ur.Request(url, method="GET")
+                req = _ur.Request(url, method="GET", headers=headers)
                 with _ur.urlopen(req, timeout=60) as resp:
-                    # The API returns a file response — save it locally
+                    # The API returns a file response - save it locally
                     content_disp = resp.headers.get("content-disposition", "")
                     filename = f"research_{topic_id}.pdf"
                     if "filename=" in content_disp:
                         filename = content_disp.split("filename=")[-1].strip('"')
-                    import os
-                    export_dir = os.path.join(os.path.dirname(api_url.replace("http://localhost:8888", ".")), "data", "exports")
-                    os.makedirs(export_dir, exist_ok=True)
-                    path = os.path.join(export_dir, filename)
+                    filename = os.path.basename(filename)
+                    # Repo root is two parents up from src/pinky_self/, same
+                    # derivation as __main__._default_agents_db.
+                    export_dir = Path(__file__).resolve().parents[2] / "data" / "exports"
+                    export_dir.mkdir(parents=True, exist_ok=True)
+                    path = export_dir / filename
                     with open(path, "wb") as f:
                         f.write(resp.read())
-                    return json.dumps({"success": True, "path": os.path.abspath(path), "filename": filename})
+                    return json.dumps({"success": True, "path": str(path), "filename": filename})
             except _ue.HTTPError as e:
                 return json.dumps({"error": e.read().decode("utf-8", errors="replace"), "status": e.code})
             except Exception as e:
@@ -1518,41 +1548,22 @@ def create_server(
         if not os.path.isfile(file_path):
             return json.dumps({"error": f"File not found: {file_path}"})
 
-        # Use the API to send the file transfer
+        # Use the API to send the file transfer. No local fallback: the daemon
+        # owns the comms DB and recipient notification, so a transfer written
+        # anywhere else is never seen by the recipient.
         result = _api("POST", f"/agents/{to_agent}/file", {
             "from_agent": agent_name,
             "file_path": file_path,
             "description": description,
         })
-        if "error" not in result:
-            return json.dumps({
-                "sent": True,
-                "to": to_agent,
-                "file_name": result.get("file_name", os.path.basename(file_path)),
-                "transferred_path": result.get("transferred_path", ""),
-            })
-
-        # Fallback: do the transfer locally via AgentComms
-        try:
-            from pinky_daemon.agent_comms import AgentComms
-            comms = AgentComms()
-            msg = comms.send_file(
-                from_session=agent_name,
-                to_session=to_agent,
-                file_path=file_path,
-                description=description,
-            )
-            comms.close()
-            return json.dumps({
-                "sent": True,
-                "to": to_agent,
-                "file_name": msg.metadata.get("file_name", os.path.basename(file_path)),
-                "transferred_path": msg.metadata.get("file_path", ""),
-            })
-        except FileNotFoundError as e:
-            return json.dumps({"error": str(e)})
-        except Exception as e:
-            return json.dumps({"error": f"File transfer failed: {e}"})
+        if "error" in result:
+            return json.dumps({"error": f"File transfer failed: {result['error']}"})
+        return json.dumps({
+            "sent": True,
+            "to": to_agent,
+            "file_name": result.get("file_name", os.path.basename(file_path)),
+            "transferred_path": result.get("transferred_path", ""),
+        })
 
     @mcp.tool()
     def list_agents() -> str:
@@ -1658,6 +1669,8 @@ def create_server(
         """Search past conversation messages by keyword."""
         # Search across all agent sessions via the agent chat-history endpoint
         result = _api("GET", f"/agents/{agent_name}/chat-history?{urllib.parse.urlencode({'q': query, 'limit': 30})}")
+        if "error" in result:
+            return f"Failed to search history: {result['error']}"
         messages = result.get("messages", [])
         if not messages:
             return f"No messages found matching '{query}'."
@@ -1930,32 +1943,34 @@ def create_server(
             """Auto-draft a SKILL.md from a completed multi-step task. Call after tasks with 3+ steps.
             auto_install=True registers immediately; default is draft-only for review.
             """
-            # Build the SKILL.md content from the task info
+            # Build the SKILL.md content from the task info. Lines must start
+            # at column 0: the frontmatter parser requires the closing '---'
+            # at the start of a line.
             skill_md = f"""---
-    name: {skill_name}
-    description: Auto-generated from task completion. {task_description[:120].rstrip('.')}. Use when facing similar tasks.
-    ---
+name: {skill_name}
+description: Auto-generated from task completion. {task_description[:120].rstrip('.')}. Use when facing similar tasks.
+---
 
-    # {skill_name.replace('-', ' ').title()}
+# {skill_name.replace('-', ' ').title()}
 
-    ## Overview
+## Overview
 
-    {task_description}
+{task_description}
 
-    ## Approach
+## Approach
 
-    {steps_taken}
+{steps_taken}
 
-    ## Expected Outcome
+## Expected Outcome
 
-    {outcome}
+{outcome}
 
-    ## Usage Notes
+## Usage Notes
 
-    - This skill was auto-generated from a real completed task — adapt as needed.
-    - Review the approach above and customize for your specific context.
-    - Consider refining the steps after the next run to sharpen the instructions.
-    """
+- This skill was auto-generated from a real completed task - adapt as needed.
+- Review the approach above and customize for your specific context.
+- Consider refining the steps after the next run to sharpen the instructions.
+"""
 
             if not auto_install:
                 # Draft mode — return the SKILL.md for review
@@ -2255,7 +2270,7 @@ def create_server(
                 "condition_value": condition_value,
                 "interval_seconds": interval_seconds,
             }
-            result = _api("POST", f"/agents/{agent_name}/triggers", body)
+            result = await _api_async("POST", f"/agents/{agent_name}/triggers", body)
             if "error" in result:
                 return f"Error creating trigger: {result['error']}"
             t = result
@@ -2274,7 +2289,7 @@ def create_server(
         @mcp.tool()
         async def list_triggers() -> str:
             """List all triggers assigned to this agent."""
-            result = _api("GET", f"/agents/{agent_name}/triggers")
+            result = await _api_async("GET", f"/agents/{agent_name}/triggers")
             if "error" in result:
                 return f"Error: {result['error']}"
             triggers = result.get("triggers", [])
@@ -2294,7 +2309,7 @@ def create_server(
         @mcp.tool()
         async def delete_trigger(trigger_id: int) -> str:
             """Delete a trigger by ID. Webhook tokens are immediately invalidated."""
-            result = _api("DELETE", f"/agents/{agent_name}/triggers/{trigger_id}")
+            result = await _api_async("DELETE", f"/agents/{agent_name}/triggers/{trigger_id}")
             if "error" in result:
                 return f"Error: {result['error']}"
             return f"Trigger {trigger_id} deleted."
@@ -2302,7 +2317,7 @@ def create_server(
         @mcp.tool()
         async def test_trigger(trigger_id: int) -> str:
             """Manually fire a trigger to test it. Does not affect fire_count."""
-            result = _api("POST", f"/agents/{agent_name}/triggers/{trigger_id}/test")
+            result = await _api_async("POST", f"/agents/{agent_name}/triggers/{trigger_id}/test")
             if "error" in result:
                 return f"Error: {result['error']}"
             woken = result.get("agent_woken", False)

--- a/tests/test_imessage_adapter.py
+++ b/tests/test_imessage_adapter.py
@@ -107,3 +107,88 @@ class TestInitDbTimeout:
         adapter = iMessageAdapter(db_path=str(tmp_path / "nope.db"), init_timeout=5)
         assert adapter.can_receive is False
         assert adapter._db is None
+
+
+def _make_full_chat_db(path: str) -> None:
+    """chat.db with enough schema for get_updates' join query."""
+    db = sqlite3.connect(path)
+    db.execute(
+        "CREATE TABLE message ("
+        "ROWID INTEGER PRIMARY KEY, text TEXT, date INTEGER, "
+        "is_from_me INTEGER DEFAULT 0, date_read INTEGER, handle_id INTEGER)"
+    )
+    db.execute("CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT)")
+    db.execute(
+        "CREATE TABLE chat (ROWID INTEGER PRIMARY KEY, "
+        "chat_identifier TEXT, display_name TEXT, style INTEGER)"
+    )
+    db.execute(
+        "CREATE TABLE chat_message_join (message_id INTEGER, chat_id INTEGER)"
+    )
+    # Seed one pre-existing message so _init_db seeds last_rowid=1.
+    db.execute(
+        "INSERT INTO message (text, date, is_from_me, handle_id) VALUES ('old', 0, 0, 1)"
+    )
+    db.execute("INSERT INTO handle (id) VALUES ('+15551234567')")
+    db.commit()
+    db.close()
+
+
+def _insert_inbound(path: str, text: str) -> None:
+    db = sqlite3.connect(path)
+    db.execute(
+        "INSERT INTO message (text, date, is_from_me, handle_id) VALUES (?, 0, 0, 1)",
+        (text,),
+    )
+    db.commit()
+    db.close()
+
+
+class _FailingConn:
+    """Stand-in connection whose queries fail like a locked chat.db."""
+
+    def __init__(self):
+        self.closed = False
+
+    def execute(self, *_a, **_k):
+        raise sqlite3.OperationalError("database is locked")
+
+    def close(self):
+        self.closed = True
+
+
+class TestGetUpdatesReconnect:
+    def test_transient_query_error_does_not_drop_pending_messages(self, tmp_path):
+        """A locked chat.db poll must not advance the high-water mark: the
+        reconnect used to reseed last_rowid to MAX(ROWID), silently skipping
+        every message that arrived but was never returned."""
+        db_path = str(tmp_path / "chat.db")
+        _make_full_chat_db(db_path)
+
+        adapter = iMessageAdapter(db_path=db_path, init_timeout=5)
+        assert adapter.can_receive is True
+        assert adapter._last_rowid == 1
+
+        # A new inbound message arrives, then the poll hits a transient error.
+        _insert_inbound(db_path, "hello while locked")
+        failing = _FailingConn()
+        adapter._db = failing
+
+        assert adapter.get_updates() == []
+        assert failing.closed is True  # old handle closed, not leaked
+        assert adapter.can_receive is True  # reconnected
+        assert adapter._last_rowid == 1  # high-water mark preserved
+
+        # The next successful poll replays the missed message.
+        messages = adapter.get_updates()
+        assert [m.content for m in messages] == ["hello while locked"]
+        assert adapter._last_rowid == 2
+        adapter.close()
+
+    def test_init_reseed_default_skips_preexisting_rows(self, tmp_path):
+        db_path = str(tmp_path / "chat.db")
+        _make_full_chat_db(db_path)
+        adapter = iMessageAdapter(db_path=db_path, init_timeout=5)
+        # Fresh init must not replay history.
+        assert adapter.get_updates() == []
+        adapter.close()

--- a/tests/test_outreach_server.py
+++ b/tests/test_outreach_server.py
@@ -543,3 +543,38 @@ class TestErrorPaths:
             result = _tools(srv)["get_chat_info"](chat_id="bad", platform="slack")
 
         assert "channel_not_found" in result or "error" in result.lower()
+
+
+# -- Tool descriptions --------------------------------------------------------
+
+class TestToolDescriptions:
+    def test_all_tools_register_with_platform_docs(self):
+        """Tool docs are f-strings (platform list interpolation), which are NOT
+        docstrings; they must be passed via the decorator's description or
+        every tool registers undocumented."""
+        with patch("pinky_outreach.server.TelegramAdapter") as MockTG:
+            MockTG.return_value = MagicMock()
+            srv = create_server(telegram_token="tok")
+
+        tools = srv._tool_manager.list_tools()
+        assert tools
+        for tool in tools:
+            assert tool.description, f"{tool.name} registered with empty description"
+            if tool.name != "list_platforms":
+                assert "telegram" in tool.description, tool.name
+
+
+# -- Telegram long-poll cap ---------------------------------------------------
+
+class TestTelegramLongPollCap:
+    def test_check_messages_caps_timeout_below_client_read_timeout(self):
+        """The adapter's httpx client read-times-out at 30s, so the long-poll
+        body param must stay below that or idle polls always error."""
+        with patch("pinky_outreach.server.TelegramAdapter") as MockTG:
+            tg = MagicMock()
+            tg.get_updates.return_value = []
+            MockTG.return_value = tg
+            srv = create_server(telegram_token="tok")
+            _tools(srv)["check_messages"](platform="telegram", timeout=50)
+
+        tg.get_updates.assert_called_once_with(timeout=25, limit=20)

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -521,6 +521,12 @@ class TestListMySchedules:
             result = _tools(srv)["list_my_schedules"]()
         assert "No schedules" in result
 
+    def test_api_error_not_reported_as_empty(self, srv):
+        with _ok({"error": "connection refused"}):
+            result = _tools(srv)["list_my_schedules"]()
+        assert "Failed to list schedules" in result
+        assert "No schedules" not in result
+
 
 # ── remove_wake_schedule ──────────────────────────────────────────────────────
 
@@ -602,6 +608,14 @@ class TestLoadMyContext:
             result = _tools(srv)["load_my_context"]()
         assert isinstance(result, str)
 
+    def test_api_error_not_reported_as_fresh_start(self, srv):
+        """A transient API failure must not masquerade as 'no saved context',
+        or the agent abandons its task and overwrites the saved state."""
+        with _ok({"error": "connection refused"}):
+            result = _tools(srv)["load_my_context"]()
+        assert "Failed to load context" in result
+        assert "No saved context" not in result
+
 
 # ── get_next_task ─────────────────────────────────────────────────────────────
 
@@ -629,6 +643,12 @@ class TestGetNextTask:
         with _ok([]):
             result = _tools(srv)["get_next_task"]()
         assert "No unblocked" in result
+
+    def test_api_error_not_reported_as_no_tasks(self, srv):
+        with _ok({"error": "connection refused"}):
+            result = _tools(srv)["get_next_task"]()
+        assert "Failed to get tasks" in result
+        assert "No unblocked" not in result
 
     def test_blocked_tasks_skipped(self, srv):
         tasks_resp = [
@@ -1018,6 +1038,12 @@ class TestSearchHistory:
             result = _tools(srv)["search_history"](query="nonexistent topic xyz")
         assert "No messages found" in result
 
+    def test_api_error_not_reported_as_no_results(self, srv):
+        with _ok({"error": "connection refused"}):
+            result = _tools(srv)["search_history"](query="login")
+        assert "Failed to search history" in result
+        assert "No messages found" not in result
+
     def test_many_results_truncated(self, srv):
         msgs = [
             {"role": "user", "content": f"message {i}", "timestamp": 1700000000 + i}
@@ -1405,6 +1431,25 @@ class TestProposeSkill:
         assert "draft" in result.lower()
         assert "perf-analysis" in result
 
+    def test_generated_skill_md_parses(self, srv, tmp_path):
+        """The drafted SKILL.md must survive the daemon's frontmatter parser
+        (indented frontmatter used to make /skills/from-md 400 every time)."""
+        from pinky_daemon.skill_loader import parse_skill_md
+
+        result = _tools(srv)["propose_skill"](
+            task_description=self._task,
+            steps_taken=self._steps,
+            outcome=self._outcome,
+            skill_name=self._name,
+        )
+        skill_md = result.split("```markdown\n", 1)[1].split("\n```", 1)[0]
+        assert skill_md.startswith("---\nname: perf-analysis")
+        path = tmp_path / "SKILL.md"
+        path.write_text(skill_md, encoding="utf-8")
+        parsed = parse_skill_md(path)
+        assert parsed is not None
+        assert parsed.name == "perf-analysis"
+
 
 # ── update_and_restart ────────────────────────────────────────────────────────
 
@@ -1675,6 +1720,42 @@ class TestTestTrigger:
         assert "Error" in result
 
 
+# -- async trigger tools must not block the event loop ------------------------
+
+class TestTriggerToolsOffLoop:
+    def test_create_trigger_api_call_runs_off_event_loop(self, srv):
+        """The blocking urlopen must run in a worker thread: async tools run
+        on the (shared) server event loop, so an inline 30s urlopen would
+        stall every agent on that loop."""
+        import asyncio
+        import threading
+
+        seen_threads: list[threading.Thread] = []
+
+        def _urlopen(req, timeout=30):
+            seen_threads.append(threading.current_thread())
+            body = json.dumps({"id": 1, "name": "t", "trigger_type": "url"}).encode()
+            resp = MagicMock()
+            resp.read.return_value = body
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        async def _run():
+            loop_thread = threading.current_thread()
+            result = await _tools(srv)["create_trigger"](
+                name="t", trigger_type="url", url="https://x.example"
+            )
+            return loop_thread, result
+
+        with patch("urllib.request.urlopen", side_effect=_urlopen):
+            loop_thread, result = asyncio.run(_run())
+
+        assert "created" in result
+        assert seen_threads
+        assert all(t is not loop_thread for t in seen_threads)
+
+
 # ── Research pipeline ─────────────────────────────────────────────────────────
 
 class TestResearchPipeline:
@@ -1809,6 +1890,48 @@ class TestResearchPipeline:
             )
         assert "Failed" in result
 
+    def test_export_research_pdf_signs_request_and_writes_to_data_exports(
+        self, srv, monkeypatch
+    ):
+        """The export request must carry internal-auth headers (/research is
+        behind the auth gate) and write under <repo>/data/exports, not a path
+        derived from string-mangling api_url."""
+        monkeypatch.setenv("PINKY_AGENT_KEY", "test-signing-key")
+        seen_reqs = []
+
+        def _urlopen(req, timeout=30):
+            seen_reqs.append(req)
+            resp = MagicMock()
+            resp.headers.get.return_value = 'attachment; filename="../sneaky.pdf"'
+            resp.read.return_value = b"%PDF-1.4 fake"
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=_urlopen):
+            result = _tools(srv)["export_research_pdf"](topic_id=7)
+
+        data = json.loads(result)
+        try:
+            assert data.get("success") is True
+            assert data["filename"] == "sneaky.pdf"
+            from pathlib import Path
+            out = Path(data["path"])
+            assert out.parent.name == "exports"
+            assert out.parent.parent.name == "data"
+            assert out.read_bytes() == b"%PDF-1.4 fake"
+            req = seen_reqs[0]
+            assert req.get_header("X-pinky-agent") == "barsik"
+            assert req.get_header("X-pinky-signature")
+            assert req.get_header("X-pinky-timestamp")
+        finally:
+            if data.get("path"):
+                import os
+                try:
+                    os.unlink(data["path"])
+                except OSError:
+                    pass
+
     def test_submit_research_review(self, srv):
         with _ok({"id": 30, "verdict": "approve"}):
             result = _tools(srv)["submit_research_review"](
@@ -1914,6 +2037,21 @@ class TestSendFileToAgent:
         data = json.loads(result)
         assert data.get("sent") is True
         assert data.get("to") == "pushok"
+
+    def test_api_error_is_reported_not_silently_retried_locally(self, srv, tmp_path):
+        """An API failure must surface as an error, never as a fake local
+        'sent' (the old AgentComms fallback wrote to a DB the daemon never
+        reads, so the recipient never saw the file)."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"PDF content")
+        with _ok({"error": "connection refused"}):
+            result = _tools(srv)["send_file_to_agent"](
+                to_agent="pushok",
+                file_path=str(test_file),
+            )
+        data = json.loads(result)
+        assert data.get("sent") is not True
+        assert "connection refused" in data.get("error", "")
 
 
 # ── agent_status (presence endpoint) ─────────────────────────────────────────

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -296,3 +296,37 @@ class TestOutreachServerSlack:
             "list_platforms",
         }
         assert expected == tool_names
+
+
+class TestUploadFileTransportErrors:
+    def test_presigned_upload_transport_error_raises_slack_error(self, tmp_path):
+        """Step-2 httpx failures (timeouts, connect errors) must surface as
+        SlackError so callers' except SlackError handlers catch them."""
+        import httpx
+
+        from pinky_outreach import slack as slack_mod
+
+        file_path = tmp_path / "report.pdf"
+        file_path.write_bytes(b"PDF")
+
+        adapter = SlackAdapter("xoxb-fake-slack-token")
+        step1 = MagicMock()
+        step1.json.return_value = {
+            "ok": True,
+            "upload_url": "https://files.slack.com/upload/abc",
+            "file_id": "F123",
+        }
+        adapter._client.post = MagicMock(return_value=step1)
+
+        def _post(url, content=None, timeout=None):
+            assert timeout == 30.0  # not httpx's 5s module-level default
+            raise httpx.ReadTimeout("stalled")
+
+        original_post = slack_mod.httpx.post
+        slack_mod.httpx.post = _post
+        try:
+            with pytest.raises(SlackError, match="File upload failed"):
+                adapter.upload_file("C12345", str(file_path))
+        finally:
+            slack_mod.httpx.post = original_post
+            adapter.close()


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **high** send_file_to_agent fallback writes to a wrong, freshly-created DB and reports success (`src/pinky_self/server.py:1538`)
  - Removed the local AgentComms fallback entirely; API failures now return an error instead of a false {"sent": true}, also eliminating the connection leak and authz bypass.
- **medium** f-string docstrings make all 9 outreach tools register with an empty description (`src/pinky_outreach/server.py:121`)
  - Moved each f-string doc into @mcp.tool(description=f"...") so all 9 tools register with their platform-interpolated documentation (smoke-tested via _tool_manager.list_tools()).
- **medium** Telegram long-poll timeout (documented max 50s) exceeds the adapter's 30s httpx timeout (`src/pinky_outreach/server.py:233`)
  - Capped check_messages long-poll at min(timeout, 25) and updated the docstring to 'max 25', keeping the long-poll below the adapter's 30s httpx client read timeout (cap option from fix_hint; telegram.py untouched to stay in scope).
- **medium** iMessage poller silently drops unread inbound messages and leaks a sqlite connection on transient chat.db errors (`src/pinky_outreach/imessage.py:259`)
  - _init_db gained a reseed flag: the get_updates reconnect path calls _init_db(reseed=False) preserving _last_rowid so missed rows replay next poll, and _init_db now closes the previous connection before reconnecting.
- **medium** export_research_pdf sends an unauthenticated request - always 401 behind the auth gate (`src/pinky_self/server.py:1418`)
  - Request now carries build_internal_auth_headers(resolve_request_signing_secret(...)) HMAC headers signed for GET /research/{topic_id}/export (query string excluded, as the verifier ignores it).
- **low** export_research_pdf derives the export directory from a string-mangled api_url (`src/pinky_self/server.py:1426`)
  - Export dir is now Path(__file__).resolve().parents[2]/data/exports (repo root, independent of api_url and cwd), and the Content-Disposition filename is passed through os.path.basename before joining.
- **medium** propose_skill emits SKILL.md with 4-space-indented frontmatter - auto_install always fails to parse (`src/pinky_self/server.py:1934`)
  - Left-aligned the generated SKILL.md f-string to column 0; regression test feeds the draft through the real pinky_daemon.skill_loader.parse_skill_md and asserts it parses.
- **medium** Blocking urllib calls run on the MCP server's event loop in async trigger tools (`src/pinky_self/server.py:2234`)
  - Added _api_async (asyncio.to_thread wrapper around _api) and switched create_trigger/list_triggers/delete_trigger/test_trigger to await it; regression test asserts urlopen runs off the loop thread.
- **medium** load_my_context and sibling list tools swallow API errors and report 'no data' (`src/pinky_self/server.py:254`)
  - load_my_context, list_my_schedules, get_next_task, and search_history now check 'error' in the _api result first and return an explicit failure message (load_my_context warns not to assume a fresh start) instead of aliasing errors to empty state.
- **low** Slack file upload uses module-level httpx.post with the default 5s timeout and buffers the whole file (`src/pinky_outreach/slack.py:143`)
  - Step-2 presigned upload now streams the open file object with an explicit timeout=30.0 and wraps httpx.HTTPError into SlackError so callers' except SlackError handlers catch transport failures.

## Testing
**mcp-servers**: From the worktree root /Users/bradbrok/Documents/Devs/PinkyBot/.claude/worktrees/wf_85885bcd-cae-8:
1) python3 -m pytest tests/test_imessage_adapter.py tests/test_outreach_server.py tests/test_pinky_self_tools.py tests/test_slack.py -q -> 259 passed (includes new regression tests for every medium/high finding: reseed replay, tool descriptions, long-poll cap, error-vs-empty-state for 4 tools, propose_skill frontmatter parse, signed export + path, off-loop trigger API call, no-fake-sent file transfer, SlackError wrapping).
2) python3 -m pytest tests/test_pinky_self.py tests/test_outreach.py tests/test_shared_mcp.py tests/test_shared_mcp_integration.py tests/test_messaging_server.py tests/test_discord.py tests/test_discord_poller.py tests/test_whatsapp.py tests/test_telegram_markdown.py tests/test_agent_comms.py tests/test_apps_mcp_tools.py tests/test_ferry_host_pinky.py tests/test_markdown_v2.py tests/test_sqlite_concurrency.py -q -> 432 passed.
3) python3 -m pytest tests/test_api.py -q -> 351 passed.
4) ruff check on all 8 changed files -> All checks passed. Added diff lines verified ASCII-only.

Generated with [Claude Code](https://claude.com/claude-code)