### PR TITLE
Load workspace MCP config in tmux launches

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2927,6 +2927,15 @@ class TmuxSession:
         if cli_effort and cli_effort != "auto":
             parts.extend(["--effort", cli_effort])
 
+        # Claude Code 2.1.215 does not reliably discover project or local-scope
+        # MCP configuration when the daemon launches its tmux REPL. Pass the
+        # agent workspace config explicitly when present so both fresh and
+        # ``--continue`` launches retain Pinky's MCP tools. Deliberately omit
+        # ``--strict-mcp-config``: desktop-provided servers must remain active.
+        mcp_config = Path(self._config.working_dir or ".") / ".mcp.json"
+        if mcp_config.is_file():
+            parts.extend(["--mcp-config", str(mcp_config)])
+
         # #151 native ultracode activation. ultracode boots at --effort xhigh
         # (above) because the CLI flag rejects the literal "ultracode". The
         # real tier — xhigh + the CLI's own standing dynamic-workflow

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -19,6 +19,7 @@ import asyncio
 import json as _json
 import os
 import re
+import shlex
 import time as _time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -403,6 +404,37 @@ def test_build_claude_cmd_resolves_ultracode_to_xhigh(tmp_path, monkeypatch) -> 
     cmd = ss._build_claude_cmd()
     assert "--effort xhigh" in cmd
     assert "ultracode" not in cmd
+
+
+@pytest.mark.parametrize("has_prior", [False, True])
+def test_build_claude_cmd_passes_workspace_mcp_config_when_present(
+    tmp_path, monkeypatch, has_prior
+) -> None:
+    """Fresh and resumed tmux launches explicitly load the workspace MCP file."""
+    working_dir = tmp_path / "agent workspace"
+    working_dir.mkdir()
+    mcp_config = working_dir / ".mcp.json"
+    mcp_config.write_text("{}")
+    cfg = StreamingSessionConfig(agent_name="dymok", working_dir=str(working_dir))
+    ss = TmuxSession(cfg, tmux_control=_make_mock_tmux())
+    monkeypatch.setattr(ss, "_has_prior_transcript", lambda: has_prior)
+
+    parts = shlex.split(ss._build_claude_cmd())
+
+    assert ("--continue" in parts) is has_prior
+    assert parts[parts.index("--mcp-config") + 1] == str(mcp_config)
+    assert "--strict-mcp-config" not in parts
+
+
+def test_build_claude_cmd_omits_mcp_config_when_workspace_file_missing(
+    tmp_path,
+) -> None:
+    working_dir = tmp_path / "agent-workspace"
+    working_dir.mkdir()
+    cfg = StreamingSessionConfig(agent_name="dymok", working_dir=str(working_dir))
+    ss = TmuxSession(cfg, tmux_control=_make_mock_tmux())
+
+    assert "--mcp-config" not in shlex.split(ss._build_claude_cmd())
 
 
 def test_build_repl_env_expects_resolved_effort_for_ultracode() -> None:


### PR DESCRIPTION
## Summary

- detect `<working_dir>/.mcp.json` in the shared Claude tmux command builder
- pass `--mcp-config <path>` for both fresh and `--continue` launches when that file exists
- leave `--strict-mcp-config` unset so desktop-provided servers such as `claude-in-chrome` and `computer-use` remain available
- cover fresh, resumed, shell-quoted path, and missing-file behavior

## Root cause

Claude Code 2.1.215 did not load either the project `.mcp.json` or local-scope `~/.claude.json` MCP servers for daemon-launched tmux sessions, so respawned agents came up with zero Pinky MCP tools.

Operational evidence from July 20: Barsik's fresh 2.1.215 REPL with the correct local-scope config made no connection attempts and left MCP logs untouched. A headless launch with explicit `--mcp-config` bound `pinky-self` in 20 ms and produced a real connection log.

## Impact

Tmux-backed Claude agents now retain their workspace Pinky MCP configuration across both cold starts and resumed sessions whenever the workspace file is present. Workspaces without `.mcp.json` keep the existing command unchanged.

## Validation

- focused command-builder tests: 14 passed
- full `tests/test_tmux_session.py`: 332 passed
- `ruff check src/pinky_daemon/tmux_session.py tests/test_tmux_session.py`
- `python3 -m compileall -q src/pinky_daemon/tmux_session.py tests/test_tmux_session.py`
- `git diff --check`

## Operations

Brad-manual deploy. Do not deploy from this PR workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)