### PR TITLE
feat(pricing): register claude-sonnet-5 in cost rate table

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -3938,6 +3938,7 @@ except Exception:
         ("anthropic", "claude-opus-4-8", "Claude Opus 4.8", "Newest Opus (2026-05-28). Sharper judgement, more honest progress reporting, longer independent runs. Effort defaults to high; adaptive thinking triggers only when needed.", "opus", 1_000_000, 1, 5.0, 25.0, 0.5, 1, 3),
         ("anthropic", "claude-opus-4-7", "Claude Opus 4.7", "Stricter instruction-following, xhigh effort, larger vision.", "opus", 1_000_000, 1, 5.0, 25.0, 0.5, 1, 5),
         ("anthropic", "claude-opus-4-6", "Claude Opus 4.6", "Maximum intelligence. Deep reasoning.", "opus", 1_000_000, 1, 5.0, 25.0, 0.5, 1, 10),
+        ("anthropic", "claude-sonnet-5", "Claude Sonnet 5", "Current Sonnet (2026-06). Best speed+intelligence balance — daily driver. 1M context; adaptive thinking, effort defaults to high. Intro pricing $2/$10 through Aug 2026.", "sonnet", 1_000_000, 1, 3.0, 15.0, 0.3, 1, 15),
         ("anthropic", "claude-sonnet-4-6", "Claude Sonnet 4.6", "Fast + smart. Daily driver.", "sonnet", 1_000_000, 1, 3.0, 15.0, 0.3, 1, 20),
         ("anthropic", "claude-haiku-4-5", "Claude Haiku 4.5", "Lightning fast. Simple tasks.", "haiku", 200_000, 0, 1.0, 5.0, 0.1, 1, 30),
         ("anthropic", "claude-opus-4-5", "Claude Opus 4.5", "Previous-gen Opus.", "opus", 200_000, 0, 5.0, 25.0, 0.5, 1, 40),

--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -258,6 +258,12 @@ class AnalyticsStore:
     _LATEST_PRICING_ADDITIONS = [
         ("openai", "gpt-5.5", "2020-01-01T00:00:00Z", None, 5.00, 30.00, 0.50, "seed"),
         ("openai", "gpt-5.3-codex", "2020-01-01T00:00:00Z", None, 1.75, 14.00, 0.175, "seed"),
+        # Sonnet 5 (2026-06): the current Sonnet tier. Standard $3/$15 (cached
+        # $0.30) — mirrors pinky_daemon.pricing.RATE_TABLE (_SONNET), pinned by
+        # test_seed_pricing_matches_rate_table. Introductory $2/$10 runs through
+        # 2026-08-31, then reverts; we seed the durable standard rate (see the
+        # RATE_TABLE comment for the rationale).
+        ("anthropic", "claude-sonnet-5", "2020-01-01T00:00:00Z", None, 3.00, 15.00, 0.30, "seed"),
     ]
 
     def _seed_default_pricing(self, conn) -> None:

--- a/src/pinky_daemon/pricing.py
+++ b/src/pinky_daemon/pricing.py
@@ -104,6 +104,14 @@ RATE_TABLE: dict[str, dict[str, float]] = {
     "claude-opus-4-5": _OPUS_STD,
     "claude-opus-4-1": _OPUS_LEGACY,
     "claude-opus-4": _OPUS_LEGACY,
+    # Sonnet 5 (2026-06): the current Sonnet tier. Standard pricing is
+    # $3/$15 per Mtok — identical to the flat ``_SONNET`` tier. NOTE:
+    # introductory pricing of $2/$10 applies through 2026-08-31, then
+    # reverts to standard. We deliberately use the durable standard rate
+    # here: this table only powers the tmux/subscription cost ESTIMATE
+    # (those agents aren't billed per-token), and a hard-coded intro rate
+    # would silently over-discount every turn after the revert date.
+    "claude-sonnet-5": _SONNET,
     "claude-sonnet-4-6": _SONNET,
     "claude-sonnet-4-5": _SONNET,
     "claude-sonnet-4": _SONNET,


### PR DESCRIPTION
## What
Adds `claude-sonnet-5` to `pricing.py` `RATE_TABLE` — the per-model cost rate table the tmux/subscription transport uses to estimate per-turn cost (analytics parity, #648).

## Why
Sonnet 5 shipped 2026-06 and is now the current Sonnet tier. Brad asked to add it to the model registry and spin up a test agent (Vaska) on it. Without a rate-table entry, `lookup_rate()` returns `None` and the new agent's turns show $0 / unknown cost in Analytics.

## Pricing choice
- Standard Sonnet 5 pricing is **$3 in / $15 out per Mtok** — identical to the existing flat `_SONNET` tier, so `claude-sonnet-5 → _SONNET`.
- **Introductory pricing of $2/$10 runs through 2026-08-31**, then reverts to standard. I deliberately used the **durable standard** rate (documented in an inline comment) rather than the intro rate: this table only powers a cost *estimate* for subscription agents (not real per-token billing), and a hard-coded intro rate would silently over-discount every turn after the revert date. If we'd rather track intro-accurate cost, that's a follow-up (intro tier + a 2026-08-31 revert task).

## Verification
- Model ID confirmed against live Anthropic docs (`claude-sonnet-5`, 1M ctx, 128K out, adaptive thinking, effort defaults to high).
- New agent `vaska` already live on `claude-sonnet-5` (transcript model field confirms); registry entry unblocks its cost analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)