### PR TITLE
feat(telegram): reply-with-quote — ReplyParameters.quote on thread()

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1431,12 +1431,17 @@ def create_api(
         parse_mode: str = "",
         silent: bool = False,
         link_preview_options: dict | None = None,
+        quote: str = "",
     ) -> SimpleNamespace:
         """Send a text message and return SimpleNamespace(message_id=...).
 
         ``link_preview_options`` (Telegram only) is the Bot API 7.0
         ``LinkPreviewOptions`` object controlling the URL preview card; it is
         ignored on other platforms.
+
+        ``quote`` (Telegram only) is an exact substring of the replied-to
+        message to quote in the reply (Bot API 7.0 ``ReplyParameters.quote``);
+        it requires ``reply_to`` and is ignored on other platforms.
         """
         # iMessage has its own adapter factory; the generic lookup below
         # never constructs one and would 503 before this branch could run.
@@ -1490,37 +1495,56 @@ def create_api(
 
         if platform == "telegram":
             reply_to_id = int(reply_to) if reply_to else None
-            if parse_mode:
-                result = adapter.send_message(
-                    chat_id,
-                    content,
-                    reply_to_message_id=reply_to_id,
-                    parse_mode=parse_mode,
-                    disable_notification=silent,
-                    link_preview_options=link_preview_options,
-                )
-                return SimpleNamespace(message_id=_extract_message_id(result))
+            # Quoting a specific passage uses Bot API 7.0 ReplyParameters; it
+            # supersedes reply_to_message_id (the adapter sends only one). The
+            # quote must be an exact substring of the replied-to message.
+            reply_parameters = None
+            if reply_to_id is not None and quote:
+                reply_parameters = {"message_id": reply_to_id, "quote": quote}
+
+            def _tg_send(rp):
+                # Send with the existing MarkdownV2->plain degradation; ``rp`` is
+                # the reply_parameters (or None for a normal/unquoted reply).
+                if parse_mode:
+                    return adapter.send_message(
+                        chat_id, content, reply_to_message_id=reply_to_id,
+                        parse_mode=parse_mode, disable_notification=silent,
+                        link_preview_options=link_preview_options, reply_parameters=rp,
+                    )
+                try:
+                    return adapter.send_message(
+                        chat_id, _md_to_tg_mdv2(content), reply_to_message_id=reply_to_id,
+                        parse_mode="MarkdownV2", disable_notification=silent,
+                        link_preview_options=link_preview_options, reply_parameters=rp,
+                    )
+                except Exception as e:
+                    _log(f"broker-send: MarkdownV2 failed ({e}), trying plain")
+                    return adapter.send_message(
+                        chat_id, content, reply_to_message_id=reply_to_id,
+                        disable_notification=silent,
+                        link_preview_options=link_preview_options, reply_parameters=rp,
+                    )
+
             try:
-                mdv2 = _md_to_tg_mdv2(content)
-                result = adapter.send_message(
-                    chat_id,
-                    mdv2,
-                    reply_to_message_id=reply_to_id,
-                    parse_mode="MarkdownV2",
-                    disable_notification=silent,
-                    link_preview_options=link_preview_options,
-                )
-                return SimpleNamespace(message_id=_extract_message_id(result))
+                result = _tg_send(reply_parameters)
             except Exception as e:
-                _log(f"broker-send: MarkdownV2 failed ({e}), trying plain")
-                result = adapter.send_message(
-                    chat_id,
-                    content,
-                    reply_to_message_id=reply_to_id,
-                    disable_notification=silent,
-                    link_preview_options=link_preview_options,
+                # An invalid quote (not an exact substring / too long) makes
+                # Telegram reject the send. Don't sink the whole reply — degrade
+                # to a normal threaded reply (no quote, reply_to preserved) so
+                # the message still lands. Scoped to quote errors so a transient
+                # failure on a VALID quote isn't silently downgraded.
+                from pinky_outreach.telegram import TelegramError
+                quote_rejected = (
+                    reply_parameters is not None
+                    and isinstance(e, TelegramError)
+                    and "quote" in (getattr(e, "description", "") or "").lower()
                 )
-                return SimpleNamespace(message_id=_extract_message_id(result))
+                if quote_rejected:
+                    _log(f"broker-send: reply quote rejected ({e.description}); resending without quote")
+                    result = _tg_send(None)
+                else:
+                    raise
+            return SimpleNamespace(message_id=_extract_message_id(result))
 
         if platform == "discord":
             result = adapter.send_message(chat_id, content, reply_to=reply_to or None)
@@ -1617,6 +1641,7 @@ def create_api(
         parse_mode: str = "",
         silent: bool = False,
         link_preview_options: dict | None = None,
+        quote: str = "",
     ) -> dict:
         """Send a message back to the platform on behalf of an agent."""
         loop = asyncio.get_running_loop()
@@ -1633,6 +1658,7 @@ def create_api(
                     parse_mode=parse_mode,
                     silent=silent,
                     link_preview_options=link_preview_options,
+                    quote=quote,
                 ),
             )
             # Once an outbound message lands, the typing indicator becomes noise —
@@ -1654,14 +1680,15 @@ def create_api(
         # vs failure handling lives in deliver_deduped.
         #
         # Presentation options that change the RENDERED message (parse_mode,
-        # link_preview_options) are folded into the dedupe identity as a
-        # canonical string so a retry with different formatting/preview settings
-        # is delivered rather than silently suppressed (#802 review). Plain sends
-        # keep key_extra="" — their historical dedupe behaviour is unchanged. The
-        # dict is serialized (never used raw) so the key stays hashable.
-        if parse_mode or link_preview_options:
+        # link_preview_options, quote) are folded into the dedupe identity as a
+        # canonical string so a retry with different formatting/preview/quote
+        # settings is delivered rather than silently suppressed (#802 review).
+        # Plain sends keep key_extra="" — their historical dedupe behaviour is
+        # unchanged. The dict is serialized (never used raw) so the key stays
+        # hashable.
+        if parse_mode or link_preview_options or quote:
             key_extra = json.dumps(
-                {"pm": parse_mode or "", "lpo": link_preview_options or None},
+                {"pm": parse_mode or "", "lpo": link_preview_options or None, "q": quote or ""},
                 sort_keys=True, separators=(",", ":"),
             )
         else:
@@ -1743,6 +1770,7 @@ def create_api(
         reply_to: str = "",
         include_text_copy: bool = False,
         link_preview_options: dict | None = None,
+        quote: str = "",
     ) -> dict:
         """Generate TTS audio and send it as a voice message."""
         if platform != "telegram":
@@ -1836,6 +1864,10 @@ def create_api(
                 else:
                     raise HTTPException(400, f"Unknown TTS provider: {provider}")
 
+                # The voice (audio) half replies to the whole message; only the
+                # text copy below carries the `quote` passage. Keeping the audio
+                # bubble quote-free also makes it immune to an invalid-quote
+                # rejection (graceful-degrade lives in _send_text_message).
                 msg = adapter.send_voice(
                     chat_id,
                     audio_path,
@@ -1853,6 +1885,7 @@ def create_api(
                     text_msg = _send_text_message(
                         agent_name, platform, chat_id, text, reply_to=reply_to,
                         link_preview_options=link_preview_options,
+                        quote=quote,
                     )
                     result["text_message_id"] = text_msg.message_id
                 return result
@@ -7571,6 +7604,13 @@ npm run build</pre>
         content = req.get("content", "").strip()
         parse_mode = req.get("parse_mode", "")
         link_preview_options = _sanitize_link_preview_options(req.get("link_preview_options"))
+        quote = req.get("quote", "")
+        if not isinstance(quote, str):
+            quote = ""
+        # Telegram caps ReplyParameters.quote at 1024 chars; a whitespace-only
+        # quote is invalid. Strip+cap so those don't reach the API (the send
+        # path also degrades to an unquoted reply if the quote still mismatches).
+        quote = quote.strip()[:1024]
         if not agent_name or not source_message_id or not content:
             raise HTTPException(400, "agent_name, message_id, and content are required")
         _deny_isolated_cross_actor(request, agent_name)
@@ -7590,6 +7630,7 @@ npm run build</pre>
                 reply_to=ctx.message_id,
                 include_text_copy=True,
                 link_preview_options=link_preview_options,
+                quote=quote,
             )
             _record_outbound_message(
                 agent_name,
@@ -7613,6 +7654,7 @@ npm run build</pre>
             reply_to=ctx.message_id,
             parse_mode=parse_mode,
             link_preview_options=link_preview_options,
+            quote=quote,
         )
         _record_outbound_message(
             agent_name,

--- a/src/pinky_messaging/server.py
+++ b/src/pinky_messaging/server.py
@@ -106,12 +106,17 @@ def create_server(
         disable_link_preview: bool = False,
         prefer_large_media: bool = False,
         link_preview_above: bool = False,
+        quote: str = "",
     ) -> str:
         """Quote-reply to a specific inbound message. The user sees your response linked to the original.
 
         Link-preview flags (Telegram): disable_link_preview suppresses the URL
         preview card; prefer_large_media forces a big thumbnail; link_preview_above
         floats the preview above your text.
+
+        quote (Telegram): an exact substring of the message you're replying to;
+        the reply then visibly quotes just that passage instead of the whole
+        message. Must match the original text exactly, or Telegram rejects it.
         """
         result = _api("POST", "/broker/thread", {
             "agent_name": agent_name,
@@ -121,6 +126,7 @@ def create_server(
             "link_preview_options": _link_preview_options(
                 disable_link_preview, prefer_large_media, link_preview_above
             ),
+            "quote": quote,
         })
         return json.dumps(result)
 

--- a/src/pinky_outreach/telegram.py
+++ b/src/pinky_outreach/telegram.py
@@ -69,6 +69,7 @@ class TelegramAdapter:
         parse_mode: str | None = None,
         disable_notification: bool = False,
         link_preview_options: dict | None = None,
+        reply_parameters: dict | None = None,
     ) -> Message:
         """Send a text message.
 
@@ -77,12 +78,19 @@ class TelegramAdapter:
         ``{"prefer_large_media": True}`` for a big thumbnail, or
         ``{"show_above_text": True}`` to float the preview above the message.
         ``None`` leaves Telegram's default behaviour (``_request`` drops it).
+
+        ``reply_parameters`` (Bot API 7.0 ``ReplyParameters``) supersedes the
+        deprecated ``reply_to_message_id`` and additionally supports quoting a
+        specific passage of the replied-to message via its ``quote`` field.
+        When set, ``reply_to_message_id`` is not sent — Telegram rejects both.
         """
         result = self._request(
             "sendMessage",
             chat_id=chat_id,
             text=text,
-            reply_to_message_id=reply_to_message_id,
+            # reply_parameters supersedes reply_to_message_id; never send both.
+            reply_to_message_id=None if reply_parameters else reply_to_message_id,
+            reply_parameters=reply_parameters,
             parse_mode=parse_mode,
             disable_notification=disable_notification,
             link_preview_options=link_preview_options,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2347,6 +2347,143 @@ class TestAPI:
                 assert history[-1].metadata["tool"] == "thread"
                 assert history[-1].metadata["source_message_id"] == "101"
 
+    def test_broker_thread_quote_builds_reply_parameters(self):
+        """thread(quote=...) builds ReplyParameters quoting the given passage."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+                app.state.broker.remember_message_context(
+                    BrokerMessage(
+                        platform="telegram", chat_id="6770805286", sender_name="Brad",
+                        sender_id="u1", content="The deploy failed at step 3",
+                        agent_name="barsik", message_id="101",
+                    )
+                )
+                with patch(
+                    "pinky_outreach.telegram.TelegramAdapter.send_message",
+                    return_value=SimpleNamespace(message_id="501"),
+                ) as mock:
+                    resp = client.post("/broker/thread", json={
+                        "agent_name": "barsik", "message_id": "101",
+                        "content": "looking now", "quote": "step 3",
+                    })
+                assert resp.status_code == 200, resp.text
+                assert mock.call_args.kwargs["reply_parameters"] == {
+                    "message_id": 101, "quote": "step 3"
+                }
+
+    def test_broker_thread_without_quote_has_no_reply_parameters(self):
+        """A plain thread() reply keeps reply_parameters=None (legacy path)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+                app.state.broker.remember_message_context(
+                    BrokerMessage(
+                        platform="telegram", chat_id="6770805286", sender_name="Brad",
+                        sender_id="u1", content="hi", agent_name="barsik", message_id="101",
+                    )
+                )
+                with patch(
+                    "pinky_outreach.telegram.TelegramAdapter.send_message",
+                    return_value=SimpleNamespace(message_id="501"),
+                ) as mock:
+                    resp = client.post("/broker/thread", json={
+                        "agent_name": "barsik", "message_id": "101", "content": "ok",
+                    })
+                assert resp.status_code == 200, resp.text
+                assert mock.call_args.kwargs["reply_parameters"] is None
+                assert mock.call_args.kwargs["reply_to_message_id"] == 101
+
+    def test_broker_thread_invalid_quote_degrades_to_plain_reply(self):
+        """An invalid quote (rejected by Telegram) degrades to a normal reply
+        instead of dropping the whole message (PR2 review high finding)."""
+        from pinky_outreach.telegram import TelegramError
+
+        calls = []
+
+        def _send(*args, **kwargs):
+            calls.append(kwargs.get("reply_parameters"))
+            if kwargs.get("reply_parameters") is not None:
+                raise TelegramError("Bad Request: QUOTE_TEXT_INVALID", 400)
+            return SimpleNamespace(message_id="777")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+                app.state.broker.remember_message_context(
+                    BrokerMessage(
+                        platform="telegram", chat_id="6770805286", sender_name="Brad",
+                        sender_id="u1", content="hello world", agent_name="barsik",
+                        message_id="101",
+                    )
+                )
+                with patch("pinky_outreach.telegram.TelegramAdapter.send_message", side_effect=_send):
+                    resp = client.post("/broker/thread", json={
+                        "agent_name": "barsik", "message_id": "101",
+                        "content": "looking", "quote": "not a substring",
+                    })
+                # The reply still lands (no 500), and the degrade dropped the quote.
+                assert resp.status_code == 200, resp.text
+                assert resp.json()["message_id"] == "777"
+                assert calls[0] == {"message_id": 101, "quote": "not a substring"}
+                assert calls[-1] is None
+
+    def test_broker_thread_whitespace_quote_is_dropped(self):
+        """A whitespace-only quote is stripped to empty → no reply_parameters."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+                app.state.broker.remember_message_context(
+                    BrokerMessage(
+                        platform="telegram", chat_id="6770805286", sender_name="Brad",
+                        sender_id="u1", content="hi there", agent_name="barsik",
+                        message_id="101",
+                    )
+                )
+                with patch(
+                    "pinky_outreach.telegram.TelegramAdapter.send_message",
+                    return_value=SimpleNamespace(message_id="501"),
+                ) as mock:
+                    resp = client.post("/broker/thread", json={
+                        "agent_name": "barsik", "message_id": "101",
+                        "content": "ok", "quote": "   ",
+                    })
+                assert resp.status_code == 200, resp.text
+                assert mock.call_args.kwargs["reply_parameters"] is None
+
+    def test_broker_thread_overlong_quote_is_capped(self):
+        """A quote longer than Telegram's 1024-char limit is capped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+                app.state.broker.remember_message_context(
+                    BrokerMessage(
+                        platform="telegram", chat_id="6770805286", sender_name="Brad",
+                        sender_id="u1", content="x" * 4000, agent_name="barsik",
+                        message_id="101",
+                    )
+                )
+                with patch(
+                    "pinky_outreach.telegram.TelegramAdapter.send_message",
+                    return_value=SimpleNamespace(message_id="501"),
+                ) as mock:
+                    resp = client.post("/broker/thread", json={
+                        "agent_name": "barsik", "message_id": "101",
+                        "content": "ok", "quote": "x" * 2000,
+                    })
+                assert resp.status_code == 200, resp.text
+                assert len(mock.call_args.kwargs["reply_parameters"]["quote"]) == 1024
+
     def test_broker_media_endpoints_scrub_file_path_from_metadata(self):
         """Regression: /broker/send-photo, /send-document, /send-animation must not
         persist the raw file_path to conversation metadata. PR #244 scrubbed the

--- a/tests/test_outreach.py
+++ b/tests/test_outreach.py
@@ -210,6 +210,33 @@ class TestTelegramAdapter:
         assert "link_preview_options" not in payload
         adapter.close()
 
+    def test_send_message_reply_parameters_supersedes_reply_to(self):
+        # When reply_parameters is set (e.g. to quote a passage), the adapter
+        # sends it and DROPS reply_to_message_id — Telegram rejects both.
+        adapter = self._make_adapter()
+        adapter._client.post = MagicMock(return_value=self._ok_text_response())
+
+        adapter.send_message(
+            "12345", "looking now",
+            reply_to_message_id=101,
+            reply_parameters={"message_id": 101, "quote": "step 3"},
+        )
+        payload = adapter._client.post.call_args.kwargs["json"]
+        assert payload["reply_parameters"] == {"message_id": 101, "quote": "step 3"}
+        assert "reply_to_message_id" not in payload
+        adapter.close()
+
+    def test_send_message_reply_to_used_when_no_reply_parameters(self):
+        # Without reply_parameters, the legacy reply_to_message_id path is intact.
+        adapter = self._make_adapter()
+        adapter._client.post = MagicMock(return_value=self._ok_text_response())
+
+        adapter.send_message("12345", "hi", reply_to_message_id=101)
+        payload = adapter._client.post.call_args.kwargs["json"]
+        assert payload["reply_to_message_id"] == 101
+        assert "reply_parameters" not in payload
+        adapter.close()
+
     def _ok_media_response(self):
         mock_response = MagicMock()
         mock_response.json.return_value = {


### PR DESCRIPTION
## Telegram reply-with-quote — PR2 (`ReplyParameters.quote`)

Follow-up to #802. `thread()` gains a **`quote`** param: reply quoting a *specific passage* of the message instead of the whole thing (Bot API 7.0 `ReplyParameters`), which also modernizes the deprecated `reply_to_message_id`.

### What's new
- **`thread(message_id, text, quote="…")`** — the reply visibly quotes just that passage. The quote must be an exact substring of the replied-to message (Telegram validates server-side).
- `TelegramAdapter.send_message` gains `reply_parameters`, which supersedes `reply_to_message_id` (only one is sent — Telegram rejects both).

### Robustness (from the adversarial review)
- **Graceful degradation:** an invalid quote (verified live — Telegram returns `Bad Request: QUOTE_TEXT_INVALID`) retries **once without the quote** so the reply still lands, instead of 500ing the whole message. Scoped to quote errors, so a transient failure on a *valid* quote isn't silently downgraded to an unquoted reply.
- **Input hygiene:** the quote is whitespace-stripped and capped at Telegram's 1024-char limit.
- **Dedupe:** `quote` is folded into the `key_extra` from #802, so a re-reply with a different quote is delivered, not suppressed.
- **Voice:** the voice-auto-reply text copy threads `quote`; the audio half intentionally replies unquoted (and is therefore immune to the invalid-quote path).

### Files
- `pinky_outreach/telegram.py` — `reply_parameters` on `send_message`.
- `pinky_daemon/api.py` — build/thread `reply_parameters`; graceful-degrade helper; input hygiene; dedupe key.
- `pinky_messaging/server.py` — `quote` on the `thread` tool.

### Verification
- **Verified live** against Telegram (`12015` → `12016` quotes one passage; invalid-quote error string confirmed as `QUOTE_TEXT_INVALID`).
- New tests: quote→`ReplyParameters`, legacy reply path unchanged, graceful degrade, whitespace-drop, 1024-cap, adapter supersession. Full suite + `ruff` green.
- Adversarial multi-lens review run on the diff; the one HIGH finding (invalid quote dropped the whole reply) and its input-hygiene facets are fixed.

🤖 Opened by Barsik
