### PR TITLE
feat(codex): state-machine parity — surface BOOTING/RECONNECTING (#206)

### DIFF
--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -947,7 +947,18 @@ class CodexSession:
             server_request_handler=self._on_appserver_request,
             log=_log,
         )
-        await self._app_client.initialize(name="pinkybot", version="1")
+        try:
+            await self._app_client.initialize(name="pinkybot", version="1")
+        except BaseException:
+            # Spawn succeeded but initialize() failed: never leave a
+            # half-initialized client/proc cached. The early-return guard above
+            # checks only (client is not None and proc still alive), so a
+            # cached-but-uninitialized substrate would make the NEXT reconnect
+            # skip initialization entirely and flip the state machine to
+            # CONNECTED on a dead app-server. Tear down before re-raising so
+            # the next _ensure_app_server() respawns from scratch.
+            await self._teardown_app_server()
+            raise
         _log(f"codex[{self.agent_name}]: app-server connected (pid={self._app_proc.pid})")
 
     async def _teardown_app_server(self) -> None:

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -35,7 +35,12 @@ from pinky_daemon.streaming_session import (
     _is_outreach_tool,
     _log,
 )
-from pinky_daemon.transport_state import SessionState
+from pinky_daemon.transport_state import (
+    OwnerToken,
+    SessionState,
+    StateMachine,
+    Trigger,
+)
 from pinky_daemon.turn_response import TurnResponse
 from pinky_daemon.wake_prompt import WakeReason
 
@@ -98,9 +103,15 @@ class CodexSession:
         self._stream_event_callback = stream_event_callback
         self._analytics_store = analytics_store
         self._registry = registry
-        self._connected = False
-        self._idle_sleeping = False
-        self._connect_attempted = False  # distinguishes UNINITIALIZED from DEAD
+        # Lifecycle state machine (#206) — Codex now uses the same explicit
+        # five-state contract as TmuxSession/StreamingSession instead of the
+        # old _connected/_idle_sleeping/_connect_attempted bool lattice. The
+        # machine is the single source of truth for ``state`` + ``stats`` and
+        # surfaces BOOTING (cold start in flight) and RECONNECTING (warm wake /
+        # recovery in flight) to the broker, watchdog, and dashboard. Internal
+        # control flow gates on ``self.state`` (e.g. the worker loop runs while
+        # CONNECTED; send is accepted only while CONNECTED).
+        self._state_machine = StateMachine(owner_label=f"codex:{config.agent_name}")
         self._processing = False  # True while a codex exec is running
         self._message_queue: asyncio.Queue[tuple[str, str, str, str]] = asyncio.Queue()
         # Serializes _exec_codex between the worker and out-of-band callers
@@ -170,28 +181,155 @@ class CodexSession:
         # app-server reports usage out-of-band, not inside turn/completed.
         self._appserver_last_usage: dict = {}
 
-    async def connect(self) -> None:
-        """Start the session. Sends wake prompt via codex exec."""
-        self._connect_attempted = True  # tracks state ≠ UNINITIALIZED
-        if self._connected:
-            self._idle_sleeping = False
+    async def connect(self, *, trigger: Trigger = Trigger.BROKER) -> None:
+        """Bring the Codex session up through the state machine (#206).
+
+        Mirrors TmuxSession.connect's owner-token discipline:
+
+        - Cold start (state ∈ {UNINITIALIZED, BOOTING}): BOOT → BOOTING →
+          CONNECTED|DEAD via the BOOT / BOOT_COMPLETE / BOOT_FAILED triplet.
+          ``trigger`` is ignored (BOOT is the only legal edge out of
+          UNINITIALIZED).
+        - Warm wake (state ∈ {IDLE_SLEEPING, DEAD}): RECONNECTING → CONNECTED|
+          DEAD via the caller-supplied ``trigger`` (BROKER on inbound auto-wake,
+          SCHEDULER on cron, WATCHDOG on recovery, API_ADMIN on operator wake).
+        - CONNECTED: no-op straggler (return).
+        - RECONNECTING: another path (force_restart/attempt_reconnect) owns the
+          transition — refuse.
+
+        "Usable" (BOOT_COMPLETE / RECONNECTING→CONNECTED) means the transport can
+        accept and DRAIN work, NOT that the first model turn finished: the
+        app-server substrate is up (app-server mode) and the worker drainer is
+        about to run. We never hold BOOTING across a model turn (#206; Murzik).
+        """
+        cold_start_token: OwnerToken | None = None
+        warm_wake_token: OwnerToken | None = None
+        st = self.state
+
+        if st in (SessionState.UNINITIALIZED, SessionState.BOOTING):
+            boot = await self._state_machine.request_transition(
+                SessionState.BOOTING, Trigger.BOOT, reason="codex_cold_start"
+            )
+            if boot.owner_token is None:
+                if boot.in_flight_handle is not None:
+                    final = await boot.in_flight_handle.wait()
+                    if final == SessionState.CONNECTED:
+                        return
+                    raise RuntimeError(
+                        f"codex[{self.agent_name}]: cold-start BOOT in-flight "
+                        f"resolved to {final.value}; not returning as connected"
+                    )
+                _log(
+                    f"codex[{self.agent_name}]: BOOT rejected "
+                    f"({boot.rejection_reason!r})"
+                )
+                if self.state == SessionState.DEAD:
+                    raise RuntimeError(
+                        f"codex[{self.agent_name}]: cold-start BOOT rejected "
+                        f"post-DEAD; not returning as connected"
+                    )
+                return
+            cold_start_token = boot.owner_token
+        elif st in (SessionState.IDLE_SLEEPING, SessionState.DEAD):
+            wake = await self._state_machine.request_transition(
+                SessionState.RECONNECTING, trigger,
+                reason=f"codex_warm_wake_from_{st.value}",
+            )
+            if wake.owner_token is None:
+                if wake.in_flight_handle is not None:
+                    final = await wake.in_flight_handle.wait()
+                    if final == SessionState.CONNECTED:
+                        return
+                    raise RuntimeError(
+                        f"codex[{self.agent_name}]: warm-wake RECONNECTING "
+                        f"in-flight resolved to {final.value}; not returning "
+                        f"as connected"
+                    )
+                _log(
+                    f"codex[{self.agent_name}]: warm-wake rejected "
+                    f"({wake.rejection_reason!r}) — state={self.state.value}"
+                )
+                if self.state == SessionState.DEAD:
+                    raise RuntimeError(
+                        f"codex[{self.agent_name}]: warm-wake rejected "
+                        f"post-DEAD; not returning as connected"
+                    )
+                return
+            warm_wake_token = wake.owner_token
+        elif st == SessionState.CONNECTED:
+            _log(
+                f"codex[{self.agent_name}]: connect() while already CONNECTED "
+                f"— no-op (post-completion straggler)"
+            )
+            return
+        else:  # RECONNECTING — owned by force_restart / attempt_reconnect
+            _log(
+                f"codex[{self.agent_name}]: connect() with state={st.value} — "
+                f"refusing (another path owns this transition)"
+            )
             return
 
-        self._connected = True
-        self._idle_sleeping = False
-        self._analytics_session_started()
+        # Bring up the substrate (app-server spawn+initialize for app-server
+        # mode; nothing persistent for exec mode). A failure here is structural
+        # — terminalize the in-flight transition to DEAD so the broker
+        # resurrects on the next inbound, never leaving a leaked owner token.
+        try:
+            await self._bring_up_substrate()
+        except BaseException as e:
+            _log(f"codex[{self.agent_name}]: substrate bring-up failed: {e}")
+            if cold_start_token is not None:
+                await self._state_machine.transition_complete(
+                    cold_start_token, SessionState.DEAD, trigger=Trigger.BOOT_FAILED
+                )
+            elif warm_wake_token is not None:
+                await self._state_machine.transition_complete(
+                    warm_wake_token, SessionState.DEAD, trigger=Trigger.INTERNAL
+                )
+            raise
 
-        # Start the message processing worker
+        # Substrate up → flip CONNECTED ("can accept and drain work").
+        if cold_start_token is not None:
+            await self._state_machine.transition_complete(
+                cold_start_token, SessionState.CONNECTED,
+                trigger=Trigger.BOOT_COMPLETE,
+            )
+        elif warm_wake_token is not None:
+            await self._state_machine.transition_complete(
+                warm_wake_token, SessionState.CONNECTED, trigger=Trigger.INTERNAL
+            )
+
+        self._analytics_session_started()
+        self._start_worker()
+        _log(f"codex[{self.agent_name}]: connected, worker started")
+        await self._enqueue_wake()
+
+    async def _bring_up_substrate(self) -> None:
+        """Bring up the structural substrate for a turn-capable session.
+
+        App-server mode: spawn + initialize the long-lived ``codex app-server``
+        connection (the persistent transport). Exec mode: nothing persistent —
+        each turn spawns its own ``codex exec``, so there's no substrate to fail
+        on boot. Raises on failure; the caller terminalizes the in-flight
+        transition to DEAD.
+        """
+        if self._use_app_server:
+            await self._ensure_app_server()
+
+    def _start_worker(self) -> None:
+        """Spawn the message-drainer worker if not already running.
+
+        Called AFTER the state flips to CONNECTED — the worker loop runs
+        ``while self.state == CONNECTED``, so spawning it earlier (during
+        BOOTING/RECONNECTING) would make it exit immediately. The done-callback
+        surfaces silent worker death and terminalizes the session to DEAD (see
+        ``_worker_done_callback``).
+        """
         if not self._worker_task or self._worker_task.done():
             self._worker_task = asyncio.create_task(self._message_worker())
-            # WEDGE FIX: surface silent worker death. Without this
-            # callback, an unhandled exception or unexpected loop exit
-            # leaves the broker thinking the session is alive while the
-            # queue piles up forever. The callback flips ``_connected``
-            # so the broker's reconnect path can re-spawn us.
             self._worker_task.add_done_callback(self._worker_done_callback)
 
-        _log(f"codex[{self.agent_name}]: connected, worker started")
+    async def _enqueue_wake(self) -> None:
+        """Assemble + enqueue the wake prompt for the freshly-connected session."""
 
         # Send wake prompt
         is_resume = bool(self.codex_session_id)
@@ -281,8 +419,11 @@ class CodexSession:
                 Mirrors StreamingSession.send so the broker can call both
                 session types polymorphically.
         """
-        if not self._connected:
-            _log(f"codex[{self.agent_name}]: not connected, dropping message")
+        if self.state != SessionState.CONNECTED:
+            _log(
+                f"codex[{self.agent_name}]: not connected "
+                f"(state={self.state.value}), dropping message"
+            )
             return
 
         self.last_active = time.time()
@@ -315,7 +456,12 @@ class CodexSession:
         """Process queued messages sequentially via codex exec."""
         _log(f"codex[{self.agent_name}]: message worker started")
         try:
-            while self._connected:
+            # Drain while CONNECTED. The worker is only spawned after the state
+            # flips to CONNECTED (see _start_worker); a transition out of
+            # CONNECTED (idle_sleep, force_restart, terminalized failure) stops
+            # the loop at the next iteration, and disconnect() cancels an
+            # in-flight ``get``. (#206 — was ``while self._connected``.)
+            while self.state == SessionState.CONNECTED:
                 prompt, platform, chat_id, message_id = await self._message_queue.get()
                 try:
                     self._processing = True
@@ -438,41 +584,72 @@ class CodexSession:
         except asyncio.CancelledError:
             _log(f"codex[{self.agent_name}]: worker cancelled")
         except Exception as e:
+            # Unhandled worker error → the worker returns and the done-callback
+            # fires; it terminalizes the session to DEAD (worker owns the queue,
+            # so its death = the session can't process — see #206 / Murzik Q3).
             _log(f"codex[{self.agent_name}]: worker error: {e}")
-            self._connected = False
 
     def _worker_done_callback(self, task: asyncio.Task) -> None:
-        """Surface silent worker death.
+        """Surface silent worker death by terminalizing the session to DEAD.
 
-        Called via ``task.add_done_callback`` when the worker exits for
-        any reason. The worker normally only exits when ``_connected``
-        is already False (graceful disconnect) or via an unhandled
-        exception (caught + flips ``_connected``). The pathological
-        case this guards is: worker exits while ``_connected`` is still
-        True — broker still thinks we're alive, queue keeps accepting
-        sends, nothing processes them. Flip ``_connected`` so the
-        broker's reconnect path can re-spawn us.
+        Called via ``task.add_done_callback`` when the worker exits for any
+        reason. A graceful disconnect cancels the worker (handled by the
+        ``task.cancelled()`` early-return). The pathological case this guards is:
+        the worker exits while the session is still CONNECTED — broker thinks
+        we're alive, queue keeps accepting sends, nothing processes them.
 
-        Defensive: callback is sync (asyncio constraint) and runs from
-        the event loop's task-finalisation step, so we keep work
-        minimal — just log + flip the flag. Anything heavier would
-        risk re-entering broker code at an awkward moment.
+        The worker owns the queue, so its unexpected death means the session
+        can't process. We drive it **straight to DEAD** — NOT an inline reconnect
+        (reconnecting from the death callback risks resurrecting on corrupted
+        queue/processing state, #206 Murzik Q3). The broker/heartbeat resurrects
+        it via ``attempt_reconnect`` on the next inbound/recovery tick
+        (DEAD → RECONNECTING → CONNECTED).
+
+        Defensive: the callback is sync (asyncio constraint) and runs from the
+        event loop's task-finalisation step, so we keep it minimal — log + schedule
+        the (async, lock-guarded) transition rather than mutate state inline.
         """
         if task.cancelled():
             return  # graceful — disconnect() cancelled us
         exc = task.exception()
-        if self._connected:
+        if self.state == SessionState.CONNECTED:
             if exc is not None:
                 _log(
                     f"codex[{self.agent_name}]: WORKER DIED with "
-                    f"{type(exc).__name__}: {exc} — flipping _connected=False"
+                    f"{type(exc).__name__}: {exc} — marking session DEAD"
                 )
             else:
                 _log(
                     f"codex[{self.agent_name}]: WORKER EXITED unexpectedly "
-                    f"(no exception, no cancel) — flipping _connected=False"
+                    f"(no exception, no cancel) — marking session DEAD"
                 )
-            self._connected = False
+            try:
+                asyncio.get_running_loop().create_task(
+                    self._terminalize_dead("worker died")
+                )
+            except RuntimeError:
+                pass  # no running loop (interpreter / loop shutdown)
+
+    async def _terminalize_dead(self, reason: str) -> None:
+        """Drive the session CONNECTED → DEAD (best-effort, tolerant).
+
+        Used by the worker-death callback and the app-server structural-failure
+        paths to terminalize a session whose transport can no longer process.
+        Requests ``DEAD`` via ``INTERNAL`` and completes it. If another path
+        already moved the state (or a transition is in flight to a different
+        target), ``request_transition`` returns no owner token and this is a
+        no-op — so it's safe to call from anywhere.
+        """
+        try:
+            res = await self._state_machine.request_transition(
+                SessionState.DEAD, Trigger.INTERNAL, reason=reason
+            )
+            if res.owner_token is not None:
+                await self._state_machine.transition_complete(
+                    res.owner_token, SessionState.DEAD, trigger=Trigger.INTERNAL
+                )
+        except Exception as e:
+            _log(f"codex[{self.agent_name}]: terminalize-dead failed: {e}")
 
     def is_healthy(self) -> dict:
         """Return diagnostic state for the broker / liveness probe.
@@ -500,12 +677,13 @@ class CodexSession:
         # 1. broker thinks we're connected but worker is dead
         # 2. processing flag stuck True for longer than the inner 600s
         #    timeout could reasonably take + a generous buffer
+        connected = self.state == SessionState.CONNECTED
         wedged = bool(
-            (self._connected and not worker_alive)
+            (connected and not worker_alive)
             or (self._processing and seconds_since_active > 900)
         )
         return {
-            "connected": self._connected,
+            "connected": connected,
             "worker_alive": worker_alive,
             "processing": self._processing,
             "queue_depth": self._message_queue.qsize(),
@@ -823,7 +1001,12 @@ class CodexSession:
         result = CodexTurnResult()
         try:
             await self._ensure_app_server()
-        except Exception as e:  # noqa: BLE001 — surface as a failed turn, keep session alive
+        except Exception as e:  # noqa: BLE001
+            # Structural (#206): the persistent app-server substrate failed to
+            # come back up mid-life — the session can't process. Terminalize to
+            # DEAD; the broker/heartbeat resurrects via attempt_reconnect on the
+            # next inbound/recovery tick. (A per-turn MODEL failure, by contrast,
+            # arrives as turn/failed and leaves the session CONNECTED.)
             result.failed = True
             result.errors.append(f"app-server connect failed: {e}")
             _log(f"codex[{self.agent_name}]: app-server connect failed: {e}")
@@ -831,6 +1014,7 @@ class CodexSession:
                 "type": "turn_failed", "agent": self.agent_name,
                 "session_id": self.id, "error": str(e),
             })
+            await self._terminalize_dead("app-server connect failed")
             return result
 
         client = self._app_client
@@ -903,9 +1087,11 @@ class CodexSession:
                 "type": "turn_failed", "agent": self.agent_name,
                 "session_id": self.id, "error": "codex app-server turn timed out after 600s",
             })
-            # A wedged thread is unrecoverable — drop the connection so the next
-            # turn respawns and resumes cleanly.
+            # A 600s timeout is a transport/thread wedge, not just a slow
+            # response (#206 Murzik): tear the connection down AND terminalize to
+            # DEAD so it can't sit silently CONNECTED behind a dead transport.
             await self._teardown_app_server()
+            await self._terminalize_dead("app-server turn timed out")
         except CodexAppServerError as e:
             result.failed = True
             result.errors.append(str(e))
@@ -915,7 +1101,11 @@ class CodexSession:
                 "session_id": self.id, "error": str(e),
             })
             await self._teardown_app_server()
-        except Exception as e:  # noqa: BLE001 — keep the session alive across turn failures
+            await self._terminalize_dead("app-server protocol error")
+        except Exception as e:  # noqa: BLE001
+            # Generic turn exception that tore down the transport (#206 Murzik):
+            # once _teardown_app_server() runs, the session must NOT stay silently
+            # CONNECTED — terminalize to DEAD for broker-driven resurrection.
             result.failed = True
             result.errors.append(str(e))
             _log(f"codex[{self.agent_name}]: app-server turn exception: {e}")
@@ -924,6 +1114,7 @@ class CodexSession:
                 "session_id": self.id, "error": str(e),
             })
             await self._teardown_app_server()
+            await self._terminalize_dead("app-server turn exception")
         finally:
             self._active_turn_result = None
             self._turn_done = None
@@ -1378,68 +1569,107 @@ class CodexSession:
 
         _log(f"codex[{self.agent_name}]: force restarting")
 
-        # Clear the resume handle
-        if self._on_resume_handle:
-            try:
-                await self._on_resume_handle(self.agent_name, "")
-            except Exception:
-                pass
-
-        await self.disconnect()
-
-        # #591 P1#1 (Murzik round-2): the prior eager refresh here ran
-        # the builder 1-arg (commit=True), consuming inbox + restart-
-        # manifest BEFORE connect() ran its own reason-aware committed
-        # rebuild — same double-consume pattern as the API-layer sites.
-        # Removed: connect() is the single source-of-truth for both the
-        # wake_context body and side-effect consumption.
-
-        self.codex_session_id = ""
-        self.resume_handle = ""
+        # Own the CONNECTED → RECONNECTING transition (USER_AGENT = the agent's
+        # own context_restart). disconnect() below sees state==RECONNECTING and
+        # skips its standalone-DEAD path, and we drive the substrate back up via
+        # the private helper rather than connect() (which would request a nested
+        # transition — #206 Murzik).
+        res = await self._state_machine.request_transition(
+            SessionState.RECONNECTING, Trigger.USER_AGENT, reason="force_restart"
+        )
+        if res.owner_token is None:
+            _log(
+                f"codex[{self.agent_name}]: force_restart could not own "
+                f"RECONNECTING (state={self.state.value}, {res.rejection_reason!r})"
+            )
+            return False
+        token = res.owner_token
 
         try:
-            await self.connect()
-            _log(f"codex[{self.agent_name}]: force restart complete")
-            return True
-        except Exception as e:
+            # Clear the resume handle (fresh start).
+            if self._on_resume_handle:
+                try:
+                    await self._on_resume_handle(self.agent_name, "")
+                except Exception:
+                    pass
+
+            await self.disconnect()
+
+            # #591 P1#1 (Murzik round-2): connect() is the single source-of-truth
+            # for the wake_context body + side-effect consumption; _enqueue_wake
+            # (below) rebuilds it reason-aware, so no eager refresh here.
+            self.codex_session_id = ""
+            self.resume_handle = ""
+
+            await self._bring_up_substrate()
+        except BaseException as e:
             _log(f"codex[{self.agent_name}]: force restart failed: {e}")
-            self._connected = False
+            await self._state_machine.transition_complete(
+                token, SessionState.DEAD, trigger=Trigger.INTERNAL
+            )
             return False
+
+        await self._state_machine.transition_complete(
+            token, SessionState.CONNECTED, trigger=Trigger.INTERNAL
+        )
+        self._analytics_session_started()
+        self._start_worker()
+        await self._enqueue_wake()
+        _log(f"codex[{self.agent_name}]: force restart complete")
+        return True
 
     async def idle_sleep(self) -> bool:
         """Put the session to sleep. Codex session ID preserved for resume."""
-        if not self._connected:
+        if self.state != SessionState.CONNECTED:
             return False
 
         _log(f"codex[{self.agent_name}]: idle sleep triggered")
 
-        # Ask agent to save state before sleeping. The lock keeps this exec
-        # from racing a worker turn against the same codex thread.
-        try:
-            async with self._exec_lock:
-                await self._exec_codex(
-                    "[SYSTEM] You've been idle for over an hour. Auto-sleep is activating.\n\n"
-                    "Before your session is suspended:\n"
-                    "1. Use reflect() to persist key learnings and current task state\n"
-                    "2. Note what you were working on so you can resume later\n\n"
-                    "Your session will be preserved and resumed when you're needed next."
-                )
-            _log(f"codex[{self.agent_name}]: memory save prompt sent before idle sleep")
-        except Exception as e:
-            _log(f"codex[{self.agent_name}]: memory save failed before idle sleep: {e}")
+        # Own CONNECTED → IDLE_SLEEPING up front (USER_AGENT). Pre-flipping the
+        # state before the save-exec + disconnect (mirrors tmux) avoids a DEAD
+        # flicker: a concurrent heartbeat-watchdog tick must observe
+        # IDLE_SLEEPING throughout the teardown window, not a transient DEAD that
+        # would trigger _heartbeat_resurrect on a session about to sleep (PR3
+        # Bug 1 class; transport_state.py §5 "no flicker" invariant).
+        res = await self._state_machine.request_transition(
+            SessionState.IDLE_SLEEPING, Trigger.USER_AGENT, reason="idle_sleep"
+        )
+        if res.owner_token is None:
+            _log(
+                f"codex[{self.agent_name}]: idle_sleep could not own "
+                f"IDLE_SLEEPING (state={self.state.value})"
+            )
+            return False
+        token = res.owner_token
 
-        # Set the idle-sleeping flag BEFORE disconnect() so the derived
-        # ``state`` property reports IDLE_SLEEPING throughout the teardown
-        # window. Otherwise a concurrent heartbeat-watchdog tick between
-        # disconnect() landing _connected=False and this line setting
-        # _idle_sleeping=True would observe state == DEAD and call
-        # _heartbeat_resurrect on a session that's about to be IDLE_SLEEPING.
-        # Same class as PR3 Bug 1 on StreamingSession.force_restart, just
-        # on the codex backend (per @pushok PR #492 Nit 2). Echoes the
-        # "no flicker DEAD ↔ IDLE_SLEEPING/RECONNECTING" invariant from
-        # transport_state.py §5.
-        self._idle_sleeping = True
-        await self.disconnect()
+        try:
+            # Ask the agent to save state before sleeping. The exec lock keeps
+            # this from racing a worker turn on the same codex thread (the worker
+            # loop has already stopped — state left CONNECTED at grant).
+            try:
+                async with self._exec_lock:
+                    await self._exec_codex(
+                        "[SYSTEM] You've been idle for over an hour. Auto-sleep is activating.\n\n"
+                        "Before your session is suspended:\n"
+                        "1. Use reflect() to persist key learnings and current task state\n"
+                        "2. Note what you were working on so you can resume later\n\n"
+                        "Your session will be preserved and resumed when you're needed next."
+                    )
+                _log(f"codex[{self.agent_name}]: memory save prompt sent before idle sleep")
+            except Exception as e:
+                _log(f"codex[{self.agent_name}]: memory save failed before idle sleep: {e}")
+
+            await self.disconnect()
+        except BaseException as e:
+            _log(f"codex[{self.agent_name}]: idle_sleep teardown failed: {e}")
+            await self._state_machine.transition_complete(
+                token, SessionState.DEAD, trigger=Trigger.INTERNAL
+            )
+            return False
+
+        await self._state_machine.transition_complete(
+            token, SessionState.IDLE_SLEEPING, trigger=Trigger.USER_AGENT
+        )
         self._stats["auto_restarts"] += 1
         _log(f"codex[{self.agent_name}]: idle sleep complete")
         return True
@@ -1448,12 +1678,30 @@ class CodexSession:
     # watchdog contract so api._heartbeat_resurrect can treat runtimes uniformly.
     _RECONNECT_BACKOFF = (2, 8, 30)
 
-    async def attempt_reconnect(self) -> None:
-        """Attempt to reconnect after a failure with bounded retries."""
-        try:
-            await self.disconnect()
-        except Exception as e:
-            _log(f"codex[{self.agent_name}]: pre-reconnect disconnect raised: {e}")
+    async def attempt_reconnect(self, *, trigger: Trigger = Trigger.WATCHDOG) -> None:
+        """Reconnect with bounded retries under a SINGLE RECONNECTING transition.
+
+        Takes RECONNECTING ownership once and retries the substrate bring-up
+        under it — rather than calling connect() per attempt, which would request
+        a nested transition (#206 Murzik). Completes to CONNECTED on the first
+        success, or DEAD once the retry budget is exhausted. Legal from CONNECTED
+        / IDLE_SLEEPING / DEAD via WATCHDOG (the default; the heartbeat-resurrect
+        + watchdog-recovery callers).
+        """
+        res = await self._state_machine.request_transition(
+            SessionState.RECONNECTING, trigger, reason="attempt_reconnect"
+        )
+        if res.owner_token is None:
+            if res.in_flight_handle is not None:
+                # Another path already owns the reconnect — inherit its outcome.
+                await res.in_flight_handle.wait()
+            else:
+                _log(
+                    f"codex[{self.agent_name}]: attempt_reconnect rejected "
+                    f"(state={self.state.value}, {res.rejection_reason!r})"
+                )
+            return
+        token = res.owner_token
 
         last_error: Exception | None = None
         for attempt_idx, delay in enumerate(self._RECONNECT_BACKOFF, start=1):
@@ -1463,28 +1711,45 @@ class CodexSession:
                 f"{len(self._RECONNECT_BACKOFF)} (#{self._stats['reconnects']} total) "
                 f"after {delay}s backoff"
             )
+            try:
+                await self.disconnect()  # state==RECONNECTING → no standalone DEAD
+            except Exception as e:
+                _log(f"codex[{self.agent_name}]: pre-attempt disconnect raised: {e}")
             await asyncio.sleep(delay)
             try:
-                await self.connect()
-                _log(f"codex[{self.agent_name}]: reconnected successfully")
-                return
+                await self._bring_up_substrate()
             except Exception as e:
                 last_error = e
                 _log(f"codex[{self.agent_name}]: reconnect attempt {attempt_idx} failed: {e}")
-                try:
-                    await self.disconnect()
-                except Exception:
-                    pass
+                continue
+            # Success — complete to CONNECTED + bring the worker/wake back up.
+            await self._state_machine.transition_complete(
+                token, SessionState.CONNECTED, trigger=Trigger.INTERNAL
+            )
+            self._analytics_session_started()
+            self._start_worker()
+            await self._enqueue_wake()
+            _log(f"codex[{self.agent_name}]: reconnected successfully")
+            return
 
-        self._connected = False
+        await self._state_machine.transition_complete(
+            token, SessionState.DEAD, trigger=Trigger.INTERNAL
+        )
         _log(
             f"codex[{self.agent_name}]: all {len(self._RECONNECT_BACKOFF)} reconnect "
-            f"attempts failed (last error: {last_error}); session left disconnected"
+            f"attempts failed (last error: {last_error}); session DEAD"
         )
 
     async def disconnect(self) -> None:
-        """Disconnect — kill any running subprocess and cancel the worker."""
-        self._connected = False
+        """Tear down the worker + any codex subprocess / app-server. Idempotent.
+
+        Per the Transport contract, disconnect is the side-effect runner, NOT the
+        intent declarer: force_restart / idle_sleep / attempt_reconnect drive the
+        state machine FIRST (to RECONNECTING / IDLE_SLEEPING), then call this for
+        teardown — so the standalone-DEAD path below is skipped for them. A bare
+        external disconnect() (state still CONNECTED, no in-flight transition) is
+        a terminal shutdown and drives CONNECTED → DEAD, matching StreamingSession.
+        """
         self._analytics_log_activity("session_end")
         self._analytics_session_ended()
 
@@ -1510,38 +1775,36 @@ class CodexSession:
                 pass
         self._worker_task = None
         self._processing = False
+
+        # Standalone terminal shutdown: only when still CONNECTED with no
+        # caller-declared intent. request_transition returns no owner token when
+        # a transition is already in flight (force_restart/idle_sleep/
+        # attempt_reconnect hold one) or the state isn't CONNECTED, so this is a
+        # no-op for those callers and a clean CONNECTED → DEAD for a bare close.
+        if self._state_machine.state == SessionState.CONNECTED:
+            res = await self._state_machine.request_transition(
+                SessionState.DEAD, Trigger.INTERNAL, reason="standalone_disconnect"
+            )
+            if res.owner_token is not None:
+                await self._state_machine.transition_complete(
+                    res.owner_token, SessionState.DEAD, trigger=Trigger.INTERNAL
+                )
         _log(f"codex[{self.agent_name}]: disconnected")
 
     @property
     def state(self) -> SessionState:
-        """Lifecycle state derived from internal ``_connected``,
-        ``_idle_sleeping``, and ``_connect_attempted`` bools.
+        """Current lifecycle state — the single source of truth (#206).
 
-        CodexSession does not (yet) embed the full ``StateMachine`` that
-        StreamingSession adopted in PR3 of #486 — the codex backend's
-        lifecycle is simpler (no reconnect retry loop, no resume handle
-        capture race). Until/unless it adopts the matrix, the state
-        property is a derived view over the legacy bools:
-
-        - ``_idle_sleeping=True``                       → ``IDLE_SLEEPING``
-        - ``_connected=True``                           → ``CONNECTED``
-        - ``_connect_attempted=False`` (never tried)    → ``UNINITIALIZED``
-        - otherwise (tried and currently disconnected)  → ``DEAD``
-
-        RECONNECTING is not modeled; the external readers (broker, api,
-        scheduler) only branch on ``CONNECTED`` / ``IDLE_SLEEPING`` /
-        ``DEAD`` / ``UNINITIALIZED`` so the coarser mapping is sufficient
-        for the Transport protocol's polymorphic contract. Distinguishing
-        UNINITIALIZED from DEAD on a never-connected fresh session
-        (@pushok PR #492 Nit 1) preserves the "never tried" semantic.
+        CodexSession now embeds the same ``StateMachine`` as TmuxSession /
+        StreamingSession instead of deriving state from the old
+        ``_connected`` / ``_idle_sleeping`` / ``_connect_attempted`` bool
+        lattice. It surfaces BOOTING (cold start in flight) and RECONNECTING
+        (warm wake / recovery in flight) in addition to CONNECTED /
+        IDLE_SLEEPING / DEAD / UNINITIALIZED, so the broker, watchdog, and
+        dashboard see the true Codex lifecycle at parity with the other
+        transports.
         """
-        if self._idle_sleeping:
-            return SessionState.IDLE_SLEEPING
-        if self._connected:
-            return SessionState.CONNECTED
-        if not getattr(self, "_connect_attempted", False):
-            return SessionState.UNINITIALIZED
-        return SessionState.DEAD
+        return self._state_machine.state
 
     @property
     def max_tokens(self) -> int:
@@ -1579,15 +1842,17 @@ class CodexSession:
 
     @property
     def stats(self) -> dict:
+        state = self.state
         return {
             **self._stats,
-            "connected": self._connected,
-            # Consistency with tmux/streaming stats (#109). Codex only ever
-            # reports CONNECTED/IDLE_SLEEPING/UNINITIALIZED/DEAD — it never
-            # models BOOTING/RECONNECTING — so it's naturally excluded from
-            # the lifecycle transition-age watchdog.
-            "state": self.state.value,
-            "idle_sleeping": self._idle_sleeping,
+            "connected": state == SessionState.CONNECTED,
+            "state": state.value,
+            # Wall-clock epoch the current state was entered (grant time) — lets
+            # the watchdog age stuck BOOTING/RECONNECTING transitions precisely
+            # instead of sampling (#206). Codex now surfaces those transitions,
+            # so it participates in the lifecycle transition-age watchdog.
+            "state_entered_at": self._state_machine.state_entered_at,
+            "idle_sleeping": state == SessionState.IDLE_SLEEPING,
             "processing": self._processing,
             "pending_messages": self._message_queue.qsize(),
             "current_activity": self._current_activity,

--- a/src/pinky_daemon/session_watchdog.py
+++ b/src/pinky_daemon/session_watchdog.py
@@ -186,6 +186,10 @@ class _SessionSnapshot:
     current_activity: str
     sample_time: float
     state: str = ""  # lifecycle state value (e.g. "booting"); "" if unknown
+    # Wall-clock epoch the session entered ``state``, stamped at grant time by
+    # the transport's StateMachine (#206). 0.0 when the transport doesn't
+    # expose it — the watchdog then falls back to its own sampled timing.
+    state_entered_at: float = 0.0
 
 
 @dataclass
@@ -338,6 +342,7 @@ class SessionWatchdog:
             current_activity=stats.get("current_activity", ""),
             sample_time=time.time(),
             state=state,
+            state_entered_at=stats.get("state_entered_at", 0.0) or 0.0,
         )
 
     async def _evaluate(self, snap: _SessionSnapshot, now: float) -> None:
@@ -485,14 +490,29 @@ class SessionWatchdog:
         required — a session stuck BOOTING can't receive anything regardless of
         queue depth.
         """
-        # (Re)start the sampled timer on first observation of this transition
-        # state, or when it changed since the last sweep. No age has accrued
-        # yet, so don't warn/recover on the same sweep.
-        if state.transition_state != snap.state:
-            state.transition_state = snap.state
-            state.transition_since = now
-            state.transition_warned = False
-            return
+        # Anchor the age clock. Prefer the session-provided ``state_entered_at``
+        # (stamped at GRANT time by the StateMachine — precise) over the sampled
+        # timer (starts on the first sweep that observes the state — up to one
+        # interval, ~60s, late). Fall back to sampling for transports that don't
+        # expose it (#206; Murzik).
+        authoritative = snap.state_entered_at if snap.state_entered_at > 0 else None
+        if authoritative is not None:
+            # (Re)anchor whenever the tracked state value changes OR the entry
+            # time advanced (a same-value re-entry, e.g. a fresh RECONNECTING
+            # grant). No early return: the real entry time may ALREADY exceed a
+            # threshold, and the sampled path would have wrongly reset to ``now``.
+            if state.transition_state != snap.state or state.transition_since != authoritative:
+                state.transition_state = snap.state
+                state.transition_since = authoritative
+                state.transition_warned = False
+        else:
+            # Sampled fallback: start the timer on first observation / on change.
+            # No age has accrued yet, so don't warn/recover on the same sweep.
+            if state.transition_state != snap.state:
+                state.transition_state = snap.state
+                state.transition_since = now
+                state.transition_warned = False
+                return
 
         age = now - state.transition_since
 

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -1703,6 +1703,10 @@ class StreamingSession:
             # enum without waiting for PR4's reader migration. Stringified
             # for JSON compatibility.
             "state": state.value,
+            # Wall-clock epoch the current state was entered (grant time). Lets
+            # the watchdog age stuck transitions precisely instead of sampling
+            # (#206).
+            "state_entered_at": self._state_machine.state_entered_at,
             "pending_responses": len(self._pending_chats),
             "current_activity": self._current_activity,
             "current_thinking": self._current_thinking,

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1517,6 +1517,10 @@ class TmuxSession:
         return {
             **self._stats,
             "state": self.state.value,
+            # Wall-clock epoch the current state was entered (grant time) — lets
+            # the watchdog age stuck transitions precisely instead of sampling
+            # (#206).
+            "state_entered_at": self._state_machine.state_entered_at,
             "pending_responses": self._message_queue.qsize(),
             "inflight_turns": len(self._inflight_metas),
             "current_activity": self._current_activity,

--- a/src/pinky_daemon/transport_state.py
+++ b/src/pinky_daemon/transport_state.py
@@ -79,6 +79,7 @@ from __future__ import annotations
 import asyncio
 import secrets
 import sys
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -418,6 +419,14 @@ class StateMachine:
             )
         self._label = owner_label
         self._state = initial_state
+        # Wall-clock time the current state was entered. Stamped at GRANT time
+        # (when ``_state`` flips), not at completion — so a BOOTING/RECONNECTING
+        # transition's age starts the instant ownership is granted. The watchdog
+        # prefers this over its own sampled timing, which removes the up-to-one-
+        # sweep (~60s) blind window before the stuck-transition clock starts
+        # (#206; Murzik). Wall-clock (not monotonic) to match the watchdog's
+        # ``time.time()``-based ``now``.
+        self._state_entered_at = time.time()
         self._lock = asyncio.Lock()
         # At most one in-flight transition per state machine (singleton, not
         # keyed by target). Same-target requests subscribe; different-target
@@ -434,6 +443,24 @@ class StateMachine:
         enum reads); callers wanting consistency with a transition should use
         the ``TransitionResult`` returned from ``request_transition``."""
         return self._state
+
+    @property
+    def state_entered_at(self) -> float:
+        """Wall-clock time (epoch seconds) the current state was entered.
+
+        Updated whenever ``_state`` flips — at grant time in
+        ``request_transition`` and at completion in ``transition_complete``.
+        The watchdog reads this to age stuck BOOTING/RECONNECTING transitions
+        precisely instead of starting the clock on its own first observation
+        (#206)."""
+        return self._state_entered_at
+
+    def _enter_state(self, new_state: SessionState) -> None:
+        """Single choke point for state mutation: flip ``_state`` and stamp the
+        entry time together so ``state_entered_at`` is always consistent with
+        ``state``. All in-lock mutation paths go through here."""
+        self._state = new_state
+        self._state_entered_at = time.time()
 
     async def request_transition(
         self,
@@ -542,7 +569,7 @@ class StateMachine:
             # Case 4: caller drives the change. Mint owner token, mutate state,
             # register the in-flight transition.
             token = OwnerToken._new(target)
-            self._state = target
+            self._enter_state(target)
             self._in_flight = _InFlight(
                 from_state=from_state,
                 target=target,
@@ -620,7 +647,7 @@ class StateMachine:
                 # "BOOT_FAILED emergency" etc.
                 if final_state == SessionState.DEAD:
                     from_state = self._state
-                    self._state = SessionState.DEAD
+                    self._enter_state(SessionState.DEAD)
                     self._audit(
                         from_state, SessionState.DEAD, trigger,
                         "emergency_completed",
@@ -642,7 +669,7 @@ class StateMachine:
                             f"DEAD is always legal as emergency exit)"
                         )
                     from_state = self._state
-                    self._state = final_state
+                    self._enter_state(final_state)
                     self._audit(
                         from_state, final_state, trigger, "completed",
                         reason=f"in-flight {in_flight.from_state.value} → "

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -12,6 +12,45 @@ import pytest
 from pinky_daemon.codex_session import CodexSession, CodexTurnResult
 from pinky_daemon.conversation_store import ConversationStore
 from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.transport_state import SessionState, Trigger
+
+
+async def _to_connected(s: CodexSession) -> None:
+    """Drive a test session's state machine straight to CONNECTED — without
+    spawning the worker or running codex (#206; replaces the old inert
+    ``s._connected = True``)."""
+    sm = s._state_machine
+    res = await sm.request_transition(SessionState.BOOTING, Trigger.BOOT)
+    await sm.transition_complete(
+        res.owner_token, SessionState.CONNECTED, trigger=Trigger.BOOT_COMPLETE
+    )
+
+
+async def _to_idle(s: CodexSession) -> None:
+    """Drive a test session to IDLE_SLEEPING."""
+    await _to_connected(s)
+    sm = s._state_machine
+    res = await sm.request_transition(SessionState.IDLE_SLEEPING, Trigger.USER_AGENT)
+    await sm.transition_complete(
+        res.owner_token, SessionState.IDLE_SLEEPING, trigger=Trigger.USER_AGENT
+    )
+
+
+async def _to_dead(s: CodexSession) -> None:
+    """Drive a test session to DEAD (via CONNECTED if fresh)."""
+    if s.state != SessionState.CONNECTED:
+        await _to_connected(s)
+    sm = s._state_machine
+    res = await sm.request_transition(SessionState.DEAD, Trigger.INTERNAL)
+    if res.owner_token is not None:
+        await sm.transition_complete(
+            res.owner_token, SessionState.DEAD, trigger=Trigger.INTERNAL
+        )
+
+
+async def _noop(*_a, **_k) -> None:
+    """Async no-op — patch over _enqueue_wake / side effects in state tests."""
+    return None
 
 
 class TestCodexTurnResult:
@@ -301,7 +340,7 @@ class TestCodexSessionSendSignature:
         """Hint should be appended to the queued prompt (matches Streaming-
         Session.send behavior) but NOT stored in the conversation log."""
         s = self._make()
-        s._connected = True  # bypass the dropped-when-disconnected branch
+        await _to_connected(s)  # state-machine CONNECTED (bypass the drop branch)
 
         await s.send(
             "actual user text",
@@ -319,7 +358,7 @@ class TestCodexSessionSendSignature:
     async def test_send_without_agent_hint_unchanged(self):
         """No-hint path is the previous behavior — prompt queued verbatim."""
         s = self._make()
-        s._connected = True
+        await _to_connected(s)
 
         await s.send("plain prompt", platform="telegram", chat_id="123")
 
@@ -365,7 +404,7 @@ class TestCodexSessionDisconnect:
             provider_url="codex_cli",
         )
         s = CodexSession(config)
-        s._connected = True
+        await _to_connected(s)
 
         async def fake_exec(prompt: str) -> CodexTurnResult:
             return CodexTurnResult()
@@ -404,8 +443,7 @@ class TestCodexSessionDisconnect:
             provider_url="codex_cli",
         )
         s = CodexSession(config)
-        s._connected = True
-        s._connect_attempted = True  # mirror post-connect()
+        await _to_connected(s)
 
         async def fake_exec(prompt: str) -> CodexTurnResult:
             return CodexTurnResult()
@@ -444,21 +482,25 @@ class TestCodexSessionDisconnect:
             provider_url="codex_cli",
         )
         s = CodexSession(config)
-        s._idle_sleeping = True
+        await _to_idle(s)
 
         async def fake_worker() -> None:
             await asyncio.sleep(60)
 
         s._message_worker = fake_worker  # type: ignore[assignment]
 
-        await s.connect()
+        await s.connect()  # warm-wake: IDLE_SLEEPING → RECONNECTING → CONNECTED
 
         from pinky_daemon.transport_state import SessionState
         assert s.state == SessionState.CONNECTED
         await s.disconnect()
 
     @pytest.mark.asyncio
-    async def test_attempt_reconnect_uses_connect_and_preserves_codex_session_id(self):
+    async def test_attempt_reconnect_preserves_codex_session_id(self):
+        # #206: attempt_reconnect now owns ONE RECONNECTING transition and
+        # retries _bring_up_substrate under it (no nested connect()). It resumes
+        # from DEAD, preserves the codex_session_id (only force_restart clears
+        # it), and completes to CONNECTED.
         config = StreamingSessionConfig(
             agent_name="test",
             working_dir="/tmp",
@@ -468,25 +510,29 @@ class TestCodexSessionDisconnect:
         s.codex_session_id = "thread-123"
         s.resume_handle = "thread-123"
         s._RECONNECT_BACKOFF = (0,)
+        await _to_dead(s)  # broker/heartbeat resurrects from DEAD
+
         calls = []
 
         async def fake_disconnect() -> None:
             calls.append("disconnect")
-            s._connected = False
 
-        async def fake_connect() -> None:
-            calls.append("connect")
-            s._connected = True
-            s._idle_sleeping = False
+        async def fake_bring_up() -> None:
+            calls.append("bring_up")
+
+        async def fake_enqueue() -> None:
+            calls.append("wake")
 
         s.disconnect = fake_disconnect  # type: ignore[method-assign]
-        s.connect = fake_connect  # type: ignore[method-assign]
+        s._bring_up_substrate = fake_bring_up  # type: ignore[method-assign]
+        s._start_worker = lambda: calls.append("worker")  # type: ignore[method-assign]
+        s._enqueue_wake = fake_enqueue  # type: ignore[method-assign]
+        s._analytics_session_started = lambda: None  # type: ignore[method-assign]
 
         await s.attempt_reconnect()
 
-        from pinky_daemon.transport_state import SessionState
-        assert calls == ["disconnect", "connect"]
         assert s.state == SessionState.CONNECTED
+        assert calls == ["disconnect", "bring_up", "worker", "wake"]
         assert s.codex_session_id == "thread-123"
         assert s.resume_handle == "thread-123"
         assert s.stats["reconnects"] == 1
@@ -666,12 +712,13 @@ class TestCodexReasoningOutputTokens:
 
 
 class TestCodexWorkerDoneCallback:
-    """Worker-task watchdog: surface silent worker death.
+    """Worker-task watchdog: surface silent worker death (#206).
 
-    Pathological case being guarded: worker exits while ``_connected``
-    is still True. Broker thinks session is alive, queue piles up, no
-    messages process. The callback flips ``_connected`` so the broker
-    can resurrect the session.
+    Pathological case: the worker exits while the session is still CONNECTED.
+    Broker thinks the session is alive, the queue piles up, nothing processes.
+    The callback drives the session straight to DEAD (no inline reconnect — the
+    worker owns the queue) so the broker/heartbeat resurrects it via
+    attempt_reconnect on the next inbound/recovery tick.
     """
 
     def _make_session(self):
@@ -682,11 +729,10 @@ class TestCodexWorkerDoneCallback:
         return CodexSession(config)
 
     @pytest.mark.asyncio
-    async def test_callback_flips_connected_on_silent_exit(self):
-        """Worker task finishes without exception while _connected=True
-        → callback flips _connected to False and logs loud."""
+    async def test_callback_marks_dead_on_silent_exit(self):
+        """Worker finishes without exception while CONNECTED → session → DEAD."""
         s = self._make_session()
-        s._connected = True  # broker's view: alive
+        await _to_connected(s)
 
         # Build a real completed task (graceful exit, no exception, no cancel).
         async def _no_op():
@@ -695,17 +741,18 @@ class TestCodexWorkerDoneCallback:
         await task
 
         s._worker_done_callback(task)
+        await asyncio.sleep(0)  # let the scheduled _terminalize_dead run
+        await asyncio.sleep(0)
 
-        assert s._connected is False, (
-            "silent worker exit must flip _connected so broker can resurrect"
+        assert s.state == SessionState.DEAD, (
+            "silent worker exit must drive DEAD so the broker can resurrect"
         )
 
     @pytest.mark.asyncio
-    async def test_callback_flips_connected_on_exception_exit(self):
-        """Worker task that raised an exception while _connected=True
-        also flips _connected."""
+    async def test_callback_marks_dead_on_exception_exit(self):
+        """Worker that raised while CONNECTED also drives the session DEAD."""
         s = self._make_session()
-        s._connected = True
+        await _to_connected(s)
 
         async def _raises():
             raise RuntimeError("simulated worker crash")
@@ -717,15 +764,17 @@ class TestCodexWorkerDoneCallback:
             pass
 
         s._worker_done_callback(task)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
 
-        assert s._connected is False
+        assert s.state == SessionState.DEAD
 
     @pytest.mark.asyncio
     async def test_callback_noop_when_cancelled(self):
-        """Graceful disconnect cancels the worker — callback must NOT
-        treat that as a wedge or flip state (disconnect already did)."""
+        """Graceful disconnect cancels the worker — callback must NOT treat
+        that as a wedge (disconnect already drove the state)."""
         s = self._make_session()
-        s._connected = False  # disconnect path already flipped this
+        await _to_connected(s)
 
         async def _block_forever():
             await asyncio.Event().wait()
@@ -737,15 +786,16 @@ class TestCodexWorkerDoneCallback:
             pass
 
         s._worker_done_callback(task)
-        # Callback shouldn't touch _connected; it stays whatever disconnect set.
-        assert s._connected is False
+        await asyncio.sleep(0)
+        # Cancelled → early return → state untouched (still CONNECTED).
+        assert s.state == SessionState.CONNECTED
 
     @pytest.mark.asyncio
-    async def test_callback_noop_when_connected_already_false(self):
-        """Worker exit during a normal disconnect: _connected already
-        False, no need to log a wedge."""
+    async def test_callback_noop_when_not_connected(self):
+        """Worker exit when the session isn't CONNECTED (already torn down):
+        callback is a no-op, no spurious transition."""
         s = self._make_session()
-        s._connected = False
+        await _to_dead(s)  # already DEAD
 
         async def _no_op():
             return None
@@ -753,7 +803,8 @@ class TestCodexWorkerDoneCallback:
         await task
 
         s._worker_done_callback(task)
-        assert s._connected is False  # unchanged
+        await asyncio.sleep(0)
+        assert s.state == SessionState.DEAD  # unchanged
 
 
 class TestCodexIsHealthy:
@@ -790,7 +841,7 @@ class TestCodexIsHealthy:
         done. ``wedged`` must be True so broker / health endpoint can
         surface it."""
         s = self._make_session()
-        s._connected = True
+        await _to_connected(s)
 
         async def _exits_immediately():
             return None
@@ -808,7 +859,7 @@ class TestCodexIsHealthy:
         worker likely hung mid-turn (the proc.wait wedge before the
         Tier 1.A timeout caught it)."""
         s = self._make_session()
-        s._connected = True
+        await _to_connected(s)
         s._processing = True
         # Pretend last_active was an hour ago.
         s.last_active = s.last_active - 3600
@@ -857,8 +908,7 @@ class TestCodexPendingWakeCallback:
             provider_url="codex_cli",
         )
         s = CodexSession(config)
-        s._connected = True
-        s._connect_attempted = True
+        await _to_connected(s)
 
         fires: list[str] = []
         s._pending_wake_callback = lambda: fires.append("delivered")
@@ -872,7 +922,7 @@ class TestCodexPendingWakeCallback:
         worker = asyncio.create_task(s._message_worker())
         # Let worker process one turn, then stop the loop.
         await asyncio.sleep(0.05)
-        s._connected = False
+        await _to_dead(s)  # flip off CONNECTED to stop the worker loop
         s._message_queue.put_nowait(("noop", "", "", ""))  # unblock get()
         try:
             await asyncio.wait_for(worker, timeout=2.0)
@@ -900,8 +950,7 @@ class TestCodexPendingWakeCallback:
             provider_url="codex_cli",
         )
         s = CodexSession(config)
-        s._connected = True
-        s._connect_attempted = True
+        await _to_connected(s)
 
         fires: list[str] = []
         s._pending_wake_callback = lambda: fires.append("delivered")
@@ -916,7 +965,7 @@ class TestCodexPendingWakeCallback:
 
         worker = asyncio.create_task(s._message_worker())
         await asyncio.sleep(0.05)
-        s._connected = False
+        await _to_dead(s)  # flip off CONNECTED to stop the worker loop
         s._message_queue.put_nowait(("noop", "", "", ""))
         try:
             await asyncio.wait_for(worker, timeout=2.0)
@@ -1412,3 +1461,146 @@ class TestAssistantDeltaDedupe:
         assert result.text_parts == ["hello"]
         deltas = [e["delta"] for e in events if e["type"] == "assistant_delta"]
         assert deltas == ["hello"]
+
+
+# ── #206: CodexSession state-machine parity (BOOTING/RECONNECTING) ──────────
+#
+# Murzik-required coverage: cold-start BOOTING→CONNECTED (and →DEAD on substrate
+# failure, no leaked owner token), warm reconnect RECONNECTING→CONNECTED/DEAD,
+# worker-death terminalization, per-turn turn/failed staying CONNECTED, and the
+# state_entered_at stamp surfaced in stats.
+
+
+class TestCodexStateMachine:
+    @pytest.mark.asyncio
+    async def test_cold_connect_exposes_booting_then_connected(self):
+        # App-server mode: BOOTING is held across spawn+initialize, then flips
+        # CONNECTED. Block _ensure_app_server to observe BOOTING.
+        s = _appserver_session()
+        gate = asyncio.Event()
+
+        async def blocked_ensure():
+            await gate.wait()
+            s._app_client = object()  # mark substrate "up"
+
+        s._ensure_app_server = blocked_ensure  # type: ignore[assignment]
+        s._start_worker = lambda: None  # type: ignore[assignment] — no real worker
+        s._enqueue_wake = _noop  # type: ignore[assignment]
+        s._analytics_session_started = lambda: None  # type: ignore[assignment]
+
+        task = asyncio.create_task(s.connect())
+        await asyncio.sleep(0.03)  # let connect reach the blocked substrate bring-up
+        assert s.state == SessionState.BOOTING
+        gate.set()
+        await asyncio.wait_for(task, timeout=2)
+        assert s.state == SessionState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_cold_connect_appserver_init_failure_dies_no_leak(self):
+        # App-server initialize failure during BOOT → BOOTING completes to DEAD,
+        # and the owner token is NOT leaked (a later resurrection can proceed).
+        s = _appserver_session()
+
+        async def failing_ensure():
+            raise RuntimeError("app-server init boom")
+
+        s._ensure_app_server = failing_ensure  # type: ignore[assignment]
+
+        with pytest.raises(RuntimeError):
+            await s.connect()
+        assert s.state == SessionState.DEAD
+        assert s._state_machine._in_flight is None, "owner token leaked on BOOT failure"
+
+        # No leak → resurrection works: DEAD → RECONNECTING → CONNECTED.
+        async def ok_ensure():
+            s._app_client = object()
+
+        s._ensure_app_server = ok_ensure  # type: ignore[assignment]
+        s._start_worker = lambda: None  # type: ignore[assignment]
+        s._enqueue_wake = _noop  # type: ignore[assignment]
+        s._analytics_session_started = lambda: None  # type: ignore[assignment]
+        await s.connect()
+        assert s.state == SessionState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_warm_reconnect_exposes_reconnecting_then_connected(self):
+        s = _appserver_session()
+        await _to_dead(s)
+        s._RECONNECT_BACKOFF = (0,)
+        gate = asyncio.Event()
+
+        async def blocked_bring_up():
+            await gate.wait()
+
+        s._bring_up_substrate = blocked_bring_up  # type: ignore[assignment]
+        s._start_worker = lambda: None  # type: ignore[assignment]
+        s._enqueue_wake = _noop  # type: ignore[assignment]
+        s._analytics_session_started = lambda: None  # type: ignore[assignment]
+
+        task = asyncio.create_task(s.attempt_reconnect())
+        await asyncio.sleep(0.03)  # grant RECONNECTING, then block in bring-up
+        assert s.state == SessionState.RECONNECTING
+        gate.set()
+        await asyncio.wait_for(task, timeout=2)
+        assert s.state == SessionState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_warm_reconnect_exhausts_budget_to_dead(self):
+        s = _appserver_session()
+        await _to_dead(s)
+        s._RECONNECT_BACKOFF = (0, 0)  # two quick attempts, both fail
+
+        async def always_fail():
+            raise RuntimeError("substrate down")
+
+        s._bring_up_substrate = always_fail  # type: ignore[assignment]
+
+        await s.attempt_reconnect()
+        assert s.state == SessionState.DEAD
+        assert s._state_machine._in_flight is None
+        assert s.stats["reconnects"] == 2
+
+    @pytest.mark.asyncio
+    async def test_worker_death_terminalizes_and_visible_in_stats(self):
+        # Worker exits unexpectedly while CONNECTED → session DEAD, and the
+        # watchdog (which reads stats) sees state=="dead"/connected=False.
+        s = _plain_session()
+        await _to_connected(s)
+
+        async def _no_op():
+            return None
+        task = asyncio.create_task(_no_op())
+        await task
+
+        s._worker_done_callback(task)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert s.state == SessionState.DEAD
+        assert s.stats["state"] == "dead"
+        assert s.stats["connected"] is False
+
+    @pytest.mark.asyncio
+    async def test_app_server_turn_failed_leaves_connected(self):
+        # A per-turn MODEL failure (turn.failed) does NOT tear down the
+        # transport, so the session stays CONNECTED (vs. a structural transport
+        # failure, which terminalizes — see codex_session app-server paths).
+        s = _appserver_session()
+        await _to_connected(s)
+        result = CodexTurnResult()
+        await s._handle_event(
+            {"type": "turn.failed", "error": {"message": "model declined"}},
+            result,
+        )
+        assert result.failed is True
+        assert s.state == SessionState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_state_entered_at_surfaced_in_stats(self):
+        s = _plain_session()
+        before = s.stats["state_entered_at"]  # UNINITIALIZED, stamped at construction
+        await _to_connected(s)
+        after = s.stats["state_entered_at"]
+        assert after >= before
+        assert s.stats["state_entered_at"] == s._state_machine.state_entered_at
+        assert s.stats["state"] == "connected"

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -1523,6 +1523,83 @@ class TestCodexStateMachine:
         assert s.state == SessionState.CONNECTED
 
     @pytest.mark.asyncio
+    async def test_ensure_app_server_init_failure_is_atomic(self, monkeypatch):
+        # P1 (#206 P2 review, Murzik): a spawn that succeeds but whose
+        # initialize() raises must NOT leave a half-initialized client/proc
+        # cached. The early-return guard in _ensure_app_server() checks only
+        # (client is not None and proc alive), so a cached-but-uninitialized
+        # substrate would make the next reconnect skip initialization and flip
+        # CONNECTED on a dead app-server.
+        s = _appserver_session()
+
+        class _FakeProc:
+            def __init__(self):
+                self.returncode = None  # "alive" — would satisfy the guard
+                self.pid = 4242
+                self.killed = False
+
+            def kill(self):
+                self.killed = True
+                self.returncode = -9
+
+            async def wait(self):
+                return self.returncode
+
+        class _InitBoomClient:
+            def __init__(self):
+                self.closed = False
+
+            async def initialize(self, **kw):
+                raise RuntimeError("initialize boom")
+
+            async def close(self):
+                self.closed = True
+
+        boom_procs: list = []
+        boom_clients: list = []
+
+        async def fake_spawn_boom(**kw):
+            proc, client = _FakeProc(), _InitBoomClient()
+            boom_procs.append(proc)
+            boom_clients.append(client)
+            return client, proc
+
+        monkeypatch.setattr(
+            "pinky_daemon.codex_session.spawn_app_server", fake_spawn_boom
+        )
+
+        with pytest.raises(RuntimeError, match="initialize boom"):
+            await s._ensure_app_server()
+
+        # Half-initialized substrate must be torn down, not cached.
+        assert s._app_client is None
+        assert s._app_proc is None
+        assert boom_clients[0].closed is True, "client not closed on init failure"
+        assert boom_procs[0].killed is True, "proc not killed on init failure"
+
+        # A later attempt must respawn AND re-run initialize — the guard must
+        # not short-circuit on the cleared (None) fields.
+        init_calls: list = []
+
+        class _OkClient:
+            async def initialize(self, **kw):
+                init_calls.append(True)
+
+            async def close(self):
+                pass
+
+        async def fake_spawn_ok(**kw):
+            return _OkClient(), _FakeProc()
+
+        monkeypatch.setattr(
+            "pinky_daemon.codex_session.spawn_app_server", fake_spawn_ok
+        )
+        await s._ensure_app_server()
+        assert init_calls == [True], "initialization was skipped on reconnect"
+        assert s._app_client is not None
+        assert s._app_proc is not None
+
+    @pytest.mark.asyncio
     async def test_warm_reconnect_exposes_reconnecting_then_connected(self):
         s = _appserver_session()
         await _to_dead(s)

--- a/tests/test_transport_state.py
+++ b/tests/test_transport_state.py
@@ -847,3 +847,45 @@ class TestOwnerToken:
             assert result.owner_token is not None
             tokens.add(result.owner_token.token)
         assert len(tokens) == 20, "OwnerToken hash collision or non-uniqueness"
+
+
+class TestStateEnteredAt:
+    """#206: StateMachine stamps ``state_entered_at`` whenever ``_state`` flips —
+    at GRANT time in request_transition (not only at completion) — so the watchdog
+    can age stuck BOOTING/RECONNECTING transitions precisely instead of sampling."""
+
+    @pytest.mark.asyncio
+    async def test_stamped_at_grant_and_each_completion(self):
+        sm = StateMachine("t")
+        t0 = sm.state_entered_at  # UNINITIALIZED — stamped at construction
+        assert t0 > 0
+
+        await asyncio.sleep(0.01)
+        res = await sm.request_transition(SessionState.BOOTING, Trigger.BOOT)
+        granted_at = sm.state_entered_at
+        # Stamped at GRANT: the timestamp advanced as soon as the state flipped
+        # to BOOTING, BEFORE the owner completes the transition.
+        assert sm.state == SessionState.BOOTING
+        assert granted_at > t0
+
+        await asyncio.sleep(0.01)
+        await sm.transition_complete(
+            res.owner_token, SessionState.CONNECTED, trigger=Trigger.BOOT_COMPLETE
+        )
+        # Completion entered a NEW state → re-stamped, strictly later than grant.
+        assert sm.state == SessionState.CONNECTED
+        assert sm.state_entered_at > granted_at
+
+    @pytest.mark.asyncio
+    async def test_not_restamped_on_observational_read(self):
+        sm = StateMachine("t")
+        res = await sm.request_transition(SessionState.BOOTING, Trigger.BOOT)
+        await sm.transition_complete(
+            res.owner_token, SessionState.CONNECTED, trigger=Trigger.BOOT_COMPLETE
+        )
+        entered = sm.state_entered_at
+        # Same-state (observational) request must NOT re-stamp the entry time.
+        await asyncio.sleep(0.01)
+        obs = await sm.request_transition(SessionState.CONNECTED, Trigger.BROKER)
+        assert obs.changed is False
+        assert sm.state_entered_at == entered


### PR DESCRIPTION
## What & why (#206 P2)

Second increment of the Codex → first-class-parity work (P1 was cost). **CodexSession derived its lifecycle state from a `_connected` / `_idle_sleeping` / `_connect_attempted` bool lattice and never surfaced `BOOTING` or `RECONNECTING`** — so the broker, watchdog, and dashboard were blind to Codex cold-starts and reconnects, and app-server / bootstrap failures left a dead session looking `CONNECTED`. The transport state machine (`transport_state.py`) already existed and was adopted by Tmux/Streaming; this brings Codex to the same contract. (Verify-first: the machine wasn't invented here — Codex was the gap.)

Design + all 5 decisions reviewed with **Murzik** before building (Option A, the structural-vs-turn-only failure taxonomy, worker-death→DEAD, `state_entered_at` at grant time).

### 1. CodexSession embeds `StateMachine`
Source of truth = `self._state_machine.state`; `stats.connected` derives from `state == CONNECTED`. `connect` / `force_restart` / `idle_sleep` / `attempt_reconnect` follow tmux's **owner-token discipline** (complete in `finally`/except, DEAD on catastrophe — no leaked tokens):
- Cold start: `BOOT → BOOTING → CONNECTED|DEAD` (`BOOT` / `BOOT_COMPLETE` / `BOOT_FAILED`).
- Warm wake: `RECONNECTING → CONNECTED|DEAD` via the caller's trigger.
- `BOOT_COMPLETE` = "can accept and **drain** work" (app-server spawn+initialize done; worker drainer up) — **never** held across a model turn (so normal first-turn latency isn't mistaken for a BOOT wedge).
- A private `_bring_up_substrate` is retried under a single RECONNECTING token in `attempt_reconnect` (no nested `connect()` → no nested transition requests). `send` is gated on `state == CONNECTED`; the worker loop runs `while state == CONNECTED`.

### 2. Terminalize structural failures (never silently CONNECTED)
- App-server spawn/initialize failure on boot → `BOOT_FAILED → DEAD`.
- Mid-life app-server failure that tears down the transport (EOF / 600s timeout / protocol error / generic exception that calls `_teardown_app_server`) → `DEAD`; the broker resurrects via `attempt_reconnect` on the next inbound.
- A per-turn **model** `turn/failed` (server healthy) → stays `CONNECTED`.
- Worker death → **straight DEAD** (the worker owns the queue; no inline reconnect from its death callback).

### 3. Precise `state_entered_at`
`StateMachine` now stamps `state_entered_at` at **grant time** (when `_state` flips), exposed in stats. The watchdog prefers this session-provided stamp over its own sampled timing — which started the stuck-transition clock up to one ~60s sweep late — and falls back to sampling for transports that don't expose it. Tmux + Streaming expose it too, so their aging tightens as well.

## Verification (backend — no UI; lifecycle transcript stands in for a screenshot)

Live state progression (audit log + derived `state` + `state_entered_at`), the user-visible effect being these states appearing for Codex agents on the Analytics/Agents dashboard post-deploy:

```
transport_state[codex:murzik]: uninitialized → booting via boot [result=owned]
transport_state[codex:murzik]: booting → connected via boot_complete [result=completed]
transport_state[codex:murzik]: connected → idle_sleeping via user_agent [result=owned]
transport_state[codex:murzik]: idle_sleeping → idle_sleeping via user_agent [result=completed]
transport_state[codex:murzik]: idle_sleeping → reconnecting via broker [result=owned]
transport_state[codex:murzik]: reconnecting → connected via internal [result=completed]
transport_state[codex:murzik]: connected → dead via internal [result=owned]
transport_state[codex:murzik]: dead → dead via internal [result=completed]

  fresh (constructed)            state=uninitialized
  connect() -> BOOT              state=booting
  substrate up -> BOOT_COMPLETE  state=connected
  idle_sleep()                   state=idle_sleeping
  inbound -> RECONNECTING        state=reconnecting
  resumed -> CONNECTED           state=connected
  worker died -> DEAD            state=dead
  stats: state='dead' connected=False
```

- **509 pass** across `test_codex_session.py` (85, +7 new), `test_transport_state.py` (45, +2 new), `test_session_watchdog.py`, `test_tmux_session.py`, `test_streaming_session.py`; `test_broker.py` 39 pass; `ruff` clean.
- New tests (Murzik's list): cold `BOOTING→CONNECTED` while app-server init blocked; app-server init failure `BOOTING→DEAD` with **no leaked owner token**; warm `RECONNECTING→CONNECTED` and budget-exhausted `→DEAD`; worker-death terminalization (+ stats visibility); per-turn `turn/failed` stays CONNECTED; `state_entered_at` at grant time + surfaced in stats.
- Existing codex tests migrated off the retired bools (state driven via the machine).

## Scope / deferred
- StreamingSession warm-reconnect still direct-mutates (the noted PR6.5/PR7 `RECONNECT_BEGIN/COMPLETE/FAILED` follow-up) — out of scope; only its stats gained `state_entered_at`.
- Mid-life app-server failures terminalize to **DEAD** (broker-driven resurrection) rather than in-worker self-heal RECONNECTING — chosen to avoid a worker-loop / owner-token race; can revisit as a follow-up if we want faster self-heal.

Reviewer: **Murzik** (signed off the design).

🤖 Opened by Barsik
