### PR TITLE
fix(frontend): define legacy/semantic CSS tokens so they stop falling back

### DIFF
--- a/frontend-svelte/src/app.css
+++ b/frontend-svelte/src/app.css
@@ -94,6 +94,20 @@
     --gray-mid: var(--text-muted);
     --gray-dark: var(--text-secondary);
     --black: var(--text-primary);
+    /* Back-compat aliases for legacy token names still referenced by some
+       components (Analytics, ChatInput, ProviderConfig, TabBar, ChatSidebar,
+       Agents, Settings). They resolve through the theme-aware tokens, so they
+       follow light/dark automatically and undefined-var fallbacks disappear. */
+    --text: var(--text-primary);
+    --bg: var(--app-bg);
+    --bg-secondary: var(--surface-2);
+    --bg-hover: var(--hover-soft);
+    --radius-md: var(--radius-lg);
+    /* Semantic tokens a few components reference with hardcoded fallbacks;
+       define them once (theme-aware) so e.g. LocalePicker's border doesn't fall
+       back to a dark rgba in light mode. */
+    --border-subtle: var(--surface-3);
+    --text-error: var(--red);
 }
 
 :root[data-theme='dark'] {


### PR DESCRIPTION
Overnight frontend pass (Brad's ask), `src/app.css`. Found by Murzik (#9, #16) + a full undefined-token scan.

## Problem
Several components reference CSS custom properties that were never defined globally, so they resolved to invalid/inherited values (no-fallback uses) or theme-inappropriate hardcoded fallbacks. Affected: Analytics, ChatInput, ProviderConfig, TabBar, ChatSidebar, Agents, Settings, LocalePicker.

## Fix
Add aliases in `:root` that resolve **through** the existing theme-aware tokens, so they follow light/dark automatically (same lazy-substitution pattern the file already uses for `--white`/`--gray-*`):

| alias | → |
|---|---|
| `--text` | `--text-primary` |
| `--bg` | `--app-bg` |
| `--bg-secondary` | `--surface-2` |
| `--bg-hover` | `--hover-soft` |
| `--radius-md` | `--radius-lg` |
| `--border-subtle` | `--surface-3` |
| `--text-error` | `--red` |

Single-place fix — no per-component churn.

## Scanned, deliberately left
A full `var(--x)` vs defined-token diff turned up a few more, but they all have **inline fallbacks** and render fine: `--seg-hue` (set dynamically inline), and `--warning-bg` / `--accent2` / `--tone-amber-bg` / `--tone-amber-text` (hardcoded fallbacks). Some of those fallbacks are theme-inappropriate (e.g. `--tone-amber-bg`'s `#3a3520` is dark, used in light mode), but giving them proper theme values is a **design color choice**, not a mechanical alias — flagging for a follow-up rather than guessing.

## Verification
- `npm run build`: green (only pre-existing warnings).
- Verified every alias target exists in both `:root` and `:root[data-theme='dark']`.

🤖 Opened by Barsik