### PR TITLE
fix(broker): auto-route agent-to-agent replies to the requester's inbox (#279)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2577,6 +2577,13 @@ def create_api(
     async def _make_streaming_response_callback():
         """Create a response callback that routes through the broker."""
         async def _on_response(turn_result):
+            # #279: agent-to-agent reply auto-routing. If this completed turn was
+            # an injected agent message (platform == "agent"), deliver its text to
+            # the requesting agent's inbox and stop — loop-safe (inbox write, no
+            # live inject). Must run BEFORE the empty-chat_id early-return, which
+            # is what used to silently drop these turns.
+            if await broker.route_agent_reply(comms, turn_result):
+                return
             if not turn_result.chat_id:
                 return
             agent = agents.get(turn_result.agent_name)

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -206,7 +206,14 @@ class MessageBroker:
         self._activity = activity_store
         self._stop_callback = stop_callback
         self._stop_all_callback = stop_all_callback
-        self._stats = {"routed": 0, "pending": 0, "denied": 0, "errors": 0, "deduped": 0}
+        self._stats = {
+            "routed": 0,
+            "routed_failed": 0,
+            "pending": 0,
+            "denied": 0,
+            "errors": 0,
+            "deduped": 0,
+        }
 
         # Auth-relay (#205): wire the tmux login-relay coordinator to this
         # broker's outbound sender + owner resolver. Harmless when the
@@ -1457,6 +1464,11 @@ class MessageBroker:
                 f"({len(text)} chars)"
             )
         except Exception as e:
+            # Delivery failed — count it so dropped replies are monitorable
+            # (the whole point of #279 is that agent replies don't vanish
+            # silently). Still return True: this WAS an agent-reply turn, so it
+            # must not fall through to route_response / get re-injected.
+            self._stats["routed_failed"] += 1
             _log(
                 f"broker: auto-route agent reply {responder} -> {requester} "
                 f"failed: {e}"

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -34,6 +34,18 @@ from pinky_daemon.transport_state import SessionState
 _INBOUND_RECONNECT_WAIT_SEC = 20.0
 _INBOUND_RECONNECT_POLL_SEC = 0.25
 
+# #279: agent-to-agent reply auto-routing. ``inject_agent_message`` stamps an
+# injected turn with ``platform == AGENT_REPLY_PLATFORM`` and ``chat_id`` = the
+# requester agent name; when that turn completes, ``route_agent_reply`` delivers
+# the recipient's turn text to the requester's INBOX (loop-safe — an inbox write
+# never spawns a live turn, so the exchange can't ping-pong). Kill-switch
+# defaults ON; set ``PINKY_AGENT_REPLY_ROUTING=0`` to revert to the old
+# drop-on-empty-chat_id behavior without a code change.
+AGENT_REPLY_PLATFORM = "agent"
+_AGENT_REPLY_ROUTING_ENABLED = os.environ.get(
+    "PINKY_AGENT_REPLY_ROUTING", "1"
+).strip().lower() not in ("0", "false", "no", "off")
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -1323,7 +1335,17 @@ class MessageBroker:
         from datetime import timezone as tz
         ts = datetime.now(tz.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
         prompt = f"[agent | {from_agent} | internal | {ts}]\n{message}"
-        await streaming.send(prompt)
+        if _AGENT_REPLY_ROUTING_ENABLED:
+            # #279: encode the requester as the route-back target so the
+            # recipient's completed turn auto-delivers to the requester's inbox
+            # (see ``route_agent_reply``). The ``platform="agent"`` sentinel is
+            # intercepted in the response callback before normal platform
+            # routing; ``chat_id`` carries the requester agent name.
+            await streaming.send(
+                prompt, platform=AGENT_REPLY_PLATFORM, chat_id=from_agent
+            )
+        else:
+            await streaming.send(prompt)
         # Server-side presence: successful delivery = agent is reachable
         try:
             self._registry.stamp_last_seen(to_agent)
@@ -1393,6 +1415,53 @@ class MessageBroker:
                 await self._send_message(agent_name, platform, chat_id, stripped)
         else:
             await self._send_message(agent_name, platform, chat_id, stripped)
+
+    async def route_agent_reply(self, comms, turn_result) -> bool:
+        """Auto-deliver a completed agent-to-agent turn to the requester's inbox.
+
+        #279: ``inject_agent_message`` stamps injected turns with
+        ``platform == AGENT_REPLY_PLATFORM`` and ``chat_id`` = the requester
+        agent name. When such a turn finishes, the recipient's turn text is
+        delivered to the requester's inbox via ``comms.send`` — the missing
+        return leg that left review verdicts (and every other agent reply)
+        stranded in the recipient's transcript with nowhere to go.
+
+        Loop-safe by construction: this writes to the inbox only and never
+        injects a live turn, so an auto-routed reply cannot itself trigger
+        another routed turn — the exchange terminates.
+
+        Returns True when the turn was an agent reply (handled here, caller
+        should stop); False for normal platform turns so the caller falls
+        through to ``route_response``.
+        """
+        if not turn_result or turn_result.platform != AGENT_REPLY_PLATFORM:
+            return False
+        requester = (turn_result.chat_id or "").strip()
+        responder = (turn_result.agent_name or "").strip()
+        text = (turn_result.response_text or "").strip()
+        if not requester or not responder:
+            _log(
+                "broker: agent reply missing requester/responder "
+                f"(requester={requester!r} responder={responder!r}); dropping"
+            )
+            return True
+        if not text:
+            # A pure tool-call turn with no final text — nothing to relay.
+            _log(f"broker: agent reply {responder} -> {requester} had no text")
+            return True
+        try:
+            comms.send(responder, requester, text, metadata={"auto_routed": True})
+            self._stats["routed"] += 1
+            _log(
+                f"broker: auto-routed agent reply {responder} -> {requester} "
+                f"({len(text)} chars)"
+            )
+        except Exception as e:
+            _log(
+                f"broker: auto-route agent reply {responder} -> {requester} "
+                f"failed: {e}"
+            )
+        return True
 
     # "file" is what Slack and Discord tag every inbound attachment as; the
     # rest are Telegram's media kinds. (Voice is handled separately.)

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -245,9 +245,9 @@ class TestMessageBrokerRouting:
 
             class _FakeStreaming:
                 state = SessionState.CONNECTED
-                sent: list[str] = []
+                sent: list = []
 
-                async def send(self, prompt: str) -> None:
+                async def send(self, prompt, *, platform="", chat_id="", message_id=""):
                     _FakeStreaming.sent.append(prompt)
 
             broker.register_streaming("barsik", _FakeStreaming(), label="main")
@@ -268,6 +268,127 @@ class TestMessageBrokerRouting:
             ok = await broker.inject_agent_message("pushok", "barsik", "hi")
             assert ok is False
             assert registry.get("barsik").last_seen_at == 0.0
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_inject_agent_message_stamps_reply_routing_metadata(self):
+        """#279: an injected agent message carries platform='agent' + chat_id=
+        the requester, so the recipient's completed turn can route back."""
+        tmpdir, registry, broker, _, _ = self._make_broker()
+        try:
+            from pinky_daemon.transport_state import SessionState
+
+            recorded: list[tuple[str, str]] = []
+
+            class _FakeStreaming:
+                state = SessionState.CONNECTED
+
+                async def send(self, prompt, *, platform="", chat_id="", message_id=""):
+                    recorded.append((platform, chat_id))
+
+            broker.register_streaming("barsik", _FakeStreaming(), label="main")
+            ok = await broker.inject_agent_message("pushok", "barsik", "review please")
+            assert ok is True
+            assert recorded == [("agent", "pushok")]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_inject_agent_message_respects_routing_killswitch(self, monkeypatch):
+        """With PINKY_AGENT_REPLY_ROUTING off, no route-back metadata is stamped —
+        reverts to the legacy (drop-on-empty-chat_id) behavior."""
+        import pinky_daemon.broker as broker_mod
+
+        monkeypatch.setattr(broker_mod, "_AGENT_REPLY_ROUTING_ENABLED", False)
+        tmpdir, registry, broker, _, _ = self._make_broker()
+        try:
+            from pinky_daemon.transport_state import SessionState
+
+            recorded: list[tuple[str, str]] = []
+
+            class _FakeStreaming:
+                state = SessionState.CONNECTED
+
+                async def send(self, prompt, *, platform="", chat_id="", message_id=""):
+                    recorded.append((platform, chat_id))
+
+            broker.register_streaming("barsik", _FakeStreaming(), label="main")
+            ok = await broker.inject_agent_message("pushok", "barsik", "hi")
+            assert ok is True
+            assert recorded == [("", "")]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_agent_reply_delivers_to_requester_inbox(self):
+        """#279: a completed agent-reply turn is delivered to the requester's
+        inbox via comms.send — and ONLY that (loop-safe: no live inject)."""
+        from pinky_daemon.turn_response import TurnResponse
+
+        tmpdir, registry, broker, _, _ = self._make_broker()
+        try:
+            sent: list = []
+
+            class _FakeComms:
+                def send(self, frm, to, content, **kw):
+                    sent.append((frm, to, content, kw.get("metadata")))
+
+            tr = TurnResponse(
+                agent_name="murzik",
+                platform="agent",
+                chat_id="barsik",
+                text="LGTM - ship it",
+            )
+            handled = await broker.route_agent_reply(_FakeComms(), tr)
+            assert handled is True
+            assert sent == [("murzik", "barsik", "LGTM - ship it", {"auto_routed": True})]
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_agent_reply_ignores_normal_platform_turns(self):
+        """A telegram turn is not an agent reply: returns False (caller falls
+        through to normal routing) and nothing is delivered to an inbox."""
+        from pinky_daemon.turn_response import TurnResponse
+
+        tmpdir, registry, broker, _, _ = self._make_broker()
+        try:
+            sent: list = []
+
+            class _FakeComms:
+                def send(self, *a, **k):
+                    sent.append((a, k))
+
+            tr = TurnResponse(
+                agent_name="barsik", platform="telegram", chat_id="123", text="hi"
+            )
+            handled = await broker.route_agent_reply(_FakeComms(), tr)
+            assert handled is False
+            assert sent == []
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_agent_reply_skips_empty_text(self):
+        """A pure tool-call agent turn (no final text) is consumed but nothing is
+        delivered — no empty inbox entries."""
+        from pinky_daemon.turn_response import TurnResponse
+
+        tmpdir, registry, broker, _, _ = self._make_broker()
+        try:
+            sent: list = []
+
+            class _FakeComms:
+                def send(self, *a, **k):
+                    sent.append((a, k))
+
+            tr = TurnResponse(
+                agent_name="murzik", platform="agent", chat_id="barsik", text="   "
+            )
+            handled = await broker.route_agent_reply(_FakeComms(), tr)
+            assert handled is True
+            assert sent == []
         finally:
             tmpdir.cleanup()
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -393,6 +393,54 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
+    async def test_route_agent_reply_counts_failed_delivery(self):
+        """If comms.send raises, the turn is still consumed (handled True, never
+        re-injected) and the failure is counted so dropped replies are visible."""
+        from pinky_daemon.turn_response import TurnResponse
+
+        tmpdir, registry, broker, _, _ = self._make_broker()
+        try:
+            class _BoomComms:
+                def send(self, *a, **k):
+                    raise RuntimeError("inbox down")
+
+            tr = TurnResponse(
+                agent_name="murzik", platform="agent", chat_id="barsik", text="x"
+            )
+            before = broker._stats["routed_failed"]
+            handled = await broker.route_agent_reply(_BoomComms(), tr)
+            assert handled is True  # loop-safe: never falls through / re-injects
+            assert broker._stats["routed_failed"] == before + 1
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_route_agent_reply_real_comms_lands_in_inbox(self):
+        """End-to-end return leg against a real AgentComms: the reply appears in
+        the requester's inbox via get_inbox, tagged auto_routed."""
+        from pinky_daemon.agent_comms import AgentComms
+        from pinky_daemon.turn_response import TurnResponse
+
+        tmpdir, registry, broker, _, _ = self._make_broker()
+        try:
+            comms = AgentComms(db_path=f"{tmpdir.name}/comms.db")
+            tr = TurnResponse(
+                agent_name="murzik",
+                platform="agent",
+                chat_id="barsik",
+                text="LGTM - ship it",
+            )
+            handled = await broker.route_agent_reply(comms, tr)
+            assert handled is True
+            inbox = comms.get_inbox("barsik")
+            assert len(inbox) == 1
+            assert inbox[0].from_session == "murzik"
+            assert inbox[0].content == "LGTM - ship it"
+            assert inbox[0].metadata.get("auto_routed") is True
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
     async def test_first_inbound_claims_primary_on_fresh_install(self, monkeypatch):
         """Fresh install: no primary user configured. The first person to
         message the bot should be claimed as primary/owner and auto-approved,


### PR DESCRIPTION
## Problem (#279)

Agent-to-agent messaging was a **one-way street**. `broker.inject_agent_message` injected the requester's prompt into the recipient's session with **no route-back metadata** (empty `platform`/`chat_id`), so when the recipient finished its turn, the streaming response callback hit `if not turn_result.chat_id: return` (`api.py`) and **dropped the turn**.

Result: codex agents' (Murzik's) code-review verdicts — and every other agent reply — only ever existed in the recipient's transcript/pane, **never reaching the requester's inbox**. This is the root cause of "Murzik's reviews never come back" (the verdict text is captured by the tailer, then discarded at routing).

## Fix

- `inject_agent_message` now stamps the injected turn with `platform="agent"` and `chat_id=<requester agent name>`.
- New `broker.route_agent_reply(comms, turn_result)`, called **first** in the response callback, delivers the completed turn's text to the requester's inbox via `comms.send(...)` and returns (short-circuiting normal platform routing).

### Loop-safety (the critical property)
Auto-routed replies are delivered to the **inbox only** — never a live inject. An inbox write never spawns a new turn, so an auto-routed reply **cannot itself trigger another routed turn**. The exchange terminates after one hop. This is why the reply path deliberately uses `comms.send` (passive) and not `inject_agent_message` (live).

### Scope / safety
- **Transport-agnostic**: SDK, tmux, and codex-tmux `send()` all already accept `platform`/`chat_id`, so this works for every agent.
- **Kill-switch**: `PINKY_AGENT_REPLY_ROUTING` (default **on**) — set to `0` to revert to the legacy drop-on-empty-`chat_id` behavior with no code change.
- Normal platform turns (telegram/discord/slack/web) are untouched: `route_agent_reply` returns `False` for any `platform != "agent"`, so they fall through to `route_response` exactly as before.

## Tests
5 new `tests/test_broker.py` cases:
- route-back metadata is stamped (`platform="agent"`, `chat_id=requester`)
- kill-switch off → legacy behavior (no metadata)
- agent reply delivered to requester inbox via `comms.send` (and **only** that — loop-safe)
- non-agent (telegram) turns pass through (`route_agent_reply` returns False, nothing delivered)
- empty-text turns consumed but nothing delivered (no empty inbox entries)

Evidence (worktree): broker + session + comms suites **469 passed, 1 skipped**; `ruff` clean.

```
$ pytest tests/test_broker.py -q
56 passed
$ pytest tests/test_broker.py tests/test_streaming_session.py tests/test_tmux_session.py \
        tests/test_codex_tmux_session.py tests/test_agent_comms.py -q
469 passed, 1 skipped in 130.17s
```

(Backend routing change — no UI surface; test output stands in for the screenshot. Live verification: send an agent→agent message and confirm it lands in the recipient's `check_inbox` post-deploy.)

## Follow-up
The #215 PR3 codex `notify` hook (low-latency turn-completion + structured payload) is a **latency layer on top** of this fix, not required for correctness (this rides the existing tailer). Tracked as a fast-follow.

🤖 Opened by Barsik