### PR TITLE
chore(deps): pin mcp<2.0 — prevent silent breaking upgrade on self-deploy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.27",
+    "mcp>=1.27,<2.0",
     "pydantic>=2.12",
     "pyyaml>=6.0",
     "numpy>=2.2",


### PR DESCRIPTION
## Summary

- Pins `mcp>=1.27,<2.0` in `pyproject.toml` (was unbounded at `>=1.27`)

## Why

Every `update_and_restart()` rebuilds dependencies. The day `mcp` 2.0.0 lands on PyPI a routine 4am self-deploy would pull it in silently. `mcp` (FastMCP) is load-bearing for the whole fleet — `pinky_memory`, `pinky_messaging`, `pinky_self`, `pinky_outreach`, `pinky_calendar`, and the shared SSE gateway on :8890 all build on it. A breaking import = every agent loses tools simultaneously.

Upstream `claude-agent-sdk` v0.2.96 already guards against this for the same reason ([release notes](https://github.com/anthropics/claude-agent-sdk-python/releases/tag/v0.2.96)).

Pure pin — zero behaviour change today, prevents a future fleet outage.

Closes #734.

https://claude.ai/code/session_011D61mHWpHKmtzFJmzcQfxx

---
_Generated by [Claude Code](https://claude.ai/code/session_011D61mHWpHKmtzFJmzcQfxx)_