### PR TITLE
feat(containerize): one-click container isolation backend (#204)

### DIFF
--- a/scripts/demo_containerize.py
+++ b/scripts/demo_containerize.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Demo for one-click containerize (#204) — backend feature walkthrough.
+
+Part A hits the REAL preflight endpoint (GET /system/container-runtime) over a
+TestClient, runtime-off then runtime-on, to show the honest readiness signal the
+UI button keys on.
+
+Part B drives the REAL ContainerLifecycle state machine (the actual provisioner
+logic over a recording podman double — no real podman) and prints every status
+transition, proving the provision → probe → persist → bounce ordering and the
+decontainerize keep-the-home-volume contract.
+
+Run: .venv/bin/python scripts/demo_containerize.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from pinky_daemon import container_ops as cops  # noqa: E402
+from pinky_daemon.agent_registry import Agent  # noqa: E402
+from pinky_daemon.provisioning import ContainerNames, ContainerProvisioner  # noqa: E402
+
+# Reuse the recording double + fakes from the test module.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tests"))
+from test_container_ops import FakeRegistry, RecordingContainerOps, _sync_runner  # noqa: E402
+
+
+def hr(title: str) -> None:
+    print(f"\n{'─' * 70}\n  {title}\n{'─' * 70}")
+
+
+def part_a() -> None:
+    hr("PART A · GET /system/container-runtime (real endpoint, real auth)")
+    from fastapi.testclient import TestClient
+
+    from pinky_daemon.api import create_api
+    from pinky_daemon.auth import SESSION_COOKIE_NAME, create_session_cookie
+
+    secret = "demo-session-secret"
+    os.environ["PINKY_SESSION_SECRET"] = secret
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    client = TestClient(create_api(max_sessions=4, default_working_dir="/tmp", db_path=path))
+    client.cookies.set(SESSION_COOKIE_NAME, create_session_cookie(secret))
+
+    os.environ.pop("PINKY_CONTAINER_RUNTIME", None)
+    os.environ.pop("PINKY_CONTAINER_DEFAULT_IMAGE", None)
+    print("runtime OFF  →", client.get("/system/container-runtime").json())
+
+    os.environ["PINKY_CONTAINER_RUNTIME"] = "podman"
+    os.environ["PINKY_CONTAINER_DEFAULT_IMAGE"] = "ghcr.io/acme/pinky-agent:1"
+    print("runtime ON   →", client.get("/system/container-runtime").json())
+
+    os.environ["PINKY_CONTAINER_RUNTIME"] = "docker"
+    print("docker host  →", client.get("/system/container-runtime").json())
+    os.environ.pop("PINKY_CONTAINER_RUNTIME", None)
+
+
+class _LoudRegistry(FakeRegistry):
+    def register(self, name, **kwargs):
+        print(f"    [DB]   persist isolation_mode={kwargs.get('isolation_mode')} "
+              f"container_image={kwargs.get('container_image','-')} "
+              f"isolated={kwargs.get('isolated')} transport={kwargs.get('transport','-')}")
+        return super().register(name, **kwargs)
+
+
+def _deps(agent, ops, reg, *, has_live=True):
+    locks: dict[str, asyncio.Lock] = {}
+
+    async def _disc(n):
+        print("    [sess] stop + unregister all labels")
+        return 1
+
+    async def _start(n):
+        print("    [sess] cold-start FRESH session from updated row")
+
+    return cops.ContainerLifecycleDeps(
+        registry=reg,
+        provisioner_for=lambda: ContainerProvisioner(
+            ops=ops, image_provider=lambda a: a.container_image or "ghcr.io/acme/pinky-agent:1",
+            signing_key_provider=lambda n: f"key-{n}",
+        ),
+        write_mcp_json=lambda n: print("    [mcp]  regenerate .mcp.json (SSE↔stdio)"),
+        disconnect_sessions=_disc,
+        start_session=_start,
+        has_live_session=lambda n: has_live,
+        lifecycle_lock=lambda n: locks.setdefault(n, asyncio.Lock()),
+        op_registry=_TracingRegistry(),
+        runner=_sync_runner,
+    )
+
+
+class _TracingRegistry(cops.ContainerOpRegistry):
+    def update(self, agent, status, message=None, **kw):
+        rec = super().update(agent, status, message, **kw)
+        print(f"    [op]   {status:<11} {message or ''}")
+        return rec
+
+
+async def part_b() -> None:
+    hr("PART B · containerize lifecycle (real provisioner, recording podman)")
+    ops = RecordingContainerOps()
+    agent = Agent(name="dymok", model="opus", working_dir="/tmp/dymok", isolation_mode="local")
+    reg = _LoudRegistry(agent)
+    deps = _deps(agent, ops, reg, has_live=True)
+    lc = cops.ContainerLifecycle(deps)
+
+    print("\n  CONTAINERIZE dymok  (image=ghcr.io/acme/pinky-agent:1, was: local/sdk)")
+    deps.op_registry.begin("dymok", cops.OP_CONTAINERIZE, image="ghcr.io/acme/pinky-agent:1")
+    await lc.containerize("dymok", image="ghcr.io/acme/pinky-agent:1", start=True)
+    n = ContainerNames.for_agent("dymok")
+    print(f"    podman: volume={ops.volume_exists(n.volume)} secret={ops.secret_exists(n.secret)} "
+          f"container={ops.container_exists(n.container)}")
+    print(f"    agent now: isolation_mode={reg.get('dymok').isolation_mode} "
+          f"transport={reg.get('dymok').transport}")
+
+    print("\n  DECONTAINERIZE dymok  (return to local — home volume kept)")
+    deps.op_registry.begin("dymok", cops.OP_DECONTAINERIZE)
+    await lc.decontainerize("dymok", start=True)
+    print(f"    podman: volume={ops.volume_exists(n.volume)} (KEPT) "
+          f"secret={ops.secret_exists(n.secret)} container={ops.container_exists(n.container)}")
+    print(f"    agent now: isolation_mode={reg.get('dymok').isolation_mode} "
+          f"isolated={reg.get('dymok').isolated}")
+
+    hr("PART C · failure safety (bad image → DB never touched)")
+    ops2 = RecordingContainerOps(fail_predicate=lambda a: len(a) > 1 and a[1] == "exec")
+    agent2 = Agent(name="ryzhik", model="opus", working_dir="/tmp/ryzhik", isolation_mode="local")
+    reg2 = _LoudRegistry(agent2)
+    deps2 = _deps(agent2, ops2, reg2, has_live=True)
+    lc2 = cops.ContainerLifecycle(deps2)
+    print("\n  CONTAINERIZE ryzhik with an image MISSING tmux/claude/python3")
+    deps2.op_registry.begin("ryzhik", cops.OP_CONTAINERIZE, image="busybox:latest")
+    await lc2.containerize("ryzhik", image="busybox:latest", start=True)
+    print(f"    persisted? {bool(reg2.register_calls)}  "
+          f"agent still: isolation_mode={reg2.get('ryzhik').isolation_mode}  ✅ intact")
+
+
+def main() -> None:
+    part_a()
+    asyncio.run(part_b())
+    print("\n✅ demo complete\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/one-click-containerize.md
+++ b/specs/one-click-containerize.md
@@ -1,0 +1,151 @@
+# One-Click Containerize — design for deliberation (Barsik ↔ Murzik)
+
+**Goal (Brad):** one click in the Agents UI to **enable** (and **disable**) Podman container
+isolation on an agent, with sensible defaults + clear feedback. Today it's a manual
+multi-step dance. "We still haven't fully closed the containerization workflow done via
+agent and front-end UI. Should basically be one click to enable."
+
+## Current state (verified in code)
+
+**Backend**
+- `Agent.isolation_mode` ∈ {`local`,`unix_user`,`container`}, `Agent.container_image`, `Agent.isolated`.
+- `PUT /agents/{name}` updates these. local→container: regenerates `.mcp.json` immediately but
+  **does NOT provision** (deferred to next session start). container→local: **deprovisions**
+  (container+secret removed, **home volume kept**).
+- `POST /agents` (register) provisions synchronously with rollback — but only at first register.
+- Runtime gated by `PINKY_CONTAINER_RUNTIME` (default OFF) → `container_runtime_enabled()` /
+  `container_runtime_binary()` (podman/docker; docker not yet supported).
+- `_isolation_block_reason()` blocks spawn: 501 if runtime not enabled; 400 if `container` mode
+  without `transport=tmux`. **Container REQUIRES transport=tmux.**
+- `ContainerProvisioner.provision()` idempotent; needs a `container_image` (**bring-your-own, NO default**).
+- `_ensure_container_started()` provisions+pulls+starts at session spawn (image pull can be **minutes**).
+
+**Frontend** (`frontend-svelte/src/pages/Agents.svelte`)
+- Detail modal → **Runtime tab** already has an isolation `<select>` (LOCAL/CONTAINER) + a
+  `container_image` text input + `saveAgentIsolation()` → `PUT /agents/{name}`.
+- Create wizard already exposes `wizIsolation` + `wizContainerImage`.
+- API client: `api('PUT', '/agents/{name}', body)` (session-cookie auth).
+
+## Why it's not "one click" yet (the friction)
+1. **No default image** — user must know/type an OCI ref.
+2. **Transport coupling** — must switch transport→tmux first (separate toggle; errors otherwise).
+3. **No preflight** — if the host runtime is OFF, the user only finds out at spawn (501).
+4. **Deferred + invisible provisioning** — must manually stop/restart; the (minutes-long) image
+   pull has no progress; provision errors surface late, at the next spawn.
+5. Two coupled fields + manual restart = several steps, not one click.
+
+## Proposed design
+
+**B1 — Preflight endpoint.** `GET /system/container-runtime` →
+`{ enabled, binary, default_image, ready }`. UI uses it to enable/disable the control, prefill the
+default image, and message "container runtime not enabled on this host."
+
+**B2 — Default image.** New env `PINKY_CONTAINER_DEFAULT_IMAGE` (fleet default; e.g. our
+`pinky-agent-runtime`). One-click uses it when the user doesn't override. *(Open: ship a canonical
+image, or doc bring-your-own + this env? v1 = env-configured default, bring-your-own override.)*
+
+**B3 — Atomic action endpoints.**
+- `POST /agents/{name}/containerize` body `{ image?: str }`: validate runtime (else 501 actionable);
+  auto-set `transport=tmux` (handle `runtime!=claude_sdk`); set `isolation_mode=container` + image
+  (default if omitted); provision (volume/secret/pull/create); restart the session so it takes effect;
+  **rollback cleanly on failure**.
+- `POST /agents/{name}/decontainerize`: `isolation_mode=local` + deprovision (keep volume) + restart.
+- *(Alternative: orchestrate from the frontend via existing `PUT` + restart. I prefer dedicated
+  endpoints — atomic, one call, encapsulated rollback + clear errors. ← deliberate.)*
+
+**B4 — Provision timing/feedback (key decision).** Image pull can take minutes.
+- (a) **Sync** + spinner + bounded timeout — simple; UI blocks; long pulls risk timeout.
+- (b) **Async**: endpoint returns 202 + status; UI polls `GET /agents/{name}/container-status`
+  (`pulling`|`provisioned`|`error`). Better UX, more code.
+- (c) **Hybrid**: provision via `_ensure_container_started` as today, but expose a status surface the
+  UI polls after the restart.
+- I lean (b)/(c). ← Murzik's take?
+
+**B5 — Restart semantics.** Apply via **stop + fresh session (cold-start)** — sidesteps the operator
+restart-guard friction I hit today (`streaming/restart` 409s on save-recency + "saved via
+save_my_context from this session" guards) — vs the `streaming/restart` endpoint. ← deliberate.
+
+**B6 — UI.** Replace the manual select+image with a single **"Containerize ⚡"** button (uses default
+image; an "advanced" disclosure for an image override). Disabled w/ hint when runtime not ready
+(from B1). Auto-handles the transport switch. Shows provisioning progress (*pulling image…*) + result.
+A **LOCAL / CONTAINERIZED** status badge on the card + detail metadata row. Symmetric
+**"Return to local"** with a confirm (volume kept).
+
+## Open questions for Murzik
+1. Dedicated endpoints (B3) vs frontend-orchestrated? (I prefer dedicated.)
+2. Provision feedback: sync vs async-with-status (B4)?
+3. Default-image story (B2): env default OK for v1, or do we need a shipped canonical image first?
+4. Restart semantics (B5): cold-start stop+create vs `streaming/restart` (guards)?
+5. v1 scope vs follow-ups — what's the MINIMUM one-click that ships *well*? (My instinct: B1 + B2 +
+   B3-enable + B6-button + a basic status, defer decontainerize polish + badge nicety if needed.)
+
+## ✅ Converged decisions (Barsik ↔ Murzik, 2026-06-15)
+
+**1. Dedicated endpoints — yes.** Frontend-orchestrated PUT+restart is the wrong boundary; too many
+coupled invariants (runtime gate, image/default, claude_sdk-only, tmux transport, `.mcp.json`
+rewrite, provision/probe, stop-old/start-new session class). Backend owns the choreography.
+Shape:
+- `POST /agents/{name}/containerize` body `{ image?, start?=true, force?=false }`
+- `POST /agents/{name}/decontainerize` body `{ start?=true, force?=false }`
+- `GET /agents/{name}/container-status`
+- `GET /system/container-runtime`
+
+**Key safety invariant — provision before persist.** Do NOT write `isolation_mode=container` to the
+DB before the slow/risky provision. Build a *desired in-memory Agent copy* (`transport=tmux`,
+`isolation_mode=container`, `isolated=True`, `container_image=image`), provision + probe it, **then**
+persist. A failed image pull / binary-contract failure must leave the prior config intact (never a
+DB stuck in unrunnable container mode). Rollback per-agent volume/secret/container only — the pulled
+image is shared cache, don't roll it back.
+
+**2. Real async (202 + status polling) — not sync, not hybrid.** Podman pulls take minutes and
+`_ensure_container_started()` already can't cancel the underlying thread. Daemon-local op record:
+`queued|validating|pulling|creating|probing|applying|restarting|ready|error` + `message`,
+`started_at`, `updated_at`, `image`, `provisioned`, `runtime_ready`. On daemon restart, reconstruct
+a **coarse** status from registry + `is_provisioned()` and report `unknown/not_running` — no fake
+continuity. The action actively provisions/probes *now*, then restarts only after the container is
+known runnable (this directly fixes today's deferred-invisible-provisioning pain).
+
+**3. Default image — `PINKY_CONTAINER_DEFAULT_IMAGE` env for v1.** Honest preflight: `ready=false`
+unless runtime enabled AND binary supported (`podman`; docker not yet) AND (default image exists OR
+caller supplies override). Validate image strings: max length, no whitespace/control chars (argv
+already avoids shell injection, but keep logs/UI sane). Shipping a canonical `pinky-agent-runtime`
+image is the right **product follow-up**, not a v1 blocker.
+
+**4. Cold stop + fresh start — NOT `/streaming/restart`.** The restart endpoint reconnects the
+*existing* session object, so an SDK session would not become a `TmuxSession` after the transport
+flip. Containerize must disconnect/unregister existing streaming sessions and call
+`_start_streaming_session()` so the session class + command runner are selected from the new
+registry row. Guard active work: return **409 unless `force=true`** if the agent has inflight turns /
+busy status; UI shows a confirm. Stop **all** labels before applying; recreate only `main` unless
+explicitly resurrecting every label.
+
+**5. v1 includes decontainerize.** Brad asked enable + disable; without a return path a bad
+image/auth problem strands the user. Polish can wait, but the backend endpoint + a simple "Return to
+local" button (confirm, **keeps home volume**) ship with enable.
+
+**Failure-mode guards (Murzik's weights, all adopted):**
+- **Wake/start race:** per-agent lifecycle lock around apply/stop/start, sharing/enclosing
+  `_streaming_ensure_locks`, so an inbound message / scheduler wake can't start a session mid-mutation.
+- **Manual PUT race:** route isolation-touching `PUT /agents/{name}` through the same lock (or
+  document the Runtime tab as legacy/advanced and let the one-click endpoint own the supported path).
+- **Runtime coupling:** auto-set `transport=tmux`, but do NOT auto-convert `runtime`→`claude_sdk`;
+  reject non-`claude_sdk` agents with a clear 400.
+- **Multi-session:** stop/unregister all labels before applying; don't leave siblings running local
+  while main is containerized.
+- **Authz:** operator/UI endpoints only, same privilege class as `PUT /agents`; NOT exposed as
+  self/MCP tools. Isolated agents must not decontainerize themselves via an internal route.
+
+**Tests (fake `ContainerOps`):** no DB mutation before provision/probe success; failed provision
+leaves prior config intact; active-work → 409 unless force; decontainerize keeps the volume.
+
+### v1 ship list (minimum that ships *well*)
+1. `GET /system/container-runtime` (honest preflight)
+2. `PINKY_CONTAINER_DEFAULT_IMAGE` env + image validation
+3. async `containerize` op + `GET /container-status` polling (provision-before-persist, per-agent lock)
+4. basic `decontainerize` op (keeps volume)
+5. one UI **"Containerize ⚡"** button + advanced image override + disabled/error states; symmetric
+   **"Return to local"** with confirm; LOCAL/CONTAINERIZED status surface
+6. cold apply via stop/unregister + `_start_streaming_session` (not `/streaming/restart`)
+7. tests above
+
+Stays gated behind `PINKY_CONTAINER_RUNTIME` (default OFF) — zero behavior change until a host opts in.

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -61,10 +61,12 @@ from pinky_daemon.api_models import (
     AuthLoginRequest,
     AuthSetupRequest,
     CloneWorkerRequest,
+    ContainerizeRequest,
     ContextResponse,
     ConversationListResponse,
     CreateGroupRequest,
     CreateSessionRequest,
+    DecontainerizeRequest,
     EffortDriftRequest,
     FederationPeerUpsertRequest,
     ForceRestartAgentRequest,
@@ -3064,6 +3066,17 @@ def create_api(
     # subprocess kept running, invisible to the watchdog.
     _streaming_ensure_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
+    # #204 one-click containerize: a per-AGENT lifecycle lock (keyed by name
+    # only, ENCLOSING the per-(agent,label) ensure locks above). The containerize
+    # / decontainerize apply phase (persist + MCP rewrite + stop-all + start-fresh)
+    # holds this so a concurrent inbound-message / scheduler wake can't start a
+    # session against a half-applied row. Acquisition order is ALWAYS lifecycle
+    # (outer) → ensure (inner); nothing takes them the other way, so no deadlock.
+    _container_lifecycle_locks: dict[str, asyncio.Lock] = {}
+
+    def _container_lifecycle_lock(agent_name: str) -> asyncio.Lock:
+        return _container_lifecycle_locks.setdefault(agent_name, asyncio.Lock())
+
     async def _ensure_streaming_session(agent_name: str, *, label: str = "main"):
         """Return a connected streaming session for an agent label.
 
@@ -3088,7 +3101,12 @@ def create_api(
             return ss
 
         lock = _streaming_ensure_locks.setdefault((agent_name, label), asyncio.Lock())
-        async with lock:
+        # #204: lifecycle (outer) → ensure (inner). The lifecycle lock blocks
+        # the slow start/reconnect path while a containerize/decontainerize apply
+        # is in flight for this agent, so we never start a session against a
+        # half-applied isolation row. The CONNECTED fast path above stays
+        # lock-free, so this adds no contention on the hot inbound path.
+        async with _container_lifecycle_lock(agent_name), lock:
             # Re-check under the lock: a concurrent caller may have started
             # or reconnected the session while we waited.
             sessions = broker._streaming.get(agent_name, {})
@@ -6074,6 +6092,287 @@ npm run build</pre>
         # The file is written once at spawn; agents edit it directly after that.
 
         return agent.to_dict()
+
+    # ── One-click containerize (#204 / specs/one-click-containerize.md) ──────
+    # Operator/UI-only endpoints to enable (and disable) Podman container
+    # isolation on an agent in one click. The backend owns the whole
+    # choreography — runtime preflight, default/override image, tmux transport,
+    # .mcp.json rewrite, provision + a real runnability probe, cold session
+    # bounce — so the UI is a single button. The cardinal invariant lives in
+    # container_ops.ContainerLifecycle: provision + probe a DESIRED copy BEFORE
+    # persisting isolation_mode=container, so a bad image can never strand the
+    # agent in an unrunnable mode.
+    from pinky_daemon import container_ops as _cops
+
+    _container_op_registry = _cops.ContainerOpRegistry()
+    # Hold strong refs to in-flight op tasks: asyncio only weakly references
+    # tasks, so a bare create_task() can be GC'd mid-provision (CPython footgun).
+    _container_op_tasks: set[asyncio.Task] = set()
+
+    def _spawn_container_op(coro) -> None:
+        task = asyncio.create_task(coro)
+        _container_op_tasks.add(task)
+        task.add_done_callback(_container_op_tasks.discard)
+
+    def _container_provisioner_for():
+        """Real ContainerProvisioner for this host, or None when the runtime gate
+        is off (PINKY_CONTAINER_RUNTIME unset, or docker — unsupported today)."""
+        from pinky_daemon.provisioning import get_provisioner
+
+        try:
+            return get_provisioner(
+                "container", signing_key_provider=agents.get_or_create_signing_key
+            )
+        except NotImplementedError:
+            return None
+
+    def _container_regen_mcp(agent_name: str) -> None:
+        a = agents.get(agent_name)
+        if a and a.working_dir:
+            _write_mcp_json(
+                Path(a.working_dir), agent_name, agent_registry=agents, skill_store=skills
+            )
+
+    async def _container_start_main(agent_name: str):
+        # Cold-start a FRESH main session — selects the session class from the
+        # updated row (sdk→tmux needs a rebuild, not a reconnect). Calls
+        # _start_streaming_session DIRECTLY, never _ensure_streaming_session,
+        # which would try to re-take the lifecycle lock we already hold.
+        return await _start_streaming_session(agent_name, label="main", resume_id="")
+
+    def _container_agent_busy(agent_name: str) -> tuple[bool, str]:
+        """Is the agent doing active work right now? Combines transport state +
+        per-class in-flight turn counts + the coarse hook-reported live status
+        (freshness-gated). Drives the 409-unless-force guard."""
+        sessions = broker._streaming.get(agent_name, {})
+        for label, ss in sessions.items():
+            try:
+                state = ss.state
+            except Exception:
+                state = None
+            if state in (
+                TransportSessionState.BOOTING,
+                TransportSessionState.RECONNECTING,
+            ):
+                return True, f"session '{label}' is {getattr(state, 'value', state)}"
+            try:
+                stats = ss.stats
+            except Exception:
+                stats = {}
+            if stats.get("inflight_turns", 0) or stats.get("pending_responses", 0):
+                return True, f"session '{label}' has work in flight"
+        live = _agent_live_status.get(agent_name)
+        if live and live.get("status") in ("working", "thinking", "tool_use"):
+            # Only trust a RECENT hook update — a stale 'working' (missed Stop
+            # hook) shouldn't pin the agent busy forever.
+            if time.time() - float(live.get("last_updated", 0)) < 90:
+                return True, f"agent is {live.get('status')}"
+        return False, ""
+
+    _container_lifecycle = _cops.ContainerLifecycle(
+        _cops.ContainerLifecycleDeps(
+            registry=agents,
+            provisioner_for=_container_provisioner_for,
+            write_mcp_json=_container_regen_mcp,
+            disconnect_sessions=_disconnect_streaming_sessions,
+            start_session=_container_start_main,
+            has_live_session=lambda n: bool(broker._streaming.get(n)),
+            lifecycle_lock=_container_lifecycle_lock,
+            op_registry=_container_op_registry,
+            log=_log,
+        )
+    )
+
+    def _require_operator(request: Request, action: str) -> None:
+        """Operator/UI-only gate. The auth middleware lets BOTH a browser session
+        AND a signed internal agent through /agents/*, so reject any
+        internal-agent caller here — a tenant must never containerize or
+        decontainerize itself (or anyone) via an internal route. A browser /
+        operator session carries no internal-agent header."""
+        caller = request.headers.get(INTERNAL_AGENT_HEADER, "")
+        if caller:
+            _log(f"containerize: denied internal caller '{caller}' from {action}")
+            raise HTTPException(403, "containerize endpoints are operator/UI-only")
+
+    @app.get("/system/container-runtime")
+    async def system_container_runtime(request: Request):
+        """Preflight for the one-click containerize UI: is the host's container
+        runtime usable, and what is the default image? ``ready`` is false unless
+        the runtime is enabled AND the binary is supported (podman; docker is
+        rejected today). The UI additionally requires default_image OR a typed
+        override before enabling the button."""
+        _require_operator(request, "GET /system/container-runtime")
+        from pinky_daemon.provisioning import (
+            container_default_image,
+            container_runtime_binary,
+            container_runtime_enabled,
+            container_runtime_supported,
+        )
+
+        enabled = container_runtime_enabled()
+        return {
+            "enabled": enabled,
+            "binary": container_runtime_binary() if enabled else None,
+            "default_image": container_default_image() or None,
+            "ready": container_runtime_supported(),
+        }
+
+    @app.get("/agents/{name}/container-status")
+    async def get_container_status(name: str, request: Request):
+        """Poll the in-flight containerize/decontainerize op, or — when there is
+        no live op record (e.g. after a daemon restart dropped it) — a coarse
+        status reconstructed from the registry + is_provisioned(). Never fakes
+        continuity of an interrupted operation."""
+        _require_operator(request, "GET container-status")
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+        from pinky_daemon.provisioning import container_runtime_supported
+
+        runtime_ready = container_runtime_supported()
+        mode = getattr(agent, "isolation_mode", "local") or "local"
+        rec = _container_op_registry.get(name)
+        if rec is not None:
+            out = rec.to_dict()
+            out["isolation_mode"] = mode
+            out["runtime_ready"] = runtime_ready
+            return out
+        # No live op record — reconstruct coarsely.
+        provisioned = False
+        status = _cops.IDLE
+        if mode == "container":
+            prov = _container_provisioner_for()
+            if prov is not None:
+                try:
+                    provisioned = await asyncio.to_thread(prov.is_provisioned, agent)
+                except Exception:
+                    provisioned = False
+            status = _cops.READY if provisioned else _cops.UNKNOWN
+        now = time.time()
+        return {
+            "agent": name,
+            "isolation_mode": mode,
+            "operation": "",
+            "status": status,
+            "message": "",
+            "image": getattr(agent, "container_image", "") or "",
+            "provisioned": provisioned,
+            "runtime_ready": runtime_ready,
+            "started_at": now,
+            "updated_at": now,
+        }
+
+    @app.post("/agents/{name}/containerize")
+    async def containerize_agent(name: str, req: ContainerizeRequest, request: Request):
+        """Enable Podman container isolation on an agent in one operator action.
+        Returns 202 with the initial op record; the UI polls container-status
+        while the (possibly minutes-long) provision + probe runs."""
+        _require_operator(request, "POST containerize")
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+        from pinky_daemon.provisioning import (
+            container_default_image,
+            container_runtime_enabled,
+            container_runtime_supported,
+        )
+
+        if not container_runtime_enabled():
+            raise HTTPException(
+                501,
+                "container runtime is not enabled on this host "
+                "(set PINKY_CONTAINER_RUNTIME)",
+            )
+        if not container_runtime_supported():
+            raise HTTPException(
+                501,
+                "container runtime is not supported on this host "
+                "(podman required; docker is not supported yet)",
+            )
+        # Don't auto-convert the runtime engine — only claude_sdk supports the
+        # tmux transport that container mode runs the session through (Murzik).
+        # Auto-setting transport=tmux is fine; changing runtime is not.
+        runtime = (getattr(agent, "runtime", "") or "claude_sdk").strip() or "claude_sdk"
+        if runtime != "claude_sdk":
+            raise HTTPException(
+                400,
+                f"containerize requires runtime='claude_sdk' (agent is {runtime!r}); "
+                "container mode runs the session inside the container via tmux",
+            )
+        # working_dir must be absolute for the same-path bind mount (hooks,
+        # transcripts, and creds all key on the identical absolute path).
+        wd = (getattr(agent, "working_dir", "") or "").strip()
+        if not wd or not Path(wd).is_absolute():
+            raise HTTPException(
+                400, f"containerize requires an absolute working_dir (agent has {wd!r})"
+            )
+        # Resolve + validate the image (override beats the fleet default).
+        try:
+            image = _cops.validate_container_image(req.image or container_default_image())
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        if _container_op_registry.in_flight(name):
+            raise HTTPException(
+                409, "a container operation is already in progress for this agent"
+            )
+        if not req.force:
+            busy, why = _container_agent_busy(name)
+            if busy:
+                raise HTTPException(
+                    409, f"agent is busy ({why}); retry with force=true to override"
+                )
+
+        _container_op_registry.begin(name, _cops.OP_CONTAINERIZE, image=image)
+        _spawn_container_op(
+            _container_lifecycle.containerize(name, image=image, start=req.start)
+        )
+        rec = _container_op_registry.get(name)
+        return JSONResponse(
+            status_code=202,
+            content={
+                "operation": _cops.OP_CONTAINERIZE,
+                "status": rec.status if rec else _cops.QUEUED,
+                "status_url": f"/agents/{name}/container-status",
+                "image": image,
+            },
+        )
+
+    @app.post("/agents/{name}/decontainerize")
+    async def decontainerize_agent(
+        name: str, req: DecontainerizeRequest, request: Request
+    ):
+        """Return a containerized agent to local: tear down the container + key
+        secret (KEEP the home volume), flip isolation_mode=local, bounce the
+        session. Returns 202; the UI polls container-status."""
+        _require_operator(request, "POST decontainerize")
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+        if _container_op_registry.in_flight(name):
+            raise HTTPException(
+                409, "a container operation is already in progress for this agent"
+            )
+        if not req.force:
+            busy, why = _container_agent_busy(name)
+            if busy:
+                raise HTTPException(
+                    409, f"agent is busy ({why}); retry with force=true to override"
+                )
+        _container_op_registry.begin(
+            name,
+            _cops.OP_DECONTAINERIZE,
+            image=getattr(agent, "container_image", "") or "",
+        )
+        _spawn_container_op(_container_lifecycle.decontainerize(name, start=req.start))
+        rec = _container_op_registry.get(name)
+        return JSONResponse(
+            status_code=202,
+            content={
+                "operation": _cops.OP_DECONTAINERIZE,
+                "status": rec.status if rec else _cops.QUEUED,
+                "status_url": f"/agents/{name}/container-status",
+            },
+        )
 
     @app.put("/agents/{name}/provider")
     async def set_agent_provider(name: str, req: dict):

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3098,7 +3098,14 @@ def create_api(
         sessions = broker._streaming.get(agent_name, {})
         ss = sessions.get(label)
         if ss and ss.state == TransportSessionState.CONNECTED:
-            return ss
+            # #204: the connected fast path stays lock-free EXCEPT while a
+            # containerize/decontainerize apply holds this agent's lifecycle
+            # lock — then returning the live session would let a new turn start
+            # on a session that's about to be torn down at cutover. If the lock
+            # is held, fall through to the slow path, which awaits it and then
+            # re-reads (picking up the freshly-started post-cutover session).
+            if not _container_lifecycle_lock(agent_name).locked():
+                return ss
 
         lock = _streaming_ensure_locks.setdefault((agent_name, label), asyncio.Lock())
         # #204: lifecycle (outer) → ensure (inner). The lifecycle lock blocks
@@ -6179,6 +6186,7 @@ npm run build</pre>
             has_live_session=lambda n: bool(broker._streaming.get(n)),
             lifecycle_lock=_container_lifecycle_lock,
             op_registry=_container_op_registry,
+            is_busy=_container_agent_busy,
             log=_log,
         )
     )
@@ -6324,7 +6332,9 @@ npm run build</pre>
 
         _container_op_registry.begin(name, _cops.OP_CONTAINERIZE, image=image)
         _spawn_container_op(
-            _container_lifecycle.containerize(name, image=image, start=req.start)
+            _container_lifecycle.containerize(
+                name, image=image, start=req.start, force=req.force
+            )
         )
         rec = _container_op_registry.get(name)
         return JSONResponse(
@@ -6363,7 +6373,9 @@ npm run build</pre>
             _cops.OP_DECONTAINERIZE,
             image=getattr(agent, "container_image", "") or "",
         )
-        _spawn_container_op(_container_lifecycle.decontainerize(name, start=req.start))
+        _spawn_container_op(
+            _container_lifecycle.decontainerize(name, start=req.start, force=req.force)
+        )
         rec = _container_op_registry.get(name)
         return JSONResponse(
             status_code=202,

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -444,6 +444,30 @@ class UpdateAgentRequest(BaseModel):
         return v
 
 
+class ContainerizeRequest(BaseModel):
+    """One-click containerize an agent — POST /agents/{name}/containerize (#204).
+
+    Backend-owned choreography: validate runtime/image, provision + probe a
+    container, and only then flip isolation_mode=container (+ tmux transport) and
+    bounce the session. Image string validation happens in the handler so a bad
+    ref returns 400 with an actionable message."""
+
+    image: str = ""  # bring-your-own override; "" → use PINKY_CONTAINER_DEFAULT_IMAGE
+    start: bool = True  # restart the session under the new mode if it was already live
+    force: bool = False  # proceed even if the agent has active/inflight work (else 409)
+
+
+class DecontainerizeRequest(BaseModel):
+    """Return a containerized agent to local — POST /agents/{name}/decontainerize.
+
+    Tears down the container + key secret (KEEPS the home volume) and flips
+    isolation_mode=local. The return path so a bad image can never strand an
+    agent in container mode."""
+
+    start: bool = True  # restart the session as local if it was already live
+    force: bool = False  # proceed even if the agent has active/inflight work (else 409)
+
+
 class AddDirectiveRequest(BaseModel):
     """Add a directive to an agent."""
 

--- a/src/pinky_daemon/container_ops.py
+++ b/src/pinky_daemon/container_ops.py
@@ -186,6 +186,10 @@ class ContainerLifecycleDeps:
     # streaming-ensure slow path so a wake can't start a session mid-apply)
     lifecycle_lock: Callable[[str], asyncio.Lock]
     op_registry: ContainerOpRegistry
+    # (agent_name) -> (busy: bool, reason: str). Re-checked AT CUTOVER under the
+    # lifecycle lock — not just at enqueue — so a turn that starts during the
+    # (lock-free) provision phase can't be killed by a non-forced apply.
+    is_busy: Callable[[str], tuple[bool, str]] = field(default=lambda _n: (False, ""))
     # off-loop executor for blocking podman work; asyncio.to_thread in prod, a
     # synchronous shim in tests.
     runner: Callable[..., Awaitable[Any]] = field(default=asyncio.to_thread)
@@ -206,7 +210,22 @@ class ContainerLifecycle:
         self.deps = deps
 
     # -- containerize ---------------------------------------------------------
-    async def containerize(self, name: str, *, image: str, start: bool = True) -> None:
+    async def containerize(
+        self, name: str, *, image: str, start: bool = True, force: bool = False
+    ) -> None:
+        """Terminal-status guard wrapper: any unexpected failure (incl. in an
+        apply step like register / write_mcp_json / disconnect) must leave the op
+        in a TERMINAL state, never stuck in-flight (which would 409 every future
+        attempt + make the UI poll forever)."""
+        try:
+            await self._containerize(name, image=image, start=start, force=force)
+        except Exception as e:  # noqa: BLE001
+            self.deps.log(f"container_ops: containerize {name!r} crashed: {e}")
+            self.deps.op_registry.update(
+                name, ERROR, f"containerize failed unexpectedly: {e}"
+            )
+
+    async def _containerize(self, name: str, *, image: str, start: bool, force: bool) -> None:
         d = self.deps
         reg = d.op_registry
         prov = d.provisioner_for()
@@ -256,6 +275,21 @@ class ContainerLifecycle:
         # the per-agent lifecycle lock so a concurrent wake can't start a session
         # against a half-applied row.
         async with d.lifecycle_lock(name):
+            # Re-check active work AT CUTOVER, not just at enqueue: a turn may
+            # have started during the (lock-free, minutes-long) provision phase.
+            # The streaming-ensure fast path respects this held lock, so no NEW
+            # turn can start once we hold it — this check is the accurate one.
+            if not force:
+                busy, why = d.is_busy(name)
+                if busy:
+                    await self._safe_deprovision(prov, desired)  # DB never flipped
+                    reg.update(
+                        name,
+                        ERROR,
+                        f"agent became busy during provisioning ({why}); "
+                        f"retry with force=true to override",
+                    )
+                    return
             reg.update(name, APPLYING, "persisting container configuration")
             d.registry.register(
                 name,
@@ -293,7 +327,19 @@ class ContainerLifecycle:
         )
 
     # -- decontainerize -------------------------------------------------------
-    async def decontainerize(self, name: str, *, start: bool = True) -> None:
+    async def decontainerize(
+        self, name: str, *, start: bool = True, force: bool = False
+    ) -> None:
+        """Terminal-status guard wrapper (see :meth:`containerize`)."""
+        try:
+            await self._decontainerize(name, start=start, force=force)
+        except Exception as e:  # noqa: BLE001
+            self.deps.log(f"container_ops: decontainerize {name!r} crashed: {e}")
+            self.deps.op_registry.update(
+                name, ERROR, f"decontainerize failed unexpectedly: {e}"
+            )
+
+    async def _decontainerize(self, name: str, *, start: bool, force: bool) -> None:
         d = self.deps
         reg = d.op_registry
         agent = d.registry.get(name)
@@ -302,6 +348,17 @@ class ContainerLifecycle:
             return
 
         async with d.lifecycle_lock(name):
+            # Active-work guard at cutover (same rationale as containerize): don't
+            # tear down a session that's mid-turn unless forced.
+            if not force:
+                busy, why = d.is_busy(name)
+                if busy:
+                    reg.update(
+                        name,
+                        ERROR,
+                        f"agent is busy ({why}); retry with force=true to override",
+                    )
+                    return
             reg.update(name, APPLYING, "reverting to local (home volume kept)")
             # Tear down container + key secret but KEEP the home volume (its CLI
             # logins survive a future re-containerize). Best-effort: a gate-off

--- a/src/pinky_daemon/container_ops.py
+++ b/src/pinky_daemon/container_ops.py
@@ -1,0 +1,349 @@
+"""One-click containerize orchestration (#204 / specs/one-click-containerize.md).
+
+Brad wants enabling/disabling Podman container isolation on an agent to be one
+click from the Agents UI. Containerize couples a lot of invariants — runtime
+preflight, a default/override image, tmux transport, ``.mcp.json`` rewrite,
+provision + a real runnability probe, stop/unregister of every old session, and
+a FRESH session class (sdk→tmux can't be reconnected, only rebuilt). Keeping
+that choreography here (backend-owned + testable) is the whole point: the API
+handlers are thin, and the failure-mode invariants are unit-tested with a fake
+``ContainerOps`` and no real Podman.
+
+The cardinal invariant (Murzik's review): **never persist ``isolation_mode=
+container`` before the slow/risky provision + probe succeed.** We build a
+DESIRED in-memory :class:`Agent` copy, provision + start + verify it against the
+container runtime, and only THEN flip the DB + rewrite MCP + bounce the session.
+A bad image / failed pull therefore leaves the agent exactly as it was, never
+stranded in an unrunnable container mode.
+
+Provisioning can take MINUTES (a cold ``podman pull``), so the API returns 202
+immediately and the UI polls a daemon-local operation record (this module's
+:class:`ContainerOpRegistry`) for ``queued|validating|pulling|probing|applying|
+restarting|ready|error``. The record is in-memory: after a daemon restart it is
+gone and the status endpoint reconstructs a coarse ``idle|ready|unknown`` from
+the registry + ``is_provisioned()`` rather than faking continuity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+# ── operation status vocabulary ──────────────────────────────────────────────
+# In-flight phases (non-terminal) + the two terminal states, plus the coarse
+# reconstructed states used when there is no live op record (e.g. after a daemon
+# restart). Strings (not an enum) to keep the JSON payload trivially serialisable
+# and to match the contract the frontend (PR #782) polls against.
+QUEUED = "queued"
+VALIDATING = "validating"
+PULLING = "pulling"
+CREATING = "creating"
+PROBING = "probing"
+APPLYING = "applying"
+RESTARTING = "restarting"
+READY = "ready"
+ERROR = "error"
+IDLE = "idle"  # no operation in flight, agent is local
+UNKNOWN = "unknown"  # container agent, pre-restart op record lost
+
+# Non-terminal phases: while the record sits in one of these an operation is
+# still running, so a second containerize/decontainerize for the same agent is
+# rejected (409) rather than racing it.
+_IN_FLIGHT = frozenset(
+    {QUEUED, VALIDATING, PULLING, CREATING, PROBING, APPLYING, RESTARTING}
+)
+
+OP_CONTAINERIZE = "containerize"
+OP_DECONTAINERIZE = "decontainerize"
+
+# Image-ref sanity bounds. subprocess argv already prevents shell injection, but
+# logs/UI/podman still deserve sane input (no whitespace-spanning or control
+# chars, bounded length).
+_IMAGE_MAX_LEN = 512
+
+
+def validate_container_image(ref: str) -> str:
+    """Return the trimmed image ref, or raise ``ValueError`` if it is empty,
+    over-long, or contains whitespace / control characters."""
+    img = (ref or "").strip()
+    if not img:
+        raise ValueError("container image is empty")
+    if len(img) > _IMAGE_MAX_LEN:
+        raise ValueError(f"container image too long (>{_IMAGE_MAX_LEN} characters)")
+    if any(c.isspace() for c in img):
+        raise ValueError("container image must not contain whitespace")
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in img):
+        raise ValueError("container image must not contain control characters")
+    return img
+
+
+@dataclass
+class ContainerOpRecord:
+    """Daemon-local record of an in-flight (or just-finished) containerize /
+    decontainerize operation for one agent. Polled by the UI via
+    ``GET /agents/{name}/container-status``."""
+
+    agent: str
+    operation: str
+    status: str
+    message: str = ""
+    image: str = ""
+    provisioned: bool = False
+    runtime_ready: bool = False
+    started_at: float = 0.0
+    updated_at: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent": self.agent,
+            "operation": self.operation,
+            "status": self.status,
+            "message": self.message,
+            "image": self.image,
+            "provisioned": self.provisioned,
+            "runtime_ready": self.runtime_ready,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+        }
+
+
+class ContainerOpRegistry:
+    """In-memory map ``agent -> ContainerOpRecord``. Single event loop, so no
+    locking; provisioning runs off-loop but only the async caller mutates the
+    record. Records are intentionally NOT persisted: a daemon restart drops them
+    and the status endpoint reconstructs a coarse state instead of pretending an
+    interrupted pull is still running."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, ContainerOpRecord] = {}
+
+    def begin(self, agent: str, operation: str, image: str = "") -> ContainerOpRecord:
+        now = time.time()
+        rec = ContainerOpRecord(
+            agent=agent,
+            operation=operation,
+            status=QUEUED,
+            image=image,
+            started_at=now,
+            updated_at=now,
+        )
+        self._records[agent] = rec
+        return rec
+
+    def update(
+        self,
+        agent: str,
+        status: str,
+        message: str | None = None,
+        *,
+        provisioned: bool | None = None,
+        runtime_ready: bool | None = None,
+    ) -> ContainerOpRecord | None:
+        rec = self._records.get(agent)
+        if rec is None:
+            return None
+        rec.status = status
+        if message is not None:
+            rec.message = message
+        if provisioned is not None:
+            rec.provisioned = provisioned
+        if runtime_ready is not None:
+            rec.runtime_ready = runtime_ready
+        rec.updated_at = time.time()
+        return rec
+
+    def get(self, agent: str) -> ContainerOpRecord | None:
+        return self._records.get(agent)
+
+    def in_flight(self, agent: str) -> bool:
+        rec = self._records.get(agent)
+        return bool(rec and rec.status in _IN_FLIGHT)
+
+
+@dataclass
+class ContainerLifecycleDeps:
+    """Everything :class:`ContainerLifecycle` needs, injected so the orchestration
+    is testable with fakes (the provisioner is the REAL ContainerProvisioner over
+    a recording ``ContainerOps``; the session/registry hooks are fakes)."""
+
+    registry: Any
+    # () -> ContainerProvisioner | None  (None when the host runtime gate is off)
+    provisioner_for: Callable[[], Any | None]
+    # (agent_name) -> None  — regenerate .mcp.json from the PERSISTED row
+    write_mcp_json: Callable[[str], None]
+    # (agent_name) -> awaitable[int]  — disconnect + unregister ALL labels
+    disconnect_sessions: Callable[[str], Awaitable[int]]
+    # (agent_name) -> awaitable  — cold-start a FRESH main session (selects the
+    # session class from the now-updated row; must NOT re-take the lifecycle lock)
+    start_session: Callable[[str], Awaitable[Any]]
+    # (agent_name) -> bool  — is there any live session right now?
+    has_live_session: Callable[[str], bool]
+    # (agent_name) -> asyncio.Lock  — per-agent lifecycle lock (shared with the
+    # streaming-ensure slow path so a wake can't start a session mid-apply)
+    lifecycle_lock: Callable[[str], asyncio.Lock]
+    op_registry: ContainerOpRegistry
+    # off-loop executor for blocking podman work; asyncio.to_thread in prod, a
+    # synchronous shim in tests.
+    runner: Callable[..., Awaitable[Any]] = field(default=asyncio.to_thread)
+    log: Callable[[str], None] = field(default=lambda _m: None)
+
+
+class ContainerLifecycle:
+    """Orchestrates one-click containerize / decontainerize.
+
+    Phase 1 (provision + start + verify) runs against a DESIRED, non-persisted
+    Agent copy and is deliberately OUTSIDE the per-agent lifecycle lock — it is
+    the minutes-long pull, and the agent stays fully live in its current mode
+    throughout. Only phase 2 (persist + rewrite MCP + stop-all + start-fresh) is
+    taken under the lock, and it is fast because the image is already pulled +
+    verified."""
+
+    def __init__(self, deps: ContainerLifecycleDeps) -> None:
+        self.deps = deps
+
+    # -- containerize ---------------------------------------------------------
+    async def containerize(self, name: str, *, image: str, start: bool = True) -> None:
+        d = self.deps
+        reg = d.op_registry
+        prov = d.provisioner_for()
+        if prov is None:
+            reg.update(name, ERROR, "container runtime is not enabled on this host")
+            return
+        agent = d.registry.get(name)
+        if agent is None:
+            reg.update(name, ERROR, f"agent {name!r} not found")
+            return
+
+        # Phase 1 — provision + start + verify a DESIRED copy (NO DB write).
+        # isolated=True + transport=tmux are coupled to container mode (the
+        # pydantic validators that normally enforce this are bypassed when we
+        # build the Agent in-process, so we set them ourselves).
+        desired = dataclasses.replace(
+            agent,
+            isolation_mode="container",
+            container_image=image,
+            isolated=True,
+            transport="tmux",
+        )
+        reg.update(name, PULLING, f"provisioning container from {image}")
+
+        result = await d.runner(prov.provision, desired)
+        if not getattr(result, "ok", False):
+            await self._safe_deprovision(prov, desired)
+            reg.update(name, ERROR, getattr(result, "message", "provision failed"))
+            return
+
+        reg.update(name, PROBING, "starting + verifying container image")
+        try:
+            await d.runner(prov.start, desired)
+        except Exception as e:  # noqa: BLE001 — surface as a clean op error
+            await self._safe_deprovision(prov, desired)
+            reg.update(name, ERROR, f"container failed to start: {e}")
+            return
+
+        verify = await d.runner(prov.verify_runnable, desired)
+        if not getattr(verify, "ok", False):
+            await self._safe_deprovision(prov, desired)
+            reg.update(name, ERROR, getattr(verify, "message", "image not runnable"),
+                       provisioned=False)
+            return
+
+        # Phase 2 — apply: persist → rewrite MCP → stop all → start fresh. Under
+        # the per-agent lifecycle lock so a concurrent wake can't start a session
+        # against a half-applied row.
+        async with d.lifecycle_lock(name):
+            reg.update(name, APPLYING, "persisting container configuration")
+            d.registry.register(
+                name,
+                isolation_mode="container",
+                container_image=image,
+                isolated=True,
+                transport="tmux",
+            )
+            d.write_mcp_json(name)
+            had_live = d.has_live_session(name)
+            await d.disconnect_sessions(name)
+            if start and had_live:
+                reg.update(name, RESTARTING, "starting containerized session")
+                try:
+                    await d.start_session(name)
+                except Exception as e:  # noqa: BLE001
+                    # The flip + MCP rewrite already landed; the agent will spawn
+                    # containerized at its next wake. Report rather than fake ready.
+                    reg.update(
+                        name,
+                        ERROR,
+                        f"containerized, but session restart failed (will start "
+                        f"on next wake): {e}",
+                        provisioned=True,
+                        runtime_ready=True,
+                    )
+                    return
+
+        reg.update(
+            name,
+            READY,
+            f"containerized on {image} (home volume created)",
+            provisioned=True,
+            runtime_ready=True,
+        )
+
+    # -- decontainerize -------------------------------------------------------
+    async def decontainerize(self, name: str, *, start: bool = True) -> None:
+        d = self.deps
+        reg = d.op_registry
+        agent = d.registry.get(name)
+        if agent is None:
+            reg.update(name, ERROR, f"agent {name!r} not found")
+            return
+
+        async with d.lifecycle_lock(name):
+            reg.update(name, APPLYING, "reverting to local (home volume kept)")
+            # Tear down container + key secret but KEEP the home volume (its CLI
+            # logins survive a future re-containerize). Best-effort: a gate-off
+            # host has nothing provisioned; either way we still flip the DB.
+            prov = d.provisioner_for()
+            if prov is not None:
+                try:
+                    await d.runner(prov.deprovision, agent)  # remove_volume=False
+                except Exception as e:  # noqa: BLE001
+                    d.log(f"container_ops: deprovision of {name!r} failed (ignored): {e}")
+            # Lift isolation: local mode → isolated=False. transport is left as
+            # tmux (local+tmux is valid); the operator can switch to sdk in the
+            # Runtime tab if desired.
+            d.registry.register(name, isolation_mode="local", isolated=False)
+            d.write_mcp_json(name)
+            had_live = d.has_live_session(name)
+            await d.disconnect_sessions(name)
+            if start and had_live:
+                reg.update(name, RESTARTING, "starting local session")
+                try:
+                    await d.start_session(name)
+                except Exception as e:  # noqa: BLE001
+                    reg.update(
+                        name,
+                        ERROR,
+                        f"reverted to local, but session restart failed (will start "
+                        f"on next wake): {e}",
+                    )
+                    return
+
+        reg.update(name, READY, "reverted to local (home volume preserved)",
+                   provisioned=False)
+
+    async def _safe_deprovision(self, prov: Any, agent: Any) -> None:
+        """Best-effort cleanup of a failed containerize: remove the container +
+        secret we just created, KEEP the home volume (never destroy a volume
+        implicitly). Never raises — the DB was never mutated, so the agent is
+        already intact; this just avoids orphaning the partial podman tenant."""
+        try:
+            await self.deps.runner(prov.deprovision, agent)
+        except Exception as e:  # noqa: BLE001
+            self.deps.log(
+                f"container_ops: cleanup deprovision of {agent.name!r} failed "
+                f"(ignored): {e}"
+            )

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -129,6 +129,19 @@ CONTAINER_MEMORY_ENV = "PINKY_CONTAINER_MEMORY"
 CONTAINER_MEMORY_DEFAULT = "2g"
 CONTAINER_PIDS_ENV = "PINKY_CONTAINER_PIDS_LIMIT"
 CONTAINER_PIDS_DEFAULT = "2048"
+# Fleet default bring-your-own image for one-click containerize: when an operator
+# clicks "Containerize" without supplying an override, this image is used. Empty
+# (default) means there is no fleet default — the operator must supply an image
+# per agent, and preflight reports default_image=null. A canonical Pinky runtime
+# image is a product follow-up; this env keeps v1 a controlled, opt-in rollout.
+CONTAINER_DEFAULT_IMAGE_ENV = "PINKY_CONTAINER_DEFAULT_IMAGE"
+# In-container tooling a containerized tenant MUST have on PATH to host a tmux +
+# claude session. The bring-your-own image is operator-supplied, so a one-click
+# containerize probes for these before persisting isolation_mode=container — a
+# missing binary means the image can't run the agent and the flip is refused
+# (rather than stranding the agent in BOOT_FAILED at next spawn). Mirrors the
+# session-side contract check in tmux_session._check_container_image_contract.
+CONTAINER_REQUIRED_BINARIES = ("tmux", "claude", "python3")
 
 
 def container_config_dir(working_dir: str) -> str:
@@ -1022,6 +1035,48 @@ class ContainerProvisioner(AgentProvisioner):
         if not result.ok:
             raise ProvisionError(result.message)
 
+    def verify_runnable(self, agent: "Agent") -> ProvisionResult:
+        """Probe that a STARTED container can actually host a tenant: the
+        bring-your-own image must provide every binary in
+        :data:`CONTAINER_REQUIRED_BINARIES` (tmux / claude / python3) on PATH.
+
+        This is the runnability half of a "verified" provision — ``provision``
+        only ``podman create``s the container (stopped) and ``is_provisioned``
+        only checks the resources EXIST, neither proves the image can run the
+        agent. A one-click containerize gates the DB flip on this so a bad image
+        is refused up front instead of stranding the agent in BOOT_FAILED at
+        next spawn (mirrors tmux_session._check_container_image_contract, but
+        callable from the provisioning layer with no live session). The caller
+        must ``start``/``ensure_started`` the container first. Returns
+        ``ok=False`` with an actionable message on a missing binary (or if the
+        exec itself fails); never raises.
+        """
+        n = self.names(agent)
+        required = CONTAINER_REQUIRED_BINARIES
+        # One `sh -c` AND-chain: exits 0 iff every binary resolves. ContainerOps
+        # .run raises on a non-zero exit, so a missing binary surfaces as the
+        # except below. Args go through argv (no shell on the host side) — the
+        # only shell is the in-container `sh` evaluating a fixed, static string.
+        check = " && ".join(f"command -v {c} >/dev/null 2>&1" for c in required)
+        try:
+            self._ops.run([self._binary, "exec", n.container, "sh", "-c", check])
+        except Exception as e:
+            image = self._image_provider(agent) or "<unset>"
+            return ProvisionResult(
+                ok=False,
+                mode=CONTAINER,
+                message=(
+                    f"container image {image!r} for {agent.name!r} is not runnable: "
+                    f"missing required tooling (needs {', '.join(required)} on PATH) "
+                    f"or exec failed: {e}"
+                ),
+            )
+        return ProvisionResult(
+            ok=True,
+            mode=CONTAINER,
+            message=f"container {n.container} is runnable ({', '.join(required)} present)",
+        )
+
     def _rollback(self, created: list[str]) -> list[str]:
         """Undo ``created`` resources in reverse; best-effort, never raises."""
         removed: list[str] = []
@@ -1074,6 +1129,24 @@ def container_runtime_binary() -> str:
     truthy value). Only meaningful when :func:`container_runtime_enabled`."""
     val = os.environ.get(CONTAINER_RUNTIME_ENV, "").strip().lower()
     return "docker" if val == "docker" else CONTAINER_BINARY
+
+
+def container_runtime_supported() -> bool:
+    """True iff the host's selected container runtime is one we can actually
+    provision against today — i.e. enabled AND podman (docker is rejected by
+    :func:`get_provisioner` because provisioning relies on podman-only secret
+    delivery). Preflight + the one-click endpoints use this to fail fast with an
+    actionable message rather than 500-ing at provision time on a docker host."""
+    return container_runtime_enabled() and container_runtime_binary() == CONTAINER_BINARY
+
+
+def container_default_image() -> str:
+    """The fleet default bring-your-own image for one-click containerize
+    (``PINKY_CONTAINER_DEFAULT_IMAGE``), or ``""`` if none is configured — in
+    which case the operator must supply a per-agent override. Never a baked
+    constant: a canonical image is a product follow-up, and this keeps v1 an
+    opt-in, host-configured rollout."""
+    return os.environ.get(CONTAINER_DEFAULT_IMAGE_ENV, "").strip()
 
 
 def get_provisioner(

--- a/tests/test_container_ops.py
+++ b/tests/test_container_ops.py
@@ -98,7 +98,7 @@ async def _sync_runner(fn, *a, **k):
     return fn(*a, **k)
 
 
-def _make_deps(agent, ops, *, has_live=True, provisioner=True):
+def _make_deps(agent, ops, *, has_live=True, provisioner=True, busy=False, mcp_raises=False):
     reg = FakeRegistry(agent)
     rec = {"disconnect": [], "start": [], "mcp": []}
     locks: dict[str, asyncio.Lock] = {}
@@ -116,15 +116,21 @@ def _make_deps(agent, ops, *, has_live=True, provisioner=True):
     async def _start(name):
         rec["start"].append(name)
 
+    def _mcp(name):
+        if mcp_raises:
+            raise RuntimeError("boom: .mcp.json write failed")
+        rec["mcp"].append(name)
+
     deps = cops.ContainerLifecycleDeps(
         registry=reg,
         provisioner_for=(lambda: prov) if provisioner else (lambda: None),
-        write_mcp_json=lambda n: rec["mcp"].append(n),
+        write_mcp_json=_mcp,
         disconnect_sessions=_disconnect,
         start_session=_start,
         has_live_session=lambda n: has_live,
         lifecycle_lock=lambda n: locks.setdefault(n, asyncio.Lock()),
         op_registry=cops.ContainerOpRegistry(),
+        is_busy=lambda n: (busy, "mid-turn") if busy else (False, ""),
         runner=_sync_runner,
     )
     return deps, reg, rec
@@ -245,6 +251,56 @@ class TestContainerizeOrchestration:
         assert reg.register_calls == []
         r = deps.op_registry.get("tenant")
         assert r.status == cops.ERROR and "not enabled" in r.message
+
+    def test_busy_at_cutover_aborts_unless_force(self):
+        """INVARIANT (Murzik #783): work that starts during the lock-free
+        provision phase must NOT be killed by a non-forced apply — the cutover
+        re-checks busy under the lock and aborts (DB never flipped)."""
+        ops = RecordingContainerOps()
+        agent = _agent()
+        deps, reg, rec = _make_deps(agent, ops, has_live=True, busy=True)
+        lc = cops.ContainerLifecycle(deps)
+        deps.op_registry.begin("tenant", cops.OP_CONTAINERIZE, image="myco/agent:1")
+
+        asyncio.run(lc.containerize("tenant", image="myco/agent:1", start=True, force=False))
+
+        assert reg.register_calls == []  # never flipped
+        assert reg.get("tenant").isolation_mode == "local"
+        assert rec["disconnect"] == []  # no session torn down
+        r = deps.op_registry.get("tenant")
+        assert r.status == cops.ERROR and "became busy" in r.message
+        # The container built during provisioning was cleaned up (volume kept).
+        n = ContainerNames.for_agent("tenant")
+        assert ops.container_exists(n.container) is False
+
+    def test_busy_at_cutover_proceeds_with_force(self):
+        ops = RecordingContainerOps()
+        agent = _agent()
+        deps, reg, rec = _make_deps(agent, ops, has_live=True, busy=True)
+        lc = cops.ContainerLifecycle(deps)
+        deps.op_registry.begin("tenant", cops.OP_CONTAINERIZE, image="myco/agent:1")
+
+        asyncio.run(lc.containerize("tenant", image="myco/agent:1", start=True, force=True))
+
+        assert len(reg.register_calls) == 1  # forced through
+        assert rec["disconnect"] == ["tenant"]
+        assert deps.op_registry.get("tenant").status == cops.READY
+
+    def test_apply_step_exception_is_terminal_not_stuck(self):
+        """INVARIANT (Murzik #783): an exception in an apply step (here
+        write_mcp_json) must leave the op in a TERMINAL error state — never stuck
+        in-flight, which would 409 every future op + poll forever."""
+        ops = RecordingContainerOps()
+        agent = _agent()
+        deps, reg, rec = _make_deps(agent, ops, has_live=True, mcp_raises=True)
+        lc = cops.ContainerLifecycle(deps)
+        deps.op_registry.begin("tenant", cops.OP_CONTAINERIZE, image="myco/agent:1")
+
+        asyncio.run(lc.containerize("tenant", image="myco/agent:1", start=True))
+
+        r = deps.op_registry.get("tenant")
+        assert r.status == cops.ERROR
+        assert deps.op_registry.in_flight("tenant") is False  # not stuck
 
     def test_no_restart_when_not_live(self):
         """start=True only restarts a session that was ALREADY live."""

--- a/tests/test_container_ops.py
+++ b/tests/test_container_ops.py
@@ -1,0 +1,428 @@
+"""Tests for one-click containerize (#204).
+
+Two layers:
+  * Unit — :class:`ContainerLifecycle` orchestration driven with fakes, but
+    against the REAL :class:`ContainerProvisioner` over a recording
+    ``ContainerOps`` double (no podman). These pin Murzik's review invariants:
+    no DB mutation before provision+probe succeed, a failed provision leaves the
+    prior config intact, and decontainerize keeps the home volume.
+  * API — the endpoints over a TestClient: preflight honesty, the
+    409-unless-force active-work guard, operator-only authz, and the
+    runtime-off 501.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import os
+import tempfile
+
+import pytest
+
+from pinky_daemon import container_ops as cops
+from pinky_daemon.agent_registry import Agent
+from pinky_daemon.provisioning import ContainerNames, ContainerProvisioner, ProvisionError
+
+
+# ── recording ContainerOps double (no real podman) ───────────────────────────
+class RecordingContainerOps:
+    """Records every podman command + tracks image/volume/secret/container state.
+
+    ``fail_predicate(argv) -> bool`` injects a command failure (e.g. a failed
+    pull, or a failed ``exec`` to simulate a missing-binary probe)."""
+
+    def __init__(
+        self, *, images=None, volumes=None, secrets=None, containers=None, fail_predicate=None
+    ):
+        self.commands: list[list[str]] = []
+        self._images = set(images or [])
+        self._volumes = set(volumes or [])
+        self._secrets = set(secrets or [])
+        self._containers = set(containers or [])
+        self._fail = fail_predicate
+
+    def run(self, argv):
+        self.commands.append(list(argv))
+        if self._fail and self._fail(list(argv)):
+            raise ProvisionError(f"injected failure: {' '.join(argv)}")
+        if len(argv) >= 4 and argv[1] == "volume" and argv[2] == "create":
+            self._volumes.add(argv[3])
+        elif len(argv) >= 3 and argv[1] == "pull":
+            self._images.add(argv[2])
+        elif len(argv) >= 4 and argv[1] == "create" and argv[2] == "--name":
+            self._containers.add(argv[3])
+        elif len(argv) >= 4 and argv[1] == "rm" and argv[2] == "-f":
+            self._containers.discard(argv[3])
+        elif len(argv) >= 4 and argv[1] == "secret" and argv[2] == "rm":
+            self._secrets.discard(argv[3])
+        elif len(argv) >= 4 and argv[1] == "volume" and argv[2] == "rm":
+            self._volumes.discard(argv[3])
+
+    def image_exists(self, ref):
+        return ref in self._images
+
+    def volume_exists(self, name):
+        return name in self._volumes
+
+    def secret_exists(self, name):
+        return name in self._secrets
+
+    def container_exists(self, name):
+        return name in self._containers
+
+    def write_secret(self, name, content):
+        self._secrets.add(name)
+
+
+# ── fake registry + session deps ─────────────────────────────────────────────
+class FakeRegistry:
+    def __init__(self, agent: Agent):
+        self._agent = agent
+        self.register_calls: list[dict] = []
+
+    def get(self, name):
+        return self._agent if (self._agent and self._agent.name == name) else None
+
+    def register(self, name, **kwargs):
+        self.register_calls.append(dict(kwargs))
+        self._agent = dataclasses.replace(self._agent, **kwargs)
+        return self._agent
+
+    def get_or_create_signing_key(self, name):
+        return f"key-{name}"
+
+
+async def _sync_runner(fn, *a, **k):
+    """Run blocking provisioner work inline (no thread) for deterministic tests."""
+    return fn(*a, **k)
+
+
+def _make_deps(agent, ops, *, has_live=True, provisioner=True):
+    reg = FakeRegistry(agent)
+    rec = {"disconnect": [], "start": [], "mcp": []}
+    locks: dict[str, asyncio.Lock] = {}
+
+    prov = ContainerProvisioner(
+        ops=ops,
+        image_provider=lambda a: a.container_image or "myco/agent:1",
+        signing_key_provider=lambda n: f"key-{n}",
+    )
+
+    async def _disconnect(name):
+        rec["disconnect"].append(name)
+        return 1
+
+    async def _start(name):
+        rec["start"].append(name)
+
+    deps = cops.ContainerLifecycleDeps(
+        registry=reg,
+        provisioner_for=(lambda: prov) if provisioner else (lambda: None),
+        write_mcp_json=lambda n: rec["mcp"].append(n),
+        disconnect_sessions=_disconnect,
+        start_session=_start,
+        has_live_session=lambda n: has_live,
+        lifecycle_lock=lambda n: locks.setdefault(n, asyncio.Lock()),
+        op_registry=cops.ContainerOpRegistry(),
+        runner=_sync_runner,
+    )
+    return deps, reg, rec
+
+
+def _agent(**kw):
+    base = dict(name="tenant", model="opus", working_dir="/tmp/tenant", isolation_mode="local")
+    base.update(kw)
+    return Agent(**base)
+
+
+# ── unit: image validation ───────────────────────────────────────────────────
+class TestValidateImage:
+    def test_ok(self):
+        assert cops.validate_container_image("  registry/img:tag ") == "registry/img:tag"
+
+    @pytest.mark.parametrize("bad", ["", "   ", "img with space", "img\ttab", "img\x00ctl"])
+    def test_rejected(self, bad):
+        with pytest.raises(ValueError):
+            cops.validate_container_image(bad)
+
+    def test_too_long(self):
+        with pytest.raises(ValueError):
+            cops.validate_container_image("x" * 600)
+
+
+# ── unit: op registry ────────────────────────────────────────────────────────
+class TestOpRegistry:
+    def test_in_flight_then_terminal(self):
+        r = cops.ContainerOpRegistry()
+        r.begin("a", cops.OP_CONTAINERIZE, image="i")
+        assert r.in_flight("a") is True
+        r.update("a", cops.READY, "done")
+        assert r.in_flight("a") is False
+        assert r.get("a").status == cops.READY
+
+    def test_unknown_agent_not_in_flight(self):
+        assert cops.ContainerOpRegistry().in_flight("nope") is False
+
+
+# ── unit: containerize / decontainerize orchestration ────────────────────────
+class TestContainerizeOrchestration:
+    def test_happy_path_provisions_probes_then_persists(self):
+        ops = RecordingContainerOps()
+        agent = _agent()
+        deps, reg, rec = _make_deps(agent, ops, has_live=True)
+        lc = cops.ContainerLifecycle(deps)
+        deps.op_registry.begin("tenant", cops.OP_CONTAINERIZE, image="myco/agent:1")
+
+        asyncio.run(lc.containerize("tenant", image="myco/agent:1", start=True))
+
+        # Persisted exactly once, with the full coupled config.
+        assert len(reg.register_calls) == 1
+        kw = reg.register_calls[0]
+        assert kw["isolation_mode"] == "container"
+        assert kw["container_image"] == "myco/agent:1"
+        assert kw["isolated"] is True
+        assert kw["transport"] == "tmux"
+        # MCP rewritten + session bounced (was live).
+        assert rec["mcp"] == ["tenant"]
+        assert rec["disconnect"] == ["tenant"]
+        assert rec["start"] == ["tenant"]
+        # Podman tenant exists.
+        n = ContainerNames.for_agent("tenant")
+        assert ops.volume_exists(n.volume)
+        assert ops.secret_exists(n.secret)
+        assert ops.container_exists(n.container)
+        # Terminal record.
+        r = deps.op_registry.get("tenant")
+        assert r.status == cops.READY and r.provisioned is True and r.runtime_ready is True
+
+    def test_no_persist_until_after_probe(self):
+        """INVARIANT: a failed runnability probe must NOT mutate the DB and must
+        leave the agent local (a bad image can never strand it)."""
+        # exec (the verify probe) fails → image missing required tooling.
+        ops = RecordingContainerOps(fail_predicate=lambda a: len(a) > 1 and a[1] == "exec")
+        agent = _agent()
+        deps, reg, rec = _make_deps(agent, ops, has_live=True)
+        lc = cops.ContainerLifecycle(deps)
+        deps.op_registry.begin("tenant", cops.OP_CONTAINERIZE, image="myco/agent:1")
+
+        asyncio.run(lc.containerize("tenant", image="myco/agent:1", start=True))
+
+        assert reg.register_calls == []  # never persisted
+        assert reg.get("tenant").isolation_mode == "local"  # config intact
+        assert rec["mcp"] == [] and rec["disconnect"] == [] and rec["start"] == []
+        r = deps.op_registry.get("tenant")
+        assert r.status == cops.ERROR and "not runnable" in r.message
+        # Cleanup kept the home volume but removed the container we created.
+        n = ContainerNames.for_agent("tenant")
+        assert ops.volume_exists(n.volume) is True
+        assert ops.container_exists(n.container) is False
+
+    def test_failed_provision_leaves_config_intact(self):
+        """INVARIANT: a failed provision (image pull failure) leaves the prior
+        DB config untouched."""
+        ops = RecordingContainerOps(fail_predicate=lambda a: len(a) > 1 and a[1] == "pull")
+        agent = _agent()
+        deps, reg, rec = _make_deps(agent, ops, has_live=True)
+        lc = cops.ContainerLifecycle(deps)
+        deps.op_registry.begin("tenant", cops.OP_CONTAINERIZE, image="bad/img:1")
+
+        asyncio.run(lc.containerize("tenant", image="bad/img:1", start=True))
+
+        assert reg.register_calls == []
+        assert reg.get("tenant").isolation_mode == "local"
+        assert deps.op_registry.get("tenant").status == cops.ERROR
+
+    def test_runtime_off_records_error_no_persist(self):
+        ops = RecordingContainerOps()
+        agent = _agent()
+        deps, reg, _ = _make_deps(agent, ops, provisioner=False)
+        lc = cops.ContainerLifecycle(deps)
+        deps.op_registry.begin("tenant", cops.OP_CONTAINERIZE, image="i")
+
+        asyncio.run(lc.containerize("tenant", image="i", start=True))
+
+        assert reg.register_calls == []
+        r = deps.op_registry.get("tenant")
+        assert r.status == cops.ERROR and "not enabled" in r.message
+
+    def test_no_restart_when_not_live(self):
+        """start=True only restarts a session that was ALREADY live."""
+        ops = RecordingContainerOps()
+        agent = _agent()
+        deps, reg, rec = _make_deps(agent, ops, has_live=False)
+        lc = cops.ContainerLifecycle(deps)
+        deps.op_registry.begin("tenant", cops.OP_CONTAINERIZE, image="myco/agent:1")
+
+        asyncio.run(lc.containerize("tenant", image="myco/agent:1", start=True))
+
+        assert len(reg.register_calls) == 1  # still persisted
+        assert rec["disconnect"] == ["tenant"]  # still stop any stragglers
+        assert rec["start"] == []  # but nothing to restart
+        assert deps.op_registry.get("tenant").status == cops.READY
+
+
+class TestDecontainerizeOrchestration:
+    def test_keeps_home_volume(self):
+        """INVARIANT: decontainerize tears down the container + secret but KEEPS
+        the home volume (its CLI logins survive a future re-containerize)."""
+        n = ContainerNames.for_agent("tenant")
+        ops = RecordingContainerOps(
+            volumes={n.volume}, secrets={n.secret}, containers={n.container}
+        )
+        agent = _agent(isolation_mode="container", container_image="myco/agent:1", isolated=True)
+        deps, reg, rec = _make_deps(agent, ops, has_live=True)
+        lc = cops.ContainerLifecycle(deps)
+        deps.op_registry.begin("tenant", cops.OP_DECONTAINERIZE, image="myco/agent:1")
+
+        asyncio.run(lc.decontainerize("tenant", start=True))
+
+        # Flipped to local, isolation lifted.
+        assert len(reg.register_calls) == 1
+        kw = reg.register_calls[0]
+        assert kw["isolation_mode"] == "local" and kw["isolated"] is False
+        # Home volume KEPT; container + secret removed.
+        assert ops.volume_exists(n.volume) is True
+        assert ops.container_exists(n.container) is False
+        assert ops.secret_exists(n.secret) is False
+        # Bounced + MCP rewritten.
+        assert rec["mcp"] == ["tenant"] and rec["disconnect"] == ["tenant"]
+        assert rec["start"] == ["tenant"]
+        assert deps.op_registry.get("tenant").status == cops.READY
+
+    def test_unknown_agent_errors(self):
+        ops = RecordingContainerOps()
+        deps, _reg, _ = _make_deps(_agent(), ops)
+        lc = cops.ContainerLifecycle(deps)
+        deps.op_registry.begin("ghost", cops.OP_DECONTAINERIZE)
+        asyncio.run(lc.decontainerize("ghost", start=True))
+        assert deps.op_registry.get("ghost").status == cops.ERROR
+
+
+# ── API-level: endpoints over a TestClient ───────────────────────────────────
+def _client():
+    from fastapi.testclient import TestClient
+
+    from pinky_daemon.api import create_api
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    app = create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
+    return TestClient(app)
+
+
+def _register(client, name="tenant", working_dir="/tmp/tenant"):
+    return client.post(
+        "/agents", json={"name": name, "model": "opus", "working_dir": working_dir}
+    )
+
+
+class TestContainerizeEndpoints:
+    def test_preflight_runtime_off(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        monkeypatch.delenv("PINKY_CONTAINER_DEFAULT_IMAGE", raising=False)
+        client = _client()
+        resp = client.get("/system/container-runtime")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["ready"] is False
+        assert data["binary"] is None
+        assert data["default_image"] is None
+
+    def test_preflight_runtime_on(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        monkeypatch.setenv("PINKY_CONTAINER_DEFAULT_IMAGE", "myco/agent:1")
+        client = _client()
+        data = client.get("/system/container-runtime").json()
+        assert data["enabled"] is True
+        assert data["binary"] == "podman"
+        assert data["ready"] is True
+        assert data["default_image"] == "myco/agent:1"
+
+    def test_preflight_docker_not_ready(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "docker")
+        client = _client()
+        data = client.get("/system/container-runtime").json()
+        assert data["enabled"] is True
+        assert data["binary"] == "docker"
+        assert data["ready"] is False  # docker unsupported today
+
+    def test_containerize_501_when_runtime_off(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        client = _client()
+        _register(client)
+        resp = client.post("/agents/tenant/containerize", json={"image": "myco/agent:1"})
+        assert resp.status_code == 501
+
+    def test_containerize_404_unknown_agent(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        client = _client()
+        resp = client.post("/agents/ghost/containerize", json={"image": "myco/agent:1"})
+        assert resp.status_code == 404
+
+    def test_operator_only_rejects_internal_caller(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        client = _client()
+        _register(client)
+        resp = client.post(
+            "/agents/tenant/containerize",
+            json={"image": "myco/agent:1"},
+            headers={"x-pinky-agent": "sometenant"},
+        )
+        assert resp.status_code == 403
+
+    def test_busy_409_unless_force(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+
+        # Keep the background task off real podman: the provisioner gate returns
+        # nothing, so a forced op records an error instead of shelling out.
+        def _no_provisioner(*_a, **_k):
+            raise NotImplementedError("test: no runtime")
+
+        monkeypatch.setattr("pinky_daemon.provisioning.get_provisioner", _no_provisioner)
+
+        client = _client()
+        _register(client)
+        # Mark the agent actively working (the hook surface the guard reads).
+        client.post(
+            "/agents/tenant/status",
+            json={"status": "working", "tool_name": "Bash", "detail": "x"},
+        )
+        busy = client.post("/agents/tenant/containerize", json={"image": "myco/agent:1"})
+        assert busy.status_code == 409
+
+        forced = client.post(
+            "/agents/tenant/containerize", json={"image": "myco/agent:1", "force": True}
+        )
+        assert forced.status_code == 202
+        body = forced.json()
+        assert body["operation"] == "containerize"
+        assert body["status_url"] == "/agents/tenant/container-status"
+
+    def test_invalid_image_400(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        client = _client()
+        _register(client)
+        resp = client.post(
+            "/agents/tenant/containerize", json={"image": "bad image with spaces"}
+        )
+        assert resp.status_code == 400
+
+    def test_no_image_no_default_400(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        monkeypatch.delenv("PINKY_CONTAINER_DEFAULT_IMAGE", raising=False)
+        client = _client()
+        _register(client)
+        resp = client.post("/agents/tenant/containerize", json={})
+        assert resp.status_code == 400
+
+    def test_container_status_local_agent(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CONTAINER_RUNTIME", raising=False)
+        client = _client()
+        _register(client)
+        data = client.get("/agents/tenant/container-status").json()
+        assert data["isolation_mode"] == "local"
+        assert data["status"] == "idle"
+        assert data["provisioned"] is False
+        assert data["runtime_ready"] is False


### PR DESCRIPTION
## One-click containerize — backend (#204)

Brad wants enabling/disabling Podman container isolation on an agent to be **one click** from the Agents UI. This is the **backend half** (Barsik). The UI is **Murzik's PR #782**, built against the contract below — the two are **cross-reviewed** before either merges.

Design was deliberated + converged with Murzik first (`specs/one-click-containerize.md`).

### Endpoints (operator/UI-only — internal-agent callers get 403)
| Method | Path | Purpose |
|---|---|---|
| `GET` | `/system/container-runtime` | Honest preflight: `{enabled, binary, default_image, ready}` (docker → `ready:false`) |
| `POST` | `/agents/{name}/containerize` | 202 + async op; provision → probe → persist |
| `POST` | `/agents/{name}/decontainerize` | 202 + async op; **keeps the home volume** |
| `GET` | `/agents/{name}/container-status` | Poll the op (or a coarse reconstruct after a daemon restart — no fake continuity) |

### The cardinal invariant (Murzik's review)
**Never persist `isolation_mode=container` before the slow/risky provision + probe succeed.** We build a *desired* in-memory `Agent` copy, provision + start + verify the image's binary contract (`tmux`/`claude`/`python3`) against it, and only **then** flip the DB, rewrite `.mcp.json`, and cold-bounce the session. A bad image / failed pull leaves the agent exactly as it was — never stranded in an unrunnable mode.

### Key decisions
- **Real async (202 + polling)** — a `podman pull` can take minutes; the op runs as a background task, the UI polls a daemon-local record.
- **Cold stop + fresh `_start_streaming_session`** — *not* `/streaming/restart`, which reconnects the stale session object and would never reclass SDK→Tmux after the transport flip.
- **Per-agent lifecycle lock** (encloses `_streaming_ensure_locks`) so a wake/scheduler can't start a session against a half-applied row. The minutes-long provision+probe runs **lock-free** against the desired copy; only the fast apply phase holds the lock.
- Auto-set `transport=tmux`, but **reject non-`claude_sdk` runtimes (400)** — never auto-convert the engine. Require an absolute `working_dir`.
- **409 on active/inflight work unless `force=true`**; one op per agent at a time.
- Default image via `PINKY_CONTAINER_DEFAULT_IMAGE` (bring-your-own override); image strings validated. Canonical image = product follow-up.

### Tests — 26 new (`tests/test_container_ops.py`)
Orchestration invariants over the **real** provisioner + a recording podman double: no-persist-before-probe, failed-provision-leaves-config-intact, decontainerize-keeps-volume; plus API-level preflight honesty, 409-unless-force, operator-only authz, 501-when-off. Existing provisioning + api suites unaffected (**480 pass**).

### Feature demo — `scripts/demo_containerize.py`
```
PART A · GET /system/container-runtime (real endpoint, real auth)
runtime OFF  → {'enabled': False, 'binary': None,     'default_image': None,                    'ready': False}
runtime ON   → {'enabled': True,  'binary': 'podman', 'default_image': 'ghcr.io/acme/pinky-agent:1', 'ready': True}
docker host  → {'enabled': True,  'binary': 'docker', 'default_image': 'ghcr.io/acme/pinky-agent:1', 'ready': False}

PART B · containerize lifecycle (real provisioner, recording podman)
  CONTAINERIZE dymok  (image=ghcr.io/acme/pinky-agent:1, was: local/sdk)
    [op]   pulling     provisioning container from ghcr.io/acme/pinky-agent:1
    [op]   probing     starting + verifying container image
    [op]   applying    persisting container configuration
    [DB]   persist isolation_mode=container container_image=ghcr.io/acme/pinky-agent:1 isolated=True transport=tmux
    [mcp]  regenerate .mcp.json (SSE↔stdio)
    [sess] stop + unregister all labels
    [op]   restarting  starting containerized session
    [sess] cold-start FRESH session from updated row
    [op]   ready       containerized on ghcr.io/acme/pinky-agent:1 (home volume created)
    podman: volume=True secret=True container=True   →  isolation_mode=container transport=tmux

  DECONTAINERIZE dymok  (return to local — home volume kept)
    [DB]   persist isolation_mode=local isolated=False
    [op]   ready       reverted to local (home volume preserved)
    podman: volume=True (KEPT) secret=False container=False   →  isolation_mode=local

PART C · failure safety (bad image → DB never touched)
  CONTAINERIZE ryzhik with an image MISSING tmux/claude/python3
    [op]   error       container image 'busybox:latest' is not runnable: missing required tooling …
    persisted? False  agent still: isolation_mode=local  ✅ intact
```

Stays gated behind `PINKY_CONTAINER_RUNTIME` (default **OFF**) — zero behavior change until a host opts in.

🤖 Opened by Barsik
