### PR TITLE
fix(frontend): route amber/warning badges to theme-aware tone tokens

### DIFF
--- a/frontend-svelte/src/pages/Agents.svelte
+++ b/frontend-svelte/src/pages/Agents.svelte
@@ -1116,7 +1116,7 @@
 
     function importStatusBadgeStyle(status) {
         if (status === 'ok') return 'background:var(--tone-success-bg,#d1fae5);color:var(--tone-success-text,#065f46)';
-        if (status === 'warn') return 'background:var(--warning-bg,#fef3c7);color:#92400e';
+        if (status === 'warn') return 'background:var(--tone-warning-bg,#fef3c7);color:var(--tone-warning-text,#92400e)';
         return 'background:rgba(239,68,68,0.15);color:var(--red,#ef4444)';
     }
     function importStatusIcon(status) {
@@ -2021,7 +2021,7 @@
                     </button>
                 </div>
                 {#if skillsPendingApply}
-                    <div style="background:var(--warning-bg, #fff3cd);border:none;border-radius:var(--radius-lg);padding:0.5rem 0.8rem;font-size:0.75rem;margin-top:0.5rem">
+                    <div style="background:var(--tone-warning-bg, #fff3cd);border:none;border-radius:var(--radius-lg);padding:0.5rem 0.8rem;font-size:0.75rem;margin-top:0.5rem">
                         {$_('agents.skill_pending_note')}
                     </div>
                 {/if}
@@ -2176,7 +2176,7 @@
                         <div class="token-item" style="flex-wrap:wrap;gap:0.4rem;{!s.enabled ? 'opacity:0.5' : ''}">
                             <span style="font-family:var(--font-grotesk);font-size:0.8rem;font-weight:700">{s.name || 'unnamed'}</span>
                             <span style="font-family:var(--font-grotesk);font-size:0.75rem;color:var(--gray-mid)">{s.cron}</span>
-                            {#if s.one_shot}<span class="badge" style="background:var(--tone-amber-bg,#3a3520);color:var(--tone-amber-text,#d4a);font-size:0.65rem">once</span>{/if}
+                            {#if s.one_shot}<span class="badge" style="background:var(--tone-warning-bg,#FEF3C7);color:var(--tone-warning-text,#92400e);font-size:0.65rem">once</span>{/if}
                             <span class="badge badge-{s.enabled ? 'on' : 'off'}">{s.enabled ? $_('common.active') : $_('common.off')}</span>
                             <span style="flex:1"></span>
                             <button class="btn btn-sm" on:click={() => toggleSchedule(s.id, !s.enabled)}>{s.enabled ? $_('common.disable') : $_('common.enable')}</button>

--- a/frontend-svelte/src/pages/Dashboard.svelte
+++ b/frontend-svelte/src/pages/Dashboard.svelte
@@ -375,7 +375,7 @@
                             <span class="feed-icon" style="color:var(--tone-lilac-text)">⏱</span>
                             <span class="feed-agent">{sched.agent_name}</span>
                             <span class="feed-title" title={sched.name}>{sched.name}</span>
-                            <span class="sched-cron mono">{sched.cron}{#if sched.one_shot} <span style="color:var(--tone-amber-text,#d4a);font-size:0.65rem">once</span>{/if}</span>
+                            <span class="sched-cron mono">{sched.cron}{#if sched.one_shot} <span style="color:var(--tone-warning-text,#92400e);font-size:0.65rem">once</span>{/if}</span>
                             <span class="feed-time">{formatNextRun(sched.next_run)}</span>
                         </div>
                     {/each}


### PR DESCRIPTION
## What
Route 4 frontend badge/pill call sites from **undefined** design tokens to the existing theme-aware tone tokens.

## Why
`--tone-amber-bg`, `--tone-amber-text`, and `--warning-bg` are referenced but never defined in `app.css`, so they fell back to their inline fallbacks:

- **Magenta "once" badges** — one-shot schedule badges (Dashboard feed + Agents schedules) rendered `#d4a` magenta instead of amber.
- **Dark-mode warn pill** — the agent import "warn" status pill used `--warning-bg` (→ fixed light amber) plus a hardcoded `#92400e` text color, which is unreadable on a dark surface.

`amber` isn't one of the defined tones (`success / error / info / warning / neutral / lilac`) — and `warning` **is** the amber tone. So all four now use `--tone-warning-bg` / `--tone-warning-text`, exactly matching the sibling `'ok'` / `'error'` badges in `importStatusBadgeStyle`. **No new tokens added.**

## Scope
| File | Sites |
|------|-------|
| `Agents.svelte` | warn status pill, skill-pending box, schedule "once" badge |
| `Dashboard.svelte` | schedule "once" badge |

4 lines, 2 files. Frontend build green locally. Pure cosmetic token-routing — verifiable from the diff.

Completes the deferred "amber / warning-bg tokens" follow-up to #774.

🤖 Opened by Barsik