### PR TITLE
fix(slack): form-encode read methods so id→name resolution works

### DIFF
--- a/src/pinky_outreach/slack.py
+++ b/src/pinky_outreach/slack.py
@@ -57,9 +57,37 @@ class SlackAdapter:
         return self._token
 
     def _request(self, method: str, **params) -> dict:
-        """Make a Slack Web API request."""
+        """Make a Slack Web API request (JSON body).
+
+        Fine for write methods like chat.postMessage that accept a JSON body.
+        Read/info methods (users.info, conversations.info, users.lookupByEmail)
+        must use ``_request_form`` instead — see that method's docstring.
+        """
         params = {k: v for k, v in params.items() if v is not None}
         resp = self._client.post(f"/{method}", json=params)
+        data = resp.json()
+
+        if not data.get("ok"):
+            raise SlackError(data.get("error", "unknown_error"))
+
+        return data
+
+    def _request_form(self, method: str, **params) -> dict:
+        """Make a Slack Web API request with form-encoded args.
+
+        Required for Slack's read/info methods (users.info, conversations.info,
+        users.lookupByEmail): those ignore a JSON request body, so a JSON call
+        arrives argument-less and Slack returns ``invalid_arguments`` or
+        ``*_not_found`` even with a valid token and scopes. They only read args
+        from the query string or an ``application/x-www-form-urlencoded`` body.
+        The client's default Content-Type is JSON, so override it per-request.
+        """
+        params = {k: v for k, v in params.items() if v is not None}
+        resp = self._client.post(
+            f"/{method}",
+            data=params,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
         data = resp.json()
 
         if not data.get("ok"):
@@ -282,7 +310,7 @@ class SlackAdapter:
 
     def get_channel_info(self, channel: str) -> Chat:
         """Get channel information."""
-        result = self._request("conversations.info", channel=channel)
+        result = self._request_form("conversations.info", channel=channel)
         ch = result.get("channel", {})
 
         # Determine type
@@ -313,7 +341,7 @@ class SlackAdapter:
         Returns a dict: user_id, name (handle), real_name, display_name
         (best human label, never empty when the user resolves), email, is_bot.
         """
-        result = self._request("users.info", user=user_id)
+        result = self._request_form("users.info", user=user_id)
         u = result.get("user", {}) or {}
         prof = u.get("profile", {}) or {}
         display = (
@@ -340,7 +368,7 @@ class SlackAdapter:
         natural tool for routing a nudge to the right person by their Zoho/
         directory email.
         """
-        result = self._request("users.lookupByEmail", email=email)
+        result = self._request_form("users.lookupByEmail", email=email)
         u = result.get("user", {}) or {}
         prof = u.get("profile", {}) or {}
         display = (

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -96,10 +96,18 @@ class TestSlackAdapter:
         assert info["real_name"] == "Alice Adams"
         assert info["email"] == "alice@example.com"
         assert info["is_bot"] is False
-        # called users.info with the user id
+        # called users.info with the user id, FORM-encoded: Slack read methods
+        # ignore a JSON body, so _request_form must send data= (not json=) with
+        # an x-www-form-urlencoded Content-Type. Regression guard for the bug
+        # where JSON-posted lookups returned user_not_found / invalid_arguments.
         assert adapter._client.post.call_args[0][0] == "/users.info"
-        payload = adapter._client.post.call_args.kwargs["json"]
+        assert "json" not in adapter._client.post.call_args.kwargs
+        payload = adapter._client.post.call_args.kwargs["data"]
         assert payload["user"] == "U123"
+        assert (
+            adapter._client.post.call_args.kwargs["headers"]["Content-Type"]
+            == "application/x-www-form-urlencoded"
+        )
         adapter.close()
 
     def test_get_user_info_display_name_falls_back_to_real_then_handle(self):
@@ -140,7 +148,8 @@ class TestSlackAdapter:
         assert info["display_name"] == "Carol"
         assert info["email"] == "carol@example.com"
         assert adapter._client.post.call_args[0][0] == "/users.lookupByEmail"
-        payload = adapter._client.post.call_args.kwargs["json"]
+        assert "json" not in adapter._client.post.call_args.kwargs
+        payload = adapter._client.post.call_args.kwargs["data"]
         assert payload["email"] == "carol@example.com"
         adapter.close()
 
@@ -151,6 +160,31 @@ class TestSlackAdapter:
         adapter._client.post = MagicMock(return_value=mock_response)
         with pytest.raises(SlackError):
             adapter.lookup_user_by_email("nobody@example.com")
+        adapter.close()
+
+    def test_get_channel_info_uses_form_encoding(self):
+        """conversations.info is a read method — must be form-encoded, not JSON.
+
+        Regression guard for the bug where a JSON body made Slack return
+        invalid_arguments (the channel arg never arrived), so chat_title fell
+        back to the raw C... id on every inbound message.
+        """
+        adapter = self._make_adapter()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "channel": {"id": "C123", "name": "orders-and-equipment"},
+        }
+        adapter._client.post = MagicMock(return_value=mock_response)
+        chat = adapter.get_channel_info("C123")
+        assert chat.title == "orders-and-equipment"
+        assert adapter._client.post.call_args[0][0] == "/conversations.info"
+        assert "json" not in adapter._client.post.call_args.kwargs
+        assert adapter._client.post.call_args.kwargs["data"]["channel"] == "C123"
+        assert (
+            adapter._client.post.call_args.kwargs["headers"]["Content-Type"]
+            == "application/x-www-form-urlencoded"
+        )
         adapter.close()
 
     def test_send_message_error(self):


### PR DESCRIPTION
## Problem

#807 added user/channel id→name resolution to the Socket Mode poller, but inbound messages still showed raw `U…`/`C…` ids. Root cause is one layer below the resolver: `SlackAdapter._request` posts **every** call as a JSON body (`Content-Type: application/json`). Slack's **read/info** methods (`users.info`, `conversations.info`, `users.lookupByEmail`) ignore a JSON body — the call arrives argument-less, so Slack returns `invalid_arguments` / `*_not_found` even with a valid token and the right scopes. `chat.postMessage` accepts JSON, which is exactly why **sending** always worked but these **new lookups** didn't.

Observed on prod (Chekov, Pi) after #807 deployed:
```
slack-poller[chekov]: users.info(U7W8RJGP5) failed: Slack API error: user_not_found
slack-poller[chekov]: conversations.info(C0BBT4WAYVA) failed: Slack API error: invalid_arguments
slack-poller[chekov]: message from U7W8RJGP5 in C0BBT4WAYVA: What's the name of this channel?
```

The identical token + ids succeed when sent as form/query (ground-truth probe):
```
users.info(U7W8RJGP5)          → ok: "Brad Brockman"
conversations.info(C0BBT4WAYVA) → ok: "bot-testing"
conversations.info(CMYGW146S)   → ok: "orders-and-equipment"
```

## Fix

Add `SlackAdapter._request_form` — POSTs `data=` with an explicit `application/x-www-form-urlencoded` Content-Type (overriding the client's default JSON header) — and route the three read methods through it. The JSON `_request` send path (`chat.postMessage`) is **byte-for-byte unchanged**, so fleet-wide Slack sending is unaffected.

## Tests

- `users.info` / `users.lookupByEmail` tests now assert form-encoding (`data=`, not `json=`) + the form Content-Type.
- New `test_get_channel_info_uses_form_encoding` regression test.
- `pytest -k "poller or slack" -q` → **177 passed, 1 skipped**.

## Deploy

Follow-up to #807 (shipped in 26.06.137). Will cut a release + redeploy to the Pi, then confirm live with a real message.

🤖 Opened by Barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)
