### PR TITLE
Improve ferry resilience and isolation guidance

### DIFF
--- a/src/pinky_daemon/__main__.py
+++ b/src/pinky_daemon/__main__.py
@@ -139,15 +139,35 @@ def _run_api(args) -> None:
     )
 
     from pinky_daemon.ferry.config import FerryConfig
+    from pinky_daemon.ferry.listener import FerryListenerState, serve_ferry_with_retry
 
     ferry_cfg = FerryConfig.from_env()
+    listener_state = getattr(app.state, "ferry_listener", None)
+    if not isinstance(listener_state, FerryListenerState):
+        listener_state = FerryListenerState.from_config(ferry_cfg)
+        app.state.ferry_listener = listener_state
+    bind = (
+        f"{ferry_cfg.bind_host}:{ferry_cfg.bind_port}"
+        if ferry_cfg.bind_host
+        else ""
+    )
     if not ferry_cfg.enabled:
         # Default / current prod: single server, unchanged behavior. If the
         # operator tried to turn ferry ON but the config is incomplete or the
         # bind host is unsafe, say why (fail-closed — we never bind publicly).
-        if (os.environ.get("PINKYBOT_FERRY_ENABLED") or "").strip().lower() in (
+        enabled_requested = (
+            os.environ.get("PINKYBOT_FERRY_ENABLED") or ""
+        ).strip().lower() in (
             "1", "true", "yes", "on",
-        ):
+        )
+        disabled_error = ferry_cfg.why_disabled() if enabled_requested else ""
+        listener_state.update(
+            "disabled",
+            bind=bind,
+            last_error=disabled_error,
+            retry_count=0,
+        )
+        if enabled_requested:
             print(f"[pinky] Ferry disabled: {ferry_cfg.why_disabled()}", file=sys.stderr)
         uvicorn.run(app, host=args.host, port=args.port)
         return
@@ -160,6 +180,12 @@ def _run_api(args) -> None:
 
     host_pinky = getattr(app.state, "host_pinky", None)
     if host_pinky is None:
+        listener_state.update(
+            "dead",
+            bind=bind,
+            last_error="ferry enabled but host_pinky missing",
+            retry_count=0,
+        )
         print(
             "[pinky] ferry enabled but host_pinky missing — starting API only",
             file=sys.stderr,
@@ -187,24 +213,20 @@ def _run_api(args) -> None:
     main_server.capture_signals = lambda: contextlib.nullcontext()
     ferry_server.capture_signals = lambda: contextlib.nullcontext()
 
-    async def _serve_ferry() -> None:
-        # Best-effort: a ferry bind failure (e.g. the Tailscale IP isn't
-        # assigned yet) must NOT take down the core daemon. Log it and let the
-        # main API keep serving.
-        try:
-            await ferry_server.serve()
-        except (Exception, SystemExit) as e:  # noqa: BLE001
-            print(
-                f"[pinky] Ferry listener failed (main API unaffected): {e}",
-                file=sys.stderr,
-            )
-
     async def _serve_both() -> None:
         loop = asyncio.get_running_loop()
+        shutdown_event = asyncio.Event()
+
+        async def _wait_for_retry(delay: float) -> None:
+            try:
+                await asyncio.wait_for(shutdown_event.wait(), timeout=delay)
+            except TimeoutError:
+                pass
 
         def _shutdown(*_a) -> None:
             main_server.should_exit = True
             ferry_server.should_exit = True
+            shutdown_event.set()
 
         for sig in (signal.SIGINT, signal.SIGTERM):
             try:
@@ -212,7 +234,14 @@ def _run_api(args) -> None:
             except (NotImplementedError, RuntimeError):
                 pass
         # main API failures propagate (core); the ferry side is best-effort.
-        await asyncio.gather(main_server.serve(), _serve_ferry())
+        await asyncio.gather(
+            main_server.serve(),
+            serve_ferry_with_retry(
+                ferry_server,
+                listener_state,
+                wait=_wait_for_retry,
+            ),
+        )
 
     asyncio.run(_serve_both())
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -124,6 +124,8 @@ from pinky_daemon.broker import BrokerMessage, MessageBroker
 from pinky_daemon.conversation_store import ConversationStore
 from pinky_daemon.dream_runner import DreamRunner
 from pinky_daemon.effort import CLI_EFFORT_LEVELS, EFFORT_LEVELS, resolve_cli_effort
+from pinky_daemon.ferry.config import FerryConfig
+from pinky_daemon.ferry.listener import FerryListenerState
 from pinky_daemon.hooks import (
     AuditStore,
     HookEvent,
@@ -985,6 +987,20 @@ _ISOLATION_PATH_RES = (
     re.compile(r"^/autonomy/([^/]+)/.+$"),
 )
 
+_ISOLATION_MESH_HINT = (
+    'cross-fleet messaging is available via mesh_remote_send(target="agent@fleet") '
+    "— requires your mesh_outbound_allowlist to include the target"
+)
+
+
+class _IsolationDeniedError(HTTPException):
+    """HTTP 403 whose existing error text can carry top-level guidance."""
+
+    def __init__(self, detail: str, *, hint: str | None) -> None:
+        super().__init__(status_code=403, detail=detail)
+        self.hint = hint
+
+
 # #149: body-actor surfaces (/broker/*) are NOT matched here. Their acting
 # agent comes from the request BODY (field ``agent_name``), not the path, so
 # path matching can't catch impersonation (e.g. an isolated agent POSTing to
@@ -1626,6 +1642,16 @@ def create_api(
         description="Stateful Claude Code session API",
         version="0.1.0",
     )
+    app.state.ferry_listener = FerryListenerState.from_config(FerryConfig.from_env())
+
+    @app.exception_handler(_IsolationDeniedError)
+    async def _isolation_denied_response(
+        _request: Request, error: _IsolationDeniedError
+    ) -> JSONResponse:
+        content = {"detail": error.detail}
+        if error.hint:
+            content["hint"] = error.hint
+        return JSONResponse(status_code=error.status_code, content=content)
 
     # ── CORS ──────────────────────────────────────────────
     # Allow origins from env (comma-separated) or default to same-origin only.
@@ -4654,6 +4680,25 @@ def create_api(
             return False
         return not bool(getattr(agent, "isolated", False))
 
+    def _isolation_denial_hint(request: Request) -> str | None:
+        """Point denied callers at ferry, except for a known-local message peer."""
+        target = _isolation_path_target(request.url.path)
+        if (
+            target
+            and request.method == "POST"
+            and request.url.path == f"/agents/{target}/message"
+        ):
+            try:
+                if agents.has_agent(target):
+                    return None
+            except Exception as e:
+                _log(
+                    f"isolation-hint: registry lookup failed for '{target}' "
+                    f"on {request.url.path}: {e} — suppressing cross-fleet hint"
+                )
+                return None
+        return _ISOLATION_MESH_HINT
+
     def _deny_isolated_cross_actor(request: Request, body_agent: str) -> None:
         """#149 body-actor guard for /broker/* (and any handler whose acting
         agent comes from the request body). Raises 403 when an *isolated*
@@ -4674,9 +4719,9 @@ def create_api(
                 f"isolation: denied isolated agent '{caller}' from acting as "
                 f"'{body_agent}' on {request.url.path}"
             )
-            raise HTTPException(
-                status_code=403,
-                detail="isolated agent may only act as itself",
+            raise _IsolationDeniedError(
+                "isolated agent may only act as itself",
+                hint=_isolation_denial_hint(request),
             )
 
     def _has_valid_session(request: Request) -> bool:
@@ -4730,12 +4775,16 @@ def create_api(
             # cross-agent /agents/{other}/* access even with a valid signature.
             caller = request.headers.get(INTERNAL_AGENT_HEADER, "")
             if _internal_isolation_denied(request, caller):
+                content = {
+                    "error": "isolated agent may only access its own resources",
+                    "agent": caller,
+                }
+                hint = _isolation_denial_hint(request)
+                if hint:
+                    content["hint"] = hint
                 return JSONResponse(
                     status_code=403,
-                    content={
-                        "error": "isolated agent may only access its own resources",
-                        "agent": caller,
-                    },
+                    content=content,
                 )
             return await call_next(request)
 
@@ -7902,7 +7951,12 @@ npm run build</pre>
         Reports the active transport (HTTP-over-Tailscale or NATS) and whether
         it is wired, without leaking the shared secret or NATS password.
         """
-        return _build_mesh_sender().diagnostics()
+        diagnostics = _build_mesh_sender().diagnostics()
+        listener_state = getattr(app.state, "ferry_listener", None)
+        if not isinstance(listener_state, FerryListenerState):
+            listener_state = FerryListenerState()
+        diagnostics["ferry_listener"] = listener_state.snapshot()
+        return diagnostics
 
     @app.post("/agents/{name}/mesh/send")
     async def mesh_send(name: str, req: MeshSendRequest):

--- a/src/pinky_daemon/ferry/listener.py
+++ b/src/pinky_daemon/ferry/listener.py
@@ -1,0 +1,146 @@
+"""Runtime state and retry policy for the best-effort ferry listener."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+FERRY_LISTENER_STATES = frozenset({"up", "retrying", "disabled", "dead"})
+DEFAULT_RETRY_DELAYS = (5.0, 15.0, 30.0, 60.0)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _error_text(error: BaseException) -> str:
+    detail = str(error).strip()
+    return f"{type(error).__name__}: {detail}" if detail else type(error).__name__
+
+
+@dataclass
+class FerryListenerState:
+    """Mutable listener status shared by the serve loop and main API."""
+
+    state: str = "disabled"
+    bind: str = ""
+    last_error: str = ""
+    retry_count: int = 0
+    since: str = field(default_factory=_utc_now)
+
+    @classmethod
+    def from_config(cls, config: Any) -> FerryListenerState:
+        bind = (
+            f"{config.bind_host}:{config.bind_port}"
+            if getattr(config, "bind_host", "")
+            else ""
+        )
+        if getattr(config, "enabled", False):
+            return cls(
+                state="dead",
+                bind=bind,
+                last_error="ferry listener has not started",
+            )
+        return cls(state="disabled", bind=bind)
+
+    def update(
+        self,
+        state: str,
+        *,
+        bind: str | None = None,
+        last_error: str | None = None,
+        retry_count: int | None = None,
+    ) -> None:
+        if state not in FERRY_LISTENER_STATES:
+            raise ValueError(f"invalid ferry listener state: {state!r}")
+        if state != self.state:
+            self.state = state
+            self.since = _utc_now()
+        if bind is not None:
+            self.bind = bind
+        if last_error is not None:
+            self.last_error = last_error
+        if retry_count is not None:
+            self.retry_count = retry_count
+
+    def snapshot(self) -> dict[str, str | int]:
+        return {
+            "state": self.state,
+            "bind": self.bind,
+            "last_error": self.last_error,
+            "retry_count": self.retry_count,
+            "since": self.since,
+        }
+
+
+async def serve_ferry_with_retry(
+    server: Any,
+    listener_state: FerryListenerState,
+    *,
+    retry_delays: Sequence[float] = DEFAULT_RETRY_DELAYS,
+    wait: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    log: Callable[[str], None] | None = None,
+) -> None:
+    """Serve forever, retrying listener failures without escaping to the API.
+
+    ``server`` is intentionally structural rather than typed as
+    :class:`uvicorn.Server`, which keeps the retry policy cheap to unit test.
+    """
+    delays = tuple(retry_delays)
+    if not delays:
+        raise ValueError("retry_delays must not be empty")
+
+    emit = log or (lambda message: print(message, file=sys.stderr))
+    original_startup = server.startup
+
+    async def _startup_with_state(*args, **kwargs) -> None:
+        await original_startup(*args, **kwargs)
+        if getattr(server, "started", False):
+            listener_state.update("up", last_error="")
+            emit(
+                f"[pinky] Ferry listener up at {listener_state.bind} "
+                f"after {listener_state.retry_count} retries"
+            )
+
+    server.startup = _startup_with_state
+    listener_state.update("retrying", last_error="", retry_count=0)
+
+    try:
+        while not server.should_exit:
+            attempt = listener_state.retry_count + 1
+            emit(
+                f"[pinky] Ferry listener attempt {attempt}: "
+                f"bind {listener_state.bind}"
+            )
+            try:
+                # ``uvicorn.Server.started`` is not reset by shutdown. Clear it
+                # so a later retry cannot report up before it has rebound.
+                server.started = False
+                await server.serve()
+                if server.should_exit:
+                    break
+                raise RuntimeError("ferry listener exited unexpectedly")
+            except (Exception, SystemExit) as error:  # noqa: BLE001
+                if server.should_exit:
+                    break
+                retry_count = listener_state.retry_count + 1
+                delay = delays[min(retry_count - 1, len(delays) - 1)]
+                error_text = _error_text(error)
+                listener_state.update(
+                    "retrying",
+                    last_error=error_text,
+                    retry_count=retry_count,
+                )
+                emit(
+                    f"[pinky] Ferry listener failed attempt {attempt} "
+                    f"(main API unaffected); retrying in {delay:g}s: {error_text}"
+                )
+                await wait(delay)
+    finally:
+        server.startup = original_startup
+        if listener_state.state != "disabled":
+            listener_state.update("dead")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -927,6 +927,11 @@ class TestAgentIsolationScoping:
     Full-trust (non-isolated) agents are unaffected by either layer.
     """
 
+    _MESH_HINT = (
+        'cross-fleet messaging is available via mesh_remote_send(target="agent@fleet") '
+        "— requires your mesh_outbound_allowlist to include the target"
+    )
+
     def _make_client_with_agents(self, monkeypatch, tmp_path):
         fd, path = tempfile.mkstemp(suffix=".db")
         os.close(fd)
@@ -970,7 +975,8 @@ class TestAgentIsolationScoping:
         client, path = self._make_client_with_agents(monkeypatch, tmp_path)
         resp = self._signed_get(client, "tenant", "/agents/other")
         assert resp.status_code == 403
-        assert "isolated" in resp.json().get("error", "").lower()
+        assert resp.json()["error"] == "isolated agent may only access its own resources"
+        assert resp.json()["hint"] == self._MESH_HINT
         os.unlink(path)
 
     def test_isolated_agent_allowed_self_access(self, monkeypatch, tmp_path):
@@ -1025,7 +1031,23 @@ class TestAgentIsolationScoping:
             {"from_agent": "geordi", "message": "hi"},
         )
         assert resp.status_code == 403
-        assert "isolated" in resp.json().get("error", "").lower()
+        assert resp.json()["error"] == "isolated agent may only access its own resources"
+        assert "hint" not in resp.json()
+        os.unlink(path)
+
+    def test_isolated_unknown_message_target_gets_cross_fleet_hint(
+        self, monkeypatch, tmp_path
+    ):
+        client, path = self._make_client_grouped(monkeypatch, tmp_path)
+        resp = self._signed_post(
+            client,
+            "geordi",
+            "/agents/onesie@tod/message",
+            {"from_agent": "geordi", "message": "hi"},
+        )
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "isolated agent may only access its own resources"
+        assert resp.json()["hint"] == self._MESH_HINT
         os.unlink(path)
 
     def test_isolated_same_group_non_message_path_still_denied(self, monkeypatch, tmp_path):
@@ -1049,6 +1071,7 @@ class TestAgentIsolationScoping:
         # middleware deny uses {"error": ...}); accept either shape.
         body = resp.json()
         assert "isolated" in (body.get("detail") or body.get("error") or "").lower()
+        assert "hint" not in body
         os.unlink(path)
 
     @pytest.mark.parametrize("from_agent", ["", "   "])
@@ -1099,7 +1122,8 @@ class TestAgentIsolationScoping:
             {"agent_name": "other", "chat_id": "123", "content": "hi"},
         )
         assert resp.status_code == 403
-        assert "isolated" in str(resp.json()).lower()
+        assert resp.json()["detail"] == "isolated agent may only act as itself"
+        assert resp.json()["hint"] == self._MESH_HINT
         os.unlink(path)
 
     def test_isolated_agent_allowed_broker_send_as_self(self, monkeypatch, tmp_path):

--- a/tests/test_ferry_listener_resilience.py
+++ b/tests/test_ferry_listener_resilience.py
@@ -1,0 +1,182 @@
+"""Retry and diagnostics coverage for the best-effort ferry listener."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pinky_daemon.api import create_api
+from pinky_daemon.ferry.listener import FerryListenerState, serve_ferry_with_retry
+
+
+class _FakeFerryServer:
+    def __init__(self, failures: int) -> None:
+        self.failures = failures
+        self.serve_calls = 0
+        self.should_exit = False
+        self.started = False
+        self.up = asyncio.Event()
+
+    async def startup(self) -> None:
+        if self.serve_calls <= self.failures:
+            raise OSError(f"bind failure {self.serve_calls}")
+        self.started = True
+
+    async def serve(self) -> None:
+        self.serve_calls += 1
+        await self.startup()
+        self.up.set()
+        while not self.should_exit:
+            await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_bind_failures_back_off_then_listener_recovers() -> None:
+    server = _FakeFerryServer(failures=5)
+    state = FerryListenerState(bind="100.64.0.8:8899")
+    waits: list[float] = []
+    logs: list[str] = []
+
+    async def _wait(delay: float) -> None:
+        waits.append(delay)
+        await asyncio.sleep(0)
+
+    task = asyncio.create_task(
+        serve_ferry_with_retry(server, state, wait=_wait, log=logs.append)
+    )
+    await asyncio.wait_for(server.up.wait(), timeout=1)
+
+    assert server.serve_calls == 6
+    assert waits == [5.0, 15.0, 30.0, 60.0, 60.0]
+    assert state.snapshot() == {
+        "state": "up",
+        "bind": "100.64.0.8:8899",
+        "last_error": "",
+        "retry_count": 5,
+        "since": state.since,
+    }
+    assert sum("Ferry listener failed attempt" in line for line in logs) == 5
+    assert "after 5 retries" in logs[-1]
+
+    server.should_exit = True
+    await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_uvicorn_bind_system_exit_is_retried() -> None:
+    server = _FakeFerryServer(failures=0)
+    state = FerryListenerState(bind="100.64.0.8:8899")
+    original_startup = server.startup
+    waits: list[float] = []
+
+    async def _startup() -> None:
+        if server.serve_calls == 1:
+            raise SystemExit(1)
+        await original_startup()
+
+    async def _wait(delay: float) -> None:
+        waits.append(delay)
+        await asyncio.sleep(0)
+
+    server.startup = _startup
+    task = asyncio.create_task(
+        serve_ferry_with_retry(server, state, wait=_wait, log=lambda _line: None)
+    )
+    await asyncio.wait_for(server.up.wait(), timeout=1)
+
+    assert waits == [5.0]
+    assert state.state == "up"
+    assert state.retry_count == 1
+
+    server.should_exit = True
+    await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_should_exit_stops_listener_during_retry_wait() -> None:
+    server = _FakeFerryServer(failures=100)
+    state = FerryListenerState(bind="100.64.0.8:8899")
+    waits: list[float] = []
+
+    async def _wait(delay: float) -> None:
+        assert state.state == "retrying"
+        assert state.retry_count == 1
+        assert state.last_error == "OSError: bind failure 1"
+        waits.append(delay)
+        server.should_exit = True
+        await asyncio.sleep(0)
+
+    await serve_ferry_with_retry(server, state, wait=_wait, log=lambda _line: None)
+
+    assert server.serve_calls == 1
+    assert waits == [5.0]
+    assert state.state == "dead"
+    assert state.retry_count == 1
+    assert state.last_error == "OSError: bind failure 1"
+
+
+@pytest.mark.asyncio
+async def test_ferry_failures_never_interrupt_main_api_task() -> None:
+    server = _FakeFerryServer(failures=3)
+    state = FerryListenerState(bind="100.64.0.8:8899")
+    stop_main = asyncio.Event()
+    main_started = asyncio.Event()
+
+    async def _main_api() -> None:
+        main_started.set()
+        await stop_main.wait()
+
+    main_task = asyncio.create_task(_main_api())
+    await main_started.wait()
+
+    async def _wait(_delay: float) -> None:
+        assert not main_task.done()
+        await asyncio.sleep(0)
+
+    ferry_task = asyncio.create_task(
+        serve_ferry_with_retry(server, state, wait=_wait, log=lambda _line: None)
+    )
+    await asyncio.wait_for(server.up.wait(), timeout=1)
+
+    assert state.state == "up"
+    assert state.retry_count == 3
+    assert not main_task.done()
+
+    server.should_exit = True
+    stop_main.set()
+    await asyncio.gather(main_task, ferry_task)
+
+
+@pytest.mark.parametrize("listener_status", ["up", "retrying", "disabled", "dead"])
+@pytest.mark.asyncio
+async def test_mesh_diagnostics_surfaces_listener_state(
+    listener_status: str, monkeypatch, tmp_path
+) -> None:
+    monkeypatch.delenv("PINKYBOT_FERRY_ENABLED", raising=False)
+    app = create_api(
+        default_working_dir=str(tmp_path),
+        db_path=str(tmp_path / f"{listener_status}.db"),
+    )
+    listener = app.state.ferry_listener
+    listener.update(
+        listener_status,
+        bind="100.64.0.8:8899",
+        last_error="bind unavailable" if listener_status == "retrying" else "",
+        retry_count=2,
+    )
+    endpoint = next(
+        route.endpoint
+        for route in app.routes
+        if getattr(route, "path", None) == "/mesh/diagnostics"
+    )
+
+    diagnostics = await endpoint()
+
+    assert diagnostics["ferry_listener"] == {
+        "state": listener_status,
+        "bind": "100.64.0.8:8899",
+        "last_error": "bind unavailable" if listener_status == "retrying" else "",
+        "retry_count": 2,
+        "since": listener.since,
+    }


### PR DESCRIPTION
## Summary

- Retry dedicated ferry listener bind/serve failures forever with capped `5s → 15s → 30s → 60s` backoff while keeping the main API alive.
- Publish ferry listener state (`up`, `retrying`, `disabled`, or `dead`) through `/mesh/diagnostics`, including bind address, last error, retry count, and transition time.
- Add lawful cross-fleet `mesh_remote_send(target="agent@fleet")` guidance to isolation 403 responses while preserving the existing error strings. A denied direct-message path only gets the hint when its target is absent from the local registry.

## Root cause

The ferry listener previously caught one startup failure, logged it, and returned. If the daemon started before Tailscale assigned its configured bind IP, the listener remained down for the daemon's lifetime and the main API had no internal visibility into that degraded state. Isolation denials also gave cross-fleet callers no indication that ferry messaging was their supported route.

## Impact

Transient listener failures now recover without a daemon restart, permanent failures remain best-effort and loud, shutdown interrupts retry backoff, and isolated agents receive actionable guidance for plausible cross-fleet targets.

## Validation

- Controlled full Python 3.11 suite: `4447 passed, 1 skipped`
- Focused listener retry, shutdown, diagnostics, isolation-body, and real uvicorn startup coverage: green
- `ruff check .`
- `git diff --check`
- Frontend `npm ci`, i18n extraction, and production build

## Deployment

No deploy or daemon restart was performed. This change is intended to ride the next normal release after review.