### PR TITLE
Authenticate dream-runner skill proposals (#421)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2491,6 +2491,7 @@ def create_api(
         ),
         owner_provider=lambda: agents.get_owner_profile(),
         setting_provider=lambda key: agents.get_setting(key, ""),
+        signing_key_provider=agents.get_signing_key,
     )
     app.state.dream_runner = dream_runner
     app.state.agent_history_resolver = _resolve_agent_history

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import re
 import sqlite3
 import sys
@@ -25,6 +26,10 @@ from pathlib import Path
 
 import numpy as np
 
+from pinky_daemon.auth import (
+    build_internal_auth_headers,
+    resolve_request_signing_secret,
+)
 from pinky_daemon.dream_prompt import DREAM_SYSTEM_PROMPT
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig
 from pinky_daemon.tmux_dream_runner import TmuxDreamConfig, TmuxDreamRunner
@@ -41,8 +46,6 @@ def _kg_proactive_enabled() -> bool:
     flipping it off fully suppresses surfacing — including any digest that was
     already computed while it was on.
     """
-    import os
-
     return os.environ.get("PINKY_KG_PROACTIVE", "0").strip() == "1"
 
 
@@ -83,6 +86,7 @@ class DreamRunner:
         history_provider: Callable[[str, float, int, str], list[dict]] | None = None,
         owner_provider: Callable[[], dict] | None = None,
         setting_provider: Callable[[str], str] | None = None,
+        signing_key_provider: Callable[[str], str | None] | None = None,
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
@@ -94,6 +98,9 @@ class DreamRunner:
         # env does NOT carry ANTHROPIC_API_KEY (it lives in system_settings), so
         # KG extraction's LLM caller must resolve the key through this. May be None.
         self._setting_provider = setting_provider
+        # Optional agent_name -> per-agent signing key resolver for daemon-internal
+        # API calls. Isolated agents cannot authenticate with the fleet-wide secret.
+        self._signing_key_provider = signing_key_provider
         self._db.execute("PRAGMA journal_mode=WAL")
         self._init_tables()
 
@@ -907,15 +914,25 @@ class DreamRunner:
                 import urllib.parse
                 import urllib.request
 
-                api_url = "http://127.0.0.1:8888/skills/from-md"
+                request_path = "/skills/from-md"
+                api_url = f"http://127.0.0.1:8888{request_path}"
                 payload = json.dumps({
                     "content": skill_md,
                     "agent_name": agent_name,
                 }).encode()
+                headers = {"Content-Type": "application/json"}
+                headers.update(build_internal_auth_headers(
+                    resolve_request_signing_secret(
+                        agent_name, self._signing_key_provider
+                    ),
+                    agent_name=agent_name,
+                    method="POST",
+                    path=request_path,
+                ))
                 req = urllib.request.Request(
                     api_url,
                     data=payload,
-                    headers={"Content-Type": "application/json"},
+                    headers=headers,
                     method="POST",
                 )
                 with urllib.request.urlopen(req, timeout=10) as resp:

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -9,9 +9,12 @@ import time
 import urllib.error
 import urllib.request
 from datetime import datetime
+from urllib.parse import urlsplit
 
 import pytest
+from fastapi.testclient import TestClient
 
+from pinky_daemon.api import create_api
 from pinky_daemon.dream_runner import DreamRunner
 
 
@@ -57,6 +60,90 @@ class TestDreamRunner:
             assert watermark == 300.0
         finally:
             os.unlink(path)
+
+
+@pytest.mark.real_auth
+@pytest.mark.parametrize(
+    ("isolated", "force_global_fallback"),
+    [(False, True), (True, False)],
+    ids=("global-fallback", "isolated-agent-key"),
+)
+def test_skill_proposal_uses_signed_headers_against_auth_gate(
+    tmp_path, monkeypatch, isolated, force_global_fallback
+):
+    """Dream-created skills authenticate; the same bare API POST is denied.
+
+    Non-isolated agents retain the shared-secret fallback. Isolated agents use
+    their per-agent key because the auth gate deliberately rejects that shared
+    secret for isolated identities.
+    """
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "dream-test-session-secret")
+    app = create_api(
+        max_sessions=10,
+        default_working_dir=str(tmp_path),
+        db_path=str(tmp_path / "pinky.db"),
+    )
+    app.state.agents.register(
+        "test-agent",
+        model="opus",
+        working_dir=str(tmp_path / "test-agent"),
+        isolated=isolated,
+    )
+
+    # Keep the route's persistent skill write inside this test's temp tree.
+    from pinky_daemon.routes import skills as skills_routes
+
+    monkeypatch.setattr(skills_routes, "_pinky_root", tmp_path)
+
+    client = TestClient(app)
+    bare = client.post(
+        "/skills/from-md",
+        json={
+            "content": "---\nname: bare-skill\ndescription: bare\n---\n\n# Bare\n",
+            "agent_name": "test-agent",
+        },
+    )
+    assert bare.status_code == 401
+
+    class _UrlResponse:
+        def __init__(self, content: bytes) -> None:
+            self._content = content
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self) -> bytes:
+            return self._content
+
+    def _urlopen(req, timeout=None):
+        response = client.request(
+            req.get_method(),
+            urlsplit(req.full_url).path,
+            headers=dict(req.header_items()),
+            content=req.data,
+        )
+        assert response.status_code == 200, response.text
+        return _UrlResponse(response.content)
+
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+    runner = app.state.dream_runner
+    if force_global_fallback:
+        runner._signing_key_provider = lambda _agent_name: None
+    dream_output = """<proposed_skills>
+    [{
+      "skill_name": "test-dream-skill",
+      "description": "Use this skill for a repeated test workflow.",
+      "task_summary": "Run the workflow and verify its output.",
+      "source_pattern": "Repeated test workflow"
+    }]
+    </proposed_skills>"""
+
+    assert runner._extract_proposed_skills(dream_output, "test-agent") == 1
+
+    assert (tmp_path / "skills" / "test-dream-skill" / "SKILL.md").exists()
 
 
 class TestBuildKGLLMCaller:


### PR DESCRIPTION
## Problem

`DreamRunner._extract_proposed_skills` POSTs to `/skills/from-md` with no auth headers, but `/skills` is in the deny-by-default auth-gated prefix list (#506). Every dream-proposed skill has been silently dying with 401 fleet-wide (observed as onesie@TOD's skill-create failures, task #420/#421).

## Fix

- Sign the POST with `build_internal_auth_headers`, resolving the secret via `resolve_request_signing_secret` (existing #623 plumbing): per-agent signing key when a resolver is injected (isolated agents), global `PINKY_SESSION_SECRET` fallback otherwise. Resolver errors degrade to the fallback — never raise into the dream pipeline.
- `create_api` injects `AgentRegistry.get_signing_key` as the resolver.

## Verification

- New regression test builds the real `create_api` app and hits the live auth gate: bare POST → 401; signed POST → 200 + skill created, parameterized for both the non-isolated global-fallback path and the isolated per-agent-key path.
- `tests/test_dream_runner.py` 15/15; auth + route-coverage suites 89/89 at this commit (Barsik, clean worktree). Murzik: 104 relevant tests pass, SHA verified.
- Built by Kuzya, reviewed by Murzik, verified by Barsik (task #421, spun out of #420 investigation).

Backend-only change — no UI surface; evidence is the test output above.

🤖 Opened by Barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)