### PR TITLE
fix(slack): deliver file_share messages (screenshots/docs) — were dropped before download

### DIFF
--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -1315,13 +1315,16 @@ class BrokerSlackPoller:
         event = (payload or {}).get("event") or {}
         if event.get("type") != "message":
             return
-        # Keep fresh text only: a normal message (incl. a thread reply) has no
-        # subtype, and bot-authored messages carry the `bot_message` subtype —
-        # both are real inbound and must reach us (peer-agent parity with the
-        # Discord poller). Every other subtype (edits/deletes/joins/topic/…) is
-        # non-fresh → drop.
+        # Keep fresh inbound only: a normal message (incl. a thread reply) has no
+        # subtype; bot-authored messages carry `bot_message`; and a file upload
+        # (a shared screenshot/document) carries `file_share` and brings the
+        # `files` we download below. All three are real inbound and must reach us
+        # (peer-agent parity with the Discord poller). Every other subtype
+        # (edits/deletes/joins/topic/…) is non-fresh → drop. NOTE: without
+        # `file_share` here, image/file messages are dropped *before* the
+        # attachment handling below ever runs — i.e. screenshots never arrive.
         subtype = event.get("subtype") or ""
-        if subtype and subtype != "bot_message":
+        if subtype and subtype not in ("bot_message", "file_share"):
             return
         user_id = event.get("user", "") or ""
         bot_id = event.get("bot_id", "") or ""

--- a/tests/test_slack_poller.py
+++ b/tests/test_slack_poller.py
@@ -161,8 +161,12 @@ class TestBrokerSlackPoller:
     @pytest.mark.asyncio
     async def test_file_attachment_normalized(self, mock_broker):
         poller = _make_poller(mock_broker)
+        # Real Slack file uploads carry subtype "file_share" — include it so the
+        # test exercises the same payload Slack actually sends (a bare `files`
+        # message with no subtype does not occur in practice).
         await poller._handle_event(_event({
-            "type": "message", "user": "U123", "text": "see file",
+            "type": "message", "subtype": "file_share",
+            "user": "U123", "text": "see file",
             "channel": "C1", "ts": "3.3",
             "files": [{
                 "id": "F1", "name": "doc.pdf",
@@ -178,6 +182,31 @@ class TestBrokerSlackPoller:
         assert att["file_name"] == "doc.pdf"
         assert att["mime_type"] == "application/pdf"
         assert att["file_size"] == 1234
+
+    @pytest.mark.asyncio
+    async def test_file_share_screenshot_no_caption_delivered(self, mock_broker):
+        """Regression: a screenshot (subtype `file_share`, often no text) must be
+        DELIVERED with its image attachment, not dropped by the subtype filter.
+        Before the fix, `file_share` was filtered out before attachment handling,
+        so screenshots never reached the agent at all."""
+        poller = _make_poller(mock_broker)
+        await poller._handle_event(_event({
+            "type": "message", "subtype": "file_share",
+            "user": "U123", "text": "",  # caption-less screenshot
+            "channel": "C1", "ts": "4.4",
+            "files": [{
+                "id": "F2", "name": "Screenshot.png",
+                "url_private_download": "https://files.slack.com/shot.png",
+                "mimetype": "image/png", "size": 5678,
+            }],
+        }))
+        await asyncio.sleep(0)
+        mock_broker.handle_inbound.assert_called_once()
+        bmsg = mock_broker.handle_inbound.call_args[0][0]
+        assert bmsg.content == ""
+        assert len(bmsg.attachments) == 1
+        assert bmsg.attachments[0]["mime_type"] == "image/png"
+        assert bmsg.attachments[0]["file_name"] == "Screenshot.png"
 
     @pytest.mark.asyncio
     async def test_start_without_app_token_is_noop(self, mock_broker):


### PR DESCRIPTION
## Symptom

Sending Chekov a **screenshot via Slack doesn't reach him at all** — not even as text (reported by Brad 2026-06-25).

## Root cause

The Socket Mode poller's subtype filter (`pollers.py`) keeps only no-subtype and `bot_message` events and drops everything else as "non-fresh":

```python
if subtype and subtype != "bot_message":
    return
```

A Slack **file upload** (screenshot/document) arrives as subtype **`file_share`** → dropped here, **before** reaching the `files` → attachments → broker-download code (#809) right below it. So image/file messages never arrive.

Verified the rest of the chain is already healthy, so this filter is the *sole* blocker:
- Chekov's Slack app already holds **`files:read`** (confirmed live via `X-OAuth-Scopes`) ✅
- The broker file-download dispatch (#809) is **deployed** to the Pi (on 26.06.145) ✅

Bug present since Socket Mode shipped (#801); nobody hit it until a file was sent.

## Fix

Allow `file_share` through the subtype filter alongside `bot_message`. The message then flows down the existing, already-working attachment/download path.

```python
if subtype and subtype not in ("bot_message", "file_share"):
    return
```

## Why CI didn't catch it

`test_file_attachment_normalized` sent a `files` payload with **no `subtype`** — unrealistic (real uploads always carry `file_share`), so it passed the filter and gave false confidence. Made it realistic (adds `file_share`) and added a dedicated regression test: a **caption-less screenshot** (subtype `file_share`, empty text, image attachment) must be delivered *with* its attachment.

Full Slack suite green (96 passed), ruff clean.

## Deploy + verify

Lands in the next release → Pi auto-updates nightly (4:45am), or coordinated manual bounce if needed sooner. **Post-deploy live check:** Brad sends Chekov a screenshot in Slack → confirm it arrives with the image (can't capture that proof until deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)