### PR TITLE
fix(auth): page only on terminal main-thread failures

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -755,6 +755,12 @@ secret = os.environ.get("PINKY_AGENT_KEY", "").strip() or os.environ.get("PINKY_
 if not secret:
     sys.exit(0)
 
+try:
+    raw = sys.stdin.read()
+    payload_in = json.loads(raw) if raw else {{}}
+except Exception:
+    payload_in = {{}}
+
 agent = "{agent_name}"
 path = "/agents/{agent_name}/transport/wake"
 ts = int(time.time())
@@ -764,7 +770,12 @@ sig = base64.urlsafe_b64encode(digest).decode().rstrip("=")
 
 req = urllib.request.Request(
     os.environ.get("PINKY_DAEMON_URL", "http://localhost:8888").rstrip("/") + path,
-    data=json.dumps({{"event": "stop_hook_summary"}}).encode(),
+    data=json.dumps({{
+        "event": "stop_hook_summary",
+        "session_id": payload_in.get("session_id", ""),
+        "agent_id": payload_in.get("agent_id", ""),
+        "agent_type": payload_in.get("agent_type", ""),
+    }}).encode(),
     method="POST",
 )
 req.add_header("Content-Type", "application/json")
@@ -989,6 +1000,8 @@ body = {{
     "error_type": error_type,
     "message": message,
     "session_id": payload_in.get("session_id", ""),
+    "agent_id": payload_in.get("agent_id", ""),
+    "agent_type": payload_in.get("agent_type", ""),
 }}
 
 req = urllib.request.Request(

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1594,6 +1594,7 @@ def create_api(
     from pinky_daemon.auth_alerts import (
         TRANSPORT_FAILURE_POLICIES,
         AuthFailureTracker,
+        auth_alert_copy_for_provider,
         format_alert_message,
         resolve_operator_chat,
     )
@@ -3014,11 +3015,25 @@ def create_api(
         except Exception:
             host_label = ""
 
+        problem = "Claude auth broken"
+        remedy = None
+        try:
+            affected_agent = agents.get(agent_name)
+            if affected_agent is not None:
+                provider_url, _, _ = _resolve_agent_provider(affected_agent)
+                problem, remedy = auth_alert_copy_for_provider(provider_url)
+        except Exception as e:
+            _log(f"auth_alerts: provider-aware remedy lookup raised: {e}")
+
+        format_kwargs = {}
+        if remedy is not None:
+            format_kwargs = {"problem": problem, "remedy": remedy}
         body = format_alert_message(
             agent_name=agent_name,
             decision=decision,
             error=error,
             host_label=host_label,
+            **format_kwargs,
         )
 
         try:
@@ -6270,6 +6285,13 @@ npm run build</pre>
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
 
+        # A main-thread Stop is positive proof that Claude completed a turn.
+        # Keep tmux/CLI auth tracking symmetric with StreamingSession's
+        # ``auth_success_callback``. Subagent successes deliberately do not
+        # clear a prior main-thread failure; Claude marks those with agent_id.
+        if req.event == "stop_hook_summary" and not req.agent_id.strip():
+            _on_auth_success(name)
+
         session = broker.get_streaming_session(name, label=req.label)
         if session is None:
             # Hook fired before the daemon registered the session, or
@@ -6292,13 +6314,15 @@ npm run build</pre>
 
         Claude Code fires ``StopFailure`` when a turn ends due to an API
         error, carrying a typed ``error_type``. Every failure is logged for
-        observability. Auth-class failures (``authentication_failed`` /
+        observability. Main-thread auth failures (``authentication_failed`` /
         ``oauth_org_not_allowed``) are routed into the shared
         ``AuthFailureTracker`` via ``_on_auth_failure`` — the same
         threshold + cooldown + operator-resolution path the SDK reader loop
-        uses. tmux/CLI agents have no SDK reader loop, so this hook is the
-        only thing that surfaces a dead token before the agent goes
-        silently dark.
+        uses. A fan-out child's terminal failure is still observable but is
+        not host-auth evidence: the parent may retry and complete normally.
+        tmux/CLI agents have no SDK reader loop, so this terminal boundary is
+        the only reliable way to surface a genuinely dead token before the
+        agent goes silently dark.
 
         Fire-and-forget: returns 200 even with no live session so the
         hook's ``|| true`` never fails the model turn. Runtime-agnostic —
@@ -6327,7 +6351,8 @@ npm run build</pre>
         # Auth-class failures → shared auth-alert path (tracker decides
         # whether the threshold + cooldown warrant an operator DM).
         auth_failure = error_type in _STOP_FAILURE_AUTH_TYPES
-        if auth_failure:
+        is_subagent = bool((req.agent_id or "").strip())
+        if auth_failure and not is_subagent:
             try:
                 await _on_auth_failure(name, error_type)
             except Exception as e:
@@ -6338,7 +6363,7 @@ npm run build</pre>
         # stays log-only. ``alert_routed`` reflects whether the failure was
         # sent to any alert tracker (auth or class) — not whether a DM fired
         # (that's the tracker's threshold/cooldown decision downstream).
-        alert_routed = auth_failure
+        alert_routed = auth_failure and not is_subagent
         if not auth_failure and error_type in TRANSPORT_FAILURE_POLICIES:
             alert_routed = True
             try:
@@ -6360,7 +6385,7 @@ npm run build</pre>
         # forget like the rest of this hook — never fail the model turn.
         turn_resolved = False
         session = broker.get_streaming_session(name, label=req.label)
-        if session is not None:
+        if session is not None and not is_subagent:
             resolver = getattr(session, "handle_stop_failure", None)
             if callable(resolver):
                 try:
@@ -6377,6 +6402,7 @@ npm run build</pre>
             "agent": name,
             "error_type": error_type,
             "auth_failure": auth_failure,
+            "subagent": is_subagent,
             "alert_routed": alert_routed,
             "turn_resolved": turn_resolved,
         }

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -940,6 +940,9 @@ class TransportWakeRequest(BaseModel):
 
     event: Literal["stop_hook_summary", "compact", "manual"] = "stop_hook_summary"
     label: str = "main"
+    session_id: str = ""
+    agent_id: str = ""
+    agent_type: str = ""
 
 
 class TransportTranscriptPathRequest(BaseModel):
@@ -1018,6 +1021,11 @@ class TransportStopFailureRequest(BaseModel):
     message: str = ""
     session_id: str = ""
     label: str = "main"
+    # Claude Code includes ``agent_id`` only when a hook fires inside a
+    # subagent call. Forwarding it lets the daemon avoid treating a burst of
+    # failed fan-out children as independent host-auth outages.
+    agent_id: str = ""
+    agent_type: str = ""
 
 
 class FederationPeerUpsertRequest(BaseModel):

--- a/src/pinky_daemon/auth_alerts.py
+++ b/src/pinky_daemon/auth_alerts.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import time
+import urllib.parse
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from typing import Iterable
@@ -51,6 +52,15 @@ DEFAULT_AUTH_REMEDY = (
     "Re-auth needed: SSH to the host, run 'claude' to log back in, "
     "then 'sudo systemctl restart pinkybot' (or equivalent)."
 )
+CODEX_PROXY_AUTH_PROBLEM = "Codex proxy auth broken"
+CODEX_PROXY_AUTH_REMEDY = (
+    "The affected credential is the proxy's ChatGPT subscription OAuth, "
+    "not Claude OAuth. On the host, run "
+    "'~/.local/bin/claude-code-proxy-patched codex auth status'; if needed, "
+    "run the same command with 'login' instead of 'status', then restart "
+    "the com.claude-code-proxy launch agent. Do NOT run 'claude /login' — "
+    "that changes the wrong credential."
+)
 BILLING_REMEDY = (
     "Billing/credits issue — the agent is blocked until it's resolved. "
     "Check the provider account's payment/credit status "
@@ -62,6 +72,26 @@ RATE_LIMIT_REMEDY = (
     "Often transient, but if it persists, check the account's usage/plan "
     "limits; turns will keep failing until capacity frees up."
 )
+
+
+def auth_alert_copy_for_provider(provider_url: str) -> tuple[str, str]:
+    """Return provider-aware auth-alert copy.
+
+    Solik's Claude Code harness talks to the local Codex translation proxy on
+    port 18765. Its 401s concern the proxy's Keychain-backed ChatGPT OAuth,
+    so the default Claude ``/login`` remedy is actively misleading. Keep the
+    match narrow: arbitrary local/custom Anthropic-compatible providers may
+    have entirely different authentication and recovery procedures.
+    """
+    try:
+        parsed = urllib.parse.urlparse((provider_url or "").strip())
+        is_loopback = parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+        if is_loopback and parsed.port == 18765:
+            return CODEX_PROXY_AUTH_PROBLEM, CODEX_PROXY_AUTH_REMEDY
+    except ValueError:
+        # Invalid/malformed URLs fall back to the long-standing Claude copy.
+        pass
+    return "Claude auth broken", DEFAULT_AUTH_REMEDY
 
 
 @dataclass(frozen=True)

--- a/tests/test_auth_alerts.py
+++ b/tests/test_auth_alerts.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from pinky_daemon.auth_alerts import (
+    CODEX_PROXY_AUTH_PROBLEM,
+    CODEX_PROXY_AUTH_REMEDY,
+    DEFAULT_AUTH_REMEDY,
     TRANSPORT_FAILURE_POLICIES,
     AuthFailureTracker,
+    auth_alert_copy_for_provider,
     format_alert_message,
     resolve_operator_chat,
 )
@@ -382,6 +386,32 @@ def test_format_alert_uses_no_markdown_so_plain_text_renders_clean():
     # Sanity: still actually informative.
     assert "sasha" in msg
     assert "authentication_failed" in msg
+
+
+def test_auth_alert_copy_for_local_codex_proxy_uses_proxy_oauth_remedy():
+    for url in (
+        "http://localhost:18765",
+        "http://127.0.0.1:18765/v1",
+        "http://[::1]:18765",
+    ):
+        problem, remedy = auth_alert_copy_for_provider(url)
+        assert problem == CODEX_PROXY_AUTH_PROBLEM
+        assert remedy == CODEX_PROXY_AUTH_REMEDY
+        assert "ChatGPT subscription OAuth" in remedy
+        assert "Do NOT run 'claude /login'" in remedy
+
+
+def test_auth_alert_copy_does_not_misclassify_other_or_spoofed_providers():
+    for url in (
+        "",
+        "https://api.anthropic.com",
+        "http://localhost:9999",
+        "http://localhost.example:18765",
+        "http://[broken",
+    ):
+        problem, remedy = auth_alert_copy_for_provider(url)
+        assert problem == "Claude auth broken"
+        assert remedy == DEFAULT_AUTH_REMEDY
 
 
 # ── /admin/watchdog integration ───────────────────────────────────

--- a/tests/test_stop_failure_hook.py
+++ b/tests/test_stop_failure_hook.py
@@ -5,11 +5,13 @@ Claude Code fires ``StopFailure`` when a turn ends due to an API error,
 carrying a typed ``error_type``. The hook forwards it so the daemon can:
 
   - log every failure for observability (all classes), and
-  - route auth-class failures (authentication_failed / oauth_org_not_allowed)
-    into the shared ``AuthFailureTracker`` — the same proactive operator-alert
-    path the SDK reader loop uses. tmux/CLI agents have no SDK reader loop, so
-    this hook is the only thing that surfaces a dead token before the agent
-    goes silently dark.
+  - route terminal main-thread auth failures
+    (authentication_failed / oauth_org_not_allowed) into the shared
+    ``AuthFailureTracker`` — the same proactive operator-alert path the SDK
+    reader loop uses. Fan-out-child failures stay observable but do not count
+    as independent host-auth evidence. tmux/CLI agents have no SDK reader
+    loop, so this hook is the only thing that surfaces a dead token before the
+    agent goes silently dark.
 
 The tracker's threshold/cooldown/host-wide logic and alert formatting are
 covered by ``test_auth_alerts.py`` — here we pin that the endpoint *routes*
@@ -187,6 +189,26 @@ class TestStopFailureEndpoint:
             )
         assert calls == [("dymok", "authentication_failed")] * 3
 
+    def test_subagent_auth_failure_is_observed_but_not_paged(self):
+        """A fan-out child has its own terminal StopFailure, but it does not
+        prove the agent's shared credential is broken. Claude's main thread
+        may still retry and finish successfully, as in #355."""
+        client, calls = self._client_with_agent()
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={
+                "error_type": "authentication_failed",
+                "agent_id": "child-a1b2",
+                "agent_type": "Explore",
+            },
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["auth_failure"] is True
+        assert body["subagent"] is True
+        assert body["alert_routed"] is False
+        assert calls == []
+
 
 # ── Observability ──────────────────────────────────────────────
 
@@ -348,6 +370,18 @@ class TestStopFailureHookPayloadContract:
         # message prefers the rendered error text CC surfaces
         assert captured["body"]["message"] == "API Error: authentication_failed"
 
+    def test_subagent_identity_is_forwarded(self):
+        captured = self._run_hook(
+            {
+                "error": "authentication_failed",
+                "session_id": "session-1",
+                "agent_id": "child-a1b2",
+                "agent_type": "Explore",
+            }
+        )
+        assert captured["body"]["agent_id"] == "child-a1b2"
+        assert captured["body"]["agent_type"] == "Explore"
+
     def test_error_details_used_when_no_last_message(self):
         captured = self._run_hook(
             {"error": "rate_limit", "error_details": "429 Too Many Requests"}
@@ -461,6 +495,27 @@ class TestStopFailureTurnResolve:
         # #108 path also ran.
         assert fake.calls and fake.calls[0][0] == "authentication_failed"
 
+    def test_subagent_failure_does_not_resolve_parent_turn(self):
+        """A child hook shares the Pinky agent endpoint but is not the
+        parent tmux turn-end marker. Resolving here would pop the live parent
+        turn while Claude Code is still retrying it."""
+        client, app, calls = self._client()
+        fake = _FakeTmuxSession(resolved=True)
+        app.state.broker._streaming["dymok"] = {"main": fake}
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={
+                "error_type": "authentication_failed",
+                "agent_id": "child-a1b2",
+            },
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["subagent"] is True
+        assert body["turn_resolved"] is False
+        assert calls == []
+        assert fake.calls == []
+
     def test_session_without_method_degrades(self):
         """An SDK/Codex session lacking handle_stop_failure → turn_resolved
         False, hook still 200 (duck-typed, tolerated absence)."""
@@ -489,3 +544,131 @@ class TestStopFailureTurnResolve:
         )
         assert r.status_code == 200
         assert r.json()["turn_resolved"] is False
+
+
+# ── Main-thread success clear ──────────────────────────────────
+
+
+class TestStopSuccessAuthClear:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._db = os.path.join(self._tmpdir, "test.db")
+
+    def _client(self):
+        app = _make_app(self._db)
+        client = TestClient(app)
+        r = client.post("/agents", json={"name": "dymok", "model": "sonnet"})
+        assert r.status_code == 200
+        calls: list[str] = []
+        app.state.auth_tracker.record_success = calls.append
+        return client, calls
+
+    def test_main_stop_clears_tmux_auth_failures_even_without_live_session(self):
+        client, calls = self._client()
+        r = client.post(
+            "/agents/dymok/transport/wake",
+            json={"event": "stop_hook_summary", "session_id": "main-session"},
+        )
+        assert r.status_code == 200
+        assert r.json()["session"] is None
+        assert calls == ["dymok"]
+
+    def test_subagent_stop_does_not_clear_main_auth_failure_state(self):
+        client, calls = self._client()
+        r = client.post(
+            "/agents/dymok/transport/wake",
+            json={
+                "event": "stop_hook_summary",
+                "agent_id": "child-a1b2",
+                "agent_type": "Explore",
+            },
+        )
+        assert r.status_code == 200
+        assert calls == []
+
+    def test_main_success_breaks_terminal_auth_failure_streak(self):
+        """Two isolated failed turns around a successful turn are not a
+        sustained three-failure outage. The Stop hook must clear the first
+        pair before the next terminal failure is recorded."""
+        app = _make_app(self._db)
+        client = TestClient(app)
+        r = client.post("/agents", json={"name": "dymok", "model": "sonnet"})
+        assert r.status_code == 200
+
+        for _ in range(2):
+            r = client.post(
+                "/agents/dymok/transport/stop-failure",
+                json={"error_type": "authentication_failed"},
+            )
+            assert r.status_code == 200
+        before = app.state.auth_tracker.status()
+        assert before["status"] == "degraded"
+        assert before["agents_failing"][0]["failures_in_window"] == 2
+
+        r = client.post(
+            "/agents/dymok/transport/wake",
+            json={"event": "stop_hook_summary", "session_id": "main-session"},
+        )
+        assert r.status_code == 200
+        assert app.state.auth_tracker.status()["status"] == "ok"
+
+        r = client.post(
+            "/agents/dymok/transport/stop-failure",
+            json={"error_type": "authentication_failed"},
+        )
+        assert r.status_code == 200
+        after = app.state.auth_tracker.status()
+        assert after["status"] == "degraded"
+        assert after["agents_failing"][0]["failures_in_window"] == 1
+
+
+class TestStopHookPayloadContract:
+    def _run_hook(self, payload: dict) -> dict:
+        import io
+        import sys
+        import urllib.request
+
+        from pinky_daemon.agent_registry import _tmux_wake_hook_source
+
+        src = _tmux_wake_hook_source("dymok")
+        captured: dict = {}
+
+        def _fake_urlopen(req, timeout=0):
+            captured["url"] = req.full_url
+            captured["body"] = json.loads(req.data.decode())
+            return None
+
+        real_stdin, real_urlopen = sys.stdin, urllib.request.urlopen
+        real_secret = os.environ.get("PINKY_SESSION_SECRET")
+        try:
+            sys.stdin = io.StringIO(json.dumps(payload))
+            urllib.request.urlopen = _fake_urlopen
+            os.environ["PINKY_SESSION_SECRET"] = "test-secret"
+            exec(
+                compile(src, "<stop_hook>", "exec"),
+                {"__name__": "__main__"},
+            )
+        finally:
+            sys.stdin = real_stdin
+            urllib.request.urlopen = real_urlopen
+            if real_secret is None:
+                os.environ.pop("PINKY_SESSION_SECRET", None)
+            else:
+                os.environ["PINKY_SESSION_SECRET"] = real_secret
+        return captured
+
+    def test_forwards_main_and_subagent_identity_fields(self):
+        captured = self._run_hook(
+            {
+                "session_id": "session-1",
+                "agent_id": "child-a1b2",
+                "agent_type": "Explore",
+            }
+        )
+        assert captured["url"].endswith("/agents/dymok/transport/wake")
+        assert captured["body"] == {
+            "event": "stop_hook_summary",
+            "session_id": "session-1",
+            "agent_id": "child-a1b2",
+            "agent_type": "Explore",
+        }


### PR DESCRIPTION
## What changed

- forward Claude Code's `session_id`, `agent_id`, and `agent_type` from the generated Stop/StopFailure hooks
- keep fan-out-child StopFailures observable, but do not count their auth errors as independent host-credential failures or let them resolve the live parent tmux turn
- treat a main-thread Stop as successful-turn evidence and clear that agent's auth-failure streak, matching the SDK callback path
- keep main-thread terminal auth failures on the existing threshold/cooldown tracker, so genuinely sustained credential failures still page
- use provider-aware operator copy for solik's localhost Codex proxy, pointing to its Keychain-backed ChatGPT-subscription OAuth and explicitly avoiding the incorrect `claude /login` remedy

## Root cause

Solik runs the Claude Code tmux harness through a local Codex translation proxy. During the proxy refresh race, several fan-out children could terminate with 401s while the parent retried and completed successfully. Every child StopFailure was fed into the host-auth tracker as if it were an independent credential outage, so one recoverable burst crossed the three-failure page threshold. The tmux Stop success path also did not clear prior auth failures, allowing isolated terminal failures to accumulate across successful turns.

This change pins the terminal boundary instead of raising the threshold: subagent failures remain visible but are not host-auth evidence; only terminal main-thread failures count, and a successful main Stop breaks the streak.

## Validation

- focused auth/StopFailure/agent-status tests: 105 passed
- registry/tmux/API affected suite: 877 passed
- regression proves two terminal main failures, one successful main Stop, and a later failure remain a one-failure degraded state rather than a false three-failure page
- generated-hook regressions prove child identity is forwarded and cannot resolve the parent turn
- provider-copy regressions cover localhost/127.0.0.1/IPv6 proxy URLs plus spoofed and non-proxy fallbacks
- `ruff check` on all changed files: clean
- `git diff --check`: clean
