### PR TITLE
feat(analytics): Codex cost parity — price codex_cli sessions (#206)

### DIFF
--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -9,6 +9,18 @@ from datetime import UTC, datetime, timedelta
 # Providers to include in analytics dashboards.
 # Only Anthropic/Claude usage — excludes Codex CLI (OpenAI) and other non-Anthropic providers.
 _ANTHROPIC_PROVIDERS = {"firstParty", "default", "anthropic", "bedrock", "vertex"}
+# Providers whose token usage carries a real per-token cost we price in the
+# overview/agent/category cost views. Extends the Anthropic set with the
+# OpenAI/Codex family so Codex agents (e.g. Murzik on gpt-5.5) appear in the
+# cost dashboards at parity with Claude agents (#206) — previously the cost
+# views were hard-gated to Anthropic-only, leaving Codex usage invisible
+# even though OpenAI pricing was already seeded.
+# NOTE: opencode is intentionally NOT included yet — it has no seeded pricing
+# and `_provider_alias` can't map it to one rate table (opencode runs either
+# Anthropic or OpenAI models depending on config), so including it would surface
+# opencode turns at a misleading $0. Add it back alongside pricing + a model-aware
+# alias when an opencode agent ships (#786).
+_COSTED_PROVIDERS = _ANTHROPIC_PROVIDERS | {"openai", "openai_api", "codex_cli"}
 
 
 def _utcnow() -> str:
@@ -208,6 +220,7 @@ class AnalyticsStore:
             self._seed_default_pricing(conn)
             self._migrate_opus_haiku_seed_pricing(conn)
             self._migrate_legacy_dotted_model_ids(conn)
+            self._ensure_pricing_rows(conn)
             # Schema migration: add user_message_snippet to turn_usage
             cols = {
                 r[1] for r in conn.execute("PRAGMA table_info(analytics_turn_usage)").fetchall()
@@ -237,6 +250,15 @@ class AnalyticsStore:
                 "CREATE INDEX IF NOT EXISTS idx_atc_status_started "
                 "ON analytics_tool_calls(status, started_at)"
             )
+
+    # Pricing rows added AFTER the original seed batch. _seed_default_pricing
+    # only fires on an empty table, so these reach already-seeded production
+    # DBs via the idempotent _ensure_pricing_rows below (insert-if-absent,
+    # never clobbering an operator-set price). Verified official 2026 rates.
+    _LATEST_PRICING_ADDITIONS = [
+        ("openai", "gpt-5.5", "2020-01-01T00:00:00Z", None, 5.00, 30.00, 0.50, "seed"),
+        ("openai", "gpt-5.3-codex", "2020-01-01T00:00:00Z", None, 1.75, 14.00, 0.175, "seed"),
+    ]
 
     def _seed_default_pricing(self, conn) -> None:
         row = conn.execute("SELECT COUNT(*) AS count FROM analytics_model_pricing").fetchone()
@@ -290,7 +312,7 @@ class AnalyticsStore:
               input_usd_per_mtok, output_usd_per_mtok, cached_input_usd_per_mtok, notes
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            seed_rows,
+            seed_rows + self._LATEST_PRICING_ADDITIONS,
         )
 
     def _migrate_opus_haiku_seed_pricing(self, conn) -> None:
@@ -415,6 +437,32 @@ class AnalyticsStore:
         if touched:
             # Drop the lazily-built cache so renamed rows are read next lookup.
             self._pricing_cache = None
+
+    def _ensure_pricing_rows(self, conn) -> None:
+        """Idempotently backfill pricing rows added after the initial seed.
+
+        ``_seed_default_pricing`` only populates an empty table, so models
+        introduced in later releases (e.g. gpt-5.5) never reach an
+        already-seeded production DB through it. Insert each addition only
+        when no row exists for that (provider, model) — never overrides an
+        operator-set or already-present price.
+        """
+        for r in self._LATEST_PRICING_ADDITIONS:
+            conn.execute(
+                """
+                INSERT INTO analytics_model_pricing (
+                  provider, model, effective_from, effective_to,
+                  input_usd_per_mtok, output_usd_per_mtok,
+                  cached_input_usd_per_mtok, notes
+                )
+                SELECT ?, ?, ?, ?, ?, ?, ?, ?
+                WHERE NOT EXISTS (
+                  SELECT 1 FROM analytics_model_pricing
+                  WHERE provider = ? AND model = ?
+                )
+                """,
+                (*r, r[0], r[1]),
+            )
 
     def ensure_session_fact(
         self,
@@ -1151,9 +1199,10 @@ class AnalyticsStore:
         """Get token usage breakdown by task category for the given range."""
         start_ts, end_ts = _range_bounds(range_name)
 
-        # Fetch all turns with their tool calls and user message snippets
-        # Filter to Anthropic providers only (exclude Codex/OpenAI)
-        provider_placeholders = ",".join("?" for _ in _ANTHROPIC_PROVIDERS)
+        # Fetch all turns with their tool calls and user message snippets.
+        # Costed providers (Anthropic + OpenAI/Codex) so Codex agents show up in
+        # the per-category cost breakdown at parity with Claude agents (#206).
+        provider_placeholders = ",".join("?" for _ in _COSTED_PROVIDERS)
         usage_query = f"""
             SELECT u.session_id, u.agent_name, u.turn_seq, u.ts,
                    u.input_tokens, u.output_tokens, u.cached_input_tokens,
@@ -1162,7 +1211,7 @@ class AnalyticsStore:
             WHERE u.ts >= ? AND u.ts <= ?
               AND u.provider IN ({provider_placeholders})
         """
-        params: list = [start_ts, end_ts, *_ANTHROPIC_PROVIDERS]
+        params: list = [start_ts, end_ts, *_COSTED_PROVIDERS]
         if agent_name:
             usage_query += " AND u.agent_name=?"
             params.append(agent_name)
@@ -1270,15 +1319,16 @@ class AnalyticsStore:
 
         start_ts, end_ts = _range_bounds(range_name)
 
-        # Fetch current period turns (Anthropic providers only)
-        provider_placeholders = ",".join("?" for _ in _ANTHROPIC_PROVIDERS)
+        # Fetch current period turns (costed providers incl. Codex/OpenAI, #206)
+        # so the hourly token chart reconciles with the overview totals.
+        provider_placeholders = ",".join("?" for _ in _COSTED_PROVIDERS)
         query = f"""
             SELECT ts, input_tokens, output_tokens, cached_input_tokens
             FROM analytics_turn_usage
             WHERE ts >= ? AND ts <= ?
               AND provider IN ({provider_placeholders})
         """
-        params: list = [start_ts, end_ts, *_ANTHROPIC_PROVIDERS]
+        params: list = [start_ts, end_ts, *_COSTED_PROVIDERS]
         if agent_name:
             query += " AND agent_name=?"
             params.append(agent_name)
@@ -1294,7 +1344,7 @@ class AnalyticsStore:
             WHERE ts >= ? AND ts < ?
               AND provider IN ({provider_placeholders})
         """
-        hist_params: list = [hist_start, start_ts, *_ANTHROPIC_PROVIDERS]
+        hist_params: list = [hist_start, start_ts, *_COSTED_PROVIDERS]
         if agent_name:
             hist_query += " AND agent_name=?"
             hist_params.append(agent_name)
@@ -1372,7 +1422,7 @@ class AnalyticsStore:
         start_ts: str,
         end_ts: str,
         agent_name: str = "",
-        anthropic_only: bool = True,
+        costed_only: bool = True,
     ) -> list[sqlite3.Row]:
         query = """
             SELECT session_id, agent_name, ts, provider, model, input_tokens, output_tokens, cached_input_tokens
@@ -1383,10 +1433,10 @@ class AnalyticsStore:
         if agent_name:
             query += " AND agent_name=?"
             params.append(agent_name)
-        if anthropic_only:
-            placeholders = ",".join("?" for _ in _ANTHROPIC_PROVIDERS)
+        if costed_only:
+            placeholders = ",".join("?" for _ in _COSTED_PROVIDERS)
             query += f" AND provider IN ({placeholders})"
-            params.extend(_ANTHROPIC_PROVIDERS)
+            params.extend(_COSTED_PROVIDERS)
         query += " ORDER BY ts"
         with self._connect() as conn:
             return conn.execute(query, params).fetchall()

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -57,6 +57,21 @@ class CodexTurnResult:
     errors: list[str] = field(default_factory=list)
     failed: bool = False
 
+    @property
+    def uncached_input_tokens(self) -> int:
+        """Billable (uncached) input under the daemon's disjoint convention.
+
+        Codex/OpenAI report ``input_tokens`` INCLUSIVE of the cached prefix
+        (``cached_input_tokens`` ⊆ ``input_tokens``), while the rest of the
+        daemon — and the analytics cost math (``_compute_usage_cost``) —
+        follow the Anthropic convention where ``input_tokens`` is the
+        *uncached* remainder priced at the full input rate and the cached
+        span is priced separately at the cached rate. Feeding the raw codex
+        ``input_tokens`` into that math double-bills the cached tokens, so
+        downstream cost/usage rows use this disjoint value instead.
+        """
+        return max(0, self.input_tokens - self.cached_input_tokens)
+
 
 class CodexSession:
     """Agent session backed by Codex CLI.
@@ -352,14 +367,19 @@ class CodexSession:
                             for tu in result.tool_uses
                         ),
                         usage={
-                            "input_tokens": result.input_tokens,
+                            "input_tokens": result.uncached_input_tokens,
                             "output_tokens": result.output_tokens,
                             "cached_input_tokens": result.cached_input_tokens,
                         },
-                        total_cost_usd=0.0,  # Codex doesn't report cost in JSONL
+                        # Per-turn dollar figure stays 0.0 here — Codex JSONL
+                        # carries no cost. The authoritative Codex cost is
+                        # computed by the analytics store from token counts +
+                        # the seeded OpenAI pricing (compute_usage_cost), same
+                        # as the tmux transport (#648).
+                        total_cost_usd=0.0,
                         num_turns=1,
                         model_usage={
-                            "input_tokens": result.input_tokens,
+                            "input_tokens": result.uncached_input_tokens,
                             "output_tokens": result.output_tokens,
                             "cached_input_tokens": result.cached_input_tokens,
                         },
@@ -1278,19 +1298,31 @@ class CodexSession:
             )
             self._current_thinking = ""
             self._current_activity = ""
+            # Log the UNCACHED input (cached span priced separately) so the
+            # analytics cost math doesn't double-bill the cached tokens. The
+            # observability metadata/stream below keep the raw codex totals.
             self._analytics_log_turn_usage(
-                input_tokens=result.input_tokens,
+                input_tokens=result.uncached_input_tokens,
                 output_tokens=result.output_tokens,
                 cached_input_tokens=result.cached_input_tokens,
                 error=False,
             )
+            # Reasoning tokens are a SUBSET of output_tokens (output = visible +
+            # reasoning) and are intentionally NOT billed — Codex cost is computed
+            # from input/output/cached only. Guard the invariant: reasoning >
+            # output means the Codex usage parse mis-attributed tokens. Surface it
+            # as an observability flag (queryable in analytics_activity_events)
+            # rather than silently trusting the number or corrupting billed counts.
+            reasoning_tokens = result.reasoning_output_tokens
+            reasoning_gt_output = reasoning_tokens > result.output_tokens
             self._analytics_log_activity(
                 "turn_completed",
                 metadata={
                     "input_tokens": result.input_tokens,
                     "output_tokens": result.output_tokens,
                     "cached_input_tokens": result.cached_input_tokens,
-                    "reasoning_output_tokens": result.reasoning_output_tokens,
+                    "reasoning_output_tokens": reasoning_tokens,
+                    "reasoning_gt_output": reasoning_gt_output,
                 },
             )
             self._stamp_last_seen()
@@ -1302,7 +1334,8 @@ class CodexSession:
                     "input_tokens": result.input_tokens,
                     "output_tokens": result.output_tokens,
                     "cached_input_tokens": result.cached_input_tokens,
-                    "reasoning_output_tokens": result.reasoning_output_tokens,
+                    "reasoning_output_tokens": reasoning_tokens,
+                    "reasoning_gt_output": reasoning_gt_output,
                 },
             })
 

--- a/tests/test_analytics_store.py
+++ b/tests/test_analytics_store.py
@@ -395,6 +395,60 @@ class TestPricingLookup:
         assert row["input_usd_per_mtok"] == 3.00
         assert store._lookup_pricing(provider="anthropic", model="no-such-model", ts=ts) is None
 
+    def test_gpt55_priced_via_codex_alias(self, tmp_path):
+        # #206: Codex agents (Murzik runs gpt-5.5) showed $0 because the
+        # pricing seed stopped at gpt-5.2. gpt-5.5 must resolve through the
+        # codex_cli -> openai alias at the verified $5/$30/$0.50 rates.
+        store = _store(tmp_path)
+        ts = _iso(datetime.now(UTC))
+        row = store._lookup_pricing(provider="codex_cli", model="gpt-5.5", ts=ts)
+        assert row is not None
+        assert row["input_usd_per_mtok"] == 5.00
+        assert row["output_usd_per_mtok"] == 30.00
+        assert row["cached_input_usd_per_mtok"] == 0.50
+
+    def test_codex_turn_cost_nonzero(self, tmp_path):
+        # End-to-end: a codex_cli/gpt-5.5 turn lands in the overview cost
+        # (regression guard for the $0-Codex bug).
+        store = _store(tmp_path)
+        _seed_session(store)
+        store.log_turn_usage(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            provider="codex_cli", model="gpt-5.5",
+            input_tokens=1_000_000, output_tokens=0, cached_input_tokens=0,
+        )
+        overview = store.get_overview(range_name="7d")
+        assert overview["totals"]["cost_usd"] == pytest.approx(5.0)
+
+    def test_ensure_pricing_rows_idempotent(self, tmp_path):
+        # The idempotent backfill runs on every init; re-opening the same DB
+        # must not duplicate the gpt-5.5 row.
+        db = str(tmp_path / "analytics.db")
+        AnalyticsStore(db)
+        store = AnalyticsStore(db)
+        with store._connect() as conn:
+            n = conn.execute(
+                "SELECT COUNT(*) AS c FROM analytics_model_pricing "
+                "WHERE provider='openai' AND model='gpt-5.5'"
+            ).fetchone()["c"]
+        assert n == 1
+
+    def test_categories_includes_codex_cost(self, tmp_path):
+        # #206 P1: the per-category cost view was hard-gated to Anthropic
+        # providers, so Codex turns never appeared. A codex_cli/gpt-5.5 turn
+        # must now show up with non-zero cost in get_categories().
+        store = _store(tmp_path)
+        _seed_session(store)
+        store.log_turn_usage(
+            session_id="sess1", agent_name="barsik", turn_seq=1,
+            provider="codex_cli", model="gpt-5.5",
+            input_tokens=1_000_000, output_tokens=0, cached_input_tokens=0,
+        )
+        cats = store.get_categories(range_name="7d")
+        assert cats["categories"], "Codex turn should produce a category row"
+        total = sum(c["cost_usd"] for c in cats["categories"])
+        assert total == pytest.approx(5.0)
+
 
 class TestSeedRateTableParity:
     """#669: the Analytics seed and pinky_daemon.pricing.RATE_TABLE are two

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -24,6 +24,22 @@ class TestCodexTurnResult:
         assert r.output_tokens == 0
         assert not r.failed
 
+    def test_uncached_input_tokens_disjoint(self):
+        # #206: Codex reports input_tokens INCLUSIVE of the cached prefix.
+        # The billable/disjoint value (Anthropic convention) is input - cached,
+        # so the analytics cost math doesn't double-bill the cached span.
+        # Real Murzik sample: input=78121, cached=77696 -> uncached=425.
+        r = CodexTurnResult(input_tokens=78121, cached_input_tokens=77696)
+        assert r.uncached_input_tokens == 425
+        # No caching: uncached == input.
+        assert CodexTurnResult(input_tokens=100).uncached_input_tokens == 100
+        # Anomalous (cached > input) clamps at 0, never negative.
+        assert (
+            CodexTurnResult(input_tokens=10, cached_input_tokens=50)
+            .uncached_input_tokens
+            == 0
+        )
+
 
 class TestCodexSessionInterface:
     """Verify CodexSession exposes the same public interface as StreamingSession."""
@@ -600,6 +616,53 @@ class TestCodexReasoningOutputTokens:
             result,
         )
         assert result.reasoning_output_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_reasoning_gt_output_flagged_anomaly(self):
+        """Guard (#206): reasoning is a subset of output, so reasoning > output
+        is a usage-parse anomaly. It must surface as a queryable observability
+        flag in the turn_completed metadata — not silently trusted."""
+        config = StreamingSessionConfig(
+            agent_name="test", working_dir="/tmp", provider_url="codex_cli",
+        )
+        session = CodexSession(config)
+        captured: list = []
+        session._analytics_log_activity = (
+            lambda event_type, *, metadata=None: captured.append((event_type, metadata))
+        )
+        result = CodexTurnResult()
+        await session._handle_event(
+            {"type": "turn.completed", "usage": {
+                "input_tokens": 100, "output_tokens": 20,
+                "cached_input_tokens": 50, "reasoning_output_tokens": 4096,
+            }},
+            result,
+        )
+        meta = next(m for e, m in captured if e == "turn_completed")
+        assert meta["reasoning_gt_output"] is True
+        assert meta["reasoning_output_tokens"] == 4096
+
+    @pytest.mark.asyncio
+    async def test_reasoning_within_output_not_flagged(self):
+        """Normal case: reasoning <= output → no anomaly flag."""
+        config = StreamingSessionConfig(
+            agent_name="test", working_dir="/tmp", provider_url="codex_cli",
+        )
+        session = CodexSession(config)
+        captured: list = []
+        session._analytics_log_activity = (
+            lambda event_type, *, metadata=None: captured.append((event_type, metadata))
+        )
+        result = CodexTurnResult()
+        await session._handle_event(
+            {"type": "turn.completed", "usage": {
+                "input_tokens": 100, "output_tokens": 5000,
+                "cached_input_tokens": 50, "reasoning_output_tokens": 4096,
+            }},
+            result,
+        )
+        meta = next(m for e, m in captured if e == "turn_completed")
+        assert meta["reasoning_gt_output"] is False
 
 
 class TestCodexWorkerDoneCallback:


### PR DESCRIPTION
## What & why (#206)

Codex (`codex_cli`) agents — e.g. Murzik on `gpt-5.5` — showed **$0** in the cost dashboards. This is the first increment of the Codex → first-class-parity work (gaps deliberated with Murzik): make Codex cost real and correct.

Three independent causes, all fixed:

### 1. Missing rate
The analytics pricing seed stopped at `gpt-5.2`; `gpt-5.5` had no row → unknown rate → $0. Added `gpt-5.5` ($5 / $30 / $0.50) and `gpt-5.3-codex` ($1.75 / $14 / $0.175) with verified 2026 rates, plus an idempotent backfill (`_ensure_pricing_rows`) — `_seed_default_pricing` only fires on an empty table, so already-seeded production DBs need insert-if-absent (never clobbers an operator-set price). Composes cleanly with the #758/#759 seed migrations (opus/haiku realign + dotted-id rename).

### 2. Provider gate dropped Codex
**Every** cost/usage view hard-filtered to Anthropic providers, so Codex rows were excluded **before pricing ran**. Added `_COSTED_PROVIDERS` (Anthropic ∪ `openai`/`openai_api`/`codex_cli`) and gated the **overview, agent-detail, category, and hourly** views on it, so Codex reconciles across all four. Claude-only views (rate-limit gating) keep `_ANTHROPIC_PROVIDERS`.

`opencode` is intentionally **not** in the costed set yet: it has no seeded pricing and `_provider_alias` can't map it to one rate table (opencode runs Anthropic **or** OpenAI models depending on config), so including it would surface a misleading $0. It goes back in alongside pricing + a model-aware alias when an opencode agent ships (tracked in #786).

### 3. Cached double-bill
Codex/OpenAI report `input_tokens` **inclusive** of the cached prefix (`cached ⊆ input`), but the cost math follows the Anthropic convention where input & cached are disjoint. Feeding raw Codex counts would bill the cached span twice (full input rate + cached rate). Normalized to uncached (`input − cached`) via `CodexTurnResult.uncached_input_tokens` before it reaches the durable `TurnResponse` usage + analytics row.

### Reasoning tokens (observability only, never billed)
`reasoning_output_tokens` is a **subset** of `output_tokens` (confirmed with real session samples), so it is persisted to the observability metadata/stream **only** — it is deliberately **not** threaded into the durable `analytics_turn_usage` row, because billing is token-count based and reasoning ⊆ output is never billed. Added a defensive anomaly flag (`reasoning_gt_output`) to the `turn_completed` metadata + stream event, so a future usage-parse regression (`reasoning > output`) is queryable in `analytics_activity_events` rather than silent.

## Verification
- `110 passed` across `test_analytics_store.py` + `test_codex_session.py`; `ruff` clean. Rebased onto current `main`.
- New tests: gpt-5.5 lookup via the codex alias; nonzero Codex turn cost in the **overview AND category** views (regression guards for $0); idempotent backfill (no dup on re-open); uncached normalization (real `input=78121 / cached=77696 → 425`); reasoning anomaly guard (flagged when `reasoning > output`, clean when within).
- Worked example (gpt-5.5, the 78121 / 77696 / 455 sample): uncached 425 @ $5 + cached 77696 @ $0.50 + output 455 @ $30 = **$0.0546** — vs the naive double-bill **$0.43**.

Backend/analytics change; the user-visible effect is Codex agents' cost appearing in the Analytics dashboard — will confirm on the live dashboard post-deploy.

## Review addressed (Murzik)
- **P1** — `get_categories` (and `get_hourly`) now use `_COSTED_PROVIDERS` + regression test. ✅
- **P2** — reasoning scoped to observability + anomaly guard added; PR wording corrected. ✅
- **P3** — `opencode` removed from the costed set until it has pricing + an alias. ✅

## Next in #206 (per Murzik's reprioritization)
2. State-machine `BOOTING`/`RECONNECTING` + reconnect visibility → 3. context soft-watermark (advisory, not auto-restart) → 4. skill MCP (HTTP/SSE).

Reviewer: **Murzik** (Codex) — deliberated the gaps + confirmed the reasoning-token semantics with real session samples.

🤖 Opened by Barsik
