### PR TITLE
fix(watchdog): pane-content liveness — stop false-wedging long ultracode reasoning turns (#832)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1177,6 +1177,16 @@ class TmuxSession:
         # gets its own ``_TURN_DONE_TIMEOUT_SEC`` window once it becomes
         # the head (Murzik review on PR for #560).
         self._head_started_at: float | None = None
+        # (#832) Absolute-ceiling anchor for the inflight pane-liveness rescue.
+        # The pane-animating branch resets ``_head_started_at`` on EVERY sample,
+        # so the ceiling can't be measured against it (age would reset each cycle
+        # and never reach the bound). Instead anchor to ``(head_meta, t0)``: ``t0``
+        # is when the CURRENT head first got pane-liveness credit, and it is NOT
+        # reset by subsequent samples — so ``now - t0`` truly accumulates toward
+        # ``_inflight_hard_ceiling_sec()``. Keyed by the head meta's identity so a
+        # genuinely new head (deque advanced) auto-starts a fresh ceiling budget
+        # without having to touch the out-of-loop head-start sites.
+        self._inflight_pane_ext_anchor: tuple[object, float] | None = None
         # Back-compat advisory signal. Pre-#560 this was the worker's
         # per-iteration gate (the bottleneck that broke steering).
         # Post-#560 the worker no longer awaits it between dispatches;
@@ -5291,11 +5301,23 @@ class TmuxSession:
                     continue
                 age = now - (self._head_started_at or now)
                 depth = len(self._inflight_metas)
+                # The head meta being judged this tick. ``verdict != "ok"``
+                # guarantees a non-empty deque (computed synchronously just above,
+                # no intervening await), so index 0 is safe here. Captured ONCE so
+                # the #832 pane-liveness anchor and the post-await staleness guard
+                # both key off the SAME identity — the pane-liveness rescue awaits
+                # (capture-pane + sample gap), during which a stop hook can pop or
+                # advance the head out from under us.
+                head_meta = self._inflight_metas[0]
                 if verdict == "growing":
                     # #118: head aged out BUT the transcript is still being
                     # written — a long/streaming turn, NOT a wedge. Extend
                     # the window instead of tearing the session down.
                     self._head_started_at = now
+                    # Real transcript/background progress → refresh the #832
+                    # pane-liveness ceiling budget (a later quiet-but-animating
+                    # stretch on this same head earns a fresh full ceiling).
+                    self._inflight_pane_ext_anchor = None
                     _log(
                         f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
                         f"but transcript or background task still active — not "
@@ -5319,6 +5341,7 @@ class TmuxSession:
                     drained = list(self._inflight_metas)
                     self._inflight_metas.clear()
                     self._head_started_at = None
+                    self._inflight_pane_ext_anchor = None
                     for m in drained:
                         ev = m.completion_event
                         if ev is not None and not ev.is_set():
@@ -5344,22 +5367,55 @@ class TmuxSession:
                 # like the "growing" branch. Bounded by an absolute ceiling so an
                 # animating-but-genuinely-stuck REPL is still recovered, and
                 # flag-gated (PINKY_WATCHDOG_PANE_LIVENESS=0) for a kill switch.
-                if (
-                    _pane_liveness_enabled()
-                    and age < _inflight_hard_ceiling_sec()
-                    and await self._pane_is_animating()
-                ):
-                    self._head_started_at = now
+                if _pane_liveness_enabled():
+                    # Anchor the absolute ceiling to when THIS head FIRST reached
+                    # the pane-liveness rescue, NOT to ``_head_started_at`` — the
+                    # extend branch below resets ``_head_started_at = now`` on every
+                    # animating sample, so ``age`` measured against it would reset
+                    # each cycle and the ceiling could NEVER be reached (a genuinely
+                    # stuck-but-animating REPL would be pinned alive forever). The
+                    # anchor's ``t0`` is set once per head and is NOT reset by
+                    # samples, so ``now - t0`` truly accumulates. Keyed by the head
+                    # meta's identity so a real new head (deque advanced) restarts
+                    # the budget automatically — no need to touch head-start sites.
+                    anchor = self._inflight_pane_ext_anchor
+                    if anchor is None or anchor[0] is not head_meta:
+                        anchor = (head_meta, self._head_started_at or now)
+                        self._inflight_pane_ext_anchor = anchor
+                    ceiling = _inflight_hard_ceiling_sec()
+                    if (now - anchor[1]) < ceiling and await self._pane_is_animating():
+                        self._head_started_at = now
+                        _log(
+                            f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
+                            f"but the pane is still animating (REPL generating) — "
+                            f"not wedged, extending window (#832; deque depth="
+                            f"{depth}, ceiling {now - anchor[1]:.1f}/{ceiling:.0f}s)"
+                        )
+                        log_watchdog_decision(
+                            watchdog="inflight", agent=self.agent_name,
+                            decision="skip", reason="pane_active",
+                            state=self.state.value, progress_stale_s=age,
+                            inflight_turns=depth, inflight_active=True,
+                        )
+                        continue
+                # (#832 follow-up) The pane-liveness rescue above awaited
+                # (capture-pane twice + a sample gap). A turn-complete (stop hook)
+                # can land during that window and pop or advance the head via
+                # ``_handle_turn_complete``, leaving the deque empty or fronted by
+                # a DIFFERENT, healthy turn. Either way the "wedged" verdict is now
+                # stale: the force_restart below would ``popleft`` an empty deque
+                # (IndexError → the watchdog task dies for this session, silently
+                # dropping recovery) or tear down an innocent fresh head. Bail if
+                # the head we judged is no longer at the front. (Mirrors the guard
+                # ``_handle_turn_complete`` itself uses before its own popleft.)
+                if not self._inflight_metas or self._inflight_metas[0] is not head_meta:
+                    self._inflight_pane_ext_anchor = None
+                    if not self._inflight_metas:
+                        self._head_started_at = None
                     _log(
-                        f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
-                        f"but the pane is still animating (REPL generating) — not "
-                        f"wedged, extending window (#832; deque depth={depth})"
-                    )
-                    log_watchdog_decision(
-                        watchdog="inflight", agent=self.agent_name,
-                        decision="skip", reason="pane_active",
-                        state=self.state.value, progress_stale_s=age,
-                        inflight_turns=depth, inflight_active=True,
+                        f"tmux[{self.agent_name}]: inflight head completed/advanced "
+                        f"during pane-liveness sampling — stale wedged verdict, not "
+                        f"restarting (#832; deque depth={len(self._inflight_metas)})"
                     )
                     continue
                 # verdict == "wedged": no output + REPL not idle → genuinely
@@ -5383,6 +5439,7 @@ class TmuxSession:
                 tail_entries = list(self._inflight_metas)
                 self._inflight_metas.clear()
                 self._head_started_at = None
+                self._inflight_pane_ext_anchor = None
                 # Also capture any in-hand-but-not-pasted turn (e.g.
                 # worker mid context-lock retry). Cleared so the
                 # post-restart worker doesn't redeliver from the stale

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -952,6 +952,44 @@ _BACKGROUND_TASK_ACTIVE_WINDOW_SEC = 180.0
 # recovery) bounded.
 _FOREGROUND_TOOL_ACTIVE_CEILING_SEC = 1800.0
 
+# #832 — pane-content liveness for the inflight stall verdict. A long pure-
+# reasoning / slow-generation turn (common at ultracode/xhigh effort) writes
+# NOTHING to the JSONL transcript and has no foreground tool or background task
+# in flight, so the stall verdict reaches "wedged" even though the REPL is alive
+# — the Claude Code TUI's spinner / token counter / elapsed timer is still
+# animating. The inflight watchdog samples the pane twice ~_PANE_LIVENESS_SAMPLE_
+# GAP_SEC apart; a CHANGED pane is positive liveness (extend the window), a frozen
+# pane is a genuine wedge (force_restart). The gap is wider than the TUI's ~1s
+# redraw tick so a single tick is always observable; capturing the last N lines is
+# enough — the status/spinner line renders at the bottom.
+_PANE_LIVENESS_CAPTURE_LINES = 40
+_PANE_LIVENESS_SAMPLE_GAP_SEC = 1.5
+
+
+def _pane_liveness_enabled() -> bool:
+    """Whether the inflight watchdog credits an animating tmux pane as liveness
+    (#832). Default ON; ``PINKY_WATCHDOG_PANE_LIVENESS=0`` is the kill switch
+    (falls back to the pre-#832 transcript/tool-only verdict). Read per call so
+    it can be flipped without a daemon restart."""
+    return os.environ.get("PINKY_WATCHDOG_PANE_LIVENESS", "1").strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
+def _inflight_hard_ceiling_sec() -> float:
+    """Absolute upper bound on an inflight head's age (#832). Pane-liveness can
+    extend a long turn for as long as the TUI keeps animating; this ceiling
+    guarantees an animating-but-genuinely-stuck REPL (e.g. a live render loop over
+    a deadlocked agent loop) is still force_restarted. Env-overridable
+    (``PINKY_INFLIGHT_HARD_CEILING_SEC``); generous so a legitimately deep
+    ultracode turn is never cut off mid-flight. Never below the base timeout."""
+    raw = os.environ.get("PINKY_INFLIGHT_HARD_CEILING_SEC", "").strip()
+    try:
+        val = float(raw) if raw else 3600.0
+    except (TypeError, ValueError):
+        val = 3600.0
+    return max(val, _TURN_DONE_TIMEOUT_SEC)
+
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
 # ``_session_ready_event`` for turns with ``internal=True and
 # reason.startswith("wake_")`` so the wake prompt's paste doesn't land while
@@ -4936,6 +4974,30 @@ class TmuxSession:
             alive = True
         return alive
 
+    async def _pane_is_animating(self) -> bool:
+        """True if the tmux pane's visible content changed across two samples
+        ~``_PANE_LIVENESS_SAMPLE_GAP_SEC`` apart — positive evidence the REPL is
+        actively rendering/generating (#832).
+
+        The Claude Code TUI animates a spinner + token counter + elapsed timer
+        every ~1s while a turn is in flight, INCLUDING a long pure-reasoning block
+        that has not yet written anything to the JSONL transcript. So a changing
+        pane means "alive, just quiet" while a frozen pane means a genuinely
+        wedged REPL. Self-contained (two captures, no persisted state): the
+        inflight watchdog calls this only on an otherwise-"wedged" verdict, so the
+        two extra ``capture-pane`` subprocesses run rarely. Any tmux failure (or a
+        non-ok capture) returns False — no liveness evidence, so the caller falls
+        through to the pre-#832 wedged/force_restart behavior."""
+        try:
+            first = await self._tmux.capture_pane(lines=_PANE_LIVENESS_CAPTURE_LINES)
+            await asyncio.sleep(_PANE_LIVENESS_SAMPLE_GAP_SEC)
+            second = await self._tmux.capture_pane(lines=_PANE_LIVENESS_CAPTURE_LINES)
+        except Exception:
+            return False
+        if not (first.ok and second.ok):
+            return False
+        return (first.stdout or "") != (second.stdout or "")
+
     def _watchdog_liveness(self, now: float) -> dict:
         """Live carve-out signal for the OUTER watchdogs (#230).
 
@@ -5271,6 +5333,33 @@ class TmuxSession:
                         decision="reconcile", reason="idle_phantom",
                         state=self.state.value, progress_stale_s=age,
                         inflight_turns=depth, inflight_active=False,
+                    )
+                    continue
+                # (#832) Last-chance liveness before tearing down a "wedged"
+                # head: a long pure-reasoning / slow-generation turn (common at
+                # ultracode/xhigh) writes nothing to the transcript and has no
+                # tool in flight, so it reaches here looking wedged — yet the CC
+                # TUI spinner/token-counter is still animating. Sample the pane
+                # twice; a changing pane is positive liveness → extend the window
+                # like the "growing" branch. Bounded by an absolute ceiling so an
+                # animating-but-genuinely-stuck REPL is still recovered, and
+                # flag-gated (PINKY_WATCHDOG_PANE_LIVENESS=0) for a kill switch.
+                if (
+                    _pane_liveness_enabled()
+                    and age < _inflight_hard_ceiling_sec()
+                    and await self._pane_is_animating()
+                ):
+                    self._head_started_at = now
+                    _log(
+                        f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
+                        f"but the pane is still animating (REPL generating) — not "
+                        f"wedged, extending window (#832; deque depth={depth})"
+                    )
+                    log_watchdog_decision(
+                        watchdog="inflight", agent=self.agent_name,
+                        decision="skip", reason="pane_active",
+                        state=self.state.value, progress_stale_s=age,
+                        inflight_turns=depth, inflight_active=True,
                     )
                     continue
                 # verdict == "wedged": no output + REPL not idle → genuinely

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -4124,6 +4124,193 @@ async def test_inflight_watchdog_restarts_over_ceiling_even_if_animating(monkeyp
             await task
         except asyncio.CancelledError:
             pass
+    # Over the ceiling, the rescue must short-circuit BEFORE sampling the pane —
+    # no point paying two capture-pane calls + a sample gap on a head we are about
+    # to tear down regardless.
+    assert tmux.capture_pane.await_count == 0, (
+        "over-ceiling head must not sample the pane (ceiling short-circuits first)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_inflight_watchdog_no_restart_when_head_completes_during_sampling(
+    monkeypatch,
+) -> None:
+    """#832 race guard: a stop hook can pop the head DURING the pane-liveness
+    sampling await (capture-pane twice + sample gap). The now-stale "wedged"
+    verdict must NOT force_restart, and must NOT ``popleft`` an emptied deque
+    (an IndexError there is swallowed by the watchdog's ``except`` and returns,
+    silently killing recovery for the session). Simulate the concurrent
+    completion by emptying the deque from inside the awaited capture_pane."""
+    from pinky_daemon import tmux_session
+
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.02)
+    monkeypatch.setattr(tmux_session, "_PANE_LIVENESS_SAMPLE_GAP_SEC", 0.0)
+
+    ss, tmux = _wedged_session()
+
+    calls = {"n": 0}
+
+    def _cap(**kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Mimic ``_handle_turn_complete`` firing mid-sample: head completed,
+            # deque emptied out from under the watchdog.
+            ss._inflight_metas.clear()
+            ss._head_started_at = None
+        return _pane("> idle")  # frozen → _pane_is_animating False → fall through
+
+    tmux.capture_pane = AsyncMock(side_effect=_cap)
+
+    restarted = {"v": False}
+
+    async def _no_restart(*, bypass_guard: bool = False):
+        restarted["v"] = True
+        return True
+
+    ss.force_restart = _no_restart
+
+    task = asyncio.create_task(ss._inflight_watchdog())
+    await asyncio.sleep(0.2)  # let several ticks run
+    crashed = task.done()
+    crash_exc = task.exception() if crashed else None
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert restarted["v"] is False, (
+        "must not force_restart a head that completed during pane sampling"
+    )
+    assert not crashed, (
+        "watchdog must survive a head emptied mid-sample (no IndexError on an "
+        f"empty-deque popleft) — task exited early: {crash_exc!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_inflight_watchdog_ceiling_accumulates_across_animating_samples(
+    monkeypatch,
+) -> None:
+    """Regression for the #832 ceiling bug: a head that starts BELOW the ceiling
+    and animates continuously must STILL force_restart once cumulative wall-time
+    crosses the ceiling. The extend branch resets ``_head_started_at`` on every
+    sample, so the ceiling must be anchored to a clock that does NOT reset — else
+    ``age`` would reset each cycle and the bound is unreachable (a stuck-but-
+    animating REPL pinned alive forever). This fails on the pre-fix code (no
+    restart, anchor-less ``age < ceiling`` always true) and passes once the
+    ceiling is anchored to the head's first pane-liveness credit."""
+    from pinky_daemon import tmux_session
+
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.02)
+    monkeypatch.setattr(tmux_session, "_PANE_LIVENESS_SAMPLE_GAP_SEC", 0.0)
+    # Ceiling spans several timeout cycles, so the rescue extends the head
+    # multiple times BEFORE the absolute bound forces recovery — exactly the
+    # accumulation the buggy code never reached.
+    monkeypatch.setenv("PINKY_INFLIGHT_HARD_CEILING_SEC", "0.3")
+
+    ss, tmux = _wedged_session()
+    # Start the head FRESH (age ~0, well under the 0.3s ceiling) so the only way
+    # to reach the ceiling is genuine accumulation across animating samples.
+    ss._head_started_at = _time.time()
+
+    flip = {"n": 0}
+
+    def _alt(**kw):
+        flip["n"] += 1
+        return _pane("a" if flip["n"] % 2 else "b")  # always changing → animating
+
+    tmux.capture_pane = AsyncMock(side_effect=_alt)
+
+    fired = asyncio.Event()
+
+    async def _restart(*, bypass_guard: bool = False):
+        fired.set()
+        return True
+
+    ss.force_restart = _restart
+
+    task = asyncio.create_task(ss._inflight_watchdog())
+    try:
+        # Must fire well after one timeout cycle (0.05s) — proving the head was
+        # extended repeatedly — but bounded by the 0.3s ceiling. 2s gives slack.
+        await asyncio.wait_for(fired.wait(), timeout=2.0)
+    except asyncio.TimeoutError:
+        pytest.fail(
+            "continuously-animating head must STILL force_restart once cumulative "
+            "age crosses the ceiling (ceiling must not reset with _head_started_at)"
+        )
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    # The pane was sampled many times → the head was genuinely extended across
+    # multiple cycles before the ceiling won (not a tick-1 over-ceiling restart).
+    assert tmux.capture_pane.await_count >= 2, (
+        "head should have been extended (pane sampled) before the ceiling fired"
+    )
+
+
+@pytest.mark.asyncio
+async def test_inflight_watchdog_ceiling_anchor_keyed_to_head_identity(
+    monkeypatch,
+) -> None:
+    """The #832 ceiling anchor is keyed to the head meta's identity. When the
+    deque advances to a genuinely new head while a STALE anchor (from the prior
+    head) is still set, the rescue must re-anchor to the new head's own start —
+    NOT judge the fresh head against the previous head's already-elapsed clock
+    (which would force_restart a brand-new healthy turn almost immediately)."""
+    from pinky_daemon import tmux_session
+
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.02)
+    monkeypatch.setattr(tmux_session, "_PANE_LIVENESS_SAMPLE_GAP_SEC", 0.0)
+    monkeypatch.setenv("PINKY_INFLIGHT_HARD_CEILING_SEC", "0.3")
+
+    ss, tmux = _wedged_session()
+    head_b = ss._inflight_metas[0]
+    # A stale anchor from a PRIOR head (some other meta) that already burned far
+    # more than the ceiling. If the rescue keyed off this instead of head_b's
+    # identity, head_b would be judged over-ceiling on tick 1 and torn down.
+    ss._inflight_pane_ext_anchor = (object(), _time.time() - 999.0)
+    ss._head_started_at = _time.time()  # head_b just started
+
+    flip = {"n": 0}
+
+    def _alt(**kw):
+        flip["n"] += 1
+        return _pane("a" if flip["n"] % 2 else "b")  # animating
+
+    tmux.capture_pane = AsyncMock(side_effect=_alt)
+
+    restarted = {"v": False}
+
+    async def _no_restart(*, bypass_guard: bool = False):
+        restarted["v"] = True
+        return True
+
+    ss.force_restart = _no_restart
+
+    task = asyncio.create_task(ss._inflight_watchdog())
+    await asyncio.sleep(0.15)  # > timeout, < the 0.3s fresh ceiling
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert restarted["v"] is False, (
+        "fresh head must get its OWN ceiling budget, not inherit a stale anchor"
+    )
+    anchor = ss._inflight_pane_ext_anchor
+    assert anchor is not None and anchor[0] is head_b, (
+        "anchor must be re-keyed to the current head's identity"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3939,6 +3939,235 @@ async def test_inflight_watchdog_drains_phantom_when_repl_idle(monkeypatch) -> N
     assert ss._head_started_at is None
 
 
+# ──────────────────────────────────────────────────────────────────────────
+# #832 — pane-content liveness (rescue a long pure-reasoning / slow-generation
+# turn the transcript/tool signals miss, esp. under ultracode/xhigh)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _pane(content: str) -> TmuxCommandResult:
+    return TmuxCommandResult(returncode=0, stdout=content, stderr="")
+
+
+@pytest.mark.asyncio
+async def test_pane_is_animating_true_when_pane_changes() -> None:
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    tmux.capture_pane = AsyncMock(side_effect=[_pane("Thinking (44s)"), _pane("Thinking (46s)")])
+    assert await ss._pane_is_animating() is True
+
+
+@pytest.mark.asyncio
+async def test_pane_is_animating_false_when_pane_frozen() -> None:
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    tmux.capture_pane = AsyncMock(return_value=_pane("> frozen prompt"))
+    assert await ss._pane_is_animating() is False
+
+
+@pytest.mark.asyncio
+async def test_pane_is_animating_false_on_capture_failure() -> None:
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    tmux.capture_pane = AsyncMock(return_value=_fail("no pane"))
+    assert await ss._pane_is_animating() is False
+    tmux.capture_pane = AsyncMock(side_effect=RuntimeError("tmux gone"))
+    assert await ss._pane_is_animating() is False
+
+
+def test_pane_liveness_enabled_default_and_killswitch(monkeypatch) -> None:
+    from pinky_daemon import tmux_session
+
+    monkeypatch.delenv("PINKY_WATCHDOG_PANE_LIVENESS", raising=False)
+    assert tmux_session._pane_liveness_enabled() is True  # default ON
+    for off in ("0", "false", "no", "off", "OFF"):
+        monkeypatch.setenv("PINKY_WATCHDOG_PANE_LIVENESS", off)
+        assert tmux_session._pane_liveness_enabled() is False
+    monkeypatch.setenv("PINKY_WATCHDOG_PANE_LIVENESS", "1")
+    assert tmux_session._pane_liveness_enabled() is True
+
+
+def test_inflight_hard_ceiling_default_and_override(monkeypatch) -> None:
+    from pinky_daemon import tmux_session
+
+    monkeypatch.delenv("PINKY_INFLIGHT_HARD_CEILING_SEC", raising=False)
+    assert tmux_session._inflight_hard_ceiling_sec() == 3600.0
+    monkeypatch.setenv("PINKY_INFLIGHT_HARD_CEILING_SEC", "1200")
+    assert tmux_session._inflight_hard_ceiling_sec() == 1200.0
+    # Never below the base timeout, even if env asks for less.
+    monkeypatch.setenv("PINKY_INFLIGHT_HARD_CEILING_SEC", "1")
+    assert tmux_session._inflight_hard_ceiling_sec() == tmux_session._TURN_DONE_TIMEOUT_SEC
+    # Garbage falls back to the default.
+    monkeypatch.setenv("PINKY_INFLIGHT_HARD_CEILING_SEC", "nope")
+    assert tmux_session._inflight_hard_ceiling_sec() == 3600.0
+
+
+def _wedged_session():
+    """A CONNECTED session whose aged-out head would classify ``wedged``:
+    transcript quiet, no fg tool, REPL ``working`` (not idle)."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {"status": "working", "last_updated": _time.time()}
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._inflight_metas.append(_mk_inflight_meta())
+    ss._head_started_at = _time.time() - 1.0  # aged past the (monkeypatched) timeout
+    return ss, tmux
+
+
+@pytest.mark.asyncio
+async def test_inflight_watchdog_extends_when_pane_animating(monkeypatch) -> None:
+    """The #832 fix: a wedged-looking head whose pane is still animating is
+    EXTENDED, not force_restarted."""
+    from pinky_daemon import tmux_session
+
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.02)
+    monkeypatch.setattr(tmux_session, "_PANE_LIVENESS_SAMPLE_GAP_SEC", 0.0)
+
+    ss, tmux = _wedged_session()
+    flip = {"n": 0}
+
+    def _alt(**kw):
+        flip["n"] += 1
+        return _pane("frame-a" if flip["n"] % 2 else "frame-b")
+
+    tmux.capture_pane = AsyncMock(side_effect=_alt)
+
+    restarted = {"v": False}
+
+    async def _no_restart(*, bypass_guard: bool = False):
+        restarted["v"] = True
+        return True
+
+    ss.force_restart = _no_restart
+
+    task = asyncio.create_task(ss._inflight_watchdog())
+    try:
+        await asyncio.sleep(0.25)  # several ticks
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert restarted["v"] is False, "animating pane must NOT be force_restarted"
+    assert tmux.capture_pane.await_count >= 2, "pane must be sampled (twice)"
+    assert ss._head_started_at is not None, "window must be extended, not cleared"
+
+
+@pytest.mark.asyncio
+async def test_inflight_watchdog_restarts_when_pane_frozen(monkeypatch) -> None:
+    """A frozen pane (genuine wedge) still force_restarts."""
+    from pinky_daemon import tmux_session
+
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.02)
+    monkeypatch.setattr(tmux_session, "_PANE_LIVENESS_SAMPLE_GAP_SEC", 0.0)
+
+    ss, tmux = _wedged_session()
+    tmux.capture_pane = AsyncMock(return_value=_pane("> frozen"))
+
+    fired = asyncio.Event()
+
+    async def _restart(*, bypass_guard: bool = False):
+        fired.set()
+        return True
+
+    ss.force_restart = _restart
+
+    task = asyncio.create_task(ss._inflight_watchdog())
+    try:
+        await asyncio.wait_for(fired.wait(), timeout=2.0)
+    except asyncio.TimeoutError:
+        pytest.fail("frozen pane must force_restart")
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_inflight_watchdog_restarts_over_ceiling_even_if_animating(monkeypatch) -> None:
+    """The absolute ceiling beats pane-liveness: an animating-but-stuck REPL
+    past the ceiling still recovers."""
+    from pinky_daemon import tmux_session
+
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.02)
+    monkeypatch.setattr(tmux_session, "_PANE_LIVENESS_SAMPLE_GAP_SEC", 0.0)
+    monkeypatch.setenv("PINKY_INFLIGHT_HARD_CEILING_SEC", "0.1")  # head aged ~1s > ceiling
+
+    ss, tmux = _wedged_session()
+    flip = {"n": 0}
+
+    def _alt(**kw):
+        flip["n"] += 1
+        return _pane("a" if flip["n"] % 2 else "b")
+
+    tmux.capture_pane = AsyncMock(side_effect=_alt)
+
+    fired = asyncio.Event()
+
+    async def _restart(*, bypass_guard: bool = False):
+        fired.set()
+        return True
+
+    ss.force_restart = _restart
+
+    task = asyncio.create_task(ss._inflight_watchdog())
+    try:
+        await asyncio.wait_for(fired.wait(), timeout=2.0)
+    except asyncio.TimeoutError:
+        pytest.fail("over-ceiling head must force_restart even if animating")
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_inflight_watchdog_killswitch_disables_pane_rescue(monkeypatch) -> None:
+    """PINKY_WATCHDOG_PANE_LIVENESS=0 restores the pre-#832 transcript/tool-only
+    verdict — an animating pane is no longer credited."""
+    from pinky_daemon import tmux_session
+
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.02)
+    monkeypatch.setattr(tmux_session, "_PANE_LIVENESS_SAMPLE_GAP_SEC", 0.0)
+    monkeypatch.setenv("PINKY_WATCHDOG_PANE_LIVENESS", "0")
+
+    ss, tmux = _wedged_session()
+    flip = {"n": 0}
+
+    def _alt(**kw):
+        flip["n"] += 1
+        return _pane("a" if flip["n"] % 2 else "b")
+
+    tmux.capture_pane = AsyncMock(side_effect=_alt)
+
+    fired = asyncio.Event()
+
+    async def _restart(*, bypass_guard: bool = False):
+        fired.set()
+        return True
+
+    ss.force_restart = _restart
+
+    task = asyncio.create_task(ss._inflight_watchdog())
+    try:
+        await asyncio.wait_for(fired.wait(), timeout=2.0)
+    except asyncio.TimeoutError:
+        pytest.fail("kill switch must restore force_restart on a wedged head")
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    assert tmux.capture_pane.await_count == 0, "kill switch must skip pane sampling"
+
+
 @pytest.mark.asyncio
 async def test_spawn_clears_turn_done_after_reconnect() -> None:
     """The turn_done invariant ("cleared between dispatches") must be


### PR DESCRIPTION
Closes #832.

## The bug
The per-session **inflight watchdog** (`tmux_session.py` `_inflight_stall_verdict` / `_inflight_watchdog`, the #118/#560/#692/#731 path) false-classifies a long **pure-reasoning** turn as `wedged` and force_restarts a healthy session. It bites specifically at **ultracode / xhigh** effort, because the longer the model thinks between tool calls, the more likely a single quiet window crosses the hardcoded 600s timeout.

Prod evidence (`logs/api.log`, two bounces in one session right after `/effort ultracode`):
```
tmux[barsik]: inflight head aged 600.1s > 600.0s, transcript quiet + REPL not idle — REPL stuck; scheduling force_restart (deque depth=9)
watchdog_decision watchdog=inflight decision=restart reason=wedged inflight_active=False
```

Root cause: the verdict's liveness signals are JSONL-transcript growth, background-task activity, foreground-tool-in-flight, and the idle hook. **None of them fire during a long reasoning block** (no transcript write, no tool, not idle) — so it's indistinguishable from a hung REPL, even though the Claude Code TUI spinner/token-counter/elapsed-timer is still animating.

## The fix
Add **pane-content liveness**. When the verdict is otherwise `wedged`, sample the tmux pane twice ~1.5s apart (wider than the TUI's ~1s redraw tick):
- **Changed pane** → the REPL is actively rendering/generating → extend the window (like the `growing` branch). This is the missing "model is thinking" signal — it catches slow generation, not just tool/transcript writes, at any effort level.
- **Frozen pane** → genuine wedge → `force_restart` exactly as before.

Safety rails:
- **Absolute ceiling** (`PINKY_INFLIGHT_HARD_CEILING_SEC`, default 3600s, floored at the base timeout) — an animating-but-genuinely-stuck REPL (e.g. a live render loop over a deadlocked agent loop) still recovers.
- **Kill switch** (`PINKY_WATCHDOG_PANE_LIVENESS=0`) restores the exact pre-fix transcript/tool-only verdict.
- The two extra `capture-pane` subprocesses run **only on an otherwise-wedged verdict** (rare in practice). Any tmux failure falls through to the prior wedged/force_restart path (no regression when the pane can't be read).

Scoped to the **per-session inflight watchdog** (the confirmed culprit). The outer `SessionWatchdog`'s `inflight_active` carve-out (#230) is a sync property and can't do an async capture, so it's intentionally untouched here — a possible follow-up if the 15-min outer path ever bites a long-think session.

## Why pane-liveness over an effort-scaled timeout
The issue floated an effort-scaled timeout as a complement. Pane-liveness **subsumes** it: a higher-effort turn animates the pane longer and is extended longer (up to the ceiling), with no effort knob to tune and no hard cutoff on a legitimately deep turn. Kept the change focused on the one real signal gap.

## Testing
- `_pane_is_animating`: changed → True, frozen → False, capture-failure/exception → False.
- Config helpers: `_pane_liveness_enabled` (default ON + kill-switch values), `_inflight_hard_ceiling_sec` (default / override / floor / garbage-fallback).
- Loop integration (drives `_inflight_watchdog`): extend-when-animating (no force_restart), restart-when-frozen, restart-over-ceiling-even-if-animating, kill-switch-disables-rescue.
- Full `test_tmux_session.py`: **299 passed**.

> Backend watchdog change — no UI surface, so the evidence is the tests above + the new `decision=skip reason=pane_active` log line replacing the false `decision=restart reason=wedged` for an animating pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
