### PR TITLE
Make task store SQLite connections thread-local

### DIFF
--- a/src/pinky_daemon/task_store.py
+++ b/src/pinky_daemon/task_store.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -184,10 +185,20 @@ class TaskStore:
 
     def __init__(self, db_path: str = "data/tasks.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA foreign_keys=ON")
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._init_tables()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA foreign_keys=ON")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_tables(self) -> None:
         self._db.executescript("""
@@ -888,4 +899,12 @@ class TaskStore:
         return cursor.rowcount > 0
 
     def close(self) -> None:
-        self._db.close()
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection

--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from fastapi.testclient import TestClient
@@ -254,6 +257,112 @@ class TestComments:
         assert d["project_id"] == 5
         assert d["tags"] == ["a"]
         assert d["blocked_by"] == [1, 2]
+
+
+class TestTaskConcurrency:
+    def test_mixed_crud_hammer_uses_thread_local_connections(self, tmp_path):
+        store = TaskStore(db_path=str(tmp_path / "tasks.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        seed_tasks = [
+            store.create(f"Point-read seed {index}", tags=["seed", str(index)])
+            for index in range(worker_count)
+        ]
+        seed_ids = [task.id for task in seed_tasks]
+
+        def hammer(worker_index):
+            snapshots = []
+            point_reads = 0
+            try:
+                start.wait(timeout=10)
+                connection_id = id(store._db)
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = store.create(
+                        f"Hammer task {marker}",
+                        assigned_agent=f"worker-{worker_index}",
+                        tags=["hammer", marker],
+                    )
+                    fetched = store.get(created.id)
+                    assert fetched is not None
+                    for offset in range(point_reads_per_round):
+                        seed_id = seed_ids[
+                            (worker_index + round_index + offset) % len(seed_ids)
+                        ]
+                        point_read = store.get(seed_id)
+                        assert point_read is not None
+                        assert point_read.tags[0] == "seed"
+                        assert point_read.to_dict()["id"] == seed_id
+                        point_reads += 1
+                    listed = store.list(
+                        assigned_agent=f"worker-{worker_index}",
+                        include_completed=True,
+                        limit=1,
+                    )
+                    assert listed
+                    assert listed[0].to_dict()["assigned_agent"] == f"worker-{worker_index}"
+                    completed = store.update(created.id, status="completed")
+                    assert completed is not None
+                    completed_read = store.get(created.id)
+                    assert completed_read is not None
+                    assert completed_read.status == "completed"
+                    snapshots.append(
+                        (
+                            created.to_dict(),
+                            fetched.to_dict(),
+                            completed.to_dict(),
+                        )
+                    )
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+
+            snapshots = [
+                snapshot
+                for _, worker_snapshots, _, _ in results
+                for snapshot in worker_snapshots
+            ]
+            completed_rows = worker_count * rounds
+            expected_rows = len(seed_tasks) + completed_rows
+            assert len(snapshots) == completed_rows
+            assert all(created["tags"][0] == "hammer" for created, _, _ in snapshots)
+            assert all(fetched["id"] == created["id"] for created, fetched, _ in snapshots)
+            assert all(completed["status"] == "completed" for _, _, completed in snapshots)
+
+            tasks = store.list(include_completed=True, limit=expected_rows + 1)
+            assert len(tasks) == expected_rows
+            assert store.count_by_status() == {
+                "completed": completed_rows,
+                "pending": len(seed_tasks),
+            }
+            assert len({task.id for task in tasks}) == expected_rows
+            assert all(task.tags[0] in {"hammer", "seed"} for task in tasks)
+        finally:
+            store.close()
 
 
 class TestTaskAPI:


### PR DESCRIPTION
## Summary

- replace `TaskStore`'s daemon-wide lockless SQLite connection with lazy per-thread connections backed by `threading.local()`
- preserve the existing WAL and foreign-key pragmas on every connection while keeping the public API unchanged
- make `close()` close the caller's connection and document lifecycle cleanup for connections owned by other threads
- add a 12-thread, 25-round concurrency hammer that repeatedly point-reads the same shared row IDs while create/complete writes and lightweight list parsing are in flight

## Root cause

`TaskStore` used one long-lived `check_same_thread=False` connection across all request threads with no serialization. Concurrent statement use could poison that connection object and make every later task caller inherit `sqlite3.DatabaseError: database disk image is malformed`, even though the database file passed integrity checks and fresh connections read it correctly.

## Impact

Each task request thread now owns its SQLite connection, so statement state cannot be shared across threads. The incident regression verifies distinct connections, zero database/malformed errors, parsed results, and exact final counts for 300 completed hammer rows plus 12 shared point-read seeds.

Fixes #927.

## Validation

- concurrency hammer: 10 consecutive passes
- task store + task/project/milestone/sprint API + autonomy + daemon matrix: `151 passed`
- Python 3.12 isolated environment: 55-package dependency check clean
- `ruff check .`
- `git diff --check`

🤖 Opened by Kuzya