### PR TITLE
fix(models): honor [1m] tier suffix in the 1M-window check (#873 follow-up)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -163,7 +163,7 @@ from pinky_daemon.shared_mcp import (
 )
 from pinky_daemon.skill_loader import discover_all_skills, register_discovered_skills
 from pinky_daemon.skill_store import SkillStore
-from pinky_daemon.streaming_session import _1M_MODELS
+from pinky_daemon.streaming_session import _1M_MODELS, is_1m_model
 from pinky_daemon.task_store import TaskStore
 
 # Alias: pinky_daemon.sessions.SessionState (imported above) is the
@@ -3218,7 +3218,7 @@ def create_api(
             total = ctx.get("totalTokens", 0)
             reported_max = ctx.get("maxTokens", 0)
             actual_max = reported_max
-            if (ss._config.model or "") in _1M_MODELS and reported_max <= 200_000:
+            if is_1m_model(ss._config.model or "", _1M_MODELS) and reported_max <= 200_000:
                 actual_max = 1_000_000
             # rawMaxTokens (SDK ≥ 0.1.x) is the raw model cap; maxTokens
             # is effective (autocompact buffer subtracted). Pass both
@@ -8770,13 +8770,13 @@ npm run build</pre>
         except Exception:
             pass
 
-        new_is_1m = req.model in _1M_MODELS
+        new_is_1m = is_1m_model(req.model, _1M_MODELS)
         if old_max > 0:
             old_is_1m = old_max > 500_000  # Current window is 1M-class
         else:
             # Usage fetch failed: fall back to the configured model class so a
             # 1M -> 200k switch still forces the context-window restart.
-            old_is_1m = (ss._config.model or "") in _1M_MODELS
+            old_is_1m = is_1m_model(ss._config.model or "", _1M_MODELS)
 
         needs_restart = new_is_1m != old_is_1m
 

--- a/src/pinky_daemon/pricing.py
+++ b/src/pinky_daemon/pricing.py
@@ -159,13 +159,16 @@ RATE_TABLE: dict[str, dict[str, float]] = {
 }
 
 
-def _strip_tier(model_id: str) -> str:
+def strip_tier(model_id: str) -> str:
+    """Strip a trailing ``[tier]`` suffix (e.g. ``gpt-5.6-sol[1m]`` →
+    ``gpt-5.6-sol``). Public so other modules (e.g. streaming_session's
+    1M-window check) share this one canonical suffix rule."""
     return _TIER_RE.sub("", (model_id or "").strip())
 
 
 def lookup_rate(model_id: str) -> dict[str, float] | None:
     """Resolve a (possibly tiered) model id to its rate dict, or None."""
-    return RATE_TABLE.get(_strip_tier(model_id))
+    return RATE_TABLE.get(strip_tier(model_id))
 
 
 def compute_turn_cost_usd(

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -47,6 +47,24 @@ _1M_MODELS = {
     "gpt-5.6-sol",
 }
 
+
+def is_1m_model(model_id: str, model_set: "set[str] | None" = None) -> bool:
+    """True if ``model_id`` is a 1M-context model, tolerant of a trailing
+    ``[tier]`` suffix (e.g. ``gpt-5.6-sol[1m]`` → ``gpt-5.6-sol``).
+
+    The ``[tier]`` suffix is a legacy way to request a 1M window. An exact
+    membership test against ``_1M_MODELS`` misses the suffixed form and
+    silently caps the model at 200k — which force-restarted solik
+    (registered ``gpt-5.6-sol[1m]``) at ~50% of 167k despite the #873 fix.
+    Strip the suffix first (reusing pricing's canonical ``strip_tier``).
+    Defaults to the static ``_1M_MODELS`` set; callers on the api path pass
+    their DB-refreshed set.
+    """
+    from pinky_daemon.pricing import strip_tier
+    base = strip_tier(model_id or "")
+    return base in (_1M_MODELS if model_set is None else model_set)
+
+
 DEFAULT_STREAMING_ALLOWED_TOOLS = [
     "Read",
     "Glob",
@@ -1166,7 +1184,7 @@ class StreamingSession:
 
             # Fix: SDK reports 200k for 1M models — use actual window
             max_t = reported_max
-            if self._config.model in _1M_MODELS and reported_max <= 200_000:
+            if is_1m_model(self._config.model or "") and reported_max <= 200_000:
                 max_t = 1_000_000
 
             pct = round(total / max_t * 100) if max_t > 0 else 0

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3676,12 +3676,11 @@ class TmuxSession:
         autocompact buffer subtracted).
         """
         try:
-            from pinky_daemon.streaming_session import _1M_MODELS
-            big_models = _1M_MODELS  # noqa: N806 - alias for readability
+            from pinky_daemon.streaming_session import is_1m_model
+            big = is_1m_model(self._config.model or "")
         except Exception:
-            big_models = set()
-        model = (self._config.model or "").strip()
-        return 1_000_000 if model in big_models else 200_000
+            big = False
+        return 1_000_000 if big else 200_000
 
     def _max_tokens_for_model(self) -> int:
         """Return the model's **effective** context-window cap.

--- a/tests/test_tmux_context_autorestart.py
+++ b/tests/test_tmux_context_autorestart.py
@@ -171,3 +171,58 @@ async def test_kill_switch_keeps_sse_but_suppresses_nudge(monkeypatch) -> None:
     assert len(nudge_events) == 1
     # ...but the agent-facing directive is suppressed.
     ss._enqueue_internal_prompt.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# [1m] tier-suffix tolerance (#873 follow-up)
+#
+# solik was registered as ``gpt-5.6-sol[1m]`` (legacy suffix requesting a 1M
+# window). The old exact-match against _1M_MODELS (bare ids) missed the suffix
+# → the model resolved to 200k → the sanity-restart fired at ~50% of the 167k
+# effective window (observed live at 83,705/167,000). Stripping the tier suffix
+# before the membership test fixes it.
+# ──────────────────────────────────────────────────────────────────────────
+
+_MODEL_1M_SUFFIXED = "gpt-5.6-sol[1m]"  # a 1M model carrying the legacy [1m] tag
+
+
+def test_is_1m_model_strips_tier_suffix() -> None:
+    from pinky_daemon.streaming_session import is_1m_model
+
+    # bare 1M id and the exact solik regression ([1m]-suffixed 1M id)
+    assert is_1m_model("gpt-5.6-sol") is True
+    assert is_1m_model("gpt-5.6-sol[1m]") is True
+    assert is_1m_model("claude-opus-4-8[1m]") is True
+    # a non-1M base: the tag must NOT fabricate a 1M window
+    assert is_1m_model("gpt-5.5") is False
+    assert is_1m_model("gpt-5.5[1m]") is False
+    # empty / junk
+    assert is_1m_model("") is False
+    # explicit model_set arg overrides the default _1M_MODELS
+    assert is_1m_model("foo[bar]", {"foo"}) is True
+    assert is_1m_model("gpt-5.6-sol", set()) is False
+
+
+def test_raw_max_tokens_honors_1m_tier_suffix() -> None:
+    ss = _make_session(model=_MODEL_1M_SUFFIXED)
+    assert ss._raw_max_tokens_for_model() == 1_000_000
+
+
+def test_effective_threshold_caps_at_400k_on_suffixed_1m_model(monkeypatch) -> None:
+    monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)
+    suffixed = _make_session(model=_MODEL_1M_SUFFIXED)
+    bare = _make_session(model="gpt-5.6-sol")
+    # The [1m] tag must not change the threshold vs the bare 1M id, and it must
+    # sit well below the old 80% point (the whole point of the fix).
+    assert suffixed._effective_restart_threshold_pct() == pytest.approx(
+        bare._effective_restart_threshold_pct(), rel=1e-6
+    )
+    assert suffixed._effective_restart_threshold_pct() < 80.0
+
+
+def test_non_1m_model_with_tier_suffix_stays_200k() -> None:
+    """The tier tag does not fabricate a 1M window for a non-1M base model:
+    gpt-5.5[1m] strips to gpt-5.5, which is not in _1M_MODELS → 200k."""
+    ss = _make_session(model="gpt-5.5[1m]")
+    assert ss._raw_max_tokens_for_model() == 200_000
+    assert ss._effective_restart_threshold_pct() == pytest.approx(80.0)


### PR DESCRIPTION
Follow-up to #873. After that shipped, solik STILL force-restarted early (observed live at **83,705 / 167,000** ≈ 50%). Root cause: solik is registered as `gpt-5.6-sol[1m]` (legacy `[1m]` tier suffix), and the "is this a 1M model?" check **exact-matched** `_1M_MODELS` (bare ids) at five sites — so the suffixed id missed → resolved to 200k → 200k−33k buffer = 167k → the restart-for-sanity watchdog fired at ~50% of that. #873 only migrated the bare `gpt-5.6-sol` row.

## Fix
New `streaming_session.is_1m_model(model_id, model_set=None)` strips the `[tier]` suffix (reusing `pricing.strip_tier`, promoted from the private `_strip_tier`) before the membership test. All five sites now route through it:
- `tmux_session._raw_max_tokens_for_model` (the solik path)
- `streaming_session` context-usage 1M rebind
- `api._streaming_context_info` + the `/streaming/model` window-class check (new + old model)

The suffix does **not** fabricate 1M for a non-1M base: `gpt-5.5[1m]` → `gpt-5.5` → not in set → 200k.

## Verification
```
strip_tier("gpt-5.6-sol[1m]") = "gpt-5.6-sol"
is_1m_model("gpt-5.6-sol[1m]") = True    # the fix
is_1m_model("gpt-5.5[1m]")     = False   # no fabrication
```
- New regressions in `test_tmux_context_autorestart.py` (helper + suffixed-model raw window + capped threshold + non-1M-stays-200k).
- Focused `test_tmux_context_autorestart` + `test_agent_registry`: 127 passed. `test_tmux_session` + `test_api`: 698 passed. `test_pricing` (rename): green. Full suite running.

No UI surface (backend window/threshold logic) — verification is the behavior + test evidence above.

🤖 Opened by Barsik