### PR TITLE
fix(sweep): cli - serve crash, connect clobbering settings, packaging fixes

### DIFF
--- a/src/pinky_cli/__main__.py
+++ b/src/pinky_cli/__main__.py
@@ -33,9 +33,15 @@ def main() -> None:
     # run (daemon)
     run_parser = subparsers.add_parser("run", help="Run the Pinky daemon (headless Claude Code)")
     run_parser.add_argument(
+        "--mode",
+        default="api",
+        choices=["api", "poll"],
+        help="Run mode: api (HTTP server) or poll (message polling daemon)",
+    )
+    run_parser.add_argument(
         "--config",
         default="pinky.yaml",
-        help="Path to pinky.yaml config",
+        help="Path to pinky.yaml config (poll mode)",
     )
     run_parser.add_argument(
         "--working-dir",
@@ -57,7 +63,12 @@ def main() -> None:
     elif args.command == "run":
         from pinky_daemon.__main__ import main as daemon_main
         # Override sys.argv for the daemon's own arg parser
-        sys.argv = ["pinky-daemon", "--config", args.config, "--working-dir", args.working_dir]
+        sys.argv = [
+            "pinky-daemon",
+            "--mode", args.mode,
+            "--config", args.config,
+            "--working-dir", args.working_dir,
+        ]
         daemon_main()
     else:
         parser.print_help()

--- a/src/pinky_cli/connect.py
+++ b/src/pinky_cli/connect.py
@@ -4,29 +4,26 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 
 def run_connect() -> None:
-    """Write MCP server config to Claude Code settings."""
-    home = Path.home()
-    settings_dir = home / ".claude"
-    settings_file = settings_dir / "settings.json"
-
-    # Build MCP server configs
+    """Write MCP server config to the project's .mcp.json (read by Claude Code)."""
     project_dir = Path.cwd().resolve()
+    mcp_file = project_dir / ".mcp.json"
     memory_db = project_dir / "data" / "memory.db"
 
     mcp_config = {
         "pinky-memory": {
-            "command": "python",
+            "command": sys.executable,
             "args": ["-m", "pinky_memory", "--db", str(memory_db)],
             "env": {
                 "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", ""),
             },
         },
         "pinky-outreach": {
-            "command": "python",
+            "command": sys.executable,
             "args": ["-m", "pinky_outreach"],
             "env": {
                 "TELEGRAM_BOT_TOKEN": os.environ.get("TELEGRAM_BOT_TOKEN", ""),
@@ -34,24 +31,40 @@ def run_connect() -> None:
         },
     }
 
-    # Read existing settings
-    settings = {}
-    if settings_file.exists():
-        settings = json.loads(settings_file.read_text())
+    # Read existing config
+    config: dict = {}
+    if mcp_file.exists():
+        try:
+            config = json.loads(mcp_file.read_text())
+        except json.JSONDecodeError as exc:
+            print(f"[pinky] Error: {mcp_file} is not valid JSON: {exc}")
+            print("[pinky] Fix or remove the file, then re-run 'pinky connect'.")
+            sys.exit(1)
 
-    # Merge MCP servers
-    if "mcpServers" not in settings:
-        settings["mcpServers"] = {}
+    # Merge MCP servers, preserving existing credentials when the env var is unset
+    servers = config.setdefault("mcpServers", {})
+    for name, entry in mcp_config.items():
+        existing = servers.get(name)
+        existing_env = existing.get("env", {}) if isinstance(existing, dict) else {}
+        env = {}
+        for key, value in entry["env"].items():
+            if value:
+                env[key] = value
+            elif existing_env.get(key):
+                env[key] = existing_env[key]
+            else:
+                print(f"[pinky] Warning: {key} is not set; {name} may not start without it.")
+        entry["env"] = env
+        servers[name] = entry
 
-    settings["mcpServers"].update(mcp_config)
+    # Write back atomically
+    tmp_file = mcp_file.with_name(mcp_file.name + ".tmp")
+    tmp_file.write_text(json.dumps(config, indent=2) + "\n")
+    os.replace(tmp_file, mcp_file)
 
-    # Write back
-    settings_dir.mkdir(parents=True, exist_ok=True)
-    settings_file.write_text(json.dumps(settings, indent=2) + "\n")
-
-    print(f"[pinky] Updated {settings_file}")
+    print(f"[pinky] Updated {mcp_file}")
     print("[pinky] MCP servers configured:")
     for name in mcp_config:
         print(f"  - {name}")
     print()
-    print("Run 'claude' to start using Pinky with Claude Code.")
+    print(f"Run 'claude' from {project_dir} to start using Pinky with Claude Code.")

--- a/src/pinky_cli/connect.py
+++ b/src/pinky_cli/connect.py
@@ -47,13 +47,13 @@ def run_connect() -> None:
         existing = servers.get(name)
         existing_env = existing.get("env", {}) if isinstance(existing, dict) else {}
         env = {}
-        for key, value in entry["env"].items():
+        for env_name, value in entry["env"].items():
             if value:
-                env[key] = value
-            elif existing_env.get(key):
-                env[key] = existing_env[key]
+                env[env_name] = value
+            elif existing_env.get(env_name):
+                env[env_name] = existing_env[env_name]
             else:
-                print(f"[pinky] Warning: {key} is not set; {name} may not start without it.")
+                print(f"[pinky] Warning: {env_name} is not set; {name} may not start without it.")
         entry["env"] = env
         servers[name] = entry
 

--- a/src/pinky_cli/serve.py
+++ b/src/pinky_cli/serve.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 
 
 def run_serve(server: str = "all") -> None:
@@ -16,13 +18,30 @@ def run_serve(server: str = "all") -> None:
     print("[pinky] Starting MCP servers...")
     print(f"[pinky] Config: {config_path}")
 
-    if server in ("memory", "all"):
+    if server == "memory":
         from pinky_memory.__main__ import main as memory_main
         print("[pinky] Starting memory server on stdio...")
+        # Override sys.argv so the server's own arg parser doesn't see ours
+        sys.argv = ["pinky-memory"]
         memory_main()
     elif server == "outreach":
         from pinky_outreach.__main__ import main as outreach_main
         print("[pinky] Starting outreach server on stdio...")
+        sys.argv = ["pinky-outreach"]
         outreach_main()
+    elif server == "all":
+        print("[pinky] Starting memory and outreach servers...")
+        procs = [
+            subprocess.Popen([sys.executable, "-m", "pinky_memory"]),
+            subprocess.Popen([sys.executable, "-m", "pinky_outreach"]),
+        ]
+        try:
+            for proc in procs:
+                proc.wait()
+        except KeyboardInterrupt:
+            for proc in procs:
+                proc.terminate()
+            for proc in procs:
+                proc.wait()
     else:
         print(f"[pinky] Unknown server: {server}. Options: memory, outreach, all")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,220 @@
+"""Tests for the pinky CLI (serve, connect, run delegation)."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from pinky_cli.connect import run_connect
+from pinky_cli.serve import run_serve
+
+# ---------------------------------------------------------------------------
+# pinky serve
+# ---------------------------------------------------------------------------
+
+
+def test_serve_memory_resets_argv(monkeypatch):
+    """The delegated server main must not see pinky's own CLI args."""
+    seen = {}
+
+    def fake_main():
+        seen["argv"] = list(sys.argv)
+
+    monkeypatch.setattr(sys, "argv", ["pinky", "serve", "--server", "memory"])
+    monkeypatch.setattr("pinky_memory.__main__.main", fake_main)
+
+    run_serve(server="memory")
+
+    assert seen["argv"] == ["pinky-memory"]
+
+
+def test_serve_outreach_resets_argv(monkeypatch):
+    seen = {}
+
+    def fake_main():
+        seen["argv"] = list(sys.argv)
+
+    monkeypatch.setattr(sys, "argv", ["pinky", "serve", "--server", "outreach"])
+    monkeypatch.setattr("pinky_outreach.__main__.main", fake_main)
+
+    run_serve(server="outreach")
+
+    assert seen["argv"] == ["pinky-outreach"]
+
+
+def test_serve_all_starts_both_servers(monkeypatch):
+    """server=all spawns memory and outreach as subprocesses and waits on both."""
+    spawned = []
+
+    class FakeProc:
+        def __init__(self, cmd):
+            self.cmd = cmd
+            self.waited = False
+
+        def wait(self):
+            self.waited = True
+
+        def terminate(self):
+            pass
+
+    def fake_popen(cmd, *args, **kwargs):
+        proc = FakeProc(cmd)
+        spawned.append(proc)
+        return proc
+
+    monkeypatch.setattr("pinky_cli.serve.subprocess.Popen", fake_popen)
+
+    run_serve(server="all")
+
+    modules = [proc.cmd[2] for proc in spawned]
+    assert modules == ["pinky_memory", "pinky_outreach"]
+    assert all(proc.cmd[0] == sys.executable for proc in spawned)
+    assert all(proc.cmd[1] == "-m" for proc in spawned)
+    assert all(proc.waited for proc in spawned)
+
+
+# ---------------------------------------------------------------------------
+# pinky connect
+# ---------------------------------------------------------------------------
+
+
+def test_connect_writes_project_mcp_json(tmp_path, monkeypatch):
+    """connect writes .mcp.json in cwd with sys.executable, not ~/.claude/settings.json."""
+    monkeypatch.chdir(tmp_path)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tg-test")
+
+    run_connect()
+
+    mcp_file = tmp_path / ".mcp.json"
+    assert mcp_file.exists()
+    assert not (fake_home / ".claude" / "settings.json").exists()
+
+    config = json.loads(mcp_file.read_text())
+    servers = config["mcpServers"]
+    assert servers["pinky-memory"]["command"] == sys.executable
+    assert servers["pinky-outreach"]["command"] == sys.executable
+    assert servers["pinky-memory"]["env"]["OPENAI_API_KEY"] == "sk-test"
+    assert servers["pinky-outreach"]["env"]["TELEGRAM_BOT_TOKEN"] == "tg-test"
+
+
+def test_connect_preserves_existing_credentials(tmp_path, monkeypatch):
+    """Re-running without env vars must not clobber stored credentials."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+
+    existing = {
+        "mcpServers": {
+            "pinky-memory": {
+                "command": "python",
+                "args": ["-m", "pinky_memory"],
+                "env": {"OPENAI_API_KEY": "sk-existing"},
+            },
+            "pinky-outreach": {
+                "command": "python",
+                "args": ["-m", "pinky_outreach"],
+                "env": {"TELEGRAM_BOT_TOKEN": "tg-existing"},
+            },
+        }
+    }
+    (tmp_path / ".mcp.json").write_text(json.dumps(existing))
+
+    run_connect()
+
+    config = json.loads((tmp_path / ".mcp.json").read_text())
+    servers = config["mcpServers"]
+    assert servers["pinky-memory"]["env"]["OPENAI_API_KEY"] == "sk-existing"
+    assert servers["pinky-outreach"]["env"]["TELEGRAM_BOT_TOKEN"] == "tg-existing"
+
+
+def test_connect_omits_unset_credentials_with_warning(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+
+    run_connect()
+
+    config = json.loads((tmp_path / ".mcp.json").read_text())
+    servers = config["mcpServers"]
+    assert "OPENAI_API_KEY" not in servers["pinky-memory"]["env"]
+    assert "TELEGRAM_BOT_TOKEN" not in servers["pinky-outreach"]["env"]
+    out = capsys.readouterr().out
+    assert "Warning: OPENAI_API_KEY is not set" in out
+    assert "Warning: TELEGRAM_BOT_TOKEN is not set" in out
+
+
+def test_connect_aborts_cleanly_on_invalid_json(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    mcp_file = tmp_path / ".mcp.json"
+    mcp_file.write_text("{not json")
+
+    with pytest.raises(SystemExit) as excinfo:
+        run_connect()
+
+    assert excinfo.value.code == 1
+    assert "not valid JSON" in capsys.readouterr().out
+    assert mcp_file.read_text() == "{not json"
+
+
+def test_connect_preserves_unrelated_keys(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tg-test")
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"other-server": {"command": "foo"}}})
+    )
+
+    run_connect()
+
+    config = json.loads((tmp_path / ".mcp.json").read_text())
+    assert config["mcpServers"]["other-server"] == {"command": "foo"}
+
+
+# ---------------------------------------------------------------------------
+# pinky run
+# ---------------------------------------------------------------------------
+
+
+def test_run_forwards_mode_to_daemon(monkeypatch):
+    from pinky_cli.__main__ import main as cli_main
+
+    seen = {}
+
+    def fake_daemon_main():
+        seen["argv"] = list(sys.argv)
+
+    monkeypatch.setattr("pinky_daemon.__main__.main", fake_daemon_main)
+    monkeypatch.setattr(
+        sys, "argv", ["pinky", "run", "--mode", "poll", "--config", "my.yaml"]
+    )
+
+    cli_main()
+
+    assert seen["argv"] == [
+        "pinky-daemon",
+        "--mode", "poll",
+        "--config", "my.yaml",
+        "--working-dir", ".",
+    ]
+
+
+def test_run_defaults_to_api_mode(monkeypatch):
+    from pinky_cli.__main__ import main as cli_main
+
+    seen = {}
+
+    def fake_daemon_main():
+        seen["argv"] = list(sys.argv)
+
+    monkeypatch.setattr("pinky_daemon.__main__.main", fake_daemon_main)
+    monkeypatch.setattr(sys, "argv", ["pinky", "run"])
+
+    cli_main()
+
+    assert seen["argv"][:3] == ["pinky-daemon", "--mode", "api"]


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **medium** pinky serve always crashes: delegated MCP server mains re-parse pinky's own sys.argv (`src/pinky_cli/serve.py:22`)
  - Reset sys.argv to ["pinky-memory"]/["pinky-outreach"] before calling the delegated main(), mirroring the existing pattern in __main__.py's run branch.
- **low** pinky serve --server all (the default) only starts the memory server, never outreach (`src/pinky_cli/serve.py:19`)
  - server=="all" now spawns both servers as subprocesses via [sys.executable, "-m", ...] and waits on both, with terminate-on-KeyboardInterrupt; single-server modes remain in-process.
- **medium** pinky connect writes mcpServers into ~/.claude/settings.json, which Claude Code does not read for MCP servers (`src/pinky_cli/connect.py:14`)
  - connect now writes the mcpServers block to the project-level .mcp.json in cwd (the file Claude Code actually reads) and no longer touches ~/.claude/settings.json.
- **low** Re-running pinky connect without env vars clobbers previously working API keys with empty strings (`src/pinky_cli/connect.py:46`)
  - Env merge now keeps an existing non-empty credential when the env var is unset, omits empty env keys, and prints a warning for each missing credential.
- **low** pinky connect rewrites the user's entire global settings.json non-atomically and crashes on invalid JSON (`src/pinky_cli/connect.py:40`)
  - Invalid JSON in .mcp.json now aborts with a friendly message and exit(1) without writing; the config is written via a temp file plus os.replace for atomic replacement.
- **low** MCP server command hardcoded as 'python', which does not exist on stock macOS and ignores the active interpreter (`src/pinky_cli/connect.py:22`)
  - Both generated server entries now use sys.executable as the command, matching the pinky_daemon/api.py pattern.
- **low** pinky run silently ignores --config: daemon defaults to api mode and --mode is never passed (`src/pinky_cli/__main__.py:60`)
  - Added --mode {api,poll} (default api) to the run subparser and forwarded it in the rewritten sys.argv, making poll mode (and thus --config) reachable; --config help now says (poll mode).

## Deferred (not fixed here, with reasons)
- pinky init cannot find templates when installed as a wheel -- templates/ is not packaged: Correct fix requires out-of-scope edits: either [tool.hatch.build.targets.wheel] changes in pyproject.toml (force-include) or moving repo-root templates/CLAUDE.md.template and templates/pinky.yaml.example under src/pinky_cli/templates/. Only src/pinky_cli/init.py is in scope; editing init.py alone (e.g. importlib.resources lookup) cannot fix the bug because the template files are simply absent from the wheel, and duplicating the templates into the package would create two sources of truth. Defect confirmed (hatch wheel target lists only src/* packages, no force-include/shared-data); integrator should move templates into the package and resolve via importlib.resources.files("pinky_cli").

## Testing
**cli**: python3 -m pytest tests/test_cli.py -q -> 10 passed (new regression file covering serve argv reset, serve all subprocess spawn, connect .mcp.json write/credential preservation/warning/invalid-JSON abort/unrelated-key preservation, run --mode forwarding and default). ruff check src/pinky_cli/serve.py src/pinky_cli/connect.py src/pinky_cli/__main__.py tests/test_cli.py -> All checks passed (after one auto-fixed I001 import sort in the new test file). Live smoke tests: PYTHONPATH=src python3 -m pinky_cli serve --server memory </dev/null -> exit 0 (previously argparse exit 2); pinky_cli connect with/without env vars -> writes .mcp.json with sys.executable, preserves credentials, warns when unset; pinky_cli run --help shows --mode. grep of tests/ found no pre-existing tests referencing run_serve/run_connect/pinky_cli, so no existing assertions needed updating.

Generated with [Claude Code](https://claude.com/claude-code)