### PR TITLE
feat(broker): channel-level approval — approve a channel once, all members flow

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1256,6 +1256,8 @@ class AgentRegistry:
                 platform TEXT NOT NULL,
                 chat_id TEXT NOT NULL,
                 reply_chat_id TEXT NOT NULL DEFAULT '',
+                is_group INTEGER NOT NULL DEFAULT 0,
+                sender_id TEXT NOT NULL DEFAULT '',
                 sender_name TEXT NOT NULL DEFAULT '',
                 content TEXT NOT NULL,
                 created_at REAL NOT NULL,
@@ -1565,6 +1567,25 @@ class AgentRegistry:
                 "UPDATE pending_messages SET reply_chat_id=chat_id WHERE reply_chat_id=''"
             )
             _log("agent_registry: migrated — added reply_chat_id to pending_messages")
+        # is_group lets a held group/channel message re-deliver with the correct
+        # group context on approval (so the prompt header + fallback gate treat
+        # it as a channel, not a DM). Defaults 0 = DM, matching prior rows.
+        if "is_group" not in pm_existing:
+            self._db.execute(
+                "ALTER TABLE pending_messages ADD COLUMN is_group INTEGER NOT NULL DEFAULT 0"
+            )
+            _log("agent_registry: migrated — added is_group to pending_messages")
+        # sender_id is the original human sender, stored separately from the
+        # approval-key chat_id (which is the channel for group messages). Backfill
+        # to chat_id for existing rows — pre-#241 the approval key WAS the sender.
+        if "sender_id" not in pm_existing:
+            self._db.execute(
+                "ALTER TABLE pending_messages ADD COLUMN sender_id TEXT NOT NULL DEFAULT ''"
+            )
+            self._db.execute(
+                "UPDATE pending_messages SET sender_id=chat_id WHERE sender_id=''"
+            )
+            _log("agent_registry: migrated — added sender_id to pending_messages")
 
         # Seed main_agent default: if unset, adopt the oldest enabled agent.
         # New installs get their main agent auto-assigned at create time (see
@@ -3468,22 +3489,27 @@ except Exception:
     def queue_pending_message(
         self, agent_name: str, platform: str, chat_id: str,
         sender_name: str, content: str, reply_chat_id: str = "",
+        is_group: bool = False, sender_id: str = "",
     ) -> int:
         """Queue a message from a pending user. Returns the message ID.
 
-        ``chat_id`` is the per-user approval key (the sender's id) — pending
-        messages are looked up and approved by it. ``reply_chat_id`` is where
-        the eventual reply should be delivered; for a group/channel message
-        that's the channel id, which differs from the sender. Defaults to
-        ``chat_id`` (correct for 1:1 DMs where sender == destination).
+        ``chat_id`` is the approval key — the sender's id for a DM, or the
+        channel id for a group/channel — and pending messages are looked up and
+        approved by it. ``reply_chat_id`` is where the eventual reply should be
+        delivered; for a group/channel message that's the channel id, which
+        differs from the sender. Defaults to ``chat_id`` (correct for 1:1 DMs
+        where sender == destination). ``is_group`` records whether the held
+        message arrived in a group/channel so it re-delivers with the right
+        context on approval.
         """
         now = time.time()
         dest = reply_chat_id or chat_id
+        sid = sender_id or chat_id
         cursor = self._db.execute(
             """INSERT INTO pending_messages
-               (agent_name, platform, chat_id, reply_chat_id, sender_name, content, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
-            (agent_name, platform, chat_id, dest, sender_name, content, now),
+               (agent_name, platform, chat_id, reply_chat_id, is_group, sender_id, sender_name, content, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (agent_name, platform, chat_id, dest, int(is_group), sid, sender_name, content, now),
         )
         self._db.commit()
         return cursor.lastrowid
@@ -3495,7 +3521,7 @@ except Exception:
         if chat_id:
             rows = self._db.execute(
                 """SELECT id, agent_name, platform, chat_id, reply_chat_id,
-                          sender_name, content, created_at
+                          is_group, sender_id, sender_name, content, created_at
                    FROM pending_messages
                    WHERE agent_name=? AND chat_id=? AND delivered=0
                    ORDER BY created_at ASC""",
@@ -3504,7 +3530,7 @@ except Exception:
         else:
             rows = self._db.execute(
                 """SELECT id, agent_name, platform, chat_id, reply_chat_id,
-                          sender_name, content, created_at
+                          is_group, sender_id, sender_name, content, created_at
                    FROM pending_messages
                    WHERE agent_name=? AND delivered=0
                    ORDER BY created_at ASC""",
@@ -3514,7 +3540,8 @@ except Exception:
             {
                 "id": r[0], "agent_name": r[1], "platform": r[2],
                 "chat_id": r[3], "reply_chat_id": r[4] or r[3],
-                "sender_name": r[5], "content": r[6], "created_at": r[7],
+                "is_group": bool(r[5]), "sender_id": r[6] or r[3],
+                "sender_name": r[7], "content": r[8], "created_at": r[9],
             }
             for r in rows
         ]

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -750,11 +750,21 @@ class MessageBroker:
                     display_name=display_name,
                     approved_by="primary_user",
                 )
+                # Is this a channel approval? Held group rows carry is_group=True.
+                # Must be checked BEFORE handle_approval marks them delivered.
+                pending_before = self._registry.get_pending_messages(
+                    agent_name, target_chat_id,
+                )
+                target_is_channel = any(p.get("is_group") for p in pending_before)
                 delivered = await self.handle_approval(agent_name, target_chat_id)
                 reply = f"✅ Approved. {delivered} pending message(s) delivered to {agent_name}."
 
-                # Notify the approved user
-                if self._send_callback:
+                # Notify the approved DM user — but NOT a channel: posting
+                # "you've been approved" into the channel would be the same
+                # in-channel noise the pending path deliberately suppresses. For
+                # a channel, the held-message delivery + the owner confirmation
+                # are enough.
+                if self._send_callback and not target_is_channel:
                     try:
                         await self._send_callback(
                             agent_name, message.platform, target_chat_id,

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -856,90 +856,115 @@ class MessageBroker:
             if handled:
                 return
 
-        # 1. Check sender status — always use the individual sender_id for approval,
-        #    not the chat_id (which is the group ID for group messages).
-        user_id = message.sender_id or message.chat_id
-        status = self._registry.get_user_status(agent_name, user_id)
+        # 1. Determine the approval key. For a group/channel message the trust
+        #    unit is the CHANNEL — an admin deliberately added the agent to it,
+        #    so one approval lets everyone in the channel talk to it (no
+        #    per-member gate). For a 1:1 DM the unit is the individual sender
+        #    (defense against strangers DMing the bot directly).
+        if message.is_group and message.chat_id:
+            approval_key = message.chat_id
+            is_channel = True
+        else:
+            approval_key = message.sender_id or message.chat_id
+            is_channel = False
+        status = self._registry.get_user_status(agent_name, approval_key)
 
         if status == "denied":
             self._stats["denied"] += 1
-            _log(f"broker: denied message from {message.sender_name} ({user_id}) for {agent_name}")
+            _log(f"broker: denied message from {message.sender_name} ({approval_key}) for {agent_name}")
             return
 
         if status is None or status == "pending":
             primary = self._registry.get_primary_user()
             # First-run ownership claim: if no primary user has ever been
-            # configured, the first person to message the bot is treated as the
-            # owner — set them as primary (which also auto-approves them across
-            # all agents). This removes the confusing "waiting for approval"
-            # message a fresh owner would otherwise get from their own bot.
-            # Tradeoff: whoever messages first claims ownership, so the owner
-            # should connect before sharing the bot. Only fires when primary is
-            # completely unset.
-            if not primary.get("chat_id"):
+            # configured, the first person to DM the bot is treated as the owner
+            # — set them as primary (which also auto-approves them across all
+            # agents). This removes the confusing "waiting for approval" message
+            # a fresh owner would otherwise get from their own bot. Tradeoff:
+            # whoever messages first claims ownership, so the owner should
+            # connect before sharing the bot. Only fires when primary is unset,
+            # and NEVER from a channel — a channel id must not become the owner.
+            if not primary.get("chat_id") and not is_channel:
                 self._registry.set_primary_user(
-                    user_id,
+                    approval_key,
                     display_name=message.sender_name or "",
                 )
                 _log(
-                    f"broker: no primary user configured — claimed {user_id} "
+                    f"broker: no primary user configured — claimed {approval_key} "
                     f"({message.sender_name}) as primary/owner for {agent_name}"
                 )
                 primary = self._registry.get_primary_user()
-            # Auto-approve primary user
-            if primary.get("chat_id") and user_id == primary["chat_id"]:
+            # Auto-approve primary user (DM only — approval_key is the sender).
+            if primary.get("chat_id") and approval_key == primary["chat_id"]:
                 self._registry.approve_user(
-                    agent_name, user_id,
+                    agent_name, approval_key,
                     display_name=primary.get("display_name") or message.sender_name,
                     approved_by="primary_user",
                 )
-                _log(f"broker: auto-approved primary user {user_id} for {agent_name}")
+                _log(f"broker: auto-approved primary user {approval_key} for {agent_name}")
                 # Fall through to routing below
             else:
-                # Unknown or pending user — queue message
+                # Unknown or pending key — queue message
                 if status is None:
                     self._registry.add_pending_user(
-                        agent_name, user_id,
-                        display_name=message.sender_name,
+                        agent_name, approval_key,
+                        display_name=(message.chat_id if is_channel else message.sender_name),
                     )
-                    # Onboarding: notify new user and primary user
+                    # Onboarding. For a 1:1 DM, ack the sender. For a channel,
+                    # stay silent in-channel — a "waiting for approval" notice
+                    # would be posted to everyone in the channel (noise);
+                    # approval is between the agent and its owner.
                     if self._send_callback:
-                        try:
-                            await self._send_callback(
-                                agent_name, message.platform, message.chat_id,
-                                "Request sent! Waiting for approval.",
-                            )
-                        except Exception as e:
-                            _log(f"broker: failed to send onboarding reply to {user_id}: {e}")
+                        if not is_channel:
+                            try:
+                                await self._send_callback(
+                                    agent_name, message.platform, message.chat_id,
+                                    "Request sent! Waiting for approval.",
+                                )
+                            except Exception as e:
+                                _log(f"broker: failed to send onboarding reply to {approval_key}: {e}")
                         primary = self._registry.get_primary_user()
                         if primary.get("chat_id"):
-                            name_display = message.sender_name or "Unknown"
-                            username = message.metadata.get("username", "")
-                            if username:
-                                name_display += f" (@{username})"
-                            notification = (
-                                f"🆕 New user wants to talk to {agent_name}:\n"
-                                f"{name_display} (ID: {user_id})\n\n"
-                                f"/approve_{user_id}\n"
-                                f"/deny_{user_id}"
-                            )
+                            if is_channel:
+                                notification = (
+                                    f"🆕 {agent_name} got a message in a new channel "
+                                    f"(ID: {approval_key}).\n\n"
+                                    f"Approve to let everyone in this channel talk to "
+                                    f"{agent_name}:\n"
+                                    f"/approve_{approval_key}\n"
+                                    f"/deny_{approval_key}"
+                                )
+                            else:
+                                name_display = message.sender_name or "Unknown"
+                                username = message.metadata.get("username", "")
+                                if username:
+                                    name_display += f" (@{username})"
+                                notification = (
+                                    f"🆕 New user wants to talk to {agent_name}:\n"
+                                    f"{name_display} (ID: {approval_key})\n\n"
+                                    f"/approve_{approval_key}\n"
+                                    f"/deny_{approval_key}"
+                                )
                             try:
                                 await self._send_callback(
                                     agent_name, message.platform, primary["chat_id"],
                                     notification,
                                 )
                             except Exception as e:
-                                _log(f"broker: failed to notify owner about new user {user_id}: {e}")
+                                kind = "channel" if is_channel else "user"
+                                _log(f"broker: failed to notify owner about new {kind} {approval_key}: {e}")
                 self._registry.queue_pending_message(
                     agent_name=agent_name,
                     platform=message.platform,
-                    chat_id=user_id,
+                    chat_id=approval_key,
                     reply_chat_id=message.chat_id,
                     sender_name=message.sender_name,
                     content=message.content,
+                    is_group=message.is_group,
+                    sender_id=message.sender_id,
                 )
                 self._stats["pending"] += 1
-                _log(f"broker: queued message from pending user {message.sender_name} ({user_id}) for {agent_name}")
+                _log(f"broker: queued pending message for {agent_name} (key={approval_key}, sender={message.sender_name})")
                 return
 
         # 2. Approved — route via streaming session
@@ -1064,10 +1089,11 @@ class MessageBroker:
                 platform=msg["platform"],
                 chat_id=msg["reply_chat_id"],
                 sender_name=msg["sender_name"],
-                sender_id=msg["chat_id"],
+                sender_id=msg.get("sender_id") or msg["chat_id"],
                 content=msg["content"],
                 agent_name=agent_name,
                 timestamp=msg["created_at"],
+                is_group=bool(msg.get("is_group")),
             )
             await self._route_streaming(agent_name, broker_msg)
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -348,14 +348,12 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_group_pending_reply_routes_to_channel_not_sender_dm(self, monkeypatch):
-        """Regression (Chekov Slack channel leak follow-up): a held message that
-        arrived in a group/channel must, on approval, be re-delivered to the
-        CHANNEL — not the sender's DM. The pending row keys approval on the
-        sender's user id but must preserve the channel as the reply destination
-        (reply_chat_id). Before the fix, queue stored chat_id=sender_id and
-        re-delivery routed the reply to the sender's DM, so channel replies
-        silently vanished from the channel."""
+    async def test_group_message_gates_on_channel_and_routes_back(self, monkeypatch):
+        """A group/channel message gates on the CHANNEL (not the sender): it's
+        held pending under the channel id, the owner is notified with
+        /approve_<channel>, and the in-channel "waiting for approval" notice is
+        suppressed (it would be noise to every member). On approval the held
+        message re-delivers to the channel with is_group preserved."""
         tmpdir, registry, broker, sent_messages, _ = self._make_broker()
         try:
             routed: list[BrokerMessage] = []
@@ -364,11 +362,11 @@ class TestMessageBrokerRouting:
                 routed.append(message)
 
             monkeypatch.setattr(broker, "_route_streaming", _fake_route)
-            registry.set_primary_user("owner-1", display_name="Brad")
+            owner = "owner-1"
+            registry.set_primary_user(owner, display_name="Brad")
 
             channel = "C0A8WUU743F"
             user = "U774M8XDE"
-            # A PM messages IN the channel: chat_id=channel, sender_id=user.
             await broker.handle_inbound(
                 BrokerMessage(
                     platform="slack",
@@ -381,31 +379,70 @@ class TestMessageBrokerRouting:
                 )
             )
 
-            # Held pending under the sender's user id, not routed yet.
-            assert registry.get_user_status("barsik", user) == "pending"
+            # Gated on the CHANNEL, not the individual sender.
+            assert registry.get_user_status("barsik", channel) == "pending"
+            assert registry.get_user_status("barsik", user) is None
             assert routed == []
-            # The "waiting for approval" notice goes to the channel it arrived in.
+            # No in-channel "waiting for approval" spam...
+            assert not any("Waiting for approval" in m[3] for m in sent_messages)
+            # ...but the owner gets a /approve_<channel> prompt.
             assert any(
-                m[1] == "slack" and m[2] == channel and "Waiting for approval" in m[3]
-                for m in sent_messages
+                m[2] == owner and f"/approve_{channel}" in m[3] for m in sent_messages
             )
-            # The pending row separates the approval key from the destination.
-            pending = registry.get_pending_messages("barsik", user)
+            # Pending row: approval key = channel, destination = channel, is_group.
+            pending = registry.get_pending_messages("barsik", channel)
             assert len(pending) == 1
-            assert pending[0]["chat_id"] == user           # approval key (sender)
-            assert pending[0]["reply_chat_id"] == channel  # reply destination
+            assert pending[0]["chat_id"] == channel
+            assert pending[0]["reply_chat_id"] == channel
+            assert pending[0]["is_group"] is True
 
-            # Owner approves → held message re-delivers.
-            registry.approve_user("barsik", user, display_name="Alex Ugrin")
-            delivered = await broker.handle_approval("barsik", user)
+            # Approve the channel → held message re-delivers to the channel.
+            registry.approve_user("barsik", channel, display_name=channel)
+            delivered = await broker.handle_approval("barsik", channel)
 
             assert delivered == 1
             assert len(routed) == 1
-            # THE FIX: re-delivered to the channel, with the sender restored —
-            # NOT routed to the sender's DM (user id).
             assert routed[0].chat_id == channel
             assert routed[0].sender_id == user
+            assert routed[0].is_group is True
             assert routed[0].content == "Hi"
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_channel_approval_admits_all_members(self, monkeypatch):
+        """Core of #241: once a CHANNEL is approved, every member's messages
+        flow without per-user approval. A user who was never individually
+        approved routes straight through in an approved channel."""
+        tmpdir, registry, broker, sent_messages, _ = self._make_broker()
+        try:
+            routed: list[BrokerMessage] = []
+
+            async def _fake_route(agent_name, message):
+                routed.append(message)
+
+            monkeypatch.setattr(broker, "_route_streaming", _fake_route)
+            registry.set_primary_user("owner-1", display_name="Brad")
+
+            channel = "C0A8WUU743F"
+            # Channel is approved once.
+            registry.approve_user("barsik", channel, display_name=channel)
+
+            # A brand-new, never-approved member messages in the channel.
+            await broker.handle_inbound(
+                BrokerMessage(
+                    platform="slack", chat_id=channel, sender_name="Jake Hredzak",
+                    sender_id="U_NEVER_APPROVED", content="status?",
+                    agent_name="barsik", is_group=True,
+                )
+            )
+
+            # Routed straight through — no pending, no approval prompt.
+            assert len(routed) == 1
+            assert routed[0].chat_id == channel
+            assert routed[0].sender_id == "U_NEVER_APPROVED"
+            assert registry.get_pending_messages("barsik", channel) == []
+            assert not any("approve" in m[3].lower() for m in sent_messages)
         finally:
             tmpdir.cleanup()
 
@@ -447,33 +484,36 @@ class TestMessageBrokerRouting:
         finally:
             tmpdir.cleanup()
 
-    def test_queue_pending_message_preserves_reply_chat_id(self):
-        """reply_chat_id is stored distinctly from the approval-key chat_id, and
-        defaults to chat_id when omitted (the DM case)."""
+    def test_queue_pending_message_preserves_reply_chat_id_and_is_group(self):
+        """reply_chat_id is stored distinctly from the approval-key chat_id
+        (defaulting to chat_id when omitted), and is_group is persisted."""
         tmpdir, registry, _broker, _sent, _ = self._make_broker()
         try:
             registry.queue_pending_message(
-                agent_name="barsik", platform="slack", chat_id="Uuser",
+                agent_name="barsik", platform="slack", chat_id="Cchan",
                 sender_name="Alex", content="hi", reply_chat_id="Cchan",
+                is_group=True,
             )
             registry.queue_pending_message(
                 agent_name="barsik", platform="telegram", chat_id="999",
                 sender_name="Stranger", content="yo",
             )
             rows = registry.get_pending_messages("barsik")
-            by_user = {r["chat_id"]: r for r in rows}
-            assert by_user["Uuser"]["reply_chat_id"] == "Cchan"
-            assert by_user["999"]["reply_chat_id"] == "999"
+            by_key = {r["chat_id"]: r for r in rows}
+            assert by_key["Cchan"]["reply_chat_id"] == "Cchan"
+            assert by_key["Cchan"]["is_group"] is True
+            assert by_key["999"]["reply_chat_id"] == "999"   # defaulted to chat_id
+            assert by_key["999"]["is_group"] is False
         finally:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_slash_approve_preserves_uppercase_slack_id(self, monkeypatch):
+    async def test_slash_approve_preserves_uppercase_channel_id(self, monkeypatch):
         """Regression: /approve_<id> must preserve the EXACT case of the target
-        id. Slack user ids are uppercase (U774M8XDE); lowercasing the whole
-        command token approved a phantom lowercased user, delivered 0 held
-        messages, and left the real user pending — so the channel reply never
-        went out. This exercises the real owner-notification flow end-to-end."""
+        id. Slack channel ids are uppercase (C0A8WUU743F); lowercasing the whole
+        command token approved a phantom lowercased id, delivered 0 held
+        messages, and left the channel unapproved — so replies never went out.
+        Exercises the real owner-notification flow end-to-end at channel scope."""
         tmpdir, registry, broker, sent_messages, _ = self._make_broker()
         try:
             routed: list[BrokerMessage] = []
@@ -486,28 +526,28 @@ class TestMessageBrokerRouting:
             registry.set_primary_user(owner, display_name="Brad")
 
             channel = "C0A8WUU743F"
-            user = "U774M8XDE"
-            # PM messages in the channel → held pending under the exact id.
+            # A message in the channel → held pending under the exact channel id.
             await broker.handle_inbound(
                 BrokerMessage(
                     platform="slack", chat_id=channel, sender_name="Alex Ugrin",
-                    sender_id=user, content="Hi", agent_name="barsik", is_group=True,
+                    sender_id="U774M8XDE", content="Hi", agent_name="barsik",
+                    is_group=True,
                 )
             )
-            assert registry.get_user_status("barsik", user) == "pending"
+            assert registry.get_user_status("barsik", channel) == "pending"
 
-            # Owner approves exactly as the notification prints it: /approve_U…
+            # Owner approves exactly as the notification prints it: /approve_C…
             await broker.handle_inbound(
                 BrokerMessage(
                     platform="slack", chat_id=owner, sender_name="Brad",
-                    sender_id=owner, content=f"/approve_{user}", agent_name="barsik",
+                    sender_id=owner, content=f"/approve_{channel}", agent_name="barsik",
                 )
             )
 
-            # The exact uppercase id is approved — no lowercased phantom user.
-            assert registry.get_user_status("barsik", user) == "approved"
-            assert registry.get_user_status("barsik", user.lower()) is None
-            # The held channel message is delivered to the CHANNEL.
+            # The exact uppercase channel id is approved — no lowercased phantom.
+            assert registry.get_user_status("barsik", channel) == "approved"
+            assert registry.get_user_status("barsik", channel.lower()) is None
+            # The held message is delivered to the CHANNEL.
             assert len(routed) == 1
             assert routed[0].chat_id == channel
             assert routed[0].content == "Hi"

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -553,6 +553,12 @@ class TestMessageBrokerRouting:
             assert routed[0].content == "Hi"
             # Owner saw a non-zero delivery count (not "0 pending message(s)").
             assert any("1 pending message" in m[3] for m in sent_messages)
+            # No approval notice posted INTO the channel — that would be the same
+            # in-channel noise the pending path suppresses (channel approval is
+            # owner business; the held-message delivery is the visible signal).
+            assert not any(
+                m[2] == channel and "approved" in m[3].lower() for m in sent_messages
+            )
         finally:
             tmpdir.cleanup()
 


### PR DESCRIPTION
## What
Per Brad's call: for a group/channel message the trust unit is the **channel** (an admin deliberately added the agent to it), so gate approval on the **channel id** instead of each sender. Approve a channel once via `/approve_<channel>` → every member talks to the agent, no per-person friction. 1:1 DMs keep per-user approval (defense against strangers DMing the bot directly).

Follow-up to #811 (the channel-reply routing fix), and addresses the per-user-approval friction + "Request sent! Waiting for approval." channel noise Brad flagged.

## Behavior
- `handle_inbound` derives the approval key by `is_group`: **channel id** for groups, **sender id** for DMs.
- First message in an *unapproved* channel → owner gets a `/approve_<channel>` prompt; message held. The in-channel "waiting for approval" notice is **suppressed** for groups (it would be noise to every member — approval is owner business).
- Once a channel is approved, **all** members (even never-individually-approved ones) route straight through.
- Never claim a channel id as the primary/owner identity on fresh install.
- Owner chose **(a)**: explicit one-tap `/approve_<channel>` (not auto-approve-on-add).

## Schema
`pending_messages` gains `is_group` + `sender_id` columns so a held group message re-delivers with the right **group context** and the **original human sender** — also closes the #811 non-blocking follow-up (re-delivery used to default `is_group=False`/lose the sender). The four facets are now stored distinctly: approval key (`chat_id`), reply destination (`reply_chat_id`), `sender_id`, `is_group`. Idempotent migrations backfill existing rows (`sender_id`=`chat_id`, since pre-#241 the approval key WAS the sender).

## Migration note for live channels
Existing channels Chekov is already in will need a one-time `/approve_<channel>` after this ships (their per-user approvals no longer admit channel traffic). Expected + intended.

## Tests (52 broker + 179 registry/ferry, ruff clean)
- `test_group_message_gates_on_channel_and_routes_back` — channel-keyed gating + silent in-channel + re-delivery with is_group/sender preserved
- `test_channel_approval_admits_all_members` — the core: approved channel lets a never-approved member through
- `test_dm_pending_reply_routes_back_to_sender` — DMs still per-user
- `test_slash_approve_preserves_uppercase_channel_id` — `/approve_<C…>` case preservation
- `test_queue_pending_message_preserves_reply_chat_id_and_is_group` — registry round-trip

## No UI
Backend approval-routing change. Evidence = the test suite above.

🤖 Opened by Barsik