### PR TITLE
fix(frontend): sanitize redirect targets + external hrefs (security)

### DIFF
--- a/frontend-svelte/src/lib/safe.js
+++ b/frontend-svelte/src/lib/safe.js
@@ -1,0 +1,49 @@
+// Frontend security helpers — keep user/agent-controlled values from turning
+// navigation into an open redirect or a javascript:/data: link.
+
+// C0 control chars + DEL — stripped so they can't smuggle a scheme or CRLF.
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
+
+/**
+ * Sanitize a `next` redirect target down to a SAME-ORIGIN app path.
+ *
+ * Accepts only a single-slash-rooted path ("/foo"). Rejects protocol-relative
+ * URLs ("//evil.com" — browsers treat these as another origin), absolute URLs
+ * with a scheme, backslash tricks ("/\\evil.com"), and embedded control chars.
+ * Anything that doesn't qualify falls back to "/".
+ *
+ * Used for the `next` query param on Login/Setup so a crafted
+ * `/login?next=https://evil.com` can't bounce a freshly-authenticated user
+ * off-origin.
+ */
+export function sanitizeNextPath(next) {
+    if (typeof next !== 'string') return '/';
+    const v = next.replace(CONTROL_CHARS, '').trim();
+    if (!v.startsWith('/')) return '/'; // must be a rooted path, not a scheme/relative
+    if (v.startsWith('//')) return '/'; // protocol-relative -> another origin
+    if (v.includes('\\')) return '/'; // backslash variants browsers normalize to //
+    return v;
+}
+
+/**
+ * Return `url` only if it's a safe external href (http/https/mailto), else null
+ * so the caller can render plain text instead of a live link.
+ *
+ * Blocks dangerous schemes (javascript:, data:, vbscript:, ...) that can be
+ * stored as agent/user-controlled URLs (repo links, KB sources, assets) and
+ * later executed on click. `rel=noopener` does NOT stop `javascript:` — the
+ * scheme has to be rejected. Other hosts are allowed on purpose: these are
+ * genuinely external links.
+ */
+export function safeExternalHref(url) {
+    if (typeof url !== 'string') return null;
+    const v = url.replace(CONTROL_CHARS, '').trim();
+    if (!v) return null;
+    let parsed;
+    try {
+        parsed = new URL(v, window.location.origin);
+    } catch {
+        return null;
+    }
+    return ['http:', 'https:', 'mailto:'].includes(parsed.protocol) ? v : null;
+}

--- a/frontend-svelte/src/pages/Login.svelte
+++ b/frontend-svelte/src/pages/Login.svelte
@@ -1,6 +1,7 @@
 <script>
     import { onMount } from 'svelte';
     import { api } from '../lib/api.js';
+    import { sanitizeNextPath } from '../lib/safe.js';
     import AuthShell from '../components/AuthShell.svelte';
     import { _ } from 'svelte-i18n';
 
@@ -9,7 +10,7 @@
     let error = '';
 
     const params = new URLSearchParams(window.location.search);
-    const nextPath = params.get('next') || '/';
+    const nextPath = sanitizeNextPath(params.get('next'));
 
     onMount(async () => {
         try {
@@ -36,7 +37,7 @@
         error = '';
         try {
             const result = await api('POST', '/auth/login', { password, next: nextPath });
-            window.location.href = result.next || nextPath;
+            window.location.href = sanitizeNextPath(result.next || nextPath);
         } catch (e) {
             error = e.message.replace(/^\d+:\s*/, '');
         } finally {

--- a/frontend-svelte/src/pages/ProjectHub.svelte
+++ b/frontend-svelte/src/pages/ProjectHub.svelte
@@ -2,6 +2,7 @@
     import { _ } from 'svelte-i18n';
     import { api } from '../lib/api.js';
     import { timeAgo } from '../lib/utils.js';
+    import { safeExternalHref } from '../lib/safe.js';
 
     export let params = {};
 
@@ -147,7 +148,10 @@
                 </div>
                 <div class="proj-meta-row">
                     {#if p.repo_url}
-                        <a href={p.repo_url} target="_blank" rel="noopener noreferrer" class="btn btn-sm">Repo →</a>
+                        {@const repoHref = safeExternalHref(p.repo_url)}
+                        {#if repoHref}
+                            <a href={repoHref} target="_blank" rel="noopener noreferrer" class="btn btn-sm">Repo →</a>
+                        {/if}
                     {/if}
                     <a href="#/tasks" class="btn btn-sm">{$_('nav.tasks')} →</a>
                 </div>
@@ -299,7 +303,12 @@
                             <span class="asset-chip">
                                 <span class="asset-icon material-symbols-outlined">{assetIcon(a.type)}</span>
                                 {#if a.url}
-                                    <a href={a.url} target="_blank" rel="noopener noreferrer" class="asset-link" title={a.description || a.title}>{a.title}</a>
+                                    {@const assetHref = safeExternalHref(a.url)}
+                                    {#if assetHref}
+                                        <a href={assetHref} target="_blank" rel="noopener noreferrer" class="asset-link" title={a.description || a.title}>{a.title}</a>
+                                    {:else}
+                                        <span class="asset-title">{a.title}</span>
+                                    {/if}
                                 {:else}
                                     <span class="asset-title">{a.title}</span>
                                 {/if}

--- a/frontend-svelte/src/pages/Setup.svelte
+++ b/frontend-svelte/src/pages/Setup.svelte
@@ -2,6 +2,7 @@
     import { onMount } from 'svelte';
     import { _ } from 'svelte-i18n';
     import { api } from '../lib/api.js';
+    import { sanitizeNextPath } from '../lib/safe.js';
     import AuthShell from '../components/AuthShell.svelte';
 
     let password = '';
@@ -10,7 +11,7 @@
     let error = '';
 
     const params = new URLSearchParams(window.location.search);
-    const nextPath = params.get('next') || '/';
+    const nextPath = sanitizeNextPath(params.get('next'));
 
     onMount(async () => {
         try {
@@ -37,7 +38,7 @@
         error = '';
         try {
             const result = await api('POST', '/auth/setup', { password, next: nextPath });
-            window.location.href = result.next || nextPath;
+            window.location.href = sanitizeNextPath(result.next || nextPath);
         } catch (e) {
             error = e.message.replace(/^\d+:\s*/, '');
         } finally {


### PR DESCRIPTION
Part of the overnight frontend hardening pass (Brad's ask) — audited by Murzik + Barsik.

## What & why
Two user/agent-controlled value sinks could be abused:

1. **Open redirect (Login/Setup).** The `next` query param flows straight into `window.location.href` after auth, so `/login?next=https://evil.com` (or `//evil.com`) bounces a freshly-authenticated user off-origin.
2. **Unsafe hrefs (ProjectHub).** Stored `repo_url` / linked-asset `url` render into `<a href target=_blank>` with no scheme check — a stored `javascript:`/`data:` URL executes on click. `rel=noopener` does **not** stop `javascript:`.

## Fix
New `src/lib/safe.js`:
- `sanitizeNextPath(next)` — only same-origin rooted paths (`/x`); rejects protocol-relative (`//host`), absolute (`https://`), backslash tricks, and control chars → falls back to `/`.
- `safeExternalHref(url)` — allows `http`/`https`/`mailto` only, else `null` so the caller renders plain text instead of a live link.

Applied to **Login**, **Setup** (the redirect + the login/setup payload + the final redirect) and **ProjectHub** (repo link + asset links). KB `source_url` gets the same helper in the KnowledgeBase PR.

## Proof (helper behavior, run in node)
```
sanitizeNextPath:
  "/dashboard"          -> "/dashboard"
  "//evil.com"          -> "/"
  "https://evil.com"    -> "/"
  "/\\evil.com"         -> "/"
  "javascript:alert(1)" -> "/"
  "/ok?x=1#h"           -> "/ok?x=1#h"
safeExternalHref:
  "https://github.com/x"      -> "https://github.com/x"
  "mailto:a@b.com"            -> "mailto:a@b.com"
  "javascript:alert(1)"       -> null
  "data:text/html,<script>x"  -> null
  "  javascript:alert(1)  "   -> null   (whitespace-stripped)
  "JAVASCRIPT:alert(1)"       -> null   (case-insensitive via URL parser)
```
No visual change (security behavior is invisible by design), so the helper-behavior table above is the artifact rather than a screenshot.

## Verification
- `npm run build`: green (only the pre-existing INEFFECTIVE_DYNAMIC_IMPORT + large-chunk warnings, unrelated).

Found by Murzik (findings #1, #5).

🤖 Opened by Barsik