### PR TITLE
fix: restore Codex agents after daemon restarts

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2095,6 +2095,10 @@ except Exception:
         existing = self.get(name)
         if not existing:
             raise KeyError(f"Agent '{name}' not found")
+        if "working_dir" in kwargs:
+            raise ValueError(
+                "working_dir is not supported by partial update; use register()"
+            )
 
         updates = {}
         for key in ("display_name", "model", "soul", "users", "boundaries",
@@ -2119,14 +2123,6 @@ except Exception:
             updates["provider_key"] = kwargs["provider_key"]
         elif kwargs.get("clear_provider_key"):
             updates["provider_key"] = ""
-
-        # Keep the create-path workspace invariants on partial update.
-        if kwargs.get("working_dir"):
-            upd_dir = Path(kwargs["working_dir"])
-            upd_dir_abs = upd_dir if upd_dir.is_absolute() else upd_dir.resolve()
-            if str(upd_dir_abs) != existing.working_dir:
-                self._init_workspace(upd_dir_abs, agent_name=name)
-            updates["working_dir"] = str(upd_dir_abs)
 
         for key in ("watchdog_config", "allowed_tools", "disallowed_tools", "groups"):
             if key in kwargs:
@@ -2166,7 +2162,30 @@ except Exception:
         existing = self.get(name)
 
         if existing:
-            updated = self.update(name, **kwargs)
+            # Keep the legacy workspace mutation on register(), whose admin
+            # callers and path-handling contract predate the partial update
+            # API. AgentRegistry.update() is intentionally path-free.
+            updated_working_dir = ""
+            if kwargs.get("working_dir"):
+                upd_dir = Path(kwargs["working_dir"])
+                upd_dir_abs = upd_dir if upd_dir.is_absolute() else upd_dir.resolve()
+                if str(upd_dir_abs) != existing.working_dir:
+                    self._init_workspace(upd_dir_abs, agent_name=name)
+                updated_working_dir = str(upd_dir_abs)
+
+            update_kwargs = dict(kwargs)
+            update_kwargs.pop("working_dir", None)
+            updated = self.update(name, **update_kwargs)
+            if updated_working_dir:
+                self._db.execute(
+                    "UPDATE agents SET working_dir=?, updated_at=? WHERE name=?",
+                    (updated_working_dir, time.time(), name),
+                )
+                self._db.commit()
+                refreshed = self.get(name)
+                if not refreshed:  # Defensive against a concurrent delete.
+                    raise KeyError(f"Agent '{name}' not found")
+                updated = refreshed
             # Preserve register()'s historical signing-key backfill contract
             # for legacy rows even though the field mutation is delegated.
             self.get_or_create_signing_key(name)

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2083,6 +2083,77 @@ except Exception:
 
     # ── Agent CRUD ──────────────────────────────────────────
 
+    def update(self, name: str, **kwargs) -> Agent:
+        """Partially update an existing agent without creating one.
+
+        Only explicitly supplied, allowlisted fields are changed.  This is
+        intentionally distinct from :meth:`register`: callers that mean to
+        mutate durable defaults must not accidentally create a half-populated
+        agent or reset fields omitted from a PATCH-like request.
+        """
+        name = _validate_agent_name(name)
+        existing = self.get(name)
+        if not existing:
+            raise KeyError(f"Agent '{name}' not found")
+
+        updates = {}
+        for key in ("display_name", "model", "soul", "users", "boundaries",
+                    "system_prompt",
+                    "permission_mode", "max_turns", "timeout", "restart_threshold_pct",
+                    "context_nudge_threshold_pct",
+                    "auto_restart", "parent", "max_sessions", "enabled",
+                    "auto_start", "heartbeat_interval", "wake_interval",
+                    "clock_aligned", "auto_sleep_hours", "plain_text_fallback", "voice_config", "role",
+                    "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
+                    "librarian_enabled", "librarian_schedule",
+                    "runtime", "transport", "provider_url", "provider_model", "provider_ref",
+                    "thinking_effort", "strict_effort_enforcement", "isolated",
+                    "isolation_mode", "container_image"):
+            if key in kwargs:
+                updates[key] = kwargs[key]
+
+        # Secret: empty/absent means "unchanged" so callers round-tripping
+        # the redacted to_dict() (provider_key_set) can't wipe the key.
+        # Wiping requires the explicit clear_provider_key flag.
+        if kwargs.get("provider_key"):
+            updates["provider_key"] = kwargs["provider_key"]
+        elif kwargs.get("clear_provider_key"):
+            updates["provider_key"] = ""
+
+        # Keep the create-path workspace invariants on partial update.
+        if kwargs.get("working_dir"):
+            upd_dir = Path(kwargs["working_dir"])
+            upd_dir_abs = upd_dir if upd_dir.is_absolute() else upd_dir.resolve()
+            if str(upd_dir_abs) != existing.working_dir:
+                self._init_workspace(upd_dir_abs, agent_name=name)
+            updates["working_dir"] = str(upd_dir_abs)
+
+        for key in ("watchdog_config", "allowed_tools", "disallowed_tools", "groups"):
+            if key in kwargs:
+                updates[key] = json.dumps(kwargs[key])
+
+        for key in ("auto_restart", "enabled", "auto_start", "clock_aligned",
+                    "plain_text_fallback", "dream_enabled", "dream_notify",
+                    "librarian_enabled", "strict_effort_enforcement", "isolated"):
+            if key in updates:
+                updates[key] = int(updates[key])
+        if "voice_config" in updates and isinstance(updates["voice_config"], dict):
+            updates["voice_config"] = json.dumps(updates["voice_config"])
+
+        if updates:
+            updates["updated_at"] = time.time()
+            set_clause = ", ".join(f"{key}=?" for key in updates)
+            self._db.execute(
+                f"UPDATE agents SET {set_clause} WHERE name=?",
+                list(updates.values()) + [name],
+            )
+            self._db.commit()
+
+        updated = self.get(name)
+        if not updated:  # Defensive against a concurrent delete.
+            raise KeyError(f"Agent '{name}' not found")
+        return updated
+
     def register(self, name: str, **kwargs) -> Agent:
         """Register a new agent or update an existing one."""
         # Sanitize before any path is constructed downstream. Same regex as
@@ -2095,83 +2166,11 @@ except Exception:
         existing = self.get(name)
 
         if existing:
-            # Merge: only update provided fields
-            updates = {}
-            for key in ("display_name", "model", "soul", "users", "boundaries",
-                        "system_prompt",
-                        "permission_mode", "max_turns", "timeout", "restart_threshold_pct",
-                        "context_nudge_threshold_pct",
-                        "auto_restart", "parent", "max_sessions", "enabled",
-                        "auto_start", "heartbeat_interval", "wake_interval",
-                        "clock_aligned", "auto_sleep_hours", "plain_text_fallback", "voice_config", "role",
-                        "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
-                        "librarian_enabled", "librarian_schedule",
-                        "runtime", "transport", "provider_url", "provider_model", "provider_ref",
-                        "thinking_effort", "strict_effort_enforcement", "isolated",
-                        "isolation_mode", "container_image"):
-                if key in kwargs:
-                    updates[key] = kwargs[key]
-
-            # Secret: empty/absent means "unchanged" so callers round-tripping
-            # the redacted to_dict() (provider_key_set) can't wipe the key.
-            # Wiping requires the explicit clear_provider_key flag, which the
-            # routes set when a caller sends provider_key="".
-            if kwargs.get("provider_key"):
-                updates["provider_key"] = kwargs["provider_key"]
-            elif kwargs.get("clear_provider_key"):
-                updates["provider_key"] = ""
-
-            # working_dir keeps the create-path invariants on update: empty
-            # means "unchanged" (POST /agents upserts always pass it, default
-            # ""), relative paths are absolutized so they don't break when the
-            # daemon CWD differs from the install dir, and the workspace is
-            # initialized for the new directory.
-            if kwargs.get("working_dir"):
-                upd_dir = Path(kwargs["working_dir"])
-                upd_dir_abs = upd_dir if upd_dir.is_absolute() else upd_dir.resolve()
-                if str(upd_dir_abs) != existing.working_dir:
-                    self._init_workspace(upd_dir_abs, agent_name=name)
-                updates["working_dir"] = str(upd_dir_abs)
-
-            if "watchdog_config" in kwargs:
-                updates["watchdog_config"] = json.dumps(kwargs["watchdog_config"])
-            if "allowed_tools" in kwargs:
-                updates["allowed_tools"] = json.dumps(kwargs["allowed_tools"])
-            if "disallowed_tools" in kwargs:
-                updates["disallowed_tools"] = json.dumps(kwargs["disallowed_tools"])
-            if "groups" in kwargs:
-                updates["groups"] = json.dumps(kwargs["groups"])
-            if "auto_restart" in updates:
-                updates["auto_restart"] = int(updates["auto_restart"])
-            if "enabled" in updates:
-                updates["enabled"] = int(updates["enabled"])
-            if "auto_start" in updates:
-                updates["auto_start"] = int(updates["auto_start"])
-            if "clock_aligned" in updates:
-                updates["clock_aligned"] = int(updates["clock_aligned"])
-            if "plain_text_fallback" in updates:
-                updates["plain_text_fallback"] = int(updates["plain_text_fallback"])
-            if "voice_config" in updates and isinstance(updates["voice_config"], dict):
-                updates["voice_config"] = json.dumps(updates["voice_config"])
-            if "dream_enabled" in updates:
-                updates["dream_enabled"] = int(updates["dream_enabled"])
-            if "dream_notify" in updates:
-                updates["dream_notify"] = int(updates["dream_notify"])
-            if "librarian_enabled" in updates:
-                updates["librarian_enabled"] = int(updates["librarian_enabled"])
-            if "strict_effort_enforcement" in updates:
-                updates["strict_effort_enforcement"] = int(updates["strict_effort_enforcement"])
-            if "isolated" in updates:
-                updates["isolated"] = int(updates["isolated"])
-
-            if updates:
-                updates["updated_at"] = now
-                set_clause = ", ".join(f"{k}=?" for k in updates)
-                self._db.execute(
-                    f"UPDATE agents SET {set_clause} WHERE name=?",
-                    list(updates.values()) + [name],
-                )
-                self._db.commit()
+            updated = self.update(name, **kwargs)
+            # Preserve register()'s historical signing-key backfill contract
+            # for legacy rows even though the field mutation is delegated.
+            self.get_or_create_signing_key(name)
+            return updated
         else:
             # Set up workspace — always store absolute path for portability.
             # Relative paths break when daemon CWD differs from install dir.

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -10234,10 +10234,30 @@ npm run build</pre>
             sessions = broker._streaming.get(name, {})
             if not sessions:
                 continue
+            restartable_sessions = {}
+            for session_label, session in sessions.items():
+                try:
+                    if session.state == TransportSessionState.IDLE_SLEEPING:
+                        _log(
+                            f"shutdown: skipping idle-sleeping session "
+                            f"{name}/{session_label} in restart manifest"
+                        )
+                        continue
+                except Exception:
+                    # Snapshotting is best-effort; an older compatible session
+                    # without a readable state keeps the historical behavior.
+                    pass
+                restartable_sessions[session_label] = session
+            if not restartable_sessions:
+                continue
             # One entry per agent; prefer the main session's state so a
             # multi-label agent does not overwrite it with a sub-session's.
-            label = "main" if "main" in sessions else next(iter(sessions))
-            ss = sessions[label]
+            label = (
+                "main"
+                if "main" in restartable_sessions
+                else next(iter(restartable_sessions))
+            )
+            ss = restartable_sessions[label]
             try:
                 s = ss.stats
                 manifest["agents"][name] = {

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8461,7 +8461,11 @@ npm run build</pre>
                 if ss.codex_session_id:
                     _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
                 ss.codex_session_id = ""
-            ss._config.model = req.model
+            # This is a retained-object rebuild, so refresh every durable
+            # launch setting (not just the newly-persisted model). Provider,
+            # effort, and Codex's transport-level caches may have changed in
+            # the registry since the object was constructed.
+            _refresh_streaming_launch_config(name, ss)
             try:
                 await ss.connect()
                 _log(f"api: restarted {name} with model {req.model}")

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2254,6 +2254,52 @@ def create_api(
             _log(f"api: could not resolve provider config for {agent.name}: {e}")
             return agent.provider_url or "", agent.provider_key or "", agent.provider_model or ""
 
+    def _refresh_streaming_launch_config(agent_name: str, ss) -> None:
+        """Refresh process-launch settings on a retained session object.
+
+        Reconnect paths reuse the object in ``broker._streaming``.  Without
+        this refresh, its constructor-time model/effort can outlive registry
+        changes and a rebuilt tmux pane starts with stale defaults.
+        """
+        agent = agents.get(agent_name)
+        if not agent or not agent.enabled:
+            raise RuntimeError(f"Agent '{agent_name}' is missing or disabled")
+
+        provider_url, provider_key, provider_model = _resolve_agent_provider(agent)
+        runtime = (getattr(agent, "runtime", "") or "").strip()
+        if not runtime:
+            runtime = "codex_cli" if (agent.provider_url or "").strip() == "codex_cli" else "claude_sdk"
+        if runtime == "codex_cli":
+            provider_url = "codex_cli"
+
+        # Codex's canonical selection is agents.model (what agent-card and the
+        # live /streaming/model control persist). provider_model may retain an
+        # older provider-era value; letting it win reproduced murzik's
+        # gpt-5.6-sol registry -> gpt-5.5 rebuilt pane mismatch (#856). An
+        # explicit provider_ref remains an intentional provider-model override.
+        if runtime == "codex_cli" and not (agent.provider_ref or "").strip():
+            model = agent.model or provider_model
+        else:
+            model = provider_model or agent.model
+        effort = agent.thinking_effort or "medium"
+        ss._config.model = model
+        ss._config.provider_url = provider_url
+        ss._config.provider_key = provider_key
+        ss._config.thinking_effort = effort
+        ss._config.strict_effort_enforcement = bool(
+            getattr(agent, "strict_effort_enforcement", False)
+        )
+
+        # Codex transports cache launch values outside StreamingSessionConfig.
+        if hasattr(ss, "_codex_model"):
+            ss._codex_model = model
+        if hasattr(ss, "_openai_api_key"):
+            ss._openai_api_key = provider_key or os.environ.get("OPENAI_API_KEY", "")
+        if hasattr(ss, "_reasoning_effort") and not getattr(ss, "_effort_override", None):
+            ss._reasoning_effort = effort
+
+    app.state._refresh_streaming_launch_config = _refresh_streaming_launch_config
+
     def _get_streaming_restart_guard(agent_name: str, ss) -> dict:
         """Build a restart guard for a live streaming session."""
         guard = _build_restart_guard(
@@ -3074,7 +3120,15 @@ def create_api(
         resolved_provider_url, resolved_provider_key, resolved_provider_model = _resolve_agent_provider(agent)
         if is_codex:
             resolved_provider_url = "codex_cli"
-        effective_model = resolved_provider_model or agent.model
+        # For Codex, agents.model is the operator-facing canonical model and
+        # must win over a stale provider_model left by older provider config.
+        # An explicit provider_ref (and all non-Codex custom providers) retains
+        # its intentional provider-model override.
+        effective_model = (
+            agent.model or resolved_provider_model
+            if is_codex and not (agent.provider_ref or "").strip()
+            else resolved_provider_model or agent.model
+        )
 
         # Build MCP server config for Codex agents (injected via -c flags)
         codex_mcp_servers = {}
@@ -3346,6 +3400,7 @@ def create_api(
                 # object — guard it too, else a local→unix_user update could wake
                 # the old local session under the daemon uid (Murzik #642 review).
                 _enforce_isolation_runnable(agent_name)
+                _refresh_streaming_launch_config(agent_name, ss)
                 await ss.connect()
                 return ss
 
@@ -6232,6 +6287,17 @@ npm run build</pre>
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
         agents.update(name, thinking_effort=level)
+        # Retained session objects are also used by watchdog/context rebuilds.
+        # Refresh their durable default now so an internal tmux relaunch cannot
+        # resurrect the constructor-time effort. Explicit session overrides
+        # remain effective until that session ends.
+        for ss in broker._streaming.get(name, {}).values():
+            try:
+                _refresh_streaming_launch_config(name, ss)
+            except Exception as exc:
+                # The durable update already succeeded; a malformed retained
+                # object must not turn the API response into a false failure.
+                _log(f"effort: live config refresh skipped for {name}: {exc}")
         return {"agent": name, "default": level}
 
     @app.post("/agents/{name}/sessions/{session_label}/effort")
@@ -8268,6 +8334,7 @@ npm run build</pre>
         agents.set_streaming_session_id(name, "", label="main")
 
         # Refresh wake context and reconnect fresh
+        _refresh_streaming_launch_config(name, ss)
         ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
         ss._config.resume_handle = ""
         ss._config.restart_reason = "context_restart"
@@ -8477,6 +8544,7 @@ npm run build</pre>
         agents.set_streaming_session_id(name, "", label="main")
 
         ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
+        _refresh_streaming_launch_config(name, ss)
         ss._config.resume_handle = ""
         ss.resume_handle = ""
         if hasattr(ss, "codex_session_id"):
@@ -9545,6 +9613,7 @@ npm run build</pre>
             return
         _log(f"api: watchdog resurrection — reconnecting {agent_name}")
         try:
+            _refresh_streaming_launch_config(agent_name, ss)
             # #202: serialize the fresh boot behind the process-global cold-start
             # gate so a watchdog batch-resurrection doesn't race the shared
             # single-use OAuth refresh token (no-op unless PINKY_COLDSTART_SERIALIZE).
@@ -9751,6 +9820,7 @@ npm run build</pre>
         except Exception:
             pass
         ss._config.wake_context = _build_streaming_wake_context(agent_name, commit=False)
+        _refresh_streaming_launch_config(agent_name, ss)
         ss._config.resume_handle = ""
         ss._config.restart_reason = "mcp_epoch_unbound"
         ss._config.force_fresh_context_once = True
@@ -9787,6 +9857,44 @@ npm run build</pre>
 
     # Shared MCP server (started in on_startup if enabled)
     shared_mcp_manager: SharedMcpManager | None = None
+
+    def _restart_manifest_sessions() -> dict[str, str]:
+        """Return fresh, previously-live agent/label pairs for reconciliation.
+
+        The manifest is written before shutdown disconnects transports.  Reading
+        it is deliberately non-consuming: each session consumes its own wake
+        context only after a successful connect.  Corrupt/stale state is a
+        startup warning, never a daemon-start failure.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        manifest_path = Path(db_path).parent / "restart_manifest.json"
+        if not manifest_path.exists():
+            return {}
+        try:
+            manifest = json.loads(manifest_path.read_text())
+            restart_time = manifest.get("restart_time", "")
+            if restart_time:
+                parsed = datetime.fromisoformat(restart_time)
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                if datetime.now(timezone.utc) - parsed >= timedelta(hours=2):
+                    _log("startup: restart manifest is stale; skipping sibling reconciliation")
+                    return {}
+
+            entries = manifest.get("agents", {})
+            if not isinstance(entries, dict):
+                raise ValueError("agents must be an object")
+            return {
+                str(name): str(entry.get("label") or "main")
+                for name, entry in entries.items()
+                if isinstance(entry, dict) and name
+            }
+        except Exception as exc:
+            _log(f"startup: restart manifest reconciliation skipped ({exc})")
+            return {}
+
+    app.state._restart_manifest_sessions = _restart_manifest_sessions
 
     @app.on_event("startup")
     async def on_startup():
@@ -9882,16 +9990,21 @@ npm run build</pre>
             await shared_mcp_manager.start()
             _log(f"startup: shared MCP server started on {shared_mcp_manager.url}")
 
-        # Boot policy (2026-05-11): only the **main agent** auto-resumes at boot.
-        # Sibling agents stay dormant until something triggers them — an inbound
-        # message, an agent-to-agent message, or a scheduled wake firing. Their
-        # autonomy loop + streaming session are created lazily on first dispatch
-        # (see `_ensure_streaming_session` and `autonomy.push_event`).
+        # Boot policy: the main agent always starts. Enabled siblings start only
+        # when the shutdown manifest proves they had a live streaming transport;
+        # all other siblings stay dormant until an inbound/scheduled wake.
         #
         # `auto_start_agents` is no longer used to gate boot startup. The
         # `agent.auto_start` flag is preserved for compat (`/admin/auto-start`
         # endpoint still reports it) but does not control which agents come up.
         main_name_for_boot = agents.get_main_agent()
+        # Belt-and-suspenders around a fail-safe parser: reconciliation must
+        # never prevent the daemon from reaching its normal startup path.
+        try:
+            restart_sessions = _restart_manifest_sessions()
+        except Exception as exc:  # pragma: no cover - helper already guards
+            _log(f"startup: restart reconciler failed open ({exc})")
+            restart_sessions = {}
 
         # Start broker pollers and streaming sessions for all enabled agents.
         from pinky_daemon.pollers import (
@@ -10022,14 +10135,14 @@ npm run build</pre>
                 except Exception as e:
                     _log(f"startup: iMessage poller failed for {agent.name}: {e}")
 
-            # Boot policy: only the main agent auto-resumes its streaming session.
-            # Sibling sessions are created on-demand via `_ensure_streaming_session`
-            # when an inbound message / agent-to-agent message / scheduled wake
-            # routes through the autonomy event queue. Persisted session IDs are
-            # kept in the DB so resume-by-id still works when siblings later wake.
-            if agent.name != main_name_for_boot:
+            # Resume the main agent plus any enabled sibling that was connected
+            # immediately before shutdown. Persisted IDs alone are not enough:
+            # they may be old/dormant and must retain the on-demand policy.
+            restart_label = restart_sessions.get(agent.name)
+            if agent.name != main_name_for_boot and restart_label is None:
                 _log(f"startup: skipping streaming session for {agent.name} (on-demand only)")
                 continue
+            label = "main" if agent.name == main_name_for_boot else restart_label or "main"
 
             # Validate working_dir exists — stale paths from a different machine
             # (e.g. migrating from Mac Mini to RPi) would cause Fatal errors.
@@ -10041,20 +10154,20 @@ npm run build</pre>
                         agents.set_streaming_session_id(agent.name, "", label=entry["label"])
                 continue
 
-            main_resume = agents.get_streaming_session_id(agent.name, label="main")
+            resume_id = agents.get_streaming_session_id(agent.name, label=label)
             try:
-                await _start_streaming_session(agent.name, label="main", resume_id=main_resume)
+                await _start_streaming_session(agent.name, label=label, resume_id=resume_id)
                 streaming_count += 1
-                if main_resume:
-                    _log(f"startup: streaming session resumed for {agent.name}/main (session {main_resume[:12]})")
+                if resume_id:
+                    _log(f"startup: streaming session resumed for {agent.name}/{label} (session {resume_id[:12]})")
                 else:
-                    _log(f"startup: streaming session connected for {agent.name}/main (new)")
+                    _log(f"startup: streaming session connected for {agent.name}/{label} (new)")
             except Exception as e:
-                _log(f"startup: streaming session failed for {agent.name}/main: {e}")
+                _log(f"startup: streaming session failed for {agent.name}/{label}: {e}")
                 # If resume failed, clear the stale session ID and try fresh on next boot
-                if main_resume:
-                    _log(f"startup: clearing stale session ID for {agent.name}/main")
-                    agents.set_streaming_session_id(agent.name, "", label="main")
+                if resume_id:
+                    _log(f"startup: clearing stale session ID for {agent.name}/{label}")
+                    agents.set_streaming_session_id(agent.name, "", label=label)
 
         # Clean up restored legacy SDK sessions: those superseded by a live
         # streaming session, plus unowned ghosts (blank agent_name) that would
@@ -10727,6 +10840,7 @@ npm run build</pre>
         agents.set_streaming_session_id(name, "", label="main")
 
         ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
+        _refresh_streaming_launch_config(name, ss)
         ss._config.resume_handle = ""
         ss._config.restart_reason = "force_restart"
         ss._config.force_fresh_context_once = True

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1226,6 +1226,7 @@ class MessageBroker:
         ``fix/inbound-msg-cold-wake``.
         """
         streaming = self._get_streaming_session(agent_name, message.chat_id)
+        idle_ensurer_attempted = False
 
         # Auto-wake: deliberate idle-sleep with a retained resume_handle can be
         # woken in-line by calling connect(). Per @murzik on PR #492 review,
@@ -1250,8 +1251,27 @@ class MessageBroker:
             else:
                 _log(f"broker: {agent_name} is idle-sleeping — auto-waking for inbound message")
                 try:
-                    await streaming.connect()
-                    _log(f"broker: {agent_name} auto-woke successfully")
+                    if self._ensure_session_callback:
+                        # Production wires the API ensurer, which refreshes the
+                        # retained object's registry-backed launch config before
+                        # connect(). Direct connect here resurrected stale
+                        # model/provider/effort after idle sleep (#856).
+                        labels = self._streaming.get(agent_name, {})
+                        label = next(
+                            (key for key, session in labels.items() if session is streaming),
+                            "main",
+                        )
+                        idle_ensurer_attempted = True
+                        streaming = await self._ensure_session_callback(
+                            agent_name, label=label
+                        )
+                    else:
+                        await streaming.connect()
+                    if streaming and streaming.state == SessionState.CONNECTED:
+                        _log(f"broker: {agent_name} auto-woke successfully")
+                    else:
+                        _log(f"broker: {agent_name} auto-wake did not connect")
+                        streaming = None
                 except Exception as e:
                     _log(f"broker: {agent_name} auto-wake failed: {e}")
                     streaming = None
@@ -1264,7 +1284,11 @@ class MessageBroker:
         # in-flight-reconnect cases (streaming exists but state != CONNECTED)
         # fall through to the wait-for-reconnect block below; cold-starting
         # over them would race the in-flight reconnect.
-        if streaming is None and self._ensure_session_callback:
+        if (
+            streaming is None
+            and self._ensure_session_callback
+            and not idle_ensurer_attempted
+        ):
             label = "main"
             try:
                 if message.chat_id:

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -315,6 +315,16 @@ class TestAgentCRUD:
             registry.update("ghost", thinking_effort="high")
         assert registry.get("ghost") is None
 
+    def test_update_rejects_working_dir_path_mutation(self, registry, tmp_path):
+        original = tmp_path / "original"
+        registry.register("murzik", working_dir=str(original))
+
+        with pytest.raises(ValueError, match="working_dir"):
+            registry.update("murzik", working_dir=str(tmp_path / "other"))
+
+        assert registry.get("murzik").working_dir == str(original)
+        assert not (tmp_path / "other").exists()
+
     def test_get(self, registry):
         registry.register("test")
         agent = registry.get("test")

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -288,6 +288,33 @@ class TestAgentCRUD:
         agent = registry.register("oleg", model="opus")
         assert agent.model == "opus"
 
+    def test_update_is_partial_and_preserves_unset_fields(self, registry):
+        registry.register(
+            "murzik",
+            display_name="Murzik",
+            model="gpt-5.6-sol",
+            thinking_effort="high",
+            runtime="codex_cli",
+            transport="tmux",
+            groups=["reviewers"],
+            allowed_tools=["Read", "Grep"],
+        )
+
+        updated = registry.update("murzik", thinking_effort="xhigh")
+
+        assert updated.thinking_effort == "xhigh"
+        assert updated.display_name == "Murzik"
+        assert updated.model == "gpt-5.6-sol"
+        assert updated.runtime == "codex_cli"
+        assert updated.transport == "tmux"
+        assert updated.groups == ["reviewers"]
+        assert updated.allowed_tools == ["Read", "Grep"]
+
+    def test_update_never_creates_a_missing_agent(self, registry):
+        with pytest.raises(KeyError, match="not found"):
+            registry.update("ghost", thinking_effort="high")
+        assert registry.get("ghost") is None
+
     def test_get(self, registry):
         registry.register("test")
         agent = registry.get("test")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2359,6 +2359,149 @@ class TestAPI:
                 assert "main" in labels
                 assert "worker" not in labels
 
+    def test_restart_manifest_reconciles_live_sibling_with_registry_config(self):
+        """#856: daemon restart restores previously-live sibling panes only.
+
+        The rebuilt Codex/tmux session must take model + effort from the
+        durable registry, while a dormant sibling with only a historical
+        session id remains on-demand. One failed sibling may not abort startup.
+        """
+        from datetime import datetime, timezone
+        from pathlib import Path
+
+        from pinky_daemon.transport_state import SessionState as TransportState
+
+        async def fake_connect(self):
+            if self.agent_name == "broken":
+                raise RuntimeError("disposable startup failure")
+            self._state_machine._state = TransportState.CONNECTED
+
+        async def fake_disconnect(self):
+            self._state_machine._state = TransportState.DEAD
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.codex_tmux_session.CodexTmuxSession.connect", new=fake_connect), \
+                patch("pinky_daemon.codex_tmux_session.CodexTmuxSession.disconnect", new=fake_disconnect), \
+                patch("pinky_daemon.api.SHARED_MCP_ENABLED", False):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            for name, model, effort in (
+                ("main", "gpt-5.5", "medium"),
+                ("murzik", "gpt-5.6-sol", "xhigh"),
+                ("dormant", "gpt-5.5", "high"),
+                ("broken", "gpt-5.5", "high"),
+            ):
+                app.state.agents.register(
+                    name,
+                    model=model,
+                    provider_model="gpt-5.5" if name == "murzik" else "",
+                    thinking_effort=effort,
+                    runtime="codex_cli",
+                    transport="tmux",
+                    working_dir=os.path.join(tmpdir, name),
+                )
+                app.state.agents.set_streaming_session_id(
+                    name, f"resume-{name}", label="main"
+                )
+            app.state.agents.set_main_agent("main")
+            Path(tmpdir, "restart_manifest.json").write_text(json.dumps({
+                "restart_time": datetime.now(timezone.utc).isoformat(),
+                "planned": True,
+                "agents": {
+                    "murzik": {"label": "main"},
+                    "broken": {"label": "main"},
+                },
+            }))
+
+            with TestClient(app) as client:
+                assert client.get("/admin/watchdog").status_code == 200
+                assert "main" in app.state.broker._streaming
+                assert "murzik" in app.state.broker._streaming
+                assert "dormant" not in app.state.broker._streaming
+                assert "broken" not in app.state.broker._streaming
+
+                rebuilt = app.state.broker._streaming["murzik"]["main"]
+                assert rebuilt._config.model == "gpt-5.6-sol"
+                assert rebuilt._config.thinking_effort == "xhigh"
+                assert rebuilt._codex_model == "gpt-5.6-sol"
+                assert rebuilt._reasoning_effort == "xhigh"
+
+    def test_retained_rebuild_refreshes_model_and_effort_from_registry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register(
+                "murzik",
+                model="gpt-5.6-sol",
+                provider_model="gpt-5.5",
+                thinking_effort="xhigh",
+                runtime="codex_cli",
+                transport="tmux",
+                working_dir=os.path.join(tmpdir, "murzik"),
+            )
+            config = SimpleNamespace(
+                model="gpt-5.5",
+                provider_url="",
+                provider_key="",
+                thinking_effort="high",
+                strict_effort_enforcement=False,
+            )
+            retained = SimpleNamespace(
+                _config=config,
+                _codex_model="gpt-5.5",
+                _reasoning_effort="high",
+                _openai_api_key="",
+                _effort_override=None,
+            )
+
+            app.state._refresh_streaming_launch_config("murzik", retained)
+
+            assert config.model == "gpt-5.6-sol"
+            assert config.thinking_effort == "xhigh"
+            assert retained._codex_model == "gpt-5.6-sol"
+            assert retained._reasoning_effort == "xhigh"
+
+    def test_put_effort_is_partial_and_durable(self):
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.api.SHARED_MCP_ENABLED", False):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                app.state.agents.register(
+                    "murzik",
+                    display_name="Murzik",
+                    model="gpt-5.6-sol",
+                    thinking_effort="high",
+                    runtime="codex_cli",
+                    transport="tmux",
+                    groups=["reviewers"],
+                    working_dir=os.path.join(tmpdir, "murzik"),
+                )
+
+                response = client.put(
+                    "/agents/murzik/effort", json={"effort": "xhigh"}
+                )
+                assert response.status_code == 200
+                assert response.json() == {"agent": "murzik", "default": "xhigh"}
+                current = client.get("/agents/murzik/effort").json()
+                assert current["default"] == "xhigh"
+
+                unchanged = app.state.agents.get("murzik")
+                assert unchanged.display_name == "Murzik"
+                assert unchanged.model == "gpt-5.6-sol"
+                assert unchanged.runtime == "codex_cli"
+                assert unchanged.transport == "tmux"
+                assert unchanged.groups == ["reviewers"]
+                registry_path = app.state.agents._db.execute(
+                    "PRAGMA database_list"
+                ).fetchone()[2]
+
+            with sqlite3.connect(registry_path) as reopened:
+                row = reopened.execute(
+                    "SELECT thinking_effort FROM agents WHERE name=?", ("murzik",)
+                ).fetchone()
+            assert row == ("xhigh",)
+
     def test_get_session(self):
         client = self._make_client()
         client.post("/sessions", json={"session_id": "test"})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2461,6 +2461,111 @@ class TestAPI:
             assert retained._codex_model == "gpt-5.6-sol"
             assert retained._reasoning_effort == "xhigh"
 
+    @pytest.mark.asyncio
+    async def test_inbound_idle_wake_refreshes_retained_launch_config(self):
+        """#856: broker idle auto-wake must route through the API ensurer."""
+        from pinky_daemon.transport_state import SessionState as TransportState
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            app.state.agents.register(
+                "murzik",
+                model="gpt-5.6-sol",
+                provider_model="gpt-5.5",
+                thinking_effort="xhigh",
+                runtime="codex_cli",
+                transport="tmux",
+                working_dir=os.path.join(tmpdir, "murzik"),
+            )
+
+            class _RetainedSleepingSession:
+                def __init__(self):
+                    self.state = TransportState.IDLE_SLEEPING
+                    self.resume_handle = "codex-resume"
+                    self._config = SimpleNamespace(
+                        model="gpt-5.5",
+                        provider_url="codex_cli",
+                        provider_key="",
+                        thinking_effort="high",
+                        strict_effort_enforcement=False,
+                    )
+                    self._codex_model = "gpt-5.5"
+                    self._reasoning_effort = "high"
+                    self._openai_api_key = ""
+                    self._effort_override = None
+                    self.sent = []
+
+                async def connect(self):
+                    self.state = TransportState.CONNECTED
+
+                async def send(self, prompt, **kwargs):
+                    self.sent.append((prompt, kwargs))
+
+            retained = _RetainedSleepingSession()
+            app.state.broker.register_streaming("murzik", retained, label="main")
+            message = BrokerMessage(
+                platform="telegram",
+                chat_id="6770805286",
+                sender_name="Brad",
+                sender_id="u-1",
+                content="wake with current defaults",
+                agent_name="murzik",
+            )
+
+            await app.state.broker._route_streaming("murzik", message)
+
+            assert retained.state == TransportState.CONNECTED
+            assert retained.sent
+            assert retained._config.model == "gpt-5.6-sol"
+            assert retained._config.thinking_effort == "xhigh"
+            assert retained._codex_model == "gpt-5.6-sol"
+            assert retained._reasoning_effort == "xhigh"
+
+    def test_shutdown_manifest_excludes_idle_sleeping_siblings(self):
+        from pathlib import Path
+
+        from pinky_daemon.transport_state import SessionState as TransportState
+
+        class _ManifestSession:
+            def __init__(self, state):
+                self.state = state
+                self.stats = {
+                    "current_activity": "",
+                    "activity_log": [],
+                    "pending_responses": 0,
+                }
+
+            async def disconnect(self):
+                self.state = TransportState.DEAD
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("pinky_daemon.api.SHARED_MCP_ENABLED", False):
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app):
+                app.state.agents.register(
+                    "idle", working_dir=os.path.join(tmpdir, "idle")
+                )
+                app.state.agents.register(
+                    "active", working_dir=os.path.join(tmpdir, "active")
+                )
+                app.state.broker.register_streaming(
+                    "idle",
+                    _ManifestSession(TransportState.IDLE_SLEEPING),
+                    label="main",
+                )
+                app.state.broker.register_streaming(
+                    "active",
+                    _ManifestSession(TransportState.CONNECTED),
+                    label="main",
+                )
+
+            manifest = json.loads(
+                Path(tmpdir, "restart_manifest.json").read_text()
+            )
+            assert set(manifest["agents"]) == {"active"}
+
     def test_put_effort_is_partial_and_durable(self):
         with tempfile.TemporaryDirectory() as tmpdir, \
                 patch("pinky_daemon.api.SHARED_MCP_ENABLED", False):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2191,6 +2191,95 @@ class TestAPI:
                 assert fake.codex_session_id == ""
                 assert fake.resume_handle == ""
 
+    def test_streaming_model_restart_refreshes_retained_launch_config(self):
+        """#856: a context-window rebuild uses current registry defaults.
+
+        A retained Codex object can predate durable provider/effort changes.
+        The model endpoint must refresh both StreamingSessionConfig and the
+        Codex launch caches before reconnecting it.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                app.state.agents.register(
+                    "murzik",
+                    model="claude-opus-4-7",
+                    runtime="codex_cli",
+                    transport="tmux",
+                    provider_url="codex_cli",
+                    provider_key="old-key",
+                    thinking_effort="low",
+                    working_dir=os.path.join(tmpdir, "murzik"),
+                )
+                fake = self._FakeStreamingSession(
+                    "murzik", "main", max_tokens=1_000_000
+                )
+                fake._config.model = "claude-opus-4-7"
+                fake._config.provider_url = "codex_cli"
+                fake._config.provider_key = "old-key"
+                fake._config.thinking_effort = "low"
+                fake._config.strict_effort_enforcement = False
+                fake._codex_model = "claude-opus-4-7"
+                fake._openai_api_key = "old-key"
+                fake._reasoning_effort = "low"
+                fake._effort_override = None
+                app.state.broker.register_streaming("murzik", fake, label="main")
+
+                app.state.agents.set_context(
+                    "murzik",
+                    task="Testing registry-backed context-window rebuild",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.resume_handle,
+                )
+                fake.last_active = time.time()
+
+                updated = client.put(
+                    "/agents/murzik",
+                    json={"provider_key": "new-key", "thinking_effort": "xhigh"},
+                )
+                assert updated.status_code == 200, updated.text
+                # The retained object is intentionally stale until a rebuild.
+                assert fake._openai_api_key == "old-key"
+                assert fake._reasoning_effort == "low"
+
+                observed = {}
+
+                async def connect_with_snapshot():
+                    observed.update(
+                        config_model=fake._config.model,
+                        config_provider_url=fake._config.provider_url,
+                        config_provider_key=fake._config.provider_key,
+                        config_effort=fake._config.thinking_effort,
+                        codex_model=fake._codex_model,
+                        openai_api_key=fake._openai_api_key,
+                        reasoning_effort=fake._reasoning_effort,
+                    )
+                    fake.connect_calls += 1
+                    fake._state = fake._TS.CONNECTED
+
+                fake.connect = connect_with_snapshot
+                response = client.post(
+                    "/agents/murzik/streaming/model",
+                    json={"model": "gpt-5.6-sol"},
+                )
+
+                assert response.status_code == 200, response.text
+                assert response.json()["restarted"] is True
+                assert observed == {
+                    "config_model": "gpt-5.6-sol",
+                    "config_provider_url": "codex_cli",
+                    "config_provider_key": "new-key",
+                    "config_effort": "xhigh",
+                    "codex_model": "gpt-5.6-sol",
+                    "openai_api_key": "new-key",
+                    "reasoning_effort": "xhigh",
+                }
+                durable = app.state.agents.get("murzik")
+                assert durable.model == "gpt-5.6-sol"
+                assert durable.provider_key == "new-key"
+                assert durable.thinking_effort == "xhigh"
+
     def test_streaming_archive_clears_codex_session_id(self):
         """/streaming/archive must clear codex_session_id alongside session_id —
         same bug pattern as /streaming/restart."""

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1438,10 +1438,10 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_route_streaming_uses_existing_disconnected_session_before_ensurer(self):
+    async def test_route_streaming_uses_ensurer_for_existing_idle_session(self):
         """If a session object exists with a persisted session_id but is
-        disconnected, the existing auto-wake (reconnect) path must run
-        first — the ensurer is only for the cold-start case.
+        idle-sleeping, production routes its reconnect through the ensurer so
+        registry-backed launch configuration is refreshed first (#856).
         """
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
@@ -1469,7 +1469,8 @@ class TestMessageBrokerRouting:
 
             async def fake_ensurer(agent_name, *, label):
                 ensure_calls.append((agent_name, label))
-                return None  # would fail if called — we expect it NOT to be
+                await ss.connect()
+                return ss
 
             broker.set_ensure_session_callback(fake_ensurer)
 
@@ -1483,13 +1484,9 @@ class TestMessageBrokerRouting:
             )
             await broker._route_streaming("lera", msg)
 
-            # Existing session's connect() was called once.
+            # The ensurer owns the existing session's one reconnect.
             assert _FakeStreaming.connect_calls == 1
-            # Ensurer was NOT called — existing session won.
-            assert ensure_calls == [], (
-                f"ensurer should not be called when an existing session is "
-                f"reconnectable, got: {ensure_calls}"
-            )
+            assert ensure_calls == [("lera", "main")]
             assert _FakeStreaming.sent, "reconnected session received no message"
         finally:
             tmpdir.cleanup()


### PR DESCRIPTION
Closes #856
Closes #855

## Summary

- reconcile enabled sibling streaming sessions from the fresh shutdown manifest, while keeping dormant historical and idle-sleeping sessions on-demand
- isolate corrupt manifests and individual launch failures so reconciliation cannot abort normal daemon startup
- rebuild fresh and retained sessions from durable registry model/effort; broker idle auto-wake routes through the same refreshing ensurer
- for Codex, the canonical agent model beats stale direct provider metadata while explicit provider refs keep their intended override
- add a true path-free, partial-only `AgentRegistry.update`; `PUT /agents/{name}/effort` is durable without clobbering omitted fields, and path mutation remains on the legacy admin register flow

## Regression coverage

- daemon restart restores manifest-listed Codex/tmux siblings without a message
- a failing sibling does not block main startup; dormant persisted and idle-sleeping siblings stay dormant
- fresh, retained, and inbound-idle rebuilds resolve the exact production split (`model=gpt-5.6-sol`, stale `provider_model=gpt-5.5`) plus durable effort
- effort PUT round-trips, survives a DB reopen, and preserves unrelated agent configuration
- public partial update rejects `working_dir`; legacy register working-directory invariants remain green

## Validation

- exact-head affected suite: 559 passed
- exact-head focused review/CI edges: 14 passed, then 7/7 after the broker contract pin
- parent implementation head full suite under CI-clean env: 4277 passed, 3 skipped
- Ruff: clean
- `git diff --check`: clean

🤖 Opened by Kuzya