### PR TITLE
fix(slack): resolve in-text @mentions / #channels / links in inbound messages

### DIFF
--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -8,6 +8,7 @@ message handler (legacy) or message broker (new).
 from __future__ import annotations
 
 import asyncio
+import re
 import sys
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
@@ -783,6 +784,64 @@ class BrokerDiscordPoller:
         _log(f"discord-poller[{self._agent_name}]: stopping")
 
 
+# Slack mrkdwn ref tokens: <@U…>, <#C…|name>, <!here>, <https://…|label>, …
+# (Slack never nests these and escapes literal </>/& as entities, so a simple
+# non-greedy, no-angle-bracket body match is safe.)
+_SLACK_REF_RE = re.compile(r"<([^<>]+)>")
+
+
+async def _resolve_slack_ref(body: str, user_namer, channel_namer) -> str:
+    """Resolve a single Slack ref token body (the text between < and >)."""
+    raw = f"<{body}>"
+    if body.startswith("@"):  # user mention: <@U123> or <@U123|label>
+        uid, _, label = body[1:].partition("|")
+        if label:
+            return "@" + label
+        name = await user_namer(uid)
+        return "@" + (name or uid)
+    if body.startswith("#"):  # channel mention: <#C123|name> or <#C123>
+        cid, _, label = body[1:].partition("|")
+        if label:
+            return "#" + label
+        name = await channel_namer(cid)
+        return "#" + (name or cid)
+    if body.startswith("!"):  # special: <!here>, <!subteam^S1|@grp>, <!date^…|fb>
+        cmd, _, label = body[1:].partition("|")
+        if cmd in ("here", "channel", "everyone"):
+            return "@" + cmd
+        if cmd.startswith("subteam^"):
+            return "@" + (label.lstrip("@") if label else "group")
+        if cmd.startswith("date^"):
+            return label or raw
+        return label or raw
+    # link: <https://x|label> or <https://x> or <mailto:a@b|a@b>
+    url, _, label = body.partition("|")
+    return label or url
+
+
+async def resolve_slack_text_refs(text: str, *, user_namer, channel_namer) -> str:
+    """Rewrite Slack mrkdwn ref tokens in inbound text to human-readable form.
+
+    `<@U774M8XDE>` → `@Brett Jones`, `<#C1|orders>` → `#orders`, `<!here>` →
+    `@here`, `<https://x|click>` → `click`. ``user_namer``/``channel_namer`` are
+    async callables (id → name) returning "" on failure, in which case the raw
+    id is kept (no regression). After ref substitution, Slack HTML entities
+    (&lt; &gt; &amp;) are unescaped so the agent reads natural text.
+    """
+    if text and "<" in text:
+        parts: list[str] = []
+        last = 0
+        for m in _SLACK_REF_RE.finditer(text):
+            parts.append(text[last : m.start()])
+            parts.append(await _resolve_slack_ref(m.group(1), user_namer, channel_namer))
+            last = m.end()
+        parts.append(text[last:])
+        text = "".join(parts)
+    if text:
+        text = text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
+    return text
+
+
 class BrokerSlackPoller:
     """Slack Socket Mode listener for one agent's bot; routes to MessageBroker.
 
@@ -1006,6 +1065,15 @@ class BrokerSlackPoller:
         self._channel_title_cache[channel_id] = title
         return title
 
+    async def _resolve_text_refs(self, text: str) -> str:
+        """Resolve in-text Slack mentions/links (<@U…>, <#C…>, <!here>, links)
+        to readable form, reusing the cached user/channel resolvers."""
+        return await resolve_slack_text_refs(
+            text,
+            user_namer=self._resolve_user_name,
+            channel_namer=self._resolve_channel_title,
+        )
+
     async def _handle_event(self, payload: dict) -> None:
         event = (payload or {}).get("event") or {}
         if event.get("type") != "message":
@@ -1050,6 +1118,7 @@ class BrokerSlackPoller:
             if resolved:
                 sender_name = resolved
         chat_title = await self._resolve_channel_title(channel)
+        text = await self._resolve_text_refs(text)
 
         attachments = [
             {

--- a/tests/test_slack_text_refs.py
+++ b/tests/test_slack_text_refs.py
@@ -1,0 +1,93 @@
+"""Inbound Slack mention/link resolution (BrokerSlackPoller text enrichment)."""
+
+import asyncio
+
+from pinky_daemon.pollers import resolve_slack_text_refs
+
+_USERS = {"U774M8XDE": "Brett Jones", "U123": "Alice"}
+_CHANNELS = {"C1": "orders-and-equipment"}
+
+
+async def _user(uid: str) -> str:
+    return _USERS.get(uid, "")
+
+
+async def _chan(cid: str) -> str:
+    return _CHANNELS.get(cid, "")
+
+
+def _run(text: str) -> str:
+    return asyncio.run(
+        resolve_slack_text_refs(text, user_namer=_user, channel_namer=_chan)
+    )
+
+
+def test_user_mention_resolved_to_name():
+    assert _run("Hi <@U774M8XDE> there") == "Hi @Brett Jones there"
+
+
+def test_user_mention_with_embedded_label_no_lookup():
+    # label after | wins; no resolver call needed
+    assert _run("ping <@U999|brett>") == "ping @brett"
+
+
+def test_unknown_user_keeps_raw_id():
+    # resolver returns "" (e.g. users:read missing) → raw id retained, no crash
+    assert _run("yo <@UZZZ>") == "yo @UZZZ"
+
+
+def test_channel_mention_with_inline_name():
+    assert _run("see <#C1|orders-and-equipment>") == "see #orders-and-equipment"
+
+
+def test_channel_mention_without_name_resolved():
+    assert _run("see <#C1>") == "see #orders-and-equipment"
+
+
+def test_special_mentions():
+    assert _run("<!here> <!channel> <!everyone>") == "@here @channel @everyone"
+
+
+def test_subteam_mention():
+    assert _run("ask <!subteam^S1|@project-mgmt>") == "ask @project-mgmt"
+
+
+def test_date_token_uses_fallback():
+    assert _run("due <!date^1700000000^{date}|Nov 14>") == "due Nov 14"
+
+
+def test_link_with_label():
+    assert _run("click <https://posspecialists.com|here>") == "click here"
+
+
+def test_bare_link_keeps_url():
+    assert _run("go <https://posspecialists.com>") == "go https://posspecialists.com"
+
+
+def test_mailto_link():
+    assert _run("mail <mailto:brad@posspecialists.com|brad@posspecialists.com>") == (
+        "mail brad@posspecialists.com"
+    )
+
+
+def test_html_entities_unescaped():
+    assert _run("a &amp; b &lt;3 x&gt;y") == "a & b <3 x>y"
+
+
+def test_plain_text_untouched():
+    assert _run("just a normal message") == "just a normal message"
+
+
+def test_empty_text():
+    assert _run("") == ""
+
+
+def test_multiple_mentions_in_one_message():
+    out = _run("Hi <@U774M8XDE> and <@U123> in <#C1|orders>")
+    assert out == "Hi @Brett Jones and @Alice in #orders"
+
+
+def test_screenshot_case():
+    # The exact failure Brad reported: a raw <@U…> in a nudge body.
+    raw = "Hi <@U774M8XDE> Re: Savor Ice Cream — Install 1905 Notre Dame Blvd"
+    assert _run(raw) == "Hi @Brett Jones Re: Savor Ice Cream — Install 1905 Notre Dame Blvd"


### PR DESCRIPTION
## Problem
Inbound Slack messages reach agents with **raw mrkdwn ref tokens** in the body. Brad hit this with a project-management nudge — the agent saw:

```
Hi <@U774M8XDE> Re: Savor Ice Cream — Install 1905 Notre Dame Blvd
```

instead of a readable name. The Socket Mode poller (`BrokerSlackPoller`) already resolves the **sender name** + **channel title** (users:read / channels:read, cached), but never rewrote tokens **embedded in the message text**. Follow-up to the Slack ID-resolution line (#807/#808/#813).

## Fix
New `resolve_slack_text_refs()` rewrites every Slack ref token, reusing the existing cached resolvers:

| token | →
|---|---|
| `<@U774M8XDE>` | `@Brett Jones` (via cached `_resolve_user_name`) |
| `<@U123\|brett>` | `@brett` (inline label, no lookup) |
| `<#C1\|orders>` / `<#C1>` | `#orders` |
| `<!here>` / `<!channel>` / `<!everyone>` | `@here` … |
| `<!subteam^S1\|@pm>` | `@pm` |
| `<!date^…\|Nov 14>` | `Nov 14` |
| `<https://x\|click>` / `<https://x>` | `click` / `https://x` |

Then unescapes Slack HTML entities (`&lt; &gt; &amp;`). **Failure-safe:** an unresolved id (e.g. `users:read` missing) keeps the raw id rather than crashing. Wired into `_handle_event` right after the existing sender/channel enrichment.

### Before → after
```
Hi <@U774M8XDE> Re: …   →   Hi @Brett Jones Re: …
```

## Tests
- 16 new unit tests (`tests/test_slack_text_refs.py`) — every token type, inline-label short-circuit, unresolved-id fallback, entity unescape, multi-mention, the exact screenshot case.
- Full slack/poller suite green: **101 passed, 1 skipped**.

## Note
User-name resolution needs the bot's `users:read` scope (already used by the existing sender resolver). Channel mentions usually carry an inline name so resolve without an API call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)