### PR TITLE
fix(models): gpt-5.6-sol has native 1M context, not 200k

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -4392,6 +4392,23 @@ except Exception:
         ("openai/gpt-5.5", (1.75, 14.0, 0.175), (5.0, 30.0, 0.5)),
     ]
 
+    # One-time context-window / 1M-flag corrections for rows already seeded
+    # with the wrong window. Same INSERT OR IGNORE gap as _PRICE_CORRECTIONS:
+    # fixing _MODEL_SEEDS alone never migrates an existing install. Each entry
+    # rewrites one model id ONLY while the row still carries the exact stale
+    # ``(context_window, is_1m)`` pair — an operator-customized window is left
+    # untouched.
+    _CONTEXT_CORRECTIONS = [
+        # (id, (stale_ctx, stale_is_1m), (correct_ctx, correct_is_1m))
+        # #873: gpt-5.6-sol has a native 1M window but deployed DBs seeded it
+        # at 200k/is_1m=0 before that was known. The tmux harness reads is_1m
+        # (api._refresh_1m_models rebinds streaming_session._1M_MODELS from the
+        # DB set), so a stale row caps context at 200k and the sanity watchdog
+        # force-restarts at ~55% of ~167k — thrashing on long tasks. Realign
+        # existing rows to 1M so all three read paths converge.
+        ("openai/gpt-5.6-sol", (200_000, 0), (1_000_000, 1)),
+    ]
+
     def _seed_models(self) -> None:
         """Ensure default models exist (idempotent).
 
@@ -4430,11 +4447,25 @@ except Exception:
                  mid, old_in, old_out, old_cached),
             )
             corrected += cur.rowcount
+        ctx_corrected = 0
+        for mid, (old_ctx, old_1m), (new_ctx, new_1m) in self._CONTEXT_CORRECTIONS:
+            cur = self._db.execute(
+                """UPDATE models
+                   SET context_window=?, is_1m=?, updated_at=?
+                   WHERE id=? AND context_window=? AND is_1m=?""",
+                (new_ctx, new_1m, now, mid, old_ctx, old_1m),
+            )
+            ctx_corrected += cur.rowcount
         self._db.commit()
         if added:
             _log(f"agent_registry: seeded {added} model(s)")
         if corrected:
             _log(f"agent_registry: corrected stale prices on {corrected} model(s)")
+        if ctx_corrected:
+            _log(
+                "agent_registry: corrected stale context windows on "
+                f"{ctx_corrected} model(s)"
+            )
 
     def list_models(self, *, provider: str = "", active_only: bool = True) -> list[dict]:
         """List available models, optionally filtered by provider."""

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -4365,7 +4365,7 @@ except Exception:
         ("anthropic", "claude-opus-4-5", "Claude Opus 4.5", "Previous-gen Opus.", "opus", 200_000, 0, 5.0, 25.0, 0.5, 1, 40),
         ("anthropic", "claude-sonnet-4-5", "Claude Sonnet 4.5", "Previous-gen Sonnet.", "sonnet", 200_000, 0, 3.0, 15.0, 0.3, 1, 50),
         # OpenAI / Codex CLI
-        ("openai", "gpt-5.6-sol", "GPT-5.6 Sol", "Current codex fleet model (2026-07). Frontier coding + reasoning. Codex sign-in auth only (API pending).", "flagship", 200_000, 0, 5.0, 30.0, 0.5, 0, 54),
+        ("openai", "gpt-5.6-sol", "GPT-5.6 Sol", "Current codex fleet model (2026-07). Frontier coding + reasoning. 1M context. Codex sign-in auth only (API pending).", "flagship", 1_000_000, 1, 5.0, 30.0, 0.5, 0, 54),
         ("openai", "gpt-5.5", "GPT-5.5", "Previous frontier. Coding + reasoning. Codex sign-in auth only (API pending).", "flagship", 200_000, 0, 5.0, 30.0, 0.5, 0, 55),
         ("openai", "gpt-5.4", "GPT-5.4", "Flagship. Complex reasoning & coding.", "flagship", 200_000, 0, 1.75, 14.0, 0.175, 0, 60),
         ("openai", "gpt-5.4-mini", "GPT-5.4 Mini", "Fast + capable. Daily driver.", "mid", 200_000, 0, 0.25, 2.0, 0.025, 0, 70),

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -41,6 +41,10 @@ _1M_MODELS = {
     "claude-opus-4-6",
     "claude-opus-4-7",
     "claude-opus-4-8",
+    # Codex fleet (proxy). gpt-5.6-sol has a native 1M window; without this the
+    # tmux harness caps it at 200k and force-restarts far too early (~55% of
+    # ~167k), thrashing on long tasks.
+    "gpt-5.6-sol",
 }
 
 DEFAULT_STREAMING_ALLOWED_TOOLS = [

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -1088,12 +1088,16 @@ class TestModelSeeds:
         contain every model the registry flags is_1m=1. PR #837 added
         claude-sonnet-5 to the three cost/registry tables but not to this set,
         so a sonnet-5 SDK session capped context at 200k and compacted early.
-        Pin them together so the next 1M model add can't silently drift."""
+        Pin them together so the next 1M model add can't silently drift.
+
+        Spans EVERY provider (not just anthropic) — #873 added an OpenAI 1M
+        model (gpt-5.6-sol); an anthropic-only filter would have stayed green
+        while an OpenAI 1M model drifted out of the set."""
         from pinky_daemon.streaming_session import _1M_MODELS
 
         registry_1m = {
             m["model_id"]
-            for m in registry.list_models(provider="anthropic", active_only=False)
+            for m in registry.list_models(active_only=False)
             if m["is_1m"] == 1
         }
         missing = registry_1m - _1M_MODELS
@@ -1201,3 +1205,41 @@ class TestModelSeeds:
             if m["id"] == "openai/gpt-5.5"
         )
         assert gpt["input_price"] == 9.99
+
+    def test_stale_gpt56_sol_context_corrected_on_existing_rows(self, registry):
+        """#873: deployed DBs seeded gpt-5.6-sol at 200k/is_1m=0 before its
+        native 1M window was known. The next seed pass migrates existing rows
+        to 1M (INSERT OR IGNORE alone never reaches them), so the tmux harness
+        stops capping context at 200k and force-restarting far too early."""
+        registry._db.execute(
+            "UPDATE models SET context_window=200000, is_1m=0"
+            " WHERE id='openai/gpt-5.6-sol'"
+        )
+        registry._db.commit()
+        registry._seed_models()
+        sol = next(
+            m for m in registry.list_models(provider="openai", active_only=False)
+            if m["id"] == "openai/gpt-5.6-sol"
+        )
+        assert sol["context_window"] == 1_000_000
+        assert sol["is_1m"] == 1
+        # The DB-derived 1M set (what api._refresh_1m_models rebinds from) now
+        # carries it, so the API context-window path converges with the DB too.
+        assert "gpt-5.6-sol" in registry.get_1m_models()
+
+    def test_operator_customized_gpt56_sol_context_survives_reseed(self, registry):
+        """Same exact-stale-pair gate as the price corrections — an operator
+        who intentionally pinned gpt-5.6-sol to a non-default window must not
+        be clobbered by the 1M migration."""
+        registry._db.execute(
+            "UPDATE models SET context_window=400000, is_1m=0"
+            " WHERE id='openai/gpt-5.6-sol'"
+        )
+        registry._db.commit()
+        registry._seed_models()
+        sol = next(
+            m for m in registry.list_models(provider="openai", active_only=False)
+            if m["id"] == "openai/gpt-5.6-sol"
+        )
+        assert sol["context_window"] == 400_000
+        assert sol["is_1m"] == 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2202,9 +2202,13 @@ class TestAPI:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             with TestClient(app) as client:
+                # Cross window classes so the change forces the rebuild path:
+                # gpt-5.5 is 200k, gpt-5.6-sol is native 1M (#873). A same-class
+                # swap (both 1M) takes the hot-swap branch instead — not what
+                # this #856 rebuild test is exercising.
                 app.state.agents.register(
                     "murzik",
-                    model="claude-opus-4-7",
+                    model="gpt-5.5",
                     runtime="codex_cli",
                     transport="tmux",
                     provider_url="codex_cli",
@@ -2213,14 +2217,14 @@ class TestAPI:
                     working_dir=os.path.join(tmpdir, "murzik"),
                 )
                 fake = self._FakeStreamingSession(
-                    "murzik", "main", max_tokens=1_000_000
+                    "murzik", "main", max_tokens=200_000
                 )
-                fake._config.model = "claude-opus-4-7"
+                fake._config.model = "gpt-5.5"
                 fake._config.provider_url = "codex_cli"
                 fake._config.provider_key = "old-key"
                 fake._config.thinking_effort = "low"
                 fake._config.strict_effort_enforcement = False
-                fake._codex_model = "claude-opus-4-7"
+                fake._codex_model = "gpt-5.5"
                 fake._openai_api_key = "old-key"
                 fake._reasoning_effort = "low"
                 fake._effort_override = None


### PR DESCRIPTION
## Problem
gpt-5.6-sol (codex fleet model — solik's model) was registered with `context_window=200_000` / `is_1m=0` and was missing from `streaming_session._1M_MODELS`. The **tmux transport** reads that static set (`api.py`'s DB override only rebinds api's own module reference, not `streaming_session`'s), so the harness capped solik's window at 200k and the restart-for-sanity watchdog force-restarted at ~55% of ~167k.

Observed impact: solik thrashed all day on the #81 approval-gate PR — a ~30-min restart cadence that repeatedly wiped in-flight subagent results (verified via pane inspection; each restart paid full re-orientation cost).

## Fix
- `agent_registry.py`: gpt-5.6-sol → `context_window=1_000_000, is_1m=1`.
- `streaming_session.py`: add `gpt-5.6-sol` to `_1M_MODELS` (consistent with the registry per the #839 pinned invariant).

The 1M restart path caps the nudge at 400k (`_RESTART_TOKENS_CAP_1M`), so codex agents get ~4x more usable context before a restart while staying well clear of overshoot.

## Testing
- `test_1m_models_set_matches_registry_is_1m` (#839 parity pin) — green.
- `test_tmux_context_autorestart.py` + `test_tmux_session.py` + `test_agent_registry.py`: **445 passed**.

## Rollout / safety
Applies on daemon restart (tmux transport reads the static set at boot). Post-deploy I'll empirically confirm solik runs past 200k without proxy/model context-overflow before calling it verified; the 400k restart cap + revert-on-overflow is the safety net.

## Review
Murzik offline at open time — self-reviewed + relied on the parity pin and the full autorestart suite.

🤖 Opened by Barsik