### PR TITLE
feat(broker): persist message routing context

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -136,6 +136,7 @@ from pinky_daemon.hooks import (
 from pinky_daemon.kb_store import KBStore
 from pinky_daemon.librarian_runner import LibrarianRunner
 from pinky_daemon.mesh_store import MeshStore
+from pinky_daemon.message_context_store import MessageContextStore
 from pinky_daemon.outreach_config import OutreachConfigStore
 from pinky_daemon.plugin_manager import PluginManager
 from pinky_daemon.presentation_store import PresentationStore
@@ -1727,13 +1728,23 @@ def create_api(
         content: str,
         metadata: dict | None = None,
     ) -> None:
+        meta = metadata or {}
+        message_id = _extract_message_id(meta.get("delivery"))
+        if message_id:
+            broker.remember_outbound_message_context(
+                agent_name,
+                message_id,
+                platform=platform,
+                chat_id=chat_id,
+                reply_to=str(meta.get("reply_to") or ""),
+            )
         store.append(
             _session_id_for_agent(agent_name),
             "assistant",
             content,
             platform=platform,
             chat_id=chat_id,
-            metadata=metadata or None,
+            metadata=meta or None,
         )
 
     def _resolve_message_context(agent_name: str, message_id: str):
@@ -2322,7 +2333,11 @@ def create_api(
         return result
 
     activity = ActivityStore(db_path=db_path.replace(".db", "_activity.db"))
+    message_context_store = MessageContextStore(
+        db_path=db_path.replace(".db", "_message_context.db")
+    )
     app.state.activity = activity
+    app.state.message_context_store = message_context_store
     # Exposed for unit-test reach-in (#591 P1#1 — verifying commit=False
     # preserves inbox state). Not part of the public API.
     app.state.comms = comms
@@ -2368,6 +2383,7 @@ def create_api(
         stop_callback=_broker_stop_agent,
         stop_all_callback=_broker_stop_all,
         activity_store=activity,
+        message_context_store=message_context_store,
     )
     _broker_pollers: list = []  # Track active broker pollers
 
@@ -8271,6 +8287,7 @@ npm run build</pre>
                 metadata={
                     "tool": "thread",
                     "source_message_id": ctx.message_id,
+                    "reply_to": effective_thread_root,
                     "delivery_mode": "voice_auto_reply",
                     "delivery": result,
                 },
@@ -8295,6 +8312,7 @@ npm run build</pre>
             metadata={
                 "tool": "thread",
                 "source_message_id": ctx.message_id,
+                "reply_to": effective_thread_root,
                 "delivery": result,
             },
         )
@@ -8496,7 +8514,13 @@ npm run build</pre>
             content=caption or content_default,
             # PII-safe: record argument key names only, not the raw file_path.
             # Matches the arg_keys pattern used in codex_session.py / streaming_session.py.
-            metadata={"tool": method, "source_message_id": source_message_id, "arg_keys": ["file_path"], "delivery": result},
+            metadata={
+                "tool": method,
+                "source_message_id": source_message_id,
+                "reply_to": reply_to,
+                "arg_keys": ["file_path"],
+                "delivery": result,
+            },
         )
         return result
 
@@ -8663,7 +8687,13 @@ npm run build</pre>
             platform=platform,
             chat_id=chat_id,
             content=caption or f"[gif] {query}",
-            metadata={"tool": "send_gif", "source_message_id": source_message_id, "query": query, "delivery": result},
+            metadata={
+                "tool": "send_gif",
+                "source_message_id": source_message_id,
+                "reply_to": reply_to,
+                "query": query,
+                "delivery": result,
+            },
         )
         return result
 
@@ -8719,7 +8749,12 @@ npm run build</pre>
             platform=platform,
             chat_id=chat_id,
             content=text,
-            metadata={"tool": "send_voice", "source_message_id": source_message_id, "delivery": result},
+            metadata={
+                "tool": "send_voice",
+                "source_message_id": source_message_id,
+                "reply_to": reply_to,
+                "delivery": result,
+            },
         )
         return result
 
@@ -10778,6 +10813,7 @@ npm run build</pre>
         if shared_mcp_manager and shared_mcp_manager.is_running:
             await shared_mcp_manager.stop()
             _log("shutdown: shared MCP server stopped")
+        message_context_store.close()
 
     # ── Admin: Session Watchdog ─────────────────────────
 

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -15,6 +15,7 @@ import json
 import os
 import sys
 import tempfile
+import threading
 import time
 import urllib.request
 from dataclasses import dataclass, field
@@ -328,6 +329,7 @@ class MessageBroker:
         self._message_contexts: dict[tuple[str, str, str, str], MessageContext] = {}
         self._message_context_stored_at: dict[tuple[str, str, str, str], float] = {}
         self._message_context_order: dict[str, list[tuple[str, str, str, str]]] = {}
+        self._message_context_lock = threading.RLock()
 
         # #215 PR3: last check-inbox nudge time per agent (monotonic seconds),
         # used to coalesce a burst of inter-agent messages into one nudge.
@@ -659,13 +661,14 @@ class MessageBroker:
     def _remember_context(self, context: MessageContext) -> None:
         """Cache immediately and persist best-effort for restart survival."""
         stored_at = time.time()
-        self._cache_message_context(context, stored_at=stored_at)
-        if self._message_context_store is None:
-            return
-        try:
-            self._message_context_store.put(context.to_dict(), stored_at=stored_at)
-        except Exception as exc:  # noqa: BLE001 — routing must survive store faults
-            _log(f"message-context persistence failed: {type(exc).__name__}")
+        with self._message_context_lock:
+            self._cache_message_context(context, stored_at=stored_at)
+            if self._message_context_store is None:
+                return
+            try:
+                self._message_context_store.put(context.to_dict(), stored_at=stored_at)
+            except Exception as exc:  # noqa: BLE001 — routing must survive store faults
+                _log(f"message-context persistence failed: {type(exc).__name__}")
 
     def remember_message_context(
         self,
@@ -713,33 +716,36 @@ class MessageBroker:
 
     def get_message_context(self, agent_name: str, message_id: str) -> MessageContext | None:
         """Resolve one context, failing closed when a chat-scoped ID is ambiguous."""
-        self._prune_expired_message_contexts(time.time())
-        cached = [
-            context
-            for key, context in self._message_contexts.items()
-            if key[0] == agent_name and key[3] == message_id
-        ]
-        if len(cached) > 1:
-            return None
-        if len(cached) == 1:
-            return cached[0]
-        if self._message_context_store is None:
-            return None
-        try:
-            stored = self._message_context_store.get(
-                agent_name,
-                message_id,
-                include_stored_at=True,
-            )
-        except Exception as exc:  # noqa: BLE001 — preserve historical 404 behavior
-            _log(f"message-context load failed: {type(exc).__name__}")
-            return None
-        if stored is None:
-            return None
-        stored_at = float(stored.pop("_stored_at"))
-        context = MessageContext(**stored)
-        self._cache_message_context(context, stored_at=stored_at)
-        return context
+        with self._message_context_lock:
+            self._prune_expired_message_contexts(time.time())
+            matches = {
+                key: (context, self._message_context_stored_at[key])
+                for key, context in self._message_contexts.items()
+                if key[0] == agent_name and key[3] == message_id
+            }
+            if self._message_context_store is None:
+                return next(iter(matches.values()))[0] if len(matches) == 1 else None
+            try:
+                stored_contexts = self._message_context_store.find(
+                    agent_name,
+                    message_id,
+                    include_stored_at=True,
+                )
+            except Exception as exc:  # noqa: BLE001 — preserve historical 404 behavior
+                _log(f"message-context load failed: {type(exc).__name__}")
+                return None
+            for stored in stored_contexts:
+                stored_at = float(stored.pop("_stored_at"))
+                context = MessageContext(**stored)
+                key = self._message_context_key(context)
+                cached = matches.get(key)
+                if cached is None or stored_at > cached[1]:
+                    matches[key] = (context, stored_at)
+            if len(matches) != 1:
+                return None
+            context, stored_at = next(iter(matches.values()))
+            self._cache_message_context(context, stored_at=stored_at)
+            return context
 
     async def _handle_stop_command(self, message: BrokerMessage) -> bool:
         """Intercept /stop commands from the owner. Returns True if handled."""

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -325,8 +325,9 @@ class MessageBroker:
 
         # Track voice-pending chats: (agent_name, chat_id) -> True when last inbound was voice
         self._voice_pending: dict[tuple[str, str], bool] = {}
-        self._message_contexts: dict[tuple[str, str], MessageContext] = {}
-        self._message_context_order: dict[str, list[str]] = {}
+        self._message_contexts: dict[tuple[str, str, str, str], MessageContext] = {}
+        self._message_context_stored_at: dict[tuple[str, str, str, str], float] = {}
+        self._message_context_order: dict[str, list[tuple[str, str, str, str]]] = {}
 
         # #215 PR3: last check-inbox nudge time per agent (monotonic seconds),
         # used to coalesce a burst of inter-agent messages into one nudge.
@@ -616,24 +617,53 @@ class MessageBroker:
         await self._reaction_callback(agent_name, platform, chat_id, message_id, emoji)
         return True
 
-    def _cache_message_context(self, context: MessageContext) -> None:
-        key = (context.agent_name, context.message_id)
+    @staticmethod
+    def _message_context_key(context: MessageContext) -> tuple[str, str, str, str]:
+        return (context.agent_name, context.platform, context.chat_id, context.message_id)
+
+    def _evict_message_context(self, key: tuple[str, str, str, str]) -> None:
+        self._message_contexts.pop(key, None)
+        self._message_context_stored_at.pop(key, None)
+        order = self._message_context_order.get(key[0])
+        if order is not None and key in order:
+            order.remove(key)
+
+    def _prune_expired_message_contexts(self, now: float) -> None:
+        retention = (
+            self._message_context_store.retention_seconds
+            if self._message_context_store is not None
+            else 30 * 86400
+        )
+        for key, stored_at in list(self._message_context_stored_at.items()):
+            if stored_at < now - retention:
+                self._evict_message_context(key)
+
+    def _cache_message_context(
+        self,
+        context: MessageContext,
+        *,
+        stored_at: float | None = None,
+    ) -> None:
+        key = self._message_context_key(context)
         self._message_contexts[key] = context
+        self._message_context_stored_at[key] = time.time() if stored_at is None else stored_at
         order = self._message_context_order.setdefault(context.agent_name, [])
-        if context.message_id in order:
-            order.remove(context.message_id)
-        order.append(context.message_id)
+        if key in order:
+            order.remove(key)
+        order.append(key)
         if len(order) > 1000:
-            stale_id = order.pop(0)
-            self._message_contexts.pop((context.agent_name, stale_id), None)
+            stale_key = order.pop(0)
+            self._message_contexts.pop(stale_key, None)
+            self._message_context_stored_at.pop(stale_key, None)
 
     def _remember_context(self, context: MessageContext) -> None:
         """Cache immediately and persist best-effort for restart survival."""
-        self._cache_message_context(context)
+        stored_at = time.time()
+        self._cache_message_context(context, stored_at=stored_at)
         if self._message_context_store is None:
             return
         try:
-            self._message_context_store.put(context.to_dict())
+            self._message_context_store.put(context.to_dict(), stored_at=stored_at)
         except Exception as exc:  # noqa: BLE001 — routing must survive store faults
             _log(f"message-context persistence failed: {type(exc).__name__}")
 
@@ -682,19 +712,33 @@ class MessageBroker:
         ))
 
     def get_message_context(self, agent_name: str, message_id: str) -> MessageContext | None:
-        """Resolve memory first, then load through the durable store."""
-        cached = self._message_contexts.get((agent_name, message_id))
-        if cached is not None or self._message_context_store is None:
-            return cached
+        """Resolve one context, failing closed when a chat-scoped ID is ambiguous."""
+        self._prune_expired_message_contexts(time.time())
+        cached = [
+            context
+            for key, context in self._message_contexts.items()
+            if key[0] == agent_name and key[3] == message_id
+        ]
+        if len(cached) > 1:
+            return None
+        if len(cached) == 1:
+            return cached[0]
+        if self._message_context_store is None:
+            return None
         try:
-            stored = self._message_context_store.get(agent_name, message_id)
+            stored = self._message_context_store.get(
+                agent_name,
+                message_id,
+                include_stored_at=True,
+            )
         except Exception as exc:  # noqa: BLE001 — preserve historical 404 behavior
             _log(f"message-context load failed: {type(exc).__name__}")
             return None
         if stored is None:
             return None
+        stored_at = float(stored.pop("_stored_at"))
         context = MessageContext(**stored)
-        self._cache_message_context(context)
+        self._cache_message_context(context, stored_at=stored_at)
         return context
 
     async def _handle_stop_command(self, message: BrokerMessage) -> bool:

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -23,6 +23,7 @@ from typing import NamedTuple
 from pinky_daemon.agent_registry import AgentRegistry
 from pinky_daemon.auth_relay import coordinator as _auth_relay
 from pinky_daemon.auth_relay import extract_auth_code
+from pinky_daemon.message_context_store import MessageContextStore
 from pinky_daemon.transport_state import SessionState
 
 # Bounded wait for an in-flight reconnect/restart to complete before we drop an
@@ -253,6 +254,7 @@ class MessageBroker:
         stop_callback=None,  # async fn(agent_name) → force-stop agent
         stop_all_callback=None,  # async fn() → force-stop all agents
         activity_store=None,  # ActivityStore — for logging message events
+        message_context_store: MessageContextStore | None = None,
     ) -> None:
         self._registry = registry
         self._sessions = session_manager
@@ -260,6 +262,7 @@ class MessageBroker:
         self._reaction_callback = reaction_callback
         self._typing_callback = typing_callback
         self._activity = activity_store
+        self._message_context_store = message_context_store
         self._stop_callback = stop_callback
         self._stop_all_callback = stop_all_callback
         self._stats = {
@@ -613,12 +616,37 @@ class MessageBroker:
         await self._reaction_callback(agent_name, platform, chat_id, message_id, emoji)
         return True
 
-    def remember_message_context(self, message: BrokerMessage, *, source_was_voice: bool = False) -> None:
+    def _cache_message_context(self, context: MessageContext) -> None:
+        key = (context.agent_name, context.message_id)
+        self._message_contexts[key] = context
+        order = self._message_context_order.setdefault(context.agent_name, [])
+        if context.message_id in order:
+            order.remove(context.message_id)
+        order.append(context.message_id)
+        if len(order) > 1000:
+            stale_id = order.pop(0)
+            self._message_contexts.pop((context.agent_name, stale_id), None)
+
+    def _remember_context(self, context: MessageContext) -> None:
+        """Cache immediately and persist best-effort for restart survival."""
+        self._cache_message_context(context)
+        if self._message_context_store is None:
+            return
+        try:
+            self._message_context_store.put(context.to_dict())
+        except Exception as exc:  # noqa: BLE001 — routing must survive store faults
+            _log(f"message-context persistence failed: {type(exc).__name__}")
+
+    def remember_message_context(
+        self,
+        message: BrokerMessage,
+        *,
+        source_was_voice: bool = False,
+    ) -> None:
         """Store inbound routing context for later reply()/react() resolution."""
         if not message.message_id:
             return
-        key = (message.agent_name, message.message_id)
-        self._message_contexts[key] = MessageContext(
+        self._remember_context(MessageContext(
             agent_name=message.agent_name,
             message_id=message.message_id,
             platform=message.platform,
@@ -629,18 +657,45 @@ class MessageBroker:
             source_was_voice=source_was_voice,
             attachments=list(message.attachments or []),
             metadata=dict(message.metadata or {}),
-        )
-        order = self._message_context_order.setdefault(message.agent_name, [])
-        if message.message_id in order:
-            order.remove(message.message_id)
-        order.append(message.message_id)
-        if len(order) > 1000:
-            stale_id = order.pop(0)
-            self._message_contexts.pop((message.agent_name, stale_id), None)
+        ))
+
+    def remember_outbound_message_context(
+        self,
+        agent_name: str,
+        message_id: str,
+        *,
+        platform: str,
+        chat_id: str,
+        reply_to: str = "",
+    ) -> None:
+        """Register a delivered outbound message so agents can self-thread."""
+        if not message_id:
+            return
+        self._remember_context(MessageContext(
+            agent_name=agent_name,
+            message_id=message_id,
+            platform=platform,
+            chat_id=chat_id,
+            timestamp=time.time(),
+            reply_to=reply_to,
+            metadata={"direction": "outbound"},
+        ))
 
     def get_message_context(self, agent_name: str, message_id: str) -> MessageContext | None:
-        """Resolve an inbound message context by agent and message ID."""
-        return self._message_contexts.get((agent_name, message_id))
+        """Resolve memory first, then load through the durable store."""
+        cached = self._message_contexts.get((agent_name, message_id))
+        if cached is not None or self._message_context_store is None:
+            return cached
+        try:
+            stored = self._message_context_store.get(agent_name, message_id)
+        except Exception as exc:  # noqa: BLE001 — preserve historical 404 behavior
+            _log(f"message-context load failed: {type(exc).__name__}")
+            return None
+        if stored is None:
+            return None
+        context = MessageContext(**stored)
+        self._cache_message_context(context)
+        return context
 
     async def _handle_stop_command(self, message: BrokerMessage) -> bool:
         """Intercept /stop commands from the owner. Returns True if handled."""

--- a/src/pinky_daemon/message_context_store.py
+++ b/src/pinky_daemon/message_context_store.py
@@ -226,7 +226,7 @@ class MessageContextStore:
                 self._db.rollback()
                 raise
 
-    def get(
+    def find(
         self,
         agent_name: str,
         message_id: str,
@@ -234,8 +234,8 @@ class MessageContextStore:
         platform: str | None = None,
         chat_id: str | None = None,
         include_stored_at: bool = False,
-    ) -> dict[str, Any] | None:
-        """Return one unambiguous, unexpired context for the owning agent."""
+    ) -> list[dict[str, Any]]:
+        """Return every unexpired full identity matching an agent/message ID."""
         cutoff = time.time() - self.retention_seconds
         identity_filter = ""
         params: list[Any] = [agent_name, message_id, cutoff]
@@ -251,28 +251,46 @@ class MessageContextStore:
                 FROM message_contexts
                 WHERE agent_name=? AND message_id=? AND stored_at>=?{identity_filter}
                 ORDER BY stored_at DESC, rowid DESC
-                LIMIT 2
                 """,
                 params,
             ).fetchall()
-        if len(rows) != 1:
-            return None
-        row = rows[0]
-        context = {
-            "agent_name": row["agent_name"],
-            "message_id": row["message_id"],
-            "platform": row["platform"],
-            "chat_id": row["chat_id"],
-            "timestamp": row["message_ts"],
-            "reply_to": row["reply_to"],
-            "is_group": bool(row["is_group"]),
-            "source_was_voice": bool(row["source_was_voice"]),
-            "attachments": self._json_list(row["attachments_json"]),
-            "metadata": self._json_dict(row["metadata_json"]),
-        }
-        if include_stored_at:
-            context["_stored_at"] = float(row["stored_at"])
-        return context
+        contexts: list[dict[str, Any]] = []
+        for row in rows:
+            context = {
+                "agent_name": row["agent_name"],
+                "message_id": row["message_id"],
+                "platform": row["platform"],
+                "chat_id": row["chat_id"],
+                "timestamp": row["message_ts"],
+                "reply_to": row["reply_to"],
+                "is_group": bool(row["is_group"]),
+                "source_was_voice": bool(row["source_was_voice"]),
+                "attachments": self._json_list(row["attachments_json"]),
+                "metadata": self._json_dict(row["metadata_json"]),
+            }
+            if include_stored_at:
+                context["_stored_at"] = float(row["stored_at"])
+            contexts.append(context)
+        return contexts
+
+    def get(
+        self,
+        agent_name: str,
+        message_id: str,
+        *,
+        platform: str | None = None,
+        chat_id: str | None = None,
+        include_stored_at: bool = False,
+    ) -> dict[str, Any] | None:
+        """Return one unambiguous, unexpired context for the owning agent."""
+        contexts = self.find(
+            agent_name,
+            message_id,
+            platform=platform,
+            chat_id=chat_id,
+            include_stored_at=include_stored_at,
+        )
+        return contexts[0] if len(contexts) == 1 else None
 
     def _sweep_retention_locked(self, now: float) -> int:
         """Prune rows while the caller owns ``_lock`` and the transaction."""

--- a/src/pinky_daemon/message_context_store.py
+++ b/src/pinky_daemon/message_context_store.py
@@ -34,8 +34,13 @@ class MessageContextStore:
         self._db.execute("PRAGMA busy_timeout=5000")
         self._create_schema()
         self._ensure_columns()
+        self._ensure_identity_key()
         self._create_indexes()
         self.sweep_retention()
+
+    @property
+    def retention_seconds(self) -> float:
+        return float(self.retention_days * 86400)
 
     def _create_schema(self) -> None:
         self._db.executescript(
@@ -52,11 +57,64 @@ class MessageContextStore:
                 attachments_json TEXT NOT NULL DEFAULT '[]',
                 metadata_json    TEXT NOT NULL DEFAULT '{}',
                 stored_at        REAL NOT NULL,
-                PRIMARY KEY (agent_name, message_id)
+                PRIMARY KEY (agent_name, platform, chat_id, message_id)
             );
             """
         )
         self._db.commit()
+
+    def _ensure_identity_key(self) -> None:
+        """Migrate legacy agent/message keys to chat-scoped message identity."""
+        info = self._db.execute("PRAGMA table_info(message_contexts)").fetchall()
+        primary_key = tuple(
+            row["name"]
+            for row in sorted((row for row in info if row["pk"]), key=lambda row: row["pk"])
+        )
+        expected = ("agent_name", "platform", "chat_id", "message_id")
+        if primary_key == expected:
+            return
+
+        with self._lock:
+            try:
+                self._db.execute("BEGIN IMMEDIATE")
+                self._db.execute("DROP TABLE IF EXISTS message_contexts_new")
+                self._db.execute(
+                    """
+                    CREATE TABLE message_contexts_new (
+                        agent_name       TEXT NOT NULL,
+                        message_id       TEXT NOT NULL,
+                        platform         TEXT NOT NULL,
+                        chat_id          TEXT NOT NULL,
+                        message_ts       REAL NOT NULL,
+                        reply_to         TEXT NOT NULL DEFAULT '',
+                        is_group         INTEGER NOT NULL DEFAULT 0,
+                        source_was_voice INTEGER NOT NULL DEFAULT 0,
+                        attachments_json TEXT NOT NULL DEFAULT '[]',
+                        metadata_json    TEXT NOT NULL DEFAULT '{}',
+                        stored_at        REAL NOT NULL,
+                        PRIMARY KEY (agent_name, platform, chat_id, message_id)
+                    )
+                    """
+                )
+                self._db.execute(
+                    """
+                    INSERT INTO message_contexts_new (
+                        agent_name, message_id, platform, chat_id, message_ts,
+                        reply_to, is_group, source_was_voice, attachments_json,
+                        metadata_json, stored_at
+                    )
+                    SELECT agent_name, message_id, platform, chat_id, message_ts,
+                           reply_to, is_group, source_was_voice, attachments_json,
+                           metadata_json, stored_at
+                    FROM message_contexts
+                    """
+                )
+                self._db.execute("DROP TABLE message_contexts")
+                self._db.execute("ALTER TABLE message_contexts_new RENAME TO message_contexts")
+                self._db.commit()
+            except Exception:
+                self._db.rollback()
+                raise
 
     def _ensure_columns(self) -> None:
         """Add forward-compatible columns following the daemon store pattern."""
@@ -77,6 +135,11 @@ class MessageContextStore:
                 self._db.execute(
                     f"ALTER TABLE message_contexts ADD COLUMN {column} {column_type}"
                 )
+        if "stored_at" not in existing:
+            self._db.execute(
+                "UPDATE message_contexts SET stored_at=? WHERE stored_at=0",
+                (time.time(),),
+            )
         self._db.commit()
 
     def _create_indexes(self) -> None:
@@ -112,63 +175,90 @@ class MessageContextStore:
         """Insert or replace one agent-scoped message context."""
         agent_name = str(context.get("agent_name") or "")
         message_id = str(context.get("message_id") or "")
-        if not agent_name or not message_id:
+        platform = str(context.get("platform") or "")
+        chat_id = str(context.get("chat_id") or "")
+        if not agent_name or not message_id or not platform or not chat_id:
             return
         attachments = context.get("attachments")
         metadata = context.get("metadata")
         now = time.time() if stored_at is None else float(stored_at)
         with self._lock:
-            self._db.execute(
-                """
-                INSERT INTO message_contexts (
-                    agent_name, message_id, platform, chat_id, message_ts,
-                    reply_to, is_group, source_was_voice, attachments_json,
-                    metadata_json, stored_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(agent_name, message_id) DO UPDATE SET
-                    platform=excluded.platform,
-                    chat_id=excluded.chat_id,
-                    message_ts=excluded.message_ts,
-                    reply_to=excluded.reply_to,
-                    is_group=excluded.is_group,
-                    source_was_voice=excluded.source_was_voice,
-                    attachments_json=excluded.attachments_json,
-                    metadata_json=excluded.metadata_json,
-                    stored_at=excluded.stored_at
-                """,
-                (
-                    agent_name,
-                    message_id,
-                    str(context.get("platform") or ""),
-                    str(context.get("chat_id") or ""),
-                    float(context.get("timestamp") or 0),
-                    str(context.get("reply_to") or ""),
-                    1 if context.get("is_group") else 0,
-                    1 if context.get("source_was_voice") else 0,
-                    json.dumps(attachments if isinstance(attachments, list) else [], default=str),
-                    json.dumps(metadata if isinstance(metadata, dict) else {}, default=str),
-                    now,
-                ),
-            )
-            self._db.commit()
-        self.sweep_retention(now=now)
+            try:
+                self._db.execute(
+                    """
+                    INSERT INTO message_contexts (
+                        agent_name, message_id, platform, chat_id, message_ts,
+                        reply_to, is_group, source_was_voice, attachments_json,
+                        metadata_json, stored_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(agent_name, platform, chat_id, message_id) DO UPDATE SET
+                        message_ts=excluded.message_ts,
+                        reply_to=excluded.reply_to,
+                        is_group=excluded.is_group,
+                        source_was_voice=excluded.source_was_voice,
+                        attachments_json=excluded.attachments_json,
+                        metadata_json=excluded.metadata_json,
+                        stored_at=excluded.stored_at
+                    """,
+                    (
+                        agent_name,
+                        message_id,
+                        platform,
+                        chat_id,
+                        float(context.get("timestamp") or 0),
+                        str(context.get("reply_to") or ""),
+                        1 if context.get("is_group") else 0,
+                        1 if context.get("source_was_voice") else 0,
+                        json.dumps(
+                            attachments if isinstance(attachments, list) else [],
+                            default=str,
+                        ),
+                        json.dumps(
+                            metadata if isinstance(metadata, dict) else {},
+                            default=str,
+                        ),
+                        now,
+                    ),
+                )
+                self._sweep_retention_locked(now)
+                self._db.commit()
+            except Exception:
+                self._db.rollback()
+                raise
 
-    def get(self, agent_name: str, message_id: str) -> dict[str, Any] | None:
-        """Return one stored context, scoped to the owning agent."""
+    def get(
+        self,
+        agent_name: str,
+        message_id: str,
+        *,
+        platform: str | None = None,
+        chat_id: str | None = None,
+        include_stored_at: bool = False,
+    ) -> dict[str, Any] | None:
+        """Return one unambiguous, unexpired context for the owning agent."""
+        cutoff = time.time() - self.retention_seconds
+        identity_filter = ""
+        params: list[Any] = [agent_name, message_id, cutoff]
+        if platform is not None and chat_id is not None:
+            identity_filter = " AND platform=? AND chat_id=?"
+            params.extend((platform, chat_id))
         with self._lock:
-            row = self._db.execute(
-                """
+            rows = self._db.execute(
+                f"""
                 SELECT agent_name, message_id, platform, chat_id, message_ts,
                        reply_to, is_group, source_was_voice, attachments_json,
-                       metadata_json
+                       metadata_json, stored_at
                 FROM message_contexts
-                WHERE agent_name=? AND message_id=?
+                WHERE agent_name=? AND message_id=? AND stored_at>=?{identity_filter}
+                ORDER BY stored_at DESC, rowid DESC
+                LIMIT 2
                 """,
-                (agent_name, message_id),
-            ).fetchone()
-        if row is None:
+                params,
+            ).fetchall()
+        if len(rows) != 1:
             return None
-        return {
+        row = rows[0]
+        context = {
             "agent_name": row["agent_name"],
             "message_id": row["message_id"],
             "platform": row["platform"],
@@ -180,35 +270,47 @@ class MessageContextStore:
             "attachments": self._json_list(row["attachments_json"]),
             "metadata": self._json_dict(row["metadata_json"]),
         }
+        if include_stored_at:
+            context["_stored_at"] = float(row["stored_at"])
+        return context
+
+    def _sweep_retention_locked(self, now: float) -> int:
+        """Prune rows while the caller owns ``_lock`` and the transaction."""
+        cutoff = now - self.retention_seconds
+        before = self._db.total_changes
+        self._db.execute(
+            "DELETE FROM message_contexts WHERE stored_at < ?",
+            (cutoff,),
+        )
+        agent_rows = self._db.execute(
+            "SELECT DISTINCT agent_name FROM message_contexts"
+        ).fetchall()
+        for row in agent_rows:
+            self._db.execute(
+                """
+                DELETE FROM message_contexts
+                WHERE rowid IN (
+                    SELECT rowid FROM message_contexts
+                    WHERE agent_name=?
+                    ORDER BY stored_at DESC, rowid DESC
+                    LIMIT -1 OFFSET ?
+                )
+                """,
+                (row["agent_name"], self.max_per_agent),
+            )
+        return self._db.total_changes - before
 
     def sweep_retention(self, *, now: float | None = None) -> int:
         """Prune contexts older than 30 days and cap each agent to 1,000 rows."""
         current = time.time() if now is None else float(now)
-        cutoff = current - (self.retention_days * 86400)
         with self._lock:
-            before = self._db.total_changes
-            self._db.execute(
-                "DELETE FROM message_contexts WHERE stored_at < ?",
-                (cutoff,),
-            )
-            agent_rows = self._db.execute(
-                "SELECT DISTINCT agent_name FROM message_contexts"
-            ).fetchall()
-            for row in agent_rows:
-                self._db.execute(
-                    """
-                    DELETE FROM message_contexts
-                    WHERE rowid IN (
-                        SELECT rowid FROM message_contexts
-                        WHERE agent_name=?
-                        ORDER BY stored_at DESC, rowid DESC
-                        LIMIT -1 OFFSET ?
-                    )
-                    """,
-                    (row["agent_name"], self.max_per_agent),
-                )
-            self._db.commit()
-            return self._db.total_changes - before
+            try:
+                deleted = self._sweep_retention_locked(current)
+                self._db.commit()
+                return deleted
+            except Exception:
+                self._db.rollback()
+                raise
 
     def close(self) -> None:
         with self._lock:

--- a/src/pinky_daemon/message_context_store.py
+++ b/src/pinky_daemon/message_context_store.py
@@ -1,0 +1,215 @@
+"""Durable routing context for message-based outreach tools."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+DEFAULT_RETENTION_DAYS = 30
+DEFAULT_MAX_PER_AGENT = 1000
+
+
+class MessageContextStore:
+    """SQLite-backed message routing contexts with bounded retention."""
+
+    def __init__(
+        self,
+        db_path: str,
+        *,
+        retention_days: int = DEFAULT_RETENTION_DAYS,
+        max_per_agent: int = DEFAULT_MAX_PER_AGENT,
+    ) -> None:
+        self.db_path = db_path
+        self.retention_days = max(1, retention_days)
+        self.max_per_agent = max(1, max_per_agent)
+        self._lock = threading.RLock()
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db.row_factory = sqlite3.Row
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA busy_timeout=5000")
+        self._create_schema()
+        self._ensure_columns()
+        self._create_indexes()
+        self.sweep_retention()
+
+    def _create_schema(self) -> None:
+        self._db.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS message_contexts (
+                agent_name       TEXT NOT NULL,
+                message_id       TEXT NOT NULL,
+                platform         TEXT NOT NULL,
+                chat_id          TEXT NOT NULL,
+                message_ts       REAL NOT NULL,
+                reply_to         TEXT NOT NULL DEFAULT '',
+                is_group         INTEGER NOT NULL DEFAULT 0,
+                source_was_voice INTEGER NOT NULL DEFAULT 0,
+                attachments_json TEXT NOT NULL DEFAULT '[]',
+                metadata_json    TEXT NOT NULL DEFAULT '{}',
+                stored_at        REAL NOT NULL,
+                PRIMARY KEY (agent_name, message_id)
+            );
+            """
+        )
+        self._db.commit()
+
+    def _ensure_columns(self) -> None:
+        """Add forward-compatible columns following the daemon store pattern."""
+        migrations = [
+            ("reply_to", "TEXT NOT NULL DEFAULT ''"),
+            ("is_group", "INTEGER NOT NULL DEFAULT 0"),
+            ("source_was_voice", "INTEGER NOT NULL DEFAULT 0"),
+            ("attachments_json", "TEXT NOT NULL DEFAULT '[]'"),
+            ("metadata_json", "TEXT NOT NULL DEFAULT '{}'"),
+            ("stored_at", "REAL NOT NULL DEFAULT 0"),
+        ]
+        existing = {
+            row["name"]
+            for row in self._db.execute("PRAGMA table_info(message_contexts)").fetchall()
+        }
+        for column, column_type in migrations:
+            if column not in existing:
+                self._db.execute(
+                    f"ALTER TABLE message_contexts ADD COLUMN {column} {column_type}"
+                )
+        self._db.commit()
+
+    def _create_indexes(self) -> None:
+        self._db.executescript(
+            """
+            CREATE INDEX IF NOT EXISTS idx_message_contexts_agent_stored
+                ON message_contexts(agent_name, stored_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_message_contexts_stored
+                ON message_contexts(stored_at);
+            """
+        )
+        self._db.commit()
+
+    @staticmethod
+    def _json_list(raw: str) -> list[dict]:
+        try:
+            value = json.loads(raw or "[]")
+        except (TypeError, ValueError):
+            return []
+        if not isinstance(value, list):
+            return []
+        return [item for item in value if isinstance(item, dict)]
+
+    @staticmethod
+    def _json_dict(raw: str) -> dict:
+        try:
+            value = json.loads(raw or "{}")
+        except (TypeError, ValueError):
+            return {}
+        return value if isinstance(value, dict) else {}
+
+    def put(self, context: dict[str, Any], *, stored_at: float | None = None) -> None:
+        """Insert or replace one agent-scoped message context."""
+        agent_name = str(context.get("agent_name") or "")
+        message_id = str(context.get("message_id") or "")
+        if not agent_name or not message_id:
+            return
+        attachments = context.get("attachments")
+        metadata = context.get("metadata")
+        now = time.time() if stored_at is None else float(stored_at)
+        with self._lock:
+            self._db.execute(
+                """
+                INSERT INTO message_contexts (
+                    agent_name, message_id, platform, chat_id, message_ts,
+                    reply_to, is_group, source_was_voice, attachments_json,
+                    metadata_json, stored_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(agent_name, message_id) DO UPDATE SET
+                    platform=excluded.platform,
+                    chat_id=excluded.chat_id,
+                    message_ts=excluded.message_ts,
+                    reply_to=excluded.reply_to,
+                    is_group=excluded.is_group,
+                    source_was_voice=excluded.source_was_voice,
+                    attachments_json=excluded.attachments_json,
+                    metadata_json=excluded.metadata_json,
+                    stored_at=excluded.stored_at
+                """,
+                (
+                    agent_name,
+                    message_id,
+                    str(context.get("platform") or ""),
+                    str(context.get("chat_id") or ""),
+                    float(context.get("timestamp") or 0),
+                    str(context.get("reply_to") or ""),
+                    1 if context.get("is_group") else 0,
+                    1 if context.get("source_was_voice") else 0,
+                    json.dumps(attachments if isinstance(attachments, list) else [], default=str),
+                    json.dumps(metadata if isinstance(metadata, dict) else {}, default=str),
+                    now,
+                ),
+            )
+            self._db.commit()
+        self.sweep_retention(now=now)
+
+    def get(self, agent_name: str, message_id: str) -> dict[str, Any] | None:
+        """Return one stored context, scoped to the owning agent."""
+        with self._lock:
+            row = self._db.execute(
+                """
+                SELECT agent_name, message_id, platform, chat_id, message_ts,
+                       reply_to, is_group, source_was_voice, attachments_json,
+                       metadata_json
+                FROM message_contexts
+                WHERE agent_name=? AND message_id=?
+                """,
+                (agent_name, message_id),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "agent_name": row["agent_name"],
+            "message_id": row["message_id"],
+            "platform": row["platform"],
+            "chat_id": row["chat_id"],
+            "timestamp": row["message_ts"],
+            "reply_to": row["reply_to"],
+            "is_group": bool(row["is_group"]),
+            "source_was_voice": bool(row["source_was_voice"]),
+            "attachments": self._json_list(row["attachments_json"]),
+            "metadata": self._json_dict(row["metadata_json"]),
+        }
+
+    def sweep_retention(self, *, now: float | None = None) -> int:
+        """Prune contexts older than 30 days and cap each agent to 1,000 rows."""
+        current = time.time() if now is None else float(now)
+        cutoff = current - (self.retention_days * 86400)
+        with self._lock:
+            before = self._db.total_changes
+            self._db.execute(
+                "DELETE FROM message_contexts WHERE stored_at < ?",
+                (cutoff,),
+            )
+            agent_rows = self._db.execute(
+                "SELECT DISTINCT agent_name FROM message_contexts"
+            ).fetchall()
+            for row in agent_rows:
+                self._db.execute(
+                    """
+                    DELETE FROM message_contexts
+                    WHERE rowid IN (
+                        SELECT rowid FROM message_contexts
+                        WHERE agent_name=?
+                        ORDER BY stored_at DESC, rowid DESC
+                        LIMIT -1 OFFSET ?
+                    )
+                    """,
+                    (row["agent_name"], self.max_per_agent),
+                )
+            self._db.commit()
+            return self._db.total_changes - before
+
+    def close(self) -> None:
+        with self._lock:
+            self._db.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2853,6 +2853,52 @@ class TestAPI:
                 assert history[-1].metadata["tool"] == "thread"
                 assert history[-1].metadata["source_message_id"] == "101"
 
+    def test_broker_send_registers_context_for_outbound_self_thread(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+
+                with patch(
+                    "pinky_outreach.telegram.TelegramAdapter.send_message",
+                    side_effect=[
+                        SimpleNamespace(message_id="501"),
+                        SimpleNamespace(message_id="502"),
+                    ],
+                ) as send:
+                    first = client.post(
+                        "/broker/send",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "telegram",
+                            "chat_id": "6770805286",
+                            "content": "First outbound",
+                        },
+                    )
+                    second = client.post(
+                        "/broker/thread",
+                        json={
+                            "agent_name": "barsik",
+                            "message_id": "501",
+                            "content": "Reply to myself",
+                        },
+                    )
+
+                assert first.status_code == 200, first.text
+                assert second.status_code == 200, second.text
+                context = app.state.broker.get_message_context("barsik", "501")
+                assert context is not None
+                assert context.platform == "telegram"
+                assert context.chat_id == "6770805286"
+                assert context.metadata == {"direction": "outbound"}
+                stored = app.state.message_context_store.get("barsik", "501")
+                assert stored is not None
+                assert stored["platform"] == "telegram"
+                assert stored["chat_id"] == "6770805286"
+                assert stored["metadata"] == {"direction": "outbound"}
+                assert send.call_args_list[1].kwargs["reply_to_message_id"] == 501
+
     def test_broker_thread_child_reply_uses_stored_root_ts(self):
         """A reply to a Slack child stays on the original thread root."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -3140,6 +3186,10 @@ class TestAPI:
                     assert file_path not in _json.dumps(entry.metadata), (
                         f"{url} leaked raw file_path value into metadata payload"
                     )
+                    context = app.state.broker.get_message_context("barsik", "999")
+                    assert context is not None, f"{url} did not register its outbound message"
+                    assert context.platform == "telegram"
+                    assert context.chat_id == "6770805286"
 
     def test_broker_send_photo_threads_caption_format_and_spoiler(self):
         """/broker/send-photo formats the caption (MarkdownV2) and forwards

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,7 @@ from fastapi.testclient import TestClient
 from pinky_daemon.agent_registry import DEFAULT_HEARTBEAT_PROMPT
 from pinky_daemon.broker import BrokerMessage
 from pinky_daemon.claude_runner import RunResult
+from pinky_daemon.message_context_store import MessageContextStore
 from pinky_daemon.sessions import (
     Checkpoint,
     ContextStatus,
@@ -2901,16 +2902,28 @@ class TestAPI:
 
     def test_broker_thread_fails_closed_on_chat_scoped_message_id_collision(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            db_path = os.path.join(tmpdir, "test.db")
+            context_db_path = db_path.replace(".db", "_message_context.db")
+            durable = MessageContextStore(context_db_path)
+            durable.put({
+                "agent_name": "barsik",
+                "message_id": "1",
+                "platform": "telegram",
+                "chat_id": "CHAT_A",
+                "timestamp": time.time(),
+            })
+            durable.close()
+
+            app = self._make_app(db_path)
             with TestClient(app) as client:
                 client.post("/agents", json={"name": "barsik", "model": "sonnet"})
                 app.state.agents.set_token("barsik", "telegram", "bot123")
-                app.state.broker.remember_outbound_message_context(
-                    "barsik", "1", platform="telegram", chat_id="CHAT_A"
-                )
+                assert app.state.broker._message_contexts == {}
                 app.state.broker.remember_outbound_message_context(
                     "barsik", "1", platform="telegram", chat_id="CHAT_B"
                 )
+                assert len(app.state.broker._message_contexts) == 1
+                assert app.state.message_context_store.get("barsik", "1") is None
 
                 with patch(
                     "pinky_outreach.telegram.TelegramAdapter.send_message"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2899,6 +2899,35 @@ class TestAPI:
                 assert stored["metadata"] == {"direction": "outbound"}
                 assert send.call_args_list[1].kwargs["reply_to_message_id"] == 501
 
+    def test_broker_thread_fails_closed_on_chat_scoped_message_id_collision(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "telegram", "bot123")
+                app.state.broker.remember_outbound_message_context(
+                    "barsik", "1", platform="telegram", chat_id="CHAT_A"
+                )
+                app.state.broker.remember_outbound_message_context(
+                    "barsik", "1", platform="telegram", chat_id="CHAT_B"
+                )
+
+                with patch(
+                    "pinky_outreach.telegram.TelegramAdapter.send_message"
+                ) as send:
+                    response = client.post(
+                        "/broker/thread",
+                        json={
+                            "agent_name": "barsik",
+                            "message_id": "1",
+                            "content": "must not route to either chat",
+                        },
+                    )
+
+                assert response.status_code == 404
+                assert "Message context '1' not found" in response.json()["detail"]
+                send.assert_not_called()
+
     def test_broker_thread_child_reply_uses_stored_root_ts(self):
         """A reply to a Slack child stays on the original thread root."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_message_context_store.py
+++ b/tests/test_message_context_store.py
@@ -1,0 +1,119 @@
+"""Durability and retention contracts for broker message context."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.broker import BrokerMessage, MessageBroker
+from pinky_daemon.message_context_store import MessageContextStore
+from pinky_daemon.sessions import SessionManager
+
+
+def _stored_context(message_id: str, *, agent_name: str = "barsik") -> dict:
+    return {
+        "agent_name": agent_name,
+        "message_id": message_id,
+        "platform": "telegram",
+        "chat_id": "6770805286",
+        "timestamp": 1_700_000_000.0,
+        "reply_to": "42",
+        "is_group": False,
+        "source_was_voice": True,
+        "attachments": [{"type": "voice", "file_id": "voice-1"}],
+        "metadata": {"chat_title": "Brad"},
+    }
+
+
+def test_context_survives_broker_restart_via_load_through(tmp_path):
+    db_path = tmp_path / "message-context.db"
+    registry = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    first_store = MessageContextStore(str(db_path))
+    first_broker = MessageBroker(
+        registry,
+        SessionManager(),
+        message_context_store=first_store,
+    )
+    first_broker.remember_message_context(
+        BrokerMessage(
+            platform="telegram",
+            chat_id="6770805286",
+            sender_name="Brad",
+            sender_id="owner",
+            content="voice note",
+            agent_name="barsik",
+            message_id="99",
+            reply_to="42",
+            attachments=[{"type": "voice", "file_id": "voice-1"}],
+            metadata={"chat_title": "Brad"},
+            timestamp=1_700_000_000.0,
+        ),
+        source_was_voice=True,
+    )
+    first_store.close()
+
+    second_store = MessageContextStore(str(db_path))
+    second_broker = MessageBroker(
+        registry,
+        SessionManager(),
+        message_context_store=second_store,
+    )
+
+    assert second_broker._message_contexts == {}
+    context = second_broker.get_message_context("barsik", "99")
+    assert context is not None
+    assert context.to_dict() == _stored_context("99")
+    assert second_broker._message_contexts[("barsik", "99")] is context
+    second_store.close()
+
+
+def test_store_uses_wal_and_self_heals_optional_columns(tmp_path):
+    db_path = tmp_path / "message-context.db"
+    legacy = sqlite3.connect(db_path)
+    legacy.execute(
+        """
+        CREATE TABLE message_contexts (
+            agent_name TEXT NOT NULL,
+            message_id TEXT NOT NULL,
+            platform TEXT NOT NULL,
+            chat_id TEXT NOT NULL,
+            message_ts REAL NOT NULL,
+            PRIMARY KEY (agent_name, message_id)
+        )
+        """
+    )
+    legacy.commit()
+    legacy.close()
+
+    store = MessageContextStore(str(db_path))
+    mode = store._db.execute("PRAGMA journal_mode").fetchone()[0]
+    columns = {
+        row["name"]
+        for row in store._db.execute("PRAGMA table_info(message_contexts)").fetchall()
+    }
+
+    assert str(mode).lower() == "wal"
+    assert {"reply_to", "attachments_json", "metadata_json", "stored_at"} <= columns
+    store.close()
+
+
+def test_retention_prunes_old_rows_and_caps_each_agent(tmp_path):
+    now = 1_800_000_000.0
+    store = MessageContextStore(
+        str(tmp_path / "message-context.db"),
+        retention_days=30,
+        max_per_agent=2,
+    )
+
+    store.put(_stored_context("expired"), stored_at=now - (31 * 86400))
+    store.put(_stored_context("recent-1"), stored_at=now - 3)
+    store.put(_stored_context("recent-2"), stored_at=now - 2)
+    store.put(_stored_context("recent-3"), stored_at=now - 1)
+    store.put(_stored_context("other", agent_name="murzik"), stored_at=now)
+
+    assert store.get("barsik", "expired") is None
+    assert store.get("barsik", "recent-1") is None
+    assert store.get("barsik", "recent-2") is not None
+    assert store.get("barsik", "recent-3") is not None
+    assert store.get("murzik", "other") is not None
+    store.close()

--- a/tests/test_message_context_store.py
+++ b/tests/test_message_context_store.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
+import time
 
 from pinky_daemon.agent_registry import AgentRegistry
 from pinky_daemon.broker import BrokerMessage, MessageBroker
@@ -63,7 +65,9 @@ def test_context_survives_broker_restart_via_load_through(tmp_path):
     context = second_broker.get_message_context("barsik", "99")
     assert context is not None
     assert context.to_dict() == _stored_context("99")
-    assert second_broker._message_contexts[("barsik", "99")] is context
+    assert second_broker._message_contexts[
+        ("barsik", "telegram", "6770805286", "99")
+    ] is context
     second_store.close()
 
 
@@ -82,6 +86,14 @@ def test_store_uses_wal_and_self_heals_optional_columns(tmp_path):
         )
         """
     )
+    legacy.execute(
+        """
+        INSERT INTO message_contexts (
+            agent_name, message_id, platform, chat_id, message_ts
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        ("barsik", "legacy-1", "telegram", "CHAT_A", 1_700_000_000.0),
+    )
     legacy.commit()
     legacy.close()
 
@@ -94,6 +106,23 @@ def test_store_uses_wal_and_self_heals_optional_columns(tmp_path):
 
     assert str(mode).lower() == "wal"
     assert {"reply_to", "attachments_json", "metadata_json", "stored_at"} <= columns
+    primary_key = tuple(
+        row["name"]
+        for row in sorted(
+            (
+                row
+                for row in store._db.execute(
+                    "PRAGMA table_info(message_contexts)"
+                ).fetchall()
+                if row["pk"]
+            ),
+            key=lambda row: row["pk"],
+        )
+    )
+    assert primary_key == ("agent_name", "platform", "chat_id", "message_id")
+    migrated = store.get("barsik", "legacy-1")
+    assert migrated is not None
+    assert migrated["chat_id"] == "CHAT_A"
     store.close()
 
 
@@ -117,3 +146,81 @@ def test_retention_prunes_old_rows_and_caps_each_agent(tmp_path):
     assert store.get("barsik", "recent-3") is not None
     assert store.get("murzik", "other") is not None
     store.close()
+
+
+def test_chat_scoped_message_id_collision_is_ambiguous_but_exact_rows_survive(tmp_path):
+    store = MessageContextStore(str(tmp_path / "message-context.db"))
+    first = _stored_context("1")
+    second = {**first, "chat_id": "CHAT_B"}
+
+    store.put(first)
+    store.put(second)
+
+    assert store.get("barsik", "1") is None
+    assert store.get(
+        "barsik", "1", platform="telegram", chat_id="6770805286"
+    )["chat_id"] == "6770805286"
+    assert store.get(
+        "barsik", "1", platform="telegram", chat_id="CHAT_B"
+    )["chat_id"] == "CHAT_B"
+    store.close()
+
+
+def test_broker_cache_honors_store_retention_after_durable_sweep(tmp_path, monkeypatch):
+    db_path = tmp_path / "message-context.db"
+    registry = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    store = MessageContextStore(str(db_path))
+    broker = MessageBroker(registry, SessionManager(), message_context_store=store)
+    now = time.time()
+    store.put(_stored_context("old"), stored_at=now)
+
+    assert broker.get_message_context("barsik", "old") is not None
+    assert broker._message_contexts
+
+    future = now + (31 * 86400)
+    store.sweep_retention(now=future)
+    monkeypatch.setattr("pinky_daemon.broker.time.time", lambda: future)
+
+    assert broker.get_message_context("barsik", "old") is None
+    assert broker._message_contexts == {}
+    store.close()
+
+
+def test_put_and_retention_sweep_hold_one_lock_against_close(tmp_path, monkeypatch):
+    store = MessageContextStore(str(tmp_path / "message-context.db"))
+    sweep_started = threading.Event()
+    allow_sweep = threading.Event()
+    close_finished = threading.Event()
+    errors: list[BaseException] = []
+    original_sweep = store._sweep_retention_locked
+
+    def blocking_sweep(now: float) -> int:
+        sweep_started.set()
+        assert allow_sweep.wait(timeout=2)
+        return original_sweep(now)
+
+    def put_context() -> None:
+        try:
+            store.put(_stored_context("locked"))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    def close_store() -> None:
+        store.close()
+        close_finished.set()
+
+    monkeypatch.setattr(store, "_sweep_retention_locked", blocking_sweep)
+    writer = threading.Thread(target=put_context)
+    writer.start()
+    assert sweep_started.wait(timeout=2)
+
+    closer = threading.Thread(target=close_store)
+    closer.start()
+    assert not close_finished.wait(timeout=0.05)
+
+    allow_sweep.set()
+    writer.join(timeout=2)
+    closer.join(timeout=2)
+    assert not writer.is_alive()
+    assert not closer.is_alive()
+    assert errors == []

--- a/tests/test_message_context_store.py
+++ b/tests/test_message_context_store.py
@@ -157,6 +157,7 @@ def test_chat_scoped_message_id_collision_is_ambiguous_but_exact_rows_survive(tm
     store.put(second)
 
     assert store.get("barsik", "1") is None
+    assert len(store.find("barsik", "1")) == 2
     assert store.get(
         "barsik", "1", platform="telegram", chat_id="6770805286"
     )["chat_id"] == "6770805286"


### PR DESCRIPTION
## Summary
- persist inbound and outbound routing contexts in a WAL-backed SQLite store with memory-to-database load-through
- key contexts by agent + platform + chat + message ID; ID-only thread/react lookups fail closed unless the union of cache and SQLite contains exactly one full identity
- register successful send, thread, photo, document, video, GIF, animation, voice, and broadcast delivery IDs so agents can reply beneath their own messages
- enforce the 30-day / 1,000-row retention contract in both SQLite and the broker cache
- keep insert + retention sweep in one locked SQLite transaction so shutdown cannot interleave after commit

## Review fixes
- migrate the legacy agent/message primary key to the chat-scoped composite key without dropping existing rows
- reconcile unexpired cache and durable identities under one broker lock; deduplicate by full composite key and deny mixed restart/cache collisions
- deny a real two-chat Telegram message-ID collision at /broker/thread before any adapter send
- expire cached contexts after the durable row ages out
- prove close() waits until write + retention commit completes

## Tests
- PINKY_SHARED_MCP=0 PINKY_DREAM_TRANSPORT=sdk .venv/bin/python -m pytest -q tests/test_message_context_store.py tests/test_broker.py tests/test_api.py tests/test_pinky_self_tools.py --disable-warnings — 644 passed
- message-context store + broker suites — 80 passed
- focused mixed-state/thread/self-thread/media endpoint matrix — 11 passed
- Ruff, compileall, and diff-check clean
- replacement final-SHA GitHub CI green: Python 3.11/3.12/3.13, Ruff, frontend, CodeQL, amd64 smoke, arm64 build

_Implemented by Kuzya (OpenAI Codex)._