### PR TITLE
feat(tmux): cap CC auto-compact window at 272k for ChatGPT-sub Codex models

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3118,15 +3118,21 @@ class TmuxSession:
         # window so it auto-compacts before the backend 502s (see
         # _CODEX_SUB_CONTEXT_WINDOW). The "[1m]" suffix otherwise lets CC ride
         # context toward ~1M and overflow the sub's real cap (2026-07-13 solik
-        # wedge). Only these proxied codex models — real 1M Claude agents are
-        # untouched. setdefault so an explicit ambient override still wins.
+        # wedge). SCOPED to the ChatGPT-sub PROXY route (trusted loopback
+        # :18765): the SAME model slug on a paid/custom API gateway has the
+        # model's real 1.05M window and must NOT be capped (Brad's paid-API
+        # alternative). An operator's ambient CLAUDE_CODE_AUTO_COMPACT_WINDOW
+        # wins — _build_repl_env's result becomes explicit tmux -e flags (the
+        # parent env is otherwise dropped), so we must forward it explicitly;
+        # a tuning escape hatch while the sub's allocation can change.
         from pinky_daemon.pricing import strip_tier
 
         auto_window = self._CODEX_SUB_CONTEXT_WINDOW.get(
             strip_tier(self._config.model or ""), 0
         )
-        if auto_window:
-            env.setdefault("CLAUDE_CODE_AUTO_COMPACT_WINDOW", str(auto_window))
+        if auto_window and self._is_codex_sub_proxy(self._config.provider_url or ""):
+            ambient = os.environ.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "").strip()
+            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = ambient or str(auto_window)
         return env
 
     async def disconnect(self) -> None:
@@ -3690,6 +3696,23 @@ class TmuxSession:
     _CODEX_SUB_CONTEXT_WINDOW = {
         "gpt-5.6-sol": 272_000,
     }
+
+    @staticmethod
+    def _is_codex_sub_proxy(provider_url: str) -> bool:
+        """True if provider_url is the local ChatGPT-sub Codex proxy (trusted
+        loopback on :18765). The 272k auto-compact cap applies ONLY to this
+        route — the same model slug on a paid/custom API gateway keeps the
+        model's real 1.05M window and must not be capped."""
+        import urllib.parse
+
+        try:
+            parsed = urllib.parse.urlparse((provider_url or "").strip())
+        except ValueError:
+            return False
+        return (
+            parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+            and parsed.port == 18765
+        )
 
     def _raw_max_tokens_for_model(self) -> int:
         """Return the model's **raw** context-window cap (no buffer).

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3700,19 +3700,22 @@ class TmuxSession:
     @staticmethod
     def _is_codex_sub_proxy(provider_url: str) -> bool:
         """True if provider_url is the local ChatGPT-sub Codex proxy (trusted
-        loopback on :18765). The 272k auto-compact cap applies ONLY to this
-        route — the same model slug on a paid/custom API gateway keeps the
-        model's real 1.05M window and must not be capped."""
+        http(s) loopback on :18765). The 272k auto-compact cap applies ONLY to
+        this route — the same model slug on a paid/custom API gateway keeps the
+        model's real 1.05M window and must not be capped. Total/fail-closed: a
+        malformed url (incl. a non-numeric or out-of-range port, which raises
+        only when ``parsed.port`` is accessed) returns False, never raises."""
         import urllib.parse
 
         try:
             parsed = urllib.parse.urlparse((provider_url or "").strip())
+            return (
+                parsed.scheme in {"http", "https"}
+                and parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+                and parsed.port == 18765
+            )
         except ValueError:
             return False
-        return (
-            parsed.hostname in {"localhost", "127.0.0.1", "::1"}
-            and parsed.port == 18765
-        )
 
     def _raw_max_tokens_for_model(self) -> int:
         """Return the model's **raw** context-window cap (no buffer).

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3113,6 +3113,20 @@ class TmuxSession:
             )
         elif secret:
             env["PINKY_SESSION_SECRET"] = secret
+
+        # ChatGPT-sub Codex models: tell Claude Code the true 272k upstream
+        # window so it auto-compacts before the backend 502s (see
+        # _CODEX_SUB_CONTEXT_WINDOW). The "[1m]" suffix otherwise lets CC ride
+        # context toward ~1M and overflow the sub's real cap (2026-07-13 solik
+        # wedge). Only these proxied codex models — real 1M Claude agents are
+        # untouched. setdefault so an explicit ambient override still wins.
+        from pinky_daemon.pricing import strip_tier
+
+        auto_window = self._CODEX_SUB_CONTEXT_WINDOW.get(
+            strip_tier(self._config.model or ""), 0
+        )
+        if auto_window:
+            env.setdefault("CLAUDE_CODE_AUTO_COMPACT_WINDOW", str(auto_window))
         return env
 
     async def disconnect(self) -> None:
@@ -3662,6 +3676,20 @@ class TmuxSession:
     # the percentage-based threshold (always true on 1M, never on 200k
     # since 400k exceeds that window entirely).
     _RESTART_TOKENS_CAP_1M = 400_000
+
+    # ChatGPT-subscription Codex models exposed to Claude Code via the local
+    # codex proxy. Their "[1m]" model suffix hints CC a 1M window, but the
+    # ChatGPT-sub Codex backend caps context at 272k (per ~/.codex/
+    # models_cache.json + the GPT-5.6 subscription update). Without
+    # CLAUDE_CODE_AUTO_COMPACT_WINDOW, CC rides context toward 1M and the
+    # backend 502s "input exceeds the context window" (the 2026-07-13 solik
+    # wedge). Map each to its true upstream window so CC auto-compacts before
+    # the limit. Real 1M Claude agents are absent — they must NOT be capped.
+    # (raine/claude-code-proxy README recommends
+    # CLAUDE_CODE_AUTO_COMPACT_WINDOW=272000 for gpt-5.6-sol[1m].)
+    _CODEX_SUB_CONTEXT_WINDOW = {
+        "gpt-5.6-sol": 272_000,
+    }
 
     def _raw_max_tokens_for_model(self) -> int:
         """Return the model's **raw** context-window cap (no buffer).

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -414,6 +414,22 @@ def test_build_repl_env_expects_resolved_effort_for_ultracode() -> None:
     assert env["PINKY_EXPECTED_EFFORT"] == "xhigh"
 
 
+def test_build_repl_env_sets_autocompact_window_for_codex_sub_model() -> None:
+    """gpt-5.6-sol (ChatGPT-sub Codex) gets CLAUDE_CODE_AUTO_COMPACT_WINDOW=272000
+    so Claude Code compacts before the sub's real 272k backend cap — the "[1m]"
+    suffix otherwise makes CC ride toward 1M and 502 (the 2026-07-13 solik wedge).
+    Tier-suffix tolerant; real 1M Claude agents must NOT be capped."""
+    ss, _ = _make_session()
+    ss._config.model = "gpt-5.6-sol[1m]"
+    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "272000"
+    ss._config.model = "gpt-5.6-sol"  # bare id too
+    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "272000"
+    ss._config.model = "claude-opus-4-8"  # real 1M Claude — NOT capped
+    assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in ss._build_repl_env()
+    ss._config.model = "claude-opus-4-8[1m]"  # 1M-suffixed Claude — NOT capped
+    assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in ss._build_repl_env()
+
+
 def test_set_effort_accepts_ultracode() -> None:
     ss, _ = _make_session()
     ss.set_effort("ultracode")

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -460,6 +460,33 @@ def test_build_repl_env_autocompact_honors_ambient_override(monkeypatch) -> None
     assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "240000"
 
 
+def test_is_codex_sub_proxy_classifier_is_total() -> None:
+    """The route classifier matches only the trusted http(s) loopback :18765 and
+    is total — malformed / non-numeric / out-of-range ports fail closed (return
+    False) rather than raising (parsed.port raises ValueError only on access)."""
+    match = TmuxSession._is_codex_sub_proxy
+    assert match("http://localhost:18765") is True
+    assert match("http://127.0.0.1:18765/v1") is True
+    assert match("https://[::1]:18765") is True
+    assert match("https://paid-api-gateway.example/anthropic") is False
+    assert match("http://localhost:9999") is False
+    assert match("http://localhost.example:18765") is False  # subdomain
+    assert match("") is False
+    assert match("http://localhost:not-a-port") is False  # non-numeric port
+    assert match("http://localhost:99999") is False  # out-of-range port
+    assert match("ftp://localhost:18765") is False  # wrong scheme
+
+
+def test_build_repl_env_fails_closed_on_malformed_provider_url() -> None:
+    """A malformed provider_url must not crash _build_repl_env or cap — it fails
+    closed (no CLAUDE_CODE_AUTO_COMPACT_WINDOW), never raises."""
+    ss, _ = _make_session()
+    ss._config.model = "gpt-5.6-sol[1m]"
+    ss._config.provider_url = "http://localhost:not-a-port"
+    env = ss._build_repl_env()  # must not raise
+    assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in env
+
+
 def test_set_effort_accepts_ultracode() -> None:
     ss, _ = _make_session()
     ss.set_effort("ultracode")

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -414,20 +414,50 @@ def test_build_repl_env_expects_resolved_effort_for_ultracode() -> None:
     assert env["PINKY_EXPECTED_EFFORT"] == "xhigh"
 
 
-def test_build_repl_env_sets_autocompact_window_for_codex_sub_model() -> None:
-    """gpt-5.6-sol (ChatGPT-sub Codex) gets CLAUDE_CODE_AUTO_COMPACT_WINDOW=272000
-    so Claude Code compacts before the sub's real 272k backend cap — the "[1m]"
-    suffix otherwise makes CC ride toward 1M and 502 (the 2026-07-13 solik wedge).
-    Tier-suffix tolerant; real 1M Claude agents must NOT be capped."""
+def test_build_repl_env_caps_autocompact_for_codex_sub_proxy(monkeypatch) -> None:
+    """gpt-5.6-sol on the ChatGPT-sub proxy (trusted loopback :18765) gets
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW=272000 so CC compacts before the sub's real
+    272k cap — the "[1m]" suffix otherwise makes CC ride toward 1M and 502 (the
+    2026-07-13 solik wedge). Tier-suffix tolerant; loopback host + path OK."""
+    monkeypatch.delenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", raising=False)
     ss, _ = _make_session()
+    ss._config.provider_url = "http://localhost:18765"
     ss._config.model = "gpt-5.6-sol[1m]"
     assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "272000"
     ss._config.model = "gpt-5.6-sol"  # bare id too
     assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "272000"
-    ss._config.model = "claude-opus-4-8"  # real 1M Claude — NOT capped
+    ss._config.provider_url = "http://127.0.0.1:18765/v1"  # 127.0.0.1 + path
+    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "272000"
+
+
+def test_build_repl_env_does_not_cap_paid_api_or_claude(monkeypatch) -> None:
+    """The 272k cap is scoped to the ChatGPT-sub proxy route ONLY. The SAME
+    gpt-5.6-sol slug on a paid API gateway keeps the model's real 1.05M window
+    (Brad's paid-API alternative); real 1M Claude agents are never capped."""
+    monkeypatch.delenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", raising=False)
+    ss, _ = _make_session()
+    ss._config.model = "gpt-5.6-sol[1m]"
+    ss._config.provider_url = "https://paid-api-gateway.example/anthropic"
     assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in ss._build_repl_env()
-    ss._config.model = "claude-opus-4-8[1m]"  # 1M-suffixed Claude — NOT capped
+    ss._config.provider_url = ""  # no provider → not the sub proxy
     assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in ss._build_repl_env()
+    ss._config.provider_url = "http://localhost:18765"  # on the proxy, but...
+    ss._config.model = "claude-opus-4-8"  # ...real 1M Claude → NOT capped
+    assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in ss._build_repl_env()
+    ss._config.model = "claude-opus-4-8[1m]"
+    assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in ss._build_repl_env()
+
+
+def test_build_repl_env_autocompact_honors_ambient_override(monkeypatch) -> None:
+    """An operator's ambient CLAUDE_CODE_AUTO_COMPACT_WINDOW wins over the mapped
+    default — a tuning escape hatch while the sub allocation can change.
+    (_build_repl_env starts empty and becomes explicit -e flags, so the ambient
+    value must be forwarded, not merely defaulted.)"""
+    monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "240000")
+    ss, _ = _make_session()
+    ss._config.provider_url = "http://localhost:18765"
+    ss._config.model = "gpt-5.6-sol[1m]"
+    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "240000"
 
 
 def test_set_effort_accepts_ultracode() -> None:


### PR DESCRIPTION
Root cause of solik's overnight wedge (2026-07-13): solik runs `gpt-5.6-sol[1m]` on the Claude Code harness via the codex proxy. The `[1m]` suffix hints CC a 1M window, so CC **never auto-compacts** before the ChatGPT-subscription Codex backend's REAL 272k cap → the backend returns `502 "input exceeds the context window"`, and the session then wedges reloading the oversized transcript on `--continue`.

## Fix
Set `CLAUDE_CODE_AUTO_COMPACT_WINDOW=272000` in the tmux launch env for these codex-sub models (`_CODEX_SUB_CONTEXT_WINDOW` map) so CC compacts **before** the upstream limit — using the full 272k runway with context preserved (a summarize-and-continue, not a hard restart). This is the raine/claude-code-proxy README's recommended value for `gpt-5.6-sol[1m]`.

- Only the mapped codex-sub models get the cap; **real 1M Claude agents are deliberately absent and untouched** (a global env var would wrongly choke them).
- Tier-suffix tolerant (via `pricing.strip_tier`).
- `setdefault` so an explicit ambient override still wins.

## Deploy sequencing (bundles with the #355 proxy deploy — same fleet bounce)
Takes effect on solik's next relaunch. **After** it's live, solik's `restart_threshold_pct` is restored to normal so PinkyBot stops preempting CC's autocompact (PinkyBot restart becomes a backstop). Until then the current ~126k emergency threshold stays as the safety net — do NOT restore it before this deploys, or solik re-wedges.

## Tests
New regression `test_build_repl_env_sets_autocompact_window_for_codex_sub_model` (gpt-5.6-sol[1m] + bare → 272000; claude-opus-4-8 and claude-opus-4-8[1m] → NOT set). Focused `-k build_repl_env` 14 passed; ruff clean; diff-check clean.

🤖 Opened by Barsik