### PR TITLE
fix(slack): honor disable_link_preview on Slack sends

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1914,8 +1914,14 @@ def create_api(
                         _log("broker-send: slack blocks not a JSON array, ignoring (text-only)")
                 except Exception as e:
                     _log(f"broker-send: slack blocks JSON parse failed ({e}), sending text-only")
+            # Honor the cross-platform "no preview" intent on Slack too:
+            # link_preview_options.is_disabled → suppress both link and media
+            # unfurls. None leaves Slack's defaults untouched.
+            no_unfurl = bool((link_preview_options or {}).get("is_disabled"))
             result = adapter.send_message(
-                chat_id, content, thread_ts=reply_to or None, blocks=parsed_blocks
+                chat_id, content, thread_ts=reply_to or None, blocks=parsed_blocks,
+                unfurl_links=False if no_unfurl else None,
+                unfurl_media=False if no_unfurl else None,
             )
             return SimpleNamespace(message_id=_extract_message_id(result))
 

--- a/src/pinky_outreach/slack.py
+++ b/src/pinky_outreach/slack.py
@@ -116,6 +116,8 @@ class SlackAdapter:
         thread_ts: str = "",
         reply_broadcast: bool = False,
         blocks: list | None = None,
+        unfurl_links: bool | None = None,
+        unfurl_media: bool | None = None,
     ) -> Message:
         """Send a message to a Slack channel or thread.
 
@@ -128,6 +130,9 @@ class SlackAdapter:
             blocks: optional Block Kit blocks (list of block dicts) for rich/
                 interactive messages. Sent via the JSON body (chat.postMessage);
                 ``_request`` drops it when None.
+            unfurl_links / unfurl_media: Slack's link-preview controls
+                (text-content unfurls / media unfurls). None leaves Slack's
+                defaults untouched; pass False to suppress preview cards.
         """
         result = self._request(
             "chat.postMessage",
@@ -136,6 +141,8 @@ class SlackAdapter:
             thread_ts=thread_ts or None,
             reply_broadcast=reply_broadcast if thread_ts else None,
             blocks=blocks or None,
+            unfurl_links=unfurl_links,
+            unfurl_media=unfurl_media,
         )
 
         msg_data = result.get("message", {})


### PR DESCRIPTION
## Summary
- `disable_link_preview` (→ `link_preview_options.is_disabled`) was Telegram-only; Slack sends always used default unfurling, so the flag was silently ignored on Slack.
- `SlackAdapter.send_message` now accepts `unfurl_links` / `unfurl_media` (`None` = leave Slack defaults untouched) and forwards them to `chat.postMessage`.
- The Slack branch of `_send_text_message` maps `is_disabled` → `unfurl_links=False, unfurl_media=False`. No behavior change unless the flag is set.

## Context
Ryan asked for the daily support brief (which now contains business-website links) to post without preview cards. The Block Kit workaround didn't suppress unfurls, so this wires the existing cross-platform flag through properly. Hotfix is already running on the Pi (daemon restarted from this working tree); this PR makes it durable across `update_and_restart()`.

## Testing
- `python -m pytest tests/test_slack.py tests/test_outreach_server.py` — 71 passed
- Live-verified on Slack: brief with links posted via `send(..., disable_link_preview=true)` showed no preview cards (Ryan confirmed)

🤖 Opened by Geordi

🤖 Generated with [Claude Code](https://claude.com/claude-code)