### PR TITLE
feat(autonomy): make idle instruction proactive — invent useful work

### DIFF
--- a/src/pinky_daemon/autonomy.py
+++ b/src/pinky_daemon/autonomy.py
@@ -193,7 +193,11 @@ You are operating autonomously. Assess the situation above and take action:
 4. **Delegate if needed** — create subtasks for workers if the work is complex
 5. **Save your state** — before stopping, save continuation context so you can resume
 
-If there's nothing to do, say so. Don't invent work.""")
+If the queue is empty, invent useful work — that's encouraged. Fix a known papercut,
+improve tests or docs, follow up on a stale thread, dig into a recurring annoyance, or
+propose a new idea to your owner. Idle time is an opportunity: bias toward doing something
+genuinely useful over doing nothing. The only bar is usefulness — don't manufacture
+busywork or churn just to look active.""")
 
     return "\n\n".join(parts)
 


### PR DESCRIPTION
## What

Brad's ask (Telegram, 2026-06-10): the autonomous-wake prompt ended with **"If there's nothing to do, say so. Don't invent work."** — which biases every agent toward idling. He wants the opposite: *"I want you to invent work if it helps all of us!"*

## Change

`build_decision_prompt()` in `autonomy.py` — the closing instruction is now:

> If the queue is empty, invent useful work — that's encouraged. Fix a known papercut, improve tests or docs, follow up on a stale thread, dig into a recurring annoyance, or propose a new idea to your owner. Idle time is an opportunity: bias toward doing something genuinely useful over doing nothing. The only bar is usefulness — don't manufacture busywork or churn just to look active.

Keeps the anti-busywork guard explicit so agents don't churn tokens to look active.

## Validation

- `pytest -k autonomy`: 8 passed, 1 skipped
- `ruff check`: clean
- No other code/tests reference the old string

(Prompt-text-only change — no UI, so no screenshot; the rendered block above is the artifact.)

🤖 Opened by Barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)