### PR TITLE
fix(tmux): compact Sol below real backend limit

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -4378,7 +4378,7 @@ except Exception:
         ("anthropic", "claude-opus-4-5", "Claude Opus 4.5", "Previous-gen Opus.", "opus", 200_000, 0, 5.0, 25.0, 0.5, 1, 40),
         ("anthropic", "claude-sonnet-4-5", "Claude Sonnet 4.5", "Previous-gen Sonnet.", "sonnet", 200_000, 0, 3.0, 15.0, 0.3, 1, 50),
         # OpenAI / Codex CLI
-        ("openai", "gpt-5.6-sol", "GPT-5.6 Sol", "Current codex fleet model (2026-07). Frontier coding + reasoning. 1M context. Codex sign-in auth only (API pending).", "flagship", 1_000_000, 1, 5.0, 30.0, 0.5, 0, 54),
+        ("openai", "gpt-5.6-sol", "GPT-5.6 Sol", "Current codex fleet model (2026-07). Frontier coding + reasoning. 200k-class context; ChatGPT-sub proxy compacts at 150k below its observed ~167k backend limit. Codex sign-in auth only (API pending).", "flagship", 200_000, 0, 5.0, 30.0, 0.5, 0, 54),
         ("openai", "gpt-5.5", "GPT-5.5", "Previous frontier. Coding + reasoning. Codex sign-in auth only (API pending).", "flagship", 200_000, 0, 5.0, 30.0, 0.5, 0, 55),
         ("openai", "gpt-5.4", "GPT-5.4", "Flagship. Complex reasoning & coding.", "flagship", 200_000, 0, 1.75, 14.0, 0.175, 0, 60),
         ("openai", "gpt-5.4-mini", "GPT-5.4 Mini", "Fast + capable. Daily driver.", "mid", 200_000, 0, 0.25, 2.0, 0.025, 0, 70),
@@ -4413,13 +4413,11 @@ except Exception:
     # untouched.
     _CONTEXT_CORRECTIONS = [
         # (id, (stale_ctx, stale_is_1m), (correct_ctx, correct_is_1m))
-        # #873: gpt-5.6-sol has a native 1M window but deployed DBs seeded it
-        # at 200k/is_1m=0 before that was known. The tmux harness reads is_1m
-        # (api._refresh_1m_models rebinds streaming_session._1M_MODELS from the
-        # DB set), so a stale row caps context at 200k and the sanity watchdog
-        # force-restarts at ~55% of ~167k — thrashing on long tasks. Realign
-        # existing rows to 1M so all three read paths converge.
-        ("openai/gpt-5.6-sol", (200_000, 0), (1_000_000, 1)),
+        # #356 supersedes #873's inferred 1M designation: live ChatGPT-sub
+        # backend evidence puts gpt-5.6-sol near 167k. Treat it as 200k-class so
+        # the 400k-only restart logic never applies; tmux independently compacts
+        # the subscription proxy at 150k. Correct only the exact stale 1M pair.
+        ("openai/gpt-5.6-sol", (1_000_000, 1), (200_000, 0)),
     ]
 
     def _seed_models(self) -> None:

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -41,10 +41,6 @@ _1M_MODELS = {
     "claude-opus-4-6",
     "claude-opus-4-7",
     "claude-opus-4-8",
-    # Codex fleet (proxy). gpt-5.6-sol has a native 1M window; without this the
-    # tmux harness caps it at 200k and force-restarts far too early (~55% of
-    # ~167k), thrashing on long tasks.
-    "gpt-5.6-sol",
 }
 
 
@@ -54,9 +50,11 @@ def is_1m_model(model_id: str, model_set: "set[str] | None" = None) -> bool:
 
     The ``[tier]`` suffix is a legacy way to request a 1M window. An exact
     membership test against ``_1M_MODELS`` misses the suffixed form and
-    silently caps the model at 200k — which force-restarted solik
-    (registered ``gpt-5.6-sol[1m]``) at ~50% of 167k despite the #873 fix.
-    Strip the suffix first (reusing pricing's canonical ``strip_tier``).
+    silently caps a genuine 1M model at 200k. Strip the suffix first (reusing
+    pricing's canonical ``strip_tier``), then require the base model to be in
+    the reviewed 1M set. A suffix does not fabricate a 1M window; in particular,
+    #356 established that ``gpt-5.6-sol[1m]`` is 200k-class with a real
+    subscription-backend limit near 167k.
     Defaults to the static ``_1M_MODELS`` set; callers on the api path pass
     their DB-refreshed set.
     """

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3114,17 +3114,16 @@ class TmuxSession:
         elif secret:
             env["PINKY_SESSION_SECRET"] = secret
 
-        # ChatGPT-sub Codex models: tell Claude Code the true 272k upstream
+        # ChatGPT-sub Codex models: tell Claude Code the safe 150k upstream
         # window so it auto-compacts before the backend 502s (see
         # _CODEX_SUB_CONTEXT_WINDOW). The "[1m]" suffix otherwise lets CC ride
-        # context toward ~1M and overflow the sub's real cap (2026-07-13 solik
-        # wedge). SCOPED to the ChatGPT-sub PROXY route (trusted loopback
-        # :18765): the SAME model slug on a paid/custom API gateway has the
-        # model's real 1.05M window and must NOT be capped (Brad's paid-API
-        # alternative). An operator's ambient CLAUDE_CODE_AUTO_COMPACT_WINDOW
-        # wins — _build_repl_env's result becomes explicit tmux -e flags (the
-        # parent env is otherwise dropped), so we must forward it explicitly;
-        # a tuning escape hatch while the sub's allocation can change.
+        # context toward ~1M and overflow the sub's real ~167k cap (2026-07-16
+        # solik wedge; the prior 272k assumption left his pane dead for 13h).
+        # SCOPED to the ChatGPT-sub PROXY route (trusted loopback
+        # :18765): paid/custom API gateways are outside this measured cap and
+        # must not inherit the subscription override. An operator's smaller
+        # ambient CLAUDE_CODE_AUTO_COMPACT_WINDOW remains a tuning escape hatch,
+        # but a larger/malformed value cannot raise the live-evidenced ceiling.
         from pinky_daemon.pricing import strip_tier
 
         auto_window = self._CODEX_SUB_CONTEXT_WINDOW.get(
@@ -3132,7 +3131,14 @@ class TmuxSession:
         )
         if auto_window and self._is_codex_sub_proxy(self._config.provider_url or ""):
             ambient = os.environ.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "").strip()
-            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = ambient or str(auto_window)
+            if ambient:
+                try:
+                    ambient_window = int(ambient)
+                except ValueError:
+                    ambient_window = 0
+                if ambient_window > 0:
+                    auto_window = min(auto_window, ambient_window)
+            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(auto_window)
         return env
 
     async def disconnect(self) -> None:
@@ -3684,25 +3690,23 @@ class TmuxSession:
     _RESTART_TOKENS_CAP_1M = 400_000
 
     # ChatGPT-subscription Codex models exposed to Claude Code via the local
-    # codex proxy. Their "[1m]" model suffix hints CC a 1M window, but the
-    # ChatGPT-sub Codex backend caps context at 272k (per ~/.codex/
-    # models_cache.json + the GPT-5.6 subscription update). Without
-    # CLAUDE_CODE_AUTO_COMPACT_WINDOW, CC rides context toward 1M and the
-    # backend 502s "input exceeds the context window" (the 2026-07-13 solik
-    # wedge). Map each to its true upstream window so CC auto-compacts before
-    # the limit. Real 1M Claude agents are absent — they must NOT be capped.
-    # (raine/claude-code-proxy README recommends
-    # CLAUDE_CODE_AUTO_COMPACT_WINDOW=272000 for gpt-5.6-sol[1m].)
+    # codex proxy. The legacy "[1m]" model suffix hints CC a 1M window, but
+    # live #356 evidence puts solik's real backend window near 167k: the prior
+    # #877 272k value overflowed and wedged his pane for 13 hours on 2026-07-16.
+    # Compact at 150k for headroom below that observed limit. This map is scoped
+    # to the subscription proxy; paid/custom gateways retain their own window.
+    # Do not restore 272k from the older cache/README evidence without a new
+    # live backend measurement.
     _CODEX_SUB_CONTEXT_WINDOW = {
-        "gpt-5.6-sol": 272_000,
+        "gpt-5.6-sol": 150_000,
     }
 
     @staticmethod
     def _is_codex_sub_proxy(provider_url: str) -> bool:
         """True if provider_url is the local ChatGPT-sub Codex proxy (trusted
-        http(s) loopback on :18765). The 272k auto-compact cap applies ONLY to
-        this route — the same model slug on a paid/custom API gateway keeps the
-        model's real 1.05M window and must not be capped. Total/fail-closed: a
+        http(s) loopback on :18765). The 150k auto-compact cap applies ONLY to
+        this route — the same model slug on a paid/custom API gateway does not
+        inherit the subscription override. Total/fail-closed: a
         malformed url (incl. a non-numeric or out-of-range port, which raises
         only when ``parsed.port`` is accessed) returns False, never raises."""
         import urllib.parse

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -1090,9 +1090,8 @@ class TestModelSeeds:
         so a sonnet-5 SDK session capped context at 200k and compacted early.
         Pin them together so the next 1M model add can't silently drift.
 
-        Spans EVERY provider (not just anthropic) — #873 added an OpenAI 1M
-        model (gpt-5.6-sol); an anthropic-only filter would have stayed green
-        while an OpenAI 1M model drifted out of the set."""
+        Spans EVERY provider (not just anthropic), so a future non-Anthropic 1M
+        model cannot drift out of the set unnoticed."""
         from pinky_daemon.streaming_session import _1M_MODELS
 
         registry_1m = {
@@ -1156,6 +1155,9 @@ class TestModelSeeds:
         assert (sol["input_price"], sol["output_price"],
                 sol["cached_input_price"]) == (5.0, 30.0, 0.5)
         assert sol["tier"] == "flagship"
+        assert sol["context_window"] == 200_000
+        assert sol["is_1m"] == 0
+        assert "gpt-5.6-sol" not in registry.get_1m_models()
 
     def test_openai_seed_prices_match_pricing_rate_table(self, registry):
         """#860 extends the #741 invariant to the OpenAI family: catalog
@@ -1207,12 +1209,11 @@ class TestModelSeeds:
         assert gpt["input_price"] == 9.99
 
     def test_stale_gpt56_sol_context_corrected_on_existing_rows(self, registry):
-        """#873: deployed DBs seeded gpt-5.6-sol at 200k/is_1m=0 before its
-        native 1M window was known. The next seed pass migrates existing rows
-        to 1M (INSERT OR IGNORE alone never reaches them), so the tmux harness
-        stops capping context at 200k and force-restarting far too early."""
+        """#356: deployed DBs carry #873's stale 1M designation. The next seed
+        pass restores the live-evidenced 200k class so 400k-only logic cannot
+        suppress compaction/restart below the real ~167k backend limit."""
         registry._db.execute(
-            "UPDATE models SET context_window=200000, is_1m=0"
+            "UPDATE models SET context_window=1000000, is_1m=1"
             " WHERE id='openai/gpt-5.6-sol'"
         )
         registry._db.commit()
@@ -1221,16 +1222,15 @@ class TestModelSeeds:
             m for m in registry.list_models(provider="openai", active_only=False)
             if m["id"] == "openai/gpt-5.6-sol"
         )
-        assert sol["context_window"] == 1_000_000
-        assert sol["is_1m"] == 1
-        # The DB-derived 1M set (what api._refresh_1m_models rebinds from) now
-        # carries it, so the API context-window path converges with the DB too.
-        assert "gpt-5.6-sol" in registry.get_1m_models()
+        assert sol["context_window"] == 200_000
+        assert sol["is_1m"] == 0
+        # The DB-derived set used by api._refresh_1m_models must drop it too.
+        assert "gpt-5.6-sol" not in registry.get_1m_models()
 
     def test_operator_customized_gpt56_sol_context_survives_reseed(self, registry):
         """Same exact-stale-pair gate as the price corrections — an operator
         who intentionally pinned gpt-5.6-sol to a non-default window must not
-        be clobbered by the 1M migration."""
+        be clobbered by the #356 context correction."""
         registry._db.execute(
             "UPDATE models SET context_window=400000, is_1m=0"
             " WHERE id='openai/gpt-5.6-sol'"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2203,13 +2203,12 @@ class TestAPI:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             with TestClient(app) as client:
-                # Cross window classes so the change forces the rebuild path:
-                # gpt-5.5 is 200k, gpt-5.6-sol is native 1M (#873). A same-class
-                # swap (both 1M) takes the hot-swap branch instead — not what
-                # this #856 rebuild test is exercising.
+                # Cross window classes so the change forces the rebuild path.
+                # Start from a genuine 1M class and switch to 200k-class Sol;
+                # #356 removed Sol's stale inferred-1M designation.
                 app.state.agents.register(
                     "murzik",
-                    model="gpt-5.5",
+                    model="claude-opus-4-8",
                     runtime="codex_cli",
                     transport="tmux",
                     provider_url="codex_cli",
@@ -2218,14 +2217,14 @@ class TestAPI:
                     working_dir=os.path.join(tmpdir, "murzik"),
                 )
                 fake = self._FakeStreamingSession(
-                    "murzik", "main", max_tokens=200_000
+                    "murzik", "main", max_tokens=1_000_000
                 )
-                fake._config.model = "gpt-5.5"
+                fake._config.model = "claude-opus-4-8"
                 fake._config.provider_url = "codex_cli"
                 fake._config.provider_key = "old-key"
                 fake._config.thinking_effort = "low"
                 fake._config.strict_effort_enforcement = False
-                fake._codex_model = "gpt-5.5"
+                fake._codex_model = "claude-opus-4-8"
                 fake._openai_api_key = "old-key"
                 fake._reasoning_effort = "low"
                 fake._effort_override = None

--- a/tests/test_tmux_context_autorestart.py
+++ b/tests/test_tmux_context_autorestart.py
@@ -176,22 +176,21 @@ async def test_kill_switch_keeps_sse_but_suppresses_nudge(monkeypatch) -> None:
 # ──────────────────────────────────────────────────────────────────────────
 # [1m] tier-suffix tolerance (#873 follow-up)
 #
-# solik was registered as ``gpt-5.6-sol[1m]`` (legacy suffix requesting a 1M
-# window). The old exact-match against _1M_MODELS (bare ids) missed the suffix
-# → the model resolved to 200k → the sanity-restart fired at ~50% of the 167k
-# effective window (observed live at 83,705/167,000). Stripping the tier suffix
-# before the membership test fixes it.
+# A trailing ``[tier]`` suffix is normalized before the reviewed-set lookup, but
+# it must never fabricate a 1M window. #356 established that gpt-5.6-sol is
+# 200k-class despite solik's legacy ``[1m]`` suffix; its subscription backend is
+# near 167k and receives a separate 150k tmux autocompact cap.
 # ──────────────────────────────────────────────────────────────────────────
 
-_MODEL_1M_SUFFIXED = "gpt-5.6-sol[1m]"  # a 1M model carrying the legacy [1m] tag
+_MODEL_SOL_SUFFIXED = "gpt-5.6-sol[1m]"
 
 
 def test_is_1m_model_strips_tier_suffix() -> None:
     from pinky_daemon.streaming_session import is_1m_model
 
-    # bare 1M id and the exact solik regression ([1m]-suffixed 1M id)
-    assert is_1m_model("gpt-5.6-sol") is True
-    assert is_1m_model("gpt-5.6-sol[1m]") is True
+    # A suffix does not promote a 200k-class base model.
+    assert is_1m_model("gpt-5.6-sol") is False
+    assert is_1m_model("gpt-5.6-sol[1m]") is False
     assert is_1m_model("claude-opus-4-8[1m]") is True
     # a non-1M base: the tag must NOT fabricate a 1M window
     assert is_1m_model("gpt-5.5") is False
@@ -203,21 +202,22 @@ def test_is_1m_model_strips_tier_suffix() -> None:
     assert is_1m_model("gpt-5.6-sol", set()) is False
 
 
-def test_raw_max_tokens_honors_1m_tier_suffix() -> None:
-    ss = _make_session(model=_MODEL_1M_SUFFIXED)
-    assert ss._raw_max_tokens_for_model() == 1_000_000
+def test_sol_suffix_stays_200k_class() -> None:
+    ss = _make_session(model=_MODEL_SOL_SUFFIXED)
+    assert ss._raw_max_tokens_for_model() == 200_000
+    assert ss._effective_restart_threshold_pct() == pytest.approx(80.0)
 
 
-def test_effective_threshold_caps_at_400k_on_suffixed_1m_model(monkeypatch) -> None:
+def test_sol_never_uses_the_400k_1m_restart_class(monkeypatch) -> None:
     monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)
-    suffixed = _make_session(model=_MODEL_1M_SUFFIXED)
+    suffixed = _make_session(model=_MODEL_SOL_SUFFIXED)
     bare = _make_session(model="gpt-5.6-sol")
-    # The [1m] tag must not change the threshold vs the bare 1M id, and it must
-    # sit well below the old 80% point (the whole point of the fix).
+    # The [1m] tag must not change the threshold or activate the absolute 400k
+    # cap. Both forms use the ordinary 200k-class percentage threshold.
     assert suffixed._effective_restart_threshold_pct() == pytest.approx(
         bare._effective_restart_threshold_pct(), rel=1e-6
     )
-    assert suffixed._effective_restart_threshold_pct() < 80.0
+    assert suffixed._effective_restart_threshold_pct() == pytest.approx(80.0)
 
 
 def test_non_1m_model_with_tier_suffix_stays_200k() -> None:

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -416,24 +416,24 @@ def test_build_repl_env_expects_resolved_effort_for_ultracode() -> None:
 
 def test_build_repl_env_caps_autocompact_for_codex_sub_proxy(monkeypatch) -> None:
     """gpt-5.6-sol on the ChatGPT-sub proxy (trusted loopback :18765) gets
-    CLAUDE_CODE_AUTO_COMPACT_WINDOW=272000 so CC compacts before the sub's real
-    272k cap — the "[1m]" suffix otherwise makes CC ride toward 1M and 502 (the
-    2026-07-13 solik wedge). Tier-suffix tolerant; loopback host + path OK."""
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW=150000 so CC compacts below the sub's real
+    ~167k cap — the old 272k value overflowed and wedged solik for 13 hours on
+    2026-07-16. Tier-suffix tolerant; loopback host + path OK."""
     monkeypatch.delenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", raising=False)
     ss, _ = _make_session()
     ss._config.provider_url = "http://localhost:18765"
     ss._config.model = "gpt-5.6-sol[1m]"
-    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "272000"
+    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "150000"
     ss._config.model = "gpt-5.6-sol"  # bare id too
-    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "272000"
+    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "150000"
     ss._config.provider_url = "http://127.0.0.1:18765/v1"  # 127.0.0.1 + path
-    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "272000"
+    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "150000"
 
 
 def test_build_repl_env_does_not_cap_paid_api_or_claude(monkeypatch) -> None:
-    """The 272k cap is scoped to the ChatGPT-sub proxy route ONLY. The SAME
-    gpt-5.6-sol slug on a paid API gateway keeps the model's real 1.05M window
-    (Brad's paid-API alternative); real 1M Claude agents are never capped."""
+    """The 150k cap is scoped to the ChatGPT-sub proxy route ONLY. The SAME
+    gpt-5.6-sol slug on a paid API gateway does not inherit that override;
+    real 1M Claude agents are never capped."""
     monkeypatch.delenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", raising=False)
     ss, _ = _make_session()
     ss._config.model = "gpt-5.6-sol[1m]"
@@ -448,16 +448,19 @@ def test_build_repl_env_does_not_cap_paid_api_or_claude(monkeypatch) -> None:
     assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in ss._build_repl_env()
 
 
-def test_build_repl_env_autocompact_honors_ambient_override(monkeypatch) -> None:
-    """An operator's ambient CLAUDE_CODE_AUTO_COMPACT_WINDOW wins over the mapped
-    default — a tuning escape hatch while the sub allocation can change.
-    (_build_repl_env starts empty and becomes explicit -e flags, so the ambient
-    value must be forwarded, not merely defaulted.)"""
-    monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "240000")
+def test_build_repl_env_autocompact_allows_only_safer_ambient_override(
+    monkeypatch,
+) -> None:
+    """An ambient override can compact earlier but cannot raise the 150k cap."""
     ss, _ = _make_session()
     ss._config.provider_url = "http://localhost:18765"
     ss._config.model = "gpt-5.6-sol[1m]"
-    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "240000"
+    monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "120000")
+    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "120000"
+    monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "240000")
+    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "150000"
+    monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "not-a-number")
+    assert ss._build_repl_env()["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "150000"
 
 
 def test_is_codex_sub_proxy_classifier_is_total() -> None:


### PR DESCRIPTION
## Summary

- pin ChatGPT-sub gpt-5.6-sol auto-compaction at 150k, below the observed ~167k backend limit
- prevent ambient overrides from raising that subscription-proxy ceiling
- restore gpt-5.6-sol (including the legacy [1m] spelling) to the 200k model class across static and DB-backed registries
- migrate only the exact stale 1M registry pair, preserving operator-customized windows
- keep genuine 1M models and non-subscription routes outside the Sol override

## Validation

- affected tmux/registry/API files: 831 passed, 1 unrelated live-dream test deselected
- full suite: 4,367 passed, 3 skipped, 1 deliberate live-dream deselection; sole failure reproduces unchanged on exact origin/main (unmapped-path auth test: 401 vs expected 404)
- focused registry correction: 3 passed
- Ruff clean
- compileall clean
- git diff --check clean

## Rollout

Barsik owns the PinkyBot daemon restart after SHA-bound review.