### PR TITLE
fix(auth): forward static CLAUDE_CODE_OAUTH_TOKEN into agent session env (#780)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1226,14 +1226,16 @@ class TmuxSession:
             "0", "false", "no",
         ):
             return
-        # #780: when the static token is being forwarded, claude authenticates
-        # via CLAUDE_CODE_OAUTH_TOKEN and never refreshes — so don't seed the
-        # refresh-prone OAuth creds at all. With no .credentials.json present
-        # there is nothing for concurrent agents to race on.
-        if self._static_oauth_token():
+        # #780: when static-token forwarding is enabled, claude authenticates
+        # via CLAUDE_CODE_OAUTH_TOKEN (no refresh) — never seed the refresh-prone
+        # .credentials.json. Keyed on the FLAG, not token presence: fail CLOSED
+        # so a rollout misconfig (flag on, token missing) surfaces as a loud
+        # login wall instead of silently falling back to the shared refresh-
+        # token file (Murzik #781 P2).
+        if self._forward_oauth_enabled():
             _log(
-                f"tmux[{self.agent_name}]: static OAuth token forwarding active — "
-                f"skipping container creds seed (#780)"
+                f"tmux[{self.agent_name}]: static OAuth token forwarding enabled — "
+                f"skipping container creds seed (#780; fail-closed if token absent)"
             )
             return
         wd = (self._config.working_dir or "").strip()
@@ -2350,9 +2352,24 @@ class TmuxSession:
         )
         return cmd
 
+    def _forward_oauth_enabled(self) -> bool:
+        """Whether static OAuth-token forwarding is enabled (#780).
+
+        Flag-gated (``PINKY_FORWARD_OAUTH_TOKEN``, default OFF) for staged
+        rollout/soak. This is the operator's *intent* signal: when ON, the
+        fleet is meant to authenticate via a long-lived static token, so the
+        refresh-prone ``.credentials.json`` container seed is suppressed
+        REGARDLESS of whether the token is currently set — a misconfig (flag
+        on, token missing) must fail CLOSED (a loud login wall) rather than
+        silently fall back to the shared refresh-token file (Murzik #781 P2).
+        """
+        return os.environ.get("PINKY_FORWARD_OAUTH_TOKEN", "0").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+
     def _static_oauth_token(self) -> str:
-        """The long-lived ``CLAUDE_CODE_OAUTH_TOKEN`` to forward into this
-        session's env, or ``""`` when static-token forwarding is inactive (#780).
+        """The long-lived ``CLAUDE_CODE_OAUTH_TOKEN`` to inject into this
+        session's env, or ``""`` when forwarding is inactive/withheld (#780).
 
         A ``claude setup-token`` token (``sk-ant-oat01-…``, ~1yr, NEVER
         refreshed) authenticates without ever touching the single-use OAuth
@@ -2361,17 +2378,15 @@ class TmuxSession:
         cold-start serialization only narrows that window; the in-REPL refresh
         still races, so a static token is the durable fix.
 
-        Flag-gated (``PINKY_FORWARD_OAUTH_TOKEN``, default OFF) for staged
-        rollout/soak. Withheld for custom-provider agents: that path already
-        injects ``ANTHROPIC_API_KEY``/``ANTHROPIC_AUTH_TOKEN`` (higher auth
-        precedence), and a gateway-routed agent must not also present a
-        subscription token.
+        Withheld for custom-provider agents — keyed on ``provider_url`` OR
+        ``provider_key`` (Murzik #781 P1): provider resolution can yield
+        ``(url, "", model)`` (a non-default base URL with an EMPTY key), and a
+        first-party Claude subscription token must NEVER be presented to a
+        gateway / custom base URL, even when no key is set.
         """
-        if self._config.provider_key:
+        if not self._forward_oauth_enabled():
             return ""
-        if os.environ.get("PINKY_FORWARD_OAUTH_TOKEN", "0").strip().lower() not in (
-            "1", "true", "yes", "on",
-        ):
+        if (self._config.provider_url or "").strip() or self._config.provider_key:
             return ""
         return os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
 

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1226,6 +1226,16 @@ class TmuxSession:
             "0", "false", "no",
         ):
             return
+        # #780: when the static token is being forwarded, claude authenticates
+        # via CLAUDE_CODE_OAUTH_TOKEN and never refreshes — so don't seed the
+        # refresh-prone OAuth creds at all. With no .credentials.json present
+        # there is nothing for concurrent agents to race on.
+        if self._static_oauth_token():
+            _log(
+                f"tmux[{self.agent_name}]: static OAuth token forwarding active — "
+                f"skipping container creds seed (#780)"
+            )
+            return
         wd = (self._config.working_dir or "").strip()
         if not wd or not Path(wd).is_absolute():
             return
@@ -2340,6 +2350,31 @@ class TmuxSession:
         )
         return cmd
 
+    def _static_oauth_token(self) -> str:
+        """The long-lived ``CLAUDE_CODE_OAUTH_TOKEN`` to forward into this
+        session's env, or ``""`` when static-token forwarding is inactive (#780).
+
+        A ``claude setup-token`` token (``sk-ant-oat01-…``, ~1yr, NEVER
+        refreshed) authenticates without ever touching the single-use OAuth
+        refresh token in ``.credentials.json`` — eliminating the shared-creds
+        refresh race that de-auths a fleet on concurrent cold-start. The #777
+        cold-start serialization only narrows that window; the in-REPL refresh
+        still races, so a static token is the durable fix.
+
+        Flag-gated (``PINKY_FORWARD_OAUTH_TOKEN``, default OFF) for staged
+        rollout/soak. Withheld for custom-provider agents: that path already
+        injects ``ANTHROPIC_API_KEY``/``ANTHROPIC_AUTH_TOKEN`` (higher auth
+        precedence), and a gateway-routed agent must not also present a
+        subscription token.
+        """
+        if self._config.provider_key:
+            return ""
+        if os.environ.get("PINKY_FORWARD_OAUTH_TOKEN", "0").strip().lower() not in (
+            "1", "true", "yes", "on",
+        ):
+            return ""
+        return os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+
     def _build_repl_env(self) -> dict[str, str]:
         """Env vars injected into the tmux session.
 
@@ -2369,6 +2404,17 @@ class TmuxSession:
         if self._config.provider_key:
             env["ANTHROPIC_API_KEY"] = self._config.provider_key
             env["ANTHROPIC_AUTH_TOKEN"] = self._config.provider_key
+        # Static OAuth token forwarding (#780): inject a long-lived, never-
+        # refreshed CLAUDE_CODE_OAUTH_TOKEN so claude authenticates with it
+        # instead of the single-use refresh token in .credentials.json (no
+        # refresh ⇒ no shared-creds de-auth race). ESSENTIAL for container
+        # agents — their isolated env does NOT inherit the daemon env, so
+        # without this -e the token never reaches them; local tmux agents get
+        # it via tmux-server inheritance, but forwarding makes it explicit and
+        # uniform. Flag-gated + provider-guarded inside _static_oauth_token.
+        oauth_token = self._static_oauth_token()
+        if oauth_token:
+            env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
         if self.agent_name:
             env["PINKY_AGENT_NAME"] = self.agent_name
         # Surface the RESOLVED effort (#151): the drift hook compares this to

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -546,6 +546,16 @@ class TestSeedContainerClaudeCreds:
         ss._seed_container_claude_creds()
         assert (wd / ".claude-container" / ".credentials.json").exists()
 
+    def test_seed_skipped_when_flag_on_but_token_missing(self, monkeypatch, tmp_path):
+        # #781 P2: flag ON but no token in env → fail CLOSED. Do NOT fall back to
+        # seeding the refresh-prone creds (operator opted into static-token auth;
+        # a misconfig must surface as a loud login wall, not a silent race).
+        ss, _host_cfg, wd = self._creds_session(monkeypatch, tmp_path)
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        ss._seed_container_claude_creds()
+        assert not (wd / ".claude-container" / ".credentials.json").exists()
+
 
 class TestStaticOAuthTokenForward:
     """#780: forward a long-lived CLAUDE_CODE_OAUTH_TOKEN into the session env so
@@ -594,6 +604,18 @@ class TestStaticOAuthTokenForward:
         env = ss._build_repl_env()
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
         assert env["ANTHROPIC_API_KEY"] == "gw-secret"
+
+    def test_withheld_for_custom_provider_url_without_key(self, monkeypatch):
+        # #781 P1: a custom base URL with an EMPTY key is still a custom-provider
+        # signal — a first-party subscription token must never reach a gateway.
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-tok")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        ss._config.provider_url = "https://gateway.example/v1"
+        env = ss._build_repl_env()
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        assert env["ANTHROPIC_BASE_URL"] == "https://gateway.example/v1"
 
     def test_flag_on_but_no_token_noop(self, monkeypatch):
         self._clear(monkeypatch)

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -527,6 +527,80 @@ class TestSeedContainerClaudeCreds:
         ss._seed_container_claude_creds()  # must not raise
         assert not (wd / ".claude-container" / ".credentials.json").exists()
 
+    def test_skipped_when_static_token_forwarded(self, monkeypatch, tmp_path):
+        # #780: with the static token forwarded, claude authenticates via
+        # CLAUDE_CODE_OAUTH_TOKEN (no refresh) — the refresh-prone creds must
+        # NOT be seeded, so there's nothing for concurrent agents to race on.
+        ss, _host_cfg, wd = self._creds_session(monkeypatch, tmp_path)
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-deadbeef")
+        ss._seed_container_claude_creds()
+        assert not (wd / ".claude-container" / ".credentials.json").exists()
+
+    def test_seeded_when_forward_flag_off(self, monkeypatch, tmp_path):
+        # Token present but flag OFF (default) → forwarding inactive → seed as
+        # before. Proves the skip is gated on the flag, not the token's presence.
+        ss, _host_cfg, wd = self._creds_session(monkeypatch, tmp_path)
+        monkeypatch.delenv("PINKY_FORWARD_OAUTH_TOKEN", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-deadbeef")
+        ss._seed_container_claude_creds()
+        assert (wd / ".claude-container" / ".credentials.json").exists()
+
+
+class TestStaticOAuthTokenForward:
+    """#780: forward a long-lived CLAUDE_CODE_OAUTH_TOKEN into the session env so
+    claude authenticates with a never-refreshed token instead of the single-use
+    OAuth refresh token — killing the shared-creds de-auth race that #777
+    serialization only narrows. Flag-gated (PINKY_FORWARD_OAUTH_TOKEN, default
+    OFF), withheld for custom-provider agents, and reaches container agents
+    (whose isolated env can't inherit the daemon env otherwise)."""
+
+    def _clear(self, monkeypatch):
+        monkeypatch.delenv("PINKY_FORWARD_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+    def test_default_off_not_forwarded(self, monkeypatch):
+        # Token present in daemon env but flag unset → not injected (soak default).
+        self._clear(monkeypatch)
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-x")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in ss._build_repl_env()
+
+    def test_forwarded_when_flag_on(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-tok")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        assert ss._build_repl_env()["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-tok"
+
+    def test_forwarded_to_container_agent(self, monkeypatch):
+        # The whole point: a container agent's isolated env can't inherit the
+        # daemon env, so the explicit -e is the only way the token reaches it.
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "on")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-c")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "container")))
+        assert ss._build_repl_env()["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-c"
+
+    def test_withheld_for_custom_provider(self, monkeypatch):
+        # Gateway-routed agents inject ANTHROPIC_* (higher precedence) — a
+        # subscription token must never be mixed in alongside them.
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-tok")
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        ss._config.provider_key = "gw-secret"
+        env = ss._build_repl_env()
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        assert env["ANTHROPIC_API_KEY"] == "gw-secret"
+
+    def test_flag_on_but_no_token_noop(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")  # no token in env
+        ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in ss._build_repl_env()
+
 
 @pytest.mark.asyncio
 class TestCheckContainerImageContract:


### PR DESCRIPTION
## What & why
Closes the durable half of the recurring fleet de-auth (#780). The #777 cold-start serialization gate only narrows the window; each running `claude` still refreshes the **single-use** OAuth refresh token (`.credentials.json`) on its own schedule, so concurrent agents on a shared `$HOME` race and de-auth each other.

**Fix:** forward a long-lived `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`, ~1yr, **never refreshed**) from the daemon env into the tmux session via `_build_repl_env`. claude then auths with the static token (precedence #5) and never touches the refresh flow. **No refresh = no race.**

## Why container agents specifically were broken
A container agent's isolated env does **not** inherit the daemon env, so even with the token in the daemon `.env` it never reached the in-container `claude` (this is exactly why Pi `lera`/`sasha` stayed dead while local agents recovered). `tmux new-session -e …` runs inside the container via `podman exec`, so injecting it in `_build_repl_env` is the one place that reaches **both** local and container agents.

## Changes
- `_static_oauth_token()` helper — flag-gated, provider-guarded token resolver.
- `_build_repl_env()` injects `CLAUDE_CODE_OAUTH_TOKEN` when active.
- `_seed_container_claude_creds()` **skips** seeding the refresh-prone `.credentials.json` when forwarding is active (so there's literally nothing to race on).
- Flag `PINKY_FORWARD_OAUTH_TOKEN` (**default OFF** — staged soak per our rollout rule).
- Withheld for custom-provider agents (their `ANTHROPIC_*` keys take higher precedence; never mix a subscription token in).

## Proof it works (backend change — env diff stands in for a screenshot)
```
flag OFF -> token in env: False
flag ON  -> token in env: True   value: sk-ant-oat01-DEMOtoken
```

## Tests
- 7 new tests (forward on/off, container path, custom-provider withholding, no-token no-op, seed-skip on/off).
- `341 passed` across `test_tmux_container_isolation.py` + `test_tmux_session.py`; ruff clean.

## Rollout
1. Merge (default OFF → zero behavior change).
2. On a shared-`$HOME` fleet: set `CLAUDE_CODE_OAUTH_TOKEN=<setup-token>` + `PINKY_FORWARD_OAUTH_TOKEN=1` in the daemon `.env`, move `.credentials.json` aside, restart. Verify each agent reaches a REPL making a token-spending call.
3. Soak, then flip on Mini.

## Scope
This is **Gate A** of the two-gate durable fix. **Gate B** (pre-seed `hasCompletedOnboarding` so the onboarding wizard never grabs a session — the actual blocker that left TOD stuck even with the token) stays in #779. Both were live-fixed by hand on TOD + Pi on 2026-06-15; this makes Gate A the daemon default.

Refs #780, #779, #777.

🤖 Opened by Barsik
