### PR TITLE
Add login-wall fleet fallback (Phase 1)

### DIFF
--- a/specs/login-wall-fallback.md
+++ b/specs/login-wall-fallback.md
@@ -6,10 +6,12 @@
 
 Phase 1 turns a silent shared-credential outage into an actionable owner page:
 
-1. The session watchdog captures active tmux panes through each
-   `TmuxSession`'s existing `_TmuxControl`. That preserves the daemon's normal
-   command runner and socket plumbing on every host; the detector does not
-   invoke `nsenter` or construct a second tmux path.
+1. The session watchdog captures active `runtime=claude_sdk`,
+   `transport=tmux` panes through each `TmuxSession`'s existing
+   `_TmuxControl`. Codex-over-tmux is not a Claude credential-fleet member.
+   The existing control preserves the daemon's normal command runner and
+   socket plumbing on every host; the detector does not invoke `nsenter` or
+   construct a second tmux path.
 2. A pane is login-walled when its joined capture contains
    `Paste code here if prompted` or `Select login method`.
 3. The wall must appear on two samples at least 30 seconds apart. One
@@ -26,6 +28,13 @@ Phase 1 turns a silent shared-credential outage into an actionable owner page:
 A confirmed shared wall plus an unclassifiable shared peer is treated as a
 possible fleet incident and paged. This is intentionally fail-closed: a
 redundant page is safer than another silent fleet outage.
+
+Capture failures retain the agent's already-resolved credential cohort;
+unknown callback failures cannot default into the shared fleet. Once every
+affected active registration is definitively clear (or no longer
+eligible/registered), the Phase 1 incident latch and `#902` hold exemption are
+released. Phase 1 does not restart or delete the preserved pane during that
+re-arm transition.
 
 ## Phase 1 operator completion
 
@@ -49,4 +58,6 @@ or flag the pane for operator review before considering recovery complete.
 Automatic owner-reply correlation, literal `send-keys -l` code injection,
 success verification, orphan cleanup, onboarding repair, and serialized
 fleet restart are explicitly deferred. No Phase 2 auto-paste path is enabled
-by this detector.
+by this detector. In particular, current `claude.com/cai` URLs are accepted
+only by the Phase 1 notification extractor and are excluded from the legacy
+flag-gated reply/paste watcher.

--- a/specs/login-wall-fallback.md
+++ b/specs/login-wall-fallback.md
@@ -1,0 +1,52 @@
+# Login-wall fleet fallback (#916)
+
+**Status:** Phase 1 · **Owner:** Barsik · **Reviewer:** Murzik
+
+## Scope
+
+Phase 1 turns a silent shared-credential outage into an actionable owner page:
+
+1. The session watchdog captures active tmux panes through each
+   `TmuxSession`'s existing `_TmuxControl`. That preserves the daemon's normal
+   command runner and socket plumbing on every host; the detector does not
+   invoke `nsenter` or construct a second tmux path.
+2. A pane is login-walled when its joined capture contains
+   `Paste code here if prompted` or `Select login method`.
+3. The wall must appear on two samples at least 30 seconds apart. One
+   confirmed agent produces a per-agent warning. At least two confirmed
+   agents in the shared-refresh-file cohort produce a fleet incident.
+4. Before the fleet page, the watchdog renames one positive session from
+   `pinky-<agent>` to `login-hold-<agent>`. The rename removes that pane from
+   normal supervisor targeting and preserves the OAuth PKCE state.
+5. The watchdog recaptures the held pane with `capture-pane -p -J`, extracts
+   its full `https://claude.com/cai/oauth/authorize?...` URL, and sends it
+   through the existing owner-notification destinations. The owner is asked
+   to reply with the exact `code#state` string.
+
+A confirmed shared wall plus an unclassifiable shared peer is treated as a
+possible fleet incident and paged. This is intentionally fail-closed: a
+redundant page is safer than another silent fleet outage.
+
+## Phase 1 operator completion
+
+Phase 1 does not consume or paste the owner's reply. An operator must enter
+the returned `code#state` string into the frozen pane without shell
+interpretation (the `#` is part of the value), verify that Claude reports a
+successful login, then restart the affected agents serially.
+
+Do not restart immediately after the login completes. Current Claude Code
+builds can rewrite `~/.claude.json` and remove both
+`hasCompletedOnboarding` and `lastOnboardingVersion`. Restore both onboarding
+markers before restarting the fleet, or valid credentials can still leave
+every pane at the onboarding wizard.
+
+Large resumed sessions can also stop at the post-boot
+resume-from-summary dialog. Select the recommended option (normally Enter)
+or flag the pane for operator review before considering recovery complete.
+
+## Deferred Phase 2
+
+Automatic owner-reply correlation, literal `send-keys -l` code injection,
+success verification, orphan cleanup, onboarding repair, and serialized
+fleet restart are explicitly deferred. No Phase 2 auto-paste path is enabled
+by this detector.

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -144,9 +144,12 @@ from pinky_daemon.research_store import ResearchStore
 from pinky_daemon.scheduler import AgentScheduler
 from pinky_daemon.session_store import SessionEventStore, SessionStore
 from pinky_daemon.session_watchdog import (
+    FrozenLoginPane,
+    LoginWallProbe,
     SessionWatchdog,
     WatchdogConfig,
     compute_mcp_checkable,
+    pane_has_login_wall,
 )
 from pinky_daemon.sessions import (
     SessionManager,
@@ -10418,6 +10421,11 @@ npm run build</pre>
             or agent.transport != "tmux"
         ):
             return None
+        # #916 deliberately removes the preserved OAuth pane from its expected
+        # ``pinky-<agent>`` name. Do not mis-page that intentional hold as the
+        # #902 dead-registered failure class on the next sweep.
+        if watchdog.is_login_hold(agent_name):
+            return None
         tmux = getattr(session, "_tmux", None)
         has_session = getattr(tmux, "has_session", None)
         if not callable(has_session):
@@ -10430,6 +10438,98 @@ npm run build</pre>
             or f"pinky-{agent_name}"
         )
         return bool(await has_session()), session_name
+
+    async def _watchdog_login_wall_probe(
+        agent_name: str,
+        label: str,
+        session: Any,
+    ) -> LoginWallProbe | None:
+        """Capture and classify one eligible pane through its tmux plumbing."""
+        agent = agents.get(agent_name)
+        if (
+            not agent
+            or not agent.enabled
+            or agent.status != "active"
+            or agent.transport != "tmux"
+        ):
+            return None
+        tmux = getattr(session, "_tmux", None)
+        capture_pane = getattr(tmux, "capture_pane", None)
+        if not callable(capture_pane):
+            raise RuntimeError(
+                f"active tmux transport {agent_name}/{label} has no tmux control"
+            )
+        session_name = (
+            str(getattr(tmux, "session_name", "") or "")
+            or str(getattr(session, "_session_name", "") or "")
+            or f"pinky-{agent_name}"
+        )
+        # Resolve the credential cohort before capture so even a failed command
+        # is classified correctly for fail-closed fleet handling.
+        from pinky_daemon.tmux_session import _claude_auth_mode
+
+        shared_credentials = (
+            _claude_auth_mode(agent_name) == "shared_refresh_file"
+        )
+        result = await capture_pane(lines=200, join=True)
+        if not result.ok:
+            return LoginWallProbe(
+                wall=None,
+                session_name=session_name,
+                shared_credentials=shared_credentials,
+                error=(
+                    result.stderr.strip()
+                    or f"capture-pane exited {result.returncode}"
+                )[:300],
+            )
+        pane_text = result.stdout or ""
+        return LoginWallProbe(
+            wall=pane_has_login_wall(pane_text),
+            pane_text=pane_text,
+            session_name=session_name,
+            shared_credentials=shared_credentials,
+        )
+
+    async def _watchdog_login_wall_freeze(
+        agent_name: str,
+        label: str,
+        session: Any,
+    ) -> FrozenLoginPane:
+        """Rename one positive pane first, then recapture its joined OAuth URL."""
+        tmux = getattr(session, "_tmux", None)
+        rename_session = getattr(tmux, "rename_session", None)
+        capture_pane = getattr(tmux, "capture_pane", None)
+        if not callable(rename_session) or not callable(capture_pane):
+            raise RuntimeError(
+                f"active tmux transport {agent_name}/{label} lacks freeze plumbing"
+            )
+        safe_agent = re.sub(r"[^A-Za-z0-9_.-]", "-", agent_name)
+        hold_session_name = f"login-hold-{safe_agent}"
+        rename_result = await rename_session(hold_session_name)
+        if not rename_result.ok:
+            detail = (
+                rename_result.stderr.strip()
+                or f"rename-session exited {rename_result.returncode}"
+            )
+            raise RuntimeError(detail[:300])
+
+        capture_result = await capture_pane(
+            lines=200,
+            join=True,
+            target_session=hold_session_name,
+        )
+        if capture_result.ok:
+            return FrozenLoginPane(
+                hold_session_name=hold_session_name,
+                pane_text=capture_result.stdout or "",
+            )
+        return FrozenLoginPane(
+            hold_session_name=hold_session_name,
+            capture_error=(
+                capture_result.stderr.strip()
+                or f"capture-pane exited {capture_result.returncode}"
+            )[:300],
+        )
 
     def _watchdog_mcp_bind_status(agent_name: str) -> dict:
         """Bind-status for the watchdog's #663 MCP-recover check.
@@ -10544,6 +10644,8 @@ npm run build</pre>
         mcp_bind_status_fn=_watchdog_mcp_bind_status,
         mcp_recover_fn=_watchdog_mcp_recover,
         tmux_liveness_fn=_watchdog_tmux_liveness,
+        login_wall_probe_fn=_watchdog_login_wall_probe,
+        login_wall_freeze_fn=_watchdog_login_wall_freeze,
     )
     # Test/diagnostic reach-in, matching app.state.broker/agents.
     app.state.watchdog = watchdog

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -10446,19 +10446,19 @@ npm run build</pre>
     ) -> LoginWallProbe | None:
         """Capture and classify one eligible pane through its tmux plumbing."""
         agent = agents.get(agent_name)
+        agent_runtime = str(
+            getattr(agent, "runtime", "") or "claude_sdk"
+        ).strip()
         if (
             not agent
             or not agent.enabled
             or agent.status != "active"
+            or agent_runtime != "claude_sdk"
             or agent.transport != "tmux"
         ):
             return None
         tmux = getattr(session, "_tmux", None)
         capture_pane = getattr(tmux, "capture_pane", None)
-        if not callable(capture_pane):
-            raise RuntimeError(
-                f"active tmux transport {agent_name}/{label} has no tmux control"
-            )
         session_name = (
             str(getattr(tmux, "session_name", "") or "")
             or str(getattr(session, "_session_name", "") or "")
@@ -10471,7 +10471,25 @@ npm run build</pre>
         shared_credentials = (
             _claude_auth_mode(agent_name) == "shared_refresh_file"
         )
-        result = await capture_pane(lines=200, join=True)
+        if not callable(capture_pane):
+            return LoginWallProbe(
+                wall=None,
+                session_name=session_name,
+                shared_credentials=shared_credentials,
+                error=(
+                    f"active Claude tmux transport {agent_name}/{label} "
+                    "has no tmux control"
+                ),
+            )
+        try:
+            result = await capture_pane(lines=200, join=True)
+        except Exception as exc:
+            return LoginWallProbe(
+                wall=None,
+                session_name=session_name,
+                shared_credentials=shared_credentials,
+                error=f"{type(exc).__name__}: {exc}"[:300],
+            )
         if not result.ok:
             return LoginWallProbe(
                 wall=None,

--- a/src/pinky_daemon/auth_relay.py
+++ b/src/pinky_daemon/auth_relay.py
@@ -34,13 +34,17 @@ from typing import Awaitable, Callable, Optional
 
 # ── Pure extractors (no daemon deps — trivially unit-testable) ───────────────
 
-# claude prints an absolute https URL on claude.ai, claude.com, or
-# console.anthropic.com. Current Claude Code builds use
-# ``https://claude.com/cai/oauth/authorize?...`` (#916).
+# Phase 1 detection accepts the current ``claude.com/cai`` URL in addition to
+# the older hosts. The legacy reply/paste relay intentionally uses the narrower
+# regex below: #916 must not make a new URL shape reachable by that Phase 2
+# mutation path.
 # ``[^\s'"]+`` stops at whitespace/quotes; with a ``-J`` (join-wrapped) capture
 # the long URL is contiguous, but we also de-wrap defensively below.
 _OAUTH_URL_RE = re.compile(
     r"https://(?:claude\.ai|claude\.com|console\.anthropic\.com)/[^\s'\"<>]+"
+)
+_RELAY_OAUTH_URL_RE = re.compile(
+    r"https://(?:claude\.ai|console\.anthropic\.com)/[^\s'\"<>]+"
 )
 
 # A pasted login code is a long URL-safe token, optionally ``<code>#<state>``.
@@ -61,6 +65,21 @@ def extract_oauth_url(pane_text: str) -> Optional[str]:
     if not pane_text:
         return None
     m = _OAUTH_URL_RE.search(pane_text)
+    if not m:
+        return None
+    return "".join(m.group(0).split())
+
+
+def extract_relay_oauth_url(pane_text: str) -> Optional[str]:
+    """Return only an OAuth URL supported by the legacy reply/paste relay.
+
+    Current ``claude.com/cai`` URLs belong to the #916 Phase 1 notification
+    lane. Keeping this extractor separate prevents the older flag-gated watcher
+    from opening reply correlation and pasting owner input for that URL shape.
+    """
+    if not pane_text:
+        return None
+    m = _RELAY_OAUTH_URL_RE.search(pane_text)
     if not m:
         return None
     return "".join(m.group(0).split())

--- a/src/pinky_daemon/auth_relay.py
+++ b/src/pinky_daemon/auth_relay.py
@@ -34,11 +34,13 @@ from typing import Awaitable, Callable, Optional
 
 # ── Pure extractors (no daemon deps — trivially unit-testable) ───────────────
 
-# claude prints an absolute https URL on claude.ai / console.anthropic.com.
+# claude prints an absolute https URL on claude.ai, claude.com, or
+# console.anthropic.com. Current Claude Code builds use
+# ``https://claude.com/cai/oauth/authorize?...`` (#916).
 # ``[^\s'"]+`` stops at whitespace/quotes; with a ``-J`` (join-wrapped) capture
 # the long URL is contiguous, but we also de-wrap defensively below.
 _OAUTH_URL_RE = re.compile(
-    r"https://(?:claude\.ai|console\.anthropic\.com)/[^\s'\"<>]+"
+    r"https://(?:claude\.ai|claude\.com|console\.anthropic\.com)/[^\s'\"<>]+"
 )
 
 # A pasted login code is a long URL-safe token, optionally ``<code>#<state>``.

--- a/src/pinky_daemon/session_watchdog.py
+++ b/src/pinky_daemon/session_watchdog.py
@@ -18,6 +18,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine
 
+from pinky_daemon.auth_relay import extract_oauth_url
 from pinky_daemon.transport_state import SessionState
 from pinky_daemon.watchdog_log import log_watchdog_decision
 
@@ -88,6 +89,21 @@ DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER = 60
 # out across adjacent 60s sweeps therefore produces one page, while a genuinely
 # new outage after a stable recovery still alerts.
 DEFAULT_TMUX_LIVENESS_REARM_AFTER = 300  # 5 min continuously healthy
+# #916: a login wall must persist across two samples separated by this interval.
+# The normal watchdog sweep is 60s, but keeping the policy explicit makes faster
+# test/canary intervals safe.
+DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER = 30
+DEFAULT_LOGIN_WALL_NOTIFY_RETRY_AFTER = 60
+LOGIN_WALL_SIGNATURES = (
+    "Paste code here if prompted",
+    "Select login method",
+)
+
+
+def pane_has_login_wall(pane_text: str) -> bool:
+    """Return True when a joined tmux capture contains a stable login-wall cue."""
+    folded = pane_text.casefold()
+    return any(signature.casefold() in folded for signature in LOGIN_WALL_SIGNATURES)
 
 
 def compute_mcp_checkable(
@@ -254,6 +270,66 @@ class _TmuxLivenessState:
     last_checked_at: float = 0.0
 
 
+@dataclass(frozen=True)
+class LoginWallProbe:
+    """One daemon-plumbing observation of an eligible tmux pane (#916).
+
+    ``wall=None`` means the pane could not be classified. It is deliberately
+    distinct from ``False``: uncertainty must not erase a previously confirmed
+    auth outage.
+    """
+
+    wall: bool | None
+    pane_text: str = ""
+    session_name: str = ""
+    shared_credentials: bool = True
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class FrozenLoginPane:
+    """Result of renaming one positively walled pane, then recapturing it."""
+
+    hold_session_name: str
+    pane_text: str = ""
+    capture_error: str = ""
+
+
+@dataclass
+class _LoginWallAgentState:
+    """Debounce and delivery state for one positively observed pane."""
+
+    first_seen_at: float = 0.0
+    last_seen_at: float = 0.0
+    confirmed: bool = False
+    session_name: str = ""
+    pane_text: str = ""
+    url: str = ""
+    shared_credentials: bool = True
+    label: str = ""
+    session: Any = None
+    single_notified: bool = False
+    single_last_notify_attempt_at: float = 0.0
+    single_notification_attempts: int = 0
+
+
+@dataclass
+class _LoginWallIncident:
+    """One fleet-level login-wall incident, including the preserved OAuth pane."""
+
+    agents: tuple[str, ...] = ()
+    uncertain_agents: tuple[str, ...] = ()
+    hold_agent: str = ""
+    hold_session_name: str = ""
+    url: str = ""
+    message: str = ""
+    freeze_succeeded: bool = False
+    freeze_error: str = ""
+    notified: bool = False
+    last_notify_attempt_at: float = 0.0
+    notification_attempts: int = 0
+
+
 class SessionWatchdog:
     """Background service that detects and recovers stuck streaming sessions."""
 
@@ -269,6 +345,14 @@ class SessionWatchdog:
         tmux_liveness_fn: Callable[
             [str, str, Any],
             Coroutine[Any, Any, bool | tuple[bool, str] | None],
+        ] | None = None,
+        login_wall_probe_fn: Callable[
+            [str, str, Any],
+            Coroutine[Any, Any, LoginWallProbe | None],
+        ] | None = None,
+        login_wall_freeze_fn: Callable[
+            [str, str, Any],
+            Coroutine[Any, Any, FrozenLoginPane],
         ] | None = None,
         check_interval: int = DEFAULT_CHECK_INTERVAL,
     ) -> None:
@@ -295,6 +379,16 @@ class SessionWatchdog:
                 tmux-transport agent. ``None`` skips non-tmux agents. Detection
                 is alert-only; this callback is never used to respawn or
                 otherwise mutate a session.
+            login_wall_probe_fn:
+                ``async (agent_name, label, session) -> LoginWallProbe | None``.
+                Uses the session's already-selected tmux control/command runner
+                to capture and classify the pane. ``None`` skips ineligible
+                agents; ``probe.wall=None`` is a fail-closed uncertainty.
+            login_wall_freeze_fn:
+                ``async (agent_name, label, session) -> FrozenLoginPane``.
+                Renames one positively walled tmux session before recapturing
+                its URL. It is called once per fleet incident and always before
+                the first owner notification.
             check_interval:
                 Seconds between sweeps.
         """
@@ -307,10 +401,14 @@ class SessionWatchdog:
         self._mcp_bind_status_fn = mcp_bind_status_fn
         self._mcp_recover_fn = mcp_recover_fn
         self._tmux_liveness_fn = tmux_liveness_fn
+        self._login_wall_probe_fn = login_wall_probe_fn
+        self._login_wall_freeze_fn = login_wall_freeze_fn
         self._interval = check_interval
 
         self._states: dict[str, _AgentState] = {}
         self._tmux_liveness_states: dict[str, _TmuxLivenessState] = {}
+        self._login_wall_states: dict[str, _LoginWallAgentState] = {}
+        self._login_wall_incident: _LoginWallIncident | None = None
         self._last_mcp_recover_at: float = 0.0  # global MCP-recover rate-limit
         self._task: asyncio.Task | None = None
         self._running = False
@@ -360,6 +458,9 @@ class SessionWatchdog:
         now = time.time()
         seen_keys: set[tuple[str, str]] = set()
         tmux_checked_agents: set[str] = set()
+        login_wall_checked_agents: set[str] = set()
+        login_wall_probes: dict[str, LoginWallProbe] = {}
+        login_wall_targets: dict[str, tuple[str, Any]] = {}
 
         for agent_name, sessions in list(streaming.items()):
             for label, ss in list(sessions.items()):
@@ -374,6 +475,14 @@ class SessionWatchdog:
                     )
                     if checked:
                         tmux_checked_agents.add(agent_name)
+                if snap.connected and agent_name not in login_wall_checked_agents:
+                    probe = await self._probe_login_wall(
+                        snap, ss,
+                    )
+                    if probe is not None:
+                        login_wall_probes[agent_name] = probe
+                        login_wall_targets[agent_name] = (label, ss)
+                    login_wall_checked_agents.add(agent_name)
                 await self._evaluate(snap, now)
 
         # Clean up state for sessions no longer streaming
@@ -390,6 +499,261 @@ class SessionWatchdog:
                 await self._evaluate_tmux_liveness(
                     agent_name, alive=True, now=now,
                 )
+
+        await self._evaluate_login_walls(
+            login_wall_probes,
+            checked_agents=login_wall_checked_agents,
+            targets=login_wall_targets,
+            now=now,
+        )
+
+    async def _probe_login_wall(
+        self,
+        snap: _SessionSnapshot,
+        ss: Any,
+    ) -> LoginWallProbe | None:
+        """Capture/classify one active registration without bypassing tmux rails."""
+        if self._login_wall_probe_fn is None or not snap.connected:
+            return None
+        try:
+            return await self._login_wall_probe_fn(
+                snap.agent_name, snap.label, ss,
+            )
+        except Exception as exc:
+            _warn(
+                "watchdog login-wall probe failed for %s/%s: %s",
+                snap.agent_name, snap.label, exc,
+            )
+            return LoginWallProbe(
+                wall=None,
+                session_name=f"pinky-{snap.agent_name}",
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+    async def _evaluate_login_walls(
+        self,
+        probes: dict[str, LoginWallProbe],
+        *,
+        checked_agents: set[str],
+        targets: dict[str, tuple[str, Any]],
+        now: float,
+    ) -> None:
+        """Debounce pane walls, distinguish one agent from a fleet, then alert.
+
+        A definitive clear resets that agent's debounce. An uncertain probe
+        preserves prior positive evidence. Once one shared-credential agent is
+        confirmed and a second shared agent is uncertain, fail closed and use
+        the confirmed pane for the fleet hold; the worst outcome is a redundant
+        owner page, while fail-open would repeat #916's silent outage.
+        """
+        for agent_name in checked_agents:
+            probe = probes.get(agent_name)
+            if probe is None:
+                self._login_wall_states.pop(agent_name, None)
+                continue
+            if probe.wall is False:
+                self._login_wall_states.pop(agent_name, None)
+                continue
+            if probe.wall is None:
+                continue
+
+            state = self._login_wall_states.get(agent_name)
+            if state is None:
+                state = _LoginWallAgentState(first_seen_at=now)
+                self._login_wall_states[agent_name] = state
+            state.last_seen_at = now
+            state.session_name = probe.session_name or f"pinky-{agent_name}"
+            state.pane_text = probe.pane_text
+            state.url = extract_oauth_url(probe.pane_text) or state.url
+            state.shared_credentials = probe.shared_credentials
+            # These reach-ins are used only for the one-shot freeze callback in
+            # this process. They are never exposed through status().
+            target = targets.get(agent_name)
+            if target is not None:
+                label, session = target
+                state.label = label
+                state.session = session
+            if (now - state.first_seen_at) >= DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER:
+                state.confirmed = True
+
+        for agent_name in list(self._login_wall_states):
+            if agent_name not in checked_agents:
+                del self._login_wall_states[agent_name]
+
+        if self._login_wall_incident is not None:
+            await self._notify_login_wall_incident(now)
+            return
+
+        confirmed_shared = sorted(
+            agent_name
+            for agent_name, state in self._login_wall_states.items()
+            if state.confirmed and state.shared_credentials
+        )
+        uncertain_shared = sorted(
+            agent_name
+            for agent_name, probe in probes.items()
+            if probe.wall is None
+            and probe.shared_credentials
+            and agent_name not in confirmed_shared
+        )
+        fleet_detected = len(confirmed_shared) >= 2 or (
+            len(confirmed_shared) >= 1 and bool(uncertain_shared)
+        )
+        if fleet_detected:
+            await self._open_login_wall_incident(
+                confirmed_shared,
+                uncertain_agents=uncertain_shared,
+                now=now,
+            )
+            return
+
+        # A lone confirmed wall is a per-agent problem, not a fleet de-auth.
+        # Do not orphan/rename its pane; tell the owner exactly that distinction.
+        for agent_name, state in self._login_wall_states.items():
+            if not state.confirmed or state.single_notified:
+                continue
+            if (
+                state.single_last_notify_attempt_at
+                and (now - state.single_last_notify_attempt_at)
+                < DEFAULT_LOGIN_WALL_NOTIFY_RETRY_AFTER
+            ):
+                continue
+            message = (
+                f"⚠️ Claude login wall detected on {agent_name} across two "
+                f"sightings at least {DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER}s apart. "
+                "No fleet de-auth is confirmed, so no tmux pane was renamed."
+            )
+            if state.url:
+                message += (
+                    f"\n\nLogin link:\n{state.url}\n\n"
+                    "Open the link and approve it, then reply with the exact "
+                    "code#state string. Phase 1 will not paste it automatically."
+                )
+            state.single_last_notify_attempt_at = now
+            state.single_notification_attempts += 1
+            delivered = await self._deliver_login_wall_alert(agent_name, message)
+            if delivered:
+                state.single_notified = True
+
+    async def _open_login_wall_incident(
+        self,
+        confirmed_agents: list[str],
+        *,
+        uncertain_agents: list[str],
+        now: float,
+    ) -> None:
+        """Freeze one confirmed pane, extract its joined URL, then notify."""
+        hold_agent = next(
+            (
+                name for name in confirmed_agents
+                if self._login_wall_states[name].url
+            ),
+            confirmed_agents[0],
+        )
+        state = self._login_wall_states[hold_agent]
+        incident = _LoginWallIncident(
+            agents=tuple(confirmed_agents),
+            uncertain_agents=tuple(uncertain_agents),
+            hold_agent=hold_agent,
+        )
+        self._login_wall_incident = incident
+
+        frozen: FrozenLoginPane | None = None
+        try:
+            if self._login_wall_freeze_fn is None:
+                raise RuntimeError("login-wall freeze callback is not configured")
+            frozen = await self._login_wall_freeze_fn(
+                hold_agent, state.label, state.session,
+            )
+            incident.freeze_succeeded = True
+            incident.hold_session_name = frozen.hold_session_name
+        except Exception as exc:
+            incident.freeze_error = f"{type(exc).__name__}: {exc}"
+            _critical(
+                "watchdog login-wall freeze failed for %s before owner notify: %s",
+                hold_agent, exc,
+            )
+
+        frozen_text = frozen.pane_text if frozen is not None else ""
+        incident.url = extract_oauth_url(frozen_text) or state.url
+        affected = ", ".join(confirmed_agents)
+        if uncertain_agents:
+            affected += (
+                "; additional unclassified agent(s): "
+                + ", ".join(uncertain_agents)
+            )
+        if incident.freeze_succeeded:
+            message = (
+                f"🚨 Fleet Claude login wall detected ({affected}). "
+                f"I froze {hold_agent}'s tmux pane as "
+                f"'{incident.hold_session_name}' before sending this alert, "
+                "preserving its OAuth state."
+            )
+        else:
+            message = (
+                f"🚨 Possible fleet Claude login wall detected ({affected}). "
+                f"The freeze was attempted before this alert but failed "
+                f"({incident.freeze_error}); operator action is required."
+            )
+        if incident.url:
+            message += (
+                f"\n\nLogin link:\n{incident.url}\n\n"
+                "Open the link and approve it, then reply with the exact "
+                "code#state string. Phase 1 will not paste it automatically."
+            )
+        else:
+            message += (
+                "\n\nThe joined pane capture did not yield a login URL. "
+                "Inspect the held pane and notify the owner manually."
+            )
+        incident.message = message
+        _critical(message)
+        await self._notify_login_wall_incident(now)
+
+    async def _notify_login_wall_incident(self, now: float) -> None:
+        incident = self._login_wall_incident
+        if incident is None or incident.notified:
+            return
+        if (
+            incident.last_notify_attempt_at
+            and (now - incident.last_notify_attempt_at)
+            < DEFAULT_LOGIN_WALL_NOTIFY_RETRY_AFTER
+        ):
+            return
+        incident.last_notify_attempt_at = now
+        incident.notification_attempts += 1
+        delivered = await self._deliver_login_wall_alert(
+            incident.hold_agent, incident.message,
+        )
+        if delivered:
+            incident.notified = True
+
+    async def _deliver_login_wall_alert(
+        self,
+        agent_name: str,
+        message: str,
+    ) -> bool:
+        """Deliver through the existing owner-notify callback, fail closed."""
+        if self._alert_fn is None:
+            _warn(
+                "watchdog login-wall alert for %s has no owner alert callback",
+                agent_name,
+            )
+            return False
+        try:
+            return await self._alert_fn(agent_name, message) is True
+        except Exception as exc:
+            _warn("watchdog login-wall alert failed for %s: %s", agent_name, exc)
+            return False
+
+    def is_login_hold(self, agent_name: str) -> bool:
+        """Whether this watchdog intentionally renamed the agent's tmux pane."""
+        incident = self._login_wall_incident
+        return bool(
+            incident
+            and incident.freeze_succeeded
+            and incident.hold_agent == agent_name
+        )
 
     async def _reconcile_tmux_liveness(
         self,
@@ -1004,9 +1368,39 @@ class SessionWatchdog:
             }
             for agent_name, state in self._tmux_liveness_states.items()
         }
+        login_walls = {
+            agent_name: {
+                "first_seen_at": state.first_seen_at,
+                "last_seen_at": state.last_seen_at,
+                "confirmed": state.confirmed,
+                "session_name": state.session_name,
+                "shared_credentials": state.shared_credentials,
+                "url_found": bool(state.url),
+                "single_notification_latched": state.single_notified,
+                "single_notification_attempts": state.single_notification_attempts,
+            }
+            for agent_name, state in self._login_wall_states.items()
+        }
+        incident = self._login_wall_incident
         return {
             "running": self._running,
             "check_interval": self._interval,
             "agents": sessions,  # kept as "agents" for API compat
             "tmux_liveness": tmux_liveness,
+            "login_walls": login_walls,
+            "login_wall_incident": (
+                {
+                    "agents": list(incident.agents),
+                    "uncertain_agents": list(incident.uncertain_agents),
+                    "hold_agent": incident.hold_agent,
+                    "hold_session_name": incident.hold_session_name,
+                    "url_found": bool(incident.url),
+                    "freeze_succeeded": incident.freeze_succeeded,
+                    "freeze_error": incident.freeze_error,
+                    "notification_latched": incident.notified,
+                    "notification_attempts": incident.notification_attempts,
+                }
+                if incident is not None
+                else None
+            ),
         }

--- a/src/pinky_daemon/session_watchdog.py
+++ b/src/pinky_daemon/session_watchdog.py
@@ -527,6 +527,7 @@ class SessionWatchdog:
             return LoginWallProbe(
                 wall=None,
                 session_name=f"pinky-{snap.agent_name}",
+                shared_credentials=False,
                 error=f"{type(exc).__name__}: {exc}",
             )
 
@@ -580,9 +581,30 @@ class SessionWatchdog:
             if agent_name not in checked_agents:
                 del self._login_wall_states[agent_name]
 
-        if self._login_wall_incident is not None:
-            await self._notify_login_wall_incident(now)
-            return
+        incident = self._login_wall_incident
+        if incident is not None:
+            affected = set(incident.agents) | set(incident.uncertain_agents)
+            unresolved = {
+                agent_name
+                for agent_name in affected
+                if agent_name in checked_agents
+                and probes.get(agent_name) is not None
+                and probes[agent_name].wall is not False
+            }
+            if unresolved:
+                await self._notify_login_wall_incident(now)
+                return
+            # Phase 1 never pastes, restarts, or cleans up the preserved pane.
+            # It does need to release its in-process hold once every affected
+            # active registration is definitively normal (or is no longer an
+            # eligible registration). Otherwise #902 is suppressed forever,
+            # including for a later replacement registration with a missing
+            # pane.
+            _log(
+                "watchdog login-wall incident recovered/re-armed for %s",
+                ", ".join(sorted(affected)),
+            )
+            self._login_wall_incident = None
 
         confirmed_shared = sorted(
             agent_name

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -595,6 +595,18 @@ class _TmuxControl:
             return TmuxCommandResult(returncode=0, stdout="", stderr=result.stderr)
         return result
 
+    async def rename_session(self, new_name: str) -> TmuxCommandResult:
+        """Rename the owned session without retargeting this control object.
+
+        #916 uses this as a freeze primitive: the daemon/supervisor continues to
+        look for ``pinky-<agent>`` while the preserved OAuth pane lives under
+        ``login-hold-<agent>``. Keeping ``self.session_name`` unchanged is
+        therefore intentional.
+        """
+        return await self._run(
+            "rename-session", "-t", self.session_name, new_name,
+        )
+
     async def resize_window(
         self, *, cols: int, rows: int,
     ) -> TmuxCommandResult:
@@ -720,7 +732,12 @@ class _TmuxControl:
         return await self._run("send-keys", "-t", self.session_name, "Enter")
 
     async def capture_pane(
-        self, *, lines: int = 200, escapes: bool = False, join: bool = False,
+        self,
+        *,
+        lines: int = 200,
+        escapes: bool = False,
+        join: bool = False,
+        target_session: str = "",
     ) -> TmuxCommandResult:
         """Capture the last ``lines`` lines of the pane's visible content.
 
@@ -741,7 +758,7 @@ class _TmuxControl:
         """
         args = [
             "capture-pane",
-            "-t", self.session_name,
+            "-t", target_session or self.session_name,
             "-p",  # print to stdout instead of paste buffer
         ]
         if escapes:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -69,7 +69,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from pinky_daemon.auth_relay import coordinator as _auth_relay
-from pinky_daemon.auth_relay import extract_oauth_url, looks_like_login_wall
+from pinky_daemon.auth_relay import extract_relay_oauth_url, looks_like_login_wall
 from pinky_daemon.command_runner import (
     CommandRunner,
     ContainerCommandRunner,
@@ -2847,7 +2847,7 @@ class TmuxSession:
                     return
                 res = await self._tmux.capture_pane(lines=40, join=True)
                 text = res.stdout if res.ok and res.stdout else ""
-                url = extract_oauth_url(text)
+                url = extract_relay_oauth_url(text)
                 if url:
                     await self._relay_login_and_inject(url)
                     return

--- a/tests/fixtures/login_wall_paste_code.txt
+++ b/tests/fixtures/login_wall_paste_code.txt
@@ -1,0 +1,6 @@
+Claude Code needs you to finish signing in.
+
+Open this URL in your browser:
+https://claude.com/cai/oauth/authorize?client_id=test-client&code=true&state=fixture-state-123
+
+Paste code here if prompted >

--- a/tests/fixtures/login_wall_select_method.txt
+++ b/tests/fixtures/login_wall_select_method.txt
@@ -1,0 +1,7 @@
+Welcome to Claude Code
+
+Select login method
+  1. Claude account with subscription
+  2. Anthropic Console account
+
+https://claude.com/cai/oauth/authorize?client_id=chooser-client&code=true&state=chooser-state-456

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -683,6 +683,177 @@ class TestAPI:
         )
 
     @pytest.mark.asyncio
+    async def test_codex_tmux_never_joins_or_freezes_claude_login_fleet(
+        self, tmp_path,
+    ):
+        """A signature-positive Codex pane is ineligible for #916."""
+        from pinky_daemon.session_watchdog import (
+            DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER,
+        )
+        from pinky_daemon.tmux_session import TmuxCommandResult
+        from pinky_daemon.transport_state import SessionState as TransportState
+
+        app = self._make_app(str(tmp_path / "test.db"))
+        app.state.agents.register(
+            "alpha-codex",
+            model="gpt-5.6-sol",
+            runtime="codex_cli",
+            transport="tmux",
+            working_dir=str(tmp_path / "alpha-codex"),
+        )
+        app.state.agents.register(
+            "zeta-claude",
+            model="sonnet",
+            runtime="claude_sdk",
+            transport="tmux",
+            working_dir=str(tmp_path / "zeta-claude"),
+        )
+        app.state.agents.set_owner_notification_destinations([
+            {
+                "platform": "telegram",
+                "account_id": "owner-bot",
+                "conversation_id": "owner-chat",
+                "principal_id": "owner",
+            }
+        ])
+        capture = (
+            Path(__file__).parent / "fixtures" / "login_wall_paste_code.txt"
+        ).read_text()
+        ok_capture = TmuxCommandResult(0, capture, "")
+        ok_command = TmuxCommandResult(0, "", "")
+        sessions = {}
+        for agent_name in ("alpha-codex", "zeta-claude"):
+            sessions[agent_name] = SimpleNamespace(
+                state=TransportState.CONNECTED,
+                stats={"state": TransportState.CONNECTED.value},
+                _tmux=SimpleNamespace(
+                    session_name=f"pinky-{agent_name}",
+                    has_session=AsyncMock(return_value=True),
+                    capture_pane=AsyncMock(return_value=ok_capture),
+                    rename_session=AsyncMock(return_value=ok_command),
+                ),
+            )
+            app.state.broker.register_streaming(
+                agent_name, sessions[agent_name], label="main",
+            )
+
+        deliveries = []
+
+        async def _capture(
+            agent_name, platform, chat_id, content, *, account_id="", **kwargs,
+        ):
+            deliveries.append((agent_name, content))
+            return {"sent": True}
+
+        app.state.broker._send_callback = _capture
+        await app.state.watchdog._sweep()
+        app.state.watchdog._login_wall_states[
+            "zeta-claude"
+        ].first_seen_at -= DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER
+        await app.state.watchdog._sweep()
+
+        assert "alpha-codex" not in app.state.watchdog._login_wall_states
+        assert app.state.watchdog._login_wall_incident is None
+        sessions["alpha-codex"]._tmux.capture_pane.assert_not_awaited()
+        sessions["alpha-codex"]._tmux.rename_session.assert_not_awaited()
+        sessions["zeta-claude"]._tmux.rename_session.assert_not_awaited()
+        assert len(deliveries) == 1
+        assert deliveries[0][0] == "zeta-claude"
+        assert "No fleet de-auth is confirmed" in deliveries[0][1]
+
+    @pytest.mark.asyncio
+    async def test_per_agent_capture_timeout_cannot_open_shared_fleet(
+        self, tmp_path, monkeypatch,
+    ):
+        """A known independent OAuth timeout remains outside the shared cohort."""
+        from pinky_daemon.session_watchdog import (
+            DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER,
+        )
+        from pinky_daemon.tmux_session import TmuxCommandResult
+        from pinky_daemon.transport_state import SessionState as TransportState
+
+        monkeypatch.setenv("PINKY_CLAUDE_AUTH_MODE", "shared_refresh_file")
+        monkeypatch.setenv(
+            "PINKY_CLAUDE_AUTH_MODE_INDIE", "per_agent_oauth",
+        )
+        app = self._make_app(str(tmp_path / "test.db"))
+        for agent_name in ("shared", "indie"):
+            app.state.agents.register(
+                agent_name,
+                model="sonnet",
+                runtime="claude_sdk",
+                transport="tmux",
+                working_dir=str(tmp_path / agent_name),
+            )
+        app.state.agents.set_owner_notification_destinations([
+            {
+                "platform": "telegram",
+                "account_id": "owner-bot",
+                "conversation_id": "owner-chat",
+                "principal_id": "owner",
+            }
+        ])
+        capture = (
+            Path(__file__).parent / "fixtures" / "login_wall_paste_code.txt"
+        ).read_text()
+        ok_capture = TmuxCommandResult(0, capture, "")
+        ok_command = TmuxCommandResult(0, "", "")
+        shared_session = SimpleNamespace(
+            state=TransportState.CONNECTED,
+            stats={"state": TransportState.CONNECTED.value},
+            _tmux=SimpleNamespace(
+                session_name="pinky-shared",
+                has_session=AsyncMock(return_value=True),
+                capture_pane=AsyncMock(return_value=ok_capture),
+                rename_session=AsyncMock(return_value=ok_command),
+            ),
+        )
+        indie_session = SimpleNamespace(
+            state=TransportState.CONNECTED,
+            stats={"state": TransportState.CONNECTED.value},
+            _tmux=SimpleNamespace(
+                session_name="pinky-indie",
+                has_session=AsyncMock(return_value=True),
+                capture_pane=AsyncMock(side_effect=TimeoutError("capture timed out")),
+                rename_session=AsyncMock(return_value=ok_command),
+            ),
+        )
+        app.state.broker.register_streaming(
+            "shared", shared_session, label="main",
+        )
+        app.state.broker.register_streaming(
+            "indie", indie_session, label="main",
+        )
+        timeout_probe = await app.state.watchdog._login_wall_probe_fn(
+            "indie", "main", indie_session,
+        )
+        assert timeout_probe is not None
+        assert timeout_probe.wall is None
+        assert timeout_probe.shared_credentials is False
+        assert "TimeoutError" in timeout_probe.error
+        deliveries = []
+
+        async def _capture(
+            agent_name, platform, chat_id, content, *, account_id="", **kwargs,
+        ):
+            deliveries.append((agent_name, content))
+            return {"sent": True}
+
+        app.state.broker._send_callback = _capture
+        await app.state.watchdog._sweep()
+        app.state.watchdog._login_wall_states[
+            "shared"
+        ].first_seen_at -= DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER
+        await app.state.watchdog._sweep()
+
+        assert app.state.watchdog._login_wall_incident is None
+        shared_session._tmux.rename_session.assert_not_awaited()
+        indie_session._tmux.rename_session.assert_not_awaited()
+        assert len(deliveries) == 1
+        assert deliveries[0][0] == "shared"
+        assert "No fleet de-auth is confirmed" in deliveries[0][1]
+
+    @pytest.mark.asyncio
     async def test_login_wall_no_owner_destination_freezes_and_fails_loud(
         self, tmp_path, caplog, capsys,
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import sqlite3
 import sys
 import tempfile
 import threading
 import time
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -608,6 +610,140 @@ class TestAPI:
         assert state.notification_attempts == 2
         assert "pinky-codex-murzik" in attempts[1][4]
         assert "tmux session 'pinky-murzik'" not in attempts[1][4]
+
+    @pytest.mark.asyncio
+    async def test_login_wall_uses_deployment_owner_destination(self, tmp_path):
+        """#916 routes the held login link to this deployment's main user."""
+        from pinky_daemon.session_watchdog import (
+            DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER,
+        )
+        from pinky_daemon.tmux_session import TmuxCommandResult
+        from pinky_daemon.transport_state import SessionState as TransportState
+
+        app = self._make_app(str(tmp_path / "test.db"))
+        for agent_name in ("barsik", "murzik"):
+            app.state.agents.register(
+                agent_name,
+                model="sonnet",
+                transport="tmux",
+                working_dir=str(tmp_path / agent_name),
+            )
+        app.state.agents.set_owner_notification_destinations([
+            {
+                "platform": "telegram",
+                "account_id": "deployment-main-bot",
+                "conversation_id": "deployment-main-chat",
+                "principal_id": "deployment-main-user",
+            }
+        ])
+        capture = (
+            Path(__file__).parent / "fixtures" / "login_wall_paste_code.txt"
+        ).read_text()
+        ok_capture = TmuxCommandResult(0, capture, "")
+        ok_command = TmuxCommandResult(0, "", "")
+        sessions = {}
+        for agent_name in ("barsik", "murzik"):
+            sessions[agent_name] = SimpleNamespace(
+                state=TransportState.CONNECTED,
+                stats={"state": TransportState.CONNECTED.value},
+                _tmux=SimpleNamespace(
+                    session_name=f"pinky-{agent_name}",
+                    has_session=AsyncMock(return_value=True),
+                    capture_pane=AsyncMock(return_value=ok_capture),
+                    rename_session=AsyncMock(return_value=ok_command),
+                ),
+            )
+            app.state.broker.register_streaming(
+                agent_name, sessions[agent_name], label="main",
+            )
+
+        deliveries = []
+
+        async def _capture(
+            agent_name, platform, chat_id, content, *, account_id="", **kwargs,
+        ):
+            deliveries.append((agent_name, platform, account_id, chat_id, content))
+            return {"sent": True}
+
+        app.state.broker._send_callback = _capture
+        await app.state.watchdog._sweep()
+        for state in app.state.watchdog._login_wall_states.values():
+            state.first_seen_at -= DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER
+        await app.state.watchdog._sweep()
+
+        assert len(deliveries) == 1
+        assert deliveries[0][1:4] == (
+            "telegram",
+            "deployment-main-bot",
+            "deployment-main-chat",
+        )
+        assert "claude.com/cai/oauth/authorize" in deliveries[0][4]
+        sessions["barsik"]._tmux.rename_session.assert_awaited_once_with(
+            "login-hold-barsik",
+        )
+
+    @pytest.mark.asyncio
+    async def test_login_wall_no_owner_destination_freezes_and_fails_loud(
+        self, tmp_path, caplog, capsys,
+    ):
+        """#916 must preserve/log the URL even when owner-notify is misconfigured."""
+        from pinky_daemon.session_watchdog import (
+            DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER,
+        )
+        from pinky_daemon.tmux_session import TmuxCommandResult
+        from pinky_daemon.transport_state import SessionState as TransportState
+
+        app = self._make_app(str(tmp_path / "test.db"))
+        capture = (
+            Path(__file__).parent / "fixtures" / "login_wall_paste_code.txt"
+        ).read_text()
+        ok_capture = TmuxCommandResult(0, capture, "")
+        ok_command = TmuxCommandResult(0, "", "")
+        sessions = {}
+        for agent_name in ("barsik", "murzik"):
+            app.state.agents.register(
+                agent_name,
+                model="sonnet",
+                transport="tmux",
+                working_dir=str(tmp_path / agent_name),
+            )
+            sessions[agent_name] = SimpleNamespace(
+                state=TransportState.CONNECTED,
+                stats={"state": TransportState.CONNECTED.value},
+                _tmux=SimpleNamespace(
+                    session_name=f"pinky-{agent_name}",
+                    has_session=AsyncMock(return_value=True),
+                    capture_pane=AsyncMock(return_value=ok_capture),
+                    rename_session=AsyncMock(return_value=ok_command),
+                ),
+            )
+            app.state.broker.register_streaming(
+                agent_name, sessions[agent_name], label="main",
+            )
+
+        send_attempts = []
+
+        async def _unexpected_send(*args, **kwargs):
+            send_attempts.append((args, kwargs))
+            return {"sent": True}
+
+        app.state.broker._send_callback = _unexpected_send
+        await app.state.watchdog._sweep()
+        for state in app.state.watchdog._login_wall_states.values():
+            state.first_seen_at -= DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER
+        with caplog.at_level(logging.CRITICAL, logger="pinky.watchdog"):
+            await app.state.watchdog._sweep()
+
+        assert send_attempts == []
+        assert app.state.watchdog.is_login_hold("barsik") is True
+        sessions["barsik"]._tmux.rename_session.assert_awaited_once_with(
+            "login-hold-barsik",
+        )
+        assert "claude.com/cai/oauth/authorize" in caplog.text
+        assert (
+            "ERROR watchdog: owner alert for barsik not delivered"
+            in capsys.readouterr().err
+        )
 
     class _FakeContextClient:
         def __init__(self, total_tokens=0, max_tokens=200_000):

--- a/tests/test_auth_relay.py
+++ b/tests/test_auth_relay.py
@@ -12,6 +12,7 @@ from pinky_daemon.auth_relay import (
     build_relay_message,
     extract_auth_code,
     extract_oauth_url,
+    extract_relay_oauth_url,
     looks_like_login_wall,
 )
 
@@ -34,6 +35,7 @@ def test_extract_oauth_url_console_anthropic():
 def test_extract_oauth_url_current_claude_com_cai_path():
     url = "https://claude.com/cai/oauth/authorize?client_id=abc&state=xyz"
     assert extract_oauth_url(f"visit {url} now") == url
+    assert extract_relay_oauth_url(f"visit {url} now") is None
 
 
 def test_extract_oauth_url_dewraps_whitespace():

--- a/tests/test_auth_relay.py
+++ b/tests/test_auth_relay.py
@@ -31,6 +31,11 @@ def test_extract_oauth_url_console_anthropic():
     assert extract_oauth_url(f"visit {url} now") == url
 
 
+def test_extract_oauth_url_current_claude_com_cai_path():
+    url = "https://claude.com/cai/oauth/authorize?client_id=abc&state=xyz"
+    assert extract_oauth_url(f"visit {url} now") == url
+
+
 def test_extract_oauth_url_dewraps_whitespace():
     # tmux may wrap a long URL across terminal columns.
     wrapped = "https://claude.ai/oauth/authorize?code=true&\n   client_id=verylongvalue123"

--- a/tests/test_auth_relay_tmux.py
+++ b/tests/test_auth_relay_tmux.py
@@ -12,6 +12,10 @@ from pinky_daemon.tmux_session import TmuxCommandResult, TmuxSession, _TmuxContr
 from pinky_daemon.transport_state import SessionState
 
 WALL = "Browse to: https://claude.ai/oauth/authorize?code=true&client_id=abc\n> "
+CURRENT_CAI_WALL = (
+    "Browse to: https://claude.com/cai/oauth/authorize?"
+    "code=true&client_id=abc&state=xyz\n> "
+)
 
 
 def _ok(stdout: str = "") -> TmuxCommandResult:
@@ -106,6 +110,24 @@ async def test_watch_detects_wall_and_relays(monkeypatch):
 
     recorder.assert_awaited_once()
     assert "claude.ai/oauth" in recorder.call_args[0][0]
+
+
+async def test_flag_on_current_cai_wall_never_opens_submits_or_pastes(monkeypatch):
+    """#916 Phase 1 URLs cannot enter the legacy reply/paste relay."""
+    monkeypatch.setenv("PINKY_TMUX_AUTH_RELAY", "1")
+    monkeypatch.setattr(tmux_session, "_AUTH_WALL_DETECT_WINDOW_SEC", 0.03)
+    monkeypatch.setattr(tmux_session, "_AUTH_WALL_POLL_SEC", 0.01)
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    tmux.capture_pane = AsyncMock(return_value=_ok(CURRENT_CAI_WALL))
+    coord = MagicMock(spec=AuthRelayCoordinator)
+    coord.open = AsyncMock()
+    monkeypatch.setattr(tmux_session, "_auth_relay", coord)
+
+    await ss._watch_for_oauth_url()
+
+    coord.open.assert_not_awaited()
+    coord.submit.assert_not_called()
+    tmux.paste_text.assert_not_awaited()
 
 
 async def test_watch_no_wall_exits_without_relay(monkeypatch):

--- a/tests/test_session_watchdog.py
+++ b/tests/test_session_watchdog.py
@@ -3,20 +3,25 @@ from __future__ import annotations
 
 import logging
 import time
+from pathlib import Path
 
 import pytest
 
 from pinky_daemon.session_watchdog import (
+    DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER,
     DEFAULT_MCP_CHECKABLE_HEARTBEAT_MAX_AGE,
     DEFAULT_MCP_PROBE_DEADLINE,
     DEFAULT_MCP_UNBOUND_FLOOR,
     DEFAULT_TMUX_LIVENESS_NOTIFY_RETRY_AFTER,
     DEFAULT_TMUX_LIVENESS_REARM_AFTER,
+    FrozenLoginPane,
+    LoginWallProbe,
     SessionWatchdog,
     WatchdogConfig,
     _AgentState,
     _SessionSnapshot,
     compute_mcp_checkable,
+    pane_has_login_wall,
 )
 from pinky_daemon.transport_state import SessionState
 
@@ -647,6 +652,271 @@ class TestTmuxLivenessReconciliation:
 
         assert alerts == []
         assert "tmux liveness check failed for billie/main" in caplog.text
+
+
+class TestLoginWallDetection:
+    """#916 Phase 1 — joined captures, debounce, fleet hold, and owner page."""
+
+    _fixtures = Path(__file__).parent / "fixtures"
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["login_wall_paste_code.txt", "login_wall_select_method.txt"],
+    )
+    def test_fixture_signatures_are_detected(self, fixture_name):
+        capture = (self._fixtures / fixture_name).read_text()
+        assert pane_has_login_wall(capture) is True
+
+    def test_normal_pane_is_not_a_wall(self):
+        assert pane_has_login_wall("Kuzya is ready.\n>") is False
+
+    @pytest.mark.asyncio
+    async def test_single_agent_debounces_and_never_freezes(self, make_watchdog):
+        alerts = []
+        freezes = []
+        capture = (self._fixtures / "login_wall_paste_code.txt").read_text()
+
+        async def _alert(agent, message):
+            alerts.append((agent, message))
+            return True
+
+        async def _freeze(agent, label, session):
+            freezes.append(agent)
+            return FrozenLoginPane("login-hold-barsik", capture)
+
+        session = FakeSession()
+        target = {"barsik": ("main", session)}
+        probe = {
+            "barsik": LoginWallProbe(
+                wall=True,
+                pane_text=capture,
+                session_name="pinky-barsik",
+            )
+        }
+        wd = make_watchdog(
+            alert_fn=_alert,
+            login_wall_freeze_fn=_freeze,
+        )
+        await wd._evaluate_login_walls(
+            probe, checked_agents={"barsik"}, targets=target, now=1_000.0,
+        )
+        await wd._evaluate_login_walls(
+            probe,
+            checked_agents={"barsik"},
+            targets=target,
+            now=1_000.0 + DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER - 1,
+        )
+        assert alerts == []
+
+        await wd._evaluate_login_walls(
+            probe,
+            checked_agents={"barsik"},
+            targets=target,
+            now=1_000.0 + DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER,
+        )
+        assert freezes == []
+        assert len(alerts) == 1
+        assert "No fleet de-auth is confirmed" in alerts[0][1]
+        assert "no tmux pane was renamed" in alerts[0][1]
+
+    @pytest.mark.asyncio
+    async def test_clear_sample_resets_consecutive_debounce(self, make_watchdog):
+        alerts = []
+        capture = (self._fixtures / "login_wall_paste_code.txt").read_text()
+
+        async def _alert(agent, message):
+            alerts.append(message)
+            return True
+
+        session = FakeSession()
+        target = {"barsik": ("main", session)}
+        positive = {
+            "barsik": LoginWallProbe(wall=True, pane_text=capture)
+        }
+        clear = {"barsik": LoginWallProbe(wall=False)}
+        wd = make_watchdog(alert_fn=_alert)
+        await wd._evaluate_login_walls(
+            positive, checked_agents={"barsik"}, targets=target, now=1_000.0,
+        )
+        await wd._evaluate_login_walls(
+            clear, checked_agents={"barsik"}, targets=target, now=1_020.0,
+        )
+        await wd._evaluate_login_walls(
+            positive, checked_agents={"barsik"}, targets=target, now=1_050.0,
+        )
+
+        assert alerts == []
+        assert wd._login_wall_states["barsik"].first_seen_at == 1_050.0
+        assert wd._login_wall_states["barsik"].confirmed is False
+
+    @pytest.mark.asyncio
+    async def test_fleet_freezes_before_notify_and_includes_joined_url(
+        self, make_watchdog,
+    ):
+        events = []
+        alerts = []
+        first_capture = (
+            self._fixtures / "login_wall_paste_code.txt"
+        ).read_text()
+        second_capture = (
+            self._fixtures / "login_wall_select_method.txt"
+        ).read_text()
+
+        async def _alert(agent, message):
+            events.append("notify")
+            alerts.append((agent, message))
+            return True
+
+        async def _freeze(agent, label, session):
+            events.append("freeze")
+            return FrozenLoginPane(
+                hold_session_name=f"login-hold-{agent}",
+                pane_text=first_capture,
+            )
+
+        sessions = {"barsik": FakeSession(), "murzik": FakeSession()}
+        targets = {
+            name: ("main", session) for name, session in sessions.items()
+        }
+        probes = {
+            "barsik": LoginWallProbe(
+                wall=True,
+                pane_text=first_capture,
+                session_name="pinky-barsik",
+            ),
+            "murzik": LoginWallProbe(
+                wall=True,
+                pane_text=second_capture,
+                session_name="pinky-murzik",
+            ),
+        }
+        wd = make_watchdog(
+            alert_fn=_alert,
+            login_wall_freeze_fn=_freeze,
+        )
+        await wd._evaluate_login_walls(
+            probes,
+            checked_agents=set(probes),
+            targets=targets,
+            now=2_000.0,
+        )
+        assert events == []
+
+        await wd._evaluate_login_walls(
+            probes,
+            checked_agents=set(probes),
+            targets=targets,
+            now=2_000.0 + DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER,
+        )
+
+        assert events == ["freeze", "notify"]
+        assert len(alerts) == 1
+        message = alerts[0][1]
+        assert "Fleet Claude login wall detected" in message
+        assert "login-hold-barsik" in message
+        assert (
+            "https://claude.com/cai/oauth/authorize?"
+            "client_id=test-client&code=true&state=fixture-state-123"
+        ) in message
+        assert "reply with the exact code#state string" in message
+        assert wd.is_login_hold("barsik") is True
+        assert wd.is_login_hold("murzik") is False
+
+    @pytest.mark.asyncio
+    async def test_confirmed_wall_plus_uncertain_peer_fails_closed(
+        self, make_watchdog,
+    ):
+        events = []
+        capture = (self._fixtures / "login_wall_paste_code.txt").read_text()
+
+        async def _alert(agent, message):
+            events.append(("notify", message))
+            return True
+
+        async def _freeze(agent, label, session):
+            events.append(("freeze", agent))
+            return FrozenLoginPane(f"login-hold-{agent}", capture)
+
+        targets = {
+            "barsik": ("main", FakeSession()),
+            "murzik": ("main", FakeSession()),
+        }
+        probes = {
+            "barsik": LoginWallProbe(wall=True, pane_text=capture),
+            "murzik": LoginWallProbe(
+                wall=None,
+                shared_credentials=True,
+                error="capture timed out",
+            ),
+        }
+        wd = make_watchdog(
+            alert_fn=_alert,
+            login_wall_freeze_fn=_freeze,
+        )
+        await wd._evaluate_login_walls(
+            probes,
+            checked_agents=set(probes),
+            targets=targets,
+            now=3_000.0,
+        )
+        await wd._evaluate_login_walls(
+            probes,
+            checked_agents=set(probes),
+            targets=targets,
+            now=3_000.0 + DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER,
+        )
+
+        assert events[0] == ("freeze", "barsik")
+        assert events[1][0] == "notify"
+        assert "additional unclassified agent(s): murzik" in events[1][1]
+
+    @pytest.mark.asyncio
+    async def test_two_independent_oauth_agents_are_not_a_fleet(
+        self, make_watchdog,
+    ):
+        alerts = []
+        freezes = []
+        capture = (self._fixtures / "login_wall_paste_code.txt").read_text()
+
+        async def _alert(agent, message):
+            alerts.append((agent, message))
+            return True
+
+        async def _freeze(agent, label, session):
+            freezes.append(agent)
+            return FrozenLoginPane(f"login-hold-{agent}", capture)
+
+        probes = {
+            name: LoginWallProbe(
+                wall=True,
+                pane_text=capture,
+                shared_credentials=False,
+            )
+            for name in ("barsik", "murzik")
+        }
+        targets = {
+            name: ("main", FakeSession()) for name in probes
+        }
+        wd = make_watchdog(
+            alert_fn=_alert,
+            login_wall_freeze_fn=_freeze,
+        )
+        await wd._evaluate_login_walls(
+            probes,
+            checked_agents=set(probes),
+            targets=targets,
+            now=4_000.0,
+        )
+        await wd._evaluate_login_walls(
+            probes,
+            checked_agents=set(probes),
+            targets=targets,
+            now=4_000.0 + DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER,
+        )
+
+        assert freezes == []
+        assert len(alerts) == 2
+        assert all("No fleet de-auth is confirmed" in msg for _, msg in alerts)
 
 
 class TestStatus:

--- a/tests/test_session_watchdog.py
+++ b/tests/test_session_watchdog.py
@@ -823,6 +823,80 @@ class TestLoginWallDetection:
         assert wd.is_login_hold("murzik") is False
 
     @pytest.mark.asyncio
+    async def test_definitive_recovery_rearms_hold_and_later_902_detection(
+        self, make_watchdog,
+    ):
+        """Incident -> clear releases the hold so a later missing pane can page."""
+        alerts = []
+        capture = (self._fixtures / "login_wall_paste_code.txt").read_text()
+        sessions = {
+            "barsik": {"main": FakeSession()},
+            "murzik": {"main": FakeSession()},
+        }
+
+        async def _alert(agent, message):
+            alerts.append((agent, message))
+            return True
+
+        async def _freeze(agent, label, session):
+            return FrozenLoginPane(f"login-hold-{agent}", capture)
+
+        async def _tmux_liveness(agent, label, session):
+            return agent != "barsik", f"pinky-{agent}"
+
+        targets = {
+            name: ("main", registrations["main"])
+            for name, registrations in sessions.items()
+        }
+        positive = {
+            name: LoginWallProbe(wall=True, pane_text=capture)
+            for name in sessions
+        }
+        clear = {
+            name: LoginWallProbe(wall=False)
+            for name in sessions
+        }
+        wd = make_watchdog(
+            sessions=sessions,
+            alert_fn=_alert,
+            login_wall_freeze_fn=_freeze,
+            tmux_liveness_fn=_tmux_liveness,
+        )
+        await wd._evaluate_login_walls(
+            positive,
+            checked_agents=set(positive),
+            targets=targets,
+            now=2_500.0,
+        )
+        await wd._evaluate_login_walls(
+            positive,
+            checked_agents=set(positive),
+            targets=targets,
+            now=2_500.0 + DEFAULT_LOGIN_WALL_DEBOUNCE_AFTER,
+        )
+        assert wd.is_login_hold("barsik") is True
+
+        await wd._evaluate_login_walls(
+            clear,
+            checked_agents=set(clear),
+            targets=targets,
+            now=2_600.0,
+        )
+
+        assert wd._login_wall_incident is None
+        assert wd.is_login_hold("barsik") is False
+        assert wd._login_wall_states == {}
+
+        await wd._sweep()
+
+        assert any(
+            agent == "barsik"
+            and "Session liveness mismatch" in message
+            and "pinky-barsik" in message
+            for agent, message in alerts
+        )
+
+    @pytest.mark.asyncio
     async def test_confirmed_wall_plus_uncertain_peer_fails_closed(
         self, make_watchdog,
     ):

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -104,6 +104,7 @@ def _make_mock_tmux(*, has_session_initial: bool = False) -> MagicMock:
     tmux.has_session = AsyncMock(return_value=has_session_initial)
     tmux.new_session = AsyncMock(return_value=_ok())
     tmux.kill_session = AsyncMock(return_value=_ok())
+    tmux.rename_session = AsyncMock(return_value=_ok())
     tmux.send_keys = AsyncMock(return_value=_ok())
     tmux.paste_text = AsyncMock(return_value=_ok())
     tmux.capture_pane = AsyncMock(return_value=_ok())
@@ -786,6 +787,45 @@ async def test_capture_pane_with_escapes_adds_e_flag() -> None:
     tmux._run = fake_run
     await tmux.capture_pane(lines=200, escapes=True)
     assert "-e" in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_capture_pane_joined_hold_target_adds_j_and_uses_target() -> None:
+    """#916 recaptures the renamed pane with ``-J`` to preserve its long URL."""
+    tmux = _TmuxControl("pinky-test")
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        return _ok()
+
+    tmux._run = fake_run
+    await tmux.capture_pane(
+        lines=200,
+        join=True,
+        target_session="login-hold-test",
+    )
+    assert "-J" in calls[0]
+    assert calls[0][calls[0].index("-t") + 1] == "login-hold-test"
+
+
+@pytest.mark.asyncio
+async def test_rename_session_freezes_without_retargeting_control() -> None:
+    """The supervisor must keep tracking the old name after #916's rename."""
+    tmux = _TmuxControl("pinky-test")
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args, timeout=5.0):
+        calls.append(args)
+        return _ok()
+
+    tmux._run = fake_run
+    await tmux.rename_session("login-hold-test")
+
+    assert calls == [
+        ("rename-session", "-t", "pinky-test", "login-hold-test")
+    ]
+    assert tmux.session_name == "pinky-test"
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

- Piggyback the existing `SessionWatchdog` sweep to capture enabled, active tmux panes through each session's existing tmux control and command runner.
- Detect both stable Claude login-wall signatures and require two positive sightings at least 30 seconds apart.
- Distinguish a lone-agent wall from a shared-credential fleet incident; a confirmed wall plus an uncertain shared peer fails closed and pages.
- Rename one positively walled session to `login-hold-<agent>` before the first fleet notification, then recapture the held pane with `capture-pane -p -J` and extract the current `claude.com/cai/oauth` URL.
- Send the login link and exact `code#state` reply instructions through the deployment-local owner-notification destinations registry. Missing notification configuration leaves the pane frozen, logs the URL at CRITICAL, and emits the existing explicit delivery error.
- Expose login-wall/hold state in watchdog diagnostics and document the manual Phase 1 completion path, onboarding-flag trap, and resume-from-summary dialog.

## Why

A shared OAuth revocation left every TOD pane at a login wall while the daemon remained healthy and silent. Normal respawn churn repeatedly destroyed each URL's PKCE state, so recovery required a human to notice the outage, freeze a pane, extract its link, and contact the deployment's main user. This change automates that proven detection-and-handoff sequence while preserving the login state before outreach.

## Scope

Phase 1 only. This PR does not correlate owner replies, paste login codes, repair onboarding state, or restart agents. No new Phase 2 auto-paste path is introduced.

## Validation

- Python 3.11 affected watchdog/tmux/API/auth-relay matrix: 824 passed.
- Full Python 3.11 suite under CI-default feature flags: 4,424 passed, 3 skipped, with one unrelated host-sensitive auth expectation (`/this-path-does-not-exist`: 401 vs 404). The exact failure reproduces unchanged on detached `origin/main` at `761ca9a`.
- Repository-wide `uv run ruff check .`: passed.
- `git diff --check`, compileall, and `uv lock --check`: passed.

Implements Phase 1 of #916.

🤖 Opened by Kuzya