### PR TITLE
Detect dead-but-registered tmux sessions

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -10228,7 +10228,7 @@ npm run build</pre>
         except Exception as exc:
             _log(f"watchdog: recovery failed for {agent_name}/{label}: {exc}")
 
-    async def _watchdog_alert(agent_name: str, message: str) -> None:
+    async def _watchdog_alert(agent_name: str, message: str) -> bool:
         """Alert callback: notify the owner over configured destinations."""
         _log(f"watchdog: alert for {agent_name} — {message}")
         try:
@@ -10247,7 +10247,7 @@ npm run build</pre>
                 f"ERROR watchdog: owner alert for {agent_name} not delivered; "
                 "owner notification destination or send callback is not configured"
             )
-            return
+            return False
 
         last_error = "no configured destination accepted the alert"
         for destination in destinations:
@@ -10269,17 +10269,18 @@ npm run build</pre>
                 f"{destination['platform']}/{destination['account_id']}/"
                 f"{destination['conversation_id']}"
             )
-            return
+            return True
         _log(
             f"ERROR watchdog: owner alert delivery failed for {agent_name}: "
             f"{last_error}"
         )
+        return False
 
     async def _watchdog_tmux_liveness(
         agent_name: str,
         label: str,
         session: Any,
-    ) -> bool | None:
+    ) -> tuple[bool, str] | None:
         """Return tmux resource liveness for an eligible active registration.
 
         ``None`` is an intentional skip for disabled, retired, or non-tmux
@@ -10301,7 +10302,12 @@ npm run build</pre>
             raise RuntimeError(
                 f"active tmux transport {agent_name}/{label} has no tmux control"
             )
-        return bool(await has_session())
+        session_name = (
+            str(getattr(tmux, "session_name", "") or "")
+            or str(getattr(session, "_session_name", "") or "")
+            or f"pinky-{agent_name}"
+        )
+        return bool(await has_session()), session_name
 
     def _watchdog_mcp_bind_status(agent_name: str) -> dict:
         """Bind-status for the watchdog's #663 MCP-recover check.

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -27,7 +27,7 @@ import urllib.request
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Literal
+from typing import Any, Literal
 
 from fastapi import (
     FastAPI,
@@ -10229,7 +10229,7 @@ npm run build</pre>
             _log(f"watchdog: recovery failed for {agent_name}/{label}: {exc}")
 
     async def _watchdog_alert(agent_name: str, message: str) -> None:
-        """Alert callback: notify the owner via the broker."""
+        """Alert callback: notify the owner over configured destinations."""
         _log(f"watchdog: alert for {agent_name} — {message}")
         try:
             activity.log(
@@ -10237,20 +10237,71 @@ npm run build</pre>
                 event_type="watchdog_warn",
                 title=message[:200],
             )
-            # Send to owner's primary chat if available
-            agent = agents.get(agent_name)
-            if agent:
-                owner = agents.get_owner_profile()
-                owner_chat = owner.get("chat_id", "") if owner else ""
-                if owner_chat:
-                    await broker.send_callback(
-                        agent_name=agent_name,
-                        platform="telegram",
-                        chat_id=str(owner_chat),
-                        content=message,
-                    )
         except Exception as exc:
-            _log(f"watchdog: alert delivery failed for {agent_name}: {exc}")
+            _log(f"watchdog: failed to record alert activity for {agent_name}: {exc}")
+
+        send_callback = broker.send_callback
+        destinations = agents.get_owner_notification_destinations()
+        if not send_callback or not destinations:
+            _log(
+                f"ERROR watchdog: owner alert for {agent_name} not delivered; "
+                "owner notification destination or send callback is not configured"
+            )
+            return
+
+        last_error = "no configured destination accepted the alert"
+        for destination in destinations:
+            try:
+                result = await send_callback(
+                    agent_name,
+                    destination["platform"],
+                    destination["conversation_id"],
+                    message,
+                    account_id=destination["account_id"],
+                )
+                if not isinstance(result, dict) or result.get("sent") is not True:
+                    raise RuntimeError("send callback did not confirm delivery")
+            except Exception as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+                continue
+            _log(
+                f"watchdog: owner alert for {agent_name} delivered via "
+                f"{destination['platform']}/{destination['account_id']}/"
+                f"{destination['conversation_id']}"
+            )
+            return
+        _log(
+            f"ERROR watchdog: owner alert delivery failed for {agent_name}: "
+            f"{last_error}"
+        )
+
+    async def _watchdog_tmux_liveness(
+        agent_name: str,
+        label: str,
+        session: Any,
+    ) -> bool | None:
+        """Return tmux resource liveness for an eligible active registration.
+
+        ``None`` is an intentional skip for disabled, retired, or non-tmux
+        agents. The watchdog already restricts calls to broker sessions whose
+        transport state is CONNECTED ("registered active"). This callback only
+        observes ``tmux has-session`` and never starts or stops a session.
+        """
+        agent = agents.get(agent_name)
+        if (
+            not agent
+            or not agent.enabled
+            or agent.status != "active"
+            or agent.transport != "tmux"
+        ):
+            return None
+        tmux = getattr(session, "_tmux", None)
+        has_session = getattr(tmux, "has_session", None)
+        if not callable(has_session):
+            raise RuntimeError(
+                f"active tmux transport {agent_name}/{label} has no tmux control"
+            )
+        return bool(await has_session())
 
     def _watchdog_mcp_bind_status(agent_name: str) -> dict:
         """Bind-status for the watchdog's #663 MCP-recover check.
@@ -10364,7 +10415,10 @@ npm run build</pre>
         agent_config_fn=_get_watchdog_config,
         mcp_bind_status_fn=_watchdog_mcp_bind_status,
         mcp_recover_fn=_watchdog_mcp_recover,
+        tmux_liveness_fn=_watchdog_tmux_liveness,
     )
+    # Test/diagnostic reach-in, matching app.state.broker/agents.
+    app.state.watchdog = watchdog
 
     # Shared MCP server (started in on_startup if enabled)
     shared_mcp_manager: SharedMcpManager | None = None

--- a/src/pinky_daemon/session_watchdog.py
+++ b/src/pinky_daemon/session_watchdog.py
@@ -23,6 +23,7 @@ from pinky_daemon.watchdog_log import log_watchdog_decision
 
 _log = logging.getLogger("pinky.watchdog").info
 _warn = logging.getLogger("pinky.watchdog").warning
+_critical = logging.getLogger("pinky.watchdog").critical
 
 # Lifecycle states a session passes THROUGH on its way to CONNECTED. If a
 # session sits in one of these past a bound it's wedged (#109) — the normal
@@ -78,6 +79,11 @@ DEFAULT_MCP_PROBE_DEADLINE = 120
 # stays checkable through detection, but bounded so a long-quiet agent stops
 # being a recovery target (and can't be falsely force-restarted).
 DEFAULT_MCP_CHECKABLE_HEARTBEAT_MAX_AGE = 1800  # 30 min
+# #902: after a dead-registered tmux mismatch alerts, require this much
+# continuously observed health before re-arming.  A pane that flickers in and
+# out across adjacent 60s sweeps therefore produces one page, while a genuinely
+# new outage after a stable recovery still alerts.
+DEFAULT_TMUX_LIVENESS_REARM_AFTER = 300  # 5 min continuously healthy
 
 
 def compute_mcp_checkable(
@@ -230,6 +236,16 @@ class _AgentState:
     mcp_recovered_at: float = 0.0  # grace period after an MCP-bind recovery
 
 
+@dataclass
+class _TmuxLivenessState:
+    """Debounce state for one registered-active tmux agent (#902)."""
+
+    missing_since: float = 0.0
+    healthy_since: float = 0.0
+    notified: bool = False
+    last_checked_at: float = 0.0
+
+
 class SessionWatchdog:
     """Background service that detects and recovers stuck streaming sessions."""
 
@@ -242,6 +258,9 @@ class SessionWatchdog:
         agent_config_fn: Callable[[str], WatchdogConfig] | None = None,
         mcp_bind_status_fn: Callable[[str], dict] | None = None,
         mcp_recover_fn: Callable[[str, str, str], Coroutine] | None = None,
+        tmux_liveness_fn: Callable[
+            [str, str, Any], Coroutine[Any, Any, bool | None]
+        ] | None = None,
         check_interval: int = DEFAULT_CHECK_INTERVAL,
     ) -> None:
         """
@@ -258,6 +277,12 @@ class SessionWatchdog:
             agent_config_fn:
                 ``(agent_name) -> WatchdogConfig``.  Returns merged
                 per-agent config.  Falls back to global defaults if None.
+            tmux_liveness_fn:
+                ``async (agent_name, label, session) -> bool | None``. Returns
+                whether the tmux session exists for an eligible enabled,
+                active, tmux-transport agent. ``None`` skips non-tmux agents.
+                Detection is alert-only; this callback is never used to
+                respawn or otherwise mutate a session.
             check_interval:
                 Seconds between sweeps.
         """
@@ -269,9 +294,11 @@ class SessionWatchdog:
         # mcp_recover_fn force-fresh restarts a wedged-MCP session.
         self._mcp_bind_status_fn = mcp_bind_status_fn
         self._mcp_recover_fn = mcp_recover_fn
+        self._tmux_liveness_fn = tmux_liveness_fn
         self._interval = check_interval
 
         self._states: dict[str, _AgentState] = {}
+        self._tmux_liveness_states: dict[str, _TmuxLivenessState] = {}
         self._last_mcp_recover_at: float = 0.0  # global MCP-recover rate-limit
         self._task: asyncio.Task | None = None
         self._running = False
@@ -320,17 +347,138 @@ class SessionWatchdog:
         streaming = self._streaming_fn()
         now = time.time()
         seen_keys: set[tuple[str, str]] = set()
+        tmux_checked_agents: set[str] = set()
 
         for agent_name, sessions in list(streaming.items()):
             for label, ss in list(sessions.items()):
                 seen_keys.add((agent_name, label))
                 snap = self._take_snapshot(agent_name, label, ss)
+                # #902: a tmux resource is per agent (``pinky-<name>``), not
+                # per broker label. Check at most one connected registration
+                # per agent on each sweep.
+                if agent_name not in tmux_checked_agents:
+                    checked = await self._reconcile_tmux_liveness(
+                        snap, ss, now,
+                    )
+                    if checked:
+                        tmux_checked_agents.add(agent_name)
                 await self._evaluate(snap, now)
 
         # Clean up state for sessions no longer streaming
         stale = [k for k in self._states if k not in seen_keys]
         for k in stale:
             del self._states[k]
+
+        # No longer registered-active is a healthy/non-actionable observation
+        # for debounce purposes. It clears the current mismatch and eventually
+        # re-arms after a stable interval, without treating an intentional
+        # broker unregister as another outage.
+        for agent_name in list(self._tmux_liveness_states):
+            if agent_name not in tmux_checked_agents:
+                await self._evaluate_tmux_liveness(
+                    agent_name, alive=True, now=now,
+                )
+
+    async def _reconcile_tmux_liveness(
+        self,
+        snap: _SessionSnapshot,
+        ss: Any,
+        now: float,
+    ) -> bool:
+        """Check one registered-active session against its tmux resource.
+
+        Returns True once this agent has been classified for the current sweep,
+        including a non-tmux skip or a failed diagnostic check. False means the
+        supplied broker registration was not active, so another label may still
+        be eligible.
+        """
+        if self._tmux_liveness_fn is None:
+            return False
+        if not snap.connected:
+            return False
+        try:
+            alive = await self._tmux_liveness_fn(
+                snap.agent_name, snap.label, ss,
+            )
+        except Exception as exc:
+            # A diagnostic failure is not proof the session is absent. Surface
+            # it, but never page (or restart) a potentially healthy agent.
+            _warn(
+                "watchdog tmux liveness check failed for %s/%s: %s",
+                snap.agent_name, snap.label, exc,
+            )
+            return True
+        if alive is None:
+            # The callback rejected this agent (disabled/retired/non-tmux).
+            # Clear any old mismatch using the same stable-health debounce.
+            await self._evaluate_tmux_liveness(
+                snap.agent_name, alive=True, now=now,
+            )
+            return True
+        await self._evaluate_tmux_liveness(
+            snap.agent_name, alive=bool(alive), now=now,
+        )
+        return True
+
+    async def _evaluate_tmux_liveness(
+        self,
+        agent_name: str,
+        *,
+        alive: bool,
+        now: float,
+    ) -> None:
+        """Latch one alert per dead-registered mismatch and debounce flaps."""
+        state = self._tmux_liveness_states.get(agent_name)
+        if alive:
+            if state is None:
+                return
+            state.last_checked_at = now
+            if state.missing_since:
+                state.missing_since = 0.0
+                state.healthy_since = now
+            elif not state.healthy_since:
+                state.healthy_since = now
+            if (
+                state.notified
+                and (now - state.healthy_since)
+                >= DEFAULT_TMUX_LIVENESS_REARM_AFTER
+            ):
+                # A continuously healthy window makes a later mismatch a new
+                # incident. Drop the state entirely so the next miss pages
+                # immediately and starts a fresh duration clock.
+                del self._tmux_liveness_states[agent_name]
+            return
+
+        if state is None:
+            state = _TmuxLivenessState()
+            self._tmux_liveness_states[agent_name] = state
+        state.last_checked_at = now
+        state.healthy_since = 0.0
+        if not state.missing_since:
+            state.missing_since = now
+
+        # Continuous misses and short healthy/missing flaps stay latched.
+        if state.notified:
+            return
+        state.notified = True
+        dead_registered_for = max(0, int(now - state.missing_since))
+        message = (
+            f"🚨 Session liveness mismatch: {agent_name} is registered active, "
+            f"but tmux session 'pinky-{agent_name}' is missing "
+            f"(dead-registered for at least {dead_registered_for}s). "
+            "Detection only; no restart was attempted."
+        )
+        # Exactly one loud line for this mismatch; the notification callback
+        # may add delivery diagnostics, but never another mismatch decision.
+        _critical(message)
+        if self._alert_fn:
+            try:
+                await self._alert_fn(agent_name, message)
+            except Exception as exc:
+                _warn(
+                    "watchdog tmux liveness alert failed for %s: %s",
+                    agent_name, exc,
+                )
 
     def _take_snapshot(
         self, agent_name: str, label: str, ss: Any
@@ -779,10 +927,11 @@ class SessionWatchdog:
 
     def status(self) -> dict:
         """Return current watchdog state for diagnostics."""
+        now = time.time()
         sessions = {}
         for key, state in self._states.items():
             agent_name, label = key
-            stale_s = time.time() - state.last_progress_at
+            stale_s = now - state.last_progress_at
             display_key = f"{agent_name}/{label}" if label else agent_name
             sessions[display_key] = {
                 "agent_name": agent_name,
@@ -793,13 +942,29 @@ class SessionWatchdog:
                 "warned": state.warned,
                 "transition_state": state.transition_state,
                 "transition_age": (
-                    round(time.time() - state.transition_since, 1)
+                    round(now - state.transition_since, 1)
                     if state.transition_since else 0.0
                 ),
                 "transition_warned": state.transition_warned,
             }
+        tmux_liveness = {
+            agent_name: {
+                "missing": bool(state.missing_since),
+                "dead_registered_seconds": (
+                    round(now - state.missing_since, 1)
+                    if state.missing_since else 0.0
+                ),
+                "notification_latched": state.notified,
+                "healthy_seconds": (
+                    round(now - state.healthy_since, 1)
+                    if state.healthy_since else 0.0
+                ),
+            }
+            for agent_name, state in self._tmux_liveness_states.items()
+        }
         return {
             "running": self._running,
             "check_interval": self._interval,
             "agents": sessions,  # kept as "agents" for API compat
+            "tmux_liveness": tmux_liveness,
         }

--- a/src/pinky_daemon/session_watchdog.py
+++ b/src/pinky_daemon/session_watchdog.py
@@ -79,6 +79,10 @@ DEFAULT_MCP_PROBE_DEADLINE = 120
 # stays checkable through detection, but bounded so a long-quiet agent stops
 # being a recovery target (and can't be falsely force-restarted).
 DEFAULT_MCP_CHECKABLE_HEARTBEAT_MAX_AGE = 1800  # 30 min
+# Failed owner pages retry at most once per normal sweep. The mismatch decision
+# and critical log remain latched separately, so a transient destination outage
+# cannot suppress delivery forever or spam the log (#902 review).
+DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER = 60
 # #902: after a dead-registered tmux mismatch alerts, require this much
 # continuously observed health before re-arming.  A pane that flickers in and
 # out across adjacent 60s sweeps therefore produces one page, while a genuinely
@@ -240,9 +244,13 @@ class _AgentState:
 class _TmuxLivenessState:
     """Debounce state for one registered-active tmux agent (#902)."""
 
+    session_name: str = ""
     missing_since: float = 0.0
     healthy_since: float = 0.0
+    mismatch_logged: bool = False
     notified: bool = False
+    last_notify_attempt_at: float = 0.0
+    notification_attempts: int = 0
     last_checked_at: float = 0.0
 
 
@@ -254,12 +262,13 @@ class SessionWatchdog:
         *,
         streaming_sessions_fn: Callable[[], dict[str, dict[str, Any]]],
         recover_fn: Callable[[str, str, str], Coroutine] | None = None,
-        alert_fn: Callable[[str, str], Coroutine] | None = None,
+        alert_fn: Callable[[str, str], Coroutine[Any, Any, bool | None]] | None = None,
         agent_config_fn: Callable[[str], WatchdogConfig] | None = None,
         mcp_bind_status_fn: Callable[[str], dict] | None = None,
         mcp_recover_fn: Callable[[str, str, str], Coroutine] | None = None,
         tmux_liveness_fn: Callable[
-            [str, str, Any], Coroutine[Any, Any, bool | None]
+            [str, str, Any],
+            Coroutine[Any, Any, bool | tuple[bool, str] | None],
         ] | None = None,
         check_interval: int = DEFAULT_CHECK_INTERVAL,
     ) -> None:
@@ -272,17 +281,20 @@ class SessionWatchdog:
                 ``async (agent_name, label, reason) -> None``.  Called when
                 a session is deemed stuck and mode == "recover".
             alert_fn:
-                ``async (agent_name, message) -> None``.  Called to send
-                a warning to the owner.
+                ``async (agent_name, message) -> bool | None``. Called to send
+                a warning to the owner. The tmux-liveness branch requires
+                ``True`` to confirm delivery and rate-limits retries otherwise;
+                legacy watchdog branches ignore the return value.
             agent_config_fn:
                 ``(agent_name) -> WatchdogConfig``.  Returns merged
                 per-agent config.  Falls back to global defaults if None.
             tmux_liveness_fn:
-                ``async (agent_name, label, session) -> bool | None``. Returns
-                whether the tmux session exists for an eligible enabled,
-                active, tmux-transport agent. ``None`` skips non-tmux agents.
-                Detection is alert-only; this callback is never used to
-                respawn or otherwise mutate a session.
+                ``async (agent_name, label, session) -> (alive, session_name)
+                | bool | None``. Returns whether the tmux session exists, plus
+                its actual resource name, for an eligible enabled, active,
+                tmux-transport agent. ``None`` skips non-tmux agents. Detection
+                is alert-only; this callback is never used to respawn or
+                otherwise mutate a session.
             check_interval:
                 Seconds between sweeps.
         """
@@ -397,7 +409,7 @@ class SessionWatchdog:
         if not snap.connected:
             return False
         try:
-            alive = await self._tmux_liveness_fn(
+            result = await self._tmux_liveness_fn(
                 snap.agent_name, snap.label, ss,
             )
         except Exception as exc:
@@ -408,15 +420,24 @@ class SessionWatchdog:
                 snap.agent_name, snap.label, exc,
             )
             return True
-        if alive is None:
+        if result is None:
             # The callback rejected this agent (disabled/retired/non-tmux).
             # Clear any old mismatch using the same stable-health debounce.
             await self._evaluate_tmux_liveness(
                 snap.agent_name, alive=True, now=now,
             )
             return True
+        if isinstance(result, tuple):
+            alive, session_name = result
+        else:
+            # Compatibility for simple/test callbacks. Production returns the
+            # actual control name so Codex-over-tmux reports pinky-codex-*.
+            alive, session_name = result, f"pinky-{snap.agent_name}"
         await self._evaluate_tmux_liveness(
-            snap.agent_name, alive=bool(alive), now=now,
+            snap.agent_name,
+            alive=bool(alive),
+            now=now,
+            session_name=session_name,
         )
         return True
 
@@ -426,23 +447,22 @@ class SessionWatchdog:
         *,
         alive: bool,
         now: float,
+        session_name: str = "",
     ) -> None:
-        """Latch one alert per dead-registered mismatch and debounce flaps."""
+        """Log once, retry owner delivery, and debounce tmux mismatch flaps."""
         state = self._tmux_liveness_states.get(agent_name)
         if alive:
             if state is None:
                 return
             state.last_checked_at = now
+            if session_name:
+                state.session_name = session_name
             if state.missing_since:
                 state.missing_since = 0.0
                 state.healthy_since = now
             elif not state.healthy_since:
                 state.healthy_since = now
-            if (
-                state.notified
-                and (now - state.healthy_since)
-                >= DEFAULT_TMUX_LIVENESS_REARM_AFTER
-            ):
+            if (now - state.healthy_since) >= DEFAULT_TMUX_LIVENESS_REARM_AFTER:
                 # A continuously healthy window makes a later mismatch a new
                 # incident. Drop the state entirely so the next miss pages
                 # immediately and starts a fresh duration clock.
@@ -452,33 +472,52 @@ class SessionWatchdog:
         if state is None:
             state = _TmuxLivenessState()
             self._tmux_liveness_states[agent_name] = state
+        state.session_name = session_name or state.session_name or f"pinky-{agent_name}"
         state.last_checked_at = now
         state.healthy_since = 0.0
         if not state.missing_since:
             state.missing_since = now
 
-        # Continuous misses and short healthy/missing flaps stay latched.
-        if state.notified:
-            return
-        state.notified = True
         dead_registered_for = max(0, int(now - state.missing_since))
         message = (
             f"🚨 Session liveness mismatch: {agent_name} is registered active, "
-            f"but tmux session 'pinky-{agent_name}' is missing "
+            f"but tmux session '{state.session_name}' is missing "
             f"(dead-registered for at least {dead_registered_for}s). "
             "Detection only; no restart was attempted."
         )
-        # Exactly one loud line for this mismatch; the notification callback
-        # may add delivery diagnostics, but never another mismatch decision.
-        _critical(message)
-        if self._alert_fn:
-            try:
-                await self._alert_fn(agent_name, message)
-            except Exception as exc:
-                _warn(
-                    "watchdog tmux liveness alert failed for %s: %s",
-                    agent_name, exc,
-                )
+        # The mismatch decision/log and the owner-delivery confirmation are
+        # independent. Log exactly once, but do not let a transient outage in
+        # every configured destination permanently suppress the page.
+        if not state.mismatch_logged:
+            state.mismatch_logged = True
+            _critical(message)
+
+        if state.notified or self._alert_fn is None:
+            return
+        if (
+            state.last_notify_attempt_at
+            and (now - state.last_notify_attempt_at)
+            < DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER
+        ):
+            return
+
+        state.last_notify_attempt_at = now
+        state.notification_attempts += 1
+        try:
+            delivered = await self._alert_fn(agent_name, message)
+        except Exception as exc:
+            _warn(
+                "watchdog tmux liveness alert failed for %s: %s",
+                agent_name, exc,
+            )
+            return
+        if delivered is True:
+            state.notified = True
+            return
+        _warn(
+            "watchdog tmux liveness alert unconfirmed for %s; retrying in %ds",
+            agent_name, DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER,
+        )
 
     def _take_snapshot(
         self, agent_name: str, label: str, ss: Any
@@ -949,12 +988,15 @@ class SessionWatchdog:
             }
         tmux_liveness = {
             agent_name: {
+                "session_name": state.session_name,
                 "missing": bool(state.missing_since),
                 "dead_registered_seconds": (
                     round(now - state.missing_since, 1)
                     if state.missing_since else 0.0
                 ),
+                "mismatch_logged": state.mismatch_logged,
                 "notification_latched": state.notified,
+                "notification_attempts": state.notification_attempts,
                 "healthy_seconds": (
                     round(now - state.healthy_since, 1)
                     if state.healthy_since else 0.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -472,6 +472,75 @@ class TestAPI:
         from pinky_daemon.api import create_api
         return create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
 
+    @pytest.mark.asyncio
+    async def test_tmux_liveness_uses_configured_owner_destination(self, tmp_path):
+        """#902 + #865: the Billie shape pages the configured owner route once."""
+        from pinky_daemon.transport_state import SessionState as TransportState
+
+        app = self._make_app(str(tmp_path / "test.db"))
+        app.state.agents.register(
+            "billie",
+            model="sonnet",
+            transport="tmux",
+            working_dir=str(tmp_path / "billie"),
+        )
+        app.state.agents.register(
+            "sdk-sibling",
+            model="sonnet",
+            transport="sdk",
+            working_dir=str(tmp_path / "sdk-sibling"),
+        )
+        app.state.agents.register(
+            "retired-tmux",
+            model="sonnet",
+            transport="tmux",
+            working_dir=str(tmp_path / "retired-tmux"),
+        )
+        app.state.agents.retire("retired-tmux")
+        app.state.agents.set_owner_notification_destinations([
+            {
+                "platform": "slack",
+                "account_id": "T_OWNER",
+                "conversation_id": "D_OWNER",
+                "principal_id": "U_OWNER",
+            }
+        ])
+
+        deliveries = []
+
+        async def _capture(
+            agent_name, platform, chat_id, content, *, account_id="", **kwargs,
+        ):
+            deliveries.append((agent_name, platform, account_id, chat_id, content))
+            return {"sent": True}
+
+        app.state.broker._send_callback = _capture
+        def _fake_session():
+            return SimpleNamespace(
+                state=TransportState.CONNECTED,
+                stats={"state": TransportState.CONNECTED.value},
+                _tmux=SimpleNamespace(has_session=AsyncMock(return_value=False)),
+            )
+
+        session = _fake_session()
+        sdk_session = _fake_session()
+        retired_session = _fake_session()
+        app.state.broker.register_streaming("billie", session, label="main")
+        app.state.broker.register_streaming("sdk-sibling", sdk_session, label="main")
+        app.state.broker.register_streaming("retired-tmux", retired_session, label="main")
+
+        await app.state.watchdog._sweep()
+        await app.state.watchdog._sweep()
+
+        assert len(deliveries) == 1
+        assert deliveries[0][:4] == (
+            "billie", "slack", "T_OWNER", "D_OWNER",
+        )
+        assert "pinky-billie" in deliveries[0][4]
+        assert session._tmux.has_session.await_count == 2
+        assert sdk_session._tmux.has_session.await_count == 0
+        assert retired_session._tmux.has_session.await_count == 0
+
     class _FakeContextClient:
         def __init__(self, total_tokens=0, max_tokens=200_000):
             self.total_tokens = total_tokens

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -515,16 +515,19 @@ class TestAPI:
             return {"sent": True}
 
         app.state.broker._send_callback = _capture
-        def _fake_session():
+        def _fake_session(session_name):
             return SimpleNamespace(
                 state=TransportState.CONNECTED,
                 stats={"state": TransportState.CONNECTED.value},
-                _tmux=SimpleNamespace(has_session=AsyncMock(return_value=False)),
+                _tmux=SimpleNamespace(
+                    session_name=session_name,
+                    has_session=AsyncMock(return_value=False),
+                ),
             )
 
-        session = _fake_session()
-        sdk_session = _fake_session()
-        retired_session = _fake_session()
+        session = _fake_session("pinky-billie")
+        sdk_session = _fake_session("pinky-sdk-sibling")
+        retired_session = _fake_session("pinky-retired-tmux")
         app.state.broker.register_streaming("billie", session, label="main")
         app.state.broker.register_streaming("sdk-sibling", sdk_session, label="main")
         app.state.broker.register_streaming("retired-tmux", retired_session, label="main")
@@ -540,6 +543,69 @@ class TestAPI:
         assert session._tmux.has_session.await_count == 2
         assert sdk_session._tmux.has_session.await_count == 0
         assert retired_session._tmux.has_session.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_tmux_liveness_retries_failed_codex_owner_page(self, tmp_path):
+        """#902 review: failed pages retry and name the actual Codex resource."""
+        from pinky_daemon.session_watchdog import (
+            DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER,
+        )
+        from pinky_daemon.transport_state import SessionState as TransportState
+
+        app = self._make_app(str(tmp_path / "test.db"))
+        app.state.agents.register(
+            "murzik",
+            model="gpt-5.6-sol",
+            runtime="codex_cli",
+            transport="tmux",
+            working_dir=str(tmp_path / "murzik"),
+        )
+        app.state.agents.set_owner_notification_destinations([
+            {
+                "platform": "telegram",
+                "account_id": "owner-bot",
+                "conversation_id": "owner-chat",
+                "principal_id": "owner",
+            }
+        ])
+
+        attempts = []
+
+        async def _flaky(
+            agent_name, platform, chat_id, content, *, account_id="", **kwargs,
+        ):
+            attempts.append((agent_name, platform, account_id, chat_id, content))
+            if len(attempts) == 1:
+                raise RuntimeError("temporary owner route failure")
+            return {"sent": True}
+
+        app.state.broker._send_callback = _flaky
+        session = SimpleNamespace(
+            state=TransportState.CONNECTED,
+            stats={"state": TransportState.CONNECTED.value},
+            _tmux=SimpleNamespace(
+                session_name="pinky-codex-murzik",
+                has_session=AsyncMock(return_value=False),
+            ),
+        )
+        app.state.broker.register_streaming("murzik", session, label="main")
+
+        await app.state.watchdog._sweep()
+        state = app.state.watchdog._tmux_liveness_states["murzik"]
+        assert len(attempts) == 1
+        assert state.mismatch_logged is True
+        assert state.notified is False
+
+        # Advance only the retry clock; the underlying mismatch stays active.
+        state.last_notify_attempt_at -= DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER
+        await app.state.watchdog._sweep()
+        await app.state.watchdog._sweep()
+
+        assert len(attempts) == 2
+        assert state.notified is True
+        assert state.notification_attempts == 2
+        assert "pinky-codex-murzik" in attempts[1][4]
+        assert "tmux session 'pinky-murzik'" not in attempts[1][4]
 
     class _FakeContextClient:
         def __init__(self, total_tokens=0, max_tokens=200_000):

--- a/tests/test_session_watchdog.py
+++ b/tests/test_session_watchdog.py
@@ -10,6 +10,7 @@ from pinky_daemon.session_watchdog import (
     DEFAULT_MCP_CHECKABLE_HEARTBEAT_MAX_AGE,
     DEFAULT_MCP_PROBE_DEADLINE,
     DEFAULT_MCP_UNBOUND_FLOOR,
+    DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER,
     DEFAULT_TMUX_LIVENESS_REARM_AFTER,
     SessionWatchdog,
     WatchdogConfig,
@@ -432,6 +433,7 @@ class TestTmuxLivenessReconciliation:
 
         async def _alert(agent, message):
             alerts.append((agent, message))
+            return True
 
         async def _recover(agent, label, reason):
             recoveries.append((agent, label, reason))
@@ -472,6 +474,7 @@ class TestTmuxLivenessReconciliation:
 
         async def _alert(agent, message):
             alerts.append(message)
+            return True
 
         wd = make_watchdog(
             sessions={
@@ -499,6 +502,7 @@ class TestTmuxLivenessReconciliation:
 
         async def _alert(agent, message):
             alerts.append(message)
+            return True
 
         wd = make_watchdog(
             sessions={"sdk-agent": {"main": FakeSession(connected=True)}},
@@ -517,6 +521,7 @@ class TestTmuxLivenessReconciliation:
 
         async def _alert(agent, message):
             alerts.append(message)
+            return True
 
         wd = make_watchdog(alert_fn=_alert)
         now = 1_000.0
@@ -545,6 +550,80 @@ class TestTmuxLivenessReconciliation:
             now=now + 241 + DEFAULT_TMUX_LIVENESS_REARM_AFTER,
         )
         assert len(alerts) == 2
+
+    @pytest.mark.asyncio
+    async def test_failed_owner_page_retries_until_confirmed(
+        self, make_watchdog, caplog,
+    ):
+        attempts = []
+
+        async def _flaky_alert(agent, message):
+            attempts.append((agent, message))
+            return len(attempts) >= 2
+
+        wd = make_watchdog(alert_fn=_flaky_alert)
+        now = 2_000.0
+        with caplog.at_level(logging.CRITICAL, logger="pinky.watchdog"):
+            await wd._evaluate_tmux_liveness(
+                "billie", alive=False, now=now,
+                session_name="pinky-billie",
+            )
+            state = wd._tmux_liveness_states["billie"]
+            assert state.mismatch_logged is True
+            assert state.notified is False
+            assert state.notification_attempts == 1
+
+            # Retry frequency is bounded even though delivery is not latched.
+            await wd._evaluate_tmux_liveness(
+                "billie", alive=False,
+                now=now + DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER - 1,
+                session_name="pinky-billie",
+            )
+            assert len(attempts) == 1
+
+            # The next eligible sweep retries and latches only after True.
+            await wd._evaluate_tmux_liveness(
+                "billie", alive=False,
+                now=now + DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER,
+                session_name="pinky-billie",
+            )
+            assert len(attempts) == 2
+            assert state.notified is True
+            assert state.notification_attempts == 2
+
+            await wd._evaluate_tmux_liveness(
+                "billie", alive=False,
+                now=now + (2 * DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER),
+                session_name="pinky-billie",
+            )
+        assert len(attempts) == 2
+        assert sum(
+            record.levelno == logging.CRITICAL
+            and "Session liveness mismatch" in record.message
+            for record in caplog.records
+        ) == 1
+
+    @pytest.mark.asyncio
+    async def test_alert_uses_actual_codex_tmux_resource_name(self, make_watchdog):
+        alerts = []
+
+        async def _missing_codex(agent, label, session):
+            return False, "pinky-codex-murzik"
+
+        async def _alert(agent, message):
+            alerts.append(message)
+            return True
+
+        wd = make_watchdog(
+            sessions={"murzik": {"main": FakeSession(connected=True)}},
+            alert_fn=_alert,
+            tmux_liveness_fn=_missing_codex,
+        )
+        await wd._sweep()
+
+        assert len(alerts) == 1
+        assert "tmux session 'pinky-codex-murzik' is missing" in alerts[0]
+        assert "tmux session 'pinky-murzik' is missing" not in alerts[0]
 
     @pytest.mark.asyncio
     async def test_check_error_is_diagnostic_not_missing(

--- a/tests/test_session_watchdog.py
+++ b/tests/test_session_watchdog.py
@@ -1,6 +1,7 @@
 """Tests for session_watchdog module."""
 from __future__ import annotations
 
+import logging
 import time
 
 import pytest
@@ -9,6 +10,7 @@ from pinky_daemon.session_watchdog import (
     DEFAULT_MCP_CHECKABLE_HEARTBEAT_MAX_AGE,
     DEFAULT_MCP_PROBE_DEADLINE,
     DEFAULT_MCP_UNBOUND_FLOOR,
+    DEFAULT_TMUX_LIVENESS_REARM_AFTER,
     SessionWatchdog,
     WatchdogConfig,
     _AgentState,
@@ -411,6 +413,161 @@ class TestInflightCarveOut:
         )
         await wd._evaluate(snap_quiet, now)
         assert len(recoveries) == 1
+
+
+class TestTmuxLivenessReconciliation:
+    """#902 — registered-active tmux sessions are reconciled with tmux itself."""
+
+    @pytest.mark.asyncio
+    async def test_billie_shape_alerts_once_and_never_recovers(
+        self, make_watchdog, caplog,
+    ):
+        alerts = []
+        recoveries = []
+        checks = []
+
+        async def _missing(agent, label, session):
+            checks.append((agent, label, session))
+            return False
+
+        async def _alert(agent, message):
+            alerts.append((agent, message))
+
+        async def _recover(agent, label, reason):
+            recoveries.append((agent, label, reason))
+
+        session = FakeSession(connected=True)
+        wd = make_watchdog(
+            sessions={"billie": {"main": session}},
+            alert_fn=_alert,
+            recover_fn=_recover,
+            tmux_liveness_fn=_missing,
+        )
+        with caplog.at_level(logging.CRITICAL, logger="pinky.watchdog"):
+            await wd._sweep()
+            await wd._sweep()
+
+        assert len(checks) == 2  # checked on every periodic sweep
+        assert len(alerts) == 1  # continuous mismatch is latched
+        assert alerts[0][0] == "billie"
+        assert "pinky-billie" in alerts[0][1]
+        assert "dead-registered for at least" in alerts[0][1]
+        assert "no restart was attempted" in alerts[0][1]
+        assert recoveries == []  # detect + notify ONLY
+        mismatch_logs = [
+            record for record in caplog.records
+            if record.levelno == logging.CRITICAL
+            and "Session liveness mismatch" in record.message
+        ]
+        assert len(mismatch_logs) == 1
+
+    @pytest.mark.asyncio
+    async def test_checks_one_tmux_resource_per_agent(self, make_watchdog):
+        checks = []
+        alerts = []
+
+        async def _missing(agent, label, session):
+            checks.append((agent, label))
+            return False
+
+        async def _alert(agent, message):
+            alerts.append(message)
+
+        wd = make_watchdog(
+            sessions={
+                "billie": {
+                    "main": FakeSession(connected=True),
+                    "worker": FakeSession(connected=True),
+                }
+            },
+            alert_fn=_alert,
+            tmux_liveness_fn=_missing,
+        )
+        await wd._sweep()
+
+        assert checks == [("billie", "main")]
+        assert len(alerts) == 1
+
+    @pytest.mark.asyncio
+    async def test_non_tmux_or_inactive_registration_is_skipped(
+        self, make_watchdog,
+    ):
+        alerts = []
+
+        async def _not_eligible(agent, label, session):
+            return None
+
+        async def _alert(agent, message):
+            alerts.append(message)
+
+        wd = make_watchdog(
+            sessions={"sdk-agent": {"main": FakeSession(connected=True)}},
+            alert_fn=_alert,
+            tmux_liveness_fn=_not_eligible,
+        )
+        await wd._sweep()
+        assert alerts == []
+        assert wd.status()["tmux_liveness"] == {}
+
+    @pytest.mark.asyncio
+    async def test_flap_stays_debounced_until_continuously_healthy(
+        self, make_watchdog,
+    ):
+        alerts = []
+
+        async def _alert(agent, message):
+            alerts.append(message)
+
+        wd = make_watchdog(alert_fn=_alert)
+        now = 1_000.0
+
+        # First miss pages; continuous misses do not.
+        await wd._evaluate_tmux_liveness("billie", alive=False, now=now)
+        await wd._evaluate_tmux_liveness("billie", alive=False, now=now + 60)
+        assert len(alerts) == 1
+
+        # A short healthy/missing flap remains latched.
+        await wd._evaluate_tmux_liveness("billie", alive=True, now=now + 120)
+        await wd._evaluate_tmux_liveness("billie", alive=False, now=now + 180)
+        assert len(alerts) == 1
+
+        # Only a continuously healthy re-arm window creates a new incident.
+        await wd._evaluate_tmux_liveness("billie", alive=True, now=now + 240)
+        await wd._evaluate_tmux_liveness(
+            "billie",
+            alive=True,
+            now=now + 240 + DEFAULT_TMUX_LIVENESS_REARM_AFTER,
+        )
+        assert "billie" not in wd._tmux_liveness_states
+        await wd._evaluate_tmux_liveness(
+            "billie",
+            alive=False,
+            now=now + 241 + DEFAULT_TMUX_LIVENESS_REARM_AFTER,
+        )
+        assert len(alerts) == 2
+
+    @pytest.mark.asyncio
+    async def test_check_error_is_diagnostic_not_missing(
+        self, make_watchdog, caplog,
+    ):
+        alerts = []
+
+        async def _broken_check(agent, label, session):
+            raise TimeoutError("tmux control timed out")
+
+        async def _alert(agent, message):
+            alerts.append(message)
+
+        wd = make_watchdog(
+            sessions={"billie": {"main": FakeSession(connected=True)}},
+            alert_fn=_alert,
+            tmux_liveness_fn=_broken_check,
+        )
+        with caplog.at_level(logging.WARNING, logger="pinky.watchdog"):
+            await wd._sweep()
+
+        assert alerts == []
+        assert "tmux liveness check failed for billie/main" in caplog.text
 
 
 class TestStatus:


### PR DESCRIPTION
Closes #902

## What changed

- Piggyback the existing 60-second `SessionWatchdog` sweep to reconcile every broker-connected, enabled, active tmux agent against its actual tmux resource via the existing `has_session()` control.
- Emit one critical mismatch log and notify the owner through the configured ordered owner-notification destinations.
- Latch continuous mismatches and require five continuously healthy minutes before re-arming, preventing a flapping pane from paging every sweep.
- Keep this phase detection-only: the reconciliation path never reconnects, restarts, or respawns an agent.
- Expose tmux-liveness debounce state in `/admin/watchdog` diagnostics.

## Why

The daemon previously trusted the in-memory CONNECTED registration. If the underlying tmux pane disappeared after registration, `/agents` continued to report the agent as streaming while the progress watchdog could not distinguish the missing OS session. Inbound messages could then disappear into a silent dead-but-registered session until a human noticed.

## Validation

- `uv run ruff check .`
- Focused watchdog/API regression suite: 68 passed
- Full Python 3.11 suite under repository-default feature flags: 4,392 passed, 3 skipped

The regression coverage includes the Billie shape (registered active + missing tmux session), exactly-one notification across repeated sweeps, one tmux check per agent, disabled/retired/non-tmux exclusions, ordered owner-destination delivery, diagnostic check failures, flap debounce, and an explicit assertion that no recovery callback fires.