### PR TITLE
fix: grandfather existing conversation approvals

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -3502,6 +3502,53 @@ except Exception:
         ).fetchone()
         return row[0] if row else None
 
+    def grandfather_approved_users(
+        self, agent_name: str, candidates: list[tuple[str, str]],
+    ) -> list[dict]:
+        """Approve chats with durable evidence of prior agent participation.
+
+        Existing approved and denied decisions are authoritative and are never
+        changed. A qualifying pending row is healed as well: its approval
+        request is settled here, while the broker-dependent held-message flush
+        is resumed by the API startup migration handler.
+
+        Each candidate is isolated so a malformed legacy row cannot brick
+        daemon startup. The caller owns cross-store candidate discovery and the
+        one-shot migration marker.
+        """
+        seeded: list[dict] = []
+        seen: set[str] = set()
+        for raw_chat_id, raw_display_name in candidates:
+            chat_id = str(raw_chat_id or "").strip()
+            if not chat_id or chat_id in seen:
+                continue
+            seen.add(chat_id)
+            display_name = str(raw_display_name or "").strip()
+            try:
+                previous_status = self.get_user_status(agent_name, chat_id)
+                if previous_status not in (None, "pending"):
+                    continue
+                approved = self.approve_user(
+                    agent_name,
+                    chat_id,
+                    display_name,
+                    approved_by="grandfather-migration",
+                )
+                was_pending = previous_status == "pending"
+                if was_pending:
+                    self.settle_approval_request(agent_name, chat_id, "approved")
+                seeded.append({
+                    "chat_id": chat_id,
+                    "display_name": approved.display_name,
+                    "pending_to_approved": was_pending,
+                })
+            except Exception as exc:
+                _log(
+                    "ERROR agent_registry: grandfather migration skipped "
+                    f"{agent_name}/{chat_id}: {exc}"
+                )
+        return seeded
+
     def get_user_timezone(self, agent_name: str, chat_id: str) -> str:
         """Get a user's timezone. Returns IANA timezone string or empty."""
         row = self._db.execute(
@@ -3637,6 +3684,15 @@ except Exception:
         )
         self._db.commit()
         return cursor.rowcount
+
+    def mark_pending_message_delivered(self, message_id: int) -> bool:
+        """Mark one held message delivered immediately after its route succeeds."""
+        cursor = self._db.execute(
+            "UPDATE pending_messages SET delivered=1 WHERE id=? AND delivered=0",
+            (message_id,),
+        )
+        self._db.commit()
+        return cursor.rowcount > 0
 
     def delete_pending_messages(self, agent_name: str, chat_id: str = "") -> int:
         """Delete pending messages. If chat_id given, only for that chat."""

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -420,6 +420,291 @@ def _refresh_1m_models(registry) -> None:
         pass  # Keep fallback
 
 
+_GRANDFATHER_MARKER = "migration:grandfather_approved_users"
+_GRANDFATHER_DIGEST_PENDING = f"{_GRANDFATHER_MARKER}:digest_pending"
+_GRANDFATHER_PLATFORMS = ("telegram", "discord", "slack", "imessage")
+
+
+def _grandfather_candidates(store, registry, agent_name: str) -> list[tuple[str, str]]:
+    """Collect prior-participation evidence without crossing store boundaries.
+
+    Active group membership comes from the registry. Authoritative tool-send
+    history is queried here, in the API composition root that already owns the
+    conversations store.
+    """
+    candidates: dict[str, str] = {}
+    for group in registry.list_group_chats(agent_name, active_only=True):
+        chat_id = str(group.get("chat_id") or "").strip()
+        if chat_id:
+            candidates[chat_id] = str(group.get("chat_title") or "").strip()
+
+    placeholders = ",".join("?" for _ in _GRANDFATHER_PLATFORMS)
+    rows = store._conn.execute(  # API composition root intentionally owns this query.
+        f"""SELECT chat_id
+            FROM messages
+            WHERE role='assistant' AND chat_id != ''
+              AND json_valid(metadata)
+              AND json_extract(metadata, '$.tool') IS NOT NULL
+              AND lower(platform) IN ({placeholders})
+              AND session_id = ?
+            GROUP BY chat_id
+            ORDER BY MIN(timestamp), chat_id""",
+        (*_GRANDFATHER_PLATFORMS, f"{agent_name}-main"),
+    ).fetchall()
+    for row in rows:
+        chat_id = str(row[0] or "").strip()
+        if chat_id:
+            candidates.setdefault(chat_id, "")
+    return list(candidates.items())
+
+
+def _run_grandfather_approved_users_migration(store, registry) -> list[dict]:
+    """Run the one-shot additive migration, leaving broker work for startup."""
+    if registry.get_setting(_GRANDFATHER_MARKER) == "1":
+        return []
+
+    try:
+        raw_pending = registry.get_setting(_GRANDFATHER_DIGEST_PENDING, "")
+        if raw_pending:
+            digest = json.loads(raw_pending)
+            if not isinstance(digest, dict) or not isinstance(digest.get("agents"), list):
+                raise ValueError("pending grandfather digest is invalid")
+        else:
+            planned_agents: list[dict] = []
+            for agent in registry.list():
+                planned_chats: list[dict] = []
+                for chat_id, display_name in _grandfather_candidates(
+                    store, registry, agent.name,
+                ):
+                    status = registry.get_user_status(agent.name, chat_id)
+                    if status not in (None, "pending"):
+                        continue
+                    planned_chats.append({
+                        "chat_id": chat_id,
+                        "display_name": (
+                            display_name
+                            or registry.get_user_display_name(agent.name, chat_id)
+                        ),
+                        "pending_to_approved": status == "pending",
+                    })
+                if planned_chats:
+                    planned_agents.append({
+                        "agent_name": agent.name,
+                        "count": len(planned_chats),
+                        "chats": planned_chats,
+                    })
+            digest = {
+                "version": 1,
+                "seeded_at": time.time(),
+                "agents": planned_agents,
+            }
+            # Journal the exact plan before the first row mutation. If the
+            # process dies between committed rows, the next boot resumes the
+            # same plan and still produces one complete owner receipt.
+            if planned_agents:
+                registry.set_setting(
+                    _GRANDFATHER_DIGEST_PENDING,
+                    json.dumps(digest, separators=(",", ":"), sort_keys=True),
+                )
+
+        seeded_agents: list[dict] = []
+        complete = True
+        for planned_agent in digest["agents"]:
+            agent_name = str(planned_agent.get("agent_name") or "").strip()
+            planned_chats = planned_agent.get("chats", [])
+            registry.grandfather_approved_users(
+                agent_name,
+                [
+                    (str(chat.get("chat_id") or ""), str(chat.get("display_name") or ""))
+                    for chat in planned_chats
+                ],
+            )
+
+            # A crash can occur after approve_user commits but before the
+            # pending request is settled. Finish that half-completed row on the
+            # journal replay before deciding the migration is complete.
+            approved_rows = {
+                user.chat_id: user for user in registry.list_approved_users(agent_name)
+            }
+            for chat in planned_chats:
+                if not chat.get("pending_to_approved"):
+                    continue
+                chat_id = str(chat.get("chat_id") or "")
+                approved = approved_rows.get(chat_id)
+                request = registry.get_approval_request(agent_name, chat_id)
+                if (
+                    approved
+                    and approved.status == "approved"
+                    and approved.approved_by == "grandfather-migration"
+                    and request
+                    and request["gate_state"] == "pending"
+                ):
+                    registry.settle_approval_request(agent_name, chat_id, "approved")
+
+            seeded_chats: list[dict] = []
+            for chat in planned_chats:
+                chat_id = str(chat.get("chat_id") or "")
+                approved = approved_rows.get(chat_id)
+                request = registry.get_approval_request(agent_name, chat_id)
+                pending_settled = (
+                    not chat.get("pending_to_approved")
+                    or request is None
+                    or request["gate_state"] == "approved"
+                )
+                if not (
+                    approved
+                    and approved.status == "approved"
+                    and approved.approved_by == "grandfather-migration"
+                    and pending_settled
+                ):
+                    complete = False
+                    continue
+                seeded_chats.append({
+                    "chat_id": chat_id,
+                    "display_name": approved.display_name,
+                    "pending_to_approved": bool(chat.get("pending_to_approved")),
+                })
+            if seeded_chats:
+                seeded_agents.append({
+                    "agent_name": agent_name,
+                    "count": len(seeded_chats),
+                    "chats": seeded_chats,
+                })
+
+        if not complete:
+            _log(
+                "ERROR startup: grandfather approval migration incomplete; "
+                "leaving marker unset for retry"
+            )
+            return seeded_agents
+
+        if seeded_agents:
+            digest["agents"] = seeded_agents
+            registry.set_setting(
+                _GRANDFATHER_DIGEST_PENDING,
+                json.dumps(digest, separators=(",", ":"), sort_keys=True),
+            )
+        registry.set_setting(_GRANDFATHER_MARKER, "1")
+        return seeded_agents
+    except Exception as exc:
+        # Migration evidence may be temporarily unreadable on a legacy DB.
+        # Keep the marker unset so the next boot retries; never brick startup.
+        _log(f"ERROR startup: grandfather approval migration failed: {exc}")
+        return []
+
+
+def _format_grandfather_digest(digest: dict) -> str:
+    """Render the durable one-time owner receipt."""
+    lines = ["Grandfather approval migration completed.", ""]
+    total = 0
+    for agent in digest.get("agents", []):
+        chats = agent.get("chats", [])
+        total += len(chats)
+        lines.append(f"{agent.get('agent_name', 'unknown')}: {len(chats)} chat(s)")
+        for chat in chats:
+            chat_id = str(chat.get("chat_id") or "")
+            display_name = str(chat.get("display_name") or "").strip()
+            label = f"{display_name} ({chat_id})" if display_name else chat_id
+            if chat.get("pending_to_approved"):
+                label += " - pending -> approved"
+            lines.append(f"- {label}")
+        lines.append("")
+    lines.append(
+        f"Seeded {total} prior conversation(s) from active groups and "
+        "authoritative outbound-send history."
+    )
+    return "\n".join(lines)
+
+
+async def _resume_grandfather_migration(registry, broker) -> bool:
+    """Flush healed pending chats and deliver the durable owner digest."""
+    if registry.get_setting(_GRANDFATHER_MARKER) != "1":
+        return False
+    raw_digest = registry.get_setting(_GRANDFATHER_DIGEST_PENDING, "")
+    if not raw_digest:
+        return False
+    try:
+        digest = json.loads(raw_digest)
+        if not isinstance(digest, dict) or not isinstance(digest.get("agents"), list):
+            raise ValueError("digest payload is not an object with agents")
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        _log(f"ERROR startup: grandfather migration digest is invalid: {exc}")
+        return False
+
+    flush_failed = False
+    preferred_agents: list[str] = []
+    for agent in digest["agents"]:
+        agent_name = str(agent.get("agent_name") or "").strip()
+        if not agent_name:
+            continue
+        preferred_agents.append(agent_name)
+        for chat in agent.get("chats", []):
+            if not chat.get("pending_to_approved"):
+                continue
+            chat_id = str(chat.get("chat_id") or "").strip()
+            try:
+                await broker.handle_approval(agent_name, chat_id)
+            except Exception as exc:
+                flush_failed = True
+                _log(
+                    "ERROR startup: grandfather pending-message flush failed "
+                    f"for {agent_name}/{chat_id}: {exc}"
+                )
+    if flush_failed:
+        # Retain the digest as the durable retry signal for both operations.
+        return False
+
+    send_callback = broker.send_callback
+    destinations = registry.get_owner_notification_destinations()
+    if not send_callback or not destinations:
+        _log(
+            "ERROR startup: grandfather migration digest pending; owner "
+            "notification destination or send callback is not configured"
+        )
+        return False
+
+    all_agent_names = preferred_agents + [
+        agent.name for agent in registry.list() if agent.name not in preferred_agents
+    ]
+    notification = _format_grandfather_digest(digest)
+    last_error = "no destination has an exactly bound token"
+    for destination in destinations:
+        sender_agent = next((
+            agent_name
+            for agent_name in all_agent_names
+            if registry.get_raw_token_for_account(
+                agent_name,
+                destination["platform"],
+                destination["account_id"],
+            )
+        ), "")
+        if not sender_agent:
+            continue
+        try:
+            result = await send_callback(
+                sender_agent,
+                destination["platform"],
+                destination["conversation_id"],
+                notification,
+                account_id=destination["account_id"],
+            )
+            if not isinstance(result, dict) or result.get("sent") is not True:
+                raise RuntimeError("send callback did not confirm delivery")
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            continue
+        registry.delete_setting(_GRANDFATHER_DIGEST_PENDING)
+        _log(
+            "startup: grandfather migration digest delivered via "
+            f"{destination['platform']}/{destination['account_id']}/"
+            f"{destination['conversation_id']}"
+        )
+        return True
+
+    _log(f"ERROR startup: grandfather migration digest delivery failed: {last_error}")
+    return False
+
+
 # ── Research Pipeline Models ──────────────────────────────────
 
 
@@ -1275,6 +1560,7 @@ def create_api(
     store = ConversationStore(db_path=db_path)
     analytics = AnalyticsStore(db_path=db_path.replace(".db", "_analytics.db"))
     agents = AgentRegistry(db_path=db_path.replace(".db", "_agents.db"))
+    _run_grandfather_approved_users_migration(store, agents)
     _refresh_1m_models(agents)
     audit = AuditStore(db_path=db_path.replace(".db", "_audit.db"))
     hooks = HookManager(audit_store=audit)
@@ -10063,6 +10349,13 @@ npm run build</pre>
             )
             await shared_mcp_manager.start()
             _log(f"startup: shared MCP server started on {shared_mcp_manager.url}")
+
+        # The migration settled qualifying approval requests synchronously in
+        # create_api. Flush their held messages only after shared MCP is ready
+        # (so a cold-started session can really accept them), but before any
+        # platform poller can ingest new traffic. The same durable journal then
+        # carries the one-time owner digest until confirmed delivery.
+        await _resume_grandfather_migration(agents, broker)
 
         # Boot policy: the main agent always starts. Enabled siblings start only
         # when the shutdown manifest proves they had a live streaming transport;

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1325,6 +1325,11 @@ class MessageBroker:
     async def handle_approval(self, agent_name: str, chat_id: str) -> int:
         """When a pending user is approved, deliver their held messages.
 
+        Successful rows are checkpointed individually so a later-row failure
+        retries only the undelivered suffix. Delivery remains at-least-once
+        across a process crash between the route handoff and its checkpoint;
+        closing that narrow window requires end-to-end idempotency support.
+
         Returns the number of messages delivered.
         """
         pending = self._registry.get_pending_messages(agent_name, chat_id)
@@ -1351,8 +1356,12 @@ class MessageBroker:
             )
             await self._route_streaming(agent_name, broker_msg)
 
-        # Mark as delivered
-        self._registry.mark_pending_delivered(agent_name, chat_id)
+            # Checkpoint each successful handoff before attempting the next
+            # row. A later-row failure can then retry without deterministically
+            # duplicating the already-routed prefix. A process crash between
+            # route and this write remains intentionally at-least-once; closing
+            # that final window requires an end-to-end idempotency key/claim.
+            self._registry.mark_pending_message_delivered(msg["id"])
 
         _log(f"broker: queued {len(pending)} pending messages for delivery to {agent_name}")
         return len(pending)

--- a/tests/test_grandfather_migration.py
+++ b/tests/test_grandfather_migration.py
@@ -1,0 +1,317 @@
+"""Regression coverage for the #863 grandfather approval migration."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.api import (
+    _GRANDFATHER_DIGEST_PENDING,
+    _GRANDFATHER_MARKER,
+    _format_grandfather_digest,
+    _resume_grandfather_migration,
+    _run_grandfather_approved_users_migration,
+)
+from pinky_daemon.broker import BrokerMessage, MessageBroker
+from pinky_daemon.conversation_store import ConversationStore
+from pinky_daemon.sessions import SessionManager
+
+
+@pytest.fixture
+def migration_stores(tmp_path):
+    registry = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    conversations = ConversationStore(db_path=str(tmp_path / "conversations.db"))
+    registry.register("kuzya", working_dir=str(tmp_path))
+    yield registry, conversations
+    conversations.close()
+    registry.close()
+
+
+def _tool_send(
+    conversations: ConversationStore,
+    chat_id: str,
+    *,
+    platform: str = "telegram",
+    agent_name: str = "kuzya",
+) -> None:
+    conversations.append(
+        f"{agent_name}-main",
+        "assistant",
+        "sent",
+        platform=platform,
+        chat_id=chat_id,
+        metadata={"tool": "send"},
+    )
+
+
+def test_migration_unions_active_groups_and_tool_sends_only(migration_stores):
+    registry, conversations = migration_stores
+    registry.upsert_group_chat("kuzya", "GROUP_A", "A Team", platform="slack")
+    registry.upsert_group_chat("kuzya", "INACTIVE", "Old Group")
+    registry.deactivate_group_chat("kuzya", "INACTIVE")
+
+    _tool_send(conversations, "DM_B")
+    _tool_send(conversations, "PREAPPROVED")
+    _tool_send(conversations, "WEB_CHAT", platform="web")
+    _tool_send(conversations, "FERRY_CHAT", platform="ferry")
+    _tool_send(conversations, "OTHER_AGENT", agent_name="barsik")
+    conversations.append(
+        "kuzya-main", "user", "inbound only",
+        platform="telegram", chat_id="INBOUND_ONLY",
+    )
+    conversations.append(
+        "kuzya-main", "assistant", "turn transcript",
+        platform="telegram", chat_id="TRANSCRIPT_ONLY",
+    )
+    registry.approve_user("kuzya", "PREAPPROVED", "Original Name", "owner")
+
+    seeded = _run_grandfather_approved_users_migration(conversations, registry)
+
+    assert registry.get_setting(_GRANDFATHER_MARKER) == "1"
+    assert {(chat["chat_id"], chat["display_name"]) for chat in seeded[0]["chats"]} == {
+        ("GROUP_A", "A Team"),
+        ("DM_B", ""),
+    }
+    assert registry.get_user_status("kuzya", "INACTIVE") is None
+    assert registry.get_user_status("kuzya", "INBOUND_ONLY") is None
+    assert registry.get_user_status("kuzya", "TRANSCRIPT_ONLY") is None
+    assert registry.get_user_status("kuzya", "WEB_CHAT") is None
+    assert registry.get_user_status("kuzya", "FERRY_CHAT") is None
+    preapproved = next(
+        user for user in registry.list_approved_users("kuzya")
+        if user.chat_id == "PREAPPROVED"
+    )
+    assert preapproved.display_name == "Original Name"
+    assert preapproved.approved_by == "owner"
+
+
+def test_outbound_history_uses_exact_agent_main_session(migration_stores):
+    registry, conversations = migration_stores
+    for agent_name in ("foo", "foo-bar", "a_b", "axb"):
+        registry.register(agent_name, working_dir=registry.get("kuzya").working_dir)
+    _tool_send(conversations, "FROM_FOO_BAR", agent_name="foo-bar")
+    _tool_send(conversations, "FROM_AXB", agent_name="axb")
+
+    _run_grandfather_approved_users_migration(conversations, registry)
+
+    assert registry.get_user_status("foo", "FROM_FOO_BAR") is None
+    assert registry.get_user_status("a_b", "FROM_AXB") is None
+    assert registry.get_user_status("foo-bar", "FROM_FOO_BAR") == "approved"
+    assert registry.get_user_status("axb", "FROM_AXB") == "approved"
+
+
+def test_denied_is_untouched_and_reruns_do_not_recreate_digest(migration_stores):
+    registry, conversations = migration_stores
+    _tool_send(conversations, "DENIED")
+    _tool_send(conversations, "NEW_CHAT")
+    registry.deny_user("kuzya", "DENIED")
+
+    _run_grandfather_approved_users_migration(conversations, registry)
+    assert registry.get_user_status("kuzya", "DENIED") == "denied"
+    assert registry.get_setting(_GRANDFATHER_DIGEST_PENDING)
+
+    registry.delete_setting(_GRANDFATHER_DIGEST_PENDING)
+    assert _run_grandfather_approved_users_migration(conversations, registry) == []
+    assert registry.get_setting(_GRANDFATHER_DIGEST_PENDING) == ""
+
+    registry.delete_setting(_GRANDFATHER_MARKER)
+    assert _run_grandfather_approved_users_migration(conversations, registry) == []
+    assert registry.get_setting(_GRANDFATHER_DIGEST_PENDING) == ""
+
+
+def test_no_seeded_rows_sets_marker_without_digest(migration_stores):
+    registry, conversations = migration_stores
+
+    assert _run_grandfather_approved_users_migration(conversations, registry) == []
+    assert registry.get_setting(_GRANDFATHER_MARKER) == "1"
+    assert registry.get_setting(_GRANDFATHER_DIGEST_PENDING) == ""
+
+
+def test_unmarked_journal_resumes_after_row_was_already_committed(migration_stores):
+    registry, conversations = migration_stores
+    digest = {
+        "version": 1,
+        "seeded_at": 1.0,
+        "agents": [{
+            "agent_name": "kuzya",
+            "count": 1,
+            "chats": [{
+                "chat_id": "PARTIAL",
+                "display_name": "Partial Group",
+                "pending_to_approved": False,
+            }],
+        }],
+    }
+    registry.set_setting(_GRANDFATHER_DIGEST_PENDING, json.dumps(digest))
+    registry.approve_user(
+        "kuzya", "PARTIAL", "Partial Group", "grandfather-migration",
+    )
+
+    seeded = _run_grandfather_approved_users_migration(conversations, registry)
+
+    assert seeded[0]["chats"][0]["chat_id"] == "PARTIAL"
+    assert registry.get_setting(_GRANDFATHER_MARKER) == "1"
+    resumed = json.loads(registry.get_setting(_GRANDFATHER_DIGEST_PENDING))
+    assert resumed["agents"] == seeded
+
+
+@pytest.mark.asyncio
+async def test_pending_chat_flushes_and_digest_retries_until_confirmed(migration_stores):
+    registry, conversations = migration_stores
+    chat_id = "C_TOD"
+    _tool_send(conversations, chat_id, platform="slack")
+    registry.add_pending_user("kuzya", chat_id, "TOD")
+    registry.queue_pending_message_with_approval_request(
+        agent_name="kuzya",
+        platform="slack",
+        chat_id=chat_id,
+        reply_chat_id=chat_id,
+        sender_id="U_TOD",
+        sender_name="TOD",
+        content="onesie?",
+        is_group=True,
+        target_name="TOD",
+    )
+    registry.set_token(
+        "kuzya", "telegram", "token",
+        settings={"account_id": "owner-bot"},
+    )
+    registry.set_owner_notification_destinations([{
+        "platform": "telegram",
+        "account_id": "owner-bot",
+        "conversation_id": "OWNER_DM",
+        "principal_id": "OWNER",
+    }])
+    _run_grandfather_approved_users_migration(conversations, registry)
+
+    routed: list[BrokerMessage] = []
+    attempts: list[str] = []
+
+    async def route(_agent_name, message):
+        routed.append(message)
+
+    async def fail_send(*args, **kwargs):
+        attempts.append(args[3])
+        raise RuntimeError("offline")
+
+    broker = MessageBroker(registry, SessionManager(), send_callback=fail_send)
+    broker._route_streaming = route
+
+    assert registry.get_user_status("kuzya", chat_id) == "approved"
+    assert registry.get_approval_request("kuzya", chat_id)["gate_state"] == "approved"
+    assert await _resume_grandfather_migration(registry, broker) is False
+    assert registry.get_pending_messages("kuzya", chat_id) == []
+    delivered = registry._db.execute(
+        "SELECT delivered FROM pending_messages WHERE agent_name=? AND chat_id=?",
+        ("kuzya", chat_id),
+    ).fetchone()
+    assert delivered[0] == 1
+    assert [message.content for message in routed] == ["onesie?"]
+    assert registry.get_setting(_GRANDFATHER_DIGEST_PENDING)
+
+    async def confirm_send(*args, **kwargs):
+        attempts.append(args[3])
+        return {"sent": True}
+
+    broker._send_callback = confirm_send
+    assert await _resume_grandfather_migration(registry, broker) is True
+    assert registry.get_setting(_GRANDFATHER_DIGEST_PENDING) == ""
+    assert len(attempts) == 2
+    assert "C_TOD" in attempts[-1]
+    assert "pending -> approved" in attempts[-1]
+
+
+@pytest.mark.asyncio
+async def test_partial_flush_retries_only_the_undelivered_row(migration_stores):
+    registry, _conversations = migration_stores
+    chat_id = "C_PARTIAL"
+    for content in ("first", "second"):
+        registry.queue_pending_message(
+            agent_name="kuzya",
+            platform="slack",
+            chat_id=chat_id,
+            reply_chat_id=chat_id,
+            sender_id="U_PARTIAL",
+            sender_name="Partial",
+            content=content,
+            is_group=True,
+        )
+
+    seen: list[str] = []
+    fail_second = True
+
+    async def route(_agent_name, message):
+        seen.append(message.content)
+        if message.content == "second" and fail_second:
+            raise RuntimeError("second row failed")
+
+    broker = MessageBroker(registry, SessionManager())
+    broker._route_streaming = route
+
+    with pytest.raises(RuntimeError, match="second row failed"):
+        await broker.handle_approval("kuzya", chat_id)
+    rows = registry._db.execute(
+        "SELECT content, delivered FROM pending_messages ORDER BY id",
+    ).fetchall()
+    assert rows == [("first", 1), ("second", 0)]
+
+    fail_second = False
+    assert await broker.handle_approval("kuzya", chat_id) == 1
+    assert seen == ["first", "second", "second"]
+    rows = registry._db.execute(
+        "SELECT content, delivered FROM pending_messages ORDER BY id",
+    ).fetchall()
+    assert rows == [("first", 1), ("second", 1)]
+
+
+@pytest.mark.asyncio
+async def test_tod_shaped_active_group_routes_without_gate(migration_stores):
+    registry, conversations = migration_stores
+    registry.upsert_group_chat("kuzya", "C_ACTIVE", "TOD", platform="slack")
+    _run_grandfather_approved_users_migration(conversations, registry)
+
+    routed: list[BrokerMessage] = []
+
+    async def route(_agent_name, message):
+        routed.append(message)
+
+    broker = MessageBroker(registry, SessionManager())
+    broker._route_streaming = route
+    await broker.handle_inbound(BrokerMessage(
+        platform="slack",
+        chat_id="C_ACTIVE",
+        sender_id="U_TOD",
+        sender_name="TOD",
+        content="post-upgrade",
+        agent_name="kuzya",
+        is_group=True,
+    ))
+
+    assert [message.content for message in routed] == ["post-upgrade"]
+    assert registry.get_pending_messages("kuzya", "C_ACTIVE") == []
+    assert registry.get_approval_request("kuzya", "C_ACTIVE") is None
+
+
+def test_digest_render_lists_exact_seeded_chats():
+    digest = {
+        "agents": [{
+            "agent_name": "kuzya",
+            "count": 2,
+            "chats": [
+                {"chat_id": "C1", "display_name": "Group One", "pending_to_approved": False},
+                {"chat_id": "D2", "display_name": "", "pending_to_approved": True},
+            ],
+        }],
+    }
+
+    rendered = _format_grandfather_digest(json.loads(json.dumps(digest)))
+
+    assert rendered.startswith("Grandfather approval migration completed.")
+    assert "✅" not in rendered
+    assert "•" not in rendered
+    assert "kuzya: 2 chat(s)" in rendered
+    assert "- Group One (C1)" in rendered
+    assert "- D2 - pending -> approved" in rendered
+    assert "Seeded 2 prior conversation(s)" in rendered


### PR DESCRIPTION
## Summary

- run a one-time startup migration that seeds per-agent `approved_users` from active `group_chats` and authoritative outbound tool-send history attributed by the exact canonical `{agent}-main` session ID
- preserve existing approved/denied decisions, heal qualifying pending rows, settle their approval requests, and flush held messages through the broker
- checkpoint each successfully routed held row so a later-row failure retries only the undelivered suffix
- persist a fail-loud owner digest through the canonical #865 destination/account binding and clear it only after confirmed delivery
- journal the exact seed plan before row mutation so crash/restart replay remains idempotent and cannot lose the receipt

## Why

The approval gate was introduced without seeding already-active conversations. A long-running group could therefore be held on its first post-upgrade message even though the agent had previously participated there.

Review also found a pre-existing amplification in the shared approval flush: if a later held row failed, earlier successfully routed rows remained unmarked and were deterministically duplicated on retry. Per-row checkpoints remove that deterministic replay.

## Validation

- `uv run ruff check .` — passed
- `uv run pytest -q tests/test_grandfather_migration.py tests/test_agent_registry.py tests/test_broker.py` — 196 passed
- exact-attribution regressions cover `foo` vs `foo-bar` and `a_b` vs `axb`
- partial-failure regression proves row 1 becomes `delivered=1`, row 2 remains `delivered=0`, and retry routes only row 2
- `env PINKY_SHARED_MCP=0 PINKY_DREAM_TRANSPORT=sdk uv run pytest -q tests/test_api.py::TestAPI::test_manual_dream_uses_full_persisted_conversation_history` — 1 passed (CI-default environment verification after live-daemon variables caused an unrelated local port/dream transport collision)

Sample digest render:

```text
Grandfather approval migration completed.

kuzya: 2 chat(s)
- Group One (C1)
- D2 - pending -> approved

Seeded 2 prior conversation(s) from active groups and authoritative outbound-send history.
```

## Accepted caveats

- Discord and Slack DM delivery-channel IDs differ from sender user IDs. Historical outbound DM rows therefore seed harmless channel-ID approvals that do not protect a never-approved sender-ID gate key; Telegram DMs and all group/channel incident paths match exactly.
- Deliveries through the broker's internal `_send_message` path are not recorded in `messages`, so outbound-history discovery cannot see them. Active `group_chats` remains the authoritative coverage for the incident-class group case.
- Held-message delivery is at-least-once across the narrow process-crash window between routing one row and checkpointing it. Closing that final window requires an end-to-end idempotency key or durable claim and is out of scope; per-row checkpoints prevent deterministic prefix duplication after later-row failures.

Refs #863.