### PR TITLE
feat(codex-tmux): CodexTmuxSession — codex agents over the tmux transport (#215 PR2)

### DIFF
--- a/specs/codex-tmux-transport-plan.md
+++ b/specs/codex-tmux-transport-plan.md
@@ -144,3 +144,51 @@ transport/wake (5488) + transport/transcript-path (5617) already duck-typed (get
 - src/pinky_daemon/api.py
 - src/pinky_daemon/codex_app_server_tmux.py (reference: tmux-under-codex + _TmuxControl reuse)
 New: src/pinky_daemon/codex_tmux_session.py, src/pinky_daemon/codex_tmux_transcript.py, codex notify hook (model on data/agents/<name>/.claude/hook_tmux_session_start.py).
+
+## 10. PR2 BUILD RECORD (2026-06-17) — Option A chosen; make-or-break validated
+
+**Decision: Option A (subclass), NOT the tentatively-planned Option B (copy).**
+Recon showed the codex seams are cleanly isolated, so `CodexTmuxSession(TmuxSession)`
+overrides ONLY `_build_session_name`, `_build_claude_cmd` (codex cmd), `_build_repl_env`,
+`_project_dir`/`_has_prior_transcript`/`_discover_transcript_path`, `_start_tailer`
+(→ `CodexTmuxTranscriptTailer`), `_spawn_tmux_repl` (wraps super() + codex trust pre-seed
++ NUX dismissal + readiness), `_watch_for_oauth_url` (no-op), and injects a
+`_CodexTmuxControl` (paste settle 4000ms vs claude's 300ms — codex composer renders
+slower). ~330 lines vs ~2500 for a copy; inherits the battle-hardened state machine /
+worker / inflight watchdog / delivery + readiness gate / analytics / restart-survival
+verbatim (zero divergence risk). The plan's Option-B caution was right for PR1 (tailer-only)
+but is superseded now that the seams are known.
+
+**Make-or-break (send-keys into codex TUI) VALIDATED LIVE 2026-06-17:** bracketed-paste
+→ Enter drives a real codex 0.125.0 TUI to run a turn; rollout written with discoverable
+`session_meta.cwd`; the merged tailer parsed `task_complete` → TurnResponse(text="PONG",
+usage, duration). Plain `send-keys` does NOT submit — bracketed paste is required (paste_text
+already does it; `_CodexTmuxControl` just lengthens the settle to 4000ms).
+
+**Two cold-start NUX blockers found + handled** (the plan's §3/#3 was under-specified):
+1. Update-available prompt — dismissed via send-keys (Down→Enter to "Skip", never "Update now").
+2. Per-directory TRUST prompt — fires even WITH `--dangerously-bypass-approvals-and-sandbox`,
+   and is NOT inherited from a trusted parent → `_seed_codex_trust` pre-writes
+   `[projects."<cwd>"] trust_level="trusted"` to `config.toml` before launch (idempotent);
+   `_codex_dismiss_nux_and_ready` is the send-keys backstop. Readiness gate (`_session_ready_event`)
+   is opened when the composer renders (codex has no SessionStart hook, and the rollout only
+   appears AFTER the first paste — so readiness can't be transcript-gated; codex FIFO-queues
+   input so an early paste buffers).
+
+**Dispatch (api.py §5):** relaxed the transport gate (all 4 runtime×transport combos valid);
+added `is_codex_tmux` (selects `CodexTmuxSession` + "codex_tmux" provider stamp); `is_codex`
+stays True for both codex transports so MCP injection + no-auth-callback/stream-callback init
+already cover codex tmux. Extended the `/transport/transcript-path` `allowed_roots` to include
+`$CODEX_HOME/sessions` (else the rollout path 403s). `/transport/wake` (`notify_tail`) is
+duck-typed → inherited, no change.
+
+**Turn-done detection** rides the polling tailer (active cadence once a turn starts), so the
+low-latency `notify` hook is DEFERRED to PR3 — not required for correctness.
+
+**Tests:** `tests/test_codex_tmux_session.py` (20 unit tests on the seams) + a gated
+`PINKY_CODEX_TMUX_SMOKE=1` integration smoke (real codex+tmux round-trip, the make-or-break,
+codifies the manual proof). Full repo suite stays green.
+
+**Deferred to PR3:** notify low-latency wake hook (`hooks/hook_codex_notify.py`), idle-sleep
+save-prompt text, resume-UUID-capture diagnostics, resume --last reopen-vs-fork verification,
+container-agent codex tmux.

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -659,6 +659,45 @@ def _isolation_path_target(path: str) -> str | None:
     return None
 
 
+def _container_isolation_block_reason(
+    *, transport: str, runtime: str, agent_name: str
+) -> tuple[int, str] | None:
+    """Preconditions for ``isolation_mode='container'`` (pure → unit-testable).
+
+    Container isolation runs the session INSIDE the container via ``tmux exec``;
+    the SDK/Codex backends don't go through the CommandRunner seam, so a
+    container agent must use ``transport='tmux'`` (else the session silently runs
+    on the host, unisolated). That's a 400 config error.
+
+    The ``codex_cli`` runtime additionally has NO container support yet: the
+    inherited tmux container spawn path seeds Claude-specific state
+    (``.credentials.json``, ``CLAUDE_CONFIG_DIR``, claude trust hooks), and
+    codex's own container auth / ``CODEX_HOME`` bootstrap is explicitly deferred
+    to #215 PR3. Running codex inside a Claude-bootstrapped container would boot
+    it under the wrong auth/config, so fail closed with a 501 until PR3 lands the
+    real bootstrap (Murzik #795 P1). One-click containerize already rejects
+    non-``claude_sdk``, but direct agent updates / imported rows can still create
+    the combo — this guard catches every (re)spawn path.
+
+    Returns ``(http_status, detail)`` to block, or ``None`` to allow.
+    """
+    if transport != "tmux":
+        return (
+            400,
+            f"isolation_mode 'container' for agent '{agent_name}' requires "
+            f"transport='tmux' (got '{transport}')",
+        )
+    if runtime == "codex_cli":
+        return (
+            501,
+            f"isolation_mode 'container' is not supported for the codex_cli "
+            f"runtime yet (agent '{agent_name}'): codex container auth/CODEX_HOME "
+            f"bootstrap is deferred to #215 PR3. Use isolation_mode='local' or "
+            f"runtime='claude_sdk'.",
+        )
+    return None
+
+
 def _redact_env_secrets(env: dict) -> dict:
     """Mask values of sensitive env vars before returning an env dict via API."""
     if not isinstance(env, dict):
@@ -2739,18 +2778,21 @@ def create_api(
         if not agent:
             return None
         mode = (getattr(agent, "isolation_mode", "") or "local").strip() or "local"
-        # Container isolation runs the session INSIDE the container via tmux
-        # exec; the SDK/Codex backends don't go through the CommandRunner seam,
-        # so a container agent must use transport="tmux". Surface this as a clear
-        # config error rather than letting it fail obscurely at spawn.
+        # Container preconditions (transport=tmux required; codex_cli deferred to
+        # #215 PR3). Surface as a clear config error rather than failing obscurely
+        # at spawn. See _container_isolation_block_reason for the rationale.
         if mode == "container":
             transport = (getattr(agent, "transport", "") or "sdk").strip() or "sdk"
-            if transport != "tmux":
-                return (
-                    400,
-                    f"isolation_mode 'container' for agent '{agent_name}' requires "
-                    f"transport='tmux' (got '{transport}')",
-                )
+            # Resolve runtime with the same legacy provider_url fallback as
+            # _start_streaming_session (rows pre-dating the runtime column).
+            runtime = (getattr(agent, "runtime", "") or "").strip()
+            if not runtime and (getattr(agent, "provider_url", "") or "").strip() == "codex_cli":
+                runtime = "codex_cli"
+            blocked = _container_isolation_block_reason(
+                transport=transport, runtime=runtime or "claude_sdk", agent_name=agent_name
+            )
+            if blocked:
+                return blocked
         try:
             from pinky_daemon.provisioning import get_provisioner
             get_provisioner(mode)
@@ -2866,7 +2908,10 @@ def create_api(
         # All four runtime×transport combos are now valid — (claude_sdk, sdk),
         # (claude_sdk, tmux), (codex_cli, sdk), (codex_cli, tmux). The codex tmux
         # transport (#215) is the last to land; runtime/transport were each range-
-        # checked above, so no combo needs an extra reject here.
+        # checked above, so no combo needs an extra reject here. The orthogonal
+        # isolation_mode='container' dimension is NOT free for all combos: the
+        # cold-start guard below rejects codex_cli+container (deferred to #215
+        # PR3) and container+non-tmux (see _container_isolation_block_reason).
 
         # #149 phase-3 cold-start guard (see _enforce_isolation_runnable).
         _enforce_isolation_runnable(agent_name)

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2777,6 +2777,7 @@ def create_api(
     ):
         """Create, connect, and register a streaming session for an agent label."""
         from pinky_daemon.codex_session import CodexSession
+        from pinky_daemon.codex_tmux_session import CodexTmuxSession
         from pinky_daemon.streaming_session import (
             DEFAULT_STREAMING_ALLOWED_TOOLS,
             StreamingSession,
@@ -2862,19 +2863,21 @@ def create_api(
             msg = f"unknown transport '{transport}' for agent '{agent_name}'"
             _log(f"api: {msg}")
             raise HTTPException(400, msg)
-        if runtime != "claude_sdk" and transport != "sdk":
-            msg = (
-                f"transport '{transport}' is only valid for claude_sdk runtime "
-                f"(agent '{agent_name}' has runtime '{runtime}')"
-            )
-            _log(f"api: {msg}")
-            raise HTTPException(400, msg)
+        # All four runtime×transport combos are now valid — (claude_sdk, sdk),
+        # (claude_sdk, tmux), (codex_cli, sdk), (codex_cli, tmux). The codex tmux
+        # transport (#215) is the last to land; runtime/transport were each range-
+        # checked above, so no combo needs an extra reject here.
 
         # #149 phase-3 cold-start guard (see _enforce_isolation_runnable).
         _enforce_isolation_runnable(agent_name)
 
         is_codex = runtime == "codex_cli"
         is_tmux = runtime == "claude_sdk" and transport == "tmux"
+        # #215: codex over the tmux transport. ``is_codex`` stays True for both
+        # codex transports (it correctly drives MCP injection + the no-auth-
+        # callback / stream-event-callback init below); ``is_codex_tmux`` only
+        # selects the session class + provider stamp.
+        is_codex_tmux = runtime == "codex_cli" and transport == "tmux"
         resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
         if is_codex:
             resolved_provider_url = "codex_cli"
@@ -2955,8 +2958,10 @@ def create_api(
         callback = await _make_streaming_response_callback()
         sid_callback = await _make_streaming_resume_handle_callback(agent_name, label)
 
-        # Select session class based on persisted runtime + Claude transport.
-        if is_tmux:
+        # Select session class based on persisted runtime + transport.
+        if is_codex_tmux:
+            SessionClass = CodexTmuxSession  # noqa: N806
+        elif is_tmux:
             SessionClass = TmuxSession  # noqa: N806
         elif is_codex:
             SessionClass = CodexSession  # noqa: N806
@@ -3032,7 +3037,7 @@ def create_api(
                 session_id=ss.id,
                 agent_name=agent_name,
                 session_label=label,
-                provider="tmux" if is_tmux else (runtime if is_codex else (resolved_provider_url or "default")),
+                provider="codex_tmux" if is_codex_tmux else ("tmux" if is_tmux else (runtime if is_codex else (resolved_provider_url or "default"))),
                 model=effective_model or "",
             )
             analytics.log_activity(
@@ -5786,6 +5791,14 @@ npm run build</pre>
         # — without this root the report 403s and the tailer never repoints
         # off its cold-start guess.
         allowed_roots = [(Path.home() / ".claude" / "projects").resolve()]
+        # #215: codex tmux agents tail rollouts under the codex session store
+        # (``$CODEX_HOME/sessions`` or ``~/.codex/sessions``), not ~/.claude.
+        _codex_home = os.environ.get("CODEX_HOME", "").strip()
+        allowed_roots.append(
+            (Path(_codex_home) / "sessions").resolve()
+            if _codex_home
+            else (Path.home() / ".codex" / "sessions").resolve()
+        )
         if getattr(agent, "isolation_mode", "local") == "container":
             wd = (agent.working_dir or "").strip()
             if wd and Path(wd).is_absolute():

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -1,0 +1,315 @@
+"""CodexTmuxSession — codex-CLI variant of TmuxSession (#215 PR2).
+
+Goal (Brad, 2026-06-17): "codex tmux sessions needs to work like the cc tmux
+sessions." Runs ``codex`` interactively in a detached ``pinky-codex-<agent>``
+tmux pane: prompts in via bracketed-paste, responses out via the codex rollout
+transcript tailer (PR1's ``CodexTmuxTranscriptTailer``), durable across daemon
+restart, attachable.
+
+**Architecture — Option A (subclass).** The design plan
+(``specs/codex-tmux-transport-plan.md``) tentatively proposed copying the
+worker/state-machine (Option B). Recon showed the codex-specific *seams* are
+cleanly isolated, so this subclasses ``TmuxSession`` and overrides ONLY those
+seams — inheriting the battle-hardened state machine, worker, inflight
+watchdog, delivery/readiness gate, analytics and restart-survival verbatim
+(zero divergence risk; future TmuxSession fixes auto-apply).
+
+Overridden seams:
+  * ``_build_session_name``      → ``pinky-codex-<agent>`` (distinct namespace)
+  * ``_build_claude_cmd``        → the in-pane ``codex`` invocation (kept name;
+                                   it's TmuxSession's spawn hook)
+  * ``_build_repl_env``          → OPENAI_API_KEY / CODEX_HOME / PATH (no ANTHROPIC_*)
+  * ``_project_dir`` / ``_has_prior_transcript`` / ``_discover_transcript_path``
+                                 → codex rollout store (``~/.codex/sessions``)
+  * ``_start_tailer``            → ``CodexTmuxTranscriptTailer``
+  * ``_spawn_tmux_repl``         → wrap super() with codex trust pre-seed +
+                                   first-run NUX dismissal + readiness gate
+  * ``_watch_for_oauth_url``     → no-op (claude OAuth wall N/A for codex)
+  * paste settle                 → ``_CodexTmuxControl`` (4000ms, codex composer
+                                   renders slower than claude's 300ms)
+
+Validated live 2026-06-17: bracketed-paste → Enter drives a real codex 0.125.0
+TUI to run a turn; the rollout is written with a discoverable ``session_meta.cwd``
+and the tailer parses ``task_complete`` cleanly. Two first-run NUX prompts
+(update-available; per-directory trust — the latter fires even with
+``--dangerously-bypass-approvals-and-sandbox``) block cold-start and are handled
+here.
+
+Deferred to PR3: the ``notify`` low-latency wake hook (the polling tailer covers
+turn-done detection without it), idle-sleep save-prompt text refinement, and the
+resume-UUID-capture diagnostics.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+from pathlib import Path
+
+from pinky_daemon.codex_tmux_transcript import (
+    CodexTmuxTranscriptTailer,
+    _discover_codex_rollout,
+)
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import (
+    _PLACEHOLDER_TRANSCRIPT_PATH,
+    TmuxSession,
+    _log,
+    _TmuxControl,
+)
+
+# Codex's inline composer renders slower than claude's REPL; the bracketed-paste
+# needs a longer settle before the submit Enter or the Enter lands before the
+# composer has captured the paste (→ text buffered, never submitted). 4000ms is
+# the value Pulse v2 uses for codex; validated live 2026-06-17.
+_CODEX_ENTER_DELAY_MS = 4000
+
+# Cold-start NUX-dismissal budget (update-available + trust prompts).
+_CODEX_NUX_TIMEOUT_SEC = 25.0
+_CODEX_NUX_POLL_SEC = 0.5
+
+
+class _CodexTmuxControl(_TmuxControl):
+    """``_TmuxControl`` whose ``paste_text`` defaults to the slower codex settle
+    so the inherited ``_deliver_turn`` (which calls ``paste_text(prompt,
+    enter=True)`` with no explicit delay) submits codex turns reliably."""
+
+    async def paste_text(
+        self, text: str, *, enter: bool = True, enter_delay_ms: int = _CODEX_ENTER_DELAY_MS,
+    ):
+        return await super().paste_text(text, enter=enter, enter_delay_ms=enter_delay_ms)
+
+
+class CodexTmuxSession(TmuxSession):
+    """Interactive codex-CLI REPL in a detached tmux pane (see module docstring)."""
+
+    def __init__(
+        self,
+        config: StreamingSessionConfig,
+        *,
+        tmux_control: _TmuxControl | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(config, tmux_control=tmux_control, **kwargs)
+        # Respect an injected control (tests). Otherwise upgrade the default
+        # control to the codex-aware one (slower paste settle).
+        if tmux_control is None:
+            self._tmux = _CodexTmuxControl(
+                self._session_name,
+                tmux_binary=self._tmux.tmux_binary,
+                socket_name=self._tmux.socket_name,
+                command_runner=self._tmux._runner,
+            )
+        # codex identity/config (mirrors CodexSession.__init__).
+        self._codex_model = config.model or ""
+        self._openai_api_key = config.provider_key or os.environ.get("OPENAI_API_KEY", "")
+        self._reasoning_effort = config.thinking_effort or "medium"
+        self._codex_mcp_servers = config.mcp_servers or {}
+
+    # ── seam: session name ──────────────────────────────────────────────────
+    def _build_session_name(self) -> str:
+        """``pinky-codex-<agent>`` — distinct from claude's ``pinky-<agent>`` and
+        the app-server's ``pinky-codex-as-<agent>`` so the three never collide."""
+        return f"pinky-codex-{self.agent_name}"
+
+    # ── seam: in-pane command ───────────────────────────────────────────────
+    def _build_claude_cmd(self) -> str:
+        """Build the in-pane ``codex`` invocation (method name kept because it's
+        the hook ``_spawn_tmux_repl`` calls).
+
+        Fresh vs resume mirrors claude's ``--continue`` gating: ``codex resume
+        --last`` continues the most-recent session for this cwd, but only when a
+        prior rollout exists (``_has_prior_transcript``) and a fresh context
+        wasn't forced. ``-C`` (cwd) is only valid on a fresh launch — codex
+        rejects it on ``resume``. Effort is set via ``-c`` at launch (no native
+        keystroke block — hence ``_native_ultracode_pending = False``)."""
+        force_fresh = bool(getattr(self._config, "force_fresh_context_once", False))
+        has_prior = self._has_prior_transcript()
+        use_resume = has_prior and not force_fresh
+
+        # Attributes the inherited machinery reads (seek-on-first-bind, stats,
+        # one-shot fresh-context reset, native-ultracode keystroke gate).
+        self._last_launch_used_continue = use_resume
+        self._last_launch_forced_fresh = force_fresh
+        self._last_launch_had_prior_transcript = has_prior
+        self._native_ultracode_pending = False
+
+        parts = ["codex"]
+        if use_resume:
+            parts += ["resume", "--last"]
+        # YOLO: bypass sandbox + approval uniformly (codex_session.py rationale).
+        # --no-alt-screen keeps codex in an inline REPL (alt-screen TUI is hostile
+        # to send-keys + transcript tail).
+        parts += ["--dangerously-bypass-approvals-and-sandbox", "--no-alt-screen"]
+        if self._codex_model:
+            parts += ["-m", self._codex_model]
+        if not use_resume:
+            parts += ["-C", str(Path(self._config.working_dir or ".").resolve())]
+        effort = self._reasoning_effort
+        if effort and effort != "medium":
+            if effort == "max":
+                effort = "high"  # codex has no "max"
+            parts += ["-c", f'model_reasoning_effort="{effort}"']
+        # MCP injection (same -c form as CodexSession; works on fresh + resume).
+        for name, cfg in (self._codex_mcp_servers or {}).items():
+            if not isinstance(cfg, dict):
+                continue
+            url = cfg.get("url", "")
+            if url:
+                parts += ["-c", f'mcp_servers.{name}.url="{url}"']
+                for hk, hv in (cfg.get("headers") or {}).items():
+                    parts += ["-c", f'mcp_servers.{name}.http_headers.{hk}="{hv}"']
+
+        cmd = " ".join(shlex.quote(p) for p in parts)
+        _log(
+            f"tmux[{self.agent_name}]: codex_cmd_built "
+            f"mode={'resume' if use_resume else 'fresh'} "
+            f"force_fresh={force_fresh} prior_rollout={has_prior}"
+        )
+        return cmd
+
+    # ── seam: env ───────────────────────────────────────────────────────────
+    def _build_repl_env(self) -> dict[str, str]:
+        """Env injected into the tmux session. Tmux ``new-session`` drops parent
+        env (except a tiny allowlist), so codex's auth + the rollout store +
+        PATH must be passed explicitly. NO ANTHROPIC_* (codex uses OpenAI auth /
+        ~/.codex/auth.json)."""
+        env: dict[str, str] = {}
+        if self._openai_api_key:
+            env["OPENAI_API_KEY"] = self._openai_api_key
+        # #792: honor the fleet's CODEX_HOME so the child writes — and discovery
+        # scans — the SAME rollout store. Without it an agent launched under a
+        # custom CODEX_HOME would never bind its transcript.
+        codex_home = os.environ.get("CODEX_HOME", "").strip()
+        if codex_home:
+            env["CODEX_HOME"] = codex_home
+        # PATH so the `codex`/`node` binaries resolve under tmux.
+        path = os.environ.get("PATH", "")
+        if path:
+            env["PATH"] = path
+        if self.agent_name:
+            env["PINKY_AGENT_NAME"] = self.agent_name
+        return env
+
+    # ── seam: transcript discovery (codex rollout store) ────────────────────
+    def _project_dir(self) -> Path:
+        """Codex's rollout store root (``$CODEX_HOME/sessions`` or
+        ``~/.codex/sessions``). Codex does NOT slug the cwd into the path the way
+        claude does — discovery is by ``session_meta.cwd`` match, not directory
+        name — so this is just the scan root."""
+        codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+        return codex_home / "sessions"
+
+    def _has_prior_transcript(self) -> bool:
+        """True iff a codex rollout for this agent's cwd already exists (gates
+        ``codex resume --last``)."""
+        return _discover_codex_rollout(self._config.working_dir or ".") is not None
+
+    def _discover_transcript_path(self) -> Path | None:
+        """Newest rollout whose ``session_meta.cwd`` == this agent's cwd, or None
+        (cold start before the first turn writes a rollout)."""
+        return _discover_codex_rollout(self._config.working_dir or ".")
+
+    # ── seam: tailer class ──────────────────────────────────────────────────
+    async def _start_tailer(self) -> None:
+        """Construct the codex tailer (the only part that differs from claude),
+        then delegate to ``super()._start_tailer()`` for the per-spawn arming /
+        first-bind / readiness-gate-reset / #565 recovery scheduling (it takes
+        the retained-instance branch because ``self._tailer`` is now set)."""
+        if self._tailer is None:
+            guessed = self._discover_transcript_path()
+            path = guessed or _PLACEHOLDER_TRANSCRIPT_PATH
+            self._tailer = CodexTmuxTranscriptTailer(
+                transcript_path=path,
+                on_turn_complete=self._handle_turn_complete,
+                agent_name=self.agent_name,
+                model=self._codex_model,
+                path_discovery=self._discover_transcript_path,
+            )
+            if guessed is not None:
+                # Warm-wake / resume: seek to EOF so we don't replay history.
+                try:
+                    self._tailer.set_offset(guessed.stat().st_size)
+                except OSError:
+                    pass
+        await super()._start_tailer()
+
+    # ── seam: cold-start (codex trust pre-seed + NUX dismissal + readiness) ──
+    async def _spawn_tmux_repl(self) -> None:
+        cwd = str(Path(self._config.working_dir or ".").resolve())
+        self._seed_codex_trust(cwd)
+        await super()._spawn_tmux_repl()
+        await self._codex_dismiss_nux_and_ready()
+
+    async def _watch_for_oauth_url(self) -> None:
+        """No-op: the claude OAuth login-wall relay (#205) doesn't apply to
+        codex; overriding prevents the inherited watcher from scanning the codex
+        pane for a wall that never appears."""
+        return
+
+    def _seed_codex_trust(self, cwd: str) -> None:
+        """Idempotently mark ``cwd`` trusted in ``config.toml`` so codex's
+        interactive "trust this directory?" NUX doesn't block cold-start.
+
+        ``--dangerously-bypass-approvals-and-sandbox`` does NOT skip this prompt
+        in the interactive TUI (verified 2026-06-17), and trust is not inherited
+        from a trusted parent dir. Best-effort; a failure here at worst leaves
+        the trust NUX for ``_codex_dismiss_nux_and_ready`` to handle."""
+        try:
+            codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+            cfg = codex_home / "config.toml"
+            real = os.path.realpath(cwd)
+            header = f'[projects."{real}"]'
+            existing = cfg.read_text(encoding="utf-8") if cfg.exists() else ""
+            if header in existing:
+                return
+            codex_home.mkdir(parents=True, exist_ok=True)
+            with cfg.open("a", encoding="utf-8") as fh:
+                fh.write(f'\n{header}\ntrust_level = "trusted"\n')
+            _log(f"tmux[{self.agent_name}]: seeded codex trust for {real}")
+        except Exception as e:
+            _log(f"tmux[{self.agent_name}]: codex trust seed failed (non-fatal): {e}")
+
+    async def _codex_dismiss_nux_and_ready(self) -> None:
+        """Navigate past codex's first-run NUX prompts (update-available; trust,
+        if the pre-seed missed it) and open the readiness gate once the composer
+        is live.
+
+        Codex has no SessionStart-equivalent hook before the first turn, and the
+        rollout (``session_meta``) is only written AFTER the first prompt is
+        submitted — so readiness can't be gated on the transcript. Instead we
+        poll the pane, dismiss known prompts via send-keys, and open
+        ``_session_ready_event`` when the composer renders. Codex FIFO-queues
+        input, so a paste that races this is buffered, not lost. Best-effort +
+        time-bounded; the gate is opened regardless on timeout (the inherited
+        delivery path also has its own gate-timeout fallback)."""
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + _CODEX_NUX_TIMEOUT_SEC
+        composer_seen = False
+        while loop.time() < deadline:
+            try:
+                snap = (await self._tmux.capture_pane(lines=40)).stdout
+            except Exception:
+                snap = ""
+            low = snap.lower()
+            if "update available" in low and "press enter to continue" in low:
+                # Menu: 1 Update now / 2 Skip / 3 Skip until next — move off
+                # "Update now" to "Skip" and confirm. NEVER pick "Update now"
+                # (it would run `bun install`).
+                await self._tmux.send_keys("Down", enter=False)
+                await self._tmux.send_keys("Enter", enter=False)
+            elif "do you trust" in low:
+                # Trust prompt (pre-seed missed it) — default highlight is
+                # "Yes, continue".
+                await self._tmux.send_keys("Enter", enter=False)
+            elif "/model to change" in low or ("directory:" in low and "permissions:" in low):
+                composer_seen = True
+                break
+            await asyncio.sleep(_CODEX_NUX_POLL_SEC)
+
+        if not self._session_ready_event.is_set():
+            self._session_ready_event.set()
+        _log(
+            f"tmux[{self.agent_name}]: codex cold-start ready "
+            f"(composer_seen={composer_seen})"
+        )

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -18,13 +18,16 @@ Overridden seams:
   * ``_build_session_name``      → ``pinky-codex-<agent>`` (distinct namespace)
   * ``_build_claude_cmd``        → the in-pane ``codex`` invocation (kept name;
                                    it's TmuxSession's spawn hook)
-  * ``_build_repl_env``          → OPENAI_API_KEY / CODEX_HOME / PATH (no ANTHROPIC_*)
+  * ``_build_repl_env``          → full daemon-env parity (Murzik #795 P1; mirrors
+                                   the subprocess + app-server codex transports)
   * ``_project_dir`` / ``_has_prior_transcript`` / ``_discover_transcript_path``
                                  → codex rollout store (``~/.codex/sessions``)
   * ``_start_tailer``            → ``CodexTmuxTranscriptTailer``
   * ``_spawn_tmux_repl``         → wrap super() with codex trust pre-seed +
                                    first-run NUX dismissal + readiness gate
   * ``_watch_for_oauth_url``     → no-op (claude OAuth wall N/A for codex)
+  * ``handle_stop_failure``      → no-op (codex turn-end = rollout tailer, not a
+                                   ``.claude`` StopFailure hook; Murzik #795 P2)
   * paste settle                 → ``_CodexTmuxControl`` (4000ms, codex composer
                                    renders slower than claude's 300ms)
 
@@ -168,25 +171,49 @@ class CodexTmuxSession(TmuxSession):
         )
         return cmd
 
+    # tmux-internal vars that must not leak into the nested REPL's children
+    # (mirrors ``CodexAppServerSupervisor._ENV_DROP``).
+    _ENV_DROP = frozenset({"TMUX", "TMUX_PANE"})
+
     # ── seam: env ───────────────────────────────────────────────────────────
     def _build_repl_env(self) -> dict[str, str]:
-        """Env injected into the tmux session. Tmux ``new-session`` drops parent
-        env (except a tiny allowlist), so codex's auth + the rollout store +
-        PATH must be passed explicitly. NO ANTHROPIC_* (codex uses OpenAI auth /
-        ~/.codex/auth.json)."""
+        """Full daemon-env parity for the codex tmux pane — NOT a small allowlist.
+
+        tmux ``new-session`` drops the parent process env entirely; only the
+        ``-e KEY=VAL`` pairs we pass survive into the pane (and its codex child).
+        Both other codex transports launch codex with the daemon's FULL env:
+        ``CodexSession._exec_codex`` uses ``env={**os.environ}`` (+ the configured
+        key), and #792's tmux app-server (``CodexAppServerSupervisor._build_env``)
+        does the same after CODEX_HOME / proxy / XDG / cert divergence proved a
+        real footgun. A 4-key allowlist silently boots codex under different auth
+        / network / session config: it drops ``HOME`` / ``XDG_*``, the proxy +
+        TLS bundle (``HTTPS_PROXY`` / ``SSL_CERT_FILE`` / ``NODE_EXTRA_CA_CERTS``),
+        ``OPENAI_BASE_URL`` / ``OPENAI_ORG`` / other ``OPENAI_*`` + ``CODEX_*``
+        knobs, and any future auth/config env (Murzik #795 P1; same class as the
+        #792 app-server env-parity fix).
+
+        So we propagate the entire daemon env — including ``CODEX_HOME`` (item G:
+        the child writes, and discovery scans, the SAME rollout store) and
+        ``PATH`` (so the ``codex`` / ``node`` binaries resolve) — minus
+        tmux-internal vars and any value tmux ``-e`` can't carry (newlines, which
+        are pathological for env anyway), then overlay the configured
+        ``OPENAI_API_KEY`` (item H) and this agent's ``PINKY_AGENT_NAME``. No
+        ANTHROPIC_* special-casing is needed: codex ignores them, exactly as the
+        subprocess transport already inherits them harmlessly.
+        """
         env: dict[str, str] = {}
+        for key, value in os.environ.items():
+            if key in self._ENV_DROP:
+                continue
+            if "\n" in value or "\r" in value:
+                _log(
+                    f"tmux[{self.agent_name}]: dropping multiline env {key!r} "
+                    f"(cannot pass via tmux -e)"
+                )
+                continue
+            env[key] = value
         if self._openai_api_key:
             env["OPENAI_API_KEY"] = self._openai_api_key
-        # #792: honor the fleet's CODEX_HOME so the child writes — and discovery
-        # scans — the SAME rollout store. Without it an agent launched under a
-        # custom CODEX_HOME would never bind its transcript.
-        codex_home = os.environ.get("CODEX_HOME", "").strip()
-        if codex_home:
-            env["CODEX_HOME"] = codex_home
-        # PATH so the `codex`/`node` binaries resolve under tmux.
-        path = os.environ.get("PATH", "")
-        if path:
-            env["PATH"] = path
         if self.agent_name:
             env["PINKY_AGENT_NAME"] = self.agent_name
         return env
@@ -246,6 +273,31 @@ class CodexTmuxSession(TmuxSession):
         codex; overriding prevents the inherited watcher from scanning the codex
         pane for a wall that never appears."""
         return
+
+    async def handle_stop_failure(
+        self, error_type: str, message: str = "", session_id: str = ""
+    ) -> bool:
+        """No-op for codex (Murzik #795 P2 hardening).
+
+        The inherited ``handle_stop_failure`` synthesizes a failed
+        ``TurnResponse`` and pops the in-flight turn off ``_inflight_metas``. That
+        is correct for Claude Code, whose ``.claude`` StopFailure hook (#584/#108)
+        POSTs ``/transport/stop-failure`` as the authoritative turn-end marker for
+        terminal API-error turns. Codex does NOT close turns that way — a codex
+        turn ends via the rollout's ``task_complete`` / ``turn_aborted`` (owned by
+        ``CodexTmuxTranscriptTailer``), and codex doesn't run ``.claude`` hooks. A
+        StopFailure POST landing on a codex-tmux agent (stale/misrouted wire)
+        would therefore falsely pop a codex turn that may still be completing
+        normally. Fail safe: ignore it and let the tailer own turn-end. Returns
+        ``False`` — the inherited "nothing was resolved" signal — so the
+        ``/transport/stop-failure`` endpoint's response shape is unchanged. A real
+        codex failure hook can replace this in a later PR."""
+        if self._inflight_metas:
+            _log(
+                f"tmux[{self.agent_name}]: ignoring StopFailure ({error_type!r}) "
+                f"for codex session — codex turn-end is owned by the rollout tailer"
+            )
+        return False
 
     def _seed_codex_trust(self, cwd: str) -> None:
         """Idempotently mark ``cwd`` trusted in ``config.toml`` so codex's

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1384,21 +1384,48 @@ class TestAPI:
                 assert session._config.model == "sonnet"
                 assert session.resume_handle == "pinky-tmux-agent"
 
-    def test_wake_rejects_tmux_transport_for_codex_runtime(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+    def test_wake_uses_codex_tmux_session_for_codex_tmux_transport(self):
+        # #215 PR2: codex_cli + transport=tmux is now a VALID combo (it was
+        # rejected before this PR). It must build a CodexTmuxSession, not error.
+        async def fake_connect(self):
+            from pinky_daemon.transport_state import SessionState
+            self._state_machine._state = SessionState.CONNECTED
+            if self._on_resume_handle:
+                await self._on_resume_handle(self.agent_name, self.resume_handle)
+
+        async def fake_send(
+            self,
+            prompt: str,
+            *,
+            platform: str = "",
+            chat_id: str = "",
+            message_id: str = "",
+            agent_hint: str = "",
+        ):
+            del prompt, platform, chat_id, message_id, agent_hint
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.tmux_session.TmuxSession.connect", new=fake_connect), \
+                patch("pinky_daemon.tmux_session.TmuxSession.send", new=fake_send):
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             with TestClient(app) as client:
                 client.post("/agents", json={
-                    "name": "bad-agent",
+                    "name": "codextmux-agent",
                     "model": "gpt-5-codex",
                     "runtime": "codex_cli",
                     "transport": "tmux",
                 })
 
-                resp = client.post("/agents/bad-agent/wake?prompt=Wake")
-                assert resp.status_code == 400
-                assert "only valid for claude_sdk runtime" in resp.text
+                resp = client.post("/agents/codextmux-agent/wake?prompt=Wake")
+                assert resp.status_code == 200
+
+                session = app.state.broker._streaming["codextmux-agent"]["main"]
+                assert session.__class__.__name__ == "CodexTmuxSession"
+                assert session._config.provider_url == "codex_cli"
+                assert session._config.model == "gpt-5-codex"
+                # codex namespace — distinct from claude's pinky-<agent>
+                assert session.resume_handle == "pinky-codex-codextmux-agent"
 
     def test_wake_rejects_opencode_runtime_until_session_exists(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_codex_tmux_session.py
+++ b/tests/test_codex_tmux_session.py
@@ -123,17 +123,39 @@ def test_build_cmd_injects_mcp(monkeypatch):
 
 # ── env ─────────────────────────────────────────────────────────────────────
 def test_build_repl_env_codex(monkeypatch):
+    # #795 P1: full daemon-env PARITY (mirrors the subprocess + #792 app-server
+    # codex transports), NOT a 4-key allowlist. tmux `new-session -e` is the only
+    # env the pane receives, so everything codex can depend on must be carried.
     monkeypatch.setenv("CODEX_HOME", "/tmp/fleet-codex")
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    # Sentinels codex can depend on (auth / network / TLS / config dirs).
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.local:3128")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://oai.internal/v1")
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/xdg")
+    monkeypatch.setenv("NODE_EXTRA_CA_CERTS", "/etc/ssl/corp.pem")
+    # tmux-internal vars must be dropped (they'd corrupt a nested session).
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+    monkeypatch.setenv("TMUX_PANE", "%7")
+    # multiline values can't be passed via tmux -e and must be dropped.
+    monkeypatch.setenv("BROKEN_MULTILINE", "line1\nline2")
+
     ss = _session(provider_key="sk-abc")
     env = ss._build_repl_env()
+
+    # configured key + agent identity overlaid
     assert env["OPENAI_API_KEY"] == "sk-abc"
+    assert env["PINKY_AGENT_NAME"] == "murzik"
+    # daemon config carried through (parity)
     assert env["CODEX_HOME"] == "/tmp/fleet-codex"
     assert env["PATH"] == "/usr/bin:/bin"
-    assert env["PINKY_AGENT_NAME"] == "murzik"
-    # codex uses OpenAI auth — never the anthropic vars.
-    assert "ANTHROPIC_API_KEY" not in env
-    assert "ANTHROPIC_BASE_URL" not in env
+    assert env["HTTPS_PROXY"] == "http://proxy.local:3128"
+    assert env["OPENAI_BASE_URL"] == "https://oai.internal/v1"
+    assert env["XDG_CONFIG_HOME"] == "/tmp/xdg"
+    assert env["NODE_EXTRA_CA_CERTS"] == "/etc/ssl/corp.pem"
+    # tmux-internal + multiline dropped
+    assert "TMUX" not in env
+    assert "TMUX_PANE" not in env
+    assert "BROKEN_MULTILINE" not in env
 
 
 def test_build_repl_env_falls_back_to_openai_env(monkeypatch):
@@ -284,6 +306,69 @@ async def test_oauth_watcher_is_noop():
     # Must return immediately without touching the pane.
     await ss._watch_for_oauth_url()
     ss._tmux.capture_pane.assert_not_called()
+
+
+# ── StopFailure hook is a no-op for codex (#795 P2) ─────────────────────────
+@pytest.mark.asyncio
+async def test_handle_stop_failure_is_noop_for_codex():
+    # Codex turn-end is owned by the rollout tailer (task_complete/turn_aborted),
+    # NOT the .claude StopFailure hook. A misrouted StopFailure POST must NOT pop
+    # a live codex turn (the inherited claude impl would synthesize + pop it).
+    ss = _session()
+    sentinel = object()
+    ss._inflight_metas.append(sentinel)
+    before = len(ss._inflight_metas)
+
+    result = await ss.handle_stop_failure("api_error", message="boom", session_id="sid")
+
+    assert result is False
+    assert len(ss._inflight_metas) == before  # in-flight codex turn left intact
+    assert ss._inflight_metas[-1] is sentinel
+
+
+# ── container isolation guard: codex_cli + container blocked (#795 P1) ──────
+def test_container_isolation_blocks_codex_cli():
+    from pinky_daemon.api import _container_isolation_block_reason
+
+    blocked = _container_isolation_block_reason(
+        transport="tmux", runtime="codex_cli", agent_name="ctr"
+    )
+    assert blocked is not None
+    status, detail = blocked
+    assert status == 501  # not-implemented-yet (deferred to PR3)
+    assert "codex_cli" in detail and "PR3" in detail
+
+
+def test_container_isolation_allows_claude_tmux():
+    from pinky_daemon.api import _container_isolation_block_reason
+
+    # The existing supported combo must keep working.
+    assert _container_isolation_block_reason(
+        transport="tmux", runtime="claude_sdk", agent_name="ctr"
+    ) is None
+
+
+def test_container_isolation_requires_tmux_transport():
+    from pinky_daemon.api import _container_isolation_block_reason
+
+    blocked = _container_isolation_block_reason(
+        transport="sdk", runtime="claude_sdk", agent_name="ctr"
+    )
+    assert blocked is not None
+    status, detail = blocked
+    assert status == 400
+    assert "transport='tmux'" in detail
+
+
+def test_container_isolation_transport_checked_before_runtime():
+    # codex_cli + non-tmux + container hits the transport wall first (400), not
+    # the codex 501 — both are blocks; this just pins the ordering.
+    from pinky_daemon.api import _container_isolation_block_reason
+
+    status, _ = _container_isolation_block_reason(
+        transport="sdk", runtime="codex_cli", agent_name="ctr"
+    )
+    assert status == 400
 
 
 # ── gated integration smoke (the make-or-break; opt-in) ─────────────────────

--- a/tests/test_codex_tmux_session.py
+++ b/tests/test_codex_tmux_session.py
@@ -1,0 +1,330 @@
+"""Unit tests for CodexTmuxSession (#215 PR2) — the codex-CLI variant of
+TmuxSession.
+
+CodexTmuxSession subclasses TmuxSession and overrides only the codex-specific
+seams; these tests pin exactly those seams (command, env, session name,
+transcript discovery, tailer class, trust pre-seed, NUX dismissal + readiness
+gate, paste settle). The inherited state machine / worker / delivery are covered
+by test_tmux_session.py and are NOT re-tested here.
+
+The real codex-under-tmux round-trip lives in the gated integration smoke at the
+bottom (opt-in, like the app-server soak) — it's the make-or-break proof and was
+validated live 2026-06-17.
+"""
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_daemon.codex_tmux_session import (
+    _CODEX_ENTER_DELAY_MS,
+    CodexTmuxSession,
+    _CodexTmuxControl,
+)
+from pinky_daemon.codex_tmux_transcript import CodexTmuxTranscriptTailer
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import TmuxCommandResult, _TmuxControl
+
+
+def _ok(stdout: str = "") -> TmuxCommandResult:
+    return TmuxCommandResult(returncode=0, stdout=stdout, stderr="")
+
+
+def _mock_tmux() -> MagicMock:
+    tmux = MagicMock(spec=_TmuxControl)
+    tmux.session_name = "pinky-codex-test"
+    tmux.tmux_binary = "tmux"
+    tmux.socket_name = ""
+    tmux.has_session = AsyncMock(return_value=False)
+    tmux.new_session = AsyncMock(return_value=_ok())
+    tmux.kill_session = AsyncMock(return_value=_ok())
+    tmux.send_keys = AsyncMock(return_value=_ok())
+    tmux.paste_text = AsyncMock(return_value=_ok())
+    tmux.capture_pane = AsyncMock(return_value=_ok())
+    return tmux
+
+
+def _session(*, model="gpt-5.5", effort="medium", mcp=None, working_dir="/tmp/codex-tmux-test",
+             provider_key="sk-test", tmux=None) -> CodexTmuxSession:
+    cfg = StreamingSessionConfig(
+        agent_name="murzik",
+        working_dir=working_dir,
+        model=model,
+        thinking_effort=effort,
+        provider_key=provider_key,
+        mcp_servers=mcp or {},
+    )
+    return CodexTmuxSession(cfg, tmux_control=tmux or _mock_tmux())
+
+
+# ── session name ────────────────────────────────────────────────────────────
+def test_session_name_codex_namespaced():
+    ss = _session()
+    assert ss._build_session_name() == "pinky-codex-murzik"
+    assert ss._session_name == "pinky-codex-murzik"  # distinct from claude's pinky-<agent>
+
+
+# ── in-pane command ─────────────────────────────────────────────────────────
+def test_build_cmd_fresh(monkeypatch):
+    ss = _session(model="gpt-5.5")
+    monkeypatch.setattr(ss, "_has_prior_transcript", lambda: False)
+    cmd = ss._build_claude_cmd()
+    assert cmd.startswith("codex ")
+    assert "resume" not in cmd
+    assert "--dangerously-bypass-approvals-and-sandbox" in cmd
+    assert "--no-alt-screen" in cmd
+    assert "-m gpt-5.5" in cmd
+    assert "-C " in cmd  # fresh launch carries the cwd
+    # effort knob set via -c at launch → native ultracode keystroke block disabled
+    assert ss._native_ultracode_pending is False
+    assert ss._last_launch_used_continue is False
+
+
+def test_build_cmd_resume_omits_cwd(monkeypatch):
+    ss = _session()
+    monkeypatch.setattr(ss, "_has_prior_transcript", lambda: True)
+    cmd = ss._build_claude_cmd()
+    assert "resume --last" in cmd
+    assert "-C " not in cmd  # codex rejects -C on resume
+    assert ss._last_launch_used_continue is True
+
+
+def test_build_cmd_force_fresh_skips_resume(monkeypatch):
+    ss = _session()
+    monkeypatch.setattr(ss, "_has_prior_transcript", lambda: True)
+    ss._config.force_fresh_context_once = True
+    cmd = ss._build_claude_cmd()
+    assert "resume" not in cmd
+    assert "-C " in cmd
+    assert ss._last_launch_forced_fresh is True
+
+
+def test_build_cmd_effort_max_maps_to_high(monkeypatch):
+    ss = _session(effort="max")
+    monkeypatch.setattr(ss, "_has_prior_transcript", lambda: False)
+    cmd = ss._build_claude_cmd()
+    assert 'model_reasoning_effort="high"' in cmd  # codex has no "max"
+
+
+def test_build_cmd_medium_effort_omitted(monkeypatch):
+    ss = _session(effort="medium")
+    monkeypatch.setattr(ss, "_has_prior_transcript", lambda: False)
+    assert "model_reasoning_effort" not in ss._build_claude_cmd()
+
+
+def test_build_cmd_injects_mcp(monkeypatch):
+    ss = _session(mcp={"pinky": {"url": "http://h:8890/sse", "headers": {"X-Agent-Name": "murzik"}}})
+    monkeypatch.setattr(ss, "_has_prior_transcript", lambda: False)
+    cmd = ss._build_claude_cmd()
+    assert 'mcp_servers.pinky.url="http://h:8890/sse"' in cmd
+    assert 'mcp_servers.pinky.http_headers.X-Agent-Name="murzik"' in cmd
+
+
+# ── env ─────────────────────────────────────────────────────────────────────
+def test_build_repl_env_codex(monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", "/tmp/fleet-codex")
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    ss = _session(provider_key="sk-abc")
+    env = ss._build_repl_env()
+    assert env["OPENAI_API_KEY"] == "sk-abc"
+    assert env["CODEX_HOME"] == "/tmp/fleet-codex"
+    assert env["PATH"] == "/usr/bin:/bin"
+    assert env["PINKY_AGENT_NAME"] == "murzik"
+    # codex uses OpenAI auth — never the anthropic vars.
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "ANTHROPIC_BASE_URL" not in env
+
+
+def test_build_repl_env_falls_back_to_openai_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+    ss = _session(provider_key="")
+    assert ss._build_repl_env()["OPENAI_API_KEY"] == "sk-env"
+
+
+# ── transcript discovery ────────────────────────────────────────────────────
+def test_project_dir_is_codex_sessions(monkeypatch, tmp_path):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "ch"))
+    ss = _session()
+    assert ss._project_dir() == (tmp_path / "ch" / "sessions")
+
+
+def test_discovery_delegates_to_codex_rollout(monkeypatch):
+    import pinky_daemon.codex_tmux_session as cm
+    sentinel = object()
+    seen = {}
+
+    def fake(wd):
+        seen["wd"] = wd
+        return sentinel
+
+    monkeypatch.setattr(cm, "_discover_codex_rollout", fake)
+    ss = _session(working_dir="/tmp/abc")
+    assert ss._discover_transcript_path() is sentinel
+    assert ss._has_prior_transcript() is True
+    assert seen["wd"] == "/tmp/abc"
+
+
+# ── codex trust pre-seed ────────────────────────────────────────────────────
+def test_seed_codex_trust_writes_and_idempotent(monkeypatch, tmp_path):
+    ch = tmp_path / "codex"
+    monkeypatch.setenv("CODEX_HOME", str(ch))
+    ss = _session()
+    ss._seed_codex_trust("/tmp/proj")
+    cfg = (ch / "config.toml").read_text()
+    real = os.path.realpath("/tmp/proj")
+    assert f'[projects."{real}"]' in cfg
+    assert 'trust_level = "trusted"' in cfg
+    # idempotent — a second call must not duplicate the block.
+    ss._seed_codex_trust("/tmp/proj")
+    assert (ch / "config.toml").read_text().count(f'[projects."{real}"]') == 1
+
+
+# ── tailer class ────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_start_tailer_uses_codex_tailer(monkeypatch):
+    import pinky_daemon.codex_tmux_session as cm
+    monkeypatch.setattr(cm, "_discover_codex_rollout", lambda wd: None)  # cold start
+    ss = _session()
+    await ss._start_tailer()
+    try:
+        assert isinstance(ss._tailer, CodexTmuxTranscriptTailer)
+    finally:
+        await ss._stop_tailer()
+
+
+# ── paste settle (codex composer is slower) ─────────────────────────────────
+def test_default_control_is_codex_aware():
+    # No injected control → the session upgrades to the slower-paste control.
+    cfg = StreamingSessionConfig(agent_name="murzik", working_dir="/tmp/x")
+    ss = CodexTmuxSession(cfg)
+    assert isinstance(ss._tmux, _CodexTmuxControl)
+
+
+def test_injected_control_is_preserved():
+    mock = _mock_tmux()
+    ss = _session(tmux=mock)
+    assert ss._tmux is mock  # tests' mock must not be swapped out
+
+
+@pytest.mark.asyncio
+async def test_codex_control_paste_defaults_to_4000ms():
+    captured = {}
+
+    async def fake_super_paste(self, text, *, enter=True, enter_delay_ms=300):
+        captured["enter_delay_ms"] = enter_delay_ms
+        return _ok()
+
+    # Patch the base _TmuxControl.paste_text so we observe the default the
+    # codex control forwards.
+    import pinky_daemon.tmux_session as tm
+    orig = tm._TmuxControl.paste_text
+    tm._TmuxControl.paste_text = fake_super_paste
+    try:
+        ctrl = _CodexTmuxControl("pinky-codex-x")
+        await ctrl.paste_text("hello")
+        assert captured["enter_delay_ms"] == _CODEX_ENTER_DELAY_MS == 4000
+    finally:
+        tm._TmuxControl.paste_text = orig
+
+
+# ── cold-start NUX dismissal + readiness gate ───────────────────────────────
+@pytest.mark.asyncio
+async def test_dismiss_nux_opens_gate_on_composer(monkeypatch):
+    import pinky_daemon.codex_tmux_session as cm
+    monkeypatch.setattr(cm, "_CODEX_NUX_POLL_SEC", 0.001)
+    tmux = _mock_tmux()
+    tmux.capture_pane = AsyncMock(return_value=_ok(
+        "model: gpt-5.5 low   /model to change\ndirectory: /tmp/x\npermissions: YOLO mode"
+    ))
+    ss = _session(tmux=tmux)
+    assert not ss._session_ready_event.is_set()
+    await ss._codex_dismiss_nux_and_ready()
+    assert ss._session_ready_event.is_set()
+    tmux.send_keys.assert_not_called()  # composer already up → no NUX keys
+
+
+@pytest.mark.asyncio
+async def test_dismiss_nux_skips_update_prompt(monkeypatch):
+    import pinky_daemon.codex_tmux_session as cm
+    monkeypatch.setattr(cm, "_CODEX_NUX_POLL_SEC", 0.001)
+    tmux = _mock_tmux()
+    update_pane = _ok(
+        "Update available! 0.125.0 -> 0.130.0\n1. Update now\n2. Skip\nPress enter to continue"
+    )
+    composer_pane = _ok("model: gpt-5.5   /model to change\ndirectory: /x")
+    tmux.capture_pane = AsyncMock(side_effect=[update_pane, composer_pane])
+    ss = _session(tmux=tmux)
+    await ss._codex_dismiss_nux_and_ready()
+    # Navigated off "Update now" to a Skip option, then confirmed.
+    keys = [c.args[0] for c in tmux.send_keys.call_args_list]
+    assert "Down" in keys and "Enter" in keys
+    # Never picked "Update now".
+    assert ss._session_ready_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_nux_opens_gate_on_timeout(monkeypatch):
+    import pinky_daemon.codex_tmux_session as cm
+    monkeypatch.setattr(cm, "_CODEX_NUX_POLL_SEC", 0.001)
+    monkeypatch.setattr(cm, "_CODEX_NUX_TIMEOUT_SEC", 0.02)
+    tmux = _mock_tmux()
+    tmux.capture_pane = AsyncMock(return_value=_ok("(unrecognized junk)"))
+    ss = _session(tmux=tmux)
+    await ss._codex_dismiss_nux_and_ready()
+    # Gate is opened regardless so delivery never hangs (inherited path also
+    # has its own gate-timeout fallback).
+    assert ss._session_ready_event.is_set()
+
+
+# ── claude-OAuth watcher is a no-op for codex ───────────────────────────────
+@pytest.mark.asyncio
+async def test_oauth_watcher_is_noop():
+    ss = _session()
+    # Must return immediately without touching the pane.
+    await ss._watch_for_oauth_url()
+    ss._tmux.capture_pane.assert_not_called()
+
+
+# ── gated integration smoke (the make-or-break; opt-in) ─────────────────────
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    os.environ.get("PINKY_CODEX_TMUX_SMOKE") != "1",
+    reason="real codex+tmux round-trip; opt-in via PINKY_CODEX_TMUX_SMOKE=1",
+)
+async def test_integration_codex_tmux_roundtrip(tmp_path):
+    """Drive a real codex TUI under real tmux: cold-start (NUX dismissal +
+    readiness), paste a trivial prompt, assert the rollout is written and the
+    codex tailer reads task_complete → TurnResponse. Validated manually
+    2026-06-17 (replied "PONG", tailer parsed text/usage/duration)."""
+    import shutil
+
+    if not shutil.which("codex") or not shutil.which("tmux"):
+        pytest.skip("codex/tmux not installed")
+
+    cwd = tmp_path / "smoke"
+    cwd.mkdir()
+    captured = []
+
+    cfg = StreamingSessionConfig(
+        agent_name="codex-smoke",
+        working_dir=str(cwd),
+        model=os.environ.get("PINKY_CODEX_SMOKE_MODEL", "gpt-5.5"),
+        thinking_effort="low",
+    )
+    ss = CodexTmuxSession(cfg, response_callback=lambda r, **_: captured.append(r))
+    try:
+        await ss._spawn_tmux_repl()  # cold-start: trust seed + NUX dismissal + ready
+        assert ss._session_ready_event.is_set()
+        await ss._tmux.paste_text("Reply with exactly one word: PONG", enter=True)
+        # Poll the tailer for the turn (codex writes the rollout on first turn).
+        for _ in range(60):
+            if ss._tailer and ss._tailer.transcript_path.exists():
+                await ss._tailer.read_once()
+            if captured:
+                break
+            await asyncio.sleep(1.0)
+        assert captured, "no turn captured from the codex rollout"
+        assert "PONG" in captured[-1].text.upper()
+    finally:
+        await ss.disconnect()


### PR DESCRIPTION
## What

**CodexTmuxSession** (#215 PR2) — makes codex agents run like the cc tmux sessions: `codex` interactive in a detached `pinky-codex-<agent>` tmux pane, prompts in via bracketed-paste, responses out via PR1's rollout transcript tailer, durable across daemon restart, attachable.

Builds directly on PR1 (#794, the `CodexTmuxTranscriptTailer`, already on main).

## Architecture — Option A (subclass), not the plan's tentative Option B (copy)

Recon showed the codex-specific *seams* are cleanly isolated, so this **subclasses `TmuxSession`** and overrides only those — inheriting the battle-hardened state machine, worker, inflight watchdog, delivery + readiness gate, analytics and restart-survival **verbatim** (zero divergence risk; ~330 lines vs ~2500 for a copy). The plan's Option-B caution was right for PR1 (tailer-only) but is superseded now the seams are known. Full rationale in `specs/codex-tmux-transport-plan.md` §10.

Overridden seams: session name (`pinky-codex-<agent>`), in-pane `codex` command (fresh vs `resume --last`, `--no-alt-screen`, YOLO, `-m`, `-c model_reasoning_effort`, MCP `-c` injection), env (OPENAI_API_KEY / CODEX_HOME / PATH — no ANTHROPIC_*), transcript discovery (codex rollout store by `session_meta.cwd`), tailer class, and a `_CodexTmuxControl` whose paste settle is **4000ms** (codex composer renders slower than claude's 300ms — a real submit-reliability fix).

## Make-or-break: VALIDATED LIVE (2026-06-17)

Drove a real codex 0.125.0 TUI under tmux end-to-end: **bracketed-paste → Enter → turn ran → rollout written with discoverable `session_meta.cwd` → the merged tailer parsed `task_complete` → `TurnResponse(text="PONG", usage, duration_ms=1043)`.** Plain `send-keys` does NOT submit — bracketed paste is required.

## Two cold-start NUX blockers found + handled

The plan under-specified codex's first-run prompts (both block session start):
1. **Update-available prompt** — dismissed via send-keys (Down→"Skip"→Enter; never "Update now").
2. **Per-directory trust prompt** — fires **even with `--dangerously-bypass-approvals-and-sandbox`**, and isn't inherited from a trusted parent. `_seed_codex_trust` pre-writes `[projects."<cwd>"] trust_level="trusted"` to `config.toml` before launch (idempotent); `_codex_dismiss_nux_and_ready` is the send-keys backstop.

Codex has no SessionStart-equivalent and the rollout only appears *after* the first paste, so the readiness gate (`_session_ready_event`) opens when the composer renders (codex FIFO-queues input, so an early paste buffers, not lost).

## Dispatch (api.py)

Relaxed the transport gate (all 4 runtime×transport combos valid); added `is_codex_tmux` → selects `CodexTmuxSession` + `"codex_tmux"` provider stamp (`is_codex` stays True for both codex transports, so MCP injection + no-auth-callback/stream-callback init already cover it); extended `/transport/transcript-path` `allowed_roots` to include `$CODEX_HOME/sessions`. `/transport/wake` (`notify_tail`) is duck-typed → inherited, no change.

## Turn-done detection rides the polling tailer

The low-latency `notify` hook is **deferred to PR3** — the tailer polls on an active cadence once a turn starts, so it's not required for correctness.

## Tests
- `tests/test_codex_tmux_session.py` — 20 unit tests on the seams (command fresh/resume/force-fresh, effort max→high, MCP injection, env, session name, codex discovery, idempotent trust seed, codex tailer wiring, 4000ms paste, NUX dismissal + readiness gate open/timeout, OAuth-watcher no-op) + a gated `PINKY_CODEX_TMUX_SMOKE=1` integration smoke (real codex+tmux round-trip — codifies the manual proof).
- Inherited tmux/codex/transcript suites stay green; ruff clean.

## Deferred to PR3
notify low-latency wake hook, idle-sleep save-prompt text, resume-UUID-capture diagnostics, `resume --last` reopen-vs-fork verification, container-agent codex tmux.

🤖 Opened by Barsik
