### PR TITLE
fix(container): pre-clear both first-spawn wedges in the in-container trust seed

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1296,8 +1296,30 @@ class TmuxSession:
             "pr.setdefault(proj,{})\n"
             "pr[proj]['hasTrustDialogAccepted']=True\n"
             "pr[proj]['hasCompletedProjectOnboarding']=True\n"
+            # Live-validated on the Pi (lera rollout, #735): a fresh container
+            # also wedges on Claude Code's "N new MCP servers found" approval
+            # prompt at first spawn — and the queued-message paste then sends
+            # Enter onto whatever is highlighted. Pre-approve the project's own
+            # .mcp.json servers (the daemon wrote that file; they're trusted).
+            "pr[proj]['enableAllProjectMcpServers']=True\n"
             "p.parent.mkdir(parents=True,exist_ok=True)\n"
             "p.write_text(json.dumps(d,indent=2))\n"
+            # Same rollout, second wedge: `--dangerously-skip-permissions`
+            # shows the Bypass Permissions accept dialog whose DEFAULT is
+            # "No, exit" — the message paste's Enter kills the REPL. The
+            # .claude.json flag above is NOT sufficient on CC 2.1.x; the
+            # actual switch is skipDangerousModePermissionPrompt in
+            # CLAUDE_CONFIG_DIR/settings.json. Merge it in, never clobber.
+            "sp=(base if cfg else base/'.claude')/'settings.json'\n"
+            "sp.parent.mkdir(parents=True,exist_ok=True)\n"
+            "s={}\n"
+            "if sp.exists():\n"
+            "    try: s=json.loads(sp.read_text())\n"
+            "    except Exception: s={}\n"
+            "if not isinstance(s,dict): s={}\n"
+            "if not s.get('skipDangerousModePermissionPrompt'):\n"
+            "    s['skipDangerousModePermissionPrompt']=True\n"
+            "    sp.write_text(json.dumps(s,indent=2))\n"
         )
         try:
             res = await runner.run(

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -247,6 +247,83 @@ class TestSeedContainerTrust:
         # sign-in step even with valid credentials present.
         assert "d['hasCompletedOnboarding']=True" in seed
         assert "CLAUDE_CONFIG_DIR" in seed  # resolves the in-container config dir
+        # #735 lera rollout: both first-spawn wedges must be pre-cleared — the
+        # project-MCP approval prompt and the bypass-permissions accept dialog
+        # (whose default is "No, exit"; the queued-message paste's Enter kills
+        # the REPL and strands the transport).
+        assert "pr[proj]['enableAllProjectMcpServers']=True" in seed
+        assert "skipDangerousModePermissionPrompt" in seed
+
+    async def test_seed_script_writes_both_files(self, monkeypatch, tmp_path):
+        """Execute the embedded seed script for real against a temp config dir:
+        it must produce a valid .claude.json (trust + MCP approval) AND a
+        settings.json with skipDangerousModePermissionPrompt, preserving any
+        pre-existing settings keys."""
+        import json
+        import subprocess
+
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(
+            _FakeAgent("dymok", "container", working_dir="/srv/agents/dymok")
+        ))
+        inner = _RecordingInner()
+        runner = ContainerCommandRunner(
+            "pinky-dymok", workdir="/srv/agents/dymok", inner=inner
+        )
+        monkeypatch.setattr(ss, "_select_command_runner", lambda: runner)
+        await ss._seed_container_trust("/srv/agents/dymok")
+        cmd = inner.calls[0]
+        seed = cmd[cmd.index("-c") + 1]
+
+        cfg = tmp_path / "cfgdir"
+        cfg.mkdir()
+        # Pre-existing settings must survive the merge.
+        (cfg / "settings.json").write_text(json.dumps({"theme": "dark"}))
+        subprocess.run(
+            ["python3", "-c", seed, str(tmp_path / "proj")],
+            check=True, env={"CLAUDE_CONFIG_DIR": str(cfg), "HOME": str(tmp_path)},
+        )
+
+        claude_json = json.loads((cfg / ".claude.json").read_text())
+        assert claude_json["bypassPermissionsModeAccepted"] is True
+        proj = claude_json["projects"][str(tmp_path / "proj")]
+        assert proj["hasTrustDialogAccepted"] is True
+        assert proj["enableAllProjectMcpServers"] is True
+
+        settings = json.loads((cfg / "settings.json").read_text())
+        assert settings["skipDangerousModePermissionPrompt"] is True
+        assert settings["theme"] == "dark"  # merged, not clobbered
+
+    async def test_seed_script_settings_path_without_config_dir(
+        self, monkeypatch, tmp_path
+    ):
+        """Without CLAUDE_CONFIG_DIR the settings seed must land in
+        ~/.claude/settings.json (claude's home-level settings path), not
+        ~/settings.json."""
+        import json
+        import subprocess
+
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        ss = _session(registry=_FakeRegistry(
+            _FakeAgent("dymok", "container", working_dir="/srv/agents/dymok")
+        ))
+        inner = _RecordingInner()
+        runner = ContainerCommandRunner(
+            "pinky-dymok", workdir="/srv/agents/dymok", inner=inner
+        )
+        monkeypatch.setattr(ss, "_select_command_runner", lambda: runner)
+        await ss._seed_container_trust("/srv/agents/dymok")
+        seed = inner.calls[0][inner.calls[0].index("-c") + 1]
+
+        subprocess.run(
+            ["python3", "-c", seed, str(tmp_path / "proj")],
+            check=True, env={"HOME": str(tmp_path)},
+        )
+        settings = json.loads(
+            (tmp_path / ".claude" / "settings.json").read_text()
+        )
+        assert settings["skipDangerousModePermissionPrompt"] is True
+        assert not (tmp_path / "settings.json").exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes the two first-spawn wedges from lera's containerization today (#735). A fresh container wedges Claude Code at interactive dialogs, and the daemon's queued-message paste then sends Enter onto whatever is highlighted — for the bypass dialog that's **"No, exit"**, killing the REPL and stranding the transport until a daemon restart.

## The two wedges (live-reproduced on the POS Pi)

**1. MCP approval prompt** — fresh home volume:
```
4 new MCP servers found in this project
Select any you wish to enable.
❯ [✓] pinky-memory ...
```
Seed now sets `projects[<proj>].enableAllProjectMcpServers = true`. The daemon wrote the project's .mcp.json itself — its servers are trusted by construction.

**2. Bypass-permissions accept dialog** — `--dangerously-skip-permissions` on a fresh config dir:
```
WARNING: Claude Code running in Bypass Permissions mode
❯ 1. No, exit        ← message paste's Enter lands here 💀
  2. Yes, I accept
```
`bypassPermissionsModeAccepted` in .claude.json is **not sufficient** on CC 2.1.x — the real switch is `skipDangerousModePermissionPrompt` in `CLAUDE_CONFIG_DIR/settings.json` (diffed working sasha vs wedging lera to find it). Seed merges it in without clobbering existing settings; falls back to `~/.claude/settings.json` when no config dir.

## After (lera, same container, post-manual-fix = what this seed now automates)
```
❯
⏵⏵ bypass permissions on (shift+tab to cycle)
```
Boots straight to the REPL, zero dialogs; lera then passed her full self-check (identity, Zoho scoped to James, tools).

## Tests
- Content assertions for both new keys in the embedded script
- Two execution tests run the seed script for real against temp dirs: writes both files, merge preserves existing settings keys, no-config-dir fallback lands in `~/.claude/settings.json`
- Full suite: 3469 passed

Remaining from today's rollout (tracked in #735): skill env/secrets provisioning, transport respawn after in-container tmux death.

🤖 Generated with [Claude Code](https://claude.com/claude-code)