### PR TITLE
feat(terminal): typeable pane view — operator input from the web terminal modal

### DIFF
--- a/frontend-svelte/src/components/TmuxPaneModal.svelte
+++ b/frontend-svelte/src/components/TmuxPaneModal.svelte
@@ -97,6 +97,13 @@
         }
         // Mixed chunk (e.g. IME/paste or burst typing). Split out any
         // embedded control sequences; send printable runs literally.
+        // Unknown control/escape bytes are DROPPED, never sent as text —
+        // the backend rejects control chars in the literal channel (they'd
+        // bypass the named-key whitelist: literal "\x04" is C-d).
+        const isControl = (ch) => {
+            const code = ch.charCodeAt(0);
+            return code < 0x20 || code === 0x7f;
+        };
         let literal = '';
         let i = 0;
         while (i < data.length) {
@@ -104,10 +111,20 @@
             for (const seq of Object.keys(KEY_SEQUENCES)) {
                 if (data.startsWith(seq, i) && seq.length > matched.length) matched = seq;
             }
+            if (matched === '\x1b' && (data[i + 1] === '[' || data[i + 1] === 'O')) {
+                // Unknown CSI/SS3 sequence (a known one would out-match bare
+                // ESC). Consume through its final byte (0x40–0x7e) and drop.
+                let j = i + 2;
+                while (j < data.length && !(data.charCodeAt(j) >= 0x40 && data.charCodeAt(j) <= 0x7e)) j += 1;
+                i = Math.min(j + 1, data.length);
+                continue;
+            }
             if (matched) {
                 if (literal) { queueSend({ text: literal }); literal = ''; }
                 queueSend({ key: KEY_SEQUENCES[matched] });
                 i += matched.length;
+            } else if (isControl(data[i])) {
+                i += 1; // unknown control byte — drop, never forward
             } else {
                 literal += data[i];
                 i += 1;

--- a/frontend-svelte/src/components/TmuxPaneModal.svelte
+++ b/frontend-svelte/src/components/TmuxPaneModal.svelte
@@ -1,12 +1,18 @@
 <!--
-  TmuxPaneModal — read-only live viewer for a tmux agent's terminal pane.
+  TmuxPaneModal — live viewer (+ optional input) for a tmux agent's terminal pane.
 
   Subscribes to `/agents/{agent}/tmux/pane/stream` (SSE, snapshot per frame)
-  and renders the captured ANSI output into an xterm.js terminal in
-  disableStdin mode. Each frame is a full pane snapshot — we clear + redraw
-  in one write so cursor/colours come through but the previous frame doesn't
-  leak. xterm.js is dynamic-imported so the ~150 KB dependency only loads
-  when the modal opens.
+  and renders the captured ANSI output into an xterm.js terminal. Each frame
+  is a full pane snapshot — we clear + redraw in one write so cursor/colours
+  come through but the previous frame doesn't leak. xterm.js is
+  dynamic-imported so the ~150 KB dependency only loads when the modal opens.
+
+  Input: read-only by default. The footer's "input" toggle arms keystroke
+  passthrough — xterm onData chunks are mapped to the backend's
+  `/tmux/pane/keys` endpoint (named keys for control sequences, literal text
+  otherwise), so an operator can answer first-run dialogs or interrupt a
+  wedged REPL without SSH + `tmux attach`. Sends are serialized through a
+  promise chain to preserve keystroke order.
 
   Props:
     show:  bool   — modal open state (bind from parent)
@@ -18,7 +24,7 @@
 <script>
     import { onDestroy } from 'svelte';
     import Modal from './Modal.svelte';
-    import { sse } from '../lib/api.js';
+    import { api, sse } from '../lib/api.js';
 
     export let show = false;
     export let agent = '';
@@ -44,6 +50,80 @@
     // opens + host div is rendered + we have an agent. Teardown when the
     // modal closes or the target changes.
     $: void reconcile(show, agent, label, hostEl);
+
+    // ── Typeable input (off by default) ──────────────────────────
+    let inputEnabled = false;
+    let inputError = '';
+    let onDataDisposable = null;
+    // Serialize sends so fast typing can't reorder keystrokes (fetches
+    // racing each other would scramble e.g. "ls" into "sl").
+    let sendChain = Promise.resolve();
+
+    // xterm onData control sequences → backend named keys (tmux names).
+    const KEY_SEQUENCES = {
+        '\r': 'Enter',
+        '\t': 'Tab',
+        '\x7f': 'BSpace',
+        '\x03': 'C-c',
+        '\x15': 'C-u',
+        '\x1b': 'Escape',
+        '\x1b[A': 'Up',
+        '\x1b[B': 'Down',
+        '\x1b[C': 'Right',
+        '\x1b[D': 'Left',
+        '\x1b[Z': 'BTab',
+        '\x1b[3~': 'DC',
+        '\x1b[H': 'Home',
+        '\x1b[1~': 'Home',
+        '\x1b[F': 'End',
+        '\x1b[4~': 'End',
+        '\x1b[5~': 'PPage',
+        '\x1b[6~': 'NPage',
+    };
+
+    function queueSend(payload) {
+        sendChain = sendChain
+            .then(() => api('POST', `/agents/${encodeURIComponent(agent)}/tmux/pane/keys`, { ...payload, label }))
+            .then(() => { if (inputError) inputError = ''; })
+            .catch((e) => { inputError = `send failed: ${e?.message || e}`; });
+    }
+
+    function handleTerminalData(data) {
+        if (!inputEnabled || !data) return;
+        const named = KEY_SEQUENCES[data];
+        if (named) {
+            queueSend({ key: named });
+            return;
+        }
+        // Mixed chunk (e.g. IME/paste or burst typing). Split out any
+        // embedded control sequences; send printable runs literally.
+        let literal = '';
+        let i = 0;
+        while (i < data.length) {
+            let matched = '';
+            for (const seq of Object.keys(KEY_SEQUENCES)) {
+                if (data.startsWith(seq, i) && seq.length > matched.length) matched = seq;
+            }
+            if (matched) {
+                if (literal) { queueSend({ text: literal }); literal = ''; }
+                queueSend({ key: KEY_SEQUENCES[matched] });
+                i += matched.length;
+            } else {
+                literal += data[i];
+                i += 1;
+            }
+        }
+        if (literal) queueSend({ text: literal });
+    }
+
+    function toggleInput() {
+        inputEnabled = !inputEnabled;
+        inputError = '';
+        if (terminal) {
+            terminal.options.disableStdin = !inputEnabled;
+            if (inputEnabled) terminal.focus();
+        }
+    }
 
     let lastKey = '';
     async function reconcile(s, a, l, host) {
@@ -138,6 +218,9 @@
             });
             fitAddon = new FitAddon();
             terminal.loadAddon(fitAddon);
+            // Input passthrough — inert until the footer toggle arms it
+            // (disableStdin stays true, so xterm emits no data).
+            onDataDisposable = terminal.onData(handleTerminalData);
 
             if (!hostEl) {
                 // Host unmounted before async resolved — abort.
@@ -178,12 +261,16 @@
         if (resizeDebounceId) { clearTimeout(resizeDebounceId); resizeDebounceId = null; }
         if (sseSource) { try { sseSource.close(); } catch {} sseSource = null; }
         if (resizeObserver) { try { resizeObserver.disconnect(); } catch {} resizeObserver = null; }
+        if (onDataDisposable) { try { onDataDisposable.dispose(); } catch {} onDataDisposable = null; }
         if (terminal) { try { terminal.dispose(); } catch {} terminal = null; }
         fitAddon = null;
         statusMessage = '';
         lastFrameAt = 0;
         lastReqCols = 0;
         lastReqRows = 0;
+        inputEnabled = false;
+        inputError = '';
+        sendChain = Promise.resolve();
     }
 
     onDestroy(teardown);
@@ -196,7 +283,18 @@
         {/if}
         <div class="pane-host" bind:this={hostEl}></div>
         {#if lastFrameAt > 0}
-            <div class="pane-footer">read-only · live · last frame {new Date(lastFrameAt * 1000).toLocaleTimeString()}</div>
+            <div class="pane-footer">
+                <button class="input-toggle" class:armed={inputEnabled} on:click={toggleInput}
+                        title={inputEnabled ? 'Disable keyboard passthrough' : 'Type into this terminal'}>
+                    ⌨ input: {inputEnabled ? 'ON' : 'off'}
+                </button>
+                {#if inputError}
+                    <span class="input-error">{inputError}</span>
+                {/if}
+                <span class="footer-status">
+                    {inputEnabled ? 'keystrokes go to the agent' : 'read-only'} · live · last frame {new Date(lastFrameAt * 1000).toLocaleTimeString()}
+                </span>
+            </div>
         {/if}
     </div>
 </Modal>
@@ -235,6 +333,33 @@
         color: var(--text-muted, #666);
         padding: 0.3rem 0.8rem;
         border-top: 1px solid #222;
-        text-align: right;
+        display: flex;
+        align-items: center;
+        gap: 0.8rem;
+    }
+    .footer-status {
+        margin-left: auto;
+    }
+    .input-toggle {
+        font-family: inherit;
+        font-size: inherit;
+        background: transparent;
+        color: var(--text-muted, #888);
+        border: 1px solid #333;
+        border-radius: 3px;
+        padding: 0.15rem 0.5rem;
+        cursor: pointer;
+    }
+    .input-toggle:hover {
+        border-color: #555;
+        color: #ccc;
+    }
+    .input-toggle.armed {
+        color: #7dd87d;
+        border-color: #3a6b3a;
+        background: #14240f;
+    }
+    .input-error {
+        color: #e07070;
     }
 </style>

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8053,6 +8053,14 @@ npm run build</pre>
             raise HTTPException(400, "provide exactly one of 'text' or 'key'")
         if len(req.text) > 1024:
             raise HTTPException(400, "text too long (max 1024 chars)")
+        if req.text and any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in req.text):
+            # Control bytes in 'text' would bypass the named-key whitelist
+            # ("\x04" is C-d either way) — controls only via whitelisted 'key'.
+            raise HTTPException(
+                400,
+                "text must not contain control characters; "
+                "use a whitelisted 'key' for control sequences",
+            )
         if req.key and req.key not in TmuxSession.PANE_KEY_WHITELIST:
             raise HTTPException(
                 400,

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -91,6 +91,7 @@ from pinky_daemon.api_models import (
     SetMainAgentRequest,
     SetModelRequest,
     SpawnSessionRequest,
+    TmuxPaneKeysRequest,
     TransportStopFailureRequest,
     TransportToolResultRequest,
     TransportToolUseRequest,
@@ -8023,6 +8024,55 @@ npm run build</pre>
         return StreamingResponse(
             event_generator(), media_type="text/event-stream",
         )
+
+    @app.post("/agents/{agent_name}/tmux/pane/keys")
+    async def send_tmux_pane_keys(agent_name: str, req: TmuxPaneKeysRequest):
+        """Type into the agent's live tmux pane from the terminal modal.
+
+        The interactive counterpart of ``stream_tmux_pane``: lets the
+        operator resolve first-run dialogs, menus, and wedged prompts
+        straight from the web UI instead of SSH + ``tmux attach`` (born
+        from lera's container rollout, #735 — three dialogs, three round
+        trips to a shell).
+
+        Exactly one of ``text`` / ``key`` per request; ``key`` must be in
+        ``TmuxSession.PANE_KEY_WHITELIST``. Bounded to 1024 chars — the
+        modal sends keystrokes, not documents. Every send is logged with
+        the agent name for auditability (input content included: this is
+        an operator-facing admin surface, and "what did I type into the
+        wedged dialog" is exactly what the log needs to answer).
+
+        404 unknown agent · 409 not a tmux session · 400 bad input.
+        """
+        from pinky_daemon.tmux_session import TmuxSession
+
+        agent = agents.get(agent_name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{agent_name}' not found")
+        if bool(req.text) == bool(req.key):
+            raise HTTPException(400, "provide exactly one of 'text' or 'key'")
+        if len(req.text) > 1024:
+            raise HTTPException(400, "text too long (max 1024 chars)")
+        if req.key and req.key not in TmuxSession.PANE_KEY_WHITELIST:
+            raise HTTPException(
+                400,
+                f"key {req.key!r} not allowed; whitelist: "
+                f"{sorted(TmuxSession.PANE_KEY_WHITELIST)}",
+            )
+
+        session = broker.get_streaming_session(agent_name, label=req.label)
+        sender = getattr(session, "send_pane_keys", None)
+        if session is None or not callable(sender):
+            raise HTTPException(
+                409, f"Agent '{agent_name}' has no live tmux session"
+            )
+
+        summary = f"text={req.text!r}" if req.text else f"key={req.key}"
+        _log(f"api: pane-keys → {agent_name} ({summary})")
+        ok = await sender(text=req.text, key=req.key)
+        if not ok:
+            raise HTTPException(502, "tmux send-keys failed (see daemon log)")
+        return {"sent": True, "agent": agent_name}
 
     @app.get("/agents/{agent_name}/sessions/{label}/tool-calls")
     async def list_session_tool_calls(

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -1051,3 +1051,16 @@ class PeerFleetAclSetRequest(BaseModel):
     """Replace the full peer-fleet ACL for an agent (full replacement, not merge)."""
 
     selectors: list[PeerFleetAclEntryRequest] = []
+
+
+class TmuxPaneKeysRequest(BaseModel):
+    """Operator keystrokes for the typeable pane view (terminal modal).
+
+    Exactly one of ``text`` (literal characters, no tmux keyname
+    interpretation) or ``key`` (named tmux key — Enter, Up, C-c, ... —
+    validated against ``TmuxSession.PANE_KEY_WHITELIST``) per request.
+    """
+
+    text: str = ""
+    key: str = ""
+    label: str = "main"

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -497,6 +497,16 @@ class _TmuxControl:
             args.append("Enter")
         return await self._run(*args)
 
+    async def send_literal(self, text: str) -> TmuxCommandResult:
+        """Send ``text`` as LITERAL characters (``send-keys -l``).
+
+        Unlike ``send_keys``, tmux performs no keyname interpretation —
+        "Enter" types the five letters, "C-c" types three characters.
+        Used by the typeable pane view, where the operator's typed text
+        must never be accidentally promoted to a control key.
+        """
+        return await self._run("send-keys", "-t", self.session_name, "-l", text)
+
     async def paste_text(
         self,
         text: str,
@@ -2850,6 +2860,55 @@ class TmuxSession:
         if not result.ok:
             _log(
                 f"tmux[{self.agent_name}]: resize_pane failed "
+                f"(rc={result.returncode}): {result.stderr.strip()}"
+            )
+            return False
+        return True
+
+    # Named keys the typeable pane view may send. Bounded on purpose:
+    # enough to drive Claude Code's dialogs/menus and edit a prompt line,
+    # without exposing tmux's full keyname surface. C-c is included —
+    # interrupting a runaway turn is half the point of operator input.
+    PANE_KEY_WHITELIST = frozenset({
+        "Enter", "Escape", "Tab", "BTab", "Space", "BSpace", "DC",
+        "Up", "Down", "Left", "Right", "Home", "End", "PPage", "NPage",
+        "C-c", "C-u",
+    })
+
+    async def send_pane_keys(self, *, text: str = "", key: str = "") -> bool:
+        """Operator keystrokes from the pane-view modal (typeable terminal).
+
+        Exactly one of ``text`` / ``key`` per call:
+
+        - ``text`` — literal characters, sent with ``send-keys -l`` so tmux
+          performs NO keyname interpretation ("Enter" types five letters).
+        - ``key`` — one named key from ``PANE_KEY_WHITELIST`` (tmux keyname
+          semantics: Enter submits, Up/Down navigate dialogs, C-c interrupts).
+
+        This is the interactive counterpart of ``get_pane_snapshot`` — same
+        pane, same defensive posture (log + False, never raise). It exists so
+        an operator can resolve first-run dialogs / wedged prompts from the
+        web UI without SSH + ``tmux attach``.
+        """
+        if bool(text) == bool(key):
+            return False  # exactly one input mode per call
+        if key and key not in self.PANE_KEY_WHITELIST:
+            _log(
+                f"tmux[{self.agent_name}]: send_pane_keys rejected "
+                f"non-whitelisted key {key!r}"
+            )
+            return False
+        try:
+            if text:
+                result = await self._tmux.send_literal(text)
+            else:
+                result = await self._tmux.send_keys(key, enter=False)
+        except Exception as e:
+            _log(f"tmux[{self.agent_name}]: send_pane_keys raised: {e}")
+            return False
+        if not result.ok:
+            _log(
+                f"tmux[{self.agent_name}]: send_pane_keys failed "
                 f"(rc={result.returncode}): {result.stderr.strip()}"
             )
             return False

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2882,6 +2882,8 @@ class TmuxSession:
 
         - ``text`` — literal characters, sent with ``send-keys -l`` so tmux
           performs NO keyname interpretation ("Enter" types five letters).
+          C0/DEL control characters are rejected — a literal "\\x04" would
+          be C-d in the pane, bypassing the named-key whitelist.
         - ``key`` — one named key from ``PANE_KEY_WHITELIST`` (tmux keyname
           semantics: Enter submits, Up/Down navigate dialogs, C-c interrupts).
 
@@ -2896,6 +2898,15 @@ class TmuxSession:
             _log(
                 f"tmux[{self.agent_name}]: send_pane_keys rejected "
                 f"non-whitelisted key {key!r}"
+            )
+            return False
+        if text and any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in text):
+            # Control bytes in the literal channel would bypass the key
+            # whitelist ("\x04" is C-d regardless of which door it came
+            # through) — control sequences are only reachable as named keys.
+            _log(
+                f"tmux[{self.agent_name}]: send_pane_keys rejected "
+                f"control characters in literal text"
             )
             return False
         try:

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -7814,6 +7814,33 @@ async def test_send_pane_keys_rejects_non_whitelisted_key() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_pane_keys_rejects_control_chars_in_text() -> None:
+    """Control bytes in the literal channel never reach tmux — a literal
+    "\\x04" is C-d in the pane, which would bypass the named-key
+    whitelist's explicit C-d exclusion."""
+    session, tmux = _make_session()
+    tmux.send_literal = AsyncMock(return_value=_ok())
+
+    assert await session.send_pane_keys(text="\x04") is False  # C-d
+    assert await session.send_pane_keys(text="ok\x04") is False  # embedded
+    assert await session.send_pane_keys(text="\x1b[A") is False  # raw ESC seq
+    assert await session.send_pane_keys(text="\x7f") is False  # DEL
+    assert await session.send_pane_keys(text="a\nb") is False  # newline
+    tmux.send_literal.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_pane_keys_allows_printable_text() -> None:
+    """The control-char guard must not over-reject: printable ASCII,
+    spaces, and non-ASCII (IME input, emoji) all pass through."""
+    session, tmux = _make_session()
+    tmux.send_literal = AsyncMock(return_value=_ok())
+
+    assert await session.send_pane_keys(text="ls -la ~/файл 🐈") is True
+    tmux.send_literal.assert_awaited_once_with("ls -la ~/файл 🐈")
+
+
+@pytest.mark.asyncio
 async def test_send_pane_keys_swallows_exceptions() -> None:
     """Same defensive posture as get_pane_snapshot/resize_pane: a tmux
     blip logs + returns False, never raises into the API layer."""

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -7731,3 +7731,101 @@ def test_stats_pending_responses_excludes_inflight_turns() -> None:
     ss._message_queue.put_nowait(_QueuedTurn(prompt="queued"))
     assert ss.stats["pending_responses"] == 1
     assert ss.stats["inflight_turns"] == 1
+
+# ──────────────────────────────────────────────────────────────────────────
+# send_literal / send_pane_keys: typeable pane view (operator input from the
+# terminal modal — born from lera's container rollout, #735)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_literal_passes_l_flag() -> None:
+    """Literal sends must use ``send-keys -l`` so tmux performs no keyname
+    interpretation — operator-typed "Enter" is five letters, not a submit."""
+    tmux = _TmuxControl("pinky-test")
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        return _ok()
+
+    tmux._run = fake_run
+    await tmux.send_literal("Enter")
+
+    assert len(calls) == 1
+    args = calls[0]
+    assert args[0] == "send-keys"
+    assert "-l" in args
+    assert args[-1] == "Enter"
+    # -l must precede the text argument (tmux flag ordering).
+    assert args.index("-l") < args.index("Enter")
+
+
+@pytest.mark.asyncio
+async def test_send_pane_keys_text_goes_literal() -> None:
+    session, tmux = _make_session()
+    tmux.send_literal = AsyncMock(return_value=_ok())
+    tmux.send_keys = AsyncMock(return_value=_ok())
+
+    ok = await session.send_pane_keys(text="hello")
+
+    assert ok is True
+    tmux.send_literal.assert_awaited_once_with("hello")
+    tmux.send_keys.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_pane_keys_named_key_goes_send_keys() -> None:
+    session, tmux = _make_session()
+    tmux.send_literal = AsyncMock(return_value=_ok())
+    tmux.send_keys = AsyncMock(return_value=_ok())
+
+    ok = await session.send_pane_keys(key="Enter")
+
+    assert ok is True
+    tmux.send_keys.assert_awaited_once_with("Enter", enter=False)
+    tmux.send_literal.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_pane_keys_requires_exactly_one_mode() -> None:
+    """Both or neither of text/key is a caller bug — refuse without
+    touching tmux."""
+    session, tmux = _make_session()
+    tmux.send_literal = AsyncMock(return_value=_ok())
+    tmux.send_keys = AsyncMock(return_value=_ok())
+
+    assert await session.send_pane_keys() is False
+    assert await session.send_pane_keys(text="x", key="Enter") is False
+    tmux.send_literal.assert_not_awaited()
+    tmux.send_keys.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_pane_keys_rejects_non_whitelisted_key() -> None:
+    """Key names outside PANE_KEY_WHITELIST never reach tmux — the
+    whitelist is the API's security boundary for named keys."""
+    session, tmux = _make_session()
+    tmux.send_keys = AsyncMock(return_value=_ok())
+
+    assert await session.send_pane_keys(key="C-d") is False
+    assert await session.send_pane_keys(key="kill-server") is False
+    tmux.send_keys.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_pane_keys_swallows_exceptions() -> None:
+    """Same defensive posture as get_pane_snapshot/resize_pane: a tmux
+    blip logs + returns False, never raises into the API layer."""
+    session, tmux = _make_session()
+    tmux.send_literal = AsyncMock(side_effect=RuntimeError("kaboom"))
+
+    assert await session.send_pane_keys(text="x") is False
+
+
+@pytest.mark.asyncio
+async def test_send_pane_keys_false_on_tmux_failure() -> None:
+    session, tmux = _make_session()
+    tmux.send_keys = AsyncMock(return_value=_fail("no server running"))
+
+    assert await session.send_pane_keys(key="Enter") is False


### PR DESCRIPTION
The terminal modal was read-only: resolving a first-run dialog or a wedged prompt meant SSH + `tmux attach` (or `podman exec` for container agents). During lera's container rollout today that was three dialogs, three round trips to a shell. Brad's ask (msg 10929): *"in term view it would be cool if we could type in it to resolve it without needing to attach."*

Screenshot sent to Brad on Telegram (docs/ is gitignored in this repo): terminal modal streaming a live pane with the footer **input** toggle armed — `⌨ input: ON · keystrokes go to the agent`.

## Backend
- `TmuxRunner.send_literal()` — `send-keys -l`: literal characters, no tmux keyname interpretation (typed "Enter" is five letters, never a submit)
- `TmuxSession.send_pane_keys(text=|key=)` — exactly one mode per call; named keys validated against `PANE_KEY_WHITELIST` (bounded surface: dialog navigation, line editing, C-c interrupt — no C-d, no kill-server); same log-and-False defensive posture as `get_pane_snapshot`/`resize_pane`
- `POST /agents/{name}/tmux/pane/keys` — 404 unknown agent / 409 not a tmux session / 400 bad input / 1024-char bound; every send logged with agent name + content (operator admin surface — "what did I type into the wedged dialog" is exactly what the log must answer)

## Frontend (TmuxPaneModal)
- Footer **input** toggle arms keystroke passthrough — off by default, reset on teardown, visually distinct when armed
- xterm `onData` chunks: control sequences map to named keys (Enter/arrows/Tab/BSpace/C-c/...), printable runs go as literal text; mixed chunks are split
- Sends serialized through a promise chain so fast typing can't reorder keystrokes

## Tests
7 new TmuxSession/TmuxRunner cases: `-l` flag ordering, text→literal vs key→named routing, mode exclusivity, whitelist enforcement (C-d and arbitrary names rejected), exception/failure posture. `test_tmux_session.py`: 269 passed; api/tmux suites: 621 passed; frontend builds clean.

Born from #735's rollout pain — with this + #736, the next container agent needs zero shell access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)