### PR TITLE
fix(sweep): federation - TOFU pin bypass, false delivery acks, CLI password exposure

### DIFF
--- a/src/pinky_daemon/ferry/host_pinky.py
+++ b/src/pinky_daemon/ferry/host_pinky.py
@@ -316,6 +316,17 @@ class HostPinky:
                     out.append(AgentCardSelector(**item))
             except (TypeError, ValueError, json.JSONDecodeError) as e:
                 _log(f"skipping invalid ACL entry for {agent_name}: {item} ({e})")
+        for sel in out:
+            if sel.pinky_type is not None:
+                # v0.1 has no verified pinky_type on inbound cards (signed
+                # agent cards land in v0.2/v0.3), so a pinky_type-bearing
+                # selector can never match. Warn so the resulting
+                # default-deny is not silent.
+                _log(
+                    f"peer_fleet_acl for {agent_name}: selector with "
+                    f"pinky_type={sel.pinky_type!r} cannot match in v0.1 "
+                    "(no verified peer pinky_type yet)"
+                )
         return out
 
     # -- Dispatch: message → broker.handle_inbound ----------------------------
@@ -381,7 +392,9 @@ class HostPinky:
                 f"broker.dispatch_pre_authorized failed for ferry envelope "
                 f"{envelope.id}: {e}"
             )
-            return DeliveryResult(status="rejected", reason="broker_error", detail={"error": str(e)})
+            # Operational failure, not a policy denial -- the broker should
+            # replay rather than terminally drop an ACL-allowed message.
+            return self._transient("broker_error", str(e))
 
         self._stats["delivered"] += 1
         self._stats["messages_routed"] += 1
@@ -401,6 +414,7 @@ class HostPinky:
 
         receiving_address = f"ferry://pinkybot/{agent_name}"
         results: list[IngestResult] = []
+        operational_failures = 0
         for entry in entries:
             populated = populate_port_history(entry, envelope, receiving_address)
             try:
@@ -414,8 +428,27 @@ class HostPinky:
                         note=f"error: {e}",
                     )
                 )
+                operational_failures += 1
                 continue
+            if result.target_store == "skipped" and result.note.endswith("not configured"):
+                operational_failures += 1
             results.append(result)
+
+        if operational_failures == len(results):
+            # Every entry failed for host-side operational reasons (ingest
+            # exception, store not configured) -- the broker must replay
+            # rather than ack an envelope nothing was stored from. Policy
+            # skips (e.g. decayed lifecycle) do not count as failures.
+            self._stats["transient_failures"] += 1
+            _log(
+                f"transient_failure reason=ingest_failed: all {len(results)} "
+                f"substrate entries failed for envelope {envelope.id}"
+            )
+            return DeliveryResult(
+                status="transient_failure",
+                reason="ingest_failed",
+                detail={"ingested": [asdict(r) for r in results]},
+            )
 
         self._stats["delivered"] += 1
         self._stats["substrate_imports"] += sum(1 for r in results if r.target_store != "skipped")

--- a/src/pinky_daemon/ferry/outbound.py
+++ b/src/pinky_daemon/ferry/outbound.py
@@ -309,13 +309,16 @@ class MeshSender:
         subject = derive_subject(fleet, agent_slug)
         wire = envelope_to_wire(envelope)
 
+        # The password goes through the child's environment (the nats CLI
+        # reads NATS_PASSWORD), never through argv -- command lines are
+        # world-readable via ps / /proc/<pid>/cmdline.
         cmd = [
             self._bin_path,
             "--user", self._user,
-            "--password", self._password,
             "-s", self._nats_url,
             "pub", subject, wire,
         ]
+        child_env = {**os.environ, "NATS_PASSWORD": self._password}
         try:
             proc = subprocess.run(
                 cmd,
@@ -323,6 +326,7 @@ class MeshSender:
                 text=True,
                 timeout=self._timeout_s,
                 check=False,
+                env=child_env,
             )
         except subprocess.TimeoutExpired:
             return SendResult(
@@ -343,7 +347,7 @@ class MeshSender:
 
         if proc.returncode != 0:
             # stderr may contain auth/ACL detail — include but do NOT
-            # include the original command (which has the password).
+            # include the child environment (which has the password).
             err_tail = (proc.stderr or proc.stdout or "").strip().splitlines()
             err_msg = err_tail[-1] if err_tail else f"nats CLI exit {proc.returncode}"
             return SendResult(

--- a/src/pinky_federation/state.py
+++ b/src/pinky_federation/state.py
@@ -622,6 +622,7 @@ class FederationStateStore:
                 enc_pk=excluded.enc_pk,
                 fingerprint=excluded.fingerprint,
                 status=excluded.status,
+                first_seen=excluded.first_seen,
                 last_seen=excluded.last_seen,
                 pending_sig_pk=excluded.pending_sig_pk,
                 pending_enc_pk=excluded.pending_enc_pk,

--- a/src/pinky_federation/tofu.py
+++ b/src/pinky_federation/tofu.py
@@ -51,6 +51,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
+from pinky_federation.fingerprint import canonical_address
 from pinky_federation.fingerprint import fingerprint as compute_fingerprint
 from pinky_federation.keys import EncryptionPublicKey, SigningPublicKey
 from pinky_federation.state import (
@@ -178,6 +179,9 @@ class TrustPolicy:
           pinned) fingerprint → the proposal was a blip / replay; return to
           pinned, clear pending, return TRUSTED.
         """
+        # Pins are keyed by the same canonical form the fingerprint hashes,
+        # so case/whitespace variants of one peer hit one pin row.
+        address = canonical_address(address)
         sig_bytes = sig_pk.to_bytes()
         enc_bytes = enc_pk.to_bytes()
         fp = compute_fingerprint(address, sig_pk, enc_pk)
@@ -254,6 +258,7 @@ class TrustPolicy:
         :meth:`verify` for that) and ``first_seen`` is reset to "now" since
         this is effectively a new trust anchor.
         """
+        address = canonical_address(address)
         existing = self._store.get_peer_pin(address)
         if existing is None:
             raise UnknownPeerError(f"no pin for peer: {address!r}")
@@ -297,6 +302,7 @@ class TrustPolicy:
         primary slot is left intact but is no longer considered trusted
         (rejected peers return REJECTED from :meth:`observe`).
         """
+        address = canonical_address(address)
         existing = self._store.get_peer_pin(address)
         if existing is None:
             raise UnknownPeerError(f"no pin for peer: {address!r}")
@@ -317,6 +323,7 @@ class TrustPolicy:
         ``changed`` / ``rejected`` peers must be resolved via
         :meth:`accept_rotation` or :meth:`reject_rotation` first.
         """
+        address = canonical_address(address)
         existing = self._store.get_peer_pin(address)
         if existing is None:
             raise UnknownPeerError(f"no pin for peer: {address!r}")
@@ -332,7 +339,7 @@ class TrustPolicy:
 
     def get(self, address: str) -> Optional[PeerPinRecord]:
         """Return the current pin record for *address*, or None."""
-        return self._store.get_peer_pin(address)
+        return self._store.get_peer_pin(canonical_address(address))
 
     def list_changed(self) -> list[PeerPinRecord]:
         """Return all peers in the ``changed`` state awaiting operator action.

--- a/src/pinky_identity/bearer_tokens.py
+++ b/src/pinky_identity/bearer_tokens.py
@@ -163,9 +163,15 @@ def _decode_token(token: str) -> bytes:
         raise BearerTokenNotFoundError("token must not contain padding")
     padding = "=" * (-len(token) % 4)
     try:
-        return base64.urlsafe_b64decode(token + padding)
+        secret_bytes = base64.urlsafe_b64decode(token + padding)
     except (ValueError, binascii.Error) as e:
         raise BearerTokenNotFoundError("malformed token encoding") from e
+    # Round-trip to enforce one canonical wire form: urlsafe_b64decode
+    # silently drops non-alphabet bytes and accepts the standard ``+/``
+    # alphabet, so distinct strings could otherwise decode to one secret.
+    if _encode_token(secret_bytes) != token:
+        raise BearerTokenNotFoundError("non-canonical token encoding")
+    return secret_bytes
 
 
 def _hash_secret(secret_bytes: bytes) -> str:

--- a/src/pinky_identity/signer_store.py
+++ b/src/pinky_identity/signer_store.py
@@ -208,6 +208,12 @@ class EncryptedSignerStore:
                     now,
                 ),
             )
+            # On a re-put the conflict clause keeps the original created_at;
+            # echo the persisted value so the returned row matches get_row().
+            row = self._db.execute(
+                "SELECT created_at FROM signing_keystore WHERE kid = ?",
+                (wrapped.kid,),
+            ).fetchone()
         return SignerStoreRow(
             kid=wrapped.kid,
             fingerprint=wrapped.fingerprint,
@@ -215,7 +221,7 @@ class EncryptedSignerStore:
             wrap_version=wrapped.version,
             nonce=wrapped.nonce,
             ciphertext=wrapped.ciphertext,
-            created_at=now,
+            created_at=float(row["created_at"]),
         )
 
     def put_keypair(self, keypair: SigningKeypair) -> SignerStoreRow:

--- a/tests/pinky_federation/test_state.py
+++ b/tests/pinky_federation/test_state.py
@@ -282,6 +282,21 @@ def test_peer_pin_upsert_preserves_first_seen_on_update(
     assert got.sig_pk == b"\x33" * 32
 
 
+def test_peer_pin_upsert_persists_new_first_seen_on_update(
+    store: FederationStateStore,
+) -> None:
+    """A caller that resets first_seen (e.g. accept_rotation's new trust
+    anchor) must see the reset land in the DB, not just on the returned
+    record."""
+    first = store.upsert_peer_pin(_pin())
+    new_anchor = first.first_seen + 100.0
+    rec = _pin()
+    rec.first_seen = new_anchor
+    store.upsert_peer_pin(rec)
+    got = store.get_peer_pin("alice@example.com")
+    assert got.first_seen == pytest.approx(new_anchor)
+
+
 def test_peer_pin_validates_lengths(store: FederationStateStore) -> None:
     with pytest.raises(ValueError):
         store.upsert_peer_pin(

--- a/tests/pinky_federation/test_tofu.py
+++ b/tests/pinky_federation/test_tofu.py
@@ -433,3 +433,55 @@ def test_get_returns_record_for_known(policy: TrustPolicy) -> None:
     record = policy.get(ADDR)
     assert record is not None
     assert record.peer_address == ADDR
+
+
+# -- address canonicalization ---------------------------------------------
+
+
+def test_observe_case_variant_hits_existing_pin(policy: TrustPolicy) -> None:
+    """A case/whitespace variant of a pinned address must not auto-pin
+    attacker keys as a brand-new peer."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    result = policy.observe("  Alice@Example.COM ", sig2.public_key, enc2.public_key)
+    assert result.decision == TrustDecision.MISMATCH
+    assert result.trusted is False
+
+
+def test_observe_case_variant_same_keys_is_trusted(policy: TrustPolicy) -> None:
+    sig, enc = _new_keys()
+    policy.observe(ADDR, sig.public_key, enc.public_key)
+    result = policy.observe("Alice@EXAMPLE.com", sig.public_key, enc.public_key)
+    assert result.decision == TrustDecision.TRUSTED
+    assert result.record.peer_address == ADDR
+
+
+def test_pin_stored_under_canonical_address(
+    policy: TrustPolicy, store: FederationStateStore
+) -> None:
+    sig, enc = _new_keys()
+    policy.observe(" Alice@Example.com ", sig.public_key, enc.public_key)
+    assert store.get_peer_pin(ADDR) is not None
+    assert policy.get("ALICE@example.com") is not None
+    assert len(store.list_peer_pins()) == 1
+
+
+def test_accept_rotation_first_seen_reset_persists(
+    policy: TrustPolicy, store: FederationStateStore
+) -> None:
+    """The new-trust-anchor first_seen reset must land in the DB, not just
+    on the returned record."""
+    sig1, enc1 = _new_keys()
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)
+    policy.observe(ADDR, sig1.public_key, enc1.public_key)  # pinned
+
+    sig2, enc2 = _new_keys()
+    policy.observe(ADDR, sig2.public_key, enc2.public_key)  # mismatch
+    record = policy.accept_rotation(ADDR)
+
+    got = store.get_peer_pin(ADDR)
+    assert got is not None
+    assert got.first_seen == pytest.approx(record.first_seen)

--- a/tests/test_ferry_host_pinky.py
+++ b/tests/test_ferry_host_pinky.py
@@ -1061,3 +1061,130 @@ class TestBrokerIntegrationFerryInbound:
         assert real_registry.get_user_status(
             "barsik", "ferry:pulse@studio@sigil",
         ) is None
+
+
+# -- Sweep regressions: operational failures must be transient, not terminal ----
+
+
+class FailingMemoryStore:
+    """Memory store whose insert always fails operationally."""
+
+    def insert(self, reflection):  # noqa: ANN001
+        raise RuntimeError("database is locked")
+
+
+class ExplodingBroker:
+    """Broker whose dispatch raises (session restart race, DB lock, ...)."""
+
+    async def dispatch_pre_authorized(self, agent_name, broker_msg) -> None:  # noqa: ANN001
+        raise RuntimeError("session restart race")
+
+
+@pytest.mark.asyncio
+class TestSubstrateIngestFailureIsTransient:
+    async def test_all_entries_failing_ingest_yields_transient_failure(
+        self, allow_misha_acl
+    ):
+        registry = FakeRegistry(allow_misha_acl)
+        host = HostPinky(
+            registry=registry,
+            broker=FakeBroker(),
+            memory_store=FailingMemoryStore(),
+            reflection_factory=lambda kw: FakeReflection(**kw),
+        )
+        envelope = _build_envelope_substrate_batch(
+            [_entry_1_feedback(), _entry_2_pattern()]
+        )
+
+        result = await host.deliver(envelope)
+
+        assert result.status == "transient_failure"
+        assert result.reason == "ingest_failed"
+        # Per-entry outcomes still surfaced for diagnostics.
+        assert len(result.detail["ingested"]) == 2
+        assert all(r["target_store"] == "skipped" for r in result.detail["ingested"])
+        assert host.stats["transient_failures"] == 1
+        assert host.stats["delivered"] == 0
+
+    async def test_stores_not_configured_yields_transient_failure(
+        self, allow_misha_acl
+    ):
+        registry = FakeRegistry(allow_misha_acl)
+        host = HostPinky(registry=registry, broker=FakeBroker())  # no stores
+
+        result = await host.deliver(
+            _build_envelope_substrate_batch([_entry_1_feedback()])
+        )
+
+        assert result.status == "transient_failure"
+        assert result.reason == "ingest_failed"
+        assert host.stats["delivered"] == 0
+
+    async def test_policy_skip_still_delivers(self, allow_misha_acl):
+        # A decayed entry is skipped by policy, not by an operational
+        # failure -- the envelope is satisfied and must be acked.
+        registry = FakeRegistry(allow_misha_acl)
+        host = HostPinky(registry=registry, broker=FakeBroker())
+        decayed = _entry_1_feedback()
+        decayed.lifecycle = SubstrateLifecycle(state="decayed")
+
+        result = await host.deliver(_build_envelope_substrate_batch([decayed]))
+
+        assert result.status == "delivered"
+        assert host.stats["delivered"] == 1
+        assert host.stats["transient_failures"] == 0
+
+    async def test_partial_ingest_success_still_delivers(self, allow_misha_acl):
+        # One entry lands, one fails -- at-least-once is satisfied for the
+        # envelope, so it is acked with per-entry detail.
+        class FlakyMemoryStore:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def insert(self, reflection):  # noqa: ANN001
+                self.calls += 1
+                if self.calls > 1:
+                    raise RuntimeError("database is locked")
+                if not getattr(reflection, "id", ""):
+                    reflection.id = "refl-1"
+                return reflection
+
+        registry = FakeRegistry(allow_misha_acl)
+        host = HostPinky(
+            registry=registry,
+            broker=FakeBroker(),
+            memory_store=FlakyMemoryStore(),
+            reflection_factory=lambda kw: FakeReflection(**kw),
+        )
+        envelope = _build_envelope_substrate_batch(
+            [_entry_1_feedback(), _entry_2_pattern()]
+        )
+
+        result = await host.deliver(envelope)
+
+        assert result.status == "delivered"
+        stores = [r["target_store"] for r in result.detail["ingested"]]
+        assert stores == ["pinky-memory", "skipped"]
+
+
+@pytest.mark.asyncio
+class TestBrokerDispatchFailureIsTransient:
+    async def test_broker_error_yields_transient_failure(self, allow_misha_acl):
+        registry = FakeRegistry(allow_misha_acl)
+        host = HostPinky(registry=registry, broker=ExplodingBroker())
+        envelope = FerryEnvelope(
+            v="0.1",
+            id="msg-broker-boom",
+            from_="misha@pinky.local",
+            to="ferry://pinkybot/barsik",
+            ts=1,
+            body={"kind": "message", "text": "hi"},
+        )
+
+        result = await host.deliver(envelope)
+
+        assert result.status == "transient_failure"
+        assert result.reason == "broker_error"
+        assert host.stats["transient_failures"] == 1
+        assert host.stats["rejected"] == 0
+        assert host.stats["delivered"] == 0

--- a/tests/test_ferry_outbound.py
+++ b/tests/test_ferry_outbound.py
@@ -305,10 +305,12 @@ class TestMeshSenderSend:
         assert cmd[0].endswith("nats")
         assert "--user" in cmd
         assert "pinkybot_fleet" in cmd
-        assert "--password" in cmd
-        assert "secret" in cmd
         assert "pub" in cmd
         assert "ferry.pulse.pulse.inbox" in cmd
+        # The password goes via the child env, never argv (visible in ps).
+        assert "--password" not in cmd
+        assert "secret" not in cmd
+        assert call.kwargs["env"]["NATS_PASSWORD"] == "secret"
         # Wire payload is the last arg; verify it's the envelope JSON.
         payload = json.loads(cmd[-1])
         assert payload["from"] == "ferry://pinkybot/barsik"

--- a/tests/test_pinky_identity_bearer_tokens.py
+++ b/tests/test_pinky_identity_bearer_tokens.py
@@ -542,6 +542,34 @@ def test_validate_rejects_token_with_internal_equals(store):
         store.validate("AAAA=AAAA")
 
 
+def test_validate_rejects_token_polluted_with_junk_chars(store):
+    """``urlsafe_b64decode`` silently drops non-alphabet bytes, so a real
+    token with junk appended decodes to the same secret. Only the one
+    canonical wire string may authenticate."""
+    result = _mint_default(store)
+    with pytest.raises(BearerTokenNotFoundError):
+        store.validate(result.token + "!!!!")
+    # The canonical form still validates fine.
+    store.validate(result.token)
+
+
+def test_decode_token_rejects_standard_alphabet_variant():
+    """A token rewritten with the standard ``+/`` alphabet decodes to the
+    same secret but is not the canonical no-padding base64url form."""
+    from pinky_identity.bearer_tokens import _decode_token, _encode_token
+
+    secret = b"\xfb\xff" + bytes(30)
+    token = _encode_token(secret)
+    assert "-" in token and "_" in token
+    variant = token.replace("-", "+").replace("_", "/")
+    assert variant != token
+    # Sanity: the variant really does decode to the same secret bytes.
+    assert base64.urlsafe_b64decode(variant + "=") == secret
+    assert _decode_token(token) == secret
+    with pytest.raises(BearerTokenNotFoundError):
+        _decode_token(variant)
+
+
 def test_claims_is_revoked_property():
     now = time.time()
     alive = BearerTokenClaims(

--- a/tests/test_pinky_identity_signer_store.py
+++ b/tests/test_pinky_identity_signer_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import secrets
+import time
 from pathlib import Path
 
 import pytest
@@ -115,6 +116,16 @@ def test_put_is_idempotent_on_kid(store, keypair):
     assert store.list_kids() == [row1.kid]
     # Still recoverable.
     assert store.get_signing_keypair(row1.kid).public == keypair.public
+
+
+def test_reput_returns_persisted_created_at(store, keypair):
+    """On a re-put the conflict clause keeps the original created_at; the
+    returned row must echo what the DB holds, not a fresh timestamp."""
+    row1 = store.put_keypair(keypair)
+    time.sleep(0.02)
+    row2 = store.put_keypair(keypair)
+    assert row2.created_at == pytest.approx(row1.created_at)
+    assert store.get_row(row2.kid).created_at == pytest.approx(row2.created_at)
 
 
 # -- has / list / iter -------------------------------------------------------


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **high** TOFU pin store keyed on raw address while fingerprint canonicalizes - pin bypass via case/whitespace variants (`src/pinky_federation/tofu.py:186`)
  - All TrustPolicy methods (observe/accept_rotation/reject_rotation/verify/get) now canonicalize the address via canonical_address() before lookup/store, so pins are keyed exactly as fingerprints are hashed; case/whitespace variants now hit the existing pin and produce MISMATCH instead of auto-pinning attacker keys.
- **medium** _deliver_substrate reports 'delivered' even when every entry failed to ingest (`src/pinky_daemon/ferry/host_pinky.py:420`)
  - Tracks operational failures (ingest exception, store not configured) separately from policy skips; when all entries fail operationally it returns status='transient_failure' reason='ingest_failed' with per-entry results in detail so the broker replays; partial success and pure policy skips still ack as 'delivered'.
- **medium** NATS fleet password passed on the nats CLI command line (`src/pinky_daemon/ferry/outbound.py:314`)
  - Removed --password from argv; the secret is now passed to the nats CLI via the child environment (NATS_PASSWORD, natscli's documented envar for --password), so it never appears in ps//proc/cmdline.
- **medium** upsert_peer_pin ON CONFLICT omits first_seen - accept_rotation's trust-anchor reset never persists (`src/pinky_federation/state.py:620`)
  - Added first_seen=excluded.first_seen to the ON CONFLICT DO UPDATE SET clause; existing preserve-on-update test still passes because callers carry the intended first_seen on the record.
- **low** Broker dispatch failure returns terminal 'rejected' instead of 'transient_failure' (`src/pinky_daemon/ferry/host_pinky.py:384`)
  - _deliver_message now returns self._transient('broker_error', str(e)) on dispatch exceptions, so the ferry broker retries and the transient_failures stat increments.
- **low** Capability-based ACL selectors (pinky_type) can never match (`src/pinky_daemon/ferry/host_pinky.py:281`)
  - Partial mitigation per fix_hint: _load_peer_fleet_acl now log-warns for every pinky_type-bearing selector ('cannot match in v0.1, no verified peer pinky_type yet') so the default-deny is no longer silent; the 400-at-API-layer option was out of scope (api.py owned by another branch).
- **low** Bearer token decoder accepts non-canonical encodings (`src/pinky_identity/bearer_tokens.py:166`)
  - _decode_token now round-trips via _encode_token after decoding and raises BearerTokenNotFoundError when the re-encoding differs, rejecting junk-polluted, standard-alphabet, and nonzero-trailing-bit variants; only the one canonical wire string authenticates.
- **low** put_wrapped returns created_at=now on overwrite while the DB row keeps the old created_at (`src/pinky_identity/signer_store.py:194`)
  - put_wrapped now re-reads created_at from the row inside the same transaction and returns the persisted value, keeping created_at semantics as 'row creation time' and making the returned row match get_row()/iter_rows().

## Deferred (not fixed here, with reasons)
- MeshSender.send blocks the daemon event loop for up to 10s per publish: Confirmed real, but the correct fix is in the caller: api.py:6581 must wrap the call in asyncio.to_thread (or use an async subprocess). api.py is not in this group's findings file and is owned by parallel branches, so editing it would violate the hard scope rule. Making send() itself async would break the existing sync caller in api.py without editing it. Integrator: change api.py mesh_send to 'result = await asyncio.to_thread(sender.send, envelope)'.

## Testing
**federation**: python3 -m pytest tests/pinky_federation/test_tofu.py tests/pinky_federation/test_state.py tests/test_ferry_host_pinky.py tests/test_ferry_outbound.py tests/test_pinky_identity_bearer_tokens.py tests/test_pinky_identity_signer_store.py -q -> 259 passed (includes 13 new regression tests: 4 tofu canonicalization, 1 state first_seen persistence, 5 host_pinky transient-vs-terminal, 2 bearer canonical-encoding, 1 signer_store created_at; plus 1 updated outbound happy-path test asserting password absent from argv and present in child env). python3 -m pytest tests/pinky_federation/ tests/test_pinky_identity_signer.py tests/test_mesh_store.py tests/test_api.py tests/test_auth.py tests/test_db_security.py tests/test_shared_mcp.py -q -> 748 passed. ruff check on all 12 changed files -> All checks passed.

Generated with [Claude Code](https://claude.com/claude-code)