### PR TITLE
Add in-place wake schedule updates

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -33,6 +33,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.cron_utils import _field_matches
 from pinky_daemon.effort import is_ultracode
 
 # Agent names appear in filesystem paths (data/agents/{name}/, hook scripts
@@ -257,8 +258,6 @@ def _cron_next_run(cron: str, timezone: str = "UTC") -> float | None:
         import datetime as dt
         import zoneinfo
 
-        from pinky_daemon.scheduler import _field_matches
-
         parts = cron.strip().split()
         if len(parts) != 5:
             return None
@@ -302,8 +301,6 @@ def _cron_next_run(cron: str, timezone: str = "UTC") -> float | None:
 
 def _validate_schedule_cron(cron: str) -> None:
     """Reject cron expressions that the scheduler cannot match."""
-    from pinky_daemon.scheduler import _field_matches
-
     parts = cron.strip().split()
     if len(parts) != 5:
         raise ValueError("Cron expression must contain exactly five fields")

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2913,6 +2913,30 @@ except Exception:
 
     # ── Schedules ───────────────────────────────────────────
 
+    def _ensure_schedule_name_available(
+        self,
+        agent_name: str,
+        name: str,
+        *,
+        exclude_schedule_id: int | None = None,
+    ) -> None:
+        """Refuse an enabled agent/name collision, optionally excluding one row."""
+        sql = """SELECT id FROM agent_schedules
+                 WHERE agent_name=? AND name=? AND enabled=1"""
+        params: list = [agent_name, name]
+        if exclude_schedule_id is not None:
+            sql += " AND id<>?"
+            params.append(exclude_schedule_id)
+        sql += " ORDER BY id ASC LIMIT 1"
+        existing = self._db.execute(sql, params).fetchone()
+        if existing:
+            raise ScheduleNameConflictError(
+                f"Enabled schedule {name!r} already exists for agent {agent_name!r} "
+                f"as ID {existing[0]}; choose a distinct name to create another "
+                f"schedule, or use update_wake_schedule with ID {existing[0]} "
+                "to edit the existing one"
+            )
+
     def add_schedule(
         self, agent_name: str, cron: str, *,
         name: str = "", prompt: str = "", timezone: str = "America/Los_Angeles",
@@ -2921,17 +2945,7 @@ except Exception:
     ) -> AgentSchedule:
         """Add a cron-based wake schedule for an agent."""
         _validate_schedule_cron(cron)
-        existing = self._db.execute(
-            """SELECT id FROM agent_schedules
-               WHERE agent_name=? AND name=? AND enabled=1
-               ORDER BY id ASC LIMIT 1""",
-            (agent_name, name),
-        ).fetchone()
-        if existing:
-            raise ScheduleNameConflictError(
-                f"Enabled schedule {name!r} already exists for agent {agent_name!r} "
-                f"as ID {existing[0]}; use update_wake_schedule to edit it"
-            )
+        self._ensure_schedule_name_available(agent_name, name)
 
         now = time.time()
         cursor = self._db.execute(
@@ -3010,6 +3024,19 @@ except Exception:
             if column in updates:
                 updates[column] = int(updates[column])
 
+        current = self._db.execute(
+            "SELECT agent_name, enabled FROM agent_schedules WHERE id=?",
+            (schedule_id,),
+        ).fetchone()
+        if current is None:
+            return None
+        if name is not None and bool(current[1]):
+            self._ensure_schedule_name_available(
+                current[0],
+                name,
+                exclude_schedule_id=schedule_id,
+            )
+
         set_clause = ", ".join(f"{field}=?" for field in updates)
         cursor = self._db.execute(
             f"UPDATE agent_schedules SET {set_clause} WHERE id=?",
@@ -3034,6 +3061,18 @@ except Exception:
 
     def toggle_schedule(self, schedule_id: int, enabled: bool) -> bool:
         """Enable/disable a schedule."""
+        current = self._db.execute(
+            "SELECT agent_name, name FROM agent_schedules WHERE id=?",
+            (schedule_id,),
+        ).fetchone()
+        if current is None:
+            return False
+        if enabled:
+            self._ensure_schedule_name_available(
+                current[0],
+                current[1],
+                exclude_schedule_id=schedule_id,
+            )
         cursor = self._db.execute(
             "UPDATE agent_schedules SET enabled=? WHERE id=?",
             (int(enabled), schedule_id),

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -300,6 +300,23 @@ def _cron_next_run(cron: str, timezone: str = "UTC") -> float | None:
         return None
 
 
+def _validate_schedule_cron(cron: str) -> None:
+    """Reject cron expressions that the scheduler cannot match."""
+    from pinky_daemon.scheduler import _field_matches
+
+    parts = cron.strip().split()
+    if len(parts) != 5:
+        raise ValueError("Cron expression must contain exactly five fields")
+
+    limits = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 6))
+    try:
+        for part, (lo, hi) in zip(parts, limits):
+            if not any(_field_matches(part, value, lo, hi) for value in range(lo, hi + 1)):
+                raise ValueError
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid cron expression: {cron!r}") from exc
+
+
 # Injected into the system prompt when an agent's effective effort is the
 # ``ultracode`` tier (#151). Replicates Claude Code's native ultracode
 # semantics — "xhigh effort plus standing dynamic-workflow orchestration" —
@@ -634,6 +651,10 @@ class AgentSchedule:
             "target_channel": self.target_channel,
             "one_shot": self.one_shot,
         }
+
+
+class ScheduleNameConflictError(ValueError):
+    """An enabled schedule already uses the requested agent/name pair."""
 
 
 @dataclass
@@ -2899,6 +2920,19 @@ except Exception:
         one_shot: bool = False,
     ) -> AgentSchedule:
         """Add a cron-based wake schedule for an agent."""
+        _validate_schedule_cron(cron)
+        existing = self._db.execute(
+            """SELECT id FROM agent_schedules
+               WHERE agent_name=? AND name=? AND enabled=1
+               ORDER BY id ASC LIMIT 1""",
+            (agent_name, name),
+        ).fetchone()
+        if existing:
+            raise ScheduleNameConflictError(
+                f"Enabled schedule {name!r} already exists for agent {agent_name!r} "
+                f"as ID {existing[0]}; use update_wake_schedule to edit it"
+            )
+
         now = time.time()
         cursor = self._db.execute(
             """INSERT INTO agent_schedules (agent_name, name, cron, prompt, timezone, enabled, last_run, created_at, direct_send, target_channel, one_shot)
@@ -2944,6 +2978,53 @@ except Exception:
         rows = self._db.execute(sql).fetchall()
         return [self._row_to_schedule(r) for r in rows
         ]
+
+    def update_schedule(
+        self,
+        schedule_id: int,
+        *,
+        cron: str | None = None,
+        prompt: str | None = None,
+        timezone: str | None = None,
+        name: str | None = None,
+        direct_send: bool | None = None,
+        target_channel: str | None = None,
+        one_shot: bool | None = None,
+    ) -> AgentSchedule | None:
+        """Partially update a schedule without changing its ID."""
+        values = {
+            "name": name,
+            "cron": cron,
+            "prompt": prompt,
+            "timezone": timezone,
+            "direct_send": direct_send,
+            "target_channel": target_channel,
+            "one_shot": one_shot,
+        }
+        updates = {field: value for field, value in values.items() if value is not None}
+        if not updates:
+            raise ValueError("update_schedule requires at least one field")
+        if cron is not None:
+            _validate_schedule_cron(cron)
+        for column in ("direct_send", "one_shot"):
+            if column in updates:
+                updates[column] = int(updates[column])
+
+        set_clause = ", ".join(f"{field}=?" for field in updates)
+        cursor = self._db.execute(
+            f"UPDATE agent_schedules SET {set_clause} WHERE id=?",
+            list(updates.values()) + [schedule_id],
+        )
+        self._db.commit()
+        if cursor.rowcount == 0:
+            return None
+        row = self._db.execute(
+            """SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run,
+                      created_at, direct_send, target_channel, one_shot
+               FROM agent_schedules WHERE id=?""",
+            (schedule_id,),
+        ).fetchone()
+        return self._row_to_schedule(row) if row else None
 
     def remove_schedule(self, schedule_id: int) -> bool:
         """Remove a schedule."""

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2917,7 +2917,13 @@ except Exception:
         *,
         exclude_schedule_id: int | None = None,
     ) -> None:
-        """Refuse an enabled agent/name collision, optionally excluding one row."""
+        """Enforce enabled agent/name uniqueness within this writer process.
+
+        Callers hold ``_rmw_lock`` across this guard and the mutation, which
+        serializes threads sharing this connection. This does not coordinate
+        with a second writer process; deployment requires one writer process
+        per agents DB file.
+        """
         sql = """SELECT id FROM agent_schedules
                  WHERE agent_name=? AND name=? AND enabled=1"""
         params: list = [agent_name, name]
@@ -2946,9 +2952,14 @@ except Exception:
         with self._rmw_lock:
             self._ensure_schedule_name_available(agent_name, name)
             cursor = self._db.execute(
-                """INSERT INTO agent_schedules (agent_name, name, cron, prompt, timezone, enabled, last_run, created_at, direct_send, target_channel, one_shot)
-                   VALUES (?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?)""",
-                (agent_name, name, cron, prompt, timezone, now, int(direct_send), target_channel, int(one_shot)),
+                """INSERT INTO agent_schedules (
+                       agent_name, name, cron, prompt, timezone, enabled, last_run,
+                       created_at, direct_send, target_channel, one_shot
+                   ) VALUES (?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?)""",
+                (
+                    agent_name, name, cron, prompt, timezone, now,
+                    int(direct_send), target_channel, int(one_shot),
+                ),
             )
             self._db.commit()
             return AgentSchedule(

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2942,22 +2942,22 @@ except Exception:
     ) -> AgentSchedule:
         """Add a cron-based wake schedule for an agent."""
         _validate_schedule_cron(cron)
-        self._ensure_schedule_name_available(agent_name, name)
-
         now = time.time()
-        cursor = self._db.execute(
-            """INSERT INTO agent_schedules (agent_name, name, cron, prompt, timezone, enabled, last_run, created_at, direct_send, target_channel, one_shot)
-               VALUES (?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?)""",
-            (agent_name, name, cron, prompt, timezone, now, int(direct_send), target_channel, int(one_shot)),
-        )
-        self._db.commit()
-        return AgentSchedule(
-            id=cursor.lastrowid, agent_name=agent_name, name=name,
-            cron=cron, prompt=prompt, timezone=timezone,
-            enabled=True, last_run=0.0, created_at=now,
-            direct_send=direct_send, target_channel=target_channel,
-            one_shot=one_shot,
-        )
+        with self._rmw_lock:
+            self._ensure_schedule_name_available(agent_name, name)
+            cursor = self._db.execute(
+                """INSERT INTO agent_schedules (agent_name, name, cron, prompt, timezone, enabled, last_run, created_at, direct_send, target_channel, one_shot)
+                   VALUES (?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?)""",
+                (agent_name, name, cron, prompt, timezone, now, int(direct_send), target_channel, int(one_shot)),
+            )
+            self._db.commit()
+            return AgentSchedule(
+                id=cursor.lastrowid, agent_name=agent_name, name=name,
+                cron=cron, prompt=prompt, timezone=timezone,
+                enabled=True, last_run=0.0, created_at=now,
+                direct_send=direct_send, target_channel=target_channel,
+                one_shot=one_shot,
+            )
 
     def _row_to_schedule(self, r) -> AgentSchedule:
         """Convert a DB row to AgentSchedule, handling optional columns."""
@@ -3021,34 +3021,35 @@ except Exception:
             if column in updates:
                 updates[column] = int(updates[column])
 
-        current = self._db.execute(
-            "SELECT agent_name, enabled FROM agent_schedules WHERE id=?",
-            (schedule_id,),
-        ).fetchone()
-        if current is None:
-            return None
-        if name is not None and bool(current[1]):
-            self._ensure_schedule_name_available(
-                current[0],
-                name,
-                exclude_schedule_id=schedule_id,
-            )
+        with self._rmw_lock:
+            current = self._db.execute(
+                "SELECT agent_name, enabled FROM agent_schedules WHERE id=?",
+                (schedule_id,),
+            ).fetchone()
+            if current is None:
+                return None
+            if name is not None and bool(current[1]):
+                self._ensure_schedule_name_available(
+                    current[0],
+                    name,
+                    exclude_schedule_id=schedule_id,
+                )
 
-        set_clause = ", ".join(f"{field}=?" for field in updates)
-        cursor = self._db.execute(
-            f"UPDATE agent_schedules SET {set_clause} WHERE id=?",
-            list(updates.values()) + [schedule_id],
-        )
-        self._db.commit()
-        if cursor.rowcount == 0:
-            return None
-        row = self._db.execute(
-            """SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run,
-                      created_at, direct_send, target_channel, one_shot
-               FROM agent_schedules WHERE id=?""",
-            (schedule_id,),
-        ).fetchone()
-        return self._row_to_schedule(row) if row else None
+            set_clause = ", ".join(f"{field}=?" for field in updates)
+            cursor = self._db.execute(
+                f"UPDATE agent_schedules SET {set_clause} WHERE id=?",
+                list(updates.values()) + [schedule_id],
+            )
+            self._db.commit()
+            if cursor.rowcount == 0:
+                return None
+            row = self._db.execute(
+                """SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run,
+                          created_at, direct_send, target_channel, one_shot
+                   FROM agent_schedules WHERE id=?""",
+                (schedule_id,),
+            ).fetchone()
+            return self._row_to_schedule(row) if row else None
 
     def remove_schedule(self, schedule_id: int) -> bool:
         """Remove a schedule."""
@@ -3058,24 +3059,31 @@ except Exception:
 
     def toggle_schedule(self, schedule_id: int, enabled: bool) -> bool:
         """Enable/disable a schedule."""
-        current = self._db.execute(
-            "SELECT agent_name, name FROM agent_schedules WHERE id=?",
-            (schedule_id,),
-        ).fetchone()
-        if current is None:
-            return False
-        if enabled:
+        if not enabled:
+            cursor = self._db.execute(
+                "UPDATE agent_schedules SET enabled=0 WHERE id=?",
+                (schedule_id,),
+            )
+            self._db.commit()
+            return cursor.rowcount > 0
+        with self._rmw_lock:
+            current = self._db.execute(
+                "SELECT agent_name, name FROM agent_schedules WHERE id=?",
+                (schedule_id,),
+            ).fetchone()
+            if current is None:
+                return False
             self._ensure_schedule_name_available(
                 current[0],
                 current[1],
                 exclude_schedule_id=schedule_id,
             )
-        cursor = self._db.execute(
-            "UPDATE agent_schedules SET enabled=? WHERE id=?",
-            (int(enabled), schedule_id),
-        )
-        self._db.commit()
-        return cursor.rowcount > 0
+            cursor = self._db.execute(
+                "UPDATE agent_schedules SET enabled=1 WHERE id=?",
+                (schedule_id,),
+            )
+            self._db.commit()
+            return cursor.rowcount > 0
 
     def update_schedule_last_run(self, schedule_id: int, timestamp: float = 0.0) -> None:
         """Record when a schedule last ran."""

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -48,7 +48,7 @@ from fastapi.staticfiles import StaticFiles
 
 from pinky_daemon.activity_store import ActivityStore
 from pinky_daemon.agent_comms import AgentComms
-from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.agent_registry import AgentRegistry, ScheduleNameConflictError
 from pinky_daemon.analytics_store import AnalyticsStore
 from pinky_daemon.api_models import (
     AddDirectiveRequest,
@@ -104,6 +104,7 @@ from pinky_daemon.api_models import (
     UpdateHeartbeatPromptRequest,
     UpdateMcpServerRequest,
     UpdatePasswordRequest,
+    UpdateScheduleRequest,
 )
 from pinky_daemon.app_store import AppStore
 from pinky_daemon.auth import (
@@ -871,7 +872,10 @@ GATE_TOOL_NAMES: dict[str, list[str]] = {
         "get_attribution", "render_pdf", "spawn_clone", "get_agent_card",
     ],
     "schedule": [
-        "set_wake_schedule", "list_my_schedules", "remove_wake_schedule",
+        "set_wake_schedule",
+        "update_wake_schedule",
+        "list_my_schedules",
+        "remove_wake_schedule",
     ],
     "tasks-admin": [
         "decompose_project", "bulk_create_tasks",
@@ -9883,12 +9887,21 @@ npm run build</pre>
         """Add a cron-based wake schedule for an agent."""
         if not agents.get(agent_name):
             raise HTTPException(404, f"Agent '{agent_name}' not found")
-        schedule = agents.add_schedule(
-            agent_name, req.cron,
-            name=req.name, prompt=req.prompt, timezone=req.timezone,
-            direct_send=req.direct_send, target_channel=req.target_channel,
-            one_shot=req.one_shot,
-        )
+        try:
+            schedule = agents.add_schedule(
+                agent_name,
+                req.cron,
+                name=req.name,
+                prompt=req.prompt,
+                timezone=req.timezone,
+                direct_send=req.direct_send,
+                target_channel=req.target_channel,
+                one_shot=req.one_shot,
+            )
+        except ScheduleNameConflictError as exc:
+            raise HTTPException(409, str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
         return schedule.to_dict()
 
     @app.get("/agents/{agent_name}/schedules")
@@ -9902,6 +9915,42 @@ npm run build</pre>
             "schedules": [s.to_dict() for s in schedules],
             "count": len(schedules),
         }
+
+    @app.patch("/agents/{agent_name}/schedules/{schedule_id}")
+    async def update_schedule(
+        agent_name: str,
+        schedule_id: int,
+        req: UpdateScheduleRequest,
+    ):
+        """Partially update an agent-owned schedule without changing its ID."""
+        if not agents.get(agent_name):
+            raise HTTPException(404, f"Agent '{agent_name}' not found")
+        owned_schedule = next(
+            (
+                schedule
+                for schedule in agents.get_schedules(agent_name, enabled_only=False)
+                if schedule.id == schedule_id
+            ),
+            None,
+        )
+        if owned_schedule is None:
+            raise HTTPException(404, f"Schedule {schedule_id} not found")
+        try:
+            schedule = agents.update_schedule(
+                schedule_id,
+                cron=req.cron,
+                prompt=req.prompt,
+                timezone=req.timezone,
+                name=req.name,
+                direct_send=req.direct_send,
+                target_channel=req.target_channel,
+                one_shot=req.one_shot,
+            )
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        if schedule is None:
+            raise HTTPException(404, f"Schedule {schedule_id} not found")
+        return schedule.to_dict()
 
     @app.delete("/agents/{agent_name}/schedules/{schedule_id}")
     async def remove_schedule(agent_name: str, schedule_id: int):

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -9946,6 +9946,8 @@ npm run build</pre>
                 target_channel=req.target_channel,
                 one_shot=req.one_shot,
             )
+        except ScheduleNameConflictError as exc:
+            raise HTTPException(409, str(exc)) from exc
         except ValueError as exc:
             raise HTTPException(400, str(exc)) from exc
         if schedule is None:
@@ -9962,7 +9964,11 @@ npm run build</pre>
     @app.post("/agents/{agent_name}/schedules/{schedule_id}/toggle")
     async def toggle_schedule(agent_name: str, schedule_id: int, enabled: bool = True):
         """Enable/disable a schedule."""
-        if not agents.toggle_schedule(schedule_id, enabled):
+        try:
+            toggled = agents.toggle_schedule(schedule_id, enabled)
+        except ScheduleNameConflictError as exc:
+            raise HTTPException(409, str(exc)) from exc
+        if not toggled:
             raise HTTPException(404, f"Schedule {schedule_id} not found")
         return {"toggled": True, "enabled": enabled}
 

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -729,6 +729,16 @@ class AddScheduleRequest(BaseModel):
     one_shot: bool = False
 
 
+class UpdateScheduleRequest(BaseModel):
+    cron: str | None = None
+    prompt: str | None = None
+    timezone: str | None = None
+    name: str | None = None
+    direct_send: bool | None = None
+    target_channel: str | None = None
+    one_shot: bool | None = None
+
+
 class CreateTriggerRequest(BaseModel):
     name: str = ""
     trigger_type: str  # 'webhook' | 'url' | 'file'

--- a/src/pinky_daemon/cron_utils.py
+++ b/src/pinky_daemon/cron_utils.py
@@ -1,0 +1,58 @@
+"""Shared cron-field parsing helpers used by scheduler and agent_registry.
+
+Extracted here to break the import cycle:
+  scheduler  → agent_registry  (top-level)
+  agent_registry → scheduler._field_matches  (would be cyclic)
+"""
+
+from __future__ import annotations
+
+# Standard cron name tokens. Day-of-week values match isoweekday() % 7
+# (0=Sunday ... 6=Saturday); month names map to 1-12.
+_CRON_NAMES = {
+    "sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6,
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+    "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+
+def _cron_int(token: str) -> int:
+    """Parse a cron token: a plain integer or a 3-letter day/month name."""
+    token = token.strip().lower()
+    if token in _CRON_NAMES:
+        return _CRON_NAMES[token]
+    return int(token)
+
+
+def _part_matches(part: str, value: int, lo: int, hi: int) -> bool:
+    """Match a single part of a cron field (e.g., '*/5', '1-3', 'mon-fri/2', '7')."""
+    if part == "*":
+        return True
+
+    step = 1
+    if "/" in part:
+        part, step_str = part.split("/", 1)
+        step = int(step_str)
+        if step <= 0:
+            raise ValueError(f"invalid cron step: {step_str!r}")
+        if part == "*":
+            return value % step == 0
+        if "-" not in part:
+            start = _cron_int(part)
+            return value >= start and (value - start) % step == 0
+
+    if "-" in part:
+        start_str, end_str = part.split("-", 1)
+        start = _cron_int(start_str)
+        end = _cron_int(end_str)
+        return start <= value <= end and (value - start) % step == 0
+
+    return value == _cron_int(part)
+
+
+def _field_matches(field: str, value: int, lo: int, hi: int) -> bool:
+    """Check if a single cron field matches a value."""
+    for part in field.split(","):
+        if _part_matches(part.strip(), value, lo, hi):
+            return True
+    return False

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -21,6 +21,7 @@ from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
 from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.cron_utils import _field_matches
 from pinky_daemon.transport_state import SessionState
 from pinky_daemon.watchdog_log import log_watchdog_decision
 
@@ -107,57 +108,6 @@ def cron_matches(cron_expr: str, dt: datetime) -> bool:
         _log(f"scheduler: invalid cron expression {cron_expr!r}; treating as no match")
         return False
     return True
-
-
-def _field_matches(field: str, value: int, lo: int, hi: int) -> bool:
-    """Check if a single cron field matches a value."""
-    for part in field.split(","):
-        if _part_matches(part.strip(), value, lo, hi):
-            return True
-    return False
-
-
-# Standard cron name tokens. Day-of-week values match isoweekday() % 7
-# (0=Sunday ... 6=Saturday); month names map to 1-12.
-_CRON_NAMES = {
-    "sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6,
-    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
-    "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
-}
-
-
-def _cron_int(token: str) -> int:
-    """Parse a cron token: a plain integer or a 3-letter day/month name."""
-    token = token.strip().lower()
-    if token in _CRON_NAMES:
-        return _CRON_NAMES[token]
-    return int(token)
-
-
-def _part_matches(part: str, value: int, lo: int, hi: int) -> bool:
-    """Match a single part of a cron field (e.g., '*/5', '1-3', 'mon-fri/2', '7')."""
-    if part == "*":
-        return True
-
-    step = 1
-    if "/" in part:
-        part, step_str = part.split("/", 1)
-        step = int(step_str)
-        if step <= 0:
-            raise ValueError(f"invalid cron step: {step_str!r}")
-        if part == "*":
-            return value % step == 0
-        if "-" not in part:
-            start = _cron_int(part)
-            return value >= start and (value - start) % step == 0
-
-    if "-" in part:
-        start_str, end_str = part.split("-", 1)
-        start = _cron_int(start_str)
-        end = _cron_int(end_str)
-        return start <= value <= end and (value - start) % step == 0
-
-    return value == _cron_int(part)
 
 
 def next_cron_description(cron_expr: str) -> str:

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -1,7 +1,7 @@
 """Pinky Self — MCP server for agent self-management.
 
 Gives agents tools to manage their own lifecycle:
-- Wake schedules (set/list/remove cron jobs)
+- Wake schedules (set/update/list/remove cron jobs)
 - Context management (save/load continuation state)
 - Task management (claim, complete, block, get next)
 - Health monitoring (check own status)
@@ -173,6 +173,42 @@ def create_server(
             mode = "direct-send" if direct_send else "wake"
             shot = ", one-shot" if one_shot else ""
             return f"Schedule '{result.get('name', name)}' set: {cron} ({timezone}), mode={mode}{shot}. ID: {result.get('id')}"
+
+        @mcp.tool()
+        def update_wake_schedule(
+            schedule_id: int,
+            cron: str | None = None,
+            prompt: str | None = None,
+            timezone: str | None = None,
+            name: str | None = None,
+            direct_send: bool | None = None,
+            target_channel: str | None = None,
+            one_shot: bool | None = None,
+        ) -> str:
+            """Update selected fields on an existing wake schedule without changing its ID."""
+            values = {
+                "cron": cron,
+                "prompt": prompt,
+                "timezone": timezone,
+                "name": name,
+                "direct_send": direct_send,
+                "target_channel": target_channel,
+                "one_shot": one_shot,
+            }
+            body = {field: value for field, value in values.items() if value is not None}
+            if not body:
+                return "Failed to update schedule: provide at least one field to change."
+            result = _api(
+                "PATCH",
+                f"/agents/{agent_name}/schedules/{schedule_id}",
+                body,
+            )
+            if "error" in result:
+                return f"Failed to update schedule #{schedule_id}: {result['error']}"
+            return (
+                f"Schedule #{schedule_id} updated: {result.get('name', '')} — "
+                f"{result.get('cron', '')} ({result.get('timezone', '')})."
+            )
 
         @mcp.tool()
         def list_my_schedules() -> str:

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -154,6 +154,8 @@ def create_server(
             one_shot: bool = False,
         ) -> str:
             """Set a cron schedule. Default: prompt sent TO YOU as input (wake mode).
+            Distinct concurrent schedules need distinct names. To edit an existing
+            schedule, use update_wake_schedule with its ID.
             direct_send=True: prompt sent as message to target_channel (no agent processing).
             one_shot=True: auto-disables after one fire.
             In wake mode, the prompt is an instruction — to send a message, tell yourself to call send().
@@ -185,7 +187,11 @@ def create_server(
             target_channel: str | None = None,
             one_shot: bool | None = None,
         ) -> str:
-            """Update selected fields on an existing wake schedule without changing its ID."""
+            """Update selected fields without changing a wake schedule's ID.
+
+            Distinct concurrent schedules need distinct names; renaming onto another
+            enabled schedule's name is refused.
+            """
             values = {
                 "cron": cron,
                 "prompt": prompt,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5191,13 +5191,65 @@ class TestAgentScheduleEndpoints:
     def test_create_schedule_rejects_enabled_duplicate_name(self):
         client = self._make_client()
         self._register(client, "alice")
-        assert self._create_schedule(client).status_code == 200
+        created = self._create_schedule(client).json()
 
         response = self._create_schedule(client, cron="0 9 * * *")
 
         assert response.status_code == 409
-        assert "update_wake_schedule" in response.json()["detail"]
+        detail = response.json()["detail"]
+        assert "distinct name" in detail
+        assert f"update_wake_schedule with ID {created['id']}" in detail
         assert client.get("/agents/alice/schedules").json()["count"] == 1
+
+    def test_patch_schedule_rejects_enabled_name_collision(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        existing = self._create_schedule(client).json()
+        renamed = self._create_schedule(
+            client,
+            name="evening",
+            cron="0 21 * * *",
+        ).json()
+
+        response = client.patch(
+            f"/agents/alice/schedules/{renamed['id']}",
+            json={"name": "morning"},
+        )
+
+        assert response.status_code == 409
+        assert f"ID {existing['id']}" in response.json()["detail"]
+        schedules = client.get("/agents/alice/schedules").json()["schedules"]
+        assert [(row["id"], row["name"]) for row in schedules] == [
+            (existing["id"], "morning"),
+            (renamed["id"], "evening"),
+        ]
+
+    def test_toggle_schedule_rejects_reenable_name_collision(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        old = self._create_schedule(client).json()
+        disabled = client.post(
+            f"/agents/alice/schedules/{old['id']}/toggle",
+            params={"enabled": False},
+        )
+        assert disabled.status_code == 200
+        replacement = self._create_schedule(client, cron="0 9 * * *").json()
+
+        response = client.post(
+            f"/agents/alice/schedules/{old['id']}/toggle",
+            params={"enabled": True},
+        )
+
+        assert response.status_code == 409
+        assert f"ID {replacement['id']}" in response.json()["detail"]
+        schedules = client.get(
+            "/agents/alice/schedules",
+            params={"enabled_only": False},
+        ).json()["schedules"]
+        assert [(row["id"], row["enabled"]) for row in schedules] == [
+            (old["id"], False),
+            (replacement["id"], True),
+        ]
 
     @pytest.mark.parametrize("one_shot", [False, True])
     def test_create_schedule_reuses_disabled_name(self, one_shot):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5072,6 +5072,162 @@ class TestOwnerProfileAPI:
         assert data["pronouns"] == "he/him"
 
 
+# Agent schedules
+
+
+class TestAgentScheduleEndpoints:
+    def _make_client(self):
+        from pinky_daemon.api import create_api
+
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        app = create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
+        return TestClient(app)
+
+    @staticmethod
+    def _register(client, name):
+        response = client.post("/agents", json={"name": name, "model": "sonnet"})
+        assert response.status_code == 200
+
+    @staticmethod
+    def _create_schedule(client, agent_name="alice", **overrides):
+        body = {
+            "name": "morning",
+            "cron": "0 8 * * *",
+            "prompt": "Original",
+            "timezone": "America/Los_Angeles",
+            "direct_send": True,
+            "target_channel": "123",
+            "one_shot": True,
+        }
+        body.update(overrides)
+        return client.post(f"/agents/{agent_name}/schedules", json=body)
+
+    def test_patch_schedule_partial_update_preserves_id_and_omitted_fields(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        created = self._create_schedule(client).json()
+
+        response = client.patch(
+            f"/agents/alice/schedules/{created['id']}",
+            json={
+                "cron": "30 8 * * 1-5",
+                "prompt": "Updated",
+                "direct_send": False,
+                "target_channel": "",
+            },
+        )
+
+        assert response.status_code == 200
+        updated = response.json()
+        assert updated["id"] == created["id"]
+        assert updated["name"] == "morning"
+        assert updated["cron"] == "30 8 * * 1-5"
+        assert updated["prompt"] == "Updated"
+        assert updated["timezone"] == "America/Los_Angeles"
+        assert updated["direct_send"] is False
+        assert updated["target_channel"] == ""
+        assert updated["one_shot"] is True
+
+    def test_patch_schedule_unknown_id_returns_404(self):
+        client = self._make_client()
+        self._register(client, "alice")
+
+        response = client.patch(
+            "/agents/alice/schedules/999",
+            json={"prompt": "Updated"},
+        )
+
+        assert response.status_code == 404
+
+    def test_patch_schedule_refuses_cross_agent_edit(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        self._register(client, "bob")
+        created = self._create_schedule(client).json()
+
+        response = client.patch(
+            f"/agents/bob/schedules/{created['id']}",
+            json={"prompt": "Cross-agent edit"},
+        )
+
+        assert response.status_code == 404
+        schedules = client.get(
+            "/agents/alice/schedules",
+            params={"enabled_only": False},
+        ).json()["schedules"]
+        assert schedules[0]["prompt"] == "Original"
+
+    def test_patch_schedule_refuses_empty_update(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        created = self._create_schedule(client).json()
+
+        response = client.patch(
+            f"/agents/alice/schedules/{created['id']}",
+            json={},
+        )
+
+        assert response.status_code == 400
+        assert "at least one field" in response.json()["detail"]
+
+    def test_patch_schedule_rejects_invalid_cron_without_mutating(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        created = self._create_schedule(client).json()
+
+        response = client.patch(
+            f"/agents/alice/schedules/{created['id']}",
+            json={"cron": "99 * * * *"},
+        )
+
+        assert response.status_code == 400
+        schedules = client.get(
+            "/agents/alice/schedules",
+            params={"enabled_only": False},
+        ).json()["schedules"]
+        assert schedules[0]["cron"] == "0 8 * * *"
+
+    def test_create_schedule_rejects_enabled_duplicate_name(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        assert self._create_schedule(client).status_code == 200
+
+        response = self._create_schedule(client, cron="0 9 * * *")
+
+        assert response.status_code == 409
+        assert "update_wake_schedule" in response.json()["detail"]
+        assert client.get("/agents/alice/schedules").json()["count"] == 1
+
+    @pytest.mark.parametrize("one_shot", [False, True])
+    def test_create_schedule_reuses_disabled_name(self, one_shot):
+        client = self._make_client()
+        self._register(client, "alice")
+        created = self._create_schedule(client, one_shot=one_shot).json()
+        toggle = client.post(
+            f"/agents/alice/schedules/{created['id']}/toggle",
+            params={"enabled": False},
+        )
+        assert toggle.status_code == 200
+
+        response = self._create_schedule(
+            client,
+            cron="0 9 * * *",
+            one_shot=False,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["id"] != created["id"]
+
+    def test_create_schedule_rejects_invalid_cron(self):
+        client = self._make_client()
+        self._register(client, "alice")
+
+        response = self._create_schedule(client, cron="not a cron")
+
+        assert response.status_code == 400
+
+
 # ── Agent CRUD ───────────────────────────────────────────────
 
 

--- a/tests/test_pinky_self.py
+++ b/tests/test_pinky_self.py
@@ -34,6 +34,7 @@ class TestSelfServerCreation:
         tool_names = [t.name for t in server._tool_manager.list_tools()]
         expected = [
             "set_wake_schedule",
+            "update_wake_schedule",
             "list_my_schedules",
             "remove_wake_schedule",
             "save_my_context",

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -493,6 +493,19 @@ class TestGetAgentCard:
 # ── set_wake_schedule ─────────────────────────────────────────────────────────
 
 class TestSetWakeSchedule:
+    def test_contract_documents_distinct_concurrent_names(self, srv):
+        descriptions = {
+            tool.name: tool.description
+            for tool in srv._tool_manager.list_tools()
+        }
+
+        assert "Distinct concurrent schedules need distinct names" in (
+            descriptions["set_wake_schedule"]
+        )
+        assert "Distinct concurrent schedules need distinct names" in (
+            descriptions["update_wake_schedule"]
+        )
+
     def test_basic_wake_mode(self, srv):
         resp = {"id": 42, "name": "morning_check", "cron": "0 8 * * *"}
         with _ok(resp):

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -523,6 +523,60 @@ class TestSetWakeSchedule:
         assert "Failed" in result
 
 
+# update_wake_schedule
+
+class TestUpdateWakeSchedule:
+    def test_partial_update(self, srv):
+        response = {
+            "id": 42,
+            "name": "morning_check",
+            "cron": "30 8 * * *",
+            "timezone": "America/Los_Angeles",
+        }
+        captured = {}
+
+        def _urlopen(req, timeout=30):
+            captured["method"] = req.method
+            captured["url"] = req.full_url
+            captured["body"] = json.loads(req.data)
+            body = json.dumps(response).encode()
+            result = MagicMock()
+            result.read.return_value = body
+            result.__enter__ = lambda value: value
+            result.__exit__ = MagicMock(return_value=False)
+            return result
+
+        with patch("urllib.request.urlopen", side_effect=_urlopen):
+            message = _tools(srv)["update_wake_schedule"](
+                schedule_id=42,
+                cron="30 8 * * *",
+                direct_send=False,
+            )
+
+        assert captured == {
+            "method": "PATCH",
+            "url": "http://localhost:9999/agents/barsik/schedules/42",
+            "body": {"cron": "30 8 * * *", "direct_send": False},
+        }
+        assert "Schedule #42 updated" in message
+
+    def test_empty_update_refused_without_request(self, srv):
+        with patch("urllib.request.urlopen") as urlopen:
+            message = _tools(srv)["update_wake_schedule"](schedule_id=42)
+
+        urlopen.assert_not_called()
+        assert "provide at least one field" in message
+
+    def test_api_error(self, srv):
+        with _ok({"error": "not found", "status": 404}):
+            message = _tools(srv)["update_wake_schedule"](
+                schedule_id=99,
+                prompt="new",
+            )
+
+        assert "Failed to update schedule #99" in message
+
+
 # ── list_my_schedules ─────────────────────────────────────────────────────────
 
 class TestListMySchedules:
@@ -2176,12 +2230,12 @@ class TestToolGates:
         tools = {t.name for t in srv._tool_manager.list_tools()}
         assert tools == CORE_TOOLS
 
-    def test_all_gates_has_70_tools(self):
+    def test_all_gates_has_71_tools(self):
         """All gates → full tool set.
 
         +1 in #145 with ``register_agent`` (admin gate) → 69, then +1 in #663
         with the core ``mcp_probe`` tool → 70. (Had dropped 69→68 in #552 with
-        the removal of ``request_sleep``.)
+        the removal of ``request_sleep``.) #924 adds ``update_wake_schedule`` → 71.
         """
         all_gates = [
             "extras", "kb", "research", "presentations", "triggers",
@@ -2189,7 +2243,7 @@ class TestToolGates:
         ]
         srv = create_server(agent_name="test", tool_gates=all_gates)
         tools = srv._tool_manager.list_tools()
-        assert len(tools) == 70
+        assert len(tools) == 71
 
     def test_extras_gate_adds_extras_tools(self):
         """Enabling 'extras' gate adds get_attribution, render_pdf, etc."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
 import pytest
@@ -369,103 +370,96 @@ class TestAgentSchedules:
         assert registry.get_schedules("oleg") == []
 
     def test_concurrent_add_same_name_allows_only_one(self, registry):
-        """Concurrent same-name creates must leave exactly one enabled schedule."""
+        """Same-process threads serialize the guard and insert."""
         registry.register("oleg")
-        errors: list[Exception] = []
-        successes: list[int] = []
-        barrier = threading.Barrier(12)
+        worker_count = 12
+        start = threading.Barrier(worker_count)
 
-        def worker():
-            barrier.wait()
+        def create_schedule(index):
+            start.wait(timeout=5)
             try:
-                s = registry.add_schedule("oleg", "0 8 * * *", name="morning")
-                successes.append(s.id)
-            except Exception as exc:
-                errors.append(exc)
+                schedule = registry.add_schedule(
+                    "oleg",
+                    f"{index} 8 * * *",
+                    name="morning",
+                )
+            except ScheduleNameConflictError:
+                return "conflict", None
+            return "created", schedule.id
 
-        threads = [threading.Thread(target=worker) for _ in range(12)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            results = list(executor.map(create_schedule, range(worker_count)))
 
-        enabled = registry.get_schedules("oleg", enabled_only=True)
-        enabled_named = [s for s in enabled if s.name == "morning"]
-        assert len(enabled_named) == 1, (
-            f"Expected 1 enabled 'morning' schedule, got {len(enabled_named)}"
+        assert [status for status, _ in results].count("created") == 1
+        assert [status for status, _ in results].count("conflict") == worker_count - 1
+        enabled = registry.get_schedules("oleg")
+        assert len(enabled) == 1
+        assert enabled[0].id == next(
+            row_id for status, row_id in results if status == "created"
         )
-        assert len(successes) == 1, f"Expected 1 successful create, got {len(successes)}"
 
     def test_concurrent_rename_to_same_free_name_allows_only_one(self, registry):
-        """Concurrent renames of distinct enabled schedules to the same free name must leave one."""
+        """Same-process threads serialize each guarded enabled-row rename."""
         registry.register("oleg")
-        barrier = threading.Barrier(12)
+        worker_count = 12
         schedules = [
-            registry.add_schedule("oleg", "0 8 * * *", name=f"slot-{i}")
-            for i in range(12)
+            registry.add_schedule("oleg", f"{index} 8 * * *", name=f"slot-{index}")
+            for index in range(worker_count)
         ]
-        errors: list[Exception] = []
-        successes: list[int] = []
+        start = threading.Barrier(worker_count)
 
-        def worker(sched_id):
-            barrier.wait()
+        def rename_schedule(schedule):
+            start.wait(timeout=5)
             try:
-                result = registry.update_schedule(sched_id, name="target")
-                if result is not None:
-                    successes.append(sched_id)
-            except Exception as exc:
-                errors.append(exc)
+                updated = registry.update_schedule(schedule.id, name="target")
+            except ScheduleNameConflictError:
+                return "conflict"
+            assert updated is not None
+            return "renamed"
 
-        threads = [threading.Thread(target=worker, args=(s.id,)) for s in schedules]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            results = list(executor.map(rename_schedule, schedules))
 
-        enabled = registry.get_schedules("oleg", enabled_only=True)
-        named_target = [s for s in enabled if s.name == "target"]
-        assert len(named_target) <= 1, (
-            f"Expected at most 1 enabled 'target' schedule, got {len(named_target)}"
-        )
+        assert results.count("renamed") == 1
+        assert results.count("conflict") == worker_count - 1
+        enabled = registry.get_schedules("oleg")
+        assert len(enabled) == worker_count
+        assert [schedule.name for schedule in enabled].count("target") == 1
 
     def test_concurrent_reenable_same_name_allows_only_one(self, registry):
-        """Concurrent re-enables of disabled same-name rows must leave exactly one enabled."""
+        """Same-process threads serialize each guarded re-enable."""
         registry.register("oleg")
+        worker_count = 12
         # Create 12 schedules with distinct names, disable them, then rename all
         # to "morning" while disabled (rename check skips disabled rows).
         schedules = [
-            registry.add_schedule("oleg", "0 8 * * *", name=f"slot-{i}")
-            for i in range(12)
+            registry.add_schedule("oleg", f"{index} 8 * * *", name=f"slot-{index}")
+            for index in range(worker_count)
         ]
-        for s in schedules:
-            registry.toggle_schedule(s.id, False)
-        for s in schedules:
-            registry.update_schedule(s.id, name="morning")
+        for schedule in schedules:
+            registry.toggle_schedule(schedule.id, False)
+        for schedule in schedules:
+            registry.update_schedule(schedule.id, name="morning")
 
-        barrier = threading.Barrier(12)
-        errors: list[Exception] = []
-        successes: list[int] = []
+        start = threading.Barrier(worker_count)
 
-        def worker(sched_id):
-            barrier.wait()
+        def enable_schedule(schedule):
+            start.wait(timeout=5)
             try:
-                if registry.toggle_schedule(sched_id, True):
-                    successes.append(sched_id)
-            except Exception as exc:
-                errors.append(exc)
+                enabled = registry.toggle_schedule(schedule.id, True)
+            except ScheduleNameConflictError:
+                return "conflict"
+            assert enabled is True
+            return "enabled"
 
-        threads = [threading.Thread(target=worker, args=(s.id,)) for s in schedules]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            results = list(executor.map(enable_schedule, schedules))
 
-        enabled = registry.get_schedules("oleg", enabled_only=True)
-        enabled_named = [s for s in enabled if s.name == "morning"]
-        assert len(enabled_named) == 1, (
-            f"Expected 1 enabled 'morning' schedule after concurrent re-enable, "
-            f"got {len(enabled_named)}"
-        )
+        assert results.count("enabled") == 1
+        assert results.count("conflict") == worker_count - 1
+        enabled = registry.get_schedules("oleg")
+        assert len(enabled) == 1
+        assert enabled[0].name == "morning"
 
 
 # ── Agent Heartbeat Tests ──────────────────────────────────

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
+import threading
 import time
 from datetime import datetime
 
@@ -366,6 +367,105 @@ class TestAgentSchedules:
         registry.delete("oleg")
         # Schedules should be cascade-deleted
         assert registry.get_schedules("oleg") == []
+
+    def test_concurrent_add_same_name_allows_only_one(self, registry):
+        """Concurrent same-name creates must leave exactly one enabled schedule."""
+        registry.register("oleg")
+        errors: list[Exception] = []
+        successes: list[int] = []
+        barrier = threading.Barrier(12)
+
+        def worker():
+            barrier.wait()
+            try:
+                s = registry.add_schedule("oleg", "0 8 * * *", name="morning")
+                successes.append(s.id)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(12)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        enabled = registry.get_schedules("oleg", enabled_only=True)
+        enabled_named = [s for s in enabled if s.name == "morning"]
+        assert len(enabled_named) == 1, (
+            f"Expected 1 enabled 'morning' schedule, got {len(enabled_named)}"
+        )
+        assert len(successes) == 1, f"Expected 1 successful create, got {len(successes)}"
+
+    def test_concurrent_rename_to_same_free_name_allows_only_one(self, registry):
+        """Concurrent renames of distinct enabled schedules to the same free name must leave one."""
+        registry.register("oleg")
+        barrier = threading.Barrier(12)
+        schedules = [
+            registry.add_schedule("oleg", "0 8 * * *", name=f"slot-{i}")
+            for i in range(12)
+        ]
+        errors: list[Exception] = []
+        successes: list[int] = []
+
+        def worker(sched_id):
+            barrier.wait()
+            try:
+                result = registry.update_schedule(sched_id, name="target")
+                if result is not None:
+                    successes.append(sched_id)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(s.id,)) for s in schedules]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        enabled = registry.get_schedules("oleg", enabled_only=True)
+        named_target = [s for s in enabled if s.name == "target"]
+        assert len(named_target) <= 1, (
+            f"Expected at most 1 enabled 'target' schedule, got {len(named_target)}"
+        )
+
+    def test_concurrent_reenable_same_name_allows_only_one(self, registry):
+        """Concurrent re-enables of disabled same-name rows must leave exactly one enabled."""
+        registry.register("oleg")
+        # Create 12 schedules with distinct names, disable them, then rename all
+        # to "morning" while disabled (rename check skips disabled rows).
+        schedules = [
+            registry.add_schedule("oleg", "0 8 * * *", name=f"slot-{i}")
+            for i in range(12)
+        ]
+        for s in schedules:
+            registry.toggle_schedule(s.id, False)
+        for s in schedules:
+            registry.update_schedule(s.id, name="morning")
+
+        barrier = threading.Barrier(12)
+        errors: list[Exception] = []
+        successes: list[int] = []
+
+        def worker(sched_id):
+            barrier.wait()
+            try:
+                if registry.toggle_schedule(sched_id, True):
+                    successes.append(sched_id)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(s.id,)) for s in schedules]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        enabled = registry.get_schedules("oleg", enabled_only=True)
+        enabled_named = [s for s in enabled if s.name == "morning"]
+        assert len(enabled_named) == 1, (
+            f"Expected 1 enabled 'morning' schedule after concurrent re-enable, "
+            f"got {len(enabled_named)}"
+        )
 
 
 # ── Agent Heartbeat Tests ──────────────────────────────────

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 import pytest
 
-from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.agent_registry import AgentRegistry, ScheduleNameConflictError
 from pinky_daemon.scheduler import AgentScheduler, cron_matches, next_cron_description
 
 # ── Cron Parser Tests ──────────────────────────────────────
@@ -148,7 +148,10 @@ class TestAgentSchedules:
         registry.register("oleg")
         schedule = registry.add_schedule("oleg", "0 8 * * *", name="morning")
 
-        with pytest.raises(ValueError, match="update_wake_schedule"):
+        with pytest.raises(
+            ScheduleNameConflictError,
+            match=rf"distinct name.*update_wake_schedule with ID {schedule.id}",
+        ):
             registry.add_schedule("oleg", "0 9 * * *", name="morning")
 
         assert [row.id for row in registry.get_schedules("oleg")] == [schedule.id]
@@ -286,6 +289,30 @@ class TestAgentSchedules:
     def test_update_schedule_missing(self, registry):
         assert registry.update_schedule(999, prompt="new") is None
 
+    def test_update_schedule_rejects_enabled_name_collision(self, registry):
+        registry.register("oleg")
+        existing = registry.add_schedule("oleg", "0 8 * * *", name="morning")
+        renamed = registry.add_schedule("oleg", "0 9 * * *", name="evening")
+
+        with pytest.raises(ScheduleNameConflictError, match=rf"ID {existing.id}"):
+            registry.update_schedule(renamed.id, name="morning")
+
+        schedules = registry.get_schedules("oleg")
+        assert [(row.id, row.name) for row in schedules] == [
+            (existing.id, "morning"),
+            (renamed.id, "evening"),
+        ]
+
+    def test_update_schedule_allows_self_rename(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule("oleg", "0 8 * * *", name="morning")
+
+        updated = registry.update_schedule(schedule.id, name="morning")
+
+        assert updated is not None
+        assert updated.id == schedule.id
+        assert updated.name == "morning"
+
     def test_remove_missing(self, registry):
         assert registry.remove_schedule(999) is False
 
@@ -296,6 +323,29 @@ class TestAgentSchedules:
 
         schedules = registry.get_schedules("oleg", enabled_only=False)
         assert schedules[0].enabled is False
+
+    def test_toggle_schedule_rejects_reenable_name_collision(self, registry):
+        registry.register("oleg")
+        old = registry.add_schedule("oleg", "0 8 * * *", name="morning")
+        assert registry.toggle_schedule(old.id, False) is True
+        replacement = registry.add_schedule("oleg", "0 9 * * *", name="morning")
+
+        with pytest.raises(ScheduleNameConflictError, match=rf"ID {replacement.id}"):
+            registry.toggle_schedule(old.id, True)
+
+        schedules = registry.get_schedules("oleg", enabled_only=False)
+        assert [(row.id, row.enabled) for row in schedules] == [
+            (old.id, False),
+            (replacement.id, True),
+        ]
+
+    def test_toggle_schedule_enables_without_conflict(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule("oleg", "0 8 * * *", name="morning")
+        assert registry.toggle_schedule(schedule.id, False) is True
+
+        assert registry.toggle_schedule(schedule.id, True) is True
+        assert registry.get_schedules("oleg")[0].id == schedule.id
 
     def test_update_last_run(self, registry):
         registry.register("oleg")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -144,6 +144,37 @@ class TestAgentSchedules:
         assert schedule.prompt == "Good morning!"
         assert schedule.enabled is True
 
+    def test_add_schedule_rejects_enabled_duplicate_name(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule("oleg", "0 8 * * *", name="morning")
+
+        with pytest.raises(ValueError, match="update_wake_schedule"):
+            registry.add_schedule("oleg", "0 9 * * *", name="morning")
+
+        assert [row.id for row in registry.get_schedules("oleg")] == [schedule.id]
+
+    @pytest.mark.parametrize("one_shot", [False, True])
+    def test_add_schedule_reuses_disabled_name(self, registry, one_shot):
+        registry.register("oleg")
+        old = registry.add_schedule(
+            "oleg",
+            "0 8 * * *",
+            name="morning",
+            one_shot=one_shot,
+        )
+        registry.toggle_schedule(old.id, False)
+
+        new = registry.add_schedule("oleg", "0 9 * * *", name="morning")
+
+        assert new.id != old.id
+        assert new.enabled is True
+
+    def test_add_schedule_rejects_invalid_cron(self, registry):
+        registry.register("oleg")
+
+        with pytest.raises(ValueError, match="five fields"):
+            registry.add_schedule("oleg", "not a cron", name="broken")
+
     def test_get_schedules(self, registry):
         registry.register("oleg")
         registry.add_schedule("oleg", "0 8 * * *", name="morning")
@@ -182,6 +213,79 @@ class TestAgentSchedules:
         assert registry.remove_schedule(s.id) is True
         assert registry.get_schedules("oleg") == []
 
+    def test_update_schedule_partial_preserves_id_and_omitted_fields(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg",
+            "0 8 * * *",
+            name="morning",
+            prompt="Original",
+            direct_send=True,
+            target_channel="123",
+            one_shot=True,
+        )
+
+        updated = registry.update_schedule(
+            schedule.id,
+            cron="30 8 * * 1-5",
+            prompt="Updated",
+            direct_send=False,
+            target_channel="",
+        )
+
+        assert updated is not None
+        assert updated.id == schedule.id
+        assert updated.name == "morning"
+        assert updated.cron == "30 8 * * 1-5"
+        assert updated.prompt == "Updated"
+        assert updated.timezone == "America/Los_Angeles"
+        assert updated.direct_send is False
+        assert updated.target_channel == ""
+        assert updated.one_shot is True
+
+    def test_update_schedule_supports_remaining_fields_and_empty_prompt(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg",
+            "0 8 * * *",
+            name="morning",
+            prompt="Original",
+            one_shot=True,
+        )
+
+        updated = registry.update_schedule(
+            schedule.id,
+            name="weekday",
+            prompt="",
+            timezone="UTC",
+            one_shot=False,
+        )
+
+        assert updated is not None
+        assert updated.name == "weekday"
+        assert updated.prompt == ""
+        assert updated.timezone == "UTC"
+        assert updated.one_shot is False
+
+    def test_update_schedule_refuses_empty_update(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule("oleg", "0 8 * * *")
+
+        with pytest.raises(ValueError, match="at least one field"):
+            registry.update_schedule(schedule.id)
+
+    def test_update_schedule_rejects_invalid_cron_without_mutating(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule("oleg", "0 8 * * *")
+
+        with pytest.raises(ValueError, match="Invalid cron"):
+            registry.update_schedule(schedule.id, cron="99 * * * *")
+
+        assert registry.get_schedules("oleg")[0].cron == "0 8 * * *"
+
+    def test_update_schedule_missing(self, registry):
+        assert registry.update_schedule(999, prompt="new") is None
+
     def test_remove_missing(self, registry):
         assert registry.remove_schedule(999) is False
 
@@ -206,8 +310,8 @@ class TestAgentSchedules:
 
     def test_cascade_delete(self, registry):
         registry.register("oleg")
-        registry.add_schedule("oleg", "0 8 * * *")
-        registry.add_schedule("oleg", "0 21 * * *")
+        registry.add_schedule("oleg", "0 8 * * *", name="morning")
+        registry.add_schedule("oleg", "0 21 * * *", name="evening")
 
         registry.delete("oleg")
         # Schedules should be cascade-deleted


### PR DESCRIPTION
## Summary

- add `AgentRegistry.update_schedule()` for ID-stable partial updates, with empty-update refusal and the same cron validation used by schedule creation
- expose an ownership-checked `PATCH /agents/{agent_name}/schedules/{schedule_id}` route and a gated `update_wake_schedule` MCP tool
- reject creation when an enabled schedule already has the same `(agent_name, name)`, while allowing reuse after disablement or one-shot completion
- cover registry, API, MCP wrapper, and shared-MCP gate behavior in pytest

## Why

Schedule prompt or timing corrections currently require create-new + delete-old, which renumbers durable schedule references. Repeated `set_wake_schedule` calls can also leave two enabled same-name rows that both fire.

## Impact

Agents can now edit a schedule in place without changing its ID. PATCH requests cannot edit another agent's schedule, and duplicate enabled-name creation fails closed with guidance to use `update_wake_schedule`.

Fixes #924.

## Validation

- focused schedule/API/MCP/shared-gate matrix: `40 passed`
- full mocked pinky-self tools plus shared gate checks: `206 passed`
- broader scheduler/API/pinky-self/shared/auth-route matrix: `799 passed`, with one production-environment-only dream transport failure; the exact selector passes on both this branch and untouched `origin/main` under CI-default SDK/shared-MCP flags
- `uv run ruff check .`
- `python3 -m compileall -q src/pinky_daemon src/pinky_self`
- `git diff --check`
- added-line width audit: all lines at or below 100 columns

🤖 Opened by Kuzya