### PR TITLE
fix(frontend): KnowledgeBase — clearable tags/url, safe source link, leak, tooltip

### DIFF
--- a/frontend-svelte/src/pages/KnowledgeBase.svelte
+++ b/frontend-svelte/src/pages/KnowledgeBase.svelte
@@ -6,6 +6,7 @@
     import { toast } from '../lib/stores.js';
     import { timeAgo, formatDate, truncate, renderMarkdown } from '../lib/utils.js';
     import { createForceSim, fitView, animateView, computeLabelSet, edgePath, zoomAt, hexToRgba } from '../lib/forceGraph.js';
+    import { safeExternalHref } from '../lib/safe.js';
 
     let loading = true;
     let refreshInterval;
@@ -441,9 +442,12 @@
         try {
             const body = {};
             body.title = editTitle.trim();
-            if (editTags.trim()) body.tags = editTags.split(',').map(t => t.trim()).filter(Boolean);
+            // Always send tags + source_url (even empty) so clearing them sticks —
+            // the backend ignores only absent/None fields, so a guarded
+            // `if (...trim())` made removal a silent no-op.
+            body.tags = editTags.trim() ? editTags.split(',').map(t => t.trim()).filter(Boolean) : [];
             if (editType) body.source_type = editType;
-            if (editUrl.trim()) body.source_url = editUrl.trim();
+            body.source_url = editUrl.trim();
             body.owner_notes = editNotes.trim();
             body.content = editContent.trim();
 
@@ -536,6 +540,7 @@
 
     onDestroy(() => {
         if (refreshInterval) clearInterval(refreshInterval);
+        if (graphLabelTimer) clearTimeout(graphLabelTimer);
         if (graphSim) { graphSim.stop(); graphSim = null; }
         if (graphFitCancel) { graphFitCancel(); graphFitCancel = null; }
     });
@@ -866,7 +871,7 @@
                                 font-size="12px"
                                 font-family="monospace"
                             >
-                                {hoveredNode.label} ({hoveredNode.degree})
+                                {hoveredNode.label} ({hoveredNode.degree ?? 0})
                             </text>
                         </g>
                     {/if}
@@ -901,10 +906,13 @@
                     <span class="meta-date">{formatDate(detailItem.filed_at)}</span>
                 {/if}
                 {#if detailItem.source_url}
-                    <a href={detailItem.source_url} target="_blank" rel="noopener" class="source-link">
-                        <span class="material-symbols-outlined" style="font-size:14px">open_in_new</span>
-                        source
-                    </a>
+                    {@const srcHref = safeExternalHref(detailItem.source_url)}
+                    {#if srcHref}
+                        <a href={srcHref} target="_blank" rel="noopener" class="source-link">
+                            <span class="material-symbols-outlined" style="font-size:14px">open_in_new</span>
+                            source
+                        </a>
+                    {/if}
                 {/if}
             {:else}
                 <Badge text="wiki" variant="model" />


### PR DESCRIPTION
Overnight frontend pass (Brad's ask), KnowledgeBase.svelte. Audited by Murzik + Barsik.

## Fixes
1. **Edit form couldn't clear tags or source URL.** `saveEdit` guarded each with `if (editTags.trim())` / `if (editUrl.trim())`, so emptying the field sent nothing — and the backend only ignores *absent/None* fields (verified in `kb_store.update_raw`: `if tags is not None` / `if source_url is not None`). So removal was a silent no-op. Now always send `tags` (`[]` when empty) and `source_url` (`''` clears) — **verified the store applies `[]`/`''` as a real clear**.
2. **Unsafe source link.** The detail-modal `source_url` rendered straight into `<a href target=_blank>` — a stored `javascript:`/`data:` URL would execute on click. Routed through `safeExternalHref` (the helper merged in #767); an unsafe URL now renders nothing instead of a live link. (Murzik #5.)
3. **Timer leak.** `graphLabelTimer` (a `setTimeout` from the graph wheel/zoom handler) was never cleared in `onDestroy` — added the clear.
4. **Tooltip `(undefined)`.** Raw graph nodes have no `degree`, so the hover tooltip showed `label (undefined)` → `(degree ?? 0)`.

## Deliberately not here
- Auto-reloading the graph in the 30s `refresh()`: switching *to* the Graph tab already calls `loadGraph()`, and forcing a reload on every poll would reheat the force sim and visibly jiggle nodes. Low value, churn risk — skipped.

## Verification
- `npm run build`: green (only pre-existing warnings).
- Backend clear-semantics verified by reading `routes/kb.py` + `kb_store.update_raw`.

Found by Murzik (#5) + Barsik audit.

🤖 Opened by Barsik