### PR TITLE
fix(registry): correct stale model-seed list prices (#741)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -3765,18 +3765,34 @@ except Exception:
         # Anthropic
         ("anthropic", "claude-fable-5", "Claude Fable 5", "Anthropic's most capable widely-released model (2026-06-09). Demanding reasoning + long-horizon agentic work. 1M context; adaptive thinking always on (use effort to control depth).", "fable", 1_000_000, 1, 10.0, 50.0, 1.0, 1, 1),
         ("anthropic", "claude-mythos-5", "Claude Mythos 5", "Claude Fable 5 capabilities without the safety classifiers. Limited availability via Project Glasswing (approved customers only).", "fable", 1_000_000, 1, 10.0, 50.0, 1.0, 1, 2),
-        ("anthropic", "claude-opus-4-8", "Claude Opus 4.8", "Newest Opus (2026-05-28). Sharper judgement, more honest progress reporting, longer independent runs. Effort defaults to high; adaptive thinking triggers only when needed.", "opus", 1_000_000, 1, 15.0, 75.0, 1.5, 1, 3),
-        ("anthropic", "claude-opus-4-7", "Claude Opus 4.7", "Stricter instruction-following, xhigh effort, larger vision.", "opus", 1_000_000, 1, 15.0, 75.0, 1.5, 1, 5),
-        ("anthropic", "claude-opus-4-6", "Claude Opus 4.6", "Maximum intelligence. Deep reasoning.", "opus", 1_000_000, 1, 15.0, 75.0, 1.5, 1, 10),
+        ("anthropic", "claude-opus-4-8", "Claude Opus 4.8", "Newest Opus (2026-05-28). Sharper judgement, more honest progress reporting, longer independent runs. Effort defaults to high; adaptive thinking triggers only when needed.", "opus", 1_000_000, 1, 5.0, 25.0, 0.5, 1, 3),
+        ("anthropic", "claude-opus-4-7", "Claude Opus 4.7", "Stricter instruction-following, xhigh effort, larger vision.", "opus", 1_000_000, 1, 5.0, 25.0, 0.5, 1, 5),
+        ("anthropic", "claude-opus-4-6", "Claude Opus 4.6", "Maximum intelligence. Deep reasoning.", "opus", 1_000_000, 1, 5.0, 25.0, 0.5, 1, 10),
         ("anthropic", "claude-sonnet-4-6", "Claude Sonnet 4.6", "Fast + smart. Daily driver.", "sonnet", 1_000_000, 1, 3.0, 15.0, 0.3, 1, 20),
-        ("anthropic", "claude-haiku-4-5", "Claude Haiku 4.5", "Lightning fast. Simple tasks.", "haiku", 200_000, 0, 0.8, 4.0, 0.08, 1, 30),
-        ("anthropic", "claude-opus-4-5", "Claude Opus 4.5", "Previous-gen Opus.", "opus", 200_000, 0, 15.0, 75.0, 1.5, 1, 40),
+        ("anthropic", "claude-haiku-4-5", "Claude Haiku 4.5", "Lightning fast. Simple tasks.", "haiku", 200_000, 0, 1.0, 5.0, 0.1, 1, 30),
+        ("anthropic", "claude-opus-4-5", "Claude Opus 4.5", "Previous-gen Opus.", "opus", 200_000, 0, 5.0, 25.0, 0.5, 1, 40),
         ("anthropic", "claude-sonnet-4-5", "Claude Sonnet 4.5", "Previous-gen Sonnet.", "sonnet", 200_000, 0, 3.0, 15.0, 0.3, 1, 50),
         # OpenAI / Codex CLI
         ("openai", "gpt-5.5", "GPT-5.5", "Newest frontier. Coding + reasoning. Codex sign-in auth only (API pending).", "flagship", 200_000, 0, 1.75, 14.0, 0.175, 0, 55),
         ("openai", "gpt-5.4", "GPT-5.4", "Flagship. Complex reasoning & coding.", "flagship", 200_000, 0, 1.75, 14.0, 0.175, 0, 60),
         ("openai", "gpt-5.4-mini", "GPT-5.4 Mini", "Fast + capable. Daily driver.", "mid", 200_000, 0, 0.25, 2.0, 0.025, 0, 70),
         ("openai", "gpt-5.4-nano", "GPT-5.4 Nano", "Cheapest. High-volume tasks.", "low", 200_000, 0, 0.05, 0.4, 0.005, 0, 80),
+    ]
+
+    # One-time data corrections for rows already seeded with wrong values.
+    # ``_seed_models`` is INSERT OR IGNORE, so fixing ``_MODEL_SEEDS`` alone
+    # never reaches an existing install. Each entry rewrites the prices of one
+    # model id ONLY while the row still carries the exact stale numbers —
+    # operator-customized prices are left untouched. (#741: Opus 4.5+ seeded
+    # at the pre-4.5 $15/$75 tier, Haiku 4.5 at the 3.5 tier's $0.80/$4;
+    # pricing.py — the actual cost engine — was always correct.)
+    _PRICE_CORRECTIONS = [
+        # (id, (stale in, out, cached), (correct in, out, cached))
+        ("anthropic/claude-opus-4-8", (15.0, 75.0, 1.5), (5.0, 25.0, 0.5)),
+        ("anthropic/claude-opus-4-7", (15.0, 75.0, 1.5), (5.0, 25.0, 0.5)),
+        ("anthropic/claude-opus-4-6", (15.0, 75.0, 1.5), (5.0, 25.0, 0.5)),
+        ("anthropic/claude-opus-4-5", (15.0, 75.0, 1.5), (5.0, 25.0, 0.5)),
+        ("anthropic/claude-haiku-4-5", (0.8, 4.0, 0.08), (1.0, 5.0, 0.1)),
     ]
 
     def _seed_models(self) -> None:
@@ -3804,9 +3820,24 @@ except Exception:
                  inp, out, cached, thinking, sort, now, now),
             )
             added += cur.rowcount
+        corrected = 0
+        for mid, (old_in, old_out, old_cached), (new_in, new_out, new_cached) \
+                in self._PRICE_CORRECTIONS:
+            cur = self._db.execute(
+                """UPDATE models
+                   SET input_price=?, output_price=?, cached_input_price=?,
+                       updated_at=?
+                   WHERE id=? AND input_price=? AND output_price=?
+                     AND cached_input_price=?""",
+                (new_in, new_out, new_cached, now,
+                 mid, old_in, old_out, old_cached),
+            )
+            corrected += cur.rowcount
         self._db.commit()
         if added:
             _log(f"agent_registry: seeded {added} model(s)")
+        if corrected:
+            _log(f"agent_registry: corrected stale prices on {corrected} model(s)")
 
     def list_models(self, *, provider: str = "", active_only: bool = True) -> list[dict]:
         """List available models, optionally filtered by provider."""

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -885,3 +885,56 @@ class TestModelSeeds:
             for m in registry.list_models(active_only=False)
         )
         assert len(registry.list_models(active_only=False)) == n
+
+    def test_anthropic_seed_prices_match_pricing_rate_table(self, registry):
+        """#741 invariant: the registry's display prices must agree with
+        pricing.py (the actual cost engine) for every Anthropic model both
+        tables know. Catches the next list-price change that lands in one
+        place but not the other."""
+        from pinky_daemon.pricing import RATE_TABLE
+
+        for m in registry.list_models(provider="anthropic", active_only=False):
+            rate = RATE_TABLE.get(m["model_id"])
+            if rate is None:
+                continue
+            assert m["input_price"] == rate["input"], m["model_id"]
+            assert m["output_price"] == rate["output"], m["model_id"]
+            assert m["cached_input_price"] == rate["cache_read"], m["model_id"]
+
+    def test_stale_prices_corrected_on_existing_rows(self, registry):
+        """#741: rows already seeded with the stale tier are rewritten on the
+        next seed pass (INSERT OR IGNORE alone never reaches existing DBs)."""
+        registry._db.execute(
+            "UPDATE models SET input_price=15.0, output_price=75.0,"
+            " cached_input_price=1.5 WHERE id='anthropic/claude-opus-4-8'"
+        )
+        registry._db.execute(
+            "UPDATE models SET input_price=0.8, output_price=4.0,"
+            " cached_input_price=0.08 WHERE id='anthropic/claude-haiku-4-5'"
+        )
+        registry._db.commit()
+        registry._seed_models()
+        models = {
+            m["id"]: m
+            for m in registry.list_models(provider="anthropic", active_only=False)
+        }
+        opus = models["anthropic/claude-opus-4-8"]
+        assert (opus["input_price"], opus["output_price"],
+                opus["cached_input_price"]) == (5.0, 25.0, 0.5)
+        haiku = models["anthropic/claude-haiku-4-5"]
+        assert (haiku["input_price"], haiku["output_price"],
+                haiku["cached_input_price"]) == (1.0, 5.0, 0.1)
+
+    def test_operator_customized_prices_survive_reseed(self, registry):
+        """The correction is gated on the exact stale triple — a price an
+        operator changed by hand must not be clobbered."""
+        registry._db.execute(
+            "UPDATE models SET input_price=12.34 WHERE id='anthropic/claude-opus-4-8'"
+        )
+        registry._db.commit()
+        registry._seed_models()
+        opus = next(
+            m for m in registry.list_models(provider="anthropic", active_only=False)
+            if m["id"] == "anthropic/claude-opus-4-8"
+        )
+        assert opus["input_price"] == 12.34


### PR DESCRIPTION
Closes #741.

The `models` table seeds priced Opus 4.5/4.6/4.7/4.8 at the pre-4.5 $15/$75 tier and Haiku 4.5 at the 3.5-tier $0.80/$4. Current Anthropic list pricing is **$5/$25** (cache read $0.50) for Opus 4.5+ and **$1/$5** (cache read $0.10) for Haiku 4.5. `pricing.py` (the #648 cost engine) was always correct — this was display-only drift in the registry, so anything rendering per-model pricing showed 3×-high Opus numbers. Found while fixing the identical bug in MenuAIv2 #58 (Murzik's review).

## Changes
- **Seed tuples corrected** in `_MODEL_SEEDS` (opus-4-8/4-7/4-6/4-5, haiku-4-5).
- **`_PRICE_CORRECTIONS` pass in `_seed_models()`** — `INSERT OR IGNORE` never touches existing rows, so the Mini + Pi DBs would keep the stale values forever without it. The UPDATE is gated on the row still carrying the *exact* stale triple, so operator-customized prices are never clobbered. Runs on every startup, no-ops after the first correction.

## Tests
- `test_anthropic_seed_prices_match_pricing_rate_table` — invariant pinning every Anthropic seed to `pricing.py`'s `RATE_TABLE`; this is the test that would have caught the drift originally, and catches the next price change that lands in one table but not the other.
- `test_stale_prices_corrected_on_existing_rows` — simulates an existing install with stale rows; reseed rewrites them.
- `test_operator_customized_prices_survive_reseed` — hand-edited price is left alone.

Full suite: 3744 passed, 1 skipped. Ruff clean.

No UI change — screenshot rule N/A (backend data fix; the existing model picker simply starts showing correct numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)