### PR TITLE
feat(ferry): Route A — Tailscale-bridge cross-fleet transport (#202)

### DIFF
--- a/src/pinky_daemon/__main__.py
+++ b/src/pinky_daemon/__main__.py
@@ -137,7 +137,81 @@ def _run_api(args) -> None:
         default_working_dir=working_dir,
     )
 
-    uvicorn.run(app, host=args.host, port=args.port)
+    from pinky_daemon.ferry.config import FerryConfig
+
+    ferry_cfg = FerryConfig.from_env()
+    if not ferry_cfg.enabled:
+        # Default / current prod: single server, unchanged behavior. If the
+        # operator tried to turn ferry ON but the config is incomplete or the
+        # bind host is unsafe, say why (fail-closed — we never bind publicly).
+        if (os.environ.get("PINKYBOT_FERRY_ENABLED") or "").strip().lower() in (
+            "1", "true", "yes", "on",
+        ):
+            print(f"[pinky] Ferry disabled: {ferry_cfg.why_disabled()}", file=sys.stderr)
+        uvicorn.run(app, host=args.host, port=args.port)
+        return
+
+    # Ferry enabled: run the main API + a dedicated ferry listener bound to the
+    # Tailscale IP only, so the cross-fleet surface is one authed endpoint and
+    # the main API keeps its existing bind. Both servers share one event loop
+    # (so HostPinky.deliver dispatches on the same loop the broker runs on).
+    from pinky_daemon.ferry.inbound_server import build_ferry_app
+
+    host_pinky = getattr(app.state, "host_pinky", None)
+    if host_pinky is None:
+        print(
+            "[pinky] ferry enabled but host_pinky missing — starting API only",
+            file=sys.stderr,
+        )
+        uvicorn.run(app, host=args.host, port=args.port)
+        return
+
+    ferry_app = build_ferry_app(host_pinky=host_pinky, config=ferry_cfg)
+    print(
+        f"[pinky] Ferry listener: {ferry_cfg.bind_host}:{ferry_cfg.bind_port} "
+        f"(fleet={ferry_cfg.fleet_name})",
+        file=sys.stderr,
+    )
+
+    main_server = uvicorn.Server(uvicorn.Config(app, host=args.host, port=args.port))
+    ferry_server = uvicorn.Server(
+        uvicorn.Config(ferry_app, host=ferry_cfg.bind_host, port=ferry_cfg.bind_port)
+    )
+    # uvicorn's serve() calls capture_signals(), which does signal.signal(...).
+    # With two servers on one loop the second would clobber the first's handler,
+    # leaving one server un-stoppable on SIGINT/SIGTERM. Disable both and
+    # install ONE loop-level handler that stops both.
+    main_server.capture_signals = lambda: None
+    ferry_server.capture_signals = lambda: None
+
+    async def _serve_ferry() -> None:
+        # Best-effort: a ferry bind failure (e.g. the Tailscale IP isn't
+        # assigned yet) must NOT take down the core daemon. Log it and let the
+        # main API keep serving.
+        try:
+            await ferry_server.serve()
+        except (Exception, SystemExit) as e:  # noqa: BLE001
+            print(
+                f"[pinky] Ferry listener failed (main API unaffected): {e}",
+                file=sys.stderr,
+            )
+
+    async def _serve_both() -> None:
+        loop = asyncio.get_running_loop()
+
+        def _shutdown(*_a) -> None:
+            main_server.should_exit = True
+            ferry_server.should_exit = True
+
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                loop.add_signal_handler(sig, _shutdown)
+            except (NotImplementedError, RuntimeError):
+                pass
+        # main API failures propagate (core); the ferry side is best-effort.
+        await asyncio.gather(main_server.serve(), _serve_ferry())
+
+    asyncio.run(_serve_both())
 
 
 def _run_poll(args) -> None:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6616,18 +6616,14 @@ npm run build</pre>
     def _build_mesh_sender():
         """Pick the outbound ferry transport from the environment.
 
-        Route A (HTTP-over-Tailscale via ``HttpMeshSender``) when a ferry
-        shared secret + peer URL map are configured; otherwise fall back to the
-        NATS ``MeshSender``. Both share the ``send``/``configured``/
-        ``diagnostics`` surface.
+        Route A (HTTP-over-Tailscale) only when ferry is fully enabled AND a
+        peer map is configured; otherwise the NATS ``MeshSender``. Gating on
+        ``FerryConfig.enabled`` preserves the flag-off contract — see
+        ``ferry.outbound.select_mesh_sender``.
         """
-        from pinky_daemon.ferry.config import FerryConfig
-        from pinky_daemon.ferry.outbound import HttpMeshSender, MeshSender
+        from pinky_daemon.ferry.outbound import select_mesh_sender
 
-        cfg = FerryConfig.from_env()
-        if cfg.shared_secret and cfg.peers:
-            return HttpMeshSender(config=cfg)
-        return MeshSender()
+        return select_mesh_sender()
 
     @app.get("/mesh/diagnostics")
     async def mesh_diagnostics():

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3099,6 +3099,21 @@ def create_api(
     trigger_store = TriggerStore(db_path=db_path.replace(".db", "_triggers.db"))
     mesh_store = MeshStore(db_path=db_path.replace(".db", "_mesh.db"))
 
+    # Ferry host-callback (cross-fleet inbound). Constructed here so it shares
+    # the live registry + broker + mesh_store; stashed on app.state for the
+    # dedicated Tailscale-bound ferry listener that __main__ starts when
+    # PINKYBOT_FERRY_ENABLED is set. memory_store/task_store stay None — v1
+    # ferry carries messages only; substrate import is a later consumer.
+    from pinky_daemon.ferry.config import fleet_name as _ferry_fleet_name
+    from pinky_daemon.ferry.host_pinky import HostPinky
+
+    app.state.host_pinky = HostPinky(
+        registry=agents,
+        broker=broker,
+        mesh_store=mesh_store,
+        fleet_name=_ferry_fleet_name(),
+    )
+
     # Knowledge Base — project-level, all agents share
     _data_dir = Path(db_path).parent
     kb = KBStore(data_dir=_data_dir)
@@ -6598,15 +6613,30 @@ npm run build</pre>
             "patterns": agents.get_mesh_outbound_allowlist(name),
         }
 
+    def _build_mesh_sender():
+        """Pick the outbound ferry transport from the environment.
+
+        Route A (HTTP-over-Tailscale via ``HttpMeshSender``) when a ferry
+        shared secret + peer URL map are configured; otherwise fall back to the
+        NATS ``MeshSender``. Both share the ``send``/``configured``/
+        ``diagnostics`` surface.
+        """
+        from pinky_daemon.ferry.config import FerryConfig
+        from pinky_daemon.ferry.outbound import HttpMeshSender, MeshSender
+
+        cfg = FerryConfig.from_env()
+        if cfg.shared_secret and cfg.peers:
+            return HttpMeshSender(config=cfg)
+        return MeshSender()
+
     @app.get("/mesh/diagnostics")
     async def mesh_diagnostics():
         """Operator-facing health snapshot for the daemon's mesh sender.
 
-        Reports whether creds + URL + nats CLI are wired without leaking
-        the password.
+        Reports the active transport (HTTP-over-Tailscale or NATS) and whether
+        it is wired, without leaking the shared secret or NATS password.
         """
-        from pinky_daemon.ferry.outbound import MeshSender
-        return MeshSender().diagnostics()
+        return _build_mesh_sender().diagnostics()
 
     @app.post("/agents/{name}/mesh/send")
     async def mesh_send(name: str, req: MeshSendRequest):
@@ -6618,8 +6648,8 @@ npm run build</pre>
         Returns ``{sent, correlation_id, subject, ts}`` on success;
         on failure the error is surfaced in ``error``.
         """
+        from pinky_daemon.ferry.config import fleet_name as _ferry_fleet_name
         from pinky_daemon.ferry.outbound import (
-            MeshSender,
             allowlist_matches,
             build_envelope,
             parse_address,
@@ -6650,7 +6680,7 @@ npm run build</pre>
         body_dict["kind"] = req.kind or "msg"
 
         envelope = build_envelope(
-            from_=f"ferry://pinkybot/{name}",
+            from_=f"ferry://{_ferry_fleet_name()}/{name}",
             to=target,
             body=body_dict,
             correlation_id=req.correlation_id or None,
@@ -6658,8 +6688,9 @@ npm run build</pre>
             priority=req.priority or "normal",
         )
 
-        sender = MeshSender()
-        result = sender.send(envelope)
+        sender = _build_mesh_sender()
+        # send() blocks (subprocess / HTTP); run it off the event loop.
+        result = await asyncio.to_thread(sender.send, envelope)
 
         # Audit log: every send attempt, success or failure. Persistence
         # failure must not propagate into the API response (defensive try).

--- a/src/pinky_daemon/ferry/config.py
+++ b/src/pinky_daemon/ferry/config.py
@@ -1,0 +1,193 @@
+"""Ferry cross-fleet config — fleet identity + Route A (Tailscale bridge) wiring.
+
+All ferry environment lives here. Two consumers:
+  - ``inbound_server.build_ferry_app`` — the dedicated ``POST /ferry/inbound``
+    listener, bound to the daemon's Tailscale IP only.
+  - ``outbound.HttpMeshSender`` — POSTs an envelope to a peer's
+    ``/ferry/inbound`` over Tailscale.
+
+Trust model (v1, task #202): Tailscale WireGuard + shared-secret bearer +
+source-IP allowlist + peer-fleet ACL. Wire signatures (``pinky_federation``
+sealed-box / TOFU) are a follow-up; ``verify_signatures`` stays ``False``
+until then. See ``data/agents/barsik/ferry_integration_report.md``.
+
+Environment variables
+---------------------
+  PINKYBOT_FLEET_NAME            this fleet's name (default ``pinkybot``).
+                                Set ``mini`` / ``tod`` to disambiguate.
+  PINKYBOT_FERRY_ENABLED        master switch for the inbound listener
+                                (``1``/``true``/``yes``/``on``). Default off.
+  PINKYBOT_FERRY_SHARED_SECRET  bearer token, identical on both fleets.
+  PINKYBOT_FERRY_BIND_HOST      Tailscale IP the listener binds to.
+  PINKYBOT_FERRY_BIND_PORT      listener port (default 8899).
+  PINKYBOT_FERRY_ALLOWED_PEER_IPS  comma-separated peer tailnet IPs allowed
+                                to POST inbound. Empty = any source (rely on
+                                bind + secret). Recommended: set it.
+  PINKYBOT_FERRY_PEERS          fleet -> base URL map for outbound. Either a
+                                JSON object ``{"tod": "http://100.112.44.64:8899"}``
+                                or a comma list ``tod=http://...,mini=http://...``.
+                                The ``/ferry/inbound`` path is appended.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+from dataclasses import dataclass
+
+DEFAULT_FLEET_NAME = "pinkybot"
+DEFAULT_FERRY_PORT = 8899
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _is_unsafe_bind_host(host: str) -> bool:
+    """True if ``host`` would expose the ferry listener beyond the tailnet.
+
+    The ferry listener MUST bind to a Tailscale/private IP only (defense-in-depth
+    layer #4). A wildcard (``0.0.0.0`` / ``::``), a public IP, or a non-literal
+    hostname is unsafe — we fail-closed (refuse to enable) rather than bind
+    publicly. Tailscale CGNAT IPs (100.64.0.0/10) are ``is_global=False`` and
+    pass; so do RFC1918 / loopback.
+    """
+    h = (host or "").strip()
+    if h in ("", "*"):
+        return True
+    try:
+        ip = ipaddress.ip_address(h)
+    except ValueError:
+        # Not an IP literal (e.g. a hostname / MagicDNS name) — require an
+        # explicit tailnet IP so the bind target is unambiguous.
+        return True
+    return ip.is_unspecified or ip.is_global
+
+
+def fleet_name(env: dict[str, str] | None = None) -> str:
+    """This daemon's fleet name (``PINKYBOT_FLEET_NAME``, default ``pinkybot``)."""
+    e = env if env is not None else os.environ
+    return (e.get("PINKYBOT_FLEET_NAME") or DEFAULT_FLEET_NAME).strip() or DEFAULT_FLEET_NAME
+
+
+def _int(value: str | None, default: int) -> int:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_peers(raw: str) -> dict[str, str]:
+    """Parse the fleet -> base-URL map from JSON or ``k=v,k=v`` form.
+
+    Malformed input yields an empty map rather than raising — a bad peer map
+    must not crash daemon startup; it degrades to "no outbound peer", which
+    surfaces as a clear per-send error.
+    """
+    s = (raw or "").strip()
+    if not s:
+        return {}
+    if s.startswith("{"):
+        try:
+            obj = json.loads(s)
+        except json.JSONDecodeError:
+            return {}
+        if not isinstance(obj, dict):
+            return {}
+        return {
+            str(k).strip(): str(v).strip()
+            for k, v in obj.items()
+            if str(k).strip() and str(v).strip()
+        }
+    out: dict[str, str] = {}
+    for pair in s.split(","):
+        if "=" not in pair:
+            continue
+        k, _, v = pair.partition("=")
+        k, v = k.strip(), v.strip()
+        if k and v:
+            out[k] = v
+    return out
+
+
+@dataclass(frozen=True)
+class FerryConfig:
+    """Resolved ferry configuration. Build via :meth:`from_env`."""
+
+    enabled: bool
+    fleet_name: str
+    bind_host: str
+    bind_port: int
+    shared_secret: str
+    allowed_peer_ips: frozenset[str]
+    peers: dict[str, str]  # fleet -> base URL (no trailing /ferry/inbound)
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "FerryConfig":
+        e = dict(env) if env is not None else dict(os.environ)
+        secret = (e.get("PINKYBOT_FERRY_SHARED_SECRET") or "").strip()
+        enabled_flag = (e.get("PINKYBOT_FERRY_ENABLED") or "").strip().lower() in _TRUTHY
+        bind_host = (e.get("PINKYBOT_FERRY_BIND_HOST") or "").strip()
+        bind_port = _int(e.get("PINKYBOT_FERRY_BIND_PORT"), DEFAULT_FERRY_PORT)
+        peer_ips = frozenset(
+            ip.strip()
+            for ip in (e.get("PINKYBOT_FERRY_ALLOWED_PEER_IPS") or "").split(",")
+            if ip.strip()
+        )
+        peers = _parse_peers(e.get("PINKYBOT_FERRY_PEERS") or "")
+        # The inbound listener only starts when explicitly enabled AND it has a
+        # secret AND a SAFE (tailnet/private, non-wildcard) bind host —
+        # fail-closed, never an unauthenticated or publicly-bound listener by
+        # omission or misconfiguration.
+        enabled = (
+            enabled_flag
+            and bool(secret)
+            and bool(bind_host)
+            and not _is_unsafe_bind_host(bind_host)
+        )
+        return cls(
+            enabled=enabled,
+            fleet_name=fleet_name(e),
+            bind_host=bind_host,
+            bind_port=bind_port,
+            shared_secret=secret,
+            allowed_peer_ips=peer_ips,
+            peers=peers,
+        )
+
+    def why_disabled(self, env: dict[str, str] | None = None) -> str:
+        """Human-readable reason the inbound listener is disabled.
+
+        For startup logging when an operator set ``PINKYBOT_FERRY_ENABLED`` but
+        the listener still won't start (missing secret/bind, or an unsafe bind).
+        """
+        e = dict(env) if env is not None else dict(os.environ)
+        if (e.get("PINKYBOT_FERRY_ENABLED") or "").strip().lower() not in _TRUTHY:
+            return "PINKYBOT_FERRY_ENABLED not set"
+        if not self.shared_secret:
+            return "PINKYBOT_FERRY_SHARED_SECRET not set"
+        if not self.bind_host:
+            return "PINKYBOT_FERRY_BIND_HOST not set"
+        if _is_unsafe_bind_host(self.bind_host):
+            return (
+                f"PINKYBOT_FERRY_BIND_HOST={self.bind_host!r} is wildcard/public/"
+                "non-literal — must be a Tailscale or private IP"
+            )
+        return "enabled"
+
+    def peer_url(self, fleet: str) -> str | None:
+        """Full ``/ferry/inbound`` URL for ``fleet``, or ``None`` if unmapped."""
+        base = self.peers.get(fleet)
+        if not base:
+            return None
+        return base.rstrip("/") + "/ferry/inbound"
+
+    def diagnostics(self) -> dict:
+        """Operator-facing snapshot. Never leaks the secret value."""
+        return {
+            "enabled": self.enabled,
+            "fleet_name": self.fleet_name,
+            "bind": f"{self.bind_host}:{self.bind_port}" if self.bind_host else "",
+            "shared_secret_set": bool(self.shared_secret),
+            "allowed_peer_ips": sorted(self.allowed_peer_ips),
+            "peers": dict(self.peers),
+        }

--- a/src/pinky_daemon/ferry/host_pinky.py
+++ b/src/pinky_daemon/ferry/host_pinky.py
@@ -24,6 +24,8 @@ from collections.abc import Callable
 from dataclasses import asdict
 from typing import Any
 
+from pinky_daemon.ferry.config import DEFAULT_FLEET_NAME
+from pinky_daemon.ferry.outbound import parse_address
 from pinky_daemon.ferry.substrate import (
     classify_entry_destination,
     populate_port_history,
@@ -53,21 +55,27 @@ def _log(msg: str) -> None:
 
 # -- Address parsing -----------------------------------------------------------
 
-_FERRY_PINKY_PREFIX = "ferry://pinkybot/"
 
+def parse_pinkybot_address(addr: str, fleet_name: str = DEFAULT_FLEET_NAME) -> str | None:
+    """Extract the local agent name from a ferry address aimed at *this* fleet.
 
-def parse_pinkybot_address(addr: str) -> str | None:
-    """Extract the agent name from a ferry://pinkybot/<name> address.
+    Accepts both address forms and verifies the fleet segment matches
+    ``fleet_name`` (default ``pinkybot``):
+      - ``ferry://<fleet_name>/<agent>``  — canonical form
+      - ``<agent>@<fleet_name>``          — at-form (what ``mesh_remote_send``
+        produces, e.g. ``onesie@tod``)
 
-    Returns the agent name on success, or None if the address is not
-    pointed at this fleet.
+    Returns the agent name on success, or ``None`` if the address is malformed
+    or pointed at a different fleet. Reuses ``outbound.parse_address`` so the
+    inbound and outbound sides parse addresses identically.
     """
-    if not addr:
+    parsed = parse_address(addr)
+    if parsed is None:
         return None
-    if not addr.startswith(_FERRY_PINKY_PREFIX):
+    addr_fleet, agent_slug = parsed
+    if addr_fleet != fleet_name:
         return None
-    name = addr[len(_FERRY_PINKY_PREFIX):].strip()
-    return name or None
+    return agent_slug or None
 
 
 def parse_peer_card(addr: str) -> tuple[str, str]:
@@ -88,6 +96,27 @@ def parse_peer_card(addr: str) -> tuple[str, str]:
     if len(parts) >= 2:
         return (parts[-1], addr)
     return ("", addr)
+
+
+def _canonical_agent_id(addr: str) -> str:
+    """Canonicalize a peer address to a stable agent_id for ACL matching.
+
+    The outbound endpoint emits ``from_`` in canonical form
+    (``ferry://<fleet>/<agent>``) while operators configure ``peer_fleet_acl``
+    selectors in at-form (``<agent>@<fleet>``). Both forms collapse to the same
+    at-form here so an ACL configured in either form matches a wire ``from_`` in
+    either form:
+
+        ferry://tod/onesie  -> onesie@tod
+        onesie@tod          -> onesie@tod
+
+    Unparseable input is returned unchanged (exact-match fallback).
+    """
+    parsed = parse_address(addr)
+    if parsed is None:
+        return addr
+    fleet, agent_slug = parsed
+    return f"{agent_slug}@{fleet}"
 
 
 # -- HostPinky -----------------------------------------------------------------
@@ -113,10 +142,16 @@ class HostPinky:
         memory_store: Any | None = None,
         task_store: Any | None = None,
         mesh_store: Any | None = None,
+        fleet_name: str = DEFAULT_FLEET_NAME,
         verify_signatures: bool = False,
         reflection_factory: Callable[[dict[str, Any]], Any] | None = None,
     ) -> None:
         """Construct a HostPinky.
+
+        ``fleet_name``: this daemon's fleet name (``PINKYBOT_FLEET_NAME``).
+        Used to recognise which inbound ``to`` addresses are local
+        (``ferry://<fleet_name>/<agent>`` or ``<agent>@<fleet_name>``).
+        Defaults to ``pinkybot`` for backward compatibility.
 
         ``reflection_factory`` (optional): callable that builds a Reflection
         from a kwargs dict. Defaults to ``pinky_memory.types.Reflection`` when
@@ -132,6 +167,7 @@ class HostPinky:
         self._memory_store = memory_store
         self._task_store = task_store
         self._mesh_store = mesh_store
+        self._fleet_name = fleet_name or DEFAULT_FLEET_NAME
         self._verify_signatures = verify_signatures
         self._reflection_factory = reflection_factory
         self._stats: dict[str, int] = {
@@ -175,7 +211,7 @@ class HostPinky:
                 return self._reject("auth_failed", verify_err)
 
         # 2. Resolve target agent
-        agent_name = parse_pinkybot_address(envelope.to)
+        agent_name = parse_pinkybot_address(envelope.to, self._fleet_name)
         if not agent_name:
             return self._reject(
                 "unknown_agent",
@@ -201,14 +237,23 @@ class HostPinky:
                 f"peer {envelope.from_!r} not on {agent_name}'s peer_fleet_acl",
             )
 
-        # 4. Dispatch by payload kind
+        # 4. Dispatch by payload kind.
+        #
+        # Substrate has two explicit kinds. Everything else is treated as a
+        # message — the outbound side (mesh_remote_send) defaults body.kind to
+        # "msg", and the protocol's body.kind is open-ended ("message", "msg",
+        # "smoke", "ack", ...). Routing all non-substrate kinds to the message
+        # path is what makes a plain mesh_remote_send actually deliver instead
+        # of being silently rejected as an unknown kind (an empty body is still
+        # rejected downstream in _deliver_message).
         kind = envelope.kind
-        if kind == "message":
-            return await self._deliver_message(agent_name, envelope)
         if kind in ("substrate.entry", "substrate.batch"):
             return await self._deliver_substrate(agent_name, envelope)
-
-        return self._reject("unsupported_payload_kind", f"kind={kind!r}")
+        if kind.startswith("substrate."):
+            # A substrate.* kind we don't handle — reject rather than dump a
+            # malformed substrate payload into the agent's chat feed.
+            return self._reject("unsupported_payload_kind", f"kind={kind!r}")
+        return await self._deliver_message(agent_name, envelope)
 
     def _log_inbound_safely(
         self,
@@ -220,7 +265,7 @@ class HostPinky:
         if self._mesh_store is None:
             return
         try:
-            local_agent = parse_pinkybot_address(envelope.to) or ""
+            local_agent = parse_pinkybot_address(envelope.to, self._fleet_name) or ""
             peer_fleet, peer_agent_id = parse_peer_card(envelope.from_)
             error: str | None = None
             if result.status in ("rejected", "transient_failure"):
@@ -272,14 +317,32 @@ class HostPinky:
         """Check peer_fleet_acl for the receiving agent.
 
         Default-deny: empty/missing ACL means no peer-fleet inbound allowed.
+
+        Both the peer's wire ``from_`` and each selector's ``agent_id`` are
+        canonicalized to at-form before comparison, so an ACL configured as
+        ``onesie@tod`` matches the canonical ``ferry://tod/onesie`` that the
+        outbound endpoint actually emits — and vice versa. (Without this, an
+        agent_id-scoped ACL silently 403s every real cross-fleet message,
+        because the stored at-form selector never string-equals the canonical
+        wire ``from_``.)
         """
         selectors = self._load_peer_fleet_acl(agent_name)
         if not selectors:
             return False
-        peer_fleet, peer_agent_id = parse_peer_card(peer_address)
+        peer_fleet, _peer_raw = parse_peer_card(peer_address)
+        peer_agent_id = _canonical_agent_id(peer_address)
         for sel in selectors:
-            if sel.matches(peer_fleet, peer_agent_id, ""):
-                return True
+            if sel.fleet is not None and sel.fleet != "*" and sel.fleet != peer_fleet:
+                continue
+            if sel.agent_id is not None and sel.agent_id != "*":
+                if _canonical_agent_id(sel.agent_id) != peer_agent_id:
+                    continue
+            if sel.pinky_type is not None:
+                # v0.1 has no verified inbound pinky_type, so a pinky_type-bearing
+                # selector can never match (mirrors the warning in
+                # _load_peer_fleet_acl).
+                continue
+            return True
         return False
 
     def _load_peer_fleet_acl(self, agent_name: str) -> list[AgentCardSelector]:
@@ -412,7 +475,7 @@ class HostPinky:
         if not entries:
             return self._reject("empty_substrate_payload", "no entries in body")
 
-        receiving_address = f"ferry://pinkybot/{agent_name}"
+        receiving_address = f"ferry://{self._fleet_name}/{agent_name}"
         results: list[IngestResult] = []
         operational_failures = 0
         for entry in entries:

--- a/src/pinky_daemon/ferry/inbound_server.py
+++ b/src/pinky_daemon/ferry/inbound_server.py
@@ -1,0 +1,174 @@
+"""Ferry inbound — dedicated Tailscale-bound listener for ``POST /ferry/inbound``.
+
+Route A (Tailscale bridge). A *separate* tiny FastAPI app + uvicorn server,
+bound to the daemon's Tailscale IP only, so the cross-fleet attack surface is
+exactly one authenticated endpoint — the main API keeps its existing bind
+(localhost on TOD, LAN on the Mini) untouched.
+
+Defense in depth, all fail-closed:
+  1. shared-secret bearer token (``PINKYBOT_FERRY_SHARED_SECRET``, both fleets)
+  2. source-IP allowlist (``PINKYBOT_FERRY_ALLOWED_PEER_IPS`` — peer tailnet IPs)
+  3. peer-fleet ACL (enforced inside ``HostPinky.deliver``)
+  4. listener bound to the Tailscale IP — never ``0.0.0.0`` / public
+
+Wire signatures (``pinky_federation`` sealed-box / TOFU) are a follow-up;
+until then trust = Tailscale WireGuard + the three checks above. See task #202.
+"""
+
+from __future__ import annotations
+
+import hmac
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from pinky_daemon.ferry.types import FerryEnvelope, TraversalRecord
+
+
+def _opt_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value)
+    return s or None
+
+
+def _opt_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _lit(value: Any, allowed: tuple[str, ...], default: str) -> str:
+    s = str(value).strip() if value is not None else ""
+    return s if s in allowed else default
+
+
+def envelope_from_wire(payload: dict[str, Any]) -> FerryEnvelope:
+    """Reconstruct a :class:`FerryEnvelope` from its on-wire JSON form.
+
+    Inverse of ``outbound.envelope_to_wire``: maps ``"from"`` → ``from_`` and
+    rebuilds the traversal records. Unknown/garbage fields are coerced to safe
+    defaults rather than trusted — this is a cross-fleet boundary, so the
+    envelope is reconstructed field-by-field, never ``**payload``-splatted.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("envelope payload must be a JSON object")
+    body = payload.get("body")
+    if not isinstance(body, dict):
+        raise ValueError("envelope.body must be an object")
+    if "kind" not in body:
+        raise ValueError("envelope.body must contain a 'kind' field")
+
+    traversal: list[TraversalRecord] = []
+    for t in payload.get("traversal") or []:
+        if isinstance(t, dict):
+            traversal.append(
+                TraversalRecord(
+                    broker=str(t.get("broker", "")),
+                    at=_opt_int(t.get("at")) or 0,
+                    via=str(t.get("via", "")),
+                    signature=str(t.get("signature", "")),
+                )
+            )
+
+    raw_headers = payload.get("headers") or {}
+    headers = (
+        {str(k): str(v) for k, v in raw_headers.items()}
+        if isinstance(raw_headers, dict)
+        else {}
+    )
+
+    return FerryEnvelope(
+        v=str(payload.get("v", "0.1")),
+        id=str(payload.get("id", "")),
+        from_=str(payload.get("from", "")),
+        to=str(payload.get("to", "")),
+        ts=_opt_int(payload.get("ts")) or 0,
+        body=dict(body),
+        priority=_lit(payload.get("priority"), ("low", "normal", "high", "urgent"), "normal"),
+        wake=_lit(payload.get("wake"), ("none", "if-idle", "when-free", "interrupt"), "if-idle"),
+        ack=_lit(payload.get("ack"), ("none", "delivery", "processed"), "delivery"),
+        ttl_ms=_opt_int(payload.get("ttl_ms")),
+        correlation_id=_opt_str(payload.get("correlation_id")),
+        reply_to=_opt_str(payload.get("reply_to")),
+        subject=_opt_str(payload.get("subject")),
+        traversal=traversal,
+        headers=headers,
+    )
+
+
+def build_ferry_app(*, host_pinky: Any, config: Any):
+    """Build the dedicated ferry FastAPI app.
+
+    ``host_pinky`` is the daemon's singleton ``HostPinky`` (shares the live
+    registry + broker so delivery reaches real streaming sessions). ``config``
+    is a :class:`pinky_daemon.ferry.config.FerryConfig`.
+    """
+    app = FastAPI(title="pinky-ferry", docs_url=None, redoc_url=None, openapi_url=None)
+
+    def _client_ip(request: Request) -> str:
+        return request.client.host if request.client else ""
+
+    def _authorized(request: Request) -> bool:
+        auth = request.headers.get("authorization", "")
+        token = auth[7:].strip() if auth[:7].lower() == "bearer " else ""
+        # Constant-time compare; fail-closed when no secret configured.
+        if not config.shared_secret or not token:
+            return False
+        if not hmac.compare_digest(token, config.shared_secret):
+            return False
+        # Source-IP allowlist — only enforced when configured. Empty list means
+        # "any tailnet source" (the bind + bearer are the boundary then).
+        if config.allowed_peer_ips and _client_ip(request) not in config.allowed_peer_ips:
+            return False
+        return True
+
+    @app.get("/ferry/health")
+    async def ferry_health():  # noqa: ANN202
+        return {"ok": True, "fleet": config.fleet_name, "service": "pinky-ferry"}
+
+    @app.post("/ferry/inbound")
+    async def ferry_inbound(request: Request):  # noqa: ANN202
+        if not config.shared_secret:
+            return JSONResponse(
+                status_code=503, content={"ok": False, "error": "ferry not configured"}
+            )
+        if not _authorized(request):
+            return JSONResponse(
+                status_code=401, content={"ok": False, "error": "unauthorized"}
+            )
+        try:
+            payload = await request.json()
+        except Exception:  # noqa: BLE001 — any parse failure is a 400
+            return JSONResponse(
+                status_code=400, content={"ok": False, "error": "invalid json"}
+            )
+        try:
+            envelope = envelope_from_wire(payload)
+        except (ValueError, TypeError) as e:
+            return JSONResponse(
+                status_code=400, content={"ok": False, "error": f"bad envelope: {e}"}
+            )
+
+        result = await host_pinky.deliver(envelope)
+
+        if result.status in ("delivered", "queued"):
+            http_status = 200
+        elif result.status == "rejected":
+            http_status = 403
+        else:  # transient_failure → 503 so the sender can retry
+            http_status = 503
+        return JSONResponse(
+            status_code=http_status,
+            content={
+                "ok": result.status in ("delivered", "queued"),
+                "status": result.status,
+                "reason": result.reason,
+            },
+        )
+
+    return app

--- a/src/pinky_daemon/ferry/outbound.py
+++ b/src/pinky_daemon/ferry/outbound.py
@@ -470,3 +470,25 @@ class HttpMeshSender:
                 error=f"peer returned HTTP {code}",
             )
         return SendResult(sent=True, correlation_id=cid, subject=url, ts=ts, error=None)
+
+
+def select_mesh_sender(config: Any | None = None):
+    """Pick the outbound ferry transport.
+
+    Route A (``HttpMeshSender``, HTTP-over-Tailscale) ONLY when ferry is fully
+    enabled (``FerryConfig.enabled`` — master flag + secret + safe bind host)
+    AND a peer URL map is configured; otherwise the legacy NATS ``MeshSender``.
+
+    Gating on ``enabled`` (not merely secret+peers) preserves the zero-prod-
+    change flag-off contract: with ``PINKYBOT_FERRY_ENABLED`` unset — or a
+    missing/unsafe bind host that disabled inbound — outbound stays on the
+    legacy transport instead of silently cutting over to Route A. (If a
+    send-only fleet is ever needed, add an explicit outbound flag rather than
+    loosening this.)
+    """
+    from pinky_daemon.ferry.config import FerryConfig
+
+    cfg = config if config is not None else FerryConfig.from_env()
+    if cfg.enabled and cfg.peers:
+        return HttpMeshSender(config=cfg)
+    return MeshSender()

--- a/src/pinky_daemon/ferry/outbound.py
+++ b/src/pinky_daemon/ferry/outbound.py
@@ -365,3 +365,108 @@ class MeshSender:
             ts=ts,
             error=None,
         )
+
+
+class HttpMeshSender:
+    """Route A outbound — POST a ferry envelope to the peer fleet's
+    ``/ferry/inbound`` over Tailscale.
+
+    Same surface as :class:`MeshSender` (``send`` / ``configured`` /
+    ``diagnostics``) so the API endpoint can pick either transport without
+    branching on shape. Where ``MeshSender`` publishes to a NATS broker, this
+    POSTs directly to the addressed peer daemon's dedicated ferry listener
+    over the tailnet — no third-party broker, no public-internet hop.
+
+    The shared secret is sent as a bearer token and never logged. The peer
+    URL map + secret come from :class:`pinky_daemon.ferry.config.FerryConfig`
+    (the environment), never from the request body, so they don't leak into
+    agent context.
+    """
+
+    DEFAULT_TIMEOUT_S = 10.0
+
+    def __init__(
+        self,
+        *,
+        config: Any | None = None,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+    ) -> None:
+        from pinky_daemon.ferry.config import FerryConfig
+
+        self._config = config if config is not None else FerryConfig.from_env()
+        self._timeout_s = timeout_s
+
+    @property
+    def configured(self) -> bool:
+        """True iff a shared secret and at least one peer URL are set."""
+        return bool(self._config.shared_secret and self._config.peers)
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Operator-facing health snapshot. Never includes the secret value."""
+        return {"transport": "http", "configured": self.configured, **self._config.diagnostics()}
+
+    def send(self, envelope: FerryEnvelope) -> SendResult:
+        """POST an envelope to its peer fleet's ferry listener. Synchronous.
+
+        Failures are returned as ``SendResult(sent=False, error=...)`` rather
+        than raised — callers want a structured response either way. This is a
+        blocking call (stdlib ``urllib``); the API endpoint runs it in a
+        threadpool so it never blocks the event loop.
+        """
+        import urllib.error
+        import urllib.request
+
+        ts = envelope.ts
+        cid = envelope.correlation_id
+
+        parsed = parse_address(envelope.to)
+        if parsed is None:
+            return SendResult(
+                sent=False, correlation_id=cid, subject="", ts=ts,
+                error=f"unparseable target address: {envelope.to!r}",
+            )
+        fleet, _agent = parsed
+        url = self._config.peer_url(fleet)
+        if not url:
+            return SendResult(
+                sent=False, correlation_id=cid, subject="", ts=ts,
+                error=f"no ferry peer URL configured for fleet {fleet!r}",
+            )
+        if not self._config.shared_secret:
+            return SendResult(
+                sent=False, correlation_id=cid, subject=url, ts=ts,
+                error="ferry shared secret not configured",
+            )
+
+        wire = envelope_to_wire(envelope)
+        req = urllib.request.Request(
+            url,
+            data=wire.encode("utf-8"),
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self._config.shared_secret}",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout_s) as resp:
+                code = resp.getcode()
+                resp.read()  # drain so the connection can be reused/closed
+        except urllib.error.HTTPError as exc:
+            # Peer reachable but rejected (401 auth, 403 ACL, 503 transient...).
+            return SendResult(
+                sent=False, correlation_id=cid, subject=url, ts=ts,
+                error=f"peer returned HTTP {exc.code}",
+            )
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            return SendResult(
+                sent=False, correlation_id=cid, subject=url, ts=ts,
+                error=f"ferry POST failed: {exc}",
+            )
+
+        if code != 200:
+            return SendResult(
+                sent=False, correlation_id=cid, subject=url, ts=ts,
+                error=f"peer returned HTTP {code}",
+            )
+        return SendResult(sent=True, correlation_id=cid, subject=url, ts=ts, error=None)

--- a/tests/test_ferry_route_a.py
+++ b/tests/test_ferry_route_a.py
@@ -1,0 +1,593 @@
+"""Tests for ferry Route A — Tailscale-bridge cross-fleet transport (task #202).
+
+Covers the pieces that turn the half-built ferry into a working barsik↔onesie
+round-trip over Tailscale:
+
+  - FerryConfig env parsing + fail-closed enable gating
+  - envelope_from_wire ⇄ envelope_to_wire round-trip
+  - fleet-aware inbound address parsing (canonical + at-form)
+  - host-pinky kind dispatch: a plain mesh_remote_send (body.kind="msg")
+    actually delivers (regression — used to be rejected as unknown kind)
+  - HttpMeshSender outbound POST (bearer auth, peer URL map, error paths)
+  - build_ferry_app listener: bearer + source-IP allowlist + ACL, fail-closed
+  - end-to-end: wire JSON → ferry app → real HostPinky → broker
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from pinky_daemon.ferry.config import DEFAULT_FERRY_PORT, FerryConfig, fleet_name
+from pinky_daemon.ferry.host_pinky import HostPinky, parse_pinkybot_address
+from pinky_daemon.ferry.inbound_server import build_ferry_app, envelope_from_wire
+from pinky_daemon.ferry.outbound import (
+    HttpMeshSender,
+    build_envelope,
+    envelope_to_wire,
+)
+from pinky_daemon.ferry.types import AgentCardSelector, DeliveryResult
+
+# -- Fakes --------------------------------------------------------------------
+
+
+class FakeRegistry:
+    def __init__(self, agents):
+        self._agents = agents
+
+    def has_agent(self, name):
+        return name in self._agents
+
+    def list_agents(self):
+        return [{"name": n} for n in self._agents]
+
+    def get_peer_fleet_acl(self, name):
+        return list(self._agents.get(name, []))
+
+
+class FakeBroker:
+    def __init__(self):
+        self.received = []
+
+    async def dispatch_pre_authorized(self, agent_name, broker_msg):
+        self.received.append((agent_name, broker_msg))
+
+
+class _FakeResp:
+    def __init__(self, code=200):
+        self._code = code
+
+    def getcode(self):
+        return self._code
+
+    def read(self):
+        return b""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+# -- FerryConfig --------------------------------------------------------------
+
+
+class TestFerryConfig:
+    def test_fleet_name_default_and_override(self):
+        assert fleet_name({}) == "pinkybot"
+        assert fleet_name({"PINKYBOT_FLEET_NAME": "mini"}) == "mini"
+        assert fleet_name({"PINKYBOT_FLEET_NAME": "  "}) == "pinkybot"
+
+    def test_disabled_without_master_flag(self):
+        cfg = FerryConfig.from_env(
+            {
+                "PINKYBOT_FERRY_SHARED_SECRET": "s",
+                "PINKYBOT_FERRY_BIND_HOST": "100.1.1.1",
+                # no PINKYBOT_FERRY_ENABLED
+            }
+        )
+        assert cfg.enabled is False
+
+    def test_disabled_without_secret_even_if_flag_on(self):
+        cfg = FerryConfig.from_env(
+            {"PINKYBOT_FERRY_ENABLED": "1", "PINKYBOT_FERRY_BIND_HOST": "100.1.1.1"}
+        )
+        assert cfg.enabled is False
+
+    def test_disabled_without_bind_host(self):
+        cfg = FerryConfig.from_env(
+            {"PINKYBOT_FERRY_ENABLED": "1", "PINKYBOT_FERRY_SHARED_SECRET": "s"}
+        )
+        assert cfg.enabled is False
+
+    def test_enabled_when_all_present(self):
+        cfg = FerryConfig.from_env(
+            {
+                "PINKYBOT_FERRY_ENABLED": "true",
+                "PINKYBOT_FERRY_SHARED_SECRET": "s",
+                "PINKYBOT_FERRY_BIND_HOST": "100.112.44.64",  # tailnet IP (CGNAT)
+                "PINKYBOT_FLEET_NAME": "tod",
+            }
+        )
+        assert cfg.enabled is True
+        assert cfg.fleet_name == "tod"
+        assert cfg.bind_port == DEFAULT_FERRY_PORT
+
+    def test_peers_json_and_kv_forms(self):
+        j = FerryConfig.from_env(
+            {"PINKYBOT_FERRY_PEERS": '{"tod": "http://100.112.44.64:8899"}'}
+        )
+        assert j.peers == {"tod": "http://100.112.44.64:8899"}
+        kv = FerryConfig.from_env(
+            {"PINKYBOT_FERRY_PEERS": "tod=http://t:8899,mini=http://m:8899"}
+        )
+        assert kv.peers == {"tod": "http://t:8899", "mini": "http://m:8899"}
+
+    def test_peers_malformed_is_empty_not_crash(self):
+        assert FerryConfig.from_env({"PINKYBOT_FERRY_PEERS": "{bad json"}).peers == {}
+        assert FerryConfig.from_env({"PINKYBOT_FERRY_PEERS": "garbage"}).peers == {}
+
+    def test_peer_url_appends_path(self):
+        cfg = FerryConfig.from_env({"PINKYBOT_FERRY_PEERS": "tod=http://t:8899/"})
+        assert cfg.peer_url("tod") == "http://t:8899/ferry/inbound"
+        assert cfg.peer_url("nope") is None
+
+    def test_allowed_peer_ips_parsed(self):
+        cfg = FerryConfig.from_env(
+            {"PINKYBOT_FERRY_ALLOWED_PEER_IPS": "100.1.1.1, 100.2.2.2 ,"}
+        )
+        assert cfg.allowed_peer_ips == frozenset({"100.1.1.1", "100.2.2.2"})
+
+    def test_diagnostics_never_leaks_secret(self):
+        cfg = FerryConfig.from_env({"PINKYBOT_FERRY_SHARED_SECRET": "topsecret"})
+        diag = cfg.diagnostics()
+        assert diag["shared_secret_set"] is True
+        assert "topsecret" not in json.dumps(diag)
+
+    @pytest.mark.parametrize("bad_host", ["0.0.0.0", "::", "8.8.8.8", "example.com", "*"])
+    def test_unsafe_bind_host_fails_closed(self, bad_host):
+        # Wildcard / public / non-literal bind host must NOT enable the listener
+        # — defense-in-depth layer #4 (Tailscale-only) enforced at the gate.
+        cfg = FerryConfig.from_env(
+            {
+                "PINKYBOT_FERRY_ENABLED": "1",
+                "PINKYBOT_FERRY_SHARED_SECRET": "s",
+                "PINKYBOT_FERRY_BIND_HOST": bad_host,
+            }
+        )
+        assert cfg.enabled is False
+        assert "wildcard/public" in cfg.why_disabled(
+            {
+                "PINKYBOT_FERRY_ENABLED": "1",
+                "PINKYBOT_FERRY_SHARED_SECRET": "s",
+                "PINKYBOT_FERRY_BIND_HOST": bad_host,
+            }
+        )
+
+    @pytest.mark.parametrize("good_host", ["100.108.59.106", "100.112.44.64", "127.0.0.1", "192.168.1.5"])
+    def test_safe_bind_host_enables(self, good_host):
+        cfg = FerryConfig.from_env(
+            {
+                "PINKYBOT_FERRY_ENABLED": "1",
+                "PINKYBOT_FERRY_SHARED_SECRET": "s",
+                "PINKYBOT_FERRY_BIND_HOST": good_host,
+            }
+        )
+        assert cfg.enabled is True
+
+    def test_why_disabled_messages(self):
+        assert "PINKYBOT_FERRY_ENABLED" in FerryConfig.from_env({}).why_disabled({})
+        assert "SHARED_SECRET" in FerryConfig.from_env(
+            {"PINKYBOT_FERRY_ENABLED": "1"}
+        ).why_disabled({"PINKYBOT_FERRY_ENABLED": "1"})
+
+
+# -- envelope_from_wire ⇄ envelope_to_wire ------------------------------------
+
+
+class TestWireRoundTrip:
+    def test_round_trip_preserves_core_fields(self):
+        env = build_envelope(
+            from_="ferry://mini/barsik",
+            to="onesie@tod",
+            body={"kind": "msg", "text": "ferry smoke 1"},
+            correlation_id="cid-1",
+            priority="high",
+        )
+        wire = json.loads(envelope_to_wire(env))
+        rebuilt = envelope_from_wire(wire)
+        assert rebuilt.from_ == "ferry://mini/barsik"
+        assert rebuilt.to == "onesie@tod"
+        assert rebuilt.body == {"kind": "msg", "text": "ferry smoke 1"}
+        assert rebuilt.correlation_id == "cid-1"
+        assert rebuilt.priority == "high"
+        assert rebuilt.id == env.id
+        assert rebuilt.ts == env.ts
+
+    def test_rejects_missing_body(self):
+        with pytest.raises(ValueError):
+            envelope_from_wire({"v": "0.1", "from": "a@x", "to": "b@y"})
+
+    def test_rejects_body_without_kind(self):
+        with pytest.raises(ValueError):
+            envelope_from_wire({"body": {"text": "no kind"}})
+
+    def test_rejects_non_dict(self):
+        with pytest.raises(ValueError):
+            envelope_from_wire("not a dict")  # type: ignore[arg-type]
+
+
+# -- fleet-aware inbound address parsing --------------------------------------
+
+
+class TestParseLocalAddress:
+    def test_default_fleet_canonical(self):
+        assert parse_pinkybot_address("ferry://pinkybot/barsik") == "barsik"
+
+    def test_default_fleet_rejects_other(self):
+        assert parse_pinkybot_address("ferry://sigil/pulse") is None
+        assert parse_pinkybot_address("misha@pinky.local") is None
+
+    def test_custom_fleet_canonical_and_atform(self):
+        assert parse_pinkybot_address("ferry://tod/onesie", "tod") == "onesie"
+        assert parse_pinkybot_address("onesie@tod", "tod") == "onesie"
+
+    def test_custom_fleet_rejects_mismatch(self):
+        assert parse_pinkybot_address("onesie@tod", "mini") is None
+        assert parse_pinkybot_address("barsik@mini", "tod") is None
+
+
+# -- host-pinky kind dispatch (the round-trip bug fix) ------------------------
+
+
+@pytest.mark.asyncio
+class TestKindDispatch:
+    async def _deliver(self, kind, fleet="mini", to="barsik@mini"):
+        registry = FakeRegistry(
+            {"barsik": [AgentCardSelector(fleet="tod", agent_id="onesie@tod")]}
+        )
+        broker = FakeBroker()
+        host = HostPinky(registry=registry, broker=broker, fleet_name=fleet)
+        env = build_envelope(from_="onesie@tod", to=to, body={"kind": kind, "text": "hi"})
+        return await host.deliver(env), broker
+
+    async def test_msg_kind_delivers(self):
+        # Regression: mesh_remote_send defaults body.kind="msg"; this used to be
+        # rejected as unsupported_payload_kind, so "sent:true" never delivered.
+        result, broker = await self._deliver("msg")
+        assert result.status == "delivered"
+        assert len(broker.received) == 1
+
+    async def test_message_kind_still_delivers(self):
+        result, broker = await self._deliver("message")
+        assert result.status == "delivered"
+
+    @pytest.mark.parametrize("kind", ["smoke", "ack", "chat", "anything"])
+    async def test_non_substrate_kinds_deliver(self, kind):
+        result, _ = await self._deliver(kind)
+        assert result.status == "delivered"
+
+    async def test_unknown_substrate_kind_rejected(self):
+        result, broker = await self._deliver("substrate.bogus")
+        assert result.status == "rejected"
+        assert result.reason == "unsupported_payload_kind"
+        assert broker.received == []
+
+
+# -- HttpMeshSender -----------------------------------------------------------
+
+
+def _http_cfg(**over):
+    base = {
+        "PINKYBOT_FERRY_SHARED_SECRET": "sekret",
+        "PINKYBOT_FERRY_PEERS": "tod=http://100.112.44.64:8899",
+    }
+    base.update(over)
+    return FerryConfig.from_env(base)
+
+
+class TestHttpMeshSender:
+    def test_configured_requires_secret_and_peers(self):
+        assert HttpMeshSender(config=_http_cfg()).configured is True
+        assert HttpMeshSender(
+            config=FerryConfig.from_env({"PINKYBOT_FERRY_PEERS": "tod=http://x:1"})
+        ).configured is False
+        assert HttpMeshSender(
+            config=FerryConfig.from_env({"PINKYBOT_FERRY_SHARED_SECRET": "s"})
+        ).configured is False
+
+    def test_diagnostics_no_secret_leak(self):
+        diag = HttpMeshSender(config=_http_cfg()).diagnostics()
+        assert diag["transport"] == "http"
+        assert "sekret" not in json.dumps(diag)
+
+    def test_unparseable_target(self):
+        env = build_envelope(from_="ferry://mini/barsik", to="onesie@tod", body={"kind": "msg"})
+        object.__setattr__(env, "to", "::::")  # force unparseable
+        res = HttpMeshSender(config=_http_cfg()).send(env)
+        assert res.sent is False
+        assert "unparseable" in res.error
+
+    def test_no_peer_url_for_fleet(self):
+        env = build_envelope(from_="ferry://mini/barsik", to="ghost@unknownfleet", body={"kind": "msg"})
+        res = HttpMeshSender(config=_http_cfg()).send(env)
+        assert res.sent is False
+        assert "no ferry peer URL" in res.error
+
+    def test_successful_post_sends_bearer_and_url(self, monkeypatch):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["req"] = req
+            return _FakeResp(200)
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        env = build_envelope(
+            from_="ferry://mini/barsik", to="onesie@tod", body={"kind": "msg", "text": "hi"}
+        )
+        res = HttpMeshSender(config=_http_cfg()).send(env)
+        assert res.sent is True
+        req = captured["req"]
+        assert req.full_url == "http://100.112.44.64:8899/ferry/inbound"
+        assert req.get_header("Authorization") == "Bearer sekret"
+        assert json.loads(req.data.decode())["to"] == "onesie@tod"
+
+    def test_http_error_surfaced(self, monkeypatch):
+        import urllib.error
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", {}, None)
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        env = build_envelope(from_="ferry://mini/barsik", to="onesie@tod", body={"kind": "msg"})
+        res = HttpMeshSender(config=_http_cfg()).send(env)
+        assert res.sent is False
+        assert "401" in res.error
+
+    def test_network_error_surfaced(self, monkeypatch):
+        import urllib.error
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        env = build_envelope(from_="ferry://mini/barsik", to="onesie@tod", body={"kind": "msg"})
+        res = HttpMeshSender(config=_http_cfg()).send(env)
+        assert res.sent is False
+        assert "failed" in res.error
+
+
+# -- build_ferry_app listener -------------------------------------------------
+
+
+class _FakeHostPinky:
+    def __init__(self, result):
+        self._result = result
+        self.delivered = []
+
+    async def deliver(self, envelope):
+        self.delivered.append(envelope)
+        return self._result
+
+
+def _client(host_pinky, **cfg_over):
+    from fastapi.testclient import TestClient
+
+    base = {
+        "PINKYBOT_FERRY_ENABLED": "1",
+        "PINKYBOT_FERRY_SHARED_SECRET": "sekret",
+        "PINKYBOT_FERRY_BIND_HOST": "100.1.1.1",
+        "PINKYBOT_FLEET_NAME": "mini",
+    }
+    base.update(cfg_over)
+    cfg = FerryConfig.from_env(base)
+    return TestClient(build_ferry_app(host_pinky=host_pinky, config=cfg)), cfg
+
+
+def _wire(to="barsik@mini", from_="onesie@tod", kind="msg"):
+    env = build_envelope(from_=from_, to=to, body={"kind": kind, "text": "hi"})
+    return json.loads(envelope_to_wire(env))
+
+
+class TestFerryApp:
+    def test_health_ok(self):
+        client, _ = _client(_FakeHostPinky(DeliveryResult(status="delivered")))
+        r = client.get("/ferry/health")
+        assert r.status_code == 200
+        assert r.json()["fleet"] == "mini"
+
+    def test_missing_bearer_401(self):
+        client, _ = _client(_FakeHostPinky(DeliveryResult(status="delivered")))
+        r = client.post("/ferry/inbound", json=_wire())
+        assert r.status_code == 401
+
+    def test_wrong_bearer_401(self):
+        client, _ = _client(_FakeHostPinky(DeliveryResult(status="delivered")))
+        r = client.post(
+            "/ferry/inbound", json=_wire(), headers={"Authorization": "Bearer nope"}
+        )
+        assert r.status_code == 401
+
+    def test_correct_bearer_delivers_200(self):
+        hp = _FakeHostPinky(DeliveryResult(status="delivered"))
+        client, _ = _client(hp)
+        r = client.post(
+            "/ferry/inbound", json=_wire(), headers={"Authorization": "Bearer sekret"}
+        )
+        assert r.status_code == 200
+        assert r.json()["status"] == "delivered"
+        assert len(hp.delivered) == 1
+
+    def test_rejected_maps_403(self):
+        hp = _FakeHostPinky(DeliveryResult(status="rejected", reason="acl_denied"))
+        client, _ = _client(hp)
+        r = client.post(
+            "/ferry/inbound", json=_wire(), headers={"Authorization": "Bearer sekret"}
+        )
+        assert r.status_code == 403
+        assert r.json()["reason"] == "acl_denied"
+
+    def test_transient_maps_503(self):
+        hp = _FakeHostPinky(DeliveryResult(status="transient_failure", reason="broker_error"))
+        client, _ = _client(hp)
+        r = client.post(
+            "/ferry/inbound", json=_wire(), headers={"Authorization": "Bearer sekret"}
+        )
+        assert r.status_code == 503
+
+    def test_bad_json_400(self):
+        client, _ = _client(_FakeHostPinky(DeliveryResult(status="delivered")))
+        r = client.post(
+            "/ferry/inbound",
+            content="{not json",
+            headers={"Authorization": "Bearer sekret", "Content-Type": "application/json"},
+        )
+        assert r.status_code == 400
+
+    def test_bad_envelope_400(self):
+        client, _ = _client(_FakeHostPinky(DeliveryResult(status="delivered")))
+        r = client.post(
+            "/ferry/inbound",
+            json={"v": "0.1", "from": "x@y", "to": "barsik@mini"},  # no body
+            headers={"Authorization": "Bearer sekret"},
+        )
+        assert r.status_code == 400
+
+    def test_source_ip_allowlist_blocks_non_peer(self):
+        # TestClient's client host is "testclient"; allow only a different IP.
+        hp = _FakeHostPinky(DeliveryResult(status="delivered"))
+        client, _ = _client(hp, PINKYBOT_FERRY_ALLOWED_PEER_IPS="100.9.9.9")
+        r = client.post(
+            "/ferry/inbound", json=_wire(), headers={"Authorization": "Bearer sekret"}
+        )
+        assert r.status_code == 401
+        assert hp.delivered == []
+
+    def test_source_ip_allowlist_permits_listed(self):
+        hp = _FakeHostPinky(DeliveryResult(status="delivered"))
+        client, _ = _client(hp, PINKYBOT_FERRY_ALLOWED_PEER_IPS="testclient")
+        r = client.post(
+            "/ferry/inbound", json=_wire(), headers={"Authorization": "Bearer sekret"}
+        )
+        assert r.status_code == 200
+
+
+# -- End-to-end: wire JSON → ferry app → real HostPinky → broker --------------
+
+
+@pytest.mark.asyncio
+class TestEndToEndInbound:
+    async def test_wire_to_broker_via_real_host_pinky(self):
+        from pinky_daemon.agent_registry import AgentRegistry
+
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        try:
+            registry = AgentRegistry(db_path=path)
+            registry.register("barsik", model="opus")
+            # ACL configured the documented way — at-form agent_id.
+            registry.add_peer_fleet_acl("barsik", fleet="tod", agent_id="onesie@tod")
+            broker = FakeBroker()
+            host = HostPinky(registry=registry, broker=broker, fleet_name="mini")
+
+            # The EXACT wire form the mesh_send endpoint emits: canonical from_
+            # (ferry://<fleet>/<agent>), NOT the at-form. The canonical form must
+            # match the at-form ACL selector (review finding #1 regression).
+            env = build_envelope(
+                from_="ferry://tod/onesie",
+                to="barsik@mini",
+                body={"kind": "msg", "text": "ferry smoke"},
+            )
+            rebuilt = envelope_from_wire(json.loads(envelope_to_wire(env)))
+            result = await host.deliver(rebuilt)
+
+            assert result.status == "delivered"
+            assert len(broker.received) == 1
+            agent_name, bm = broker.received[0]
+            assert agent_name == "barsik"
+            assert bm.content == "ferry smoke"
+            assert bm.platform == "ferry"
+        finally:
+            registry.close()
+            os.unlink(path)
+
+    async def test_acl_denied_blocks_unlisted_peer(self):
+        from pinky_daemon.agent_registry import AgentRegistry
+
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        try:
+            registry = AgentRegistry(db_path=path)
+            registry.register("barsik", model="opus")
+            # No ACL entry → default-deny
+            broker = FakeBroker()
+            host = HostPinky(registry=registry, broker=broker, fleet_name="mini")
+            env = build_envelope(
+                from_="onesie@tod", to="barsik@mini", body={"kind": "msg", "text": "x"}
+            )
+            result = await host.deliver(envelope_from_wire(json.loads(envelope_to_wire(env))))
+            assert result.status == "rejected"
+            assert result.reason == "acl_denied"
+            assert broker.received == []
+        finally:
+            registry.close()
+            os.unlink(path)
+
+
+# -- ACL address-form matching matrix (review finding #1) ---------------------
+
+
+@pytest.mark.asyncio
+class TestAclAddressFormMatching:
+    """The wire ``from_`` (canonical) and the stored selector ``agent_id``
+    (at-form) must match regardless of which address form each uses.
+    """
+
+    async def _deliver(self, *, selector_kwargs, from_):
+        registry = FakeRegistry(
+            {"barsik": [AgentCardSelector(**selector_kwargs)]}
+        )
+        broker = FakeBroker()
+        host = HostPinky(registry=registry, broker=broker, fleet_name="mini")
+        env = build_envelope(from_=from_, to="barsik@mini", body={"kind": "msg", "text": "hi"})
+        return (await host.deliver(env)).status
+
+    async def test_canonical_from_matches_atform_selector(self):
+        # mesh_send emits canonical; operators store at-form. Must match.
+        status = await self._deliver(
+            selector_kwargs={"fleet": "tod", "agent_id": "onesie@tod"},
+            from_="ferry://tod/onesie",
+        )
+        assert status == "delivered"
+
+    async def test_atform_from_matches_ferryform_selector(self):
+        status = await self._deliver(
+            selector_kwargs={"fleet": "tod", "agent_id": "ferry://tod/onesie"},
+            from_="onesie@tod",
+        )
+        assert status == "delivered"
+
+    async def test_fleet_only_selector_matches_canonical(self):
+        status = await self._deliver(
+            selector_kwargs={"fleet": "tod", "agent_id": "*"},
+            from_="ferry://tod/onesie",
+        )
+        assert status == "delivered"
+
+    async def test_wrong_agent_still_denied(self):
+        status = await self._deliver(
+            selector_kwargs={"fleet": "tod", "agent_id": "someone-else@tod"},
+            from_="ferry://tod/onesie",
+        )
+        assert status == "rejected"
+
+    async def test_wrong_fleet_still_denied(self):
+        status = await self._deliver(
+            selector_kwargs={"fleet": "sigil", "agent_id": "onesie@sigil"},
+            from_="ferry://tod/onesie",
+        )
+        assert status == "rejected"

--- a/tests/test_ferry_route_a.py
+++ b/tests/test_ferry_route_a.py
@@ -26,8 +26,10 @@ from pinky_daemon.ferry.host_pinky import HostPinky, parse_pinkybot_address
 from pinky_daemon.ferry.inbound_server import build_ferry_app, envelope_from_wire
 from pinky_daemon.ferry.outbound import (
     HttpMeshSender,
+    MeshSender,
     build_envelope,
     envelope_to_wire,
+    select_mesh_sender,
 )
 from pinky_daemon.ferry.types import AgentCardSelector, DeliveryResult
 
@@ -359,6 +361,61 @@ class TestHttpMeshSender:
         res = HttpMeshSender(config=_http_cfg()).send(env)
         assert res.sent is False
         assert "failed" in res.error
+
+
+# -- outbound transport selection (flag-off contract) -------------------------
+
+
+class TestSenderSelection:
+    """Outbound must NOT cut over to Route A HTTP unless ferry is fully enabled
+    (review: Murzik #753). Flag-off → legacy NATS transport, zero prod change.
+    """
+
+    def test_flag_off_with_secret_and_peers_stays_nats(self):
+        # secret + peers present but NO master flag / bind host → enabled False.
+        cfg = FerryConfig.from_env(
+            {
+                "PINKYBOT_FERRY_SHARED_SECRET": "s",
+                "PINKYBOT_FERRY_PEERS": "tod=http://100.112.44.64:8899",
+            }
+        )
+        assert cfg.enabled is False
+        assert isinstance(select_mesh_sender(cfg), MeshSender)
+
+    def test_unsafe_bind_with_secret_and_peers_stays_nats(self):
+        # Inbound disabled by an unsafe bind must not silently enable Route A out.
+        cfg = FerryConfig.from_env(
+            {
+                "PINKYBOT_FERRY_ENABLED": "1",
+                "PINKYBOT_FERRY_SHARED_SECRET": "s",
+                "PINKYBOT_FERRY_BIND_HOST": "0.0.0.0",
+                "PINKYBOT_FERRY_PEERS": "tod=http://100.112.44.64:8899",
+            }
+        )
+        assert cfg.enabled is False
+        assert isinstance(select_mesh_sender(cfg), MeshSender)
+
+    def test_enabled_with_peers_uses_http(self):
+        cfg = FerryConfig.from_env(
+            {
+                "PINKYBOT_FERRY_ENABLED": "1",
+                "PINKYBOT_FERRY_SHARED_SECRET": "s",
+                "PINKYBOT_FERRY_BIND_HOST": "100.108.59.106",
+                "PINKYBOT_FERRY_PEERS": "tod=http://100.112.44.64:8899",
+            }
+        )
+        assert cfg.enabled is True
+        assert isinstance(select_mesh_sender(cfg), HttpMeshSender)
+
+    def test_enabled_without_peers_stays_nats(self):
+        cfg = FerryConfig.from_env(
+            {
+                "PINKYBOT_FERRY_ENABLED": "1",
+                "PINKYBOT_FERRY_SHARED_SECRET": "s",
+                "PINKYBOT_FERRY_BIND_HOST": "100.108.59.106",
+            }
+        )
+        assert isinstance(select_mesh_sender(cfg), MeshSender)
 
 
 # -- build_ferry_app listener -------------------------------------------------


### PR DESCRIPTION
## What

Turns the **half-built ferry** into a working **barsik(mini) ↔ onesie(tod)** round-trip over the **tailnet**, replacing the public-NATS-broker transport with direct daemon-to-daemon HTTP over Tailscale (Route A from the integration report).

**Everything is flag-gated behind `PINKYBOT_FERRY_ENABLED` (off by default → zero prod behavior change).** Merging this does not change how prod runs until the flag is set on both fleets.

## Why Route A (vs NATS)
The shipped outbound path published to a **public** third-party NATS broker (`wss://fleet-nats.kostverse.com`) — plaintext envelopes, metadata leak, no daemon-to-daemon path, and the **inbound side was never built** (`HostPinky` was never instantiated; a send "succeeded" but nothing received). Route A keeps all cross-fleet traffic on the private WireGuard tailnet.

## Design
- **`ferry/config.py`** — `FerryConfig`: all ferry env in one place. **Fail-closed** enable gate (master flag **+** shared secret **+** *safe* tailnet/private bind host; wildcard/public/non-literal binds refuse to enable). `fleet_name()` makes the hardcoded `pinkybot` configurable (`mini`/`tod`).
- **`ferry/inbound_server.py`** — a **dedicated** `POST /ferry/inbound` listener bound to the **Tailscale IP only**, so the cross-fleet attack surface is exactly one authed endpoint and the main API keeps its existing bind. Defense in depth, all fail-closed: shared-secret **bearer** (constant-time compare) + **source-IP allowlist** + per-agent **peer_fleet_acl**.
- **`ferry/outbound.py`** — `HttpMeshSender`: POST the envelope to the peer fleet's `/ferry/inbound` over Tailscale. Same surface (`send`/`configured`/`diagnostics`) as the NATS `MeshSender`.
- **`__main__.py`** — when ferry is enabled, run the main API + ferry listener on one event loop. The ferry serve is **best-effort** — a bind failure (e.g. Tailscale IP not yet up) can **never** take down the core daemon. One loop-level signal handler stops both servers cleanly.
- **`api.py`** — `mesh_send` builds `from_` as `ferry://<fleet>/<name>` and selects transport (HTTP-over-Tailscale when configured, else NATS); the blocking send runs off the event loop. `HostPinky` singleton constructed on `app.state`.

## Bugs fixed in the half-built ferry
1. **`kind="msg"` silently rejected** — `mesh_remote_send` defaults `body.kind="msg"`, but inbound only routed `"message"` → every real send was `unsupported_payload_kind` (sent ≠ delivered). Non-substrate kinds now route to the message path.
2. **At-form address unparseable** — inbound couldn't parse `onesie@tod` (the form the tool emits) nor a non-`pinkybot` fleet. `parse_pinkybot_address` is now fleet-aware and accepts both forms.
3. **ACL exact-match form mismatch** *(production-breaking)* — `mesh_send` emits canonical `from_` (`ferry://tod/onesie`) but operators configure selectors in at-form (`onesie@tod`), so every `agent_id`-scoped ACL silently 403'd real messages. Peer identity + selector `agent_id` are now canonicalized before matching.

## Trust model (v1 — intentional)
Tailscale WireGuard + bearer + source-IP allowlist + `peer_fleet_acl`. Wire signatures (`pinky_federation` sealed-box/TOFU) are a deliberate follow-up; `verify_signatures` stays `False`.

## Review
Built and hardened via an **adversarial multi-lens security review** (auth / fail-closed / network-bind / wiring / startup-concurrency → verify each finding). **All 4 confirmed findings are fixed in this PR** (the ACL bug + bind-to-0.0.0.0 + daemon-killed-by-ferry-bind-failure + dead signal override).

## Tests
```
186 passed  (tests/test_ferry_route_a.py + ferry_host_pinky + ferry_outbound + mesh_store)
ruff: All checks passed!
full suite collects clean: 3790 tests
```
New coverage: the 3 bug regressions, bind-safety matrix, ACL address-form matrix, and an end-to-end `wire JSON → ferry app → real HostPinky → broker` path that drives the **actual canonical `from_`** the endpoint emits (the prior tests masked bug #3 by hand-crafting at-form `from_`).

## Rollout (separate, after merge)
Code lands flag-off. Live cutover (Brad-authorized, TOD first then Mini) = set ferry env on both boxes + restart + barsik↔onesie round-trip. Runbook staged separately.

🤖 Opened by Barsik