### PR TITLE
fix(chat): stale thinking dots, duplicate tool chips, stale model picker

### DIFF
--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -34,18 +34,14 @@
     let thinkingActivity = '';
     let thinkingContent = '';
     let activityLog = [];
-    // Task #94: per-turn tool-call chips driven by tmux SSE events
-    // (`tool_use_start` / `tool_use_finish` — see PR #527). Each entry
-    // is `{ id, toolName, namespace, description, argKeys, startedAt,
-    // finished, isError, resultPreview, finishedAt }`. Cleared when a
-    // new user turn begins; persists between the streaming assistant
-    // bubble and the next user send so finished calls stay visible.
-    let liveToolCalls = [];
-    // Persisted tool calls fetched from analytics on chat load — same
-    // shape as liveToolCalls but with `_startedAtEpoch` for chronological
-    // interleaving with messages. Survives page refresh; PR #527 hooks
-    // write the rows, this list rebuilds the chip strips inline with
-    // the message history.
+    // Persisted tool calls fetched from analytics on chat load — entries
+    // are `{ id, toolName, namespace, description, argKeys, finished,
+    // isError, resultPreview, _startedAtEpoch }`, slotted chronologically
+    // between messages. Survives page refresh; PR #527 hooks write the
+    // rows, this list rebuilds the chip strips inline with the message
+    // history. (The live in-turn chip strip these duplicated was removed:
+    // during a turn the thinking-bubble activity log is the single live
+    // view; chips render as history once the turn lands here.)
     let persistedToolCalls = [];
     // Reactive: chip strips slotted just before the message they precede.
     // Both arrays are sorted ASC; chips with started_at in
@@ -151,12 +147,31 @@
     let savingNudge = false;
     let savingSoftNudge = false;
 
-    const availableModels = [
+    // Model picker options come from the live registry (`GET /models`,
+    // same source as the Agents page) so new models appear without a
+    // frontend change — this list was previously hardcoded and went
+    // stale (Brad's msg #10942: no Fable 5 on the Pi). The static list
+    // is only the fallback when the registry fetch fails.
+    const fallbackModels = [
         { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6 (1M)' },
         { value: 'claude-opus-4-6', label: 'Opus 4.6 (1M)' },
-        { value: 'claude-sonnet-4-5-20250514', label: 'Sonnet 4.5' },
-        { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
+        { value: 'claude-haiku-4-5', label: 'Haiku 4.5' },
     ];
+    let availableModels = fallbackModels;
+    async function loadModelRegistry() {
+        try {
+            const registry = await api('GET', '/models');
+            const anthropic = (registry || [])
+                .filter((m) => m.provider === 'anthropic')
+                .map((m) => ({
+                    value: m.model_id,
+                    label: m.display_name || m.model_id,
+                }));
+            if (anthropic.length) availableModels = anthropic;
+        } catch (e) {
+            console.warn('Failed to load model registry:', e);
+        }
+    }
 
     let chatPollInterval;
     let streamEventSource = null;
@@ -510,8 +525,8 @@
         } catch { /* non-critical */ }
 
         // Fetch persisted tool calls so the chip strips survive a page
-        // refresh. Same shape as liveToolCalls; the render loop later
-        // interleaves these chronologically with messages by timestamp.
+        // refresh. The render loop interleaves these chronologically
+        // with messages by timestamp.
         try {
             const refreshLabel = activeSessionRecord?._streaming_label
                 || labelFromSessionId(sessionId, agentName);
@@ -703,52 +718,19 @@
                     thinkingActivity = labelText;
                     activityLog = [...activityLog, labelText].slice(-20);
                 }
-            } else if (data.type === 'tool_use_start') {
-                // tmux transport (PR #527): per-call begin event. Push a
-                // new in-flight entry keyed by tool_use_id so the finish
-                // event can match it. Synthetic id covers the (unlikely)
-                // case where Claude Code omits one for a tool call.
-                const callId = data.tool_use_id ||
-                    `synthetic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-                liveToolCalls = [...liveToolCalls, {
-                    id: callId,
-                    toolName: String(data.tool_name || ''),
-                    namespace: String(data.tool_namespace || ''),
-                    description: String(data.description || ''),
-                    argKeys: Array.isArray(data.arg_keys) ? data.arg_keys : [],
-                    startedAt: Date.now(),
-                    finished: false,
-                    isError: false,
-                    resultPreview: '',
-                    finishedAt: null,
-                }];
-            } else if (data.type === 'tool_use_finish') {
-                // tmux transport (PR #527): close the matching in-flight
-                // chip. No-op if we never saw the start (e.g. SSE was
-                // disconnected mid-turn) — the chip just stays absent.
-                const callId = data.tool_use_id;
-                if (callId) {
-                    liveToolCalls = liveToolCalls.map((tc) =>
-                        tc.id === callId
-                            ? {
-                                ...tc,
-                                finished: true,
-                                isError: !!data.is_error,
-                                resultPreview: String(data.result_preview || ''),
-                                finishedAt: Date.now(),
-                            }
-                            : tc
-                    );
-                }
             } else if (data.type === 'turn_completed' || data.type === 'turn_failed') {
                 localMessages = localMessages.filter((m) => m._localKind !== 'pending-assistant-stream');
                 if (data.type === 'turn_failed' && data.error) {
                     addLocalMessage({ role: 'system', content: `Codex turn failed: ${data.error}` });
                 }
+                // Turn done: refreshChat re-fetches persisted tool calls,
+                // so the turn's chips slot inline as history
+                // (chipsByMessageIndex). tmux `tool_use_start`/`finish`
+                // events are intentionally unhandled — during the turn the
+                // thinking-bubble activity log (fed by the status poll) is
+                // the single live view; a parallel live chip strip rendered
+                // every call twice.
                 await refreshChat();
-                // Turn done: persisted chips (chipsByMessageIndex) now render these
-                // inline, so drop the live strip to avoid double-rendering each chip.
-                liveToolCalls = [];
             }
         };
     }
@@ -864,7 +846,6 @@
         thinkingActivity = '';
         thinkingContent = '';
         activityLog = [];
-        liveToolCalls = [];
         persistedToolCalls = [];
         agentWorking = false;
         wasWorking = false;
@@ -918,7 +899,6 @@
         thinkingActivity = '';
         thinkingContent = '';
         activityLog = [];
-        liveToolCalls = [];   // task #94: new user turn — clear last turn's chips
         pendingReply = { sessionId, sentAt, priorAssistantTs };
         if (pendingReplyTimer) clearTimeout(pendingReplyTimer);
         pendingReplyTimer = setTimeout(() => {
@@ -1307,6 +1287,7 @@
     // ── Lifecycle ──────────────────────────────────────────
 
     onMount(async () => {
+        loadModelRegistry();
         await refreshSessions();
         refreshInterval = setInterval(refreshSessions, 10000);
         document.addEventListener('click', handleGlobalClick);
@@ -1589,32 +1570,6 @@
                         />
                     {/if}
                 {/each}
-                {#if liveToolCalls.length > 0}
-                    <!-- Task #94: per-turn tool-call chips from tmux SSE events (PR #527). -->
-                    <div class="tool-call-strip">
-                        {#each liveToolCalls as tc (tc.id)}
-                            <div class="tool-call-chip" class:in-flight={!tc.finished} class:finished={tc.finished} class:tool-error={tc.finished && tc.isError}>
-                                <span class="tc-head">
-                                    {#if tc.namespace}<span class="tc-ns">{tc.namespace}/</span>{/if}
-                                    <span class="tc-name">{tc.toolName || '(tool)'}</span>
-                                    {#if tc.finished}
-                                        <span class="tc-status">{tc.isError ? '×' : '✓'}</span>
-                                    {:else}
-                                        <span class="tc-spinner" aria-label="running">·</span>
-                                    {/if}
-                                </span>
-                                {#if tc.description}<span class="tc-desc">{tc.description}</span>{/if}
-                                {#if tc.argKeys && tc.argKeys.length}<span class="tc-keys">[{tc.argKeys.join(', ')}]</span>{/if}
-                                {#if tc.finished && tc.resultPreview}
-                                    <details class="tc-preview-wrap">
-                                        <summary class="tc-preview-summary">result</summary>
-                                        <pre class="tc-preview">{tc.resultPreview}</pre>
-                                    </details>
-                                {/if}
-                            </div>
-                        {/each}
-                    </div>
-                {/if}
                 {#if thinking || agentWorking}
                     <div class="thinking-bubble">
                         <div class="thinking-dots-row">

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3488,11 +3488,31 @@ class TmuxSession:
         # ── Critical section: synchronous deque mutation + signals ────
         if not self._inflight_metas:
             # No meta to pop. Stop hook arrived without a dispatch
-            # behind it — race or stale tailer firing post-reconnect.
-            # Bail cleanly; routing must NOT be synthesized.
+            # behind it — most commonly an AUTONOMOUS turn (background-
+            # task notification, harness re-invocation) that never had a
+            # daemon dispatch; also race/stale tailer. Bail on the
+            # callback chain; routing must NOT be synthesized. But the
+            # turn DID end: clear per-turn live-activity state and tell
+            # the UI, or Chat.svelte shows stale thinking dots + frozen
+            # activity log until the next dispatched turn completes.
             _log(
                 f"tmux[{self.agent_name}]: stop hook with empty inflight_metas "
-                f"(race/stale tailer) — skipping callback chain"
+                f"(autonomous turn / race) — skipping callback chain"
+            )
+            self._current_activity = ""
+            self._current_thinking = ""
+            self._activity_log = []
+            await self._emit_stream_event(
+                {
+                    "type": "turn_completed",
+                    "agent_name": self.agent_name,
+                    "stop_reason": response.stop_reason,
+                    "usage": response.usage,
+                    "duration_ms": response.duration_ms,
+                    "assistant_entry_count": response.assistant_entry_count,
+                    "tool_use_count": len(response.tool_uses),
+                    "autonomous": True,
+                }
             )
             return
 

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -2013,6 +2013,39 @@ async def test_handle_turn_complete_resets_live_activity_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_handle_turn_complete_autonomous_turn_clears_activity() -> None:
+    """Empty-deque stop hooks (autonomous turns — background-task
+    notifications, harness re-invocations with no daemon dispatch) must
+    still clear live-activity state and emit ``turn_completed``.
+
+    The empty-deque bail correctly skips the routing chain (no meta to
+    synthesize), but before this fix it returned ABOVE the per-turn
+    activity reset — Chat.svelte showed stale thinking dots + a frozen
+    activity log after the agent stopped (Brad's msg #10938 screenshot,
+    2026-06-11)."""
+    events: list[dict] = []
+
+    async def stream_cb(evt):
+        events.append(evt)
+
+    ss, _ = _make_session_with_response_cb(stream_evt=stream_cb)
+    ss._current_activity = "Bash — gh run watch 12345"
+    ss._current_thinking = "waiting on CI"
+    ss._activity_log = ["Bash — gh run watch 12345"]
+    assert not ss._inflight_metas  # autonomous: nothing dispatched
+    response = TurnResponse(text="", stop_reason="end_turn")
+
+    await ss._handle_turn_complete(response)
+
+    assert ss._current_activity == ""
+    assert ss._current_thinking == ""
+    assert ss._activity_log == []
+    types = [e["type"] for e in events]
+    assert types == ["turn_completed"]
+    assert events[0]["autonomous"] is True
+
+
+@pytest.mark.asyncio
 async def test_handle_turn_complete_swallows_callback_exceptions() -> None:
     """A misbehaving response_callback must not strand the session.
 


### PR DESCRIPTION
Three Chat.svelte/tmux fixes from Brad's live reports today (msgs #10938/#10939/#10942/#10945):

**1. Stuck thinking dots after autonomous turns (backend)**
Empty-deque stop hooks (background-task notifications / harness re-invocations with no daemon dispatch) bailed out of `_handle_turn_complete` ABOVE the per-turn activity reset — `/streaming/status` kept serving the dead turn's `current_activity`/`activity_log`, so the UI showed thinking dots + a frozen tool log after the agent stopped. The bail still skips the routing chain (correct — nothing to synthesize) but now clears activity state and emits `turn_completed` (`autonomous: true`). New test: `test_handle_turn_complete_autonomous_turn_clears_activity`.

**2. Duplicate tool-call badges (frontend)**
During a turn, tmux `tool_use_start/finish` SSE events rendered a live chip strip in parallel with the thinking-bubble activity log — every call appeared twice. The bubble is now the single live view (Brad's preference); persisted chips still render inline as history after the turn (`chipsByMessageIndex`, unchanged).

**3. Stale hardcoded model picker (frontend)**
The session model picker was a hardcoded 4-model list (stale since Sonnet 4.6 — no Fable 5 on the Pi). Now loads from `GET /models` like the Agents page; static list is fallback-only.

**Verification**
- `pytest tests/test_tmux_session.py -k handle_turn_complete` → 12 passed; ruff clean; frontend builds.
- Live UI (hot-served dist on the Mini): picker options now `['Claude Fable 5', 'Claude Mythos 5', 'Claude Opus 4.8', 'Claude Opus 4.7', 'Claude Opus 4.6', 'Claude Sonnet 4.6', 'Claude Haiku 4.5', 'Claude Opus 4.5', 'Claude Sonnet 4.5']` (Playwright dump); single activity card during live turns. Screenshot sent to Brad on Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)