### PR TITLE
fix(autonomy): collapse stale continuation replays to a breadcrumb (#732)

### DIFF
--- a/src/pinky_daemon/autonomy.py
+++ b/src/pinky_daemon/autonomy.py
@@ -118,6 +118,46 @@ class EventQueue:
         return {name: q.qsize() for name, q in self._queues.items()}
 
 
+def mark_stale_context(
+    context: dict | None,
+    last_message_time: float | None,
+    *,
+    slack_sec: float = 2.0,
+) -> dict | None:
+    """Flag a saved-context dict as stale when the conversation has moved on.
+
+    #732: autonomy event-wakes fire into LIVE sessions, where the
+    conversation itself is the freshest record. If the agent has exchanged
+    messages since the snapshot was saved (``last_message_time`` past
+    ``updated_at`` + slack), the full continuation replay is redundant at
+    best and misleading at worst — a stale ``wake_action`` ("deploy X")
+    can invite duplicate execution after X already shipped.
+
+    Pure helper (returns the same dict, mutated) so the verdict is unit-
+    testable without the async loop. Missing timestamps on either side
+    mean "can't tell" — the context is left as-is (today's behavior).
+    """
+    if not context:
+        return context
+    saved_at = float(context.get("updated_at") or 0)
+    if saved_at and last_message_time and last_message_time > saved_at + slack_sec:
+        context["stale"] = True
+    return context
+
+
+def _format_saved_age(updated_at: float) -> str:
+    """Human age stamp for the continuation header, e.g. ' (saved 42m ago)'."""
+    if not updated_at:
+        return ""
+    age_sec = max(0.0, time.time() - updated_at)
+    if age_sec < 90:
+        return " (saved moments ago)"
+    age_min = int(age_sec / 60)
+    if age_min < 120:
+        return f" (saved {age_min}m ago)"
+    return f" (saved {age_min // 60}h {age_min % 60}m ago)"
+
+
 def build_wake_prompt(
     agent_name: str,
     *,
@@ -133,14 +173,29 @@ def build_wake_prompt(
     """
     parts = []
 
-    # Continuation context (if any)
+    # Continuation context (if any). A snapshot flagged stale (see
+    # mark_stale_context) collapses to a one-line breadcrumb: the live
+    # conversation already carries everything the full block would replay,
+    # and replaying a stale wake_action invites double execution (#732).
     if context:
-        if context.get("task"):
-            parts.append(f"## Continuation\nYou were working on: {context['task']}")
-        if context.get("context"):
-            parts.append(f"### Previous Context\n{context['context']}")
-        if context.get("notes"):
-            parts.append(f"### Notes\n{context['notes']}")
+        stamp = _format_saved_age(float(context.get("updated_at") or 0))
+        if context.get("stale"):
+            if context.get("task"):
+                parts.append(
+                    f"## Continuation — STALE snapshot{stamp}\n"
+                    f"The conversation has continued past this save; trust the "
+                    f"live thread over it. Last saved task, for reference only: "
+                    f"{context['task']}"
+                )
+        else:
+            if context.get("task"):
+                parts.append(
+                    f"## Continuation{stamp}\nYou were working on: {context['task']}"
+                )
+            if context.get("context"):
+                parts.append(f"### Previous Context\n{context['context']}")
+            if context.get("notes"):
+                parts.append(f"### Notes\n{context['notes']}")
 
     # Events that triggered this wake
     if events:
@@ -342,6 +397,16 @@ class AutonomyEngine:
 
                 wake_context = self._registry.get_context(agent_name)
                 ctx_dict = wake_context.to_dict() if wake_context else None
+
+                # #732: collapse the continuation block when the live
+                # conversation already moved past the snapshot. Probe
+                # failure means "can't tell" — keep today's behavior.
+                if ctx_dict:
+                    try:
+                        last_msg = self._convos.last_message_time(f"{agent_name}-")
+                    except Exception:
+                        last_msg = None
+                    ctx_dict = mark_stale_context(ctx_dict, last_msg)
 
                 # Build decision prompt
                 prompt = build_wake_prompt(

--- a/src/pinky_daemon/conversation_store.py
+++ b/src/pinky_daemon/conversation_store.py
@@ -319,6 +319,23 @@ class ConversationStore:
             for r in rows
         ]
 
+    def last_message_time(self, session_prefix: str) -> float | None:
+        """Most recent message timestamp for sessions of one agent.
+
+        ``session_prefix`` is matched as ``{prefix}%`` so it covers the
+        agent's main session and any labeled siblings (``barsik-main``,
+        ``barsik-research``, …). Used by the autonomy engine's
+        continuation-staleness guard (#732): a saved-context snapshot
+        older than the agent's last conversation activity is history the
+        live thread already supersedes. Returns ``None`` when the agent
+        has no recorded messages.
+        """
+        row = self._conn.execute(
+            "SELECT MAX(timestamp) FROM messages WHERE session_id LIKE ?",
+            (f"{session_prefix}%",),
+        ).fetchone()
+        return float(row[0]) if row and row[0] is not None else None
+
     def count(self, session_id: str = "") -> int:
         """Count messages, optionally filtered by session."""
         if session_id:

--- a/src/pinky_daemon/conversation_store.py
+++ b/src/pinky_daemon/conversation_store.py
@@ -329,10 +329,20 @@ class ConversationStore:
         older than the agent's last conversation activity is history the
         live thread already supersedes. Returns ``None`` when the agent
         has no recorded messages.
+
+        LIKE wildcards in the prefix (``_``/``%`` are legal in agent
+        names) are escaped so ``foo_bar-`` can't match ``fooXbar-main``.
+        Known residual ambiguity (Murzik, PR #733): the ``agent-label``
+        session-id encoding can't distinguish prefix-FAMILY agent names —
+        ``foo-`` also matches ``foo-bar-main``. Worst case is a false
+        STALE verdict (a collapsed continuation, never a wrong replay),
+        and the fleet has no prefix-family names today; the real fix is
+        an ``agent_name`` column on conversation rows.
         """
+        escaped = session_prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         row = self._conn.execute(
-            "SELECT MAX(timestamp) FROM messages WHERE session_id LIKE ?",
-            (f"{session_prefix}%",),
+            "SELECT MAX(timestamp) FROM messages WHERE session_id LIKE ? ESCAPE '\\'",
+            (f"{escaped}%",),
         ).fetchone()
         return float(row[0]) if row and row[0] is not None else None
 

--- a/tests/test_autonomy_continuation_staleness.py
+++ b/tests/test_autonomy_continuation_staleness.py
@@ -134,3 +134,21 @@ class TestLastMessageTime:
         convos.append("barsik-main", "user", "hi", timestamp=100.0)
         convos.append("pushok-main", "user", "yo", timestamp=999.0)
         assert convos.last_message_time("barsik-") == 100.0
+
+    def test_underscore_in_agent_name_is_not_a_wildcard(self, convos):
+        # `_` is a SQL LIKE wildcard — unescaped, foo_bar- would match
+        # fooXbar-main (Murzik repro, PR #733 review).
+        convos.append("fooXbar-main", "user", "imposter", timestamp=1234.0)
+        convos.append("foo_bar-main", "user", "real", timestamp=100.0)
+        assert convos.last_message_time("foo_bar-") == 100.0
+
+    def test_known_ambiguity_prefix_family_names(self, convos):
+        # PINS the documented residual: the agent-label session-id encoding
+        # cannot distinguish prefix-family agent names, so foo- also sees
+        # foo-bar's sessions. Worst case = false STALE (collapsed
+        # continuation), never a wrong replay. Real fix = agent_name column
+        # on conversation rows. If this test starts failing because the
+        # encoding got fixed, delete it and the docstring caveat together.
+        convos.append("foo-main", "user", "mine", timestamp=100.0)
+        convos.append("foo-bar-main", "user", "sibling agent", timestamp=999.0)
+        assert convos.last_message_time("foo-") == 999.0

--- a/tests/test_autonomy_continuation_staleness.py
+++ b/tests/test_autonomy_continuation_staleness.py
@@ -1,0 +1,136 @@
+"""Tests for the continuation-staleness guard (#732).
+
+Autonomy event-wakes fire into LIVE sessions, where the conversation is the
+freshest record. A saved-context snapshot older than the agent's last
+conversation activity must collapse to a one-line breadcrumb instead of
+replaying the full task/context/notes block (and, critically, instead of
+replaying a stale wake_action that could double-fire completed work).
+
+Pinned behaviors:
+- ``mark_stale_context``: strictly-newer message activity (beyond slack)
+  flags the snapshot; missing timestamps on either side leave it alone.
+- ``build_wake_prompt``: stale context renders the STALE one-liner only;
+  fresh context renders the full block with an age stamp.
+- ``ConversationStore.last_message_time``: prefix-scoped MAX(timestamp),
+  None when the agent has no messages.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+
+import pytest
+
+from pinky_daemon.autonomy import build_wake_prompt, mark_stale_context
+from pinky_daemon.conversation_store import ConversationStore
+
+
+@pytest.fixture
+def convos():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    store = ConversationStore(db_path=path)
+    yield store
+    store.close()
+    os.unlink(path)
+
+
+def _ctx(saved_at: float) -> dict:
+    return {
+        "task": "deploy release 26.06.125",
+        "context": "long context body",
+        "notes": "some notes",
+        "wake_action": "deploy X then report",
+        "updated_at": saved_at,
+    }
+
+
+class TestMarkStaleContext:
+    def test_newer_message_flags_stale(self):
+        ctx = _ctx(saved_at=1000.0)
+        out = mark_stale_context(ctx, last_message_time=1100.0)
+        assert out["stale"] is True
+
+    def test_message_within_slack_not_stale(self):
+        ctx = _ctx(saved_at=1000.0)
+        out = mark_stale_context(ctx, last_message_time=1001.0)
+        assert "stale" not in out
+
+    def test_older_message_not_stale(self):
+        ctx = _ctx(saved_at=1000.0)
+        out = mark_stale_context(ctx, last_message_time=900.0)
+        assert "stale" not in out
+
+    def test_missing_probe_keeps_context_untouched(self):
+        ctx = _ctx(saved_at=1000.0)
+        out = mark_stale_context(ctx, last_message_time=None)
+        assert "stale" not in out
+
+    def test_missing_saved_at_keeps_context_untouched(self):
+        ctx = _ctx(saved_at=0.0)
+        out = mark_stale_context(ctx, last_message_time=1100.0)
+        assert "stale" not in out
+
+    def test_none_context_passthrough(self):
+        assert mark_stale_context(None, last_message_time=1100.0) is None
+
+
+class TestBuildWakePromptStaleness:
+    def test_fresh_context_renders_full_block_with_age_stamp(self):
+        ctx = _ctx(saved_at=time.time() - 600)  # 10 minutes old, not flagged
+        prompt = build_wake_prompt(
+            "barsik", events=[], pending_tasks=[], inbox_messages=[], context=ctx
+        )
+        assert "## Continuation (saved 10m ago)" in prompt
+        assert "You were working on: deploy release 26.06.125" in prompt
+        assert "### Previous Context" in prompt
+        assert "long context body" in prompt
+        assert "### Notes" in prompt
+
+    def test_stale_context_collapses_to_one_liner(self):
+        ctx = _ctx(saved_at=time.time() - 3600)
+        ctx["stale"] = True
+        prompt = build_wake_prompt(
+            "barsik", events=[], pending_tasks=[], inbox_messages=[], context=ctx
+        )
+        assert "STALE snapshot" in prompt
+        assert "trust the live thread" in prompt
+        # breadcrumb keeps the task title…
+        assert "deploy release 26.06.125" in prompt
+        # …but the body, notes, and full-block header are gone
+        assert "### Previous Context" not in prompt
+        assert "long context body" not in prompt
+        assert "### Notes" not in prompt
+        assert "You were working on:" not in prompt
+
+    def test_stale_context_without_task_renders_nothing(self):
+        ctx = {"context": "body only", "updated_at": 1000.0, "stale": True}
+        prompt = build_wake_prompt(
+            "barsik", events=[], pending_tasks=[], inbox_messages=[], context=ctx
+        )
+        assert "Continuation" not in prompt
+        assert "body only" not in prompt
+
+    def test_no_context_unchanged(self):
+        prompt = build_wake_prompt(
+            "barsik", events=[], pending_tasks=[], inbox_messages=[], context=None
+        )
+        assert "Continuation" not in prompt
+
+
+class TestLastMessageTime:
+    def test_none_when_no_messages(self, convos):
+        assert convos.last_message_time("barsik-") is None
+
+    def test_returns_max_timestamp_for_prefix(self, convos):
+        convos.append("barsik-main", "user", "hi", timestamp=100.0)
+        convos.append("barsik-main", "assistant", "hello", timestamp=200.0)
+        convos.append("barsik-research", "user", "side task", timestamp=300.0)
+        assert convos.last_message_time("barsik-") == 300.0
+
+    def test_prefix_does_not_match_other_agents(self, convos):
+        convos.append("barsik-main", "user", "hi", timestamp=100.0)
+        convos.append("pushok-main", "user", "yo", timestamp=999.0)
+        assert convos.last_message_time("barsik-") == 100.0


### PR DESCRIPTION
## Problem (#732, flagged by Brad)

Autonomy event-wakes inject the FULL saved-context block (`## Continuation` + previous context + notes) into every wake prompt — including mid-stream into live sessions whose conversation is already ahead of the snapshot. Tonight's examples: a replay of "idle until 23:55" landing mid-outage-recovery. Redundant tokens at best; at worst a stale `wake_action` ("deploy X") replayed after X shipped invites duplicate execution. Same redundancy class as #591 (`to_prompt(resume_mode=True)`), on the autonomy path.

## Fix

- `ConversationStore.last_message_time(prefix)` — prefix-scoped `MAX(timestamp)` over the agent's sessions.
- `mark_stale_context(ctx, last_msg_time)` — pure, unit-testable verdict: conversation activity newer than `updated_at` (+2s slack) flags the snapshot. Missing data on either side = "can't tell" = today's behavior.
- `build_wake_prompt`: stale → one-line breadcrumb (task title, explicit "trust the live thread", **no** wake_action/context/notes); fresh → full block, now with a saved-age stamp (`(saved 42m ago)`).

Transport relaunch wake prompts (tmux/SDK `wake_prompt.py` path) are deliberately untouched — after a real relaunch the saved state is load-bearing.

## Verification

- 13 new tests (`tests/test_autonomy_continuation_staleness.py`) pinning the verdict matrix, prompt rendering both ways, and the store query's prefix scoping.
- Full suite: **3719 passed, 1 skipped**. ruff clean.

## Deploy note

Merge tonight on review; deploy is deliberately held until AFTER the 7:10am first-tmux-dream verification so tonight's dream run stays attributed to 26.06.125.

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)