### PR TITLE
fix(sweep): stores - analytics crash, broken dedup, FTS5 injection, pagination bugs

### DIFF
--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -50,6 +50,7 @@ def _prev_range_bounds(range_name: str) -> tuple[str, str]:
 class AnalyticsStore:
     def __init__(self, db_path: str) -> None:
         self.db_path = db_path
+        self._pricing_cache: dict[tuple[str, str], list[dict]] | None = None
         self._init_db()
 
     @contextmanager
@@ -1053,6 +1054,8 @@ class AnalyticsStore:
                 WHERE started_at >= ? AND started_at <= ?
                   AND (tool_name = 'Bash' OR tool_name LIKE '%__Bash')
             """
+            if agent_name:
+                bash_query += " AND agent_name=?"
             bash_rows = conn.execute(bash_query, tool_params).fetchall()
 
         # Index tools and bash commands by (session_id, turn_seq)
@@ -1265,25 +1268,29 @@ class AnalyticsStore:
         cached_cost = (int(row["cached_input_tokens"]) / 1_000_000) * float(pricing["cached_input_usd_per_mtok"])
         return input_cost + output_cost + cached_cost
 
-    def _lookup_pricing(self, *, provider: str, model: str, ts: str) -> sqlite3.Row | None:
+    def _pricing_table(self) -> dict[tuple[str, str], list[dict]]:
+        """Pricing rows keyed by (provider, model), newest effective_from first."""
+        if self._pricing_cache is None:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT * FROM analytics_model_pricing ORDER BY effective_from DESC"
+                ).fetchall()
+            table: dict[tuple[str, str], list[dict]] = {}
+            for row in rows:
+                table.setdefault((row["provider"], row["model"]), []).append(dict(row))
+            self._pricing_cache = table
+        return self._pricing_cache
+
+    def _lookup_pricing(self, *, provider: str, model: str, ts: str) -> dict | None:
+        table = self._pricing_table()
         provider_aliases = [provider or "", self._provider_alias(provider)]
         model_aliases = self._model_aliases(model)
-        with self._connect() as conn:
-            for provider_name in provider_aliases:
-                for model_name in model_aliases:
-                    row = conn.execute(
-                        """
-                        SELECT *
-                        FROM analytics_model_pricing
-                        WHERE provider=? AND model=?
-                          AND effective_from <= ?
-                          AND (effective_to IS NULL OR effective_to > ?)
-                        ORDER BY effective_from DESC
-                        LIMIT 1
-                        """,
-                        (provider_name, model_name, ts, ts),
-                    ).fetchone()
-                    if row:
+        for provider_name in provider_aliases:
+            for model_name in model_aliases:
+                for row in table.get((provider_name, model_name), []):
+                    if row["effective_from"] <= ts and (
+                        row["effective_to"] is None or row["effective_to"] > ts
+                    ):
                         return row
         return None
 

--- a/src/pinky_daemon/conversation_store.py
+++ b/src/pinky_daemon/conversation_store.py
@@ -18,6 +18,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
+def _fts5_phrase(query: str) -> str:
+    """Escape a user query as quoted FTS5 phrase tokens (no operator syntax)."""
+    return " ".join('"' + token.replace('"', '""') + '"' for token in query.split())
+
+
 @dataclass
 class StoredMessage:
     """A message persisted in the conversation store."""
@@ -248,14 +253,24 @@ class ConversationStore:
         where = " AND ".join(conditions)
         params.append(limit)
 
-        rows = self._conn.execute(
-            f"""SELECT m.* FROM messages m
+        sql = f"""SELECT m.* FROM messages m
                 JOIN messages_fts ON m.id = messages_fts.rowid
                 WHERE {where}
                 ORDER BY m.timestamp DESC
-                LIMIT ?""",
-            params,
-        ).fetchall()
+                LIMIT ?"""
+        try:
+            rows = self._conn.execute(sql, params).fetchall()
+        except sqlite3.OperationalError:
+            # Invalid FTS5 syntax (apostrophes, stray operators) -- retry
+            # with the query escaped as plain phrase tokens.
+            escaped = _fts5_phrase(query)
+            if not escaped:
+                return []
+            params[0] = escaped
+            try:
+                rows = self._conn.execute(sql, params).fetchall()
+            except sqlite3.OperationalError:
+                return []
 
         return [self._row_to_message(r) for r in rows]
 

--- a/src/pinky_daemon/kb_store.py
+++ b/src/pinky_daemon/kb_store.py
@@ -65,6 +65,11 @@ def _content_preview(content: str) -> str:
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)", re.DOTALL)
 
 
+def _fts5_phrase(query: str) -> str:
+    """Escape a user query as quoted FTS5 phrase tokens (no operator syntax)."""
+    return " ".join('"' + token.replace('"', '""') + '"' for token in query.split())
+
+
 def _parse_frontmatter(text: str) -> tuple[dict, str]:
     """Parse YAML frontmatter and body from a markdown file.
 
@@ -327,7 +332,9 @@ class KBStore:
         full_path.write_text(full_content, encoding="utf-8")
 
         c_hash = _content_hash(full_content)
-        c_preview = _content_preview(full_content)
+        # Preview is computed from the bare content so check_duplicate(content=...)
+        # lookups match what is stored here.
+        c_preview = _content_preview(content)
 
         # Index in SQLite
         conn = self._conn()
@@ -350,6 +357,9 @@ class KBStore:
             )
 
             conn.commit()
+        except Exception:
+            full_path.unlink(missing_ok=True)
+            raise
         finally:
             conn.close()
 
@@ -475,7 +485,7 @@ class KBStore:
         full_path.write_text(full_content, encoding="utf-8")
 
         c_hash = _content_hash(full_content)
-        c_preview = _content_preview(full_content)
+        c_preview = _content_preview(body)
 
         # Update DB
         new_tags = fm.get("tags", source.tags)
@@ -590,23 +600,31 @@ class KBStore:
         conn = self._conn()
         try:
             kind_filter = ""
-            params: list = [query]
 
             if scope == "raw":
                 kind_filter = " AND kind = 'raw'"
             elif scope == "wiki":
                 kind_filter = " AND kind = 'wiki'"
 
-            rows = conn.execute(
-                f"""SELECT ref_id, kind, title,
+            sql = f"""SELECT ref_id, kind, title,
                            snippet(fts_content, 3, '<mark>', '</mark>', '...', 40) as snippet,
                            rank
                     FROM fts_content
                     WHERE fts_content MATCH ?{kind_filter}
                     ORDER BY rank
-                    LIMIT ?""",
-                params + [limit],
-            ).fetchall()
+                    LIMIT ?"""
+            try:
+                rows = conn.execute(sql, [query, limit]).fetchall()
+            except sqlite3.OperationalError:
+                # Invalid FTS5 syntax (apostrophes, stray operators) -- retry
+                # with the query escaped as plain phrase tokens.
+                escaped = _fts5_phrase(query)
+                if not escaped:
+                    return []
+                try:
+                    rows = conn.execute(sql, [escaped, limit]).fetchall()
+                except sqlite3.OperationalError:
+                    return []
 
             return [
                 {
@@ -826,14 +844,12 @@ class KBStore:
                 full_path = self.kb_dir / row["file_path"]
                 if full_path.exists():
                     content = full_path.read_text(encoding="utf-8")
-                    body = _content_preview(content)  # Use preview for FTS body
-                    # Actually use full body after frontmatter
                     match = _FRONTMATTER_RE.match(content)
                     body = match.group(2) if match else content
                     conn.execute(
                         "INSERT INTO fts_content (ref_id, kind, title, body, tags) "
                         "VALUES (?, ?, ?, ?, ?)",
-                        (row["id"], "raw", row["title"], body, row["tags"]),
+                        (row["id"], "raw", row["title"], body, " ".join(json.loads(row["tags"]))),
                     )
                     indexed_raw += 1
 

--- a/src/pinky_daemon/presentation_store.py
+++ b/src/pinky_daemon/presentation_store.py
@@ -412,17 +412,18 @@ class PresentationStore:
         if research_topic_id is not None:
             conditions.append("research_topic_id=?")
             params.append(research_topic_id)
+        if tag:
+            conditions.append(
+                "EXISTS (SELECT 1 FROM json_each(presentations.tags) WHERE json_each.value = ?)"
+            )
+            params.append(tag)
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         rows = self._db.execute(
             f"SELECT {self._P_COLS} FROM presentations {where} "
             f"ORDER BY updated_at DESC LIMIT ? OFFSET ?",
             [*params, limit, offset],
         ).fetchall()
-        results = [self._row_to_presentation(r) for r in rows]
-        # Filter by tag in Python (tags stored as JSON array)
-        if tag:
-            results = [p for p in results if tag in p.tags]
-        return results
+        return [self._row_to_presentation(r) for r in rows]
 
     # ── Update ────────────────────────────────────────────────
 
@@ -440,7 +441,13 @@ class PresentationStore:
         if not pres:
             return None
         now = time.time()
-        new_version = pres.current_version + 1
+        # MAX(version) rather than current_version + 1: restore_version() can
+        # rewind current_version below already-existing version rows.
+        new_version = self._db.execute(
+            "SELECT COALESCE(MAX(version), 0) + 1 FROM presentation_versions "
+            "WHERE presentation_id=?",
+            (presentation_id,),
+        ).fetchone()[0]
 
         self._db.execute(
             """INSERT INTO presentation_versions

--- a/src/pinky_daemon/task_store.py
+++ b/src/pinky_daemon/task_store.py
@@ -367,9 +367,17 @@ class TaskStore:
         return self.get(task_id)
 
     def delete(self, task_id: int) -> bool:
-        """Delete a task and its subtasks."""
-        # Delete subtasks first
-        self._db.execute("DELETE FROM tasks WHERE parent_id=?", (task_id,))
+        """Delete a task and all its descendant subtasks."""
+        # Delete descendants first (any depth)
+        self._db.execute(
+            """WITH RECURSIVE descendants(id) AS (
+                   SELECT id FROM tasks WHERE parent_id=?
+                   UNION
+                   SELECT t.id FROM tasks t JOIN descendants d ON t.parent_id=d.id
+               )
+               DELETE FROM tasks WHERE id IN (SELECT id FROM descendants)""",
+            (task_id,),
+        )
         cursor = self._db.execute("DELETE FROM tasks WHERE id=?", (task_id,))
         self._db.commit()
         return cursor.rowcount > 0
@@ -414,6 +422,12 @@ class TaskStore:
             conditions.append("parent_id=?")
             params.append(parent_id)
 
+        if tag:
+            conditions.append(
+                "EXISTS (SELECT 1 FROM json_each(tasks.tags) WHERE json_each.value = ?)"
+            )
+            params.append(tag)
+
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         params.append(limit)
 
@@ -427,13 +441,7 @@ class TaskStore:
             params,
         ).fetchall()
 
-        tasks = [self._row_to_task(r) for r in rows]
-
-        # Filter by tag in Python (JSON array)
-        if tag:
-            tasks = [t for t in tasks if tag in t.tags]
-
-        return tasks
+        return [self._row_to_task(r) for r in rows]
 
     def get_subtasks(self, parent_id: int) -> list[Task]:
         """Get all subtasks of a task."""

--- a/tests/test_analytics_store.py
+++ b/tests/test_analytics_store.py
@@ -16,6 +16,8 @@ import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
 from pinky_daemon.analytics_store import AnalyticsStore
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -341,3 +343,53 @@ class TestTurnClassification:
             store._classify_turn(["mcp__pinky-messaging__send_video"], [])
             == "messaging"
         )
+
+
+class TestGetCategoriesAgentFilter:
+    def test_agent_filter_does_not_crash_and_scopes_turns(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store, session_id="s1", agent="barsik")
+        _seed_session(store, session_id="s2", agent="murka")
+        now = _iso(datetime.now(UTC))
+        store.log_turn_usage(
+            session_id="s1", agent_name="barsik", turn_seq=1,
+            provider="anthropic", model="claude-sonnet-4",
+            input_tokens=100, output_tokens=50, cached_input_tokens=0,
+            ts=now,
+        )
+        store.start_tool_call(
+            session_id="s1", agent_name="barsik", turn_seq=1,
+            tool_call_key="k1", tool_name="Bash",
+            metadata={"command": "pytest tests/"}, ts=now,
+        )
+        store.log_turn_usage(
+            session_id="s2", agent_name="murka", turn_seq=1,
+            provider="anthropic", model="claude-sonnet-4",
+            input_tokens=10, output_tokens=5, cached_input_tokens=0,
+            ts=now,
+        )
+        result = store.get_categories(range_name="7d", agent_name="barsik")
+        assert sum(c["turns"] for c in result["categories"]) == 1
+        assert sum(c["input_tokens"] for c in result["categories"]) == 100
+
+
+class TestPricingLookup:
+    def test_overview_costs_use_seeded_pricing(self, tmp_path):
+        store = _store(tmp_path)
+        _seed_session(store)
+        store.log_turn_usage(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            provider="anthropic", model="claude-sonnet-4",
+            input_tokens=1_000_000, output_tokens=0, cached_input_tokens=0,
+        )
+        overview = store.get_overview(range_name="7d")
+        # claude-sonnet-4 seeded at 3.00 USD per MTok input
+        assert overview["totals"]["cost_usd"] == pytest.approx(3.0)
+
+    def test_lookup_pricing_resolves_aliases(self, tmp_path):
+        store = _store(tmp_path)
+        ts = _iso(datetime.now(UTC))
+        row = store._lookup_pricing(provider="claude_code", model="Claude-Sonnet-4", ts=ts)
+        assert row is not None
+        assert row["input_usd_per_mtok"] == 3.00
+        assert store._lookup_pricing(provider="anthropic", model="no-such-model", ts=ts) is None

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -135,6 +135,27 @@ class TestConversationStore:
         assert results == []
         self._cleanup(store, path)
 
+    def test_search_apostrophe_query_does_not_crash(self):
+        store, path = self._make_store()
+        store.append("s1", "user", "I don't like mondays")
+        results = store.search("don't")
+        assert len(results) == 1
+        assert results[0].content == "I don't like mondays"
+        self._cleanup(store, path)
+
+    def test_search_unbalanced_quote_returns_empty(self):
+        store, path = self._make_store()
+        store.append("s1", "user", "plain text body")
+        results = store.search('something "unbalanced')
+        assert results == []
+        self._cleanup(store, path)
+
+    def test_search_whitespace_query_returns_empty(self):
+        store, path = self._make_store()
+        store.append("s1", "user", "Hello")
+        assert store.search("   ") == []
+        self._cleanup(store, path)
+
     def test_list_conversations(self):
         store, path = self._make_store()
         store.append("s1", "user", "Hello")

--- a/tests/test_kb_store.py
+++ b/tests/test_kb_store.py
@@ -1,5 +1,7 @@
 """Tests for KB store — raw source CRUD operations."""
 
+import sqlite3
+
 import pytest
 
 from pinky_daemon.kb_store import KBStore, _parse_frontmatter
@@ -148,3 +150,66 @@ class TestCountRaw:
         kb.ingest(title="A", content="a", tags=["python"])
         kb.ingest(title="B", content="b", tags=["rust"])
         assert kb.count_raw(tag="python") == 1
+
+
+class TestCheckDuplicate:
+    def test_url_duplicate(self, kb):
+        kb.ingest(title="A", content="x", source_url="https://example.com/a")
+        dup = kb.check_duplicate(source_url="https://example.com/a")
+        assert dup is not None
+
+    def test_content_duplicate_matches_ingested_content(self, kb):
+        content = "substantial body " * 10
+        source = kb.ingest(title="Some Note", content=content)
+        dup = kb.check_duplicate(content=content)
+        assert dup is not None
+        assert dup.id == source.id
+
+    def test_short_content_not_deduped(self, kb):
+        kb.ingest(title="Tiny", content="short")
+        assert kb.check_duplicate(content="short") is None
+
+
+class TestSearchRobustness:
+    def test_apostrophe_query_does_not_crash(self, kb):
+        kb.ingest(title="Mondays", content="I don't like mondays at all")
+        results = kb.search("don't")
+        assert len(results) == 1
+
+    def test_unbalanced_quote_returns_no_error(self, kb):
+        kb.ingest(title="Q", content="some plain text body")
+        assert kb.search('something "unbalanced') == []
+
+    def test_whitespace_query_returns_empty(self, kb):
+        kb.ingest(title="Q", content="some plain text body")
+        assert kb.search("   ") == []
+
+
+class TestIngestFailureCleanup:
+    def test_duplicate_url_insert_cleans_up_file(self, kb):
+        kb.ingest(title="First", content="body one", source_url="https://example.com/dup")
+        files_before = sorted(p.name for p in kb.raw_dir.glob("*.md"))
+        with pytest.raises(sqlite3.IntegrityError):
+            kb.ingest(title="Second", content="body two", source_url="https://example.com/dup")
+        files_after = sorted(p.name for p in kb.raw_dir.glob("*.md"))
+        assert files_after == files_before
+
+
+class TestReindex:
+    def test_reindex_preserves_space_joined_tags(self, kb):
+        source = kb.ingest(title="Tagged", content="body text here", tags=["alpha", "beta"])
+        kb.reindex()
+        conn = sqlite3.connect(str(kb.db_path))
+        try:
+            row = conn.execute(
+                "SELECT tags FROM fts_content WHERE ref_id = ? AND kind = 'raw'",
+                (source.id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == "alpha beta"
+
+    def test_reindex_keeps_search_working(self, kb):
+        kb.ingest(title="Searchable", content="unique keyword xyzzy")
+        kb.reindex()
+        assert len(kb.search("xyzzy")) == 1

--- a/tests/test_presentation_store.py
+++ b/tests/test_presentation_store.py
@@ -1,0 +1,63 @@
+"""Tests for presentation store - versioning and listing."""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_daemon.presentation_store import PresentationStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return PresentationStore(str(tmp_path / "presentations.db"))
+
+
+class TestVersioning:
+    def test_update_increments_version(self, store):
+        pres = store.create("Deck", "<p>v1</p>")
+        assert pres.current_version == 1
+        updated = store.update(pres.id, "<p>v2</p>")
+        assert updated.current_version == 2
+
+    def test_restore_version_rewinds(self, store):
+        pres = store.create("Deck", "<p>v1</p>")
+        store.update(pres.id, "<p>v2</p>")
+        restored = store.restore_version(pres.id, 1)
+        assert restored.current_version == 1
+        assert restored.current_html == "<p>v1</p>"
+
+    def test_update_after_restore_does_not_collide(self, store):
+        pres = store.create("Deck", "<p>v1</p>")
+        store.update(pres.id, "<p>v2</p>")
+        store.update(pres.id, "<p>v3</p>")
+        restored = store.restore_version(pres.id, 2)
+        assert restored.current_version == 2
+
+        updated = store.update(pres.id, "<p>v4</p>")
+        assert updated is not None
+        assert updated.current_version == 4
+        assert updated.current_html == "<p>v4</p>"
+
+        # Subsequent edits keep working
+        again = store.update(pres.id, "<p>v5</p>")
+        assert again.current_version == 5
+
+
+class TestListTagFilter:
+    def test_tag_filter_applies_before_limit(self, store):
+        # Tagged presentation is the oldest (lowest updated_at), so it falls
+        # outside the LIMIT window unless the tag filter runs in SQL.
+        tagged = store.create("Tagged", "<p>t</p>", tags=["demo"])
+        for i in range(3):
+            store.create(f"Other {i}", "<p>o</p>")
+        results = store.list(tag="demo", limit=2)
+        assert [p.id for p in results] == [tagged.id]
+
+    def test_tag_filter_no_match(self, store):
+        store.create("Plain", "<p>p</p>")
+        assert store.list(tag="missing") == []
+
+    def test_list_without_tag_unaffected(self, store):
+        store.create("A", "<p>a</p>")
+        store.create("B", "<p>b</p>")
+        assert len(store.list()) == 2

--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -74,6 +74,15 @@ class TestTaskCRUD:
         store.delete(parent.id)
         assert store.get(child.id) is None
 
+    def test_delete_cascades_grandchildren(self, store):
+        parent = store.create("Parent")
+        child = store.create("Child", parent_id=parent.id)
+        grandchild = store.create("Grandchild", parent_id=child.id)
+        store.delete(parent.id)
+        assert store.get(parent.id) is None
+        assert store.get(child.id) is None
+        assert store.get(grandchild.id) is None
+
 
 class TestTaskQueries:
     def test_list_default(self, store):
@@ -116,6 +125,15 @@ class TestTaskQueries:
         tasks = store.list(tag="bug")
         assert len(tasks) == 1
         assert "bug" in tasks[0].tags
+
+    def test_list_by_tag_beyond_limit(self, store):
+        # Tagged task sorts last (low priority); tag filter must apply
+        # before LIMIT so it is still returned.
+        tagged = store.create("Tagged", tags=["bug"], priority="low")
+        for i in range(3):
+            store.create(f"Other {i}", priority="high")
+        tasks = store.list(tag="bug", limit=3)
+        assert [t.id for t in tasks] == [tagged.id]
 
     def test_list_by_project(self, store):
         p = store.create_project("Proj")


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **medium** get_categories crashes with sqlite3.ProgrammingError whenever an agent filter is passed (`src/pinky_daemon/analytics_store.py:1056`)
  - Appends ' AND agent_name=?' to bash_query under the same agent_name guard so placeholders match tool_params and bash rows are agent-scoped.
- **medium** Content-based dedup in check_duplicate can never match - previews are computed from different inputs (`src/pinky_daemon/kb_store.py:265`)
  - ingest() now stores content_preview from the bare content and update_raw() from the parsed body, matching check_duplicate's lookup key.
- **medium** Per-row pricing lookups open a new SQLite connection per usage row (N+1) in every analytics dashboard call (`src/pinky_daemon/analytics_store.py:1268`)
  - Loads analytics_model_pricing once per store instance into a (provider, model)-keyed cache; _lookup_pricing resolves aliases and effective ranges in memory (returns dict instead of sqlite3.Row).
- **medium** update() after restore_version() raises UNIQUE constraint violation, permanently breaking edits (`src/pinky_daemon/presentation_store.py:443`)
  - update() computes new_version via SELECT COALESCE(MAX(version), 0) + 1 FROM presentation_versions instead of current_version + 1.
- **low** User-supplied query passed raw to FTS5 MATCH - common inputs like apostrophes cause unhandled OperationalError (HTTP 500) (`src/pinky_daemon/conversation_store.py:251`)
  - search() catches sqlite3.OperationalError, retries with the query escaped as quoted FTS5 phrase tokens (_fts5_phrase), and returns [] if even the escaped form fails.
- **low** KBStore.search has the same raw FTS5 MATCH crash on user queries (`src/pinky_daemon/kb_store.py:605`)
  - Same fallback as conversation_store: retry the MATCH with phrase-escaped tokens on OperationalError, return [] on empty/unsalvageable queries.
- **low** TaskStore.delete only removes one level of subtasks - grandchildren become orphaned rows (`src/pinky_daemon/task_store.py:372`)
  - delete() collects all descendants with a recursive CTE (UNION, so cycles terminate) and deletes the whole subtree before the task itself.
- **low** Tag filter applied in Python after SQL LIMIT silently drops matching tasks (`src/pinky_daemon/task_store.py:434`)
  - Tag match moved into SQL via EXISTS (SELECT 1 FROM json_each(tasks.tags) WHERE json_each.value = ?) before LIMIT; Python post-filter removed.
- **low** ingest() writes the markdown file before the DB insert - a failed insert leaves an orphaned, unindexed file (`src/pinky_daemon/kb_store.py:327`)
  - ingest() wraps the insert/commit in except Exception: full_path.unlink(missing_ok=True); raise, so a failed insert (e.g. UNIQUE source_url) leaves no orphan file.
- **low** Dead assignment in reindex(); rebuilt FTS rows also index raw JSON tags instead of the space-joined form used at ingest (`src/pinky_daemon/kb_store.py:829`)
  - Removed the dead _content_preview body assignment and its comment; reindex now inserts ' '.join(json.loads(row['tags'])) to match ingest()/update_raw().
- **low** list(tag=...) filters tags in Python after SQL LIMIT/OFFSET - broken pagination and silently missing results (`src/pinky_daemon/presentation_store.py:424`)
  - Tag match moved into SQL via EXISTS json_each(presentations.tags) before LIMIT/OFFSET; Python post-filter removed.

## Deferred (not fixed here, with reasons)
- ResearchStore.list_topics post-LIMIT tag filter (mentioned inside the task_store tag-filter finding): research_store.py is not a file cited in my findings group, so editing it would violate the scope rule (owned by another branch). The path is also latent: routes/research.py never passes tag. Fixed only the cited task_store.py half.
- list_agents re-runs _compute_active_seconds once per agent (secondary mention in the pricing N+1 finding): The fix_hint targeted the pricing memoization, which I implemented. Restructuring list_agents' per-agent active-seconds query is a larger refactor with no hint coverage; deferring rather than risking behavior drift. The dominant per-row connection churn is gone.

## Testing
**stores**: All run from the worktree root. python3 -m pytest tests/test_analytics_store.py tests/test_kb_store.py tests/test_task_store.py tests/test_conversation_store.py tests/test_presentation_store.py -q -> 117 passed. Pre-fix verification (git stash push -- src/): all 12 new regression tests FAIL against unfixed code, pass after (12 failed -> 0). Broader sweeps: python3 -m pytest tests/test_api.py tests/test_agent_status.py tests/test_route_auth_coverage.py tests/test_auth.py -q -> 465 passed; tests/test_pinky_self.py tests/test_scheduler.py tests/test_hub.py tests/test_session_store.py -> 135 passed; tests/test_autonomy.py tests/test_agent_status.py -> 38 passed; tests/test_pinky_self_tools.py -> 180 passed; tests/test_shared_mcp_integration.py -> 10 passed. ruff check on all 10 changed files -> All checks passed. Zero failures anywhere.

Generated with [Claude Code](https://claude.com/claude-code)