### PR TITLE
fix(analytics): correct Opus 4.5+ / Haiku 4.5 seed pricing + drift guard (#669)

### DIFF
--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -206,6 +206,7 @@ class AnalyticsStore:
                 """
             )
             self._seed_default_pricing(conn)
+            self._migrate_opus_haiku_seed_pricing(conn)
             # Schema migration: add user_message_snippet to turn_usage
             cols = {
                 r[1] for r in conn.execute("PRAGMA table_info(analytics_turn_usage)").fetchall()
@@ -255,18 +256,29 @@ class AnalyticsStore:
             ("openai", "gpt-5.2-chat-latest", "2020-01-01T00:00:00Z", None, 1.75, 14.00, 0.175, "seed"),
             ("openai", "gpt-5.2-codex", "2020-01-01T00:00:00Z", None, 1.75, 14.00, 0.175, "seed"),
             # Anthropic defaults seeded for future provider expansion.
+            # NOTE: these rates must mirror pinky_daemon.pricing.RATE_TABLE — the
+            # live per-turn cost path reads that table, this Analytics path reads
+            # this seed, and the two must agree on the same turn's dollar figure.
+            # test_seed_pricing_matches_rate_table pins them together (#669).
             ("anthropic", "claude-fable-5", "2020-01-01T00:00:00Z", None, 10.00, 50.00, 1.00, "seed"),
             ("anthropic", "claude-mythos-5", "2020-01-01T00:00:00Z", None, 10.00, 50.00, 1.00, "seed"),
-            ("anthropic", "claude-opus-4-8", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),
-            ("anthropic", "claude-opus-4-7", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),
-            ("anthropic", "claude-opus-4-6", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),
+            # Opus 4.5+ is the standard $5/$25 tier (flat across 4.5→4.8), not the
+            # pre-4.5 legacy $15/$75 tier. Mispriced as legacy until #669.
+            ("anthropic", "claude-opus-4-8", "2020-01-01T00:00:00Z", None, 5.00, 25.00, 0.50, "seed"),
+            ("anthropic", "claude-opus-4-7", "2020-01-01T00:00:00Z", None, 5.00, 25.00, 0.50, "seed"),
+            ("anthropic", "claude-opus-4-6", "2020-01-01T00:00:00Z", None, 5.00, 25.00, 0.50, "seed"),
+            ("anthropic", "claude-opus-4-5", "2020-01-01T00:00:00Z", None, 5.00, 25.00, 0.50, "seed"),
+            # Pre-4.5 Opus stays on the legacy $15/$75 tier.
             ("anthropic", "claude-opus-4.1", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),
             ("anthropic", "claude-opus-4", "2020-01-01T00:00:00Z", None, 15.00, 75.00, 1.50, "seed"),
             ("anthropic", "claude-sonnet-4-6", "2020-01-01T00:00:00Z", None, 3.00, 15.00, 0.30, "seed"),
+            ("anthropic", "claude-sonnet-4-5", "2020-01-01T00:00:00Z", None, 3.00, 15.00, 0.30, "seed"),
             ("anthropic", "claude-sonnet-4", "2020-01-01T00:00:00Z", None, 3.00, 15.00, 0.30, "seed"),
             ("anthropic", "claude-sonnet-3.7", "2020-01-01T00:00:00Z", None, 3.00, 15.00, 0.30, "seed"),
             ("anthropic", "claude-sonnet-3.5", "2020-01-01T00:00:00Z", None, 3.00, 15.00, 0.30, "seed"),
-            ("anthropic", "claude-haiku-4-5", "2020-01-01T00:00:00Z", None, 0.80, 4.00, 0.08, "seed"),
+            # Haiku 4.5 is the $1/$5 tier; 0.80/4.00/0.08 was the old Haiku 3.5
+            # price. Corrected in #669.
+            ("anthropic", "claude-haiku-4-5", "2020-01-01T00:00:00Z", None, 1.00, 5.00, 0.10, "seed"),
             ("anthropic", "claude-haiku-3.5", "2020-01-01T00:00:00Z", None, 0.80, 4.00, 0.08, "seed"),
             ("anthropic", "claude-haiku-3", "2020-01-01T00:00:00Z", None, 0.25, 1.25, 0.03, "seed"),
         ]
@@ -279,6 +291,76 @@ class AnalyticsStore:
             """,
             seed_rows,
         )
+
+    def _migrate_opus_haiku_seed_pricing(self, conn) -> None:
+        """Realign mispriced Anthropic seed rows on already-seeded DBs (#669).
+
+        ``_seed_default_pricing`` only runs on an empty table, so deployed
+        Analytics DBs keep their original (wrong) rates after a seed fix
+        lands. This one-shot, idempotent migration corrects them to match
+        ``pinky_daemon.pricing.RATE_TABLE``:
+
+        * Opus 4.6/4.7/4.8 were seeded at the legacy $15/$75 tier — a ~3x
+          overstatement. Corrected to the standard $5/$25 tier.
+        * ``claude-opus-4-5`` was missing — inserted at $5/$25.
+        * Haiku 4.5 was seeded at the old Haiku-3.5 $0.80/$4.00 price —
+          corrected to $1.00/$5.00.
+        * ``claude-sonnet-4-5`` was missing — inserted at $3/$15.
+
+        Safe/idempotent: only ``notes='seed'`` rows are touched (operator
+        overrides with any other ``notes`` are left alone); the UPDATEs match
+        only the known-stale rate, so a second run is a no-op; the INSERTs are
+        skipped when the model already has a row.
+        """
+        # Opus 4.5+ standard tier: fix legacy-priced seed rows in place.
+        conn.execute(
+            """
+            UPDATE analytics_model_pricing
+            SET input_usd_per_mtok = 5.00,
+                output_usd_per_mtok = 25.00,
+                cached_input_usd_per_mtok = 0.50
+            WHERE provider = 'anthropic'
+              AND model IN ('claude-opus-4-8', 'claude-opus-4-7', 'claude-opus-4-6')
+              AND notes = 'seed'
+              AND input_usd_per_mtok = 15.00
+            """
+        )
+        # Haiku 4.5: replace the old Haiku-3.5 price.
+        conn.execute(
+            """
+            UPDATE analytics_model_pricing
+            SET input_usd_per_mtok = 1.00,
+                output_usd_per_mtok = 5.00,
+                cached_input_usd_per_mtok = 0.10
+            WHERE provider = 'anthropic'
+              AND model = 'claude-haiku-4-5'
+              AND notes = 'seed'
+              AND input_usd_per_mtok = 0.80
+            """
+        )
+        # Models absent from older seeds — insert at the correct tier.
+        for model, inp, out, cached in (
+            ("claude-opus-4-5", 5.00, 25.00, 0.50),
+            ("claude-sonnet-4-5", 3.00, 15.00, 0.30),
+        ):
+            exists = conn.execute(
+                "SELECT 1 FROM analytics_model_pricing "
+                "WHERE provider = 'anthropic' AND model = ? LIMIT 1",
+                (model,),
+            ).fetchone()
+            if not exists:
+                conn.execute(
+                    """
+                    INSERT INTO analytics_model_pricing (
+                      provider, model, effective_from, effective_to,
+                      input_usd_per_mtok, output_usd_per_mtok,
+                      cached_input_usd_per_mtok, notes
+                    ) VALUES ('anthropic', ?, '2020-01-01T00:00:00Z', NULL, ?, ?, ?, 'seed')
+                    """,
+                    (model, inp, out, cached),
+                )
+        # Drop the lazily-built cache so corrected rows are read next lookup.
+        self._pricing_cache = None
 
     def ensure_session_fact(
         self,

--- a/tests/test_analytics_store.py
+++ b/tests/test_analytics_store.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 
 from pinky_daemon.analytics_store import AnalyticsStore
+from pinky_daemon.pricing import RATE_TABLE
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -393,3 +394,128 @@ class TestPricingLookup:
         assert row is not None
         assert row["input_usd_per_mtok"] == 3.00
         assert store._lookup_pricing(provider="anthropic", model="no-such-model", ts=ts) is None
+
+
+class TestSeedRateTableParity:
+    """#669: the Analytics seed and pinky_daemon.pricing.RATE_TABLE are two
+    hand-maintained rate tables that feed two cost paths (dashboard vs live
+    per-turn). They must agree for the same model, or the same usage reports
+    different dollar figures. This pins them together as a drift guard."""
+
+    def test_seed_pricing_matches_rate_table(self, tmp_path):
+        store = _store(tmp_path)
+        with store._connect() as conn:
+            rows = conn.execute(
+                "SELECT model, input_usd_per_mtok, output_usd_per_mtok, "
+                "cached_input_usd_per_mtok FROM analytics_model_pricing "
+                "WHERE provider = 'anthropic'"
+            ).fetchall()
+        # Normalize dotted legacy ids (claude-opus-4.1) to the hyphenated form
+        # RATE_TABLE uses (claude-opus-4-1) so the two key spaces line up.
+        seeded = {r["model"].replace(".", "-"): r for r in rows}
+
+        missing = [m for m in RATE_TABLE if m not in seeded]
+        assert not missing, f"models in RATE_TABLE but absent from Analytics seed: {missing}"
+
+        mismatches = []
+        for model, rates in RATE_TABLE.items():
+            row = seeded[model]
+            if (
+                row["input_usd_per_mtok"] != rates["input"]
+                or row["output_usd_per_mtok"] != rates["output"]
+                or row["cached_input_usd_per_mtok"] != rates["cache_read"]
+            ):
+                mismatches.append(
+                    f"{model}: seed "
+                    f"{row['input_usd_per_mtok']}/{row['output_usd_per_mtok']}/"
+                    f"{row['cached_input_usd_per_mtok']} != RATE_TABLE "
+                    f"{rates['input']}/{rates['output']}/{rates['cache_read']}"
+                )
+        assert not mismatches, "Analytics seed disagrees with pricing.RATE_TABLE:\n" + "\n".join(
+            mismatches
+        )
+
+
+class TestSeedPricingMigration:
+    """#669: deployed Analytics DBs are already seeded, so _seed_default_pricing
+    (empty-table guard) won't re-run. _migrate_opus_haiku_seed_pricing corrects
+    the stale rows on every init; these cover a stale DB and operator safety."""
+
+    def _stomp_stale(self, db_path: str) -> None:
+        """Rewrite a seeded DB to its pre-#669 (wrong) state."""
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE analytics_model_pricing SET input_usd_per_mtok=15.00, "
+                "output_usd_per_mtok=75.00, cached_input_usd_per_mtok=1.50 "
+                "WHERE notes='seed' AND model IN "
+                "('claude-opus-4-8','claude-opus-4-7','claude-opus-4-6')"
+            )
+            conn.execute(
+                "UPDATE analytics_model_pricing SET input_usd_per_mtok=0.80, "
+                "output_usd_per_mtok=4.00, cached_input_usd_per_mtok=0.08 "
+                "WHERE notes='seed' AND model='claude-haiku-4-5'"
+            )
+            conn.execute(
+                "DELETE FROM analytics_model_pricing "
+                "WHERE model IN ('claude-opus-4-5','claude-sonnet-4-5')"
+            )
+
+    def test_migration_corrects_stale_seed_on_reopen(self, tmp_path):
+        db_path = str(tmp_path / "stale.db")
+        AnalyticsStore(db_path)  # seeds correct rows
+        self._stomp_stale(db_path)  # simulate a pre-#669 deployed DB
+        store = AnalyticsStore(db_path)  # __init__ runs the migration
+
+        ts = _iso(datetime.now(UTC))
+        for model in (
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-opus-4-5",
+        ):
+            row = store._lookup_pricing(provider="anthropic", model=model, ts=ts)
+            assert row is not None, f"{model} missing after migration"
+            assert row["input_usd_per_mtok"] == 5.00, model
+            assert row["output_usd_per_mtok"] == 25.00, model
+            assert row["cached_input_usd_per_mtok"] == 0.50, model
+
+        haiku = store._lookup_pricing(provider="anthropic", model="claude-haiku-4-5", ts=ts)
+        assert haiku["input_usd_per_mtok"] == 1.00
+        assert haiku["output_usd_per_mtok"] == 5.00
+        assert haiku["cached_input_usd_per_mtok"] == 0.10
+
+        sonnet45 = store._lookup_pricing(provider="anthropic", model="claude-sonnet-4-5", ts=ts)
+        assert sonnet45 is not None and sonnet45["input_usd_per_mtok"] == 3.00
+
+    def test_migration_is_idempotent_and_inserts_once(self, tmp_path):
+        db_path = str(tmp_path / "idem.db")
+        AnalyticsStore(db_path)
+        self._stomp_stale(db_path)
+        AnalyticsStore(db_path)  # first migration
+        AnalyticsStore(db_path)  # second init — must not double-insert or re-touch
+        with sqlite3.connect(db_path) as conn:
+            for model in ("claude-opus-4-5", "claude-sonnet-4-5"):
+                count = conn.execute(
+                    "SELECT COUNT(*) FROM analytics_model_pricing WHERE model=?",
+                    (model,),
+                ).fetchone()[0]
+                assert count == 1, f"{model} duplicated: {count} rows"
+
+    def test_migration_preserves_operator_overrides(self, tmp_path):
+        db_path = str(tmp_path / "override.db")
+        AnalyticsStore(db_path)
+        # Operator-priced row (non-'seed' notes) at the legacy tier must survive.
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "INSERT INTO analytics_model_pricing (provider, model, effective_from, "
+                "effective_to, input_usd_per_mtok, output_usd_per_mtok, "
+                "cached_input_usd_per_mtok, notes) VALUES "
+                "('anthropic','claude-opus-4-8','2026-06-01T00:00:00Z',NULL,15.00,75.00,1.50,'operator')"
+            )
+        AnalyticsStore(db_path)  # migration must not touch the operator row
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT input_usd_per_mtok FROM analytics_model_pricing "
+                "WHERE model='claude-opus-4-8' AND notes='operator'"
+            ).fetchone()
+        assert row is not None and row[0] == 15.00


### PR DESCRIPTION
Closes #669.

## Bug
Two cost paths, two different dollar figures for the same usage:
- **Live per-turn path** (`pricing.RATE_TABLE`) had Opus 4.5+ right at **$5/$25** and Haiku 4.5 at **$1/$5**.
- **Analytics dashboard path** (`AnalyticsStore._seed_default_pricing`) seeded Opus 4.6/4.7/4.8 at the legacy **$15/$75** tier (a ~3× overstatement), Haiku 4.5 at the old Haiku-3.5 **$0.80/$4.00** price, and was missing `claude-opus-4-5` and `claude-sonnet-4-5` entirely.

Opus 4.8 is what Barsik and most agents run on, so the dashboard Brad reads overstated flagship spend ~3×.

## Fix
1. **Seed** corrected to mirror `pricing.RATE_TABLE`: Opus 4.6/4.7/4.8 → `$5/$25/$0.50`, add `claude-opus-4-5`; Haiku 4.5 → `$1/$5/$0.10`; add `claude-sonnet-4-5`. Pre-4.5 Opus (`claude-opus-4.1`, `claude-opus-4`) stays on the legacy `$15/$75` tier (correct for those).
2. **Migration** (`_migrate_opus_haiku_seed_pricing`): the seed only runs on an empty table, so deployed Analytics DBs would never pick up the fix. Added an idempotent migration that runs on every init — corrects stale `notes='seed'` rows in place (guarded on the known-stale rate, so a second run is a no-op) and inserts the missing models when absent. Operator-customized rows (`notes != 'seed'`) are left untouched.
3. **Parity drift guard** (`test_seed_pricing_matches_rate_table`): asserts the seed agrees with `pricing.RATE_TABLE` for every shared model. The root cause is two hand-maintained rate tables; this pins them together so they can't silently diverge again.

## Scope note
The issue is framed around Opus, but a *parity* drift guard only works if it covers all shared models — so it also surfaced (and this PR fixes) the Haiku 4.5 row, which had the wrong tier price for the same reason. Scoping the guard to Opus only would leave it blind to exactly the class of bug it exists to prevent. Verified all rates against the `claude-api` skill's canonical Anthropic pricing.

## Demonstration (no UI surface — showing the cost path directly)
```
=== analytics_model_pricing — BEFORE migration (stale prod state) ===
  claude-opus-4-8        (15.0, 75.0, 1.5)
  claude-opus-4-5        None
  claude-sonnet-4-5      None
=== AFTER migration (AnalyticsStore re-init) ===
  claude-opus-4-8        (5.0, 25.0, 0.5)
  claude-opus-4-5        (5.0, 25.0, 0.5)
  claude-sonnet-4-5      (3.0, 15.0, 0.3)

=== Reported cost for one Opus-4.8 turn (1M in / 1M out / 0.5M cache-read) ===
  BEFORE (legacy $15/$75): $90.75
  AFTER  (correct $5/$25): $30.25   (3.0x overstatement removed)
```

## Tests
`pytest tests/test_analytics_store.py` → 23 passed; ruff clean. New coverage:
- `test_seed_pricing_matches_rate_table` — parity drift guard.
- `test_migration_corrects_stale_seed_on_reopen` — stale prod DB → corrected on re-init.
- `test_migration_is_idempotent_and_inserts_once` — two inits, no duplicate inserts / re-touch.
- `test_migration_preserves_operator_overrides` — `notes != 'seed'` rows survive.

🤖 Opened by Barsik