### PR TITLE
fix(auth): allow per-agent Claude auth mode override

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -161,23 +161,47 @@ _CLAUDE_AUTH_MODES = {
 }
 
 
-def _claude_auth_mode() -> str:
-    """Fleet auth mode for Claude Code tmux sessions.
+def _claude_auth_mode_env_for_agent(agent_name: str | None) -> str | None:
+    if not agent_name:
+        return None
+    suffix = re.sub(r"[^A-Za-z0-9]", "_", agent_name).upper()
+    return f"{_CLAUDE_AUTH_MODE_ENV}_{suffix}"
 
-    The default preserves the historical bootstrap path: copy the daemon user's
-    Claude subscription OAuth credentials into container agents. ``per_agent_oauth``
-    is the durable interactive-container mode: each agent owns its own Claude
-    login in its container home volume, and the daemon must never import shared
-    host credentials on normal restart/update.
-    """
-    raw = os.environ.get(_CLAUDE_AUTH_MODE_ENV, _CLAUDE_AUTH_MODE_SHARED_REFRESH)
+
+def _resolve_claude_auth_mode(raw: str, *, source: str) -> str | None:
     mode = raw.strip().lower() or _CLAUDE_AUTH_MODE_SHARED_REFRESH
     if mode in _CLAUDE_AUTH_MODES:
         return mode
     _log(
-        f"tmux: unsupported {_CLAUDE_AUTH_MODE_ENV}={raw!r}; "
-        f"falling back to {_CLAUDE_AUTH_MODE_SHARED_REFRESH}"
+        f"tmux: unsupported {source}={raw!r}; "
+        f"falling back to {_CLAUDE_AUTH_MODE_ENV}"
     )
+    return None
+
+
+def _claude_auth_mode(agent_name: str | None = None) -> str:
+    """Auth mode for Claude Code tmux sessions.
+
+    The default preserves the historical bootstrap path: copy the daemon user's
+    Claude subscription OAuth credentials into container agents. A per-agent
+    ``PINKY_CLAUDE_AUTH_MODE_<AGENT>`` override wins over the fleet-wide
+    ``PINKY_CLAUDE_AUTH_MODE`` so one container can be canaried without putting
+    the whole daemon into ``per_agent_oauth``. ``per_agent_oauth`` is the durable
+    interactive-container mode: each agent owns its own Claude login in its
+    container home volume, and the daemon must never import shared host
+    credentials on normal restart/update.
+    """
+    agent_env = _claude_auth_mode_env_for_agent(agent_name)
+    if agent_env:
+        raw_agent = os.environ.get(agent_env)
+        if raw_agent is not None:
+            mode = _resolve_claude_auth_mode(raw_agent, source=agent_env)
+            if mode is not None:
+                return mode
+    raw = os.environ.get(_CLAUDE_AUTH_MODE_ENV, _CLAUDE_AUTH_MODE_SHARED_REFRESH)
+    mode = _resolve_claude_auth_mode(raw, source=_CLAUDE_AUTH_MODE_ENV)
+    if mode is not None:
+        return mode
     return _CLAUDE_AUTH_MODE_SHARED_REFRESH
 
 
@@ -1345,7 +1369,7 @@ class TmuxSession:
             "0", "false", "no",
         ):
             return
-        mode = _claude_auth_mode()
+        mode = _claude_auth_mode(self.agent_name)
         if mode == _CLAUDE_AUTH_MODE_PER_AGENT_OAUTH:
             _log(
                 f"tmux[{self.agent_name}]: claude_auth_mode={mode} — "
@@ -1424,7 +1448,7 @@ class TmuxSession:
         runner = self._select_command_runner()
         if not isinstance(runner, ContainerCommandRunner):
             return
-        mode = _claude_auth_mode()
+        mode = _claude_auth_mode(self.agent_name)
         if mode == _CLAUDE_AUTH_MODE_PER_AGENT_OAUTH:
             try:
                 res = await runner.run(
@@ -2279,7 +2303,7 @@ class TmuxSession:
         container_agent = self._container_agent(strict=True)
         self._tmux.set_command_runner(self._select_command_runner(container_agent))
         _log(
-            f"tmux[{self.agent_name}]: claude_auth_mode={_claude_auth_mode()} "
+            f"tmux[{self.agent_name}]: claude_auth_mode={_claude_auth_mode(self.agent_name)} "
             f"container_agent={str(container_agent is not None).lower()}"
         )
 

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -25,6 +25,8 @@ from pinky_daemon.streaming_session import StreamingSessionConfig
 from pinky_daemon.tmux_session import (
     TmuxCommandResult,
     TmuxSession,
+    _claude_auth_mode,
+    _claude_auth_mode_env_for_agent,
     _claude_creds_state,
     _container_start_timeout_sec,
     _credential_fingerprint,
@@ -82,6 +84,41 @@ class _FakeRegistry:
 
     def get_or_create_signing_key(self, name):
         return f"key-{name}"
+
+
+class TestClaudeAuthMode:
+    def _clear(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CLAUDE_AUTH_MODE", raising=False)
+        monkeypatch.delenv("PINKY_CLAUDE_AUTH_MODE_DYMOK", raising=False)
+        monkeypatch.delenv("PINKY_CLAUDE_AUTH_MODE_YARIK", raising=False)
+        monkeypatch.delenv("PINKY_CLAUDE_AUTH_MODE_AGENT_ONE", raising=False)
+
+    def test_default_is_shared_refresh_file(self, monkeypatch):
+        self._clear(monkeypatch)
+        assert _claude_auth_mode("dymok") == "shared_refresh_file"
+
+    def test_global_mode_applies_without_agent_override(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE", "per_agent_oauth")
+        assert _claude_auth_mode("dymok") == "per_agent_oauth"
+
+    def test_agent_override_wins_over_global(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE", "shared_refresh_file")
+        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE_YARIK", "per_agent_oauth")
+        assert _claude_auth_mode("yarik") == "per_agent_oauth"
+        assert _claude_auth_mode("dymok") == "shared_refresh_file"
+
+    def test_agent_env_name_is_sanitized(self):
+        assert _claude_auth_mode_env_for_agent("agent-one") == (
+            "PINKY_CLAUDE_AUTH_MODE_AGENT_ONE"
+        )
+
+    def test_invalid_agent_override_falls_back_to_global(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE", "per_agent_oauth")
+        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE_DYMOK", "nope")
+        assert _claude_auth_mode("dymok") == "per_agent_oauth"
 
 
 def _session(agent_name="dymok", registry=None, working_dir="/tmp/x"):
@@ -364,7 +401,8 @@ class TestSeedContainerHomeCreds:
 
     async def test_per_agent_oauth_probes_but_never_copies(self, monkeypatch):
         monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
-        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE", "per_agent_oauth")
+        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE", "shared_refresh_file")
+        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE_DYMOK", "per_agent_oauth")
         ss = _session(registry=_FakeRegistry(
             _FakeAgent("dymok", "container", working_dir="/srv/agents/dymok")
         ))
@@ -509,6 +547,7 @@ class TestSeedContainerClaudeCreds:
         monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
         monkeypatch.delenv("PINKY_CONTAINER_SEED_CREDS", raising=False)
         monkeypatch.delenv("PINKY_CLAUDE_AUTH_MODE", raising=False)
+        monkeypatch.delenv("PINKY_CLAUDE_AUTH_MODE_DYMOK", raising=False)
         host_cfg = tmp_path / "host-claude"
         host_cfg.mkdir()
         if host_creds is not None:
@@ -547,7 +586,8 @@ class TestSeedContainerClaudeCreds:
 
     def test_per_agent_oauth_never_seeds_shared_host_creds(self, monkeypatch, tmp_path):
         ss, _host_cfg, wd = self._creds_session(monkeypatch, tmp_path)
-        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE", "per_agent_oauth")
+        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE", "shared_refresh_file")
+        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE_DYMOK", "per_agent_oauth")
         ss._seed_container_claude_creds()
         assert not (wd / ".claude-container" / ".credentials.json").exists()
 


### PR DESCRIPTION
## Summary
- add per-agent `PINKY_CLAUDE_AUTH_MODE_<AGENT>` override with fallback to global `PINKY_CLAUDE_AUTH_MODE`
- thread agent-aware auth-mode resolution through tmux spawn and both credential seed gates
- cover default/global/per-agent/invalid override behavior and guardrail seed suppression via tests

## Verification
- `uv run ruff check src/pinky_daemon/tmux_session.py tests/test_tmux_container_isolation.py`
- `git diff --check`
- `uv run pytest tests/test_tmux_container_isolation.py -q` (70 passed)
- `uv run pytest tests/test_tmux_session.py -q` (282 passed)