### PR TITLE
feat(isolation): same-group isolated agents may message each other (#637)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -944,6 +944,35 @@ def _isolation_path_target(path: str) -> str | None:
     return None
 
 
+def _isolated_peer_message_allowed(
+    path: str, target: str, caller_groups, peer_groups
+) -> bool:
+    """#637 tenant-grouping: the ONE narrow exception to the #149 isolation
+    deny — teammate coordination.
+
+    An isolated agent is otherwise barred from every ``/agents/{other}/*``
+    surface. This predicate carves out a single case: an isolated caller may
+    reach ``target`` **only** at ``target``'s inter-agent message-delivery
+    endpoint (``POST /agents/{target}/message``), and **only** when the two
+    agents share at least one explicit group. Everything else stays denied —
+    admin, config, autonomy, session, file, even a ``/message/<sub>`` path
+    (the match is exact, so nothing nested slips through).
+
+    Groups are membership-only: co-membership already does NOT grant
+    cross-agent memory access (see the isolation note near the group
+    endpoints), so this widens the tenant boundary strictly to message
+    delivery between agents an operator has deliberately grouped together
+    (e.g. a support team). Message delivery injects a prompt into the peer,
+    so shared-group co-membership IS the trust signal that authorizes it.
+
+    Pure (no I/O) so the isolation policy is unit-testable on its own; the
+    caller resolves the two group lists and passes them in.
+    """
+    if path != f"/agents/{target}/message":
+        return False
+    return bool(set(caller_groups or []) & set(peer_groups or []))
+
+
 def _container_isolation_block_reason(
     *, transport: str, runtime: str, agent_name: str
 ) -> tuple[int, str] | None:
@@ -4463,6 +4492,32 @@ def create_api(
             )
             return True
         if caller and getattr(caller, "isolated", False):
+            # #637: an isolated agent may still MESSAGE a peer it shares a
+            # group with (teammate coordination) — the inter-agent message
+            # endpoint ONLY, never admin/config/autonomy. Only a message-path
+            # target pays the extra peer lookup; every other cross-agent
+            # attempt short-circuits to the deny below. Fail CLOSED if the peer
+            # can't be resolved.
+            if request.url.path == f"/agents/{target}/message":
+                try:
+                    peer = agents.get(target)
+                except Exception as e:
+                    _log(
+                        f"isolation-check: peer lookup failed for '{target}' "
+                        f"on {request.url.path}: {e} — failing closed (deny)"
+                    )
+                    return True
+                if _isolated_peer_message_allowed(
+                    request.url.path,
+                    target,
+                    getattr(caller, "groups", None),
+                    getattr(peer, "groups", None) if peer else None,
+                ):
+                    _log(
+                        f"isolation: allowed isolated '{caller_name}' -> peer "
+                        f"'{target}' message (shared group)"
+                    )
+                    return False
             _log(
                 f"isolation: denied isolated agent '{caller_name}' cross-agent "
                 f"access to {request.url.path}"
@@ -9040,7 +9095,9 @@ npm run build</pre>
         }
 
     @app.post("/agents/{name}/message")
-    async def send_agent_message_direct(name: str, req: AgentMessageRequest):
+    async def send_agent_message_direct(
+        name: str, req: AgentMessageRequest, request: Request
+    ):
         """Send a message from one agent directly into another's streaming context.
 
         Always stores in comms DB for audit trail. If the target agent is
@@ -9048,6 +9105,12 @@ npm run build</pre>
         """
         if not agents.get(name):
             raise HTTPException(404, f"Agent '{name}' not found")
+        # #149/#637 body-actor guard: an isolated caller is now permitted to
+        # reach a same-group peer's message endpoint (path-level, above), so it
+        # must still act AS ITSELF here — block ``from_agent`` spoofing on this
+        # cross-agent surface. No-op for non-isolated callers and for
+        # operator/browser sessions (no verified internal-agent header).
+        _deny_isolated_cross_actor(request, req.from_agent)
         # Always store in comms DB for audit/visibility
         msg = comms.send(
             req.from_agent, name, req.message,

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -944,8 +944,24 @@ def _isolation_path_target(path: str) -> str | None:
     return None
 
 
+def _clean_group_set(groups) -> set[str]:
+    """Return explicit non-blank names from the persisted group-list shape.
+
+    Any other container shape is corrupt and therefore empty.  In particular,
+    ``set("support")`` would split a legacy JSON string into characters and
+    could authorize an unrelated group such as ``"sales"`` via shared ``"s"``.
+    """
+    if not isinstance(groups, (list, tuple)):
+        return set()
+    return {
+        group.strip()
+        for group in groups
+        if isinstance(group, str) and group.strip()
+    }
+
+
 def _isolated_peer_message_allowed(
-    path: str, target: str, caller_groups, peer_groups
+    method: str, path: str, target: str, caller_groups, peer_groups
 ) -> bool:
     """#637 tenant-grouping: the ONE narrow exception to the #149 isolation
     deny — teammate coordination.
@@ -968,9 +984,9 @@ def _isolated_peer_message_allowed(
     Pure (no I/O) so the isolation policy is unit-testable on its own; the
     caller resolves the two group lists and passes them in.
     """
-    if path != f"/agents/{target}/message":
+    if method != "POST" or path != f"/agents/{target}/message":
         return False
-    return bool(set(caller_groups or []) & set(peer_groups or []))
+    return bool(_clean_group_set(caller_groups) & _clean_group_set(peer_groups))
 
 
 def _container_isolation_block_reason(
@@ -4498,7 +4514,10 @@ def create_api(
             # target pays the extra peer lookup; every other cross-agent
             # attempt short-circuits to the deny below. Fail CLOSED if the peer
             # can't be resolved.
-            if request.url.path == f"/agents/{target}/message":
+            if (
+                request.method == "POST"
+                and request.url.path == f"/agents/{target}/message"
+            ):
                 try:
                     peer = agents.get(target)
                 except Exception as e:
@@ -4508,6 +4527,7 @@ def create_api(
                     )
                     return True
                 if _isolated_peer_message_allowed(
+                    request.method,
                     request.url.path,
                     target,
                     getattr(caller, "groups", None),
@@ -4584,7 +4604,7 @@ def create_api(
         browser request has no such header and is left untouched here.
         """
         caller = request.headers.get(INTERNAL_AGENT_HEADER, "")
-        if not caller or not body_agent or body_agent == caller:
+        if not caller or body_agent == caller:
             return
         if _is_isolated_agent(caller):
             _log(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -987,6 +987,70 @@ class TestAgentIsolationScoping:
         assert resp.status_code != 403
         os.unlink(path)
 
+    # ── #637: isolated teammates in the SAME group may message each other ──
+
+    def _make_client_grouped(self, monkeypatch, tmp_path):
+        """Two isolated teammates (chekov, geordi) share the 'support' group;
+        a third isolated agent (sasha) sits in a different group."""
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        monkeypatch.setenv("PINKY_SESSION_SECRET", "test-session-secret")
+        monkeypatch.delenv("PINKY_UI_PASSWORD", raising=False)
+        app = create_api(max_sessions=10, default_working_dir=str(tmp_path), db_path=path)
+        reg = app.state.agents
+        reg.register("chekov", model="opus", isolated=True, groups=["support"],
+                     working_dir=str(tmp_path / "chekov"))
+        reg.register("geordi", model="opus", isolated=True, groups=["support"],
+                     working_dir=str(tmp_path / "geordi"))
+        reg.register("sasha", model="opus", isolated=True, groups=["sales"],
+                     working_dir=str(tmp_path / "sasha"))
+        return TestClient(app), path
+
+    def test_isolated_same_group_peer_message_allowed(self, monkeypatch, tmp_path):
+        # geordi → chekov /message, shared group → isolation guard lets it
+        # through (handler runs; the guard's own signal is "not 403").
+        client, path = self._make_client_grouped(monkeypatch, tmp_path)
+        resp = self._signed_post(
+            client, "geordi", "/agents/chekov/message",
+            {"from_agent": "geordi", "message": "calendar for site X?"},
+        )
+        assert resp.status_code != 403, resp.text
+        os.unlink(path)
+
+    def test_isolated_no_shared_group_peer_message_denied(self, monkeypatch, tmp_path):
+        # geordi (support) → sasha (sales) /message: no shared group → 403.
+        client, path = self._make_client_grouped(monkeypatch, tmp_path)
+        resp = self._signed_post(
+            client, "geordi", "/agents/sasha/message",
+            {"from_agent": "geordi", "message": "hi"},
+        )
+        assert resp.status_code == 403
+        assert "isolated" in resp.json().get("error", "").lower()
+        os.unlink(path)
+
+    def test_isolated_same_group_non_message_path_still_denied(self, monkeypatch, tmp_path):
+        # Shared group does NOT open admin/read surfaces — only /message.
+        client, path = self._make_client_grouped(monkeypatch, tmp_path)
+        resp = self._signed_get(client, "geordi", "/agents/chekov")
+        assert resp.status_code == 403
+        assert "isolated" in resp.json().get("error", "").lower()
+        os.unlink(path)
+
+    def test_isolated_same_group_message_spoofed_sender_denied(self, monkeypatch, tmp_path):
+        # geordi may reach chekov/message, but naming a THIRD agent as sender
+        # is blocked by the body-actor guard (act only as yourself).
+        client, path = self._make_client_grouped(monkeypatch, tmp_path)
+        resp = self._signed_post(
+            client, "geordi", "/agents/chekov/message",
+            {"from_agent": "sasha", "message": "spoofed"},
+        )
+        assert resp.status_code == 403
+        # handler-level guard raises HTTPException → {"detail": ...} (the
+        # middleware deny uses {"error": ...}); accept either shape.
+        body = resp.json()
+        assert "isolated" in (body.get("detail") or body.get("error") or "").lower()
+        os.unlink(path)
+
     # ── PATH-target: /autonomy/{name}/* (middleware) ──────────────────────
 
     def test_isolated_agent_denied_cross_agent_autonomy(self, monkeypatch, tmp_path):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1051,6 +1051,21 @@ class TestAgentIsolationScoping:
         assert "isolated" in (body.get("detail") or body.get("error") or "").lower()
         os.unlink(path)
 
+    @pytest.mark.parametrize("from_agent", ["", "   "])
+    def test_isolated_same_group_message_blank_sender_denied(
+        self, monkeypatch, tmp_path, from_agent
+    ):
+        # Empty/blank is not self. The generic body-actor guard must deny it,
+        # never treat a falsey actor as an operator/no-op identity.
+        client, path = self._make_client_grouped(monkeypatch, tmp_path)
+        resp = self._signed_post(
+            client, "geordi", "/agents/chekov/message",
+            {"from_agent": from_agent, "message": "anonymous spoof"},
+        )
+        assert resp.status_code == 403
+        assert "isolated" in resp.json().get("detail", "").lower()
+        os.unlink(path)
+
     # ── PATH-target: /autonomy/{name}/* (middleware) ──────────────────────
 
     def test_isolated_agent_denied_cross_agent_autonomy(self, monkeypatch, tmp_path):

--- a/tests/test_isolated_peer_messaging.py
+++ b/tests/test_isolated_peer_messaging.py
@@ -14,24 +14,49 @@ MSG = "/agents/chekov/message"
 
 
 def test_shared_group_message_path_allowed():
-    assert _isolated_peer_message_allowed(MSG, "chekov", ["support"], ["support"]) is True
+    assert _isolated_peer_message_allowed(
+        "POST", MSG, "chekov", ["support"], ["support"]
+    ) is True
 
 
 def test_multiple_groups_any_intersection_allows():
     assert (
-        _isolated_peer_message_allowed(MSG, "chekov", ["a", "support", "b"], ["c", "support"])
+        _isolated_peer_message_allowed(
+            "POST", MSG, "chekov", ["a", "support", "b"], ["c", "support"]
+        )
         is True
     )
 
 
 def test_no_shared_group_denied():
-    assert _isolated_peer_message_allowed(MSG, "chekov", ["support"], ["sales"]) is False
+    assert _isolated_peer_message_allowed(
+        "POST", MSG, "chekov", ["support"], ["sales"]
+    ) is False
 
 
 def test_empty_or_missing_groups_denied():
     # a group each but no overlap, one side empty, both empty, both None
     for cg, pg in [([], ["support"]), (["support"], []), ([], []), (None, None)]:
-        assert _isolated_peer_message_allowed(MSG, "chekov", cg, pg) is False
+        assert _isolated_peer_message_allowed("POST", MSG, "chekov", cg, pg) is False
+
+
+def test_blank_or_malformed_group_values_never_authorize():
+    for caller_groups, peer_groups in (
+        ([""], [""]),
+        (["   "], ["   "]),
+        ("support", "sales"),
+        (["support", {"bad": "shape"}], ["sales", {"bad": "shape"}]),
+    ):
+        assert _isolated_peer_message_allowed(
+            "POST", MSG, "chekov", caller_groups, peer_groups
+        ) is False
+
+
+def test_non_post_methods_at_exact_message_path_denied():
+    for method in ("GET", "DELETE", "PATCH", "OPTIONS"):
+        assert _isolated_peer_message_allowed(
+            method, MSG, "chekov", ["support"], ["support"]
+        ) is False
 
 
 def test_non_message_cross_agent_paths_denied_even_with_shared_group():
@@ -48,14 +73,19 @@ def test_non_message_cross_agent_paths_denied_even_with_shared_group():
         "/agents/chekov/sessions/main/message",
     ):
         assert (
-            _isolated_peer_message_allowed(path, "chekov", ["support"], ["support"]) is False
+            _isolated_peer_message_allowed(
+                "POST", path, "chekov", ["support"], ["support"]
+            )
+            is False
         ), path
 
 
 def test_message_subpath_not_matched():
     # exact-match only — nothing nested under /message slips through.
     assert (
-        _isolated_peer_message_allowed(MSG + "/evil", "chekov", ["support"], ["support"])
+        _isolated_peer_message_allowed(
+            "POST", MSG + "/evil", "chekov", ["support"], ["support"]
+        )
         is False
     )
 
@@ -64,6 +94,8 @@ def test_target_must_match_path_segment():
     # target is the path-extracted agent; a mismatch between the named target
     # and the path segment must never match (belt-and-braces on the invariant).
     assert (
-        _isolated_peer_message_allowed("/agents/sasha/message", "chekov", ["support"], ["support"])
+        _isolated_peer_message_allowed(
+            "POST", "/agents/sasha/message", "chekov", ["support"], ["support"]
+        )
         is False
     )

--- a/tests/test_isolated_peer_messaging.py
+++ b/tests/test_isolated_peer_messaging.py
@@ -1,0 +1,69 @@
+"""#637 tenant-grouping: the isolated-agent same-group messaging exception.
+
+The #149 isolation boundary denies an isolated agent every cross-agent
+``/agents/{other}/*`` surface. #637 carves out exactly one case — teammate
+coordination: an isolated agent may reach a PEER it shares a group with, and
+ONLY at that peer's inter-agent message-delivery endpoint. These tests pin the
+pure policy predicate (`_isolated_peer_message_allowed`) so the exception can
+never silently widen past "same-group peer, message endpoint only".
+"""
+
+from pinky_daemon.api import _isolated_peer_message_allowed
+
+MSG = "/agents/chekov/message"
+
+
+def test_shared_group_message_path_allowed():
+    assert _isolated_peer_message_allowed(MSG, "chekov", ["support"], ["support"]) is True
+
+
+def test_multiple_groups_any_intersection_allows():
+    assert (
+        _isolated_peer_message_allowed(MSG, "chekov", ["a", "support", "b"], ["c", "support"])
+        is True
+    )
+
+
+def test_no_shared_group_denied():
+    assert _isolated_peer_message_allowed(MSG, "chekov", ["support"], ["sales"]) is False
+
+
+def test_empty_or_missing_groups_denied():
+    # a group each but no overlap, one side empty, both empty, both None
+    for cg, pg in [([], ["support"]), (["support"], []), ([], []), (None, None)]:
+        assert _isolated_peer_message_allowed(MSG, "chekov", cg, pg) is False
+
+
+def test_non_message_cross_agent_paths_denied_even_with_shared_group():
+    # admin / config / autonomy / session / file / bare-agent surfaces all stay
+    # denied — the exception is message-delivery only.
+    for path in (
+        "/agents/chekov/restart",
+        "/agents/chekov/soul",
+        "/agents/chekov/config",
+        "/agents/chekov/update",
+        "/autonomy/chekov/pause",
+        "/agents/chekov/file",
+        "/agents/chekov",
+        "/agents/chekov/sessions/main/message",
+    ):
+        assert (
+            _isolated_peer_message_allowed(path, "chekov", ["support"], ["support"]) is False
+        ), path
+
+
+def test_message_subpath_not_matched():
+    # exact-match only — nothing nested under /message slips through.
+    assert (
+        _isolated_peer_message_allowed(MSG + "/evil", "chekov", ["support"], ["support"])
+        is False
+    )
+
+
+def test_target_must_match_path_segment():
+    # target is the path-extracted agent; a mismatch between the named target
+    # and the path segment must never match (belt-and-braces on the invariant).
+    assert (
+        _isolated_peer_message_allowed("/agents/sasha/message", "chekov", ["support"], ["support"])
+        is False
+    )


### PR DESCRIPTION
## What
Isolated agents (#149) are denied every cross-agent `/agents/{other}/*` surface — which also blocks the one thing teammates legitimately need: messaging each other. This adds a single narrow exception: an isolated agent may reach a **peer it shares an explicit group with**, and **only** at that peer's inter-agent message endpoint (`POST /agents/{peer}/message`).

## Why
`geordi` and `chekov` (support team, both hard-isolated on the Pi fleet) need to exchange calendar info. Today `geordi`'s `send_to_agent(chekov, …)` posts to `/agents/chekov/message` and is hard-denied by the isolation middleware.

## Scope / safety
- **Opt-in per pair** — activates only when an operator deliberately co-groups two agents. No shared group → behavior identical to today (full deny). The shared group **is** the gate, so no separate feature flag is needed.
- **Message endpoint only** — admin/config/autonomy/session/file surfaces all stay denied. `/agents/{peer}/message/<sub>` stays denied (exact match, nothing nested slips through).
- **No spoofing** — the now-reachable endpoint gets the existing body-actor guard (`_deny_isolated_cross_actor`), so an isolated caller can't set `from_agent` to a third agent.
- **Groups are membership-only** — co-membership already grants no cross-agent *memory* access; this widens the tenant boundary strictly to message delivery.
- **Fail-closed** peer lookup (registry error → deny).

## Design
- `_isolated_peer_message_allowed(path, target, caller_groups, peer_groups)` — pure module-level predicate (exact `/agents/{target}/message` match + non-empty group intersection), unit-testable on its own.
- Wired into `_internal_isolation_denied`: only a message-path target pays the extra peer lookup; every other cross-agent attempt short-circuits to the existing deny.

## Tests
- `tests/test_isolated_peer_messaging.py` — pure predicate (shared-group allow; no-overlap/empty/None deny; admin/session/file paths deny; `/message/<sub>` deny; target-mismatch deny).
- `tests/test_auth.py::TestAgentIsolationScoping` — integration through the **signed** middleware: allowed same-group message, denied no-shared-group, denied non-message path, denied spoofed sender.

## Evidence (live TestClient run at this SHA)
- `geordi → chekov /message` (shared group `support`) → **200** `{"delivered":true,"confirmed":true,"from":"geordi","to":"chekov"}`
- spoofed sender (`from_agent: sasha`) → **403** `{"detail":"isolated agent may only act as itself"}`
- `geordi → sasha /message` (no shared group) → **403** (isolation deny)

Backend authz change — no UI surface; the TestClient allow/deny transcript above is the behavioral artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Opened by Barsik