### PR TITLE
Cap Claude tmux subagent concurrency at 6

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -107,6 +107,10 @@ from pinky_daemon.watchdog_log import log_watchdog_decision
 # early, graceful heads-up to checkpoint before the safety net trips.
 DEFAULT_CONTEXT_NUDGE_THRESHOLD_PCT = 35.0
 
+# Claude Code defaults to 20 concurrent subagents, which exceeds the Mini's
+# stable fan-out envelope. Keep the fleet cap explicit in every tmux launch.
+DEFAULT_MAX_CONCURRENT_SUBAGENTS = 6
+
 # ──────────────────────────────────────────────────────────────────────────
 # Tmux subprocess control
 # ──────────────────────────────────────────────────────────────────────────
@@ -3047,6 +3051,9 @@ class TmuxSession:
             env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
         if self.agent_name:
             env["PINKY_AGENT_NAME"] = self.agent_name
+        env["CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS"] = str(
+            DEFAULT_MAX_CONCURRENT_SUBAGENTS
+        )
         # Surface the RESOLVED effort (#151): the drift hook compares this to
         # the runtime $CLAUDE_EFFORT, which reports xhigh under ultracode — so
         # expect xhigh, not the literal "ultracode", to avoid false drift.

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -196,6 +196,17 @@ async def test_cold_start_drives_state_through_booting_to_connected() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cold_start_caps_concurrent_subagents_in_spawn_env() -> None:
+    """Every Claude tmux launch carries the Mini-safe fleet fan-out cap."""
+    ss, tmux = _make_session()
+
+    await ss.connect()
+
+    env = tmux.new_session.await_args.kwargs["env"]
+    assert env["CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS"] == "6"
+
+
+@pytest.mark.asyncio
 async def test_cold_start_failure_drives_to_dead_via_boot_failed() -> None:
     """If ``tmux new-session`` fails, cold-start lands BOOTING → DEAD via
     BOOT_FAILED (not silent disconnect)."""


### PR DESCRIPTION
## What changed

- Inject `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS=6` into every Claude tmux launch environment.
- Add a cold-start regression test that asserts the exact value reaches `tmux new-session`.

## Configuration scope

The current agent configuration has no generic runtime/spawn environment override pattern. Per the issue constraint, this PR does not invent a new per-agent config surface; it applies the fleet default of 6 uniformly to Claude tmux sessions. Codex tmux sessions retain their separate environment builder.

## Nested-spawn check

The requested nested-specific grep (`nested.*subagent`, `subagent.*nested`, and `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`) returned no matches. A broader spawn grep found only the expected top-level `Agent` tool allowances/definitions and subagent telemetry/comments; there is no code or configuration that depends on subagents spawning nested subagents.

## Validation

- `pytest -q tests/test_tmux_session.py`: 333 passed
- `ruff check src/pinky_daemon/tmux_session.py tests/test_tmux_session.py`: passed
- `git diff --check`: passed

Closes #896