### PR TITLE
fix(api): serialize cold-start boots to stop shared-OAuth fleet de-auth (#202)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import hmac
 import json
@@ -218,6 +219,69 @@ COLD_START_CONNECT_TIMEOUT_SEC = float(
     os.environ.get("PINKY_COLD_START_CONNECT_TIMEOUT_SEC", "120")
 )
 
+# ── Cold-start serialization (#202) ──────────────────────────
+# The Claude OAuth credentials file (``~/.claude/.credentials.json``) is shared
+# by every agent in a fleet that shares ``$HOME``, and its refresh token is
+# *single-use* — the auth server rotates it on each refresh. When several agents
+# boot a fresh ``claude`` at once (the daemon-restart boot loop, or a watchdog
+# batch-resurrection), their concurrent token refreshes race: one wins the
+# rotation and the rest fail with a now-invalid refresh token, de-authing most
+# of the fleet (the "thundering herd"). Serializing the spawn→ready window —
+# plus a short post-ready settle so the just-booted process can flush its
+# rotated token to disk — removes the race; each refresh completes and persists
+# before the next boot starts.
+#
+# Default OFF (flag-gated soak, per trust rails): enable with
+# ``PINKY_COLDSTART_SERIALIZE=1`` on a fleet that shares creds. Scope is *fresh
+# boots only* (cold start + resurrection); warm reconnects / interactive wakes
+# don't pass through the gate, so they keep their lock-free latency.
+COLDSTART_SERIALIZE = os.environ.get(
+    "PINKY_COLDSTART_SERIALIZE", "0"
+).strip().lower() in ("1", "true", "yes", "on")
+COLDSTART_SETTLE_SEC = float(os.environ.get("PINKY_COLDSTART_SETTLE_SEC", "3.0"))
+
+# Process-global gate. Lazily created and rebound if the running loop changes
+# (keeps a single instance in the daemon's one loop; stays correct under
+# pytest-asyncio's per-test loops).
+_coldstart_lock: "asyncio.Lock | None" = None
+_coldstart_lock_loop = None
+
+
+def _get_coldstart_lock() -> "asyncio.Lock":
+    """Return the process-global cold-start lock bound to the running loop."""
+    global _coldstart_lock, _coldstart_lock_loop
+    loop = asyncio.get_running_loop()
+    if _coldstart_lock is None or _coldstart_lock_loop is not loop:
+        _coldstart_lock = asyncio.Lock()
+        _coldstart_lock_loop = loop
+    return _coldstart_lock
+
+
+@contextlib.asynccontextmanager
+async def _coldstart_gate(agent_name: str, label: str):
+    """Serialize a fresh-``claude`` boot across the process (#202).
+
+    No-op (no lock, no settle) when ``COLDSTART_SERIALIZE`` is disabled. When
+    enabled, holds a process-global lock for the duration of the wrapped boot
+    and, on success, sleeps ``COLDSTART_SETTLE_SEC`` before releasing so the
+    just-booted process flushes its rotated OAuth token before the next boot
+    begins. The settle is skipped if the wrapped boot raises — a failed boot
+    rotated nothing worth waiting on, and the next attempt shouldn't be delayed.
+    """
+    if not COLDSTART_SERIALIZE:
+        yield
+        return
+    lock = _get_coldstart_lock()
+    if lock.locked():
+        _log(
+            f"streaming-start: {agent_name}/{label} cold boot queued — "
+            f"serializing behind an in-flight boot (#202)"
+        )
+    async with lock:
+        yield
+        if COLDSTART_SETTLE_SEC > 0:
+            await asyncio.sleep(COLDSTART_SETTLE_SEC)
+
 
 async def _bounded_cold_start_connect(
     ss,
@@ -235,22 +299,28 @@ async def _bounded_cold_start_connect(
     bypassing that handler and leaving an unregistered-but-connected client. So
     we always best-effort ``disconnect()`` before re-raising; the caller must
     treat any raise as "do NOT register this session".
+
+    #202: the spawn→ready window runs under the process-global cold-start gate
+    (``_coldstart_gate``) so concurrent boots don't race the shared single-use
+    OAuth refresh token. The gate is a no-op unless ``PINKY_COLDSTART_SERIALIZE``
+    is enabled.
     """
-    try:
-        await asyncio.wait_for(ss.connect(), timeout=timeout)
-    except asyncio.TimeoutError:
-        _log(
-            f"streaming-start: cold start timed out for {agent_name}/{label} "
-            f"after {timeout:.0f}s — discarding unregistered session"
-        )
+    async with _coldstart_gate(agent_name, label):
         try:
-            await ss.disconnect()
-        except Exception as de:  # best-effort cleanup; never mask the timeout
+            await asyncio.wait_for(ss.connect(), timeout=timeout)
+        except asyncio.TimeoutError:
             _log(
-                f"streaming-start: post-timeout disconnect failed for "
-                f"{agent_name}/{label}: {de}"
+                f"streaming-start: cold start timed out for {agent_name}/{label} "
+                f"after {timeout:.0f}s — discarding unregistered session"
             )
-        raise
+            try:
+                await ss.disconnect()
+            except Exception as de:  # best-effort cleanup; never mask the timeout
+                _log(
+                    f"streaming-start: post-timeout disconnect failed for "
+                    f"{agent_name}/{label}: {de}"
+                )
+            raise
 
 
 # ── Request/Response Models ──────────────────────────────────
@@ -8808,27 +8878,31 @@ npm run build</pre>
             return
         _log(f"api: watchdog resurrection — reconnecting {agent_name}")
         try:
-            # TODO(#338-followup): wrap in asyncio.create_task so the scheduler
-            # tick isn't blocked for up to ~40s during the internal backoff.
-            attempt_reconnect = getattr(ss, "attempt_reconnect", None)
-            if callable(attempt_reconnect):
-                await attempt_reconnect()
-            else:
-                # Runtime-tolerant fallback for future StreamingSession-compatible
-                # implementations that have connect/disconnect but not the richer
-                # watchdog reconnect helper yet.
-                try:
-                    disconnect = getattr(ss, "disconnect", None)
-                    if callable(disconnect):
-                        await disconnect()
-                except Exception as e:
-                    _log(f"api: resurrection pre-disconnect failed for {agent_name}: {e}")
-                connect = getattr(ss, "connect", None)
-                if not callable(connect):
-                    raise AttributeError(
-                        f"{ss.__class__.__name__} has no attempt_reconnect or connect"
-                    )
-                await connect()
+            # #202: serialize the fresh boot behind the process-global cold-start
+            # gate so a watchdog batch-resurrection doesn't race the shared
+            # single-use OAuth refresh token (no-op unless PINKY_COLDSTART_SERIALIZE).
+            async with _coldstart_gate(agent_name, "main"):
+                # TODO(#338-followup): wrap in asyncio.create_task so the scheduler
+                # tick isn't blocked for up to ~40s during the internal backoff.
+                attempt_reconnect = getattr(ss, "attempt_reconnect", None)
+                if callable(attempt_reconnect):
+                    await attempt_reconnect()
+                else:
+                    # Runtime-tolerant fallback for future StreamingSession-compatible
+                    # implementations that have connect/disconnect but not the richer
+                    # watchdog reconnect helper yet.
+                    try:
+                        disconnect = getattr(ss, "disconnect", None)
+                        if callable(disconnect):
+                            await disconnect()
+                    except Exception as e:
+                        _log(f"api: resurrection pre-disconnect failed for {agent_name}: {e}")
+                    connect = getattr(ss, "connect", None)
+                    if not callable(connect):
+                        raise AttributeError(
+                            f"{ss.__class__.__name__} has no attempt_reconnect or connect"
+                        )
+                    await connect()
             if getattr(ss, "state", None) == TransportSessionState.CONNECTED:
                 activity.log(
                     agent_name, "watchdog_resurrect",

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -9091,7 +9091,12 @@ npm run build</pre>
         if hasattr(ss, "codex_session_id"):
             ss.codex_session_id = ""
         try:
-            await ss.connect()
+            # #202: a force-fresh MCP recovery boots a brand-new `claude`, so
+            # serialize it behind the cold-start gate too — it's globally
+            # rate-limited, but can still overlap a daemon cold boot / manual
+            # cold start and race the shared single-use OAuth refresh token.
+            async with _coldstart_gate(agent_name, label):
+                await ss.connect()
             session_event_store.log(
                 session_id=ss.id,
                 agent_name=agent_name,

--- a/tests/test_coldstart_serialize.py
+++ b/tests/test_coldstart_serialize.py
@@ -1,0 +1,152 @@
+"""Cold-start serialization gate (#202).
+
+A fleet that shares ``$HOME`` shares one Claude OAuth credentials file whose
+refresh token is single-use (rotated on every refresh). When several agents
+boot a fresh ``claude`` at once — the daemon-restart boot loop or a watchdog
+batch-resurrection — their concurrent token refreshes race: one wins the
+rotation and the rest die with a now-invalid refresh token, de-authing most of
+the fleet.
+
+``_coldstart_gate`` serializes the spawn→ready window behind a process-global
+lock (plus a short post-ready settle so the just-booted process flushes its
+rotated token before the next boot starts). It is flag-gated
+(``PINKY_COLDSTART_SERIALIZE``) and defaults OFF.
+
+These tests drive ``_bounded_cold_start_connect`` (which wraps its connect in
+the gate) with a fake session that records boot concurrency and timing.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pinky_daemon import api
+
+
+@pytest.fixture(autouse=True)
+def _reset_gate(monkeypatch):
+    """Each test starts with a fresh, unbound process-global gate."""
+    monkeypatch.setattr(api, "_coldstart_lock", None)
+    monkeypatch.setattr(api, "_coldstart_lock_loop", None)
+    yield
+
+
+class _Recorder:
+    def __init__(self, loop):
+        self._loop = loop
+        self.active = 0
+        self.max_active = 0
+        self.events: list[tuple[str, str, float]] = []
+
+    def mark(self, kind: str, name: str) -> None:
+        self.events.append((kind, name, self._loop.time()))
+
+
+class _FakeBootSession:
+    """connect() that tracks concurrency; can run fast or wedge (for timeout)."""
+
+    def __init__(self, rec: _Recorder, name: str, *, delay: float = 0.05, fail: bool = False):
+        self.rec = rec
+        self.name = name
+        self.delay = delay
+        self.fail = fail
+        self.disconnect_called = False
+
+    async def connect(self) -> None:
+        self.rec.active += 1
+        self.rec.max_active = max(self.rec.max_active, self.rec.active)
+        self.rec.mark("start", self.name)
+        try:
+            if self.fail:
+                await asyncio.sleep(3600)  # cancelled by the umbrella timeout
+            await asyncio.sleep(self.delay)
+        finally:
+            self.rec.active -= 1
+        self.rec.mark("end", self.name)
+
+    async def disconnect(self) -> None:
+        self.disconnect_called = True
+
+
+async def _boot(ss, name: str):
+    await api._bounded_cold_start_connect(ss, agent_name=name, label="main")
+
+
+@pytest.mark.asyncio
+async def test_serialized_boots_never_overlap(monkeypatch):
+    monkeypatch.setattr(api, "COLDSTART_SERIALIZE", True)
+    monkeypatch.setattr(api, "COLDSTART_SETTLE_SEC", 0.0)
+    rec = _Recorder(asyncio.get_running_loop())
+    a = _FakeBootSession(rec, "A", delay=0.05)
+    b = _FakeBootSession(rec, "B", delay=0.05)
+    await asyncio.gather(_boot(a, "A"), _boot(b, "B"))
+    assert rec.max_active == 1, f"serialized boots must not overlap (max_active={rec.max_active})"
+    kinds = [(k, n) for (k, n, _t) in rec.events]
+    assert kinds in (
+        [("start", "A"), ("end", "A"), ("start", "B"), ("end", "B")],
+        [("start", "B"), ("end", "B"), ("start", "A"), ("end", "A")],
+    ), f"boots interleaved: {kinds}"
+
+
+@pytest.mark.asyncio
+async def test_disabled_gate_allows_overlap_and_creates_no_lock(monkeypatch):
+    monkeypatch.setattr(api, "COLDSTART_SERIALIZE", False)
+    rec = _Recorder(asyncio.get_running_loop())
+    a = _FakeBootSession(rec, "A", delay=0.1)
+    b = _FakeBootSession(rec, "B", delay=0.1)
+    await asyncio.gather(_boot(a, "A"), _boot(b, "B"))
+    assert rec.max_active == 2, "without serialization, concurrent boots should overlap"
+    assert api._coldstart_lock is None, "disabled gate must not create a lock"
+
+
+@pytest.mark.asyncio
+async def test_settle_delays_the_next_boot(monkeypatch):
+    monkeypatch.setattr(api, "COLDSTART_SERIALIZE", True)
+    monkeypatch.setattr(api, "COLDSTART_SETTLE_SEC", 0.3)
+    loop = asyncio.get_running_loop()
+    rec = _Recorder(loop)
+    a = _FakeBootSession(rec, "A", delay=0.0)
+    b = _FakeBootSession(rec, "B", delay=0.0)
+    ta = asyncio.create_task(_boot(a, "A"))
+    await asyncio.sleep(0.02)  # ensure A grabs the lock first
+    tb = asyncio.create_task(_boot(b, "B"))
+    await asyncio.gather(ta, tb)
+    starts = {n: t for (k, n, t) in rec.events if k == "start"}
+    # A is instantaneous but holds the lock through the 0.3s settle, so B's
+    # boot can't start until ~settle after A's.
+    assert starts["B"] - starts["A"] >= 0.25, (
+        f"settle did not hold the gate (gap={starts['B'] - starts['A']:.3f}s)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_boot_skips_settle_and_releases_lock(monkeypatch):
+    monkeypatch.setattr(api, "COLDSTART_SERIALIZE", True)
+    # A huge settle that would hang the test if (wrongly) applied after a failure.
+    monkeypatch.setattr(api, "COLDSTART_SETTLE_SEC", 10.0)
+    loop = asyncio.get_running_loop()
+    rec = _Recorder(loop)
+    bad = _FakeBootSession(rec, "BAD", fail=True)
+    t0 = loop.time()
+    with pytest.raises(asyncio.TimeoutError):
+        await api._bounded_cold_start_connect(
+            bad, agent_name="BAD", label="main", timeout=0.05
+        )
+    elapsed = loop.time() - t0
+    assert elapsed < 1.0, f"failed boot must skip the 10s settle (took {elapsed:.2f}s)"
+    assert bad.disconnect_called, "umbrella cleanup must still run under the gate"
+    assert not api._get_coldstart_lock().locked(), "lock must be released after a failed boot"
+
+
+@pytest.mark.asyncio
+async def test_lock_is_singleton_within_a_loop():
+    assert api._get_coldstart_lock() is api._get_coldstart_lock()
+
+
+def test_default_is_off():
+    """Ships disabled — enabled per-fleet via env, soaked before flipping default."""
+    import os
+
+    assert os.environ.get("PINKY_COLDSTART_SERIALIZE") in (None, "", "0", "false", "off", "no")
+    assert api.COLDSTART_SERIALIZE is False


### PR DESCRIPTION
## Problem (#202)

A fleet that shares `\$HOME` shares **one** Claude OAuth credentials file (`~/.claude/.credentials.json`), and its refresh token is **single-use** — the auth server rotates it on every refresh. When several agents boot a fresh `claude` at once, their concurrent token refreshes race: one wins the rotation, the rest fail with a now-invalid refresh token and de-auth. This is the recurring TOD fleet outage (and the same class of bug noted on the Mini in `shared-cred-refresh-race`).

Two paths boot a fresh `claude` concurrently:
- **Daemon-restart boot loop** — `_start_streaming_session` → `_bounded_cold_start_connect` for every agent at once.
- **Watchdog batch-resurrection** — `_heartbeat_resurrect` reconnecting several dead agents.

## Fix

A process-global **cold-start gate** (`_coldstart_gate`) that serializes the spawn→ready window so only one `claude` boots at a time, plus a short **post-ready settle** so the just-booted process flushes its rotated token to disk before the next boot starts. Applied at both fresh-boot choke points above.

- **Warm reconnects / interactive wakes** (`_ensure_streaming_session`'s CONNECTED/IDLE path) do **not** pass through the gate — they keep their lock-free latency.
- The lock **rebinds on event-loop change**, so it's a true singleton in the daemon's one loop while staying correct under pytest-asyncio's per-test loops.
- Settle is **skipped on a failed boot** (a failed boot rotated nothing worth waiting on; don't delay the retry).

## Flagging / rollout

Default **OFF**. Enable per-fleet with `PINKY_COLDSTART_SERIALIZE=1` (settle tunable via `PINKY_COLDSTART_SETTLE_SEC`, default `3.0`). Per our trust rails (flag-gate → soak → flip), it's being enabled on the **TOD fleet first** to soak before any default flip on the Mini.

## Tests

6 new (`tests/test_coldstart_serialize.py`): serialization (no overlap), no-op-when-disabled (+ no lock created), settle timing holds the next boot, failed boot skips settle and releases the lock, lock singleton, default-off. Existing `tests/test_cold_start_umbrella.py` unchanged and green (gate is a no-op by default).

```
$ pytest tests/test_coldstart_serialize.py tests/test_cold_start_umbrella.py -q
11 passed in 1.14s
$ pytest tests/test_session_watchdog.py tests/test_scheduler.py -q
127 passed in 0.78s
```

> Backend concurrency fix — no UI surface. Evidence is the test runs above plus the live serialized-boot log lines (`… cold boot queued — serializing behind an in-flight boot (#202)`) captured on the TOD deploy, posted as a comment after rollout.

🤖 Opened by Barsik