### PR TITLE
fix(kb): replace nightly snapshot in place instead of re-INSERTing (#703)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3212,44 +3212,40 @@ def create_api(
         if not content or not content.strip():
             return False
 
-        # Check for existing source by URL (snapshot replace) or content (dedup)
+        # Snapshot sources (internal:// URLs) are singletons keyed by
+        # source_url — regenerated on a schedule and replaced in place.
+        # One-off sources are deduped by content. The snapshot path used to
+        # hand-roll a file overwrite guarded by ``Path(file_path).exists()``,
+        # but file_path is stored relative to kb_dir, so the check resolved
+        # against the wrong CWD and was always False — the overwrite was
+        # skipped and execution fell through to a second INSERT, tripping the
+        # UNIQUE raw_sources.source_url index on every run (issue #703).
         existing = kb.check_duplicate(source_url=source_url, content=content)
-        if existing:
-            if source_url and existing.source_url == source_url:
-                # Snapshot replace: overwrite the file with updated content
-                try:
-                    file_path = existing.file_path
-                    if file_path and Path(file_path).exists():
-                        from datetime import datetime
-                        from datetime import timezone as tz
-                        now_iso = datetime.now(tz.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-                        frontmatter = (
-                            f"---\nid: {existing.id}\ntitle: {title}\n"
-                            f"source_type: {source_type}\nfiled_at: {now_iso}\n"
-                            f"filed_by: {filed_by}\ntags: {tags or []}\n"
-                            f"source_url: {source_url}\n---\n\n"
-                        )
-                        Path(file_path).write_text(frontmatter + f"# {title}\n\n{content}")
-                        _log(f"kb-auto-ingest: updated snapshot '{title}' ({existing.id})")
-                        _schedule_librarian()
-                        return True
-                except Exception as e:
-                    _log(f"kb-auto-ingest: snapshot update failed for '{title}': {e}")
-                    return False
-            else:
-                # Content duplicate — skip
-                _log(f"kb-auto-ingest: skipped duplicate '{title}' (existing: {existing.id})")
-                return False
+        if existing and not (source_url and existing.source_url == source_url):
+            # Content duplicate of a different source — skip.
+            _log(f"kb-auto-ingest: skipped duplicate '{title}' (existing: {existing.id})")
+            return False
 
         try:
-            source = kb.ingest(
-                title=title,
-                content=content,
-                source_url=source_url,
-                source_type=source_type,
-                filed_by=filed_by,
-                tags=tags or [],
-            )
+            if source_url:
+                # Insert first time, replace file + DB row + FTS in place
+                # thereafter — never a second INSERT for the same URL.
+                source = kb.upsert_snapshot(
+                    source_url=source_url,
+                    title=title,
+                    content=content,
+                    source_type=source_type,
+                    filed_by=filed_by,
+                    tags=tags or [],
+                )
+            else:
+                source = kb.ingest(
+                    title=title,
+                    content=content,
+                    source_type=source_type,
+                    filed_by=filed_by,
+                    tags=tags or [],
+                )
             _log(f"kb-auto-ingest: filed '{title}' as {source.id}")
             _schedule_librarian()
             return True

--- a/src/pinky_daemon/kb_store.py
+++ b/src/pinky_daemon/kb_store.py
@@ -525,6 +525,51 @@ class KBStore:
 
         return self.get_raw(source_id)
 
+    def upsert_snapshot(
+        self,
+        *,
+        source_url: str,
+        title: str,
+        content: str,
+        source_type: str = "note",
+        filed_by: str = "system",
+        tags: list[str] | None = None,
+    ) -> RawSource:
+        """File-or-replace a singleton snapshot keyed by ``source_url``.
+
+        Scheduled snapshots (people-profiles, project-state, ...) regenerate
+        under a constant ``source_url``. The first call inserts; every later
+        call replaces the file + DB row + FTS index in place via
+        ``update_raw``. It never issues a second INSERT for the same URL,
+        which would violate the UNIQUE ``raw_sources.source_url`` index
+        (issue #703). If the row exists but its backing file has gone
+        missing, the orphan is dropped and re-created cleanly.
+        """
+        tags = tags or []
+        existing = self.check_duplicate(source_url=source_url)
+        if existing:
+            updated = self.update_raw(
+                existing.id,
+                title=title,
+                content=content,
+                tags=tags,
+                source_type=source_type,
+                source_url=source_url,
+            )
+            if updated:
+                return updated
+            # Row exists but its file is gone — drop the orphan so the
+            # insert below re-creates it instead of colliding on the index.
+            self.delete_raw(existing.id)
+        return self.ingest(
+            title=title,
+            content=content,
+            source_url=source_url,
+            source_type=source_type,
+            filed_by=filed_by,
+            tags=tags,
+        )
+
     def count_raw(
         self,
         *,

--- a/src/pinky_daemon/kb_store.py
+++ b/src/pinky_daemon/kb_store.py
@@ -438,11 +438,17 @@ class KBStore:
         source_url: str | None = None,
         source_type: str | None = None,
         owner_notes: str | None = None,
+        refresh_filed_at: bool = False,
     ) -> RawSource | None:
         """Update fields on an existing raw source.
 
         Only provided (non-None) fields are updated. Rewrites the markdown file
         and updates the DB row + FTS index.
+
+        ``refresh_filed_at`` bumps ``filed_at`` to now (off by default so a
+        manual metadata edit keeps the original file time). Snapshot
+        replacements set it so the librarian's ``list_raw(since=last_run)``
+        discovery (``filed_at > last_run``) re-sees the refreshed content.
 
         Returns:
             The updated RawSource, or None if not found.
@@ -474,6 +480,14 @@ class KBStore:
             else:
                 fm.pop("owner_notes", None)
 
+        # Snapshot replacements refresh filed_at (file + DB) so downstream
+        # discovery re-sees the new content; metadata edits leave it as-is.
+        if refresh_filed_at:
+            new_filed_at = datetime.now(timezone.utc).isoformat()
+            fm["filed_at"] = new_filed_at
+        else:
+            new_filed_at = source.filed_at
+
         # Apply content update — rebuild body section
         if content is not None:
             body = content
@@ -497,11 +511,13 @@ class KBStore:
             conn.execute(
                 """UPDATE raw_sources
                    SET title = ?, source_url = ?, source_type = ?,
-                       tags = ?, content_hash = ?, content_preview = ?
+                       tags = ?, content_hash = ?, content_preview = ?,
+                       filed_at = ?
                    WHERE id = ?""",
                 (
                     new_title, new_url, new_type,
                     json.dumps(new_tags), c_hash, c_preview,
+                    new_filed_at,
                     source_id,
                 ),
             )
@@ -555,6 +571,7 @@ class KBStore:
                 tags=tags,
                 source_type=source_type,
                 source_url=source_url,
+                refresh_filed_at=True,
             )
             if updated:
                 return updated

--- a/tests/test_kb_store.py
+++ b/tests/test_kb_store.py
@@ -261,3 +261,20 @@ class TestUpsertSnapshot:
         b = kb.upsert_snapshot(source_url="internal://projects", title="Projects", content="bbb")
         assert a.id != b.id
         assert kb.count_raw() == 2
+
+    def test_replacement_bumps_filed_at_for_rediscovery(self, kb):
+        # The librarian discovers work via list_raw(since=last_run), which
+        # filters filed_at > last_run. If a replacement keeps the original
+        # filed_at, curation silently misses every snapshot after the first
+        # once the watermark has advanced (issue #703 P1, caught in review).
+        s1 = kb.upsert_snapshot(source_url=self.URL, title="Snap", content="first")
+        first_filed_at = s1.filed_at
+        # Simulate the librarian having curated up to s1: nothing is newer.
+        assert kb.list_raw(since=first_filed_at) == []
+
+        s2 = kb.upsert_snapshot(source_url=self.URL, title="Snap", content="second")
+        assert s2.id == s1.id
+        # filed_at advanced, so the since-watermark query re-sees the snapshot.
+        assert s2.filed_at > first_filed_at
+        rediscovered = kb.list_raw(since=first_filed_at)
+        assert any(r.id == s1.id for r in rediscovered)

--- a/tests/test_kb_store.py
+++ b/tests/test_kb_store.py
@@ -213,3 +213,51 @@ class TestReindex:
         kb.ingest(title="Searchable", content="unique keyword xyzzy")
         kb.reindex()
         assert len(kb.search("xyzzy")) == 1
+
+
+class TestUpsertSnapshot:
+    """Idempotent singleton snapshots keyed by source_url (issue #703).
+
+    The nightly people-profiles / project-state snapshots re-file under a
+    constant source_url. A second call must REPLACE in place, never a second
+    INSERT (which trips the UNIQUE raw_sources.source_url index).
+    """
+
+    URL = "internal://people-profiles-snapshot"
+
+    def test_first_call_inserts(self, kb):
+        s = kb.upsert_snapshot(source_url=self.URL, title="Snap", content="v1 body")
+        assert s.source_url == self.URL
+        assert (kb.kb_dir / s.file_path).exists()
+        assert kb.count_raw() == 1
+
+    def test_repeat_call_replaces_in_place(self, kb):
+        s1 = kb.upsert_snapshot(source_url=self.URL, title="Snap", content="version one")
+        # Pre-#703 this second call raised: UNIQUE constraint failed.
+        s2 = kb.upsert_snapshot(source_url=self.URL, title="Snap", content="version two now")
+        # Replaced, not duplicated.
+        assert s2.id == s1.id
+        assert kb.count_raw() == 1
+        # File holds the new content, not the old.
+        body = (kb.kb_dir / s2.file_path).read_text()
+        assert "version two now" in body
+        assert "version one" not in body
+        # FTS reflects the new content (old tokens gone).
+        assert len(kb.search("two")) == 1
+        assert len(kb.search("one")) == 0
+
+    def test_replaces_after_backing_file_deleted(self, kb):
+        s1 = kb.upsert_snapshot(source_url=self.URL, title="Snap", content="v1")
+        # Orphan the row: drop the file but leave the DB row + its UNIQUE url.
+        (kb.kb_dir / s1.file_path).unlink()
+        # Must re-create cleanly, not collide on the UNIQUE source_url index.
+        s2 = kb.upsert_snapshot(source_url=self.URL, title="Snap", content="v2 reborn")
+        assert (kb.kb_dir / s2.file_path).exists()
+        assert "v2 reborn" in (kb.kb_dir / s2.file_path).read_text()
+        assert kb.count_raw() == 1
+
+    def test_distinct_urls_coexist(self, kb):
+        a = kb.upsert_snapshot(source_url="internal://people", title="People", content="aaa")
+        b = kb.upsert_snapshot(source_url="internal://projects", title="Projects", content="bbb")
+        assert a.id != b.id
+        assert kb.count_raw() == 2


### PR DESCRIPTION
Closes #703.

## Problem
Every dream run's post-dream KB snapshot (`People Profiles Snapshot`, and the same for `Project State Snapshot`) failed after the first night:

```
kb-auto-ingest: failed to file 'People Profiles Snapshot': UNIQUE constraint failed: raw_sources.source_url
```

These snapshots re-file under a **constant** `source_url` (`internal://people-profiles-snapshot`, `internal://project-state-snapshot`), so they're meant to *replace* the previous copy.

## Root cause
`_kb_auto_ingest`'s snapshot-replace branch overwrote the file only if `Path(file_path).exists()`:

```python
file_path = existing.file_path                 # stored RELATIVE: "raw/2026-…-snapshot.md"
if file_path and Path(file_path).exists():     # resolved against the daemon CWD, not kb_dir
    ...overwrite...
    return True
# (no else) → falls through ↓
source = kb.ingest(...)                         # second INSERT, same source_url
```

`file_path` is stored **relative to `kb_dir`** (the real file is at `kb_dir/raw/…`), but the guard checked `Path(file_path)` against the process CWD — **always False**. So the overwrite was skipped, execution fell through to a second `kb.ingest()`, and that INSERT collided with the `UNIQUE raw_sources.source_url` index. Net effect: the snapshot threw every night after the first and the KB copy went stale (the DB row + file from night 1 persisted; nothing updated).

The replace path also only rewrote the file, never the DB row (`content_hash`/`content_preview`/`filed_at`) — so even on the intended path the index would have drifted.

## Fix
Add `KBStore.upsert_snapshot()` — a tested, file-or-replace primitive keyed by `source_url` that delegates to the existing `update_raw()` (correct `kb_dir`-based path; rewrites file **+** DB row **+** FTS), and self-heals (drop + re-create) if the backing file has gone missing. Route `_kb_auto_ingest`'s snapshot sources through it; one-off sources (e.g. research briefs, no `source_url`) keep content-dedup + `ingest()`.

This also removes the duplicated frontmatter-string building and the inline `datetime` imports in `_kb_auto_ingest`.

## Verification
New `tests/test_kb_store.py::TestUpsertSnapshot`:

```
test_first_call_inserts PASSED
test_repeat_call_replaces_in_place PASSED            (same id, one row, new content, FTS refreshed)
test_replaces_after_backing_file_deleted PASSED      (orphan row self-heals, no UNIQUE collision)
test_distinct_urls_coexist PASSED
```

Full `tests/test_kb_store.py`: **29 passed**. `ruff` clean on all changed files. `import pinky_daemon.api` OK.

Backend-only fix (no UI surface) — verification artifact is the test suite above. This reproduces the exact `UNIQUE constraint failed` path (`test_repeat_call_replaces_in_place` raised it pre-fix) and proves the replace-in-place behavior.

🤖 Opened by Barsik