### PR TITLE
Make KG extraction model configurable

### DIFF
--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -70,6 +70,9 @@ _DREAM_ALLOWED_TOOLS = [
 # Keeps the dream prompt under a reasonable context budget.
 _MAX_HISTORY_CHARS = 200_000
 
+# Bare alias only: dated Haiku 4.5 snapshots return 404 from Anthropic.
+_KG_EXTRACTION_MODEL_DEFAULT = "claude-haiku-4-5"
+
 
 class DreamRunner:
     """Runs nightly dream consolidation sessions for agents.
@@ -1064,9 +1067,19 @@ class DreamRunner:
         if not api_key:
             return None
 
-        # Use a fast, cheap model for extraction — sonnet is good enough.
-        # Use the bare alias (no date suffix); dated Sonnet 4.6 snapshots 404.
-        model = "claude-sonnet-4-6"
+        # Resolve the extraction model from durable settings first, then the
+        # process environment, with a cheap bare-alias default. Keep provider
+        # failures non-fatal so an unavailable settings DB cannot stop dreams.
+        model = ""
+        if self._setting_provider:
+            try:
+                model = (self._setting_provider("KG_EXTRACTION_MODEL") or "").strip()
+            except Exception:
+                model = ""
+        if not model:
+            model = os.environ.get("KG_EXTRACTION_MODEL", "").strip()
+        if not model:
+            model = _KG_EXTRACTION_MODEL_DEFAULT
 
         # 30s was too short once #686 raised max_tokens 2048->8192: the heaviest
         # reflections now generate longer responses that blew past it, losing

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -174,10 +174,10 @@ class TestBuildKGLLMCaller:
         finally:
             os.unlink(path)
 
-    def test_calls_api_with_alias_model_and_resolved_key(self, monkeypatch):
-        # End-to-end: proves both the key-resolution fix and the corrected
-        # model alias (a dated Sonnet 4.6 snapshot would 404).
+    def test_calls_api_with_default_model_when_override_absent(self, monkeypatch):
+        # End-to-end: absent model settings fall back to the cheap bare alias.
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("KG_EXTRACTION_MODEL", raising=False)
         captured: dict = {}
 
         class _FakeResp:
@@ -203,8 +203,53 @@ class TestBuildKGLLMCaller:
             caller = runner._build_kg_llm_caller(_FakeAgentConfig())
             assert caller is not None
             assert caller("extract triples") == "ok"
-            assert captured["body"]["model"] == "claude-sonnet-4-6"
+            assert captured["body"]["model"] == "claude-haiku-4-5"
             assert captured["headers"]["x-api-key"] == "sk-from-settings"
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.parametrize(
+        ("settings_model", "env_model", "expected"),
+        [
+            ("claude-settings-model", "claude-env-model", "claude-settings-model"),
+            ("", "claude-env-model", "claude-env-model"),
+            ("  ", "  ", "claude-haiku-4-5"),
+        ],
+        ids=("settings-override", "environment-fallback", "blank-default"),
+    )
+    def test_resolves_configurable_model(
+        self, monkeypatch, settings_model, env_model, expected
+    ):
+        monkeypatch.setenv("KG_EXTRACTION_MODEL", env_model)
+        captured: dict = {}
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return json.dumps({"content": [{"type": "text", "text": "ok"}]}).encode()
+
+        def _fake_urlopen(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            return _FakeResp()
+
+        def _setting_provider(key):
+            return {
+                "ANTHROPIC_API_KEY": "sk-from-settings",
+                "KG_EXTRACTION_MODEL": settings_model,
+            }.get(key, "")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+        runner, path = _new_runner(setting_provider=_setting_provider)
+        try:
+            caller = runner._build_kg_llm_caller(_FakeAgentConfig())
+            assert caller is not None
+            assert caller("extract triples") == "ok"
+            assert captured["body"]["model"] == expected
         finally:
             os.unlink(path)
 


### PR DESCRIPTION
## Summary

- resolve `KG_EXTRACTION_MODEL` from `system_settings` via the injected settings provider, then the process environment
- default to the bare `claude-haiku-4-5` alias when neither override is configured
- keep settings lookup failures non-fatal and bind the exact Anthropic request model in regression tests

## Why

The KG extractor hardcoded Sonnet 4.6. Making the model configurable supports the lower-cost Haiku 4.5 default while preserving an operational override path. The default is intentionally the bare alias because dated snapshots return 404.

## Validation

- `pytest` dream/KG matrix: 198 passed
- `ruff check src tests`
- `python -m compileall` on changed files
- `git diff --check`

## Operations

Merge only. Do not release or deploy this PR; the release is intentionally deferred until after tonight's queued wakes.