### PR TITLE
feat(viz): flavor-network polish for KG + KB graphs — shared force engine, auto-fit zoom

### DIFF
--- a/frontend-svelte/src/lib/forceGraph.js
+++ b/frontend-svelte/src/lib/forceGraph.js
@@ -1,0 +1,246 @@
+// Shared force-graph engine for the KG (Memories) and KB graph views.
+//
+// Design goals (Brad, 2026-06-10, "make it look like the flavor network"):
+//  - tight organic clusters: collision resolution + per-cluster gravity
+//  - no corner-flinging: capped forces/velocities, no hard wall clamp
+//  - quiet edges: callers render curved, cluster-tinted paths via edgePath()
+//  - labels that earn their space: greedy rect declutter via computeLabelSet()
+//  - auto-zoom: fitView() computes the transform framing the settled layout
+//
+// The sim mutates node objects in place ({x, y, vx, vy, r}) — both pages rely
+// on persistent node identity so positions survive filter changes.
+
+const FORCE_CAP = 6;      // max per-pair force magnitude per tick
+const VELOCITY_CAP = 10;  // max node speed per tick — kills runaway flings
+
+/**
+ * Start a force simulation. Returns { stop() }.
+ *
+ * opts:
+ *   nodes          [{id, x, y, vx, vy, r, ...}]  mutated in place
+ *   edges          [{source, target, weight?}]   ids into nodeById
+ *   nodeById       Map(id -> node)
+ *   clusterCenter  (node) => {x, y} | null       per-node gravity anchor
+ *   gravity        cluster gravity strength      (default 0.03)
+ *   repulsion      repulsion constant            (default 1100)
+ *   linkBase       base link rest length         (default 70)
+ *   maxIter        ticks before settle           (default 260)
+ *   speed          sim iterations per RAF frame  (default 3 — fast settle)
+ *   skip           (node) => bool                true = pinned (dragged) node
+ *   onTick         (iteration) => void           reassign state for reactivity
+ *   onSettle       () => void                    layout done — fit the view
+ */
+export function createForceSim(opts) {
+    const {
+        nodes, edges, nodeById,
+        clusterCenter = null,
+        gravity = 0.03,
+        repulsion = 1100,
+        linkBase = 70,
+        maxIter = 260,
+        speed = 3,
+        skip = () => false,
+        onTick = () => {},
+        onSettle = () => {},
+    } = opts;
+
+    let raf = null;
+    let iteration = 0;
+    let stopped = false;
+
+    function frame() {
+        if (stopped) return;
+        for (let s = 0; s < speed && iteration < maxIter; s++) step();
+        if (iteration >= maxIter) { raf = null; onSettle(); return; }
+        onTick(iteration);
+        raf = requestAnimationFrame(frame);
+    }
+
+    function step() {
+        iteration++;
+        const decay = 1 - iteration / maxIter;
+        const len = nodes.length;
+
+        // Pairwise repulsion (O(n^2) on the filtered subset — small in practice)
+        for (let i = 0; i < len; i++) {
+            for (let j = i + 1; j < len; j++) {
+                const a = nodes[i], b = nodes[j];
+                const dx = b.x - a.x, dy = b.y - a.y;
+                const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+                let force = (repulsion / (dist * dist)) * decay;
+                if (force > FORCE_CAP) force = FORCE_CAP;
+                const fx = (dx / dist) * force, fy = (dy / dist) * force;
+                a.vx -= fx; a.vy -= fy;
+                b.vx += fx; b.vy += fy;
+            }
+        }
+
+        // Spring attraction along edges; rest length grows with node radii so
+        // hubs keep breathing room, and weight tightens repeated relations.
+        for (const e of edges) {
+            const a = nodeById.get(e.source), b = nodeById.get(e.target);
+            if (!a || !b) continue;
+            const dx = b.x - a.x, dy = b.y - a.y;
+            const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+            const rest = linkBase + a.r + b.r;
+            const w = Math.min(3, e.weight || 1);
+            let force = (dist - rest) * 0.008 * w * decay;
+            if (force > FORCE_CAP) force = FORCE_CAP;
+            else if (force < -FORCE_CAP) force = -FORCE_CAP;
+            const fx = (dx / dist) * force, fy = (dy / dist) * force;
+            a.vx += fx; a.vy += fy;
+            b.vx -= fx; b.vy -= fy;
+        }
+
+        // Cluster gravity + integration. No hard wall clamp: walls + strong
+        // gravity were what pinned runaway nodes into the corners; the view
+        // is framed by fitView() instead.
+        for (const n of nodes) {
+            if (skip(n)) { n.vx = 0; n.vy = 0; continue; }
+            const c = clusterCenter ? clusterCenter(n) : null;
+            if (c) {
+                n.vx += (c.x - n.x) * gravity * decay;
+                n.vy += (c.y - n.y) * gravity * decay;
+            }
+            n.vx *= 0.85; n.vy *= 0.85;
+            const spd = Math.sqrt(n.vx * n.vx + n.vy * n.vy);
+            if (spd > VELOCITY_CAP) {
+                n.vx = (n.vx / spd) * VELOCITY_CAP;
+                n.vy = (n.vy / spd) * VELOCITY_CAP;
+            }
+            n.x += n.vx; n.y += n.vy;
+        }
+
+        // Positional collision resolution — two passes separate overlapping
+        // circles directly, which is what keeps dense clusters readable.
+        for (let pass = 0; pass < 2; pass++) {
+            for (let i = 0; i < len; i++) {
+                for (let j = i + 1; j < len; j++) {
+                    const a = nodes[i], b = nodes[j];
+                    const dx = b.x - a.x, dy = b.y - a.y;
+                    const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
+                    const minDist = a.r + b.r + 3;
+                    if (dist < minDist) {
+                        const push = (minDist - dist) / 2;
+                        const ux = dx / dist, uy = dy / dist;
+                        const aPinned = skip(a), bPinned = skip(b);
+                        if (!aPinned) { a.x -= ux * push * (bPinned ? 2 : 1); a.y -= uy * push * (bPinned ? 2 : 1); }
+                        if (!bPinned) { b.x += ux * push * (aPinned ? 2 : 1); b.y += uy * push * (aPinned ? 2 : 1); }
+                    }
+                }
+            }
+        }
+
+    }
+
+    raf = requestAnimationFrame(frame);
+    return {
+        stop() {
+            stopped = true;
+            if (raf) { cancelAnimationFrame(raf); raf = null; }
+        },
+    };
+}
+
+/**
+ * Compute the {zoom, panX, panY} that frames all nodes in a viewW×viewH
+ * viewBox with `pad` graph-units of breathing room. The transform contract is
+ * translate(panX panY) scale(zoom) — matching both pages' <g> wrapper.
+ */
+export function fitView(nodes, viewW, viewH, pad = 70, minZoom = 0.25, maxZoom = 1.6) {
+    if (!nodes.length) return { zoom: 1, panX: 0, panY: 0 };
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const n of nodes) {
+        if (n.x - n.r < minX) minX = n.x - n.r;
+        if (n.x + n.r > maxX) maxX = n.x + n.r;
+        if (n.y - n.r < minY) minY = n.y - n.r;
+        if (n.y + n.r > maxY) maxY = n.y + n.r;
+    }
+    minX -= pad; minY -= pad; maxX += pad; maxY += pad;
+    const w = Math.max(1, maxX - minX), h = Math.max(1, maxY - minY);
+    const zoom = Math.max(minZoom, Math.min(maxZoom, Math.min(viewW / w, viewH / h)));
+    return {
+        zoom,
+        panX: (viewW - w * zoom) / 2 - minX * zoom,
+        panY: (viewH - h * zoom) / 2 - minY * zoom,
+    };
+}
+
+/**
+ * Smoothly animate a view-state object toward a target transform.
+ * `apply` receives {zoom, panX, panY} every frame — assign to page state.
+ * Returns a cancel function.
+ */
+export function animateView(from, to, apply, duration = 380) {
+    const start = performance.now();
+    let raf = null;
+    const ease = (t) => 1 - Math.pow(1 - t, 3); // easeOutCubic
+    function frame(now) {
+        const t = Math.min(1, (now - start) / duration);
+        const k = ease(t);
+        apply({
+            zoom: from.zoom + (to.zoom - from.zoom) * k,
+            panX: from.panX + (to.panX - from.panX) * k,
+            panY: from.panY + (to.panY - from.panY) * k,
+        });
+        if (t < 1) raf = requestAnimationFrame(frame);
+    }
+    raf = requestAnimationFrame(frame);
+    return () => { if (raf) cancelAnimationFrame(raf); };
+}
+
+/**
+ * Greedy label declutter: walk nodes by degree (hubs first) and keep a label
+ * only if its estimated text rect doesn't collide with an already-placed one.
+ * Font size is in graph units (labels live inside the zoomed <g>), so the
+ * result is zoom-independent and only needs recomputing per layout/filter.
+ * Returns a Set of node ids whose labels should render.
+ */
+export function computeLabelSet(nodes, { fontSize = 11, charW = 6.6, maxLabels = 80 } = {}) {
+    const placed = [];
+    const visible = new Set();
+    const sorted = [...nodes].sort((a, b) => (b.degree || 0) - (a.degree || 0) || b.r - a.r);
+    for (const n of sorted) {
+        if (visible.size >= maxLabels) break;
+        const label = n.label || '';
+        const w = Math.min(22, label.length) * charW;
+        const h = fontSize + 4;
+        // label rect sits centered below the node (matches both renderers)
+        const rect = { x: n.x - w / 2, y: n.y + n.r + 3, w, h };
+        let collides = false;
+        for (const p of placed) {
+            if (rect.x < p.x + p.w && rect.x + rect.w > p.x &&
+                rect.y < p.y + p.h && rect.y + rect.h > p.y) { collides = true; break; }
+        }
+        if (!collides) { placed.push(rect); visible.add(n.id); }
+    }
+    return visible;
+}
+
+/**
+ * Slightly-curved quadratic path between two nodes — the organic look from
+ * the flavor-network reference. Curvature is a fraction of edge length
+ * applied perpendicular to the midpoint.
+ */
+export function edgePath(src, tgt, curvature = 0.12) {
+    const dx = tgt.x - src.x, dy = tgt.y - src.y;
+    const mx = (src.x + tgt.x) / 2, my = (src.y + tgt.y) / 2;
+    const cx = mx - dy * curvature, cy = my + dx * curvature;
+    return `M ${src.x} ${src.y} Q ${cx} ${cy} ${tgt.x} ${tgt.y}`;
+}
+
+/** Cursor-anchored wheel zoom: returns the next {zoom, panX, panY}. */
+export function zoomAt(state, vbX, vbY, factor, minZoom = 0.2, maxZoom = 4) {
+    const gx = (vbX - state.panX) / state.zoom;
+    const gy = (vbY - state.panY) / state.zoom;
+    const zoom = Math.max(minZoom, Math.min(maxZoom, state.zoom * factor));
+    return { zoom, panX: vbX - gx * zoom, panY: vbY - gy * zoom };
+}
+
+/** '#rrggbb' -> 'rgba(r,g,b,a)' — for cluster-tinted edges. */
+export function hexToRgba(hex, alpha) {
+    const m = /^#?([0-9a-f]{6})$/i.exec(hex || '');
+    if (!m) return `rgba(255,255,255,${alpha})`;
+    const v = parseInt(m[1], 16);
+    return `rgba(${(v >> 16) & 255},${(v >> 8) & 255},${v & 255},${alpha})`;
+}

--- a/frontend-svelte/src/lib/forceGraph.js
+++ b/frontend-svelte/src/lib/forceGraph.js
@@ -119,7 +119,7 @@ export function createForceSim(opts) {
                     const a = nodes[i], b = nodes[j];
                     const dx = b.x - a.x, dy = b.y - a.y;
                     const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
-                    const minDist = a.r + b.r + 3;
+                    const minDist = a.r + b.r + 5;
                     if (dist < minDist) {
                         const push = (minDist - dist) / 2;
                         const ux = dx / dist, uy = dy / dist;
@@ -192,19 +192,22 @@ export function animateView(from, to, apply, duration = 380) {
 /**
  * Greedy label declutter: walk nodes by degree (hubs first) and keep a label
  * only if its estimated text rect doesn't collide with an already-placed one.
- * Font size is in graph units (labels live inside the zoomed <g>), so the
- * result is zoom-independent and only needs recomputing per layout/filter.
+ * Labels render at constant SCREEN size (callers divide font-size by zoom),
+ * so collision rects grow in graph units as zoom shrinks — pass the current
+ * `zoom` and recompute when it changes: zooming in reveals more labels.
  * Returns a Set of node ids whose labels should render.
  */
-export function computeLabelSet(nodes, { fontSize = 11, charW = 6.6, maxLabels = 80 } = {}) {
+export function computeLabelSet(nodes, { fontSize = 11, charW = 6.6, maxLabels = 80, zoom = 1 } = {}) {
+    const z = Math.max(0.05, zoom);
+    const fs = fontSize / z, cw = charW / z;
     const placed = [];
     const visible = new Set();
     const sorted = [...nodes].sort((a, b) => (b.degree || 0) - (a.degree || 0) || b.r - a.r);
     for (const n of sorted) {
         if (visible.size >= maxLabels) break;
         const label = n.label || '';
-        const w = Math.min(22, label.length) * charW;
-        const h = fontSize + 4;
+        const w = Math.min(22, label.length) * cw;
+        const h = fs + 4;
         // label rect sits centered below the node (matches both renderers)
         const rect = { x: n.x - w / 2, y: n.y + n.r + 3, w, h };
         let collides = false;

--- a/frontend-svelte/src/pages/KnowledgeBase.svelte
+++ b/frontend-svelte/src/pages/KnowledgeBase.svelte
@@ -5,6 +5,7 @@
     import { api } from '../lib/api.js';
     import { toast } from '../lib/stores.js';
     import { timeAgo, formatDate, truncate, renderMarkdown } from '../lib/utils.js';
+    import { createForceSim, fitView, animateView, computeLabelSet, edgePath, zoomAt, hexToRgba } from '../lib/forceGraph.js';
 
     let loading = true;
     let refreshInterval;
@@ -19,13 +20,23 @@
     let graphData = null;
     let graphNodes = [];
     let graphEdges = [];
-    let graphSimRunning = false;
-    let graphRafId = null;
+    let graphNodeMap = new Map();    // id -> node (persistent across re-inits)
+    let graphSim = null;             // createForceSim handle
+    let graphFitCancel = null;       // in-flight auto-fit animation canceller
+    let graphLabelSet = new Set();   // decluttered label set
+    let graphCategories = [];        // wiki categories present (cluster anchors)
     let showRawInGraph = false;
     let graphWidth = 800;
     let graphHeight = 500;
     let hoveredNode = null;
-    let dragNode = null;
+    let graphSvgEl;
+    let graphZoom = 1;
+    let graphPanX = 0;
+    let graphPanY = 0;
+    let graphPanning = false;
+    let graphPanLast = null;
+    let graphUserMoved = false;
+    let graphDragMoved = false;      // suppress node-click after a drag-pan
 
     // Sources list
     let sources = [];
@@ -145,86 +156,106 @@
     function initGraph() {
         if (!graphData) return;
 
+        // Reuse persistent node objects so positions survive re-init (raw toggle).
+        const map = new Map();
         const nodes = graphData.nodes
             .filter(n => showRawInGraph || n.type === 'wiki')
-            .map(n => ({
-                ...n,
-                x: graphWidth / 2 + (Math.random() - 0.5) * 300,
-                y: graphHeight / 2 + (Math.random() - 0.5) * 200,
-                vx: 0, vy: 0,
-                r: n.type === 'wiki' ? Math.max(18, 12 + n.degree * 3) : 10,
-            }));
+            .map(n => {
+                const prev = graphNodeMap.get(n.id);
+                const node = {
+                    ...n,
+                    x: prev?.x ?? (graphWidth / 2 + (Math.random() - 0.5) * 300),
+                    y: prev?.y ?? (graphHeight / 2 + (Math.random() - 0.5) * 200),
+                    vx: 0, vy: 0,
+                    r: n.type === 'wiki' ? Math.max(14, Math.min(34, 10 + Math.sqrt(n.degree || 0) * 6)) : 8,
+                };
+                map.set(n.id, node);
+                return node;
+            });
+        graphNodeMap = map;
 
         const nodeIds = new Set(nodes.map(n => n.id));
         const edges = graphData.edges.filter(e => nodeIds.has(e.source) && nodeIds.has(e.target));
 
+        graphCategories = [...new Set(nodes.filter(n => n.type === 'wiki').map(n => n.category || 'other'))].sort();
         graphNodes = nodes;
         graphEdges = edges;
         runSimulation();
     }
 
-    function runSimulation() {
-        if (graphSimRunning) {
-            if (graphRafId !== null) cancelAnimationFrame(graphRafId);
-            graphRafId = null;
-            graphSimRunning = false;
-        }
-        graphSimRunning = true;
-
-        const alpha = 1;
-        let iteration = 0;
-        const maxIter = 200;
-        const centerX = graphWidth / 2;
-        const centerY = graphHeight / 2;
-
-        function tick() {
-            if (iteration >= maxIter) { graphRafId = null; graphSimRunning = false; return; }
-            iteration++;
-            const decay = 1 - iteration / maxIter;
-
-            // Repulsion between nodes
-            for (let i = 0; i < graphNodes.length; i++) {
-                for (let j = i + 1; j < graphNodes.length; j++) {
-                    const a = graphNodes[i], b = graphNodes[j];
-                    let dx = b.x - a.x, dy = b.y - a.y;
-                    let dist = Math.sqrt(dx * dx + dy * dy) || 1;
-                    const force = 800 / (dist * dist) * decay;
-                    const fx = dx / dist * force, fy = dy / dist * force;
-                    a.vx -= fx; a.vy -= fy;
-                    b.vx += fx; b.vy += fy;
-                }
-            }
-
-            // Attraction along edges
-            for (const e of graphEdges) {
-                const a = graphNodes.find(n => n.id === e.source);
-                const b = graphNodes.find(n => n.id === e.target);
-                if (!a || !b) continue;
-                let dx = b.x - a.x, dy = b.y - a.y;
-                let dist = Math.sqrt(dx * dx + dy * dy) || 1;
-                const force = (dist - 100) * 0.01 * decay;
-                const fx = dx / dist * force, fy = dy / dist * force;
-                a.vx += fx; a.vy += fy;
-                b.vx -= fx; b.vy -= fy;
-            }
-
-            // Center gravity
-            for (const n of graphNodes) {
-                if (n === dragNode) continue;
-                n.vx += (centerX - n.x) * 0.005 * decay;
-                n.vy += (centerY - n.y) * 0.005 * decay;
-                n.vx *= 0.9; n.vy *= 0.9;
-                n.x += n.vx; n.y += n.vy;
-                // Bounds
-                n.x = Math.max(n.r + 10, Math.min(graphWidth - n.r - 10, n.x));
-                n.y = Math.max(n.r + 10, Math.min(graphHeight - n.r - 10, n.y));
-            }
-
-            graphNodes = graphNodes; // trigger reactivity
-            graphRafId = requestAnimationFrame(tick);
-        }
-        graphRafId = requestAnimationFrame(tick);
+    // Wiki categories claim regions on a ring; raw sources get no anchor —
+    // their edges pull them next to the wiki page they feed.
+    function kbClusterCenter(node) {
+        if (node.type !== 'wiki') return null;
+        const i = Math.max(0, graphCategories.indexOf(node.category || 'other'));
+        const n = Math.max(1, graphCategories.length);
+        const angle = (i / n) * Math.PI * 2 - Math.PI / 2;
+        return {
+            x: graphWidth / 2 + Math.cos(angle) * graphWidth * 0.3,
+            y: graphHeight / 2 + Math.sin(angle) * graphHeight * 0.28,
+        };
     }
+
+    function runSimulation() {
+        if (graphSim) { graphSim.stop(); graphSim = null; }
+        if (graphNodes.length === 0) { graphLabelSet = new Set(); return; }
+        graphSim = createForceSim({
+            nodes: graphNodes,
+            edges: graphEdges,
+            nodeById: graphNodeMap,
+            clusterCenter: kbClusterCenter,
+            gravity: 0.012,
+            repulsion: 2000,
+            linkBase: 80,
+            onTick: (it) => {
+                graphNodes = graphNodes;                    // trigger reactivity
+                if (!graphUserMoved && it % 20 === 0) {
+                    const v = fitView(graphNodes, graphWidth, graphHeight, 55);
+                    graphZoom = v.zoom; graphPanX = v.panX; graphPanY = v.panY;
+                }
+            },
+            onSettle: () => {
+                graphSim = null;
+                graphLabelSet = computeLabelSet(graphNodes, { maxLabels: 60 });
+                graphAutoFit();
+            },
+        });
+    }
+
+    function graphAutoFit(force = false) {
+        if (graphUserMoved && !force) return;
+        if (graphFitCancel) graphFitCancel();
+        const target = fitView(graphNodes, graphWidth, graphHeight, 55);
+        graphFitCancel = animateView(
+            { zoom: graphZoom, panX: graphPanX, panY: graphPanY },
+            target,
+            (v) => { graphZoom = v.zoom; graphPanX = v.panX; graphPanY = v.panY; },
+        );
+        if (force) graphUserMoved = false;
+    }
+
+    // --- pan / zoom (mirrors the KG view) ---
+    function graphWheel(e) {
+        e.preventDefault();
+        if (graphFitCancel) { graphFitCancel(); graphFitCancel = null; }
+        graphUserMoved = true;
+        const rect = graphSvgEl.getBoundingClientRect();
+        const vbX = (e.clientX - rect.left) * (graphWidth / rect.width);
+        const vbY = (e.clientY - rect.top) * (graphHeight / rect.height);
+        const next = zoomAt({ zoom: graphZoom, panX: graphPanX, panY: graphPanY }, vbX, vbY, e.deltaY < 0 ? 1.12 : 1 / 1.12);
+        graphZoom = next.zoom; graphPanX = next.panX; graphPanY = next.panY;
+    }
+    function graphPointerDown(e) { graphPanning = true; graphDragMoved = false; graphPanLast = { x: e.clientX, y: e.clientY }; }
+    function graphPointerMove(e) {
+        if (!graphPanning || !graphPanLast) return;
+        if (graphFitCancel) { graphFitCancel(); graphFitCancel = null; }
+        graphUserMoved = true; graphDragMoved = true;
+        const rect = graphSvgEl.getBoundingClientRect();
+        graphPanX += (e.clientX - graphPanLast.x) * (graphWidth / rect.width);
+        graphPanY += (e.clientY - graphPanLast.y) * (graphHeight / rect.height);
+        graphPanLast = { x: e.clientX, y: e.clientY };
+    }
+    function graphPointerUp() { graphPanning = false; graphPanLast = null; }
 
     function nodeColor(node) {
         if (node.type === 'raw') return '#555';
@@ -235,11 +266,16 @@
         return colors[node.category] || colors.other;
     }
 
-    function edgeColor(edge) {
-        return edge.type === 'related' ? 'rgba(255,255,255,0.25)' : 'rgba(255,255,255,0.08)';
+    // Edges tinted by the wiki endpoint's category color (flavor-network look);
+    // wiki<->wiki "related" links read stronger than wiki<-source feeds.
+    function edgeColor(edge, src, tgt) {
+        const wiki = src?.type === 'wiki' ? src : tgt?.type === 'wiki' ? tgt : null;
+        const base = wiki ? nodeColor(wiki) : '#888888';
+        return hexToRgba(base, edge.type === 'related' ? 0.35 : 0.12);
     }
 
     function onGraphNodeClick(node) {
+        if (graphDragMoved) return;   // it was a pan, not a click
         if (node.type === 'wiki') {
             openWikiDetail({ slug: node.id, title: node.label });
         } else {
@@ -491,7 +527,8 @@
 
     onDestroy(() => {
         if (refreshInterval) clearInterval(refreshInterval);
-        if (graphRafId !== null) cancelAnimationFrame(graphRafId);
+        if (graphSim) { graphSim.stop(); graphSim = null; }
+        if (graphFitCancel) { graphFitCancel(); graphFitCancel = null; }
     });
 </script>
 
@@ -723,30 +760,44 @@
                     </label>
                     <span class="graph-stats">
                         {graphNodes.length} nodes · {graphEdges.length} edges
+                        · <span style="opacity:0.6">scroll = zoom · drag = pan · double-click = fit</span>
                     </span>
+                    <button class="btn btn-sm" style="background:var(--surface-3);color:var(--text-muted);font-size:0.72rem" on:click={() => graphAutoFit(true)}>Fit</button>
                 </div>
+                <!-- svelte-ignore a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions -->
                 <svg
+                    bind:this={graphSvgEl}
                     width={graphWidth}
                     height={graphHeight}
-                    style="background: var(--surface-inverse); border-radius: 8px; cursor: grab;"
+                    style="background: var(--surface-inverse); border-radius: 8px; cursor: {graphPanning ? 'grabbing' : 'grab'}; touch-action: none;"
                     viewBox="0 0 {graphWidth} {graphHeight}"
+                    role="application"
+                    aria-label="Knowledge base graph"
+                    on:wheel={graphWheel}
+                    on:mousedown={graphPointerDown}
+                    on:mousemove={graphPointerMove}
+                    on:mouseup={graphPointerUp}
+                    on:mouseleave={graphPointerUp}
+                    on:dblclick={() => graphAutoFit(true)}
                 >
-                    <!-- Edges -->
+                    <g transform="translate({graphPanX} {graphPanY}) scale({graphZoom})">
+                    <!-- Edges: curved + tinted by the wiki endpoint's category -->
                     {#each graphEdges as edge}
-                        {@const src = graphNodes.find(n => n.id === edge.source)}
-                        {@const tgt = graphNodes.find(n => n.id === edge.target)}
+                        {@const src = graphNodeMap.get(edge.source)}
+                        {@const tgt = graphNodeMap.get(edge.target)}
                         {#if src && tgt}
-                            <line
-                                x1={src.x} y1={src.y}
-                                x2={tgt.x} y2={tgt.y}
-                                stroke={edgeColor(edge)}
-                                stroke-width={edge.type === 'related' ? 2 : 1}
+                            {@const lit = hoveredNode && (hoveredNode.id === edge.source || hoveredNode.id === edge.target)}
+                            <path
+                                d={edgePath(src, tgt)}
+                                fill="none"
+                                stroke={lit ? 'rgba(255,255,255,0.6)' : edgeColor(edge, src, tgt)}
+                                stroke-width={lit ? 2 : edge.type === 'related' ? 1.6 : 1}
                             />
                         {/if}
                     {/each}
 
                     <!-- Nodes -->
-                    {#each graphNodes as node}
+                    {#each graphNodes as node (node.id)}
                         <g
                             role="button"
                             tabindex="0"
@@ -754,7 +805,7 @@
                             style="cursor: pointer;"
                             on:mouseenter={() => hoveredNode = node}
                             on:mouseleave={() => hoveredNode = null}
-                            on:click={() => onGraphNodeClick(node)}
+                            on:click|stopPropagation={() => onGraphNodeClick(node)}
                             on:keydown={(e) => {
                                 if (e.key === 'Enter' || e.key === ' ') {
                                     e.preventDefault();
@@ -769,17 +820,20 @@
                                 fill={nodeColor(node)}
                                 stroke={hoveredNode === node ? '#fff' : 'rgba(255,255,255,0.2)'}
                                 stroke-width={hoveredNode === node ? 2.5 : 1}
-                                opacity={hoveredNode && hoveredNode !== node ? 0.4 : 0.9}
+                                opacity={hoveredNode && hoveredNode !== node ? 0.4 : 0.92}
                             />
-                            <text
-                                x={node.x} y={node.y + node.r + 14}
-                                text-anchor="middle"
-                                fill={hoveredNode === node ? '#fff' : 'rgba(255,255,255,0.6)'}
-                                font-size={node.type === 'wiki' ? '11px' : '9px'}
-                                font-family="monospace"
-                            >
-                                {node.label.length > 20 ? node.label.slice(0, 18) + '…' : node.label}
-                            </text>
+                            {#if hoveredNode === node || graphLabelSet.has(node.id)}
+                                <text
+                                    x={node.x} y={node.y + node.r + 14}
+                                    text-anchor="middle"
+                                    fill={hoveredNode === node ? '#fff' : 'rgba(255,255,255,0.7)'}
+                                    font-size={node.type === 'wiki' ? '11px' : '9px'}
+                                    font-family="monospace"
+                                    style="pointer-events:none"
+                                >
+                                    {node.label.length > 20 ? node.label.slice(0, 18) + '…' : node.label}
+                                </text>
+                            {/if}
                         </g>
                     {/each}
 
@@ -804,6 +858,7 @@
                             {hoveredNode.label} ({hoveredNode.degree})
                         </text>
                     {/if}
+                    </g>
                 </svg>
 
                 <!-- Legend -->

--- a/frontend-svelte/src/pages/KnowledgeBase.svelte
+++ b/frontend-svelte/src/pages/KnowledgeBase.svelte
@@ -216,7 +216,11 @@
             },
             onSettle: () => {
                 graphSim = null;
-                graphLabelSet = computeLabelSet(graphNodes, { maxLabels: 60 });
+                // labels are screen-constant — declutter against the upcoming fit zoom
+                const target = graphUserMoved
+                    ? { zoom: graphZoom }
+                    : fitView(graphNodes, graphWidth, graphHeight, 55);
+                graphLabelSet = computeLabelSet(graphNodes, { maxLabels: 60, zoom: target.zoom });
                 graphAutoFit();
             },
         });
@@ -226,6 +230,7 @@
         if (graphUserMoved && !force) return;
         if (graphFitCancel) graphFitCancel();
         const target = fitView(graphNodes, graphWidth, graphHeight, 55);
+        graphLabelSet = computeLabelSet(graphNodes, { maxLabels: 60, zoom: target.zoom });
         graphFitCancel = animateView(
             { zoom: graphZoom, panX: graphPanX, panY: graphPanY },
             target,
@@ -235,6 +240,7 @@
     }
 
     // --- pan / zoom (mirrors the KG view) ---
+    let graphLabelTimer = null;
     function graphWheel(e) {
         e.preventDefault();
         if (graphFitCancel) { graphFitCancel(); graphFitCancel = null; }
@@ -244,6 +250,9 @@
         const vbY = (e.clientY - rect.top) * (graphHeight / rect.height);
         const next = zoomAt({ zoom: graphZoom, panX: graphPanX, panY: graphPanY }, vbX, vbY, e.deltaY < 0 ? 1.12 : 1 / 1.12);
         graphZoom = next.zoom; graphPanX = next.panX; graphPanY = next.panY;
+        // screen-constant labels free up room as you zoom in — re-declutter
+        clearTimeout(graphLabelTimer);
+        graphLabelTimer = setTimeout(() => { graphLabelSet = computeLabelSet(graphNodes, { maxLabels: 60, zoom: graphZoom }); }, 150);
     }
     function graphPointerDown(e) { graphPanning = true; graphDragMoved = false; graphPanLast = { x: e.clientX, y: e.clientY }; }
     function graphPointerMove(e) {
@@ -271,7 +280,7 @@
     function edgeColor(edge, src, tgt) {
         const wiki = src?.type === 'wiki' ? src : tgt?.type === 'wiki' ? tgt : null;
         const base = wiki ? nodeColor(wiki) : '#888888';
-        return hexToRgba(base, edge.type === 'related' ? 0.35 : 0.12);
+        return hexToRgba(base, edge.type === 'related' ? 0.45 : 0.22);
     }
 
     function onGraphNodeClick(node) {
@@ -787,11 +796,12 @@
                         {@const tgt = graphNodeMap.get(edge.target)}
                         {#if src && tgt}
                             {@const lit = hoveredNode && (hoveredNode.id === edge.source || hoveredNode.id === edge.target)}
+                            <!-- strokes/fonts divide by zoom: constant SCREEN size at any fit level -->
                             <path
                                 d={edgePath(src, tgt)}
                                 fill="none"
                                 stroke={lit ? 'rgba(255,255,255,0.6)' : edgeColor(edge, src, tgt)}
-                                stroke-width={lit ? 2 : edge.type === 'related' ? 1.6 : 1}
+                                stroke-width={(lit ? 2 : edge.type === 'related' ? 1.6 : 1.1) / graphZoom}
                             />
                         {/if}
                     {/each}
@@ -819,15 +829,15 @@
                                 cx={node.x} cy={node.y} r={node.r}
                                 fill={nodeColor(node)}
                                 stroke={hoveredNode === node ? '#fff' : 'rgba(255,255,255,0.2)'}
-                                stroke-width={hoveredNode === node ? 2.5 : 1}
+                                stroke-width={(hoveredNode === node ? 2.5 : 1.2) / graphZoom}
                                 opacity={hoveredNode && hoveredNode !== node ? 0.4 : 0.92}
                             />
                             {#if hoveredNode === node || graphLabelSet.has(node.id)}
                                 <text
-                                    x={node.x} y={node.y + node.r + 14}
+                                    x={node.x} y={node.y + node.r + 14 / graphZoom}
                                     text-anchor="middle"
-                                    fill={hoveredNode === node ? '#fff' : 'rgba(255,255,255,0.7)'}
-                                    font-size={node.type === 'wiki' ? '11px' : '9px'}
+                                    fill={hoveredNode === node ? '#fff' : 'rgba(255,255,255,0.75)'}
+                                    font-size="{(node.type === 'wiki' ? 11 : 9) / graphZoom}px"
                                     font-family="monospace"
                                     style="pointer-events:none"
                                 >
@@ -837,26 +847,28 @@
                         </g>
                     {/each}
 
-                    <!-- Tooltip -->
+                    <!-- Tooltip (inverse-scaled group = constant screen size) -->
                     {#if hoveredNode}
-                        <rect
-                            x={hoveredNode.x + hoveredNode.r + 8}
-                            y={hoveredNode.y - 16}
-                            width={Math.max(120, hoveredNode.label.length * 7 + 40)}
-                            height="32"
-                            rx="4"
-                            fill="rgba(0,0,0,0.85)"
-                            stroke="rgba(255,255,255,0.2)"
-                        />
-                        <text
-                            x={hoveredNode.x + hoveredNode.r + 14}
-                            y={hoveredNode.y + 1}
-                            fill="#fff"
-                            font-size="12px"
-                            font-family="monospace"
-                        >
-                            {hoveredNode.label} ({hoveredNode.degree})
-                        </text>
+                        <g transform="translate({hoveredNode.x} {hoveredNode.y}) scale({1 / graphZoom})">
+                            <rect
+                                x={hoveredNode.r * graphZoom + 8}
+                                y="-16"
+                                width={Math.max(120, hoveredNode.label.length * 7 + 40)}
+                                height="32"
+                                rx="4"
+                                fill="rgba(0,0,0,0.85)"
+                                stroke="rgba(255,255,255,0.2)"
+                            />
+                            <text
+                                x={hoveredNode.r * graphZoom + 14}
+                                y="4"
+                                fill="#fff"
+                                font-size="12px"
+                                font-family="monospace"
+                            >
+                                {hoveredNode.label} ({hoveredNode.degree})
+                            </text>
+                        </g>
                     {/if}
                     </g>
                 </svg>

--- a/frontend-svelte/src/pages/Memories.svelte
+++ b/frontend-svelte/src/pages/Memories.svelte
@@ -6,6 +6,7 @@
     import { api } from '../lib/api.js';
     import { toast } from '../lib/stores.js';
     import { escapeHtml } from '../lib/utils.js';
+    import { createForceSim, fitView, animateView, computeLabelSet, edgePath, zoomAt, hexToRgba } from '../lib/forceGraph.js';
 
     let agentList = [];
     let currentAgent = '';
@@ -33,11 +34,13 @@
     let kgEdges = [];
     let kgStats = null;
     let kgLoading = false;
-    let kgSimRunning = false;
     let kgWidth = 1000;
     let kgHeight = 640;
     let kgHoveredNode = null;
-    let kgRaf = null;
+    let kgSim = null;            // createForceSim handle
+    let kgFitCancel = null;      // in-flight auto-fit animation canceller
+    let kgLabelSet = new Set();  // decluttered label set (recomputed at settle)
+    let kgUserMoved = false;     // user panned/zoomed — don't yank the view on settle
     let kgDestroyed = false;
     // --- KG viz rework (#153): raw data, filters, cluster layout, pan/zoom ---
     let kgRawNodes = [];
@@ -56,7 +59,6 @@
     let kgPanY = 0;
     let kgPanning = false;
     let kgPanLast = null;
-    const KG_HUB_DEGREE = 5;         // always label nodes at/above this degree
 
     // Dreams tab state
     let dreamStates = [];
@@ -281,19 +283,20 @@
 
     function nodeRadius(degree) {
         // sqrt scaling + hard cap so hub nodes don't swallow the canvas
-        return Math.max(9, Math.min(30, 8 + Math.sqrt(degree) * 5));
+        return Math.max(7, Math.min(26, 6 + Math.sqrt(degree) * 4.5));
     }
 
     // Reset every piece of KG state (rendered + raw + filters + view + sim) so
     // an empty/errored (re)load shows a truthful no-data state. (Murzik review.)
     function clearKgState() {
-        if (kgRaf) { cancelAnimationFrame(kgRaf); kgRaf = null; }
-        kgSimRunning = false;
+        if (kgSim) { kgSim.stop(); kgSim = null; }
+        if (kgFitCancel) { kgFitCancel(); kgFitCancel = null; }
         kgNodes = []; kgEdges = [];
         kgRawNodes = []; kgRawEdges = [];
         kgNodeMap = new Map(); kgAdj = new Map();
         kgAllTypes = []; kgActiveTypes = new Set();
         kgSelectedId = null; kgHoveredNode = null; kgSearch = '';
+        kgLabelSet = new Set(); kgUserMoved = false;
         kgZoom = 1; kgPanX = 0; kgPanY = 0;
     }
 
@@ -359,60 +362,44 @@
     }
 
     function restartKgSim() {
-        if (kgRaf) { cancelAnimationFrame(kgRaf); kgRaf = null; }
-        kgSimRunning = false;
-        runKgSimulation();
+        if (kgSim) { kgSim.stop(); kgSim = null; }
+        if (kgDestroyed || kgNodes.length === 0) { kgLabelSet = new Set(); return; }
+        kgSim = createForceSim({
+            nodes: kgNodes,
+            edges: kgEdges,
+            nodeById: kgNodeMap,
+            clusterCenter: (n) => clusterCenter(n.type),
+            gravity: 0.016,        // soft islands — repulsion does the spreading
+            repulsion: 2400,
+            linkBase: 90,
+            onTick: (it) => {
+                kgNodes = kgNodes;                          // trigger reactivity
+                // keep the growing layout framed while it settles
+                if (!kgUserMoved && it % 20 === 0) {
+                    const v = fitView(kgNodes, kgWidth, kgHeight);
+                    kgZoom = v.zoom; kgPanX = v.panX; kgPanY = v.panY;
+                }
+            },
+            onSettle: () => {
+                kgSim = null;
+                kgLabelSet = computeLabelSet(kgNodes);
+                kgAutoFit();
+            },
+        });
     }
 
-    function runKgSimulation() {
-        if (kgSimRunning) return;
-        kgSimRunning = true;
-        let iteration = 0;
-        const maxIter = 240;
-        function tick() {
-            if (kgDestroyed) { kgSimRunning = false; return; }
-            if (iteration >= maxIter) { kgSimRunning = false; kgRaf = null; return; }
-            iteration++;
-            const decay = 1 - iteration / maxIter;
-            const len = kgNodes.length;
-            // Repulsion (O(n^2), but on the FILTERED subset — small)
-            for (let i = 0; i < len; i++) {
-                for (let j = i + 1; j < len; j++) {
-                    const a = kgNodes[i], b = kgNodes[j];
-                    let dx = b.x - a.x, dy = b.y - a.y;
-                    let dist = Math.sqrt(dx * dx + dy * dy) || 1;
-                    const force = 900 / (dist * dist) * decay;
-                    const fx = dx / dist * force, fy = dy / dist * force;
-                    a.vx -= fx; a.vy -= fy;
-                    b.vx += fx; b.vy += fy;
-                }
-            }
-            // Attraction along edges (eased off so cross-type edges don't drag
-            // clusters back together; same-type edges still tighten within an island)
-            for (const e of kgEdges) {
-                const a = kgNodeMap.get(e.source), b = kgNodeMap.get(e.target);
-                if (!a || !b) continue;
-                let dx = b.x - a.x, dy = b.y - a.y;
-                let dist = Math.sqrt(dx * dx + dy * dy) || 1;
-                const force = (dist - 80) * 0.006 * decay;
-                const fx = dx / dist * force, fy = dy / dist * force;
-                a.vx += fx; a.vy += fy;
-                b.vx -= fx; b.vy -= fy;
-            }
-            // Cluster gravity (dominant): pull each node hard toward its type centroid
-            for (const nd of kgNodes) {
-                const c = clusterCenter(nd.type);
-                nd.vx += (c.x - nd.x) * 0.045 * decay;
-                nd.vy += (c.y - nd.y) * 0.045 * decay;
-                nd.vx *= 0.9; nd.vy *= 0.9;
-                nd.x += nd.vx; nd.y += nd.vy;
-                nd.x = Math.max(nd.r + 8, Math.min(kgWidth - nd.r - 8, nd.x));
-                nd.y = Math.max(nd.r + 8, Math.min(kgHeight - nd.r - 8, nd.y));
-            }
-            kgNodes = kgNodes; // trigger reactivity
-            kgRaf = requestAnimationFrame(tick);
-        }
-        kgRaf = requestAnimationFrame(tick);
+    // Auto-zoom: frame the settled layout. Skipped when the user has already
+    // panned/zoomed by hand (their view, their rules — Fit button re-engages).
+    function kgAutoFit(force = false) {
+        if (kgUserMoved && !force) return;
+        if (kgFitCancel) kgFitCancel();
+        const target = fitView(kgNodes, kgWidth, kgHeight);
+        kgFitCancel = animateView(
+            { zoom: kgZoom, panX: kgPanX, panY: kgPanY },
+            target,
+            (v) => { kgZoom = v.zoom; kgPanX = v.panX; kgPanY = v.panY; },
+        );
+        if (force) kgUserMoved = false;
     }
 
     const KG_COLORS = {
@@ -436,16 +423,17 @@
         applyKgFilters();
     }
     function kgResetView() {
-        kgZoom = 1; kgPanX = 0; kgPanY = 0;
         kgSelectedId = null; kgSearch = ''; kgMinDegree = 2;
         kgActiveTypes = new Set(kgAllTypes);
+        kgUserMoved = false;
         applyKgFilters();
     }
-    function kgLabelVisible(node) {
+    function kgLabelVisible(node, labelSet) {
         return kgHoveredNode?.id === node.id
             || kgSelectedId === node.id
             || (kgSelectedId && kgAdj.get(kgSelectedId)?.has(node.id))
-            || node.degree >= KG_HUB_DEGREE;
+            || (kgHoveredNode && kgAdj.get(kgHoveredNode.id)?.has(node.id))
+            || labelSet.has(node.id);
     }
     function kgNodeDimmed(node) {
         if (!kgHoveredNode) return false;
@@ -455,18 +443,19 @@
     // --- pan / zoom (background-drag pans, wheel zooms at cursor) ---
     function kgWheel(e) {
         e.preventDefault();
+        if (kgFitCancel) { kgFitCancel(); kgFitCancel = null; }
+        kgUserMoved = true;
         const rect = kgSvgEl.getBoundingClientRect();
         const vbX = (e.clientX - rect.left) * (kgWidth / rect.width);
         const vbY = (e.clientY - rect.top) * (kgHeight / rect.height);
-        const gx = (vbX - kgPanX) / kgZoom, gy = (vbY - kgPanY) / kgZoom;
-        const factor = e.deltaY < 0 ? 1.12 : 1 / 1.12;
-        kgZoom = Math.max(0.3, Math.min(4, kgZoom * factor));
-        kgPanX = vbX - gx * kgZoom;
-        kgPanY = vbY - gy * kgZoom;
+        const next = zoomAt({ zoom: kgZoom, panX: kgPanX, panY: kgPanY }, vbX, vbY, e.deltaY < 0 ? 1.12 : 1 / 1.12);
+        kgZoom = next.zoom; kgPanX = next.panX; kgPanY = next.panY;
     }
     function kgPointerDown(e) { kgPanning = true; kgPanLast = { x: e.clientX, y: e.clientY }; }
     function kgPointerMove(e) {
         if (!kgPanning || !kgPanLast) return;
+        if (kgFitCancel) { kgFitCancel(); kgFitCancel = null; }
+        kgUserMoved = true;
         const rect = kgSvgEl.getBoundingClientRect();
         kgPanX += (e.clientX - kgPanLast.x) * (kgWidth / rect.width);
         kgPanY += (e.clientY - kgPanLast.y) * (kgHeight / rect.height);
@@ -482,7 +471,11 @@
     }
 
     onMount(init);
-    onDestroy(() => { kgDestroyed = true; if (kgRaf) cancelAnimationFrame(kgRaf); kgSimRunning = false; });
+    onDestroy(() => {
+        kgDestroyed = true;
+        if (kgSim) { kgSim.stop(); kgSim = null; }
+        if (kgFitCancel) { kgFitCancel(); kgFitCancel = null; }
+    });
 </script>
 
 <div class="content">
@@ -657,6 +650,7 @@
                 <label style="display:flex;align-items:center;gap:0.3rem;font-family:var(--font-grotesk);font-size:0.7rem;color:var(--text-muted);cursor:pointer">
                     <input type="checkbox" bind:checked={kgShowEdgeLabels} /> edge labels
                 </label>
+                <button class="btn btn-sm" style="background:var(--surface-3);color:var(--text-muted);font-size:0.72rem" on:click={() => kgAutoFit(true)}>Fit</button>
                 <button class="btn btn-sm" style="background:var(--surface-3);color:var(--text-muted);font-size:0.72rem" on:click={kgResetView}>Reset</button>
                 <button class="btn btn-sm" style="background:var(--surface-3);color:var(--text-muted);font-size:0.72rem" on:click={loadKnowledgeGraph}>Refresh</button>
             </div>
@@ -680,7 +674,7 @@
                     {kgNodes.length} / {kgRawNodes.length} nodes · {kgEdges.length} edges
                     {#if kgSelectedId}· <span style="color:var(--accent-contrast)">focus: {kgSelectedId}</span> <button on:click={() => { kgSelectedId = null; applyKgFilters(); }} style="background:none;border:none;color:var(--text-muted);cursor:pointer;text-decoration:underline;font-size:0.7rem">clear</button>{/if}
                 </span>
-                <span style="font-size:0.62rem;color:var(--text-muted)">scroll = zoom · drag = pan · click node = focus</span>
+                <span style="font-size:0.62rem;color:var(--text-muted)">scroll = zoom · drag = pan · click node = focus · double-click = fit</span>
             </div>
 
             <!-- svelte-ignore a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions -->
@@ -697,21 +691,23 @@
                 on:mousemove={kgPointerMove}
                 on:mouseup={kgPointerUp}
                 on:mouseleave={kgPointerUp}
+                on:dblclick={() => kgAutoFit(true)}
             >
                 <g transform="translate({kgPanX} {kgPanY}) scale({kgZoom})">
-                    <!-- Edges -->
+                    <!-- Edges: curved + tinted by source-node cluster color (flavor-network look) -->
                     {#each kgEdges as edge}
                         {@const src = kgNodeMap.get(edge.source)}
                         {@const tgt = kgNodeMap.get(edge.target)}
                         {#if src && tgt}
                             {@const lit = (kgHoveredNode && (kgHoveredNode.id === edge.source || kgHoveredNode.id === edge.target)) || (kgSelectedId && (kgSelectedId === edge.source || kgSelectedId === edge.target))}
-                            <line
-                                x1={src.x} y1={src.y}
-                                x2={tgt.x} y2={tgt.y}
-                                stroke={lit ? 'rgba(255,255,255,0.55)' : 'rgba(255,255,255,0.14)'}
-                                stroke-width={lit ? 2 : 1}
+                            {@const sameType = src.type === tgt.type}
+                            <path
+                                d={edgePath(src, tgt)}
+                                fill="none"
+                                stroke={lit ? 'rgba(255,255,255,0.6)' : hexToRgba(kgNodeColor(src), sameType ? 0.3 : 0.13)}
+                                stroke-width={lit ? 2 : sameType ? 1.4 : 1}
                             />
-                            {#if kgShowEdgeLabels || lit}
+                            {#if (kgShowEdgeLabels && kgZoom >= 1.05) || lit}
                                 <text
                                     x={(src.x + tgt.x) / 2}
                                     y={(src.y + tgt.y) / 2 - 4}
@@ -746,13 +742,14 @@
                                 stroke-width={sel ? 3 : kgHoveredNode?.id === node.id ? 2.5 : 1}
                                 opacity={dim ? 0.25 : 0.92}
                             />
-                            {#if kgLabelVisible(node)}
+                            {#if kgLabelVisible(node, kgLabelSet)}
                                 <text
                                     x={node.x} y={node.y + node.r + 13}
                                     text-anchor="middle"
-                                    fill={dim ? 'rgba(255,255,255,0.3)' : kgHoveredNode?.id === node.id || sel ? '#fff' : 'rgba(255,255,255,0.7)'}
-                                    font-size="11px"
+                                    fill={dim ? 'rgba(255,255,255,0.3)' : kgHoveredNode?.id === node.id || sel ? '#fff' : 'rgba(255,255,255,0.75)'}
+                                    font-size={node.degree >= 8 ? '12px' : '11px'}
                                     font-family="monospace"
+                                    style="pointer-events:none"
                                 >
                                     {node.label.length > 22 ? node.label.slice(0, 20) + '…' : node.label}
                                 </text>

--- a/frontend-svelte/src/pages/Memories.svelte
+++ b/frontend-svelte/src/pages/Memories.svelte
@@ -361,17 +361,52 @@
         return { x: kgWidth / 2 + Math.cos(angle) * rx, y: kgHeight / 2 + Math.sin(angle) * ry };
     }
 
+    // "unknown" isn't a semantic cluster — it's missing taxonomy. Piling those
+    // nodes into their own island rendered a giant dead-gray continent, so
+    // anchor each one near the centroid of its TYPED neighbors' islands with a
+    // deterministic per-node scatter — without the scatter, every gray whose
+    // neighbors span types lands on the same centroid and knots up; with no
+    // anchor at all, the link web drags the whole layout into one center blob.
+    function kgIdHash(id) {
+        let h = 0;
+        const s = String(id);
+        for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+        return Math.abs(h);
+    }
+    function computeKgAnchors() {
+        for (const node of kgNodes) {
+            node._anchor = null;
+            if (node.type !== 'unknown') continue;
+            let sx = 0, sy = 0, k = 0;
+            for (const nb of (kgAdj.get(node.id) || [])) {
+                const o = kgNodeMap.get(nb);
+                if (!o || o.type === 'unknown') continue;
+                const c = clusterCenter(o.type);
+                sx += c.x; sy += c.y; k++;
+            }
+            if (k === 0) continue;
+            const h = kgIdHash(node.id);
+            const angle = (h % 360) * Math.PI / 180;
+            const radius = 60 + (h >> 3) % 110;
+            node._anchor = {
+                x: sx / k + Math.cos(angle) * radius,
+                y: sy / k + Math.sin(angle) * radius,
+            };
+        }
+    }
+
     function restartKgSim() {
         if (kgSim) { kgSim.stop(); kgSim = null; }
         if (kgDestroyed || kgNodes.length === 0) { kgLabelSet = new Set(); return; }
+        computeKgAnchors();
         kgSim = createForceSim({
             nodes: kgNodes,
             edges: kgEdges,
             nodeById: kgNodeMap,
-            clusterCenter: (n) => clusterCenter(n.type),
+            clusterCenter: (n) => n._anchor || clusterCenter(n.type),
             gravity: 0.016,        // soft islands — repulsion does the spreading
-            repulsion: 2400,
-            linkBase: 90,
+            repulsion: 2800,
+            linkBase: 110,         // longer leashes = looser hub neighborhoods
             onTick: (it) => {
                 kgNodes = kgNodes;                          // trigger reactivity
                 // keep the growing layout framed while it settles
@@ -382,7 +417,12 @@
             },
             onSettle: () => {
                 kgSim = null;
-                kgLabelSet = computeLabelSet(kgNodes);
+                // labels are screen-constant: declutter against the zoom the
+                // view is about to animate to, not wherever it is mid-flight
+                const target = kgUserMoved
+                    ? { zoom: kgZoom }
+                    : fitView(kgNodes, kgWidth, kgHeight);
+                kgLabelSet = computeLabelSet(kgNodes, { zoom: target.zoom });
                 kgAutoFit();
             },
         });
@@ -394,6 +434,7 @@
         if (kgUserMoved && !force) return;
         if (kgFitCancel) kgFitCancel();
         const target = fitView(kgNodes, kgWidth, kgHeight);
+        kgLabelSet = computeLabelSet(kgNodes, { zoom: target.zoom });
         kgFitCancel = animateView(
             { zoom: kgZoom, panX: kgPanX, panY: kgPanY },
             target,
@@ -441,6 +482,7 @@
     }
 
     // --- pan / zoom (background-drag pans, wheel zooms at cursor) ---
+    let kgLabelTimer = null;
     function kgWheel(e) {
         e.preventDefault();
         if (kgFitCancel) { kgFitCancel(); kgFitCancel = null; }
@@ -450,6 +492,9 @@
         const vbY = (e.clientY - rect.top) * (kgHeight / rect.height);
         const next = zoomAt({ zoom: kgZoom, panX: kgPanX, panY: kgPanY }, vbX, vbY, e.deltaY < 0 ? 1.12 : 1 / 1.12);
         kgZoom = next.zoom; kgPanX = next.panX; kgPanY = next.panY;
+        // screen-constant labels free up room as you zoom in — re-declutter
+        clearTimeout(kgLabelTimer);
+        kgLabelTimer = setTimeout(() => { kgLabelSet = computeLabelSet(kgNodes, { zoom: kgZoom }); }, 150);
     }
     function kgPointerDown(e) { kgPanning = true; kgPanLast = { x: e.clientX, y: e.clientY }; }
     function kgPointerMove(e) {
@@ -701,19 +746,23 @@
                         {#if src && tgt}
                             {@const lit = (kgHoveredNode && (kgHoveredNode.id === edge.source || kgHoveredNode.id === edge.target)) || (kgSelectedId && (kgSelectedId === edge.source || kgSelectedId === edge.target))}
                             {@const sameType = src.type === tgt.type}
+                            {@const heavy = (edge.weight || 1) > 1}
+                            <!-- strokes/fonts divide by zoom: constant SCREEN size at any fit level.
+                                 weight-graded alpha: repeated relations read strong, one-off facts
+                                 fade back — kills the edge soup around hub nodes -->
                             <path
                                 d={edgePath(src, tgt)}
                                 fill="none"
-                                stroke={lit ? 'rgba(255,255,255,0.6)' : hexToRgba(kgNodeColor(src), sameType ? 0.3 : 0.13)}
-                                stroke-width={lit ? 2 : sameType ? 1.4 : 1}
+                                stroke={lit ? 'rgba(255,255,255,0.6)' : hexToRgba(kgNodeColor(src), (sameType ? 0.42 : 0.26) * (heavy ? 1 : 0.55))}
+                                stroke-width={(lit ? 2 : heavy ? 1.5 : 1) / kgZoom}
                             />
                             {#if (kgShowEdgeLabels && kgZoom >= 1.05) || lit}
                                 <text
                                     x={(src.x + tgt.x) / 2}
-                                    y={(src.y + tgt.y) / 2 - 4}
+                                    y={(src.y + tgt.y) / 2 - 4 / kgZoom}
                                     text-anchor="middle"
                                     fill="rgba(255,255,255,0.5)"
-                                    font-size="9px"
+                                    font-size="{9 / kgZoom}px"
                                     font-family="monospace"
                                 >{edge.label}</text>
                             {/if}
@@ -739,15 +788,15 @@
                                 cx={node.x} cy={node.y} r={node.r}
                                 fill={kgNodeColor(node)}
                                 stroke={sel || kgHoveredNode?.id === node.id ? '#fff' : 'rgba(255,255,255,0.2)'}
-                                stroke-width={sel ? 3 : kgHoveredNode?.id === node.id ? 2.5 : 1}
+                                stroke-width={(sel ? 3 : kgHoveredNode?.id === node.id ? 2.5 : 1.2) / kgZoom}
                                 opacity={dim ? 0.25 : 0.92}
                             />
                             {#if kgLabelVisible(node, kgLabelSet)}
                                 <text
-                                    x={node.x} y={node.y + node.r + 13}
+                                    x={node.x} y={node.y + node.r + 13 / kgZoom}
                                     text-anchor="middle"
-                                    fill={dim ? 'rgba(255,255,255,0.3)' : kgHoveredNode?.id === node.id || sel ? '#fff' : 'rgba(255,255,255,0.75)'}
-                                    font-size={node.degree >= 8 ? '12px' : '11px'}
+                                    fill={dim ? 'rgba(255,255,255,0.3)' : kgHoveredNode?.id === node.id || sel ? '#fff' : 'rgba(255,255,255,0.78)'}
+                                    font-size="{(node.degree >= 8 ? 12 : 11) / kgZoom}px"
                                     font-family="monospace"
                                     style="pointer-events:none"
                                 >
@@ -757,32 +806,34 @@
                         </g>
                     {/each}
 
-                    <!-- Tooltip -->
+                    <!-- Tooltip (inverse-scaled group = constant screen size) -->
                     {#if kgHoveredNode}
-                        <rect
-                            x={kgHoveredNode.x + kgHoveredNode.r + 8}
-                            y={kgHoveredNode.y - 16}
-                            width={Math.max(140, kgHoveredNode.label.length * 7 + 60)}
-                            height="32"
-                            rx="4"
-                            fill="rgba(0,0,0,0.85)"
-                            stroke="rgba(255,255,255,0.2)"
-                        />
-                        <text
-                            x={kgHoveredNode.x + kgHoveredNode.r + 14}
-                            y={kgHoveredNode.y + 1}
-                            fill="#fff"
-                            font-size="12px"
-                            font-family="monospace"
-                        >
-                            {kgHoveredNode.label} ({kgHoveredNode.type}) · {kgHoveredNode.degree}
-                        </text>
+                        <g transform="translate({kgHoveredNode.x} {kgHoveredNode.y}) scale({1 / kgZoom})">
+                            <rect
+                                x={kgHoveredNode.r * kgZoom + 8}
+                                y="-16"
+                                width={Math.max(140, kgHoveredNode.label.length * 7 + 60)}
+                                height="32"
+                                rx="4"
+                                fill="rgba(0,0,0,0.85)"
+                                stroke="rgba(255,255,255,0.2)"
+                            />
+                            <text
+                                x={kgHoveredNode.r * kgZoom + 14}
+                                y="4"
+                                fill="#fff"
+                                font-size="12px"
+                                font-family="monospace"
+                            >
+                                {kgHoveredNode.label} ({kgHoveredNode.type}) · {kgHoveredNode.degree}
+                            </text>
+                        </g>
                     {/if}
                 </g>
             </svg>
 
             <div style="display:flex;justify-content:center;margin-top:0.5rem;font-family:var(--font-grotesk);font-size:0.62rem;color:var(--text-muted)">
-                node size = connections · nodes cluster by type · labels show on hover &amp; for hubs
+                node size = connections · nodes cluster by type · zoom in to reveal more labels
             </div>
         </div>
     {/if}


### PR DESCRIPTION
## What

Brad's ask (Telegram, 2026-06-10): make the Knowledge Graph and Knowledge Base graph views look like the classic flavor-network viz, with zoom / auto-zoom. Before-state problems: nodes flung to the corners, dense clusters collapsing into opaque mush, edge-label soup, KB graph had no pan/zoom at all.

## How

New shared engine `frontend-svelte/src/lib/forceGraph.js` replaces the two hand-rolled sims:

- **Collision resolution** (positional, 2 passes) — dense clusters stay readable
- **Capped forces/velocities, no hard wall clamp** — kills corner-flinging (walls + strong gravity used to pin runaway nodes)
- **Cluster anchors on a ring** (KG: entity type; KB: wiki category — raw sources ride their edges) with repulsion doing the spreading
- **Auto-fit**: `fitView()` + eased `animateView()` at settle, periodic snap-fit while settling, Fit button + double-click; manual pan/zoom suppresses auto-fit until re-engaged
- **Greedy label declutter** — hubs first, no overlapping label rects (instead of hover-only/all)
- **Curved cluster-tinted edges**; KG edge labels gated to lit/zoomed-in
- **speed=3 iterations per RAF** — settles ~1.5s instead of ~4.5s

KB graph additionally gains pan/zoom, persistent node positions across the raw-toggle, and a node Map instead of O(E·N) `find()` per render.

## Validation

- `npm run build` green; i18n extract clean (no new keys)
- Playwright-verified on the live daemon: layout settles, labels appear decluttered (80 KG / up to 60 KB), auto-fit frames content, both graphs pan/zoom
- After-screenshots sent to Brad on Telegram (`docs/` is gitignored, so not committed)

🤖 Opened by Barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)