### PR TITLE
fix(prompts): drop plain-text fallback hint from agent prompts

### DIFF
--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1781,7 +1781,6 @@ class MessageBroker:
         lines.append("- **broadcast(text)**: Send to every active channel")
         lines.append("")
         lines.append("## Delivery Model")
-        lines.append("- If you do not call an outreach tool, Pinky may deliver your plain text automatically")
         lines.append("- `send()` is the default tool for responding to inbound messages")
 
         return "\n".join(lines)

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -385,15 +385,13 @@ class CodexSession:
             "Pick up where you left off. Users will message you through Telegram. "
             "Use send(chat_id, platform, text) for normal responses. "
             "Use thread(message_id, text) only when you want to quote/thread a specific message. "
-            f"{tools_hint} If you do not call an outreach tool, Pinky may fall back to "
-            "plain-text delivery based on agent settings."
+            f"{tools_hint}"
             if is_resume else
             f"New session started.{ctx_block}\n\n"
             "You're connected via Pinky's message broker. Users will message you through Telegram. "
             "Use send(chat_id, platform, text) for normal responses. "
             "Use thread(message_id, text) only when you want to quote/thread a specific message. "
-            f"{tools_hint} If you do not call an outreach tool, Pinky may fall back to "
-            "plain-text delivery based on agent settings."
+            f"{tools_hint}"
         )
 
         # #591 P1#2 (Murzik round-2): arm the post-delivery callback

--- a/src/pinky_daemon/wake_prompt.py
+++ b/src/pinky_daemon/wake_prompt.py
@@ -275,7 +275,7 @@ def build_wake_prompt(inp: WakePromptInput) -> str:
         {context_body}
         ──────────────────
 
-        {instruction_lead} {messaging_tool_reminder} {tools_hint} {fallback_note}
+        {instruction_lead} {messaging_tool_reminder} {tools_hint}
     """
     now = _resolve_now(inp.timezone, inp.now)
     time_str = _format_time(now)
@@ -290,5 +290,5 @@ def build_wake_prompt(inp: WakePromptInput) -> str:
         f"{lead} Users will message you through Telegram. "
         "Use send(chat_id, platform, text) for normal responses. "
         "Use thread(message_id, text) only when you want to quote/thread a specific message. "
-        f"{_TOOLS_HINT} If you do not call an outreach tool, Pinky may fall back to plain-text delivery based on agent settings."
+        f"{_TOOLS_HINT}"
     )

--- a/tests/test_wake_prompt.py
+++ b/tests/test_wake_prompt.py
@@ -113,8 +113,10 @@ class TestToolHintIsAlwaysPresent:
         # to call on cold start.
         assert "select:mcp__pinky-messaging__send,mcp__pinky-messaging__thread" in out
         assert "select:mcp__pinky-memory__reflect,mcp__pinky-memory__recall" in out
-        # The fallback note about Pinky plain-text delivery.
-        assert "Pinky may fall back to plain-text delivery" in out
+        # The plain-text fallback hint was removed: agents must use an explicit
+        # outreach tool, so the prompt must never advertise auto plain-text delivery.
+        assert "fall back to plain-text" not in out
+        assert "plain text automatically" not in out
 
     @pytest.mark.parametrize("reason", list(WakeReason))
     def test_messaging_tools_listed(self, reason: WakeReason):
@@ -203,8 +205,7 @@ class TestContractRegression:
         idx_lead = out.index("You're connected via Pinky's message broker")
         idx_msg = out.index("Users will message you through Telegram")
         idx_hint = out.index("If your tools are deferred")
-        idx_fallback = out.index("Pinky may fall back to plain-text")
-        assert idx_header < idx_lead < idx_msg < idx_hint < idx_fallback
+        assert idx_header < idx_lead < idx_msg < idx_hint
 
     def test_context_restart_with_body_snapshot(self):
         body = "Saved: do X\nThen Y"


### PR DESCRIPTION
## Why

Agent-facing prompts advertised an implicit *"if you don't call an outreach tool, Pinky may deliver your plain text automatically / fall back to plain-text delivery based on agent settings"* path. That actively nudges agents toward lazy plain-text replies — which is **unreliable** (plain prose can land on the console instead of reaching the owner) and undercuts the standing *"always reply with an explicit pinky-messaging tool"* contract.

## What

Removes the hint from **all four** emission sites (the only places it's rendered — verified by sweep; every transport routes through `wake_prompt.build_wake_prompt`):

| Site | Context |
|------|---------|
| `broker.py` `## Delivery Model` block | system-prompt messaging-tools block |
| `wake_prompt.py` wake-prompt tail | SDK / tmux transport (+ docstring `{fallback_note}`) |
| `codex_session.py` ×2 | Codex resume + new-session prompts |

**Kept** (these steer toward the tools, no fallback language):
- the `💬 Reply on … using pinky-messaging: send(...) / thread(...)` inbound footer
- the `` `send()` is the default tool for responding to inbound messages `` line

## Before / after — rendered wake-prompt tail

**Before:** `…Call both ToolSearch queries in parallel in a single response. If you do not call an outreach tool, Pinky may fall back to plain-text delivery based on agent settings.`

**After:** `…Call both ToolSearch queries in parallel in a single response.`  ← ends clean, no dangling sentence.

## Scope note (for Brad)

This removes the **hint only**. The underlying mechanism is intentionally untouched: the per-agent `plain_text_fallback` DB setting + `broker._deliver_plaintext_fallback()` still exist (migration default is ON for existing agents), so plain text *can* still auto-deliver — agents just won't be told to lean on it. Flip the mechanism off separately if desired.

## Tests / validation

- `tests/test_wake_prompt.py` fallback assertions → **regression guards** (`assert "fall back to plain-text" not in out`), so the hint can't silently return.
- `ruff` clean on all changed files.
- `pytest tests/test_wake_prompt.py tests/test_codex_session.py tests/test_broker.py tests/test_codex_session_tmux_app_server.py` → **170 passed**.
- Rendered `build_wake_prompt` confirmed to end cleanly with no fallback text.

🤖 Opened by Barsik