### PR TITLE
fix(frontend): harden misc page actions

### DIFF
--- a/frontend-svelte/src/pages/Analytics.svelte
+++ b/frontend-svelte/src/pages/Analytics.svelte
@@ -167,6 +167,7 @@
 
     async function selectAgent(name) {
         if (selectedAgent === name) {
+            detailSeq++;
             selectedAgent = null;
             agentDetail = null;
             return;
@@ -186,6 +187,7 @@
     }
 
     function changeRange(newRange) {
+        detailSeq++;
         range = newRange;
         loading = true;
         selectedAgent = null;

--- a/frontend-svelte/src/pages/Dashboard.svelte
+++ b/frontend-svelte/src/pages/Dashboard.svelte
@@ -27,6 +27,14 @@
 
     let refreshInterval;
     let uptimeInterval;
+    let stoppingAgents = new Set();
+
+    function setAgentStopping(name, stopping) {
+        const next = new Set(stoppingAgents);
+        if (stopping) next.add(name);
+        else next.delete(name);
+        stoppingAgents = next;
+    }
 
     function formatUptime() {
         if (!serverStartedAt) return '--';
@@ -54,15 +62,14 @@
     async function stopAgent(name, event) {
         event.preventDefault();
         event.stopPropagation();
-        const agent = agents.find(a => a.name === name);
-        if (agent?.stopping) return;
-        if (agent) { agent.stopping = true; agents = agents; }
+        if (stoppingAgents.has(name)) return;
+        setAgentStopping(name, true);
         try {
             await api('POST', `/agents/${name}/stop`);
             refresh();
         } catch (e) {
             toast(`Failed to stop ${name}`, 'error');
-            if (agent) { agent.stopping = false; agents = agents; }
+            setAgentStopping(name, false);
         }
     }
 
@@ -169,6 +176,7 @@
                     contextRestarts: restartsByAgent[agent.name] || 0,
                     workerCount: streamingSessions.filter(s => s.label !== 'main' && s.connected).length,
                     recommendation: health.recommendation || null,
+                    stopping: stoppingAgents.has(agent.name),
                 };
             }));
 
@@ -176,6 +184,7 @@
             const statusOrder = { online: 0, idle: 1, offline: 2, unknown: 3 };
             agentDetails.sort((a, b) => (statusOrder[a.status] ?? 3) - (statusOrder[b.status] ?? 3));
             agents = agentDetails;
+            stoppingAgents = new Set([...stoppingAgents].filter(name => agentDetails.some(a => a.name === name && a.connected)));
 
             const noisy = new Set(['agent_working', 'agent_idle']);
             const freshEvents = (activityData.events || []).filter(e => !noisy.has(e.event_type));

--- a/frontend-svelte/src/pages/Memories.svelte
+++ b/frontend-svelte/src/pages/Memories.svelte
@@ -18,7 +18,7 @@
     let activeOnly = true;
     let searchInput = '';
     let memLoading = false;
-    let memSeq = 0; let statsSeq = 0; let chatSeq = 0; let kgSeq = 0;
+    let memSeq = 0; let statsSeq = 0; let chatSeq = 0; let kgSeq = 0; let dreamSeq = 0;
 
     // Tab: memories vs chat vs dreams
     let activeTab = 'memories';
@@ -227,16 +227,25 @@
 
     async function loadDreamHistory() {
         dreamLoading = true;
+        const seq = ++dreamSeq; const agent = currentAgent;
         try {
-            if (currentAgent) {
-                const data = await api('GET', `/agents/${currentAgent}/dream/history`);
+            if (agent) {
+                const data = await api('GET', `/agents/${agent}/dream/history`);
+                if (seq !== dreamSeq || agent !== currentAgent) return;
                 dreamStates = data.dream_state ? [data.dream_state] : [];
             } else {
                 const data = await api('GET', '/dreams');
+                if (seq !== dreamSeq || agent !== currentAgent) return;
                 dreamStates = data.dream_states || [];
             }
-        } catch (e) { console.error('Dream history error:', e); dreamStates = []; }
-        dreamLoading = false;
+        } catch (e) {
+            if (seq === dreamSeq && agent === currentAgent) {
+                console.error('Dream history error:', e);
+                dreamStates = [];
+            }
+        } finally {
+            if (seq === dreamSeq && agent === currentAgent) dreamLoading = false;
+        }
     }
 
     async function triggerDream(agentName) {
@@ -518,6 +527,7 @@
     onMount(init);
     onDestroy(() => {
         kgDestroyed = true;
+        if (kgLabelTimer) clearTimeout(kgLabelTimer);
         if (kgSim) { kgSim.stop(); kgSim = null; }
         if (kgFitCancel) { kgFitCancel(); kgFitCancel = null; }
     });

--- a/frontend-svelte/src/pages/Onboarding.svelte
+++ b/frontend-svelte/src/pages/Onboarding.svelte
@@ -49,6 +49,12 @@
     let createdAgentName = '';
     let existingAgents = [];
 
+    function normalizeAgentsResponse(data) {
+        if (Array.isArray(data)) return data;
+        if (Array.isArray(data?.agents)) return data.agents;
+        return [];
+    }
+
     // Step 4: Channel
     let selectedPlatform = 'telegram';
     let platformToken = '';
@@ -78,8 +84,7 @@
                 ownerLanguages = profile.languages || '';
                 ownerCommStyle = profile.comm_style || '';
             } else if (step === 4) {
-                existingAgents = await api('GET', '/agents').catch(() => []);
-                if (!Array.isArray(existingAgents)) existingAgents = [];
+                existingAgents = normalizeAgentsResponse(await api('GET', '/agents').catch(() => []));
             } else if (step === 5) {
                 const platforms = await api('GET', '/outreach/platforms').catch(() => ({}));
                 configuredPlatforms = (platforms.platforms || []).filter(p => p.enabled);
@@ -97,7 +102,7 @@
                         api('GET', '/settings/owner-profile').catch(() => ({})),
                     ]);
                     authStatus = authResp;
-                    existingAgents = Array.isArray(agentsResp) ? agentsResp : [];
+                    existingAgents = normalizeAgentsResponse(agentsResp);
                     configuredPlatforms = (platformsResp.platforms || []).filter(p => p.enabled);
                     ownerName = profileResp.name || ownerName;
                 } finally {
@@ -191,7 +196,7 @@
             await api('POST', `/agents/${agentName}/streaming-sessions?label=main`);
             createdAgentName = agentName;
             agentCreated = true;
-            existingAgents = await api('GET', '/agents').catch(() => []);
+            existingAgents = normalizeAgentsResponse(await api('GET', '/agents').catch(() => []));
             toast(`${agentDisplayName || agentName} created`);
             // Auto-advance after brief pause so user sees the success
             advanceTimer = setTimeout(() => { advanceTimer = null; next(); }, 800);

--- a/frontend-svelte/src/pages/People.svelte
+++ b/frontend-svelte/src/pages/People.svelte
@@ -36,8 +36,23 @@
 
     // Pending flags to prevent double-submit
     let savingEntry = false;
+    let savingEdit = false;
     let savingRel = false;
     let deletingUser = false;
+    let deletingEntries = new Set();
+    let deletingRelationships = new Set();
+    let togglingVisibility = new Set();
+
+    function setPending(setValue, key, pending) {
+        const next = new Set(setValue);
+        if (pending) next.add(key);
+        else next.delete(key);
+        return next;
+    }
+
+    function visibilityPendingKey(uid, agentName) {
+        return `${uid || ''}:${agentName}`;
+    }
 
     const REL_TYPES = [
         'wife', 'husband', 'partner', 'friend', 'collaborator', 'colleague',
@@ -147,20 +162,28 @@
     }
 
     async function deleteRelationship(relId) {
+        if (deletingRelationships.has(relId)) return;
         if (!confirm('Remove this relationship?')) return;
+        deletingRelationships = setPending(deletingRelationships, relId, true);
         try {
             await api('DELETE', `/user-profiles/relationships/${relId}`);
             await loadRelationships();
             toast('Relationship removed');
         } catch (e) { toast('Failed to delete', 'error'); }
+        finally { deletingRelationships = setPending(deletingRelationships, relId, false); }
     }
 
     async function toggleVisibility(agentName, currentVisible) {
+        const uid = selectedUser;
+        const pendingKey = visibilityPendingKey(uid, agentName);
+        if (!uid || togglingVisibility.has(pendingKey)) return;
+        togglingVisibility = setPending(togglingVisibility, pendingKey, true);
         try {
-            await api('PUT', `/user-profiles/${selectedUser}/visibility/${agentName}`, { visible: !currentVisible });
-            await loadVisibility();
+            await api('PUT', `/user-profiles/${uid}/visibility/${agentName}`, { visible: !currentVisible });
+            await loadVisibility(uid);
             toast(`${agentName}: ${!currentVisible ? 'visible' : 'hidden'}`);
         } catch (e) { toast('Failed to update visibility', 'error'); }
+        finally { togglingVisibility = setPending(togglingVisibility, pendingKey, false); }
     }
 
     function startEdit(entry) {
@@ -170,24 +193,35 @@
     }
 
     async function saveEdit() {
+        if (savingEdit) return;
+        const value = String(editValue ?? '').trim();
+        if (!value) {
+            toast('Value is required', 'error');
+            return;
+        }
+        savingEdit = true;
         try {
             await api('PUT', `/user-profiles/entries/${editingEntry}`, {
-                value: editValue,
+                value,
                 confidence: editConfidence,
             });
             editingEntry = null;
             await loadEntries();
             toast('Updated');
         } catch (e) { toast('Failed to update', 'error'); }
+        finally { savingEdit = false; }
     }
 
     async function deleteEntry(id) {
+        if (deletingEntries.has(id)) return;
         if (!confirm('Delete this entry?')) return;
+        deletingEntries = setPending(deletingEntries, id, true);
         try {
             await api('DELETE', `/user-profiles/entries/${id}`);
             await loadEntries();
             toast('Deleted');
         } catch (e) { toast('Failed to delete', 'error'); }
+        finally { deletingEntries = setPending(deletingEntries, id, false); }
     }
 
     async function addEntry() {
@@ -355,8 +389,8 @@
                                             <span class="entry-key">{entry.key}</span>
                                             <input type="text" bind:value={editValue} class="edit-input">
                                             <input type="range" min="0" max="1" step="0.1" bind:value={editConfidence} style="width:60px" title="Confidence">
-                                            <button class="btn btn-xs btn-primary" on:click={saveEdit}>Save</button>
-                                            <button class="btn btn-xs" on:click={() => { editingEntry = null; }}>Cancel</button>
+                                            <button class="btn btn-xs btn-primary" on:click={saveEdit} disabled={savingEdit}>Save</button>
+                                            <button class="btn btn-xs" on:click={() => { editingEntry = null; }} disabled={savingEdit}>Cancel</button>
                                         </div>
                                     {:else}
                                         <div class="entry-content">
@@ -370,7 +404,7 @@
                                             <button class="btn-icon" on:click={() => startEdit(entry)} title="Edit">
                                                 <span class="material-symbols-outlined" style="font-size:0.85rem">edit</span>
                                             </button>
-                                            <button class="btn-icon" on:click={() => deleteEntry(entry.id)} title="Delete">
+                                            <button class="btn-icon" on:click={() => deleteEntry(entry.id)} disabled={deletingEntries.has(entry.id)} title="Delete">
                                                 <span class="material-symbols-outlined" style="font-size:0.85rem">delete</span>
                                             </button>
                                         </div>
@@ -441,7 +475,7 @@
                                             <span class="rel-context">{rel.context}</span>
                                         {/if}
                                         <span class="confidence-badge" style="color:{confidenceColor(rel.confidence)}">{confidenceLabel(rel.confidence)}</span>
-                                        <button class="btn-icon" on:click={() => deleteRelationship(rel.id)} title="Remove">
+                                        <button class="btn-icon" on:click={() => deleteRelationship(rel.id)} disabled={deletingRelationships.has(rel.id)} title="Remove">
                                             <span class="material-symbols-outlined" style="font-size:0.85rem">close</span>
                                         </button>
                                     </div>
@@ -484,6 +518,7 @@
                                     class="visibility-chip"
                                     class:visible={v.visible}
                                     on:click={() => toggleVisibility(v.agent_name, v.visible)}
+                                    disabled={togglingVisibility.has(visibilityPendingKey(selectedUser, v.agent_name))}
                                 >
                                     <span class="material-symbols-outlined" style="font-size:0.85rem">
                                         {v.visible ? 'visibility' : 'visibility_off'}


### PR DESCRIPTION
🤖 Opened by Murzik

## Summary
- add stale-response guards for Memories dream history and Analytics agent detail deselect/range changes
- prevent duplicate People profile edit/delete/visibility actions and reject empty edited values
- preserve Dashboard stop-agent pending state across refresh rebuilds
- normalize Onboarding `/agents` responses whether the API returns an array or `{ agents: [...] }`

## Validation
- `npm run build` in `frontend-svelte/` (passes; only existing Vite outDir / dynamic import / chunk-size warnings)
- `git diff --check`
