### PR TITLE
fix(agents-db): take conversations_agents.db off WAL — kills the -shm SIGBUS surface (#797/#220)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1067,6 +1067,59 @@ except Exception:
 '''
 
 
+class AgentDbConfigError(RuntimeError):
+    """Raised when conversations_agents.db cannot be confirmed in the required
+    rollback-journal (TRUNCATE) mode. We refuse to run the agents DB on WAL —
+    the WAL ``-shm`` mmap is the SIGBUS fault surface (#797/#220)."""
+
+
+def _configure_agents_db_connection(
+    conn: sqlite3.Connection, *, retries: int = 6, busy_ms: int = 5000
+) -> str:
+    """Put the agents-DB connection into rollback (TRUNCATE) journal mode.
+
+    Why not WAL (#797/#220): the WAL wal-index ``-shm`` is always memory-mapped
+    in WAL mode. Under the daemon's long-lived registry connection plus the
+    per-request read-only signing-key resolver churn, that mapped ``-shm`` page
+    went stale and a SQLite pager read SIGBUS'd the daemon (``si_addr`` confirmed
+    inside ``conversations_agents.db-shm``; ``mmap_size=0`` was already set, so
+    the main-db is not mapped — the ``-shm`` is the inherent fault surface).
+    Rollback journal mode has no ``-shm`` at all, so the daemon never maps it.
+
+    Must run BEFORE table init and before any local MCP / agent-session resume
+    can spawn stdio children that hold the DB.
+
+    Fails LOUD: if the connection cannot be confirmed in ``truncate`` mode after
+    bounded retries, raises :class:`AgentDbConfigError` rather than silently
+    running on WAL. Returns the effective journal mode (``"truncate"``).
+    """
+    conn.execute(f"PRAGMA busy_timeout={int(busy_ms)}")
+    last: str | None = None
+    for attempt in range(retries):
+        # If still on WAL, drain it first so no hot WAL content is stranded
+        # before the wal-index is dropped. Busy here is non-fatal — the mode
+        # switch below retries.
+        try:
+            cur = conn.execute("PRAGMA journal_mode").fetchone()
+            if cur and str(cur[0]).lower() == "wal":
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except sqlite3.OperationalError:
+            pass
+        try:
+            row = conn.execute("PRAGMA journal_mode=TRUNCATE").fetchone()
+            last = str(row[0]).lower() if row else None
+            if last == "truncate":
+                return last
+        except sqlite3.OperationalError as exc:
+            last = f"error:{exc}"
+        time.sleep(0.2 * (attempt + 1))
+    raise AgentDbConfigError(
+        f"conversations_agents.db refused to leave WAL: journal_mode={last!r} "
+        f"after {retries} attempts — refusing to run on the WAL -shm SIGBUS "
+        f"surface (#797/#220)."
+    )
+
+
 class AgentRegistry:
     """SQLite-backed agent registry."""
 
@@ -1077,7 +1130,14 @@ class AgentRegistry:
         # signing-key lookup (#641) rather than relying on their cwd.
         self._db_path = str(Path(db_path).resolve())
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        # #797/#220: the agents DB runs in ROLLBACK (TRUNCATE) journal mode, NOT
+        # WAL. The WAL wal-index (-shm) is always mmap'd; under the long-lived
+        # registry connection + per-request RO signing-key resolver churn, that
+        # mapped -shm went stale and a SQLite pager read SIGBUS'd the daemon
+        # (si_addr confirmed inside conversations_agents.db-shm). Rollback mode
+        # has no -shm, so the daemon never maps it. Runs before _init_tables and
+        # before any MCP/session resume spawns stdio children. Agents DB only.
+        _configure_agents_db_connection(self._db)
         self._db.execute("PRAGMA foreign_keys=ON")
         # Guard read-modify-write sequences (e.g. peer_fleet_acl mutation)
         # from concurrent admin-API requests. SQLite connection is shared

--- a/src/pinky_daemon/auth.py
+++ b/src/pinky_daemon/auth.py
@@ -192,6 +192,13 @@ def make_db_signing_key_resolver(db_path: str):
         if not agent_name or not db_path or not _name_re.fullmatch(agent_name):
             return None
         try:
+            # #797/#220: the agents DB is now rollback-journal (no WAL), so a
+            # read-only reader can hit SQLITE_BUSY while a writer holds the lock
+            # (WAL allowed concurrent read+write; rollback does not). timeout=5 is
+            # the busy_timeout (Python maps the connect timeout -> busy_timeout),
+            # so the SELECT waits up to 5s; on timeout the except below keeps the
+            # resolver fail-soft (None -> global-secret fallback), never raising
+            # into the request path.
             conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
             try:
                 row = conn.execute(

--- a/tests/test_agents_db_no_wal.py
+++ b/tests/test_agents_db_no_wal.py
@@ -1,0 +1,129 @@
+"""#797/#220 — agents DB must run in rollback (TRUNCATE) journal mode, never WAL.
+
+The WAL wal-index (``-shm``) is always memory-mapped in WAL mode. Under the
+daemon's long-lived registry connection plus the per-request read-only
+signing-key resolver churn, that mapped ``-shm`` page went stale and a SQLite
+pager read SIGBUS'd the daemon (``si_addr`` confirmed inside
+``conversations_agents.db-shm``). Rollback journal mode has no ``-shm`` at all,
+so the daemon never maps it. These tests pin the contract.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from pinky_daemon.agent_registry import (
+    AgentDbConfigError,
+    AgentRegistry,
+    _configure_agents_db_connection,
+)
+from pinky_daemon.auth import make_db_signing_key_resolver
+
+
+def _journal_mode(db_path: str) -> str:
+    c = sqlite3.connect(db_path)
+    try:
+        return str(c.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+    finally:
+        c.close()
+
+
+def test_new_registry_is_truncate_and_creates_no_shm():
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "agents.db")
+        reg = AgentRegistry(db_path=path)
+        # ordinary register/get/update
+        reg.register(name="alpha", display_name="Alpha")
+        assert reg.get("alpha") is not None
+        reg.register(name="alpha", display_name="Alpha Updated")
+        # the registry's OWN connection is in rollback (TRUNCATE) mode; a fresh
+        # connection defaults to "delete" (also rollback) — both are non-WAL.
+        assert reg._db.execute("PRAGMA journal_mode").fetchone()[0].lower() == "truncate"
+        assert _journal_mode(path) != "wal"
+        # the real SIGBUS-relevant invariant: never WAL, so no wal-index (-shm)
+        assert not os.path.exists(path + "-shm"), "agents DB must not create a -shm (WAL) file"
+
+
+def test_existing_wal_db_is_converted_in_place():
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "agents.db")
+        # seed an existing WAL-mode DB that has a live -wal/-shm pair
+        seed = sqlite3.connect(path)
+        seed.execute("PRAGMA journal_mode=WAL")
+        seed.execute("CREATE TABLE warmup(x)")
+        seed.execute("INSERT INTO warmup VALUES (1)")
+        seed.commit()
+        assert os.path.exists(path + "-shm")  # WAL mode created the wal-index
+        seed.close()
+        # registry init must convert it and keep working
+        reg = AgentRegistry(db_path=path)
+        reg.register(name="beta")
+        assert reg.get("beta") is not None
+        assert reg._db.execute("PRAGMA journal_mode").fetchone()[0].lower() == "truncate"
+        # the prior WAL was left persistently: fresh opens aren't WAL, -shm gone
+        assert _journal_mode(path) != "wal"
+        assert not os.path.exists(path + "-shm")
+
+
+def test_resolver_resolves_current_key_in_truncate_mode():
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "agents.db")
+        reg = AgentRegistry(db_path=path)
+        reg.register(name="gamma")
+        key1 = reg.get_or_create_signing_key("gamma")
+        resolver = make_db_signing_key_resolver(path)
+        assert resolver("gamma") == key1
+        # "rotation": the resolver must read the CURRENT DB value, not a stale one (#641)
+        reg._db.execute(
+            "INSERT OR REPLACE INTO agent_signing_keys (agent_name, signing_key, created_at) "
+            "VALUES (?, ?, ?)",
+            ("gamma", "rotated-key-v2", 0),
+        )
+        reg._db.commit()
+        assert resolver("gamma") == "rotated-key-v2"
+        # fail-soft: unknown agent / bad name -> None (global-secret fallback)
+        assert resolver("does-not-exist") is None
+        assert resolver("BAD NAME!") is None
+        # still rollback (registry conn = truncate), DB non-WAL, no -shm
+        assert reg._db.execute("PRAGMA journal_mode").fetchone()[0].lower() == "truncate"
+        assert _journal_mode(path) != "wal"
+        assert not os.path.exists(path + "-shm")
+
+
+class _FakeConn:
+    """Minimal connection stub: journal_mode=TRUNCATE returns the scripted
+    sequence of effective modes; everything else is a no-op."""
+
+    def __init__(self, truncate_results):
+        self._seq = list(truncate_results)
+
+    def execute(self, sql, *args):
+        s = sql.strip().lower()
+        fake = self
+
+        class _Cur:
+            def fetchone(self):
+                if "journal_mode=truncate" in s:
+                    return (fake._seq.pop(0),) if fake._seq else ("wal",)
+                if s == "pragma journal_mode":
+                    return ("wal",)
+                return None
+
+        return _Cur()
+
+
+def test_configure_fails_loud_when_it_cannot_leave_wal():
+    # A persistent writer / lock: PRAGMA journal_mode=TRUNCATE keeps reporting
+    # 'wal'. The helper must retry then RAISE, never silently stay on WAL.
+    conn = _FakeConn(truncate_results=["wal", "wal", "wal"])
+    with pytest.raises(AgentDbConfigError):
+        _configure_agents_db_connection(conn, retries=3, busy_ms=10)
+
+
+def test_configure_retries_then_succeeds():
+    # Busy once (reports 'wal'), then the lock clears and it reports 'truncate'.
+    conn = _FakeConn(truncate_results=["wal", "truncate"])
+    assert _configure_agents_db_connection(conn, retries=4, busy_ms=10) == "truncate"


### PR DESCRIPTION
## Root cause (captured + confirmed to the byte)

The TOD daemon SIGBUS'd inside SQLite reading the `conversations_agents.db` **wal-index (`-shm`) mmap**:

```
#0 libsqlite3 → #1 sqlite3PagerDirectReadOk → #4 sqlite3VdbeExec → #5 sqlite3_step → #6 _sqlite3 (python)
```

Core dump: **`si_addr = 0x7e45c8b60f40` falls inside the `conversations_agents.db-shm` mapping** (0x7e45c8b5b000–0x7e45c8b63000, 32768B — the only agents mapping in the core; no main-db mmap → `mmap_size=0` is effective).

**The external-truncator theory is disproven.** 17h of armed bpftrace traps (ftruncate≤64K / openat-O_TRUNC / truncate / unlinkat / fallocate / SIGBUS) + a 0.3s `-shm` size/inode poller ran *through* the crash: `agents-shm` (inode 11272224) never changed — 120,312 samples all `32768|11272224`; zero truncate/hole-punch/unlink on it. It's the WAL wal-index mmap going **stale** under the daemon's long-lived registry connection + the per-request RO signing-key resolver churn. `mmap_size=0` doesn't help — the `-shm` mmap is inherent to WAL mode.

## The fix

Take the agents DB **off WAL** — rollback journal mode has no `-shm`, so the daemon never maps it.

- New `_configure_agents_db_connection(conn) -> str` helper: checkpoint any existing WAL → `journal_mode=TRUNCATE` → accept **only** `'truncate'`, else bounded retry then **fail loud** (`AgentDbConfigError`), never silently stay on WAL. Sets `busy_timeout`. Runs in `AgentRegistry.__init__` **before** `_init_tables()` and before any MCP/session resume can spawn stdio children.
- Replaces the unconditional `PRAGMA journal_mode=WAL` at `agent_registry.py`.
- **Agents DB only** — every other store keeps WAL.
- Resolver (`auth.py`): documents that `timeout=5` is the busy_timeout for rollback-mode reader/writer contention; stays fail-soft (None → global-secret fallback, preserving #641).

Approach reviewed/approved by @murzik (the `si_addr ∈ -shm` datum was his signoff condition for non-WAL journal mode).

## Test plan

`tests/test_agents_db_no_wal.py` (5 tests, all green):
- new DB → registry conn is `truncate`, **never** creates a `-shm`
- existing WAL DB (with live `-wal/-shm`) → converted in place, `-shm` removed
- busy/lock path → retries then fails loud (no silent stay-on-WAL)
- resolver resolves current (rotated) keys in rollback mode; fail-softs to None

`280` existing registry/auth/provisioning tests still pass; ruff clean. (No UI surface — evidence is the test suite + the core analysis above, in lieu of a screenshot.)

## Rollout (gated — not auto-deploy)

Staged: deploy to **TOD first** with the `-shm`/inode poller still live — success = the daemon holds **no agents `-shm` mapping at all** — soak, then fleet-wide. If SIGBUS were to persist without WAL, root isn't the wal-index and we pivot to connection-misuse (not expected given `si_addr`). The `.claude.json` self-heal stopgap stays until the soak is clean. Revert path: release rollback (or we can add an env escape-hatch if you'd prefer — open question for review).

Closes #797 root cause; advances #220.

🤖 Opened by Barsik via [Claude Code](https://claude.com/claude-code)