### PR TITLE
fix: FTS5 quote escape, core-skill disable guard, Anthropic key clear (#726 #727 #728)

### DIFF
--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -638,10 +638,11 @@
             provider_model: providerModel,
             provider_ref: providerRef,
         };
-        // Only send a key the user actually typed; absent means "keep the saved key".
+        // Send the key the user typed; or explicitly clear it when resetting to Anthropic.
         if (providerKey) body.provider_key = providerKey;
+        else if (!providerUrl && !providerRef) body.provider_key = '';
         await api('PUT', `/agents/${currentAgent}/provider`, body);
-        providerKeySet = providerKeySet || !!providerKey;
+        providerKeySet = providerKey ? true : (providerUrl || providerRef ? providerKeySet : false);
         providerKey = '';
         providerDirty = false;
         toast('Provider saved — restart session to apply');

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -5033,9 +5033,11 @@ npm run build</pre>
     @app.post("/agents/{name}/skills/{skill_name}/disable")
     async def disable_agent_skill(name: str, skill_name: str):
         """Disable an assigned skill for an agent (opt-out)."""
+        skill = skills.get(skill_name)
+        if skill and skill.category == "core":
+            raise HTTPException(400, f"Cannot disable core skill '{skill_name}'")
         if not skills.set_agent_skill_enabled(name, skill_name, False):
             # For shared skills, create a disabled assignment to opt out
-            skill = skills.get(skill_name)
             if skill and skill.shared:
                 skills.assign_to_agent(name, skill_name, assigned_by="user")
                 skills.set_agent_skill_enabled(name, skill_name, False)

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -1019,8 +1019,9 @@ class ReflectionStore:
         if not tokens:
             return []
 
-        # Use OR matching so partial keyword hits still return results
-        fts_query = " OR ".join(f'"{t}"' for t in tokens)
+        # Use OR matching so partial keyword hits still return results.
+        # Escape internal quotes so user input can't break FTS5 query syntax.
+        fts_query = " OR ".join('"' + t.replace('"', '""') + '"' for t in tokens)
 
         # Join FTS5 with the main table for filtering + full row data.
         # FTS5 MATCH goes in the WHERE clause alongside other filters.


### PR DESCRIPTION
## Summary

- **#726** `pinky_memory` FTS5 — tokens with embedded `"` now escaped as `""` before phrase-wrapping, matching the `_fts5_phrase` pattern already used in `kb_store` / `conversation_store`; malformed user input no longer silently degrades to the LIKE fallback.
- **#727** `POST /agents/{name}/skills/{skill}/disable` — added `category == "core"` guard (HTTP 400) matching the identical guard on `DELETE`; one-click strip of `pinky-self` is now blocked from the UI and API.
- **#728** `saveProvider()` — sends `provider_key: ""` when resetting to Anthropic (`!providerUrl && !providerRef`), making #712's backend clear path reachable from the UI; `providerKeySet` is also set to `false` so the indicator stays consistent.

## Test plan

- [ ] Memory keyword search with a query containing `"` (e.g. `"O'Brien"` or `cat"dog`) returns results instead of falling back to LIKE
- [ ] `POST /agents/<name>/skills/pinky-self/disable` returns 400, not 200
- [ ] Switch agent provider to a custom key, save, then switch dropdown back to Anthropic and save — backend `provider_key` is cleared (no longer returns `provider_key_set: true`)

https://claude.ai/code/session_014okzggPa5jSZk5AUyGSujb

---
_Generated by [Claude Code](https://claude.ai/code/session_014okzggPa5jSZk5AUyGSujb)_