### PR TITLE
fix(frontend): clear provider key when resetting agent to Anthropic (#728)

### DIFF
--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -638,10 +638,13 @@
             provider_model: providerModel,
             provider_ref: providerRef,
         };
-        // Only send a key the user actually typed; absent means "keep the saved key".
+        // Send the key the user typed; or explicitly clear it when resetting to
+        // Anthropic (no custom URL, no global ref). Absent means "keep the saved
+        // key", so without the explicit "" the backend's clear path is unreachable.
         if (providerKey) body.provider_key = providerKey;
+        else if (!providerUrl && !providerRef) body.provider_key = '';
         await api('PUT', `/agents/${currentAgent}/provider`, body);
-        providerKeySet = providerKeySet || !!providerKey;
+        providerKeySet = providerKey ? true : (providerUrl || providerRef ? providerKeySet : false);
         providerKey = '';
         providerDirty = false;
         toast('Provider saved — restart session to apply');


### PR DESCRIPTION
## Summary

`saveProvider()` only attached `provider_key` to the PUT body when the user typed a new key. The secret-protection convention is **absent/null = keep, `""` = clear** — so without an explicit `""`, the backend clear path was unreachable from the UI.

Result: resetting an agent from a custom provider back to Anthropic (clearing the URL + global ref) left the **stale provider key in the DB**, and the "provider key is set" indicator stayed stuck on.

## Fix (one file, `Agents.svelte` `saveProvider()`)

- Send `provider_key: ""` when both `providerUrl` and `providerRef` are empty (back to vanilla Anthropic) **and** the user hasn't typed a new key.
- Recompute `providerKeySet` to reflect set / cleared / unchanged.

## Verified backend chain (read end-to-end, not assumed)

1. `PUT /agents/{name}/provider` (`api.py:5979`): `provider_key:""` → `updates["clear_provider_key"]=True`; absent/null → unchanged.
2. `agents.register()` (`agent_registry.py:2010`): `clear_provider_key` → sets `provider_key=""` (wipes secret). The `provider_key` truthiness guard means a plain round-trip of the redacted `to_dict()` still can't wipe it — only the explicit `""` does.

So the clear path is correct and working; it was simply never reached from the frontend. This wires #712's backend clear path to the UI.

## Behavior (before → after)

Reset agent to Anthropic, no key typed:
- **Before:** body omits `provider_key` → backend keeps stale key → indicator stuck "set".
- **After:** body sends `provider_key: ""` → `clear_provider_key` → key wiped → indicator clears.

User typed a new key → still sent (set). Changing only the model on an existing custom provider (URL/ref still present, no new key) → `provider_key` still omitted (key preserved). Unchanged for those paths.

## Test plan (manual — no frontend unit-test harness in repo)

- [ ] Agent on a custom provider with a key set → reset to Anthropic (clear URL + ref), Save → "provider key is set" indicator clears; DB `provider_key` is empty.
- [ ] Agent on custom provider, change only the model (keep URL) → Save → key preserved.
- [ ] Type a new key → Save → key set.

`vite build` passes (207 modules; only pre-existing chunk-size warnings).

## Note on screenshot
This is a request-*payload* fix (which key value the PUT sends); a static screenshot of the provider panel wouldn't show the behavior. The before/after payload + verified backend chain above is the high-signal artifact. Happy to attach a short clip of the indicator clearing against a local daemon if wanted.

## Supersedes
Extracted from bundle PR #750. Its other two slices already shipped as **#757** (#726 FTS5) and **#760** (#727 core-skill guard). #750 will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)