### PR TITLE
fix(broker): plain-text fallback delivers to internal surfaces only (no outreach-channel leak)

### DIFF
--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1363,32 +1363,28 @@ class MessageBroker:
         if not stripped or not fallback_enabled or not chat_id:
             return
 
-        # Plain-text fallback must FAIL CLOSED on any platform that could be a
-        # shared/public channel. When an agent decides to stay silent it often
-        # "thinks out loud" (emits reasoning text without calling an outreach
-        # tool); blindly delivering that text leaks internal deliberation to the
-        # channel — the Chekov-on-Slack leak. So on external platforms we only
-        # auto-deliver when we have POSITIVE confirmation this is a 1:1 DM: a
-        # MessageContext (stored at dispatch in remember_message_context) that
-        # matches this platform+chat and is not a group. Absence, a
-        # platform/chat mismatch (e.g. a colliding per-chat message_id from
-        # another conversation), or a group context all suppress. Owner-only
-        # surfaces (web/api/internal) are never public channels and carry no
-        # message_id/context, so they keep the fallback convenience.
-        _non_public_platforms = {"web", "api", ""}
-        if platform not in _non_public_platforms:
-            ctx = self.get_message_context(agent_name, message_id) if message_id else None
-            if (
-                ctx is None
-                or ctx.platform != platform
-                or ctx.chat_id != chat_id
-                or ctx.is_group
-            ):
-                _log(
-                    f"broker: suppressed plain-text fallback for {agent_name} on "
-                    f"{platform}/{chat_id} — no positive 1:1 DM context (fail-closed)"
-                )
-                return
+        # Plain-text fallback is for INTERNAL / owner surfaces only — the web UI,
+        # API, and console. Owner rule (Brad, 2026-06-22): never auto-deliver an
+        # agent's bare plain text to an outreach channel (telegram/discord/slack),
+        # not even a 1:1 owner DM. When an agent stays silent it often "thinks
+        # out loud" (emits reasoning text without calling an outreach tool);
+        # pushing that to a real channel leaks internal deliberation (the
+        # Chekov-on-Slack leak) and trains lazy non-tool replies. To reach any
+        # external channel the agent MUST call an explicit pinky-messaging tool
+        # (send/thread). Errors still surface — they route back on their own
+        # paths (API-error content is suppressed upstream so raw error JSON never
+        # reaches chat; auth failures fire the operator alert), not through this
+        # fallback. (Supersedes the #810 1:1-DM allowance with a stricter
+        # fail-closed rule; the group-leak guard is subsumed — groups are
+        # external, so they're suppressed here too.)
+        _internal_surfaces = {"web", "api", ""}
+        if platform not in _internal_surfaces:
+            _log(
+                f"broker: suppressed plain-text fallback for {agent_name} on "
+                f"{platform}/{chat_id} — outreach channels are tool-only "
+                f"(fallback delivers to web UI / internal surfaces only)"
+            )
+            return
 
         voice_key = (agent_name, chat_id)
         if self._voice_pending.pop(voice_key, False):

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -41,11 +41,13 @@ class TestMessageBrokerRouting:
         return tmpdir, registry, broker, sent_messages, reactions
 
     @pytest.mark.asyncio
-    async def test_route_response_sends_plain_text_when_fallback_enabled(self):
+    async def test_route_response_suppresses_fallback_on_external_dm(self):
+        # Owner rule (Brad, 2026-06-22): plain-text fallback NEVER auto-delivers
+        # to an outreach channel — not even a 1:1 owner DM with a valid stored
+        # context. Agents must call an explicit outreach tool to reach external
+        # channels; bare text only surfaces on internal surfaces (web/api/console).
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
-            # Fallback is fail-closed: it only delivers with a positive matching
-            # 1:1 DM context (stored at dispatch).
             broker.remember_message_context(
                 BrokerMessage(
                     platform="telegram",
@@ -68,9 +70,7 @@ class TestMessageBrokerRouting:
                 fallback_enabled=True,
             )
 
-            assert sent_messages == [
-                ("barsik", "telegram", "6770805286", "Ping from Barsik"),
-            ]
+            assert sent_messages == []
         finally:
             tmpdir.cleanup()
 
@@ -141,34 +141,22 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_route_response_allows_fallback_on_dm_context(self):
-        # Fallback convenience still works in a 1:1 DM (is_group False).
+    async def test_route_response_allows_fallback_on_api_surface(self):
+        # Internal surfaces (web/api/console) keep the fallback convenience and
+        # need no message context — they're owner-only, never public channels.
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
-            broker.remember_message_context(
-                BrokerMessage(
-                    platform="telegram",
-                    chat_id="6770805286",
-                    sender_name="Brad",
-                    sender_id="u-1",
-                    content="hey",
-                    agent_name="barsik",
-                    message_id="556",
-                    is_group=False,
-                )
-            )
             await broker.route_response(
                 "barsik",
-                "telegram",
-                "6770805286",
-                "Replying in a DM via fallback",
-                message_id="556",
+                "api",
+                "api",
+                "api console reply via fallback",
                 used_outreach=False,
                 fallback_enabled=True,
             )
 
             assert sent_messages == [
-                ("barsik", "telegram", "6770805286", "Replying in a DM via fallback"),
+                ("barsik", "api", "api", "api console reply via fallback"),
             ]
         finally:
             tmpdir.cleanup()


### PR DESCRIPTION
## Why

Owner rule (Brad, 2026-06-22): an agent's bare plain-text output must **never** auto-deliver to an outreach channel (telegram / discord / slack) — **not even a 1:1 owner DM**. To reach any external channel the agent must call an explicit `pinky-messaging` outreach tool (`send`/`thread`). When an agent decides to stay silent it often "thinks out loud" (emits reasoning text without calling a tool); auto-pushing that to a real channel leaks internal deliberation (the Chekov-on-Slack leak) and trains lazy non-tool replies. Bare text should only ever appear on the **web UI / internal surfaces**.

This is the mechanism half of the fallback work — #815 removed the *hint*; this removes the *behavior* for outreach channels.

## What

`broker.route_response` now gates purely on platform:

| Platform | Plain-text fallback |
|----------|--------------------|
| `web` / `api` / `""` (console, internal) | ✅ delivered (unchanged) |
| telegram / discord / slack — **incl. 1:1 owner DM** | 🚫 suppressed |
| group / public channel | 🚫 suppressed (already was, via #810) |

This **supersedes the #810 logic** (which allowed 1:1-DM fallback while blocking group leaks) with a stricter, simpler fail-closed rule: *outreach channels are tool-only*. The group-leak guard is subsumed — groups are external, so they're suppressed here too. The per-message-context lookup is no longer needed for the suppression decision.

## Errors still surface

Unaffected — errors route back on their **own** paths, not through this fallback:
- API-level errors (rate-limit, content-filter, invalid-request) have their content suppressed upstream in `streaming_session` so raw error JSON never reaches chat.
- Auth failures fire the dedicated `_auth_alert_callback` to notify the operator.

So "only errors route back to outreach channels" holds without any new error-routing code.

## Scope note — legacy `--mode poll` left untouched

`daemon.py`'s `response_callback` (poll mode) also delivers text to telegram, but that's poll mode's **primary** reply mechanism (no webui alternative) — not a fallback — and suppressing it would break replies entirely. Production runs `--mode api` (broker path), so this rule applies where it matters. Documented here rather than changed.

## Tests

- `test_route_response_sends_plain_text_when_fallback_enabled` → **`_suppresses_fallback_on_external_dm`**: even a valid 1:1 owner DM context + fallback enabled now suppresses on telegram.
- `test_route_response_allows_fallback_on_dm_context` → **`_allows_fallback_on_api_surface`**: keeps positive-delivery coverage on an internal surface (`api`), complementing the existing `web` test.
- Unchanged & still green: group suppression, no-context suppression, context-collision suppression, web delivery, outreach-used skip, fallback-disabled skip.
- `ruff` clean; `pytest tests/test_broker.py tests/test_agent_registry.py` → **152 passed**.

## Net behavior

Agents must use `send`/`thread` to reach Brad (or anyone) on a real channel; bare non-tool text only shows in the web UI. Errors still surface via their existing operator-alert path.

🤖 Opened by Barsik