### PR TITLE
fix(tmux): surface context% mid-turn — gauge no longer lags a full turn

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1121,6 +1121,14 @@ class TmuxSession:
         # context_restart), so it can fire once per window.
         self._soft_nudge_fired = False
 
+        # Mid-turn context gauge. The tailer surfaces every assistant
+        # entry's usage block as it lands (``on_usage`` hook), not just
+        # at turn end; ``_on_transcript_usage`` folds it into
+        # ``usage.last_usage`` and schedules a coalesced
+        # ``context_usage`` emit. Single-flight task ref so a burst of
+        # entries in one read chunk produces one SSE, not N.
+        self._ctx_usage_emit_task: asyncio.Task | None = None
+
         # Effort knob. tmux's claude REPL doesn't currently honor a
         # per-session effort override (CLAUDE_EFFORT env is set at
         # spawn time and we'd have to relaunch to change it). We accept
@@ -3794,6 +3802,61 @@ class TmuxSession:
             "mcp_tools": [],
         }
 
+    def _on_transcript_usage(self, usage: dict) -> None:
+        """Tailer ``on_usage`` hook: an assistant entry carried a fresh
+        usage block — fold it into the live context snapshot NOW.
+
+        Fires once per API call while a turn is in flight. This is what
+        makes the context gauge real-time: before this hook, usage sat in
+        the tailer's turn buffer until the closing ``stop_hook_summary``,
+        so a long tool-loop turn showed the PREVIOUS turn's context for
+        its entire duration — the gauge lagged by a whole turn.
+
+        Sync on purpose (the tailer calls it between entries in its read
+        loop, where an await would reopen the mid-chunk transcript-swap
+        race). The state update lands immediately — pull-based readers
+        (the heartbeat reconciler's ``context_used_pct``, the
+        streaming-status endpoint's ``get_context_info``) see it on
+        their next read — while the push side (``context_usage`` SSE +
+        nudge evaluation) rides a fire-and-forget task.
+
+        Coalescing: if an emit task is already in flight we skip
+        scheduling another — the in-flight one reads current state at
+        each step, and the turn-complete emit always runs and carries
+        the final value, so nothing is lost. This also serializes
+        ``_emit_context_usage_event`` bodies, keeping the nudge latch
+        check-and-set free of concurrent interleavings.
+        """
+        if not isinstance(usage, dict) or not usage:
+            return
+        self.usage.last_usage = dict(usage)
+        if (
+            self._ctx_usage_emit_task is not None
+            and not self._ctx_usage_emit_task.done()
+        ):
+            return
+        self._ctx_usage_emit_task = asyncio.create_task(
+            self._guarded_context_usage_emit(),
+            name=f"tmux_ctx_emit:{self.agent_name}",
+        )
+
+    async def _guarded_context_usage_emit(self) -> None:
+        """Exception fence for the fire-and-forget mid-turn emit task.
+
+        ``_emit_stream_event`` swallows its own errors, but the nudge
+        paths (``_enqueue_autorestart_nudge`` / ``_enqueue_internal_prompt``)
+        can raise — an unobserved task exception would just splat into
+        the loop's default handler. Telemetry must never look like a
+        crash.
+        """
+        try:
+            await self._emit_context_usage_event()
+        except Exception as e:
+            _log(
+                f"tmux[{self.agent_name}]: mid-turn context emit raised "
+                f"({type(e).__name__}: {e})"
+            )
+
     async def _emit_context_usage_event(self) -> None:
         """Emit a ``context_usage`` SSE event and a ``restart_nudge``
         when the cumulative token total crosses the agent's
@@ -4311,6 +4374,11 @@ class TmuxSession:
                 # is covered by ``_attempt_first_bind_recovery``
                 # (issue #565).
                 path_discovery=self._discover_transcript_path,
+                # Mid-turn context gauge: surface each assistant
+                # entry's usage block as it lands so context% tracks
+                # the live window instead of freezing at the previous
+                # turn's value for the whole in-flight turn.
+                on_usage=self._on_transcript_usage,
             )
             await self._tailer.start()
             if guessed is None:
@@ -4508,6 +4576,14 @@ class TmuxSession:
         ):
             self._first_bind_recovery_task.cancel()
         self._first_bind_recovery_task = None
+        # Cancel any in-flight mid-turn context emit — it belongs to the
+        # session that just ended; the next spawn re-emits fresh state.
+        if (
+            self._ctx_usage_emit_task is not None
+            and not self._ctx_usage_emit_task.done()
+        ):
+            self._ctx_usage_emit_task.cancel()
+        self._ctx_usage_emit_task = None
         if self._tailer is not None:
             try:
                 await self._tailer.stop()

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -110,6 +110,12 @@ class _TurnBuffer:
         self._assistant_count: int = 0
         self._turn_started_at: float | None = None  # epoch seconds
         self._turn_ended_at: float | None = None
+        # Monotonic counter bumped each time an assistant entry carries a
+        # real usage block. Lets the tailer detect "this entry refreshed
+        # the usage snapshot" without re-parsing the entry — the hook for
+        # mid-turn context surfacing. Never reset by drain(): callers
+        # compare before/after values, not absolutes.
+        self._usage_seq: int = 0
 
     def feed(self, entry: dict) -> bool:
         """Process one transcript entry. Return True iff this closes a turn."""
@@ -164,9 +170,13 @@ class _TurnBuffer:
         sr = msg.get("stop_reason")
         if sr:
             self._last_stop_reason = sr
+        # Non-empty guard: synthetic/error rows can carry ``"usage": {}``
+        # — letting that overwrite would erase the last real snapshot
+        # right before drain() ships it in the TurnResponse.
         usage = msg.get("usage")
-        if isinstance(usage, dict):
+        if isinstance(usage, dict) and usage:
             self._last_usage = usage
+            self._usage_seq += 1
         # Capture the model that produced this turn. The configured model
         # (``config.model``) can be empty when the agent relies on Claude
         # Code's default, so the transcript's own ``model`` field is the
@@ -206,6 +216,16 @@ class _TurnBuffer:
         self._turn_ended_at = None
 
         return resp
+
+    @property
+    def usage_seq(self) -> int:
+        """Bumped per assistant entry that carried a real usage block."""
+        return self._usage_seq
+
+    @property
+    def last_usage(self) -> dict:
+        """Most recent usage block seen this turn ({} after drain)."""
+        return self._last_usage
 
     @property
     def is_empty(self) -> bool:
@@ -273,6 +293,7 @@ class TmuxTranscriptTailer:
         fallback_poll_sec: float = _FALLBACK_POLL_SEC,
         active_poll_sec: float = _ACTIVE_POLL_SEC,
         path_discovery: Callable[[], Path | None] | None = None,
+        on_usage: Callable[[dict], None] | None = None,
     ) -> None:
         self._path = Path(transcript_path)
         # #291: wall-clock when ``_path`` was last bound via an explicit
@@ -299,6 +320,17 @@ class TmuxTranscriptTailer:
         # This makes the tailer correct without dependence on the
         # SessionStart hook firing at all. See ``TmuxSession._discover_transcript_path``.
         self._path_discovery = path_discovery
+        # Mid-turn usage hook: invoked (sync) with the usage dict every
+        # time an assistant entry carries a fresh usage block — i.e. once
+        # per API call inside the turn's tool loop, not just at turn end.
+        # This is what keeps the context gauge live during long agentic
+        # turns: before it, usage sat in the buffer until the closing
+        # stop_hook_summary and the gauge showed the PREVIOUS turn's
+        # value for the whole in-flight turn. Sync on purpose — an await
+        # here would add a mid-chunk suspension point and reopen the
+        # transcript-swap race that ``_swap_generation`` guards around
+        # turn callbacks.
+        self._on_usage = on_usage
 
         self._offset: int = 0
         # Bumped by every path-changing ``set_transcript_path``. Lets
@@ -325,6 +357,9 @@ class TmuxTranscriptTailer:
             # #291: count self-heal discoveries we REFUSED because the
             # candidate predated the current bind (the stale-clobber guard).
             "self_heal_stale_skips": 0,
+            # Mid-turn usage callbacks fired (one per assistant entry
+            # that carried a fresh usage block).
+            "usage_events": 0,
         }
         # ``_active`` flips True after we see a user entry but before we see
         # the closing stop_hook_summary. Drives the tighter poll cadence so
@@ -697,6 +732,7 @@ class TmuxTranscriptTailer:
 
                 closes_turn = False
                 prevented = False
+                usage_seq_before = self._buffer.usage_seq
                 try:
                     closes_turn = self._buffer.feed(entry)
                     if closes_turn:
@@ -709,6 +745,24 @@ class TmuxTranscriptTailer:
                     )
 
                 bytes_read += len(line.encode("utf-8")) + 1  # +1 for the \n
+
+                # Mid-turn context surfacing: this entry refreshed the
+                # usage snapshot — hand it to the consumer NOW rather
+                # than letting it age in the buffer until turn end.
+                # Copy so the consumer can't mutate buffer state.
+                if (
+                    self._on_usage is not None
+                    and self._buffer.usage_seq != usage_seq_before
+                ):
+                    self._stats["usage_events"] += 1
+                    try:
+                        self._on_usage(dict(self._buffer.last_usage))
+                    except Exception as e:
+                        self._stats["callback_errors"] += 1
+                        _log(
+                            f"tmux_tailer[{self._agent_name}]: on_usage raised "
+                            f"({type(e).__name__}: {e}); continuing"
+                        )
 
                 if closes_turn and not self._buffer.is_empty:
                     response = self._buffer.drain(prevented_continuation=prevented)

--- a/tests/test_tmux_context_realtime.py
+++ b/tests/test_tmux_context_realtime.py
@@ -1,0 +1,227 @@
+"""Tests for the real-time (mid-turn) context gauge on tmux sessions.
+
+Before this feature, ``usage.last_usage`` — the source for
+``context_used_pct``, ``get_context_info()`` and the ``context_usage``
+SSE — was written only by ``_record_turn_usage`` at turn end
+(``stop_hook_summary``). A long tool-loop turn therefore showed the
+PREVIOUS turn's context% for its entire duration.
+
+The fix: the tailer's ``on_usage`` hook fires per assistant entry;
+``TmuxSession._on_transcript_usage`` folds the block into
+``usage.last_usage`` synchronously (pull-based readers see it at once)
+and schedules a coalesced ``_emit_context_usage_event`` (push side:
+SSE + nudges).
+
+Mirrors test_tmux_context_autorestart.py's mock strategy — never shells
+out to tmux.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import TmuxSession, _TmuxControl
+
+_MODEL_1M = "claude-opus-4-8"
+_MODEL_200K = "claude-haiku-4-5"
+
+
+def _make_mock_tmux() -> MagicMock:
+    tmux = MagicMock(spec=_TmuxControl)
+    tmux.session_name = "pinky-test"
+    tmux.has_session = AsyncMock(return_value=False)
+    tmux.new_session = AsyncMock()
+    tmux.kill_session = AsyncMock()
+    tmux.send_keys = AsyncMock()
+    tmux.paste_text = AsyncMock()
+    tmux.capture_pane = AsyncMock()
+    return tmux
+
+
+def _make_session(*, model: str = _MODEL_200K) -> TmuxSession:
+    cfg = StreamingSessionConfig(
+        agent_name="dreamer",
+        working_dir="/tmp/tmux-ctx-realtime-test",
+        model=model,
+    )
+    ss = TmuxSession(cfg, tmux_control=_make_mock_tmux())
+    ss._skip_wake_prompt_for_tests = True
+    ss._emit_stream_event = AsyncMock()
+    ss._enqueue_internal_prompt = AsyncMock()
+    return ss
+
+
+async def _drain_emit_task(ss: TmuxSession) -> None:
+    """Await the fire-and-forget emit task if one was scheduled."""
+    if ss._ctx_usage_emit_task is not None:
+        await ss._ctx_usage_emit_task
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# State update — pull-based readers see mid-turn usage immediately
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_usage_updates_gauge_immediately() -> None:
+    ss = _make_session()
+    assert ss.context_used_pct == 0.0
+
+    ss._on_transcript_usage({"input_tokens": 50_000, "output_tokens": 500})
+
+    # No turn completed, yet the pull-based gauge already moved.
+    assert ss.usage.last_usage == {"input_tokens": 50_000, "output_tokens": 500}
+    assert ss.context_used_pct > 0.0
+    info = ss.get_context_info()
+    assert info["totalTokens"] == 50_500
+    await _drain_emit_task(ss)
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_usage_counts_all_four_token_kinds() -> None:
+    ss = _make_session()
+    ss._on_transcript_usage({
+        "input_tokens": 1_000,
+        "output_tokens": 200,
+        "cache_read_input_tokens": 30_000,
+        "cache_creation_input_tokens": 4_000,
+    })
+    assert ss.get_context_info()["totalTokens"] == 35_200
+    await _drain_emit_task(ss)
+
+
+@pytest.mark.asyncio
+async def test_empty_or_malformed_usage_is_ignored() -> None:
+    ss = _make_session()
+    ss.usage.last_usage = {"input_tokens": 123}
+
+    ss._on_transcript_usage({})
+    ss._on_transcript_usage(None)  # type: ignore[arg-type]
+    ss._on_transcript_usage("nope")  # type: ignore[arg-type]
+
+    assert ss.usage.last_usage == {"input_tokens": 123}
+    assert ss._ctx_usage_emit_task is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Push side — coalesced context_usage SSE emit
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_usage_emits_context_usage_sse() -> None:
+    ss = _make_session()
+    ss._on_transcript_usage({"input_tokens": 10_000, "output_tokens": 100})
+    await _drain_emit_task(ss)
+
+    ctx_events = [
+        c.args[0]
+        for c in ss._emit_stream_event.call_args_list
+        if c.args and c.args[0].get("type") == "context_usage"
+    ]
+    assert len(ctx_events) == 1
+    assert ctx_events[0]["totalTokens"] == 10_100
+
+
+@pytest.mark.asyncio
+async def test_emit_tasks_coalesce_while_one_is_in_flight() -> None:
+    ss = _make_session()
+    gate = asyncio.Event()
+
+    async def _blocked_emit(event: dict) -> None:
+        await gate.wait()
+
+    ss._emit_stream_event = AsyncMock(side_effect=_blocked_emit)
+
+    ss._on_transcript_usage({"input_tokens": 1_000})
+    first_task = ss._ctx_usage_emit_task
+    assert first_task is not None
+    await asyncio.sleep(0)  # let the task reach the blocked emit
+
+    # Burst of further entries while the emit is parked: no new task.
+    ss._on_transcript_usage({"input_tokens": 2_000})
+    ss._on_transcript_usage({"input_tokens": 3_000})
+    assert ss._ctx_usage_emit_task is first_task
+
+    # State still tracked the newest value even though the emit coalesced.
+    assert ss.usage.last_usage == {"input_tokens": 3_000}
+
+    gate.set()
+    await first_task
+    # Next usage block schedules a fresh emit.
+    ss._on_transcript_usage({"input_tokens": 4_000})
+    assert ss._ctx_usage_emit_task is not first_task
+    await _drain_emit_task(ss)
+
+
+@pytest.mark.asyncio
+async def test_emit_exception_is_fenced() -> None:
+    """A raising nudge path must not surface as an unobserved task error."""
+    ss = _make_session(model=_MODEL_1M)
+    ss._enqueue_internal_prompt = AsyncMock(side_effect=RuntimeError("queue down"))
+    # Above the ~41% 1M cap → nudge path runs and raises.
+    ss._on_transcript_usage({"input_tokens": 450_000})
+    await _drain_emit_task(ss)  # must not raise
+    assert ss._ctx_usage_emit_task.done()
+    assert ss._ctx_usage_emit_task.exception() is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Nudges now fire mid-turn (not just at turn end)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_threshold_crossing_mid_turn_fires_autorestart_nudge() -> None:
+    ss = _make_session(model=_MODEL_1M)
+    ss._on_transcript_usage({"input_tokens": 450_000})  # past the 400k cap
+    await _drain_emit_task(ss)
+
+    assert ss._enqueue_internal_prompt.await_count == 1
+    _, kwargs = ss._enqueue_internal_prompt.call_args
+    assert kwargs.get("reason") == "context_autorestart_nudge"
+
+    # Latch holds across subsequent mid-turn blocks.
+    ss._on_transcript_usage({"input_tokens": 460_000})
+    await _drain_emit_task(ss)
+    assert ss._enqueue_internal_prompt.await_count == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Wiring + lifecycle
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_tailer_wires_on_usage_hook() -> None:
+    ss = _make_session()
+    try:
+        await ss._start_tailer()
+        assert ss._tailer is not None
+        assert ss._tailer._on_usage == ss._on_transcript_usage
+    finally:
+        await ss._stop_tailer()
+
+
+@pytest.mark.asyncio
+async def test_stop_tailer_cancels_pending_emit_task() -> None:
+    ss = _make_session()
+    gate = asyncio.Event()
+
+    async def _blocked_emit(event: dict) -> None:
+        await gate.wait()
+
+    ss._emit_stream_event = AsyncMock(side_effect=_blocked_emit)
+    ss._on_transcript_usage({"input_tokens": 1_000})
+    task = ss._ctx_usage_emit_task
+    await asyncio.sleep(0)
+
+    await ss._stop_tailer()
+
+    assert ss._ctx_usage_emit_task is None
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_tmux_transcript.py
+++ b/tests/test_tmux_transcript.py
@@ -1246,3 +1246,120 @@ class TestSelfHealDiscovery:
         assert tailer.transcript_path == new, "must heal forward to the live file"
         assert tailer.stats["self_heal_repoints"] == 1
         assert tailer.stats["self_heal_stale_skips"] == 0
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Mid-turn usage callback (real-time context gauge)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestMidTurnUsageCallback:
+    """``on_usage`` fires per assistant entry that carries a fresh usage
+    block — the hook that keeps context% live during long tool-loop
+    turns instead of freezing at the previous turn's value."""
+
+    @pytest.mark.asyncio
+    async def test_fires_per_assistant_entry_mid_turn(self, transcript):
+        cb = _Captor()
+        seen: list[dict] = []
+        tailer = TmuxTranscriptTailer(transcript, cb, on_usage=seen.append)
+        # A turn IN FLIGHT: three API calls, no stop_hook_summary yet.
+        _write_jsonl(transcript, [
+            _user(text="do a big thing"),
+            _assistant(text="", tool_use={"name": "Bash"},
+                       usage={"input_tokens": 1000, "output_tokens": 50}),
+            _assistant(text="", tool_use={"name": "Read"},
+                       usage={"input_tokens": 2000, "output_tokens": 60}),
+            _assistant(text="done",
+                       usage={"input_tokens": 3000, "output_tokens": 70}),
+        ])
+        await tailer.read_once()
+        # Turn hasn't closed — no turn callback yet — but usage surfaced
+        # three times, tracking the live window per API call.
+        assert cb.responses == []
+        assert [u["input_tokens"] for u in seen] == [1000, 2000, 3000]
+        assert tailer.stats["usage_events"] == 3
+
+    @pytest.mark.asyncio
+    async def test_not_fired_for_entries_without_usage(self, transcript):
+        cb = _Captor()
+        seen: list[dict] = []
+        tailer = TmuxTranscriptTailer(transcript, cb, on_usage=seen.append)
+        no_usage = _assistant(text="synthetic")
+        no_usage["message"]["usage"] = {}
+        del_usage = _assistant(text="missing")
+        del del_usage["message"]["usage"]
+        _write_jsonl(transcript, [_user(), no_usage, del_usage])
+        await tailer.read_once()
+        assert seen == []
+        assert tailer.stats["usage_events"] == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_usage_does_not_clobber_last_real_snapshot(self, transcript):
+        """A trailing ``"usage": {}`` row must not erase the last real
+        usage block from the TurnResponse."""
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        empty = _assistant(text="")
+        empty["message"]["usage"] = {}
+        _write_jsonl(transcript, [
+            _user(),
+            _assistant(text="real", usage={"input_tokens": 500, "output_tokens": 5}),
+            empty,
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()
+        assert len(cb.responses) == 1
+        assert cb.responses[0].usage == {"input_tokens": 500, "output_tokens": 5}
+
+    @pytest.mark.asyncio
+    async def test_on_usage_exception_swallowed_and_turn_still_fires(self, transcript):
+        cb = _Captor()
+
+        def boom(usage: dict) -> None:
+            raise RuntimeError("gauge exploded")
+
+        tailer = TmuxTranscriptTailer(transcript, cb, on_usage=boom)
+        _write_jsonl(transcript, [
+            _user(),
+            _assistant(text="reply", usage={"input_tokens": 100, "output_tokens": 10}),
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()
+        # Callback error is counted, tailing continues, turn completes.
+        assert len(cb.responses) == 1
+        assert cb.responses[0].text == "reply"
+        assert tailer.stats["callback_errors"] == 1
+
+    @pytest.mark.asyncio
+    async def test_callback_receives_copy_not_buffer_state(self, transcript):
+        cb = _Captor()
+        seen: list[dict] = []
+
+        def mutate(usage: dict) -> None:
+            seen.append(dict(usage))
+            usage["input_tokens"] = -999  # must not corrupt the buffer
+
+        tailer = TmuxTranscriptTailer(transcript, cb, on_usage=mutate)
+        _write_jsonl(transcript, [
+            _user(),
+            _assistant(text="reply", usage={"input_tokens": 100, "output_tokens": 10}),
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()
+        assert seen == [{"input_tokens": 100, "output_tokens": 10}]
+        assert cb.responses[0].usage["input_tokens"] == 100
+
+    @pytest.mark.asyncio
+    async def test_no_callback_configured_is_no_op(self, transcript):
+        cb = _Captor()
+        tailer = TmuxTranscriptTailer(transcript, cb)
+        _write_jsonl(transcript, [
+            _user(),
+            _assistant(text="reply", usage={"input_tokens": 100, "output_tokens": 10}),
+            _stop_hook_summary(),
+        ])
+        await tailer.read_once()
+        assert len(cb.responses) == 1
+        # Stat counts CALLBACKS fired, not usage sightings — stays 0.
+        assert tailer.stats["usage_events"] == 0


### PR DESCRIPTION
## Problem

Context% for CC tmux sessions lags: it only refreshes at turn boundaries. The transcript tailer reads every `assistant` JSONL entry in near-real-time — each carries a `usage` block that approximates the live context window — but buffers it in `_TurnBuffer._last_usage` until the closing `stop_hook_summary`. Only then does `_record_turn_usage` fold it into `usage.last_usage`, the single source for:

- `context_used_pct` (heartbeat reconciler)
- `get_context_info()` (`/agents/{name}/streaming/status`, which the Chat UI polls)
- the `context_usage` SSE + restart/soft nudge evaluation

So during a long agentic turn (tool loop running for minutes), everything shows the context as of the **end of the previous turn**.

## Fix

**`tmux_transcript.py`**
- New optional `on_usage` hook on `TmuxTranscriptTailer`, fired synchronously per assistant entry that carries a fresh usage block (once per API call inside the tool loop). Sync on purpose — an await there would reopen the mid-chunk transcript-swap race that `_swap_generation` guards around turn callbacks.
- `_TurnBuffer` gets a monotonic `usage_seq` so the tailer detects refreshes without re-parsing entries.
- Bonus guard: a trailing `"usage": {}` row no longer clobbers the last real snapshot before drain.

**`tmux_session.py`**
- `_on_transcript_usage` updates `usage.last_usage` immediately — pull-based readers (UI status poll, heartbeat reconciler) see the live value on their next read.
- Push side (`context_usage` SSE + nudge evaluation) rides a coalesced single-flight task: a burst of entries in one read chunk produces one emit, and the serialization keeps the nudge latch check-and-set race-free. Restart/soft nudges now fire when the threshold is actually crossed mid-turn, not a turn later.
- Pending emit task cancelled in `_stop_tailer`.

## Tests

- 6 new tailer tests (`TestMidTurnUsageCallback`): fires per API call mid-turn, skips entries without usage, empty-usage clobber guard, exception fencing, defensive copy, no-op without hook.
- 9 new session tests (`test_tmux_context_realtime.py`): immediate gauge update, all four token kinds, malformed input, SSE emit, coalescing, exception fence, mid-turn autorestart nudge + latch, wiring, lifecycle cancel.
- Full suite: 4235 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)