### PR TITLE
fix(codex): rebind tailer to newer rollout after resume + inflight watchdog kill-switch + replay caps (#846)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3135,6 +3135,13 @@ def create_api(
             on_wake_delivered=_log_agent_wake_event,
             restart_guard=lambda session, _agent_name=agent_name: _get_streaming_restart_guard(_agent_name, session),
             live_status_fn=lambda _agent_name=agent_name: _agent_live_status.get(_agent_name),
+            # #846 — expose watchdog_config.enabled to the tmux inflight
+            # watchdog so it honors the same operator kill-switch the daemon
+            # SessionWatchdog already respects. Deferred (called per watchdog
+            # tick) so a live PUT /agents/{name} toggle takes effect without a
+            # session respawn. Mirrors live_status_fn's per-tick closure and
+            # reuses the _get_watchdog_config merge (single source of truth).
+            watchdog_enabled_fn=lambda _agent_name=agent_name: _get_watchdog_config(_agent_name).enabled,
             context_warn_pct=warn_pct,
             context_restart_pct=restart_pct,
             timezone=agents.get_owner_profile().get("timezone", "America/Los_Angeles"),

--- a/src/pinky_daemon/codex_tmux_transcript.py
+++ b/src/pinky_daemon/codex_tmux_transcript.py
@@ -469,16 +469,38 @@ class CodexTmuxTranscriptTailer:
                 )
 
     def _try_self_heal_repoint(self) -> None:
-        """If the watched path is missing and a discovery callback is
-        configured, scan for the real rollout and rebind.
+        """Scan for the real rollout and rebind if a strictly-newer one exists.
 
-        Called once per poll tick. Cheap when the path exists (single
-        stat). Discovery is only paid when the path is missing.
+        Called once per poll tick. Runs discovery on EVERY tick (not just
+        when the bound path is missing) because ``codex resume --last``
+        writes to a BRAND-NEW rollout file — new session_meta/uuid — while
+        the old file it resumed from still exists on disk (#846). The
+        pre-#846 "only self-heal when the bound path is MISSING" guard
+        early-returned in exactly that case, so ``task_complete`` markers
+        landed in a file nobody read: the inflight-meta head never popped,
+        the watchdog force_restarted every ``_TURN_DONE_TIMEOUT_SEC``, and
+        each restart's ``codex resume`` replayed rollout history — a
+        self-amplifying loop.
+
+        Repoint iff BOTH hold:
+          - the discovered path differs from the bound path, AND
+          - the discovered file's mtime is STRICTLY newer than the bound
+            file's (a missing bound file counts as infinitely old, so the
+            original placeholder→real cold-start heal still fires).
+
+        The strictly-newer guard is load-bearing: in normal operation the
+        bound file IS the newest rollout for this cwd, so discovery returns
+        it and we no-op — no flap. It mirrors #291's never-repoint-backward
+        rule, inverted for the codex resume-writes-a-NEW-file case.
+
+        Repoint seeks to byte 0 (``seek_to_start=True``) so the
+        task_complete markers already accumulated on the new file are
+        consumed, draining the wedged inflight deque. The ``is_empty``
+        guard in ``_read_and_dispatch`` prevents firing empty turns.
+
         Errors are swallowed; the next tick retries.
         """
         if self._path_discovery is None:
-            return
-        if self._path.exists():
             return
         try:
             discovered = self._path_discovery()
@@ -490,13 +512,32 @@ class CodexTmuxTranscriptTailer:
             return
         if discovered is None:
             return
-        if Path(discovered) == self._path:
+        discovered = Path(discovered)
+        if discovered == self._path:
+            return
+        # mtime comparison — only advance to a STRICTLY newer rollout. A
+        # missing/unreadable bound file is treated as infinitely old so the
+        # cold-start placeholder→real heal always fires.
+        try:
+            bound_mtime = self._path.stat().st_mtime if self._path.exists() else None
+        except OSError:
+            bound_mtime = None
+        try:
+            discovered_mtime = discovered.stat().st_mtime
+        except OSError:
+            # Discovered file vanished between glob and stat — retry next tick.
+            return
+        if bound_mtime is not None and discovered_mtime <= bound_mtime:
+            # Not newer than what we're already reading — normal operation
+            # (bound file is the active rollout) or a stale older file. Do
+            # not repoint; this prevents flap.
             return
         _log(
-            f"codex_tailer[{self._agent_name}]: self-heal repointing "
-            f"{self._path} → {discovered}"
+            f"codex_tailer[{self._agent_name}]: self-heal repointing to newer "
+            f"rollout {self._path} (mtime={bound_mtime}) → {discovered} "
+            f"(mtime={discovered_mtime})"
         )
-        self.set_transcript_path(Path(discovered), seek_to_start=True)
+        self.set_transcript_path(discovered, seek_to_start=True)
         self._stats["self_heal_repoints"] += 1
 
     async def _read_and_dispatch(self) -> int:

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -85,6 +85,7 @@ class StreamingSessionConfig:
     on_wake_delivered: object = None  # Callable(agent_name, WakeReason) -> None
     restart_guard: object = None  # Callable(session) -> dict; blocks restart if persistence is stale
     live_status_fn: object = None  # Callable() -> dict|None; agent's live REPL status {"status","last_updated"} from Claude Code working/idle hooks. Tmux inflight watchdog uses it to avoid force-restarting an idle (not wedged) REPL (#118).
+    watchdog_enabled_fn: object = None  # Callable() -> bool; whether this agent's watchdog_config.enabled is set. The tmux inflight watchdog reads it per tick so watchdog_config.enabled=false is an operator kill-switch for BOTH the daemon SessionWatchdog and per-session inflight recovery (#846). None → treated as enabled (default True).
     context_warn_pct: int = 40  # Warn agent to save state at this %
     context_restart_pct: int = 80  # Force restart at this %
     restart_guard_cooldown_sec: int = 60  # Minimum gap between restart-block warnings

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -791,6 +791,13 @@ class _QueuedTurn:
     # non-wake turns and for any internal turn whose enqueuer doesn't
     # care about post-delivery hooks.
     on_delivered: object = None  # Callable() -> None — fires on paste-success
+    # #846 — replay-amplification guard. Incremented each time the inflight
+    # watchdog requeues this turn for replay after a stuck-head force_restart.
+    # Once it exceeds ``_inflight_replay_cap()`` the watchdog DROPS the turn
+    # (fires its completion_event, logs loudly) instead of requeuing it again,
+    # so a never-clearing wedge can't replay the same turn forever and grow
+    # the deque unboundedly (the murzik #846 loop).
+    replay_count: int = 0
 
 
 @dataclass
@@ -989,6 +996,38 @@ def _inflight_hard_ceiling_sec() -> float:
     except (TypeError, ValueError):
         val = 3600.0
     return max(val, _TURN_DONE_TIMEOUT_SEC)
+
+
+# #846 — replay-amplification defense for the inflight watchdog. Each
+# force_restart requeues the stuck head's tail (and any in-hand) turn for
+# replay; codex resume then replays rollout history. If the underlying wedge
+# never clears, the same turns get replayed every ``_TURN_DONE_TIMEOUT_SEC``
+# and the deque GROWS unboundedly (the #846 murzik loop: 3→6→7). These caps
+# bound the blast radius so a stuck agent degrades instead of amplifying.
+def _inflight_replay_cap() -> int:
+    """Max times a single turn may be requeued for replay before it is DROPPED
+    (with a loud log) instead of replayed again (#846). Default 3;
+    ``PINKY_INFLIGHT_REPLAY_CAP=0`` disables the cap (revert to unbounded
+    replay without a deploy). Read per call so ops can flip it live."""
+    raw = os.environ.get("PINKY_INFLIGHT_REPLAY_CAP", "").strip()
+    try:
+        val = int(raw) if raw else 3
+    except (TypeError, ValueError):
+        val = 3
+    return max(0, val)
+
+
+def _inflight_replay_tail_cap() -> int:
+    """Max number of TAIL entries requeued for replay in a single force_restart
+    (#846). Bounds a pathological deque (amplified across prior cycles) from
+    all being replayed at once. Default 20; ``PINKY_INFLIGHT_REPLAY_TAIL_CAP=0``
+    disables the cap. Read per call so ops can flip it live."""
+    raw = os.environ.get("PINKY_INFLIGHT_REPLAY_TAIL_CAP", "").strip()
+    try:
+        val = int(raw) if raw else 20
+    except (TypeError, ValueError):
+        val = 20
+    return max(0, val)
 
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
 # ``_session_ready_event`` for turns with ``internal=True and
@@ -5518,6 +5557,24 @@ class TmuxSession:
             f"inflight_tools={len(self._inflight_tool_calls)}"
         )
 
+    def _watchdog_enabled(self) -> bool:
+        """Whether this session's inflight watchdog is allowed to act (#846).
+
+        Reads ``self._config.watchdog_enabled_fn`` (wired in api.py to the
+        agent's ``watchdog_config.enabled``, evaluated per tick so a live
+        ``PUT /agents/{name}`` toggle takes effect without a respawn).
+        Default-ON: ``None`` fn, a fn that raises, or a non-callable all
+        return True — the watchdog fails OPEN so a wiring gap can't silently
+        disable stuck-REPL recovery.
+        """
+        fn = getattr(self._config, "watchdog_enabled_fn", None)
+        if fn is None:
+            return True
+        try:
+            return bool(fn())
+        except Exception:
+            return True
+
     async def _inflight_watchdog(self) -> None:
         """Age the ``_inflight_metas`` head; force_restart if it sticks.
 
@@ -5525,6 +5582,16 @@ class TmuxSession:
         worker used to enforce. With concurrent dispatch the worker no
         longer waits between turns, so the "stop hook never fires"
         failure mode needs a separate watcher.
+
+        **Kill-switch** (#846). ``watchdog_config.enabled=false`` now
+        disables BOTH the daemon ``SessionWatchdog`` (existing behavior,
+        session_watchdog.py:127,158,371,395) AND this per-session inflight
+        recovery — one operator kill-switch for all watchdog force_restarts.
+        When disabled we ``continue`` at the TOP of the loop (skip the
+        force_restart decision) but KEEP the task alive, so re-enabling
+        takes effect on the next tick with no respawn. Before #846 the
+        inflight watchdog ignored the toggle entirely, so an agent with
+        ``enabled: false`` (murzik) still got force_restarted in a loop.
 
         **Head-age, not paste-age** (Murzik review point #1). When a
         turn becomes the deque head (either by being the first append
@@ -5581,6 +5648,12 @@ class TmuxSession:
         try:
             while self.state == SessionState.CONNECTED:
                 await asyncio.sleep(_WATCHDOG_TICK_SEC)
+                # #846 kill-switch: if watchdog_config.enabled=false, skip the
+                # force_restart decision but keep the loop alive so re-enabling
+                # takes effect live (no respawn). Checked at the TOP so nothing
+                # below (verdict, pane-liveness sampling, force_restart) runs.
+                if not self._watchdog_enabled():
+                    continue
                 now = time.time()
                 verdict = self._inflight_stall_verdict(now)
                 if verdict == "ok":
@@ -5769,9 +5842,63 @@ class TmuxSession:
                 # B then C. (Pre-paste-retry edge: deque empty, in_hand
                 # is the sole entry — ``tail_entries`` is empty, so
                 # in_hand becomes the lone replay entry, correct.)
+                # #846 replay-amplification defense (defense-in-depth):
+                #  - skip requeue of any turn whose completion_event is
+                #    already SET (it was answered — replaying re-processes an
+                #    answered turn, the murzik duplicate-ack amplification),
+                #  - increment a per-turn replay counter and DROP a turn once
+                #    it exceeds ``_inflight_replay_cap()`` (default 3) instead
+                #    of requeuing it forever,
+                #  - cap the number of TAIL entries requeued per restart at
+                #    ``_inflight_replay_tail_cap()`` (default 20) so a deque
+                #    already amplified across prior cycles can't all replay.
+                # Dropped turns fire their completion_event so any
+                # wait_for_completion caller unblocks (definitively abandoned).
+                replay_cap = _inflight_replay_cap()
+                tail_cap = _inflight_replay_tail_cap()
+
+                def _consider_replay(t: _QueuedTurn, *, kind: str) -> bool:
+                    ev = t.completion_event
+                    if ev is not None and ev.is_set():
+                        _log(
+                            f"tmux[{self.agent_name}]: skipping replay of "
+                            f"already-completed {kind} turn "
+                            f"(completion_event set) — #846"
+                        )
+                        return False
+                    t.replay_count += 1
+                    if replay_cap and t.replay_count > replay_cap:
+                        _log(
+                            f"tmux[{self.agent_name}]: DROPPING {kind} turn "
+                            f"after {t.replay_count - 1} replay(s) "
+                            f"(cap={replay_cap}) instead of requeuing — #846 "
+                            f"replay-amplification guard"
+                        )
+                        if ev is not None and not ev.is_set():
+                            ev.set()
+                        return False
+                    return True
+
                 replay: list[_QueuedTurn] = []
-                replay.extend(entry.turn for entry in tail_entries)
-                if in_hand is not None:
+                tail_replayed = 0
+                for i, entry in enumerate(tail_entries):
+                    if tail_cap and tail_replayed >= tail_cap:
+                        remaining = tail_entries[i:]
+                        _log(
+                            f"tmux[{self.agent_name}]: tail replay cap "
+                            f"{tail_cap} reached — dropping {len(remaining)} "
+                            f"remaining tail turn(s) (#846); firing their "
+                            f"completion_events"
+                        )
+                        for dropped in remaining:
+                            de = dropped.turn.completion_event
+                            if de is not None and not de.is_set():
+                                de.set()
+                        break
+                    if _consider_replay(entry.turn, kind="tail"):
+                        replay.append(entry.turn)
+                        tail_replayed += 1
+                if in_hand is not None and _consider_replay(in_hand, kind="in_hand"):
                     replay.append(in_hand)
                 if replay:
                     # Prepend ``replay`` to ``_message_queue``: drain
@@ -5792,7 +5919,8 @@ class TmuxSession:
                     _log(
                         f"tmux[{self.agent_name}]: requeued "
                         f"{len(replay)} turn(s) for replay after "
-                        f"force_restart (tail={len(tail_entries)}, "
+                        f"force_restart (tail={tail_replayed}/"
+                        f"{len(tail_entries)}, "
                         f"in_hand={'yes' if in_hand else 'no'})"
                     )
 

--- a/tests/test_codex_tmux_transcript.py
+++ b/tests/test_codex_tmux_transcript.py
@@ -731,20 +731,120 @@ class TestSelfHealDiscovery:
         assert tailer.stats["self_heal_repoints"] == 0
 
     @pytest.mark.asyncio
-    async def test_discovery_not_called_when_path_exists(self, transcript, tmp_path):
+    async def test_discovery_runs_every_tick_even_when_path_exists(
+        self, transcript, tmp_path
+    ):
+        """#846: discovery now runs on EVERY tick, not only when the bound path
+        is missing — ``codex resume --last`` writes a BRAND-NEW rollout while
+        the old (bound) one still exists on disk. But a discovered path that is
+        not strictly newer (here it doesn't exist → unreadable) must NOT
+        repoint."""
         cb = _Captor()
         call_count = {"n": 0}
 
         def discover() -> Path | None:
             call_count["n"] += 1
-            return tmp_path / "other.jsonl"
+            return tmp_path / "other.jsonl"  # never created → stat fails
 
         tailer = CodexTmuxTranscriptTailer(
-            transcript, cb,  # path exists (touched by fixture)
+            transcript, cb,  # bound path exists (touched by fixture)
             path_discovery=discover,
         )
         tailer._try_self_heal_repoint()
-        assert call_count["n"] == 0
+        assert call_count["n"] == 1, "discovery is consulted every tick now (#846)"
+        assert tailer.stats["self_heal_repoints"] == 0
+        assert tailer.transcript_path == transcript
+
+    @pytest.mark.asyncio
+    async def test_repoint_to_strictly_newer_rollout(self, tmp_path):
+        """#846 PRIMARY: tailer bound to an OLDER file A; a NEWER rollout B
+        (session_meta + task_complete) appears — the file ``codex resume
+        --last`` wrote. A tick must repoint A→B, reset the offset to 0
+        (seek_to_start), and drain the accumulated task_complete through the
+        callback so the wedged inflight head resolves."""
+        cb = _Captor()
+        cwd = str(tmp_path)
+        old = tmp_path / "rollout-old.jsonl"
+        _write_jsonl(old, [
+            _session_meta(cwd=cwd, session_id="old-uuid"),
+            _agent_message("stale"),
+            _task_complete(last_agent_message="Old reply."),
+        ])
+        new = tmp_path / "rollout-new.jsonl"
+        _write_jsonl(new, [
+            _session_meta(cwd=cwd, session_id="new-uuid"),
+            _agent_message("fresh"),
+            _task_complete(last_agent_message="Resumed reply."),
+        ])
+        # B strictly newer than A.
+        old_t = time.time() - 100
+        new_t = time.time()
+        os.utime(old, (old_t, old_t))
+        os.utime(new, (new_t, new_t))
+
+        tailer = CodexTmuxTranscriptTailer(
+            old, cb,
+            path_discovery=lambda: new,
+        )
+        # Bind offset to A's EOF (as _start_tailer does on a warm resume) so we
+        # prove seek_to_start=True resets it to 0.
+        tailer.set_offset(old.stat().st_size)
+        assert tailer.offset > 0
+
+        tailer._try_self_heal_repoint()
+        assert tailer.transcript_path == new
+        assert tailer.offset == 0
+        assert tailer.stats["self_heal_repoints"] == 1
+
+        await tailer.read_once()
+        assert len(cb.responses) == 1
+        assert cb.responses[0].text == "Resumed reply."
+
+    @pytest.mark.asyncio
+    async def test_no_repoint_when_bound_is_newest(self, tmp_path):
+        """#846 regression: when the bound file IS the newest rollout (normal
+        operation — the active rollout is the one being written), discovery
+        returns it and we no-op. No flap."""
+        cb = _Captor()
+        bound = tmp_path / "rollout-bound.jsonl"
+        _write_jsonl(bound, [_session_meta(cwd=str(tmp_path))])
+        older = tmp_path / "rollout-older.jsonl"
+        _write_jsonl(older, [_session_meta(cwd=str(tmp_path))])
+        now = time.time()
+        os.utime(older, (now - 50, now - 50))
+        os.utime(bound, (now, now))
+
+        # Discovery returns the OLDER file — the bound one is strictly newer.
+        tailer = CodexTmuxTranscriptTailer(
+            bound, cb,
+            path_discovery=lambda: older,
+        )
+        tailer._try_self_heal_repoint()
+        assert tailer.transcript_path == bound
+        assert tailer.stats["self_heal_repoints"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_repoint_when_discovered_not_strictly_newer(self, tmp_path):
+        """#846 edge: discovered file EXISTS and differs from the bound path but
+        its mtime is EQUAL (or older) — do NOT repoint (strictly-newer guard,
+        the inverted #291 never-repoint-backward rule)."""
+        cb = _Captor()
+        bound = tmp_path / "rollout-a.jsonl"
+        _write_jsonl(bound, [_session_meta(cwd=str(tmp_path))])
+        other = tmp_path / "rollout-b.jsonl"
+        _write_jsonl(other, [_session_meta(cwd=str(tmp_path))])
+        # Identical mtimes → not strictly newer.
+        stamp = time.time() - 10
+        os.utime(bound, (stamp, stamp))
+        os.utime(other, (stamp, stamp))
+
+        tailer = CodexTmuxTranscriptTailer(
+            bound, cb,
+            path_discovery=lambda: other,
+        )
+        tailer._try_self_heal_repoint()
+        assert tailer.transcript_path == bound
+        assert tailer.stats["self_heal_repoints"] == 0
 
     @pytest.mark.asyncio
     async def test_discovery_rebinds_with_seek_to_start(self, tmp_path):

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -7768,6 +7768,269 @@ class TestInflightDequeConcurrentDispatch:
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# #846 — inflight watchdog kill-switch (watchdog_config.enabled) + replay caps
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestInflightWatchdogKillSwitch:
+    """(b) ``watchdog_config.enabled=false`` disables the per-session inflight
+    watchdog's force_restart decision — the same operator kill-switch the
+    daemon SessionWatchdog already respects (#846)."""
+
+    def test_watchdog_enabled_defaults_true_and_fails_open(self):
+        ss, _ = _make_session()
+        # No fn wired → enabled (default True).
+        assert ss._config.watchdog_enabled_fn is None
+        assert ss._watchdog_enabled() is True
+        # Explicit False.
+        ss._config.watchdog_enabled_fn = lambda: False
+        assert ss._watchdog_enabled() is False
+        # Explicit True.
+        ss._config.watchdog_enabled_fn = lambda: True
+        assert ss._watchdog_enabled() is True
+
+        # A raising fn must fail OPEN (return True) — a wiring bug must never
+        # silently disable stuck-REPL recovery.
+        def _boom():
+            raise RuntimeError("config lookup exploded")
+
+        ss._config.watchdog_enabled_fn = _boom
+        assert ss._watchdog_enabled() is True
+
+    @pytest.mark.asyncio
+    async def test_disabled_watchdog_skips_force_restart(self, monkeypatch):
+        """enabled=false → aged-out head with NULL live-status (would be
+        'wedged') is NOT force_restarted, and the deque is left intact. The
+        task stays alive so re-enabling takes effect live."""
+        from pinky_daemon import tmux_session as _ts
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.02)
+
+        ss, _ = _make_session()
+        ss._config.watchdog_enabled_fn = lambda: False
+        await ss.connect()
+        # Isolate the watchdog from the worker.
+        ss._worker_task.cancel()
+        try:
+            await ss._worker_task
+        except asyncio.CancelledError:
+            pass
+
+        force_called = asyncio.Event()
+
+        async def _stub(*, bypass_guard: bool = False):
+            force_called.set()
+            return True
+
+        ss.force_restart = _stub
+
+        _seed_inflight(ss, prompt="A", meta={"chat_id": "A"})
+        ss._head_started_at = 0.0  # ancient → would trip immediately
+        assert ss._config.live_status_fn is None  # verdict would be "wedged"
+
+        # Give the watchdog many ticks — it must NOT force_restart.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(force_called.wait(), timeout=0.3)
+        assert not force_called.is_set()
+        assert len(ss._inflight_metas) == 1, "disabled watchdog must not drain"
+        assert ss._stats.get("turn_timeouts", 0) == 0
+
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_enabled_watchdog_still_fires(self, monkeypatch):
+        """enabled=true (explicit) → aged-out quiet head with null live-status
+        still force_restarts, as before. Confirms the gate doesn't break the
+        normal recovery path."""
+        from pinky_daemon import tmux_session as _ts
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.02)
+        # Disable pane-liveness so the wedged path doesn't spend the ~1.5s
+        # capture-pane sampling gap (orthogonal to the kill-switch under test).
+        monkeypatch.setenv("PINKY_WATCHDOG_PANE_LIVENESS", "0")
+
+        ss, _ = _make_session()
+        ss._config.watchdog_enabled_fn = lambda: True
+        await ss.connect()
+        ss._worker_task.cancel()
+        try:
+            await ss._worker_task
+        except asyncio.CancelledError:
+            pass
+
+        force_called = asyncio.Event()
+
+        async def _stub(*, bypass_guard: bool = False):
+            force_called.set()
+            return True
+
+        ss.force_restart = _stub
+
+        _seed_inflight(ss, prompt="A", meta={"chat_id": "A"})
+        ss._head_started_at = 0.0
+
+        try:
+            await asyncio.wait_for(force_called.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pytest.fail("enabled watchdog must still force_restart a wedged head")
+        assert ss._stats.get("turn_timeouts", 0) == 1
+
+        await ss.disconnect()
+
+
+class TestInflightWatchdogReplayCaps:
+    """(c) replay-amplification defenses on the watchdog requeue path (#846)."""
+
+    async def _wedge_once(self, ss, monkeypatch):
+        """Shrink the watchdog timers, disable pane-liveness (orthogonal ~1.5s
+        capture-pane gap), cancel the worker so it can't re-pull the requeue,
+        and stub force_restart. Returns an Event set when force_restart fires."""
+        from pinky_daemon import tmux_session as _ts
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.02)
+        monkeypatch.setenv("PINKY_WATCHDOG_PANE_LIVENESS", "0")
+        ss._worker_task.cancel()
+        try:
+            await ss._worker_task
+        except asyncio.CancelledError:
+            pass
+        force_called = asyncio.Event()
+
+        async def _stub(*, bypass_guard: bool = False):
+            force_called.set()
+            return True
+
+        ss.force_restart = _stub
+        return force_called
+
+    @pytest.mark.asyncio
+    async def test_single_wedge_requeues_and_bumps_replay_count(self, monkeypatch):
+        """Single wedge → tail requeued normally, replay_count → 1."""
+        ss, _ = _make_session()
+        await ss.connect()
+        force_called = await self._wedge_once(ss, monkeypatch)
+
+        _seed_inflight(ss, prompt="A", meta={"chat_id": "A"})  # head
+        b_entry = _seed_inflight(ss, prompt="B", meta={"chat_id": "B"})  # tail
+        ss._head_started_at = 0.0
+
+        await asyncio.wait_for(force_called.wait(), timeout=2.0)
+
+        assert ss._message_queue.qsize() == 1
+        b_replay = ss._message_queue.get_nowait()
+        assert b_replay.prompt == "B"
+        assert b_replay is b_entry.turn
+        assert b_replay.replay_count == 1, "each requeue bumps the counter"
+
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_turn_dropped_after_replay_cap(self, monkeypatch):
+        """A turn already replayed cap-many times is DROPPED (not requeued);
+        its completion_event fires so any waiter unblocks."""
+        monkeypatch.setenv("PINKY_INFLIGHT_REPLAY_CAP", "3")
+
+        ss, _ = _make_session()
+        await ss.connect()
+        force_called = await self._wedge_once(ss, monkeypatch)
+
+        _seed_inflight(ss, prompt="A", meta={"chat_id": "A"})  # head
+        b_event = asyncio.Event()
+        b_entry = _seed_inflight(
+            ss, prompt="B", meta={"chat_id": "B"}, completion_event=b_event
+        )
+        # B has already been replayed 3 times (== cap). This wedge bumps it to
+        # 4 > 3 → drop.
+        b_entry.turn.replay_count = 3
+        ss._head_started_at = 0.0
+
+        await asyncio.wait_for(force_called.wait(), timeout=2.0)
+
+        assert ss._message_queue.qsize() == 0, "over-cap turn must NOT be requeued"
+        assert b_event.is_set(), "dropped turn fires its completion_event"
+
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_replay_cap_zero_disables_drop(self, monkeypatch):
+        """PINKY_INFLIGHT_REPLAY_CAP=0 disables the cap — high replay_count
+        still requeues (ops revert lever, no deploy)."""
+        monkeypatch.setenv("PINKY_INFLIGHT_REPLAY_CAP", "0")
+
+        ss, _ = _make_session()
+        await ss.connect()
+        force_called = await self._wedge_once(ss, monkeypatch)
+
+        _seed_inflight(ss, prompt="A", meta={"chat_id": "A"})
+        b_entry = _seed_inflight(ss, prompt="B", meta={"chat_id": "B"})
+        b_entry.turn.replay_count = 99  # way past any cap
+        ss._head_started_at = 0.0
+
+        await asyncio.wait_for(force_called.wait(), timeout=2.0)
+
+        assert ss._message_queue.qsize() == 1, "cap=0 disables the drop"
+        assert ss._message_queue.get_nowait().prompt == "B"
+
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_completed_turn_not_requeued(self, monkeypatch):
+        """A tail turn whose completion_event is ALREADY set (answered) must not
+        be requeued — that is the murzik duplicate-ack amplification."""
+        ss, _ = _make_session()
+        await ss.connect()
+        force_called = await self._wedge_once(ss, monkeypatch)
+
+        _seed_inflight(ss, prompt="A", meta={"chat_id": "A"})  # head
+        done_event = asyncio.Event()
+        done_event.set()  # B already completed
+        b_entry = _seed_inflight(
+            ss, prompt="B", meta={"chat_id": "B"}, completion_event=done_event
+        )
+        ss._head_started_at = 0.0
+
+        await asyncio.wait_for(force_called.wait(), timeout=2.0)
+
+        assert ss._message_queue.qsize() == 0, "already-completed turn not requeued"
+        assert b_entry.turn.replay_count == 0, "skip is before the counter bump"
+
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_tail_cap_respected(self, monkeypatch):
+        """No more than PINKY_INFLIGHT_REPLAY_TAIL_CAP tail entries are requeued
+        per restart; the overflow is dropped with completion_events fired."""
+        monkeypatch.setenv("PINKY_INFLIGHT_REPLAY_TAIL_CAP", "2")
+
+        ss, _ = _make_session()
+        await ss.connect()
+        force_called = await self._wedge_once(ss, monkeypatch)
+
+        _seed_inflight(ss, prompt="A", meta={"chat_id": "A"})  # head
+        events = {}
+        for name in ("B", "C", "D", "E"):
+            ev = asyncio.Event()
+            events[name] = ev
+            _seed_inflight(ss, prompt=name, meta={"chat_id": name}, completion_event=ev)
+        ss._head_started_at = 0.0
+
+        await asyncio.wait_for(force_called.wait(), timeout=2.0)
+
+        # Only the first 2 tail entries (B, C) requeued.
+        assert ss._message_queue.qsize() == 2
+        assert ss._message_queue.get_nowait().prompt == "B"
+        assert ss._message_queue.get_nowait().prompt == "C"
+        # Dropped overflow (D, E) fired their completion_events; requeued ones
+        # (B, C) did NOT (they wait for the actual rerun).
+        assert not events["B"].is_set()
+        assert not events["C"].is_set()
+        assert events["D"].is_set()
+        assert events["E"].is_set()
+
+        await ss.disconnect()
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # #108 — StopFailure POST resolves the in-flight turn (turn-end-detection gap)
 # ──────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Root cause

`codex resume --last` writes a **brand-new** rollout file (new `session_meta`/uuid), but the codex tailer stayed bound to the OLD file: `_start_tailer`'s retained-instance branch just restarts the task, the #565 first-bind recovery is guarded off for resume (`_last_launch_used_continue=True`), and the codex tailer self-heal only repointed when the bound path was **missing** (early-returns because the stale file still exists). So `task_complete` markers landed in a file nobody read → the inflight-meta head never popped → `_inflight_stall_verdict` was permanently "wedged" for codex (no `.claude` hooks, empty tools, quiet transcript) → `_inflight_watchdog` force_restarted every 600s, requeuing all tail turns; codex resume replayed rollout, and the deque **grew** each cycle (murzik loop, 3→6→7).

## The three changes

**(a) PRIMARY — codex tailer repoint-to-newer** (`codex_tmux_transcript.py::_try_self_heal_repoint`): removed the bound-path-exists short-circuit; discovery now runs **every tick**; repoint iff discovered path != bound path **AND** discovered mtime is **strictly newer** than the bound file's (a missing bound file counts as infinitely old, preserving the cold-start placeholder→real heal). The strictly-newer guard is load-bearing — in normal operation the bound file IS the newest, so we no-op (no flap); mirrors #291's never-repoint-backward, inverted for the codex new-file case. Repoint uses `seek_to_start=True` so accumulated `task_complete` markers on the new file drain the wedged deque; the existing `is_empty` guard prevents firing empty turns.

**(b) Honor `watchdog_config.enabled` on the inflight watchdog.** Investigation confirmed the session did **not** receive the agent's watchdog config. Added an additive `watchdog_enabled_fn` callable on `StreamingSessionConfig`, wired in `api.py` to `lambda: _get_watchdog_config(agent_name).enabled` — evaluated **per tick** (deferred closure, mirrors `live_status_fn`) so a live `PUT /agents/{name}` toggle takes effect with no respawn. Gated at the **top** of the `_inflight_watchdog` loop: when disabled it skips the force_restart decision but keeps the task alive. `watchdog_config.enabled=false` now disables **BOTH** the daemon `SessionWatchdog` (existing) and per-session inflight recovery — one operator kill-switch. Default enabled=True; fails **open** (None fn / raising fn → enabled) so a wiring gap can't silently disable recovery.

**(c) Replay-requeue safety (defense-in-depth).** Added a `replay_count` to `_QueuedTurn`, incremented on each watchdog requeue. After `PINKY_INFLIGHT_REPLAY_CAP` (default 3, `0` disables) replays a turn is **dropped** with a loud log instead of requeued. Requeue is skipped for any turn whose `completion_event` is already set (the duplicate-ack amplification). Total requeued tail entries per restart capped at `PINKY_INFLIGHT_REPLAY_TAIL_CAP` (default 20). Dropped turns fire their `completion_event` so `wait_for_completion` callers unblock. Both knobs are env-flag reverts (no deploy).

## Test evidence

New tests (all green):
- `test_codex_tmux_transcript.py`: repoint to strictly-newer rollout (offset reset + callback drains); regression (bound IS newest → no repoint); edge (discovered exists but mtime older/equal → no repoint); discovery-runs-every-tick contract.
- `test_tmux_session.py` `TestInflightWatchdogKillSwitch`: `_watchdog_enabled` default-true + fail-open; disabled → aged-out null-live-status head NOT force_restarted (deque intact, task alive); enabled → still fires.
- `test_tmux_session.py` `TestInflightWatchdogReplayCaps`: single wedge requeues + bumps counter; drop after cap (fires event); cap=0 disables drop; completed-turn not requeued; tail cap respected (overflow dropped + events fired).

```
tests/test_codex_tmux_transcript.py  48 passed
tests/test_codex_tmux_session.py + test_tmux_session.py + test_tmux_context_realtime.py + test_tmux_transcript.py + test_codex_tmux_transcript.py  457 passed, 1 skipped
tests/test_session_watchdog.py  62 passed
ruff check (all touched files)  All checks passed
```

No UI surface — backend watchdog/tailer fix, so no screenshot applies; test suite is the verification.

Fixes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)