### PR TITLE
fix(sweep): runners-comms - claude CLI --prompt flag, timeout reaping, resume semantics

### DIFF
--- a/src/pinky_daemon/agent_comms.py
+++ b/src/pinky_daemon/agent_comms.py
@@ -65,6 +65,9 @@ class AgentComms:
 
     def __init__(self, db_path: str = "data/agent_comms.db") -> None:
         self._db_path = db_path
+        # Anchor file transfers next to the DB so the destination does not
+        # depend on the caller's cwd at send time.
+        self._transfers_root = Path(db_path).resolve().parent / "transfers"
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
@@ -272,6 +275,15 @@ class AgentComms:
         ttl_seconds: int | None = None,
     ) -> AgentMessage:
         """Internal: store message and deliver to recipients' inboxes."""
+        if parent_message_id is not None:
+            parent = self._conn.execute(
+                "SELECT 1 FROM messages WHERE id = ?", (parent_message_id,)
+            ).fetchone()
+            if parent is None:
+                raise ValueError(
+                    f"parent_message_id {parent_message_id} does not reference an existing message"
+                )
+
         ts = time.time()
         meta_json = json.dumps(metadata or {})
 
@@ -336,8 +348,18 @@ class AgentComms:
         if not os.path.isfile(file_path):
             raise FileNotFoundError(f"Source file does not exist: {file_path}")
 
+        if (
+            not to_session
+            or to_session in (".", "..")
+            or os.path.basename(to_session) != to_session
+        ):
+            raise ValueError(f"Invalid file transfer recipient: {to_session!r}")
+
         filename = os.path.basename(file_path)
-        dest_dir = os.path.join("data", "transfers", to_session)
+        dest_root = os.path.realpath(self._transfers_root)
+        dest_dir = os.path.realpath(os.path.join(dest_root, to_session))
+        if os.path.dirname(dest_dir) != dest_root:
+            raise ValueError(f"Invalid file transfer recipient: {to_session!r}")
         os.makedirs(dest_dir, exist_ok=True)
 
         dest_path = os.path.join(dest_dir, filename)
@@ -408,7 +430,9 @@ class AgentComms:
         Returns:
             Number of messages marked.
         """
-        if message_ids:
+        if message_ids is not None:
+            if not message_ids:
+                return 0
             placeholders = ",".join("?" * len(message_ids))
             cursor = self._conn.execute(
                 f"""UPDATE inbox SET read = 1
@@ -510,21 +534,25 @@ class AgentComms:
                 break
             root_id = row["parent_message_id"]
 
-        # Recursive CTE to get all descendants at any depth.
+        # Recursive CTE to get all descendants at any depth. UNION (not
+        # UNION ALL) so cyclic parent chains in legacy data terminate.
         # Left-join inbox to get the real read state for this session
         # (falls back to False when the session has no inbox entry).
+        # A session is authorized to see a message if it sent it, is the
+        # direct recipient, or had it delivered to its inbox (group and
+        # broadcast messages store the group name or "*" in to_session).
         if session_id:
             query = """
                 WITH RECURSIVE thread AS (
                     SELECT m.* FROM messages m WHERE m.id = ?
-                    UNION ALL
+                    UNION
                     SELECT m.* FROM messages m
                     JOIN thread t ON m.parent_message_id = t.id
                 )
                 SELECT t.*, COALESCE(i.read, 0) as read
                 FROM thread t
                 LEFT JOIN inbox i ON i.message_id = t.id AND i.session_id = ?
-                WHERE t.from_session = ? OR t.to_session = ?
+                WHERE t.from_session = ? OR t.to_session = ? OR i.session_id IS NOT NULL
                 ORDER BY t.timestamp ASC
             """
             params: list = [root_id, session_id, session_id, session_id]
@@ -532,7 +560,7 @@ class AgentComms:
             query = """
                 WITH RECURSIVE thread AS (
                     SELECT m.* FROM messages m WHERE m.id = ?
-                    UNION ALL
+                    UNION
                     SELECT m.* FROM messages m
                     JOIN thread t ON m.parent_message_id = t.id
                 )
@@ -556,9 +584,10 @@ class AgentComms:
         """
         total = self._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
         rows = self._conn.execute(
-            """SELECT m.*, COALESCE(i.read, 0) as read
+            """SELECT m.*, COALESCE(MAX(i.read), 0) as read
                FROM messages m
                LEFT JOIN inbox i ON m.id = i.message_id
+               GROUP BY m.id
                ORDER BY m.timestamp DESC
                LIMIT ? OFFSET ?""",
             (limit, offset),

--- a/src/pinky_daemon/claude_runner.py
+++ b/src/pinky_daemon/claude_runner.py
@@ -172,6 +172,11 @@ class ClaudeRunner:
 
         except asyncio.TimeoutError:
             _log(f"runner: timeout after {self._config.timeout}s")
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+            await process.wait()
             return RunResult(
                 output="",
                 exit_code=1,
@@ -232,8 +237,8 @@ class ClaudeRunner:
         if system_prompt:
             cmd.extend(["--system-prompt", system_prompt])
 
-        # The prompt itself
-        cmd.extend(["--prompt", prompt])
+        # The prompt itself (positional argument; the CLI has no --prompt flag)
+        cmd.append(prompt)
 
         return cmd
 

--- a/src/pinky_daemon/claude_runner.py
+++ b/src/pinky_daemon/claude_runner.py
@@ -127,19 +127,40 @@ class ClaudeRunner:
 
         Args:
             prompt: The message/prompt to send.
-            session_id: Override session ID for this call.
-            resume: Resume the previous session (--continue).
+            session_id: Override session ID for this call (must be a UUID).
+            resume: Resume the session (--resume when session_id is set,
+                otherwise --continue). If the session does not exist yet,
+                it is created with that ID instead.
             system_prompt: Additional system prompt for this call.
         """
+        session_id = session_id or self._config.session_id
+        resume = resume or self._config.resume
+        system_prompt = system_prompt or self._config.system_prompt
+
         cmd = self._build_command(
             prompt,
-            session_id=session_id or self._config.session_id,
-            resume=resume or self._config.resume,
-            system_prompt=system_prompt or self._config.system_prompt,
+            session_id=session_id,
+            resume=resume,
+            system_prompt=system_prompt,
         )
 
         _log(f"runner: executing claude with prompt length={len(prompt)}")
+        result = await self._execute(cmd)
 
+        if resume and session_id and not result.ok and "No conversation found" in result.error:
+            # First message for this session ID: create the session instead.
+            cmd = self._build_command(
+                prompt,
+                session_id=session_id,
+                resume=False,
+                system_prompt=system_prompt,
+            )
+            result = await self._execute(cmd)
+
+        return result
+
+    async def _execute(self, cmd: list[str]) -> RunResult:
+        """Execute a built claude command and parse the result."""
         try:
             process = await asyncio.create_subprocess_exec(
                 *cmd,
@@ -206,10 +227,14 @@ class ClaudeRunner:
         # Output format
         cmd.extend(["--output-format", "text"])
 
-        # Session management
-        if session_id:
+        # Session management. --resume continues an existing session by ID,
+        # --session-id starts a new one with that ID, --continue resumes the
+        # most recent conversation in the working dir.
+        if session_id and resume:
+            cmd.extend(["--resume", session_id])
+        elif session_id:
             cmd.extend(["--session-id", session_id])
-        if resume:
+        elif resume:
             cmd.append("--continue")
 
         # Model
@@ -232,8 +257,8 @@ class ClaudeRunner:
         if system_prompt:
             cmd.extend(["--system-prompt", system_prompt])
 
-        # The prompt itself
-        cmd.extend(["--prompt", prompt])
+        # The prompt itself (positional argument; there is no --prompt flag)
+        cmd.append(prompt)
 
         return cmd
 

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -88,6 +88,11 @@ class CodexSession:
         self._connect_attempted = False  # distinguishes UNINITIALIZED from DEAD
         self._processing = False  # True while a codex exec is running
         self._message_queue: asyncio.Queue[tuple[str, str, str, str]] = asyncio.Queue()
+        # Serializes _exec_codex between the worker and out-of-band callers
+        # (idle_sleep's save turn): two concurrent execs would resume the same
+        # codex thread and clobber the shared _current_proc / app-server
+        # turn-correlation state.
+        self._exec_lock = asyncio.Lock()
         self._worker_task: asyncio.Task | None = None
         self._current_proc: asyncio.subprocess.Process | None = None  # For cleanup on disconnect
         # #591 P1#2 (Murzik round-2): callback fired after the NEXT
@@ -284,8 +289,8 @@ class CodexSession:
                     self.id, "user", prompt,
                     platform=platform, chat_id=chat_id,
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                _log(f"codex[{self.agent_name}]: conversation store append failed: {e}")
 
         queued_prompt = prompt + agent_hint if agent_hint else prompt
         await self._message_queue.put((queued_prompt, platform, chat_id, message_id))
@@ -300,7 +305,8 @@ class CodexSession:
                 try:
                     self._processing = True
                     self._current_turn_seq = self._stats["turns"] + 1
-                    result = await self._exec_codex(prompt)
+                    async with self._exec_lock:
+                        result = await self._exec_codex(prompt)
 
                     # #591 P1#2 (Murzik round-2): fire the pending wake
                     # callback after exec confirms delivery. Only on
@@ -584,6 +590,7 @@ class CodexSession:
         )
 
         proc = None
+        stderr_task = None
         try:
             # limit=10MB — codex emits large tool-result events that exceed
             # asyncio's default 64KB StreamReader limit and kill the session
@@ -598,6 +605,12 @@ class CodexSession:
                 limit=10 * 1024 * 1024,
             )
             self._current_proc = proc
+
+            # Drain stderr concurrently: an undrained PIPE blocks the child
+            # once the OS buffer (~64KiB) fills, wedging the turn (same hazard
+            # codex_app_server._drain_stderr guards against).
+            if proc.stderr:
+                stderr_task = asyncio.create_task(proc.stderr.read())
 
             # Feed prompt via stdin, then close stdin to signal EOF
             proc.stdin.write(prompt.encode())
@@ -663,8 +676,8 @@ class CodexSession:
                 except Exception:
                     pass
 
-            if proc.stderr:
-                stderr_data = await proc.stderr.read()
+            if stderr_task is not None:
+                stderr_data = await stderr_task
                 if stderr_data:
                     stderr_str = stderr_data.decode().strip()
                     if stderr_str:
@@ -682,8 +695,11 @@ class CodexSession:
             _log(f"codex[{self.agent_name}]: exec timed out")
             await self._emit_stream_event({"type": "turn_failed", "agent": self.agent_name, "session_id": self.id, "error": "codex exec timed out after 600s"})
             if proc:
-                proc.kill()
-                await proc.wait()
+                try:
+                    proc.kill()
+                    await proc.wait()
+                except Exception:
+                    pass
         except Exception as e:
             result.failed = True
             result.errors.append(str(e))
@@ -697,6 +713,8 @@ class CodexSession:
                     pass
         finally:
             self._current_proc = None
+            if stderr_task is not None and not stderr_task.done():
+                stderr_task.cancel()
 
         return result
 
@@ -1057,12 +1075,16 @@ class CodexSession:
                 text = item.get("text", "")
                 if text:
                     result.text_parts.append(text)
-                    await self._emit_stream_event({
-                        "type": "assistant_delta",
-                        "agent": self.agent_name,
-                        "session_id": self.id,
-                        "delta": text,
-                    })
+                    # App-server mode already streamed this text incrementally
+                    # via item/agentMessage/delta; emitting the full text again
+                    # would duplicate it in the live chat stream.
+                    if not self._use_app_server:
+                        await self._emit_stream_event({
+                            "type": "assistant_delta",
+                            "agent": self.agent_name,
+                            "session_id": self.id,
+                            "delta": text,
+                        })
 
             elif item_type == "command_execution":
                 cmd_str = item.get("command", "")
@@ -1358,15 +1380,17 @@ class CodexSession:
 
         _log(f"codex[{self.agent_name}]: idle sleep triggered")
 
-        # Ask agent to save state before sleeping
+        # Ask agent to save state before sleeping. The lock keeps this exec
+        # from racing a worker turn against the same codex thread.
         try:
-            await self._exec_codex(
-                "[SYSTEM] You've been idle for over an hour. Auto-sleep is activating.\n\n"
-                "Before your session is suspended:\n"
-                "1. Use reflect() to persist key learnings and current task state\n"
-                "2. Note what you were working on so you can resume later\n\n"
-                "Your session will be preserved and resumed when you're needed next."
-            )
+            async with self._exec_lock:
+                await self._exec_codex(
+                    "[SYSTEM] You've been idle for over an hour. Auto-sleep is activating.\n\n"
+                    "Before your session is suspended:\n"
+                    "1. Use reflect() to persist key learnings and current task state\n"
+                    "2. Note what you were working on so you can resume later\n\n"
+                    "Your session will be preserved and resumed when you're needed next."
+                )
             _log(f"codex[{self.agent_name}]: memory save prompt sent before idle sleep")
         except Exception as e:
             _log(f"codex[{self.agent_name}]: memory save failed before idle sleep: {e}")

--- a/src/pinky_daemon/message_handler.py
+++ b/src/pinky_daemon/message_handler.py
@@ -9,10 +9,14 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 from pinky_daemon.claude_runner import ClaudeRunner
+
+# Namespace for deriving deterministic session UUIDs from chat keys.
+SESSION_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_DNS, "pinkybot.session")
 
 
 @dataclass
@@ -116,7 +120,7 @@ class MessageHandler:
             result = await self._runner.run(
                 prompt,
                 session_id=session_id,
-                resume=True,  # Always resume to maintain context
+                resume=True,  # Maintain context; the runner creates the session on first use
             )
 
         if result.ok:
@@ -146,15 +150,20 @@ class MessageHandler:
         )
 
     def _get_session_id(self, message: InboundMessage) -> str:
-        """Generate a session ID based on the configured strategy."""
+        """Derive a session UUID based on the configured strategy.
+
+        The claude CLI only accepts UUID session ids, so the chat key is
+        hashed into a stable UUID: the same chat always maps to the same
+        session, and different chats never share one.
+        """
         prefix = self._config.session_prefix
 
         if self._config.session_strategy == "shared":
-            return f"{prefix}-shared"
-        elif self._config.session_strategy == "per_chat":
-            return f"{prefix}-{message.platform}-{message.chat_id}"
+            key = f"{prefix}-shared"
         else:
-            return f"{prefix}-{message.platform}-{message.chat_id}"
+            key = f"{prefix}-{message.platform}-{message.chat_id}"
+
+        return str(uuid.uuid5(SESSION_NAMESPACE, key))
 
     @property
     def message_count(self) -> int:

--- a/src/pinky_daemon/sdk_runner.py
+++ b/src/pinky_daemon/sdk_runner.py
@@ -200,7 +200,6 @@ class SDKRunner:
         usage = {}
         model_usage = {}
         duration_api_ms = 0
-        turn_usage: list[dict] = []  # Per-turn usage tracking
 
         # Fire session_start hook
         await self._fire_hook(HookEvent.session_start, session_id=session_id)
@@ -233,10 +232,6 @@ class SDKRunner:
                     duration_api_ms = getattr(message, "duration_api_ms", 0) or 0
 
                 elif isinstance(message, AssistantMessage) and not got_result:
-                    # Track per-turn usage
-                    turn_data = getattr(message, "usage", None)
-                    if turn_data:
-                        turn_usage.append(dict(turn_data) if hasattr(turn_data, "__iter__") else {"raw": turn_data})
                     # Collect text content + detect tool use
                     for block in message.content:
                         if isinstance(block, TextBlock):

--- a/tests/test_agent_comms.py
+++ b/tests/test_agent_comms.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 
+import pytest
 from fastapi.testclient import TestClient
 
 from pinky_daemon.agent_comms import AgentComms, AgentMessage
@@ -629,6 +630,127 @@ class TestAgentCommsNewFeatures:
         import time
         # Should expire roughly 7 days from now
         assert row["expires_at"] > time.time() + 6 * 24 * 3600
+        self._cleanup(comms, path)
+
+    # -- Thread visibility for group/broadcast recipients --
+
+    def test_get_thread_group_recipient_sees_messages(self):
+        """A group message recipient must see the thread even though
+        to_session stores the group name, not their session id."""
+        comms, path = self._make_comms()
+        comms.create_group("team", ["alice", "bob", "charlie"])
+        root = comms.send_group("alice", "team", "Team update")
+        comms.send_group("bob", "team", "Ack", parent_message_id=root.id)
+
+        thread = comms.get_thread(root.id, session_id="charlie")
+        contents = {m.content for m in thread}
+        assert "Team update" in contents
+        assert "Ack" in contents
+        self._cleanup(comms, path)
+
+    def test_get_thread_broadcast_recipient_sees_message(self):
+        comms, path = self._make_comms()
+        root = comms.broadcast("alice", "Hear ye", active_sessions=["bob", "charlie"])
+
+        thread = comms.get_thread(root.id, session_id="bob")
+        assert len(thread) == 1
+        assert thread[0].content == "Hear ye"
+        assert thread[0].read is False
+        self._cleanup(comms, path)
+
+    def test_get_thread_still_hides_unrelated_messages(self):
+        comms, path = self._make_comms()
+        root = comms.send("alice", "bob", "A->B")
+        comms.send("bob", "charlie", "B->C", parent_message_id=root.id)
+
+        thread = comms.get_thread(root.id, session_id="dave")
+        assert thread == []
+        self._cleanup(comms, path)
+
+    # -- Parent validation / cycle safety --
+
+    def test_send_rejects_unknown_parent(self):
+        comms, path = self._make_comms()
+        with pytest.raises(ValueError):
+            comms.send("alice", "bob", "reply", parent_message_id=999)
+        self._cleanup(comms, path)
+
+    def test_get_thread_terminates_on_cyclic_parents(self):
+        """Legacy rows with cyclic parent chains must not hang the CTE."""
+        comms, path = self._make_comms()
+        a = comms.send("alice", "bob", "A")
+        b = comms.send("bob", "alice", "B", parent_message_id=a.id)
+        comms._conn.execute(
+            "UPDATE messages SET parent_message_id = ? WHERE id = ?", (b.id, a.id)
+        )
+        comms._conn.commit()
+
+        thread = comms.get_thread(a.id)
+        assert {m.content for m in thread} == {"A", "B"}
+
+        thread = comms.get_thread(a.id, session_id="alice")
+        assert {m.content for m in thread} == {"A", "B"}
+        self._cleanup(comms, path)
+
+    # -- File transfer hardening --
+
+    def test_send_file_rejects_path_traversal(self):
+        comms, path = self._make_comms()
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"payload")
+            src = f.name
+        try:
+            for bad in ("../../evil", "..", ".", "", "/tmp/abs"):
+                with pytest.raises(ValueError):
+                    comms.send_file("alice", bad, src)
+        finally:
+            os.unlink(src)
+        self._cleanup(comms, path)
+
+    def test_send_file_writes_under_transfers_root(self):
+        comms, path = self._make_comms()
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"payload")
+            src = f.name
+        try:
+            msg = comms.send_file("alice", "bob", src)
+            dest = msg.metadata["file_path"]
+            root = os.path.realpath(os.path.join(os.path.dirname(path), "transfers"))
+            assert os.path.realpath(dest).startswith(root + os.sep)
+            assert os.path.isfile(dest)
+            os.unlink(dest)
+        finally:
+            os.unlink(src)
+        self._cleanup(comms, path)
+
+    # -- Audit listing dedup --
+
+    def test_get_all_messages_no_duplicates_for_multi_recipient(self):
+        comms, path = self._make_comms()
+        comms.create_group("team", ["alice", "bob", "charlie"])
+        comms.send_group("alice", "team", "Team update")
+        comms.send("alice", "bob", "Direct")
+
+        messages, total = comms.get_all_messages()
+        assert total == 2
+        assert len(messages) == 2
+        assert len({m.id for m in messages}) == 2
+
+        # Pagination over deduped rows must not overlap
+        page1, _ = comms.get_all_messages(limit=1, offset=0)
+        page2, _ = comms.get_all_messages(limit=1, offset=1)
+        assert page1[0].id != page2[0].id
+        self._cleanup(comms, path)
+
+    # -- mark_read empty list --
+
+    def test_mark_read_empty_list_marks_nothing(self):
+        comms, path = self._make_comms()
+        comms.send("alice", "bob", "Msg 1")
+        comms.send("alice", "bob", "Msg 2")
+
+        assert comms.mark_read("bob", []) == 0
+        assert comms.unread_count("bob") == 2
         self._cleanup(comms, path)
 
     # ── Inbox Fallback (API) ──────────────────────────────────

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 import tempfile
 
 import pytest
@@ -1220,3 +1221,131 @@ class TestCodexAppServerTurn:
         result = await s._exec_codex_app_server("hi")
         assert result.failed
         assert "spawn failed" in result.errors[0]
+
+
+# -- Exec serialization / stderr drain / delta dedupe regressions ---------
+
+
+def _plain_session(**overrides):
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        label="main",
+        model="",
+        working_dir=overrides.pop("working_dir", "/tmp"),
+        provider_url="codex_cli",
+        provider_key="test-key",
+        **overrides,
+    )
+    return CodexSession(config)
+
+
+class TestExecSerialization:
+    @pytest.mark.asyncio
+    async def test_idle_sleep_save_exec_serializes_with_worker(self):
+        """idle_sleep()'s save turn must not run concurrently with a worker
+        turn -- two parallel execs would resume the same codex thread and
+        clobber the shared kill handle / app-server turn state."""
+        s = _plain_session()
+
+        active = 0
+        max_active = 0
+        exec_started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def fake_exec(prompt: str) -> CodexTurnResult:
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            exec_started.set()
+            await release.wait()
+            active -= 1
+            return CodexTurnResult()
+
+        s._exec_codex = fake_exec  # type: ignore[assignment]
+
+        await s.connect()  # queues the wake prompt; worker starts executing it
+        await asyncio.wait_for(exec_started.wait(), timeout=5)
+
+        sleep_task = asyncio.create_task(s.idle_sleep())
+        await asyncio.sleep(0.05)  # give idle_sleep a chance to start its exec
+        release.set()
+
+        assert await asyncio.wait_for(sleep_task, timeout=5) is True
+        assert max_active == 1
+
+
+class TestExecStderrDrain:
+    @pytest.mark.asyncio
+    async def test_large_stderr_does_not_wedge_exec(self, tmp_path):
+        """A child writing more than the OS pipe buffer (~64KiB) to stderr
+        mid-turn must not block the turn: stderr is drained concurrently
+        rather than read only after stdout EOF."""
+        s = _plain_session(working_dir=str(tmp_path))
+        s._use_app_server = False  # exercise the legacy exec path
+        script = tmp_path / "fake_codex.py"
+        script.write_text(
+            "import json, sys\n"
+            "sys.stdin.read()\n"
+            "sys.stderr.write('x' * (256 * 1024))\n"
+            "sys.stderr.flush()\n"
+            "print(json.dumps({'type': 'item.completed',\n"
+            "                  'item': {'type': 'agent_message', 'text': 'hi'}}))\n"
+        )
+        s._build_codex_cmd = lambda: [sys.executable, str(script)]  # type: ignore[assignment]
+
+        result = await asyncio.wait_for(s._exec_codex("hello"), timeout=30)
+
+        assert not result.failed
+        assert result.text_parts == ["hi"]
+
+
+class TestAssistantDeltaDedupe:
+    @pytest.mark.asyncio
+    async def test_app_server_streams_assistant_text_once(self):
+        """item/completed must not re-emit text already streamed via
+        item/agentMessage/delta notifications."""
+        s = _appserver_session()
+        events: list[dict] = []
+
+        async def capture(ev: dict) -> None:
+            events.append(ev)
+
+        s._stream_event_callback = capture
+        notifications = [
+            ("thread/started", {"thread": {"id": "thr-1"}}),
+            ("item/agentMessage/delta", {"delta": "hel"}),
+            ("item/agentMessage/delta", {"delta": "lo"}),
+            ("item/completed", {"item": {"id": "0", "type": "agentMessage", "text": "hello"}}),
+            ("turn/completed", {"turn": {"status": "completed"}}),
+        ]
+        fake = _FakeAppClient(s, notifications)
+        _patch_ensure(s, fake)
+
+        result = await s._exec_codex_app_server("hi")
+
+        assert result.text_parts == ["hello"]
+        deltas = [e["delta"] for e in events if e["type"] == "assistant_delta"]
+        assert deltas == ["hel", "lo"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_agent_message_still_emits_delta(self, monkeypatch):
+        """The legacy exec path has no incremental deltas -- the full text on
+        item.completed is its only assistant_delta and must keep flowing."""
+        monkeypatch.delenv("PINKY_CODEX_APP_SERVER", raising=False)
+        s = _plain_session()
+        events: list[dict] = []
+
+        async def capture(ev: dict) -> None:
+            events.append(ev)
+
+        s._stream_event_callback = capture
+        result = CodexTurnResult()
+        await s._handle_event(
+            {"type": "item.completed",
+             "item": {"id": "0", "type": "agent_message", "text": "hello"}},
+            result,
+        )
+
+        assert result.text_parts == ["hello"]
+        deltas = [e["delta"] for e in events if e["type"] == "assistant_delta"]
+        assert deltas == ["hello"]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -66,8 +66,10 @@ class TestClaudeRunner:
         cmd = runner._build_command("Hello")
         assert "/usr/bin/claude" in cmd
         assert "--print" in cmd
-        assert "--prompt" in cmd
-        assert "Hello" in cmd
+        # The claude CLI takes the prompt as a positional argument; there is
+        # no --prompt option (it exits with "unknown option '--prompt'").
+        assert "--prompt" not in cmd
+        assert cmd[-1] == "Hello"
 
     def test_build_command_with_session(self):
         config = ClaudeRunnerConfig(claude_bin="/usr/bin/claude")
@@ -142,6 +144,34 @@ class TestClaudeRunner:
         result = await slow_run("test")
         assert result.ok is False
         assert "Timed out" in result.error
+
+    @pytest.mark.asyncio
+    async def test_run_timeout_kills_subprocess(self, monkeypatch):
+        """Timeout must kill and reap the spawned process, not orphan it."""
+        config = ClaudeRunnerConfig(claude_bin="/bin/sleep", timeout=0.2)
+        runner = ClaudeRunner(config)
+        monkeypatch.setattr(
+            runner, "_build_command",
+            lambda prompt, **kwargs: ["/bin/sleep", "30"],
+        )
+
+        spawned = []
+        real_exec = asyncio.create_subprocess_exec
+
+        async def capture_exec(*args, **kwargs):
+            proc = await real_exec(*args, **kwargs)
+            spawned.append(proc)
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", capture_exec)
+
+        result = await runner.run("hi")
+
+        assert result.exit_code == 1
+        assert "Timed out" in result.error
+        assert len(spawned) == 1
+        # Killed and reaped: returncode is set, process is no longer running.
+        assert spawned[0].returncode is not None
 
     @pytest.mark.asyncio
     async def test_run_missing_binary(self):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
+import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from pinky_daemon.claude_runner import ClaudeRunner, ClaudeRunnerConfig, RunResult
 from pinky_daemon.daemon import Daemon, DaemonConfig, _resolve_env
-from pinky_daemon.message_handler import HandlerConfig, InboundMessage, MessageHandler
+from pinky_daemon.message_handler import (
+    SESSION_NAMESPACE,
+    HandlerConfig,
+    InboundMessage,
+    MessageHandler,
+)
 
 # ── RunResult ────────────────────────────────────────────────
 
@@ -66,8 +72,9 @@ class TestClaudeRunner:
         cmd = runner._build_command("Hello")
         assert "/usr/bin/claude" in cmd
         assert "--print" in cmd
-        assert "--prompt" in cmd
-        assert "Hello" in cmd
+        # The prompt is a positional argument (the CLI has no --prompt flag)
+        assert "--prompt" not in cmd
+        assert cmd[-1] == "Hello"
 
     def test_build_command_with_session(self):
         config = ClaudeRunnerConfig(claude_bin="/usr/bin/claude")
@@ -81,6 +88,43 @@ class TestClaudeRunner:
         runner = ClaudeRunner(config)
         cmd = runner._build_command("Hi", resume=True)
         assert "--continue" in cmd
+
+    def test_build_command_resume_with_session_uses_resume_flag(self):
+        """session_id + resume must use --resume <id>, not --session-id + --continue."""
+        config = ClaudeRunnerConfig(claude_bin="/usr/bin/claude")
+        runner = ClaudeRunner(config)
+        sid = "b9c529fb-f998-47ba-8fc0-0895aa481656"
+        cmd = runner._build_command("Hi", session_id=sid, resume=True)
+        assert "--resume" in cmd
+        assert cmd[cmd.index("--resume") + 1] == sid
+        assert "--session-id" not in cmd
+        assert "--continue" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_run_creates_session_when_resume_finds_nothing(self):
+        """First message for a chat: --resume fails, runner retries with --session-id."""
+        config = ClaudeRunnerConfig(claude_bin="/usr/bin/claude")
+        runner = ClaudeRunner(config)
+        sid = "b9c529fb-f998-47ba-8fc0-0895aa481656"
+
+        calls = []
+
+        async def fake_execute(cmd):
+            calls.append(cmd)
+            if "--resume" in cmd:
+                return RunResult(
+                    output="", exit_code=1,
+                    error=f"No conversation found with session ID: {sid}",
+                )
+            return RunResult(output="ok", exit_code=0)
+
+        runner._execute = fake_execute
+        result = await runner.run("Hi", session_id=sid, resume=True)
+        assert result.ok
+        assert len(calls) == 2
+        assert "--resume" in calls[0]
+        assert "--session-id" in calls[1]
+        assert "--continue" not in calls[1]
 
     def test_build_command_with_model(self):
         config = ClaudeRunnerConfig(claude_bin="/usr/bin/claude", model="opus")
@@ -239,7 +283,27 @@ class TestMessageHandler:
         await handler.handle(msg)
 
         call_kwargs = runner.run.call_args[1]
-        assert call_kwargs["session_id"] == "test-telegram-111"
+        expected = str(uuid.uuid5(SESSION_NAMESPACE, "test-telegram-111"))
+        assert call_kwargs["session_id"] == expected
+
+    @pytest.mark.asyncio
+    async def test_session_ids_are_uuids_and_chat_scoped(self):
+        """Session ids must be valid UUIDs (claude CLI requirement), stable per
+        chat, and distinct across chats."""
+        handler, runner = self._make_handler()
+        config = HandlerConfig(session_strategy="per_chat", rate_limit_seconds=0)
+        handler = MessageHandler(runner, config)
+
+        await handler.handle(self._make_message(chat_id="111"))
+        first = runner.run.call_args[1]["session_id"]
+        await handler.handle(self._make_message(chat_id="111"))
+        again = runner.run.call_args[1]["session_id"]
+        await handler.handle(self._make_message(chat_id="222"))
+        other = runner.run.call_args[1]["session_id"]
+
+        assert uuid.UUID(first)  # parses as UUID
+        assert first == again
+        assert first != other
 
     @pytest.mark.asyncio
     async def test_session_shared(self):
@@ -251,7 +315,8 @@ class TestMessageHandler:
         await handler.handle(msg)
 
         call_kwargs = runner.run.call_args[1]
-        assert call_kwargs["session_id"] == "pinky-shared"
+        expected = str(uuid.uuid5(SESSION_NAMESPACE, "pinky-shared"))
+        assert call_kwargs["session_id"] == expected
 
     @pytest.mark.asyncio
     async def test_rate_limiting(self):


### PR DESCRIPTION
## Summary
Part of a full-codebase bug sweep: every finding below came from a multi-agent audit and was independently re-verified against the code before fixing. Fixes are minimal and scoped to the files cited; no two sweep PRs touch the same source file, so they can merge in any order.

## Findings fixed
- **high** ClaudeRunner passes prompt via nonexistent --prompt flag; every CLI invocation fails (`src/pinky_daemon/claude_runner.py:236`)
  - Pass the prompt as the final positional argument instead of cmd.extend(["--prompt", prompt]); updated tests/test_daemon.py which asserted the buggy flag and now pins cmd[-1] == prompt and absence of --prompt.
- **medium** ClaudeRunner timeout path never kills the subprocess (`src/pinky_daemon/claude_runner.py:173`)
  - On asyncio.TimeoutError, process.kill() (catching ProcessLookupError) then await process.wait() to reap the child before returning the timeout RunResult; regression test asserts the spawned proc has returncode set.
- **medium** codex exec stderr pipe never drained during the turn (`src/pinky_daemon/codex_session.py:595`)
  - Start stderr_task = asyncio.create_task(proc.stderr.read()) right after spawn and await it after proc.wait() (mirrors codex_app_server._drain_stderr); finally-block cancels it on error paths. Regression test wedges pre-fix (child writes 256KiB to stderr before any stdout).
- **medium** idle_sleep() runs _exec_codex directly, racing the message worker (`src/pinky_daemon/codex_session.py:1363`)
  - Added self._exec_lock = asyncio.Lock(); both the worker's exec call and idle_sleep's save-turn exec acquire it, so two execs can never run concurrently against the same codex thread. Regression test asserts max concurrent execs == 1.
- **low** App-server mode emits assistant text twice to the UI stream (`src/pinky_daemon/codex_session.py:1060`)
  - _handle_event's agent_message branch skips the full-text assistant_delta emit when self._use_app_server (deltas already streamed it); text_parts append stays unconditional. Tests cover both app-server dedupe and legacy path still emitting.
- **low** User-message conversation-store append swallows errors with no log (`src/pinky_daemon/codex_session.py:282`)
  - Replaced except Exception: pass with a _log of the append failure, matching the assistant-side handler and StreamingSession.
- **low** Unguarded proc.kill() in exec timeout handler can raise and discard the turn result (`src/pinky_daemon/codex_session.py:685`)
  - Wrapped proc.kill()/await proc.wait() in the TimeoutError handler in try/except Exception: pass, mirroring the sibling except-Exception branch.
- **low** turn_usage per-turn tracking is collected but never used (`src/pinky_daemon/sdk_runner.py:203`)
  - Deleted the dead turn_usage declaration and the per-AssistantMessage append block; nothing read it (verified by repo-wide grep).
- **medium** Per-chat session ids are not UUIDs and resume semantics break chat isolation - poll-mode pipeline cannot work (`src/pinky_daemon/message_handler.py:116`)
  - _get_session_id now derives deterministic per-chat UUIDs (uuid5); ClaudeRunner uses --resume <id> for continuation instead of --session-id + --continue, passes the prompt positionally (the --prompt flag does not exist), and falls back to creating the session with --session-id when --resume reports 'No conversation found' (first message of a chat / fresh disk).
- **medium** get_thread hides group and broadcast messages from their recipients (`src/pinky_daemon/agent_comms.py:527`)
  - Session-filtered thread query now also accepts inbox delivery (OR i.session_id IS NOT NULL on the already-session-scoped LEFT JOIN), so group/broadcast recipients see the thread; unrelated sessions still see nothing.
- **medium** Unvalidated parent_message_id enables cyclic threads that hang the recursive CTE (`src/pinky_daemon/agent_comms.py:517`)
  - _send raises ValueError when parent_message_id does not reference an existing message (rejects self/forward/guessed ids, so cycles cannot be created), and both recursive CTEs use UNION instead of UNION ALL so cyclic legacy data terminates instead of generating rows forever.
- **medium** send_file builds the destination path from unsanitized to_session - path traversal and cwd-relative writes (`src/pinky_daemon/agent_comms.py:340`)
  - to_session is validated (rejects empty, '.', '..', and anything containing path separators), the destination is realpath-contained as a direct child of the transfers root, and the root is anchored next to the comms DB (Path(db_path).resolve().parent/'transfers') instead of cwd-relative 'data' - same location for the daemon, but cwd-independent.
- **low** get_all_messages duplicates each multi-recipient message and breaks pagination (`src/pinky_daemon/agent_comms.py:559`)
  - Audit query now GROUP BY m.id with COALESCE(MAX(i.read), 0), so each message appears once and LIMIT/OFFSET pagination is consistent with the total count.
- **low** mark_read with an explicit empty list marks the entire inbox as read (`src/pinky_daemon/agent_comms.py:411`)
  - mark_read distinguishes None (mark all) from [] (mark nothing, return 0), matching the docstring contract; also avoids the IN () SQL syntax error an empty list would otherwise hit.

## Deferred (not fixed here, with reasons)
- get_thread via run_in_executor (sub-item of the cyclic-CTE finding's fix_hint): Moving the synchronous sqlite3 call off the event loop requires editing api.py, which is owned by parallel branches. The hang itself is fixed at the source: parents are validated at send time and the CTE uses UNION, so the query is always finite.

## Testing
**runners**: python3 -m pytest tests/test_codex_session.py tests/test_daemon.py tests/test_claude_runner_binary.py -q -> 113 passed (re-run after ASCII cleanup: 110 passed across the first two files). python3 -m pytest tests/test_api.py tests/test_tmux_session.py -q -> 606 passed. python3 -m pytest tests/test_sdk_runner.py tests/test_effort_verification.py -q -> 56 passed. python3 -m pytest tests/test_tmux_dream_runner.py -q -> 12 passed. ruff check on all 5 changed files -> All checks passed. New regression tests: test_run_timeout_kills_subprocess (test_daemon.py), TestExecSerialization.test_idle_sleep_save_exec_serializes_with_worker, TestExecStderrDrain.test_large_stderr_does_not_wedge_exec, TestAssistantDeltaDedupe (2 tests) (test_codex_session.py); test_build_command_basic updated to pin the positional-prompt contract.
**comms**: python3 -m pytest tests/test_agent_comms.py tests/test_daemon.py tests/test_claude_runner_binary.py -q -> 99 passed. python3 -m pytest tests/test_api.py tests/test_pinky_self_tools.py tests/test_route_auth_coverage.py -q -> 538 passed (6m10s). Re-run after ASCII header cleanup: python3 -m pytest tests/test_agent_comms.py tests/test_daemon.py -q -> 96 passed. ruff check on all 5 changed files -> All checks passed. New regression tests: 8 in tests/test_agent_comms.py (group/broadcast thread visibility, unrelated-session denial, unknown-parent rejection, cyclic-parent termination, traversal rejection, transfers-root containment, audit dedup + pagination, empty-list mark_read) and 4 in tests/test_daemon.py (resume-with-session flag shape, create-on-resume-miss fallback, UUID/determinism of session ids); 3 existing tests updated (--prompt removal, uuid5 session id expectations). Existing claude CLI semantics verified empirically: --session-id creates (errors 'already in use' on reuse), --resume <uuid> resumes (errors 'No conversation found' on stderr when missing).

Generated with [Claude Code](https://claude.com/claude-code)