### PR TITLE
fix(ferry): dual-server capture_signals override must be a context manager

### DIFF
--- a/src/pinky_daemon/__main__.py
+++ b/src/pinky_daemon/__main__.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import faulthandler
 import os
 import signal
@@ -177,12 +178,14 @@ def _run_api(args) -> None:
     ferry_server = uvicorn.Server(
         uvicorn.Config(ferry_app, host=ferry_cfg.bind_host, port=ferry_cfg.bind_port)
     )
-    # uvicorn's serve() calls capture_signals(), which does signal.signal(...).
-    # With two servers on one loop the second would clobber the first's handler,
-    # leaving one server un-stoppable on SIGINT/SIGTERM. Disable both and
-    # install ONE loop-level handler that stops both.
-    main_server.capture_signals = lambda: None
-    ferry_server.capture_signals = lambda: None
+    # uvicorn's serve() does `with self.capture_signals():` — a context manager
+    # that installs signal.signal(...) handlers. With two servers on one loop the
+    # second would clobber the first's handler, leaving one server un-stoppable
+    # on SIGINT/SIGTERM. Replace it with a no-op CONTEXT MANAGER (nullcontext) —
+    # NOT `lambda: None`, which makes `with None:` raise — so neither server
+    # installs handlers; we install ONE loop-level handler that stops both.
+    main_server.capture_signals = lambda: contextlib.nullcontext()
+    ferry_server.capture_signals = lambda: contextlib.nullcontext()
 
     async def _serve_ferry() -> None:
         # Best-effort: a ferry bind failure (e.g. the Tailscale IP isn't

--- a/tests/test_ferry_route_a.py
+++ b/tests/test_ferry_route_a.py
@@ -15,6 +15,7 @@ round-trip over Tailscale:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
@@ -648,3 +649,71 @@ class TestAclAddressFormMatching:
             from_="ferry://tod/onesie",
         )
         assert status == "rejected"
+
+
+# -- Listener startup (regression: capture_signals override must be a CM) ------
+
+
+@pytest.mark.asyncio
+class TestFerryListenerStartup:
+    """Actually start the ferry uvicorn.Server the way __main__ does — with the
+    capture_signals override — and confirm it serves /ferry/health.
+
+    Regression for: uvicorn's serve() does `with self.capture_signals():`, so
+    overriding capture_signals with `lambda: None` makes `with None:` raise
+    "'NoneType' object does not support the context manager protocol" and the
+    listener never binds. The override must return a context manager
+    (contextlib.nullcontext). A unit test of the app alone would NOT catch this
+    — it only manifests through a real uvicorn.Server.serve().
+    """
+
+    async def test_listener_serves_with_capture_signals_override(self):
+        import contextlib as _ctx
+        import json as _json
+        import socket
+        import urllib.request
+
+        import uvicorn
+
+        s = socket.socket()
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        s.close()
+
+        cfg = FerryConfig.from_env(
+            {
+                "PINKYBOT_FERRY_ENABLED": "1",
+                "PINKYBOT_FERRY_SHARED_SECRET": "s",
+                "PINKYBOT_FERRY_BIND_HOST": "127.0.0.1",
+                "PINKYBOT_FLEET_NAME": "mini",
+            }
+        )
+        app = build_ferry_app(
+            host_pinky=_FakeHostPinky(DeliveryResult(status="delivered")), config=cfg
+        )
+        server = uvicorn.Server(
+            uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+        )
+        # Mirror __main__: no-op CONTEXT MANAGER (the bug was `lambda: None`).
+        server.capture_signals = lambda: _ctx.nullcontext()
+
+        task = asyncio.create_task(server.serve())
+        try:
+            for _ in range(100):
+                if getattr(server, "started", False):
+                    break
+                await asyncio.sleep(0.05)
+            assert getattr(server, "started", False), "ferry listener failed to start"
+
+            def _get():
+                with urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/ferry/health", timeout=5
+                ) as r:
+                    return r.getcode(), r.read()
+
+            code, body = await asyncio.to_thread(_get)
+            assert code == 200
+            assert _json.loads(body)["ok"] is True
+        finally:
+            server.should_exit = True
+            await asyncio.gather(task, return_exceptions=True)


### PR DESCRIPTION
## What
Hotfix for #753 (ferry Route A), found on the live TOD cutover.

uvicorn's `Server.serve()` does `with self.capture_signals():` — `capture_signals` is a `@contextlib.contextmanager`. The merged code overrode it with `lambda: None`, so the ferry server hit `with None:` and raised **`'NoneType' object does not support the context manager protocol`**. The listener never bound.

## Impact (and what held)
On the live TOD enable, the ferry listener failed at startup — but the **best-effort wrapper did its job**: the main daemon kept serving, TOD's fleet (angel/onesie/…) stayed healthy. So this was "ferry didn't come up," not "daemon down." Confirmed in TOD's `api.log`:
```
[pinky] Ferry listener: 100.112.44.64:8899 (fleet=tod)
[pinky] Ferry listener failed (main API unaffected): 'NoneType' object does not support the context manager protocol
```

## Fix
Override `capture_signals` with `lambda: contextlib.nullcontext()` — a no-op **context manager**. Neither server installs uvicorn's own signal handlers (we install one loop-level handler that stops both), and the `with` block is valid.

## Test
`TestFerryListenerStartup` actually starts the ferry `uvicorn.Server` with the override and GETs `/ferry/health`. A unit test of the app alone can't catch this — it only manifests through a real `Server.serve()`. **The old `lambda: None` fails this test; the fix passes it.** 171 ferry tests green, ruff clean.

## Why it slipped #753
The startup-concurrency review lens flagged the *dead* `install_signal_handlers` override (uvicorn renamed it to `capture_signals`); switching to override `capture_signals` was correct but I returned `None` instead of a context manager, and no test exercised a real `Server.serve()`. This PR adds that test.

🤖 Opened by Barsik