### PR TITLE
fix(frontend): Agents 'Chat' button selects the session (deep-link)

### DIFF
--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -459,7 +459,10 @@
     }
 
     function openChat(id) {
-        window.location.hash = `/chat#${id}`;
+        // `?session=<id>` is read by Chat's onMount, which selects that exact
+        // session after refreshSessions(). The old `/chat#<id>` form was ignored
+        // by the router, so the button landed on an empty "select a session".
+        window.location.hash = `/chat?session=${encodeURIComponent(id)}`;
     }
 
     function openGroupModal() { groupName = ''; groupMembers = ''; groupModalOpen = true; }

--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -1292,7 +1292,15 @@
         refreshInterval = setInterval(refreshSessions, 10000);
         document.addEventListener('click', handleGlobalClick);
         document.addEventListener('keydown', handleGlobalKeydown);
-        if (params?.agent && !activeSession) {
+        // Deep-link: `#/chat?session=<id>` (e.g. the Agents page "Chat" button)
+        // selects that exact session; `/chat/:agent` falls back to main.
+        const hashQ = window.location.hash.indexOf('?');
+        const deepSession = hashQ >= 0
+            ? new URLSearchParams(window.location.hash.slice(hashQ + 1)).get('session')
+            : null;
+        if (deepSession && !activeSession && sessionsList.some((s) => s.id === deepSession)) {
+            selectSession(deepSession, agentFromSessionId(deepSession));
+        } else if (params?.agent && !activeSession) {
             const mainSessionId = `${params.agent}-main`;
             if (sessionsList.some(s => s.id === mainSessionId)) selectSession(mainSessionId, params.agent);
         }


### PR DESCRIPTION
Overnight frontend pass (Brad's ask). Audited by Murzik (#4) + Barsik.

## Bug
The "Chat" button on each session row in the Agents page calls `openChat(s.id)`, which set `window.location.hash = '/chat#<sessionId>'`. But:
- `svelte-spa-router` ignores the second `#` fragment (routes match `/chat`), and
- `Chat`'s onMount only consumes the `:agent` route param.

So clicking "Chat" landed on the empty *"select a session"* state instead of the intended session.

## Fix
- `Agents.openChat(id)` → `window.location.hash = '/chat?session=<id>'`.
- `Chat` onMount reads `session` from the hash query and, after `refreshSessions()`, selects that exact session (deriving the agent via the existing `agentFromSessionId`). The `/chat/:agent` path still falls back to the agent's `-main` session.

Two-line change each side, reuses existing `selectSession` / `agentFromSessionId`.

## Verification
- `npm run build`: green (only pre-existing warnings).

Found by Murzik (#4) + Barsik audit.

🤖 Opened by Barsik