### PR TITLE
fix(tmux): disallow AskUserQuestion in headless agents (#850, #876)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2927,6 +2927,10 @@ class TmuxSession:
         if cli_effort and cli_effort != "auto":
             parts.extend(["--effort", cli_effort])
 
+        # CC 2.1.200 removed AskUserQuestion's auto-continue fallback; headless
+        # agents now hang indefinitely if the model calls it (#850, #876).
+        parts.extend(["--disallowedTools", "AskUserQuestion"])
+
         # Claude Code 2.1.215 does not reliably discover project or local-scope
         # MCP configuration when the daemon launches its tmux REPL. Pass the
         # agent workspace config explicitly when present so both fresh and


### PR DESCRIPTION
## Problem

CC 2.1.200 (live on fleet since 2026-07-04) removed the `AskUserQuestion` auto-continue fallback. Any headless tmux agent that calls it now hangs indefinitely — pane alive, transport CONNECTED, but zero API traffic — until the inflight watchdog force-restarts it 600 s later.

The SDK path is already safe: `AskUserQuestion` is not in `DEFAULT_STREAMING_ALLOWED_TOOLS`, so it can't be called there.

The tmux path was unguarded: `_build_claude_cmd` launched `claude --dangerously-skip-permissions` with no `--disallowedTools`, leaving `AskUserQuestion` reachable.

## Fix

One line in `_build_claude_cmd`: pass `--disallowedTools AskUserQuestion` on every tmux REPL launch.

## Test

329 tmux session tests pass.

Closes #850, closes #876.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMiF52XXdqSU7V5hJUovqQ)_