### PR TITLE
fix(memory): quote-escape FTS5 MATCH tokens in _search_by_fts5 (#726)

### DIFF
--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -32,6 +32,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _fts5_quote_token(token: str) -> str:
+    """Quote one token as an FTS5 phrase, doubling embedded ``"`` chars.
+
+    Mirrors the escaping in ``conversation_store._fts5_phrase`` / ``kb_store``
+    (#717), per-token so ``_search_by_fts5`` can keep its OR-of-tokens matching.
+    Without the quote-doubling, a token containing ``"`` produces invalid FTS5
+    syntax (the MATCH errors and silently degrades to the slower LIKE path).
+    """
+    return '"' + token.replace('"', '""') + '"'
+
+
 class InvalidQueryEmbeddingError(ValueError):
     """Raised when a query embedding cannot be used for similarity search.
 
@@ -1019,8 +1030,10 @@ class ReflectionStore:
         if not tokens:
             return []
 
-        # Use OR matching so partial keyword hits still return results
-        fts_query = " OR ".join(f'"{t}"' for t in tokens)
+        # Use OR matching so partial keyword hits still return results.
+        # Quote-escape each token (#726) so embedded " chars don't break the
+        # MATCH expression and silently degrade the query to LIKE.
+        fts_query = " OR ".join(_fts5_quote_token(t) for t in tokens)
 
         # Join FTS5 with the main table for filtering + full row data.
         # FTS5 MATCH goes in the WHERE clause alongside other filters.

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -246,11 +246,11 @@ class TestKeywordSearch:
         assert scored[both.id] == 1.0
         assert scored[one.id] == 0.0
 
-    def test_fts5_fallback_preserves_type_exclude(self, tmp_path):
-        """A query that breaks FTS5 syntax falls back to LIKE; the fallback
-        must still honour type_exclude."""
+    def test_quote_in_token_escaped_honors_type_exclude(self, tmp_path):
+        """A token containing a `"` is now quote-escaped (#726) so the query is
+        handled by FTS5 instead of silently degrading to LIKE — and type_exclude
+        is still honoured. (Previously this token broke the MATCH expression.)"""
         store = _store(tmp_path)
-        # Double quote in the token breaks the manually built MATCH expression
         query = 'cool"stuff'
         store.insert(Reflection(
             type=ReflectionType.insight, content='cool"stuff should be excluded',
@@ -259,7 +259,32 @@ class TestKeywordSearch:
         results = store.search_by_keyword_scored(
             query, type_exclude=[ReflectionType.insight],
         )
-        assert results, "fallback should still match by LIKE"
+        assert results, "escaped quote query should still match"
+        assert all(ref.type != ReflectionType.insight for _, ref in results)
+
+    def test_quote_in_token_does_not_error_and_finds_match(self, tmp_path):
+        """Regression for #726: a quote in the query must not raise / silently
+        return nothing — it finds the reflection via the escaped FTS5 path."""
+        store = _store(tmp_path)
+        if not store._fts5_available:
+            pytest.skip("FTS5 not available")
+        r = store.insert(_fact('the alpha"beta gamma report'))
+        results = store.search_by_keyword_scored('alpha"beta')
+        assert any(ref.id == r.id for _, ref in results)
+
+    def test_like_fallback_still_honors_type_exclude(self, tmp_path):
+        """Preserve the original coverage: when FTS5 is unavailable the LIKE
+        path must still honour type_exclude (forced via _fts5_available=False)."""
+        store = _store(tmp_path)
+        store._fts5_available = False
+        store.insert(Reflection(
+            type=ReflectionType.insight, content="brightwidget should be excluded",
+        ))
+        store.insert(_fact("brightwidget should remain"))
+        results = store.search_by_keyword_scored(
+            "brightwidget", type_exclude=[ReflectionType.insight],
+        )
+        assert results, "LIKE path should still match"
         assert all(ref.type != ReflectionType.insight for _, ref in results)
 
     def test_search_batches_access_tracking(self, tmp_path):


### PR DESCRIPTION
Closes #726.

## Bug
`pinky_memory/store.py` `_search_by_fts5` built the MATCH expression as `" OR ".join(f'"{t}"' for t in tokens)` — no doubling of embedded `"` chars. A token containing a quote (e.g. `alpha"beta`) produces invalid FTS5 syntax → `OperationalError` → the query silently degrades to the slower/lower-quality LIKE path (#295 fallback). Found during the #715/#717 sweeps (which avoided each other's files, so this slipped through).

## Fix
Add `_fts5_quote_token` (per-token quote-doubling, mirroring #717's `_fts5_phrase` in `conversation_store`/`kb_store`) and use it in the OR-join — preserving the intentional OR-of-tokens matching (so partial keyword hits still return).

```python
fts_query = " OR ".join(_fts5_quote_token(t) for t in tokens)
```

## Tests (111 memory-store green, ruff clean)
- Repurposed the old `test_fts5_fallback_preserves_type_exclude` → `test_quote_in_token_escaped_honors_type_exclude`: the quote no longer breaks FTS5 (it's escaped + handled), `type_exclude` still honoured. (Avoids a test that passes for the wrong reason.)
- New `test_quote_in_token_does_not_error_and_finds_match`: a quoted query finds its reflection via the escaped FTS5 path.
- New `test_like_fallback_still_honors_type_exclude`: forces `_fts5_available=False` to preserve the original LIKE-fallback + `type_exclude` coverage.

## Follow-up (not in this PR)
`_fts5_phrase`/`_fts5_quote_token` now exists in 3 modules — a shared util is a reasonable cleanup; kept inline here to minimize blast radius (the OR-token semantics differ from `_fts5_phrase`'s phrase-join).

🤖 Opened by Barsik