### PR TITLE
Fix Slack file uploads to user-ID DMs

### DIFF
--- a/src/pinky_outreach/slack.py
+++ b/src/pinky_outreach/slack.py
@@ -8,6 +8,7 @@ Requires a Slack Bot Token (xoxb-...) with appropriate scopes:
 - channels:history / groups:history / im:history
 - reactions:write
 - files:write (for uploads)
+- im:write (resolve U-prefixed user IDs to DM conversations for file uploads)
 - channels:read (for channel info)
 - users:read (resolve user id -> display name)
 - users:read.email (resolve user id -> email; email lookup-by-email routing)
@@ -48,6 +49,7 @@ class SlackAdapter:
             timeout=timeout,
         )
         self._bot_info: dict | None = None
+        self._dm_conversation_ids: dict[str, str] = {}
 
     def close(self) -> None:
         self._client.close()
@@ -172,6 +174,41 @@ class SlackAdapter:
         if resp.status_code >= 400:
             raise SlackError(f"response_url post failed: {resp.status_code}")
 
+    def _ensure_conversation_id(self, channel: str) -> str:
+        """Resolve a U-prefixed user ID to the D-prefixed DM conversation ID.
+
+        ``chat.postMessage`` accepts a user ID and opens the DM implicitly, but
+        ``files.completeUploadExternal(channel_id=...)`` requires a conversation
+        ID. Resolve before starting the external upload so a missing ``im:write``
+        scope fails without creating an upload ticket or transferring bytes.
+        Successful U→D mappings are stable and cached for this adapter/token.
+        Existing C/D/G conversation IDs pass through without an API call.
+        """
+        if not channel.startswith("U"):
+            return channel
+
+        cached = self._dm_conversation_ids.get(channel)
+        if cached:
+            return cached
+
+        try:
+            result = self._request_form("conversations.open", users=channel)
+        except SlackError as exc:
+            if exc.error == "missing_scope":
+                raise SlackError(
+                    "im:write is required to resolve U-prefixed user IDs "
+                    "for Slack DM file uploads"
+                ) from exc
+            raise
+
+        conversation_id = str((result.get("channel") or {}).get("id") or "")
+        if not conversation_id.startswith("D"):
+            raise SlackError(
+                "conversations.open returned no valid DM conversation ID"
+            )
+        self._dm_conversation_ids[channel] = conversation_id
+        return conversation_id
+
     def upload_file(
         self,
         channel: str,
@@ -193,6 +230,7 @@ class SlackAdapter:
         import os
         filename = os.path.basename(file_path)
         file_size = os.path.getsize(file_path)
+        conversation_id = self._ensure_conversation_id(channel)
 
         # Step 1: Get an upload URL. files.getUploadURLExternal is a form/query
         # method — like users.info / conversations.info it ignores a JSON request
@@ -223,7 +261,7 @@ class SlackAdapter:
         self._request_form(
             "files.completeUploadExternal",
             files=json.dumps([{"id": file_id, "title": title or filename}]),
-            channel_id=channel,
+            channel_id=conversation_id,
             initial_comment=initial_comment or None,
             thread_ts=thread_ts or None,
         )

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -21,6 +21,7 @@ class TestSlackAdapter:
         adapter = self._make_adapter()
         assert adapter._token == "xoxb-fake-slack-token"
         assert adapter._bot_info is None
+        assert adapter._dm_conversation_ids == {}
         adapter.close()
 
     def test_headers(self):
@@ -72,6 +73,25 @@ class TestSlackAdapter:
         call_kwargs = adapter._client.post.call_args
         payload = call_kwargs.kwargs.get("json", call_kwargs[1].get("json", {}))
         assert payload["thread_ts"] == "1711584000.000100"
+        adapter.close()
+
+    def test_send_message_keeps_user_id_path_unchanged(self):
+        """Slack already accepts U-prefixed IDs on chat.postMessage."""
+        adapter = self._make_adapter()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "channel": "D12345",
+            "message": {"text": "Hello", "ts": "1711584000.000100"},
+        }
+        adapter._client.post = MagicMock(return_value=mock_response)
+
+        msg = adapter.send_message("U12345", "Hello")
+
+        assert msg.chat_id == "U12345"
+        assert adapter._client.post.call_args[0][0] == "/chat.postMessage"
+        assert adapter._client.post.call_args.kwargs["json"]["channel"] == "U12345"
+        assert adapter._dm_conversation_ids == {}
         adapter.close()
 
     def test_get_user_info_success(self):
@@ -304,6 +324,170 @@ class TestSlackAdapter:
         complete_call = adapter._client.post.call_args_list[1]
         assert "thread_ts" not in complete_call.kwargs["data"]
         assert "thread_ts" not in msg.metadata
+        adapter.close()
+
+    def test_upload_file_resolves_user_id_before_upload(self, tmp_path, monkeypatch):
+        """U-prefixed destinations are opened as D-prefixed conversations first."""
+        adapter = self._make_adapter()
+        f = tmp_path / "rma.png"
+        f.write_bytes(b"\x89PNG\r\n")
+
+        open_resp = MagicMock()
+        open_resp.json.return_value = {"ok": True, "channel": {"id": "D456"}}
+        url_resp = MagicMock()
+        url_resp.json.return_value = {
+            "ok": True,
+            "upload_url": "https://files.slack.com/upload/xyz",
+            "file_id": "F123",
+        }
+        complete_resp = MagicMock()
+        complete_resp.json.return_value = {"ok": True, "files": [{"id": "F123"}]}
+        adapter._client.post = MagicMock(
+            side_effect=[open_resp, url_resp, complete_resp]
+        )
+        monkeypatch.setattr(
+            "pinky_outreach.slack.httpx.post",
+            MagicMock(return_value=MagicMock(status_code=200)),
+        )
+
+        msg = adapter.upload_file("U123", str(f), initial_comment="RMA")
+
+        calls = adapter._client.post.call_args_list
+        assert [call.args[0] for call in calls] == [
+            "/conversations.open",
+            "/files.getUploadURLExternal",
+            "/files.completeUploadExternal",
+        ]
+        assert calls[0].kwargs["data"] == {"users": "U123"}
+        assert (
+            calls[0].kwargs["headers"]["Content-Type"]
+            == "application/x-www-form-urlencoded"
+        )
+        assert calls[2].kwargs["data"]["channel_id"] == "D456"
+        assert adapter._dm_conversation_ids == {"U123": "D456"}
+        assert msg.chat_id == "U123"
+        adapter.close()
+
+    def test_upload_file_threads_after_user_id_resolution(self, tmp_path, monkeypatch):
+        """The U→D resolution also covers photo/document replies in a DM."""
+        adapter = self._make_adapter()
+        f = tmp_path / "reply.png"
+        f.write_bytes(b"\x89PNG\r\n")
+
+        open_resp = MagicMock()
+        open_resp.json.return_value = {"ok": True, "channel": {"id": "D456"}}
+        url_resp = MagicMock()
+        url_resp.json.return_value = {
+            "ok": True,
+            "upload_url": "https://files.slack.com/upload/xyz",
+            "file_id": "F456",
+        }
+        complete_resp = MagicMock()
+        complete_resp.json.return_value = {"ok": True, "files": [{"id": "F456"}]}
+        adapter._client.post = MagicMock(
+            side_effect=[open_resp, url_resp, complete_resp]
+        )
+        monkeypatch.setattr(
+            "pinky_outreach.slack.httpx.post",
+            MagicMock(return_value=MagicMock(status_code=200)),
+        )
+
+        msg = adapter.upload_file(
+            "U123",
+            str(f),
+            thread_ts="1784133332.936979",
+        )
+
+        complete_call = adapter._client.post.call_args_list[2]
+        assert complete_call.kwargs["data"]["channel_id"] == "D456"
+        assert complete_call.kwargs["data"]["thread_ts"] == "1784133332.936979"
+        assert msg.metadata["thread_ts"] == "1784133332.936979"
+        adapter.close()
+
+    def test_user_id_resolution_is_cached_per_adapter(self):
+        adapter = self._make_adapter()
+        open_resp = MagicMock()
+        open_resp.json.return_value = {"ok": True, "channel": {"id": "D456"}}
+        adapter._client.post = MagicMock(return_value=open_resp)
+
+        assert adapter._ensure_conversation_id("U123") == "D456"
+        assert adapter._ensure_conversation_id("U123") == "D456"
+
+        adapter._client.post.assert_called_once()
+        adapter.close()
+
+    def test_user_id_resolution_missing_scope_fails_before_upload(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        adapter = self._make_adapter()
+        f = tmp_path / "rma.png"
+        f.write_bytes(b"\x89PNG\r\n")
+        missing_scope = MagicMock()
+        missing_scope.json.return_value = {
+            "ok": False,
+            "error": "missing_scope",
+            "needed": "im:write",
+        }
+        adapter._client.post = MagicMock(return_value=missing_scope)
+        upload_post = MagicMock()
+        monkeypatch.setattr("pinky_outreach.slack.httpx.post", upload_post)
+
+        with pytest.raises(SlackError, match="im:write"):
+            adapter.upload_file("U123", str(f))
+
+        adapter._client.post.assert_called_once()
+        assert adapter._client.post.call_args.args[0] == "/conversations.open"
+        upload_post.assert_not_called()
+        assert adapter._dm_conversation_ids == {}
+        adapter.close()
+
+    def test_user_id_resolution_rejects_missing_dm_id(self):
+        adapter = self._make_adapter()
+        invalid_response = MagicMock()
+        invalid_response.json.return_value = {"ok": True, "channel": {}}
+        adapter._client.post = MagicMock(return_value=invalid_response)
+
+        with pytest.raises(SlackError, match="no valid DM conversation ID"):
+            adapter._ensure_conversation_id("U123")
+
+        assert adapter._dm_conversation_ids == {}
+        adapter.close()
+
+    @pytest.mark.parametrize("channel", ["D123", "G123"])
+    def test_upload_file_preserves_existing_conversation_ids(
+        self,
+        channel,
+        tmp_path,
+        monkeypatch,
+    ):
+        """D/G uploads bypass conversations.open; C is covered above."""
+        adapter = self._make_adapter()
+        f = tmp_path / "note.txt"
+        f.write_text("hello")
+        url_resp = MagicMock()
+        url_resp.json.return_value = {
+            "ok": True,
+            "upload_url": "https://files.slack.com/upload/xyz",
+            "file_id": "F123",
+        }
+        complete_resp = MagicMock()
+        complete_resp.json.return_value = {"ok": True, "files": [{"id": "F123"}]}
+        adapter._client.post = MagicMock(side_effect=[url_resp, complete_resp])
+        monkeypatch.setattr(
+            "pinky_outreach.slack.httpx.post",
+            MagicMock(return_value=MagicMock(status_code=200)),
+        )
+
+        adapter.upload_file(channel, str(f))
+
+        calls = adapter._client.post.call_args_list
+        assert [call.args[0] for call in calls] == [
+            "/files.getUploadURLExternal",
+            "/files.completeUploadExternal",
+        ]
+        assert calls[1].kwargs["data"]["channel_id"] == channel
         adapter.close()
 
     def test_send_message_error(self):


### PR DESCRIPTION
Closes #897.

## What changed

- Resolve U-prefixed Slack user IDs through `conversations.open` before completing external file uploads.
- Cache stable user-to-DM conversation mappings per adapter instance.
- Fail before requesting an upload URL when the token lacks `im:write`, with a clear scope error.
- Preserve existing C/D/G conversation paths and the unchanged `chat.postMessage` behavior.
- Cover root uploads, threaded DM uploads, caching, missing scope, malformed resolution responses, and non-user conversation IDs.

## Root cause

Slack accepts a user ID for `chat.postMessage`, but `files.completeUploadExternal(channel_id=...)` requires a conversation ID. The upload path forwarded `U...` directly, so file sends failed with `invalid_arguments`.

## Impact

Slack-connected agents can send photos, documents, and videos to user-ID DMs, including threaded replies. Tokens need the documented `im:write` scope for first-time U→D resolution.

## Validation

- `pytest tests/test_slack.py tests/test_outreach_server.py -q`: 81 passed
- `ruff check src/pinky_outreach/slack.py tests/test_slack.py`: passed
- `git diff --check`: passed
- Full suite: 4,383 passed / 3 skipped; two unrelated baseline/environment failures remained. The stale auth expectation reproduces unchanged on `origin/main`; the dream test passes when the host's `PINKY_DREAM_TRANSPORT=tmux` override is set back to its test-default `sdk`.
