### PR TITLE
fix(watchdog): credit in-flight foreground tool calls as liveness (#731)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -798,6 +798,20 @@ _TRANSCRIPT_PASTE_SLACK = 5.0
 # silent this long AND whose main REPL is quiet is genuinely stuck.
 _BACKGROUND_TASK_ACTIVE_WINDOW_SEC = 180.0
 
+# #731 — absolute ceiling for crediting an in-flight FOREGROUND tool call as
+# liveness. A single long blocking foreground tool call (e.g. a deliberate
+# ``gh run watch`` up to ~10 min, or a slow build) writes nothing to the main
+# transcript and — unlike a Workflow/Agent — spawns no subagent dir, so it
+# looks identical to a wedge to the stall verdict. The PreToolUse/PostToolUse
+# hooks (task #93) tell us a tool is genuinely in flight, and we extend the
+# wedge window while one is. The ceiling bounds that trust: a tool "in flight"
+# longer than this is treated as a lost finish-POST or a genuinely hung child
+# and is NOT credited (and is pruned), so a real stuck REPL still recovers —
+# just later. 30 min is generous headroom over the ~10 min worst-case legit
+# foreground wait while keeping the worst-case false-negative (delayed wedge
+# recovery) bounded.
+_FOREGROUND_TOOL_ACTIVE_CEILING_SEC = 1800.0
+
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
 # ``_session_ready_event`` for turns with ``internal=True and
 # reason.startswith("wake_")`` so the wake prompt's paste doesn't land while
@@ -932,6 +946,11 @@ class TmuxSession:
         self.account_info: dict = {"apiProvider": "tmux_claude_repl"}
         self._current_activity = ""
         self._current_thinking = ""
+        # #731: tool_use_id → start-time for tool calls that have started
+        # (PreToolUse hook) but not finished (PostToolUse hook). The inflight
+        # watchdog reads this as positive liveness so a long foreground tool
+        # call isn't mistaken for a wedged REPL. Bounded/pruned by the verdict.
+        self._inflight_tool_calls: dict[str, float] = {}
         self._activity_log: list[str] = []
 
         # Response capture pipeline (PR8b). Lazily constructed in
@@ -1522,6 +1541,14 @@ class TmuxSession:
         if not tool_name:
             return
 
+        # #731: mark this tool call in-flight so the inflight watchdog doesn't
+        # mistake a long foreground tool call (e.g. a blocking `gh run watch`)
+        # for a wedged REPL. Cleared by record_tool_use_finish; bounded by
+        # _FOREGROUND_TOOL_ACTIVE_CEILING_SEC in the verdict so a lost
+        # finish-POST can't extend the window forever.
+        if tool_use_id:
+            self._inflight_tool_calls[tool_use_id] = time.time()
+
         # Human-readable activity line — mirror SDK by importing the
         # shared describer if available, falling back to a basic format.
         try:
@@ -1615,6 +1642,11 @@ class TmuxSession:
         """
         if not tool_name and not tool_use_id:
             return
+
+        # #731: this tool call is done — drop it from the in-flight set so the
+        # watchdog stops extending the wedge window on its behalf.
+        if tool_use_id:
+            self._inflight_tool_calls.pop(tool_use_id, None)
 
         # Short result snippet for the stream event — same cap SDK
         # uses for parity. Tool responses can be huge (file contents,
@@ -2457,6 +2489,9 @@ class TmuxSession:
         drained = list(self._inflight_metas)
         self._inflight_metas.clear()
         self._head_started_at = None
+        # #731: session is being torn down — drop in-flight tool state so a
+        # stale entry can't leak across the disconnect/reconnect boundary.
+        self._inflight_tool_calls.clear()
         for entry in drained:
             if entry.completion_event is not None and not entry.completion_event.is_set():
                 entry.completion_event.set()
@@ -3502,6 +3537,11 @@ class TmuxSession:
         twist (route to wrong chat from an empty/zero state).
         """
         # ── Critical section: synchronous deque mutation + signals ────
+        # #731: a Stop hook means the model yielded — no foreground tool is
+        # executing, so any remaining in-flight tool entries are leaked (a lost
+        # PostToolUse finish-POST). Clear them here so the next turn's wedge
+        # verdict can't be spuriously extended by a stale entry.
+        self._inflight_tool_calls.clear()
         if not self._inflight_metas:
             # No meta to pop. Stop hook arrived without a dispatch
             # behind it — most commonly an AUTONOMOUS turn (background-
@@ -4469,6 +4509,39 @@ class TmuxSession:
                 continue
         return False
 
+    def _foreground_tool_in_flight(self, now: float) -> bool:
+        """True if a FOREGROUND tool call is still running (#731).
+
+        A single long blocking foreground tool call (e.g. a deliberate
+        ``gh run watch`` up to ~10 min, or a slow build) writes nothing to the
+        main transcript until it returns and — unlike a Workflow/Agent — spawns
+        no subagent transcript, so both ``_transcript_recently_grew`` and
+        ``_background_tasks_recently_active`` read it as "quiet". With the REPL
+        legitimately ``working`` that is indistinguishable from a wedge, and the
+        watchdog force_restarts a healthy turn, SIGKILLing the tool child (#731).
+
+        The PreToolUse/PostToolUse hooks (task #93) already POST tool-start and
+        tool-finish to the daemon, so ``_inflight_tool_calls`` holds the
+        ``tool_use_id``s that have started but not finished — an authoritative
+        "a tool is genuinely running" signal. We credit that as liveness, the
+        same carve-out background tasks get.
+
+        Bounded by ``_FOREGROUND_TOOL_ACTIVE_CEILING_SEC``: an entry older than
+        the ceiling is a lost finish-POST or a genuinely hung child, so it is
+        NOT credited and is pruned here (keeping the set bounded). A real stuck
+        REPL therefore still recovers — just one ceiling-window later.
+        """
+        if not self._inflight_tool_calls:
+            return False
+        alive = False
+        for tool_use_id, started_at in list(self._inflight_tool_calls.items()):
+            if (now - started_at) >= _FOREGROUND_TOOL_ACTIVE_CEILING_SEC:
+                # Suspected lost finish / hung child — stop crediting + prune.
+                del self._inflight_tool_calls[tool_use_id]
+                continue
+            alive = True
+        return alive
+
     def _inflight_stall_verdict(self, now: float) -> str:
         """Classify a possibly-stalled inflight head for the watchdog (#118).
 
@@ -4477,8 +4550,10 @@ class TmuxSession:
           - ``"growing"`` — aged out BUT the main transcript is still being
                             written, OR a background task (a Workflow / Agent
                             tool call) is still writing its own subagent
-                            transcript → a long/streaming or background-busy
-                            turn, not wedged (#692).
+                            transcript (#692), OR a foreground tool call is
+                            still in flight (#731) → a long/streaming,
+                            background-busy, or foreground-tool-busy turn, not
+                            wedged.
           - ``"idle"``    — aged out, transcript quiet, and Claude Code last
                             reported *idle* (Stop hook) at-or-after this head
                             started → the REPL finished and is waiting for
@@ -4512,6 +4587,14 @@ class TmuxSession:
         if self._background_tasks_recently_active(
             now, _BACKGROUND_TASK_ACTIVE_WINDOW_SEC
         ):
+            return "growing"
+        # (a3) Parked on a long-running FOREGROUND tool call (#731)? The
+        # PreToolUse/PostToolUse hooks (task #93) track in-flight tool_use_ids;
+        # a tool that has started but not finished (within the ceiling) is
+        # genuine liveness — extend, don't restart. Checked before the idle
+        # reconcile for the same reason as (a2): an actively-working foreground
+        # turn must never be drained as a phantom.
+        if self._foreground_tool_in_flight(now):
             return "growing"
         # (b) REPL reported idle? Consult Claude Code's working/idle hook
         # signal (Stop hook → "idle"; PreToolUse/etc → "working"). An idle
@@ -4618,7 +4701,8 @@ class TmuxSession:
             f"head_started_at={self._head_started_at} "
             f"transcript_mtime={transcript_mtime} "
             f"age_s={age_str} "
-            f"depth={len(self._inflight_metas)}"
+            f"depth={len(self._inflight_metas)} "
+            f"inflight_tools={len(self._inflight_tool_calls)}"
         )
 
     async def _inflight_watchdog(self) -> None:

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3581,6 +3581,77 @@ def test_background_tasks_recently_active_false_without_session_dir(tmp_path) ->
     )
 
 
+def test_inflight_verdict_growing_when_foreground_tool_in_flight() -> None:
+    """#731: a long FOREGROUND tool call (main transcript quiet, no subagent
+    dir, REPL 'working') must be ``growing`` while its tool_use_id is in
+    flight — otherwise the watchdog SIGKILLs a healthy turn's tool child."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    _age_out_head(ss)
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": _time.time(),
+    }
+    # A foreground tool started recently and hasn't reported finish.
+    ss._inflight_tool_calls = {"toolu_x": _time.time()}
+    assert ss._inflight_stall_verdict(_time.time()) == "growing"
+
+
+def test_inflight_verdict_wedged_when_no_foreground_tool() -> None:
+    """#731 negative: no in-flight tool + quiet + 'working' → still ``wedged``,
+    preserving genuine stuck-REPL recovery (the wedge the model actually hit
+    has no tool running)."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    _age_out_head(ss)
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": _time.time(),
+    }
+    assert ss._inflight_tool_calls == {}
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+
+
+def test_inflight_verdict_wedged_when_foreground_tool_past_ceiling() -> None:
+    """#731 bound: a tool 'in flight' longer than the ceiling is a lost
+    finish-POST or a hung child — NOT credited (and pruned), so a real wedge
+    still recovers (just later)."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    _age_out_head(ss)
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": _time.time(),
+    }
+    stale = _time.time() - (
+        tmux_session._FOREGROUND_TOOL_ACTIVE_CEILING_SEC + 60.0
+    )
+    ss._inflight_tool_calls = {"toolu_stale": stale}
+    assert ss._inflight_stall_verdict(_time.time()) == "wedged"
+    # Stale entry pruned so the set can't grow unbounded.
+    assert ss._inflight_tool_calls == {}
+
+
+def test_foreground_tool_in_flight_prunes_stale_keeps_fresh() -> None:
+    """Helper prunes only entries past the ceiling; a fresh concurrent entry
+    still counts as live."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    now = _time.time()
+    stale = now - (tmux_session._FOREGROUND_TOOL_ACTIVE_CEILING_SEC + 1.0)
+    ss._inflight_tool_calls = {"old": stale, "new": now}
+    assert ss._foreground_tool_in_flight(now) is True
+    assert "old" not in ss._inflight_tool_calls  # pruned
+    assert "new" in ss._inflight_tool_calls  # retained
+
+
+def test_foreground_tool_in_flight_false_when_empty() -> None:
+    """Helper returns False with no in-flight tools — preserves the
+    wedged/idle fall-through for ordinary turns."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    assert ss._inflight_tool_calls == {}
+    assert ss._foreground_tool_in_flight(_time.time()) is False
+
+
 def test_inflight_verdict_wedged_when_idle_predates_head() -> None:
     """Hang-on-paste: a turn was pasted (head started) but the REPL's idle
     status is STALE (predates the head) — the REPL never came alive for this
@@ -4416,6 +4487,46 @@ async def test_record_tool_use_finish_caps_huge_response_at_200() -> None:
         tool_response=huge,
     )
     assert len(events[0]["result_preview"]) == 200
+
+
+@pytest.mark.asyncio
+async def test_record_tool_use_start_marks_inflight() -> None:
+    """#731: record_tool_use_start adds the tool_use_id to the in-flight set so
+    the watchdog can credit a long foreground call as liveness."""
+    ss, _analytics, _events = _make_session_with_analytics()
+    await ss.record_tool_use_start(
+        tool_use_id="toolu_fg",
+        tool_name="Bash",
+        tool_input={"command": "gh run watch 123 --exit-status"},
+    )
+    assert "toolu_fg" in ss._inflight_tool_calls
+
+
+@pytest.mark.asyncio
+async def test_record_tool_use_finish_clears_inflight() -> None:
+    """#731: record_tool_use_finish removes the tool_use_id so the watchdog
+    stops crediting it once the tool returns."""
+    ss, _analytics, _events = _make_session_with_analytics()
+    await ss.record_tool_use_start(
+        tool_use_id="toolu_fg", tool_name="Bash", tool_input={"command": "sleep 1"}
+    )
+    assert "toolu_fg" in ss._inflight_tool_calls
+    await ss.record_tool_use_finish(
+        tool_use_id="toolu_fg", tool_name="Bash", is_error=False, tool_response="done"
+    )
+    assert "toolu_fg" not in ss._inflight_tool_calls
+
+
+@pytest.mark.asyncio
+async def test_record_tool_use_start_untracked_without_id() -> None:
+    """#731: a synthetic-key tool call (no tool_use_id) isn't tracked for the
+    watchdog — analytics still opens a row, but with no id there'd be nothing
+    to clear on finish, so we avoid a permanent in-flight leak."""
+    ss, _analytics, _events = _make_session_with_analytics()
+    await ss.record_tool_use_start(
+        tool_use_id="", tool_name="Bash", tool_input={"command": "ls"}
+    )
+    assert ss._inflight_tool_calls == {}
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem (#731)

The inflight watchdog force_restarted a **healthy** turn — SIGKILLing the running tool child (exit 137) — when a single **foreground** tool call blocked >600s. Observed 2026-06-10 on barsik: a deliberate 614s `gh run watch … >/dev/null`.

Root cause in `_inflight_stall_verdict` (`tmux_session.py`): a turn is called `wedged` when aged >`_TURN_DONE_TIMEOUT_SEC` **+** main transcript quiet **+** no subagent activity **+** REPL still `working`. A long foreground call trips all four — it writes nothing to the main transcript until it returns, and (unlike a Workflow/Agent) spawns no subagent transcript dir. Background tasks already dodge this via `_background_tasks_recently_active`; plain foreground tool calls got **zero** liveness credit.

## Fix

Give foreground tool calls the same carve-out — using an authoritative signal the daemon **already receives**. The `PreToolUse`/`PostToolUse` hooks (task #93) POST tool-start (`/transport/tool-use`) and tool-finish (`/transport/tool-result`) for every tmux-agent tool call.

- `record_tool_use_start` records `tool_use_id → start-time` in a new `_inflight_tool_calls` dict; `record_tool_use_finish` removes it.
- New verdict carve-out **(a3)** — after the background check, before the idle reconcile: if `_foreground_tool_in_flight(now)` → `"growing"` (extend, don't restart).
- **Absolute ceiling** `_FOREGROUND_TOOL_ACTIVE_CEILING_SEC = 1800s`: an entry older than the ceiling is treated as a lost finish-POST or a genuinely hung child — **not** credited, and **pruned** in the check (keeps the dict bounded). So a real stuck REPL still recovers, just one ceiling-window later — the **only** regression path, and it's bounded to "today's behavior, later."
- In-flight state is cleared at turn-complete (Stop hook → the model yielded, so any leftover entries are leaked) and on disconnect (session teardown).
- `verdict_wedged_inputs` log line gains `inflight_tools=<n>` for prod observability.

**No marker files, no process-tree walking, no hook/settings changes** — it consumes existing plumbing.

## Why this is the right signal

A *real* wedge = the model stuck with **no tool executing** → `_inflight_tool_calls` empty → still classified `wedged` (recovery preserved). A long foreground call = a tool started-but-not-finished → credited as live. The hooks are fire-and-forget (`|| true`, 2s timeout); a lost **start** POST degrades to today's behavior (no regression), a lost **finish** POST is bounded by the ceiling + cleared at the next Stop.

## Tests

8 new in `tests/test_tmux_session.py`:
- `…verdict_growing_when_foreground_tool_in_flight` (the fix)
- `…verdict_wedged_when_no_foreground_tool` (real wedge preserved)
- `…verdict_wedged_when_foreground_tool_past_ceiling` (bound + prune)
- `…foreground_tool_in_flight_prunes_stale_keeps_fresh`, `…false_when_empty`
- `…record_tool_use_start_marks_inflight`, `…finish_clears_inflight`, `…start_untracked_without_id`

**340** tmux + watchdog tests green, ruff clean.

## Note on screenshot
Backend watchdog logic — no UI surface. Artifact is the test matrix above + the new `inflight_tools=` field in the `verdict_wedged_inputs` prod log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)