### PR TITLE
fix(sweep): fe-chat - XSS in markdown links, poll wiping scrollback, session rename

### DIFF
--- a/frontend-svelte/src/components/ChatSidebar.svelte
+++ b/frontend-svelte/src/components/ChatSidebar.svelte
@@ -61,7 +61,7 @@
             </div>
             {#each aSessions as s}
                 {@const isMain = (s.session_type || '') === 'main'}
-                {@const label = s.id.replace(new RegExp(`^${agent.name}-`), '').replace(/-?main$/, '') || 'main'}
+                {@const label = s._streaming_label || s.id.replace(new RegExp(`^${agent.name}-`), '') || 'main'}
                 {@const isRenaming = renamingSession && renamingSession.agentName === agent.name && renamingSession.label === label}
                 <div
                     class="session-item"

--- a/frontend-svelte/src/lib/utils.js
+++ b/frontend-svelte/src/lib/utils.js
@@ -62,9 +62,19 @@ export function contextClass(pct) {
 }
 
 export function escapeHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
+    return String(text ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+// Allow http(s)/mailto and scheme-less relative URLs; blocks javascript:,
+// data:, vbscript: etc. from becoming clickable hrefs.
+function isSafeLinkUrl(url) {
+    if (/^(?:https?|mailto):/i.test(url)) return true;
+    return !url.split(/[/?#]/, 1)[0].includes(':');
 }
 
 export function renderMarkdown(text) {
@@ -88,7 +98,8 @@ export function renderMarkdown(text) {
 
     const applyInline = (value) => {
         let html = escapeHtml(value);
-        html = html.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>');
+        html = html.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (match, label, url) =>
+            isSafeLinkUrl(url) ? `<a href="${url}" target="_blank" rel="noreferrer">${label}</a>` : match);
         // [[Wiki Link]] → clickable wiki cross-link
         html = html.replace(/\[\[([^\]]+)\]\]/g, (_, title) => {
             const slug = title.toLowerCase().replace(/\s+/g, '-');

--- a/frontend-svelte/src/locales/en.json
+++ b/frontend-svelte/src/locales/en.json
@@ -313,7 +313,8 @@
     "session": "Session",
     "show_agents": "Show Agents",
     "upload_file": "Upload file",
-    "search_placeholder": "Search chats..."
+    "search_placeholder": "Search chats...",
+    "offline_banner": "daemon unreachable - showing cached data"
   },
   "fleet": {
     "search_placeholder": "Search agents...",

--- a/frontend-svelte/src/locales/es.json
+++ b/frontend-svelte/src/locales/es.json
@@ -313,7 +313,8 @@
     "session": "Sesión",
     "show_agents": "Mostrar agentes",
     "upload_file": "Subir archivo",
-    "search_placeholder": "Buscar chats..."
+    "search_placeholder": "Buscar chats...",
+    "offline_banner": "daemon inaccesible - mostrando datos en caché"
   },
   "fleet": {
     "search_placeholder": "Buscar agentes...",

--- a/frontend-svelte/src/locales/ja.json
+++ b/frontend-svelte/src/locales/ja.json
@@ -313,7 +313,8 @@
     "session": "セッション",
     "show_agents": "エージェントを表示",
     "upload_file": "ファイルをアップロード",
-    "search_placeholder": "チャットを検索..."
+    "search_placeholder": "チャットを検索...",
+    "offline_banner": "デーモンに接続できません - キャッシュデータを表示中"
   },
   "fleet": {
     "search_placeholder": "エージェントを検索...",

--- a/frontend-svelte/src/locales/ko.json
+++ b/frontend-svelte/src/locales/ko.json
@@ -313,7 +313,8 @@
     "session": "세션",
     "show_agents": "에이전트 표시",
     "upload_file": "파일 업로드",
-    "search_placeholder": "채팅 검색..."
+    "search_placeholder": "채팅 검색...",
+    "offline_banner": "데몬에 연결할 수 없음 - 캐시된 데이터 표시 중"
   },
   "fleet": {
     "search_placeholder": "에이전트 검색...",

--- a/frontend-svelte/src/locales/ru.json
+++ b/frontend-svelte/src/locales/ru.json
@@ -313,7 +313,8 @@
     "session": "Сессия",
     "show_agents": "Показать агентов",
     "upload_file": "Загрузить файл",
-    "search_placeholder": "Поиск чатов..."
+    "search_placeholder": "Поиск чатов...",
+    "offline_banner": "демон недоступен - показаны кэшированные данные"
   },
   "fleet": {
     "search_placeholder": "Поиск агентов...",

--- a/frontend-svelte/src/locales/uk.json
+++ b/frontend-svelte/src/locales/uk.json
@@ -313,7 +313,8 @@
     "session": "Сесія",
     "show_agents": "Показати агентів",
     "upload_file": "Завантажити файл",
-    "search_placeholder": "Пошук чатів..."
+    "search_placeholder": "Пошук чатів...",
+    "offline_banner": "демон недоступний - показано кешовані дані"
   },
   "fleet": {
     "search_placeholder": "Пошук агентів...",

--- a/frontend-svelte/src/locales/zh.json
+++ b/frontend-svelte/src/locales/zh.json
@@ -313,7 +313,8 @@
     "session": "会话",
     "show_agents": "显示智能体",
     "upload_file": "上传文件",
-    "search_placeholder": "搜索聊天..."
+    "search_placeholder": "搜索聊天...",
+    "offline_banner": "无法连接守护进程 - 显示缓存数据"
   },
   "fleet": {
     "search_placeholder": "搜索智能体...",

--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -119,6 +119,7 @@
     let replyTo = null;
 
     const PAGE_SIZE = 100;
+    const HISTORY_LIMIT_MAX = 1000;
     let hasMore = false;
     let totalMessages = 0;
     let loadedPersistedCount = 0;
@@ -202,7 +203,7 @@
         persistedMessages = cached.persistedMessages || [];
         localMessages = cached.localMessages || [];
         totalMessages = cached.totalMessages || persistedMessages.length;
-        loadedPersistedCount = cached.loadedPersistedCount || persistedMessages.length;
+        loadedPersistedCount = cached.loadedPersistedCount || 0;
         hasMore = !!cached.hasMore;
         currentHistorySource = cached.currentHistorySource || { kind: null, sessionId: null };
         infoMessages = cached.infoMessages ?? totalMessages;
@@ -417,12 +418,14 @@
         let loadedFromConversation = false;
 
         // Keep the window the user paged in via loadOlderMessages instead of
-        // shrinking back to the newest page on every poll.
+        // shrinking back to the newest page on every poll. loadedPersistedCount
+        // only counts store-loaded messages (session events are merged in
+        // afterwards), and the window is capped so polling stays bounded.
         const historyLimit = (target) => (
             currentHistorySource.kind === 'conversation'
             && currentHistorySource.sessionId === target
             && loadedPersistedCount > PAGE_SIZE
-                ? loadedPersistedCount
+                ? Math.min(loadedPersistedCount, HISTORY_LIMIT_MAX)
                 : PAGE_SIZE
         );
 
@@ -469,6 +472,10 @@
                 nextSource = { kind: null, sessionId: null };
             }
         }
+
+        // Store-loaded count, captured before session events inflate the list;
+        // drives historyLimit and loadOlderMessages' offset.
+        const nextStoreCount = nextPersisted.length;
 
         // Merge session events (agent-level covers all sessions + lifecycle events)
         try {
@@ -536,7 +543,7 @@
 
         persistedMessages = nextPersisted;
         totalMessages = nextTotal;
-        loadedPersistedCount = nextPersisted.length;
+        loadedPersistedCount = nextStoreCount;
         hasMore = nextHasMore;
         infoMessages = nextTotal;
         infoSession = sessionId;
@@ -1344,7 +1351,7 @@
 
     <div class="chat-area">
         {#if !connected}
-            <div class="offline-banner">daemon unreachable - showing cached data</div>
+            <div class="offline-banner">{$_('chat.offline_banner')}</div>
         {/if}
         {#if !activeSession}
             <div class="empty-state">{$_('chat.select_agent')}</div>

--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -286,6 +286,30 @@
 
     // ── Session & Chat Data ────────────────────────────────
 
+    // Session ids are `${agentName}-${label}` and agent names may themselves
+    // contain hyphens, so resolve via longest-prefix match against the known
+    // agents instead of split('-').
+    function agentFromSessionId(sessionId) {
+        if (!sessionId) return null;
+        let best = null;
+        for (const a of agentsList) {
+            if (sessionId === a.name || sessionId.startsWith(`${a.name}-`)) {
+                if (!best || a.name.length > best.length) best = a.name;
+            }
+        }
+        return best || sessionId.split('-')[0];
+    }
+
+    function labelFromSessionId(sessionId, agentName = null) {
+        if (!sessionId) return 'main';
+        const name = agentName || agentFromSessionId(sessionId);
+        if (name) {
+            if (sessionId === name) return 'main';
+            if (sessionId.startsWith(`${name}-`)) return sessionId.slice(name.length + 1) || 'main';
+        }
+        return sessionId.split('-').slice(1).join('-') || 'main';
+    }
+
     async function refreshSessions() {
         try {
             const [agentsData, sessData, convsData] = await Promise.all([
@@ -317,7 +341,7 @@
                     model: 'streaming',
                     message_count: c.message_count,
                     last_active: c.last_message_at,
-                    agent_name: c.session_id.split('-')[0],
+                    agent_name: agentFromSessionId(c.session_id),
                     session_type: 'streaming',
                     _from_store: true,
                 }));
@@ -361,8 +385,9 @@
 
             sessionsList = [...merged, ...streamingSessions];
             connected = true;
-        } catch {
+        } catch (e) {
             connected = false;
+            console.error('Failed to refresh sessions:', e);
         }
     }
 
@@ -381,7 +406,7 @@
 
         const requestSeq = ++chatRefreshSeq;
         const sessionId = activeSession;
-        const agentName = activeAgent || sessionId.split('-')[0];
+        const agentName = activeAgent || agentFromSessionId(sessionId);
         const sessionRecord = sessionsList.find((s) => s.id === sessionId) || null;
         const { preferred, fallback } = getConversationTargets(sessionId, agentName);
 
@@ -391,9 +416,19 @@
         let nextSource = { kind: null, sessionId: null };
         let loadedFromConversation = false;
 
+        // Keep the window the user paged in via loadOlderMessages instead of
+        // shrinking back to the newest page on every poll.
+        const historyLimit = (target) => (
+            currentHistorySource.kind === 'conversation'
+            && currentHistorySource.sessionId === target
+            && loadedPersistedCount > PAGE_SIZE
+                ? loadedPersistedCount
+                : PAGE_SIZE
+        );
+
         // Try preferred conversation history
         try {
-            const history = await api('GET', `/conversations/${preferred}/history?limit=${PAGE_SIZE}`);
+            const history = await api('GET', `/conversations/${preferred}/history?limit=${historyLimit(preferred)}`);
             if (requestSeq !== chatRefreshSeq || sessionId !== activeSession) return;
             if ((history.total || 0) > 0 || preferred === fallback || sessionRecord?._from_store) {
                 nextPersisted = sortMessages(history.messages || []);
@@ -407,7 +442,7 @@
         // Try fallback
         if (!loadedFromConversation && fallback) {
             try {
-                const history = await api('GET', `/conversations/${fallback}/history?limit=${PAGE_SIZE}`);
+                const history = await api('GET', `/conversations/${fallback}/history?limit=${historyLimit(fallback)}`);
                 if (requestSeq !== chatRefreshSeq || sessionId !== activeSession) return;
                 if ((history.total || 0) > 0) {
                     nextPersisted = sortMessages(history.messages || []);
@@ -472,8 +507,7 @@
         // interleaves these chronologically with messages by timestamp.
         try {
             const refreshLabel = activeSessionRecord?._streaming_label
-                || sessionId?.split('-').slice(1).join('-')
-                || 'main';
+                || labelFromSessionId(sessionId, agentName);
             const tcData = await api(
                 'GET',
                 `/agents/${agentName}/sessions/${encodeURIComponent(refreshLabel)}/tool-calls?limit=500`,
@@ -494,7 +528,9 @@
                 };
             }).filter((tc) => tc._startedAtEpoch != null)
               .sort((a, b) => a._startedAtEpoch - b._startedAtEpoch);
-        } catch { persistedToolCalls = []; }
+        } catch {
+            if (requestSeq === chatRefreshSeq && sessionId === activeSession) persistedToolCalls = [];
+        }
 
         if (preserveScroll) captureScroll('refresh');
 
@@ -536,7 +572,7 @@
 
         // Fetch session-level effort (overrides agent default if set)
         try {
-            const refreshLabel = activeSessionRecord?._streaming_label || sessionId?.split('-').slice(1).join('-') || 'main';
+            const refreshLabel = activeSessionRecord?._streaming_label || labelFromSessionId(sessionId, agentName);
             const effortData = await api('GET', `/agents/${agentName}/effort?label=${encodeURIComponent(refreshLabel)}`);
             if (requestSeq !== chatRefreshSeq || sessionId !== activeSession) return;
             if (effortData.effective) selectedEffort = effortData.effective;
@@ -544,7 +580,7 @@
 
         let gotStreamingContext = false;
         try {
-            const refreshLabel = activeSessionRecord?._streaming_label || sessionId?.split('-').slice(1).join('-') || 'main';
+            const refreshLabel = activeSessionRecord?._streaming_label || labelFromSessionId(sessionId, agentName);
             const streamStatus = await api('GET', `/agents/${agentName}/streaming/status?label=${encodeURIComponent(refreshLabel)}`);
             if (requestSeq !== chatRefreshSeq || sessionId !== activeSession) return;
             if (streamStatus.connected) {
@@ -633,7 +669,7 @@
     function startStreamEvents() {
         stopStreamEvents();
         if (!activeAgent || !activeSession || !canUseStreamingChat) return;
-        const label = activeSessionRecord?._streaming_label || activeSession?.split('-').slice(1).join('-') || 'main';
+        const label = activeSessionRecord?._streaming_label || labelFromSessionId(activeSession, activeAgent);
         streamEventSource = sse(`/agents/${activeAgent}/streaming/events?label=${encodeURIComponent(label)}`);
         streamEventSource.onmessage = async (evt) => {
             let data = null;
@@ -724,7 +760,7 @@
     async function fetchSessionMeta() {
         if (!activeAgent || !activeSession) { sessionMeta = null; return; }
         try {
-            const label = activeSessionRecord?._streaming_label || activeSession?.split('-').slice(1).join('-') || 'main';
+            const label = activeSessionRecord?._streaming_label || labelFromSessionId(activeSession, activeAgent);
             sessionMeta = await api('GET', `/agents/${activeAgent}/session-meta?label=${encodeURIComponent(label)}`);
         } catch { sessionMeta = null; }
     }
@@ -749,10 +785,10 @@
     function startActivityPolling() {
         stopActivityPolling();
         const pollSessionId = activeSession;
-        const pollAgentName = activeAgent || (activeSession ? activeSession.split('-')[0] : null);
+        const pollAgentName = activeAgent || agentFromSessionId(activeSession);
         if (!pollAgentName) return;
         const pollRecord = sessionsList.find((s) => s.id === pollSessionId);
-        const pollLabel = pollRecord?._streaming_label || pollSessionId?.split('-').slice(1).join('-') || 'main';
+        const pollLabel = pollRecord?._streaming_label || labelFromSessionId(pollSessionId, pollAgentName);
 
         activityPollInterval = setInterval(async () => {
             if (pollSessionId !== activeSession) return;
@@ -822,6 +858,7 @@
         thinkingContent = '';
         activityLog = [];
         liveToolCalls = [];
+        persistedToolCalls = [];
         agentWorking = false;
         wasWorking = false;
         if (window.innerWidth <= 768) sidebarCollapsed = true;
@@ -888,7 +925,7 @@
 
         try {
             if (canUseStreamingChat) {
-                const sessionLabel = activeSessionRecord?._streaming_label || activeSession?.split('-').slice(1).join('-') || 'main';
+                const sessionLabel = activeSessionRecord?._streaming_label || labelFromSessionId(activeSession, activeAgent);
                 const sessionParam = sessionLabel !== 'main' ? `?session=${encodeURIComponent(sessionLabel)}` : '';
                 await api('POST', `/agents/${activeAgent}/chat${sessionParam}`, { content: text });
                 sending = false;
@@ -1076,7 +1113,7 @@
         if (!activeAgent) return;
         savingEffort = true;
         try {
-            const label = activeSessionRecord?._streaming_label || activeSession?.split('-').slice(1).join('-') || 'main';
+            const label = activeSessionRecord?._streaming_label || labelFromSessionId(activeSession, activeAgent);
             await api('POST', `/agents/${activeAgent}/sessions/${encodeURIComponent(label)}/effort`, { effort: selectedEffort });
         } catch (e) { toast(`Failed to update effort: ${e.message}`, 'error'); }
         savingEffort = false;
@@ -1153,8 +1190,11 @@
         }
         try {
             await api('PATCH', `/agents/${agentName}/streaming-sessions/${encodeURIComponent(label)}`, { label: newLabel });
-            if (activeSession === `${agentName}-${label}`) activeSession = `${agentName}-${newLabel}`;
+            const wasActive = activeSession === `${agentName}-${label}`;
             await refreshSessions();
+            // Re-select so polling and stream events rebind to the new id;
+            // the old interval/SSE callbacks captured the previous session id.
+            if (wasActive) await selectSession(`${agentName}-${newLabel}`, agentName);
         } catch (e) {
             addLocalMessage({ role: 'system', content: `Rename failed: ${e.message}` });
         }
@@ -1303,6 +1343,9 @@
     </div>
 
     <div class="chat-area">
+        {#if !connected}
+            <div class="offline-banner">daemon unreachable - showing cached data</div>
+        {/if}
         {#if !activeSession}
             <div class="empty-state">{$_('chat.select_agent')}</div>
         {:else}
@@ -1686,7 +1729,7 @@
         {:else}
             <div class="search-modal-count">{chatSearchResults.length} result{chatSearchResults.length !== 1 ? 's' : ''}</div>
             {#each chatSearchResults as r}
-                {@const agentName = (r.session_id || '').split('-')[0]}
+                {@const agentName = agentFromSessionId(r.session_id)}
                 {@const ts = r.timestamp ? new Date(r.timestamp * 1000) : null}
                 <div class="search-modal-item" role="button" tabindex="0" on:click={() => { selectSession(r.session_id, agentName || null); chatSearchOpen = false; }} on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectSession(r.session_id, agentName || null); chatSearchOpen = false; } }}>
                     <div class="search-modal-item-header">
@@ -1706,7 +1749,7 @@
 <TmuxPaneModal
     bind:show={showTmuxPane}
     agent={activeAgent || ''}
-    label={activeSessionRecord?._streaming_label || activeSession?.split('-').slice(1).join('-') || 'main'}
+    label={activeSessionRecord?._streaming_label || labelFromSessionId(activeSession, activeAgent)}
 />
 
 <style>
@@ -1718,6 +1761,7 @@
 
     /* Chat area */
     .chat-area { flex: 1; display: flex; flex-direction: column; background: var(--app-bg); }
+    .offline-banner { padding: 0.35rem 1.5rem; background: var(--red, #b91c1c); color: #fff; font-family: var(--font-grotesk); font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; text-align: center; }
     .empty-state { flex: 1; display: flex; align-items: center; justify-content: center; font-family: var(--font-grotesk); color: var(--text-muted); font-size: 0.9rem; }
 
     /* Header bar */

--- a/frontend-svelte/src/pages/Memories.svelte
+++ b/frontend-svelte/src/pages/Memories.svelte
@@ -112,7 +112,7 @@
             const byType = stats.by_type || {};
             const byProject = stats.by_project || {};
             statsHtml = `<div class="stat-item"><div class="stat-value">${stats.total || 0}</div><div class="stat-label">Total</div></div>` +
-                Object.entries(byType).map(([k, v]) => `<div class="stat-item"><div class="stat-value">${v}</div><div class="stat-label">${k.replace('_', ' ')}</div></div>`).join('');
+                Object.entries(byType).map(([k, v]) => `<div class="stat-item"><div class="stat-value">${v}</div><div class="stat-label">${escapeHtml(k.replace('_', ' '))}</div></div>`).join('');
             projectOptions = Object.entries(byProject).map(([k, v]) => ({ value: k, label: `${k} (${v})` }));
             statsVisible = true;
         } catch (e) { console.error('Stats error:', e); toast('Failed to load memory stats', 'error'); }


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **high** Stored XSS in chat via renderMarkdown links (javascript: URLs + attribute injection) (`frontend-svelte/src/lib/utils.js:91`)
  - escapeHtml now escapes double/single quotes (pure string replace) and markdown links only render as <a> for http(s)/mailto/relative URLs; unsafe schemes (javascript:, data:, vbscript:) are left as escaped plain text. Quote-escaping also closes the wiki-link data-attribute breakout.
- **medium** 3-second chat poll wipes older message pages loaded via infinite scroll (`frontend-svelte/src/pages/Chat.svelte:501`)
  - refreshChat now fetches limit=loadedPersistedCount (instead of always PAGE_SIZE) when the refresh targets the same conversation source and the user has paged in more than one page, so polling preserves the loaded history window (backend history endpoint has no limit cap; verified in conversation_store.py).
- **medium** Renaming the active session silently kills polling and SSE for the open chat (`frontend-svelte/src/pages/Chat.svelte:1156`)
  - finishRename now calls selectSession(`${agentName}-${newLabel}`, agentName) after a successful PATCH + refreshSessions when the renamed session was active, restarting chat polling, activity polling, and the EventSource against the new id.
- **medium** Agent name derived via split('-')[0] breaks for hyphenated agent names (`frontend-svelte/src/pages/Chat.svelte:1689`)
  - Added agentFromSessionId (longest-prefix match against agentsList) and labelFromSessionId helpers; replaced all split('-')[0] agent derivations (refreshSessions conv-sessions, refreshChat, startActivityPolling, search modal) and all split('-').slice(1).join('-') label derivations (tool-calls, effort, streaming status, SSE, session-meta, sendMessage, saveEffort, TmuxPaneModal) with them.
- **low** Sidebar label regex mangles session labels ending in 'main' (`frontend-svelte/src/components/ChatSidebar.svelte:64`)
  - Label now prefers s._streaming_label and otherwise strips only the agent-name prefix (dropped the /-?main$/ replace that turned 'domain' into 'do'); '<agent>-main' still displays as 'main' via the existing || 'main' fallback, so rename PATCH targets the real label.
- **low** 'connected' flag is dead state - daemon-unreachable condition never shown to user (`frontend-svelte/src/pages/Chat.svelte:365`)
  - Added a 'daemon unreachable - showing cached data' banner at the top of the chat area bound to !connected, and refreshSessions' catch now logs the error via console.error (matching existing frontend convention).
- **low** persistedToolCalls not reset on session switch and its error path ignores the refresh sequence guard (`frontend-svelte/src/pages/Chat.svelte:497`)
  - selectSession now clears persistedToolCalls alongside liveToolCalls, and the tool-call fetch catch only wipes persistedToolCalls when requestSeq === chatRefreshSeq && sessionId === activeSession, matching the other guarded catches.

## Testing
**fe-chat**: cd frontend-svelte && npm install --no-audit --no-fund (ok, 130 packages); npm run build (success, 206 modules transformed, only pre-existing warnings about chunk size/dynamic import); node smoke test of the XSS fix importing renderMarkdown/escapeHtml directly: [click](javascript:alert`1`) no longer renders an anchor, the "onmouseover= attribute-breakout payload stays inside href as &quot;, wiki-link attributes are quote-escaped, and normal https/relative links still render. No frontend test suite exists; no Python code was touched so pytest was not run.

Generated with [Claude Code](https://claude.com/claude-code)