### PR TITLE
fix(ferry): wire send()/thread() outbound adapter for platform=ferry (#755)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1336,8 +1336,8 @@ def create_api(
                 raise HTTPException(400, str(e))
             except PermissionError as e:
                 raise HTTPException(403, str(e))
-            if not result.sent:
-                raise HTTPException(502, f"ferry send failed: {result.error}")
+            # Audit-log every attempt (success or failure) BEFORE raising, for
+            # failure-evidence parity with /mesh/send (Murzik #756 review note).
             try:
                 tf, ta = parse_address(chat_id) or ("", "")
                 mesh_store.log_message(
@@ -1348,6 +1348,8 @@ def create_api(
                 )
             except Exception as exc:  # noqa: BLE001 — audit log must not break send
                 _log(f"ferry outbound log failed (non-fatal): {exc}")
+            if not result.sent:
+                raise HTTPException(502, f"ferry send failed: {result.error}")
             return SimpleNamespace(message_id=envelope.id)
 
         adapter = _get_platform_adapter(agent_name, platform)

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1315,6 +1315,41 @@ def create_api(
             result = im.send_message(chat_id, content)
             return SimpleNamespace(message_id=_extract_message_id(result))
 
+        # Ferry (cross-fleet) has no platform adapter — it routes over the
+        # daemon mesh sender (Route A / Tailscale), with the same default-deny
+        # allowlist as /mesh/send. (#755 — so send()/thread() replies to a ferry
+        # message work, matching the inbound reply-hint, instead of 503ing.)
+        if platform == "ferry":
+            from pinky_daemon.ferry.config import fleet_name as _ferry_fleet_name
+            from pinky_daemon.ferry.outbound import parse_address, send_ferry_text
+
+            try:
+                envelope, result = send_ferry_text(
+                    agent_name=agent_name,
+                    fleet=_ferry_fleet_name(),
+                    target=chat_id,
+                    text=content,
+                    allowlist=agents.get_mesh_outbound_allowlist(agent_name),
+                    reply_to=reply_to or None,
+                )
+            except ValueError as e:
+                raise HTTPException(400, str(e))
+            except PermissionError as e:
+                raise HTTPException(403, str(e))
+            if not result.sent:
+                raise HTTPException(502, f"ferry send failed: {result.error}")
+            try:
+                tf, ta = parse_address(chat_id) or ("", "")
+                mesh_store.log_message(
+                    direction="outbound", local_agent=agent_name, remote_fleet=tf,
+                    remote_agent=ta, correlation_id=envelope.correlation_id or "",
+                    kind="msg", body=envelope.body, envelope_ts=envelope.ts,
+                    reply_to=envelope.reply_to, error=result.error,
+                )
+            except Exception as exc:  # noqa: BLE001 — audit log must not break send
+                _log(f"ferry outbound log failed (non-fatal): {exc}")
+            return SimpleNamespace(message_id=envelope.id)
+
         adapter = _get_platform_adapter(agent_name, platform)
         if not adapter:
             raise HTTPException(503, f"No {platform} adapter for {agent_name}")

--- a/src/pinky_daemon/ferry/outbound.py
+++ b/src/pinky_daemon/ferry/outbound.py
@@ -492,3 +492,42 @@ def select_mesh_sender(config: Any | None = None):
     if cfg.enabled and cfg.peers:
         return HttpMeshSender(config=cfg)
     return MeshSender()
+
+
+def send_ferry_text(
+    *,
+    agent_name: str,
+    fleet: str,
+    target: str,
+    text: str,
+    allowlist: list[str],
+    reply_to: str | None = None,
+    sender: Any | None = None,
+) -> tuple[FerryEnvelope, SendResult]:
+    """Build + send a ferry text message — the outbound path for ``platform="ferry"``.
+
+    Enforces the same default-deny ``mesh_outbound_allowlist`` as the
+    ``/mesh/send`` endpoint, builds a canonical ``from_`` (``ferry://<fleet>/
+    <agent>``), and dispatches via the selected transport. Returns
+    ``(envelope, SendResult)`` so the caller can audit-log and surface the id.
+
+    Raises:
+        ValueError       — target address is unparseable.
+        PermissionError  — target not in the agent's allowlist (default-deny).
+
+    ``sender`` is injectable for tests; production leaves it ``None`` →
+    :func:`select_mesh_sender`.
+    """
+    tgt = (target or "").strip()
+    if parse_address(tgt) is None:
+        raise ValueError(f"unparseable ferry target address: {target!r}")
+    if not allowlist_matches(tgt, allowlist):
+        raise PermissionError(f"target {tgt!r} not in agent's mesh_outbound_allowlist")
+    envelope = build_envelope(
+        from_=f"ferry://{fleet}/{agent_name}",
+        to=tgt,
+        body={"text": text, "kind": "msg"},
+        reply_to=reply_to or None,
+    )
+    s = sender if sender is not None else select_mesh_sender()
+    return envelope, s.send(envelope)

--- a/tests/test_ferry_route_a.py
+++ b/tests/test_ferry_route_a.py
@@ -28,9 +28,11 @@ from pinky_daemon.ferry.inbound_server import build_ferry_app, envelope_from_wir
 from pinky_daemon.ferry.outbound import (
     HttpMeshSender,
     MeshSender,
+    SendResult,
     build_envelope,
     envelope_to_wire,
     select_mesh_sender,
+    send_ferry_text,
 )
 from pinky_daemon.ferry.types import AgentCardSelector, DeliveryResult
 
@@ -417,6 +419,58 @@ class TestSenderSelection:
             }
         )
         assert isinstance(select_mesh_sender(cfg), MeshSender)
+
+
+# -- send_ferry_text (platform="ferry" outbound path, #755) -------------------
+
+
+class _RecordingSender:
+    def __init__(self, sent=True, error=None):
+        self.envelopes = []
+        self._sent = sent
+        self._error = error
+
+    def send(self, envelope):
+        self.envelopes.append(envelope)
+        return SendResult(sent=self._sent, correlation_id=envelope.correlation_id,
+                          subject="test", ts=envelope.ts, error=self._error)
+
+
+class TestSendFerryText:
+    def test_builds_canonical_from_and_sends(self):
+        s = _RecordingSender()
+        env, res = send_ferry_text(
+            agent_name="barsik", fleet="mini", target="onesie@tod",
+            text="hi there", allowlist=["onesie@tod"], sender=s,
+        )
+        assert res.sent is True
+        assert len(s.envelopes) == 1
+        assert env.from_ == "ferry://mini/barsik"
+        assert env.to == "onesie@tod"
+        assert env.body == {"text": "hi there", "kind": "msg"}
+
+    def test_allowlist_deny_raises_permissionerror(self):
+        with pytest.raises(PermissionError):
+            send_ferry_text(agent_name="barsik", fleet="mini", target="onesie@tod",
+                            text="x", allowlist=[], sender=_RecordingSender())
+
+    def test_unparseable_target_raises_valueerror(self):
+        with pytest.raises(ValueError):
+            send_ferry_text(agent_name="barsik", fleet="mini", target="::::",
+                            text="x", allowlist=["*"], sender=_RecordingSender())
+
+    def test_reply_to_threaded_through(self):
+        s = _RecordingSender()
+        env, _ = send_ferry_text(agent_name="barsik", fleet="mini", target="onesie@tod",
+                                 text="re", allowlist=["onesie@tod"], reply_to="cid-9", sender=s)
+        assert env.reply_to == "cid-9"
+
+    def test_send_failure_propagates_result(self):
+        s = _RecordingSender(sent=False, error="peer returned HTTP 503")
+        _, res = send_ferry_text(agent_name="barsik", fleet="mini", target="onesie@tod",
+                                 text="x", allowlist=["onesie@tod"], sender=s)
+        assert res.sent is False
+        assert "503" in res.error
 
 
 # -- build_ferry_app listener -------------------------------------------------


### PR DESCRIPTION
Closes #755.

## What
`send()`/`thread()` (pinky-messaging) 503'd on `platform="ferry"` ("No ferry adapter for <agent>") — but the **inbound ferry reply-hint explicitly tells agents to reply with `send(platform="ferry")`**. So the suggested reply path failed; only `mesh_remote_send` (pinky-self) worked for ferry outbound. Found during the #202 live cutover (onesie flagged it too).

## Fix
Add a `platform == "ferry"` branch to the daemon's `_send_text_message` (right after the existing `imessage` special-case) that routes over the daemon mesh sender (Route A / Tailscale), enforcing the **same default-deny `mesh_outbound_allowlist`** as `/mesh/send`. Extracted `ferry.outbound.send_ferry_text` as the shared core (allowlist-check + canonical `from_` + dispatch; `sender` injectable for tests).

## Zero regression risk
The branch is **only reached when `platform == "ferry"`** — telegram/discord/slack/imessage hit their own branches first and are completely untouched. For all existing traffic the new code is a single `if` that evaluates False. The only behavior change is ferry: a 503 becomes a working send. With this, the inbound reply-hint is truthful and `send()`/`thread()` work uniformly across platforms.

## Tests
`TestSendFerryText`: canonical `from_` build, allowlist-deny → `PermissionError`, unparseable target → `ValueError`, `reply_to` threading, send-failure propagation. **69 ferry-route-a tests green, ruff clean.**

## Rollout
Merges to main; ships with the next release (no forced redeploy). Live ferry today uses `mesh_remote_send` for outbound, which is unaffected.

🤖 Opened by Barsik