### PR TITLE
fix(tmux): seed hasCompletedOnboarding so a blanked .claude.json self-heals (no login-wizard wedge)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -127,9 +127,10 @@ _TRANSPORT_LOCK_DIR = Path("data/transport-locks")
 # ──────────────────────────────────────────────────────────────────────────
 #
 # A fresh ``claude`` REPL on a box that has never run Claude Code in this
-# agent-home wedges at two interactive first-run gates:
-#   1. "Do you trust the files in this folder?"
-#   2. "Bypass Permissions mode" acceptance
+# agent-home wedges at three interactive first-run gates:
+#   1. the login / onboarding wizard ("Welcome to Claude Code")
+#   2. "Do you trust the files in this folder?"
+#   3. "Bypass Permissions mode" acceptance
 # ``claude --dangerously-skip-permissions`` does NOT auto-accept either —
 # the pane parks at the prompt, no transcript is ever written, and the
 # session sits CONNECTED-but-mute with ``pending_responses=true`` forever
@@ -332,8 +333,9 @@ def _seed_claude_trust_file(config_path: Path, project_dir: str) -> bool:
     """Idempotently pre-seed first-run trust/bypass flags in
     ``config_path`` (Claude Code's ``.claude.json``) for ``project_dir``.
 
-    Sets top-level ``bypassPermissionsModeAccepted`` and, under
-    ``projects[<resolved project_dir>]``, ``hasTrustDialogAccepted`` +
+    Sets top-level ``bypassPermissionsModeAccepted`` +
+    ``hasCompletedOnboarding`` and, under ``projects[<resolved
+    project_dir>]``, ``hasTrustDialogAccepted`` +
     ``hasCompletedProjectOnboarding`` — all to ``True``. Preserves every
     other key (the file also holds oauth creds + per-project history).
 
@@ -358,9 +360,18 @@ def _seed_claude_trust_file(config_path: Path, project_dir: str) -> bool:
                 )
 
         changed = False
-        if data.get("bypassPermissionsModeAccepted") is not True:
-            data["bypassPermissionsModeAccepted"] = True
-            changed = True
+        # Top-level first-run gates, re-asserted on every launch.
+        # ``hasCompletedOnboarding`` skips the initial login/onboarding wizard
+        # ("Welcome to Claude Code"); ``bypassPermissionsModeAccepted`` skips
+        # the "Bypass Permissions mode" consent. Both persist globally in
+        # ``.claude.json`` — but when a shared-home fleet corrupts that file and
+        # the CLI recreates it BLANK, both vanish and every agent re-wedges at
+        # the wizard. Seeding them here makes the corruption self-heal: the next
+        # launch repairs the config instead of parking at an interactive prompt.
+        for flag in ("bypassPermissionsModeAccepted", "hasCompletedOnboarding"):
+            if data.get(flag) is not True:
+                data[flag] = True
+                changed = True
 
         projects = data.setdefault("projects", {})
         if not isinstance(projects, dict):

--- a/tests/test_tmux_trust_seed.py
+++ b/tests/test_tmux_trust_seed.py
@@ -51,6 +51,7 @@ def test_seed_creates_missing_file(tmp_path: Path):
     assert cfg.exists()
     data = json.loads(cfg.read_text())
     assert data["bypassPermissionsModeAccepted"] is True
+    assert data["hasCompletedOnboarding"] is True
     entry = data["projects"][str(proj.resolve())]
     assert entry["hasTrustDialogAccepted"] is True
     assert entry["hasCompletedProjectOnboarding"] is True
@@ -110,6 +111,67 @@ def test_seed_completes_partial_flags(tmp_path: Path):
     entry = data["projects"][str(proj.resolve())]
     assert entry["hasTrustDialogAccepted"] is True
     assert entry["hasCompletedProjectOnboarding"] is True
+
+
+def test_seed_restores_onboarding_flag_on_blanked_config(tmp_path: Path):
+    """Regression (TOD 2026-06-23): a shared-home fleet periodically corrupts
+    ``.claude.json``; the CLI then recreates it BLANK, dropping the global
+    ``hasCompletedOnboarding`` flag. Without it the next ``claude`` launch parks
+    at the login/onboarding wizard ("Welcome to Claude Code"). The seed must
+    re-assert it so the agent boots clean instead of wedging."""
+    cfg = tmp_path / ".claude.json"
+    # A freshly-recreated, near-blank config — no onboarding flag at all.
+    cfg.write_text(json.dumps({"projects": {}}))
+    proj = tmp_path / "agents" / "angel"
+    proj.mkdir(parents=True)
+
+    wrote = _seed_claude_trust_file(cfg, str(proj))
+
+    assert wrote is True
+    data = json.loads(cfg.read_text())
+    assert data["hasCompletedOnboarding"] is True
+    assert data["bypassPermissionsModeAccepted"] is True
+
+
+def test_seed_adds_onboarding_when_only_that_flag_missing(tmp_path: Path):
+    """The exact TOD gap: trust + bypass + per-project flags are all present,
+    yet the top-level ``hasCompletedOnboarding`` is missing — the agent still
+    wedged at the login wizard while trust was fine. The seed must detect this
+    and write."""
+    cfg = tmp_path / ".claude.json"
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    proj_key = str(proj.resolve())
+    cfg.write_text(
+        json.dumps(
+            {
+                "bypassPermissionsModeAccepted": True,
+                "projects": {
+                    proj_key: {
+                        "hasTrustDialogAccepted": True,
+                        "hasCompletedProjectOnboarding": True,
+                    }
+                },
+            }
+        )
+    )
+
+    wrote = _seed_claude_trust_file(cfg, str(proj))
+
+    assert wrote is True  # only hasCompletedOnboarding was missing
+    data = json.loads(cfg.read_text())
+    assert data["hasCompletedOnboarding"] is True
+
+
+def test_seed_idempotent_includes_onboarding(tmp_path: Path):
+    """Once onboarding + trust + bypass are all set, a re-seed is a no-op."""
+    cfg = tmp_path / ".claude.json"
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    assert _seed_claude_trust_file(cfg, str(proj)) is True
+    # Everything (incl. hasCompletedOnboarding) now set → second call writes
+    # nothing.
+    assert _seed_claude_trust_file(cfg, str(proj)) is False
 
 
 def test_seed_corrupt_file_raises_and_does_not_overwrite(tmp_path: Path):


### PR DESCRIPTION
## Problem

The TOD fleet went dark this morning (2026-06-23): all 8 agents wedged at the Claude Code first-run **login/onboarding wizard** ("Welcome to Claude Code" → "Paste code here if prompted"), connected-but-mute. It *looked* like a de-auth/outage, but the auth token was valid throughout — live `claude -p` calls against the account returned normally.

Root cause: on a shared-home fleet all agents run under one user sharing one `~/.claude.json`. Concurrent `claude` writes corrupt it periodically (the box shows `.claude.json.corrupted.*` on Jun 14/18/19/20/23). On corruption the CLI backs up the bad file and recreates a **blank** one — dropping the global `hasCompletedOnboarding` flag.

`_seed_claude_trust_file()` already re-asserts `bypassPermissionsModeAccepted` + per-project trust before each launch, but **not** `hasCompletedOnboarding`. So after a corruption it restored trust/bypass yet agents still dropped into the onboarding *wizard* and wedged.

## Fix

Add `hasCompletedOnboarding` to the top-level seed in `_seed_claude_trust_file()` (folded into a small loop alongside `bypassPermissionsModeAccepted`). Now corruption **self-heals**: the next agent launch repairs the config instead of parking at an interactive prompt. No new system — a one-flag addition to existing, already-tested plumbing.

## Tests
- `test_seed_creates_missing_file` now also asserts `hasCompletedOnboarding`.
- **+** `test_seed_restores_onboarding_flag_on_blanked_config` — the blanked-recreate scenario.
- **+** `test_seed_adds_onboarding_when_only_that_flag_missing` — the exact gap (trust/bypass fine, onboarding missing → still writes).
- **+** `test_seed_idempotent_includes_onboarding`.
- 13 trust-seed + 70 container-isolation tests pass; `ruff` clean.

## Live validation (TOD, 2026-06-23)

**Before** — agent pane wedged at the wizard:
```
Welcome to Claude Code v2.1.186
 ...
 Browser didn't open? Use the url below to sign in
 https://claude.com/cai/oauth/authorize?code=true&client_id=...
 Paste code here if prompted >
```

**After** — flags seeded, agent boots clean and processes a live turn:
```
● Back up after the restart — state intact. Inbox empty, no new messages...
✻ Worked for 29s
❯
  ⏵⏵ bypass permissions on (shift+tab to cycle)
```

(The fleet was hotfixed live by manually patching the flags; this PR makes the daemon do it automatically on every launch so it never recurs.)

## Follow-up
This is the self-heal mitigation. The durable fix for the underlying corruption is **per-agent config isolation** (separate `CLAUDE_CONFIG_DIR`/HOME per agent) so agents don't share one `.claude.json` — the #229 per-agent-OAuth direction.

🤖 Opened by Barsik
