### PR TITLE
fix(broker): route approved group/channel replies to the channel, not the sender's DM

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1255,6 +1255,7 @@ class AgentRegistry:
                 agent_name TEXT NOT NULL,
                 platform TEXT NOT NULL,
                 chat_id TEXT NOT NULL,
+                reply_chat_id TEXT NOT NULL DEFAULT '',
                 sender_name TEXT NOT NULL DEFAULT '',
                 content TEXT NOT NULL,
                 created_at REAL NOT NULL,
@@ -1545,6 +1546,25 @@ class AgentRegistry:
                 "ALTER TABLE agent_contexts ADD COLUMN wake_action TEXT NOT NULL DEFAULT ''"
             )
             _log("agent_registry: migrated — added wake_action to agent_contexts")
+
+        # Migrate pending_messages table — reply_chat_id preserves the true reply
+        # destination (e.g. the Slack/Telegram channel a group message arrived in).
+        # The chat_id column is the per-user approval key (the sender's id); in a
+        # group/channel that differs from the destination, so without a separate
+        # field a held message would be re-delivered to the sender's DM instead of
+        # the channel. Backfill to chat_id so pre-existing rows keep their prior
+        # (DM-correct) behavior.
+        pm_existing = {
+            row[1] for row in self._db.execute("PRAGMA table_info(pending_messages)").fetchall()
+        }
+        if "reply_chat_id" not in pm_existing:
+            self._db.execute(
+                "ALTER TABLE pending_messages ADD COLUMN reply_chat_id TEXT NOT NULL DEFAULT ''"
+            )
+            self._db.execute(
+                "UPDATE pending_messages SET reply_chat_id=chat_id WHERE reply_chat_id=''"
+            )
+            _log("agent_registry: migrated — added reply_chat_id to pending_messages")
 
         # Seed main_agent default: if unset, adopt the oldest enabled agent.
         # New installs get their main agent auto-assigned at create time (see
@@ -3447,15 +3467,23 @@ except Exception:
 
     def queue_pending_message(
         self, agent_name: str, platform: str, chat_id: str,
-        sender_name: str, content: str,
+        sender_name: str, content: str, reply_chat_id: str = "",
     ) -> int:
-        """Queue a message from a pending user. Returns the message ID."""
+        """Queue a message from a pending user. Returns the message ID.
+
+        ``chat_id`` is the per-user approval key (the sender's id) — pending
+        messages are looked up and approved by it. ``reply_chat_id`` is where
+        the eventual reply should be delivered; for a group/channel message
+        that's the channel id, which differs from the sender. Defaults to
+        ``chat_id`` (correct for 1:1 DMs where sender == destination).
+        """
         now = time.time()
+        dest = reply_chat_id or chat_id
         cursor = self._db.execute(
             """INSERT INTO pending_messages
-               (agent_name, platform, chat_id, sender_name, content, created_at)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (agent_name, platform, chat_id, sender_name, content, now),
+               (agent_name, platform, chat_id, reply_chat_id, sender_name, content, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (agent_name, platform, chat_id, dest, sender_name, content, now),
         )
         self._db.commit()
         return cursor.lastrowid
@@ -3466,7 +3494,8 @@ except Exception:
         """Get undelivered pending messages. If chat_id given, filter by it."""
         if chat_id:
             rows = self._db.execute(
-                """SELECT id, agent_name, platform, chat_id, sender_name, content, created_at
+                """SELECT id, agent_name, platform, chat_id, reply_chat_id,
+                          sender_name, content, created_at
                    FROM pending_messages
                    WHERE agent_name=? AND chat_id=? AND delivered=0
                    ORDER BY created_at ASC""",
@@ -3474,7 +3503,8 @@ except Exception:
             ).fetchall()
         else:
             rows = self._db.execute(
-                """SELECT id, agent_name, platform, chat_id, sender_name, content, created_at
+                """SELECT id, agent_name, platform, chat_id, reply_chat_id,
+                          sender_name, content, created_at
                    FROM pending_messages
                    WHERE agent_name=? AND delivered=0
                    ORDER BY created_at ASC""",
@@ -3483,8 +3513,8 @@ except Exception:
         return [
             {
                 "id": r[0], "agent_name": r[1], "platform": r[2],
-                "chat_id": r[3], "sender_name": r[4], "content": r[5],
-                "created_at": r[6],
+                "chat_id": r[3], "reply_chat_id": r[4] or r[3],
+                "sender_name": r[5], "content": r[6], "created_at": r[7],
             }
             for r in rows
         ]

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -928,6 +928,7 @@ class MessageBroker:
                     agent_name=agent_name,
                     platform=message.platform,
                     chat_id=user_id,
+                    reply_chat_id=message.chat_id,
                     sender_name=message.sender_name,
                     content=message.content,
                 )
@@ -1046,13 +1047,18 @@ class MessageBroker:
             _log(f"broker: delivered 0/0 pending messages for {chat_id} to {agent_name}")
             return 0
 
-        # Route pending messages through streaming
+        # Route pending messages through streaming. Deliver to reply_chat_id
+        # (the original destination — the channel for a group message), NOT the
+        # chat_id column, which is the per-user approval key (the sender's id).
+        # Using chat_id here would re-route a held channel reply to the sender's
+        # DM. sender_id is restored from the approval key so group context (and
+        # the reply hint) reflect the right surface.
         for msg in pending:
             broker_msg = BrokerMessage(
                 platform=msg["platform"],
-                chat_id=msg["chat_id"],
+                chat_id=msg["reply_chat_id"],
                 sender_name=msg["sender_name"],
-                sender_id="",
+                sender_id=msg["chat_id"],
                 content=msg["content"],
                 agent_name=agent_name,
                 timestamp=msg["created_at"],

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -715,13 +715,19 @@ class MessageBroker:
             return False
 
         text = message.content.strip()
-        cmd = text.split()[0].lower()
+        # Match the command prefix case-insensitively, but preserve the RAW case
+        # of the target id — Slack user ids are uppercase (e.g. U774M8XDE) and the
+        # pending row is keyed under the exact id. Lowercasing the whole token
+        # approved a phantom lowercased user, delivered 0 held messages, and left
+        # the real user pending (so the channel reply never went out).
+        raw_cmd = text.split()[0]
+        cmd = raw_cmd.lower()
 
         if cmd.startswith("/approve_"):
-            target_chat_id = cmd[len("/approve_"):]
+            target_chat_id = raw_cmd[len("/approve_"):]
             action = "approve"
         elif cmd.startswith("/deny_"):
-            target_chat_id = cmd[len("/deny_"):]
+            target_chat_id = raw_cmd[len("/deny_"):]
             action = "deny"
         else:
             return False

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -348,6 +348,126 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
+    async def test_group_pending_reply_routes_to_channel_not_sender_dm(self, monkeypatch):
+        """Regression (Chekov Slack channel leak follow-up): a held message that
+        arrived in a group/channel must, on approval, be re-delivered to the
+        CHANNEL — not the sender's DM. The pending row keys approval on the
+        sender's user id but must preserve the channel as the reply destination
+        (reply_chat_id). Before the fix, queue stored chat_id=sender_id and
+        re-delivery routed the reply to the sender's DM, so channel replies
+        silently vanished from the channel."""
+        tmpdir, registry, broker, sent_messages, _ = self._make_broker()
+        try:
+            routed: list[BrokerMessage] = []
+
+            async def _fake_route(agent_name, message):
+                routed.append(message)
+
+            monkeypatch.setattr(broker, "_route_streaming", _fake_route)
+            registry.set_primary_user("owner-1", display_name="Brad")
+
+            channel = "C0A8WUU743F"
+            user = "U774M8XDE"
+            # A PM messages IN the channel: chat_id=channel, sender_id=user.
+            await broker.handle_inbound(
+                BrokerMessage(
+                    platform="slack",
+                    chat_id=channel,
+                    sender_name="Alex Ugrin",
+                    sender_id=user,
+                    content="Hi",
+                    agent_name="barsik",
+                    is_group=True,
+                )
+            )
+
+            # Held pending under the sender's user id, not routed yet.
+            assert registry.get_user_status("barsik", user) == "pending"
+            assert routed == []
+            # The "waiting for approval" notice goes to the channel it arrived in.
+            assert any(
+                m[1] == "slack" and m[2] == channel and "Waiting for approval" in m[3]
+                for m in sent_messages
+            )
+            # The pending row separates the approval key from the destination.
+            pending = registry.get_pending_messages("barsik", user)
+            assert len(pending) == 1
+            assert pending[0]["chat_id"] == user           # approval key (sender)
+            assert pending[0]["reply_chat_id"] == channel  # reply destination
+
+            # Owner approves → held message re-delivers.
+            registry.approve_user("barsik", user, display_name="Alex Ugrin")
+            delivered = await broker.handle_approval("barsik", user)
+
+            assert delivered == 1
+            assert len(routed) == 1
+            # THE FIX: re-delivered to the channel, with the sender restored —
+            # NOT routed to the sender's DM (user id).
+            assert routed[0].chat_id == channel
+            assert routed[0].sender_id == user
+            assert routed[0].content == "Hi"
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_dm_pending_reply_routes_back_to_sender(self, monkeypatch):
+        """DM (1:1): sender == destination. A held DM re-delivers to the same
+        chat on approval — reply_chat_id defaults to chat_id, so DM behavior is
+        unchanged by the group-routing fix."""
+        tmpdir, registry, broker, _sent, _ = self._make_broker()
+        try:
+            routed: list[BrokerMessage] = []
+
+            async def _fake_route(agent_name, message):
+                routed.append(message)
+
+            monkeypatch.setattr(broker, "_route_streaming", _fake_route)
+            registry.set_primary_user("owner-1", display_name="Brad")
+
+            dm_user = "999"
+            await broker.handle_inbound(
+                BrokerMessage(
+                    platform="telegram",
+                    chat_id=dm_user,
+                    sender_name="Stranger",
+                    sender_id=dm_user,
+                    content="let me in",
+                    agent_name="barsik",
+                )
+            )
+            assert registry.get_user_status("barsik", dm_user) == "pending"
+            pending = registry.get_pending_messages("barsik", dm_user)
+            assert pending[0]["reply_chat_id"] == dm_user  # defaulted to chat_id
+
+            registry.approve_user("barsik", dm_user, display_name="Stranger")
+            delivered = await broker.handle_approval("barsik", dm_user)
+            assert delivered == 1
+            assert routed[0].chat_id == dm_user
+            assert routed[0].sender_id == dm_user
+        finally:
+            tmpdir.cleanup()
+
+    def test_queue_pending_message_preserves_reply_chat_id(self):
+        """reply_chat_id is stored distinctly from the approval-key chat_id, and
+        defaults to chat_id when omitted (the DM case)."""
+        tmpdir, registry, _broker, _sent, _ = self._make_broker()
+        try:
+            registry.queue_pending_message(
+                agent_name="barsik", platform="slack", chat_id="Uuser",
+                sender_name="Alex", content="hi", reply_chat_id="Cchan",
+            )
+            registry.queue_pending_message(
+                agent_name="barsik", platform="telegram", chat_id="999",
+                sender_name="Stranger", content="yo",
+            )
+            rows = registry.get_pending_messages("barsik")
+            by_user = {r["chat_id"]: r for r in rows}
+            assert by_user["Uuser"]["reply_chat_id"] == "Cchan"
+            assert by_user["999"]["reply_chat_id"] == "999"
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
     async def test_route_streaming_waits_for_in_flight_reconnect(self, monkeypatch):
         """Regression: messages arriving during ``context_restart`` (where the
         streaming session object exists but ``state`` is briefly != CONNECTED

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -468,6 +468,55 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
+    async def test_slash_approve_preserves_uppercase_slack_id(self, monkeypatch):
+        """Regression: /approve_<id> must preserve the EXACT case of the target
+        id. Slack user ids are uppercase (U774M8XDE); lowercasing the whole
+        command token approved a phantom lowercased user, delivered 0 held
+        messages, and left the real user pending — so the channel reply never
+        went out. This exercises the real owner-notification flow end-to-end."""
+        tmpdir, registry, broker, sent_messages, _ = self._make_broker()
+        try:
+            routed: list[BrokerMessage] = []
+
+            async def _fake_route(agent_name, message):
+                routed.append(message)
+
+            monkeypatch.setattr(broker, "_route_streaming", _fake_route)
+            owner = "owner-1"
+            registry.set_primary_user(owner, display_name="Brad")
+
+            channel = "C0A8WUU743F"
+            user = "U774M8XDE"
+            # PM messages in the channel → held pending under the exact id.
+            await broker.handle_inbound(
+                BrokerMessage(
+                    platform="slack", chat_id=channel, sender_name="Alex Ugrin",
+                    sender_id=user, content="Hi", agent_name="barsik", is_group=True,
+                )
+            )
+            assert registry.get_user_status("barsik", user) == "pending"
+
+            # Owner approves exactly as the notification prints it: /approve_U…
+            await broker.handle_inbound(
+                BrokerMessage(
+                    platform="slack", chat_id=owner, sender_name="Brad",
+                    sender_id=owner, content=f"/approve_{user}", agent_name="barsik",
+                )
+            )
+
+            # The exact uppercase id is approved — no lowercased phantom user.
+            assert registry.get_user_status("barsik", user) == "approved"
+            assert registry.get_user_status("barsik", user.lower()) is None
+            # The held channel message is delivered to the CHANNEL.
+            assert len(routed) == 1
+            assert routed[0].chat_id == channel
+            assert routed[0].content == "Hi"
+            # Owner saw a non-zero delivery count (not "0 pending message(s)").
+            assert any("1 pending message" in m[3] for m in sent_messages)
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
     async def test_route_streaming_waits_for_in_flight_reconnect(self, monkeypatch):
         """Regression: messages arriving during ``context_restart`` (where the
         streaming session object exists but ``state`` is briefly != CONNECTED


### PR DESCRIPTION
## Problem
The Chekov Slack agent received messages in a public channel but its replies never appeared there — Brad: *"chekov's messages didn't reach slack channel."*

## Root cause
`pending_messages.chat_id` was overloaded as **both** the per-user approval key **and** the reply destination — equal for 1:1 DMs, divergent for group/channels.

For an unapproved user messaging **in a channel**:
1. inbound: `chat_id=C0A8WUU743F` (channel), `sender_id=U…` (user) ✅
2. queued pending with `chat_id=user_id` (the approval key) ❌ — channel destination lost
3. `/approve_<user_id>` → `handle_approval` rebuilds `BrokerMessage(chat_id=user_id)`
4. the broker's reply hint then tells the agent `send(chat_id="U…")` → reply lands in the **sender's DM**, not the channel

Logs confirmed: inbound `slack-poller[chekov]: message from … in C0A8WUU743F`, but `broker: route_response for chekov (slack/U09H7NP0WBC)` (and the other PMs' user-ids).

## Fix
Add a `reply_chat_id` column to `pending_messages` = the true reply destination (the channel for group messages). `chat_id` stays the approval key. `handle_approval` re-delivers to `reply_chat_id` and restores `sender_id`. DM behavior is unchanged — `reply_chat_id` defaults to `chat_id`. Idempotent migration backfills existing rows (`reply_chat_id = chat_id`), preserving prior DM-correct behavior; pre-fix group rows can't recover their original channel but new traffic is correct.

## Tests
- `test_group_pending_reply_routes_to_channel_not_sender_dm` — the regression
- `test_dm_pending_reply_routes_back_to_sender` — DM path unchanged
- `test_queue_pending_message_preserves_reply_chat_id` — registry unit

49 broker tests + 180 registry/ferry/sweep tests pass locally; ruff clean.

## No UI to screenshot
Backend routing fix — no UI surface. Evidence is the Pi log pattern above (inbound-in-channel vs reply-to-user-DM) and the passing regression test.

## Deliberately NOT in this PR (flagged to Brad — behavioral/product calls)
- "Request sent! Waiting for approval." posting into the channel + doubling (approval UX)
- owner-notify `channel_not_found` for Slack agents

🤖 Opened by Barsik