### PR TITLE
fix(broker): platform-aware inbound attachment download — Slack/Discord files (#222)

### DIFF
--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1323,7 +1323,30 @@ class MessageBroker:
         else:
             await self._send_message(agent_name, platform, chat_id, stripped)
 
-    _DOWNLOADABLE_TYPES = {"photo", "document", "video", "animation", "sticker"}
+    # "file" is what Slack and Discord tag every inbound attachment as; the
+    # rest are Telegram's media kinds. (Voice is handled separately.)
+    _DOWNLOADABLE_TYPES = {"photo", "document", "video", "animation", "sticker", "file"}
+
+    @staticmethod
+    def _attachment_download_adapter(platform: str, raw_token: str):
+        """Return ``(adapter, ref_key)`` for downloading inbound attachments.
+
+        Each platform's ``download_file()`` takes a different first argument:
+        Telegram resolves a ``file_id`` via getFile, while Slack and Discord
+        fetch a direct (token-authorized) URL. ``ref_key`` is the attachment
+        field holding that argument. Returns ``(None, "")`` for a platform with
+        no attachment-download support.
+        """
+        if platform == "telegram":
+            from pinky_outreach.telegram import TelegramAdapter
+            return TelegramAdapter(raw_token), "file_id"
+        if platform == "slack":
+            from pinky_outreach.slack import SlackAdapter
+            return SlackAdapter(raw_token), "url"
+        if platform == "discord":
+            from pinky_outreach.discord import DiscordAdapter
+            return DiscordAdapter(raw_token), "url"
+        return None, ""
 
     async def _download_photo_attachments(
         self, agent_name: str, message: BrokerMessage,
@@ -1334,7 +1357,7 @@ class MessageBroker:
 
         downloadable = [
             a for a in message.attachments
-            if a.get("type") in self._DOWNLOADABLE_TYPES and a.get("file_id")
+            if a.get("type") in self._DOWNLOADABLE_TYPES
         ]
         if not downloadable:
             return
@@ -1352,15 +1375,25 @@ class MessageBroker:
         dest_dir = os.path.join(agent.working_dir, "attachments")
         os.makedirs(dest_dir, exist_ok=True)
 
-        from pinky_outreach.telegram import TelegramAdapter
-        adapter = TelegramAdapter(raw_token)
+        adapter, ref_key = self._attachment_download_adapter(message.platform, raw_token)
+        if adapter is None:
+            _log(
+                f"broker: no attachment-download support for platform "
+                f"{message.platform}, skip attachments"
+            )
+            return
 
         for att in downloadable:
+            # Telegram needs a file_id; Slack/Discord need a url. Skip any
+            # attachment missing the identifier this platform's adapter wants.
+            ref = att.get(ref_key)
+            if not ref:
+                continue
             try:
                 # download_file is sync (blocking httpx GET) -- offload so a
                 # multi-MB download doesn't freeze the daemon event loop.
                 local_path = await asyncio.to_thread(
-                    adapter.download_file, att["file_id"], dest_dir=dest_dir,
+                    adapter.download_file, ref, dest_dir=dest_dir,
                 )
                 local_path = os.path.abspath(local_path)
                 att["local_path"] = local_path

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1180,6 +1180,50 @@ class TestEventLoopOffload:
         finally:
             tmpdir.cleanup()
 
+    async def test_download_photo_attachments_slack_uses_url(self, monkeypatch):
+        """Slack tags every inbound attachment ``type="file"`` and downloads via
+        a ``url_private_download`` URL through the SlackAdapter -- NOT a file_id
+        through the TelegramAdapter. Regression for the Telegram-hardcoded
+        download path that left Chekov unable to read inbound Slack files."""
+        import os
+
+        from pinky_outreach.slack import SlackAdapter
+
+        tmpdir, registry, broker, _ = self._make_broker()
+        try:
+            registry.set_token("barsik", "slack", "xoxb-123")
+            seen: dict = {}
+
+            def fake_download(self, url, dest_dir=""):
+                seen["url"] = url
+                return os.path.join(dest_dir, "report.md")
+
+            monkeypatch.setattr(SlackAdapter, "download_file", fake_download)
+
+            url = "https://files.slack.com/files-pri/T-F123/download/report.md"
+            msg = BrokerMessage(
+                platform="slack",
+                chat_id="C0BBT4WAYVA",
+                sender_name="Brad",
+                sender_id="U1",
+                content="here's the doc",
+                agent_name="barsik",
+                attachments=[{
+                    "type": "file",
+                    "file_id": "F123",
+                    "url": url,
+                    "file_name": "report.md",
+                }],
+            )
+            await broker._download_photo_attachments("barsik", msg)
+
+            assert seen.get("url") == url, (
+                "Slack download must use url_private_download, not the file_id"
+            )
+            assert msg.attachments[0]["local_path"].endswith("report.md")
+        finally:
+            tmpdir.cleanup()
+
     @pytest.mark.asyncio
     async def test_try_voice_reply_uses_daemon_url_and_offloads(self, monkeypatch):
         """The voice-reply HTTP loopback targets THIS process: a sync urlopen


### PR DESCRIPTION
## Problem
Brad reported Chekov (Slack agent, #222) can't read or send files over Slack.

**Reading inbound files was fully broken in code.** `broker._download_photo_attachments`:
- filtered attachments by `type in {photo, document, video, animation, sticker}` — but Slack **and** Discord tag every inbound attachment `type="file"`, so they were dropped before download even ran.
- hardcoded `TelegramAdapter` for every platform and passed `att["file_id"]` — but Slack/Discord `download_file()` expect a token-authorized **URL** (`url_private_download`), not a Telegram file_id.

Net: inbound Slack (and Discord) files never downloaded.

**Sending files was already wired** (`_send_file_message` → `SlackAdapter.upload_file`). The Pi logs show that failure is a missing `files:write` scope on Chekov's Slack app (also a `reactions:write` gap) — an app-side config fix Brad is making, not code.

## Fix
- Add `"file"` to `_DOWNLOADABLE_TYPES`.
- Add `_attachment_download_adapter(platform, token) -> (adapter, ref_key)`:
  telegram → `TelegramAdapter` + `file_id`; slack → `SlackAdapter` + `url`; discord → `DiscordAdapter` + `url`. Unknown platforms skip cleanly with a log line.
- Skip attachments missing the per-platform identifier (preserves the previous Telegram `file_id` guard).

## Test evidence
No UI surface (backend message-path fix), so the evidence is the test run:

```
$ PYTHONPATH=src python3 -m pytest tests/test_broker.py -q
.........................................                                [100%]
41 passed in 1.44s
```

- New `test_download_photo_attachments_slack_uses_url`: a Slack `type="file"` attachment downloads via `SlackAdapter` using `url_private_download`, not the file_id.
- Existing Telegram offload test unchanged & green.

## Scope note
Discord inbound files are fixed by the same change (same `type="file"` + url shape). Verifying the Discord broker poller actually populates `BrokerMessage.attachments` is out of scope here.

🤖 Opened by Barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)
