### PR TITLE
feat(codex): tmux-backed app-server transport via UDS shim (#791)

### DIFF
--- a/src/pinky_daemon/codex_app_server_shim.py
+++ b/src/pinky_daemon/codex_app_server_shim.py
@@ -1,0 +1,187 @@
+"""Design-A UDS<->stdio bridge for tmux-backed ``codex app-server`` (#791).
+
+``codex app-server`` only speaks JSON-RPC over **stdio** — its experimental
+``--listen unix://`` + ``proxy`` path accepts the connection but never
+responds (verified silent against codex-cli 0.125.0, ×2 with Murzik). So we
+front a plain stdio ``codex app-server`` child with our own ~70-line Unix-
+socket bridge and run that under tmux, giving the same live-substrate /
+per-turn-warmth win the claude REPL gets (#98) without the dead native path.
+
+**Why the child can't be warm across reconnects.** ``initialize`` is
+per-CHILD-PROCESS: a 2nd ``initialize`` on the same child returns
+``-32600 "Already initialized"`` (Murzik). So this bridge does NOT keep the
+child alive across daemon-client reconnects. The child's lifetime is COUPLED
+to the single daemon connection:
+
+  * spawn one plain ``codex app-server`` child (the proven stdio mode)
+  * bind our UDS, accept exactly ONE daemon connection
+  * byte-bridge both ways — the child stays warm ACROSS TURNS within that one
+    connection (the #98 win), torn down only when the connection ends
+  * client EOF (disconnect / force_restart / idle_sleep) -> kill child, exit
+  * child stdout EOF (child died) -> drop the client socket, kill child, exit
+  * a 2nd concurrent connection is rejected (no multiplexing onto one stdio)
+  * NO in-shim respawn: the daemon's CodexAppServerSupervisor owns recovery
+
+The bridge is **byte-transparent**: it ``read()``s fixed chunks and forwards
+them verbatim, never parsing lines. That sidesteps the client reader's 10 MiB
+NDJSON frame limit entirely — frame boundaries are the daemon's concern, not
+the bridge's. The child's stderr inherits this process's stderr -> the tmux
+pane/log; the child's stdout is reserved for JSON frames and is never tee'd to
+the pane.
+
+Usage: ``python -m pinky_daemon.codex_app_server_shim <sock_path>``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+import signal
+import sys
+
+# The stdio child this bridge fronts. Overridable via env for tests (point it
+# at a fake JSON echo server — CI has no ``codex``) and as an operator escape
+# hatch (e.g. an absolute codex path). Default is the proven stdio invocation.
+_DEFAULT_CHILD_CMD = ("codex", "app-server")
+# Verbatim forwarding chunk. Decoupled from any JSON frame size — the bridge
+# never parses, so a frame may span many chunks with no special handling.
+_READ_CHUNK = 65536
+# Match codex_app_server._STREAM_LIMIT so the child-side pipe can hold a large
+# tool-result frame without the subprocess transport raising LimitOverrunError.
+_CHILD_STREAM_LIMIT = 10 * 1024 * 1024
+
+
+def _child_cmd() -> list[str]:
+    override = os.environ.get("PINKY_CODEX_APP_SERVER_CMD", "").strip()
+    return shlex.split(override) if override else list(_DEFAULT_CHILD_CMD)
+
+
+async def _run(sock_path: str) -> int:
+    sock_dir = os.path.dirname(sock_path)
+    if sock_dir:
+        os.makedirs(sock_dir, exist_ok=True)
+    # Stale-socket unlink: a prior shim that was SIGKILLed (no clean exit) can
+    # leave the socket file behind; bind() would then fail with EADDRINUSE.
+    if os.path.exists(sock_path):
+        os.unlink(sock_path)
+
+    child = await asyncio.create_subprocess_exec(
+        *_child_cmd(),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=None,  # inherit -> tmux pane/log; never tee'd into the JSON stream
+        limit=_CHILD_STREAM_LIMIT,
+    )
+
+    state = {"connected": False}
+
+    def _teardown_and_exit(reason: str) -> None:
+        """Synchronous, terminal teardown — the only exit path.
+
+        Run inline the instant a bridge ends; we deliberately do NOT bounce
+        back through ``await``/the loop teardown. Two asyncio hazards on this
+        Python/macOS made the graceful path unreliable: ``await child.wait()``
+        after ``child.kill()`` intermittently stalls, and the listening-server
+        + subprocess-transport combo wedges ``asyncio.run``'s unwind for 20s+.
+        This process exists only to serve ONE connection's lifetime, so once
+        the child is signalled and the socket removed there is nothing to
+        preserve — we ``os._exit``. SIGKILL is uncatchable so the child is
+        dead-on-arrival; on our exit it reparents to launchd/init which reaps
+        the zombie (no orphan). Under tmux this ends the pane command -> the
+        session closes; the supervisor's kill_session is idempotent anyway.
+        """
+        print(f"shim: bridge ended ({reason}); tearing down child + socket", flush=True)
+        try:
+            if child.returncode is None:
+                os.kill(child.pid, signal.SIGKILL)
+        except (ProcessLookupError, Exception):  # noqa: BLE001 — best-effort
+            pass
+        try:
+            if os.path.exists(sock_path):
+                os.unlink(sock_path)
+        except OSError:
+            pass
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(0)
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        if state["connected"]:
+            # Single active client: never interleave two daemons onto one
+            # stdio child (responses are correlated by id within one peer).
+            print("shim: rejecting concurrent connection", flush=True)
+            try:
+                writer.close()
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        state["connected"] = True
+        print("shim: daemon connected", flush=True)
+
+        async def c2s() -> str:
+            while True:
+                data = await reader.read(_READ_CHUNK)
+                if not data:
+                    return "client_eof"
+                child.stdin.write(data)
+                await child.stdin.drain()
+
+        async def s2c() -> str:
+            while True:
+                data = await child.stdout.read(_READ_CHUNK)
+                if not data:
+                    return "child_eof"
+                writer.write(data)
+                await writer.drain()
+
+        c = asyncio.create_task(c2s())
+        s = asyncio.create_task(s2c())
+        try:
+            done, _pending = await asyncio.wait({c, s}, return_when=asyncio.FIRST_COMPLETED)
+            reason = next(iter(done)).result()
+        except Exception as exc:  # noqa: BLE001 — any bridge fault ends the connection
+            reason = f"bridge_error:{exc}"
+        # Terminal: hard-exit inline. No task-cancel / writer-close dance needed
+        # — os._exit drops every fd and task at once.
+        _teardown_and_exit(reason)
+
+    server = await asyncio.start_unix_server(handle, path=sock_path)
+    # Fail-closed perms: only the owning uid may connect. The supervisor also
+    # 0700s the parent dir. (#149-isolated agents run the shim under their own
+    # uid and the daemon connects as a different uid — that path needs the
+    # socket inside the agent boundary; see the supervisor TODO. Increment-1 is
+    # non-isolated, so daemon-uid == shim-uid and 0600 is exactly right.)
+    try:
+        os.chmod(sock_path, 0o600)
+    except OSError:
+        pass
+    print(f"shim: listening on {sock_path} child_pid={child.pid}", flush=True)
+
+    # Also exit if the child dies before any daemon ever connects (e.g. a bad
+    # OPENAI_API_KEY makes app-server exit immediately): the supervisor's
+    # accept-readiness would otherwise wait on a socket whose child is gone.
+    async def _watch_child_preconnect() -> None:
+        await child.wait()
+        if not state["connected"]:
+            _teardown_and_exit("child_exit_preconnect")
+
+    asyncio.create_task(_watch_child_preconnect())
+
+    # Live until a bridge (or the pre-connect watcher) hard-exits the process.
+    async with server:
+        await asyncio.Event().wait()
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            "usage: python -m pinky_daemon.codex_app_server_shim <sock_path>",
+            flush=True,
+        )
+        return 2
+    return asyncio.run(_run(argv[1]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/pinky_daemon/codex_app_server_tmux.py
+++ b/src/pinky_daemon/codex_app_server_tmux.py
@@ -33,9 +33,9 @@ with no changes to those call sites.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import os
 import shlex
+import stat
 import sys
 import tempfile
 from collections.abc import Callable
@@ -107,27 +107,33 @@ class CodexAppServerSupervisor:
         self.agent_name = agent_name
         self._log = log
         self._openai_api_key = openai_api_key
-        self._sock_dir = self._resolve_sock_dir(agent_name, working_dir)
+        self._sock_dir, self._sock_dir_is_tmp = self._resolve_sock_dir(agent_name, working_dir)
         self.sock_path = os.path.join(self._sock_dir, "app.sock")
         self._tmux = _TmuxControl(self.session_name, command_runner=LocalCommandRunner())
         self._kill_requested = False
 
     @staticmethod
-    def _resolve_sock_dir(agent_name: str, working_dir: str) -> str:
-        """Socket dir inside the agent's working dir (keeps it within the agent
-        boundary — forward-compatible with #149 isolation — and under our own
-        perms). Absolute so bind()/connect() don't depend on cwd.
+    def _resolve_sock_dir(agent_name: str, working_dir: str) -> tuple[str, bool]:
+        """Pick the socket dir; return (dir, is_tmp_fallback).
+
+        Default: ``<working_dir>/.codex-app-server`` — inside the agent boundary
+        (forward-compatible with #149 isolation) and under a parent only we can
+        write. Absolute so bind()/connect() don't depend on cwd.
 
         macOS AF_UNIX paths cap near 104 chars; a long working_dir would
-        otherwise surface as a 30s readiness timeout. If the in-boundary path is
-        too long, fall back to a short, agent-stable ``/tmp`` runtime dir so the
-        transport still works (the #149 isolated path will need an in-boundary
-        socket regardless — tracked separately)."""
+        otherwise surface as a 30s readiness timeout. Fall back to a short dir —
+        but NOT a predictable ``/tmp/<name>`` (world-writable + sticky /tmp, for
+        an approvals=never danger-full-access codex, is the worst place for a
+        perms slip: a predictable name invites a pre-create/symlink race). Use
+        ``mkdtemp(dir=/tmp)`` instead: it creates an unguessable, atomically
+        0700, owner-only dir — the parent-dir perms, not just the 0600 socket,
+        are what close the create-race window. (gettempdir() on macOS is itself
+        long, so anchor to /tmp to stay under the limit.) The #149-isolated path
+        will need an in-boundary socket regardless — tracked in #793."""
         in_boundary = os.path.abspath(os.path.join(working_dir or ".", ".codex-app-server"))
         if len(os.path.join(in_boundary, "app.sock")) <= 100:
-            return in_boundary
-        digest = hashlib.sha1(in_boundary.encode()).hexdigest()[:10]
-        return os.path.join(tempfile.gettempdir(), f"pinky-codex-as-{digest}")
+            return in_boundary, False
+        return tempfile.mkdtemp(dir="/tmp", prefix=f"pinky-codex-as-{agent_name}-"), True
 
     @property
     def session_name(self) -> str:
@@ -149,11 +155,7 @@ class CodexAppServerSupervisor:
         await self._tmux.kill_session()
         self._unlink_sock()
 
-        os.makedirs(self._sock_dir, exist_ok=True)
-        try:
-            os.chmod(self._sock_dir, 0o700)  # fail-closed dir; shim 0600s the file
-        except OSError:
-            pass
+        self._ensure_sock_dir_secure()
 
         command = " ".join(
             shlex.quote(p)
@@ -239,6 +241,32 @@ class CodexAppServerSupervisor:
             f"codex app-server shim for {self.agent_name} did not accept on "
             f"{self.sock_path} within {_READINESS_TIMEOUT}s (last: {last_err})"
         )
+
+    def _ensure_sock_dir_secure(self) -> None:
+        """Create the socket dir and assert it's a 0700 dir we own.
+
+        The /tmp fallback was born 0700 via mkdtemp (no race); the in-boundary
+        dir lives under a parent only we can write, so its makedirs+chmod race is
+        benign. Either way we verify before binding: a socket dir that isn't an
+        owner-only directory we own is a hard stop, never a silent downgrade —
+        the parent-dir perms are what gate who can connect to an
+        approvals=never codex."""
+        os.makedirs(self._sock_dir, exist_ok=True)
+        try:
+            os.chmod(self._sock_dir, 0o700)
+        except OSError:
+            pass
+        st = os.lstat(self._sock_dir)
+        if not stat.S_ISDIR(st.st_mode) or st.st_uid != os.getuid():
+            raise RuntimeError(
+                f"refusing app-server socket dir {self._sock_dir}: "
+                f"not an owner-owned directory"
+            )
+        if stat.S_IMODE(st.st_mode) != 0o700:
+            raise RuntimeError(
+                f"refusing app-server socket dir {self._sock_dir}: "
+                f"perms {oct(stat.S_IMODE(st.st_mode))} != 0o700"
+            )
 
     def request_kill(self) -> None:
         self._kill_requested = True

--- a/src/pinky_daemon/codex_app_server_tmux.py
+++ b/src/pinky_daemon/codex_app_server_tmux.py
@@ -32,9 +32,11 @@ with no changes to those call sites.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
 import shlex
 import sys
+import tempfile
 from collections.abc import Callable
 
 from pinky_daemon.codex_app_server import (
@@ -99,21 +101,32 @@ class CodexAppServerSupervisor:
         *,
         working_dir: str,
         openai_api_key: str = "",
-        env_path: str = "",
         log: Callable[[str], None] = _log,
     ) -> None:
         self.agent_name = agent_name
         self._log = log
         self._openai_api_key = openai_api_key
-        # tmux drops parent env; without PATH the shell can't resolve ``codex``.
-        self._env_path = env_path or os.environ.get("PATH", "")
-        # Socket inside the agent's working dir keeps it within the agent
-        # boundary (forward-compatible with #149 isolation) and under our own
-        # perms. Absolute so bind()/connect() don't depend on cwd.
-        self._sock_dir = os.path.abspath(os.path.join(working_dir or ".", ".codex-app-server"))
+        self._sock_dir = self._resolve_sock_dir(agent_name, working_dir)
         self.sock_path = os.path.join(self._sock_dir, "app.sock")
         self._tmux = _TmuxControl(self.session_name, command_runner=LocalCommandRunner())
         self._kill_requested = False
+
+    @staticmethod
+    def _resolve_sock_dir(agent_name: str, working_dir: str) -> str:
+        """Socket dir inside the agent's working dir (keeps it within the agent
+        boundary — forward-compatible with #149 isolation — and under our own
+        perms). Absolute so bind()/connect() don't depend on cwd.
+
+        macOS AF_UNIX paths cap near 104 chars; a long working_dir would
+        otherwise surface as a 30s readiness timeout. If the in-boundary path is
+        too long, fall back to a short, agent-stable ``/tmp`` runtime dir so the
+        transport still works (the #149 isolated path will need an in-boundary
+        socket regardless — tracked separately)."""
+        in_boundary = os.path.abspath(os.path.join(working_dir or ".", ".codex-app-server"))
+        if len(os.path.join(in_boundary, "app.sock")) <= 100:
+            return in_boundary
+        digest = hashlib.sha1(in_boundary.encode()).hexdigest()[:10]
+        return os.path.join(tempfile.gettempdir(), f"pinky-codex-as-{digest}")
 
     @property
     def session_name(self) -> str:
@@ -145,15 +158,9 @@ class CodexAppServerSupervisor:
             shlex.quote(p)
             for p in [sys.executable, "-m", "pinky_daemon.codex_app_server_shim", self.sock_path]
         )
-        env: dict[str, str] = {}
-        if self._env_path:
-            env["PATH"] = self._env_path
-        if self._openai_api_key:
-            # Reaches the tmux session -> the shim -> the grandchild ``codex``
-            # (the shim spawns it inheriting this env). Item H.
-            env["OPENAI_API_KEY"] = self._openai_api_key
-
-        result = await self._tmux.new_session(cwd=self._sock_dir, command=command, env=env)
+        result = await self._tmux.new_session(
+            cwd=self._sock_dir, command=command, env=self._build_env()
+        )
         if not result.ok:
             raise RuntimeError(
                 f"codex app-server tmux new-session failed for {self.agent_name}: "
@@ -176,6 +183,40 @@ class CodexAppServerSupervisor:
             f"(session={self.session_name} sock={self.sock_path})"
         )
         return client, _TmuxAppServerProc(self, pid=0)
+
+    # tmux-internal vars that must not leak into a nested session's children.
+    _ENV_DROP = frozenset({"TMUX", "TMUX_PANE"})
+
+    def _build_env(self) -> dict[str, str]:
+        """Full daemon-env parity for the tmux session — NOT just PATH.
+
+        tmux ``new-session`` drops the parent process env (only ``-e KEY=VAL``
+        survive), and the tmux *server's* env is not the daemon's. The
+        direct-subprocess app-server path passes ``env={**os.environ}``, so the
+        codex child sees the daemon's full config; we must reproduce that here or
+        the child silently runs under different CODEX_HOME / HOME / XDG_* / proxy
+        / cert / OPENAI_*/CODEX_* settings. That breaks auth and — critically —
+        item G: a fresh child's ``thread/resume`` only finds the prior thread if
+        it points at the SAME Codex home/session store (Murzik, #792 P1).
+
+        We propagate the entire daemon env (overlaying the configured key for
+        item H), minus tmux-internal vars and any value tmux ``-e`` can't carry
+        (newlines), which are pathological for env anyway.
+        """
+        env: dict[str, str] = {}
+        for key, value in os.environ.items():
+            if key in self._ENV_DROP:
+                continue
+            if "\n" in value or "\r" in value:
+                self._log(
+                    f"codex[{self.agent_name}]: dropping multiline env {key!r} "
+                    f"(cannot pass via tmux -e)"
+                )
+                continue
+            env[key] = value
+        if self._openai_api_key:
+            env["OPENAI_API_KEY"] = self._openai_api_key
+        return env
 
     async def _await_accept(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         """Readiness probe: poll until the shim's socket ACCEPTS our connection.

--- a/src/pinky_daemon/codex_app_server_tmux.py
+++ b/src/pinky_daemon/codex_app_server_tmux.py
@@ -11,9 +11,10 @@ from the daemon process.
 What this supervisor owns:
 
   * spawn the shim in a detached tmux session ``pinky-codex-as-<agent>``,
-    passing PATH + OPENAI_API_KEY via tmux ``-e`` (tmux drops parent env, so
-    these must be injected explicitly — and OPENAI_API_KEY must reach the
-    grandchild ``codex`` the shim spawns, not just the shim)
+    passing the full daemon env via tmux ``-e`` (tmux drops parent env, so it
+    must be injected explicitly — parity with the subprocess path's
+    ``{**os.environ}`` so CODEX_HOME/HOME/XDG/proxy/cert all reach the
+    grandchild ``codex`` the shim spawns, not just the shim; see _build_env)
   * idempotent pre-start cleanup: kill a stale tmux session + unlink a stale
     socket so a crashed predecessor can't wedge bind()
   * readiness = socket ACCEPT only. We open the one allowed connection and

--- a/src/pinky_daemon/codex_app_server_tmux.py
+++ b/src/pinky_daemon/codex_app_server_tmux.py
@@ -1,0 +1,224 @@
+"""tmux supervisor for the Design-A ``codex app-server`` shim (#791).
+
+The native ``codex app-server --listen unix://`` + ``proxy`` transport is
+silent (experimental, never responds — verified against codex-cli 0.125.0), so
+the daemon talks to a plain stdio ``codex app-server`` fronted by our own
+byte-transparent UDS bridge (``codex_app_server_shim``), and we run that bridge
+under tmux. tmux gives the same live-substrate / inspectable-pane win the
+claude REPL already gets (#98 family), and decouples the codex child's lifetime
+from the daemon process.
+
+What this supervisor owns:
+
+  * spawn the shim in a detached tmux session ``pinky-codex-as-<agent>``,
+    passing PATH + OPENAI_API_KEY via tmux ``-e`` (tmux drops parent env, so
+    these must be injected explicitly — and OPENAI_API_KEY must reach the
+    grandchild ``codex`` the shim spawns, not just the shim)
+  * idempotent pre-start cleanup: kill a stale tmux session + unlink a stale
+    socket so a crashed predecessor can't wedge bind()
+  * readiness = socket ACCEPT only. We open the one allowed connection and
+    HAND IT to the client — we do NOT throw a probe ``initialize`` at it, which
+    would burn the child's single-use ``initialize`` (per-process; a 2nd one
+    returns -32600). The real end-to-end gate stays the existing single
+    ``.initialize()`` in CodexSession._ensure_app_server; a dead child shows up
+    there as an EOF/timeout and terminalizes the turn.
+
+The returned proc adapter (:class:`_TmuxAppServerProc`) quacks like
+``asyncio.subprocess.Process`` so CodexSession's teardown paths
+(``.returncode`` / ``.pid`` / ``.kill()`` / ``.wait()``) map onto tmux teardown
+with no changes to those call sites.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+import sys
+from collections.abc import Callable
+
+from pinky_daemon.codex_app_server import (
+    _STREAM_LIMIT,
+    CodexAppServerClient,
+    NotificationHandler,
+    ServerRequestHandler,
+)
+from pinky_daemon.command_runner import LocalCommandRunner
+from pinky_daemon.streaming_session import _log
+from pinky_daemon.tmux_session import _TmuxControl
+
+# Generous: covers tmux new-session + python import + shim bind. The shim binds
+# its socket before any slow work, so accept usually lands in well under a
+# second; 30s only defends a pathological cold start.
+_READINESS_TIMEOUT = 30.0
+_READINESS_POLL = 0.1
+
+
+class _TmuxAppServerProc:
+    """Process-shaped adapter over a tmux-hosted shim.
+
+    CodexSession treats the app-server "process" as an
+    ``asyncio.subprocess.Process``: it reads ``.returncode`` (the reuse check in
+    _ensure_app_server, and the guard in _teardown_app_server) and ``.pid`` (a
+    log line), and calls ``.kill()`` then ``await .wait()`` to tear it down.
+    Here the real process tree lives inside a tmux session, so those map onto
+    ``CodexAppServerSupervisor.teardown()``.
+
+    ``returncode`` stays ``None`` until we tear down. That matches a live,
+    not-yet-reaped subprocess: if the codex child crashes under us, returncode
+    is still None and the connection is reused once, the next request fails, and
+    _exec_codex_app_server's handlers call _teardown_app_server -> respawn. We
+    can't poll tmux liveness from a *sync* property, and proactively reflecting
+    it would buy only one saved failed turn, so we keep the simple invariant.
+    """
+
+    def __init__(self, supervisor: CodexAppServerSupervisor, *, pid: int) -> None:
+        self._sup = supervisor
+        self.pid = pid
+        self.returncode: int | None = None
+
+    def kill(self) -> None:
+        # Mirror Process.kill(): request, don't block. The real async teardown
+        # (kill tmux session + unlink socket) is awaited in wait(), which
+        # _teardown_app_server always calls immediately after kill().
+        self._sup.request_kill()
+
+    async def wait(self) -> int:
+        await self._sup.teardown()
+        if self.returncode is None:
+            self.returncode = -9
+        return self.returncode
+
+
+class CodexAppServerSupervisor:
+    """Owns the tmux session + socket lifecycle for one agent's app-server."""
+
+    def __init__(
+        self,
+        agent_name: str,
+        *,
+        working_dir: str,
+        openai_api_key: str = "",
+        env_path: str = "",
+        log: Callable[[str], None] = _log,
+    ) -> None:
+        self.agent_name = agent_name
+        self._log = log
+        self._openai_api_key = openai_api_key
+        # tmux drops parent env; without PATH the shell can't resolve ``codex``.
+        self._env_path = env_path or os.environ.get("PATH", "")
+        # Socket inside the agent's working dir keeps it within the agent
+        # boundary (forward-compatible with #149 isolation) and under our own
+        # perms. Absolute so bind()/connect() don't depend on cwd.
+        self._sock_dir = os.path.abspath(os.path.join(working_dir or ".", ".codex-app-server"))
+        self.sock_path = os.path.join(self._sock_dir, "app.sock")
+        self._tmux = _TmuxControl(self.session_name, command_runner=LocalCommandRunner())
+        self._kill_requested = False
+
+    @property
+    def session_name(self) -> str:
+        return f"pinky-codex-as-{self.agent_name}"
+
+    async def start(
+        self,
+        *,
+        notification_handler: NotificationHandler | None = None,
+        server_request_handler: ServerRequestHandler | None = None,
+    ) -> tuple[CodexAppServerClient, _TmuxAppServerProc]:
+        """Launch the shim under tmux and return a started, UN-initialized
+        client plus its process adapter. Raises on tmux failure or readiness
+        timeout. The caller (CodexSession) performs the single ``initialize``."""
+        self._kill_requested = False
+
+        # Idempotent pre-start cleanup: a crashed predecessor can leave a live
+        # tmux session and/or a stale socket; either would wedge a fresh start.
+        await self._tmux.kill_session()
+        self._unlink_sock()
+
+        os.makedirs(self._sock_dir, exist_ok=True)
+        try:
+            os.chmod(self._sock_dir, 0o700)  # fail-closed dir; shim 0600s the file
+        except OSError:
+            pass
+
+        command = " ".join(
+            shlex.quote(p)
+            for p in [sys.executable, "-m", "pinky_daemon.codex_app_server_shim", self.sock_path]
+        )
+        env: dict[str, str] = {}
+        if self._env_path:
+            env["PATH"] = self._env_path
+        if self._openai_api_key:
+            # Reaches the tmux session -> the shim -> the grandchild ``codex``
+            # (the shim spawns it inheriting this env). Item H.
+            env["OPENAI_API_KEY"] = self._openai_api_key
+
+        result = await self._tmux.new_session(cwd=self._sock_dir, command=command, env=env)
+        if not result.ok:
+            raise RuntimeError(
+                f"codex app-server tmux new-session failed for {self.agent_name}: "
+                f"{result.stderr.strip()}"
+            )
+
+        reader, writer = await self._await_accept()
+
+        client = CodexAppServerClient(
+            reader,
+            writer,
+            stderr=None,  # child stderr is the tmux pane, not a pipe we drain
+            notification_handler=notification_handler,
+            server_request_handler=server_request_handler,
+            log=self._log,
+        )
+        client.start()
+        self._log(
+            f"codex[{self.agent_name}]: tmux app-server ready "
+            f"(session={self.session_name} sock={self.sock_path})"
+        )
+        return client, _TmuxAppServerProc(self, pid=0)
+
+    async def _await_accept(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        """Readiness probe: poll until the shim's socket ACCEPTS our connection.
+
+        The first successful connect IS the daemon's one allowed connection — we
+        return it, never a throwaway (the shim rejects a 2nd connection, and a
+        throwaway initialize would consume the child's single-use one).
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _READINESS_TIMEOUT
+        last_err: Exception | None = None
+        while loop.time() < deadline:
+            try:
+                return await asyncio.open_unix_connection(self.sock_path, limit=_STREAM_LIMIT)
+            except (FileNotFoundError, ConnectionRefusedError) as exc:
+                last_err = exc
+                await asyncio.sleep(_READINESS_POLL)
+        raise TimeoutError(
+            f"codex app-server shim for {self.agent_name} did not accept on "
+            f"{self.sock_path} within {_READINESS_TIMEOUT}s (last: {last_err})"
+        )
+
+    def request_kill(self) -> None:
+        self._kill_requested = True
+
+    async def teardown(self) -> None:
+        """Idempotent: kill the tmux session and unlink the socket."""
+        try:
+            await self._tmux.kill_session()
+        except Exception as exc:  # noqa: BLE001 — teardown is best-effort
+            self._log(f"codex[{self.agent_name}]: tmux app-server kill_session failed: {exc}")
+        self._unlink_sock()
+
+    def stats(self) -> dict:
+        return {
+            "app_server_mode": "tmux",
+            "tmux_session": self.session_name,
+            "sock_path": self.sock_path,
+        }
+
+    def _unlink_sock(self) -> None:
+        try:
+            if os.path.exists(self.sock_path):
+                os.unlink(self.sock_path)
+        except OSError:
+            pass

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -28,6 +28,7 @@ from pinky_daemon.codex_app_server import (
     CodexAppServerError,
     spawn_app_server,
 )
+from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor
 from pinky_daemon.context_estimator import ContextTextEstimator
 from pinky_daemon.sessions import MODEL_CONTEXT_SIZES, SessionUsage
 from pinky_daemon.streaming_session import (
@@ -170,6 +171,22 @@ class CodexSession:
         # app-server process + one thread per session here (chunk 2); a shared
         # supervisor lands in chunk 3.
         self._use_app_server = os.environ.get("PINKY_CODEX_APP_SERVER") == "1"
+        # #791: when additionally PINKY_CODEX_TMUX_APP_SERVER=1, front the
+        # app-server with a tmux-hosted UDS shim (Design A) instead of a daemon
+        # child subprocess. Same JSON-RPC client + initialize/thread-resume flow
+        # downstream; only how the process is spawned and torn down differs.
+        # Default-off, side-by-side with the direct-subprocess path.
+        self._use_tmux_app_server = (
+            self._use_app_server and os.environ.get("PINKY_CODEX_TMUX_APP_SERVER") == "1"
+        )
+        self._app_supervisor: CodexAppServerSupervisor | None = None
+        if self._use_tmux_app_server:
+            self._app_supervisor = CodexAppServerSupervisor(
+                self.agent_name,
+                working_dir=self._working_dir,
+                openai_api_key=self._openai_api_key,
+                log=_log,
+            )
         self._app_client: CodexAppServerClient | None = None
         self._app_proc: asyncio.subprocess.Process | None = None
         # Active turn correlation: the read loop dispatches notifications onto
@@ -936,17 +953,29 @@ class CodexSession:
             # Process died under us — drop the stale client and respawn.
             await self._teardown_app_server()
 
-        env = {**os.environ}
-        if self._openai_api_key:
-            env["OPENAI_API_KEY"] = self._openai_api_key
+        if self._use_tmux_app_server:
+            # #791 Design A: the supervisor spawns the shim under tmux and hands
+            # back an UN-initialized client (accept-readiness only — no probe
+            # initialize, which would burn the child's single-use one). The
+            # single initialize below stays the real end-to-end gate, and its
+            # half-initialized guard covers a dead tmux child (item F).
+            assert self._app_supervisor is not None
+            self._app_client, self._app_proc = await self._app_supervisor.start(
+                notification_handler=self._on_appserver_notification,
+                server_request_handler=self._on_appserver_request,
+            )
+        else:
+            env = {**os.environ}
+            if self._openai_api_key:
+                env["OPENAI_API_KEY"] = self._openai_api_key
 
-        self._app_client, self._app_proc = await spawn_app_server(
-            cwd=self._working_dir,
-            env=env,
-            notification_handler=self._on_appserver_notification,
-            server_request_handler=self._on_appserver_request,
-            log=_log,
-        )
+            self._app_client, self._app_proc = await spawn_app_server(
+                cwd=self._working_dir,
+                env=env,
+                notification_handler=self._on_appserver_notification,
+                server_request_handler=self._on_appserver_request,
+                log=_log,
+            )
         try:
             await self._app_client.initialize(name="pinkybot", version="1")
         except BaseException:
@@ -1854,8 +1883,17 @@ class CodexSession:
     @property
     def stats(self) -> dict:
         state = self.state
+        app_server: dict = {}
+        if self._use_app_server:
+            app_server["app_server_mode"] = "tmux" if self._use_tmux_app_server else "subprocess"
+            if self._app_proc is not None:
+                app_server["child_pid"] = self._app_proc.pid
+            if self._app_supervisor is not None:
+                app_server["tmux_session"] = self._app_supervisor.session_name
+                app_server["sock_path"] = self._app_supervisor.sock_path
         return {
             **self._stats,
+            **app_server,
             "connected": state == SessionState.CONNECTED,
             "state": state.value,
             # Wall-clock epoch the current state was entered (grant time) — lets

--- a/tests/_fake_app_server.py
+++ b/tests/_fake_app_server.py
@@ -1,0 +1,51 @@
+"""A fake stdio ``codex app-server`` for shim/supervisor tests.
+
+Speaks the same NDJSON dialect CodexAppServerClient expects (see
+codex_app_server.py): one JSON object per line, requests carry ``id`` +
+``method``, responses carry ``id`` + ``result``. Lets the bridge be exercised
+end-to-end with no real ``codex`` binary.
+
+  * ``initialize``         -> {"id", "result": {"userAgent": "fake/1", ...}}
+  * any other request      -> {"id", "result": {"echo": <params>}}  (round-trips
+                              arbitrary payloads, incl. frames >64 KiB)
+  * notifications (no id)  -> ignored
+
+Env knobs:
+  * FAKE_AS_EXIT_AFTER_INIT=1  -> exit right after answering initialize (used to
+    test the child-dies-under-the-bridge path)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def main() -> int:
+    exit_after_init = os.environ.get("FAKE_AS_EXIT_AFTER_INIT") == "1"
+    for raw in sys.stdin.buffer:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        mid = msg.get("id")
+        method = msg.get("method")
+        if mid is None:
+            continue  # notification — ignore
+        if method == "initialize":
+            resp = {"id": mid, "result": {"userAgent": "fake/1", "ok": True}}
+        else:
+            resp = {"id": mid, "result": {"echo": msg.get("params")}}
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+        if method == "initialize" and exit_after_init:
+            return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_codex_app_server_shim.py
+++ b/tests/test_codex_app_server_shim.py
@@ -1,0 +1,213 @@
+"""End-to-end tests for the Design-A UDS<->stdio bridge (#791).
+
+Spawns the real ``codex_app_server_shim`` as a subprocess, but points its child
+at ``tests/_fake_app_server`` via PINKY_CODEX_APP_SERVER_CMD so no ``codex``
+binary is needed. Exercises the byte-transparent bridge, single-client policy,
+and terminal teardown (child reaped + socket unlinked + shim exits).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+_REPO_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+_FAKE = os.path.join(os.path.dirname(__file__), "_fake_app_server.py")
+_STREAM_LIMIT = 10 * 1024 * 1024
+
+
+@pytest.fixture
+def sock_path():
+    """A short UDS path. pytest's tmp_path blows past macOS's ~104-char
+    AF_UNIX limit, so anchor the socket under a short /tmp dir instead."""
+    d = tempfile.mkdtemp(dir="/tmp", prefix="kzas")
+    try:
+        yield os.path.join(d, "app.sock")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+class _Shim:
+    """A running shim subprocess. Spawned via plain ``subprocess.Popen`` — NOT
+    ``asyncio.create_subprocess_exec`` — because pytest-asyncio's per-test event
+    loop breaks the asyncio child watcher (the shim's own socket I/O still runs
+    on asyncio fine; only the process management sidesteps it). Its stdout/stderr
+    go to a real file, not a pipe, so pytest's stdio capture can't interfere."""
+
+    def __init__(self, proc: subprocess.Popen, child_pid: int) -> None:
+        self.proc = proc
+        self.child_pid = child_pid
+
+    async def wait(self, timeout: float = 10.0) -> int:
+        return await asyncio.wait_for(asyncio.to_thread(self.proc.wait), timeout)
+
+    def kill(self) -> None:
+        try:
+            self.proc.kill()
+            self.proc.wait(timeout=5)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+async def _spawn_shim(sock_path: str, *, exit_after_init: bool = False) -> _Shim:
+    env = {
+        **os.environ,
+        "PYTHONPATH": _REPO_SRC + os.pathsep + os.environ.get("PYTHONPATH", ""),
+        "PINKY_CODEX_APP_SERVER_CMD": f"{sys.executable} {_FAKE}",
+    }
+    if exit_after_init:
+        env["FAKE_AS_EXIT_AFTER_INIT"] = "1"
+    log_path = sock_path + ".log"
+    log = open(log_path, "w+")
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "pinky_daemon.codex_app_server_shim", sock_path],
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+
+    # Poll the log file for the "...child_pid=<pid>" line (off the event loop).
+    def _read_pid() -> int:
+        deadline = 150  # ~15s at 0.1s
+        with open(log_path) as fh:
+            for _ in range(deadline):
+                for line in fh:
+                    if "child_pid=" in line:
+                        return int(line.split("child_pid=")[1])
+                if proc.poll() is not None:
+                    fh.seek(0)
+                    raise RuntimeError(f"shim exited rc={proc.returncode}; log:\n{fh.read()}")
+                import time
+
+                time.sleep(0.1)
+        raise RuntimeError("shim never reported child_pid")
+
+    child_pid = await asyncio.wait_for(asyncio.to_thread(_read_pid), timeout=20)
+    return _Shim(proc, child_pid)
+
+
+async def _request(reader, writer, mid, method, params=None):
+    writer.write((json.dumps({"id": mid, "method": method, "params": params or {}}) + "\n").encode())
+    await writer.drain()
+    line = await asyncio.wait_for(reader.readline(), timeout=10)
+    return json.loads(line)
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+@pytest.mark.asyncio
+async def test_initialize_round_trips_through_bridge(sock_path):
+    sock = sock_path
+    shim = await _spawn_shim(sock)
+    try:
+        reader, writer = await asyncio.open_unix_connection(sock, limit=_STREAM_LIMIT)
+        resp = await _request(reader, writer, 1, "initialize", {"clientInfo": {"name": "t"}})
+        assert resp["id"] == 1
+        assert resp["result"]["userAgent"] == "fake/1"
+        writer.close()
+    finally:
+        shim.kill()
+
+
+@pytest.mark.asyncio
+async def test_large_frame_is_byte_transparent(sock_path):
+    """A >64 KiB frame must round-trip — the bridge reads fixed chunks and never
+    parses lines, so it can't trip the client reader's frame limit."""
+    sock = sock_path
+    shim = await _spawn_shim(sock)
+    try:
+        reader, writer = await asyncio.open_unix_connection(sock, limit=_STREAM_LIMIT)
+        big = "x" * (256 * 1024)
+        resp = await _request(reader, writer, 7, "thread/start", {"blob": big})
+        assert resp["id"] == 7
+        assert resp["result"]["echo"]["blob"] == big
+        writer.close()
+    finally:
+        shim.kill()
+
+
+@pytest.mark.asyncio
+async def test_second_connection_is_rejected(sock_path):
+    sock = sock_path
+    shim = await _spawn_shim(sock)
+    try:
+        r1, w1 = await asyncio.open_unix_connection(sock, limit=_STREAM_LIMIT)
+        await _request(r1, w1, 1, "initialize")
+        # Second connection: shim closes it immediately (EOF), child stays alive.
+        r2, w2 = await asyncio.open_unix_connection(sock, limit=_STREAM_LIMIT)
+        assert await asyncio.wait_for(r2.read(1), timeout=5) == b""
+        w2.close()
+        await asyncio.sleep(0.2)
+        assert _pid_alive(shim.child_pid)
+        # Primary connection still works.
+        resp = await _request(r1, w1, 2, "ping")
+        assert resp["id"] == 2
+        w1.close()
+    finally:
+        shim.kill()
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_kills_child_and_unlinks_sock(sock_path):
+    sock = sock_path
+    shim = await _spawn_shim(sock)
+    reader, writer = await asyncio.open_unix_connection(sock, limit=_STREAM_LIMIT)
+    await _request(reader, writer, 1, "initialize")
+    assert _pid_alive(shim.child_pid)
+    writer.close()
+    await writer.wait_closed()
+    # Shim should reap the child, unlink the socket, and exit.
+    await shim.wait(timeout=10)
+    for _ in range(50):
+        if not _pid_alive(shim.child_pid):
+            break
+        await asyncio.sleep(0.1)
+    assert not _pid_alive(shim.child_pid)
+    assert not os.path.exists(sock)
+
+
+@pytest.mark.asyncio
+async def test_child_death_tears_down_the_bridge(sock_path):
+    """If the child exits (item F at the bridge layer), the shim drops the
+    client connection and exits rather than wedging."""
+    sock = sock_path
+    shim = await _spawn_shim(sock, exit_after_init=True)
+    reader, writer = await asyncio.open_unix_connection(sock, limit=_STREAM_LIMIT)
+    # initialize triggers the fake child to exit right after replying.
+    resp = await _request(reader, writer, 1, "initialize")
+    assert resp["result"]["userAgent"] == "fake/1"
+    # Child EOF -> shim closes our connection and exits.
+    assert await asyncio.wait_for(reader.read(), timeout=10) == b""
+    await shim.wait(timeout=10)
+    assert not os.path.exists(sock)
+
+
+@pytest.mark.asyncio
+async def test_stale_socket_is_unlinked_before_bind(sock_path):
+    sock = sock_path
+    # Pre-create a stale regular file at the socket path (its dir already exists).
+    with open(sock, "w") as f:
+        f.write("stale")
+    shim = await _spawn_shim(sock)
+    try:
+        reader, writer = await asyncio.open_unix_connection(sock, limit=_STREAM_LIMIT)
+        resp = await _request(reader, writer, 1, "initialize")
+        assert resp["id"] == 1
+        writer.close()
+    finally:
+        shim.kill()

--- a/tests/test_codex_app_server_tmux.py
+++ b/tests/test_codex_app_server_tmux.py
@@ -1,0 +1,198 @@
+"""Tests for CodexAppServerSupervisor (#791 Design A).
+
+The supervisor's tmux dependency is replaced with a fake ``_TmuxControl`` that,
+on ``new_session``, actually launches the real ``codex_app_server_shim`` via
+``subprocess.Popen`` (pointed at ``tests/_fake_app_server`` — no ``codex``
+needed). That exercises the real accept-readiness probe, the real
+CodexAppServerClient over the real socket, and the real teardown, while letting
+the tests assert how the supervisor drives tmux (idempotent kill, env injection,
+session lifecycle) with no actual tmux server.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+from pinky_daemon import codex_app_server_tmux as mod
+from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor, _TmuxAppServerProc
+
+_REPO_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+_FAKE = os.path.join(os.path.dirname(__file__), "_fake_app_server.py")
+
+
+class FakeTmuxResult:
+    def __init__(self, ok: bool = True, stderr: str = "") -> None:
+        self.ok = ok
+        self.returncode = 0 if ok else 1
+        self.stdout = ""
+        self.stderr = stderr
+
+
+class FakeTmux:
+    """Records tmux calls; really runs the shim command on new_session."""
+
+    def __init__(self, *, new_session_ok: bool = True, spawn: bool = True) -> None:
+        self.calls: list[str] = []
+        self.new_session_env: dict | None = None
+        self.new_session_ok = new_session_ok
+        self.spawn = spawn
+        self._proc: subprocess.Popen | None = None
+        self._has = False
+
+    async def has_session(self) -> bool:
+        return self._has
+
+    async def new_session(self, *, cwd: str, command: str, env=None) -> FakeTmuxResult:
+        self.calls.append("new_session")
+        self.new_session_env = dict(env or {})
+        if not self.new_session_ok:
+            return FakeTmuxResult(ok=False, stderr="boom")
+        if self.spawn:
+            run_env = {
+                **os.environ,
+                **(env or {}),
+                "PYTHONPATH": _REPO_SRC + os.pathsep + os.environ.get("PYTHONPATH", ""),
+                "PINKY_CODEX_APP_SERVER_CMD": f"{sys.executable} {_FAKE}",
+            }
+            self._proc = subprocess.Popen(
+                shlex.split(command),
+                cwd=cwd,
+                env=run_env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            self._has = True
+        return FakeTmuxResult(ok=True)
+
+    async def kill_session(self) -> FakeTmuxResult:
+        self.calls.append("kill_session")
+        if self._proc is not None:
+            try:
+                self._proc.kill()
+                self._proc.wait(timeout=5)
+            except Exception:  # noqa: BLE001
+                pass
+            self._proc = None
+        self._has = False
+        return FakeTmuxResult(ok=True)
+
+
+@pytest.fixture
+def workdir():
+    # Short path so the derived socket stays under macOS's AF_UNIX limit.
+    d = tempfile.mkdtemp(dir="/tmp", prefix="kzwd")
+    try:
+        yield d
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def _make_supervisor(workdir: str, fake: FakeTmux, **kw) -> CodexAppServerSupervisor:
+    sup = CodexAppServerSupervisor(
+        "kztest", working_dir=workdir, openai_api_key=kw.get("key", "sk-SENTINEL"),
+    )
+    sup._tmux = fake
+    return sup
+
+
+@pytest.mark.asyncio
+async def test_start_spawns_shim_and_initialize_round_trips(workdir):
+    fake = FakeTmux()
+    sup = _make_supervisor(workdir, fake)
+    client, proc = await sup.start()
+    try:
+        # Idempotent pre-start cleanup ran before the spawn.
+        assert fake.calls[0] == "kill_session"
+        assert "new_session" in fake.calls
+        # Env injected for the shell/child: PATH (codex resolution) + the key
+        # (item H — must reach the grandchild codex via tmux -e -> shim -> child).
+        assert "PATH" in fake.new_session_env
+        assert fake.new_session_env.get("OPENAI_API_KEY") == "sk-SENTINEL"
+        # The single initialize (the daemon's real gate) round-trips end to end.
+        res = await client.initialize(name="pinkybot", version="1")
+        assert res["userAgent"] == "fake/1"
+        assert isinstance(proc, _TmuxAppServerProc)
+        assert proc.returncode is None
+        # Fail-closed perms: dir 0700, socket 0600.
+        assert stat.S_IMODE(os.stat(sup._sock_dir).st_mode) == 0o700
+        assert stat.S_IMODE(os.stat(sup.sock_path).st_mode) == 0o600
+    finally:
+        await client.close()
+        await fake.kill_session()
+
+
+@pytest.mark.asyncio
+async def test_new_session_failure_raises(workdir):
+    fake = FakeTmux(new_session_ok=False)
+    sup = _make_supervisor(workdir, fake)
+    with pytest.raises(RuntimeError, match="new-session failed"):
+        await sup.start()
+
+
+@pytest.mark.asyncio
+async def test_readiness_timeout_raises(workdir, monkeypatch):
+    # new_session "succeeds" but never spawns a listener -> accept never lands.
+    monkeypatch.setattr(mod, "_READINESS_TIMEOUT", 0.5)
+    fake = FakeTmux(spawn=False)
+    sup = _make_supervisor(workdir, fake)
+    with pytest.raises(TimeoutError, match="did not accept"):
+        await sup.start()
+
+
+@pytest.mark.asyncio
+async def test_teardown_kills_session_and_unlinks_sock(workdir):
+    fake = FakeTmux()
+    sup = _make_supervisor(workdir, fake)
+    client, _proc = await sup.start()
+    await client.close()
+    assert os.path.exists(sup.sock_path) or True  # shim may already self-unlink
+    await sup.teardown()
+    assert "kill_session" in fake.calls
+    assert not os.path.exists(sup.sock_path)
+
+
+@pytest.mark.asyncio
+async def test_proc_adapter_kill_then_wait_tears_down(workdir):
+    fake = FakeTmux()
+    sup = _make_supervisor(workdir, fake)
+    client, proc = await sup.start()
+    await client.close()
+    kills_before = fake.calls.count("kill_session")
+    proc.kill()  # request only — non-blocking, mirrors Process.kill()
+    rc = await proc.wait()  # performs the real async teardown
+    assert rc == -9
+    assert proc.returncode == -9
+    assert fake.calls.count("kill_session") == kills_before + 1
+    assert not os.path.exists(sup.sock_path)
+
+
+@pytest.mark.asyncio
+async def test_start_unlinks_stale_socket(workdir):
+    fake = FakeTmux()
+    sup = _make_supervisor(workdir, fake)
+    # Pre-create a stale file where the socket will live.
+    os.makedirs(sup._sock_dir, exist_ok=True)
+    with open(sup.sock_path, "w") as f:
+        f.write("stale")
+    client, _proc = await sup.start()
+    try:
+        # A real, connectable socket now exists (not the stale regular file).
+        assert stat.S_ISSOCK(os.stat(sup.sock_path).st_mode)
+        res = await client.initialize()
+        assert res["userAgent"] == "fake/1"
+    finally:
+        await client.close()
+        await fake.kill_session()
+
+
+def test_session_name_is_agent_scoped():
+    sup = CodexAppServerSupervisor("dymok", working_dir="/tmp/x")
+    assert sup.session_name == "pinky-codex-as-dymok"

--- a/tests/test_codex_app_server_tmux.py
+++ b/tests/test_codex_app_server_tmux.py
@@ -130,6 +130,52 @@ async def test_start_spawns_shim_and_initialize_round_trips(workdir):
 
 
 @pytest.mark.asyncio
+async def test_full_daemon_env_propagated_to_session(workdir, monkeypatch):
+    """#792 P1 (Murzik): tmux drops parent env, so the supervisor must carry the
+    daemon's full Codex config — not just PATH — or a fresh child runs under a
+    different CODEX_HOME/session store and breaks auth + item G resume."""
+    monkeypatch.setenv("CODEX_HOME", "/fleet/codex")
+    monkeypatch.setenv("HOME", "/fleet/home")
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/fleet/xdg")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy:8080")
+    monkeypatch.setenv("no_proxy", "localhost")
+    monkeypatch.setenv("SSL_CERT_FILE", "/fleet/ca.pem")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://fleet.example/v1")
+    monkeypatch.setenv("TMUX", "/private/tmp/tmux-0/default,123,4")  # must be dropped
+    # spawn=False -> no listener -> readiness times out, but new_session (and the
+    # env build it exercises) has already run by then; shrink the wait.
+    monkeypatch.setattr(mod, "_READINESS_TIMEOUT", 0.3)
+    fake = FakeTmux(spawn=False)
+    sup = _make_supervisor(workdir, fake)
+    with pytest.raises(TimeoutError):
+        await sup.start()
+    env = fake.new_session_env
+    for key, val in {
+        "CODEX_HOME": "/fleet/codex",
+        "HOME": "/fleet/home",
+        "XDG_CONFIG_HOME": "/fleet/xdg",
+        "HTTPS_PROXY": "http://proxy:8080",
+        "no_proxy": "localhost",
+        "SSL_CERT_FILE": "/fleet/ca.pem",
+        "OPENAI_BASE_URL": "https://fleet.example/v1",
+    }.items():
+        assert env.get(key) == val, f"daemon env {key} not propagated to tmux session"
+    # The configured key is overlaid (item H), and tmux-internal vars are dropped.
+    assert env.get("OPENAI_API_KEY") == "sk-SENTINEL"
+    assert "TMUX" not in env
+
+
+@pytest.mark.asyncio
+async def test_long_working_dir_falls_back_to_short_sock_dir():
+    """A working_dir long enough to blow past the AF_UNIX limit must not yield
+    an unbindable socket path (would surface as a readiness timeout)."""
+    long_wd = "/tmp/" + ("d" * 140)
+    sup = CodexAppServerSupervisor("kztest", working_dir=long_wd)
+    assert len(sup.sock_path) <= 104
+    assert sup.sock_path.startswith(tempfile.gettempdir())
+
+
+@pytest.mark.asyncio
 async def test_new_session_failure_raises(workdir):
     fake = FakeTmux(new_session_ok=False)
     sup = _make_supervisor(workdir, fake)

--- a/tests/test_codex_app_server_tmux.py
+++ b/tests/test_codex_app_server_tmux.py
@@ -167,12 +167,23 @@ async def test_full_daemon_env_propagated_to_session(workdir, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_long_working_dir_falls_back_to_short_sock_dir():
-    """A working_dir long enough to blow past the AF_UNIX limit must not yield
-    an unbindable socket path (would surface as a readiness timeout)."""
+    """A working_dir long enough to blow past the AF_UNIX limit must fall back
+    to a short, owner-only 0700 dir — not a predictable /tmp path, and not an
+    unbindable long one (would surface as a readiness timeout)."""
     long_wd = "/tmp/" + ("d" * 140)
     sup = CodexAppServerSupervisor("kztest", working_dir=long_wd)
-    assert len(sup.sock_path) <= 104
-    assert sup.sock_path.startswith(tempfile.gettempdir())
+    try:
+        assert sup._sock_dir_is_tmp is True
+        assert len(sup.sock_path) <= 104
+        assert sup.sock_path.startswith("/tmp/")
+        # mkdtemp gives an unguessable, atomically-0700, owner-only dir — the
+        # parent-dir perms are what gate connect() to an approvals=never codex.
+        st = os.lstat(sup._sock_dir)
+        assert stat.S_ISDIR(st.st_mode)
+        assert stat.S_IMODE(st.st_mode) == 0o700
+        assert st.st_uid == os.getuid()
+    finally:
+        shutil.rmtree(sup._sock_dir, ignore_errors=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_session_tmux_app_server.py
+++ b/tests/test_codex_session_tmux_app_server.py
@@ -1,0 +1,124 @@
+"""Integration wiring for the tmux app-server transport in CodexSession (#791).
+
+Covers the flag gating (PINKY_CODEX_TMUX_APP_SERVER, layered on
+PINKY_CODEX_APP_SERVER) and that _ensure_app_server routes through the
+supervisor (vs the direct-subprocess spawn) without changing the downstream
+initialize / stats contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor
+from pinky_daemon.codex_session import CodexSession
+from pinky_daemon.streaming_session import StreamingSessionConfig
+
+
+def _make_session(**overrides) -> CodexSession:
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        label="main",
+        model="",
+        working_dir="/tmp",
+        provider_url="codex_cli",
+        provider_key="test-key",
+        **overrides,
+    )
+    return CodexSession(config)
+
+
+def test_tmux_flag_off_by_default(monkeypatch):
+    monkeypatch.delenv("PINKY_CODEX_APP_SERVER", raising=False)
+    monkeypatch.delenv("PINKY_CODEX_TMUX_APP_SERVER", raising=False)
+    s = _make_session()
+    assert s._use_tmux_app_server is False
+    assert s._app_supervisor is None
+
+
+def test_tmux_flag_requires_base_app_server_flag(monkeypatch):
+    # The tmux flag is meaningless without the app-server path itself.
+    monkeypatch.delenv("PINKY_CODEX_APP_SERVER", raising=False)
+    monkeypatch.setenv("PINKY_CODEX_TMUX_APP_SERVER", "1")
+    s = _make_session()
+    assert s._use_tmux_app_server is False
+    assert s._app_supervisor is None
+
+
+def test_tmux_flag_on_creates_supervisor(monkeypatch):
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER", "1")
+    monkeypatch.setenv("PINKY_CODEX_TMUX_APP_SERVER", "1")
+    s = _make_session()
+    assert s._use_tmux_app_server is True
+    assert isinstance(s._app_supervisor, CodexAppServerSupervisor)
+    assert s._app_supervisor.session_name == "pinky-codex-as-test-agent"
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.initialized = False
+
+    def start(self) -> None:  # pragma: no cover - not called on this path
+        pass
+
+    async def initialize(self, *, name: str = "", version: str = "") -> dict:
+        self.initialized = True
+        return {"userAgent": "fake/1"}
+
+    async def close(self) -> None:
+        pass
+
+
+class _FakeProc:
+    def __init__(self) -> None:
+        self.pid = 4321
+        self.returncode = None
+
+    def kill(self) -> None:
+        pass
+
+    async def wait(self) -> int:
+        return -9
+
+
+class _FakeSupervisor:
+    def __init__(self) -> None:
+        self.started = 0
+        self.session_name = "pinky-codex-as-test-agent"
+        self.sock_path = "/tmp/x/.codex-app-server/app.sock"
+        self.client = _FakeClient()
+        self.proc = _FakeProc()
+
+    async def start(self, *, notification_handler=None, server_request_handler=None):
+        self.started += 1
+        return self.client, self.proc
+
+
+@pytest.mark.asyncio
+async def test_ensure_app_server_uses_supervisor_in_tmux_mode(monkeypatch):
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER", "1")
+    monkeypatch.setenv("PINKY_CODEX_TMUX_APP_SERVER", "1")
+    s = _make_session()
+    fake = _FakeSupervisor()
+    s._app_supervisor = fake
+
+    await s._ensure_app_server()
+
+    assert fake.started == 1
+    assert s._app_client is fake.client
+    assert s._app_proc is fake.proc
+    assert fake.client.initialized is True  # the single real gate still runs
+
+    # Stats surface the tmux transport.
+    stats = s.stats
+    assert stats["app_server_mode"] == "tmux"
+    assert stats["tmux_session"] == "pinky-codex-as-test-agent"
+    assert stats["sock_path"] == fake.sock_path
+    assert stats["child_pid"] == 4321
+
+
+def test_stats_mode_subprocess_when_tmux_off(monkeypatch):
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER", "1")
+    monkeypatch.delenv("PINKY_CODEX_TMUX_APP_SERVER", raising=False)
+    s = _make_session()
+    assert s.stats["app_server_mode"] == "subprocess"


### PR DESCRIPTION
## What

The native `codex app-server --listen unix://` + `proxy` transport that #791 originally specced is **dead**: it accepts the connection but never responds — no reverse handshake, no error, total silence. `app-server` is `[experimental]` and no feature flag unlocks the listener. Reproduced ×2 (with Murzik) against **codex-cli 0.125.0**.

**Pivot — Design A (Barsik + Murzik greenlit):** front a plain stdio `codex app-server` with our own ~byte-transparent UDS bridge, and run that bridge under tmux. Same live-substrate / per-turn-warmth win the claude REPL already has (#98), without the dead native path. Flag-gated, default-off, side-by-side with the existing direct-subprocess app-server.

### Probe table (codex-cli 0.125.0)
| transport | result |
|---|---|
| `codex app-server` stdio + `initialize` | ✅ round-trips |
| `codex app-server --listen unix://` + `proxy --sock` | ❌ total silence (accepts conn, never responds) |
| our UDS↔stdio shim under tmux | ✅ round-trips end-to-end |

> Stamped to **0.125.0** deliberately — re-test the native path on the next codex upgrade (see the de-experimentalize follow-up issue).

## The single-`initialize` constraint
`initialize` is **per-child-process**: a 2nd `initialize` on the same child returns `-32600 "Already initialized"` (Murzik). So the child can't be warm across reconnects. Design A couples the child's lifetime to the daemon connection — **warm across TURNS** (preserves #98), torn on disconnect/force_restart. Thread continuity rides the existing `thread/resume {threadId}` call.

**Item G (verified live):** app-server persists threads to **disk** (`~/.codex` rollout) — `thread/resume` on a *fresh* child after teardown succeeds, so `force_restart` keeps thread continuity.

## Changes
- **`codex_app_server_shim.py`** — byte-transparent UDS↔stdio bridge. Single active client (rejects a 2nd conn), stale-sock unlink, child stderr→pane, terminal hard-exit (dodges an asyncio-3.14 subprocess-reap + loop-teardown stall). Child command overridable via env (tests + operator escape hatch).
- **`codex_app_server_tmux.py`** — `CodexAppServerSupervisor` over `_TmuxControl`. Idempotent stale session/sock cleanup; `PATH` + `OPENAI_API_KEY` injected via tmux `-e` so the key reaches the **grandchild** codex; **readiness = socket ACCEPT only** (no probe `initialize` — it would burn the child's single-use one); the daemon's existing single `.initialize()` stays the real gate (a dead child surfaces there → teardown → respawn). Sock dir `0700`, file `0600`, daemon uid. `_TmuxAppServerProc` quacks like `asyncio.subprocess.Process` so teardown call-sites are unchanged.
- **`codex_session.py`** — flag `PINKY_CODEX_TMUX_APP_SERVER` (layered on `PINKY_CODEX_APP_SERVER`), default-off. Only spawn/teardown differs; initialize / thread-resume / notifications unchanged. Stats surface `app_server_mode` + `tmux_session` + `sock_path` + `child_pid`.

## Idle-sleep note
`idle_sleep → disconnect → _teardown_app_server`, so idle **tears** the connection (and the tmux child) today — same as the existing subprocess app-server path. No regression; thread continuity is preserved on wake via `thread/resume` (item G). Keeping the child warm across idle (skip teardown on idle only) is a possible future optimization, out of this increment.

## Tests — 18 new, 123 codex tests total green
Shim bridge (initialize round-trip, 256 KiB byte-transparency, single-client reject, disconnect→child-reaped+sock-unlinked, child-death teardown, stale-sock); supervisor (idempotent cleanup, env injection incl `OPENAI_API_KEY`, accept-readiness, `0700`/`0600` perms, readiness timeout, proc-adapter teardown); session wiring (flag gating, supervisor routing, stats shape). pytest-asyncio's per-test loop breaks `create_subprocess_exec`, so shim tests spawn via `Popen` + short `/tmp` UDS paths (macOS 104-char limit).

## Live e2e proof
No UI to screenshot — this is a headless transport, so here's the live run (real codex-cli 0.125.0, real tmux):

```
== #791 Design A: tmux-backed codex app-server (live, codex-cli 0.125.0) ==
[1] tmux session up: pinky-codex-as-kzdemo  (proc.returncode=None)
[2] perms: sock dir=0o700  file=0o600
[3] initialize round-trip thru tmux->shim->child: pinkybot/0.125.0 (Mac OS 26.3.1; arm64) tmux/3.6a
[4] item H: OPENAI_API_KEY reaches codex child pid=70292 (via tmux -e)
[5] live turn completed on thread 019ed633-ee4b-7512…
[6] child A torn down (tmux gone: True)
[7] item G: thread/resume on FRESH child SUCCEEDED -> threads persist to DISK; force_restart keeps continuity
[8] clean teardown — no stray procs, sock unlinked: True
```

## Follow-ups
- **#149-isolated agents**: sock under a different uid needs it inside the agent boundary + uid match — left as a documented TODO; increment-1 is default-off / non-isolated.
- De-experimentalize follow-up issue (stopgap-removal rule): revisit native `--listen`/`proxy` when codex de-experimentalizes app-server → drop the ~70-line shim. *(filed, linked from #791)*

🤖 Opened by Kuzya
