### PR TITLE
feat(api): make heartbeat_interval editable via PUT /agents/{name}

### DIFF
--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -403,6 +403,7 @@ class UpdateAgentRequest(BaseModel):
     plain_text_fallback: bool | None = None
     restart_threshold_pct: float | None = None
     context_nudge_threshold_pct: float | None = None  # Soft nudge %; 0=use global default (#614)
+    heartbeat_interval: int | None = None  # Seconds between heartbeats (0=disabled → demand-woken)
     wake_interval: int | None = None  # Seconds (0=disabled, 1800=30m, 3600=1h)
     clock_aligned: bool | None = None  # Align to wall clock boundaries
     auto_sleep_hours: int | None = None  # Auto-sleep after N hours idle (0=disabled)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -672,6 +672,33 @@ class TestAPI:
                 # Unchanged after the rejected update.
                 assert client.get("/agents/tenant").json()["isolation_mode"] == "container"
 
+    def test_update_heartbeat_interval_round_trips(self):
+        """PUT /agents/{name} can change heartbeat_interval. The field was
+        missing from UpdateAgentRequest, so a passive worker couldn't be flipped
+        to demand-woken (0) without a clobbering re-register — it just churned a
+        full force_restart every heartbeat. The registry merge already supports
+        the field by key-presence; this exposes it on the update model."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post(
+                    "/agents",
+                    json={"name": "worker", "model": "sonnet", "heartbeat_interval": 300},
+                )
+                assert client.get("/agents/worker").json()["heartbeat_interval"] == 300
+
+                # Flip to demand-woken (0) — now editable via the update model.
+                r = client.put("/agents/worker", json={"heartbeat_interval": 0})
+                assert r.status_code == 200
+                assert r.json()["heartbeat_interval"] == 0
+                assert client.get("/agents/worker").json()["heartbeat_interval"] == 0
+
+                # Merge-by-key-presence: an unrelated update must NOT resurrect
+                # the old cadence (heartbeat_interval absent => unchanged).
+                client.put("/agents/worker", json={"display_name": "Worker"})
+                assert client.get("/agents/worker").json()["heartbeat_interval"] == 0
+
     def test_container_agent_cannot_start_before_activation(self, monkeypatch):
         """Container isolation is opt-in but DORMANT by default: with the runtime
         gate OFF, a container agent registers fine yet REFUSES to start (501) —


### PR DESCRIPTION
## What
Adds `heartbeat_interval` to `UpdateAgentRequest` so it is settable via `PUT /agents/{name}`.

## Why
The field was missing from the agent-update model, so a passive worker stuck on a short heartbeat (e.g. murzik @ 300s) could not be flipped to demand-woken (`0`) through the update API — only a full `POST /agents` re-register, which clobbers every unspecified field with its default. The dashboard's save hits the same gap: the field silently drops, so the UI can appear to accept a change the backend ignores.

Observed live: murzik (codex-tmux, idle/passive) does a full `force_restart` on every ~300s heartbeat (reload context → check empty inbox → idle-sleep), where kuzya (heartbeat=0, demand-woken) does not.

## How
- One field on `UpdateAgentRequest`. The registry merge (`agent_registry.register`) already supports it by key-presence, and the scheduler reads `agent.heartbeat_interval` live (skips agents with `<= 0`), so `PUT {\"heartbeat_interval\": 0}` takes effect without a restart.
- Test: round-trip + merge-preservation (an unrelated update must not resurrect the old cadence).

## Test plan
- `pytest tests/test_api.py -k heartbeat_interval_round_trips` (added) — green locally
- ruff clean

🤖 Opened by Barsik