### PR TITLE
fix(broker): durable canonical owner approval notifications (#863)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1269,6 +1269,29 @@ class AgentRegistry:
                 FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE
             );
 
+            CREATE TABLE IF NOT EXISTS approval_requests (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_name TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                target_name TEXT NOT NULL DEFAULT '',
+                is_channel INTEGER NOT NULL DEFAULT 0,
+                gate_state TEXT NOT NULL DEFAULT 'pending',
+                held_count INTEGER NOT NULL DEFAULT 0,
+                oldest_held_at REAL NOT NULL DEFAULT 0,
+                notification_state TEXT NOT NULL DEFAULT 'retrying',
+                notification_attempts INTEGER NOT NULL DEFAULT 0,
+                notified_held_count INTEGER NOT NULL DEFAULT 0,
+                last_notified_at REAL NOT NULL DEFAULT 0,
+                next_retry_at REAL NOT NULL DEFAULT 0,
+                last_error TEXT NOT NULL DEFAULT '',
+                notification_destination TEXT NOT NULL DEFAULT '{}',
+                fallback_path TEXT NOT NULL DEFAULT '[]',
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
+                UNIQUE(agent_name, chat_id)
+            );
+
             CREATE TABLE IF NOT EXISTS group_chats (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 agent_name TEXT NOT NULL,
@@ -1338,6 +1361,8 @@ class AgentRegistry:
                 ON agent_schedules(agent_name);
             CREATE INDEX IF NOT EXISTS idx_pending_messages_agent_chat
                 ON pending_messages(agent_name, chat_id, delivered);
+            CREATE INDEX IF NOT EXISTS idx_approval_requests_retry
+                ON approval_requests(gate_state, notification_state, next_retry_at);
             CREATE INDEX IF NOT EXISTS idx_group_chats_agent
                 ON group_chats(agent_name);
             CREATE INDEX IF NOT EXISTS idx_streaming_session_labels_agent
@@ -3592,6 +3617,163 @@ except Exception:
         self._db.commit()
         return cursor.rowcount
 
+    # ── Approval Requests (#863 emergency lane) ─────────────
+
+    @staticmethod
+    def _approval_request_dict(row) -> dict:
+        return {
+            "id": row[0], "agent_name": row[1], "chat_id": row[2],
+            "target_name": row[3], "is_channel": bool(row[4]),
+            "gate_state": row[5], "held_count": row[6],
+            "oldest_held_at": row[7], "notification_state": row[8],
+            "notification_attempts": row[9], "notified_held_count": row[10],
+            "last_notified_at": row[11], "next_retry_at": row[12],
+            "last_error": row[13],
+            "notification_destination": json.loads(row[14] or "{}"),
+            "fallback_path": json.loads(row[15] or "[]"),
+            "created_at": row[16], "updated_at": row[17],
+        }
+
+    def get_approval_request(self, agent_name: str, chat_id: str) -> dict | None:
+        """Return the stable request for a legacy ``(agent, chat_id)`` gate.
+
+        Inc 0 deliberately does not accept platform/team/conversation here.
+        Those composite approval keys belong to Inc 1 after row-key migration.
+        """
+        row = self._db.execute(
+            """SELECT id, agent_name, chat_id, target_name, is_channel,
+                      gate_state, held_count, oldest_held_at, notification_state,
+                      notification_attempts, notified_held_count, last_notified_at,
+                      next_retry_at, last_error, notification_destination,
+                      fallback_path, created_at, updated_at
+               FROM approval_requests WHERE agent_name=? AND chat_id=?""",
+            (agent_name, chat_id),
+        ).fetchone()
+        return self._approval_request_dict(row) if row else None
+
+    def record_approval_hold(
+        self, agent_name: str, chat_id: str, *, target_name: str = "",
+        is_channel: bool = False, held_at: float | None = None,
+    ) -> dict:
+        """Create or aggregate one approval request on the legacy gate key."""
+        now = held_at if held_at is not None else time.time()
+        self._db.execute(
+            """INSERT INTO approval_requests
+               (agent_name, chat_id, target_name, is_channel, gate_state,
+                held_count, oldest_held_at, notification_state, created_at, updated_at)
+               VALUES (?, ?, ?, ?, 'pending', 1, ?, 'retrying', ?, ?)
+               ON CONFLICT(agent_name, chat_id) DO UPDATE SET
+                   target_name=CASE WHEN excluded.target_name != ''
+                                    THEN excluded.target_name ELSE target_name END,
+                   is_channel=excluded.is_channel,
+                   gate_state='pending',
+                   held_count=held_count + 1,
+                   oldest_held_at=CASE WHEN oldest_held_at=0
+                                      THEN excluded.oldest_held_at ELSE oldest_held_at END,
+                   updated_at=excluded.updated_at""",
+            (agent_name, chat_id, target_name, int(is_channel), now, now, now),
+        )
+        self._db.commit()
+        return self.get_approval_request(agent_name, chat_id)  # type: ignore[return-value]
+
+    def begin_approval_notification(self, request_id: int, *, reset_attempts: bool) -> None:
+        """Mark a notification cycle active, optionally resetting re-notify attempts."""
+        reset_sql = ", notification_attempts=0" if reset_attempts else ""
+        self._db.execute(
+            f"""UPDATE approval_requests
+                SET notification_state='retrying', last_error='', updated_at=?
+                    {reset_sql}
+                WHERE id=? AND gate_state='pending'""",
+            (time.time(), request_id),
+        )
+        self._db.commit()
+
+    def record_approval_notification_failure(
+        self, request_id: int, *, error: str, next_retry_at: float,
+        failed: bool, fallback_path: list[dict],
+    ) -> None:
+        state = "failed" if failed else "retrying"
+        self._db.execute(
+            """UPDATE approval_requests
+               SET notification_state=?, notification_attempts=notification_attempts+1,
+                   next_retry_at=?, last_error=?, fallback_path=?, updated_at=?
+               WHERE id=? AND gate_state='pending'""",
+            (
+                state, next_retry_at, error[:1000],
+                json.dumps(fallback_path, separators=(",", ":")), time.time(), request_id,
+            ),
+        )
+        self._db.commit()
+
+    def record_approval_notification_delivered(
+        self, request_id: int, *, destination: dict, fallback_path: list[dict],
+    ) -> None:
+        now = time.time()
+        self._db.execute(
+            """UPDATE approval_requests
+               SET notification_state='delivered', notification_attempts=0,
+                   notified_held_count=held_count, last_notified_at=?, next_retry_at=0,
+                   last_error='', notification_destination=?, fallback_path=?, updated_at=?
+               WHERE id=? AND gate_state='pending'""",
+            (
+                now, json.dumps(destination, separators=(",", ":")),
+                json.dumps(fallback_path, separators=(",", ":")), now, request_id,
+            ),
+        )
+        self._db.commit()
+
+    def settle_approval_request(self, agent_name: str, chat_id: str, state: str) -> None:
+        if state not in ("approved", "denied"):
+            raise ValueError(f"invalid approval gate state: {state}")
+        self._db.execute(
+            """UPDATE approval_requests
+               SET gate_state=?, next_retry_at=0, updated_at=?
+               WHERE agent_name=? AND chat_id=?""",
+            (state, time.time(), agent_name, chat_id),
+        )
+        self._db.commit()
+
+    def list_due_approval_notifications(self, now: float | None = None) -> list[dict]:
+        due_at = time.time() if now is None else now
+        rows = self._db.execute(
+            """SELECT id, agent_name, chat_id, target_name, is_channel,
+                      gate_state, held_count, oldest_held_at, notification_state,
+                      notification_attempts, notified_held_count, last_notified_at,
+                      next_retry_at, last_error, notification_destination,
+                      fallback_path, created_at, updated_at
+               FROM approval_requests
+               WHERE gate_state='pending' AND notification_state='retrying'
+                 AND next_retry_at <= ? ORDER BY next_retry_at, id""",
+            (due_at,),
+        ).fetchall()
+        return [self._approval_request_dict(row) for row in rows]
+
+    def get_approval_notification_health(self, agent_name: str) -> dict:
+        rows = self._db.execute(
+            """SELECT id, chat_id, held_count, oldest_held_at, notification_state,
+                      notification_attempts, next_retry_at, last_error
+               FROM approval_requests
+               WHERE agent_name=? AND gate_state='pending'
+                 AND notification_state IN ('retrying', 'failed')
+               ORDER BY created_at""",
+            (agent_name,),
+        ).fetchall()
+        requests = [
+            {
+                "request_id": r[0], "chat_id": r[1], "held_count": r[2],
+                "oldest_age_seconds": max(0, int(time.time() - r[3])) if r[3] else 0,
+                "notification_state": r[4], "attempts": r[5],
+                "next_retry_at": r[6], "last_error": r[7],
+            }
+            for r in rows
+        ]
+        return {
+            "healthy": not requests,
+            "retrying": sum(r[4] == "retrying" for r in rows),
+            "failed": sum(r[4] == "failed" for r in rows),
+            "requests": requests,
+        }
+
     # ── Group Chats ─────────────────────────────────────────
 
     def upsert_group_chat(
@@ -3766,6 +3948,77 @@ except Exception:
             if status != "approved":
                 self.approve_user(agent.name, chat_id, display_name, "primary_user")
                 _log(f"agent_registry: auto-approved primary user {chat_id} for {agent.name}")
+
+    # ── Owner notification destinations (#863) ─────────────
+
+    @staticmethod
+    def _normalize_owner_destination(destination: dict) -> dict:
+        if not isinstance(destination, dict):
+            raise ValueError("owner notification destination must be an object")
+        normalized = {
+            "platform": str(destination.get("platform") or "").strip().lower(),
+            "account_id": str(
+                destination.get("account_id")
+                or destination.get("team_id")
+                or destination.get("workspace_id")
+                or ""
+            ).strip(),
+            "conversation_id": str(destination.get("conversation_id") or "").strip(),
+        }
+        if not all(normalized.values()):
+            raise ValueError(
+                "owner notification destination requires platform, "
+                "account_id/team_id/workspace_id, and conversation_id"
+            )
+        return normalized
+
+    def get_owner_notification_destinations(self) -> list[dict]:
+        """Return the primary destination followed by ordered fallbacks."""
+        raw = self.get_setting("owner_notification_destinations", "")
+        if not raw:
+            return []
+        try:
+            parsed = json.loads(raw)
+            if not isinstance(parsed, list):
+                raise ValueError("must be a list")
+            return [self._normalize_owner_destination(item) for item in parsed]
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            _log(f"agent_registry: invalid owner_notification_destinations: {exc}")
+            return []
+
+    def set_owner_notification_destinations(self, destinations: list[dict]) -> list[dict]:
+        """Store a canonical primary destination and ordered fallback list."""
+        if not isinstance(destinations, list) or not destinations:
+            raise ValueError("at least one owner notification destination is required")
+        normalized = [self._normalize_owner_destination(item) for item in destinations]
+        self.set_setting(
+            "owner_notification_destinations",
+            json.dumps(normalized, separators=(",", ":")),
+        )
+        return normalized
+
+    def migrate_primary_user_notification_destination(
+        self, *, platform: str, account_id: str,
+    ) -> list[dict]:
+        """Seed the destination tuple from the legacy primary-user chat id.
+
+        ``platform`` and ``account_id`` are mandatory migration inputs. They
+        are never guessed from inbound traffic or the shape of the legacy id.
+        Existing canonical configuration is preserved unchanged.
+        """
+        existing = self.get_owner_notification_destinations()
+        if existing:
+            return existing
+        primary_chat_id = self.get_setting("primary_user_chat_id", "").strip()
+        if not primary_chat_id:
+            raise ValueError("primary_user_chat_id is not configured")
+        return self.set_owner_notification_destinations([
+            {
+                "platform": platform,
+                "account_id": account_id,
+                "conversation_id": primary_chat_id,
+            }
+        ])
 
     # ── Purchase Approvers (financial boundary, #249) ─────────
     #

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2834,6 +2834,27 @@ except Exception:
             return ref_row[0] if ref_row else ""
         return ""
 
+    def get_token_account_id(self, agent_name: str, platform: str) -> str:
+        """Return the explicit provider account/team/workspace binding."""
+        token = self.get_token(agent_name, platform)
+        if not token or not token.enabled or not token.token_set:
+            return ""
+        return str(
+            token.settings.get("account_id")
+            or token.settings.get("team_id")
+            or token.settings.get("workspace_id")
+            or ""
+        ).strip()
+
+    def get_raw_token_for_account(
+        self, agent_name: str, platform: str, account_id: str,
+    ) -> str:
+        """Resolve a token only when its explicit account binding is exact."""
+        requested = str(account_id or "").strip()
+        if not requested or self.get_token_account_id(agent_name, platform) != requested:
+            return ""
+        return self.get_raw_token(agent_name, platform)
+
     def list_tokens(self, agent_name: str) -> list[AgentToken]:
         """List all tokens for an agent."""
         rows = self._db.execute(
@@ -3549,6 +3570,20 @@ except Exception:
         message arrived in a group/channel so it re-delivers with the right
         context on approval.
         """
+        cursor = self._queue_pending_message_uncommitted(
+            agent_name=agent_name, platform=platform, chat_id=chat_id,
+            sender_name=sender_name, content=content, reply_chat_id=reply_chat_id,
+            is_group=is_group, sender_id=sender_id,
+        )
+        self._db.commit()
+        return cursor
+
+    def _queue_pending_message_uncommitted(
+        self, *, agent_name: str, platform: str, chat_id: str,
+        sender_name: str, content: str, reply_chat_id: str = "",
+        is_group: bool = False, sender_id: str = "",
+    ) -> int:
+        """Insert one held row without committing (transaction helper)."""
         now = time.time()
         dest = reply_chat_id or chat_id
         sid = sender_id or chat_id
@@ -3558,7 +3593,6 @@ except Exception:
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (agent_name, platform, chat_id, dest, int(is_group), sid, sender_name, content, now),
         )
-        self._db.commit()
         return cursor.lastrowid
 
     def get_pending_messages(
@@ -3656,6 +3690,18 @@ except Exception:
         is_channel: bool = False, held_at: float | None = None,
     ) -> dict:
         """Create or aggregate one approval request on the legacy gate key."""
+        self._record_approval_hold_uncommitted(
+            agent_name, chat_id, target_name=target_name,
+            is_channel=is_channel, held_at=held_at,
+        )
+        self._db.commit()
+        return self.get_approval_request(agent_name, chat_id)  # type: ignore[return-value]
+
+    def _record_approval_hold_uncommitted(
+        self, agent_name: str, chat_id: str, *, target_name: str = "",
+        is_channel: bool = False, held_at: float | None = None,
+    ) -> None:
+        """Upsert the legacy aggregate without committing (transaction helper)."""
         now = held_at if held_at is not None else time.time()
         self._db.execute(
             """INSERT INTO approval_requests
@@ -3673,8 +3719,40 @@ except Exception:
                    updated_at=excluded.updated_at""",
             (agent_name, chat_id, target_name, int(is_channel), now, now, now),
         )
-        self._db.commit()
-        return self.get_approval_request(agent_name, chat_id)  # type: ignore[return-value]
+
+    def queue_pending_message_with_approval_request(
+        self, *, agent_name: str, platform: str, chat_id: str,
+        sender_name: str, content: str, reply_chat_id: str = "",
+        is_group: bool = False, sender_id: str = "", target_name: str = "",
+        held_at: float | None = None,
+    ) -> tuple[int, dict]:
+        """Atomically persist a held row and its legacy approval aggregate.
+
+        The explicit transaction closes the #863 crash boundary: after commit,
+        a durable held row always has the request discovered by the restart
+        retry loop; before commit, neither side survives.
+        """
+        with self._rmw_lock:
+            try:
+                self._db.execute("BEGIN IMMEDIATE")
+                message_id = self._queue_pending_message_uncommitted(
+                    agent_name=agent_name, platform=platform, chat_id=chat_id,
+                    sender_name=sender_name, content=content,
+                    reply_chat_id=reply_chat_id, is_group=is_group,
+                    sender_id=sender_id,
+                )
+                self._record_approval_hold_uncommitted(
+                    agent_name, chat_id, target_name=target_name,
+                    is_channel=is_group, held_at=held_at,
+                )
+                self._db.commit()
+            except BaseException:
+                self._db.rollback()
+                raise
+        request = self.get_approval_request(agent_name, chat_id)
+        if request is None:  # defensive invariant check after successful commit
+            raise RuntimeError("approval request missing after atomic hold commit")
+        return message_id, request
 
     def begin_approval_notification(self, request_id: int, *, reset_attempts: bool) -> None:
         """Mark a notification cycle active, optionally resetting re-notify attempts."""
@@ -3964,11 +4042,12 @@ except Exception:
                 or ""
             ).strip(),
             "conversation_id": str(destination.get("conversation_id") or "").strip(),
+            "principal_id": str(destination.get("principal_id") or "").strip(),
         }
         if not all(normalized.values()):
             raise ValueError(
                 "owner notification destination requires platform, "
-                "account_id/team_id/workspace_id, and conversation_id"
+                "account_id/team_id/workspace_id, conversation_id, and principal_id"
             )
         return normalized
 
@@ -4017,6 +4096,7 @@ except Exception:
                 "platform": platform,
                 "account_id": account_id,
                 "conversation_id": primary_chat_id,
+                "principal_id": primary_chat_id,
             }
         ])
 

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -3582,12 +3582,14 @@ except Exception:
         self, *, agent_name: str, platform: str, chat_id: str,
         sender_name: str, content: str, reply_chat_id: str = "",
         is_group: bool = False, sender_id: str = "",
+        db: sqlite3.Connection | None = None,
     ) -> int:
         """Insert one held row without committing (transaction helper)."""
+        connection = db or self._db
         now = time.time()
         dest = reply_chat_id or chat_id
         sid = sender_id or chat_id
-        cursor = self._db.execute(
+        cursor = connection.execute(
             """INSERT INTO pending_messages
                (agent_name, platform, chat_id, reply_chat_id, is_group, sender_id, sender_name, content, created_at)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
@@ -3700,10 +3702,12 @@ except Exception:
     def _record_approval_hold_uncommitted(
         self, agent_name: str, chat_id: str, *, target_name: str = "",
         is_channel: bool = False, held_at: float | None = None,
+        db: sqlite3.Connection | None = None,
     ) -> None:
         """Upsert the legacy aggregate without committing (transaction helper)."""
+        connection = db or self._db
         now = held_at if held_at is not None else time.time()
-        self._db.execute(
+        connection.execute(
             """INSERT INTO approval_requests
                (agent_name, chat_id, target_name, is_channel, gate_state,
                 held_count, oldest_held_at, notification_state, created_at, updated_at)
@@ -3732,23 +3736,29 @@ except Exception:
         a durable held row always has the request discovered by the restart
         retry loop; before commit, neither side survives.
         """
-        with self._rmw_lock:
-            try:
-                self._db.execute("BEGIN IMMEDIATE")
-                message_id = self._queue_pending_message_uncommitted(
-                    agent_name=agent_name, platform=platform, chat_id=chat_id,
-                    sender_name=sender_name, content=content,
-                    reply_chat_id=reply_chat_id, is_group=is_group,
-                    sender_id=sender_id,
-                )
-                self._record_approval_hold_uncommitted(
-                    agent_name, chat_id, target_name=target_name,
-                    is_channel=is_group, held_at=held_at,
-                )
-                self._db.commit()
-            except BaseException:
-                self._db.rollback()
-                raise
+        transaction_db = sqlite3.connect(
+            self._db_path, timeout=5.0, check_same_thread=False,
+        )
+        transaction_db.execute("PRAGMA busy_timeout=5000")
+        transaction_db.execute("PRAGMA foreign_keys=ON")
+        try:
+            transaction_db.execute("BEGIN IMMEDIATE")
+            message_id = self._queue_pending_message_uncommitted(
+                agent_name=agent_name, platform=platform, chat_id=chat_id,
+                sender_name=sender_name, content=content,
+                reply_chat_id=reply_chat_id, is_group=is_group,
+                sender_id=sender_id, db=transaction_db,
+            )
+            self._record_approval_hold_uncommitted(
+                agent_name, chat_id, target_name=target_name,
+                is_channel=is_group, held_at=held_at, db=transaction_db,
+            )
+            transaction_db.commit()
+        except BaseException:
+            transaction_db.rollback()
+            raise
+        finally:
+            transaction_db.close()
         request = self.get_approval_request(agent_name, chat_id)
         if request is None:  # defensive invariant check after successful commit
             raise RuntimeError("approval request missing after atomic hold commit")

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1326,15 +1326,21 @@ def create_api(
     }
 
     # Message broker — routes platform messages through approval checks to agent sessions
-    _platform_adapters: dict[tuple[str, str], object] = {}
+    _platform_adapters: dict[tuple[str, ...], object] = {}
 
-    def _get_platform_adapter(agent_name: str, platform: str):
+    def _get_platform_adapter(
+        agent_name: str, platform: str, *, account_id: str = "",
+    ):
         """Get or create a platform adapter for an agent."""
-        key = (agent_name, platform)
+        key = (agent_name, platform, account_id)
         if key in _platform_adapters:
             return _platform_adapters[key]
 
-        token = agents.get_raw_token(agent_name, platform)
+        token = (
+            agents.get_raw_token_for_account(agent_name, platform, account_id)
+            if account_id
+            else agents.get_raw_token(agent_name, platform)
+        )
         if not token:
             return None
 
@@ -1352,6 +1358,12 @@ def create_api(
         if adapter:
             _platform_adapters[key] = adapter
         return adapter
+
+    def _evict_platform_adapters(agent_name: str, platform: str) -> None:
+        """Drop generic and account-bound adapters after token mutation."""
+        for key in list(_platform_adapters):
+            if len(key) >= 2 and key[0] == agent_name and key[1] == platform:
+                _platform_adapters.pop(key, None)
 
     def _get_imessage_adapter(agent_name: str = ""):
         """Get or create the iMessage adapter for an agent."""
@@ -1427,6 +1439,7 @@ def create_api(
         chat_id: str,
         content: str,
         *,
+        account_id: str = "",
         reply_to: str = "",
         parse_mode: str = "",
         silent: bool = False,
@@ -1495,7 +1508,9 @@ def create_api(
                 raise HTTPException(502, f"ferry send failed: {result.error}")
             return SimpleNamespace(message_id=envelope.id)
 
-        adapter = _get_platform_adapter(agent_name, platform)
+        adapter = _get_platform_adapter(
+            agent_name, platform, account_id=account_id,
+        )
         if not adapter:
             raise HTTPException(503, f"No {platform} adapter for {agent_name}")
 
@@ -1664,20 +1679,13 @@ def create_api(
         blocks: str = "",
     ) -> dict:
         """Send a message back to the platform on behalf of an agent."""
-        if account_id:
-            token_config = agents.get_token(agent_name, platform)
-            settings = token_config.settings if token_config else {}
-            configured_account = str(
-                settings.get("account_id")
-                or settings.get("team_id")
-                or settings.get("workspace_id")
-                or ""
-            ).strip()
-            if configured_account and configured_account != account_id:
-                raise HTTPException(
-                    409,
-                    f"Configured {platform} account does not match destination account",
-                )
+        if account_id and not agents.get_raw_token_for_account(
+            agent_name, platform, account_id,
+        ):
+            raise HTTPException(
+                409,
+                f"No {platform} token bound to destination account {account_id}",
+            )
         loop = asyncio.get_running_loop()
 
         async def _deliver() -> dict:
@@ -1688,6 +1696,7 @@ def create_api(
                     platform,
                     chat_id,
                     content,
+                    account_id=account_id,
                     reply_to=reply_to,
                     parse_mode=parse_mode,
                     silent=silent,
@@ -1722,9 +1731,10 @@ def create_api(
         # Plain sends keep key_extra="" — their historical dedupe behaviour is
         # unchanged. The dict is serialized (never used raw) so the key stays
         # hashable.
-        if parse_mode or link_preview_options or quote or blocks:
+        if account_id or parse_mode or link_preview_options or quote or blocks:
             key_extra = json.dumps(
                 {
+                    "acct": account_id or "",
                     "pm": parse_mode or "",
                     "lpo": link_preview_options or None,
                     "q": quote or "",
@@ -6973,7 +6983,7 @@ npm run build</pre>
 
         # Evict the cached outbound adapter so sends pick up the new token
         # immediately (adapters bind the token at construction).
-        _platform_adapters.pop((name, platform), None)
+        _evict_platform_adapters(name, platform)
         if platform == "imessage":
             _platform_adapters.pop(("__global__", "imessage"), None)
 
@@ -7060,7 +7070,7 @@ npm run build</pre>
             raise HTTPException(404, "Token not found")
 
         # Evict the cached outbound adapter so sends stop using the removed token
-        _platform_adapters.pop((name, platform), None)
+        _evict_platform_adapters(name, platform)
         if platform == "imessage":
             _platform_adapters.pop(("__global__", "imessage"), None)
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1655,6 +1655,7 @@ def create_api(
         chat_id: str,
         content: str,
         *,
+        account_id: str = "",
         reply_to: str = "",
         parse_mode: str = "",
         silent: bool = False,
@@ -1663,6 +1664,20 @@ def create_api(
         blocks: str = "",
     ) -> dict:
         """Send a message back to the platform on behalf of an agent."""
+        if account_id:
+            token_config = agents.get_token(agent_name, platform)
+            settings = token_config.settings if token_config else {}
+            configured_account = str(
+                settings.get("account_id")
+                or settings.get("team_id")
+                or settings.get("workspace_id")
+                or ""
+            ).strip()
+            if configured_account and configured_account != account_id:
+                raise HTTPException(
+                    409,
+                    f"Configured {platform} account does not match destination account",
+                )
         loop = asyncio.get_running_loop()
 
         async def _deliver() -> dict:
@@ -1690,6 +1705,7 @@ def create_api(
                 "sent": True,
                 "agent": agent_name,
                 "platform": platform,
+                "account_id": account_id,
                 "chat_id": chat_id,
                 "message_id": msg.message_id,
             }
@@ -5532,12 +5548,47 @@ npm run build</pre>
         return agents.get_primary_user()
 
     @app.put("/system/primary-user")
-    async def set_primary_user(chat_id: str, display_name: str = ""):
+    async def set_primary_user(
+        chat_id: str,
+        display_name: str = "",
+        notification_platform: str = "",
+        notification_account_id: str = "",
+    ):
         """Set the primary user — auto-approved for all agents."""
         if not chat_id.strip():
             raise HTTPException(400, "chat_id is required")
+        if bool(notification_platform.strip()) != bool(notification_account_id.strip()):
+            raise HTTPException(
+                400,
+                "notification_platform and notification_account_id must be provided together",
+            )
         agents.set_primary_user(chat_id.strip(), display_name.strip())
+        if notification_platform.strip():
+            try:
+                agents.migrate_primary_user_notification_destination(
+                    platform=notification_platform.strip(),
+                    account_id=notification_account_id.strip(),
+                )
+            except ValueError as exc:
+                raise HTTPException(400, str(exc)) from exc
         return {"updated": True, **agents.get_primary_user()}
+
+    @app.get("/system/owner-notification-destinations")
+    async def get_owner_notification_destinations():
+        """Return canonical owner destination followed by ordered fallbacks."""
+        destinations = agents.get_owner_notification_destinations()
+        return {"destinations": destinations, "count": len(destinations)}
+
+    @app.put("/system/owner-notification-destinations")
+    async def set_owner_notification_destinations(req: dict):
+        """Replace the canonical owner destination and ordered fallbacks."""
+        try:
+            destinations = agents.set_owner_notification_destinations(
+                req.get("destinations", []),
+            )
+        except (AttributeError, ValueError) as exc:
+            raise HTTPException(400, str(exc)) from exc
+        return {"updated": True, "destinations": destinations}
 
     @app.get("/system/api-keys")
     async def get_api_keys():
@@ -7193,6 +7244,7 @@ npm run build</pre>
         if not agents.get(name):
             raise HTTPException(404, f"Agent '{name}' not found")
         user = agents.approve_user(name, req.chat_id, req.display_name or "", req.approved_by or "admin")
+        agents.settle_approval_request(name, req.chat_id, "approved")
         # Deliver pending messages in background
         delivered = 0
         try:
@@ -7207,6 +7259,7 @@ npm run build</pre>
     async def deny_user(name: str, chat_id: str):
         """Deny a user."""
         agents.deny_user(name, chat_id)
+        agents.settle_approval_request(name, chat_id, "denied")
         return {"denied": True, "chat_id": chat_id}
 
     @app.delete("/agents/{name}/approved-users/{chat_id}")
@@ -9915,6 +9968,12 @@ npm run build</pre>
         except Exception as exc:  # never let hardening abort startup
             _log(f"startup: db permission sweep skipped ({exc})")
 
+        # #863: resume durable owner-approval notification retries before
+        # pollers can accept more inbound messages.
+        app.state.approval_notification_retry_task = (
+            broker.start_approval_notification_retries()
+        )
+
         # Rotate the daemon console log (logs/api.log): daily + size-capped,
         # gzipped 0600 archives with Telegram tokens redacted, pruned past the
         # retention window. copytruncate keeps launchd's open fd valid (it does
@@ -10226,6 +10285,8 @@ npm run build</pre>
         """Stop scheduler, autonomy, broker pollers, and streaming sessions on shutdown."""
         import json as _json
         from datetime import datetime, timezone
+
+        await broker.stop_approval_notification_retries()
 
         # Write restart manifest before disconnecting — captures each agent's in-progress state
         # so it can be injected into the wake prompt on next startup.
@@ -11329,6 +11390,10 @@ npm run build</pre>
 
         # Cost
         cost_info = audit.get_costs(agent_name=agent_name)
+        approval_notification_health = agents.get_approval_notification_health(
+            agent_name,
+        )
+        checks = {"approval_notifications": approval_notification_health}
 
         return {
             "agent": agent_name,
@@ -11343,11 +11408,14 @@ npm run build</pre>
                 "pending_events": pending_events,
             },
             "costs": cost_info,
+            "checks": checks,
             "recent_errors": [e.to_dict() for e in errors],
-            "recommendation": _health_recommendation(session_info, heartbeat_info, task_info, errors),
+            "recommendation": _health_recommendation(
+                session_info, heartbeat_info, task_info, errors, checks,
+            ),
         }
 
-    def _health_recommendation(session, heartbeat, tasks, errors) -> str:
+    def _health_recommendation(session, heartbeat, tasks, errors, checks=None) -> str:
         """Generate a health recommendation based on metrics."""
         issues = []
         if session and session.get("needs_restart"):
@@ -11360,6 +11428,11 @@ npm run build</pre>
             issues.append("tasks_blocked")
         if len(errors) >= 3:
             issues.append("high_error_rate")
+        approval_check = (checks or {}).get("approval_notifications", {})
+        if approval_check.get("failed"):
+            issues.append("owner_notification_failed")
+        elif approval_check.get("retrying"):
+            issues.append("owner_notification_retrying")
 
         if not issues:
             return "healthy"
@@ -11369,6 +11442,8 @@ npm run build</pre>
             return "needs_attention"
         if "high_error_rate" in issues:
             return "unstable"
+        if "owner_notification_failed" in issues:
+            return "needs_attention"
         return "degraded"
 
     # time is imported at module level

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -35,6 +35,17 @@ from pinky_daemon.transport_state import SessionState
 _INBOUND_RECONNECT_WAIT_SEC = 20.0
 _INBOUND_RECONNECT_POLL_SEC = 0.25
 
+# #863 approval-notification policy. A delivered request is re-notified after
+# four hours OR ten newly held messages, whichever arrives first. Failures retry
+# exponentially (30s..30m) and become operator-visible terminal ``failed`` after
+# five cycles; every cycle walks the canonical primary + ordered fallbacks.
+_APPROVAL_RENOTIFY_INTERVAL_SEC = 4 * 60 * 60
+_APPROVAL_RENOTIFY_HELD_COUNT = 10
+_APPROVAL_NOTIFY_RETRY_BASE_SEC = 30
+_APPROVAL_NOTIFY_RETRY_MAX_SEC = 30 * 60
+_APPROVAL_NOTIFY_MAX_ATTEMPTS = 5
+_APPROVAL_NOTIFY_POLL_SEC = 5
+
 # #279: agent-to-agent reply auto-routing. ``inject_agent_message`` stamps an
 # injected turn with ``platform == AGENT_REPLY_PLATFORM`` and ``chat_id`` = the
 # requester agent name; when that turn completes, ``route_agent_reply`` delivers
@@ -324,6 +335,8 @@ class MessageBroker:
         # Strong refs to background cleanup tasks (e.g. disconnecting a
         # displaced streaming session) so the GC can't collect them mid-flight.
         self._background_tasks: set[asyncio.Task] = set()
+        self._approval_notification_task: asyncio.Task | None = None
+        self._approval_notification_locks: dict[int, asyncio.Lock] = {}
 
     @property
     def send_callback(self):
@@ -819,6 +832,9 @@ class MessageBroker:
                     display_name=display_name,
                     approved_by="primary_user",
                 )
+                self._registry.settle_approval_request(
+                    agent_name, target_chat_id, "approved",
+                )
                 # Is this a channel approval? Held group rows carry is_group=True.
                 # Must be checked BEFORE handle_approval marks them delivered.
                 pending_before = self._registry.get_pending_messages(
@@ -843,6 +859,9 @@ class MessageBroker:
                         _log(f"broker: failed to notify approved user {target_chat_id}: {e}")
         else:
             self._registry.deny_user(agent_name, target_chat_id)
+            self._registry.settle_approval_request(
+                agent_name, target_chat_id, "denied",
+            )
             reply = f"🚫 User {target_chat_id} denied."
 
         if self._send_callback:
@@ -904,6 +923,163 @@ class MessageBroker:
                 f'Got it — signing "{agent_name}" in.',
             )
         return True
+
+    @staticmethod
+    def _format_approval_notification(request: dict) -> str:
+        approval_key = request["chat_id"]
+        agent_name = request["agent_name"]
+        held_count = request["held_count"]
+        oldest_age = max(0, int(time.time() - request["oldest_held_at"]))
+        if request["is_channel"]:
+            subject = (
+                f"{agent_name} has messages held from a new channel "
+                f"(ID: {approval_key})."
+            )
+            action = f"Approve to let everyone in this channel talk to {agent_name}:"
+        else:
+            name_display = request["target_name"] or "Unknown"
+            subject = (
+                f"New user wants to talk to {agent_name}:\n"
+                f"{name_display} (ID: {approval_key})"
+            )
+            action = "Review the request:"
+        return (
+            f"🆕 {subject}\n\n"
+            f"Held messages: {held_count}; oldest: {oldest_age}s\n"
+            f"{action}\n"
+            f"/approve_{approval_key}\n"
+            f"/deny_{approval_key}"
+        )
+
+    @staticmethod
+    def _approval_request_needs_notification(request: dict, now: float) -> bool:
+        if request["gate_state"] != "pending":
+            return False
+        if request["notification_state"] == "retrying":
+            return request["next_retry_at"] <= now
+        if request["notification_state"] == "failed":
+            return False
+        new_holds = request["held_count"] - request["notified_held_count"]
+        elapsed = now - request["last_notified_at"]
+        return (
+            new_holds >= _APPROVAL_RENOTIFY_HELD_COUNT
+            or (new_holds > 0 and elapsed >= _APPROVAL_RENOTIFY_INTERVAL_SEC)
+        )
+
+    async def _notify_approval_request(self, request: dict) -> None:
+        """Deliver one durable approval notification over ordered fallbacks."""
+        request_id = request["id"]
+        lock = self._approval_notification_locks.setdefault(request_id, asyncio.Lock())
+        async with lock:
+            current = self._registry.get_approval_request(
+                request["agent_name"], request["chat_id"],
+            )
+            now = time.time()
+            if not current or not self._approval_request_needs_notification(current, now):
+                return
+
+            reset_attempts = current["notification_state"] == "delivered"
+            self._registry.begin_approval_notification(
+                request_id, reset_attempts=reset_attempts,
+            )
+            current = self._registry.get_approval_request(
+                current["agent_name"], current["chat_id"],
+            )
+            if not current:
+                return
+
+            destinations = self._registry.get_owner_notification_destinations()
+            fallback_path: list[dict] = []
+            notification = self._format_approval_notification(current)
+            last_error = "owner notification destination is not configured"
+
+            if self._send_callback:
+                for destination in destinations:
+                    try:
+                        await self._send_callback(
+                            current["agent_name"],
+                            destination["platform"],
+                            destination["conversation_id"],
+                            notification,
+                            account_id=destination["account_id"],
+                        )
+                    except Exception as exc:
+                        last_error = f"{type(exc).__name__}: {exc}"
+                        fallback_path.append({
+                            "destination": destination,
+                            "error": last_error[:500],
+                        })
+                        continue
+                    self._registry.record_approval_notification_delivered(
+                        request_id,
+                        destination=destination,
+                        fallback_path=fallback_path,
+                    )
+                    _log(
+                        "broker: owner approval notification delivered "
+                        f"request={request_id} via "
+                        f"{destination['platform']}/{destination['account_id']}/"
+                        f"{destination['conversation_id']}"
+                    )
+                    return
+            elif destinations:
+                last_error = "broker send callback is not configured"
+
+            attempt = current["notification_attempts"] + 1
+            failed = attempt >= _APPROVAL_NOTIFY_MAX_ATTEMPTS or not destinations
+            delay = min(
+                _APPROVAL_NOTIFY_RETRY_BASE_SEC * (2 ** max(0, attempt - 1)),
+                _APPROVAL_NOTIFY_RETRY_MAX_SEC,
+            )
+            self._registry.record_approval_notification_failure(
+                request_id,
+                error=last_error,
+                next_retry_at=0 if failed else now + delay,
+                failed=failed,
+                fallback_path=fallback_path,
+            )
+            state = "failed" if failed else "retrying"
+            _log(
+                f"broker: owner approval notification {state} request={request_id} "
+                f"attempt={attempt}: {last_error}"
+            )
+
+    async def retry_due_approval_notifications(self) -> int:
+        """Attempt every due durable notification; return requests examined."""
+        due = self._registry.list_due_approval_notifications()
+        for request in due:
+            await self._notify_approval_request(request)
+        return len(due)
+
+    async def run_approval_notification_retries(self) -> None:
+        """Daemon loop that resumes retrying receipts after process restarts."""
+        while True:
+            try:
+                await self.retry_due_approval_notifications()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                _log(f"broker: approval notification retry loop error: {exc}")
+            await asyncio.sleep(_APPROVAL_NOTIFY_POLL_SEC)
+
+    def start_approval_notification_retries(self) -> asyncio.Task:
+        if self._approval_notification_task and not self._approval_notification_task.done():
+            return self._approval_notification_task
+        self._approval_notification_task = asyncio.create_task(
+            self.run_approval_notification_retries()
+        )
+        return self._approval_notification_task
+
+    async def stop_approval_notification_retries(self) -> None:
+        task = self._approval_notification_task
+        self._approval_notification_task = None
+        if not task:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
     async def handle_inbound(self, message: BrokerMessage) -> None:
         """Handle an incoming platform message. Non-blocking."""
@@ -1002,36 +1178,6 @@ class MessageBroker:
                                 )
                             except Exception as e:
                                 _log(f"broker: failed to send onboarding reply to {approval_key}: {e}")
-                        primary = self._registry.get_primary_user()
-                        if primary.get("chat_id"):
-                            if is_channel:
-                                notification = (
-                                    f"🆕 {agent_name} got a message in a new channel "
-                                    f"(ID: {approval_key}).\n\n"
-                                    f"Approve to let everyone in this channel talk to "
-                                    f"{agent_name}:\n"
-                                    f"/approve_{approval_key}\n"
-                                    f"/deny_{approval_key}"
-                                )
-                            else:
-                                name_display = message.sender_name or "Unknown"
-                                username = message.metadata.get("username", "")
-                                if username:
-                                    name_display += f" (@{username})"
-                                notification = (
-                                    f"🆕 New user wants to talk to {agent_name}:\n"
-                                    f"{name_display} (ID: {approval_key})\n\n"
-                                    f"/approve_{approval_key}\n"
-                                    f"/deny_{approval_key}"
-                                )
-                            try:
-                                await self._send_callback(
-                                    agent_name, message.platform, primary["chat_id"],
-                                    notification,
-                                )
-                            except Exception as e:
-                                kind = "channel" if is_channel else "user"
-                                _log(f"broker: failed to notify owner about new {kind} {approval_key}: {e}")
                 self._registry.queue_pending_message(
                     agent_name=agent_name,
                     platform=message.platform,
@@ -1042,6 +1188,18 @@ class MessageBroker:
                     is_group=message.is_group,
                     sender_id=message.sender_id,
                 )
+                target_name = message.chat_id if is_channel else message.sender_name
+                username = message.metadata.get("username", "")
+                if username and not is_channel:
+                    target_name = f"{target_name or 'Unknown'} (@{username})"
+                approval_request = self._registry.record_approval_hold(
+                    agent_name,
+                    approval_key,
+                    target_name=target_name,
+                    is_channel=is_channel,
+                    held_at=message.timestamp,
+                )
+                await self._notify_approval_request(approval_request)
                 self._stats["pending"] += 1
                 _log(f"broker: queued pending message for {agent_name} (key={approval_key}, sender={message.sender_name})")
                 return

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -789,11 +789,29 @@ class MessageBroker:
             )
         return True
 
-    async def _handle_approval_command(self, message: BrokerMessage) -> bool:
-        """Intercept /approve_<id> and /deny_<id> commands from the owner."""
-        primary = self._registry.get_primary_user()
+    def _is_owner_approval_authorized(self, message: BrokerMessage) -> bool:
+        """Require an exact configured owner DM destination + principal."""
         sender_id = message.sender_id or message.chat_id
-        if not primary.get("chat_id") or sender_id != primary["chat_id"]:
+        if message.is_group or not sender_id or not message.chat_id:
+            return False
+        for destination in self._registry.get_owner_notification_destinations():
+            if (
+                destination["platform"] != message.platform
+                or destination["conversation_id"] != message.chat_id
+                or destination["principal_id"] != sender_id
+            ):
+                continue
+            if self._registry.get_raw_token_for_account(
+                message.agent_name,
+                message.platform,
+                destination["account_id"],
+            ):
+                return True
+        return False
+
+    async def _handle_approval_command(self, message: BrokerMessage) -> bool:
+        """Intercept owner approval commands from a configured secure DM."""
+        if not self._is_owner_approval_authorized(message):
             return False
 
         text = message.content.strip()
@@ -1178,7 +1196,11 @@ class MessageBroker:
                                 )
                             except Exception as e:
                                 _log(f"broker: failed to send onboarding reply to {approval_key}: {e}")
-                self._registry.queue_pending_message(
+                target_name = message.chat_id if is_channel else message.sender_name
+                username = message.metadata.get("username", "")
+                if username and not is_channel:
+                    target_name = f"{target_name or 'Unknown'} (@{username})"
+                _, approval_request = self._registry.queue_pending_message_with_approval_request(
                     agent_name=agent_name,
                     platform=message.platform,
                     chat_id=approval_key,
@@ -1187,16 +1209,7 @@ class MessageBroker:
                     content=message.content,
                     is_group=message.is_group,
                     sender_id=message.sender_id,
-                )
-                target_name = message.chat_id if is_channel else message.sender_name
-                username = message.metadata.get("username", "")
-                if username and not is_channel:
-                    target_name = f"{target_name or 'Unknown'} (@{username})"
-                approval_request = self._registry.record_approval_hold(
-                    agent_name,
-                    approval_key,
                     target_name=target_name,
-                    is_channel=is_channel,
                     held_at=message.timestamp,
                 )
                 await self._notify_approval_request(approval_request)

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -20,6 +20,51 @@ def registry():
     os.unlink(path)
 
 
+class TestOwnerNotificationDestinations:
+    def test_explicit_migration_seeds_legacy_primary_chat_id(self, registry):
+        registry.set_primary_user("6770805286", "Brad")
+
+        destinations = registry.migrate_primary_user_notification_destination(
+            platform="telegram",
+            account_id="primary-telegram-bot",
+        )
+
+        assert destinations == [
+            {
+                "platform": "telegram",
+                "account_id": "primary-telegram-bot",
+                "conversation_id": "6770805286",
+            }
+        ]
+
+    def test_migration_never_infers_platform_or_account(self, registry):
+        registry.set_primary_user("6770805286", "Brad")
+
+        with pytest.raises(ValueError, match="requires platform"):
+            registry.migrate_primary_user_notification_destination(
+                platform="", account_id="",
+            )
+
+        assert registry.get_owner_notification_destinations() == []
+
+    def test_primary_and_ordered_fallbacks_round_trip(self, registry):
+        destinations = registry.set_owner_notification_destinations([
+            {
+                "platform": "telegram",
+                "account_id": "tg-owner",
+                "conversation_id": "6770805286",
+            },
+            {
+                "platform": "slack",
+                "team_id": "T_FALLBACK",
+                "conversation_id": "D_FALLBACK",
+            },
+        ])
+
+        assert destinations[1]["account_id"] == "T_FALLBACK"
+        assert registry.get_owner_notification_destinations() == destinations
+
+
 class TestSigningKeys:
     """Per-agent signing keys (#623)."""
 

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import threading
 
 import pytest
 
@@ -74,30 +75,68 @@ class TestOwnerNotificationDestinations:
         db_path = tmp_path / "agents.db"
         registry = AgentRegistry(db_path=str(db_path))
         registry.register("barsik", model="sonnet", working_dir=str(tmp_path))
-        original = registry._record_approval_hold_uncommitted
+        at_boundary = threading.Event()
+        release_crash = threading.Event()
+        writer_done = threading.Event()
+        atomic_errors: list[BaseException] = []
+        writer_errors: list[BaseException] = []
 
         def crash_between_writes(*args, **kwargs):
             # Exact boundary proof: the pending row exists inside the open
             # transaction, but the aggregate has not been written yet.
-            held_inside_tx = registry._db.execute(
+            transaction_db = kwargs["db"]
+            held_inside_tx = transaction_db.execute(
                 "SELECT COUNT(*) FROM pending_messages WHERE agent_name='barsik'"
             ).fetchone()[0]
-            request_inside_tx = registry._db.execute(
+            request_inside_tx = transaction_db.execute(
                 "SELECT COUNT(*) FROM approval_requests WHERE agent_name='barsik'"
             ).fetchone()[0]
             assert held_inside_tx == 1
             assert request_inside_tx == 0
+            at_boundary.set()
+            assert release_crash.wait(2), "test did not release crash boundary"
             raise RuntimeError("simulated crash after held insert")
+
+        def persist_hold():
+            try:
+                registry.queue_pending_message_with_approval_request(
+                    agent_name="barsik", platform="slack", chat_id="C_CRASH",
+                    reply_chat_id="C_CRASH", sender_name="Alex", content="hello",
+                    is_group=True, sender_id="U_ALEX", target_name="C_CRASH",
+                )
+            except BaseException as exc:
+                atomic_errors.append(exc)
+
+        def unrelated_writer():
+            try:
+                registry.set_setting("concurrent_writer", "committed")
+            except BaseException as exc:
+                writer_errors.append(exc)
+            finally:
+                writer_done.set()
 
         monkeypatch.setattr(
             registry, "_record_approval_hold_uncommitted", crash_between_writes,
         )
-        with pytest.raises(RuntimeError, match="after held insert"):
-            registry.queue_pending_message_with_approval_request(
-                agent_name="barsik", platform="slack", chat_id="C_CRASH",
-                reply_chat_id="C_CRASH", sender_name="Alex", content="hello",
-                is_group=True, sender_id="U_ALEX", target_name="C_CRASH",
-            )
+        atomic_thread = threading.Thread(target=persist_hold)
+        atomic_thread.start()
+        assert at_boundary.wait(2), "atomic transaction never reached crash boundary"
+
+        writer_thread = threading.Thread(target=unrelated_writer)
+        writer_thread.start()
+        # Dedicated BEGIN IMMEDIATE owns the DB write lock. The unrelated
+        # shared-connection commit must block, never commit the half-transaction.
+        assert writer_done.wait(0.1) is False
+        release_crash.set()
+        atomic_thread.join(2)
+        writer_thread.join(2)
+        assert not atomic_thread.is_alive()
+        assert not writer_thread.is_alive()
+        assert len(atomic_errors) == 1
+        assert isinstance(atomic_errors[0], RuntimeError)
+        assert "after held insert" in str(atomic_errors[0])
+        assert writer_errors == []
+        assert registry.get_setting("concurrent_writer") == "committed"
         registry.close()
 
         restarted = AgentRegistry(db_path=str(db_path))
@@ -107,14 +146,10 @@ class TestOwnerNotificationDestinations:
             assert restarted.get_pending_messages("barsik", "C_CRASH") == []
             assert restarted.get_approval_request("barsik", "C_CRASH") is None
             assert restarted.list_due_approval_notifications() == []
+            assert restarted.get_setting("concurrent_writer") == "committed"
 
             # Provider redelivery after restart commits both sides together;
             # the request is immediately discoverable by the retry loop.
-            monkeypatch.setattr(
-                restarted, "_record_approval_hold_uncommitted", original.__func__.__get__(
-                    restarted, AgentRegistry,
-                ),
-            )
             _, request = restarted.queue_pending_message_with_approval_request(
                 agent_name="barsik", platform="slack", chat_id="C_CRASH",
                 reply_chat_id="C_CRASH", sender_name="Alex", content="hello",

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -34,6 +34,7 @@ class TestOwnerNotificationDestinations:
                 "platform": "telegram",
                 "account_id": "primary-telegram-bot",
                 "conversation_id": "6770805286",
+                "principal_id": "6770805286",
             }
         ]
 
@@ -53,16 +54,79 @@ class TestOwnerNotificationDestinations:
                 "platform": "telegram",
                 "account_id": "tg-owner",
                 "conversation_id": "6770805286",
+                "principal_id": "6770805286",
             },
             {
                 "platform": "slack",
                 "team_id": "T_FALLBACK",
                 "conversation_id": "D_FALLBACK",
+                "principal_id": "U_FALLBACK",
             },
         ])
 
         assert destinations[1]["account_id"] == "T_FALLBACK"
         assert registry.get_owner_notification_destinations() == destinations
+
+    def test_atomic_hold_rolls_back_exact_crash_boundary_and_restart_recovers(
+        self, tmp_path, monkeypatch,
+    ):
+        """Crash after held INSERT/before request UPSERT leaves no orphan."""
+        db_path = tmp_path / "agents.db"
+        registry = AgentRegistry(db_path=str(db_path))
+        registry.register("barsik", model="sonnet", working_dir=str(tmp_path))
+        original = registry._record_approval_hold_uncommitted
+
+        def crash_between_writes(*args, **kwargs):
+            # Exact boundary proof: the pending row exists inside the open
+            # transaction, but the aggregate has not been written yet.
+            held_inside_tx = registry._db.execute(
+                "SELECT COUNT(*) FROM pending_messages WHERE agent_name='barsik'"
+            ).fetchone()[0]
+            request_inside_tx = registry._db.execute(
+                "SELECT COUNT(*) FROM approval_requests WHERE agent_name='barsik'"
+            ).fetchone()[0]
+            assert held_inside_tx == 1
+            assert request_inside_tx == 0
+            raise RuntimeError("simulated crash after held insert")
+
+        monkeypatch.setattr(
+            registry, "_record_approval_hold_uncommitted", crash_between_writes,
+        )
+        with pytest.raises(RuntimeError, match="after held insert"):
+            registry.queue_pending_message_with_approval_request(
+                agent_name="barsik", platform="slack", chat_id="C_CRASH",
+                reply_chat_id="C_CRASH", sender_name="Alex", content="hello",
+                is_group=True, sender_id="U_ALEX", target_name="C_CRASH",
+            )
+        registry.close()
+
+        restarted = AgentRegistry(db_path=str(db_path))
+        try:
+            # Rollback survived restart: never a durable held row invisible to
+            # the retry loop.
+            assert restarted.get_pending_messages("barsik", "C_CRASH") == []
+            assert restarted.get_approval_request("barsik", "C_CRASH") is None
+            assert restarted.list_due_approval_notifications() == []
+
+            # Provider redelivery after restart commits both sides together;
+            # the request is immediately discoverable by the retry loop.
+            monkeypatch.setattr(
+                restarted, "_record_approval_hold_uncommitted", original.__func__.__get__(
+                    restarted, AgentRegistry,
+                ),
+            )
+            _, request = restarted.queue_pending_message_with_approval_request(
+                agent_name="barsik", platform="slack", chat_id="C_CRASH",
+                reply_chat_id="C_CRASH", sender_name="Alex", content="hello",
+                is_group=True, sender_id="U_ALEX", target_name="C_CRASH",
+            )
+            assert len(restarted.get_pending_messages("barsik", "C_CRASH")) == 1
+            assert restarted.get_approval_request("barsik", "C_CRASH")["id"] == request["id"]
+            assert [row["id"] for row in restarted.list_due_approval_notifications()] == [
+                request["id"]
+            ]
+        finally:
+            restarted.close()
 
 
 class TestSigningKeys:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2879,6 +2879,70 @@ class TestAPI:
                 assert resp.status_code == 200, resp.text
                 assert mock.call_args.kwargs["thread_ts"] == "1711584000.000100"
 
+    @pytest.mark.asyncio
+    async def test_broker_send_binds_account_before_delivery_and_dedupe(self):
+        """#863: requested account must select the token and dedupe identity."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            agents = app.state.agents
+            agents.register("barsik", model="sonnet", working_dir=tmpdir)
+            callback = app.state.broker.send_callback
+
+            with patch(
+                "pinky_outreach.slack.SlackAdapter.send_message",
+                return_value=SimpleNamespace(message_id="1711584000.000100"),
+            ) as send:
+                # Missing binding: fail before adapter construction/delivery.
+                agents.set_token("barsik", "slack", "xoxb-test", settings={})
+                with pytest.raises(Exception) as missing:
+                    await callback(
+                        "barsik", "slack", "D_OWNER", "approve?",
+                        account_id="T_OWNER_A",
+                    )
+                assert missing.value.status_code == 409
+                assert send.call_count == 0
+
+                # Mismatched binding: also zero delivery.
+                agents.set_token(
+                    "barsik", "slack", "xoxb-test",
+                    settings={"team_id": "T_OTHER"},
+                )
+                with pytest.raises(Exception) as mismatch:
+                    await callback(
+                        "barsik", "slack", "D_OWNER", "approve?",
+                        account_id="T_OWNER_A",
+                    )
+                assert mismatch.value.status_code == 409
+                assert send.call_count == 0
+
+                # Exact account A sends. Rotating the explicit binding to B and
+                # repeating the same payload sends again (account is in dedupe).
+                agents.set_token(
+                    "barsik", "slack", "xoxb-test",
+                    settings={"team_id": "T_OWNER_A"},
+                )
+                first = await callback(
+                    "barsik", "slack", "D_OWNER", "approve?",
+                    account_id="T_OWNER_A",
+                )
+                agents.set_token(
+                    "barsik", "slack", "xoxb-test",
+                    settings={"team_id": "T_OWNER_B"},
+                )
+                second = await callback(
+                    "barsik", "slack", "D_OWNER", "approve?",
+                    account_id="T_OWNER_B",
+                )
+                duplicate = await callback(
+                    "barsik", "slack", "D_OWNER", "approve?",
+                    account_id="T_OWNER_B",
+                )
+
+                assert first["account_id"] == "T_OWNER_A"
+                assert second["account_id"] == "T_OWNER_B"
+                assert duplicate["deduped"] is True
+                assert send.call_count == 2
+
     def test_broker_thread_quote_builds_reply_parameters(self):
         """thread(quote=...) builds ReplyParameters quoting the given passage."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4407,6 +4407,30 @@ class TestAgentCRUD:
         assert "session" in data
         assert "tasks" in data
 
+    def test_agent_health_surfaces_failed_owner_notification(self):
+        client, registry = self._make_client_with_registry()
+        client.post("/agents", json={"name": "alice", "model": "sonnet"})
+        request = registry.record_approval_hold(
+            "alice", "C_GATED", target_name="C_GATED", is_channel=True,
+        )
+        registry.record_approval_notification_failure(
+            request["id"],
+            error="RuntimeError: channel_not_found",
+            next_retry_at=0,
+            failed=True,
+            fallback_path=[],
+        )
+
+        resp = client.get("/agents/alice/health")
+
+        assert resp.status_code == 200
+        check = resp.json()["checks"]["approval_notifications"]
+        assert check["healthy"] is False
+        assert check["failed"] == 1
+        assert check["requests"][0]["notification_state"] == "failed"
+        assert "channel_not_found" in check["requests"][0]["last_error"]
+        assert resp.json()["recommendation"] == "needs_attention"
+
     def test_agent_health_not_found(self):
         client = self._make_client()
         resp = client.get("/agents/nobody/health")

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -20,7 +20,10 @@ class TestMessageBrokerRouting:
         sent_messages: list[tuple[str, str, str, str]] = []
         reactions: list[tuple[str, str, str, str, str]] = []
 
-        async def send_callback(agent_name: str, platform: str, chat_id: str, content: str):
+        async def send_callback(
+            agent_name: str, platform: str, chat_id: str, content: str,
+            *, account_id: str = "",
+        ):
             sent_messages.append((agent_name, platform, chat_id, content))
 
         async def reaction_callback(
@@ -776,6 +779,13 @@ class TestMessageBrokerRouting:
             monkeypatch.setattr(broker, "_route_streaming", _fake_route)
             owner = "owner-1"
             registry.set_primary_user(owner, display_name="Brad")
+            registry.set_owner_notification_destinations([
+                {
+                    "platform": "telegram",
+                    "account_id": "owner-bot",
+                    "conversation_id": owner,
+                }
+            ])
 
             channel = "C0A8WUU743F"
             user = "U774M8XDE"
@@ -818,6 +828,165 @@ class TestMessageBrokerRouting:
             assert routed[0].sender_id == user
             assert routed[0].is_group is True
             assert routed[0].content == "Hi"
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_owner_notification_uses_full_tuple_with_legacy_gate_key(self):
+        """#863: destination identity is composite; approval rows are not yet."""
+        tmpdir, registry, broker, _sent, _ = self._make_broker()
+        deliveries: list[tuple[str, str, str, str]] = []
+
+        async def capture(
+            agent_name, platform, chat_id, content, *, account_id="",
+        ):
+            if platform == "slack":
+                raise RuntimeError("owner primary unavailable")
+            deliveries.append((platform, account_id, chat_id, content))
+
+        broker._send_callback = capture
+        try:
+            registry.set_primary_user("legacy-owner-id", display_name="Brad")
+            registry.set_owner_notification_destinations([
+                {
+                    "platform": "slack",
+                    "account_id": "T_OWNER",
+                    "conversation_id": "D_OWNER",
+                },
+                {
+                    "platform": "telegram",
+                    "account_id": "owner-telegram-account",
+                    "conversation_id": "owner-conversation",
+                }
+            ])
+            channel = "C_GATED"
+            await broker.handle_inbound(
+                BrokerMessage(
+                    platform="slack", chat_id=channel, sender_name="Alex",
+                    sender_id="U_ALEX", content="hello", agent_name="barsik",
+                    is_group=True,
+                )
+            )
+
+            assert len(deliveries) == 1
+            assert deliveries[0][:3] == (
+                "telegram", "owner-telegram-account", "owner-conversation",
+            )
+            assert f"/approve_{channel}" in deliveries[0][3]
+
+            request = registry.get_approval_request("barsik", channel)
+            assert request is not None
+            assert request["chat_id"] == channel
+            assert request["notification_destination"]["platform"] == "telegram"
+            assert request["fallback_path"][0]["destination"]["platform"] == "slack"
+            columns = {
+                row[1]
+                for row in registry._db.execute(
+                    "PRAGMA table_info(approval_requests)"
+                ).fetchall()
+            }
+            assert "platform" not in columns
+            assert "account_id" not in columns
+            assert "conversation_id" not in columns
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_owner_notification_failure_retries_and_is_operator_visible(
+        self, monkeypatch,
+    ):
+        import pinky_daemon.broker as broker_mod
+
+        monkeypatch.setattr(broker_mod, "_APPROVAL_NOTIFY_RETRY_BASE_SEC", 0)
+        tmpdir, registry, broker, _sent, _ = self._make_broker()
+        attempts = 0
+
+        async def flaky(
+            agent_name, platform, chat_id, content, *, account_id="",
+        ):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("channel_not_found")
+
+        broker._send_callback = flaky
+        try:
+            registry.set_primary_user("owner", display_name="Brad")
+            registry.set_owner_notification_destinations([
+                {
+                    "platform": "telegram",
+                    "account_id": "owner-account",
+                    "conversation_id": "owner",
+                }
+            ])
+            await broker.handle_inbound(
+                BrokerMessage(
+                    platform="slack", chat_id="C_RETRY", sender_name="Alex",
+                    sender_id="U_ALEX", content="hello", agent_name="barsik",
+                    is_group=True,
+                )
+            )
+
+            request = registry.get_approval_request("barsik", "C_RETRY")
+            assert request["notification_state"] == "retrying"
+            health = registry.get_approval_notification_health("barsik")
+            assert health["healthy"] is False
+            assert health["retrying"] == 1
+            assert "channel_not_found" in health["requests"][0]["last_error"]
+
+            assert await broker.retry_due_approval_notifications() == 1
+            request = registry.get_approval_request("barsik", "C_RETRY")
+            assert request["notification_state"] == "delivered"
+            assert attempts == 2
+            assert registry.get_approval_notification_health("barsik")["healthy"] is True
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_repeat_contacts_aggregate_with_bounded_renotify(self, monkeypatch):
+        import pinky_daemon.broker as broker_mod
+
+        monkeypatch.setattr(broker_mod, "_APPROVAL_RENOTIFY_HELD_COUNT", 2)
+        monkeypatch.setattr(broker_mod, "_APPROVAL_RENOTIFY_INTERVAL_SEC", 999999)
+        tmpdir, registry, broker, _sent, _ = self._make_broker()
+        notifications: list[str] = []
+
+        async def capture(
+            agent_name, platform, chat_id, content, *, account_id="",
+        ):
+            notifications.append(content)
+
+        broker._send_callback = capture
+        try:
+            registry.set_primary_user("owner", display_name="Brad")
+            registry.set_owner_notification_destinations([
+                {
+                    "platform": "telegram",
+                    "account_id": "owner-account",
+                    "conversation_id": "owner",
+                }
+            ])
+            channel = "C_BURST"
+            request_ids: list[int] = []
+            for index in range(3):
+                await broker.handle_inbound(
+                    BrokerMessage(
+                        platform="slack", chat_id=channel, sender_name="Alex",
+                        sender_id="U_ALEX", content=f"message {index}",
+                        agent_name="barsik", is_group=True,
+                    )
+                )
+                request_ids.append(
+                    registry.get_approval_request("barsik", channel)["id"]
+                )
+
+            request = registry.get_approval_request("barsik", channel)
+            assert len(set(request_ids)) == 1
+            assert request["held_count"] == 3
+            assert len(registry.get_pending_messages("barsik", channel)) == 3
+            assert len(notifications) == 2
+            assert "Held messages: 1" in notifications[0]
+            assert "Held messages: 3" in notifications[1]
         finally:
             tmpdir.cleanup()
 
@@ -936,6 +1105,13 @@ class TestMessageBrokerRouting:
             monkeypatch.setattr(broker, "_route_streaming", _fake_route)
             owner = "owner-1"
             registry.set_primary_user(owner, display_name="Brad")
+            registry.set_owner_notification_destinations([
+                {
+                    "platform": "slack",
+                    "account_id": "T_OWNER",
+                    "conversation_id": owner,
+                }
+            ])
 
             channel = "C0A8WUU743F"
             # A message in the channel → held pending under the exact channel id.

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -784,6 +784,7 @@ class TestMessageBrokerRouting:
                     "platform": "telegram",
                     "account_id": "owner-bot",
                     "conversation_id": owner,
+                    "principal_id": owner,
                 }
             ])
 
@@ -852,11 +853,13 @@ class TestMessageBrokerRouting:
                     "platform": "slack",
                     "account_id": "T_OWNER",
                     "conversation_id": "D_OWNER",
+                    "principal_id": "U_OWNER",
                 },
                 {
                     "platform": "telegram",
                     "account_id": "owner-telegram-account",
                     "conversation_id": "owner-conversation",
+                    "principal_id": "legacy-owner-id",
                 }
             ])
             channel = "C_GATED"
@@ -892,6 +895,116 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
+    async def test_fallback_recipient_can_approve_and_deny_fail_closed(
+        self, monkeypatch,
+    ):
+        """Fallback DM principal gets usable commands; wrong authority gets none."""
+        tmpdir, registry, broker, _sent, _ = self._make_broker()
+        sends: list[tuple[str, str, str, str]] = []
+        routed: list[BrokerMessage] = []
+
+        async def send(
+            agent_name, platform, chat_id, content, *, account_id="",
+        ):
+            if account_id == "tg-owner-account":
+                raise RuntimeError("telegram owner destination unavailable")
+            sends.append((platform, account_id, chat_id, content))
+
+        async def route(agent_name, message):
+            routed.append(message)
+
+        broker._send_callback = send
+        monkeypatch.setattr(broker, "_route_streaming", route)
+        try:
+            registry.set_primary_user("legacy-telegram-owner", display_name="Brad")
+            registry.set_token(
+                "barsik", "telegram", "tg-token",
+                settings={"account_id": "tg-owner-account"},
+            )
+            registry.set_token(
+                "barsik", "slack", "xoxb-token",
+                settings={"team_id": "T_OWNER"},
+            )
+            registry.set_owner_notification_destinations([
+                {
+                    "platform": "telegram",
+                    "account_id": "tg-owner-account",
+                    "conversation_id": "legacy-telegram-owner",
+                    "principal_id": "legacy-telegram-owner",
+                },
+                {
+                    "platform": "slack",
+                    "account_id": "T_OWNER",
+                    "conversation_id": "D_OWNER",
+                    "principal_id": "U_OWNER",
+                },
+            ])
+
+            approve_channel = "C_APPROVE"
+            await broker.handle_inbound(
+                BrokerMessage(
+                    platform="slack", chat_id=approve_channel, sender_name="Alex",
+                    sender_id="U_ALEX", content="approve me", agent_name="barsik",
+                    is_group=True,
+                )
+            )
+            request = registry.get_approval_request("barsik", approve_channel)
+            assert request["notification_destination"] == {
+                "platform": "slack", "account_id": "T_OWNER",
+                "conversation_id": "D_OWNER", "principal_id": "U_OWNER",
+            }
+            assert sends[0][0:3] == ("slack", "T_OWNER", "D_OWNER")
+
+            command = BrokerMessage(
+                platform="slack", chat_id="D_OWNER", sender_name="Brad",
+                sender_id="U_OWNER", content=f"/approve_{approve_channel}",
+                agent_name="barsik",
+            )
+            # Public-channel and wrong-principal copies are never authorized.
+            public_command = BrokerMessage(**{**command.__dict__, "is_group": True})
+            wrong_principal = BrokerMessage(**{**command.__dict__, "sender_id": "U_EVIL"})
+            assert await broker._handle_approval_command(public_command) is False
+            assert await broker._handle_approval_command(wrong_principal) is False
+            assert registry.get_user_status("barsik", approve_channel) == "pending"
+
+            # Token/account drift after delivery also fails closed with zero
+            # gate mutation. Restoring the exact binding makes the command usable.
+            registry.set_token(
+                "barsik", "slack", "xoxb-token",
+                settings={"team_id": "T_OTHER"},
+            )
+            assert await broker._handle_approval_command(command) is False
+            assert registry.get_user_status("barsik", approve_channel) == "pending"
+            registry.set_token(
+                "barsik", "slack", "xoxb-token",
+                settings={"team_id": "T_OWNER"},
+            )
+            await broker.handle_inbound(command)
+            assert registry.get_user_status("barsik", approve_channel) == "approved"
+            assert [message.content for message in routed] == ["approve me"]
+
+            deny_channel = "C_DENY"
+            await broker.handle_inbound(
+                BrokerMessage(
+                    platform="slack", chat_id=deny_channel, sender_name="Alex",
+                    sender_id="U_ALEX", content="deny me", agent_name="barsik",
+                    is_group=True,
+                )
+            )
+            await broker.handle_inbound(
+                BrokerMessage(
+                    platform="slack", chat_id="D_OWNER", sender_name="Brad",
+                    sender_id="U_OWNER", content=f"/deny_{deny_channel}",
+                    agent_name="barsik",
+                )
+            )
+            assert registry.get_user_status("barsik", deny_channel) == "denied"
+            assert registry.get_approval_request("barsik", deny_channel)["gate_state"] == "denied"
+            assert len(routed) == 1
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
     async def test_owner_notification_failure_retries_and_is_operator_visible(
         self, monkeypatch,
     ):
@@ -917,6 +1030,7 @@ class TestMessageBrokerRouting:
                     "platform": "telegram",
                     "account_id": "owner-account",
                     "conversation_id": "owner",
+                    "principal_id": "owner",
                 }
             ])
             await broker.handle_inbound(
@@ -964,6 +1078,7 @@ class TestMessageBrokerRouting:
                     "platform": "telegram",
                     "account_id": "owner-account",
                     "conversation_id": "owner",
+                    "principal_id": "owner",
                 }
             ])
             channel = "C_BURST"
@@ -1105,11 +1220,16 @@ class TestMessageBrokerRouting:
             monkeypatch.setattr(broker, "_route_streaming", _fake_route)
             owner = "owner-1"
             registry.set_primary_user(owner, display_name="Brad")
+            registry.set_token(
+                "barsik", "slack", "xoxb-test",
+                settings={"team_id": "T_OWNER"},
+            )
             registry.set_owner_notification_destinations([
                 {
                     "platform": "slack",
                     "account_id": "T_OWNER",
                     "conversation_id": owner,
+                    "principal_id": owner,
                 }
             ])
 


### PR DESCRIPTION
## Summary

- Store the owner notification primary destination and ordered fallbacks as canonical platform/account/conversation tuples with an explicit authorized principal.
- Add one durable approval request per legacy `(agent_name, chat_id)` gate, aggregating held count and oldest age across repeat contacts.
- Persist the held message and legacy approval aggregate in one `BEGIN IMMEDIATE` transaction on a dedicated SQLite connection, isolating it from every commit on the registry shared connection.
- Deliver owner prompts only through exact account-bound tokens and ordered fallbacks; account identity participates in adapter selection and outbound dedupe.
- Authorize approve/deny only from a configured DM whose platform, bound account, conversation, and principal all match. Public channels, wrong principals, and missing/mismatched token bindings fail closed.
- Persist notification receipt state (`delivered`, `retrying`, or `failed`), retry transient failures with exponential backoff after restart, and surface retrying/failed requests in `/health`.

## Inc 0 scope fence

Approval aggregation and pending-row selection intentionally remain on the legacy `(agent_name, chat_id)` key. The `approval_requests` schema has no platform/account/conversation columns. Composite approval keys remain Inc 1 work after the row-key migration. Grandfather approval migration is excluded pending the policy decision.

Re-notify defaults are documented in code: after four hours or ten newly held messages, whichever occurs first. Delivery retries begin at 30 seconds, cap at 30 minutes, and become operator-visible `failed` after five cycles. Each cycle walks the ordered fallback list.

## Explicit owner migration/configuration

The legacy `primary_user_chat_id` seeds the conversation and principal only when the operator explicitly supplies notification platform and account ID. Neither platform nor account is inferred from inbound traffic or ID shape. Cross-platform destinations/fallbacks require their explicit principal IDs through `/system/owner-notification-destinations`, and the selected agent token must carry the exact account/team/workspace binding.

## Review-round P1 closures

1. Concurrent atomic crash boundary: the regression pauses exactly after the held-row INSERT and before the approval-request UPSERT on the dedicated transaction connection. While paused, an unrelated thread calls `set_setting()` through the registry shared connection; the test proves that foreign writer is blocked. Injected `BaseException` rolls back the dedicated transaction, after which the unrelated setting commits independently. Reopening the DB proves held/request/due = `0/0/0`; simulated provider redelivery commits both rows and makes the request immediately discoverable.
2. Account binding: the real production broker callback is exercised. Missing and mismatched bindings raise before adapter delivery; rotating from account A to B with the same payload performs two sends, while a repeat on B dedupes.
3. Fallback authority: a forced Telegram-primary failure delivers through the configured Slack fallback; public-channel, wrong-principal, and token-account-drift commands make zero gate mutation, while the exact Slack DM principal can approve and deny.

## Integration base

Rebased onto `main` at `5ac1c101e` after independent Inc 0.5 merged. The only rebase overlap was adjacent test placement; both the merged child-thread regression and this PRs account-binding regression are retained and pass together.

## Verification

- `env -u PINKY_DREAM_TRANSPORT -u PINKY_AUTH_DENY_DEFAULT PINKY_SHARED_MCP=0 uv run pytest -q` — 4315 passed, 3 skipped
- Focused Inc 0 + P1 closures + merged thread regression — 12 passed
- `uv run ruff check src/pinky_daemon/agent_registry.py src/pinky_daemon/broker.py src/pinky_daemon/api.py tests/test_agent_registry.py tests/test_broker.py tests/test_api.py`
- `git diff --check`

Fixes #863
Refs #341