### PR TITLE
Register claude-opus-5 in the model registry (4 parity-pinned tables)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -4369,6 +4369,7 @@ except Exception:
         # Anthropic
         ("anthropic", "claude-fable-5", "Claude Fable 5", "Anthropic's most capable widely-released model (2026-06-09). Demanding reasoning + long-horizon agentic work. 1M context; adaptive thinking always on (use effort to control depth).", "fable", 1_000_000, 1, 10.0, 50.0, 1.0, 1, 1),
         ("anthropic", "claude-mythos-5", "Claude Mythos 5", "Claude Fable 5 capabilities without the safety classifiers. Limited availability via Project Glasswing (approved customers only).", "fable", 1_000_000, 1, 10.0, 50.0, 1.0, 1, 2),
+        ("anthropic", "claude-opus-5", "Claude Opus 5", "For complex agentic coding + enterprise work. 1M context; effort defaults high; adaptive thinking. Knowledge cutoff May 2026.", "opus", 1_000_000, 1, 5.0, 25.0, 0.5, 1, 2),
         ("anthropic", "claude-opus-4-8", "Claude Opus 4.8", "Newest Opus (2026-05-28). Sharper judgement, more honest progress reporting, longer independent runs. Effort defaults to high; adaptive thinking triggers only when needed.", "opus", 1_000_000, 1, 5.0, 25.0, 0.5, 1, 3),
         ("anthropic", "claude-opus-4-7", "Claude Opus 4.7", "Stricter instruction-following, xhigh effort, larger vision.", "opus", 1_000_000, 1, 5.0, 25.0, 0.5, 1, 5),
         ("anthropic", "claude-opus-4-6", "Claude Opus 4.6", "Maximum intelligence. Deep reasoning.", "opus", 1_000_000, 1, 5.0, 25.0, 0.5, 1, 10),

--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -270,6 +270,8 @@ class AnalyticsStore:
         # 2026-08-31, then reverts; we seed the durable standard rate (see the
         # RATE_TABLE comment for the rationale).
         ("anthropic", "claude-sonnet-5", "2020-01-01T00:00:00Z", None, 3.00, 15.00, 0.30, "seed"),
+        # Opus 5 (2026-07-24): same durable $5/$25 standard tier as Opus 4.8.
+        ("anthropic", "claude-opus-5", "2020-01-01T00:00:00Z", None, 5.00, 25.00, 0.50, "seed"),
     ]
 
     def _seed_default_pricing(self, conn) -> None:

--- a/src/pinky_daemon/pricing.py
+++ b/src/pinky_daemon/pricing.py
@@ -44,7 +44,7 @@ _M = 1_000_000
 # --------------------------------------------------------------------- #
 
 # Standard Opus tier (4.5 and newer): the price has been flat across
-# 4.5 → 4.6 → 4.7 → 4.8. 1M context is sold at the same per-token price
+# 4.5 → 4.6 → 4.7 → 4.8 → 5. 1M context is sold at the same per-token price
 # as 200K, so no tier split is needed here.
 _OPUS_STD = {
     "input": 5.00,
@@ -131,6 +131,7 @@ _GPT_53_CODEX = {
 RATE_TABLE: dict[str, dict[str, float]] = {
     "claude-fable-5": _FABLE,
     "claude-mythos-5": _FABLE,
+    "claude-opus-5": _OPUS_STD,
     "claude-opus-4-8": _OPUS_STD,
     "claude-opus-4-7": _OPUS_STD,
     "claude-opus-4-6": _OPUS_STD,

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -41,6 +41,7 @@ _1M_MODELS = {
     "claude-opus-4-6",
     "claude-opus-4-7",
     "claude-opus-4-8",
+    "claude-opus-5",
 }
 
 


### PR DESCRIPTION
Registers **`claude-opus-5`** (launched 2026-07-24) as a first-class model across the 4 parity-pinned registry tables, so cost tracking and the 1M-context budget math are correct fleet-wide.

Facts (from anthropic.com/news/claude-opus-5 + platform docs): id `claude-opus-5`, 1M context, 128k max output, $5/$25 in/out, cache-read $0.5, effort defaults `high`, adaptive thinking, knowledge cutoff May 2026.

### Changes (6 insertions, 1 comment update — 4 files)
- `agent_registry.py` `_MODEL_SEEDS` — opus tier, 1M ctx, is_1m=1, $5/$25/$0.5, sort=2 (after Mythos, before Opus 4.8).
- `analytics_store.py` `_LATEST_PRICING_ADDITIONS` — seed row $5/$25/$0.5.
- `pricing.py` `RATE_TABLE` — `_OPUS_STD` tier (+ comment `4.5→…→4.8→5`).
- `streaming_session.py` `_1M_MODELS` — add `claude-opus-5` (1M native).

New row (not a value change), so no `_CONTEXT_CORRECTIONS`/`_PRICE_CORRECTIONS` entry needed — reaches deployed DBs via `INSERT OR IGNORE` on the next daemon restart.

### Review + verification
- **Murzik formal exact review: PASS, no findings** — bound to `1b9b5f0e5a454c963efafb1422f4cf315d9d75a7` / tree `43817d23cc739ac2a120d6db6236f658f7bbe263` / parent `5b33a6e` (tagged 26.07.016).
- Independent re-verify on the exact SHA: parity tests 3/3 PASS (`seed_pricing_matches_rate_table`, `anthropic_seed_prices_match_pricing_rate_table`, `1m_models_set_matches_registry_is_1m`); 4 affected-module test files 207/207 PASS; ruff + diff-check clean.
- Merge is conflict-free: the only main-advance since the base (`#903`) touches none of the 4 files.

Context: Chekov (Pi) is already switched to `claude-opus-5` and running on it; this PR makes his cost/1M-budget tracking accurate (was booting freeform → $0 cost, 200k-assumed budget). Task #437.

🤖 Opened by Barsik