### PR TITLE
fix(comms): fail-closed inter-agent delivery + check-inbox nudge (#215 PR3)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8624,12 +8624,35 @@ npm run build</pre>
                         _log(f"api: agent message delivered after auto-wake {name}")
             except Exception as e:
                 _log(f"api: auto-wake failed for {name}: {e}")
-        if delivered:
-            # Agent saw it live — mark as read so it doesn't repeat on wake
+        # Fail-closed retire: only mark the durable inbox copy read when the
+        # target's transport POSITIVELY confirms the injected message will be
+        # consumed. ``delivered`` (inject returned True) only means the session
+        # was CONNECTED and ``send`` didn't raise — for a tmux/codex agent that
+        # is a best-effort enqueue behind an external pane, so a dead / busy /
+        # mid-turn / restarted pane silently drops it. Marking read on that bare
+        # bool is exactly what black-holed codex-tmux messages: the row went
+        # read=1, so check_inbox (unread-only) never surfaced it. Keep the row
+        # unread+queued unless consumption is confirmed (SDK in-process query),
+        # so check_inbox remains the durable backstop.
+        confirmed = delivered and broker.injection_confirms_consumption(name)
+        if confirmed:
             comms.mark_read(name, [msg.id])
+        else:
+            # Left durably queued (unread). Nudge tmux targets to check their
+            # inbox (best-effort, coalesced, PINKYBOT_AGENT_MSG_NOTIFY). No-op
+            # for SDK / offline / unknown transports.
+            try:
+                await broker.notify_unread_agent_messages(comms, name)
+            except Exception as e:
+                _log(f"api: check-inbox nudge for {name} failed: {e}")
+        # ``queued`` stays ``not delivered`` (unchanged tool semantics): it flags
+        # "no live session — will see on wake". A live-injected-but-unconfirmed
+        # tmux delivery is NOT reported as offline; ``confirmed`` carries the
+        # honest "was the durable copy retired?" signal for observability.
         return {
             "delivered": delivered,
             "queued": not delivered,
+            "confirmed": confirmed,
             "message_id": msg.id,
             "from": req.from_agent,
             "to": name,

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8608,7 +8608,7 @@ npm run build</pre>
             parent_message_id=req.parent_message_id,
             priority=req.priority,
         )
-        delivered = await broker.inject_agent_message(
+        delivered, confirmed = await broker.inject_agent_message(
             req.from_agent, name, req.message,
         )
         # Auto-wake sleeping agents on inter-agent messages
@@ -8617,7 +8617,7 @@ npm run build</pre>
             try:
                 streaming = await _ensure_streaming_session(name, label="main")
                 if streaming and streaming.state == TransportSessionState.CONNECTED:
-                    delivered = await broker.inject_agent_message(
+                    delivered, confirmed = await broker.inject_agent_message(
                         req.from_agent, name, req.message,
                     )
                     if delivered:
@@ -8625,16 +8625,16 @@ npm run build</pre>
             except Exception as e:
                 _log(f"api: auto-wake failed for {name}: {e}")
         # Fail-closed retire: only mark the durable inbox copy read when the
-        # target's transport POSITIVELY confirms the injected message will be
-        # consumed. ``delivered`` (inject returned True) only means the session
-        # was CONNECTED and ``send`` didn't raise — for a tmux/codex agent that
-        # is a best-effort enqueue behind an external pane, so a dead / busy /
-        # mid-turn / restarted pane silently drops it. Marking read on that bare
-        # bool is exactly what black-holed codex-tmux messages: the row went
-        # read=1, so check_inbox (unread-only) never surfaced it. Keep the row
-        # unread+queued unless consumption is confirmed (SDK in-process query),
-        # so check_inbox remains the durable backstop.
-        confirmed = delivered and broker.injection_confirms_consumption(name)
+        # inject POSITIVELY confirmed consumption. ``confirmed`` comes from the
+        # inject call itself — computed by the broker on the exact session
+        # object that performed the inject (per-call send() handoff AND the
+        # transport capability; Murzik #853 P1 — no second session lookup that
+        # could race a swap, and a transport-static capability can't overrule a
+        # failed handoff, e.g. an SDK query that raised). ``delivered`` alone
+        # (attempt-level) is exactly what black-holed codex-tmux messages: the
+        # row went read=1 while the paste vanished, so check_inbox (unread-only)
+        # never surfaced it. Unconfirmed → the row stays unread+queued and
+        # check_inbox remains the durable backstop.
         if confirmed:
             comms.mark_read(name, [msg.id])
         else:

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -46,6 +46,28 @@ _AGENT_REPLY_ROUTING_ENABLED = os.environ.get(
     "PINKY_AGENT_REPLY_ROUTING", "1"
 ).strip().lower() not in ("0", "false", "no", "off")
 
+# #215 PR3 / fail-closed inter-agent delivery: when an agent message is left
+# durably queued (unread) for a tmux-transport target, nudge that target to
+# call ``check_inbox`` so it retrieves the message promptly. The nudge is
+# best-effort — the DURABLE truth is the unread comms row; this only makes
+# retrieval timely when the pane is alive. Coalesced (one per burst) and
+# readiness-gated (can't corrupt a mid-turn pane). Default ON; disable with
+# ``PINKYBOT_AGENT_MSG_NOTIFY=0`` to kill a bad interaction without a rollback.
+# NOTE: the fail-closed mark-read fix in the API handler is deliberately NOT
+# gated by this flag — only the notify nudge is.
+_AGENT_MSG_NOTIFY_ENABLED = os.environ.get(
+    "PINKYBOT_AGENT_MSG_NOTIFY", "1"
+).strip().lower() not in ("0", "false", "no", "off")
+
+# Coalesce window for the check-inbox nudge: at most one nudge per target per
+# window, so a burst of messages collapses to a single nudge (never a storm).
+try:
+    _AGENT_MSG_NUDGE_BACKOFF_SEC = float(
+        os.environ.get("PINKYBOT_AGENT_MSG_NUDGE_BACKOFF", "15")
+    )
+except (TypeError, ValueError):
+    _AGENT_MSG_NUDGE_BACKOFF_SEC = 15.0
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -213,6 +235,7 @@ class MessageBroker:
             "denied": 0,
             "errors": 0,
             "deduped": 0,
+            "nudged": 0,
         }
 
         # Auth-relay (#205): wire the tmux login-relay coordinator to this
@@ -267,6 +290,10 @@ class MessageBroker:
         self._voice_pending: dict[tuple[str, str], bool] = {}
         self._message_contexts: dict[tuple[str, str], MessageContext] = {}
         self._message_context_order: dict[str, list[str]] = {}
+
+        # #215 PR3: last check-inbox nudge time per agent (monotonic seconds),
+        # used to coalesce a burst of inter-agent messages into one nudge.
+        self._agent_msg_nudge_at: dict[str, float] = {}
 
         # Active typing indicator tasks: (agent_name, chat_id) -> asyncio.Task
         self._typing_tasks: dict[tuple[str, str], asyncio.Task] = {}
@@ -1360,6 +1387,87 @@ class MessageBroker:
             _log(f"broker: stamp_last_seen failed for {to_agent}: {e}")
         self._stats["routed"] += 1
         _log(f"broker: injected agent message {from_agent} -> {to_agent}")
+        return True
+
+    def injection_confirms_consumption(self, to_agent: str) -> bool:
+        """Does the target's live transport positively confirm that an injected
+        agent message will actually be consumed?
+
+        ``inject_agent_message`` returning ``True`` only means "session was
+        CONNECTED and ``send`` didn't raise". For an in-process transport (SDK
+        ``StreamingSession``) that IS a positive handoff — ``send`` enqueues
+        straight into the live turn stream. For a tmux/codex transport it is
+        NOT: ``send`` merely appends to a volatile in-memory queue drained by a
+        worker that pastes into an EXTERNAL pane; a dead / mid-turn / restarted
+        or stale-CONNECTED pane silently drops the paste and the queue is lost
+        on teardown. So the durable comms inbox copy may only be retired
+        (marked read) on inject when this returns ``True``.
+
+        Fail-closed: an unknown / missing session (or a transport that doesn't
+        advertise the capability) returns ``False`` — never retire the durable
+        copy on an unconfirmed inject.
+        """
+        session = self._get_streaming_session(to_agent)
+        return bool(getattr(session, "injection_confirms_consumption", False))
+
+    async def notify_unread_agent_messages(self, comms, to_agent: str) -> bool:
+        """Best-effort nudge (#215 PR3): tell a tmux-transport agent it has
+        unread inbox messages so it calls ``check_inbox``.
+
+        The durable unread comms rows are the real delivery guarantee; this
+        just makes retrieval timely when the pane is alive. No-op when:
+        - the notify flag (``PINKYBOT_AGENT_MSG_NOTIFY``) is off;
+        - the target has no live tmux session (SDK / offline / unknown
+          transport — nothing to nudge, or its live-inject already confirmed);
+        - there is nothing unread;
+        - a recent nudge is still inside the coalesce window (one nudge per
+          burst, simple backoff).
+
+        The nudge rides the session's readiness-gated internal-prompt queue
+        (``_enqueue_internal_prompt``), so it can't corrupt a half-typed /
+        mid-turn pane, and it is a daemon-internal prompt (not a comms
+        message), so it never enqueues another agent message → no nudge loop.
+        Returns ``True`` iff a nudge was actually enqueued.
+        """
+        if not _AGENT_MSG_NOTIFY_ENABLED:
+            return False
+        session = self._get_streaming_session(to_agent)
+        enqueue = getattr(session, "_enqueue_internal_prompt", None)
+        if session is None or not callable(enqueue):
+            return False  # SDK / offline / unknown transport — no tmux pane
+        if getattr(session, "state", None) != SessionState.CONNECTED:
+            return False
+        try:
+            unread = comms.unread_count(to_agent)
+        except Exception as e:
+            _log(f"broker: unread_count for {to_agent} failed: {e}")
+            return False
+        if unread <= 0:
+            return False
+        now = time.monotonic()
+        last = self._agent_msg_nudge_at.get(to_agent, 0.0)
+        if now - last < _AGENT_MSG_NUDGE_BACKOFF_SEC:
+            return False  # coalesce: a nudge already fired this window
+        # Reserve the window BEFORE the await so concurrent deliveries in the
+        # same burst don't each enqueue a nudge.
+        self._agent_msg_nudge_at[to_agent] = now
+        plural = "s" if unread != 1 else ""
+        nudge = (
+            f"[pinky] {unread} unread agent message{plural} — "
+            f"call check_inbox to read {'them' if unread != 1 else 'it'}."
+        )
+        try:
+            await enqueue(nudge, reason="agent_msg_notify")
+        except Exception as e:
+            # Roll back the reservation so a transient failure can retry.
+            self._agent_msg_nudge_at.pop(to_agent, None)
+            _log(f"broker: check-inbox nudge for {to_agent} failed: {e}")
+            return False
+        self._stats["nudged"] += 1
+        _log(
+            f"broker: nudged {to_agent} — {unread} unread agent "
+            f"message{plural} (check_inbox)"
+        )
         return True
 
     # ── Response Routing ───────────────────────────────────

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 import urllib.request
 from dataclasses import dataclass, field
+from typing import NamedTuple
 
 from pinky_daemon.agent_registry import AgentRegistry
 from pinky_daemon.auth_relay import coordinator as _auth_relay
@@ -71,6 +72,28 @@ except (TypeError, ValueError):
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
+
+
+class InjectResult(NamedTuple):
+    """Outcome of a live agent-message injection attempt.
+
+    ``delivered`` — attempt-level: the target had a CONNECTED session and the
+    inject was handed to its transport (legacy bool semantics; drives the
+    offline auto-wake path and the API's ``queued`` flag).
+
+    ``confirmed`` — outcome-level: THIS message's handoff was positively
+    confirmed by the exact session object that performed the inject (the
+    transport's ``injection_confirms_consumption`` capability AND the
+    per-call ``send()`` handoff bool). Only a confirmed inject may retire the
+    durable comms inbox copy (mark it read); anything less keeps the row
+    unread so ``check_inbox`` remains the backstop. (Murzik #853 P1: a
+    transport-static capability alone must never overrule a failed handoff,
+    and confirmation must not come from a second session lookup that can
+    race a session swap.)
+    """
+
+    delivered: bool
+    confirmed: bool
 
 
 def _make_gif_preview(src_path: str) -> str | None:
@@ -1358,12 +1381,24 @@ class MessageBroker:
 
     async def inject_agent_message(
         self, from_agent: str, to_agent: str, message: str,
-    ) -> bool:
-        """Inject a message from one agent into another's streaming session."""
+    ) -> InjectResult:
+        """Inject a message from one agent into another's streaming session.
+
+        Returns an :class:`InjectResult`. ``confirmed`` is computed HERE, on
+        the exact session object that performed the inject, in the same call:
+        the transport's ``injection_confirms_consumption`` capability ANDed
+        with the per-call handoff bool returned by that session's ``send()``.
+        This closes both halves of Murzik's #853 P1: a transport-static
+        capability can't overrule a failed handoff (e.g. StreamingSession's
+        swallowed ``client.query`` exception now returns handoff=False), and
+        there is no second session lookup that could race a session swap.
+        Fail-closed: a transport that doesn't advertise the capability, or a
+        ``send()`` that doesn't report a truthy handoff, never confirms.
+        """
         streaming = self._get_streaming_session(to_agent)
         if not streaming or streaming.state != SessionState.CONNECTED:
             _log(f"broker: can't deliver agent message to {to_agent} — not connected")
-            return False
+            return InjectResult(delivered=False, confirmed=False)
 
         from datetime import datetime
         from datetime import timezone as tz
@@ -1375,40 +1410,25 @@ class MessageBroker:
             # (see ``route_agent_reply``). The ``platform="agent"`` sentinel is
             # intercepted in the response callback before normal platform
             # routing; ``chat_id`` carries the requester agent name.
-            await streaming.send(
+            handoff = await streaming.send(
                 prompt, platform=AGENT_REPLY_PLATFORM, chat_id=from_agent
             )
         else:
-            await streaming.send(prompt)
+            handoff = await streaming.send(prompt)
+        confirmed = bool(handoff) and bool(
+            getattr(streaming, "injection_confirms_consumption", False)
+        )
         # Server-side presence: successful delivery = agent is reachable
         try:
             self._registry.stamp_last_seen(to_agent)
         except Exception as e:
             _log(f"broker: stamp_last_seen failed for {to_agent}: {e}")
         self._stats["routed"] += 1
-        _log(f"broker: injected agent message {from_agent} -> {to_agent}")
-        return True
-
-    def injection_confirms_consumption(self, to_agent: str) -> bool:
-        """Does the target's live transport positively confirm that an injected
-        agent message will actually be consumed?
-
-        ``inject_agent_message`` returning ``True`` only means "session was
-        CONNECTED and ``send`` didn't raise". For an in-process transport (SDK
-        ``StreamingSession``) that IS a positive handoff — ``send`` enqueues
-        straight into the live turn stream. For a tmux/codex transport it is
-        NOT: ``send`` merely appends to a volatile in-memory queue drained by a
-        worker that pastes into an EXTERNAL pane; a dead / mid-turn / restarted
-        or stale-CONNECTED pane silently drops the paste and the queue is lost
-        on teardown. So the durable comms inbox copy may only be retired
-        (marked read) on inject when this returns ``True``.
-
-        Fail-closed: an unknown / missing session (or a transport that doesn't
-        advertise the capability) returns ``False`` — never retire the durable
-        copy on an unconfirmed inject.
-        """
-        session = self._get_streaming_session(to_agent)
-        return bool(getattr(session, "injection_confirms_consumption", False))
+        _log(
+            f"broker: injected agent message {from_agent} -> {to_agent} "
+            f"(confirmed={confirmed})"
+        )
+        return InjectResult(delivered=True, confirmed=confirmed)
 
     async def notify_unread_agent_messages(self, comms, to_agent: str) -> bool:
         """Best-effort nudge (#215 PR3): tell a tmux-transport agent it has

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -86,6 +86,14 @@ class CodexSession:
     interface so the broker/API can treat them interchangeably.
     """
 
+    # ``send`` only appends to the in-memory ``_message_queue``; a worker
+    # later runs ``codex exec`` out-of-process. Enqueue is NOT consumption,
+    # so an inject through this transport never confirms — the durable comms
+    # inbox copy stays unread until check_inbox. (Explicit for clarity; the
+    # broker's getattr default is False anyway.) See
+    # MessageBroker.inject_agent_message / InjectResult.
+    injection_confirms_consumption: bool = False
+
     def __init__(
         self,
         config: StreamingSessionConfig,
@@ -421,7 +429,7 @@ class CodexSession:
         chat_id: str = "",
         message_id: str = "",
         agent_hint: str = "",
-    ) -> None:
+    ) -> bool:
         """Send a message to the agent. Non-blocking — queued for processing.
 
         Args:
@@ -433,13 +441,18 @@ class CodexSession:
                 stored in conversation history (e.g. reply-platform hints).
                 Mirrors StreamingSession.send so the broker can call both
                 session types polymorphically.
+
+        Returns the per-call handoff bool of the Transport ``send`` contract
+        (#853 P1): ``True`` on successful enqueue, ``False`` on drop. Enqueue
+        is not consumption — ``injection_confirms_consumption`` is False, so
+        the broker never confirms an inject off this value alone.
         """
         if self.state != SessionState.CONNECTED:
             _log(
                 f"codex[{self.agent_name}]: not connected "
                 f"(state={self.state.value}), dropping message"
             )
-            return
+            return False
 
         self.last_active = time.time()
         self._stats["messages_sent"] += 1
@@ -466,6 +479,7 @@ class CodexSession:
         queued_prompt = prompt + agent_hint if agent_hint else prompt
         await self._message_queue.put((queued_prompt, platform, chat_id, message_id))
         _log(f"codex[{self.agent_name}]: queued message (chat={chat_id})")
+        return True
 
     async def _message_worker(self) -> None:
         """Process queued messages sequentially via codex exec."""

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -1175,7 +1175,11 @@ class BrokerSlackPoller:
         )
 
         try:
-            delivered = await self._broker.inject_agent_message(
+            # InjectResult: attempt-level ``delivered`` is the right signal
+            # here (the Slack card feedback means "routed to agent");
+            # ``confirmed`` is comms-inbox retire semantics and this path has
+            # no comms row to retire.
+            delivered, _confirmed = await self._broker.inject_agent_message(
                 "slack-approval", self._agent_name, msg
             )
         except Exception as e:

--- a/src/pinky_daemon/routes/presentations.py
+++ b/src/pinky_daemon/routes/presentations.py
@@ -362,7 +362,9 @@ async def generate_presentation_from_research(req: GeneratePresentationRequest):
     agent_cfg = _agents.get_agent(req.agent_name)
     if not agent_cfg:
         raise HTTPException(404, f"Agent '{req.agent_name}' not found")
-    # Route through the broker to the agent's active session
+    # Route through the broker to the agent's active session. The InjectResult
+    # is deliberately discarded: this endpoint reports queued unconditionally
+    # (pre-existing semantics) and has no durable comms copy to retire.
     await _broker.inject_agent_message("system", req.agent_name, prompt)
     return {"queued": True, "agent": req.agent_name, "topic_id": req.topic_id}
 

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -230,10 +230,12 @@ class StreamingSession:
     """
 
     # An in-process transport: ``send`` calls ``client.query`` which enqueues
-    # straight into the live turn stream. A successful inject is a positive
-    # handoff, so the broker may retire (mark read) the durable comms inbox
-    # copy on inject. Contrast TmuxSession (external pane) which sets this
-    # False. See MessageBroker.injection_confirms_consumption.
+    # straight into the live turn stream, and returns a PER-CALL handoff bool
+    # (False when the query raised — swallowed + reconnect, #853 P1). The
+    # broker confirms an inject only when this capability AND that per-call
+    # handoff are both true, and only then retires (marks read) the durable
+    # comms inbox copy. Contrast TmuxSession (external pane) which sets this
+    # False. See MessageBroker.inject_agent_message / InjectResult.
     injection_confirms_consumption: bool = True
 
     def __init__(
@@ -648,7 +650,7 @@ class StreamingSession:
         chat_id: str = "",
         message_id: str = "",
         agent_hint: str = "",
-    ) -> None:
+    ) -> bool:
         """Send a message to the agent. Non-blocking — returns immediately.
 
         Args:
@@ -658,10 +660,18 @@ class StreamingSession:
             message_id: The source message_id to route reactions back to.
             agent_hint: Extra context appended to the query but NOT stored in
                 conversation history (e.g. reply-platform hints).
+
+        Returns:
+            Per-call handoff bool (#853 P1): ``True`` when ``client.query()``
+            accepted THIS message; ``False`` when it was dropped (not
+            connected) or the query raised. The exception path is unchanged —
+            swallowed, reconnect attempted, no raise — it just reports the
+            failed handoff so the broker never treats this exact message as
+            consumed (the capability attr alone must not confirm).
         """
         if self.state != SessionState.CONNECTED or not self._client:
             _log(f"streaming[{self.agent_name}]: not connected, dropping message")
-            return
+            return False
 
         self.last_active = time.time()
         self._stats["messages_sent"] += 1
@@ -689,11 +699,13 @@ class StreamingSession:
             # system/internal turn can't consume a user turn's routing.
             self._pending_chats.append((platform, chat_id, message_id))
             _log(f"streaming[{self.agent_name}]: sent message (chat={chat_id})")
+            return True
         except Exception as e:
             self._stats["errors"] += 1
             _log(f"streaming[{self.agent_name}]: send error: {e}")
             # Try to reconnect
             await self.attempt_reconnect()
+            return False
 
     async def _reader_loop(self) -> None:
         """Background loop that reads responses and fires callbacks."""

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -229,6 +229,13 @@ class StreamingSession:
     - Response callback fires when agent finishes a turn
     """
 
+    # An in-process transport: ``send`` calls ``client.query`` which enqueues
+    # straight into the live turn stream. A successful inject is a positive
+    # handoff, so the broker may retire (mark read) the durable comms inbox
+    # copy on inject. Contrast TmuxSession (external pane) which sets this
+    # False. See MessageBroker.injection_confirms_consumption.
+    injection_confirms_consumption: bool = True
+
     def __init__(
         self,
         config: StreamingSessionConfig,

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1090,6 +1090,16 @@ class TmuxSession:
     (the response capture pipeline is the principal remaining gap).
     """
 
+    # ``send`` only appends a turn to the in-memory ``_message_queue``; a
+    # worker later pastes it into an EXTERNAL tmux pane. A dead / mid-turn /
+    # restarted or stale-CONNECTED pane silently drops the paste and the queue
+    # is lost on teardown, so a successful inject is NOT a positive handoff.
+    # The durable comms inbox stays the source of truth (fail-closed): the
+    # broker must never mark an agent message read merely because it was
+    # injected here. Inherited by CodexTmuxSession. See
+    # MessageBroker.injection_confirms_consumption.
+    injection_confirms_consumption: bool = False
+
     def __init__(
         self,
         config: StreamingSessionConfig,

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3226,20 +3226,26 @@ class TmuxSession:
         chat_id: str = "",
         message_id: str = "",
         agent_hint: str = "",
-    ) -> None:
+    ) -> bool:
         """Queue a turn for delivery to the in-pane claude REPL.
 
         Non-blocking. Callers must ensure ``state == CONNECTED`` before
         calling (per Transport contract). Behavior when called while
         non-CONNECTED: drop with a log line (matches StreamingSession's
         legacy behavior).
+
+        Returns the per-call handoff bool of the Transport ``send`` contract
+        (#853 P1): ``True`` on successful ENQUEUE, ``False`` on drop. Note
+        for this transport an enqueue is still not consumption — the class
+        sets ``injection_confirms_consumption = False``, so the broker never
+        confirms off this value alone.
         """
         if self.state != SessionState.CONNECTED:
             _log(
                 f"tmux[{self.agent_name}]: not connected (state={self.state.value}), "
                 f"dropping message"
             )
-            return
+            return False
 
         self.last_active = time.time()
         self._stats["messages_sent"] += 1
@@ -3263,6 +3269,7 @@ class TmuxSession:
             message_id=message_id,
         ))
         _log(f"tmux[{self.agent_name}]: queued message (chat={chat_id})")
+        return True
 
     async def _enqueue_internal_prompt(
         self,

--- a/src/pinky_daemon/transport.py
+++ b/src/pinky_daemon/transport.py
@@ -228,7 +228,7 @@ class Transport(Protocol):
         chat_id: str = "",
         message_id: str = "",
         agent_hint: str = "",
-    ) -> None:
+    ) -> bool:
         """Send a message to the agent. Non-blocking.
 
         Args:
@@ -240,6 +240,18 @@ class Transport(Protocol):
             agent_hint: Reply-platform context appended to the query but
                 NOT stored in conversation history. Lets the agent know
                 where to reply without polluting the persistent record.
+
+        Returns:
+            Per-call handoff bool (#853): ``True`` when the transport
+            accepted THIS message (SDK ``client.query`` succeeded / turn
+            enqueued for a pane worker), ``False`` when it was dropped or
+            the handoff failed. Handoff is NOT consumption — whether a
+            truthy handoff also confirms consumption is declared by the
+            transport's ``injection_confirms_consumption`` class attr
+            (``True`` only for in-process SDK streams; ``False`` for
+            external-pane tmux/codex transports). The broker combines
+            both into ``InjectResult.confirmed``; only a confirmed inject
+            may retire the durable comms inbox copy.
 
         **Caller contract.** Callers must ensure the transport is in
         ``SessionState.CONNECTED`` before invoking ``send``. ``send`` itself
@@ -253,11 +265,12 @@ class Transport(Protocol):
         is either CONNECTED or terminally DEAD, then call ``send``.
 
         Behavior when called while NOT CONNECTED is **unspecified by this
-        Protocol**:
+        Protocol** beyond the return value:
 
-        - Current ``StreamingSession`` drops silently (legacy; see
-          ``streaming_session.py:send``).
-        - Future backends MAY raise instead.
+        - Current ``StreamingSession`` drops silently and returns ``False``
+          (see ``streaming_session.py:send``).
+        - Future backends MAY raise instead; if they return, a dropped
+          message MUST be reported as ``False``, never ``True``.
 
         Callers must not depend on the drop-vs-raise behavior; if you need
         delivery guarantees during non-CONNECTED windows, drive the

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -218,6 +218,35 @@ class TestStreamingSession:
         session.attempt_reconnect.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_send_returns_per_call_handoff(self):
+        """#853 P1: StreamingSession.send() reports THIS call's handoff —
+        True when client.query() succeeded, False when the exception path was
+        taken (swallow + reconnect preserved, no raise). The broker ANDs this
+        with the transport capability to decide whether an injected agent
+        message may retire its durable inbox copy."""
+        from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
+        from pinky_daemon.transport_state import SessionState
+
+        session = StreamingSession(StreamingSessionConfig(agent_name="test-agent"))
+        session._state_machine._state = SessionState.CONNECTED
+
+        class OkClient:
+            async def query(self, prompt):
+                pass
+
+        session._client = OkClient()
+        assert await session.send("hello", platform="web", chat_id="c1") is True
+
+        class FailingClient:
+            async def query(self, prompt):
+                raise RuntimeError("boom")
+
+        session._client = FailingClient()
+        session.attempt_reconnect = AsyncMock()
+        assert await session.send("hello2", platform="web", chat_id="c1") is False
+        session.attempt_reconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_send_video_is_classified_as_outreach_tool(self):
         """send_video must be in the outreach set so a video-send turn is marked
         used_outreach_tools=True — otherwise plain_text_fallback could deliver the
@@ -486,6 +515,8 @@ class TestAPI:
 
         async def send(self, prompt: str, platform: str = "", chat_id: str = ""):
             self.sent.append((prompt, platform, chat_id))
+            # Transport send contract (#853 P1): per-call handoff bool.
+            return True
 
         async def disconnect(self):
             self.disconnect_calls += 1
@@ -643,6 +674,45 @@ class TestAPI:
                 assert body["confirmed"] is True
                 # Confirmed handoff → durable copy retired.
                 assert app.state.comms.unread_count("gemma") == 0
+
+    def test_agent_message_sdk_failed_handoff_stays_unread(self):
+        """#853 P1 regression: the SDK capability is transport-static, but
+        StreamingSession.send() swallows a failed client.query() (reconnect,
+        no raise) and reports handoff=False. That exact message must NOT be
+        retired: durable row stays unread, response says confirmed=false, and
+        the nudge no-ops for SDK (no internal-prompt queue)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "gemma", "model": "sonnet"})
+
+                session = self._FakeStreamingSession("gemma", "main")
+                session.injection_confirms_consumption = True
+
+                async def _failing_send(prompt, platform="", chat_id=""):
+                    # SDK-fidelity: client.query() raised; StreamingSession
+                    # swallowed it, scheduled reconnect, and reports the
+                    # failed per-call handoff.
+                    return False
+
+                session.send = _failing_send
+                app.state.broker.register_streaming("gemma", session, label="main")
+
+                resp = client.post("/agents/gemma/message", json={
+                    "from_agent": "barsik", "message": "important verdict",
+                })
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["delivered"] is True   # attempt-level unchanged
+                assert body["confirmed"] is False  # handoff failed → no retire
+                # No mark_read — the message is still visible to check_inbox.
+                assert app.state.comms.unread_count("gemma") == 1
+                inbox = client.get("/sessions/gemma/inbox?unread_only=true").json()
+                assert len(inbox["messages"]) == 1
+                assert "important verdict" in inbox["messages"][0]["content"]
+                # SDK session has no tmux internal-prompt queue → no nudge.
+                assert app.state.broker._stats["nudged"] == 0
 
     def test_register_isolation_mode_round_trips(self):
         """#149 phase-3: POST /agents carries isolation_mode through to the

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -576,6 +576,74 @@ class TestAPI:
                 assert len(data) == 1
                 assert data[0]["id"] == "adhoc"
 
+    def test_agent_message_tmux_stays_unread_and_nudges(self):
+        """Fail-closed inter-agent delivery (#215 PR3): a tmux-transport
+        target's live-inject does NOT retire the durable inbox copy. The
+        message stays unread, check_inbox still surfaces it, and the target is
+        nudged to read its inbox. This is the codex-tmux black-hole fix."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "murzik", "model": "sonnet"})
+
+                # tmux-style transport: inject is best-effort (not confirmed),
+                # and it exposes the internal-prompt queue used for the nudge.
+                session = self._FakeStreamingSession("murzik", "main")
+                session.injection_confirms_consumption = False
+                nudges: list[tuple[str, str]] = []
+
+                async def _enqueue_internal_prompt(prompt, *, reason, **kw):
+                    nudges.append((prompt, reason))
+
+                session._enqueue_internal_prompt = _enqueue_internal_prompt
+                app.state.broker.register_streaming("murzik", session, label="main")
+
+                resp = client.post("/agents/murzik/message", json={
+                    "from_agent": "barsik", "message": "review chez#104 please",
+                })
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["delivered"] is True   # live-inject happened
+                assert body["confirmed"] is False  # but not confirmed → not retired
+
+                # Durable copy remains UNREAD — the whole point of the fix.
+                assert app.state.comms.unread_count("murzik") == 1
+                # ... so check_inbox (unread-only) still returns it.
+                inbox = client.get("/sessions/murzik/inbox?unread_only=true").json()
+                msgs = inbox["messages"]
+                assert len(msgs) == 1
+                assert "review chez#104" in msgs[0]["content"]
+                assert msgs[0]["read"] == 0
+                # ... and the target was nudged (once) to check its inbox.
+                assert len(nudges) == 1
+                assert nudges[0][1] == "agent_msg_notify"
+                assert "check_inbox" in nudges[0][0]
+
+    def test_agent_message_sdk_confirmed_marks_read(self):
+        """An in-process (SDK) transport confirms consumption, so the durable
+        copy IS retired (marked read) — preserves the working path's
+        no-repeat-on-wake behavior and avoids duplicates."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "gemma", "model": "sonnet"})
+
+                session = self._FakeStreamingSession("gemma", "main")
+                session.injection_confirms_consumption = True
+                app.state.broker.register_streaming("gemma", session, label="main")
+
+                resp = client.post("/agents/gemma/message", json={
+                    "from_agent": "barsik", "message": "fyi heads up",
+                })
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["delivered"] is True
+                assert body["confirmed"] is True
+                # Confirmed handoff → durable copy retired.
+                assert app.state.comms.unread_count("gemma") == 0
+
     def test_register_isolation_mode_round_trips(self):
         """#149 phase-3: POST /agents carries isolation_mode through to the
         stored agent; default is 'local'."""

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -320,6 +320,176 @@ class TestMessageBrokerRouting:
         finally:
             tmpdir.cleanup()
 
+    # ── Fail-closed delivery + check-inbox nudge (#215 PR3) ────────
+
+    @pytest.mark.asyncio
+    async def test_injection_confirms_consumption_fail_closed_without_session(self):
+        """No live session → not confirmed (never retire the durable copy)."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            assert broker.injection_confirms_consumption("barsik") is False
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_injection_confirms_consumption_false_for_tmux_transport(self):
+        """A tmux-style transport (advertises False) does NOT confirm — its
+        live-inject is a best-effort enqueue behind an external pane."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            from pinky_daemon.transport_state import SessionState
+
+            class _Tmuxish:
+                state = SessionState.CONNECTED
+                injection_confirms_consumption = False
+
+                async def send(self, *a, **k):
+                    pass
+
+            broker.register_streaming("barsik", _Tmuxish(), label="main")
+            assert broker.injection_confirms_consumption("barsik") is False
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_injection_confirms_consumption_true_for_sdk_transport(self):
+        """An SDK-style in-process transport (advertises True) confirms."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            from pinky_daemon.transport_state import SessionState
+
+            class _Sdkish:
+                state = SessionState.CONNECTED
+                injection_confirms_consumption = True
+
+                async def send(self, *a, **k):
+                    pass
+
+            broker.register_streaming("barsik", _Sdkish(), label="main")
+            assert broker.injection_confirms_consumption("barsik") is True
+        finally:
+            tmpdir.cleanup()
+
+    class _NudgeComms:
+        def __init__(self, unread: int):
+            self._unread = unread
+
+        def unread_count(self, session_id: str) -> int:
+            return self._unread
+
+    def _tmux_nudge_session(self):
+        from pinky_daemon.transport_state import SessionState
+
+        class _TmuxNudge:
+            state = SessionState.CONNECTED
+            injection_confirms_consumption = False
+
+            def __init__(self):
+                self.nudges: list[tuple[str, str]] = []
+
+            async def send(self, *a, **k):
+                pass
+
+            async def _enqueue_internal_prompt(self, prompt, *, reason, **kw):
+                self.nudges.append((prompt, reason))
+
+        return _TmuxNudge()
+
+    @pytest.mark.asyncio
+    async def test_notify_unread_enqueues_nudge_for_tmux(self):
+        """A tmux target with unread messages gets one readiness-gated nudge
+        via the internal-prompt queue."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            session = self._tmux_nudge_session()
+            broker.register_streaming("barsik", session, label="main")
+            fired = await broker.notify_unread_agent_messages(self._NudgeComms(2), "barsik")
+            assert fired is True
+            assert len(session.nudges) == 1
+            prompt, reason = session.nudges[0]
+            assert reason == "agent_msg_notify"
+            assert "2 unread agent messages" in prompt
+            assert "check_inbox" in prompt
+            assert broker._stats["nudged"] == 1
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_notify_unread_coalesces_within_window(self):
+        """A burst collapses to a single nudge (no storm)."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            session = self._tmux_nudge_session()
+            broker.register_streaming("barsik", session, label="main")
+            comms = self._NudgeComms(3)
+            assert await broker.notify_unread_agent_messages(comms, "barsik") is True
+            # Second delivery in the same burst → coalesced, no new nudge.
+            assert await broker.notify_unread_agent_messages(comms, "barsik") is False
+            assert len(session.nudges) == 1
+            assert broker._stats["nudged"] == 1
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_notify_unread_flag_off_no_nudge(self, monkeypatch):
+        """PINKYBOT_AGENT_MSG_NOTIFY off → no nudge (kill-switch)."""
+        import pinky_daemon.broker as broker_mod
+
+        monkeypatch.setattr(broker_mod, "_AGENT_MSG_NOTIFY_ENABLED", False)
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            session = self._tmux_nudge_session()
+            broker.register_streaming("barsik", session, label="main")
+            fired = await broker.notify_unread_agent_messages(self._NudgeComms(5), "barsik")
+            assert fired is False
+            assert session.nudges == []
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_notify_unread_noop_for_non_tmux_transport(self):
+        """An SDK-style session (no internal-prompt queue) is never nudged —
+        its live-inject already confirmed consumption."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            from pinky_daemon.transport_state import SessionState
+
+            class _Sdkish:
+                state = SessionState.CONNECTED
+                injection_confirms_consumption = True
+
+                async def send(self, *a, **k):
+                    pass
+
+            broker.register_streaming("barsik", _Sdkish(), label="main")
+            fired = await broker.notify_unread_agent_messages(self._NudgeComms(2), "barsik")
+            assert fired is False
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_notify_unread_noop_when_nothing_unread(self):
+        """Nothing unread → no nudge."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            session = self._tmux_nudge_session()
+            broker.register_streaming("barsik", session, label="main")
+            fired = await broker.notify_unread_agent_messages(self._NudgeComms(0), "barsik")
+            assert fired is False
+            assert session.nudges == []
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_notify_unread_noop_without_session(self):
+        """No live session → no nudge (durable unread row is the backstop)."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            fired = await broker.notify_unread_agent_messages(self._NudgeComms(4), "barsik")
+            assert fired is False
+        finally:
+            tmpdir.cleanup()
+
     @pytest.mark.asyncio
     async def test_route_agent_reply_delivers_to_requester_inbox(self):
         """#279: a completed agent-reply turn is delivered to the requester's

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -249,12 +249,16 @@ class TestMessageBrokerRouting:
 
                 async def send(self, prompt, *, platform="", chat_id="", message_id=""):
                     _FakeStreaming.sent.append(prompt)
+                    return True
 
             broker.register_streaming("barsik", _FakeStreaming(), label="main")
             assert registry.get("barsik").last_seen_at == 0.0
 
-            ok = await broker.inject_agent_message("pushok", "barsik", "hi")
-            assert ok is True
+            delivered, confirmed = await broker.inject_agent_message("pushok", "barsik", "hi")
+            assert delivered is True
+            # Handoff succeeded but the fake advertises no capability →
+            # fail-closed unconfirmed.
+            assert confirmed is False
             assert registry.get("barsik").last_seen_at > 0.0
             assert _FakeStreaming.sent  # delivery happened
         finally:
@@ -265,8 +269,9 @@ class TestMessageBrokerRouting:
         tmpdir, registry, broker, _, _ = self._make_broker()
         try:
             # No streaming session registered — inject should fail without stamping.
-            ok = await broker.inject_agent_message("pushok", "barsik", "hi")
-            assert ok is False
+            delivered, confirmed = await broker.inject_agent_message("pushok", "barsik", "hi")
+            assert delivered is False
+            assert confirmed is False
             assert registry.get("barsik").last_seen_at == 0.0
         finally:
             tmpdir.cleanup()
@@ -286,10 +291,11 @@ class TestMessageBrokerRouting:
 
                 async def send(self, prompt, *, platform="", chat_id="", message_id=""):
                     recorded.append((platform, chat_id))
+                    return True
 
             broker.register_streaming("barsik", _FakeStreaming(), label="main")
-            ok = await broker.inject_agent_message("pushok", "barsik", "review please")
-            assert ok is True
+            delivered, _ = await broker.inject_agent_message("pushok", "barsik", "review please")
+            assert delivered is True
             assert recorded == [("agent", "pushok")]
         finally:
             tmpdir.cleanup()
@@ -312,29 +318,36 @@ class TestMessageBrokerRouting:
 
                 async def send(self, prompt, *, platform="", chat_id="", message_id=""):
                     recorded.append((platform, chat_id))
+                    return True
 
             broker.register_streaming("barsik", _FakeStreaming(), label="main")
-            ok = await broker.inject_agent_message("pushok", "barsik", "hi")
-            assert ok is True
+            delivered, _ = await broker.inject_agent_message("pushok", "barsik", "hi")
+            assert delivered is True
             assert recorded == [("", "")]
         finally:
             tmpdir.cleanup()
 
     # ── Fail-closed delivery + check-inbox nudge (#215 PR3) ────────
+    # Confirmation is per-inject: computed by inject_agent_message on the SAME
+    # session object it injected through — transport capability AND the
+    # per-call send() handoff (Murzik #853 P1).
 
     @pytest.mark.asyncio
-    async def test_injection_confirms_consumption_fail_closed_without_session(self):
-        """No live session → not confirmed (never retire the durable copy)."""
+    async def test_inject_result_fail_closed_without_session(self):
+        """No live session → (delivered=False, confirmed=False): never retire
+        the durable copy."""
         tmpdir, _, broker, _, _ = self._make_broker()
         try:
-            assert broker.injection_confirms_consumption("barsik") is False
+            result = await broker.inject_agent_message("pushok", "barsik", "hi")
+            assert result == (False, False)
         finally:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_injection_confirms_consumption_false_for_tmux_transport(self):
-        """A tmux-style transport (advertises False) does NOT confirm — its
-        live-inject is a best-effort enqueue behind an external pane."""
+    async def test_inject_unconfirmed_for_tmux_transport(self):
+        """A tmux-style transport (capability False) never confirms even on a
+        successful enqueue handoff — its inject is best-effort behind an
+        external pane → (True, False)."""
         tmpdir, _, broker, _, _ = self._make_broker()
         try:
             from pinky_daemon.transport_state import SessionState
@@ -344,16 +357,19 @@ class TestMessageBrokerRouting:
                 injection_confirms_consumption = False
 
                 async def send(self, *a, **k):
-                    pass
+                    return True  # enqueue succeeded — still not consumption
 
             broker.register_streaming("barsik", _Tmuxish(), label="main")
-            assert broker.injection_confirms_consumption("barsik") is False
+            delivered, confirmed = await broker.inject_agent_message("pushok", "barsik", "hi")
+            assert delivered is True
+            assert confirmed is False
         finally:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_injection_confirms_consumption_true_for_sdk_transport(self):
-        """An SDK-style in-process transport (advertises True) confirms."""
+    async def test_inject_confirmed_for_sdk_transport_success(self):
+        """SDK-style transport (capability True) + successful per-call handoff
+        → (True, True): the durable copy may be retired."""
         tmpdir, _, broker, _, _ = self._make_broker()
         try:
             from pinky_daemon.transport_state import SessionState
@@ -363,10 +379,36 @@ class TestMessageBrokerRouting:
                 injection_confirms_consumption = True
 
                 async def send(self, *a, **k):
-                    pass
+                    return True  # client.query() accepted this message
 
             broker.register_streaming("barsik", _Sdkish(), label="main")
-            assert broker.injection_confirms_consumption("barsik") is True
+            delivered, confirmed = await broker.inject_agent_message("pushok", "barsik", "hi")
+            assert delivered is True
+            assert confirmed is True
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_inject_unconfirmed_when_sdk_handoff_fails(self):
+        """#853 P1: capability True must NOT overrule a failed per-call
+        handoff. An SDK send whose client.query() raised internally (swallowed
+        + reconnect, returns False) → (True, False): the exact message that
+        failed stays unretired."""
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            from pinky_daemon.transport_state import SessionState
+
+            class _SdkishFailing:
+                state = SessionState.CONNECTED
+                injection_confirms_consumption = True
+
+                async def send(self, *a, **k):
+                    return False  # query raised; exception swallowed upstream
+
+            broker.register_streaming("barsik", _SdkishFailing(), label="main")
+            delivered, confirmed = await broker.inject_agent_message("pushok", "barsik", "hi")
+            assert delivered is True
+            assert confirmed is False
         finally:
             tmpdir.cleanup()
 

--- a/tests/test_slack_purchase_approval.py
+++ b/tests/test_slack_purchase_approval.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from pinky_daemon.broker import InjectResult
 from pinky_daemon.pollers import (
     _PURCHASE_APPROVE_ACTION_ID,
     _PURCHASE_REJECT_ACTION_ID,
@@ -36,7 +37,11 @@ def _make_poller(
     adapter.bot_token = "xoxb-test"
     adapter.respond_via_url = MagicMock()
     broker = MagicMock()
-    broker.inject_agent_message = AsyncMock(return_value=inject_ok)
+    # inject_agent_message returns an InjectResult; the poller destructures
+    # (delivered, _confirmed) and keys the Slack card feedback off delivered.
+    broker.inject_agent_message = AsyncMock(
+        return_value=InjectResult(delivered=inject_ok, confirmed=False)
+    )
 
     if registry is None and registry is not False:
         registry = MagicMock()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -58,7 +58,8 @@ class _StubTransport:
         chat_id: str = "",
         message_id: str = "",
         agent_hint: str = "",
-    ) -> None: ...
+    ) -> bool:
+        return True
 
     async def force_restart(self) -> bool:
         return True


### PR DESCRIPTION
## Problem — inter-agent messages to codex-tmux agents silently black-hole

`send_to_agent` reports success, the target's `check_inbox` never shows the message. Chronic for codex-tmux targets (murzik, kuzya) — bad enough that murzik ran `*/5min` check-inbox crons as a workaround.

**Root cause** (`api.py:8627-8629` pre-fix): `send_agent_message_direct` persisted the message as an unread inbox row (correct), then called `broker.inject_agent_message(...)` and **marked the row read on the bare `delivered` bool**. But `delivered=True` only means "session was CONNECTED and `send()` didn't raise":

- SDK `StreamingSession.send()` → in-process `client.query` into the live turn stream — a real handoff.
- `TmuxSession.send()` (base of `CodexTmuxSession`, `tmux_session.py:3211`) → appends to a **volatile in-memory `asyncio.Queue`** drained by a worker that pastes into an **external tmux pane**. Dead / busy / mid-turn / restarted / stale-CONNECTED pane ⇒ paste silently drops; queue lost on teardown.

Marking read on that bool retires the durable copy from `check_inbox`'s unread-only view ⇒ black hole. Classic fail-open-on-absence.

**Forensics** (live comms store, read-only, 2026-07-09): daemon log pairs `comms: barsik -> murzik` with `broker: injected agent message` for each delivery; every injected message's row is `read=1`. The one message whose inject returned `False` (msg 4491) is correctly `read=0` and was the *only* one to surface. Aggregate: **barsik→murzik all-time 1686 read-on-inject vs 1 unread; barsik→kuzya 188 vs 1.** Essentially every message ever sent to the codex agents was retired on inject — whether or not the pane consumed it.

## Fix

1. **Fail-closed retire (not flag-gated):** `api.py` now computes `confirmed = delivered and broker.injection_confirms_consumption(name)` and only `mark_read`s when confirmed. Otherwise the row stays unread+queued so `check_inbox` remains the durable backstop. Response gains a `"confirmed"` field; `"queued"` semantics unchanged.
2. **Transport capability:** `injection_confirms_consumption` class attr — `StreamingSession = True` (in-process handoff), `TmuxSession = False` (inherited by `CodexTmuxSession`). Broker helper is fail-closed: missing session / unknown transport ⇒ `False`.
3. **Check-inbox nudge (#215 PR3):** when a message is left unread for a live tmux target, `broker.notify_unread_agent_messages()` enqueues `[pinky] N unread agent message(s) — call check_inbox…` via the readiness-gated `_enqueue_internal_prompt` (can't corrupt a mid-turn pane; daemon-internal, so no nudge loops). Coalesced per-agent (reserve-before-await; default 15s window via `PINKYBOT_AGENT_MSG_NUDGE_BACKOFF`). Best-effort by design — the unread row is the guarantee, the nudge is timeliness.
4. **Flag:** `PINKYBOT_AGENT_MSG_NOTIFY` (default **ON**; `0/false/no/off` disables the nudge only). The correctness fix is deliberately unflagged.

## Known tradeoff

A healthy tmux pane may now see a message twice: once live-injected, once via `check_inbox` (row intentionally stays unread until retrieval). Never-drop > never-dup. Cleaner future model (nudge-only for tmux, single delivery through `check_inbox`) interacts with the #279 reply-routing flow — tracked as a follow-up.

## Overlap with PR #831 (#280 dedup, open/held)

Shared files `broker.py`/`test_broker.py`, **no semantic collision** — #831 dedupes the *reply* path (`route_agent_reply`), this fixes the *send* path. Both add a `_stats` key + adjacent blocks; whichever lands second needs a trivial rebase.

## Testing

- `ruff check` on all 6 touched files: clean.
- 11 new tests: 9 broker (capability fail-closed ×3, nudge enqueue/coalesce/flag-off/non-tmux/nothing-unread/no-session) + 2 end-to-end API (tmux inject ⇒ stays unread, `check_inbox` returns it, one nudge; SDK inject ⇒ marked read).
- Suites: `test_broker.py`+`test_agent_comms.py` **126 passed**; `test_api.py` **363 passed**; `test_streaming_session.py`+`test_tmux_session.py` **360 passed**. Independently re-verified post-build: affected subsets re-run green from the worktree (pytest `pythonpath=["src"]` confirmed to import branch code, not the editable prod install).

Closes the delivery-drop incident from 2026-07-09 (two observed drops; murzik's polling workaround since removed). Implements #215 PR3.

🤖 Opened by Barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)
