### PR TITLE
fix(sweep): voice - TwiML escaping, WS teardown race, client leak

### DIFF
--- a/src/pinky_daemon/voice_engine.py
+++ b/src/pinky_daemon/voice_engine.py
@@ -19,9 +19,25 @@ from typing import Any, AsyncIterator, Callable
 _HAIKU_MODEL = "claude-haiku-4-5-20251001"
 _OPUS_MODEL = "claude-opus-4-8"
 
+# Reuse one AsyncAnthropic client (and its connection pool) per API key so
+# each conversation turn doesn't pay a fresh TLS handshake.
+_anthropic_clients: dict[str, Any] = {}
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
+
+
+def _get_anthropic_client(api_key: str = "") -> Any:
+    """Get a cached AsyncAnthropic client for the given (or env) API key."""
+    import anthropic
+
+    key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+    client = _anthropic_clients.get(key)
+    if client is None:
+        client = anthropic.AsyncAnthropic(api_key=key)
+        _anthropic_clients[key] = client
+    return client
 
 
 # ── Twilio helpers ───────────────────────────────────────────────────────────
@@ -132,10 +148,7 @@ async def haiku_respond(
     Yields text chunks as they arrive. Caller is responsible for
     sending them as CR text messages.
     """
-    import anthropic
-
-    key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
-    client = anthropic.AsyncAnthropic(api_key=key)
+    client = _get_anthropic_client(api_key)
 
     async with client.messages.stream(
         model=_HAIKU_MODEL,
@@ -259,7 +272,7 @@ def build_outbound_twiml(ws_url: str, welcome_greeting: str = "") -> str:
     greeting_attr = ""
     if welcome_greeting:
         greeting_attr = (
-            f' welcomeGreeting="{saxutils.escape(welcome_greeting)}"'
+            f" welcomeGreeting={saxutils.quoteattr(welcome_greeting)}"
             ' welcomeGreetingInterruptible="speech"'
         )
 
@@ -306,10 +319,7 @@ async def extract_outcome_with_opus(
     api_key: str = "",
 ) -> dict:
     """Use Opus to review a call transcript and extract structured outcome."""
-    import anthropic
-
-    key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
-    client = anthropic.AsyncAnthropic(api_key=key)
+    client = _get_anthropic_client(api_key)
 
     transcript_text = "\n".join(
         f"[{t.get('role', 'unknown')}] {t.get('text', '')}"
@@ -397,16 +407,20 @@ async def finalize_call(
         session, transcript, goal, api_key=api_key
     )
 
-    # Save artifact
-    voice_store.save_artifact(
-        call_sid=session.call_sid,
-        call_session_id=session.id,
-        transcript_url="",  # local only for now
-        summary=outcome.get("summary", ""),
-        extracted_outcome=outcome,
-        caller_name="",
-        caller_purpose="",
-    )
+    # Save artifact (duplicate finalize hits the UNIQUE call_sid constraint;
+    # log and still deliver the owner notification)
+    try:
+        voice_store.save_artifact(
+            call_sid=session.call_sid,
+            call_session_id=session.id,
+            transcript_url="",  # local only for now
+            summary=outcome.get("summary", ""),
+            extracted_outcome=outcome,
+            caller_name="",
+            caller_purpose="",
+        )
+    except Exception as e:
+        _log(f"voice: artifact save failed for {session.call_sid} - {e}")
 
     # Notify owner
     if broker_send and agents:

--- a/src/pinky_daemon/voice_routes.py
+++ b/src/pinky_daemon/voice_routes.py
@@ -33,6 +33,10 @@ _base_url: str = ""
 # Active WebSocket connections keyed by session ID (for mid-call control)
 _active_ws: dict[str, WebSocket] = {}
 
+# Strong references to in-flight finalize tasks; the event loop only keeps
+# weak refs, so a bare create_task() can be garbage-collected mid-run.
+_finalize_tasks: set[asyncio.Task] = set()
+
 # Agents trusted for auto-approve (skip manual approval, dial immediately)
 AUTO_APPROVE_AGENTS = {"barsik"}
 
@@ -619,6 +623,13 @@ async def conversationrelay_ws(ws: WebSocket, call_session_id: str):
         await ws.close(code=4003, reason="Session not active")
         return
 
+    # One live WS per session; a duplicate would clobber the registration
+    # the control endpoints (terminate/transfer/dtmf) rely on.
+    if call_session_id in _active_ws:
+        _log(f"voice: WS rejected - session {call_session_id} already connected")
+        await ws.close(code=4003, reason="Session already connected")
+        return
+
     _active_ws[call_session_id] = ws
     _log(f"voice: WS connected for session {call_session_id}")
 
@@ -665,6 +676,9 @@ async def conversationrelay_ws(ws: WebSocket, call_session_id: str):
     messages: list[dict] = []
     call_active = True
     setup_received = False
+    # False when this handler rejected the connection during setup validation:
+    # the call may still be live elsewhere, so don't stamp it completed.
+    mark_completed = True
     # Track mutable call state locally (session object is stale after DB updates)
     live_call_sid = session.call_sid
     live_answered_at: float | None = session.answered_at
@@ -694,6 +708,7 @@ async def conversationrelay_ws(ws: WebSocket, call_session_id: str):
                              f"expected {session.call_sid}, got {call_sid}")
                         await ws.close(code=4003, reason="callSid mismatch")
                         call_active = False
+                        mark_completed = False
                         continue
 
                 # Validate: accountSid should match our Twilio account
@@ -703,6 +718,7 @@ async def conversationrelay_ws(ws: WebSocket, call_session_id: str):
                         _log("voice: accountSid mismatch — rejecting")
                         await ws.close(code=4003, reason="Invalid account")
                         call_active = False
+                        mark_completed = False
                         continue
 
                 if call_sid and call_sid != session.call_sid:
@@ -858,19 +874,22 @@ async def conversationrelay_ws(ws: WebSocket, call_session_id: str):
     except Exception as e:
         _log(f"voice: WS error — {e}")
     finally:
-        _active_ws.pop(call_session_id, None)
+        # Only unregister our own WS, never another handler's.
+        if _active_ws.get(call_session_id) is ws:
+            _active_ws.pop(call_session_id, None)
 
-        # Update session as ended
-        _voice_store.update_session(
-            session.id, status="completed", ended_at=time.time()
-        )
+        if mark_completed:
+            # Update session as ended
+            _voice_store.update_session(
+                session.id, status="completed", ended_at=time.time()
+            )
 
         # Finalize call in background (Opus review + artifact + notify).
         # get_session() can return None under session-expiry races (session
         # was cleaned up between the update above and this lookup, or it was
         # never committed). Check explicitly — handing None to finalize_call()
         # would raise AttributeError on session.call_sid. (#286)
-        if messages:
+        if messages and mark_completed:
             finalize_session = _voice_store.get_session(call_session_id)
             if finalize_session is None:
                 _log(
@@ -879,13 +898,15 @@ async def conversationrelay_ws(ws: WebSocket, call_session_id: str):
                     f"skipping Opus review + artifact"
                 )
             else:
-                asyncio.create_task(
+                task = asyncio.create_task(
                     finalize_call(
                         finalize_session,
                         _voice_store, _agents, _broker_send,
                         api_key=_api_key,
                     )
                 )
+                _finalize_tasks.add(task)
+                task.add_done_callback(_finalize_tasks.discard)
 
         _log(f"voice: WS closed for session {call_session_id}")
 
@@ -908,6 +929,7 @@ async def terminate_session(
         raise HTTPException(status_code=404, detail="Session not found")
 
     # Send end message over WS if connected
+    ws_ended = False
     ws = _active_ws.get(session.id)
     if ws:
         try:
@@ -915,10 +937,13 @@ async def terminate_session(
                 "type": "end",
                 "handoffData": json.dumps({"reason": body.reason}),
             }))
+            ws_ended = True
         except Exception:
             pass
 
     # Also hang up via Twilio REST
+    rest_ended = False
+    rest_error = ""
     try:
         from pinky_daemon.voice_engine import get_twilio_client
         client = get_twilio_client(_agents)
@@ -927,8 +952,16 @@ async def terminate_session(
             None,
             lambda: client.calls(call_sid).update(status="completed"),
         )
+        rest_ended = True
     except Exception as e:
-        _log(f"voice: terminate failed — {e}")
+        rest_error = str(e)
+        _log(f"voice: terminate failed - {e}")
+
+    if not ws_ended and not rest_ended:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to terminate call: {rest_error or 'no active connection'}",
+        )
 
     _voice_store.update_session(
         session.id, status="completed", ended_at=time.time()

--- a/src/pinky_daemon/voice_store.py
+++ b/src/pinky_daemon/voice_store.py
@@ -11,15 +11,12 @@ and inbound AI voicemail. Four tables:
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import json
 import re
 import sqlite3
 import sys
 import time
 import uuid
-from base64 import urlsafe_b64decode, urlsafe_b64encode
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -55,37 +52,9 @@ def _normalize_e164(phone: str) -> str:
     return result
 
 
-# ── HMAC approval tokens ─────────────────────────────────────────────────────
+# -- Approval window ----------------------------------------------------------
 
 _APPROVAL_TOKEN_TTL = 3600  # 1 hour
-
-
-def make_approval_token(request_id: str, secret: str) -> str:
-    """Generate HMAC-signed token encoding request_id + expiry."""
-    expiry = str(int(time.time() + _APPROVAL_TOKEN_TTL))
-    payload = f"{request_id}:{expiry}"
-    sig = hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()[:16]
-    raw = f"{payload}:{sig}"
-    return urlsafe_b64encode(raw.encode()).decode().rstrip("=")
-
-
-def verify_approval_token(token: str, secret: str) -> str | None:
-    """Verify token and return request_id if valid and not expired, else None."""
-    try:
-        padded = token + "=" * (4 - len(token) % 4)
-        raw = urlsafe_b64decode(padded.encode()).decode()
-        request_id, expiry_str, sig = raw.rsplit(":", 2)
-        payload = f"{request_id}:{expiry_str}"
-        expected = hmac.new(
-            secret.encode(), payload.encode(), hashlib.sha256
-        ).hexdigest()[:16]
-        if not hmac.compare_digest(sig, expected):
-            return None
-        if time.time() > float(expiry_str):
-            return None
-        return request_id
-    except Exception:
-        return None
 
 
 # ── Dataclasses ───────────────────────────────────────────────────────────────

--- a/tests/test_voice_engine.py
+++ b/tests/test_voice_engine.py
@@ -1,17 +1,21 @@
 """Tests for pinky_daemon.voice_engine helpers.
 
 Focused on regression coverage for #286 — finalize_call() getting handed
-a None session under WS-disconnect races.
+a None session under WS-disconnect races, plus TwiML attribute escaping,
+finalize-time artifact-save resilience, and Anthropic client reuse.
 """
 
 from __future__ import annotations
 
 import asyncio
+import sqlite3
+import xml.dom.minidom
 from unittest.mock import MagicMock
 
 import pytest
 
-from pinky_daemon.voice_engine import finalize_call
+import pinky_daemon.voice_engine as voice_engine
+from pinky_daemon.voice_engine import build_outbound_twiml, finalize_call
 
 
 class TestFinalizeCallNoneGuard:
@@ -92,3 +96,102 @@ def test_finalize_call_parametrized_nones(bad_value):
             api_key="",
         )
     )
+
+
+class TestBuildOutboundTwiml:
+    """welcomeGreeting is agent-goal-derived text embedded in an XML
+    attribute; it must be quote-escaped or quotes break the TwiML."""
+
+    def test_greeting_with_double_quotes_produces_wellformed_xml(self):
+        greeting = 'Ask for the "early bird" rate, please.'
+        twiml = build_outbound_twiml("wss://example/ws/abc", welcome_greeting=greeting)
+
+        doc = xml.dom.minidom.parseString(twiml)
+        relay = doc.getElementsByTagName("ConversationRelay")[0]
+        assert relay.getAttribute("welcomeGreeting") == greeting
+
+    def test_greeting_cannot_inject_attributes(self):
+        greeting = 'hi" ttsProvider="Evil'
+        twiml = build_outbound_twiml("wss://example/ws/abc", welcome_greeting=greeting)
+
+        doc = xml.dom.minidom.parseString(twiml)
+        relay = doc.getElementsByTagName("ConversationRelay")[0]
+        assert relay.getAttribute("ttsProvider") == "Google"
+        assert relay.getAttribute("welcomeGreeting") == greeting
+
+    def test_no_greeting_omits_attribute(self):
+        twiml = build_outbound_twiml("wss://example/ws/abc")
+        doc = xml.dom.minidom.parseString(twiml)
+        relay = doc.getElementsByTagName("ConversationRelay")[0]
+        assert not relay.hasAttribute("welcomeGreeting")
+
+
+class TestFinalizeCallArtifactResilience:
+    """A duplicate finalize hits the UNIQUE call_sid constraint on
+    voice_call_artifact; the owner notification must still go out."""
+
+    def test_save_artifact_failure_still_notifies(self, monkeypatch):
+        session = MagicMock()
+        session.call_sid = "CA123"
+        session.id = "sess-abc"
+        session.call_request_id = "req-1"
+        session.to_number = "+15551234567"
+
+        req = MagicMock()
+        req.goal = "book a table"
+        req.target_name = "Pizza Place"
+
+        event = MagicMock()
+        event.event_type = "prompt"
+        event.role = "caller"
+        event.content = "hello"
+        event.ts = 1.0
+
+        voice_store = MagicMock()
+        voice_store.get_call_request.return_value = req
+        voice_store.get_events.return_value = [event]
+        voice_store.save_artifact.side_effect = sqlite3.IntegrityError(
+            "UNIQUE constraint failed: voice_call_artifact.call_sid"
+        )
+
+        agents = MagicMock()
+        agents.get_primary_user.return_value = {
+            "chat_id": "12345", "default_agent": "barsik",
+        }
+
+        async def fake_outcome(session, transcript, goal, api_key=""):
+            return {"success": True, "summary": "done"}
+
+        monkeypatch.setattr(
+            voice_engine, "extract_outcome_with_opus", fake_outcome
+        )
+
+        sent = []
+
+        async def broker_send(agent, platform, chat_id, text):
+            sent.append((agent, platform, chat_id, text))
+
+        asyncio.run(
+            finalize_call(
+                session, voice_store, agents,
+                broker_send=broker_send, api_key="test",
+            )
+        )
+
+        voice_store.save_artifact.assert_called_once()
+        assert len(sent) == 1
+
+
+class TestAnthropicClientReuse:
+    """One AsyncAnthropic client per API key, not one per conversation turn."""
+
+    def test_same_key_returns_same_client(self):
+        voice_engine._anthropic_clients.clear()
+        try:
+            a = voice_engine._get_anthropic_client("key-1")
+            b = voice_engine._get_anthropic_client("key-1")
+            c = voice_engine._get_anthropic_client("key-2")
+            assert a is b
+            assert a is not c
+        finally:
+            voice_engine._anthropic_clients.clear()

--- a/tests/test_voice_engine.py
+++ b/tests/test_voice_engine.py
@@ -186,6 +186,9 @@ class TestAnthropicClientReuse:
     """One AsyncAnthropic client per API key, not one per conversation turn."""
 
     def test_same_key_returns_same_client(self):
+        # anthropic is an optional dependency imported lazily by the voice
+        # engine; CI installs only the [dev] extras.
+        pytest.importorskip("anthropic")
         voice_engine._anthropic_clients.clear()
         try:
             a = voice_engine._get_anthropic_client("key-1")

--- a/tests/test_voice_routes.py
+++ b/tests/test_voice_routes.py
@@ -1,0 +1,197 @@
+"""Tests for pinky_daemon.voice_routes.
+
+Covers the ConversationRelay WS lifecycle guards (duplicate connections,
+setup-validation rejections, ownership of the _active_ws registration) and
+the terminate endpoint's failure reporting.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import pinky_daemon.voice_engine as voice_engine
+import pinky_daemon.voice_routes as voice_routes
+
+
+class FakeWS:
+    """Minimal stand-in for a Starlette WebSocket."""
+
+    def __init__(self, incoming: list[str] | None = None):
+        self.incoming = list(incoming or [])
+        self.sent: list[str] = []
+        self.accepted = False
+        self.closed: tuple[int, str] | None = None
+
+    async def accept(self):
+        self.accepted = True
+
+    async def close(self, code: int = 1000, reason: str = ""):
+        self.closed = (code, reason)
+
+    async def receive_text(self) -> str:
+        if self.incoming:
+            return self.incoming.pop(0)
+        raise RuntimeError("client disconnected")
+
+    async def send_text(self, text: str):
+        self.sent.append(text)
+
+
+def _make_session(**overrides):
+    session = MagicMock()
+    session.id = overrides.get("id", "sess-1")
+    session.status = overrides.get("status", "connecting")
+    session.call_sid = overrides.get("call_sid", "CA_expected")
+    session.call_request_id = overrides.get("call_request_id", None)
+    session.to_number = overrides.get("to_number", "+15551234567")
+    session.agent_name = overrides.get("agent_name", "barsik")
+    session.max_duration_sec = overrides.get("max_duration_sec", 300)
+    session.answered_at = overrides.get("answered_at", 0.0)
+    session.started_at = overrides.get("started_at", 0.0)
+    session.ended_at = overrides.get("ended_at", 0.0)
+    return session
+
+
+@pytest.fixture
+def voice_deps():
+    """Save/restore voice_routes module-level state around each test."""
+    saved = (
+        voice_routes._voice_store,
+        voice_routes._agents,
+        voice_routes._broker_send,
+        voice_routes._base_url,
+    )
+    saved_ws = dict(voice_routes._active_ws)
+    voice_routes._active_ws.clear()
+    yield
+    (
+        voice_routes._voice_store,
+        voice_routes._agents,
+        voice_routes._broker_send,
+        voice_routes._base_url,
+    ) = saved
+    voice_routes._active_ws.clear()
+    voice_routes._active_ws.update(saved_ws)
+
+
+# -- ConversationRelay WS guards ----------------------------------------------
+
+
+async def test_ws_duplicate_connection_rejected(voice_deps):
+    """A second WS for a live session must not clobber the first registration
+    or stamp the session completed when it exits."""
+    store = MagicMock()
+    session = _make_session()
+    store.get_session.return_value = session
+    voice_routes.set_dependencies(voice_store=store, agents=None)
+
+    first_ws = object()
+    voice_routes._active_ws[session.id] = first_ws  # type: ignore[assignment]
+
+    second = FakeWS()
+    await voice_routes.conversationrelay_ws(second, session.id)
+
+    assert second.closed is not None
+    assert second.closed[0] == 4003
+    # The live handler's registration is untouched.
+    assert voice_routes._active_ws[session.id] is first_ws
+    # The live session was not marked completed by the rejected connection.
+    store.update_session.assert_not_called()
+
+
+async def test_ws_callsid_mismatch_does_not_complete_session(voice_deps):
+    """A setup-validation rejection must not stamp the session completed."""
+    store = MagicMock()
+    session = _make_session(call_sid="CA_expected")
+    store.get_session.return_value = session
+    voice_routes.set_dependencies(voice_store=store, agents=None)
+
+    ws = FakeWS([
+        json.dumps({
+            "type": "setup",
+            "sessionId": "CR1",
+            "callSid": "CA_other",
+            "accountSid": "",
+        })
+    ])
+    await voice_routes.conversationrelay_ws(ws, session.id)
+
+    assert ws.closed == (4003, "callSid mismatch")
+    assert session.id not in voice_routes._active_ws
+    store.update_session.assert_not_called()
+
+
+async def test_ws_normal_disconnect_marks_completed(voice_deps):
+    """The owning handler still marks the session completed on a real end."""
+    store = MagicMock()
+    session = _make_session()
+    store.get_session.return_value = session
+    voice_routes.set_dependencies(voice_store=store, agents=None)
+
+    ws = FakeWS()  # immediate disconnect
+    await voice_routes.conversationrelay_ws(ws, session.id)
+
+    assert session.id not in voice_routes._active_ws
+    completed_calls = [
+        c for c in store.update_session.call_args_list
+        if c.kwargs.get("status") == "completed"
+    ]
+    assert len(completed_calls) == 1
+    assert completed_calls[0].kwargs.get("ended_at")
+
+
+# -- terminate endpoint --------------------------------------------------------
+
+
+def _make_client():
+    app = FastAPI()
+    app.include_router(voice_routes.router)
+    return TestClient(app)
+
+
+def test_terminate_reports_failure_when_both_paths_fail(voice_deps, monkeypatch):
+    """No WS registered + Twilio REST failure must surface as an error, not
+    a bogus {terminated: true} with the session stamped completed."""
+    store = MagicMock()
+    session = _make_session()
+    store.get_session_by_call_sid.return_value = session
+    voice_routes.set_dependencies(voice_store=store, agents=MagicMock())
+
+    def boom(agents):
+        raise RuntimeError("no twilio creds")
+
+    monkeypatch.setattr(voice_engine, "get_twilio_client", boom)
+
+    client = _make_client()
+    resp = client.post(
+        f"/api/voice/session/{session.call_sid}/terminate",
+        json={"reason": "test"},
+    )
+
+    assert resp.status_code == 502
+    store.update_session.assert_not_called()
+
+
+def test_terminate_succeeds_via_rest(voice_deps, monkeypatch):
+    store = MagicMock()
+    session = _make_session()
+    store.get_session_by_call_sid.return_value = session
+    voice_routes.set_dependencies(voice_store=store, agents=MagicMock())
+
+    monkeypatch.setattr(voice_engine, "get_twilio_client", lambda agents: MagicMock())
+
+    client = _make_client()
+    resp = client.post(
+        f"/api/voice/session/{session.call_sid}/terminate",
+        json={"reason": "test"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["terminated"] is True
+    store.update_session.assert_called_once()
+    assert store.update_session.call_args.kwargs.get("status") == "completed"


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **medium** welcomeGreeting XML attribute not quote-escaped - TwiML breakage / attribute injection (`src/pinky_daemon/voice_engine.py:262`)
  - build_outbound_twiml now embeds the greeting with saxutils.quoteattr(), so double quotes are escaped and attribute injection via the call goal is impossible.
- **medium** WS finally block unconditionally pops _active_ws and marks session completed (`src/pinky_daemon/voice_routes.py:861`)
  - conversationrelay_ws rejects a second WS for an already-connected session (close 4003), only pops _active_ws when the entry is its own ws, and a mark_completed flag skips the status=completed stamp (and finalize) on the callSid/accountSid setup-rejection paths.
- **medium** terminate_session reports {terminated: true} even when both hangup attempts failed (`src/pinky_daemon/voice_routes.py:930`)
  - Tracks ws_ended/rest_ended; if neither the WS end message nor the Twilio REST hangup succeeded it raises HTTPException 502 with the error and does not stamp the session completed.
- **low** finalize_call launched as fire-and-forget task; duplicate-artifact IntegrityError lost (`src/pinky_daemon/voice_routes.py:882`)
  - Finalize task is held in a module-level _finalize_tasks set with add_done_callback(discard) to prevent GC, and finalize_call (voice_engine.py) wraps save_artifact in try/except so a duplicate-call_sid IntegrityError is logged and the owner notification still goes out.
- **low** Dead code: HMAC approval-token helpers never called (`src/pinky_daemon/voice_store.py:63`)
  - Deleted make_approval_token/verify_approval_token and the now-unused hmac/hashlib/base64 imports; kept _APPROVAL_TOKEN_TTL which is still used for call_request.expires_at.
- **low** New unclosed AsyncAnthropic client created per conversation turn (`src/pinky_daemon/voice_engine.py:138`)
  - Added module-level _get_anthropic_client() cache keyed by api_key; haiku_respond and extract_outcome_with_opus now reuse one client (and its connection pool) per key instead of building one per turn.

## Testing
**voice**: python3 -m pytest tests/test_voice_engine.py tests/test_voice_routes.py -q -> 13 passed (includes new regression tests: TwiML quote-escaping + injection, duplicate-WS rejection, callSid-mismatch not marking completed, normal disconnect still marking completed, terminate 502 on dual failure, terminate success path, finalize survives save_artifact IntegrityError and still notifies, Anthropic client cache identity). python3 -m pytest tests/test_route_auth_coverage.py -q -> 7 passed. python3 -m pytest tests/test_api.py -q -> 351 passed. ruff check on all 5 changed files -> All checks passed. Import sanity: pinky_daemon.api/voice_* import ok.

Generated with [Claude Code](https://claude.com/claude-code)