### PR TITLE
fix(effort/model): deterministic launch, live per-session apply, honest selector

### DIFF
--- a/frontend-svelte/src/pages/Chat.svelte
+++ b/frontend-svelte/src/pages/Chat.svelte
@@ -158,6 +158,19 @@
         { value: 'claude-haiku-4-5', label: 'Haiku 4.5' },
     ];
     let availableModels = fallbackModels;
+
+    // Full effort vocabulary (matches the backend's EFFORT_LEVELS minus
+    // "auto"). The old hardcoded low/medium/high/max list could not even
+    // REPRESENT xhigh/ultracode — a session running at those rendered a
+    // blank select.
+    const effortOptions = [
+        { value: 'low', label: 'Low' },
+        { value: 'medium', label: 'Medium' },
+        { value: 'high', label: 'High' },
+        { value: 'xhigh', label: 'XHigh' },
+        { value: 'max', label: 'Max' },
+        { value: 'ultracode', label: 'Ultracode' },
+    ];
     async function loadModelRegistry() {
         try {
             const registry = await api('GET', '/models');
@@ -586,7 +599,9 @@
             const agentData = await api('GET', `/agents/${agentName}`);
             if (requestSeq !== chatRefreshSeq || sessionId !== activeSession) return;
             if (agentData.model && !selectedModel) selectedModel = agentData.model;
-            if (agentData.thinking_effort) selectedEffort = agentData.thinking_effort;
+            // Don't clobber the dropdown while a save is in flight — the
+            // session-level GET below refines this with the effective value.
+            if (agentData.thinking_effort && !savingEffort) selectedEffort = agentData.thinking_effort;
             if (agentData.restart_threshold_pct != null) contextNudgePct = agentData.restart_threshold_pct;
             if (agentData.context_nudge_threshold_pct != null && agentData.context_nudge_threshold_pct > 0) softNudgePct = agentData.context_nudge_threshold_pct;
             if (agentData.model) infoModel = agentData.model;
@@ -597,7 +612,7 @@
             const refreshLabel = activeSessionRecord?._streaming_label || labelFromSessionId(sessionId, agentName);
             const effortData = await api('GET', `/agents/${agentName}/effort?label=${encodeURIComponent(refreshLabel)}`);
             if (requestSeq !== chatRefreshSeq || sessionId !== activeSession) return;
-            if (effortData.effective) selectedEffort = effortData.effective;
+            if (effortData.effective && !savingEffort) selectedEffort = effortData.effective;
         } catch { /* non-critical */ }
 
         let gotStreamingContext = false;
@@ -1082,6 +1097,8 @@
                 addLocalMessage({ role: 'system', content: `Model changed to ${selectedModel} \u2014 session restarted for new context window (${result.old_turns} turns saved)` });
                 await refreshChat();
                 await refreshSessions();
+            } else if (result.applied === 'pending_restart') {
+                addLocalMessage({ role: 'system', content: `Model set to ${selectedModel} \u2014 session busy, applies on next restart` });
             } else {
                 addLocalMessage({ role: 'system', content: `Model switched to ${selectedModel} (mid-session, no restart needed)` });
             }
@@ -1115,7 +1132,15 @@
         savingEffort = true;
         try {
             const label = activeSessionRecord?._streaming_label || labelFromSessionId(activeSession, activeAgent);
-            await api('POST', `/agents/${activeAgent}/sessions/${encodeURIComponent(label)}/effort`, { effort: selectedEffort });
+            const result = await api('POST', `/agents/${activeAgent}/sessions/${encodeURIComponent(label)}/effort`, { effort: selectedEffort });
+            const applied = result.applied || 'pending_restart';
+            if (applied === 'live') {
+                toast(`Effort set to ${result.effective} (applied live)`, 'success');
+            } else if (applied === 'deferred') {
+                toast(`Effort set to ${result.effective} — applies when the agent finishes its current task`, 'success');
+            } else {
+                toast(`Effort saved as ${result.effective} — takes effect on next session restart`, 'success');
+            }
         } catch (e) { toast(`Failed to update effort: ${e.message}`, 'error'); }
         savingEffort = false;
     }
@@ -1418,10 +1443,12 @@
                     <label class="setting-item">
                         <span>{$_('agents_extra.effort_label')}</span>
                         <select bind:value={selectedEffort} on:change={saveEffort} disabled={savingEffort}>
-                            <option value="low">Low</option>
-                            <option value="medium">Medium</option>
-                            <option value="high">High</option>
-                            <option value="max">Max</option>
+                            {#each effortOptions as opt}
+                                <option value={opt.value}>{opt.label}</option>
+                            {/each}
+                            {#if selectedEffort && !effortOptions.some(o => o.value === selectedEffort)}
+                                <option value={selectedEffort}>{selectedEffort}</option>
+                            {/if}
                         </select>
                     </label>
                     <label class="setting-item" title={$_('chat.restart_threshold_help')}>
@@ -1474,7 +1501,12 @@
                         {#if sessionMeta.effective_effort}
                         <div class="session-info-row">
                             <span class="session-info-label">Effort</span>
-                            <span class="session-info-value">{sessionMeta.effective_effort}{sessionMeta.session_effort ? ' (override)' : ''}</span>
+                            <span class="session-info-value">
+                                {sessionMeta.effective_effort}{sessionMeta.session_effort ? ' (override)' : ''}
+                                {#if sessionMeta.live_effort && sessionMeta.live_effort !== (sessionMeta.effective_effort === 'ultracode' ? 'xhigh' : sessionMeta.effective_effort)}
+                                    <span class="session-info-warn" title="Runtime effort reported by the session's hooks differs from the configured level">(repl: {sessionMeta.live_effort})</span>
+                                {/if}
+                            </span>
                         </div>
                         {/if}
                     {/if}

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -828,6 +828,10 @@ body = {{
     "tool_use_id": payload_in.get("tool_use_id", ""),
     "tool_name": tool_name,
     "tool_input": payload_in.get("tool_input") or {{}},
+    # Piggyback the runtime thinking effort (Claude Code v2.1.133+) so the
+    # daemon can surface what the REPL is ACTUALLY running at — the read
+    # side of the model/effort selector. Empty on older CLIs.
+    "effort": os.environ.get("CLAUDE_EFFORT", ""),
 }}
 
 req = urllib.request.Request(

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -123,7 +123,7 @@ from pinky_daemon.autonomy import AgentEvent, AutonomyEngine, EventType
 from pinky_daemon.broker import BrokerMessage, MessageBroker
 from pinky_daemon.conversation_store import ConversationStore
 from pinky_daemon.dream_runner import DreamRunner
-from pinky_daemon.effort import CLI_EFFORT_LEVELS, EFFORT_LEVELS
+from pinky_daemon.effort import CLI_EFFORT_LEVELS, EFFORT_LEVELS, resolve_cli_effort
 from pinky_daemon.hooks import (
     AuditStore,
     HookEvent,
@@ -5784,6 +5784,33 @@ npm run build</pre>
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
+
+        # Stale-expectation guard: PINKY_EXPECTED_EFFORT is baked into the
+        # session env at spawn, so after a LIVE mid-session effort change
+        # (apply_effort_live) the hook keeps comparing against the old
+        # level. When the reported ACTUAL matches what the daemon currently
+        # wants, the "drift" is the env var lagging — record the readback
+        # and skip the drift event instead of spamming false positives.
+        ss = broker._get_streaming_session(name)
+        if ss is not None and req.actual:
+            if hasattr(ss, "last_reported_effort"):
+                ss.last_reported_effort = req.actual
+            effective = getattr(ss, "effective_effort", "") or ""
+            if req.actual == resolve_cli_effort(effective):
+                _log(
+                    f"api: effort-drift for {name} matches current effective "
+                    f"({req.actual}) — stale expected={req.expected}, skipping"
+                )
+                return {
+                    "ok": True,
+                    "agent": name,
+                    "event_id": 0,
+                    "expected": req.expected,
+                    "actual": req.actual,
+                    "strict": req.strict,
+                    "stale_expected": True,
+                }
+
         event_id = agents.record_effort_drift(
             name,
             expected=req.expected,
@@ -6053,6 +6080,13 @@ npm run build</pre>
         if session is None:
             return {"ok": True, "agent": name, "session": None}
 
+        # Actual-effort readback: the hook piggybacks $CLAUDE_EFFORT on
+        # every tool call, so this is the freshest signal for what the
+        # REPL is really running at (surfaced via GET /agents/{name}/effort
+        # and the session meta endpoint).
+        if req.effort and hasattr(session, "last_reported_effort"):
+            session.last_reported_effort = req.effort
+
         record = getattr(session, "record_tool_use_start", None)
         if callable(record):
             try:
@@ -6150,7 +6184,14 @@ npm run build</pre>
 
     @app.get("/agents/{name}/effort")
     async def get_agent_effort(name: str, label: str = "main"):
-        """Get an agent's thinking effort (default + session override)."""
+        """Get an agent's thinking effort (default + session override).
+
+        ``live`` is the runtime effort the session last REPORTED (hooks
+        piggyback ``$CLAUDE_EFFORT`` on their tool-use POSTs) — what the
+        CLI is actually running at, not what we asked for. Empty until
+        the first hook fires. ``pending_live`` is a level waiting to be
+        typed into a busy tmux REPL.
+        """
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
@@ -6168,6 +6209,8 @@ npm run build</pre>
             "default": default,
             "session_override": session_override,
             "effective": effective,
+            "live": getattr(ss, "last_reported_effort", "") or None,
+            "pending_live": getattr(ss, "_pending_live_effort", None),
         }
 
     @app.put("/agents/{name}/effort")
@@ -6186,7 +6229,18 @@ npm run build</pre>
 
     @app.post("/agents/{name}/sessions/{session_label}/effort")
     async def set_session_effort(name: str, session_label: str, req: dict):
-        """Set session-level thinking effort override (label-aware)."""
+        """Set session-level thinking effort override (label-aware).
+
+        ``applied`` reports how far the change actually got:
+
+        - ``live`` — pushed into the running tmux REPL (interactive
+          ``/effort``, confirmation dialog auto-accepted).
+        - ``deferred`` — tmux REPL is mid-turn; applies when the current
+          work drains.
+        - ``pending_restart`` — stashed only; takes effect on the next
+          session relaunch. Always the case for SDK sessions (the SDK
+          client exposes no mid-session effort control).
+        """
         level = req.get("effort", "medium")
         if level not in EFFORT_LEVELS:
             raise HTTPException(400, f"Invalid effort level: {level}")
@@ -6198,16 +6252,22 @@ npm run build</pre>
         ss = (sessions.get(session_label) or sessions.get("main")) if sessions else None
         if not ss or not hasattr(ss, "set_effort"):
             raise HTTPException(404, f"No active session '{session_label}' for '{name}'")
-        if level == "auto":
-            ss.clear_effort_override()
+        apply_live = getattr(ss, "apply_effort_live", None)
+        if callable(apply_live):
+            applied = await apply_live(level)
         else:
-            ss.set_effort(level)
+            if level == "auto":
+                ss.clear_effort_override()
+            else:
+                ss.set_effort(level)
+            applied = "pending_restart"
         default = agent.thinking_effort or "medium"
         effective = level if level != "auto" else default
         return {"agent": name, "label": session_label,
                 "default": default,
                 "session_override": None if level == "auto" else level,
-                "effective": effective}
+                "effective": effective,
+                "applied": applied}
 
     @app.get("/agents/{name}/presence")
     async def get_agent_presence(name: str):
@@ -8244,13 +8304,38 @@ npm run build</pre>
     async def set_streaming_model(name: str, req: SetModelRequest):
         """Change the model on a running streaming session.
 
-        If the context window size changes (e.g. 200k → 1M), automatically
-        saves state and restarts the session. Otherwise switches mid-session.
+        SDK sessions: if the context window class changes (200k ↔ 1M) the
+        session is saved + restarted, else hot-swapped via the SDK's
+        ``set_model`` control. Tmux sessions have no ``_client`` — they
+        hot-swap by typing the interactive ``/model`` into the REPL (the
+        CLI renegotiates the window itself, so no restart is forced);
+        ``applied`` in the response reports how far the change got.
         """
         ss = broker._get_streaming_session(name)
         if not ss:
             raise HTTPException(404, f"No streaming session for '{name}'")
-        if ss.state != TransportSessionState.CONNECTED or not ss._client:
+        client = getattr(ss, "_client", None)
+
+        # Tmux path — interactive /model, no client, no forced restart.
+        apply_model_live = getattr(ss, "apply_model_live", None)
+        if client is None and callable(apply_model_live):
+            applied = await apply_model_live(req.model)
+            if applied == "rejected":
+                raise HTTPException(
+                    400, f"Model '{req.model}' rejected by the CLI"
+                )
+            # Persist only after the session accepted the change (config
+            # updated → relaunches use --model <new>).
+            agents.register(name, model=req.model)
+            return {
+                "updated": True,
+                "agent": name,
+                "model": req.model,
+                "restarted": False,
+                "applied": applied,
+            }
+
+        if ss.state != TransportSessionState.CONNECTED or not client:
             raise HTTPException(409, f"Streaming session for '{name}' not connected")
 
         # Check if context window would change
@@ -8315,6 +8400,7 @@ npm run build</pre>
                 "agent": name,
                 "model": req.model,
                 "restarted": True,
+                "applied": "restarted",
                 "old_session_id": old_resume_handle[:12] if old_resume_handle else "",
                 "old_turns": old_turns,
             }
@@ -8328,7 +8414,8 @@ npm run build</pre>
 
             # Persist only after the live session actually switched
             agents.register(name, model=req.model)
-            return {"updated": True, "agent": name, "model": req.model, "restarted": False}
+            return {"updated": True, "agent": name, "model": req.model,
+                    "restarted": False, "applied": "live"}
 
     @app.post("/agents/{name}/streaming/compact")
     async def compact_streaming_session(name: str):
@@ -8492,6 +8579,9 @@ npm run build</pre>
             "default_effort": default_effort,
             "session_effort": session_effort,
             "effective_effort": effective_effort,
+            # Runtime effort last reported by hooks ($CLAUDE_EFFORT) — the
+            # REPL's actual level, empty until the first tool call fires.
+            "live_effort": getattr(ss, "last_reported_effort", "") or None,
         }
 
     @app.post("/agents/{name}/message")

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -976,6 +976,10 @@ class TransportToolUseRequest(BaseModel):
     tool_input: dict = {}
     session_id: str = ""
     label: str = "main"
+    # Runtime thinking effort ($CLAUDE_EFFORT) piggybacked by the hook —
+    # lets the daemon track the REPL's actual effort without an extra
+    # request. Empty on CLIs predating the env var.
+    effort: str = ""
 
 
 class TransportToolResultRequest(BaseModel):

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -171,6 +171,29 @@ class CodexTmuxSession(TmuxSession):
         )
         return cmd
 
+    # ── seam: live REPL control ─────────────────────────────────────────────
+    # The inherited live-apply machinery types CLAUDE slash commands
+    # (/effort, /model) into the pane — the codex REPL doesn't speak them
+    # (effort is a -c launch flag; /model is an interactive picker). Stash
+    # only; the change lands on the next relaunch.
+
+    async def apply_effort_live(self, level: str) -> str:
+        from pinky_daemon.effort import resolve_cli_effort
+
+        self.set_effort(level)
+        # ultracode is Claude-native — resolve it so the codex launch flag
+        # never sees the literal (max→high still maps at build time).
+        self._reasoning_effort = resolve_cli_effort(self.effective_effort)
+        return "pending_restart"
+
+    async def apply_model_live(self, model: str) -> str:
+        model = (model or "").strip()
+        if not model:
+            return "rejected"
+        self._config.model = model
+        self._codex_model = model
+        return "pending_restart"
+
     # tmux-internal vars that must not leak into the nested REPL's children
     # (mirrors ``CodexAppServerSupervisor._ENV_DROP``).
     _ENV_DROP = frozenset({"TMUX", "TMUX_PANE"})

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -309,6 +309,10 @@ class StreamingSession:
         self._context_warned = False  # Track if we've already warned this session
         self._last_restart_block_notice_at = 0.0
         self._effort_override: str | None = None  # Session-level thinking effort override
+        # Runtime effort last reported by hooks ($CLAUDE_EFFORT via the
+        # effort-drift endpoint) — the CLI's actual level, "" until a hook
+        # reports. Read side of the effort knob (model/effort selector).
+        self.last_reported_effort: str = ""
         self._turn_seq = 0  # Monotonic turn counter for analytics
         self._last_user_message = ""  # For analytics keyword classification
 
@@ -442,9 +446,12 @@ class StreamingSession:
 
         # Apply thinking effort. ultracode resolves to xhigh (#151) — the SDK
         # forwards options.effort to the CLI's --effort flag, which rejects
-        # the literal "ultracode".
+        # the literal "ultracode". Medium is passed EXPLICITLY: the CLI
+        # persists the last effort per project dir, so omitting the option
+        # for medium-configured agents boots them at whatever the previous
+        # session ran at instead of medium.
         effort = resolve_cli_effort(self.effective_effort)
-        if effort and effort != "medium":
+        if effort and effort != "auto":
             options.effort = effort
 
         # Build provider env overrides (Ollama / custom compatible endpoints)

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1025,6 +1025,20 @@ _AUTH_LOGIN_SETTLE_SEC = 2.5
 # slack between two send paths into the same pane.
 _NATIVE_ULTRACODE_SETTLE_SEC = 0.4
 
+# Live REPL control commands (/effort, /model — issue: model/effort selector).
+# Settle after typing a slash command so the CLI processes it (and renders a
+# confirmation dialog, if any) before the pane is inspected or reused.
+_REPL_COMMAND_SETTLE_SEC = 0.8
+# Case-insensitive substrings that identify the mid-session /effort
+# confirmation dialog ("Change effort level?" — the prompt-cache re-read
+# warning) in a pane capture. Deliberately narrow: the idle input line also
+# renders selector-ish glyphs, so generic markers would false-positive.
+_EFFORT_DIALOG_NEEDLES = ("change effort", "effort level?")
+# Same idea for a mid-session /model switch dialog, plus failure needles the
+# CLI prints for an unknown model id.
+_MODEL_DIALOG_NEEDLES = ("change model", "switch model?")
+_MODEL_ERROR_NEEDLES = ("unknown model", "invalid model", "not a valid model")
+
 
 class TmuxSession:
     """Agent session backed by an interactive ``claude`` REPL in tmux.
@@ -1121,12 +1135,25 @@ class TmuxSession:
         # context_restart), so it can fire once per window.
         self._soft_nudge_fired = False
 
-        # Effort knob. tmux's claude REPL doesn't currently honor a
-        # per-session effort override (CLAUDE_EFFORT env is set at
-        # spawn time and we'd have to relaunch to change it). We accept
-        # the call to keep the Transport contract consistent and log a
-        # warning when it's used.
+        # Effort knob. The stashed override feeds ``--effort`` on the next
+        # relaunch (see ``_build_claude_cmd``); ``apply_effort_live`` also
+        # tries to push it into the RUNNING REPL by typing the interactive
+        # ``/effort`` command when the pane is idle.
         self._effort_override: str | None = None
+        # Serializes typed REPL control commands (/effort, /model) against
+        # turn-prompt pastes — two send paths into the same pane. Held by
+        # ``_type_repl_command`` and by ``_deliver_turn`` around its sends.
+        self._repl_control_lock = asyncio.Lock()
+        # Effort level (CLI vocabulary) waiting to be typed into the REPL
+        # once the current work drains — armed by ``apply_effort_live`` when
+        # the pane is busy, consumed by ``_handle_turn_complete`` at idle.
+        self._pending_live_effort: str | None = None
+        # Actual runtime effort as last reported by hooks ($CLAUDE_EFFORT
+        # piggybacked on the PreToolUse tool-use POST, or a drift report).
+        # Empty until the first hook fires. This is the READ side of the
+        # effort knob — what the REPL is really running at, not what we
+        # asked for.
+        self.last_reported_effort: str = ""
 
         # Resume-handle update callback (e.g. AgentRegistry persistence).
         # For tmux the resume_handle is stable from construction (= session
@@ -1968,9 +1995,13 @@ class TmuxSession:
         )
 
     def set_effort(self, level: str) -> None:
-        """Accept the call for protocol parity. tmux's claude REPL doesn't
-        honor mid-session effort changes — log a warning and stash the
-        value. A force_restart picks it up on the relaunched REPL."""
+        """Stash a per-session effort override (Transport protocol parity).
+
+        The stash feeds ``--effort`` on the next REPL relaunch. Callers that
+        want the change pushed into the RUNNING REPL should use
+        ``apply_effort_live`` instead — it stashes AND types the interactive
+        ``/effort`` command into the pane.
+        """
         valid = set(EFFORT_LEVELS)
         if level not in valid:
             raise ValueError(
@@ -1978,12 +2009,173 @@ class TmuxSession:
             )
         self._effort_override = None if level == "auto" else level
         _log(
-            f"tmux[{self.agent_name}]: set_effort({level!r}) stashed — "
-            f"takes effect on next force_restart (REPL relaunch)"
+            f"tmux[{self.agent_name}]: set_effort({level!r}) stashed for "
+            f"next relaunch"
         )
 
     def clear_effort_override(self) -> None:
         self._effort_override = None
+
+    def _repl_busy(self) -> bool:
+        """True when typing a slash command into the pane is unsafe —
+        a turn is in flight (queued, pasted, or a foreground tool call
+        is running). Typed text would land in the input buffer and be
+        submitted as a MESSAGE instead of executed as a command."""
+        return bool(
+            self._inflight_metas
+            or not self._message_queue.empty()
+            or self._inflight_tool_calls
+        )
+
+    async def _type_repl_command(
+        self, command: str, *, dialog_needles: tuple[str, ...] = ()
+    ) -> bool:
+        """Type a slash command into the REPL and settle it (caller holds
+        ``_repl_control_lock``).
+
+        Mid-session, some commands (notably ``/effort``) pop a confirmation
+        dialog (the prompt-cache full re-read warning). When the post-send
+        pane tail matches one of ``dialog_needles``, press Enter to accept
+        the highlighted default. If the dialog survives the confirm, press
+        Escape to cancel — leaving a modal dialog open would wedge the next
+        pasted prompt — and report failure so the caller falls back to the
+        relaunch path.
+        """
+        res = await self._tmux.send_keys(command, enter=True)
+        if not res.ok:
+            _log(
+                f"tmux[{self.agent_name}]: repl command {command!r} send "
+                f"failed (rc={res.returncode})"
+            )
+            return False
+        await asyncio.sleep(_REPL_COMMAND_SETTLE_SEC)
+        if not dialog_needles:
+            return True
+
+        async def _pane_tail() -> str:
+            cap = await self._tmux.capture_pane(lines=25, join=True)
+            return (cap.stdout or "").lower() if cap.ok else ""
+
+        tail = await _pane_tail()
+        if not any(n in tail for n in dialog_needles):
+            return True
+        # Confirmation dialog — Enter accepts the highlighted default (Yes).
+        await self._tmux.send_keys("", enter=True)
+        await asyncio.sleep(_REPL_COMMAND_SETTLE_SEC)
+        tail = await _pane_tail()
+        if any(n in tail for n in dialog_needles):
+            # Dialog survived the confirm — cancel it rather than leave a
+            # modal open under the next prompt paste.
+            await self._tmux.send_keys("Escape", enter=False)
+            _log(
+                f"tmux[{self.agent_name}]: repl command {command!r} dialog "
+                f"did not clear — cancelled"
+            )
+            return False
+        return True
+
+    async def apply_effort_live(self, level: str) -> str:
+        """Set the per-session effort AND push it into the running REPL.
+
+        Returns how far the change got:
+
+        - ``"live"`` — ``/effort <level>`` was typed into the idle REPL
+          (confirmation dialog auto-accepted if one appeared).
+        - ``"deferred"`` — the REPL is mid-turn; the command is armed and
+          ``_handle_turn_complete`` types it when the work drains.
+        - ``"pending_restart"`` — the session isn't connected or the typed
+          command failed; the stashed override applies on the next
+          relaunch (``--effort`` flag).
+
+        The override is stashed in all three cases, so relaunches and
+        ``effective_effort`` readers agree with the requested level even
+        when the live push fails.
+        """
+        self.set_effort(level)  # validates + stashes ("auto" clears)
+        # Type the EFFECTIVE level verbatim — unlike the --effort flag, the
+        # interactive /effort accepts "ultracode" (that's how the native
+        # activation path types it too). effective_effort never returns
+        # "auto".
+        cli_level = self.effective_effort
+        if self.state != SessionState.CONNECTED or not cli_level:
+            return "pending_restart"
+        if self._repl_busy():
+            self._pending_live_effort = cli_level
+            return "deferred"
+        async with self._repl_control_lock:
+            # Re-check under the lock: a turn paste may have grabbed the
+            # lock (and appended its inflight meta) while we waited.
+            if self._repl_busy():
+                self._pending_live_effort = cli_level
+                return "deferred"
+            ok = await self._type_repl_command(
+                f"/effort {cli_level}",
+                dialog_needles=_EFFORT_DIALOG_NEEDLES,
+            )
+        if ok:
+            _log(f"tmux[{self.agent_name}]: /effort {cli_level} applied live")
+            return "live"
+        return "pending_restart"
+
+    async def _apply_pending_effort(self, cli_level: str) -> None:
+        """Type an armed ``/effort`` into the REPL at idle (task spawned by
+        ``_handle_turn_complete``). Re-arms if a new turn slipped in."""
+        async with self._repl_control_lock:
+            if self._repl_busy():
+                self._pending_live_effort = cli_level
+                return
+            ok = await self._type_repl_command(
+                f"/effort {cli_level}",
+                dialog_needles=_EFFORT_DIALOG_NEEDLES,
+            )
+        _log(
+            f"tmux[{self.agent_name}]: deferred /effort {cli_level} "
+            f"{'applied live' if ok else 'failed — applies on next relaunch'}"
+        )
+
+    async def apply_model_live(self, model: str) -> str:
+        """Switch the running REPL's model via the interactive ``/model``.
+
+        Unlike the SDK transport, the REPL handles a window-class change
+        (200k ↔ 1M) itself, so no restart is forced for it. Returns:
+
+        - ``"live"`` — typed into the idle REPL, no error printed.
+        - ``"pending_restart"`` — REPL busy / not connected / send failed;
+          ``_config.model`` is updated so the next relaunch boots with
+          ``--model <model>`` (and the context-cap math follows now).
+        - ``"rejected"`` — the CLI reported the model id as unknown;
+          config is left untouched so a relaunch can't wedge on a bad
+          ``--model`` flag.
+        """
+        model = (model or "").strip()
+        if not model:
+            return "rejected"
+        if self.state != SessionState.CONNECTED or self._repl_busy():
+            self._config.model = model
+            return "pending_restart"
+        async with self._repl_control_lock:
+            # Re-check under the lock: a turn paste may have grabbed the
+            # lock (and appended its inflight meta) while we waited.
+            if self._repl_busy():
+                self._config.model = model
+                return "pending_restart"
+            ok = await self._type_repl_command(
+                f"/model {model}", dialog_needles=_MODEL_DIALOG_NEEDLES
+            )
+            if not ok:
+                self._config.model = model
+                return "pending_restart"
+            cap = await self._tmux.capture_pane(lines=25, join=True)
+            tail = (cap.stdout or "").lower() if cap.ok else ""
+        if any(n in tail for n in _MODEL_ERROR_NEEDLES):
+            _log(
+                f"tmux[{self.agent_name}]: /model {model} rejected by CLI — "
+                f"config unchanged"
+            )
+            return "rejected"
+        self._config.model = model
+        _log(f"tmux[{self.agent_name}]: /model {model} applied live")
+        return "live"
 
     # ── Lifecycle methods ───────────────────────────────────────────────
 
@@ -2421,6 +2613,10 @@ class TmuxSession:
         # ``_has_completed_turn = True``. force_restart / attempt_reconnect
         # both flow through here, so this is the structural reset point.
         self._has_completed_turn = False
+        # A deferred live /effort armed against the PREVIOUS REPL is moot:
+        # the fresh launch carries the stashed override via --effort, and
+        # typing into the new pane's splash phase would get eaten anyway.
+        self._pending_live_effort = None
 
         # If a stale session is left over from a previous daemon run (e.g.
         # crash without graceful disconnect), reap it. We're the cold-start
@@ -2662,13 +2858,16 @@ class TmuxSession:
             parts.extend(["--model", self._config.model])
         # Thinking effort (#151). tmux historically never passed --effort, so a
         # configured effort was only hook-detected, never actually applied.
-        # Mirror the SDK contract — set --effort for any explicit non-medium
-        # level. ultracode resolves to xhigh because the CLI flag rejects the
-        # literal "ultracode" (it's only reachable via interactive /effort);
-        # the workflow-orchestration half is carried by ULTRACODE_DIRECTIVE in
+        # Pass the flag for EVERY resolved level — including medium. The CLI
+        # persists the last interactive /effort choice per project dir, so a
+        # flagless launch inherits whatever the previous session ran at; an
+        # explicit medium config must not boot at a stale xhigh. ultracode
+        # resolves to xhigh because the CLI flag rejects the literal
+        # "ultracode" (it's only reachable via interactive /effort); the
+        # workflow-orchestration half is carried by ULTRACODE_DIRECTIVE in
         # the system prompt.
         cli_effort = resolve_cli_effort(self.effective_effort)
-        if cli_effort and cli_effort not in ("medium", "auto"):
+        if cli_effort and cli_effort != "auto":
             parts.extend(["--effort", cli_effort])
 
         # #151 native ultracode activation. ultracode boots at --effort xhigh
@@ -4143,6 +4342,17 @@ class TmuxSession:
         self._current_activity = ""
         self._current_thinking = ""
         self._activity_log = []
+
+        # Deferred live effort (model/effort selector): an
+        # ``apply_effort_live`` call that arrived mid-turn armed
+        # ``_pending_live_effort``. The work just drained — type it into
+        # the now-idle REPL. Fire-and-forget task: the apply sequence
+        # sleeps between sends, and this callback runs on the tailer's
+        # read loop, which must not stall.
+        if self._pending_live_effort and not self._repl_busy():
+            pending = self._pending_live_effort
+            self._pending_live_effort = None
+            asyncio.create_task(self._apply_pending_effort(pending))
 
     async def handle_stop_failure(
         self,
@@ -5784,7 +5994,11 @@ class TmuxSession:
         # fresh session doesn't get wedged in claude's input buffer.
         # Wake-prompt timing is additionally protected by the readiness
         # gate above (#570 / Murzik #571 review).
-        result = await self._tmux.paste_text(turn.prompt, enter=True)
+        # Held under the REPL-control lock so a live /effort or /model
+        # apply (which sends, settles, and may confirm a dialog) can't
+        # interleave with this paste — two send paths into one pane.
+        async with self._repl_control_lock:
+            result = await self._tmux.paste_text(turn.prompt, enter=True)
         if not result.ok:
             # Send failed — no response will arrive. Re-arm turn_done
             # (back-compat) and unblock any wait_for_completion caller

--- a/tests/test_effort_verification.py
+++ b/tests/test_effort_verification.py
@@ -341,6 +341,15 @@ class TestHookInstaller:
         assert "sys.stdin.read()" in pre.read_text()
         assert "sys.stdin.read()" in post.read_text()
 
+    def test_pre_tool_hook_piggybacks_runtime_effort(self, tmp_path):
+        """The PreToolUse hook must carry $CLAUDE_EFFORT in its POST body so
+        the daemon can surface the REPL's ACTUAL effort per session (the
+        read side of the model/effort selector)."""
+        AgentRegistry._setup_hooks(tmp_path, "alpha")
+        pre = (tmp_path / ".claude" / "hook_tmux_pre_tool.py").read_text()
+        assert 'os.environ.get("CLAUDE_EFFORT"' in pre
+        assert '"effort"' in pre
+
     def test_setup_settings_wires_pre_and_post_tool_use(self, tmp_path):
         AgentRegistry._setup_hooks(tmp_path, "alpha")
         settings = json.loads(

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -376,11 +376,15 @@ def test_build_claude_cmd_includes_dangerously_skip_when_no_transcript(
 # ──────────────────────────────────────────────────────────────────────────
 
 
-def test_build_claude_cmd_omits_effort_for_medium(tmp_path, monkeypatch) -> None:
+def test_build_claude_cmd_passes_effort_for_medium(tmp_path, monkeypatch) -> None:
+    """Medium is passed EXPLICITLY (model/effort selector fix): the CLI
+    persists the last interactive /effort per project dir, so a flagless
+    launch would boot a medium-configured agent at whatever the previous
+    session ran at."""
     monkeypatch.setenv("HOME", str(tmp_path))
     ss, _ = _make_session()
     ss._config.thinking_effort = "medium"
-    assert "--effort" not in ss._build_claude_cmd()
+    assert "--effort medium" in ss._build_claude_cmd()
 
 
 def test_build_claude_cmd_passes_effort_for_xhigh(tmp_path, monkeypatch) -> None:
@@ -415,6 +419,167 @@ def test_set_effort_accepts_ultracode() -> None:
     ss.set_effort("ultracode")
     assert ss._effort_override == "ultracode"
     assert ss.effective_effort == "ultracode"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Live per-session effort/model apply (model/effort selector fix).
+# apply_effort_live types the interactive /effort into an idle REPL,
+# auto-confirming the mid-session dialog; busy REPLs defer to next idle;
+# disconnected sessions stash for the relaunch --effort flag.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _capture(text: str) -> TmuxCommandResult:
+    return TmuxCommandResult(returncode=0, stdout=text, stderr="")
+
+
+@pytest.fixture()
+def fast_settle(monkeypatch):
+    """Shrink the post-command settle so live-apply tests don't sleep
+    real wall-clock time."""
+    monkeypatch.setattr(tmux_session, "_REPL_COMMAND_SETTLE_SEC", 0.001)
+
+
+@pytest.mark.asyncio
+async def test_apply_effort_live_idle_types_command(fast_settle) -> None:
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    tmux.capture_pane = AsyncMock(return_value=_capture("> \n"))
+    result = await ss.apply_effort_live("xhigh")
+    assert result == "live"
+    assert ss._effort_override == "xhigh"
+    tmux.send_keys.assert_awaited_once_with("/effort xhigh", enter=True)
+
+
+@pytest.mark.asyncio
+async def test_apply_effort_live_types_ultracode_verbatim(fast_settle) -> None:
+    """Unlike the --effort flag, interactive /effort accepts the literal
+    ultracode tier — the live apply must not resolve it to xhigh."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    tmux.capture_pane = AsyncMock(return_value=_capture("> \n"))
+    result = await ss.apply_effort_live("ultracode")
+    assert result == "live"
+    tmux.send_keys.assert_awaited_once_with("/effort ultracode", enter=True)
+
+
+@pytest.mark.asyncio
+async def test_apply_effort_live_busy_defers() -> None:
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    _seed_inflight(ss)
+    result = await ss.apply_effort_live("high")
+    assert result == "deferred"
+    assert ss._pending_live_effort == "high"
+    assert ss._effort_override == "high"  # stash still lands
+    tmux.send_keys.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_effort_live_disconnected_pends_restart() -> None:
+    ss, tmux = _make_session()  # UNINITIALIZED
+    result = await ss.apply_effort_live("max")
+    assert result == "pending_restart"
+    assert ss._effort_override == "max"
+    tmux.send_keys.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_effort_live_confirms_dialog(fast_settle) -> None:
+    """Mid-session /effort pops the 'Change effort level?' confirmation —
+    the apply presses Enter to accept and reports live once it clears."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    tmux.capture_pane = AsyncMock(
+        side_effect=[
+            _capture("Change effort level?\n> 1. Yes  2. No"),
+            _capture("> \n"),
+        ]
+    )
+    result = await ss.apply_effort_live("xhigh")
+    assert result == "live"
+    # /effort send + the Enter that confirmed the dialog.
+    assert tmux.send_keys.await_count == 2
+    assert tmux.send_keys.await_args_list[1].args == ("",)
+
+
+@pytest.mark.asyncio
+async def test_apply_effort_live_escapes_stuck_dialog(fast_settle) -> None:
+    """If the dialog survives the confirm, Escape it (a modal left open
+    would wedge the next prompt paste) and fall back to the relaunch path."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    tmux.capture_pane = AsyncMock(
+        return_value=_capture("Change effort level?\n> 1. Yes  2. No")
+    )
+    result = await ss.apply_effort_live("xhigh")
+    assert result == "pending_restart"
+    assert ss._effort_override == "xhigh"  # stash still applies on relaunch
+    escape_calls = [
+        c for c in tmux.send_keys.await_args_list if c.args == ("Escape",)
+    ]
+    assert len(escape_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_effort_live_auto_reverts_to_default(fast_settle) -> None:
+    """'auto' clears the override and pushes the agent DEFAULT live."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.thinking_effort = "high"
+    ss._effort_override = "xhigh"
+    tmux.capture_pane = AsyncMock(return_value=_capture("> \n"))
+    result = await ss.apply_effort_live("auto")
+    assert result == "live"
+    assert ss._effort_override is None
+    tmux.send_keys.assert_awaited_once_with("/effort high", enter=True)
+
+
+@pytest.mark.asyncio
+async def test_turn_complete_consumes_pending_live_effort(fast_settle) -> None:
+    """A deferred live effort is typed once the in-flight work drains."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    tmux.capture_pane = AsyncMock(return_value=_capture("> \n"))
+    _seed_inflight(ss)
+    ss._pending_live_effort = "xhigh"
+    response = TurnResponse(text="done", stop_reason="stop_hook_summary")
+    await ss._handle_turn_complete(response)
+    # The apply runs as a fire-and-forget task — let it settle.
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if tmux.send_keys.await_count:
+            break
+    assert ss._pending_live_effort is None
+    tmux.send_keys.assert_awaited_once_with("/effort xhigh", enter=True)
+
+
+@pytest.mark.asyncio
+async def test_apply_model_live_idle_types_command(fast_settle) -> None:
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    tmux.capture_pane = AsyncMock(return_value=_capture("> \n"))
+    result = await ss.apply_model_live("claude-opus-4-8")
+    assert result == "live"
+    assert ss._config.model == "claude-opus-4-8"
+    tmux.send_keys.assert_awaited_once_with("/model claude-opus-4-8", enter=True)
+
+
+@pytest.mark.asyncio
+async def test_apply_model_live_busy_pends_restart() -> None:
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    _seed_inflight(ss)
+    result = await ss.apply_model_live("claude-opus-4-8")
+    assert result == "pending_restart"
+    # Config still updated → next relaunch boots with --model <new>.
+    assert ss._config.model == "claude-opus-4-8"
+    tmux.send_keys.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_model_live_rejected_keeps_config(fast_settle) -> None:
+    """A CLI 'unknown model' rejection must NOT update config — a
+    relaunch with a bad --model flag would wedge the boot."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    old_model = ss._config.model
+    tmux.capture_pane = AsyncMock(
+        return_value=_capture("Unknown model: claude-bogus")
+    )
+    result = await ss.apply_model_live("claude-bogus")
+    assert result == "rejected"
+    assert ss._config.model == old_model
 
 
 # Native ultracode activation arming (#151). A fresh cold-start with ultracode


### PR DESCRIPTION
## Problem

The chat model/effort selector was janky on all three verbs, and launch effort silently fell back to whatever the CLI last persisted.

- **Read**: the Chat effort dropdown only offered low/medium/high/max — a session at xhigh/ultracode rendered a blank select. Nothing anywhere reported what the REPL was *actually* running at.
- **Set**: on tmux, `set_effort` stashed the override until a force_restart (with only a log warning); `POST /streaming/model` dereferenced `ss._client` (SDK-only) so tmux agents 500'd and the UI silently fell back to a DB-only write.
- **Confirm**: the endpoints reported success regardless of whether anything reached the session.
- **Launch**: both transports skipped `--effort`/`options.effort` for medium, but Claude Code persists the last interactive `/effort` per project dir — a medium-configured agent whose pane ever ran xhigh booted at xhigh forever. (Model was already explicit at launch when configured.)

## Fix

- **Launch determinism**: `--effort` / `options.effort` passed for every configured level, medium included (tmux + SDK).
- **Live apply (tmux)**: `apply_effort_live` types `/effort <level>` into the idle REPL, auto-confirms the mid-session "Change effort level?" dialog, Escapes a stuck dialog rather than leaving a modal under the next paste, defers to next-idle when mid-turn, and keeps the stash as relaunch fallback. `apply_model_live` types `/model <id>` (no forced restart — the CLI renegotiates the window) and rejects unknown ids without touching config. A control lock serializes typed commands against prompt pastes. `CodexTmuxSession` overrides both to stash-only.
- **Confirm loop**: session-effort endpoint returns `applied: live|deferred|pending_restart` (SDK is always pending_restart — no SDK effort control exists); UI toasts accordingly. PreToolUse hook piggybacks `$CLAUDE_EFFORT` on its existing tool-use POST → `GET /agents/{name}/effort` and session meta expose the REPL's actual effort; the info panel flags `(repl: X)` on disagreement. Drift endpoint drops stale-expectation false positives after live changes.
- **UI**: full effort vocabulary + unknown-value fallback; poll no longer clobbers the dropdown mid-save.

## Testing

- 13 new tests (live apply idle/busy/disconnected/dialog/escape/auto/deferred-consumption, model live/busy/rejected, hook payload) + 2 updated pins.
- `pytest tests/test_tmux_session.py tests/test_ultracode_effort.py tests/test_effort_verification.py tests/test_codex_tmux_session.py tests/test_api.py tests/test_sweep_api_fixes.py tests/test_streaming_session.py` — 811 passed, 1 skipped.
- ruff clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)