### PR TITLE
fix(slack): thread file uploads under reply_to (send_photo/document/video)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1991,7 +1991,13 @@ def create_api(
             return SimpleNamespace(message_id=_extract_message_id(result))
 
         if platform == "slack":
-            result = adapter.upload_file(chat_id, file_path, initial_comment=caption)
+            # reply_to is the parent's ts on Slack — thread the file under it,
+            # same as the text path passes reply_to as thread_ts. Without this
+            # a send_photo/document/video reply spawned a new root instead of
+            # threading (the file-upload path silently dropped reply_to).
+            result = adapter.upload_file(
+                chat_id, file_path, initial_comment=caption, thread_ts=reply_to,
+            )
             return SimpleNamespace(message_id=_extract_message_id(result))
 
         raise HTTPException(400, f"Unsupported platform: {platform}")

--- a/src/pinky_outreach/slack.py
+++ b/src/pinky_outreach/slack.py
@@ -179,10 +179,16 @@ class SlackAdapter:
         *,
         title: str = "",
         initial_comment: str = "",
+        thread_ts: str = "",
     ) -> Message:
         """Upload a file to a Slack channel.
 
         Uses the files.uploadV2 flow: get upload URL, upload, then complete.
+
+        ``thread_ts`` threads the file under an existing message (a Slack reply);
+        empty posts it as a new root. Mirrors ``send_message``'s threading so
+        send_photo/send_document/send_video with a ``message_id`` reply in-thread
+        instead of spawning a new root message.
         """
         import os
         filename = os.path.basename(file_path)
@@ -219,6 +225,7 @@ class SlackAdapter:
             files=json.dumps([{"id": file_id, "title": title or filename}]),
             channel_id=channel,
             initial_comment=initial_comment or None,
+            thread_ts=thread_ts or None,
         )
 
         return Message(
@@ -229,7 +236,8 @@ class SlackAdapter:
             timestamp=datetime.now(timezone.utc),
             message_id=file_id,
             is_outbound=True,
-            metadata={"type": "file", "filename": filename},
+            metadata={"type": "file", "filename": filename,
+                      **({"thread_ts": thread_ts} if thread_ts else {})},
         )
 
     # ── Downloading ──────────────────────────────────────────

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -242,6 +242,70 @@ class TestSlackAdapter:
         assert msg.message_id == "F123"
         adapter.close()
 
+    def test_upload_file_threads_when_thread_ts(self, tmp_path, monkeypatch):
+        """A file uploaded with thread_ts must thread under that parent (a Slack
+        reply), not spawn a new root. Regression guard: the file-upload path
+        silently dropped reply_to, so send_photo/document/video replies posted a
+        new root instead of threading (Pi-fleet RMA screenshot flow, 2026-07)."""
+        adapter = self._make_adapter()
+        f = tmp_path / "shot.png"
+        f.write_bytes(b"\x89PNG\r\n")
+
+        url_resp = MagicMock()
+        url_resp.json.return_value = {
+            "ok": True,
+            "upload_url": "https://files.slack.com/upload/xyz",
+            "file_id": "F777",
+        }
+        complete_resp = MagicMock()
+        complete_resp.json.return_value = {"ok": True, "files": [{"id": "F777"}]}
+        adapter._client.post = MagicMock(side_effect=[url_resp, complete_resp])
+        monkeypatch.setattr(
+            "pinky_outreach.slack.httpx.post",
+            MagicMock(return_value=MagicMock(status_code=200)),
+        )
+
+        msg = adapter.upload_file(
+            "C123", str(f), initial_comment="approved",
+            thread_ts="1784133332.936979",
+        )
+
+        # completeUploadExternal must carry thread_ts so Slack threads the file.
+        complete_call = adapter._client.post.call_args_list[1]
+        assert complete_call[0][0] == "/files.completeUploadExternal"
+        assert complete_call.kwargs["data"]["thread_ts"] == "1784133332.936979"
+        # and the returned Message records the thread it landed in.
+        assert msg.metadata.get("thread_ts") == "1784133332.936979"
+        adapter.close()
+
+    def test_upload_file_no_thread_ts_omits_it(self, tmp_path, monkeypatch):
+        """Standalone upload (no thread_ts) must NOT send a thread_ts arg —
+        _request_form drops None, so the file posts as a new root as before."""
+        adapter = self._make_adapter()
+        f = tmp_path / "note.txt"
+        f.write_text("hi")
+
+        url_resp = MagicMock()
+        url_resp.json.return_value = {
+            "ok": True,
+            "upload_url": "https://files.slack.com/upload/xyz",
+            "file_id": "F888",
+        }
+        complete_resp = MagicMock()
+        complete_resp.json.return_value = {"ok": True, "files": [{"id": "F888"}]}
+        adapter._client.post = MagicMock(side_effect=[url_resp, complete_resp])
+        monkeypatch.setattr(
+            "pinky_outreach.slack.httpx.post",
+            MagicMock(return_value=MagicMock(status_code=200)),
+        )
+
+        msg = adapter.upload_file("C123", str(f), initial_comment="hi")
+
+        complete_call = adapter._client.post.call_args_list[1]
+        assert "thread_ts" not in complete_call.kwargs["data"]
+        assert "thread_ts" not in msg.metadata
+        adapter.close()
+
     def test_send_message_error(self):
         adapter = self._make_adapter()
         mock_response = MagicMock()


### PR DESCRIPTION
## Problem

A Pi-fleet agent reported (relayed via Brad) that `send_photo` — and `send_document`/`send_video` — on **Slack** post the file as a **new root message** instead of a thread reply when given a `message_id`. It bit the RMA workflow: Ryan wanted approval screenshots in the original request thread, but they spawned their own root.

**Repro:** `send_photo message_id=1784133332.936979` in `C09T4N19Q4Q` → new root `1784133855.292459` instead of threading under the parent.

## Root cause

Two spots dropped the thread:

1. `pinky_daemon/api.py` — the Slack branch of `_send_file_message` called `adapter.upload_file(chat_id, file_path, initial_comment=caption)`, **dropping `reply_to`** — even though `reply_to` is populated (from `_resolve_message_context`) and is exactly what the working *text* path passes as `thread_ts`.
2. `pinky_outreach/slack.py` — `upload_file` had no `thread_ts` parameter, so `files.completeUploadExternal` never threaded.

## Fix

- `slack.py upload_file`: accept `thread_ts`, forward it to `files.completeUploadExternal` (`_request_form` drops it when empty, so standalone uploads are unchanged), and record it in the returned `Message.metadata`.
- `api.py`: pass `reply_to` through as `thread_ts` on the Slack file branch.

The single Slack branch is shared by photo/document/video, so **all three now thread**. Telegram/Discord paths untouched. Backward compatible — `thread_ts` defaults to `""` and a standalone send behaves exactly as before.

## Tests

- `test_upload_file_threads_when_thread_ts` — asserts `completeUploadExternal` carries `thread_ts` and the returned message records it.
- `test_upload_file_no_thread_ts_omits_it` — control: no `thread_ts` arg is sent for a standalone upload (still posts a new root).

```
$ pytest tests/test_slack.py -q
28 passed

$ pytest tests/test_broker.py tests/test_messaging_server.py tests/test_outreach.py \
         tests/test_outreach_server.py tests/test_pinky_messaging.py -q
194 passed
```

No UI surface — the regression guards above are the pre-merge evidence. Live-verifiable after deploy: `send_photo(message_id=<a Slack message>)` should land the image in that message's thread rather than a new root.

🤖 Opened by Barsik
