### PR TITLE
fix(slack): preserve thread roots and provenance (#341)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7790,6 +7790,7 @@ npm run build</pre>
         _deny_isolated_cross_actor(request, agent_name)
 
         ctx = _resolve_message_context(agent_name, source_message_id)
+        effective_thread_root = ctx.reply_to or ctx.message_id
         voice_settings = _get_voice_reply_settings(agent_name, ctx.platform)
 
         if ctx.source_was_voice and voice_settings:
@@ -7801,7 +7802,7 @@ npm run build</pre>
                 provider=voice_settings["provider"],
                 voice=voice_settings["voice"],
                 model=voice_settings["model"],
-                reply_to=ctx.message_id,
+                reply_to=effective_thread_root,
                 include_text_copy=True,
                 link_preview_options=link_preview_options,
                 quote=quote,
@@ -7825,7 +7826,7 @@ npm run build</pre>
             ctx.platform,
             ctx.chat_id,
             content,
-            reply_to=ctx.message_id,
+            reply_to=effective_thread_root,
             parse_mode=parse_mode,
             link_preview_options=link_preview_options,
             quote=quote,

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1108,12 +1108,16 @@ class MessageBroker:
         except Exception:
             ts = datetime.fromtimestamp(message.timestamp, tz=tz.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
         msg_id = f" | msg_id:{message.message_id}" if message.message_id else ""
+        thread_provenance = (
+            f" | thread_root_ts:{message.reply_to} | is_thread_reply:true"
+            if message.reply_to else ""
+        )
         if message.is_group:
             alias = self._registry.get_group_chat_alias(message.agent_name, message.chat_id)
             display = alias or message.chat_title or message.chat_id
-            header = f"[{message.platform} | group | {display} | {message.sender_name} | {message.chat_id} | {ts}{msg_id}]"
+            header = f"[{message.platform} | group | {display} | {message.sender_name} | {message.chat_id} | {ts}{msg_id}{thread_provenance}]"
         else:
-            header = f"[{message.platform} | dm | {message.sender_name} | {message.chat_id} | {ts}{msg_id}]"
+            header = f"[{message.platform} | dm | {message.sender_name} | {message.chat_id} | {ts}{msg_id}{thread_provenance}]"
 
         body = message.content
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2849,6 +2849,36 @@ class TestAPI:
                 assert history[-1].metadata["tool"] == "thread"
                 assert history[-1].metadata["source_message_id"] == "101"
 
+    def test_broker_thread_child_reply_uses_stored_root_ts(self):
+        """A reply to a Slack child stays on the original thread root."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "slack", "xoxb-test")
+                app.state.broker.remember_message_context(
+                    BrokerMessage(
+                        platform="slack", chat_id="C123", sender_name="Alex",
+                        sender_id="U123", content="child reply", agent_name="barsik",
+                        message_id="1711584001.000200",
+                        reply_to="1711584000.000100",
+                        is_group=True,
+                    )
+                )
+
+                with patch(
+                    "pinky_outreach.slack.SlackAdapter.send_message",
+                    return_value=SimpleNamespace(message_id="1711584002.000300"),
+                ) as mock:
+                    resp = client.post("/broker/thread", json={
+                        "agent_name": "barsik",
+                        "message_id": "1711584001.000200",
+                        "content": "on the same thread",
+                    })
+
+                assert resp.status_code == 200, resp.text
+                assert mock.call_args.kwargs["thread_ts"] == "1711584000.000100"
+
     def test_broker_thread_quote_builds_reply_parameters(self):
         """thread(quote=...) builds ReplyParameters quoting the given passage."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -40,6 +40,49 @@ class TestMessageBrokerRouting:
         )
         return tmpdir, registry, broker, sent_messages, reactions
 
+    def test_format_prompt_includes_thread_provenance_for_child_reply(self):
+        tmpdir, registry, broker, _sent, _reactions = self._make_broker()
+        try:
+            registry.set_default_timezone("UTC")
+            prompt = broker._format_prompt(
+                BrokerMessage(
+                    platform="slack", chat_id="C123", sender_name="Alex",
+                    sender_id="U123", content="in thread", agent_name="barsik",
+                    message_id="1711584001.000200",
+                    reply_to="1711584000.000100",
+                    is_group=True,
+                    timestamp=0,
+                )
+            )
+            header = prompt.splitlines()[0]
+            assert "thread_root_ts:1711584000.000100" in header
+            assert "is_thread_reply:true" in header
+        finally:
+            tmpdir.cleanup()
+
+    def test_format_prompt_top_level_header_is_unchanged(self):
+        tmpdir, registry, broker, _sent, _reactions = self._make_broker()
+        try:
+            registry.set_default_timezone("UTC")
+            prompt = broker._format_prompt(
+                BrokerMessage(
+                    platform="slack", chat_id="C123", sender_name="Alex",
+                    sender_id="U123", content="top level", agent_name="barsik",
+                    message_id="1711584000.000100",
+                    is_group=True,
+                    timestamp=0,
+                )
+            )
+            header = prompt.splitlines()[0]
+            assert "thread_root_ts:" not in header
+            assert "is_thread_reply:" not in header
+            assert header == (
+                "[slack | group | C123 | Alex | C123 | "
+                "1970-01-01 00:00:00 UTC | msg_id:1711584000.000100]"
+            )
+        finally:
+            tmpdir.cleanup()
+
     @pytest.mark.asyncio
     async def test_route_response_suppresses_fallback_on_external_dm(self):
         # Owner rule (Brad, 2026-06-22): plain-text fallback NEVER auto-delivers


### PR DESCRIPTION
## Summary

- Make `/broker/thread` use the stored thread root (`ctx.reply_to`) when replying to a child, falling back to the source message ID for top-level inbound messages.
- Apply the same effective root to text and automatic voice replies.
- Add `thread_root_ts` and `is_thread_reply:true` to inbound prompt headers only for in-thread messages; top-level headers remain unchanged.

## Scope

This is the independent Inc 0.5 correctness patch from the approved #341 scope. It is based directly on `origin/main` at `cd33f02` and does not stack on the #863 emergency branch.

## Verification

- `env -u PINKY_DREAM_TRANSPORT -u PINKY_AUTH_DENY_DEFAULT PINKY_SHARED_MCP=0 uv run pytest -q` — 4305 passed, 3 skipped
- `PINKY_SHARED_MCP=0 uv run pytest -q tests/test_broker.py tests/test_api.py -k "broker_thread or format_prompt"` — 10 passed
- `uv run ruff check src/pinky_daemon/api.py src/pinky_daemon/broker.py tests/test_api.py tests/test_broker.py`
- `git diff --check`

Refs #341