### PR TITLE
fix(models): add claude-sonnet-5 to _1M_MODELS + pin to registry is_1m (#839)

### DIFF
--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -29,10 +29,14 @@ from pinky_daemon.wake_prompt import (
     wake_reason_from_runtime,
 )
 
-# Models with native 1M context (SDK reports 200k incorrectly)
+# Models with native 1M context (SDK reports 200k incorrectly).
+# INVARIANT: must contain every model the registry flags is_1m=1
+# (agent_registry._MODEL_SEEDS) — pinned by
+# test_1m_models_set_matches_registry_is_1m so this can't drift again (#839).
 _1M_MODELS = {
     "claude-fable-5",
     "claude-mythos-5",
+    "claude-sonnet-5",
     "claude-sonnet-4-6",
     "claude-opus-4-6",
     "claude-opus-4-7",

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -901,6 +901,26 @@ class TestModelSeeds:
             assert m["output_price"] == rate["output"], m["model_id"]
             assert m["cached_input_price"] == rate["cache_read"], m["model_id"]
 
+    def test_1m_models_set_matches_registry_is_1m(self, registry):
+        """#839 invariant: streaming_session._1M_MODELS (the hand-maintained set
+        that corrects the SDK's 200k report on the StreamingSession path) must
+        contain every model the registry flags is_1m=1. PR #837 added
+        claude-sonnet-5 to the three cost/registry tables but not to this set,
+        so a sonnet-5 SDK session capped context at 200k and compacted early.
+        Pin them together so the next 1M model add can't silently drift."""
+        from pinky_daemon.streaming_session import _1M_MODELS
+
+        registry_1m = {
+            m["model_id"]
+            for m in registry.list_models(provider="anthropic", active_only=False)
+            if m["is_1m"] == 1
+        }
+        missing = registry_1m - _1M_MODELS
+        assert not missing, (
+            f"models flagged is_1m=1 but absent from streaming_session._1M_MODELS "
+            f"(would cap context at 200k on the SDK path): {sorted(missing)}"
+        )
+
     def test_stale_prices_corrected_on_existing_rows(self, registry):
         """#741: rows already seeded with the stale tier are rewritten on the
         next seed pass (INSERT OR IGNORE alone never reaches existing DBs)."""


### PR DESCRIPTION
Fixes #839.

## Problem
PR #837 registered `claude-sonnet-5` in the three cost/registry tables (`agent_registry._MODEL_SEEDS`, `analytics_store`, `pricing.RATE_TABLE`) but missed `streaming_session._1M_MODELS` — the hand-maintained set that corrects the Agent SDK reporting 200k for a 1M model (`streaming_session.py:1134`). So a `claude-sonnet-5` agent on the SDK `StreamingSession` path capped its context at 200k and compacted early.

## Fix
- Add `claude-sonnet-5` to `_1M_MODELS`.
- Add `test_1m_models_set_matches_registry_is_1m`: every model the registry flags `is_1m=1` must be in `_1M_MODELS`. This pins the invariant so the next 1M model add can't silently drift — the same class of miss that caused this. The test fails on exactly the pre-fix state (`missing={claude-sonnet-5}`), verified.

## Testing
- `test_agent_registry.py`: 102 passed (incl. the new parity test), ruff clean.
- Verified the guard has teeth: pre-fix it reports `missing=['claude-sonnet-5']`.

## Urgency
Low — the fleet is tmux-primary, so this only bites agents on the SDK `StreamingSession` fallback path (Vaska, on sonnet-5, runs on tmux and is not affected today). Real correctness gap regardless.

## Note
This is a backend/data fix with no UI surface; the parity-test run above is the behavioral evidence. Same bug class was just fixed in bradbrok/MenuAIv2#194 (`_MODEL_CONTEXT_WINDOWS`).

🤖 Opened by Barsik