### PR TITLE
Fix context restart acknowledgment and stale respawns

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -8848,16 +8848,22 @@ npm run build</pre>
         )
         return {"reacted": True}
 
-    _context_restarts_inflight: set[str] = set()
+    _context_restarts_inflight: dict[str, object] = {}
     _context_restart_tasks: set[asyncio.Task[None]] = set()
-    # Private test reach-in for cancellation/overlap-guard regressions.
+    # Private test reach-in for cancellation/generation-guard regressions.
     app.state._context_restarts_inflight = _context_restarts_inflight
     app.state._context_restart_tasks = _context_restart_tasks
+
+    def _release_context_restart(name: str, token: object) -> None:
+        """Release the reservation only while ``token`` still owns it."""
+        if _context_restarts_inflight.get(name) is token:
+            del _context_restarts_inflight[name]
 
     async def _restart_streaming_session_after_response(
         name: str,
         ss,
         old_resume_handle: str,
+        restart_token: object,
     ) -> None:
         """Run a restart handed off after the acknowledgement send returns."""
         try:
@@ -8927,7 +8933,7 @@ npm run build</pre>
                     f"api: post-response context restart failed for {name}: {e}"
                 )
         finally:
-            _context_restarts_inflight.discard(name)
+            _release_context_restart(name, restart_token)
 
     @app.post("/agents/{name}/streaming/restart")
     async def restart_streaming_session(
@@ -8952,7 +8958,8 @@ npm run build</pre>
 
         old_resume_handle = ss.resume_handle
         old_turns = ss._stats["turns"]
-        _context_restarts_inflight.add(name)
+        restart_token = object()
+        _context_restarts_inflight[name] = restart_token
 
         def _schedule_restart() -> None:
             task = asyncio.create_task(
@@ -8960,6 +8967,7 @@ npm run build</pre>
                     name,
                     ss,
                     old_resume_handle,
+                    restart_token,
                 )
             )
             _context_restart_tasks.add(task)
@@ -8968,14 +8976,15 @@ npm run build</pre>
                 _context_restart_tasks.discard(done_task)
                 # Fallback for cancellation before the coroutine executes its
                 # first instruction (and therefore before its ``finally`` can
-                # run).  ``discard`` is idempotent with helper-side cleanup.
-                _context_restarts_inflight.discard(name)
+                # run).  Token ownership prevents an old callback from
+                # releasing a newer restart generation's reservation.
+                _release_context_restart(name, restart_token)
 
             task.add_done_callback(_restart_done)
 
         request.scope[_RESPONSE_SENT_HANDOFF_SCOPE_KEY] = {
             "schedule": _schedule_restart,
-            "abandon": lambda: _context_restarts_inflight.discard(name),
+            "abandon": lambda: _release_context_restart(name, restart_token),
         }
 
         return {

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -30,6 +30,7 @@ from types import SimpleNamespace
 from typing import Any, Literal
 
 from fastapi import (
+    BackgroundTasks,
     FastAPI,
     HTTPException,
     Request,
@@ -178,6 +179,12 @@ from pinky_daemon.wake_prompt import WakeReason
 
 # Feature flag: shared MCP mode uses a single HTTP/SSE server instead of per-agent stdio
 SHARED_MCP_ENABLED = os.environ.get("PINKY_SHARED_MCP", "0") == "1"
+
+# ``BackgroundTasks`` starts after a route response enters Starlette's
+# middleware channel, which can still precede the outer socket write when
+# BaseHTTPMiddleware is stacked.  Give the local loopback response a short
+# flush window before context_restart tears down its own MCP transport.
+CONTEXT_RESTART_ACK_DELAY_SEC = 0.25
 
 try:
     from pinky_memory.store import ReflectionStore
@@ -8793,24 +8800,22 @@ npm run build</pre>
         )
         return {"reacted": True}
 
-    @app.post("/agents/{name}/streaming/restart")
-    async def restart_streaming_session(name: str):
-        """Restart an agent's streaming session — fresh context, new CC session."""
-        ss = broker._get_streaming_session(name)
-        if not ss:
-            raise HTTPException(404, f"No streaming session for '{name}'")
+    _context_restarts_inflight: set[str] = set()
 
-        # #149 P1: restart relaunches the transport — guard before we disconnect,
-        # so a blocked (e.g. relabeled unix_user) agent isn't torn down then left
-        # down. An unrunnable isolation_mode means "do not (re)spawn".
-        _enforce_isolation_runnable(name)
+    async def _restart_streaming_session_after_response(
+        name: str,
+        ss,
+        old_resume_handle: str,
+    ) -> None:
+        """Run a context restart only after its acknowledgement is sent.
 
-        guard = _get_streaming_restart_guard(name, ss)
-        if not guard["restart_safe"]:
-            raise HTTPException(409, guard["message"])
-
-        old_resume_handle = ss.resume_handle
-        old_turns = ss._stats["turns"]
+        ``context_restart`` is invoked over the same MCP transport this
+        teardown replaces.  Running disconnect inline severs that transport
+        before the caller can receive the RPC result, so Starlette schedules
+        this coroutine as a response background task.  The short delay also
+        lets stacked HTTP middleware flush the body to the loopback caller.
+        """
+        await asyncio.sleep(CONTEXT_RESTART_ACK_DELAY_SEC)
 
         # #667 diag: capture pre-restart live-session state so an orphan that's
         # recovered by this (often EXTERNAL) restart isn't a black box. The
@@ -8828,31 +8833,37 @@ npm run build</pre>
         except Exception:
             pass
 
-        # Disconnect and clear persisted resume handle
-        await ss.disconnect()
-        agents.set_streaming_session_id(name, "", label="main")
-
-        # Refresh wake context and reconnect fresh
-        _refresh_streaming_launch_config(name, ss)
-        ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
-        ss._config.resume_handle = ""
-        ss._config.restart_reason = "context_restart"
-        # PR for #543: explicit launch-behavior contract — the next
-        # transport spawn must NOT resume the prior conversation. For
-        # SDK this is implicit (resume_handle="" already accomplishes
-        # it), but tmux ``_build_claude_cmd`` checks transcript existence
-        # only and would silently re-apply ``--continue`` unless this
-        # flag is set. One-shot: consumed by the transport on the next
-        # launch and reset to False.
-        ss._config.force_fresh_context_once = True
-        ss.resume_handle = ""
-        # Codex sessions track the thread_id separately on the session object;
-        # clear it too or `codex exec resume <stale-id>` keeps firing next turn.
-        if hasattr(ss, "codex_session_id"):
-            if ss.codex_session_id:
-                _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
-            ss.codex_session_id = ""
         try:
+            # Arm fresh-launch intent BEFORE disconnect.  If a broker/watchdog
+            # wake races the teardown's transient DEAD state, its launch must
+            # inherit the force-fresh contract rather than resume the old
+            # transcript.
+            _refresh_streaming_launch_config(name, ss)
+            ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
+            ss._config.resume_handle = ""
+            ss._config.restart_reason = "context_restart"
+            # PR for #543: explicit launch-behavior contract — the next
+            # transport spawn must NOT resume the prior conversation. For
+            # SDK this is implicit (resume_handle="" already accomplishes
+            # it), but tmux ``_build_claude_cmd`` checks transcript existence
+            # only and would silently re-apply ``--continue`` unless this
+            # flag is set. One-shot: consumed by the transport on the next
+            # successful launch.
+            ss._config.force_fresh_context_once = True
+            ss.resume_handle = ""
+            # Codex sessions track the thread_id separately on the session
+            # object; clear it too or `codex exec resume <stale-id>` keeps
+            # firing next turn.
+            if hasattr(ss, "codex_session_id"):
+                if ss.codex_session_id:
+                    _log(
+                        f"api: clearing stale codex thread "
+                        f"{ss.codex_session_id[:12]} for {name}"
+                    )
+                ss.codex_session_id = ""
+
+            await ss.disconnect()
+            agents.set_streaming_session_id(name, "", label="main")
             await ss.connect()
             _log(f"api: streaming session restarted for {name}")
             activity.log(name, "context_restart", f"{name} context restarted")
@@ -8864,10 +8875,44 @@ npm run build</pre>
             )
         except Exception as e:
             broker.unregister_streaming(name)
-            raise HTTPException(500, f"Failed to restart: {e}")
+            _log(f"api: post-response context restart failed for {name}: {e}")
+        finally:
+            _context_restarts_inflight.discard(name)
+
+    @app.post("/agents/{name}/streaming/restart")
+    async def restart_streaming_session(
+        name: str,
+        background_tasks: BackgroundTasks,
+    ):
+        """Schedule a fresh-context restart after acknowledging its caller."""
+        ss = broker._get_streaming_session(name)
+        if not ss:
+            raise HTTPException(404, f"No streaming session for '{name}'")
+
+        # #149 P1: restart relaunches the transport — guard before scheduling
+        # teardown, so a blocked (e.g. relabeled unix_user) agent isn't accepted
+        # then left down. An unrunnable isolation_mode means "do not (re)spawn".
+        _enforce_isolation_runnable(name)
+
+        guard = _get_streaming_restart_guard(name, ss)
+        if not guard["restart_safe"]:
+            raise HTTPException(409, guard["message"])
+        if name in _context_restarts_inflight:
+            raise HTTPException(409, "Context restart already in progress")
+
+        old_resume_handle = ss.resume_handle
+        old_turns = ss._stats["turns"]
+        _context_restarts_inflight.add(name)
+        background_tasks.add_task(
+            _restart_streaming_session_after_response,
+            name,
+            ss,
+            old_resume_handle,
+        )
 
         return {
-            "restarted": True,
+            "accepted": True,
+            "restart_scheduled": True,
             "agent": name,
             "old_session_id": old_resume_handle[:12] if old_resume_handle else "",
             "old_turns": old_turns,

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -30,7 +30,6 @@ from types import SimpleNamespace
 from typing import Any, Literal
 
 from fastapi import (
-    BackgroundTasks,
     FastAPI,
     HTTPException,
     Request,
@@ -180,11 +179,7 @@ from pinky_daemon.wake_prompt import WakeReason
 # Feature flag: shared MCP mode uses a single HTTP/SSE server instead of per-agent stdio
 SHARED_MCP_ENABLED = os.environ.get("PINKY_SHARED_MCP", "0") == "1"
 
-# ``BackgroundTasks`` starts after a route response enters Starlette's
-# middleware channel, which can still precede the outer socket write when
-# BaseHTTPMiddleware is stacked.  Give the local loopback response a short
-# flush window before context_restart tears down its own MCP transport.
-CONTEXT_RESTART_ACK_DELAY_SEC = 0.25
+_RESPONSE_SENT_HANDOFF_SCOPE_KEY = "pinky.response_sent_handoff"
 
 try:
     from pinky_memory.store import ReflectionStore
@@ -196,6 +191,59 @@ except ImportError:
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
+
+
+class _ResponseSentHandoffMiddleware:
+    """Run a registered handoff only after the outer response send returns.
+
+    Route-level ``BackgroundTasks`` run behind Starlette's internal
+    ``BaseHTTPMiddleware`` memory channel.  A final body can therefore be
+    queued there while an outer middleware or ASGI server is still sending it.
+    This pure-ASGI middleware is installed last (outermost in the FastAPI
+    middleware stack), so awaiting its downstream ``send`` includes every
+    stacked middleware and the server-facing send call.
+
+    A route registers ``schedule`` and ``abandon`` callbacks in its mutable
+    request scope.  ``schedule`` is called only after the final body send
+    returns.  If the response never reaches that point, ``abandon`` releases
+    any reservation the route made before returning.
+    """
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_handoff(message) -> None:
+            await send(message)
+            if (
+                message["type"] != "http.response.body"
+                or message.get("more_body", False)
+            ):
+                return
+
+            handoff = scope.pop(_RESPONSE_SENT_HANDOFF_SCOPE_KEY, None)
+            if handoff is None:
+                return
+            try:
+                handoff["schedule"]()
+                # Let the independently owned handoff task start before this
+                # request unwinds.  It was created only after ``send`` returned,
+                # so this yield cannot move teardown ahead of acknowledgement.
+                await asyncio.sleep(0)
+            except Exception as exc:
+                handoff["abandon"]()
+                _log(f"api: response-sent handoff scheduling failed: {exc}")
+
+        try:
+            await self.app(scope, receive, send_with_handoff)
+        finally:
+            handoff = scope.pop(_RESPONSE_SENT_HANDOFF_SCOPE_KEY, None)
+            if handoff is not None:
+                handoff["abandon"]()
 
 
 def _agent_is_dreamer(agent) -> bool:
@@ -8801,88 +8849,90 @@ npm run build</pre>
         return {"reacted": True}
 
     _context_restarts_inflight: set[str] = set()
+    _context_restart_tasks: set[asyncio.Task[None]] = set()
+    # Private test reach-in for cancellation/overlap-guard regressions.
+    app.state._context_restarts_inflight = _context_restarts_inflight
+    app.state._context_restart_tasks = _context_restart_tasks
 
     async def _restart_streaming_session_after_response(
         name: str,
         ss,
         old_resume_handle: str,
     ) -> None:
-        """Run a context restart only after its acknowledgement is sent.
-
-        ``context_restart`` is invoked over the same MCP transport this
-        teardown replaces.  Running disconnect inline severs that transport
-        before the caller can receive the RPC result, so Starlette schedules
-        this coroutine as a response background task.  The short delay also
-        lets stacked HTTP middleware flush the body to the loopback caller.
-        """
-        await asyncio.sleep(CONTEXT_RESTART_ACK_DELAY_SEC)
-
-        # #667 diag: capture pre-restart live-session state so an orphan that's
-        # recovered by this (often EXTERNAL) restart isn't a black box. The
-        # connected/state fields distinguish a connected-but-MCP-wedged orphan
-        # from a disconnected-dead one — the open question from the 2026-06-02
-        # power-loss incident. Fail-safe: never block a restart on diagnostics.
+        """Run a restart handed off after the acknowledgement send returns."""
         try:
-            _st = ss.stats if hasattr(ss, "stats") else {}
-            _log(
-                f"#667 diag: pre-restart state for {name}: "
-                f"transport={type(ss).__name__} state={_st.get('state')!r} "
-                f"connected={_st.get('connected')} turns={_st.get('turns')} "
-                f"resume_handle={'set' if old_resume_handle else 'empty'}"
-            )
-        except Exception:
-            pass
+            # #667 diag: capture pre-restart live-session state so an orphan
+            # recovered by this restart isn't a black box. Diagnostics are
+            # deliberately inside the cleanup-safe lifetime: cancellation at
+            # any point must release the overlap reservation.
+            try:
+                _st = ss.stats if hasattr(ss, "stats") else {}
+                _log(
+                    f"#667 diag: pre-restart state for {name}: "
+                    f"transport={type(ss).__name__} state={_st.get('state')!r} "
+                    f"connected={_st.get('connected')} turns={_st.get('turns')} "
+                    f"resume_handle={'set' if old_resume_handle else 'empty'}"
+                )
+            except Exception:
+                pass
 
-        try:
-            # Arm fresh-launch intent BEFORE disconnect.  If a broker/watchdog
-            # wake races the teardown's transient DEAD state, its launch must
-            # inherit the force-fresh contract rather than resume the old
-            # transcript.
-            _refresh_streaming_launch_config(name, ss)
-            ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
-            ss._config.resume_handle = ""
-            ss._config.restart_reason = "context_restart"
-            # PR for #543: explicit launch-behavior contract — the next
-            # transport spawn must NOT resume the prior conversation. For
-            # SDK this is implicit (resume_handle="" already accomplishes
-            # it), but tmux ``_build_claude_cmd`` checks transcript existence
-            # only and would silently re-apply ``--continue`` unless this
-            # flag is set. One-shot: consumed by the transport on the next
-            # successful launch.
-            ss._config.force_fresh_context_once = True
-            ss.resume_handle = ""
-            # Codex sessions track the thread_id separately on the session
-            # object; clear it too or `codex exec resume <stale-id>` keeps
-            # firing next turn.
-            if hasattr(ss, "codex_session_id"):
-                if ss.codex_session_id:
-                    _log(
-                        f"api: clearing stale codex thread "
-                        f"{ss.codex_session_id[:12]} for {name}"
-                    )
-                ss.codex_session_id = ""
+            try:
+                # Arm fresh-launch intent BEFORE disconnect.  If a
+                # broker/watchdog wake races the teardown's transient DEAD
+                # state, its launch must inherit the force-fresh contract
+                # rather than resume the old transcript.
+                _refresh_streaming_launch_config(name, ss)
+                ss._config.wake_context = _build_streaming_wake_context(
+                    name, commit=False
+                )
+                ss._config.resume_handle = ""
+                ss._config.restart_reason = "context_restart"
+                # PR for #543: explicit launch-behavior contract — the next
+                # transport spawn must NOT resume the prior conversation.
+                ss._config.force_fresh_context_once = True
+                ss.resume_handle = ""
+                # Codex sessions track thread_id separately on the session.
+                if hasattr(ss, "codex_session_id"):
+                    if ss.codex_session_id:
+                        _log(
+                            f"api: clearing stale codex thread "
+                            f"{ss.codex_session_id[:12]} for {name}"
+                        )
+                    ss.codex_session_id = ""
 
-            await ss.disconnect()
-            agents.set_streaming_session_id(name, "", label="main")
-            await ss.connect()
-            _log(f"api: streaming session restarted for {name}")
-            activity.log(name, "context_restart", f"{name} context restarted")
-            session_event_store.log(
-                session_id=ss.id,
-                agent_name=name,
-                event_type="context_restart",
-                metadata={"label": "main", "old_session_id": old_resume_handle[:12] if old_resume_handle else ""},
-            )
-        except Exception as e:
-            broker.unregister_streaming(name)
-            _log(f"api: post-response context restart failed for {name}: {e}")
+                await ss.disconnect()
+                agents.set_streaming_session_id(name, "", label="main")
+                await ss.connect()
+                _log(f"api: streaming session restarted for {name}")
+                activity.log(
+                    name, "context_restart", f"{name} context restarted"
+                )
+                session_event_store.log(
+                    session_id=ss.id,
+                    agent_name=name,
+                    event_type="context_restart",
+                    metadata={
+                        "label": "main",
+                        "old_session_id": (
+                            old_resume_handle[:12] if old_resume_handle else ""
+                        ),
+                    },
+                )
+            except asyncio.CancelledError:
+                _log(f"api: post-response context restart cancelled for {name}")
+                raise
+            except Exception as e:
+                broker.unregister_streaming(name)
+                _log(
+                    f"api: post-response context restart failed for {name}: {e}"
+                )
         finally:
             _context_restarts_inflight.discard(name)
 
     @app.post("/agents/{name}/streaming/restart")
     async def restart_streaming_session(
         name: str,
-        background_tasks: BackgroundTasks,
+        request: Request,
     ):
         """Schedule a fresh-context restart after acknowledging its caller."""
         ss = broker._get_streaming_session(name)
@@ -8903,12 +8953,30 @@ npm run build</pre>
         old_resume_handle = ss.resume_handle
         old_turns = ss._stats["turns"]
         _context_restarts_inflight.add(name)
-        background_tasks.add_task(
-            _restart_streaming_session_after_response,
-            name,
-            ss,
-            old_resume_handle,
-        )
+
+        def _schedule_restart() -> None:
+            task = asyncio.create_task(
+                _restart_streaming_session_after_response(
+                    name,
+                    ss,
+                    old_resume_handle,
+                )
+            )
+            _context_restart_tasks.add(task)
+
+            def _restart_done(done_task: asyncio.Task[None]) -> None:
+                _context_restart_tasks.discard(done_task)
+                # Fallback for cancellation before the coroutine executes its
+                # first instruction (and therefore before its ``finally`` can
+                # run).  ``discard`` is idempotent with helper-side cleanup.
+                _context_restarts_inflight.discard(name)
+
+            task.add_done_callback(_restart_done)
+
+        request.scope[_RESPONSE_SENT_HANDOFF_SCOPE_KEY] = {
+            "schedule": _schedule_restart,
+            "abandon": lambda: _context_restarts_inflight.discard(name),
+        }
 
         return {
             "accepted": True,
@@ -12116,5 +12184,10 @@ npm run build</pre>
         _log("voice: WS endpoint registered at /ws/voice/{id}")
     except ImportError:
         pass
+
+    # Installed last so this pure-ASGI layer wraps every BaseHTTPMiddleware
+    # registered above.  Its final-body ``send`` return is the deterministic
+    # response-delivery barrier used by context_restart.
+    app.add_middleware(_ResponseSentHandoffMiddleware)
 
     return app

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -111,6 +111,14 @@ DEFAULT_CONTEXT_NUDGE_THRESHOLD_PCT = 35.0
 # stable fan-out envelope. Keep the fleet cap explicit in every tmux launch.
 DEFAULT_MAX_CONCURRENT_SUBAGENTS = 6
 
+# A successful force-fresh launch can be followed by delayed watchdog/broker
+# wakes that still see the old transcript on disk.  Keep those respawns fresh
+# long enough to cover the scheduler's five-attempt resurrection burst
+# (30-second ticks).  The first completed replacement turn clears it sooner;
+# otherwise it remains deliberately bounded so legitimate warm-wake-after-
+# crash returns to normal ``--continue`` behavior.
+FRESH_CONTEXT_RESPAWN_GRACE_SEC = 180.0
+
 # ──────────────────────────────────────────────────────────────────────────
 # Tmux subprocess control
 # ──────────────────────────────────────────────────────────────────────────
@@ -1307,6 +1315,9 @@ class TmuxSession:
         self._last_launch_used_continue: bool = False
         self._last_launch_forced_fresh: bool = False
         self._last_launch_had_prior_transcript: bool = False
+        self._last_launch_force_fresh_once: bool = False
+        self._last_launch_in_fresh_grace: bool = False
+        self._fresh_context_respawn_grace_until: float = 0.0
 
         # Issue #563 — "first transcript bind" tracking. Set to True in
         # ``_start_tailer`` after the tailer is constructed; consumed
@@ -2769,8 +2780,15 @@ class TmuxSession:
         # and rolled back the whole launch. The invariant pinned here:
         # the flag remains set until launch (REPL + tailer) succeeds
         # as a complete unit.
-        if self._last_launch_forced_fresh:
+        if self._last_launch_force_fresh_once:
             self._config.force_fresh_context_once = False
+            self._fresh_context_respawn_grace_until = (
+                time.monotonic() + FRESH_CONTEXT_RESPAWN_GRACE_SEC
+            )
+            _log(
+                f"tmux[{self.agent_name}]: armed post-fresh respawn grace "
+                f"for {FRESH_CONTEXT_RESPAWN_GRACE_SEC:.0f}s"
+            )
 
         # Auth-relay (#205): if enabled + configured, start a flag-gated
         # background watcher that detects the claude OAuth login wall and relays
@@ -2884,11 +2902,15 @@ class TmuxSession:
         ``config.force_fresh_context_once = True``. This launch will
         skip ``--continue`` even when a prior transcript exists,
         producing a fresh Claude Code session. The flag is one-shot —
-        consumed here and reset to False so the next spawn behaves
-        normally. This is a separate contract from ``restart_reason``,
-        which controls the wake-prompt TEXT; coupling them was the
-        root cause of #543 (tmux context_restart silently resumed the
-        old transcript because we only checked transcript existence).
+        consumed only after the complete REPL + tailer boot succeeds.
+        That successful boot also arms a bounded grace period: subsequent
+        respawns remain fresh until the replacement's first completed turn
+        (or grace expiry), so a delayed warm wake cannot resume the stale
+        pre-restart transcript. This is a separate contract from
+        ``restart_reason``, which controls the wake-prompt TEXT; coupling
+        them was the root cause of #543 (tmux context_restart silently
+        resumed the old transcript because we only checked transcript
+        existence).
         """
         # Resolve launch mode. The flag is one-shot ("next launch only,"
         # not "every launch from now on") but consumption happens in
@@ -2899,7 +2921,13 @@ class TmuxSession:
         # ``--continue`` while still emitting context_restart wake copy.
         # By deferring the consume, a retry sees the flag still set
         # and honors it again. See ``_spawn_tmux_repl`` for the clear.
-        force_fresh = bool(getattr(self._config, "force_fresh_context_once", False))
+        force_fresh_once = bool(
+            getattr(self._config, "force_fresh_context_once", False)
+        )
+        in_fresh_grace = (
+            time.monotonic() < self._fresh_context_respawn_grace_until
+        )
+        force_fresh = force_fresh_once or in_fresh_grace
         has_prior = self._has_prior_transcript()
         use_continue = has_prior and not force_fresh
 
@@ -2909,6 +2937,8 @@ class TmuxSession:
         self._last_launch_used_continue = use_continue
         self._last_launch_forced_fresh = force_fresh
         self._last_launch_had_prior_transcript = has_prior
+        self._last_launch_force_fresh_once = force_fresh_once
+        self._last_launch_in_fresh_grace = in_fresh_grace
 
         parts = ["claude"]
         if use_continue:
@@ -2967,6 +2997,7 @@ class TmuxSession:
             f"tmux[{self.agent_name}]: claude_cmd_built "
             f"mode={'continue' if use_continue else 'fresh'} "
             f"force_fresh={force_fresh} "
+            f"fresh_grace={in_fresh_grace} "
             f"prior_transcript={has_prior}"
         )
         return cmd
@@ -4376,6 +4407,16 @@ class TmuxSession:
         # PostToolUse finish-POST). Clear them here so the next turn's wedge
         # verdict can't be spuriously extended by a stale entry.
         self._inflight_tool_calls.clear()
+        if self._fresh_context_respawn_grace_until:
+            grace_was_active = (
+                time.monotonic() < self._fresh_context_respawn_grace_until
+            )
+            self._fresh_context_respawn_grace_until = 0.0
+            if grace_was_active:
+                _log(
+                    f"tmux[{self.agent_name}]: first post-fresh turn "
+                    f"completed; respawn grace ended"
+                )
         if not self._inflight_metas:
             # No meta to pop. Stop hook arrived without a dispatch
             # behind it — most commonly an AUTONOMOUS turn (background-

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -888,6 +888,12 @@ class _InflightMeta:
     # this turn's paste time regardless of write lag. Both None ⇒ fall back to wedged.
     transcript_mtime_at_paste: float | None = None
     paste_succeeded_at: float | None = None
+    # Non-zero only for turns delivered during the active post-fresh lineage.
+    # A completion may end ``_fresh_context_respawn_grace_until`` only when
+    # this epoch matches the session's active epoch.  This prevents an
+    # autonomous/stale Stop hook (or any pre-fresh metadata) from reopening
+    # ``--continue`` before the replacement turn completes.
+    fresh_context_epoch: int = 0
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -1318,6 +1324,8 @@ class TmuxSession:
         self._last_launch_force_fresh_once: bool = False
         self._last_launch_in_fresh_grace: bool = False
         self._fresh_context_respawn_grace_until: float = 0.0
+        self._fresh_context_respawn_epoch_seq: int = 0
+        self._fresh_context_respawn_epoch: int = 0
 
         # Issue #563 — "first transcript bind" tracking. Set to True in
         # ``_start_tailer`` after the tailer is constructed; consumed
@@ -2782,6 +2790,8 @@ class TmuxSession:
         # as a complete unit.
         if self._last_launch_force_fresh_once:
             self._config.force_fresh_context_once = False
+            self._fresh_context_respawn_epoch_seq += 1
+            self._fresh_context_respawn_epoch = self._fresh_context_respawn_epoch_seq
             self._fresh_context_respawn_grace_until = (
                 time.monotonic() + FRESH_CONTEXT_RESPAWN_GRACE_SEC
             )
@@ -4407,16 +4417,6 @@ class TmuxSession:
         # PostToolUse finish-POST). Clear them here so the next turn's wedge
         # verdict can't be spuriously extended by a stale entry.
         self._inflight_tool_calls.clear()
-        if self._fresh_context_respawn_grace_until:
-            grace_was_active = (
-                time.monotonic() < self._fresh_context_respawn_grace_until
-            )
-            self._fresh_context_respawn_grace_until = 0.0
-            if grace_was_active:
-                _log(
-                    f"tmux[{self.agent_name}]: first post-fresh turn "
-                    f"completed; respawn grace ended"
-                )
         if not self._inflight_metas:
             # No meta to pop. Stop hook arrived without a dispatch
             # behind it — most commonly an AUTONOMOUS turn (background-
@@ -4448,6 +4448,22 @@ class TmuxSession:
             return
 
         entry = self._inflight_metas.popleft()
+        if (
+            self._fresh_context_respawn_grace_until
+            and self._fresh_context_respawn_epoch
+            and entry.fresh_context_epoch
+            == self._fresh_context_respawn_epoch
+        ):
+            grace_was_active = (
+                time.monotonic() < self._fresh_context_respawn_grace_until
+            )
+            self._fresh_context_respawn_grace_until = 0.0
+            self._fresh_context_respawn_epoch = 0
+            if grace_was_active:
+                _log(
+                    f"tmux[{self.agent_name}]: first correlated post-fresh "
+                    f"turn completed; respawn grace ended"
+                )
         # Unblock any wait_for_completion caller for THIS entry's turn
         # before the awaitable callbacks run — keeps the caller's wakeup
         # tight (no waiting on conversation_store / response_callback /
@@ -6458,6 +6474,7 @@ class TmuxSession:
             turn=turn,
             transcript_mtime_at_paste=_tmtime_at_paste,
             paste_succeeded_at=_paste_succeeded_at,
+            fresh_context_epoch=self._fresh_context_respawn_epoch,
         ))
         # Watchdog head-clock. If this entry just became the head (deque
         # was empty before append), start its timeout window NOW. If

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -1168,7 +1168,10 @@ def create_server(
 
         old_id = result.get("old_session_id", "")
         old_turns = result.get("old_turns", 0)
-        return f"Context restarted. Previous session: {old_id} ({old_turns} turns). Fresh context ready."
+        return (
+            f"Context restart accepted. Previous session: {old_id} "
+            f"({old_turns} turns). Teardown will begin after this response."
+        )
 
     # ── Heartbeat ──────────────────────────────────────────
     # Note: agent-initiated `request_sleep` tool was removed in #552.

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -1165,6 +1165,14 @@ def create_server(
         result = _api("POST", f"/agents/{agent_name}/streaming/restart")
         if "error" in result:
             return f"Restart failed: {result.get('error', 'unknown')}"
+        if (
+            result.get("accepted") is not True
+            or result.get("restart_scheduled") is not True
+        ):
+            return (
+                "Restart failed: daemon did not confirm accepted=true and "
+                "restart_scheduled=true"
+            )
 
         old_id = result.get("old_session_id", "")
         old_turns = result.get("old_turns", 0)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1945,6 +1945,107 @@ class TestAPI:
                 assert retry.status_code == 200
                 assert retry.json()["restart_scheduled"] is True
 
+    def test_streaming_restart_late_done_callback_keeps_next_generation_guard(self):
+        """A's late done callback cannot release B's overlap reservation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post(
+                    "/agents",
+                    json={"name": "test-agent", "model": "sonnet"},
+                )
+                fake = self._FakeStreamingSession("test-agent", "main")
+                app.state.broker.register_streaming(
+                    "test-agent", fake, label="main"
+                )
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="Testing restart-generation ownership",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.resume_handle,
+                )
+                fake.last_active = time.time()
+
+                restart_endpoint = next(
+                    route.endpoint
+                    for route in app.routes
+                    if getattr(route, "path", None)
+                    == "/agents/{name}/streaming/restart"
+                )
+                b_accepted = threading.Event()
+                b_helper_blocked = threading.Event()
+                b_result = []
+                gates = []
+
+                async def run_queued_b():
+                    await gates[0].wait()
+                    scope = {"type": "http"}
+                    result = await restart_endpoint(
+                        name="test-agent",
+                        request=SimpleNamespace(scope=scope),
+                    )
+                    handoff = scope["pinky.response_sent_handoff"]
+                    handoff["schedule"]()
+                    b_result.append(result)
+                    b_accepted.set()
+
+                async def prime_queued_b():
+                    gates.extend((asyncio.Event(), asyncio.Event()))
+                    asyncio.create_task(run_queued_b())
+
+                client.portal.call(prime_queued_b)
+
+                async def interleaved_disconnect():
+                    fake.disconnect_calls += 1
+                    fake._state = fake._TS.DEAD
+                    if fake.disconnect_calls == 2:
+                        b_helper_blocked.set()
+                        await gates[1].wait()
+
+                async def interleaved_connect():
+                    fake.connect_calls += 1
+                    fake._state = fake._TS.CONNECTED
+                    if fake.connect_calls == 1:
+                        # Wake the already-queued B endpoint task.  B's wakeup
+                        # is queued before helper A completes and queues its
+                        # task-done callback.
+                        gates[0].set()
+
+                fake.disconnect = interleaved_disconnect
+                fake.connect = interleaved_connect
+
+                try:
+                    first = client.post(
+                        "/agents/test-agent/streaming/restart"
+                    )
+                    assert first.status_code == 200
+                    assert b_accepted.wait(timeout=2.0)
+                    assert b_result[0]["accepted"] is True
+                    assert b_result[0]["old_session_id"] == ""
+                    assert b_helper_blocked.wait(timeout=2.0)
+
+                    guard_for_b_present = client.portal.call(
+                        lambda: "test-agent"
+                        in app.state._context_restarts_inflight
+                    )
+                    third = client.post(
+                        "/agents/test-agent/streaming/restart"
+                    )
+
+                    assert guard_for_b_present is True
+                    assert third.status_code == 409
+                    assert "already in progress" in third.text
+                    assert fake.disconnect_calls == 2
+                finally:
+                    async def release_helpers():
+                        for gate in gates:
+                            gate.set()
+                        while app.state._context_restart_tasks:
+                            await asyncio.sleep(0)
+
+                    client.portal.call(release_helpers)
+
     def test_streaming_restart_clears_codex_session_id_on_codex_sessions(self):
         """Codex sessions track thread_id in `codex_session_id`; restart must clear it
         or the next turn will run `codex exec resume <stale-id>` and fail."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sqlite3
 import sys
 import tempfile
+import threading
 import time
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -1805,28 +1807,34 @@ class TestAPI:
                 assert fake.connect_calls == 1
 
     def test_streaming_restart_acks_before_teardown(self):
-        """The response body must leave the ASGI app before disconnect starts.
+        """Disconnect waits for a delayed outermost ASGI send to return.
 
         ``context_restart`` rides the MCP connection owned by the session being
         replaced.  Inline teardown closes that connection and turns every
-        otherwise-successful tool call into MCP -32000.
+        otherwise-successful tool call into MCP -32000.  A delay outside the
+        complete FastAPI/BaseHTTPMiddleware stack reproduces Murzik's
+        body-queued-but-not-delivered adversarial case.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             response_complete = False
+            delay_outer_send = False
 
             async def observed_app(scope, receive, send):
                 if scope["type"] != "http":
                     return await app(scope, receive, send)
 
                 async def observed_send(message):
-                    nonlocal response_complete
-                    await send(message)
-                    if (
+                    nonlocal response_complete, delay_outer_send
+                    is_final_body = (
                         message["type"] == "http.response.body"
                         and not message.get("more_body", False)
-                    ):
+                    )
+                    if is_final_body and delay_outer_send:
+                        await asyncio.sleep(0.75)
+                    await send(message)
+                    if is_final_body:
                         response_complete = True
 
                 return await app(scope, receive, observed_send)
@@ -1849,20 +1857,93 @@ class TestAPI:
                 fake.last_active = time.time()
 
                 disconnect_observations = []
+                disconnect_started = threading.Event()
                 original_disconnect = fake.disconnect
 
                 async def observed_disconnect():
                     disconnect_observations.append(response_complete)
+                    disconnect_started.set()
                     await original_disconnect()
 
                 fake.disconnect = observed_disconnect
                 response_complete = False
+                delay_outer_send = True
 
                 resp = client.post("/agents/test-agent/streaming/restart")
 
                 assert resp.status_code == 200
                 assert resp.json()["restart_scheduled"] is True
+                assert disconnect_started.wait(timeout=2.0)
                 assert disconnect_observations == [True]
+
+    def test_streaming_restart_cancellation_releases_overlap_guard(self):
+        """Cancellation anywhere in the helper cannot poison later restarts."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                client.post(
+                    "/agents",
+                    json={"name": "test-agent", "model": "sonnet"},
+                )
+                fake = self._FakeStreamingSession("test-agent", "main")
+                app.state.broker.register_streaming(
+                    "test-agent", fake, label="main"
+                )
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="Testing cancellation-safe restart",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.resume_handle,
+                )
+                fake.last_active = time.time()
+
+                disconnect_entered = threading.Event()
+                original_disconnect = fake.disconnect
+
+                async def blocking_disconnect():
+                    fake.disconnect_calls += 1
+                    disconnect_entered.set()
+                    await asyncio.Event().wait()
+
+                fake.disconnect = blocking_disconnect
+                resp = client.post("/agents/test-agent/streaming/restart")
+
+                assert resp.status_code == 200
+                assert disconnect_entered.wait(timeout=2.0)
+                task_box = []
+                client.portal.call(
+                    lambda: task_box.append(
+                        next(iter(app.state._context_restart_tasks))
+                    )
+                )
+                task = task_box[0]
+                task_done = threading.Event()
+                client.portal.call(
+                    lambda: task.add_done_callback(lambda _: task_done.set())
+                )
+                client.portal.call(task.cancel)
+                assert task_done.wait(timeout=2.0)
+                assert client.portal.call(
+                    lambda: "test-agent"
+                    not in app.state._context_restarts_inflight
+                )
+
+                # Restore a healthy transport/save binding and prove the next
+                # valid request is accepted rather than permanently 409'd.
+                fake.disconnect = original_disconnect
+                fake.resume_handle = "test-agent-main-sdk"
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="Testing cancellation-safe retry",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.resume_handle,
+                )
+                fake.last_active = time.time()
+
+                retry = client.post("/agents/test-agent/streaming/restart")
+                assert retry.status_code == 200
+                assert retry.json()["restart_scheduled"] is True
 
     def test_streaming_restart_clears_codex_session_id_on_codex_sessions(self):
         """Codex sessions track thread_id in `codex_session_id`; restart must clear it

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1800,9 +1800,69 @@ class TestAPI:
 
                 resp = client.post("/agents/test-agent/streaming/restart")
                 assert resp.status_code == 200
-                assert resp.json()["restarted"] is True
+                assert resp.json()["restart_scheduled"] is True
                 assert fake.disconnect_calls == 1
                 assert fake.connect_calls == 1
+
+    def test_streaming_restart_acks_before_teardown(self):
+        """The response body must leave the ASGI app before disconnect starts.
+
+        ``context_restart`` rides the MCP connection owned by the session being
+        replaced.  Inline teardown closes that connection and turns every
+        otherwise-successful tool call into MCP -32000.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            app = self._make_app(db_path)
+            response_complete = False
+
+            async def observed_app(scope, receive, send):
+                if scope["type"] != "http":
+                    return await app(scope, receive, send)
+
+                async def observed_send(message):
+                    nonlocal response_complete
+                    await send(message)
+                    if (
+                        message["type"] == "http.response.body"
+                        and not message.get("more_body", False)
+                    ):
+                        response_complete = True
+
+                return await app(scope, receive, observed_send)
+
+            with TestClient(observed_app) as client:
+                client.post(
+                    "/agents",
+                    json={"name": "test-agent", "model": "sonnet"},
+                )
+                fake = self._FakeStreamingSession("test-agent", "main")
+                app.state.broker.register_streaming(
+                    "test-agent", fake, label="main"
+                )
+                app.state.agents.set_context(
+                    "test-agent",
+                    task="Testing post-response restart",
+                    metadata={"source": "save_my_context"},
+                    updated_by=fake.resume_handle,
+                )
+                fake.last_active = time.time()
+
+                disconnect_observations = []
+                original_disconnect = fake.disconnect
+
+                async def observed_disconnect():
+                    disconnect_observations.append(response_complete)
+                    await original_disconnect()
+
+                fake.disconnect = observed_disconnect
+                response_complete = False
+
+                resp = client.post("/agents/test-agent/streaming/restart")
+
+                assert resp.status_code == 200
+                assert resp.json()["restart_scheduled"] is True
+                assert disconnect_observations == [True]
 
     def test_streaming_restart_clears_codex_session_id_on_codex_sessions(self):
         """Codex sessions track thread_id in `codex_session_id`; restart must clear it
@@ -1827,7 +1887,7 @@ class TestAPI:
 
                 resp = client.post("/agents/test-agent/streaming/restart")
                 assert resp.status_code == 200
-                assert resp.json()["restarted"] is True
+                assert resp.json()["restart_scheduled"] is True
                 assert fake.codex_session_id == "", (
                     "codex_session_id must be cleared so next turn does not "
                     "issue `codex exec resume <stale-id>`"

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -436,6 +436,7 @@ class TestCheckForUpdates:
 class TestContextRestart:
     def test_restart_success(self, srv):
         with _ok({
+            "accepted": True,
             "restart_scheduled": True,
             "old_session_id": "barsik-main",
             "old_turns": 42,
@@ -447,7 +448,24 @@ class TestContextRestart:
     def test_restart_error(self, srv):
         with _ok({"error": "no session to restart"}):
             result = _tools(srv)["context_restart"]()
-        assert isinstance(result, str)
+        assert result.startswith("Restart failed:")
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            {},
+            {"accepted": False, "restart_scheduled": True},
+            {"accepted": True, "restart_scheduled": False},
+            {"accepted": True},
+            {"restart_scheduled": True},
+            {"accepted": 1, "restart_scheduled": True},
+            {"accepted": True, "restart_scheduled": "true"},
+        ],
+    )
+    def test_restart_requires_complete_positive_contract(self, srv, response):
+        with _ok(response):
+            result = _tools(srv)["context_restart"]()
+        assert result.startswith("Restart failed:")
 
 
 # ── get_agent_card ────────────────────────────────────────────────────────────

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -435,9 +435,14 @@ class TestCheckForUpdates:
 
 class TestContextRestart:
     def test_restart_success(self, srv):
-        with _ok({"old_session_id": "barsik-main", "old_turns": 42}):
+        with _ok({
+            "restart_scheduled": True,
+            "old_session_id": "barsik-main",
+            "old_turns": 42,
+        }):
             result = _tools(srv)["context_restart"]()
-        assert "restarted" in result.lower() or "42" in result
+        assert "accepted" in result.lower()
+        assert "after this response" in result.lower()
 
     def test_restart_error(self, srv):
         with _ok({"error": "no session to restart"}):

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -6426,6 +6426,61 @@ class TestForceFreshContextOnce:
         cmd = ss._build_claude_cmd()
         assert "--continue" in cmd
 
+    @pytest.mark.asyncio
+    async def test_successful_force_fresh_boot_arms_respawn_grace(self):
+        ss, _ = _make_session()
+        ss._has_prior_transcript = lambda: True
+        ss._config.force_fresh_context_once = True
+
+        await ss.connect()
+        try:
+            assert ss._config.force_fresh_context_once is False
+            assert (
+                ss._fresh_context_respawn_grace_until > _time.monotonic()
+            )
+        finally:
+            await ss.disconnect()
+
+    def test_respawn_grace_suppresses_continue(self, monkeypatch):
+        ss, _ = _make_session()
+        ss._has_prior_transcript = lambda: True
+        monkeypatch.setattr(
+            "pinky_daemon.tmux_session.time.monotonic",
+            lambda: 100.0,
+        )
+        ss._fresh_context_respawn_grace_until = 150.0
+
+        cmd = ss._build_claude_cmd()
+
+        assert "--continue" not in cmd
+        assert ss._last_launch_forced_fresh is True
+        assert ss._last_launch_in_fresh_grace is True
+
+    def test_respawn_after_grace_uses_legit_warm_continue(self, monkeypatch):
+        ss, _ = _make_session()
+        ss._has_prior_transcript = lambda: True
+        monkeypatch.setattr(
+            "pinky_daemon.tmux_session.time.monotonic",
+            lambda: 151.0,
+        )
+        ss._fresh_context_respawn_grace_until = 150.0
+
+        cmd = ss._build_claude_cmd()
+
+        assert "--continue" in cmd
+        assert ss._last_launch_forced_fresh is False
+        assert ss._last_launch_in_fresh_grace is False
+
+    @pytest.mark.asyncio
+    async def test_first_post_fresh_turn_ends_respawn_grace(self):
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        ss._fresh_context_respawn_grace_until = _time.monotonic() + 180.0
+        _seed_inflight(ss, internal=True)
+
+        await ss._handle_turn_complete(_turn_response(text="wake complete"))
+
+        assert ss._fresh_context_respawn_grace_until == 0.0
+
 
 class TestWakePromptEnqueueOnConnect:
     """Wake-prompt assembly + enqueue is the parent defect from #543.

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -46,6 +46,7 @@ def _seed_inflight(
     internal: bool = False,
     completion_event: asyncio.Event | None = None,
     prompt: str = "",
+    fresh_context_epoch: int = 0,
 ) -> _InflightMeta:
     """Append one ``_InflightMeta`` entry to ``ss._inflight_metas``.
 
@@ -74,6 +75,7 @@ def _seed_inflight(
         internal=internal,
         dispatched_at=_time.time(),
         turn=synthetic_turn,
+        fresh_context_epoch=fresh_context_epoch,
     )
     was_empty = not ss._inflight_metas
     ss._inflight_metas.append(entry)
@@ -6438,6 +6440,7 @@ class TestForceFreshContextOnce:
             assert (
                 ss._fresh_context_respawn_grace_until > _time.monotonic()
             )
+            assert ss._fresh_context_respawn_epoch > 0
         finally:
             await ss.disconnect()
 
@@ -6475,11 +6478,50 @@ class TestForceFreshContextOnce:
     async def test_first_post_fresh_turn_ends_respawn_grace(self):
         ss, _ = _make_session(state=SessionState.CONNECTED)
         ss._fresh_context_respawn_grace_until = _time.monotonic() + 180.0
-        _seed_inflight(ss, internal=True)
+        ss._fresh_context_respawn_epoch = 7
+        _seed_inflight(ss, internal=True, fresh_context_epoch=7)
 
         await ss._handle_turn_complete(_turn_response(text="wake complete"))
 
         assert ss._fresh_context_respawn_grace_until == 0.0
+        assert ss._fresh_context_respawn_epoch == 0
+
+    def test_delivered_replacement_turn_captures_active_fresh_epoch(self):
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        ss._fresh_context_respawn_epoch = 7
+
+        ss._finish_turn_delivery(
+            _QueuedTurn(prompt="replacement wake", internal=True)
+        )
+
+        assert ss._inflight_metas[0].fresh_context_epoch == 7
+
+    @pytest.mark.asyncio
+    async def test_uncorrelated_empty_stop_hook_does_not_end_respawn_grace(self):
+        """An autonomous/stale Stop hook has no replacement-turn correlation."""
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        grace_until = _time.monotonic() + 180.0
+        ss._fresh_context_respawn_grace_until = grace_until
+        ss._fresh_context_respawn_epoch = 7
+
+        await ss._handle_turn_complete(_turn_response(text="stale completion"))
+
+        assert ss._fresh_context_respawn_grace_until == grace_until
+        assert ss._fresh_context_respawn_epoch == 7
+
+    @pytest.mark.asyncio
+    async def test_prefresh_inflight_completion_does_not_end_respawn_grace(self):
+        """Even a queued meta must carry the active post-fresh epoch."""
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        grace_until = _time.monotonic() + 180.0
+        ss._fresh_context_respawn_grace_until = grace_until
+        ss._fresh_context_respawn_epoch = 7
+        _seed_inflight(ss, internal=True, fresh_context_epoch=6)
+
+        await ss._handle_turn_complete(_turn_response(text="old completion"))
+
+        assert ss._fresh_context_respawn_grace_until == grace_until
+        assert ss._fresh_context_respawn_epoch == 7
 
 
 class TestWakePromptEnqueueOnConnect:


### PR DESCRIPTION
Fixes #908.

## What changed

- Hand off context teardown only after the outermost final response-body `send` returns. A pure-ASGI outer layer now observes the server-facing send barrier; the restart task is not created while the acknowledgement is merely queued inside stacked `BaseHTTPMiddleware`.
- Require the tool-side complete positive contract: `accepted is True` and `restart_scheduled is True`. Missing, false, partial, or wrong-typed responses fail closed.
- Keep the complete restart helper, including diagnostics and teardown, inside cleanup-safe `try/finally` ownership. Cancellation releases the overlap reservation, with a task-done fallback for cancellation before first coroutine execution.
- Give each accepted restart an opaque ownership token. Helper cleanup, the task-done fallback, and handoff abandonment release the name-keyed reservation only while their own generation still owns it, so a late callback cannot clear a newer restart's guard.
- Arm `force_fresh_context_once` before disconnect so a teardown-time broker/watchdog wake cannot resume the stale transcript.
- Add a tmux post-fresh respawn grace: for up to 180 seconds after a complete force-fresh REPL + tailer boot, subsequent respawns stay fresh instead of using `--continue`. Grace ends early only when an in-flight replacement turn carrying the active post-fresh epoch completes; autonomous/stale Stop hooks and pre-fresh metadata cannot clear it.
- Reject overlapping direct context-restart requests while one is scheduled or in progress.

## Root cause and impact

The restart endpoint previously awaited `disconnect()` before returning. Because `context_restart` rides the MCP transport owned by that same session, teardown severed the RPC and callers saw MCP `-32000` whether the restart succeeded or failed. Moving teardown to a route-level background task with a fixed delay was still insufficient: Starlette can start that task after the body is queued in an internal middleware channel but before an outer ASGI/socket send completes.

The replacement uses the return of the outermost final-body send as the deterministic delivery barrier, then transfers restart ownership to an independent cleanup-safe task. Reservation cleanup is generation-owned: an old helper's queued done callback is harmless after a newer endpoint call reserves the same agent name. Separately, the one-shot force-fresh flag was consumed after the first successful boot, so a delayed warm respawn could immediately select `--continue` from the still-present pre-restart transcript and restore the old context window. The bounded, epoch-correlated grace keeps recovery launches fresh without disabling legitimate later warm recovery.

## Five-respawn investigation

The exact five-attempt shape strongly correlates with `AgentScheduler.RESURRECTION_MAX_ATTEMPTS = 5`: dead-heartbeat handling retries on 30-second scheduler ticks, up to five attempts in a one-hour window. The per-session inflight watchdog, by contrast, schedules one `force_restart` and returns, so it cannot alone produce a sequential five-launch cluster.

I did not disable or no-op the scheduler recovery lane because a session repeatedly reaching `DEAD` may be a genuine crash and #868/#869 require that warm recovery remain available. The grace makes every retry in that burst fresh until the replacement transcript is established. This change does not damp the five-attempt driver itself. If TOD still churns after deployment, follow-up work should correlate the affected line ranges with `scheduler: resurrection attempt N/5` and instrument respawn trigger IDs; that will distinguish dead-heartbeat resurrection from another external wake source without weakening crash recovery.

## Validation

- `PINKY_DREAM_TRANSPORT=sdk PINKY_SHARED_MCP=0 uv run pytest -q tests/test_api.py` — 381 passed
- `PINKY_DREAM_TRANSPORT=sdk PINKY_SHARED_MCP=0 uv run pytest -q tests/test_tmux_session.py tests/test_pinky_self_tools.py` — 535 passed (340 tmux + 195 pinky-self)
- Focused round-1 adversarial selection — 24 passed, including a 750 ms outer-send delay, cancellation followed by a second accepted restart, fail-closed absent/false/partial/wrong-type contracts, and stale/empty Stop-hook grace preservation
- Round-2 A/B/C generation interleaving — failed on the frozen round-2 head with B's guard absent and C accepted while B's helper was blocked; passed after token-owned cleanup, together with the acknowledgement and cancellation focus cases
- `uv run pytest -q tests/test_broker.py -k reconnect` — 3 passed
- `uv run ruff check .` — passed
- `git diff --check` — passed
- Complete base delta remains exactly six implementation/test files; no tool was added or removed, so there is no registry-set ripple.

Unit/offline tests only. No daemon kickstart/restart, live verification, merge, release, or deployment was performed.