### PR TITLE
fix(frontend): Chat — stop async callbacks writing to a stale session

### DIFF
--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -691,9 +691,15 @@
     function startStreamEvents() {
         stopStreamEvents();
         if (!activeAgent || !activeSession || !canUseStreamingChat) return;
-        const label = activeSessionRecord?._streaming_label || labelFromSessionId(activeSession, activeAgent);
-        streamEventSource = sse(`/agents/${activeAgent}/streaming/events?label=${encodeURIComponent(label)}`);
+        const streamSessionId = activeSession;
+        const streamAgentName = activeAgent;
+        const label = activeSessionRecord?._streaming_label || labelFromSessionId(streamSessionId, streamAgentName);
+        streamEventSource = sse(`/agents/${streamAgentName}/streaming/events?label=${encodeURIComponent(label)}`);
         streamEventSource.onmessage = async (evt) => {
+            // Stale-session guard: switching sessions closes the old EventSource,
+            // but an already-queued event can still fire — it must not mutate the
+            // newly-active session's messages/activity.
+            if (activeSession !== streamSessionId) return;
             let data = null;
             try { data = JSON.parse(evt.data || '{}'); } catch { return; }
             if (!data || !data.type) return;
@@ -892,6 +898,10 @@
         }
         const sentAt = Date.now() / 1000;
         const sessionId = activeSession;
+        // Snapshot the target before any await — a session/agent switch mid-send
+        // must not redirect this POST to the newly-selected agent.
+        const sendAgent = activeAgent;
+        const sendSessionRecord = activeSessionRecord;
         const priorAssistantTs = latestAssistantTimestamp(persistedMessages);
         messageInput = '';
         sending = true;
@@ -912,9 +922,9 @@
 
         try {
             if (canUseStreamingChat) {
-                const sessionLabel = activeSessionRecord?._streaming_label || labelFromSessionId(activeSession, activeAgent);
+                const sessionLabel = sendSessionRecord?._streaming_label || labelFromSessionId(sessionId, sendAgent);
                 const sessionParam = sessionLabel !== 'main' ? `?session=${encodeURIComponent(sessionLabel)}` : '';
-                await api('POST', `/agents/${activeAgent}/chat${sessionParam}`, { content: text });
+                await api('POST', `/agents/${sendAgent}/chat${sessionParam}`, { content: text });
                 sending = false;
                 await refreshChat();
             } else if (canUseLegacySessionChat) {
@@ -961,7 +971,7 @@
         await tick();
         scrollToBottom();
         try {
-            const resp = await fetch(`/agents/${activeAgent}/upload`, { method: 'POST', body: formData, credentials: 'same-origin' });
+            const resp = await fetch(`/agents/${uploadAgent}/upload`, { method: 'POST', body: formData, credentials: 'same-origin' });
             if (resp.status === 401) {
                 let payload = null;
                 if ((resp.headers.get('content-type') || '').includes('application/json')) {

--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -898,10 +898,14 @@
         }
         const sentAt = Date.now() / 1000;
         const sessionId = activeSession;
-        // Snapshot the target before any await — a session/agent switch mid-send
-        // must not redirect this POST to the newly-selected agent.
+        // Snapshot the target AND transport before any await — a session/agent
+        // switch mid-send must not redirect this POST to the newly-selected agent,
+        // and the captured target must stay coherent with the captured mode
+        // (else e.g. a legacy→streaming switch posts to /agents/null/chat).
         const sendAgent = activeAgent;
         const sendSessionRecord = activeSessionRecord;
+        const sendCanUseStreamingChat = canUseStreamingChat;
+        const sendCanUseLegacySessionChat = canUseLegacySessionChat;
         const priorAssistantTs = latestAssistantTimestamp(persistedMessages);
         messageInput = '';
         sending = true;
@@ -921,13 +925,13 @@
         await restoreScroll({ forceBottom: true });
 
         try {
-            if (canUseStreamingChat) {
+            if (sendCanUseStreamingChat) {
                 const sessionLabel = sendSessionRecord?._streaming_label || labelFromSessionId(sessionId, sendAgent);
                 const sessionParam = sessionLabel !== 'main' ? `?session=${encodeURIComponent(sessionLabel)}` : '';
                 await api('POST', `/agents/${sendAgent}/chat${sessionParam}`, { content: text });
                 sending = false;
                 await refreshChat();
-            } else if (canUseLegacySessionChat) {
+            } else if (sendCanUseLegacySessionChat) {
                 const data = await api('POST', `/sessions/${sessionId}/message`, { content: text });
                 localMessages = [...localMessages, buildLocalMessage({
                     role: 'assistant', content: data.content, duration_ms: data.duration_ms,
@@ -954,7 +958,7 @@
             // timer is safe to clear here. Streaming path returns from the POST while
             // pendingReply/thinking remain true on purpose — leave the 60s failsafe
             // armed so a crashed/never-replying agent doesn't spin forever.
-            if (!canUseStreamingChat && pendingReplyTimer) { clearTimeout(pendingReplyTimer); pendingReplyTimer = null; }
+            if (!sendCanUseStreamingChat && pendingReplyTimer) { clearTimeout(pendingReplyTimer); pendingReplyTimer = null; }
         }
     }
 


### PR DESCRIPTION
Overnight frontend pass (Brad's ask), Chat.svelte. Audited by Murzik + Barsik.

Three **stale-async-target** races, all from switching session/agent while a request/stream is in flight:

1. **`sendMessage` (streaming path)** read live `activeAgent` / `activeSessionRecord` *after* the `await restoreScroll()` boundary — a quick switch posted the message to the **newly-selected** agent while the optimistic UI/error handling was keyed to the old one. Now snapshot `sendAgent` / `sendSessionRecord` before the await and use them in the POST URL + label. (The legacy path already used the captured `sessionId`.)
2. **`handleFileUpload`** snapshotted `uploadAgent` but still built the fetch URL from live `activeAgent` after `await tick()` — the file could upload to the **wrong agent**. Use `uploadAgent` (the result/error messages were already guarded on it).
3. **`startStreamEvents` `onmessage`** mutated `localMessages` / `thinkingActivity` with no session check. Switching closes the old EventSource, but an already-queued event can still fire and append deltas / failed-turn notices to the **new** chat. Snapshot `streamSessionId` and early-return when `activeSession !== streamSessionId`.

## Verification
- `npm run build`: green (only the pre-existing INEFFECTIVE_DYNAMIC_IMPORT + chunk-size warnings).
- Invisible by nature (race conditions on fast session switching) — no meaningful screenshot; the fix is the snapshot/guard logic.

## Not in this PR
The Chat deep-link bug (Agents "Chat" button → `#/chat#<id>` not selecting the session) is a separate navigation/routing change → its own PR.

Found by Murzik (#3, #10) + Barsik audit.

🤖 Opened by Barsik