### PR TITLE
fix(sweep): fe-rest - dead filters/toggles, wizard state leaks, provider key redaction

### DIFF
--- a/frontend-svelte/src/components/Layout.svelte
+++ b/frontend-svelte/src/components/Layout.svelte
@@ -46,7 +46,7 @@
             ]);
             statusText = `v${root.version}`;
             authenticated = !!auth.authenticated;
-            if (Array.isArray(agentsResp)) agents = agentsResp;
+            agents = Array.isArray(agentsResp?.agents) ? agentsResp.agents : [];
 
             // First-run: redirect to onboarding if no agents and not yet completed
             if (authenticated) {
@@ -140,7 +140,7 @@
                             class="sidebar-nav-item sidebar-agent"
                             on:click={closeSidebar}
                         >
-                            <span class="agent-dot" class:alive={agent.status === 'running'} class:idle={agent.status !== 'running'}></span>
+                            <span class="agent-dot" class:alive={agent.streaming} class:idle={!agent.streaming}></span>
                             <span>{agent.name}</span>
                         </a>
                     {/each}

--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -98,6 +98,7 @@
     // Model provider state
     let providerUrl = '';
     let providerKey = '';
+    let providerKeySet = false; // backend reports provider_key_set instead of the plaintext key
     let providerModel = '';
     let providerPreset = 'anthropic'; // 'anthropic' | 'ollama' | 'zai' | 'openrouter' | 'deepseek' | 'codex_cli' | 'custom'
     let providerRef = '';  // ID of a global provider (empty = use agent-specific config)
@@ -466,8 +467,13 @@
         const members = groupMembers.split(',').map(m => m.trim()).filter(Boolean);
         if (!groupName.trim()) { toast('Group name required', 'error'); return; }
         if (!members.length) { toast('Add at least one member', 'error'); return; }
+        try {
+            await api('POST', '/groups', { name: groupName, members });
+        } catch (e) {
+            toast('Failed to create group: ' + (e?.message || e), 'error');
+            return;
+        }
         groupModalOpen = false;
-        await api('POST', '/groups', { name: groupName, members });
         toast(`Group "${groupName}" created`);
         refreshAgents();
     }
@@ -487,8 +493,13 @@
     async function confirmRetire() {
         if (!pendingRetireAgent || retireConfirmInput !== pendingRetireAgent) return;
         const name = pendingRetireAgent;
+        try {
+            await api('DELETE', `/agents/${name}`);
+        } catch (e) {
+            toast(`Failed to retire ${name}: ` + (e?.message || e), 'error');
+            return;
+        }
         closeRetireModal();
-        await api('DELETE', `/agents/${name}`);
         toast(`${name} retired`);
         if (currentAgent === name) closeDetail();
         refreshAgents();
@@ -546,7 +557,8 @@
             dreamNotify = agent.dream_notify !== false;
             dreamDirty = false;
             providerUrl = agent.provider_url || '';
-            providerKey = agent.provider_key || '';
+            providerKey = '';
+            providerKeySet = !!(agent.provider_key_set ?? agent.provider_key);
             providerModel = agent.provider_model || '';
             providerRef = agent.provider_ref || '';
             if (providerUrl === 'http://localhost:11434') {
@@ -559,7 +571,7 @@
                 providerPreset = 'deepseek';
             } else if (providerUrl === 'codex_cli') {
                 providerPreset = 'codex_cli';
-            } else if (providerUrl || providerKey) {
+            } else if (providerUrl || providerKeySet) {
                 providerPreset = 'custom';
             } else {
                 providerPreset = 'anthropic';
@@ -594,7 +606,7 @@
         }
     }
 
-    function closeDetail() { currentAgent = ''; detailOpen = false; }
+    function closeDetail() { openDetailSeq++; currentAgent = ''; detailOpen = false; }
 
     async function saveClaudeMd() {
         await api('PUT', `/agents/${currentAgent}/files/CLAUDE.md`, { content: claudeMdContent });
@@ -621,12 +633,16 @@
     }
     // Provider preset/selection logic moved to ProviderConfig component
     async function saveProvider() {
-        await api('PUT', `/agents/${currentAgent}/provider`, {
+        const body = {
             provider_url: providerUrl,
-            provider_key: providerKey,
             provider_model: providerModel,
             provider_ref: providerRef,
-        });
+        };
+        // Only send a key the user actually typed; absent means "keep the saved key".
+        if (providerKey) body.provider_key = providerKey;
+        await api('PUT', `/agents/${currentAgent}/provider`, body);
+        providerKeySet = providerKeySet || !!providerKey;
+        providerKey = '';
         providerDirty = false;
         toast('Provider saved — restart session to apply');
     }
@@ -637,12 +653,12 @@
     }
     async function saveWorkingDir() { if (!detailWorkingDir) { toast('Enter a path', 'error'); return; } await api('PUT', `/agents/${currentAgent}`, { working_dir: detailWorkingDir }); toast('Working directory saved'); refreshAgents(); }
 
-    async function loadDirectives() { const data = await api('GET', `/agents/${currentAgent}/directives?active_only=false`); directives = data.directives || []; }
+    async function loadDirectives() { const req = openDetailSeq; const data = await api('GET', `/agents/${currentAgent}/directives?active_only=false`); if (req !== openDetailSeq) return; directives = data.directives || []; }
     async function addDirective() { if (!newDirective.trim()) { toast('Enter a directive', 'error'); return; } await api('POST', `/agents/${currentAgent}/directives`, { directive: newDirective.trim(), priority: newDirectivePriority }); newDirective = ''; toast('Directive added'); loadDirectives(); }
     async function removeDirective(id) { if (!confirm('Remove this directive?')) return; await api('DELETE', `/agents/${currentAgent}/directives/${id}`); toast('Directive removed'); loadDirectives(); }
     async function toggleDirective(id, active) { await api('POST', `/agents/${currentAgent}/directives/${id}/toggle?active=${active}`); loadDirectives(); }
 
-    async function loadTokens() { const data = await api('GET', `/agents/${currentAgent}/tokens`); tokens = data.tokens || []; }
+    async function loadTokens() { const req = openDetailSeq; const data = await api('GET', `/agents/${currentAgent}/tokens`); if (req !== openDetailSeq) return; tokens = data.tokens || []; }
     async function setToken() {
         const hasGlobalTokens = globalBotTokens.some(bt => bt.platform === tokenPlatform);
         const useRef = hasGlobalTokens && tokenRefId && tokenRefId !== '__manual__';
@@ -659,7 +675,7 @@
     async function removeToken(platform) { if (!confirm(`Remove ${platform} token?`)) return; await api('DELETE', `/agents/${currentAgent}/tokens/${platform}`); toast(`${platform} token removed`); loadTokens(); }
 
     // MCP Servers
-    async function loadMcpServers() { try { const data = await api('GET', `/agents/${currentAgent}/mcp-servers`); mcpServers = data.servers || []; } catch { mcpServers = []; } }
+    async function loadMcpServers() { const req = openDetailSeq; try { const data = await api('GET', `/agents/${currentAgent}/mcp-servers`); if (req !== openDetailSeq) return; mcpServers = data.servers || []; } catch { if (req === openDetailSeq) mcpServers = []; } }
     function openMcpModal() { mcpName = ''; mcpType = 'stdio'; mcpCommand = ''; mcpArgs = ''; mcpUrl = ''; mcpEnvPairs = [{ key: '', value: '' }]; mcpModalOpen = true; }
     async function addMcpServer() {
         if (!mcpName.trim()) { toast('Server name required', 'error'); return; }
@@ -682,10 +698,12 @@
 
     // Triggers
     async function loadTriggers(agentName) {
+        const req = openDetailSeq;
         try {
             const data = await api('GET', `/agents/${agentName}/triggers`);
+            if (req !== openDetailSeq) return;
             triggers = data.triggers || [];
-        } catch { triggers = []; }
+        } catch { if (req === openDetailSeq) triggers = []; }
     }
 
     async function deleteTrigger(id) {
@@ -766,15 +784,18 @@
 
     // Agent Skills
     async function loadAgentSkills() {
+        const req = openDetailSeq;
         try {
             const data = await api('GET', `/agents/${currentAgent}/skills?enabled_only=false`);
+            if (req !== openDetailSeq) return;
             agentSkills = data.skills || [];
-        } catch { agentSkills = []; }
+        } catch { if (req !== openDetailSeq) return; agentSkills = []; }
         try {
             const params = skillCategoryFilter ? `&category=${skillCategoryFilter}` : '';
             const avail = await api('GET', `/agents/${currentAgent}/skills/available?self_assignable=false${params}`);
+            if (req !== openDetailSeq) return;
             availableSkills = avail.skills || [];
-        } catch { availableSkills = []; }
+        } catch { if (req !== openDetailSeq) return; availableSkills = []; }
         skillsPendingApply = false;
     }
     async function assignSkill(skillName) {
@@ -831,12 +852,12 @@
         } catch (e) { toast(e.message || 'Failed to create skill', 'error'); }
     }
 
-    async function loadFiles() { const data = await api('GET', `/agents/${currentAgent}/files`); files = data.exists ? (data.files || []) : []; }
+    async function loadFiles() { const req = openDetailSeq; const data = await api('GET', `/agents/${currentAgent}/files`); if (req !== openDetailSeq) return; files = data.exists ? (data.files || []) : []; }
     async function editFile(filename) { const data = await api('GET', `/agents/${currentAgent}/files/${filename}`); editingFile = filename; fileEditorName = filename; fileEditorContent = data.content; fileEditorOpen = true; }
     function closeFileEditor() { fileEditorOpen = false; editingFile = ''; }
     async function saveFile() { await api('PUT', `/agents/${currentAgent}/files/${editingFile}`, { content: fileEditorContent }); toast(`${editingFile} saved`); loadFiles(); }
 
-    async function loadSchedules() { const data = await api('GET', `/agents/${currentAgent}/schedules?enabled_only=false`); schedules = data.schedules || []; }
+    async function loadSchedules() { const req = openDetailSeq; const data = await api('GET', `/agents/${currentAgent}/schedules?enabled_only=false`); if (req !== openDetailSeq) return; schedules = data.schedules || []; }
     function closeCronModal() { cronModalOpen = false; cronName = ''; cronExpression = ''; cronPrompt = ''; cronOneShot = false; }
     function describeCron(expr) {
         const [min, hour, dom, mon, dow] = expr.trim().split(/\s+/);
@@ -903,14 +924,18 @@
     async function toggleSchedule(id, enabled) { await api('POST', `/agents/${currentAgent}/schedules/${id}/toggle?enabled=${enabled}`); loadSchedules(); }
     async function removeSchedule(id) { if (!confirm('Remove this schedule?')) return; await api('DELETE', `/agents/${currentAgent}/schedules/${id}`); toast('Schedule removed'); loadSchedules(); }
 
-    async function loadSessions() { const data = await api('GET', `/agents/${currentAgent}/sessions`); agentSessions = data.sessions || []; }
+    async function loadSessions() { const req = openDetailSeq; const data = await api('GET', `/agents/${currentAgent}/sessions`); if (req !== openDetailSeq) return; agentSessions = data.sessions || []; }
 
     async function loadStreamingSessions() {
+        const req = openDetailSeq;
         const data = await api('GET', `/agents/${currentAgent}/streaming-sessions`);
+        if (req !== openDetailSeq) return;
         streamingSessions = data.sessions || [];
     }
     async function loadChannelSessions() {
+        const req = openDetailSeq;
         const data = await api('GET', `/agents/${currentAgent}/channel-sessions`);
+        if (req !== openDetailSeq) return;
         channelSessions = {};
         for (const m of (data.mappings || [])) {
             channelSessions[m.chat_id] = m.session_label;
@@ -941,7 +966,7 @@
     let approvedUsers = [];
     let newUserChatId = '';
     let newUserName = '';
-    async function loadApprovedUsers() { const data = await api('GET', `/agents/${currentAgent}/approved-users`); approvedUsers = data.users || []; }
+    async function loadApprovedUsers() { const req = openDetailSeq; const data = await api('GET', `/agents/${currentAgent}/approved-users`); if (req !== openDetailSeq) return; approvedUsers = data.users || []; }
     async function approveUser() {
         if (!newUserChatId.trim()) { toast('Enter a chat ID', 'error'); return; }
         await api('POST', `/agents/${currentAgent}/approved-users`, { chat_id: newUserChatId.trim(), display_name: newUserName.trim() });
@@ -957,7 +982,9 @@
     let pendingUserCount = 0;
     let pendingTotalCount = 0;
     async function loadPendingMessages() {
+        const req = openDetailSeq;
         const data = await api('GET', `/agents/${currentAgent}/pending-messages`);
+        if (req !== openDetailSeq) return;
         pendingMessages = data.by_sender || {};
         pendingUserCount = data.pending_users || 0;
         pendingTotalCount = data.total_messages || 0;
@@ -979,7 +1006,9 @@
     // Group chats (broker)
     let groupChats = [];
     async function loadGroupChats() {
+        const req = openDetailSeq;
         const data = await api('GET', `/agents/${currentAgent}/group-chats`);
+        if (req !== openDetailSeq) return;
         groupChats = data.group_chats || [];
     }
     async function setGroupAlias(chatId, alias) {
@@ -996,7 +1025,7 @@
 
     // Wizard
     let wizPronouns = '';
-    function openWizard() { wizStep = -1; importMode = false; importStep = 1; importFiles = { workspace: null, config: null, lock: null }; importDirPath = ''; importParseId = null; importPreview = null; importLoading = false; importTaskId = null; importProgress = { total: 0, imported: 0, failed: 0, done: false }; importDragover = false; importError = null; importAgentName = null; if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizName = ''; wizDisplayName = ''; wizPronouns = ''; wizModel = 'claude-opus-4-6'; wizProviderRef = ''; wizCustomProvider = false; wizProviderPreset = 'anthropic'; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; wizMode = 'bypassPermissions'; wizHeart = 'sidekick'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizThinkingEffort = 'medium'; wizShowAdvanced = false; wizMaxTurns = 0; wizTimeout = 300; wizMaxSessions = 5; wizPlainTextFallback = false; wizTransport = 'tmux'; wizTransportUserSet = false; wizIsolation = 'local'; wizContainerImage = ''; wizIsolationHint = ''; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; globalProviders = []; api('GET', '/providers').then(d => { globalProviders = d || []; }).catch(() => { globalProviders = []; }); wizardOpen = true; }
+    function openWizard() { wizStep = -1; importMode = false; importStep = 1; importFiles = { workspace: null, config: null, lock: null }; importDirPath = ''; importParseId = null; importPreview = null; importLoading = false; importTaskId = null; importProgress = { total: 0, imported: 0, failed: 0, done: false }; importDragover = false; importError = null; importAgentName = null; if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizName = ''; wizDisplayName = ''; wizPronouns = ''; wizModel = 'claude-opus-4-6'; wizProviderRef = ''; wizCustomProvider = false; wizProviderPreset = 'anthropic'; wizProviderUrl = ''; wizProviderKey = ''; wizProviderModel = ''; wizMode = 'bypassPermissions'; wizHeart = 'sidekick'; wizRole = 'sidekick'; wizAutoStart = true; wizHeartbeatInterval = 300; wizThinkingEffort = 'medium'; wizShowAdvanced = false; wizMaxTurns = 0; wizTimeout = 300; wizMaxSessions = 5; wizPlainTextFallback = false; wizTransport = 'tmux'; wizTransportUserSet = false; wizIsolation = 'local'; wizContainerImage = ''; wizIsolationHint = ''; wizCustomSoul = ''; wizTelegramToken = ''; wizDiscordToken = ''; wizSlackToken = ''; wizTelegramRef = ''; wizDiscordRef = ''; wizSlackRef = ''; globalProviders = []; api('GET', '/providers').then(d => { globalProviders = d || []; }).catch(() => { globalProviders = []; }); api('GET', '/bot-tokens').then(d => { globalBotTokens = d || []; }).catch(() => { globalBotTokens = []; }); wizardOpen = true; }
     function closeWizard() { if (importProgressInterval) { clearInterval(importProgressInterval); importProgressInterval = null; } wizardOpen = false; }
 
     // Import (OpenClaw migration) helpers
@@ -1800,6 +1829,9 @@
                     {globalProviders}
                     on:change={() => providerDirty = true}
                 />
+                {#if providerKeySet && !providerKey && !providerRef && providerUrl}
+                    <div style="font-size:0.75rem;color:var(--gray-mid);padding:0.35rem 1.5rem 0">API key (saved) - leave blank to keep it</div>
+                {/if}
             </div>
 
             {#if providerRef}
@@ -2115,7 +2147,7 @@
                                 <span style="font-family:var(--font-body);font-size:0.7rem;color:var(--text-muted)">{t.fire_count}× fired</span>
                             {/if}
                             {#if t.last_fired_at}
-                                <span style="font-family:var(--font-body);font-size:0.7rem;color:var(--text-muted)">{timeAgo(t.last_fired_at * 1000)}</span>
+                                <span style="font-family:var(--font-body);font-size:0.7rem;color:var(--text-muted)">{timeAgo(t.last_fired_at)}</span>
                             {/if}
                             <button class="btn btn-sm" on:click={() => toggleTrigger(t.id, !t.enabled)}>{t.enabled ? $_('common.disable') : $_('common.enable')}</button>
                             {#if t.trigger_type === 'webhook'}<button class="btn btn-sm" on:click={() => rotateTriggerToken(t.id)} title="Rotate webhook token"><span class="material-symbols-outlined" style="font-size:0.9rem">key</span></button>{/if}

--- a/frontend-svelte/src/pages/Dashboard.svelte
+++ b/frontend-svelte/src/pages/Dashboard.svelte
@@ -100,7 +100,9 @@
     async function refresh() {
         if (refreshing) return;
         refreshing = true;
-        const activityLimit = Math.max(ACTIVITY_PAGE, activityEvents.length);
+        // Refetch as many raw events as previously fetched (activityOffset tracks the
+        // raw count); sizing off the filtered list would shrink it on every tick.
+        const activityLimit = Math.max(ACTIVITY_PAGE, activityOffset);
         try {
             const [root, agentsData, schedulerStatus, heartbeats, activityData, schedulesData, activityStats] = await Promise.all([
                 api('GET', '/api'),

--- a/frontend-svelte/src/pages/Memories.svelte
+++ b/frontend-svelte/src/pages/Memories.svelte
@@ -127,9 +127,9 @@
             params.set('offset', currentOffset);
             if (filterType) params.set('type', filterType);
             if (filterProject) params.set('project', filterProject);
-            if (filterSalience === 'high') params.set('min_salience', 4);
-            else if (filterSalience) { params.set('min_salience', filterSalience); params.set('max_salience', filterSalience); }
-            if (filterSort) params.set('sort', filterSort);
+            if (filterSalience === 'high') params.set('salience_min', 4);
+            else if (filterSalience) { params.set('salience_min', filterSalience); params.set('salience_max', filterSalience); }
+            if (filterSort) params.set('sort_by', filterSort);
             if (activeOnly) params.set('active', 'true');
 
             const data = await api('GET', `/agents/${currentAgent}/memories?${params}`);

--- a/frontend-svelte/src/pages/Settings.svelte
+++ b/frontend-svelte/src/pages/Settings.svelte
@@ -96,24 +96,6 @@
     let updateInfo = null;
     let updateLoading = false;
     let updateApplying = false;
-    let channelSwitching = false;
-
-    async function switchChannel(newChannel) {
-        if (channelSwitching) return;
-        if (!confirm(`Switch to ${newChannel} channel? This will change which branch updates pull from.`)) return;
-        channelSwitching = true;
-        try {
-            await api('POST', `/admin/channel?channel=${newChannel}`);
-            serverInfo = { ...serverInfo, channel: newChannel };
-            toast(`Switched to ${newChannel} channel`);
-            // Auto-check for updates on the new channel
-            await checkForUpdates();
-        } catch (e) {
-            toast('Failed to switch channel', 'error');
-        } finally {
-            channelSwitching = false;
-        }
-    }
 
     async function loadServerInfo() {
         serverInfo = await api('GET', '/api');
@@ -608,6 +590,7 @@
     let provFormPreset = 'custom';
     let provFormUrl = '';
     let provFormKey = '';
+    let provFormKeySet = false;
     let provFormModel = '';
 
     // Provider presets and helpers moved to ProviderConfig component
@@ -643,6 +626,7 @@
         provFormPreset = 'custom';
         provFormUrl = '';
         provFormKey = '';
+        provFormKeySet = false;
         provFormModel = '';
         providerFormVisible = true;
     }
@@ -651,7 +635,10 @@
         editingProvider = p;
         provFormName = p.name;
         provFormUrl = p.provider_url;
-        provFormKey = p.provider_key;
+        // Keys are write-only: the API reports provider_key_set instead of the
+        // plaintext key. Leave the field blank; blank on save means "keep".
+        provFormKey = '';
+        provFormKeySet = !!(p.provider_key_set ?? p.provider_key);
         provFormModel = p.provider_model;
         provFormPreset = p.preset || detectProvFormPreset(p.provider_url);
         providerFormVisible = true;
@@ -669,9 +656,9 @@
             name: provFormName.trim(),
             preset: provFormPreset,
             provider_url: provFormUrl.trim(),
-            provider_key: provFormKey.trim(),
             provider_model: provFormModel.trim(),
         };
+        if (provFormKey.trim()) body.provider_key = provFormKey.trim();
         try {
             if (editingProvider) {
                 await api('PUT', `/providers/${editingProvider.id}`, body);
@@ -715,6 +702,7 @@
         loadServerInfo();
         loadCalendarStatus();
         loadProviders();
+        refreshSkills();
     });
 
     onDestroy(() => {
@@ -800,20 +788,7 @@
                 </div>
                 <div>
                     <div style="font-size:0.75rem;text-transform:uppercase;color:var(--gray-mid);letter-spacing:0.05em">Release Channel</div>
-                    <div style="display:flex;gap:0.4rem;margin-top:0.35rem">
-                        <button
-                            class="btn btn-sm"
-                            style={serverInfo.channel === 'stable' ? 'background:var(--accent);color:white;border-color:var(--accent)' : ''}
-                            on:click={() => switchChannel('stable')}
-                            disabled={channelSwitching || serverInfo.channel === 'stable'}
-                        >stable</button>
-                        <button
-                            class="btn btn-sm"
-                            style={serverInfo.channel === 'beta' ? 'background:var(--accent);color:white;border-color:var(--accent)' : ''}
-                            on:click={() => switchChannel('beta')}
-                            disabled={channelSwitching || serverInfo.channel === 'beta'}
-                        >beta</button>
-                    </div>
+                    <div style="font-size:0.9rem;margin-top:0.25rem;font-family:var(--font-grotesk)">{serverInfo.channel || 'stable'}</div>
                 </div>
             </div>
             <div class="form-inline" style="margin-bottom:1rem">
@@ -1781,6 +1756,9 @@
                 bind:providerPreset={provFormPreset}
                 bind:providerName={provFormName}
             />
+            {#if editingProvider && provFormKeySet && !provFormKey}
+                <div style="padding:0 1.5rem 0.5rem;background:var(--surface-2);font-size:0.75rem;color:var(--gray-mid)">API key (saved) - leave blank to keep it</div>
+            {/if}
             <div style="padding:0 1.5rem 1rem;background:var(--surface-2);border-radius:0 0 var(--radius-lg) var(--radius-lg);display:flex;gap:0.5rem">
                 <button class="btn btn-primary" on:click={saveProvider}>{$_('common.save')}</button>
                 <button class="btn" on:click={cancelProviderForm}>{$_('common.cancel')}</button>
@@ -1810,7 +1788,7 @@
                                 <td><StatusBadge variant="model" label={p.preset || 'custom'} /></td>
                                 <td style="font-size:0.75rem;font-family:var(--font-grotesk);max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title={p.provider_url}>{p.provider_url || '—'}</td>
                                 <td style="font-size:0.75rem;font-family:var(--font-grotesk)">{p.provider_model || '—'}</td>
-                                <td><StatusBadge status={p.provider_key ? 'on' : 'off'} label={p.provider_key ? $_('settings.prov_key_set') : $_('settings.prov_key_none')} /></td>
+                                <td><StatusBadge status={(p.provider_key_set ?? p.provider_key) ? 'on' : 'off'} label={(p.provider_key_set ?? p.provider_key) ? $_('settings.prov_key_set') : $_('settings.prov_key_none')} /></td>
                                 <td>
                                     <div style="display:flex;gap:0.3rem">
                                         <button class="btn btn-sm" on:click={() => openEditProvider(p)}>{$_('common.edit')}</button>


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **medium** Skill Catalog never loads on page mount (`frontend-svelte/src/pages/Settings.svelte:703`)
  - Added refreshSkills() to the onMount loader block so the catalog populates on page open.
- **medium** Wizard does not reset wizTelegramRef/wizDiscordRef/wizSlackRef (`frontend-svelte/src/pages/Agents.svelte:999`)
  - openWizard() now resets all three wiz*Ref vars alongside the wiz*Token resets, so a canceled run's token selection is never applied to the next agent.
- **medium** Memory salience filter and sort dropdown silently do nothing (`frontend-svelte/src/pages/Memories.svelte:130`)
  - Renamed query params to salience_min/salience_max/sort_by to match the backend route signature in routes/memory.py.
- **low** Agent wizard never fetches global bot tokens (`frontend-svelte/src/pages/Agents.svelte:999`)
  - openWizard() now fetches /bot-tokens into globalBotTokens (mirroring the /providers fetch) so the Outreach step dropdowns work on a fresh install.
- **low** Trigger 'last fired' timestamp double-converted to ms (`frontend-svelte/src/pages/Agents.svelte:2118`)
  - Dropped the *1000 at the timeAgo callsite; timeAgo already converts numeric unix seconds to ms.
- **low** Release-channel 'beta' button always fails (`frontend-svelte/src/pages/Settings.svelte:810`)
  - Removed the dead stable/beta toggle and switchChannel()/channelSwitching; channel now renders as static text (serverInfo.channel || 'stable').
- **low** Group-create and retire modals close before the API call (`frontend-svelte/src/pages/Agents.svelte:469`)
  - submitGroup() and confirmRetire() now await the API in try/catch, toast the error and keep the modal open on failure, closing only after success.
- **low** openDetail sub-loaders lack the request-sequence guard (`frontend-svelte/src/pages/Agents.svelte:578`)
  - All 14 sub-loaders capture openDetailSeq before their await and bail before assigning state if superseded; closeDetail() bumps the seq to invalidate in-flight loaders.
- **low** Sidebar 'Active agents' list never renders (`frontend-svelte/src/components/Layout.svelte:49`)
  - Unwraps agentsResp.agents from the {agents,count,main_agent} envelope; status dot now keys off agent.streaming (agent.status never existed).
- **low** Activity feed collapses 'Load more' results on every 10s auto-refresh (`frontend-svelte/src/pages/Dashboard.svelte:103`)
  - refresh() sizes the activity refetch from activityOffset (raw fetched count) instead of the filtered activityEvents.length, so the expanded list no longer shrinks each tick.
- **n/a** group_note: provider_key_set migration (write-only provider keys) (`frontend-svelte/src/pages/Agents.svelte, frontend-svelte/src/pages/Settings.svelte`)
  - Key fields prefill empty and track (provider_key_set ?? provider_key) booleans, show an 'API key (saved) - leave blank to keep it' hint, and PUT bodies include provider_key only when the user typed a new value; tolerant of both old and new backend response shapes.

## Deferred (not fixed here, with reasons)
- 'Active only' toggle is non-functional - inactive memories can never be shown: The only correct fix is backend-side (make routes/memory.py active param tri-state, MemoryQueryFilters.active Optional in pinky_memory/types.py, gate the WHERE clause in store.py) - all out-of-scope files owned by parallel branches. A frontend-only change (sending active=false when the toggle is off) would show ONLY inactive memories instead of all memories, which is wrong semantics, so I did not force it.

## Testing
**fe-rest**: cd frontend-svelte && npm install --no-audit --no-fund: succeeded (130 packages). npm run build: succeeded twice (1.7s / 1.6s, 206 modules transformed); only pre-existing warnings (chunk >500kB, ineffective dynamic import of i18n.js). No frontend test suite exists; no Python files were touched so pytest was not run. Verified all added lines are ASCII-only (git diff grep for non-ASCII: clean).

Generated with [Claude Code](https://claude.com/claude-code)