### PR TITLE
feat(slack): resolve user + channel ids to names (users:read / channels:read)

### DIFF
--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -831,6 +831,14 @@ class BrokerSlackPoller:
         self._bot_user_id = ""
         self._bot_id = ""  # our own bot_id (from auth.test) — filters our bot_message echoes
         self._client = None  # slack_sdk SocketModeClient, created in start()
+        # Cosmetic identity resolution (users:read / channels:read). sender_id and
+        # approval routing always key on the raw id; only the display name and
+        # chat_title are enriched. Cached for the poller's lifetime (renames are
+        # rare); a missing users:read scope disables user resolution after the
+        # first failure so we don't hammer the API.
+        self._user_name_cache: dict[str, str] = {}
+        self._channel_title_cache: dict[str, str] = {}
+        self._users_read_ok = True
 
     @property
     def agent_name(self) -> str:
@@ -930,6 +938,74 @@ class BrokerSlackPoller:
             _log(f"slack-poller[{self._agent_name}]: connect failed: {e}")
             self._running = False
 
+    async def _resolve_user_name(self, user_id: str) -> str:
+        """Best-effort display name for a human Slack user id (users:read).
+
+        Cached; returns "" on any failure so the caller keeps the raw id.
+        A missing_scope failure disables further lookups (no API hammering).
+        Defensive about the return shape so a mocked/odd response degrades to "".
+        """
+        if not user_id or not self._users_read_ok:
+            return ""
+        cached = self._user_name_cache.get(user_id)
+        if cached is not None:
+            return cached
+        loop = asyncio.get_running_loop()
+        try:
+            info = await loop.run_in_executor(
+                None, self._adapter.get_user_info, user_id
+            )
+        except Exception as e:
+            if "missing_scope" in str(e):
+                self._users_read_ok = False
+                _log(
+                    f"slack-poller[{self._agent_name}]: users:read scope missing; "
+                    f"disabling user-name resolution"
+                )
+            else:
+                _log(
+                    f"slack-poller[{self._agent_name}]: users.info({user_id}) "
+                    f"failed: {e}"
+                )
+            return ""  # transient: not cached, retried on the next message
+        name = info.get("display_name", "") if isinstance(info, dict) else ""
+        if not isinstance(name, str):
+            name = ""
+        self._user_name_cache[user_id] = name
+        return name
+
+    async def _resolve_channel_title(self, channel_id: str) -> str:
+        """Best-effort channel name (channels:read via conversations.info).
+
+        Cached per channel; returns "" on failure. A scope failure for a given
+        channel (e.g. a DM with no im:read) is cached as "" for that channel
+        only — it won't change — so other channels still resolve. Transient
+        failures are not cached, so they retry.
+        """
+        if not channel_id:
+            return ""
+        cached = self._channel_title_cache.get(channel_id)
+        if cached is not None:
+            return cached
+        loop = asyncio.get_running_loop()
+        try:
+            chat = await loop.run_in_executor(
+                None, self._adapter.get_channel_info, channel_id
+            )
+        except Exception as e:
+            if "missing_scope" in str(e):
+                self._channel_title_cache[channel_id] = ""  # permanent for this channel
+            _log(
+                f"slack-poller[{self._agent_name}]: conversations.info({channel_id}) "
+                f"failed: {e}"
+            )
+            return ""
+        title = getattr(chat, "title", "") if chat is not None else ""
+        if not isinstance(title, str):
+            title = ""
+        self._channel_title_cache[channel_id] = title
+        return title
+
     async def _handle_event(self, payload: dict) -> None:
         event = (payload or {}).get("event") or {}
         if event.get("type") != "message":
@@ -964,10 +1040,16 @@ class BrokerSlackPoller:
         channel_type = event.get("channel_type", "")  # im | channel | group | mpim
         is_group = channel_type != "im"
         # Identity: humans carry `user`; bot-authored messages carry `bot_id`
-        # (and often `username`). sender_id is what approval keys on; name is
-        # cosmetic. TODO(parity): resolve a display name via users.info (users:read).
+        # (and often `username`). sender_id is what approval keys on and ALWAYS
+        # stays the raw id; sender_name / chat_title are cosmetic and enriched
+        # best-effort via users:read / channels:read (cached, fall back to id).
         sender_id = user_id or bot_id
         sender_name = user_id or event.get("username", "") or bot_id or "unknown"
+        if user_id:
+            resolved = await self._resolve_user_name(user_id)
+            if resolved:
+                sender_name = resolved
+        chat_title = await self._resolve_channel_title(channel)
 
         attachments = [
             {
@@ -996,7 +1078,7 @@ class BrokerSlackPoller:
             content=text,
             agent_name=self._agent_name,
             message_id=ts,
-            chat_title="",
+            chat_title=chat_title,
             is_group=is_group,
             reply_to=thread_ts,
             metadata=meta,

--- a/src/pinky_outreach/slack.py
+++ b/src/pinky_outreach/slack.py
@@ -9,6 +9,8 @@ Requires a Slack Bot Token (xoxb-...) with appropriate scopes:
 - reactions:write
 - files:write (for uploads)
 - channels:read (for channel info)
+- users:read (resolve user id -> display name)
+- users:read.email (resolve user id -> email; email lookup-by-email routing)
 """
 
 from __future__ import annotations
@@ -299,6 +301,63 @@ class SlackAdapter:
             title=ch.get("name", ""),
             chat_type=chat_type,
         )
+
+    def get_user_info(self, user_id: str) -> dict:
+        """Resolve a Slack user id (U...) to profile info.
+
+        Requires the ``users:read`` scope; ``email`` is only populated when
+        ``users:read.email`` is also granted (else it's an empty string).
+        Raises SlackError on API failure (e.g. ``missing_scope``,
+        ``user_not_found``) — callers should treat resolution as best-effort.
+
+        Returns a dict: user_id, name (handle), real_name, display_name
+        (best human label, never empty when the user resolves), email, is_bot.
+        """
+        result = self._request("users.info", user=user_id)
+        u = result.get("user", {}) or {}
+        prof = u.get("profile", {}) or {}
+        display = (
+            prof.get("display_name")
+            or prof.get("real_name")
+            or u.get("real_name")
+            or u.get("name")
+            or user_id
+        )
+        return {
+            "user_id": user_id,
+            "name": u.get("name", ""),
+            "real_name": u.get("real_name", "") or prof.get("real_name", ""),
+            "display_name": display,
+            "email": prof.get("email", ""),
+            "is_bot": bool(u.get("is_bot", False)),
+        }
+
+    def lookup_user_by_email(self, email: str) -> dict:
+        """Find a Slack user by email (requires ``users:read.email``).
+
+        Returns the same shape as ``get_user_info``. Raises SlackError on
+        failure (notably ``users_not_found`` when no member matches) — the
+        natural tool for routing a nudge to the right person by their Zoho/
+        directory email.
+        """
+        result = self._request("users.lookupByEmail", email=email)
+        u = result.get("user", {}) or {}
+        prof = u.get("profile", {}) or {}
+        display = (
+            prof.get("display_name")
+            or prof.get("real_name")
+            or u.get("real_name")
+            or u.get("name")
+            or u.get("id", "")
+        )
+        return {
+            "user_id": u.get("id", ""),
+            "name": u.get("name", ""),
+            "real_name": u.get("real_name", "") or prof.get("real_name", ""),
+            "display_name": display,
+            "email": prof.get("email", "") or email,
+            "is_bot": bool(u.get("is_bot", False)),
+        }
 
     # ── Reactions ────────────────────────────────────────────
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -74,6 +74,85 @@ class TestSlackAdapter:
         assert payload["thread_ts"] == "1711584000.000100"
         adapter.close()
 
+    def test_get_user_info_success(self):
+        adapter = self._make_adapter()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "user": {
+                "id": "U123", "name": "alice", "real_name": "Alice Adams",
+                "is_bot": False,
+                "profile": {
+                    "display_name": "Alice", "real_name": "Alice Adams",
+                    "email": "alice@example.com",
+                },
+            },
+        }
+        adapter._client.post = MagicMock(return_value=mock_response)
+
+        info = adapter.get_user_info("U123")
+        assert info["user_id"] == "U123"
+        assert info["display_name"] == "Alice"
+        assert info["real_name"] == "Alice Adams"
+        assert info["email"] == "alice@example.com"
+        assert info["is_bot"] is False
+        # called users.info with the user id
+        assert adapter._client.post.call_args[0][0] == "/users.info"
+        payload = adapter._client.post.call_args.kwargs["json"]
+        assert payload["user"] == "U123"
+        adapter.close()
+
+    def test_get_user_info_display_name_falls_back_to_real_then_handle(self):
+        adapter = self._make_adapter()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "user": {"id": "U9", "name": "bob", "real_name": "Bob B", "profile": {}},
+        }
+        adapter._client.post = MagicMock(return_value=mock_response)
+        info = adapter.get_user_info("U9")
+        assert info["display_name"] == "Bob B"  # no profile.display_name -> real_name
+        adapter.close()
+
+    def test_get_user_info_missing_scope_raises(self):
+        adapter = self._make_adapter()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": False, "error": "missing_scope"}
+        adapter._client.post = MagicMock(return_value=mock_response)
+        with pytest.raises(SlackError) as exc:
+            adapter.get_user_info("U123")
+        assert "missing_scope" in str(exc.value)
+        adapter.close()
+
+    def test_lookup_user_by_email_success(self):
+        adapter = self._make_adapter()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "user": {
+                "id": "U777", "name": "carol", "real_name": "Carol C",
+                "profile": {"display_name": "Carol", "email": "carol@example.com"},
+            },
+        }
+        adapter._client.post = MagicMock(return_value=mock_response)
+        info = adapter.lookup_user_by_email("carol@example.com")
+        assert info["user_id"] == "U777"
+        assert info["display_name"] == "Carol"
+        assert info["email"] == "carol@example.com"
+        assert adapter._client.post.call_args[0][0] == "/users.lookupByEmail"
+        payload = adapter._client.post.call_args.kwargs["json"]
+        assert payload["email"] == "carol@example.com"
+        adapter.close()
+
+    def test_lookup_user_by_email_not_found_raises(self):
+        adapter = self._make_adapter()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": False, "error": "users_not_found"}
+        adapter._client.post = MagicMock(return_value=mock_response)
+        with pytest.raises(SlackError):
+            adapter.lookup_user_by_email("nobody@example.com")
+        adapter.close()
+
     def test_send_message_error(self):
         adapter = self._make_adapter()
         mock_response = MagicMock()

--- a/tests/test_slack_poller.py
+++ b/tests/test_slack_poller.py
@@ -299,6 +299,106 @@ class TestBrokerSlackPoller:
         assert poller._client.responses[0].envelope_id == "env-123"  # ACKed
         mock_broker.handle_inbound.assert_called_once()
 
+    # ── Identity resolution (users:read / channels:read) ──────────────
+
+    @pytest.mark.asyncio
+    async def test_user_and_channel_names_resolved(self, mock_broker):
+        """users:read -> sender_name display name; channels:read -> chat_title.
+        sender_id always stays the raw id (approval keys on it)."""
+        poller = _make_poller(mock_broker)
+        poller._adapter.get_user_info.return_value = {
+            "user_id": "U123", "display_name": "Alice", "real_name": "Alice A",
+            "name": "alice", "email": "alice@example.com",
+        }
+        poller._adapter.get_channel_info.return_value = MagicMock(title="general")
+        await poller._handle_event(_event({
+            "type": "message", "user": "U123", "text": "hi",
+            "channel": "C999", "channel_type": "channel", "ts": "1.1",
+        }))
+        await asyncio.sleep(0)
+        bmsg = mock_broker.handle_inbound.call_args[0][0]
+        assert bmsg.sender_name == "Alice"
+        assert bmsg.sender_id == "U123"   # unchanged — raw id
+        assert bmsg.chat_title == "general"
+
+    @pytest.mark.asyncio
+    async def test_resolution_is_cached(self, mock_broker):
+        """Repeat messages from the same user/channel hit the cache, not the API."""
+        poller = _make_poller(mock_broker)
+        poller._adapter.get_user_info.return_value = {"display_name": "Bob"}
+        poller._adapter.get_channel_info.return_value = MagicMock(title="ops")
+        for _ in range(3):
+            await poller._handle_event(_event({
+                "type": "message", "user": "U7", "text": "x",
+                "channel": "C7", "channel_type": "channel", "ts": "1.1",
+            }))
+            await asyncio.sleep(0)
+        assert poller._adapter.get_user_info.call_count == 1
+        assert poller._adapter.get_channel_info.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_resolution_falls_back_to_raw_id_on_error(self, mock_broker):
+        """A transient API error must not break delivery: keep the raw id/empty title."""
+        poller = _make_poller(mock_broker)
+        poller._adapter.get_user_info.side_effect = Exception("network boom")
+        poller._adapter.get_channel_info.side_effect = Exception("network boom")
+        await poller._handle_event(_event({
+            "type": "message", "user": "U123", "text": "hi",
+            "channel": "C999", "channel_type": "channel", "ts": "1.1",
+        }))
+        await asyncio.sleep(0)
+        mock_broker.handle_inbound.assert_called_once()
+        bmsg = mock_broker.handle_inbound.call_args[0][0]
+        assert bmsg.sender_name == "U123"   # fell back to raw id
+        assert bmsg.sender_id == "U123"
+        assert bmsg.chat_title == ""
+
+    @pytest.mark.asyncio
+    async def test_missing_users_scope_disables_user_resolution(self, mock_broker):
+        """A missing_scope failure disables further users.info calls (no hammering)."""
+        poller = _make_poller(mock_broker)
+        poller._adapter.get_user_info.side_effect = Exception("missing_scope")
+        for uid in ("U1", "U2", "U3"):
+            await poller._handle_event(_event({
+                "type": "message", "user": uid, "text": "x",
+                "channel": "C1", "channel_type": "channel", "ts": "1.1",
+            }))
+            await asyncio.sleep(0)
+        assert poller._adapter.get_user_info.call_count == 1  # disabled after first
+        assert poller._users_read_ok is False
+
+    @pytest.mark.asyncio
+    async def test_channel_missing_scope_cached_per_channel(self, mock_broker):
+        """A channel scope failure is cached per-channel ("" title), not retried."""
+        poller = _make_poller(mock_broker)
+        poller._adapter.get_user_info.return_value = {"display_name": "Z"}
+        poller._adapter.get_channel_info.side_effect = Exception("missing_scope")
+        for _ in range(3):
+            await poller._handle_event(_event({
+                "type": "message", "user": "U9", "text": "x",
+                "channel": "C5", "channel_type": "channel", "ts": "1.1",
+            }))
+            await asyncio.sleep(0)
+        assert poller._adapter.get_channel_info.call_count == 1  # cached "" for C5
+        bmsg = mock_broker.handle_inbound.call_args[0][0]
+        assert bmsg.chat_title == ""
+
+    @pytest.mark.asyncio
+    async def test_bot_message_skips_user_resolution(self, mock_broker):
+        """Bot-authored messages (bot_id, no user) never call users.info."""
+        poller = _make_poller(mock_broker, bot_id="B_SELF")
+        poller._adapter.get_channel_info.return_value = MagicMock(title="general")
+        await poller._handle_event(_event({
+            "type": "message", "subtype": "bot_message", "bot_id": "B_PEER",
+            "username": "peerbot", "text": "hi", "channel": "C1",
+            "channel_type": "channel", "ts": "1.1",
+        }))
+        await asyncio.sleep(0)
+        poller._adapter.get_user_info.assert_not_called()
+        bmsg = mock_broker.handle_inbound.call_args[0][0]
+        assert bmsg.sender_name == "peerbot"  # username kept for bots
+        assert bmsg.chat_title == "general"
+
     @pytest.mark.asyncio
     async def test_non_events_api_request_acked_but_not_routed(self, monkeypatch, mock_broker):
         """A non-events_api envelope that carries an envelope_id (slash command /


### PR DESCRIPTION
## What
Wires up the new **users:read** + **channels:read** Slack scopes so inbound Slack messages carry a human **display name** and **channel title** instead of raw `U…` / `C…` ids.

## Changes
- **`SlackAdapter.get_user_info`** (`users.info`) — resolve a user id → display name / real name / email / is_bot. Email populated only when `users:read.email` is also granted.
- **`SlackAdapter.lookup_user_by_email`** (`users.lookupByEmail`) — the natural tool for routing a nudge to the right person by their directory/Zoho email (Chekov's milestone-owner routing).
- **`BrokerSlackPoller`** resolves `sender_name` (display name) + `chat_title` best-effort via cached lookups, replacing the prior `TODO(parity)` and the always-empty `chat_title`.

## Safety / invariants
- **`sender_id` is unchanged** — approval routing still keys on the raw id. Only the *cosmetic* `sender_name` / `chat_title` are enriched.
- **Fail-soft:** any resolution error falls back to the raw id / empty title — inbound delivery is **never** blocked.
- **No API hammering:** a `missing_scope` failure disables user lookups after the first hit; channel failures are cached per-channel (so a DM lacking `im:read` doesn't disable channel resolution everywhere).
- **Cached** for the poller's lifetime (renames are rare), one Slack call per distinct user/channel.

## Tests
`tests/test_slack.py` (adapter: success, display-name fallback, `missing_scope`, `users_not_found`) + `tests/test_slack_poller.py` (resolution, caching, transient-error fallback, scope-disable, bot-message skip). **Full slack suite: 46 passed**, ruff clean.

## Note
Backend-only (no UI) — verification evidence is the test suite + the before/after of the poller log line (`message from U7W8RJGP5` → `message from <Name>`). Deploys via the normal release pipeline; the live local fleet picks it up on the next `update_and_restart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)