### PR TITLE
Broker: prefer threaded reply hints for threaded inbound messages

### DIFF
--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1631,15 +1631,26 @@ class MessageBroker:
         hint = ""
         _no_hint_platforms = {"web", "api", ""}
         if message.platform and message.platform not in _no_hint_platforms:
-            hint = (
-                f"\n💬 Reply on {message.platform} using pinky-messaging: "
-                f'send(chat_id="{message.chat_id}", platform="{message.platform}", text=...)'
-            )
-            if message.message_id:
-                hint += (
-                    f' — or thread(message_id="{message.message_id}", text=...) '
-                    f"to quote-reply to this message"
+            if message.reply_to and message.message_id:
+                hint = (
+                    f"\n💬 Reply IN THREAD to this message on {message.platform} "
+                    f"using pinky-messaging: "
+                    f'thread(message_id="{message.message_id}", text=...). '
+                    f'Fallback: send(chat_id="{message.chat_id}", '
+                    f'platform="{message.platform}", text=...) posts to the channel '
+                    f"OUTSIDE the thread"
                 )
+            else:
+                hint = (
+                    f"\n💬 Reply on {message.platform} using pinky-messaging: "
+                    f'send(chat_id="{message.chat_id}", '
+                    f'platform="{message.platform}", text=...)'
+                )
+                if message.message_id:
+                    hint += (
+                        f' — or thread(message_id="{message.message_id}", text=...) '
+                        f"to quote/thread-reply to this message"
+                    )
         await streaming.send(
             prompt,
             platform=message.platform,

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -43,6 +43,45 @@ class TestMessageBrokerRouting:
         )
         return tmpdir, registry, broker, sent_messages, reactions
 
+    async def _capture_reply_hint(
+        self,
+        *,
+        platform: str = "telegram",
+        message_id: str = "9999",
+        reply_to: str = "",
+    ) -> str:
+        tmpdir, _, broker, _, _ = self._make_broker()
+        try:
+            from pinky_daemon.transport_state import SessionState
+
+            class _CapturingStreaming:
+                state = SessionState.CONNECTED
+                resume_handle = "live"
+
+                def __init__(self):
+                    self.captured: dict = {}
+
+                async def send(self, prompt, **kwargs) -> None:
+                    self.captured = kwargs
+
+            streaming = _CapturingStreaming()
+            broker.register_streaming("barsik", streaming, label="main")
+
+            msg = BrokerMessage(
+                platform=platform,
+                chat_id="6770805286",
+                sender_name="Brad",
+                sender_id="u-1",
+                content="hi barsik",
+                agent_name="barsik",
+                message_id=message_id,
+                reply_to=reply_to,
+            )
+            await broker._route_streaming("barsik", msg)
+            return streaming.captured.get("agent_hint", "")
+        finally:
+            tmpdir.cleanup()
+
     def test_format_prompt_includes_thread_provenance_for_child_reply(self):
         tmpdir, registry, broker, _sent, _reactions = self._make_broker()
         try:
@@ -1653,46 +1692,48 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_route_streaming_reply_hint_names_pinky_messaging_tools(self):
+    async def test_route_streaming_top_level_reply_hint_prefers_send_tool(self):
         """The agent reply hint must reference real pinky-messaging tools
         (send/thread), not the non-existent send_message()/reply() that the
         old hint named. Regression for Brad's 2026-05-29 report."""
-        tmpdir, _, broker, _, _ = self._make_broker()
-        try:
-            from pinky_daemon.transport_state import SessionState
+        hint = await self._capture_reply_hint()
 
-            class _CapturingStreaming:
-                state = SessionState.CONNECTED
-                resume_handle = "live"
-                captured: dict = {}
+        assert hint, "no agent_hint passed to streaming.send()"
+        assert "send_message()" not in hint
+        assert "reply()" not in hint
+        assert "Reply on telegram using pinky-messaging" in hint
+        assert 'send(chat_id="6770805286"' in hint
+        assert 'platform="telegram"' in hint
+        assert 'thread(message_id="9999"' in hint
+        assert hint.index("send(") < hint.index("thread(")
+        assert "quote/thread-reply to this message" in hint
 
-                async def send(self, prompt, **kwargs) -> None:
-                    _CapturingStreaming.captured = kwargs
+    @pytest.mark.asyncio
+    async def test_route_streaming_thread_reply_hint_prefers_thread_tool(self):
+        hint = await self._capture_reply_hint(reply_to="thread-root")
 
-            broker.register_streaming("barsik", _CapturingStreaming(), label="main")
+        assert "Reply IN THREAD to this message" in hint
+        assert 'thread(message_id="9999", text=...)' in hint
+        assert 'send(chat_id="6770805286", platform="telegram", text=...)' in hint
+        assert hint.index("thread(") < hint.index("send(")
+        assert "posts to the channel OUTSIDE the thread" in hint
 
-            msg = BrokerMessage(
-                platform="telegram",
-                chat_id="6770805286",
-                sender_name="Brad",
-                sender_id="u-1",
-                content="hi barsik",
-                agent_name="barsik",
-                message_id="9999",
-            )
-            await broker._route_streaming("barsik", msg)
+    @pytest.mark.asyncio
+    async def test_route_streaming_reply_hint_without_message_id_has_no_thread_clause(self):
+        hint = await self._capture_reply_hint(
+            message_id="",
+            reply_to="thread-root",
+        )
 
-            hint = _CapturingStreaming.captured.get("agent_hint", "")
-            assert hint, "no agent_hint passed to streaming.send()"
-            # The bogus tool names must be gone.
-            assert "send_message()" not in hint
-            assert "reply()" not in hint
-            # Real pinky-messaging tools, with the live chat_id/platform/message_id.
-            assert 'send(chat_id="6770805286"' in hint
-            assert 'platform="telegram"' in hint
-            assert 'thread(message_id="9999"' in hint
-        finally:
-            tmpdir.cleanup()
+        assert "Reply on telegram using pinky-messaging" in hint
+        assert 'send(chat_id="6770805286", platform="telegram", text=...)' in hint
+        assert "thread(" not in hint
+        assert "Reply IN THREAD" not in hint
+
+    @pytest.mark.parametrize("platform", ["web", "api", ""])
+    @pytest.mark.asyncio
+    async def test_route_streaming_internal_platforms_have_no_reply_hint(self, platform):
+        assert await self._capture_reply_hint(platform=platform) == ""
 
     @pytest.mark.asyncio
     async def test_route_streaming_falls_back_when_no_ensurer_wired(self):


### PR DESCRIPTION
## Summary

- Lead with `thread(message_id=..., text=...)` when an external inbound message is already in a thread and has a message ID.
- Keep `send(chat_id=..., platform=..., text=...)` first for top-level messages, with `thread(...)` described as a quote/thread-reply option.
- Omit thread guidance when no message ID is available and preserve the existing web/API/empty-platform and no-hint gating.

## Root cause

The broker always presented flat `send(...)` as the primary reply path, even for an inbound thread reply. That wording steered agents to post outside the active thread. Credit to Chekov for the diagnosis, relayed by Brad.

## Impact

Agents now receive thread-aware reply guidance without changing prompt formatting, delivery behavior, platform plumbing, or the messaging tools themselves. The flat-send fallback is explicitly labeled as posting to the channel outside the thread.

## Validation

- `tests/test_broker.py`: 74 passed on Python 3.11, 3.12, and 3.13
- Reply-hint regression slice: 6 passed on Python 3.11, 3.12, and 3.13
- Repository-wide Ruff: passed
- `compileall` and `git diff --check`: passed

## Rollout

Merge target is tonight. Deploy with the NEXT release only; do not bounce the daemon tonight.