### PR TITLE
Deprecate agent inbox delivery

### DIFF
--- a/src/pinky_daemon/agent_comms.py
+++ b/src/pinky_daemon/agent_comms.py
@@ -6,7 +6,9 @@ Enables sessions (agents) to send messages to each other:
 - Broadcast: to all active agents
 
 Messages are stored in SQLite for durability and searchability.
-Each session has an inbox that accumulates messages until read.
+Delivery is handled separately by the daemon's live-injection path. The legacy
+inbox schema remains as read-only recipient bookkeeping for audit/thread
+authorization, but it is never exposed as a delivery inbox.
 """
 
 from __future__ import annotations
@@ -148,6 +150,11 @@ class AgentComms:
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_inbox_expires ON inbox(expires_at)"
             )
+            retired = self._conn.execute(
+                "UPDATE inbox SET read = 1 WHERE read = 0"
+            ).rowcount
+            if retired:
+                _log(f"agent_comms: retired {retired} legacy unread inbox row(s)")
             self._conn.execute("COMMIT")
         except Exception:
             self._conn.execute("ROLLBACK")
@@ -274,7 +281,7 @@ class AgentComms:
         priority: int = 0,
         ttl_seconds: int | None = None,
     ) -> AgentMessage:
-        """Internal: store message and deliver to recipients' inboxes."""
+        """Internal: store a message for audit/thread history only."""
         if parent_message_id is not None:
             parent = self._conn.execute(
                 "SELECT 1 FROM messages WHERE id = ?", (parent_message_id,)
@@ -296,19 +303,23 @@ class AgentComms:
         )
         msg_id = cursor.lastrowid
 
-        # Compute expiry for inbox entries
+        # Preserve recipient bookkeeping for group/broadcast thread
+        # authorization and audit history, but never create unread delivery
+        # state. Live injection is the sole delivery path.
         expires_at = (ts + ttl_seconds) if ttl_seconds else None
-
-        # Deliver to each recipient's inbox
         for recipient in recipients:
             self._conn.execute(
-                "INSERT INTO inbox (session_id, message_id, expires_at) VALUES (?, ?, ?)",
+                """INSERT INTO inbox (session_id, message_id, read, expires_at)
+                   VALUES (?, ?, 1, ?)""",
                 (recipient, msg_id, expires_at),
             )
 
         self._conn.commit()
 
-        _log(f"comms: {from_session} -> {to_session} ({message_type}, {len(recipients)} recipients)")
+        _log(
+            f"comms audit: {from_session} -> {to_session} "
+            f"({message_type}, {len(recipients)} addressed; inbox deprecated)"
+        )
 
         return AgentMessage(
             id=msg_id,
@@ -322,6 +333,7 @@ class AgentComms:
             content_type=content_type,
             parent_message_id=parent_message_id,
             priority=priority,
+            read=True,
         )
 
     # ── File Transfer ───────────────────────────────────────
@@ -402,59 +414,16 @@ class AgentComms:
         unread_only: bool = True,
         limit: int = 50,
     ) -> list[AgentMessage]:
-        """Get messages from a session's inbox."""
-        read_filter = "AND i.read = 0" if unread_only else ""
-        now = time.time()
-
-        rows = self._conn.execute(
-            f"""SELECT m.*, i.read, i.id as inbox_id
-                FROM inbox i
-                JOIN messages m ON m.id = i.message_id
-                WHERE i.session_id = ?
-                {read_filter}
-                AND (i.expires_at IS NULL OR i.expires_at > ?)
-                ORDER BY m.priority DESC, m.timestamp DESC
-                LIMIT ?""",
-            (session_id, now, limit),
-        ).fetchall()
-
-        return [self._row_to_message(r) for r in rows]
+        """Return no messages; durable agent inboxes are deprecated."""
+        return []
 
     def mark_read(self, session_id: str, message_ids: list[int] | None = None) -> int:
-        """Mark messages as read in a session's inbox.
-
-        Args:
-            session_id: Session whose inbox to update.
-            message_ids: Specific message IDs to mark. None = mark all.
-
-        Returns:
-            Number of messages marked.
-        """
-        if message_ids is not None:
-            if not message_ids:
-                return 0
-            placeholders = ",".join("?" * len(message_ids))
-            cursor = self._conn.execute(
-                f"""UPDATE inbox SET read = 1
-                    WHERE session_id = ? AND message_id IN ({placeholders}) AND read = 0""",
-                [session_id, *message_ids],
-            )
-        else:
-            cursor = self._conn.execute(
-                "UPDATE inbox SET read = 1 WHERE session_id = ? AND read = 0",
-                (session_id,),
-            )
-
-        self._conn.commit()
-        return cursor.rowcount
+        """Return zero; durable agent inboxes are deprecated."""
+        return 0
 
     def unread_count(self, session_id: str) -> int:
-        """Count unread messages for a session."""
-        row = self._conn.execute(
-            "SELECT COUNT(*) FROM inbox WHERE session_id = ? AND read = 0",
-            (session_id,),
-        ).fetchone()
-        return row[0]
+        """Return zero; durable agent inboxes are deprecated."""
+        return 0
 
     # ── Groups ───────────────────────────────────────────────
 
@@ -549,7 +518,7 @@ class AgentComms:
                     SELECT m.* FROM messages m
                     JOIN thread t ON m.parent_message_id = t.id
                 )
-                SELECT t.*, COALESCE(i.read, 0) as read
+                SELECT t.*, COALESCE(i.read, 1) as read
                 FROM thread t
                 LEFT JOIN inbox i ON i.message_id = t.id AND i.session_id = ?
                 WHERE t.from_session = ? OR t.to_session = ? OR i.session_id IS NOT NULL
@@ -564,7 +533,7 @@ class AgentComms:
                     SELECT m.* FROM messages m
                     JOIN thread t ON m.parent_message_id = t.id
                 )
-                SELECT t.*, 0 as read FROM thread t
+                SELECT t.*, 1 as read FROM thread t
                 ORDER BY t.timestamp ASC
             """
             params = [root_id]
@@ -584,7 +553,7 @@ class AgentComms:
         """
         total = self._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
         rows = self._conn.execute(
-            """SELECT m.*, COALESCE(MAX(i.read), 0) as read
+            """SELECT m.*, COALESCE(MAX(i.read), 1) as read
                FROM messages m
                LEFT JOIN inbox i ON m.id = i.message_id
                GROUP BY m.id
@@ -595,12 +564,8 @@ class AgentComms:
         return [self._row_to_message(r) for r in rows], total
 
     def get_all_inbox_summaries(self) -> list[dict]:
-        """Get unread message count per agent for all agents with inbox entries."""
-        rows = self._conn.execute(
-            "SELECT session_id, COUNT(*) as unread "
-            "FROM inbox WHERE read = 0 GROUP BY session_id",
-        ).fetchall()
-        return [{"agent": r[0], "unread": r[1]} for r in rows]
+        """Return no summaries; durable agent inboxes are deprecated."""
+        return []
 
     def cleanup_expired(self) -> int:
         """Delete expired inbox entries. Returns count deleted."""

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -333,7 +333,6 @@ DEFAULT_HEARTBEAT_PROMPT = (
     "1. Call send_heartbeat(status, context_pct, notes) first "
     "(status: ok/busy/finishing).\n"
     "2. Then be proactive:\n"
-    "   - check_inbox() for messages from other agents\n"
     "   - get_next_task() for pending work\n"
     "   - Follow up on anything you're tracking\n"
     "   - Reach out to the owner if you have updates, ideas, or finished something\n"

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2807,16 +2807,10 @@ def create_api(
         before. The default value preserves pre-#591 behavior for the
         ``wake_context_builder(name)`` 1-arg callers.
 
-        ``commit`` gates the side-effecting consumption steps embedded in
-        the build (inbox ``mark_read`` and restart-manifest deletion).
+        ``commit`` gates restart-manifest deletion.
         When ``False``, the function renders the *current* state without
-        consuming — used by the eager pre-build at session-config creation
-        time, which would otherwise consume inbox + manifest BEFORE the
-        delivered connect-time rebuild runs (Murzik P1#1: production saw
-        unread agent messages and restart-manifest content silently
-        vanish from real wake prompts). ``True`` (the default) preserves
-        pre-#591 behavior for legacy callers and is what the connect-time
-        rebuild uses.
+        consuming it — used by the eager pre-build at session-config creation
+        time. ``True`` (the default) is what the connect-time rebuild uses.
         """
         wake_ctx = ""
         emitted_manifest = False  # Whether saved-context contributed to wake_ctx
@@ -2883,21 +2877,6 @@ def create_api(
             kg_insights = dream_runner.get_kg_insights(agent_name)
             if kg_insights:
                 wake_ctx = f"{wake_ctx}\n\n{kg_insights}" if wake_ctx else kg_insights
-
-        # Inject unread inbox messages from other agents
-        inbox_messages = comms.get_inbox(agent_name, unread_only=True, limit=10)
-        if inbox_messages:
-            lines = []
-            for m in inbox_messages:
-                lines.append(f"  From {m.from_session}: {m.content}")
-            inbox_ctx = (
-                f"Unread agent messages ({len(inbox_messages)}):\n"
-                + "\n".join(lines)
-                + "\nReply via send_to_agent, not by messaging the owner."
-            )
-            wake_ctx = f"{wake_ctx}\n\n{inbox_ctx}" if wake_ctx else inbox_ctx
-            if commit:
-                comms.mark_read(agent_name, [m.id for m in inbox_messages])
 
         # Inject open task summary
         try:
@@ -3070,9 +3049,8 @@ def create_api(
         async def _on_response(turn_result):
             # #279: agent-to-agent reply auto-routing. If this completed turn was
             # an injected agent message (platform == "agent"), deliver its text to
-            # the requesting agent's inbox and stop — loop-safe (inbox write, no
-            # live inject). Must run BEFORE the empty-chat_id early-return, which
-            # is what used to silently drop these turns.
+            # the requesting agent via a one-way live inject and stop. Must run
+            # BEFORE the empty-chat_id early-return.
             if await broker.route_agent_reply(comms, turn_result):
                 return
             if not turn_result.chat_id:
@@ -3639,10 +3617,8 @@ def create_api(
             resume_handle=resume_id,
             # commit=False here: the connect-time rebuild via
             # ``wake_context_builder`` is the delivered (committed) build
-            # that consumes inbox + restart_manifest. An eager committed
-            # build here would consume both before the delivered one
-            # runs, leaving the actual wake prompt without unread inbox
-            # or restart-manifest content (Murzik P1#1).
+            # that consumes restart_manifest. An eager committed build here
+            # would consume it before the delivered one runs.
             wake_context=_build_streaming_wake_context(agent_name, commit=False),
             wake_context_builder=_build_streaming_wake_context,
             on_wake_delivered=_log_agent_wake_event,
@@ -4407,7 +4383,7 @@ def create_api(
         # peer CRUD + operator diagnostics).
         "/analytics",      # agent usage/cost analytics (dashboard)
         "/api/migrate",    # OpenClaw migration (admin)
-        "/comms",          # inter-agent comms inboxes/messages
+        "/comms",          # inter-agent comms audit/messages
         "/dreams",         # dream-runner data
         "/federation",     # federation peer CRUD (local management)
         "/mesh",           # mesh operator diagnostics (local)
@@ -5753,20 +5729,19 @@ npm run build</pre>
 
     @app.get("/sessions/{session_id}/inbox")
     async def get_inbox(session_id: str, unread_only: bool = True, limit: int = 50):
-        """Get a session's inbox — messages from other agents."""
-        messages = comms.get_inbox(session_id, unread_only=unread_only, limit=limit)
+        """Return an empty compatibility response; agent inboxes are deprecated."""
         return {
             "session_id": session_id,
-            "messages": [m.to_dict() for m in messages],
-            "count": len(messages),
-            "unread": comms.unread_count(session_id),
+            "messages": [],
+            "count": 0,
+            "unread": 0,
+            "deprecated": True,
         }
 
     @app.post("/sessions/{session_id}/inbox/read")
     async def mark_inbox_read(session_id: str, message_ids: list[int] | None = None):
-        """Mark messages as read. Pass message_ids or omit to mark all."""
-        count = comms.mark_read(session_id, message_ids)
-        return {"marked": count}
+        """Return an inert compatibility response; agent inboxes are deprecated."""
+        return {"marked": 0, "deprecated": True}
 
     @app.get("/sessions/{session_id}/inbox/{message_id}/thread")
     async def get_message_thread(session_id: str, message_id: int):
@@ -5792,8 +5767,8 @@ npm run build</pre>
 
     @app.get("/comms/inboxes")
     async def get_inbox_summaries():
-        """Get unread message counts per agent."""
-        return {"inboxes": comms.get_all_inbox_summaries()}
+        """Return no summaries; agent inboxes are deprecated."""
+        return {"inboxes": [], "deprecated": True}
 
     @app.post("/groups")
     async def create_group(req: CreateGroupRequest):
@@ -9304,7 +9279,8 @@ npm run build</pre>
         # cross-agent surface. No-op for non-isolated callers and for
         # operator/browser sessions (no verified internal-agent header).
         _deny_isolated_cross_actor(request, req.from_agent)
-        # Always store in comms DB for audit/visibility
+        # Store in the messages table for audit/visibility. Agent inboxes are
+        # deprecated, so this creates no durable delivery copy.
         msg = comms.send(
             req.from_agent, name, req.message,
             metadata=req.metadata,
@@ -9315,9 +9291,12 @@ npm run build</pre>
         delivered, confirmed = await broker.inject_agent_message(
             req.from_agent, name, req.message,
         )
-        # Auto-wake sleeping agents on inter-agent messages
+        # Auto-wake sleeping agents, or retry after a failed live handoff.
         if not delivered:
-            _log(f"api: agent message {req.from_agent} -> {name} — target offline, auto-waking")
+            _log(
+                f"api: agent message {req.from_agent} -> {name} "
+                "not live-delivered, ensuring session"
+            )
             try:
                 streaming = await _ensure_streaming_session(name, label="main")
                 if streaming and streaming.state == TransportSessionState.CONNECTED:
@@ -9328,34 +9307,11 @@ npm run build</pre>
                         _log(f"api: agent message delivered after auto-wake {name}")
             except Exception as e:
                 _log(f"api: auto-wake failed for {name}: {e}")
-        # Fail-closed retire: only mark the durable inbox copy read when the
-        # inject POSITIVELY confirmed consumption. ``confirmed`` comes from the
-        # inject call itself — computed by the broker on the exact session
-        # object that performed the inject (per-call send() handoff AND the
-        # transport capability; Murzik #853 P1 — no second session lookup that
-        # could race a swap, and a transport-static capability can't overrule a
-        # failed handoff, e.g. an SDK query that raised). ``delivered`` alone
-        # (attempt-level) is exactly what black-holed codex-tmux messages: the
-        # row went read=1 while the paste vanished, so check_inbox (unread-only)
-        # never surfaced it. Unconfirmed → the row stays unread+queued and
-        # check_inbox remains the durable backstop.
-        if confirmed:
-            comms.mark_read(name, [msg.id])
-        else:
-            # Left durably queued (unread). Nudge tmux targets to check their
-            # inbox (best-effort, coalesced, PINKYBOT_AGENT_MSG_NOTIFY). No-op
-            # for SDK / offline / unknown transports.
-            try:
-                await broker.notify_unread_agent_messages(comms, name)
-            except Exception as e:
-                _log(f"api: check-inbox nudge for {name} failed: {e}")
-        # ``queued`` stays ``not delivered`` (unchanged tool semantics): it flags
-        # "no live session — will see on wake". A live-injected-but-unconfirmed
-        # tmux delivery is NOT reported as offline; ``confirmed`` carries the
-        # honest "was the durable copy retired?" signal for observability.
+        # Delivery is live-only. ``confirmed`` remains a transport-consumption
+        # observability signal; it no longer controls inbox retirement.
         return {
             "delivered": delivered,
-            "queued": not delivered,
+            "queued": False,
             "confirmed": confirmed,
             "message_id": msg.id,
             "from": req.from_agent,

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -50,38 +50,13 @@ _APPROVAL_NOTIFY_POLL_SEC = 5
 
 # #279: agent-to-agent reply auto-routing. ``inject_agent_message`` stamps an
 # injected turn with ``platform == AGENT_REPLY_PLATFORM`` and ``chat_id`` = the
-# requester agent name; when that turn completes, ``route_agent_reply`` delivers
-# the recipient's turn text to the requester's INBOX (loop-safe — an inbox write
-# never spawns a live turn, so the exchange can't ping-pong). Kill-switch
-# defaults ON; set ``PINKY_AGENT_REPLY_ROUTING=0`` to revert to the old
-# drop-on-empty-chat_id behavior without a code change.
+# requester agent name; when that turn completes, ``route_agent_reply`` performs
+# a one-way live injection back to the requester. The return injection disables
+# reply routing so the exchange cannot ping-pong.
 AGENT_REPLY_PLATFORM = "agent"
 _AGENT_REPLY_ROUTING_ENABLED = os.environ.get(
     "PINKY_AGENT_REPLY_ROUTING", "1"
 ).strip().lower() not in ("0", "false", "no", "off")
-
-# #215 PR3 / fail-closed inter-agent delivery: when an agent message is left
-# durably queued (unread) for a tmux-transport target, nudge that target to
-# call ``check_inbox`` so it retrieves the message promptly. The nudge is
-# best-effort — the DURABLE truth is the unread comms row; this only makes
-# retrieval timely when the pane is alive. Coalesced (one per burst) and
-# readiness-gated (can't corrupt a mid-turn pane). Default ON; disable with
-# ``PINKYBOT_AGENT_MSG_NOTIFY=0`` to kill a bad interaction without a rollback.
-# NOTE: the fail-closed mark-read fix in the API handler is deliberately NOT
-# gated by this flag — only the notify nudge is.
-_AGENT_MSG_NOTIFY_ENABLED = os.environ.get(
-    "PINKYBOT_AGENT_MSG_NOTIFY", "1"
-).strip().lower() not in ("0", "false", "no", "off")
-
-# Coalesce window for the check-inbox nudge: at most one nudge per target per
-# window, so a burst of messages collapses to a single nudge (never a storm).
-try:
-    _AGENT_MSG_NUDGE_BACKOFF_SEC = float(
-        os.environ.get("PINKYBOT_AGENT_MSG_NUDGE_BACKOFF", "15")
-    )
-except (TypeError, ValueError):
-    _AGENT_MSG_NUDGE_BACKOFF_SEC = 15.0
-
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -90,19 +65,14 @@ def _log(msg: str) -> None:
 class InjectResult(NamedTuple):
     """Outcome of a live agent-message injection attempt.
 
-    ``delivered`` — attempt-level: the target had a CONNECTED session and the
-    inject was handed to its transport (legacy bool semantics; drives the
-    offline auto-wake path and the API's ``queued`` flag).
+    ``delivered`` — the target had a CONNECTED session and that exact session's
+    ``send()`` accepted the message.
 
-    ``confirmed`` — outcome-level: THIS message's handoff was positively
-    confirmed by the exact session object that performed the inject (the
+    ``confirmed`` — the handoff was positively confirmed as consumption by the
+    exact session object that performed the inject (the
     transport's ``injection_confirms_consumption`` capability AND the
-    per-call ``send()`` handoff bool). Only a confirmed inject may retire the
-    durable comms inbox copy (mark it read); anything less keeps the row
-    unread so ``check_inbox`` remains the backstop. (Murzik #853 P1: a
-    transport-static capability alone must never overrule a failed handoff,
-    and confirmation must not come from a second session lookup that can
-    race a session swap.)
+    per-call ``send()`` handoff bool). This remains an observability signal even
+    though the durable comms inbox is deprecated.
     """
 
     delivered: bool
@@ -330,10 +300,6 @@ class MessageBroker:
         self._message_context_stored_at: dict[tuple[str, str, str, str], float] = {}
         self._message_context_order: dict[str, list[tuple[str, str, str, str]]] = {}
         self._message_context_lock = threading.RLock()
-
-        # #215 PR3: last check-inbox nudge time per agent (monotonic seconds),
-        # used to coalesce a burst of inter-agent messages into one nudge.
-        self._agent_msg_nudge_at: dict[str, float] = {}
 
         # Active typing indicator tasks: (agent_name, chat_id) -> asyncio.Task
         self._typing_tasks: dict[tuple[str, str], asyncio.Task] = {}
@@ -1693,7 +1659,12 @@ class MessageBroker:
         _log(f"broker: streamed message to {agent_name} (non-blocking)")
 
     async def inject_agent_message(
-        self, from_agent: str, to_agent: str, message: str,
+        self,
+        from_agent: str,
+        to_agent: str,
+        message: str,
+        *,
+        route_reply: bool = True,
     ) -> InjectResult:
         """Inject a message from one agent into another's streaming session.
 
@@ -1705,11 +1676,14 @@ class MessageBroker:
         capability can't overrule a failed handoff (e.g. StreamingSession's
         swallowed ``client.query`` exception now returns handoff=False), and
         there is no second session lookup that could race a session swap.
-        Fail-closed: a transport that doesn't advertise the capability, or a
-        ``send()`` that doesn't report a truthy handoff, never confirms.
+        ``route_reply=False`` makes the injection one-way by omitting the
+        agent-reply routing sentinel. A transport that doesn't advertise the
+        confirmation capability never confirms, but a truthy per-call handoff
+        still counts as live delivery.
         """
         streaming = self._get_streaming_session(to_agent)
         if not streaming or streaming.state != SessionState.CONNECTED:
+            self._stats["routed_failed"] += 1
             _log(f"broker: can't deliver agent message to {to_agent} — not connected")
             return InjectResult(delivered=False, confirmed=False)
 
@@ -1717,9 +1691,9 @@ class MessageBroker:
         from datetime import timezone as tz
         ts = datetime.now(tz.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
         prompt = f"[agent | {from_agent} | internal | {ts}]\n{message}"
-        if _AGENT_REPLY_ROUTING_ENABLED:
+        if _AGENT_REPLY_ROUTING_ENABLED and route_reply:
             # #279: encode the requester as the route-back target so the
-            # recipient's completed turn auto-delivers to the requester's inbox
+            # recipient's completed turn auto-delivers live to the requester
             # (see ``route_agent_reply``). The ``platform="agent"`` sentinel is
             # intercepted in the response callback before normal platform
             # routing; ``chat_id`` carries the requester agent name.
@@ -1731,6 +1705,13 @@ class MessageBroker:
         confirmed = bool(handoff) and bool(
             getattr(streaming, "injection_confirms_consumption", False)
         )
+        delivered = bool(handoff)
+        if not delivered:
+            self._stats["routed_failed"] += 1
+            _log(
+                f"broker: agent message handoff failed {from_agent} -> {to_agent}"
+            )
+            return InjectResult(delivered=False, confirmed=False)
         # Server-side presence: successful delivery = agent is reachable
         try:
             self._registry.stamp_last_seen(to_agent)
@@ -1744,64 +1725,8 @@ class MessageBroker:
         return InjectResult(delivered=True, confirmed=confirmed)
 
     async def notify_unread_agent_messages(self, comms, to_agent: str) -> bool:
-        """Best-effort nudge (#215 PR3): tell a tmux-transport agent it has
-        unread inbox messages so it calls ``check_inbox``.
-
-        The durable unread comms rows are the real delivery guarantee; this
-        just makes retrieval timely when the pane is alive. No-op when:
-        - the notify flag (``PINKYBOT_AGENT_MSG_NOTIFY``) is off;
-        - the target has no live tmux session (SDK / offline / unknown
-          transport — nothing to nudge, or its live-inject already confirmed);
-        - there is nothing unread;
-        - a recent nudge is still inside the coalesce window (one nudge per
-          burst, simple backoff).
-
-        The nudge rides the session's readiness-gated internal-prompt queue
-        (``_enqueue_internal_prompt``), so it can't corrupt a half-typed /
-        mid-turn pane, and it is a daemon-internal prompt (not a comms
-        message), so it never enqueues another agent message → no nudge loop.
-        Returns ``True`` iff a nudge was actually enqueued.
-        """
-        if not _AGENT_MSG_NOTIFY_ENABLED:
-            return False
-        session = self._get_streaming_session(to_agent)
-        enqueue = getattr(session, "_enqueue_internal_prompt", None)
-        if session is None or not callable(enqueue):
-            return False  # SDK / offline / unknown transport — no tmux pane
-        if getattr(session, "state", None) != SessionState.CONNECTED:
-            return False
-        try:
-            unread = comms.unread_count(to_agent)
-        except Exception as e:
-            _log(f"broker: unread_count for {to_agent} failed: {e}")
-            return False
-        if unread <= 0:
-            return False
-        now = time.monotonic()
-        last = self._agent_msg_nudge_at.get(to_agent, 0.0)
-        if now - last < _AGENT_MSG_NUDGE_BACKOFF_SEC:
-            return False  # coalesce: a nudge already fired this window
-        # Reserve the window BEFORE the await so concurrent deliveries in the
-        # same burst don't each enqueue a nudge.
-        self._agent_msg_nudge_at[to_agent] = now
-        plural = "s" if unread != 1 else ""
-        nudge = (
-            f"[pinky] {unread} unread agent message{plural} — "
-            f"call check_inbox to read {'them' if unread != 1 else 'it'}."
-        )
-        try:
-            await enqueue(nudge, reason="agent_msg_notify")
-        except Exception as e:
-            # Roll back the reservation so a transient failure can retry.
-            self._agent_msg_nudge_at.pop(to_agent, None)
-            _log(f"broker: check-inbox nudge for {to_agent} failed: {e}")
-            return False
-        self._stats["nudged"] += 1
-        _log(
-            f"broker: nudged {to_agent} — {unread} unread agent "
-            f"message{plural} (check_inbox)"
-        )
-        return True
+        """Return false; unread-agent-message nudges are deprecated."""
+        return False
 
     # ── Response Routing ───────────────────────────────────
 
@@ -1865,18 +1790,16 @@ class MessageBroker:
             await self._send_message(agent_name, platform, chat_id, stripped)
 
     async def route_agent_reply(self, comms, turn_result) -> bool:
-        """Auto-deliver a completed agent-to-agent turn to the requester's inbox.
+        """Auto-deliver a completed agent-to-agent turn live to the requester.
 
         #279: ``inject_agent_message`` stamps injected turns with
         ``platform == AGENT_REPLY_PLATFORM`` and ``chat_id`` = the requester
         agent name. When such a turn finishes, the recipient's turn text is
-        delivered to the requester's inbox via ``comms.send`` — the missing
-        return leg that left review verdicts (and every other agent reply)
-        stranded in the recipient's transcript with nowhere to go.
-
-        Loop-safe by construction: this writes to the inbox only and never
-        injects a live turn, so an auto-routed reply cannot itself trigger
-        another routed turn — the exchange terminates.
+        delivered by a one-way live injection. The reply is also stored in the
+        comms messages table for audit/thread history, with only read recipient
+        bookkeeping and no unread inbox state. The return injection sets
+        ``route_reply=False``, so it cannot trigger another auto-routed reply
+        and the exchange terminates.
 
         Returns True when the turn was an agent reply (handled here, caller
         should stop); False for normal platform turns so the caller falls
@@ -1899,10 +1822,18 @@ class MessageBroker:
             return True
         try:
             comms.send(responder, requester, text, metadata={"auto_routed": True})
-            self._stats["routed"] += 1
+            delivered, _confirmed = await self.inject_agent_message(
+                responder, requester, text, route_reply=False
+            )
+            if not delivered:
+                _log(
+                    f"broker: auto-route agent reply {responder} -> {requester} "
+                    "failed: requester has no accepting live session"
+                )
+                return True
             _log(
                 f"broker: auto-routed agent reply {responder} -> {requester} "
-                f"({len(text)} chars)"
+                f"live ({len(text)} chars)"
             )
         except Exception as e:
             # Delivery failed — count it so dropped replies are monitorable

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -88,8 +88,8 @@ class CodexSession:
 
     # ``send`` only appends to the in-memory ``_message_queue``; a worker
     # later runs ``codex exec`` out-of-process. Enqueue is NOT consumption,
-    # so an inject through this transport never confirms — the durable comms
-    # inbox copy stays unread until check_inbox. (Explicit for clarity; the
+    # so an inject through this transport never confirms consumption even
+    # though a truthy enqueue is live delivery. (Explicit for clarity; the
     # broker's getattr default is False anyway.) See
     # MessageBroker.inject_agent_message / InjectResult.
     injection_confirms_consumption: bool = False

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -1177,8 +1177,8 @@ class BrokerSlackPoller:
         try:
             # InjectResult: attempt-level ``delivered`` is the right signal
             # here (the Slack card feedback means "routed to agent");
-            # ``confirmed`` is comms-inbox retire semantics and this path has
-            # no comms row to retire.
+            # ``confirmed`` is transport-consumption observability and is not
+            # required for this routing acknowledgement.
             delivered, _confirmed = await self._broker.inject_agent_message(
                 "slack-approval", self._agent_name, msg
             )

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -235,7 +235,7 @@ class AgentScheduler:
         # Used to skip eval for idle-sleeping agents (which the API callback
         # would refuse anyway, but at the cost of a budget slot and a log line).
         self._is_resurrectable_fn = is_resurrectable_fn  # fn(agent_name) -> bool
-        self._comms_cleanup_fn = comms_cleanup_fn  # fn() -> int (expired inbox cleanup)
+        self._comms_cleanup_fn = comms_cleanup_fn  # fn() -> int (expired comms bookkeeping cleanup)
         self._trigger_store = trigger_store  # TriggerStore | None
         self._activity = activity  # ActivityStore | None
         self._tick_interval = tick_interval

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -254,9 +254,8 @@ class StreamingSession:
     # straight into the live turn stream, and returns a PER-CALL handoff bool
     # (False when the query raised — swallowed + reconnect, #853 P1). The
     # broker confirms an inject only when this capability AND that per-call
-    # handoff are both true, and only then retires (marks read) the durable
-    # comms inbox copy. Contrast TmuxSession (external pane) which sets this
-    # False. See MessageBroker.inject_agent_message / InjectResult.
+    # handoff are both true. Contrast TmuxSession (external pane) which sets
+    # this False. See MessageBroker.inject_agent_message / InjectResult.
     injection_confirms_consumption: bool = True
 
     def __init__(
@@ -1292,9 +1291,8 @@ class StreamingSession:
         self._state_machine._state = SessionState.RECONNECTING
 
         # #591 P1#1 (Murzik round-2): the prior eager refresh here ran
-        # the builder 1-arg (commit=True), consuming inbox + restart-
-        # manifest BEFORE connect() ran its own reason-aware committed
-        # rebuild — same double-consume pattern as the API-layer sites.
+        # the builder 1-arg (commit=True), consuming restart-manifest BEFORE
+        # connect() ran its own reason-aware committed rebuild.
         # Removed entirely: connect() is now the single source-of-truth
         # for both the wake_context body and side-effect consumption.
 

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1129,9 +1129,9 @@ class TmuxSession:
     # worker later pastes it into an EXTERNAL tmux pane. A dead / mid-turn /
     # restarted or stale-CONNECTED pane silently drops the paste and the queue
     # is lost on teardown, so a successful inject is NOT a positive handoff.
-    # The durable comms inbox stays the source of truth (fail-closed): the
-    # broker must never mark an agent message read merely because it was
-    # injected here. Inherited by CodexTmuxSession. See
+    # The transport therefore never confirms consumption; agent delivery is
+    # nevertheless live-only with no durable inbox fallback. Inherited by
+    # CodexTmuxSession. See
     # MessageBroker.injection_confirms_consumption.
     injection_confirms_consumption: bool = False
 

--- a/src/pinky_daemon/transport.py
+++ b/src/pinky_daemon/transport.py
@@ -250,8 +250,7 @@ class Transport(Protocol):
             transport's ``injection_confirms_consumption`` class attr
             (``True`` only for in-process SDK streams; ``False`` for
             external-pane tmux/codex transports). The broker combines
-            both into ``InjectResult.confirmed``; only a confirmed inject
-            may retire the durable comms inbox copy.
+            both into ``InjectResult.confirmed`` for observability.
 
         **Caller contract.** Callers must ensure the transport is in
         ``SessionState.CONNECTED`` before invoking ``send``. ``send`` itself

--- a/src/pinky_daemon/wake_prompt.py
+++ b/src/pinky_daemon/wake_prompt.py
@@ -25,7 +25,7 @@ The builder is pure: no I/O, no MCP, no broker. ``context_body`` is the
 already-assembled context string from the upstream context collector
 (e.g. ``api._build_streaming_wake_context``) which has the registry /
 broker dependencies and is responsible for saved state, restart manifest,
-freshness warnings, active-channel preamble, inbox/task previews, etc.
+freshness warnings, active-channel preamble, task previews, etc.
 """
 
 from __future__ import annotations

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -1486,7 +1486,7 @@ def create_server(
         reply_to: int | None = None,
         priority: str = "normal",
     ) -> str:
-        """Message another agent (delivered immediately or queued if offline).
+        """Message another agent through live delivery only.
         Reply to agent messages here — don't message the owner unless human attention is needed.
         """
         priority_map = {"normal": 0, "high": 1, "urgent": 2}
@@ -1499,8 +1499,11 @@ def create_server(
         })
         if "error" in result:
             return f"Failed to message {to}: {result.get('error', 'unknown')}"
-        if result.get("queued"):
-            return f"Message queued for {to} (they're offline). They'll see it in their inbox when they wake up."
+        if not result.get("delivered"):
+            return (
+                f"Message not delivered to {to} — no live session accepted it. "
+                "Agent inboxes are deprecated, so it was not queued."
+            )
         return f"Message delivered to {to}."
 
     @mcp.tool()
@@ -1616,43 +1619,8 @@ def create_server(
 
     @mcp.tool()
     def check_inbox(unread_only: bool = True, limit: int = 20) -> str:
-        """Read queued messages from other agents. Messages are auto-marked as read when retrieved."""
-        result = _api(
-            "GET",
-            f"/sessions/{agent_name}/inbox?unread_only={'true' if unread_only else 'false'}&limit={limit}",
-        )
-        if "error" in result:
-            return f"Failed to check inbox: {result.get('error', 'unknown')}"
-
-        messages = result.get("messages", [])
-        unread = result.get("unread", 0)
-
-        if not messages:
-            return "Inbox empty — no unread messages."
-
-        # Auto-mark retrieved messages as read
-        msg_ids = [m["id"] for m in messages]
-        _api("POST", f"/sessions/{agent_name}/inbox/read", msg_ids)
-
-        parts = [f"Inbox: {len(messages)} message(s) ({unread} unread total)\n"]
-        for m in messages:
-            sender = m.get("from", "?")
-            content = m.get("content", "")
-            msg_type = m.get("content_type", m.get("type", "text"))
-            priority = m.get("priority", 0)
-            msg_id = m.get("id", "")
-            parent = m.get("parent_message_id")
-
-            header = f"[#{msg_id}] From {sender}"
-            if msg_type != "text":
-                header += f" ({msg_type})"
-            if priority > 0:
-                header += f" {'!' * priority}PRIORITY"
-            if parent:
-                header += f" (reply to #{parent})"
-
-            parts.append(f"{header}\n{content}\n")
-        return "\n".join(parts)
+        """Deprecated compatibility tool; agent messages are delivered live only."""
+        return "Agent inbox deprecated — messages are delivered live only; nothing queued."
 
     @mcp.tool()
     def agent_status(name: str) -> str:

--- a/tests/test_agent_comms.py
+++ b/tests/test_agent_comms.py
@@ -33,16 +33,37 @@ class TestAgentComms:
         assert msg.message_type == "direct"
         self._cleanup(comms, path)
 
-    def test_direct_appears_in_inbox(self):
+    def test_direct_is_audit_only_and_inbox_stays_empty(self):
         comms, path = self._make_comms()
-        comms.send("alice", "bob", "Hey!")
+        msg = comms.send("alice", "bob", "Hey!")
 
-        inbox = comms.get_inbox("bob")
-        assert len(inbox) == 1
-        assert inbox[0].content == "Hey!"
-        assert inbox[0].from_session == "alice"
-        assert inbox[0].read is False
+        assert comms.get_inbox("bob") == []
+        assert comms.unread_count("bob") == 0
+        unread_rows = comms._conn.execute(
+            "SELECT COUNT(*) FROM inbox WHERE session_id = 'bob' AND read = 0"
+        ).fetchone()[0]
+        assert unread_rows == 0
+        messages, total = comms.get_all_messages()
+        assert total == 1
+        assert messages[0].id == msg.id
+        assert messages[0].content == "Hey!"
         self._cleanup(comms, path)
+
+    def test_startup_retires_legacy_unread_rows(self):
+        comms, path = self._make_comms()
+        comms.send("alice", "bob", "Legacy queued message")
+        comms._conn.execute("UPDATE inbox SET read = 0 WHERE session_id = 'bob'")
+        comms._conn.commit()
+        comms.close()
+
+        reopened = AgentComms(db_path=path)
+        unread_rows = reopened._conn.execute(
+            "SELECT COUNT(*) FROM inbox WHERE session_id = 'bob' AND read = 0"
+        ).fetchone()[0]
+        assert unread_rows == 0
+        assert reopened.get_inbox("bob") == []
+        assert reopened.unread_count("bob") == 0
+        self._cleanup(reopened, path)
 
     def test_direct_not_in_sender_inbox(self):
         comms, path = self._make_comms()
@@ -56,17 +77,13 @@ class TestAgentComms:
         comms, path = self._make_comms()
         msg = comms.send("alice", "bob", "Hey!")
 
-        assert comms.unread_count("bob") == 1
-        comms.mark_read("bob", [msg.id])
+        assert comms.unread_count("bob") == 0
+        assert comms.mark_read("bob", [msg.id]) == 0
         assert comms.unread_count("bob") == 0
 
-        # Unread_only should now be empty
-        inbox = comms.get_inbox("bob", unread_only=True)
-        assert len(inbox) == 0
-
-        # But all messages should still show
-        inbox = comms.get_inbox("bob", unread_only=False)
-        assert len(inbox) == 1
+        assert comms.get_inbox("bob", unread_only=True) == []
+        assert comms.get_inbox("bob", unread_only=False) == []
+        assert msg.read is True
         self._cleanup(comms, path)
 
     def test_mark_all_read(self):
@@ -75,9 +92,9 @@ class TestAgentComms:
         comms.send("alice", "bob", "Msg 2")
         comms.send("alice", "bob", "Msg 3")
 
-        assert comms.unread_count("bob") == 3
+        assert comms.unread_count("bob") == 0
         count = comms.mark_read("bob")
-        assert count == 3
+        assert count == 0
         assert comms.unread_count("bob") == 0
         self._cleanup(comms, path)
 
@@ -87,11 +104,15 @@ class TestAgentComms:
         comms.send("charlie", "bob", "Hi Bob from Charlie")
         comms.send("alice", "charlie", "Hi Charlie")
 
-        bob_inbox = comms.get_inbox("bob")
-        assert len(bob_inbox) == 2
-
-        charlie_inbox = comms.get_inbox("charlie")
-        assert len(charlie_inbox) == 1
+        assert comms.get_inbox("bob") == []
+        assert comms.get_inbox("charlie") == []
+        messages, total = comms.get_all_messages()
+        assert total == 3
+        assert {message.content for message in messages} == {
+            "Hi Bob",
+            "Hi Bob from Charlie",
+            "Hi Charlie",
+        }
         self._cleanup(comms, path)
 
     # ── Broadcast ────────────────────────────────────────────
@@ -105,10 +126,9 @@ class TestAgentComms:
         assert msg.message_type == "broadcast"
         assert msg.to_session == "*"
 
-        # Should be in bob and charlie's inbox, not alice's
-        assert len(comms.get_inbox("bob")) == 1
-        assert len(comms.get_inbox("charlie")) == 1
-        assert len(comms.get_inbox("alice")) == 0
+        assert comms.get_inbox("bob") == []
+        assert comms.get_inbox("charlie") == []
+        assert comms.get_inbox("alice") == []
         self._cleanup(comms, path)
 
     def test_broadcast_content(self):
@@ -118,9 +138,10 @@ class TestAgentComms:
             active_sessions=["bob", "charlie"],
         )
 
-        bob_msg = comms.get_inbox("bob")[0]
-        assert bob_msg.content == "Important update"
-        assert bob_msg.from_session == "alice"
+        messages, total = comms.get_all_messages()
+        assert total == 1
+        assert messages[0].content == "Important update"
+        assert messages[0].from_session == "alice"
         self._cleanup(comms, path)
 
     # ── Groups ───────────────────────────────────────────────
@@ -140,10 +161,9 @@ class TestAgentComms:
         assert msg.message_type == "group"
         assert msg.group == "team"
 
-        # bob and charlie get it, alice doesn't
-        assert len(comms.get_inbox("bob")) == 1
-        assert len(comms.get_inbox("charlie")) == 1
-        assert len(comms.get_inbox("alice")) == 0
+        assert comms.get_inbox("bob") == []
+        assert comms.get_inbox("charlie") == []
+        assert comms.get_inbox("alice") == []
         self._cleanup(comms, path)
 
     def test_join_group(self):
@@ -235,8 +255,13 @@ class TestAgentCommsAPI:
         resp = client.get("/sessions/bob/inbox")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == 1
-        assert data["unread"] == 1
+        assert data == {
+            "session_id": "bob",
+            "messages": [],
+            "count": 0,
+            "unread": 0,
+            "deprecated": True,
+        }
         os.unlink(path)
 
     def test_mark_read(self):
@@ -247,7 +272,7 @@ class TestAgentCommsAPI:
 
         resp = client.post("/sessions/bob/inbox/read")
         assert resp.status_code == 200
-        assert resp.json()["marked"] == 1
+        assert resp.json() == {"marked": 0, "deprecated": True}
         os.unlink(path)
 
     def test_broadcast(self):
@@ -324,9 +349,9 @@ class TestAgentCommsAPI:
         assert resp.status_code == 200
         assert resp.json()["type"] == "group"
 
-        # Bob should have it
         inbox = client.get("/sessions/bob/inbox").json()
-        assert inbox["count"] == 1
+        assert inbox["count"] == 0
+        assert inbox["deprecated"] is True
         os.unlink(path)
 
     def test_send_not_found_session(self):
@@ -353,9 +378,8 @@ class TestAgentCommsAPI:
         assert data["priority"] == 2
 
         inbox = client.get("/sessions/bob/inbox").json()
-        msg = inbox["messages"][0]
-        assert msg["content_type"] == "task_request"
-        assert msg["priority"] == 2
+        assert inbox["messages"] == []
+        assert inbox["deprecated"] is True
         os.unlink(path)
 
     def test_send_with_threading(self):
@@ -424,8 +448,10 @@ class TestAgentCommsNewFeatures:
         msg = comms.send("alice", "bob", "Do task X", content_type="task_request")
         assert msg.content_type == "task_request"
 
-        inbox = comms.get_inbox("bob")
-        assert inbox[0].content_type == "task_request"
+        assert comms.get_inbox("bob") == []
+        messages, total = comms.get_all_messages()
+        assert total == 1
+        assert messages[0].content_type == "task_request"
         self._cleanup(comms, path)
 
     def test_default_content_type_is_text(self):
@@ -450,9 +476,7 @@ class TestAgentCommsNewFeatures:
         original = comms.send("alice", "bob", "Question?")
         reply = comms.send("bob", "alice", "Answer!", parent_message_id=original.id)
         assert reply.parent_message_id == original.id
-
-        inbox = comms.get_inbox("alice")
-        assert inbox[0].parent_message_id == original.id
+        assert comms.get_inbox("alice") == []
         self._cleanup(comms, path)
 
     def test_get_thread(self):
@@ -512,22 +536,19 @@ class TestAgentCommsNewFeatures:
         assert "B->C" not in contents
         self._cleanup(comms, path)
 
-    def test_get_thread_read_state(self):
-        """Thread with session_id should reflect real inbox read state."""
+    def test_get_thread_has_no_unread_state(self):
+        """Thread history is always read because delivery inboxes are deprecated."""
         comms, path = self._make_comms()
         root = comms.send("alice", "bob", "Question?")
         comms.send("bob", "alice", "Answer!", parent_message_id=root.id)
 
-        # Bob has root in inbox (unread)
         thread = comms.get_thread(root.id, session_id="bob")
         assert len(thread) == 2
         root_msg = [m for m in thread if m.content == "Question?"][0]
-        assert root_msg.read is False
+        assert root_msg.read is True
 
-        # Mark as read
-        comms.mark_read("bob", [root.id])
+        assert comms.mark_read("bob", [root.id]) == 0
 
-        # Now read state should be True
         thread2 = comms.get_thread(root.id, session_id="bob")
         root_msg2 = [m for m in thread2 if m.content == "Question?"][0]
         assert root_msg2.read is True
@@ -535,19 +556,20 @@ class TestAgentCommsNewFeatures:
 
     # ── Priority ──────────────────────────────────────────────
 
-    def test_priority_sorting(self):
+    def test_priority_is_preserved_in_audit_without_an_inbox(self):
         comms, path = self._make_comms()
         comms.send("alice", "bob", "Normal message", priority=0)
         comms.send("charlie", "bob", "Urgent!", priority=2)
         comms.send("dave", "bob", "High priority", priority=1)
 
-        inbox = comms.get_inbox("bob")
-        assert len(inbox) == 3
-        # Should be sorted by priority DESC
-        assert inbox[0].priority == 2
-        assert inbox[0].content == "Urgent!"
-        assert inbox[1].priority == 1
-        assert inbox[2].priority == 0
+        assert comms.get_inbox("bob") == []
+        messages, total = comms.get_all_messages()
+        assert total == 3
+        assert {message.content: message.priority for message in messages} == {
+            "Normal message": 0,
+            "Urgent!": 2,
+            "High priority": 1,
+        }
         self._cleanup(comms, path)
 
     def test_default_priority_is_zero(self):
@@ -560,10 +582,13 @@ class TestAgentCommsNewFeatures:
 
     def test_message_with_ttl(self):
         comms, path = self._make_comms()
-        _msg = comms.send("alice", "bob", "Temporary", ttl_seconds=3600)
-        inbox = comms.get_inbox("bob")
-        assert len(inbox) == 1
-        assert inbox[0].content == "Temporary"
+        msg = comms.send("alice", "bob", "Temporary", ttl_seconds=3600)
+        assert comms.get_inbox("bob") == []
+        row = comms._conn.execute(
+            "SELECT read, expires_at FROM inbox WHERE message_id = ?", (msg.id,)
+        ).fetchone()
+        assert row["read"] == 1
+        assert row["expires_at"] is not None
         self._cleanup(comms, path)
 
     def test_expired_message_not_in_inbox(self):
@@ -571,8 +596,7 @@ class TestAgentCommsNewFeatures:
         # Send with a TTL of 1 second
         comms.send("alice", "bob", "Ephemeral", ttl_seconds=1)
 
-        # Immediately should be visible
-        assert len(comms.get_inbox("bob")) == 1
+        assert comms.get_inbox("bob") == []
 
         # Manually expire it by updating the DB
         import time
@@ -582,8 +606,7 @@ class TestAgentCommsNewFeatures:
         )
         comms._conn.commit()
 
-        # Now should be filtered out
-        assert len(comms.get_inbox("bob")) == 0
+        assert comms.get_inbox("bob") == []
         self._cleanup(comms, path)
 
     def test_cleanup_expired(self):
@@ -602,10 +625,11 @@ class TestAgentCommsNewFeatures:
         count = comms.cleanup_expired()
         assert count == 1
 
-        # Only the permanent message remains
-        inbox = comms.get_inbox("bob")
-        assert len(inbox) == 1
-        assert inbox[0].content == "Permanent msg"
+        remaining = comms._conn.execute(
+            """SELECT m.content FROM inbox i
+               JOIN messages m ON m.id = i.message_id"""
+        ).fetchall()
+        assert [row["content"] for row in remaining] == ["Permanent msg"]
         self._cleanup(comms, path)
 
     def test_no_ttl_never_expires(self):
@@ -615,7 +639,7 @@ class TestAgentCommsNewFeatures:
         # Cleanup should not remove messages without TTL
         count = comms.cleanup_expired()
         assert count == 0
-        assert len(comms.get_inbox("bob")) == 1
+        assert comms.get_inbox("bob") == []
         self._cleanup(comms, path)
 
     def test_broadcast_default_ttl(self):
@@ -624,8 +648,9 @@ class TestAgentCommsNewFeatures:
 
         # Broadcasts should have expires_at set (7-day default)
         row = comms._conn.execute(
-            "SELECT expires_at FROM inbox WHERE session_id = 'bob'"
+            "SELECT read, expires_at FROM inbox WHERE session_id = 'bob'"
         ).fetchone()
+        assert row["read"] == 1
         assert row["expires_at"] is not None
         import time
         # Should expire roughly 7 days from now
@@ -655,7 +680,7 @@ class TestAgentCommsNewFeatures:
         thread = comms.get_thread(root.id, session_id="bob")
         assert len(thread) == 1
         assert thread[0].content == "Hear ye"
-        assert thread[0].read is False
+        assert thread[0].read is True
         self._cleanup(comms, path)
 
     def test_get_thread_still_hides_unrelated_messages(self):
@@ -750,13 +775,13 @@ class TestAgentCommsNewFeatures:
         comms.send("alice", "bob", "Msg 2")
 
         assert comms.mark_read("bob", []) == 0
-        assert comms.unread_count("bob") == 2
+        assert comms.unread_count("bob") == 0
         self._cleanup(comms, path)
 
     # ── Inbox Fallback (API) ──────────────────────────────────
 
-    def test_agent_message_auto_wake_or_queue(self):
-        """Inter-agent messages auto-wake sleeping agents. Falls back to queue if wake fails."""
+    def test_agent_message_auto_wake_or_live_delivery_only(self):
+        """Inter-agent messages may auto-wake, but they are never queued."""
         fd, path = tempfile.mkstemp(suffix=".db")
         os.close(fd)
         from pinky_daemon.api import create_api
@@ -771,12 +796,11 @@ class TestAgentCommsNewFeatures:
             "from_agent": "sender",
             "message": "Hello offline agent",
         })
-        # Should succeed (200) — either delivered after auto-wake or queued
         assert resp.status_code == 200
         data = resp.json()
         assert data["message_id"] > 0
-        # Auto-wake may or may not succeed depending on environment
-        assert data["delivered"] is True or data["queued"] is True
+        assert data["queued"] is False
+        assert client.get("/sessions/target_agent/inbox").json()["messages"] == []
         os.unlink(path)
 
     # ── Agent Card (API) ──────────────────────────────────────

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -227,8 +227,8 @@ class TestStreamingSession:
         """#853 P1: StreamingSession.send() reports THIS call's handoff —
         True when client.query() succeeded, False when the exception path was
         taken (swallow + reconnect preserved, no raise). The broker ANDs this
-        with the transport capability to decide whether an injected agent
-        message may retire its durable inbox copy."""
+        with the transport capability to report confirmed consumption for
+        observability."""
         from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
         from pinky_daemon.transport_state import SessionState
 
@@ -1052,19 +1052,14 @@ class TestAPI:
                 assert len(data) == 1
                 assert data[0]["id"] == "adhoc"
 
-    def test_agent_message_tmux_stays_unread_and_nudges(self):
-        """Fail-closed inter-agent delivery (#215 PR3): a tmux-transport
-        target's live-inject does NOT retire the durable inbox copy. The
-        message stays unread, check_inbox still surfaces it, and the target is
-        nudged to read its inbox. This is the codex-tmux black-hole fix."""
+    def test_agent_message_tmux_is_live_only_with_zero_unread_or_nags(self):
+        """A live tmux handoff creates audit bookkeeping but no inbox delivery."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             with TestClient(app) as client:
                 client.post("/agents", json={"name": "murzik", "model": "sonnet"})
 
-                # tmux-style transport: inject is best-effort (not confirmed),
-                # and it exposes the internal-prompt queue used for the nudge.
                 session = self._FakeStreamingSession("murzik", "main")
                 session.injection_confirms_consumption = False
                 nudges: list[tuple[str, str]] = []
@@ -1080,26 +1075,26 @@ class TestAPI:
                 })
                 assert resp.status_code == 200
                 body = resp.json()
-                assert body["delivered"] is True   # live-inject happened
-                assert body["confirmed"] is False  # but not confirmed → not retired
+                assert body["delivered"] is True
+                assert body["confirmed"] is False
+                assert body["queued"] is False
+                assert len(session.sent) == 1
+                assert "review chez#104" in session.sent[0][0]
 
-                # Durable copy remains UNREAD — the whole point of the fix.
-                assert app.state.comms.unread_count("murzik") == 1
-                # ... so check_inbox (unread-only) still returns it.
+                assert app.state.comms.unread_count("murzik") == 0
+                unread_rows = app.state.comms._conn.execute(
+                    "SELECT COUNT(*) FROM inbox WHERE session_id = ? AND read = 0",
+                    ("murzik",),
+                ).fetchone()[0]
+                assert unread_rows == 0
                 inbox = client.get("/sessions/murzik/inbox?unread_only=true").json()
-                msgs = inbox["messages"]
-                assert len(msgs) == 1
-                assert "review chez#104" in msgs[0]["content"]
-                assert msgs[0]["read"] == 0
-                # ... and the target was nudged (once) to check its inbox.
-                assert len(nudges) == 1
-                assert nudges[0][1] == "agent_msg_notify"
-                assert "check_inbox" in nudges[0][0]
+                assert inbox["messages"] == []
+                assert inbox["unread"] == 0
+                assert inbox["deprecated"] is True
+                assert nudges == []
 
-    def test_agent_message_sdk_confirmed_marks_read(self):
-        """An in-process (SDK) transport confirms consumption, so the durable
-        copy IS retired (marked read) — preserves the working path's
-        no-repeat-on-wake behavior and avoids duplicates."""
+    def test_agent_message_sdk_confirmation_is_observability_only(self):
+        """SDK confirmation remains visible without creating unread state."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
@@ -1117,15 +1112,11 @@ class TestAPI:
                 body = resp.json()
                 assert body["delivered"] is True
                 assert body["confirmed"] is True
-                # Confirmed handoff → durable copy retired.
+                assert body["queued"] is False
                 assert app.state.comms.unread_count("gemma") == 0
 
-    def test_agent_message_sdk_failed_handoff_stays_unread(self):
-        """#853 P1 regression: the SDK capability is transport-static, but
-        StreamingSession.send() swallows a failed client.query() (reconnect,
-        no raise) and reports handoff=False. That exact message must NOT be
-        retired: durable row stays unread, response says confirmed=false, and
-        the nudge no-ops for SDK (no internal-prompt queue)."""
+    def test_agent_message_sdk_failed_handoff_is_not_queued(self):
+        """A failed live handoff remains audited but is not inbox-queued."""
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
@@ -1149,14 +1140,13 @@ class TestAPI:
                 })
                 assert resp.status_code == 200
                 body = resp.json()
-                assert body["delivered"] is True   # attempt-level unchanged
-                assert body["confirmed"] is False  # handoff failed → no retire
-                # No mark_read — the message is still visible to check_inbox.
-                assert app.state.comms.unread_count("gemma") == 1
+                assert body["delivered"] is False
+                assert body["confirmed"] is False
+                assert body["queued"] is False
+                assert app.state.comms.unread_count("gemma") == 0
                 inbox = client.get("/sessions/gemma/inbox?unread_only=true").json()
-                assert len(inbox["messages"]) == 1
-                assert "important verdict" in inbox["messages"][0]["content"]
-                # SDK session has no tmux internal-prompt queue → no nudge.
+                assert inbox["messages"] == []
+                assert inbox["deprecated"] is True
                 assert app.state.broker._stats["nudged"] == 0
 
     def test_register_isolation_mode_round_trips(self):
@@ -7167,7 +7157,7 @@ class TestBuildStreamingWakeContextReasonGating:
     On any other reason (CONTEXT_RESTART / AUTO_RESTART / NEW_SESSION /
     IDLE_WAKE) the full manifest is emitted as before.
 
-    Transient context (inbox, tasks, channels, dreams, restart manifest)
+    Transient context (tasks, channels, dreams, restart manifest)
     is fresh per-wake and continues to fire on RESUME — only the saved
     manifest is gated.
     """
@@ -7386,11 +7376,10 @@ class TestBuildStreamingWakeContextReasonGating:
             assert "WARNING: Saved continuation context" not in out
 
     def test_resume_preserves_channel_context(self):
-        """Transient context (channel preamble, inbox, tasks, dreams,
+        """Transient context (channel preamble, tasks, dreams,
         restart manifest) is fresh per wake and continues to fire on
         RESUME — only the saved-context manifest is gated by reason.
-        The model wouldn't otherwise know about active channels or
-        new inbox messages received while asleep.
+        The model wouldn't otherwise know about active channels.
         """
         from pinky_daemon.wake_prompt import WakeReason
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -7407,48 +7396,31 @@ class TestBuildStreamingWakeContextReasonGating:
             assert "## ⚡ Wake Action" not in out
             assert "## Continuation" not in out
 
-    def test_commit_false_does_not_consume_inbox(self):
-        """#591 P1#1 (Murzik): the eager pre-build at session-config
-        creation time must NOT consume inbox messages — that would
-        leave the delivered (connect-time) rebuild with an empty
-        inbox and a wake prompt missing the new agent messages.
-        """
+    def test_wake_context_never_replays_agent_audit_messages(self):
+        """Audit history is never treated as a wake-time delivery inbox."""
         from pinky_daemon.wake_prompt import WakeReason
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             app.state.agents.register("dymok", model="sonnet")
             app.state.agents.register("barsik", model="sonnet")
-            # barsik sends dymok a message — appears in dymok's inbox.
             app.state.comms.send(
                 from_session="barsik",
                 to_session="dymok",
                 content="Phase 2 plan looks right — ship it",
             )
-            unread_before = len(
-                app.state.comms.get_inbox("dymok", unread_only=True)
-            )
-            assert unread_before == 1
+            assert app.state.comms.get_inbox("dymok", unread_only=True) == []
 
-            # Eager pre-build (commit=False): must NOT mark inbox read.
             out_preview = app.state._build_streaming_wake_context(
                 "dymok", WakeReason.NEW_SESSION, commit=False
             )
-            assert "Phase 2 plan looks right" in out_preview  # content rendered
-            unread_after_preview = len(
-                app.state.comms.get_inbox("dymok", unread_only=True)
-            )
-            assert unread_after_preview == 1  # NOT marked read
+            assert "Phase 2 plan looks right" not in out_preview
 
-            # Delivered build (commit=True): marks inbox read.
             out_delivered = app.state._build_streaming_wake_context(
                 "dymok", WakeReason.NEW_SESSION, commit=True
             )
-            assert "Phase 2 plan looks right" in out_delivered
-            unread_after_delivered = len(
-                app.state.comms.get_inbox("dymok", unread_only=True)
-            )
-            assert unread_after_delivered == 0  # NOW marked read
+            assert "Phase 2 plan looks right" not in out_delivered
+            assert app.state.comms.unread_count("dymok") == 0
 
     def test_commit_false_does_not_consume_restart_manifest(self):
         """#591 P1#1 (Murzik): the eager pre-build must NOT delete

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -436,10 +436,7 @@ class TestMessageBrokerRouting:
 
     @pytest.mark.asyncio
     async def test_inject_unconfirmed_when_sdk_handoff_fails(self):
-        """#853 P1: capability True must NOT overrule a failed per-call
-        handoff. An SDK send whose client.query() raised internally (swallowed
-        + reconnect, returns False) → (True, False): the exact message that
-        failed stays unretired."""
+        """A failed per-call handoff is not live delivery."""
         tmpdir, _, broker, _, _ = self._make_broker()
         try:
             from pinky_daemon.transport_state import SessionState
@@ -453,7 +450,7 @@ class TestMessageBrokerRouting:
 
             broker.register_streaming("barsik", _SdkishFailing(), label="main")
             delivered, confirmed = await broker.inject_agent_message("pushok", "barsik", "hi")
-            assert delivered is True
+            assert delivered is False
             assert confirmed is False
         finally:
             tmpdir.cleanup()
@@ -484,114 +481,43 @@ class TestMessageBrokerRouting:
         return _TmuxNudge()
 
     @pytest.mark.asyncio
-    async def test_notify_unread_enqueues_nudge_for_tmux(self):
-        """A tmux target with unread messages gets one readiness-gated nudge
-        via the internal-prompt queue."""
+    async def test_notify_unread_is_deprecated_noop(self):
+        """The compatibility method never emits an unread-inbox nudge."""
         tmpdir, _, broker, _, _ = self._make_broker()
         try:
             session = self._tmux_nudge_session()
             broker.register_streaming("barsik", session, label="main")
             fired = await broker.notify_unread_agent_messages(self._NudgeComms(2), "barsik")
-            assert fired is True
-            assert len(session.nudges) == 1
-            prompt, reason = session.nudges[0]
-            assert reason == "agent_msg_notify"
-            assert "2 unread agent messages" in prompt
-            assert "check_inbox" in prompt
-            assert broker._stats["nudged"] == 1
-        finally:
-            tmpdir.cleanup()
-
-    @pytest.mark.asyncio
-    async def test_notify_unread_coalesces_within_window(self):
-        """A burst collapses to a single nudge (no storm)."""
-        tmpdir, _, broker, _, _ = self._make_broker()
-        try:
-            session = self._tmux_nudge_session()
-            broker.register_streaming("barsik", session, label="main")
-            comms = self._NudgeComms(3)
-            assert await broker.notify_unread_agent_messages(comms, "barsik") is True
-            # Second delivery in the same burst → coalesced, no new nudge.
-            assert await broker.notify_unread_agent_messages(comms, "barsik") is False
-            assert len(session.nudges) == 1
-            assert broker._stats["nudged"] == 1
-        finally:
-            tmpdir.cleanup()
-
-    @pytest.mark.asyncio
-    async def test_notify_unread_flag_off_no_nudge(self, monkeypatch):
-        """PINKYBOT_AGENT_MSG_NOTIFY off → no nudge (kill-switch)."""
-        import pinky_daemon.broker as broker_mod
-
-        monkeypatch.setattr(broker_mod, "_AGENT_MSG_NOTIFY_ENABLED", False)
-        tmpdir, _, broker, _, _ = self._make_broker()
-        try:
-            session = self._tmux_nudge_session()
-            broker.register_streaming("barsik", session, label="main")
-            fired = await broker.notify_unread_agent_messages(self._NudgeComms(5), "barsik")
             assert fired is False
             assert session.nudges == []
+            assert broker._stats["nudged"] == 0
         finally:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_notify_unread_noop_for_non_tmux_transport(self):
-        """An SDK-style session (no internal-prompt queue) is never nudged —
-        its live-inject already confirmed consumption."""
-        tmpdir, _, broker, _, _ = self._make_broker()
-        try:
-            from pinky_daemon.transport_state import SessionState
-
-            class _Sdkish:
-                state = SessionState.CONNECTED
-                injection_confirms_consumption = True
-
-                async def send(self, *a, **k):
-                    pass
-
-            broker.register_streaming("barsik", _Sdkish(), label="main")
-            fired = await broker.notify_unread_agent_messages(self._NudgeComms(2), "barsik")
-            assert fired is False
-        finally:
-            tmpdir.cleanup()
-
-    @pytest.mark.asyncio
-    async def test_notify_unread_noop_when_nothing_unread(self):
-        """Nothing unread → no nudge."""
-        tmpdir, _, broker, _, _ = self._make_broker()
-        try:
-            session = self._tmux_nudge_session()
-            broker.register_streaming("barsik", session, label="main")
-            fired = await broker.notify_unread_agent_messages(self._NudgeComms(0), "barsik")
-            assert fired is False
-            assert session.nudges == []
-        finally:
-            tmpdir.cleanup()
-
-    @pytest.mark.asyncio
-    async def test_notify_unread_noop_without_session(self):
-        """No live session → no nudge (durable unread row is the backstop)."""
-        tmpdir, _, broker, _, _ = self._make_broker()
-        try:
-            fired = await broker.notify_unread_agent_messages(self._NudgeComms(4), "barsik")
-            assert fired is False
-        finally:
-            tmpdir.cleanup()
-
-    @pytest.mark.asyncio
-    async def test_route_agent_reply_delivers_to_requester_inbox(self):
-        """#279: a completed agent-reply turn is delivered to the requester's
-        inbox via comms.send — and ONLY that (loop-safe: no live inject)."""
+    async def test_route_agent_reply_is_one_way_live_injection(self):
+        """The return leg is live, audited, and cannot trigger another reply."""
+        from pinky_daemon.transport_state import SessionState
         from pinky_daemon.turn_response import TurnResponse
 
         tmpdir, registry, broker, _, _ = self._make_broker()
         try:
             sent: list = []
+            injected: list = []
 
             class _FakeComms:
                 def send(self, frm, to, content, **kw):
                     sent.append((frm, to, content, kw.get("metadata")))
 
+            class _FakeStreaming:
+                state = SessionState.CONNECTED
+                injection_confirms_consumption = True
+
+                async def send(self, prompt, *, platform="", chat_id="", message_id=""):
+                    injected.append((prompt, platform, chat_id))
+                    return True
+
+            broker.register_streaming("barsik", _FakeStreaming(), label="main")
             tr = TurnResponse(
                 agent_name="murzik",
                 platform="agent",
@@ -601,13 +527,16 @@ class TestMessageBrokerRouting:
             handled = await broker.route_agent_reply(_FakeComms(), tr)
             assert handled is True
             assert sent == [("murzik", "barsik", "LGTM - ship it", {"auto_routed": True})]
+            assert len(injected) == 1
+            assert "LGTM - ship it" in injected[0][0]
+            assert injected[0][1:] == ("", "")
         finally:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
     async def test_route_agent_reply_ignores_normal_platform_turns(self):
         """A telegram turn is not an agent reply: returns False (caller falls
-        through to normal routing) and nothing is delivered to an inbox."""
+        through to normal routing) and nothing is agent-routed."""
         from pinky_daemon.turn_response import TurnResponse
 
         tmpdir, registry, broker, _, _ = self._make_broker()
@@ -630,7 +559,7 @@ class TestMessageBrokerRouting:
     @pytest.mark.asyncio
     async def test_route_agent_reply_skips_empty_text(self):
         """A pure tool-call agent turn (no final text) is consumed but nothing is
-        delivered — no empty inbox entries."""
+        delivered."""
         from pinky_daemon.turn_response import TurnResponse
 
         tmpdir, registry, broker, _, _ = self._make_broker()
@@ -652,7 +581,7 @@ class TestMessageBrokerRouting:
 
     @pytest.mark.asyncio
     async def test_route_agent_reply_counts_failed_delivery(self):
-        """If comms.send raises, the turn is still consumed (handled True, never
+        """If audit storage raises, the turn is still consumed (handled True, never
         re-injected) and the failure is counted so dropped replies are visible."""
         from pinky_daemon.turn_response import TurnResponse
 
@@ -660,7 +589,7 @@ class TestMessageBrokerRouting:
         try:
             class _BoomComms:
                 def send(self, *a, **k):
-                    raise RuntimeError("inbox down")
+                    raise RuntimeError("audit down")
 
             tr = TurnResponse(
                 agent_name="murzik", platform="agent", chat_id="barsik", text="x"
@@ -673,15 +602,26 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_route_agent_reply_real_comms_lands_in_inbox(self):
-        """End-to-end return leg against a real AgentComms: the reply appears in
-        the requester's inbox via get_inbox, tagged auto_routed."""
+    async def test_route_agent_reply_real_comms_is_audited_and_live(self):
+        """End-to-end return leg is live and retained only in audit history."""
         from pinky_daemon.agent_comms import AgentComms
+        from pinky_daemon.transport_state import SessionState
         from pinky_daemon.turn_response import TurnResponse
 
         tmpdir, registry, broker, _, _ = self._make_broker()
         try:
             comms = AgentComms(db_path=f"{tmpdir.name}/comms.db")
+            injected: list = []
+
+            class _FakeStreaming:
+                state = SessionState.CONNECTED
+                injection_confirms_consumption = True
+
+                async def send(self, prompt, *, platform="", chat_id="", message_id=""):
+                    injected.append((prompt, platform, chat_id))
+                    return True
+
+            broker.register_streaming("barsik", _FakeStreaming(), label="main")
             tr = TurnResponse(
                 agent_name="murzik",
                 platform="agent",
@@ -690,11 +630,16 @@ class TestMessageBrokerRouting:
             )
             handled = await broker.route_agent_reply(comms, tr)
             assert handled is True
-            inbox = comms.get_inbox("barsik")
-            assert len(inbox) == 1
-            assert inbox[0].from_session == "murzik"
-            assert inbox[0].content == "LGTM - ship it"
-            assert inbox[0].metadata.get("auto_routed") is True
+            assert comms.get_inbox("barsik") == []
+            assert comms.unread_count("barsik") == 0
+            messages, total = comms.get_all_messages()
+            assert total == 1
+            assert messages[0].from_session == "murzik"
+            assert messages[0].content == "LGTM - ship it"
+            assert messages[0].metadata.get("auto_routed") is True
+            assert len(injected) == 1
+            assert "LGTM - ship it" in injected[0][0]
+            assert injected[0][1:] == ("", "")
         finally:
             tmpdir.cleanup()
 

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -399,17 +399,18 @@ class TestCheckInbox:
         }
         with _ok(inbox):
             result = _tools(srv)["check_inbox"]()
-        assert "pushok" in result or "hello" in result or "1" in result
+        assert "deprecated" in result.lower()
+        assert "nothing queued" in result.lower()
 
     def test_empty_inbox(self, srv):
         with _ok({"messages": [], "unread_count": 0}):
             result = _tools(srv)["check_inbox"]()
-        assert "0" in result or "empty" in result.lower() or isinstance(result, str)
+        assert "deprecated" in result.lower()
 
     def test_error(self, srv):
         with _ok({"error": "no inbox"}):
             result = _tools(srv)["check_inbox"]()
-        assert isinstance(result, str)
+        assert "deprecated" in result.lower()
 
 
 # ── check_for_updates ─────────────────────────────────────────────────────────
@@ -1019,10 +1020,11 @@ class TestSendToAgent:
             result = _tools(srv)["send_to_agent"](to="pushok", message="Hello!")
         assert "delivered" in result.lower() or "pushok" in result
 
-    def test_queued(self, srv):
+    def test_not_delivered_is_not_queued(self, srv):
         with _ok({"queued": True}):
             result = _tools(srv)["send_to_agent"](to="pushok", message="Hey, async")
-        assert "queued" in result.lower() or "offline" in result.lower()
+        assert "not delivered" in result.lower()
+        assert "not queued" in result.lower()
 
     def test_with_reply_and_priority(self, srv):
         with _ok({"delivered": True}):


### PR DESCRIPTION
## Summary

Deprecates the agent inbox delivery system in favor of live injection only.

- Agent messages are retained in `messages` for audit/thread history, with legacy `inbox` rows kept read-only (`read=1`) only for recipient authorization/bookkeeping.
- Startup retires any legacy unread rows; inbox/read/summary surfaces are inert and `check_inbox` returns a deprecation notice.
- Removes wake-time inbox replay and unread reminder generation.
- Makes auto-routed agent replies a one-way live injection (`route_reply=False`) so the existing inbox-only return leg is not lost and cannot ping-pong.
- Reports a failed per-call transport handoff as not delivered; `confirmed` remains observability only.

## Design choice

This is a clean behavioral deprecation rather than a feature flag. The SQLite schema is retained surgically because group/broadcast thread authorization and audit history use recipient mappings; those rows can never become unread delivery state.

## Validation

- `ruff check .`
- `python3 -m compileall -q src/pinky_daemon src/pinky_self`
- affected regression: 709 passed
- CPython 3.12.13 full repository suite with declared `.[dev]` dependencies: 4,425 passed / 3 skipped
- `git diff --check`

The production daemon already owns shared-MCP port 8890 on this host; one test that deliberately enables shared MCP emits an expected thread warning, without a test failure.

## Deployment

No merge, release, deploy, daemon restart, or live write performed. Barsik owns merge, release cut, and `update_and_restart`.