### PR TITLE
fix(watchdog): exempt live Workflow/background turns from idle-sleep + recover (#230)

### DIFF
--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -630,6 +630,13 @@ class AgentScheduler:
                         )
                         continue
                     _log(f"scheduler: {name}/{label} idle for {int(idle_seconds)}s (threshold: {idle_timeout}s) — auto-sleeping")
+                    log_watchdog_decision(
+                        watchdog="idle_sleep", agent=name, label=label,
+                        decision="sleep", reason="idle_timeout",
+                        state=getattr(ss.state, "value", str(ss.state)),
+                        last_active_age_s=idle_seconds,
+                        idle_timeout_s=idle_timeout, inflight_active=False,
+                    )
                     if self._activity:
                         try:
                             self._activity.log(name, "agent_sleep", f"{name} auto-slept (idle timeout)")
@@ -764,7 +771,39 @@ class AgentScheduler:
 
                 idle_seconds = now - ss.last_active
                 if idle_seconds >= threshold_seconds:
+                    # #230 — never auto-sleep a session running a live Workflow /
+                    # background turn. This path shares the stale-``last_active``
+                    # threshold with _check_idle_sessions AND runs BEFORE it in
+                    # _tick(), and ``auto_sleep_hours`` also feeds the tmux
+                    # session ``idle_timeout`` — so without the SAME carve-out it
+                    # would tear down an in-flight Workflow here first, before the
+                    # _check_idle_sessions guard ever runs (Murzik #825 review).
+                    # Releases the instant liveness stops (finished work sleeps).
+                    stats = getattr(ss, "stats", None) or {}
+                    state_val = getattr(ss.state, "value", str(ss.state))
+                    if stats.get("inflight_active"):
+                        log_watchdog_decision(
+                            watchdog="auto_sleep", agent=agent.name, label=label,
+                            decision="skip", reason="inflight_active",
+                            state=state_val, last_active_age_s=idle_seconds,
+                            idle_timeout_s=threshold_seconds,
+                            inflight_turns=stats.get("inflight_turns"),
+                            inflight_active=True,
+                            inflight_liveness_reason=stats.get(
+                                "inflight_liveness_reason"
+                            ),
+                            inflight_liveness_age_s=stats.get(
+                                "inflight_liveness_age_s"
+                            ),
+                        )
+                        continue
                     _log(f"scheduler: auto-sleep for '{agent.name}/{label}' — idle {idle_seconds / 3600:.1f}h (threshold: {agent.auto_sleep_hours}h)")
+                    log_watchdog_decision(
+                        watchdog="auto_sleep", agent=agent.name, label=label,
+                        decision="sleep", reason="auto_sleep_idle",
+                        state=state_val, last_active_age_s=idle_seconds,
+                        idle_timeout_s=threshold_seconds, inflight_active=False,
+                    )
                     if self._auto_sleep_callback:
                         try:
                             await self._auto_sleep_callback(

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -22,6 +22,7 @@ from zoneinfo import ZoneInfo
 
 from pinky_daemon.agent_registry import AgentRegistry
 from pinky_daemon.transport_state import SessionState
+from pinky_daemon.watchdog_log import log_watchdog_decision
 
 
 def _log(msg: str) -> None:
@@ -600,6 +601,34 @@ class AgentScheduler:
 
                 idle_seconds = now - ss.last_active
                 if idle_seconds >= idle_timeout:
+                    # #230 — never idle-sleep a session running a live Workflow /
+                    # background turn. ``last_active`` is bumped only at turn
+                    # delivery, NOT by subagent/workflow progress, so a long
+                    # quiet-main-transcript Workflow looks "idle" and idle_sleep()
+                    # would tear the REPL down mid-flight, killing the work. The
+                    # transport's live ``inflight_active`` signal (reusing the
+                    # #692/#731 liveness plumbing) flips False the moment liveness
+                    # stops, so a FINISHED workflow still sleeps normally on a
+                    # later tick. Absent on codex/legacy stats → falsy → sleeps
+                    # exactly as before.
+                    stats = getattr(ss, "stats", None) or {}
+                    if stats.get("inflight_active"):
+                        log_watchdog_decision(
+                            watchdog="idle_sleep", agent=name, label=label,
+                            decision="skip", reason="inflight_active",
+                            state=getattr(ss.state, "value", str(ss.state)),
+                            last_active_age_s=idle_seconds,
+                            idle_timeout_s=idle_timeout,
+                            inflight_turns=stats.get("inflight_turns"),
+                            inflight_active=True,
+                            inflight_liveness_reason=stats.get(
+                                "inflight_liveness_reason"
+                            ),
+                            inflight_liveness_age_s=stats.get(
+                                "inflight_liveness_age_s"
+                            ),
+                        )
+                        continue
                     _log(f"scheduler: {name}/{label} idle for {int(idle_seconds)}s (threshold: {idle_timeout}s) — auto-sleeping")
                     if self._activity:
                         try:

--- a/src/pinky_daemon/session_watchdog.py
+++ b/src/pinky_daemon/session_watchdog.py
@@ -476,6 +476,14 @@ class SessionWatchdog:
                 f"{snap.pending} pending message(s)."
             )
             _warn(msg)
+            log_watchdog_decision(
+                watchdog="session", agent=snap.agent_name, label=snap.label,
+                decision="warn", reason="stale_progress", state=snap.state,
+                pending=snap.pending, turns=snap.turns,
+                current_activity=snap.current_activity,
+                progress_stale_s=stale_seconds, warn_after_s=cfg.warn_after_seconds,
+                inflight_turns=snap.inflight_turns, inflight_active=False,
+            )
             if self._alert_fn:
                 try:
                     await self._alert_fn(snap.agent_name, msg)
@@ -493,6 +501,15 @@ class SessionWatchdog:
                 f"{snap.pending} pending message(s)"
             )
             _warn("watchdog recovering %s: %s", snap.agent_name, reason)
+            log_watchdog_decision(
+                watchdog="session", agent=snap.agent_name, label=snap.label,
+                decision="recover", reason="stale_progress", state=snap.state,
+                pending=snap.pending, turns=snap.turns,
+                current_activity=snap.current_activity,
+                progress_stale_s=stale_seconds,
+                recover_after_s=cfg.recover_after_seconds,
+                inflight_turns=snap.inflight_turns, inflight_active=False,
+            )
             if self._recover_fn:
                 try:
                     await self._recover_fn(snap.agent_name, snap.label, reason)

--- a/src/pinky_daemon/session_watchdog.py
+++ b/src/pinky_daemon/session_watchdog.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine
 
 from pinky_daemon.transport_state import SessionState
+from pinky_daemon.watchdog_log import log_watchdog_decision
 
 _log = logging.getLogger("pinky.watchdog").info
 _warn = logging.getLogger("pinky.watchdog").warning
@@ -190,6 +191,17 @@ class _SessionSnapshot:
     # the transport's StateMachine (#206). 0.0 when the transport doesn't
     # expose it — the watchdog then falls back to its own sampled timing.
     state_entered_at: float = 0.0
+    # #230 — live in-flight carve-out signal (from the transport's
+    # ``stats["inflight_active"]``). True iff the session has an in-flight turn
+    # that is genuinely busy right now (foreground tool / main- or background-
+    # transcript growth). The progress watchdog skips warn+recover while True so
+    # a long Workflow isn't force-recovered mid-flight — WITHOUT resetting the
+    # stale clock, so it acts immediately once liveness stops. False/empty for
+    # transports that don't expose it (codex/streaming/legacy).
+    inflight_turns: int = 0
+    inflight_active: bool = False
+    inflight_liveness_reason: str = ""
+    inflight_liveness_age_s: float | None = None
 
 
 @dataclass
@@ -343,6 +355,10 @@ class SessionWatchdog:
             sample_time=time.time(),
             state=state,
             state_entered_at=stats.get("state_entered_at", 0.0) or 0.0,
+            inflight_turns=stats.get("inflight_turns", 0) or 0,
+            inflight_active=bool(stats.get("inflight_active", False)),
+            inflight_liveness_reason=stats.get("inflight_liveness_reason", "") or "",
+            inflight_liveness_age_s=stats.get("inflight_liveness_age_s"),
         )
 
     async def _evaluate(self, snap: _SessionSnapshot, now: float) -> None:
@@ -420,6 +436,31 @@ class SessionWatchdog:
         if not snap.connected:
             return
         if cfg.require_backlog and snap.pending < cfg.min_pending:
+            return
+
+        # #230 — in-flight Workflow/background carve-out. A session running a
+        # live Workflow/Agent emits nothing this progress logic sees (turns and
+        # current_activity stay static), so without this it would warn+recover
+        # mid-flight once a message queues behind the long turn. Skip warn+recover
+        # while the transport reports a genuinely-busy in-flight turn — but do
+        # NOT reset ``last_progress_at``: the stale clock keeps aging BEHIND the
+        # exemption, so the moment liveness stops (turn still not progressing) we
+        # act on the next sweep instead of granting a fresh full window. Parity
+        # for the daemon-level warn/recover path of what #692/#731 gave the
+        # per-session _inflight_watchdog's force_restart path.
+        if snap.inflight_active:
+            log_watchdog_decision(
+                watchdog="session", agent=snap.agent_name, label=snap.label,
+                decision="skip", reason="inflight_active", state=snap.state,
+                pending=snap.pending, turns=snap.turns,
+                current_activity=snap.current_activity,
+                progress_stale_s=stale_seconds,
+                warn_after_s=cfg.warn_after_seconds,
+                recover_after_s=cfg.recover_after_seconds,
+                inflight_turns=snap.inflight_turns, inflight_active=True,
+                inflight_liveness_reason=snap.inflight_liveness_reason,
+                inflight_liveness_age_s=snap.inflight_liveness_age_s,
+            )
             return
 
         # Warn tier

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -99,6 +99,7 @@ from pinky_daemon.wake_prompt import (
     build_idle_sleep_prompt,
     build_wake_prompt,
 )
+from pinky_daemon.watchdog_log import log_watchdog_decision
 
 # Soft context-watermark default (#614) — used when an agent's
 # ``context_nudge_threshold_pct`` is unset (0). Sits well below the
@@ -1683,6 +1684,13 @@ class TmuxSession:
         # a running turn there would warn/auto-recover mid-turn on any
         # long turn. ``inflight_turns`` exposes the pasted-awaiting-stop
         # span separately for busy-state consumers (UI badge).
+        #
+        # #230 — ``inflight_active`` is the live carve-out signal the OUTER
+        # watchdogs (daemon SessionWatchdog warn/recover + scheduler idle-sleep)
+        # read to avoid tearing down a session mid-Workflow. Computed live here
+        # so those paths don't recompute slightly-different truth; cheap when no
+        # turn is in flight (returns early before any filesystem stat).
+        live = self._watchdog_liveness(time.time())
         return {
             **self._stats,
             "state": self.state.value,
@@ -1692,6 +1700,9 @@ class TmuxSession:
             "state_entered_at": self._state_machine.state_entered_at,
             "pending_responses": self._message_queue.qsize(),
             "inflight_turns": len(self._inflight_metas),
+            "inflight_active": live["active"],
+            "inflight_liveness_reason": live["reason"],
+            "inflight_liveness_age_s": live["age_s"],
             "current_activity": self._current_activity,
             "current_thinking": self._current_thinking,
             "activity_log": list(self._activity_log[-20:]),
@@ -4800,6 +4811,24 @@ class TmuxSession:
             return False
         return result.ok and marker in (result.stdout or "")
 
+    def _main_transcript_age(self, now: float) -> float | None:
+        """Seconds since the main transcript was last written, or None.
+
+        None when the path is the cold-start placeholder, missing, or
+        unstattable — absence of evidence (callers treat None as "no growth"
+        so a real stall isn't masked). Single source of truth for both
+        ``_transcript_recently_grew`` (bool) and ``_watchdog_liveness`` (age).
+        """
+        tailer = self._tailer
+        path = getattr(tailer, "transcript_path", None) if tailer else None
+        if not path:
+            return None
+        try:
+            mtime = Path(path).stat().st_mtime
+        except OSError:
+            return None
+        return now - mtime
+
     def _transcript_recently_grew(self, now: float, window: float) -> bool:
         """True if the transcript file was written within ``window`` seconds.
 
@@ -4809,18 +4838,11 @@ class TmuxSession:
         absence of evidence is treated as "not growing" so the caller falls
         through to the idle/wedged checks rather than masking a real stall.
         """
-        tailer = self._tailer
-        path = getattr(tailer, "transcript_path", None) if tailer else None
-        if not path:
-            return False
-        try:
-            mtime = Path(path).stat().st_mtime
-        except OSError:
-            return False
-        return (now - mtime) < window
+        age = self._main_transcript_age(now)
+        return age is not None and age < window
 
-    def _background_tasks_recently_active(self, now: float, window: float) -> bool:
-        """True if a background task wrote a transcript within ``window`` seconds.
+    def _background_task_recent_age(self, now: float, window: float) -> float | None:
+        """Seconds since a background task last wrote a transcript, or None.
 
         A blocking turn can be legitimately busy with NO main-transcript output:
         the REPL is parked on a long-running background task (a Dynamic
@@ -4836,21 +4858,24 @@ class TmuxSession:
         and puts subagent/workflow transcripts under the sibling ``<session>/``
         directory (``subagents/`` and ``workflows/``). We derive that directory
         from the tailer's transcript path and look for any entry modified within
-        the window, short-circuiting on the first hit. Absence of evidence →
-        False (same convention as ``_transcript_recently_grew``: fall through to
-        the idle/wedged checks rather than masking a real stall).
+        the window, short-circuiting on (and returning the age of) the FIRST hit.
+        None when there is no recent background write (same convention as
+        ``_main_transcript_age``: absence of evidence, so the caller falls
+        through to the idle/wedged checks rather than masking a real stall).
+        Single source of truth for ``_background_tasks_recently_active`` (bool)
+        and ``_watchdog_liveness`` (age).
         """
         tailer = self._tailer
         path = getattr(tailer, "transcript_path", None) if tailer else None
         if not path:
-            return False
+            return None
         try:
             path = Path(path)
         except (TypeError, ValueError):
-            return False
+            return None
         name = path.name
         if not name.endswith(".jsonl"):
-            return False
+            return None
         # ``<session>.jsonl`` → sibling ``<session>/`` dir holding background work.
         session_dir = path.with_name(name[: -len(".jsonl")])
         cutoff = now - window
@@ -4861,13 +4886,22 @@ class TmuxSession:
                     continue
                 for entry in root.rglob("*"):
                     try:
-                        if entry.stat().st_mtime >= cutoff:
-                            return True
+                        mtime = entry.stat().st_mtime
                     except OSError:
                         continue
+                    if mtime >= cutoff:
+                        return now - mtime
             except OSError:
                 continue
-        return False
+        return None
+
+    def _background_tasks_recently_active(self, now: float, window: float) -> bool:
+        """True if a background task wrote a transcript within ``window`` seconds.
+
+        Thin bool wrapper over ``_background_task_recent_age`` (single source of
+        truth). See that method for the layout/convention rationale (#692).
+        """
+        return self._background_task_recent_age(now, window) is not None
 
     def _foreground_tool_in_flight(self, now: float) -> bool:
         """True if a FOREGROUND tool call is still running (#731).
@@ -4901,6 +4935,67 @@ class TmuxSession:
                 continue
             alive = True
         return alive
+
+    def _watchdog_liveness(self, now: float) -> dict:
+        """Live carve-out signal for the OUTER watchdogs (#230).
+
+        Answers "is this session's in-flight turn genuinely busy *right now*?"
+        for the daemon ``SessionWatchdog`` (warn/recover) and the scheduler
+        idle-sleep — the two teardown paths that, unlike the per-session
+        ``_inflight_watchdog`` (#692/#731), had no background/foreground
+        liveness awareness and would tear a session down mid-Workflow.
+
+        Returns ``{"active": bool, "reason": str, "age_s": float | None}``.
+        ``active`` is True ONLY when BOTH hold:
+
+          * there is an in-flight turn (``_inflight_metas`` non-empty), AND
+          * positive liveness evidence — a foreground tool in flight (#731), a
+            recently-written main transcript, or a recently-written subagent/
+            workflow transcript (#692), within
+            ``_BACKGROUND_TASK_ACTIVE_WINDOW_SEC``.
+
+        Computed LIVE on every call — never latched/persisted — so the carve-out
+        RELEASES the instant liveness stops (a finished workflow sleeps normally;
+        a turn that goes quiet is no longer exempt). Distinct from
+        ``_inflight_stall_verdict``, which is age-gated on
+        ``_TURN_DONE_TIMEOUT_SEC`` before it even looks: this answers "live now",
+        so B/C can act the moment liveness stops while their OWN stale clocks keep
+        aging behind the exemption (we never reset their timers — Murzik review).
+
+        A bare "recent subagent dir exists" is NOT credited without an in-flight
+        turn. Cheapest→costliest evidence order; first positive wins (``reason``
+        is diagnostic only — ``active`` is the same regardless of which fired).
+        """
+        if not self._inflight_metas:
+            return {"active": False, "reason": "no_inflight_turn", "age_s": None}
+        # (1) Foreground tool in flight — authoritative (hook-tracked), cheapest.
+        if self._foreground_tool_in_flight(now):
+            ages = [now - t for t in self._inflight_tool_calls.values()]
+            return {
+                "active": True,
+                "reason": "foreground_tool_in_flight",
+                "age_s": min(ages) if ages else None,
+            }
+        # (2) Main transcript recently written — one stat.
+        main_age = self._main_transcript_age(now)
+        if main_age is not None and main_age < _BACKGROUND_TASK_ACTIVE_WINDOW_SEC:
+            return {
+                "active": True,
+                "reason": "main_transcript_recent",
+                "age_s": main_age,
+            }
+        # (3) Background (subagent/workflow) transcript recently written — rglob,
+        # last because it's the costliest; the common long-Workflow case.
+        bg_age = self._background_task_recent_age(
+            now, _BACKGROUND_TASK_ACTIVE_WINDOW_SEC
+        )
+        if bg_age is not None:
+            return {
+                "active": True,
+                "reason": "background_transcript_recent",
+                "age_s": bg_age,
+            }
+        return {"active": False, "reason": "quiet", "age_s": None}
 
     def _inflight_stall_verdict(self, now: float) -> str:
         """Classify a possibly-stalled inflight head for the watchdog (#118).
@@ -5144,6 +5239,12 @@ class TmuxSession:
                         f"but transcript or background task still active — not "
                         f"wedged, extending window (deque depth={depth})"
                     )
+                    log_watchdog_decision(
+                        watchdog="inflight", agent=self.agent_name,
+                        decision="skip", reason="growing", state=self.state.value,
+                        progress_stale_s=age, inflight_turns=depth,
+                        inflight_active=True,
+                    )
                     continue
                 if verdict == "idle":
                     # #118: head aged out, transcript quiet, and the REPL last
@@ -5165,6 +5266,12 @@ class TmuxSession:
                         f"but REPL is idle — reconciled {len(drained)} phantom "
                         f"meta(s), NOT restarting (#118)"
                     )
+                    log_watchdog_decision(
+                        watchdog="inflight", agent=self.agent_name,
+                        decision="reconcile", reason="idle_phantom",
+                        state=self.state.value, progress_stale_s=age,
+                        inflight_turns=depth, inflight_active=False,
+                    )
                     continue
                 # verdict == "wedged": no output + REPL not idle → genuinely
                 # stuck. Fall through to the force_restart recovery path.
@@ -5173,6 +5280,12 @@ class TmuxSession:
                     f"> {_TURN_DONE_TIMEOUT_SEC}s, transcript quiet + REPL not "
                     f"idle — REPL stuck; scheduling force_restart "
                     f"(deque depth={depth})"
+                )
+                log_watchdog_decision(
+                    watchdog="inflight", agent=self.agent_name,
+                    decision="restart", reason="wedged", state=self.state.value,
+                    progress_stale_s=age, inflight_turns=depth,
+                    inflight_active=False,
                 )
                 # Snapshot deque state before mutation so this critical
                 # section is atomic from the outside (no awaits between

--- a/src/pinky_daemon/watchdog_log.py
+++ b/src/pinky_daemon/watchdog_log.py
@@ -22,7 +22,7 @@ _log = logging.getLogger("pinky.watchdog").info
 # Canonical field order. A path omits any field it doesn't have (None is dropped),
 # so every emitted line is a stable subset of this ordering.
 _FIELDS = (
-    "watchdog",  # session | idle_sleep | inflight — which watchdog acted
+    "watchdog",  # session | idle_sleep | auto_sleep | inflight — which acted
     "agent",
     "label",
     "decision",  # skip | warn | recover | sleep | restart | reconcile | no_op

--- a/src/pinky_daemon/watchdog_log.py
+++ b/src/pinky_daemon/watchdog_log.py
@@ -1,0 +1,66 @@
+"""Shared structured-log schema for the watchdog decision points (#230).
+
+All three watchdog paths emit ONE consistent ``key=value`` line so decisions are
+greppable and auditable side-by-side:
+
+  * the per-session in-flight watchdog (``TmuxSession._inflight_watchdog`` —
+    force_restart / growing / idle-reconcile),
+  * the daemon ``SessionWatchdog`` (warn / recover / inflight-skip), and
+  * the scheduler idle-sleep (``_check_idle_sessions`` — sleep / inflight-skip).
+
+The schema (key set + ordering + rounding) lives here, in ONE place, while each
+path keeps its own decision logic and passes only the fields it has. Centralising
+the schema — not the decisions — is the shape Murzik signed off on for #230: a
+reader greps ``watchdog_decision`` and sees the same keys from every path.
+"""
+from __future__ import annotations
+
+import logging
+
+_log = logging.getLogger("pinky.watchdog").info
+
+# Canonical field order. A path omits any field it doesn't have (None is dropped),
+# so every emitted line is a stable subset of this ordering.
+_FIELDS = (
+    "watchdog",  # session | idle_sleep | inflight — which watchdog acted
+    "agent",
+    "label",
+    "decision",  # skip | warn | recover | sleep | restart | reconcile | no_op
+    "reason",
+    "state",
+    "pending",
+    "turns",
+    "current_activity",
+    "last_active_age_s",
+    "progress_stale_s",
+    "idle_timeout_s",
+    "warn_after_s",
+    "recover_after_s",
+    "inflight_turns",
+    "inflight_active",
+    "inflight_liveness_reason",
+    "inflight_liveness_age_s",
+)
+
+
+def format_watchdog_decision(**fields) -> str:
+    """Render the standard ``watchdog_decision`` line from the given fields.
+
+    Fields absent or ``None`` are dropped; floats are rounded to 1 dp so the line
+    stays stable and readable. Unknown keys (not in ``_FIELDS``) are ignored so a
+    caller can't silently pollute the schema.
+    """
+    parts = []
+    for key in _FIELDS:
+        val = fields.get(key)
+        if val is None:
+            continue
+        if isinstance(val, float):
+            val = round(val, 1)
+        parts.append(f"{key}={val}")
+    return "watchdog_decision " + " ".join(parts)
+
+
+def log_watchdog_decision(**fields) -> None:
+    """Emit the standard structured decision line at INFO on ``pinky.watchdog``."""
+    _log(format_watchdog_decision(**fields))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -704,7 +704,9 @@ class TestHeartbeatResurrection:
 class _FakeIdleSession:
     """Streaming-session stand-in for idle/auto-sleep scheduling tests."""
 
-    def __init__(self, *, idle_timeout: int = 60) -> None:
+    def __init__(
+        self, *, idle_timeout: int = 60, inflight_active: bool = False
+    ) -> None:
         from types import SimpleNamespace
 
         from pinky_daemon.transport_state import SessionState
@@ -715,6 +717,21 @@ class _FakeIdleSession:
         self.sleep_calls = 0
         self.started = asyncio.Event()
         self.release = asyncio.Event()
+        self._inflight_active = inflight_active
+
+    @property
+    def stats(self) -> dict:
+        # #230 — the scheduler reads ``inflight_active`` to skip idle-sleeping a
+        # session running a live Workflow/background turn.
+        active = self._inflight_active
+        return {
+            "inflight_active": active,
+            "inflight_turns": 1 if active else 0,
+            "inflight_liveness_reason": (
+                "background_transcript_recent" if active else "quiet"
+            ),
+            "inflight_liveness_age_s": 5.0 if active else None,
+        }
 
     async def idle_sleep(self) -> bool:
         self.sleep_calls += 1
@@ -784,6 +801,33 @@ class TestIdleSleepNonBlocking:
         await asyncio.sleep(0)
         await scheduler.stop()
         assert scheduler._sleep_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_inflight_active_skips_idle_sleep(self, registry):
+        # A session running a live Workflow/background turn must NOT be
+        # idle-slept even though last_active is stale (#230).
+        ss = _FakeIdleSession(inflight_active=True)
+        scheduler = AgentScheduler(
+            registry, streaming_sessions_fn=lambda: {"ivan": {"main": ss}}
+        )
+        await scheduler._check_idle_sessions(time.time())
+        await asyncio.sleep(0)
+        assert ss.sleep_calls == 0
+        assert ("ivan", "main") not in scheduler._sleep_tasks
+
+    @pytest.mark.asyncio
+    async def test_inflight_inactive_still_sleeps(self, registry):
+        # The carve-out RELEASES when there's no live work: a quiet/finished
+        # session still sleeps normally (#230).
+        ss = _FakeIdleSession(inflight_active=False)
+        scheduler = AgentScheduler(
+            registry, streaming_sessions_fn=lambda: {"ivan": {"main": ss}}
+        )
+        await scheduler._check_idle_sessions(time.time())
+        await asyncio.wait_for(ss.started.wait(), timeout=2)
+        assert ss.sleep_calls == 1
+        ss.release.set()
+        await asyncio.wait_for(scheduler._sleep_tasks[("ivan", "main")], timeout=2)
 
 
 # ── Non-blocking dream/librarian fires (issue #702) ────────────────────────

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -829,6 +829,52 @@ class TestIdleSleepNonBlocking:
         ss.release.set()
         await asyncio.wait_for(scheduler._sleep_tasks[("ivan", "main")], timeout=2)
 
+    # #230 (Murzik #825 review) — _check_auto_sleep runs BEFORE
+    # _check_idle_sessions in _tick() and shares the stale-last_active threshold
+    # (auto_sleep_hours also feeds idle_timeout), so it needs the SAME carve-out.
+
+    @pytest.mark.asyncio
+    async def test_auto_sleep_fallback_skipped_when_inflight_active(self, registry):
+        registry.register("ivan", model="opus", auto_sleep_hours=1)
+        ss = _FakeIdleSession(idle_timeout=0, inflight_active=True)
+        scheduler = AgentScheduler(
+            registry, streaming_sessions_fn=lambda: {"ivan": {"main": ss}}
+        )
+        await scheduler._check_auto_sleep(time.time())
+        await asyncio.sleep(0)
+        assert ss.sleep_calls == 0
+        assert ("ivan", "main") not in scheduler._sleep_tasks
+
+    @pytest.mark.asyncio
+    async def test_auto_sleep_callback_skipped_when_inflight_active(self, registry):
+        registry.register("ivan", model="opus", auto_sleep_hours=1)
+        ss = _FakeIdleSession(idle_timeout=0, inflight_active=True)
+        calls = []
+
+        async def _cb(agent_name, reason):
+            calls.append(agent_name)
+
+        scheduler = AgentScheduler(
+            registry,
+            streaming_sessions_fn=lambda: {"ivan": {"main": ss}},
+            auto_sleep_callback=_cb,
+        )
+        await scheduler._check_auto_sleep(time.time())
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_auto_sleep_still_fires_when_inactive(self, registry):
+        registry.register("ivan", model="opus", auto_sleep_hours=1)
+        ss = _FakeIdleSession(idle_timeout=0, inflight_active=False)
+        scheduler = AgentScheduler(
+            registry, streaming_sessions_fn=lambda: {"ivan": {"main": ss}}
+        )
+        await asyncio.wait_for(scheduler._check_auto_sleep(time.time()), timeout=2)
+        await asyncio.wait_for(ss.started.wait(), timeout=2)
+        assert ss.sleep_calls == 1
+        ss.release.set()
+        await asyncio.wait_for(scheduler._sleep_tasks[("ivan", "main")], timeout=2)
+
 
 # ── Non-blocking dream/librarian fires (issue #702) ────────────────────────
 

--- a/tests/test_session_watchdog.py
+++ b/tests/test_session_watchdog.py
@@ -299,6 +299,120 @@ class TestEvaluation:
         assert "stuck" in alerts[0][1]
 
 
+class TestInflightCarveOut:
+    """#230 — a session running a live Workflow/background turn must not be
+    warned or force-recovered, but the stale clock must keep aging so recovery
+    fires the moment liveness stops (no fresh window granted)."""
+
+    @pytest.mark.asyncio
+    async def test_take_snapshot_carries_inflight_fields(self, make_watchdog):
+        class TmuxLike:
+            @property
+            def stats(self):
+                return {
+                    "state": "connected",
+                    "turns": 3,
+                    "pending_responses": 2,
+                    "current_activity": "Workflow",
+                    "inflight_turns": 1,
+                    "inflight_active": True,
+                    "inflight_liveness_reason": "background_transcript_recent",
+                    "inflight_liveness_age_s": 4.2,
+                }
+
+        wd = make_watchdog()
+        snap = wd._take_snapshot("a", "main", TmuxLike())
+        assert snap.inflight_active is True
+        assert snap.inflight_turns == 1
+        assert snap.inflight_liveness_reason == "background_transcript_recent"
+        assert snap.inflight_liveness_age_s == 4.2
+
+    @pytest.mark.asyncio
+    async def test_inflight_active_skips_recover_and_keeps_clock(
+        self, make_watchdog
+    ):
+        recoveries = []
+
+        async def _recover(agent, label, reason):
+            recoveries.append((agent, label, reason))
+
+        wd = make_watchdog(recover_fn=_recover)
+        now = time.time()
+        stale_at = now - 1000  # past the 900s recover threshold
+        wd._states[("a", "main")] = _AgentState(
+            last_progress_turns=5,
+            last_progress_activity="Workflow",
+            last_progress_at=stale_at,
+            warned=True,
+        )
+        snap = _SessionSnapshot(
+            agent_name="a", label="main", connected=True,
+            turns=5, pending=3, current_activity="Workflow",
+            sample_time=now, inflight_active=True,
+            inflight_liveness_reason="background_transcript_recent",
+        )
+        await wd._evaluate(snap, now)
+        # No recovery while the workflow is live...
+        assert recoveries == []
+        # ...and the stale clock was NOT reset — it ages behind the exemption.
+        assert wd._states[("a", "main")].last_progress_at == stale_at
+
+    @pytest.mark.asyncio
+    async def test_inflight_active_skips_warn(self, make_watchdog):
+        alerts = []
+
+        async def _alert(agent, msg):
+            alerts.append(msg)
+
+        wd = make_watchdog(alert_fn=_alert)
+        now = time.time()
+        wd._states[("a", "main")] = _AgentState(
+            last_progress_turns=5,
+            last_progress_activity="Workflow",
+            last_progress_at=now - 700,  # past the 600s warn threshold
+        )
+        snap = _SessionSnapshot(
+            agent_name="a", label="main", connected=True,
+            turns=5, pending=3, current_activity="Workflow",
+            sample_time=now, inflight_active=True,
+        )
+        await wd._evaluate(snap, now)
+        assert alerts == []
+
+    @pytest.mark.asyncio
+    async def test_recovers_immediately_when_liveness_stops(self, make_watchdog):
+        recoveries = []
+
+        async def _recover(agent, label, reason):
+            recoveries.append((agent, label, reason))
+
+        wd = make_watchdog(recover_fn=_recover)
+        now = time.time()
+        wd._states[("a", "main")] = _AgentState(
+            last_progress_turns=5,
+            last_progress_activity="Workflow",
+            last_progress_at=now - 1000,
+            warned=True,
+        )
+        # Sweep 1: workflow live → skip recover, clock preserved.
+        snap_live = _SessionSnapshot(
+            agent_name="a", label="main", connected=True,
+            turns=5, pending=3, current_activity="Workflow",
+            sample_time=now, inflight_active=True,
+        )
+        await wd._evaluate(snap_live, now)
+        assert recoveries == []
+        # Sweep 2: liveness stopped, same already-stale clock → recover at once,
+        # NOT after a fresh 900s window.
+        snap_quiet = _SessionSnapshot(
+            agent_name="a", label="main", connected=True,
+            turns=5, pending=3, current_activity="Workflow",
+            sample_time=now, inflight_active=False,
+        )
+        await wd._evaluate(snap_quiet, now)
+        assert len(recoveries) == 1
+
+
 class TestStatus:
     def test_status_empty(self, make_watchdog):
         wd = make_watchdog()

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -17,8 +17,10 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
+import os
 import re
 import time as _time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -8019,3 +8021,118 @@ async def test_send_pane_keys_false_on_tmux_failure() -> None:
     tmux.send_keys = AsyncMock(return_value=_fail("no server running"))
 
     assert await session.send_pane_keys(key="Enter") is False
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #230 — _watchdog_liveness: live carve-out signal for the OUTER watchdogs
+# (daemon SessionWatchdog warn/recover + scheduler idle-sleep). Active ONLY
+# when an in-flight turn is genuinely busy right now; computed live (never
+# latched) so it releases the instant liveness stops.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _point_transcript(ss: TmuxSession, path) -> None:
+    """Point the session's tailer at ``path`` for liveness mtime checks."""
+    ss._tailer = SimpleNamespace(transcript_path=str(path))
+
+
+def _age_file(path, seconds: float) -> None:
+    """Backdate a file's mtime by ``seconds`` so it reads as 'old'."""
+    old = _time.time() - seconds
+    os.utime(path, (old, old))
+
+
+def test_watchdog_liveness_inactive_without_inflight_turn(tmp_path) -> None:
+    ss, _ = _make_session()
+    # Even with a freshly-written transcript, NO in-flight turn → not active:
+    # a session between turns must be sleepable/recoverable as normal.
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}")
+    _point_transcript(ss, main)
+    live = ss._watchdog_liveness(_time.time())
+    assert live["active"] is False
+    assert live["reason"] == "no_inflight_turn"
+
+
+def test_watchdog_liveness_foreground_tool_in_flight(tmp_path) -> None:
+    ss, _ = _make_session()
+    _seed_inflight(ss)
+    ss._inflight_tool_calls = {"tool-1": _time.time()}
+    live = ss._watchdog_liveness(_time.time())
+    assert live["active"] is True
+    assert live["reason"] == "foreground_tool_in_flight"
+    assert live["age_s"] is not None
+
+
+def test_watchdog_liveness_main_transcript_recent(tmp_path) -> None:
+    ss, _ = _make_session()
+    _seed_inflight(ss)
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}")  # just written → recent mtime
+    _point_transcript(ss, main)
+    live = ss._watchdog_liveness(_time.time())
+    assert live["active"] is True
+    assert live["reason"] == "main_transcript_recent"
+
+
+def test_watchdog_liveness_background_transcript_recent(tmp_path) -> None:
+    ss, _ = _make_session()
+    _seed_inflight(ss)
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}")
+    _age_file(main, 1000)  # main quiet → fall through to background evidence
+    wf = tmp_path / "session" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "agent-1.jsonl").write_text("{}")  # recent subagent/workflow write
+    _point_transcript(ss, main)
+    live = ss._watchdog_liveness(_time.time())
+    assert live["active"] is True
+    assert live["reason"] == "background_transcript_recent"
+
+
+def test_watchdog_liveness_quiet_inflight_is_inactive(tmp_path) -> None:
+    ss, _ = _make_session()
+    _seed_inflight(ss)
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}")
+    _age_file(main, 1000)  # main quiet, no fg tool, no background dir
+    _point_transcript(ss, main)
+    live = ss._watchdog_liveness(_time.time())
+    assert live["active"] is False
+    assert live["reason"] == "quiet"
+
+
+def test_watchdog_liveness_stale_background_no_longer_active(tmp_path) -> None:
+    # Murzik correctness point: a stale-but-present subagent dir must STOP
+    # masking once its writes age out of the window.
+    ss, _ = _make_session()
+    _seed_inflight(ss)
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}")
+    _age_file(main, 1000)
+    wf = tmp_path / "session" / "workflows"
+    wf.mkdir(parents=True)
+    stale = wf / "agent-1.jsonl"
+    stale.write_text("{}")
+    _age_file(stale, 1000)  # background write aged out of the 180s window
+    _point_transcript(ss, main)
+    live = ss._watchdog_liveness(_time.time())
+    assert live["active"] is False
+    assert live["reason"] == "quiet"
+
+
+def test_watchdog_liveness_surfaced_in_stats(tmp_path) -> None:
+    ss, _ = _make_session()
+    _seed_inflight(ss)
+    ss._inflight_tool_calls = {"tool-1": _time.time()}
+    stats = ss.stats
+    assert stats["inflight_active"] is True
+    assert stats["inflight_liveness_reason"] == "foreground_tool_in_flight"
+    assert stats["inflight_turns"] == 1
+
+
+def test_stats_inflight_inactive_when_idle(tmp_path) -> None:
+    ss, _ = _make_session()
+    stats = ss.stats
+    assert stats["inflight_active"] is False
+    assert stats["inflight_liveness_reason"] == "no_inflight_turn"


### PR DESCRIPTION
## What & why (#230)

A session running a live background **Workflow/Agent** could be torn down
mid-flight. The per-session in-flight watchdog already protects the
`force_restart` path (#692 background-task + #731 foreground-tool liveness), but
**two other teardown paths had no workflow-awareness**:

- **Daemon `SessionWatchdog`** (`_evaluate` warn/recover) — progress = `turns++`
  or `current_activity` change; a long Workflow moves neither, so it warned @600s
  / **recovered @900s**. Only `require_backlog` gated it, so a >15 min Workflow
  with a message queued behind it was force-recovered.
- **Scheduler idle-sleep** (`_check_idle_sessions`) — decides on
  `now - last_active >= idle_timeout`, and `last_active` is bumped **only at turn
  delivery** (`tmux_session.py` 2756/2863), never by subagent/workflow progress —
  so a long quiet-main-transcript Workflow was auto-slept, tearing down the REPL.

## Shape (vetted by Murzik — option 2, explicit flag)

One live signal, `TmuxSession._watchdog_liveness(now) -> {active, reason, age_s}`,
reusing the Path-A plumbing. `active` is True **only** when there is an in-flight
turn **and** positive evidence — a foreground tool in flight, or the main- or
background-transcript written within `_BACKGROUND_TASK_ACTIVE_WINDOW_SEC` (180s).
Computed **live every call (never latched)**, gated on `_inflight_metas` non-empty,
exposed on `stats` as `inflight_active` / `inflight_liveness_reason` /
`inflight_liveness_age_s`. (Did **not** overload `last_active` — keeps its
persisted/ordering/activity semantics clean.)

- `SessionWatchdog._evaluate` skips warn+recover while `inflight_active` — **without
  resetting the stale clock**, so it acts the instant liveness stops (no fresh
  900s window).
- `scheduler._check_idle_sessions` skips idle-sleep while `inflight_active`.
- A **finished** Workflow sleeps/recovers normally (signal flips false at once).
- New `watchdog_log.format_watchdog_decision` gives all three paths one
  structured, greppable `watchdog_decision` schema.

**Part 3 (concurrency cap, `min(16, cpu-2)`)** is harness-side, not daemon code —
documented in `scripts/issue230_watchdog_scope.md`, no code change here.

## Evidence

```
watchdog_decision watchdog=inflight  agent=barsik decision=skip   reason=growing          progress_stale_s=612.4 inflight_turns=1 inflight_active=True
watchdog_decision watchdog=session   agent=barsik label=main decision=skip reason=inflight_active pending=2 progress_stale_s=931.0 recover_after_s=900 inflight_turns=1 inflight_active=True inflight_liveness_reason=background_transcript_recent inflight_liveness_age_s=3.1
watchdog_decision watchdog=idle_sleep agent=barsik label=main decision=skip reason=inflight_active last_active_age_s=1801.0 idle_timeout_s=1800 inflight_turns=1 inflight_active=True inflight_liveness_reason=background_transcript_recent

Path B: recoveries while workflow live: []           (expected [])
        stale clock preserved (ages behind exemption): True
        recoveries after liveness stops: ['barsik']  (expected ['barsik'])
```

## Tests

- `_watchdog_liveness` matrix: no-turn / foreground-tool / main-transcript /
  background-transcript / quiet-inflight / **stale-background-stops-masking** /
  surfaced-in-stats.
- `SessionWatchdog`: skip recover + **clock preserved**; skip warn; **recovers
  immediately when liveness stops** (no fresh window); snapshot carries fields.
- Scheduler: inflight skips idle-sleep; inactive still sleeps.
- Full suite green locally (`.venv` python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Opened by Barsik
