### PR TITLE
fix(slack): form-encode files.uploadV2 calls (uploads failing with invalid_arguments)

### DIFF
--- a/src/pinky_outreach/slack.py
+++ b/src/pinky_outreach/slack.py
@@ -15,6 +15,7 @@ Requires a Slack Bot Token (xoxb-...) with appropriate scopes:
 
 from __future__ import annotations
 
+import json
 import os
 from datetime import datetime, timezone
 
@@ -161,15 +162,16 @@ class SlackAdapter:
         filename = os.path.basename(file_path)
         file_size = os.path.getsize(file_path)
 
-        # Step 1: Get upload URL
-        resp = self._client.post(
-            "/files.getUploadURLExternal",
-            json={"filename": filename, "length": file_size},
+        # Step 1: Get an upload URL. files.getUploadURLExternal is a form/query
+        # method — like users.info / conversations.info it ignores a JSON request
+        # body and returns invalid_arguments, so it must be form-encoded (same
+        # root cause as #808). Sending JSON here was why uploads failed even on a
+        # minimal file.
+        url_data = self._request_form(
+            "files.getUploadURLExternal",
+            filename=filename,
+            length=str(file_size),
         )
-        url_data = resp.json()
-        if not url_data.get("ok"):
-            raise SlackError(url_data.get("error", "upload_url_failed"))
-
         upload_url = url_data["upload_url"]
         file_id = url_data["file_id"]
 
@@ -183,10 +185,12 @@ class SlackAdapter:
             if upload_resp.status_code >= 400:
                 raise SlackError(f"File upload failed: {upload_resp.status_code}")
 
-        # Step 3: Complete the upload
-        self._request(
+        # Step 3: Complete the upload. files.completeUploadExternal also takes
+        # form-encoded args; `files` is a JSON-encoded array string (the
+        # canonical uploadV2 shape), not a native JSON-body field.
+        self._request_form(
             "files.completeUploadExternal",
-            files=[{"id": file_id, "title": title or filename}],
+            files=json.dumps([{"id": file_id, "title": title or filename}]),
             channel_id=channel,
             initial_comment=initial_comment or None,
         )

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -187,6 +187,61 @@ class TestSlackAdapter:
         )
         adapter.close()
 
+    def test_upload_file_uses_form_encoding(self, tmp_path, monkeypatch):
+        """files.getUploadURLExternal + completeUploadExternal are form/query
+        methods: a JSON body makes Slack ignore the args and return
+        invalid_arguments, so uploads failed even on a minimal file. Regression
+        guard — both must be form-encoded (data=, not json=) with the uploadV2
+        argument shape (filename+length, then a JSON-encoded `files` array)."""
+        import json as _json
+
+        adapter = self._make_adapter()
+        f = tmp_path / "note.txt"
+        f.write_text("hello")  # 5 bytes
+
+        url_resp = MagicMock()
+        url_resp.json.return_value = {
+            "ok": True,
+            "upload_url": "https://files.slack.com/upload/xyz",
+            "file_id": "F123",
+        }
+        complete_resp = MagicMock()
+        complete_resp.json.return_value = {"ok": True, "files": [{"id": "F123"}]}
+        adapter._client.post = MagicMock(side_effect=[url_resp, complete_resp])
+
+        # Step 2 streams bytes to the returned upload_url via module-level httpx.
+        upload_resp = MagicMock(status_code=200)
+        monkeypatch.setattr(
+            "pinky_outreach.slack.httpx.post", MagicMock(return_value=upload_resp)
+        )
+
+        msg = adapter.upload_file("C123", str(f), title="Note", initial_comment="here")
+
+        calls = adapter._client.post.call_args_list
+        # Step 1: getUploadURLExternal — form-encoded, filename + length.
+        assert calls[0][0][0] == "/files.getUploadURLExternal"
+        assert "json" not in calls[0].kwargs
+        assert (
+            calls[0].kwargs["headers"]["Content-Type"]
+            == "application/x-www-form-urlencoded"
+        )
+        assert calls[0].kwargs["data"]["filename"] == "note.txt"
+        assert calls[0].kwargs["data"]["length"] == "5"
+        # Step 3: completeUploadExternal — form-encoded; files is a JSON string.
+        assert calls[1][0][0] == "/files.completeUploadExternal"
+        assert "json" not in calls[1].kwargs
+        assert (
+            calls[1].kwargs["headers"]["Content-Type"]
+            == "application/x-www-form-urlencoded"
+        )
+        assert calls[1].kwargs["data"]["channel_id"] == "C123"
+        files_arg = calls[1].kwargs["data"]["files"]
+        assert isinstance(files_arg, str)
+        assert _json.loads(files_arg) == [{"id": "F123", "title": "Note"}]
+
+        assert msg.message_id == "F123"
+        adapter.close()
+
     def test_send_message_error(self):
         adapter = self._make_adapter()
         mock_response = MagicMock()


### PR DESCRIPTION
## Problem
Chekov's `send_document` to Slack failed with `Slack API error: invalid_arguments` on **every** upload — Brad confirmed it on a minimal 24-byte `.txt`, both post-to-channel and reply-to-message paths. Scopes (`files:write`) were already correct (the earlier `missing_scope` was gone).

## Root cause — same as #808
`files.getUploadURLExternal` and `files.completeUploadExternal` are form/query methods: like `users.info`/`conversations.info`, they **ignore a JSON request body** and read args only from the query string or an `x-www-form-urlencoded` body. `upload_file` posted JSON, so `filename`/`length` never arrived → Slack returned `invalid_arguments`, which raised `SlackError("invalid_arguments")` at the get-URL step before the upload even started.

## Fix
Route both Web API calls through the existing `_request_form` helper:
- `getUploadURLExternal` → form `filename` + `length`
- `completeUploadExternal` → form `channel_id` + a **JSON-encoded `files` array** string (the canonical uploadV2 shape)

Step 2 (the raw byte upload to the returned `upload_url`) is unchanged.

## Test
`test_upload_file_uses_form_encoding` asserts both calls are form-encoded (`data=`, not `json=`, with the `x-www-form-urlencoded` Content-Type) and carry the right argument shapes (filename+length; JSON-stringified `files` array + channel_id). Mirrors the #808 form-encoding regression guards. 26 slack + 135 outreach/slack-poller tests pass, ruff clean.

## No UI
Backend adapter fix. Evidence = the test; will verify a real file-send from Chekov to #bot-testing after deploy.

🤖 Opened by Barsik