### PR TITLE
fix(context): tmux heartbeat pct + Codex >100% gauge (#745)

### DIFF
--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -1531,7 +1531,10 @@ class CodexSession:
     def context_used_pct(self) -> float:
         if self.max_tokens <= 0:
             return 0.0
-        return (self.estimated_tokens / self.max_tokens) * 100
+        # Clamped for the same reason as ContextTextEstimator.context_info
+        # (#745): the char-count estimate never learns about Codex CLI's
+        # internal auto-compaction, so beyond the window size it's drift.
+        return min(100.0, (self.estimated_tokens / self.max_tokens) * 100)
 
     def get_context_info(self) -> dict:
         """Best-effort context info for APIs that expect session context details."""

--- a/src/pinky_daemon/context_estimator.py
+++ b/src/pinky_daemon/context_estimator.py
@@ -55,7 +55,12 @@ class ContextTextEstimator:
             conversation_store=conversation_store,
             history_limit=history_limit,
         )
-        pct = round(total / max_tokens * 100, 1) if max_tokens > 0 else 0.0
+        # Clamp at 100: the estimate sums ALL persisted history plus every
+        # internal prompt ever recorded, but runtimes like Codex CLI compact
+        # their real context internally — so past the window size the excess
+        # is pure drift, not signal (#745: murzik's gauge read 108%). A live
+        # context can never truly exceed its window.
+        pct = min(100.0, round(total / max_tokens * 100, 1)) if max_tokens > 0 else 0.0
         return {
             "total_tokens": total,
             "max_tokens": max_tokens,

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3264,6 +3264,22 @@ class TmuxSession:
         except (TypeError, ValueError):
             return 0
 
+    @property
+    def context_used_pct(self) -> float:
+        """Context-window usage as a percentage (#745).
+
+        ``StreamingSession`` and ``CodexSession`` both expose this
+        property, and callers that don't know the transport — the
+        scheduler's heartbeat reconciler in particular — read it via
+        ``getattr(session, "context_used_pct", 0.0)``. Without it every
+        reconciled heartbeat for a tmux agent recorded 0.0% while the
+        real number sat one call away in ``get_context_info()``.
+        """
+        max_tokens = self._max_tokens_for_model()
+        if max_tokens <= 0:
+            return 0.0
+        return round(self._current_total_tokens() / max_tokens * 100.0, 1)
+
     def get_context_info(self) -> dict:
         """Return SDK-compatible context-window snapshot.
 

--- a/tests/test_context_estimator.py
+++ b/tests/test_context_estimator.py
@@ -70,3 +70,17 @@ def test_context_info_shape_and_percentage():
         "categories": [],
         "mcp_tools": [],
     }
+
+
+def test_context_info_percentage_clamped_at_100():
+    """#745: the estimate sums all persisted history and never learns about
+    a runtime's internal compaction (Codex CLI), so it drifts past the
+    window size — murzik's gauge read 108%. A live context can't exceed
+    its window; clamp the reported percentage."""
+    estimator = ContextTextEstimator(chars_per_token=4)
+    estimator.record_internal_text("x" * 80)  # 20 tokens vs max 10
+
+    info = estimator.context_info(session_id="agent-main", max_tokens=10)
+
+    assert info["total_tokens"] == 20  # raw estimate stays honest
+    assert info["percentage"] == 100.0  # display gauge is clamped

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -4781,6 +4781,24 @@ async def test_get_context_info_returns_sdk_shape() -> None:
 
 
 @pytest.mark.asyncio
+async def test_context_used_pct_property_for_heartbeat_reconciler() -> None:
+    """#745: the scheduler's heartbeat reconciler reads
+    ``context_used_pct`` via ``getattr(session, ..., 0.0)`` across all
+    transports. TmuxSession didn't define it, so every reconciled
+    heartbeat for a tmux agent recorded 0.0% while the real number sat
+    in ``get_context_info()``. The property must agree with the
+    percentage that the status endpoints already serve."""
+    ss, _ = _make_session_with_response_cb()
+    _seed_inflight(ss)  # #560
+    await ss._handle_turn_complete(
+        _turn_response(input_tokens=5_000, output_tokens=200)
+    )
+    pct = ss.context_used_pct
+    assert pct > 0.0
+    assert pct == ss.get_context_info()["percentage"]
+
+
+@pytest.mark.asyncio
 async def test_raw_max_tokens_for_1m_vs_200k_model() -> None:
     """``_raw_max_tokens_for_model`` returns the raw cap unaltered —
     1M for ``_1M_MODELS`` members, 200k otherwise. Without this split,


### PR DESCRIPTION
Closes #745. Investigated after Brad reported context % looking broken; the live UI surfaces for Claude tmux agents turned out fine (they read `get_context_info()` via `/health` and `/streaming/status`), but two adjacent things were real:

## Bug 1 — heartbeat path recorded 0.0% for every tmux agent
`scheduler._reconcile_server_liveness` reads `getattr(session, "context_used_pct", 0.0)` across transports. `StreamingSession` and `CodexSession` have that property; `TmuxSession` didn't — so 48h of `agent_heartbeats` showed flat 0.0 for every tmux agent. **Fix:** `TmuxSession.context_used_pct` property, same numbers `get_context_info()` already serves (`_current_total_tokens()` / effective max).

## Bug 2 — Codex gauge drifts past 100% (murzik read 108.6% live)
`ContextTextEstimator` char-estimates ALL persisted history + every internal prompt ever recorded, and never learns about Codex CLI's internal auto-compaction — so the estimate grows monotonically past the window. **Fix:** clamp the reported percentage at 100 in both `CodexSession.context_used_pct` and `ContextTextEstimator.context_info`. Raw `total_tokens` stays unclamped so the drift remains observable. A real estimator reset at Codex compaction boundaries needs a compaction signal the CLI doesn't currently expose — out of scope here, noted in #745.

## Tests
- `test_context_used_pct_property_for_heartbeat_reconciler` — property exists, >0 after a turn, agrees with `get_context_info()["percentage"]`
- `test_context_info_percentage_clamped_at_100` — gauge clamps, raw total stays honest
- Affected suites 354 green; full suite 3746 passed / 1 skipped; ruff clean.

No UI change — screenshot rule N/A (the existing dashboards/heartbeat consumers just start receiving correct numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)