### PR TITLE
fix(broker): never auto-deliver plain-text fallback to group/public channels (Chekov Slack leak)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1420,7 +1420,11 @@ class AgentRegistry:
         migrations = [
             ("auto_start", "INTEGER NOT NULL DEFAULT 0"),
             ("heartbeat_interval", "INTEGER NOT NULL DEFAULT 0"),
-            ("plain_text_fallback", "INTEGER NOT NULL DEFAULT 1"),
+            # Off by default — must match the dataclass + CREATE TABLE default (0).
+            # A DEFAULT 1 here silently backfilled every pre-existing agent with
+            # fallback ON, which leaked their internal reasoning into chats (the
+            # broker also hard-gates fallback on group/public channels).
+            ("plain_text_fallback", "INTEGER NOT NULL DEFAULT 0"),
             ("role", "TEXT NOT NULL DEFAULT ''"),
             ("users", "TEXT NOT NULL DEFAULT ''"),
             ("boundaries", "TEXT NOT NULL DEFAULT ''"),

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1315,20 +1315,32 @@ class MessageBroker:
         if not stripped or not fallback_enabled or not chat_id:
             return
 
-        # Never auto-deliver the plain-text fallback to a group/public channel.
-        # When an agent decides to stay silent it often "thinks out loud" (emits
-        # reasoning text without calling an outreach tool); the fallback would
-        # then post that internal deliberation to a shared channel — exactly the
-        # leak seen with Chekov on Slack. The fallback is a convenience for owner
-        # DMs only. The inbound message's is_group is stored at dispatch time in
-        # remember_message_context(), so this has no cold-start gap.
-        ctx = self.get_message_context(agent_name, message_id) if message_id else None
-        if ctx and ctx.is_group:
-            _log(
-                f"broker: suppressed plain-text fallback for {agent_name} on "
-                f"group chat {platform}/{chat_id} (no leak to public channel)"
-            )
-            return
+        # Plain-text fallback must FAIL CLOSED on any platform that could be a
+        # shared/public channel. When an agent decides to stay silent it often
+        # "thinks out loud" (emits reasoning text without calling an outreach
+        # tool); blindly delivering that text leaks internal deliberation to the
+        # channel — the Chekov-on-Slack leak. So on external platforms we only
+        # auto-deliver when we have POSITIVE confirmation this is a 1:1 DM: a
+        # MessageContext (stored at dispatch in remember_message_context) that
+        # matches this platform+chat and is not a group. Absence, a
+        # platform/chat mismatch (e.g. a colliding per-chat message_id from
+        # another conversation), or a group context all suppress. Owner-only
+        # surfaces (web/api/internal) are never public channels and carry no
+        # message_id/context, so they keep the fallback convenience.
+        _non_public_platforms = {"web", "api", ""}
+        if platform not in _non_public_platforms:
+            ctx = self.get_message_context(agent_name, message_id) if message_id else None
+            if (
+                ctx is None
+                or ctx.platform != platform
+                or ctx.chat_id != chat_id
+                or ctx.is_group
+            ):
+                _log(
+                    f"broker: suppressed plain-text fallback for {agent_name} on "
+                    f"{platform}/{chat_id} — no positive 1:1 DM context (fail-closed)"
+                )
+                return
 
         voice_key = (agent_name, chat_id)
         if self._voice_pending.pop(voice_key, False):

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1315,6 +1315,21 @@ class MessageBroker:
         if not stripped or not fallback_enabled or not chat_id:
             return
 
+        # Never auto-deliver the plain-text fallback to a group/public channel.
+        # When an agent decides to stay silent it often "thinks out loud" (emits
+        # reasoning text without calling an outreach tool); the fallback would
+        # then post that internal deliberation to a shared channel — exactly the
+        # leak seen with Chekov on Slack. The fallback is a convenience for owner
+        # DMs only. The inbound message's is_group is stored at dispatch time in
+        # remember_message_context(), so this has no cold-start gap.
+        ctx = self.get_message_context(agent_name, message_id) if message_id else None
+        if ctx and ctx.is_group:
+            _log(
+                f"broker: suppressed plain-text fallback for {agent_name} on "
+                f"group chat {platform}/{chat_id} (no leak to public channel)"
+            )
+            return
+
         voice_key = (agent_name, chat_id)
         if self._voice_pending.pop(voice_key, False):
             sent_voice = await self._try_voice_reply(agent_name, platform, chat_id, stripped)

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -44,6 +44,20 @@ class TestMessageBrokerRouting:
     async def test_route_response_sends_plain_text_when_fallback_enabled(self):
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
+            # Fallback is fail-closed: it only delivers with a positive matching
+            # 1:1 DM context (stored at dispatch).
+            broker.remember_message_context(
+                BrokerMessage(
+                    platform="telegram",
+                    chat_id="6770805286",
+                    sender_name="Brad",
+                    sender_id="u-1",
+                    content="ping",
+                    agent_name="barsik",
+                    message_id="42",
+                    is_group=False,
+                )
+            )
             await broker.route_response(
                 "barsik",
                 "telegram",
@@ -155,6 +169,82 @@ class TestMessageBrokerRouting:
 
             assert sent_messages == [
                 ("barsik", "telegram", "6770805286", "Replying in a DM via fallback"),
+            ]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_response_suppresses_fallback_when_no_context(self):
+        # Fail-closed: with no positive DM context for an external platform, the
+        # fallback must NOT auto-deliver (absence is not authorization).
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            await broker.route_response(
+                "barsik",
+                "telegram",
+                "-100groupchat",
+                "reasoning with no stored context",
+                message_id="not-remembered",
+                used_outreach=False,
+                fallback_enabled=True,
+            )
+
+            assert sent_messages == []
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_response_suppresses_fallback_on_context_collision(self):
+        # Per-chat message ids collide: a DM context overwrites a group context
+        # with the same message_id. Routing the group turn must still suppress —
+        # the stored ctx.chat_id no longer matches the group chat (fail-closed).
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            broker.remember_message_context(
+                BrokerMessage(
+                    platform="telegram", chat_id="-100public", sender_name="x",
+                    sender_id="u-1", content="group msg", agent_name="barsik",
+                    message_id="42", is_group=True,
+                )
+            )
+            broker.remember_message_context(  # same message_id, overwrites
+                BrokerMessage(
+                    platform="telegram", chat_id="6770805286", sender_name="Brad",
+                    sender_id="u-2", content="dm msg", agent_name="barsik",
+                    message_id="42", is_group=False,
+                )
+            )
+            await broker.route_response(
+                "barsik",
+                "telegram",
+                "-100public",
+                "internal hold reasoning",
+                message_id="42",
+                used_outreach=False,
+                fallback_enabled=True,
+            )
+
+            assert sent_messages == []
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_response_allows_fallback_on_web_without_context(self):
+        # Owner-only surfaces (web/api/internal) are never public channels and
+        # carry no message context — the fallback convenience is preserved.
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            await broker.route_response(
+                "barsik",
+                "web",
+                "web",
+                "web console reply via fallback",
+                used_outreach=False,
+                fallback_enabled=True,
+            )
+
+            assert sent_messages == [
+                ("barsik", "web", "web", "web console reply via fallback"),
             ]
         finally:
             tmpdir.cleanup()

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -95,6 +95,71 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
+    async def test_route_response_suppresses_fallback_on_group_chat(self):
+        # An agent's reasoning must NEVER auto-deliver to a group/public channel,
+        # even with fallback enabled — regression guard for the Chekov Slack leak.
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            broker.remember_message_context(
+                BrokerMessage(
+                    platform="slack",
+                    chat_id="C0PUBLIC",
+                    sender_name="teammate",
+                    sender_id="u-9",
+                    content="team chatter",
+                    agent_name="barsik",
+                    message_id="555",
+                    is_group=True,
+                )
+            )
+            await broker.route_response(
+                "barsik",
+                "slack",
+                "C0PUBLIC",
+                "This isn't directed at me, I'll hold and stay quiet.",
+                message_id="555",
+                used_outreach=False,
+                fallback_enabled=True,
+            )
+
+            assert sent_messages == []
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_response_allows_fallback_on_dm_context(self):
+        # Fallback convenience still works in a 1:1 DM (is_group False).
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            broker.remember_message_context(
+                BrokerMessage(
+                    platform="telegram",
+                    chat_id="6770805286",
+                    sender_name="Brad",
+                    sender_id="u-1",
+                    content="hey",
+                    agent_name="barsik",
+                    message_id="556",
+                    is_group=False,
+                )
+            )
+            await broker.route_response(
+                "barsik",
+                "telegram",
+                "6770805286",
+                "Replying in a DM via fallback",
+                message_id="556",
+                used_outreach=False,
+                fallback_enabled=True,
+            )
+
+            assert sent_messages == [
+                ("barsik", "telegram", "6770805286", "Replying in a DM via fallback"),
+            ]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
     async def test_inject_agent_message_stamps_last_seen_on_success(self):
         tmpdir, registry, broker, _, _ = self._make_broker()
         try:


### PR DESCRIPTION
## The bug
Brad caught **Chekov posting its internal hold-reasoning to a public Slack channel**: after Brad tagged six human teammates ("reply back here please"), Chekov replied to the channel with _"This message is Brad rallying the human team members… it's not directed at me… Staying in listen-mode, I'll hold and let the team respond."_ — it "thought out loud" about staying silent, and that deliberation got auto-posted to the shared channel.

## Root cause — two coupled bugs
**1. Migration default mismatch.** `plain_text_fallback` (auto-deliver an agent's plain text when it doesn't call an outreach tool) is meant to default **OFF**: the dataclass field and `CREATE TABLE` both use `DEFAULT 0`. But the `_ensure_columns` migration that adds the column to existing DBs used **`DEFAULT 1`**, so every pre-existing agent was silently backfilled with fallback **ON** — **6 of 9 agents** on the Pi fleet (chekov, daria, lera, luka, olga, yarik).

**2. No channel-type gate.** `route_response()` delivered the fallback regardless of channel type, so a fallback-on agent that emitted reasoning text on a **group/public** channel had it posted there.

## The fix (fail-closed, after review)
- `agent_registry.py`: migration default `1 → 0`.
- `broker.route_response()`: the plain-text fallback now **fails closed** on any external (potentially-public) platform. It auto-delivers only with a **positive matching 1:1 DM context** — a `MessageContext` (stored at dispatch in `remember_message_context`) whose `platform` and `chat_id` match this turn and whose `is_group` is false. **Absence**, a **platform/chat mismatch** (e.g. a colliding per-chat `message_id` from another conversation), or a **group context** all suppress. Owner-only surfaces (`web`/`api`/internal) are never public channels and carry no message context, so they keep the fallback convenience.

This closes the fail-open hole Murzik flagged: a DM context could overwrite a group context sharing the same `message_id` and re-authorize a public fallback. Slack public channels carry `is_group=True` (`pollers.py:965`).

## Immediate mitigation (already applied out-of-band)
Flipped `chekov.plain_text_fallback → 0` directly on the Pi DB to stop the live leak. `AgentRegistry.get()` re-reads per-turn, so it took effect immediately — no restart.

## Tests
```
tests/test_broker.py  -> 46 passed
  + suppresses_fallback_on_group_chat         (group ctx              -> suppressed)
  + allows_fallback_on_dm_context             (matching DM ctx        -> delivered)
  + suppresses_fallback_when_no_context       (fail-closed            -> suppressed)
  + suppresses_fallback_on_context_collision  (DM/group id collision  -> suppressed)
  + allows_fallback_on_web_without_context    (owner console          -> delivered)
tests/test_agent_registry.py  -> 101 passed
```

Reviewed and approved by Murzik (Codex). Known limitation (non-blocking): the migration default fix is forward-only; pre-existing rows already populated as `1` are not repaired, but the fail-closed gate is the real safety boundary so those are harmless (DM fallback only; public channels gated).

🤖 Opened by Barsik
