### PR TITLE
fix(memory): self-heal stranded ('[]') reflections via heal-on-write (#630)

### DIFF
--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import re
 import sys
 from collections.abc import Callable
@@ -36,6 +37,22 @@ def _log(msg: str) -> None:
 # store-factory path resolution against traversal / injection even though the
 # resolver also validates against the registry (defense in depth).
 _AGENT_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+# #630: cap on how many stranded ('[]') rows a single successful write
+# re-embeds. Bounds the embed calls added to a reflect; a backlog drains over
+# successive writes rather than blocking one.
+_HEAL_BATCH = 5
+
+
+def _heal_disabled() -> bool:
+    """Kill-switch for heal-on-write (#630). Heal is on by default — it's a
+    best-effort safety net — but ``PINKY_MEMORY_DISABLE_HEAL=1`` turns it off
+    fleet-wide without a redeploy if it ever misbehaves in prod."""
+    return os.getenv("PINKY_MEMORY_DISABLE_HEAL", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
 
 def _safe_embed(
@@ -157,6 +174,39 @@ def create_server(
                 f"agent '{caller}' is not authorized for cross-agent memory access"
             )
 
+    def _heal_unembedded(s: "ReflectionStore", *, limit: int = _HEAL_BATCH) -> int:
+        """Re-embed up to ``limit`` stranded ('[]') rows in ``s`` (#630).
+
+        Called right after a *successful* embed, so the embedder is known live;
+        a row whose re-embed still degrades (-> []) is left for a future write
+        and the batch stops early. Best-effort and fully guarded: a heal failure
+        must never break the write that triggered it. Returns the count healed.
+        """
+        if _heal_disabled():
+            return 0
+        try:
+            stranded = s.get_unembedded(limit)
+        except Exception as exc:  # noqa: BLE001 — heal must never break a write
+            _log(f"[backfill] get_unembedded failed: {type(exc).__name__}: {exc}")
+            return 0
+        healed = 0
+        for rid, content in stranded:
+            vec = _safe_embed(embedder, content, "backfill")
+            if not vec:
+                # Embedder degraded mid-batch — stop and retry on a later write.
+                break
+            try:
+                if s.set_embedding(rid, vec):
+                    healed += 1
+            except Exception as exc:  # noqa: BLE001 — best-effort
+                _log(
+                    f"[backfill] set_embedding failed for {rid}: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+        if healed:
+            _log(f"[backfill] re-embedded {healed} stranded reflection(s) (#630)")
+        return healed
+
     def _embed_build_insert(s: "ReflectionStore", input_data: "ReflectInput") -> dict:
         """Embed + build + insert a Reflection into ``s``; handle supersession.
 
@@ -185,6 +235,12 @@ def create_server(
             # replacing — intended for consolidation, but it means these tools
             # are not strictly insert-only.
             s.deactivate_superseded(input_data.supersedes, superseded_by=ref.id)
+        if embedding:
+            # Heal-on-write (#630): this embed just succeeded, so the embedder is
+            # live now — opportunistically re-embed a bounded few rows that a
+            # prior degraded/NoOp embedder stranded at '[]' (silently invisible
+            # to semantic recall). Best-effort; never raises into the write.
+            _heal_unembedded(s)
         return {
             "id": ref.id,
             "type": ref.type.value,

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -490,6 +490,79 @@ class ReflectionStore:
             self._conn.commit()
             return reflection
 
+    # ── Re-embed / heal (#630) ──
+
+    def get_unembedded(self, limit: int = 50) -> list[tuple[str, str]]:
+        """Return ``(id, content)`` for active reflections stored without an
+        embedding (``embedding == '[]'``), oldest first.
+
+        These rows persist and are findable via structured/keyword query but
+        silently miss semantic ``recall`` (the primary retrieval path) because
+        they have no vector. They arise whenever the embedder is a NoOp (no
+        key) or transiently degraded at insert time. The server's heal-on-write
+        backfill re-embeds them once the embedder is live again (#630).
+        """
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT id, content FROM reflections "
+                "WHERE embedding = '[]' AND active = 1 "
+                "ORDER BY created_at ASC LIMIT ?",
+                (max(0, limit),),
+            ).fetchall()
+        return [(row[0], row[1]) for row in rows]
+
+    def set_embedding(self, reflection_id: str, embedding: list[float]) -> bool:
+        """Attach ``embedding`` to an existing reflection and sync the vec table.
+
+        Mirrors :meth:`insert`'s embedding + ``reflections_vec`` write so a
+        re-embedded row is equivalent to one embedded at insert time (same JSON
+        storage, same blob packing, same lazy dim-table creation). Idempotent:
+        clears any stale vec row for the rowid first.
+
+        Used by the server's heal-on-write backfill (#630). Returns ``True`` if
+        a row was updated. A falsy ``embedding`` is a no-op (returns ``False``)
+        — callers must pass a validated, non-degraded vector (see
+        ``server._safe_embed``), never ``[]``.
+        """
+        if not embedding:
+            return False
+        with self._lock:
+            cur = self._conn.execute(
+                "SELECT rowid FROM reflections WHERE id = ?", (reflection_id,)
+            ).fetchone()
+            if cur is None:
+                return False
+            rowid = cur[0]
+            self._conn.execute(
+                "UPDATE reflections SET embedding = ? WHERE id = ?",
+                (json.dumps(embedding), reflection_id),
+            )
+            if self._vec_available:
+                # Lazily create the vec table on the first embedding the store
+                # ever sees (mirrors insert()).
+                if self._vec_dimensions == 0:
+                    self._create_vec_table(len(embedding))
+                if len(embedding) == self._vec_dimensions:
+                    try:
+                        # An un-embedded row was never in the vec table, but
+                        # clearing first keeps a re-heal idempotent.
+                        self._conn.execute(
+                            "DELETE FROM reflections_vec WHERE rowid = ?", (rowid,)
+                        )
+                        self._conn.execute(
+                            "INSERT INTO reflections_vec(rowid, embedding) VALUES (?, ?)",
+                            (rowid, self._embedding_to_blob(embedding)),
+                        )
+                    except sqlite3.OperationalError as exc:
+                        # Non-fatal: vector search for this row degrades to the
+                        # numpy fallback (same handling as insert(), #295).
+                        logger.debug(
+                            "vec set_embedding failed for rowid=%s id=%s: %s",
+                            rowid, reflection_id, exc,
+                        )
+            self._conn.commit()
+        return True
+
     # ── Get ──
 
     def get(self, reflection_id: str) -> Reflection | None:

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -83,6 +83,13 @@ CREATE INDEX IF NOT EXISTS idx_reflections_project ON reflections(project);
 CREATE INDEX IF NOT EXISTS idx_reflections_active ON reflections(active);
 CREATE INDEX IF NOT EXISTS idx_reflections_salience ON reflections(salience);
 CREATE INDEX IF NOT EXISTS idx_reflections_created_at ON reflections(created_at);
+-- #630: partial index over only stranded ('[]') active rows. Keeps the
+-- heal-on-write backlog probe (get_unembedded, run after every successful
+-- reflect) a near-empty index scan in steady state — a store with zero strays
+-- pays ~nothing instead of scanning active rows. Mirrors get_unembedded's
+-- WHERE + created_at order exactly so the planner uses it.
+CREATE INDEX IF NOT EXISTS idx_reflections_unembedded
+    ON reflections(created_at) WHERE active = 1 AND embedding = '[]';
 
 CREATE TABLE IF NOT EXISTS daemon_sync_counts (
     session_id TEXT PRIMARY KEY,
@@ -503,8 +510,16 @@ class ReflectionStore:
         backfill re-embeds them once the embedder is live again (#630).
         """
         with self._lock:
+            # INDEXED BY pins the partial index idx_reflections_unembedded (only
+            # stranded active rows): without the hint SQLite's planner prefers
+            # the active=? equality search + a temp-b-tree sort, scanning every
+            # active row on each reflect. The partial index makes the
+            # steady-state (zero-stray) probe a scan of an empty index and drops
+            # the sort. The index is created in SCHEMA (IF NOT EXISTS) so the
+            # hint is always satisfiable.
             rows = self._conn.execute(
                 "SELECT id, content FROM reflections "
+                "INDEXED BY idx_reflections_unembedded "
                 "WHERE embedding = '[]' AND active = 1 "
                 "ORDER BY created_at ASC LIMIT ?",
                 (max(0, limit),),

--- a/tests/test_memory_heal_unembedded.py
+++ b/tests/test_memory_heal_unembedded.py
@@ -1,0 +1,200 @@
+"""Tests for #630 heal-on-write: re-embedding stranded ('[]') reflections.
+
+A reflection stored while the embedder is a NoOp (no key) or transiently
+degraded persists with ``embedding == '[]'`` — findable via structured/keyword
+query but silently invisible to semantic ``recall``. These tests cover the
+store primitives (``get_unembedded`` / ``set_embedding``) and the server's
+heal-on-write backfill wired into ``_embed_build_insert`` (exercised via the
+``reflect`` tool), including the degraded, bounded, kill-switch, and
+never-break-the-write paths.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pinky_memory.embeddings import NoOpEmbeddingClient
+from pinky_memory.server import _HEAL_BATCH, create_server
+from pinky_memory.store import ReflectionStore
+from pinky_memory.types import Reflection, ReflectionType
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _store(tmp_path: Path) -> ReflectionStore:
+    return ReflectionStore(str(tmp_path / "heal.db"))
+
+
+def _stranded(store: ReflectionStore, content: str) -> str:
+    """Insert an active reflection with no embedding ('[]'), as a degraded or
+    NoOp embedder would have. Returns its id."""
+    r = store.insert(Reflection(type=ReflectionType.fact, content=content))
+    assert store.get(r.id).embedding == []  # stored as '[]'
+    return r.id
+
+
+class _RealEmbedder:
+    """Non-NoOp embedder returning a fixed finite, non-zero-norm vector so
+    ``_safe_embed`` accepts it. Content-insensitive — tests assert *that* a row
+    got embedded, not similarity."""
+
+    dimensions = 8
+
+    def embed(self, text: str) -> list[float]:
+        return [0.1] * self.dimensions
+
+
+def _tools(srv):
+    return {t.name: t.fn for t in srv._tool_manager.list_tools()}
+
+
+def _unembedded_count(store: ReflectionStore) -> int:
+    return len(store.get_unembedded(limit=10_000))
+
+
+# ── Store: get_unembedded ────────────────────────────────────────────────────
+
+
+class TestGetUnembedded:
+    def test_returns_only_active_stranded(self, tmp_path):
+        store = _store(tmp_path)
+        a = _stranded(store, "stranded one")
+        b = _stranded(store, "stranded two")
+        # An embedded row must not be reported.
+        store.insert(Reflection(type=ReflectionType.fact, content="has vec", embedding=[0.2] * 8))
+        # An inactive stranded row must not be reported (recall returns active).
+        inactive = store.insert(Reflection(type=ReflectionType.fact, content="old stranded"))
+        store.deactivate_superseded(inactive.id)  # sets active = 0
+
+        ids = [rid for rid, _ in store.get_unembedded(limit=50)]
+        assert set(ids) == {a, b}
+
+    def test_oldest_first_and_bounded(self, tmp_path):
+        store = _store(tmp_path)
+        ids = [_stranded(store, f"s{i}") for i in range(5)]
+        got = store.get_unembedded(limit=3)
+        assert [rid for rid, _ in got] == ids[:3]  # oldest three, in order
+
+    def test_returns_id_and_content(self, tmp_path):
+        store = _store(tmp_path)
+        rid = _stranded(store, "remember the milk")
+        assert store.get_unembedded(limit=1) == [(rid, "remember the milk")]
+
+    def test_empty_when_all_embedded(self, tmp_path):
+        store = _store(tmp_path)
+        store.insert(Reflection(type=ReflectionType.fact, content="x", embedding=[0.1] * 8))
+        assert store.get_unembedded() == []
+
+
+# ── Store: set_embedding ─────────────────────────────────────────────────────
+
+
+class TestSetEmbedding:
+    def test_persists_and_makes_searchable(self, tmp_path):
+        store = _store(tmp_path)
+        rid = _stranded(store, "find me by vector")
+        vec = [0.1] * 8
+
+        assert store.set_embedding(rid, vec) is True
+        assert store.get(rid).embedding == vec
+        assert rid not in [r for r, _ in store.get_unembedded()]
+        # End-to-end: now reachable by vector search (proves vec-table sync).
+        hits = store.search_by_embedding(query_embedding=vec, limit=5)
+        assert rid in [h.id for h in hits]
+
+    def test_missing_id_returns_false(self, tmp_path):
+        store = _store(tmp_path)
+        assert store.set_embedding("does-not-exist", [0.1] * 8) is False
+
+    def test_empty_vector_is_noop(self, tmp_path):
+        store = _store(tmp_path)
+        rid = _stranded(store, "stays stranded")
+        assert store.set_embedding(rid, []) is False
+        assert store.get(rid).embedding == []
+
+    def test_idempotent_reheal(self, tmp_path):
+        store = _store(tmp_path)
+        rid = _stranded(store, "double heal")
+        vec = [0.1] * 8
+        assert store.set_embedding(rid, vec) is True
+        # Second call must not raise or duplicate the vec row.
+        assert store.set_embedding(rid, vec) is True
+        hits = store.search_by_embedding(query_embedding=vec, limit=10)
+        assert [h.id for h in hits].count(rid) == 1
+
+
+# ── Server: heal-on-write ────────────────────────────────────────────────────
+
+
+class TestHealOnWrite:
+    def test_reflect_reembeds_stranded(self, tmp_path):
+        store = _store(tmp_path)
+        s1 = _stranded(store, "stranded A")
+        s2 = _stranded(store, "stranded B")
+        srv = create_server(store, _RealEmbedder())
+
+        result = json.loads(_tools(srv)["reflect"](content="fresh fact", type="fact"))
+        assert result["embedded"] is True
+        # Both previously-stranded rows are now embedded.
+        assert store.get(s1).embedding == [0.1] * 8
+        assert store.get(s2).embedding == [0.1] * 8
+        assert _unembedded_count(store) == 0
+
+    def test_skipped_when_embedder_degraded(self, tmp_path):
+        store = _store(tmp_path)
+        sid = _stranded(store, "still stranded")
+        srv = create_server(store, NoOpEmbeddingClient())
+
+        result = json.loads(_tools(srv)["reflect"](content="no vec either", type="fact"))
+        assert result["embedded"] is False
+        # Nothing healed; the new row is also un-embedded. No crash.
+        assert store.get(sid).embedding == []
+        assert _unembedded_count(store) == 2
+
+    def test_recovers_after_embedder_restored(self, tmp_path):
+        store = _store(tmp_path)
+        # Write under a degraded/NoOp embedder → stranded.
+        noop_srv = create_server(store, NoOpEmbeddingClient())
+        r = json.loads(_tools(noop_srv)["reflect"](content="written while degraded", type="fact"))
+        assert r["embedded"] is False
+        assert _unembedded_count(store) == 1
+        # Embedder recovers → next write heals the backlog.
+        live_srv = create_server(store, _RealEmbedder())
+        json.loads(_tools(live_srv)["reflect"](content="now healthy", type="fact"))
+        assert _unembedded_count(store) == 0
+
+    def test_heal_is_batch_bounded(self, tmp_path):
+        store = _store(tmp_path)
+        for i in range(_HEAL_BATCH + 2):
+            _stranded(store, f"backlog {i}")
+        srv = create_server(store, _RealEmbedder())
+
+        json.loads(_tools(srv)["reflect"](content="trigger 1", type="fact"))
+        # One write heals at most _HEAL_BATCH; the remaining 2 persist.
+        assert _unembedded_count(store) == 2
+        json.loads(_tools(srv)["reflect"](content="trigger 2", type="fact"))
+        assert _unembedded_count(store) == 0
+
+    def test_kill_switch_disables_heal(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PINKY_MEMORY_DISABLE_HEAL", "1")
+        store = _store(tmp_path)
+        sid = _stranded(store, "left alone")
+        srv = create_server(store, _RealEmbedder())
+
+        result = json.loads(_tools(srv)["reflect"](content="healthy write", type="fact"))
+        assert result["embedded"] is True  # the new row still embeds
+        assert store.get(sid).embedding == []  # but heal did not run
+
+    def test_heal_never_breaks_the_write(self, tmp_path, monkeypatch):
+        store = _store(tmp_path)
+        _stranded(store, "boom row")
+        srv = create_server(store, _RealEmbedder())
+
+        def _explode(*a, **k):
+            raise RuntimeError("backfill query blew up")
+
+        monkeypatch.setattr(store, "get_unembedded", _explode)
+        # The reflect must still succeed and store/embed its own row.
+        result = json.loads(_tools(srv)["reflect"](content="must survive", type="fact"))
+        assert result["stored"] is True
+        assert result["embedded"] is True


### PR DESCRIPTION
## Problem (#630)

A reflection written while the embedder is a **NoOp** (no key) or **transiently degraded** persists with `embedding = '[]'`. It's findable via structured/keyword query but **silently invisible to semantic `recall`** — the primary retrieval path — and there was **no automatic recovery**: a stranded row stayed stranded forever. Surfaced during Mora's first cross-agent consolidation (#145); the same silent-permanent-loss class that #695 fixed for the KG side.

## Fix — heal-on-write (no new scheduler)

When a `reflect` / `reflect_for` embed **succeeds** (so the embedder is provably live *right now*), `_embed_build_insert` opportunistically re-embeds a bounded few stranded rows in that same store:

- **`store.get_unembedded(limit)`** — active rows with `embedding='[]'`, oldest first.
- **`store.set_embedding(id, vec)`** — mirrors `insert()`'s embedding + `reflections_vec` write exactly (same JSON storage, same blob packing, lazy dim-table creation); idempotent (clears any stale vec row first).
- **`server._heal_unembedded(s, limit=_HEAL_BATCH)`** — re-embeds via the same `_safe_embed`; a re-embed that still degrades (`[]`) stops the batch and retries on a later write.

Properties:
- **Bounded** (`_HEAL_BATCH=5`): a backlog drains over successive writes, never blocking one write on a large re-embed.
- **Best-effort & fully guarded**: every heal path is wrapped — a heal failure can *never* break the write that triggered it (test: `test_heal_never_breaks_the_write`).
- **Embedder-proven-live**: only runs after a successful embed, so it won't thrash during an outage.
- **Covers `reflect_for`**: the nightly dreamer consolidation re-embeds every agent's store as a side effect.
- **Kill-switch**: `PINKY_MEMORY_DISABLE_HEAL=1` turns it off fleet-wide without a redeploy.

## Why this shape (and not a backfill cron)

Fleet check at time of fix: **0 un-embedded rows across all live agent stores** — the 06-05 embedder fix (#679) + its one-time backfill already cleared the live backlog, and ~1500 writes since have all embedded cleanly. So the live impact is already resolved; what was missing is the *durable guarantee* that the next embedder hiccup can't silently strand rows again. Heal-on-write delivers that by riding the existing write path — no new scheduler, no startup embed calls, zero cost in the normal (no-stray) case (one cheap indexed-ish `SELECT … LIMIT 5` returning nothing).

## Tests

14 new (`tests/test_memory_heal_unembedded.py`):
- store: `get_unembedded` (active-only, oldest-first, bounded, id+content), `set_embedding` (persists + vector-searchable, missing-id, empty-vec no-op, idempotent re-heal)
- server: re-embeds stranded on next write; **skipped when embedder degraded**; **recovers after embedder restored**; **batch-bounded**; **kill-switch**; **never breaks the write**

`196` existing memory tests (store/server/cross-agent/shared-mcp) green; ruff clean.

## Note on screenshot
Backend memory-store fix — no UI surface. The artifact is the test matrix above + the fleet 0-stray evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)