### PR TITLE
fix(tmux): stop self-heal clobbering a fresh transcript bind to a stale file (#291)

### DIFF
--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+import time
 from pathlib import Path
 from typing import Awaitable, Callable
 
@@ -274,6 +275,19 @@ class TmuxTranscriptTailer:
         path_discovery: Callable[[], Path | None] | None = None,
     ) -> None:
         self._path = Path(transcript_path)
+        # #291: wall-clock when ``_path`` was last bound via an explicit
+        # ``set_transcript_path`` call. Starts at 0.0 — the "no real bind yet"
+        # sentinel — so the self-heal mtime-floor (``_try_self_heal_repoint``)
+        # is UNRESTRICTED at cold start: the placeholder→fresh discovery is
+        # exactly what #515 is for, and at genuine cold start there is no live
+        # session yet to clobber to (any pre-existing JSONL is bound directly by
+        # ``_start_tailer`` and so already exists → self-heal never fires). The
+        # floor engages the moment a real path is bound (below + the hook path):
+        # from then on the self-heal refuses to repoint to any transcript OLDER
+        # than the current bind — a stale previous-session file surfacing
+        # because the freshly-bound JSONL hasn't hit disk yet. Re-stamped on
+        # every real path change in ``set_transcript_path``.
+        self._path_bound_at = 0.0
         self._on_turn_complete = on_turn_complete
         self._agent_name = agent_name or self._path.stem[:12]
         self._fallback_poll_sec = fallback_poll_sec
@@ -308,6 +322,9 @@ class TmuxTranscriptTailer:
             # surface "the tailer fell back to mtime-scan N times" in
             # diagnostics.
             "self_heal_repoints": 0,
+            # #291: count self-heal discoveries we REFUSED because the
+            # candidate predated the current bind (the stale-clobber guard).
+            "self_heal_stale_skips": 0,
         }
         # ``_active`` flips True after we see a user entry but before we see
         # the closing stop_hook_summary. Drives the tighter poll cadence so
@@ -393,6 +410,12 @@ class TmuxTranscriptTailer:
         """
         if Path(path) != self._path:
             self._path = Path(path)
+            # #291: re-stamp the bind clock on every real path change so the
+            # self-heal floor measures staleness against THIS bind, not a
+            # stale construction-time value — the tailer instance is retained
+            # across ``force_restart`` respawns, so a fresh launch rebinds
+            # through here and must reset the floor.
+            self._path_bound_at = time.time()
             self._swap_generation += 1
             if seek_to_start:
                 self._offset = 0
@@ -548,6 +571,38 @@ class TmuxTranscriptTailer:
         if discovered is None:
             return
         if Path(discovered) == self._path:
+            return
+        # #291: never repoint to a transcript whose mtime PREDATES the current
+        # bind. On a fresh launch (context_restart / new session) the
+        # SessionStart hook binds the new JSONL the instant Claude Code
+        # announces the session — before CC has flushed the file to disk. The
+        # next poll sees ``_path`` missing and lands here; ``path_discovery``
+        # (newest-existing-by-mtime) then returns the PREVIOUS session's file,
+        # and the pre-#291 code clobbered the correct bind with it. That wedges
+        # the tailer on a frozen file forever: the stale path EXISTS so this
+        # self-heal never re-fires, and the first-bind flag was already consumed
+        # so #565 won't either — leaving the watchdog blind (frozen
+        # ``transcript_mtime`` reads "quiet" + undetected stop hooks pile the
+        # inflight deque) until it force_restarts a perfectly healthy agent.
+        # The freshly-bound session's own JSONL, once it materialises, has
+        # mtime >= the bind; a strictly-older file is always a previous session
+        # and never a valid heal target. Strict ``<`` (no slack): the stale
+        # candidate is often the *immediately* preceding session, whose last
+        # write can be only seconds before the new bind — any positive slack
+        # would re-admit it. Fail-safe: if the candidate's mtime can't be read,
+        # skip rather than risk the clobber.
+        try:
+            discovered_mtime = Path(discovered).stat().st_mtime
+        except OSError:
+            return
+        if discovered_mtime < self._path_bound_at:
+            _log(
+                f"tmux_tailer[{self._agent_name}]: self-heal SKIP stale "
+                f"discovery {discovered} (mtime {discovered_mtime:.0f} predates "
+                f"bind {self._path_bound_at:.0f}) — awaiting bound path to "
+                f"materialise (#291)"
+            )
+            self._stats["self_heal_stale_skips"] += 1
             return
         _log(
             f"tmux_tailer[{self._agent_name}]: self-heal repointing "

--- a/tests/test_tmux_transcript.py
+++ b/tests/test_tmux_transcript.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import time
 from pathlib import Path
 
 import pytest
@@ -1115,3 +1117,97 @@ class TestSelfHealDiscovery:
             assert tailer.transcript_path == real_path
         finally:
             await tailer.stop()
+
+    # ── #291: self-heal mtime-floor (stale-clobber guard) ────────────────
+
+    @pytest.mark.asyncio
+    async def test_self_heal_skips_discovery_older_than_bind(self, tmp_path):
+        """#291: once a real path is bound (SessionStart hook), the self-heal
+        must NEVER repoint to a transcript whose mtime predates that bind — the
+        stale-previous-session clobber that wedged the tailer on a frozen file
+        (frozen ``transcript_mtime`` → watchdog false-wedge → force_restart)."""
+        cb = _Captor()
+        old = tmp_path / "old-session.jsonl"
+        _write_jsonl(old, [_assistant(text="prev session"), _stop_hook_summary()])
+        os.utime(old, (time.time() - 3600, time.time() - 3600))  # clearly stale
+        fresh = tmp_path / "fresh-session.jsonl"  # hook announced it; not on disk yet
+
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl", cb,
+            path_discovery=lambda: old,
+        )
+        # SessionStart hook binds the fresh (not-yet-written) path → arms the floor.
+        tailer.set_transcript_path(fresh, seek_to_start=True)
+        assert tailer.transcript_path == fresh
+
+        # Next poll: fresh is missing → self-heal → discovery returns the OLD file.
+        tailer._try_self_heal_repoint()
+
+        assert tailer.transcript_path == fresh, "must not clobber to the stale file"
+        assert tailer.stats["self_heal_repoints"] == 0
+        assert tailer.stats["self_heal_stale_skips"] == 1
+
+    @pytest.mark.asyncio
+    async def test_self_heal_strict_floor_blocks_recent_previous_session(self, tmp_path):
+        """#291: the floor is STRICT (no slack). The clobber target is often the
+        *immediately* preceding session, whose last write can be only seconds
+        before the new bind — a positive slack window would re-admit it and the
+        fix would silently regress. A file only 5s older than the bind must
+        still be refused. (This test fails under a 60s slack and passes under a
+        strict ``<`` comparison.)"""
+        cb = _Captor()
+        recent = tmp_path / "recent-prev.jsonl"
+        _write_jsonl(recent, [_assistant(text="x"), _stop_hook_summary()])
+        os.utime(recent, (time.time() - 5, time.time() - 5))  # only 5s stale
+        fresh = tmp_path / "fresh.jsonl"
+
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl", cb,
+            path_discovery=lambda: recent,
+        )
+        tailer.set_transcript_path(fresh)  # arms the floor at ~now
+        tailer._try_self_heal_repoint()
+
+        assert tailer.transcript_path == fresh
+        assert tailer.stats["self_heal_stale_skips"] == 1
+
+    @pytest.mark.asyncio
+    async def test_self_heal_unrestricted_before_first_real_bind(self, tmp_path):
+        """#291: the floor must NOT block cold-start (#515) discovery. Before any
+        explicit ``set_transcript_path``, ``_path_bound_at`` is the 0.0 sentinel,
+        so even a discovery whose mtime predates tailer construction heals — at
+        genuine cold start there is no live session to clobber to."""
+        cb = _Captor()
+        real = tmp_path / "real.jsonl"
+        _write_jsonl(real, [_assistant(text="cold-start"), _stop_hook_summary()])
+        os.utime(real, (time.time() - 3600, time.time() - 3600))  # old, yet valid here
+
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl", cb,
+            path_discovery=lambda: real,
+        )
+        assert tailer._path_bound_at == 0.0
+        tailer._try_self_heal_repoint()
+
+        assert tailer.transcript_path == real, "#515 cold-start heal must still fire"
+        assert tailer.stats["self_heal_repoints"] == 1
+        assert tailer.stats["self_heal_stale_skips"] == 0
+
+    @pytest.mark.asyncio
+    async def test_self_heal_failsafe_on_unstattable_discovery(self, tmp_path):
+        """#291: if the discovered candidate can't be stat()'d (vanished between
+        glob and stat), fail SAFE — skip the repoint, never risk the clobber,
+        never raise."""
+        cb = _Captor()
+        ghost = tmp_path / "ghost.jsonl"  # never created
+        fresh = tmp_path / "fresh.jsonl"
+
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl", cb,
+            path_discovery=lambda: ghost,
+        )
+        tailer.set_transcript_path(fresh)  # arms the floor
+        tailer._try_self_heal_repoint()  # ghost.stat() → OSError → skip, no crash
+
+        assert tailer.transcript_path == fresh
+        assert tailer.stats["self_heal_repoints"] == 0

--- a/tests/test_tmux_transcript.py
+++ b/tests/test_tmux_transcript.py
@@ -1211,3 +1211,38 @@ class TestSelfHealDiscovery:
 
         assert tailer.transcript_path == fresh
         assert tailer.stats["self_heal_repoints"] == 0
+
+    @pytest.mark.asyncio
+    async def test_self_heal_forward_heal_with_carried_over_floor(self, tmp_path):
+        """#291: the tailer instance is retained across ``force_restart``, so a
+        respawn carries the PRIOR session's bind time in ``_path_bound_at``. A
+        genuinely NEW session transcript (created after the respawn, so newer
+        than the carried floor) must still heal FORWARD — the carried-over floor
+        only blocks true previous-session files, never the live one."""
+        cb = _Captor()
+        new = tmp_path / "new-session.jsonl"
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl", cb,
+            path_discovery=lambda: new,
+        )
+        # Prior session: a real bind stamps _path_bound_at (the value that
+        # survives a force_restart respawn of the retained instance).
+        prior = tmp_path / "prior-session.jsonl"
+        prior.write_text("{}\n")
+        tailer.set_transcript_path(prior)
+        carried_floor = tailer._path_bound_at
+        assert carried_floor > 0.0
+
+        # Respawn: prior file is gone, the NEW session's JSONL appears, newer
+        # than the carried floor.
+        prior.unlink()
+        _write_jsonl(new, [_assistant(text="new session"), _stop_hook_summary()])
+        os.utime(new, (carried_floor + 10, carried_floor + 10))
+
+        # _path (prior) is now missing → self-heal fires → discovery returns the
+        # NEW (newer) file → floor ALLOWS the forward heal.
+        tailer._try_self_heal_repoint()
+
+        assert tailer.transcript_path == new, "must heal forward to the live file"
+        assert tailer.stats["self_heal_repoints"] == 1
+        assert tailer.stats["self_heal_stale_skips"] == 0


### PR DESCRIPTION
## The bug (#291 watchdog false-wedge)
A perfectly healthy tmux agent gets force_restarted ~600s after a `context_restart`. Root-caused from `logs/api.log`:

1. Fresh launch → SessionStart hook **correctly** binds the new JSONL the instant CC announces the session — but **before CC has flushed the file to disk** (L1165 binds `f577d81b`).
2. The tailer's next poll sees `_path` missing → runs the #515 self-heal → `path_discovery` (newest-existing-by-mtime) returns the **previous** session's file → pre-fix code **repoints to it** (L1167 clobbers to `e4c63557`).
3. **Permanent**: the stale path EXISTS so the self-heal never re-fires; the first-bind flag was already consumed so #565 won't either.
4. The wedged-on-frozen-file tailer **blinds the watchdog**: `transcript_mtime` frozen (~60min in the log) → reads "quiet"; real stop hooks land in the unwatched fresh JSONL → inflight deque never drains (depth 15) → false "wedged" → force_restart (L1322).

This clobber repeats on **every** `context_restart` in the log (L43→45, 461→463, 576→578, 813→815, 1165→1167). Vaska (a brand-new agent) reproduced it live on first boot.

## The fix (`tmux_transcript.py`, +55 lines)
An **mtime floor** on the self-heal. Track `_path_bound_at`:
- **0.0 at construction** — the "no real bind yet" sentinel, so cold-start #515 discovery stays unrestricted (at genuine cold start there's no live session to clobber to).
- **Re-stamped to now on every real `set_transcript_path` change** (the retained tailer instance is reused across `force_restart`, so the hook's fresh-path bind re-arms the floor).

`_try_self_heal_repoint` then **refuses to repoint to any candidate whose mtime predates the current bind** — the freshly-bound session's own JSONL has mtime ≥ the bind once it materialises, so a strictly-older file is always a previous session. **Strict `<`, no slack**: the clobber target is often the *immediately* preceding session (only seconds stale), so any positive slack would re-admit it. Fail-safe (skip) on an unstattable candidate.

## Tests (+96 lines, 4 regression tests)
- skips a clearly-stale (1h-old) discovery after a real bind
- **strict-floor blocks a 5s-stale previous session** (this one fails under *any* slack — guards the fix from regressing to a slack window)
- cold-start #515 heal still fires (the 0.0 sentinel)
- fail-safe on an unstattable candidate

All **47 tailer tests** + relevant session-level bind tests pass; ruff clean. Pure-additive (no deletions).

## Validation
Root cause + fix confirmed by a 3-lens adversarial validation pass (forensics / regression-hunting / alternatives). The lenses flagged the strict-vs-slack point (the 5s test encodes it) and recommended a watchdog-verdict backstop for *other* stale-path triggers — **tracked as a follow-up**, kept out of this PR to keep the fleet-critical change surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)