### PR TITLE
Make hot SQLite stores thread-local

### DIFF
--- a/src/pinky_daemon/agent_comms.py
+++ b/src/pinky_daemon/agent_comms.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import sqlite3
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -71,11 +72,20 @@ class AgentComms:
         # depend on the caller's cwd at send time.
         self._transfers_root = Path(db_path).resolve().parent / "transfers"
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(db_path, check_same_thread=False)
-        self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._thread_local = threading.local()
         self._init_schema()
         self._migrate()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA journal_mode=WAL")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_schema(self) -> None:
         # executescript issues an implicit COMMIT before running, so
@@ -479,7 +489,15 @@ class AgentComms:
     # ── Helpers ──────────────────────────────────────────────
 
     def close(self) -> None:
-        self._conn.close()
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection
 
     def get_thread(self, message_id: int, *, session_id: str = "") -> list[AgentMessage]:
         """Get all messages in a thread (root + all descendants at any depth).

--- a/src/pinky_daemon/conversation_store.py
+++ b/src/pinky_daemon/conversation_store.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -83,10 +84,19 @@ class ConversationStore:
     def __init__(self, db_path: str = "data/conversations.db") -> None:
         self._db_path = db_path
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(db_path, check_same_thread=False)
-        self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._thread_local = threading.local()
         self._init_schema()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA journal_mode=WAL")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_schema(self) -> None:
         self._conn.executescript("""
@@ -367,7 +377,15 @@ class ConversationStore:
         return cursor.rowcount
 
     def close(self) -> None:
-        self._conn.close()
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection
 
     def _row_to_message(self, row: sqlite3.Row) -> StoredMessage:
         meta = {}

--- a/src/pinky_daemon/session_store.py
+++ b/src/pinky_daemon/session_store.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -60,9 +61,19 @@ class SessionStore:
 
     def __init__(self, db_path: str = "data/sessions.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._init_tables()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_tables(self) -> None:
         self._db.executescript("""
@@ -276,7 +287,15 @@ class SessionStore:
         )
 
     def close(self) -> None:
-        self._db.close()
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection
 
 
 class SessionEventStore:
@@ -284,9 +303,19 @@ class SessionEventStore:
 
     def __init__(self, db_path: str = "data/sessions.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._init_tables()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_tables(self) -> None:
         self._db.executescript("""
@@ -358,4 +387,12 @@ class SessionEventStore:
         ]
 
     def close(self) -> None:
-        self._db.close()
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection

--- a/tests/test_agent_comms.py
+++ b/tests/test_agent_comms.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from fastapi.testclient import TestClient
@@ -220,6 +223,81 @@ class TestAgentComms:
         assert d["to"] == "bob"
         assert d["type"] == "direct"
         assert d["read"] is False
+
+
+class TestAgentCommsConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        comms = AgentComms(db_path=str(tmp_path / "agent-comms.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        seed = comms.send(
+            "seed-sender",
+            "shared-recipient",
+            "Shared point-read seed",
+            metadata={"kind": "shared-seed"},
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection_id = id(comms._conn)
+                sender = f"worker-{worker_index}"
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = comms.send(
+                        sender,
+                        "shared-recipient",
+                        f"Hammer message {marker}",
+                        metadata={"marker": marker},
+                    )
+                    own_thread = comms.get_thread(created.id)
+                    assert own_thread[0].id == created.id
+                    assert own_thread[0].metadata == {"marker": marker}
+                    for _ in range(point_reads_per_round):
+                        shared_thread = comms.get_thread(seed.id)
+                        assert shared_thread[0].content == "Shared point-read seed"
+                        assert shared_thread[0].metadata == {"kind": "shared-seed"}
+                        point_reads += 1
+                    snapshots.append(
+                        (created.to_dict(), own_thread[0].to_dict())
+                    )
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                comms.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            messages, total = comms.get_all_messages(
+                limit=worker_count * rounds + 1
+            )
+            assert total == worker_count * rounds + 1
+            assert len(messages) == total
+        finally:
+            comms.close()
 
 
 class TestAgentCommsAPI:

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 from fastapi.testclient import TestClient
 
@@ -219,6 +222,79 @@ class TestConversationStore:
         d = cs.to_dict()
         assert d["session_id"] == "s1"
         assert d["message_count"] == 5
+
+
+class TestConversationStoreConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        store = ConversationStore(db_path=str(tmp_path / "conversations.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        store.append(
+            "shared-session",
+            "user",
+            "Shared point-read seed",
+            metadata={"kind": "shared-seed"},
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection_id = id(store._conn)
+                session_id = f"worker-{worker_index}"
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = store.append(
+                        session_id,
+                        "assistant",
+                        f"Hammer message {marker}",
+                        metadata={"marker": marker},
+                    )
+                    own = store.get_history(session_id, limit=1)
+                    assert own[0].id == created.id
+                    assert own[0].metadata == {"marker": marker}
+                    for _ in range(point_reads_per_round):
+                        shared = store.get_history("shared-session", limit=1)
+                        assert shared[0].content == "Shared point-read seed"
+                        assert shared[0].metadata == {"kind": "shared-seed"}
+                        point_reads += 1
+                    snapshots.append((created.to_dict(), own[0].to_dict()))
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            assert store.count() == worker_count * rounds + 1
+            assert all(
+                store.count(f"worker-{index}") == rounds
+                for index in range(worker_count)
+            )
+        finally:
+            store.close()
 
 
 class TestConversationAPI:

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
 from pinky_daemon.conversation_store import ConversationStore
-from pinky_daemon.session_store import SessionRecord, SessionStore
+from pinky_daemon.session_store import SessionEventStore, SessionRecord, SessionStore
 
 
 @pytest.fixture
@@ -129,6 +132,117 @@ class TestSessionStore:
         store.save(_make_record(auto_restart=False))
         got = store.get("test-session")
         assert got.auto_restart is False
+
+
+class TestSessionStoreConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        db_path = str(tmp_path / "sessions.db")
+        store = SessionStore(db_path=db_path)
+        event_store = SessionEventStore(db_path=db_path)
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        store.save(
+            _make_record(
+                id="shared-session",
+                agent_name="shared-agent",
+                allowed_tools=["Read", "Glob"],
+                disallowed_tools=["Bash"],
+            )
+        )
+        event_store.log(
+            "shared-session",
+            "shared-agent",
+            "seed",
+            {"kind": "shared-seed"},
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                session_connection_id = id(store._db)
+                event_connection_id = id(event_store._db)
+                session_id = f"worker-{worker_index}"
+                agent_name = f"agent-{worker_index}"
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    store.save(
+                        _make_record(
+                            id=session_id,
+                            agent_name=agent_name,
+                            sdk_session_id=marker,
+                            allowed_tools=["Read", marker],
+                        )
+                    )
+                    event_store.log(
+                        session_id,
+                        agent_name,
+                        "hammer",
+                        {"marker": marker},
+                    )
+                    for _ in range(point_reads_per_round):
+                        shared = store.get("shared-session")
+                        assert shared is not None
+                        assert shared.allowed_tools == ["Read", "Glob"]
+                        assert shared.disallowed_tools == ["Bash"]
+                        shared_events = event_store.get_for_session(
+                            "shared-session",
+                            limit=1,
+                        )
+                        assert shared_events[0]["metadata"] == {
+                            "kind": "shared-seed"
+                        }
+                        point_reads += 1
+                    own = store.get(session_id)
+                    assert own is not None
+                    assert own.sdk_session_id == marker
+                    snapshots.append((own.id, own.allowed_tools, marker))
+                return (
+                    session_connection_id,
+                    event_connection_id,
+                    snapshots,
+                    point_reads,
+                    None,
+                )
+            except Exception as exc:
+                return None, None, snapshots, point_reads, exc
+            finally:
+                event_store.close()
+                store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for *_, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            session_connection_ids = [result[0] for result in results]
+            event_connection_ids = [result[1] for result in results]
+            assert len(set(session_connection_ids)) == worker_count
+            assert len(set(event_connection_ids)) == worker_count
+            assert sum(result[3] for result in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(result[2]) == rounds for result in results)
+            assert len(store.list_all()) == worker_count + 1
+            assert sum(
+                len(event_store.get_for_session(f"worker-{index}", limit=rounds))
+                for index in range(worker_count)
+            ) == worker_count * rounds
+        finally:
+            event_store.close()
+            store.close()
 
 
 class TestSessionManagerPersistence:


### PR DESCRIPTION
## Summary

- replace the daemon-wide unserialized SQLite connections in `SessionStore`, `SessionEventStore`, `ConversationStore`, and `AgentComms` with lazy per-thread connections backed by `threading.local()`
- preserve each store's existing connection setup on every connection (`journal_mode=WAL`, plus the `sqlite3.Row` factories where applicable) while restoring SQLite's default same-thread enforcement
- make `close()` caller-local, matching the established `TaskStore` lifecycle contract from #929
- add one 12-thread, 25-round, shared-row point-read-heavy concurrency hammer per dispatched store; the session hammer also exercises `SessionEventStore`

## Call-site thread census and classification

- **session store:** one instance is created at API composition time and shared through `SessionManager` with restored/new `Session` objects. It is touched during bootstrap restore, async session-management routes, session worker persistence, and restart/lifecycle callbacks. `SessionEventStore` follows the same composition path and is also called directly by API lifecycle, watchdog, and context-restart tasks.
- **conversation store:** one API instance is shared by conversation/session routes, outbound broker logging, `SessionManager`, Claude streaming/Codex/tmux session workers, and `AutonomyEngine`; standalone daemon mode likewise shares one instance between its asyncio workflows.
- **agent comms:** one API instance is shared by messaging/group/audit routes, direct live-agent injection, and the scheduler's expiry-cleanup callback.

The current production route/session call sites are async tasks on the server loop; none deliberately wraps a store call in `run_in_executor()`/`to_thread()`. That does not establish a safe single-thread invariant: the synchronous store objects are constructed before serving, passed across component boundaries, and have no ownership assertion; supported ASGI embedding/TestClient lifecycles can construct and serve the same app on different threads. A thread-affinity assertion would therefore reject existing supported usage rather than make it safe.

All multi-statement transactional work remains within one synchronous call (`AgentComms._migrate()` and `_send()` included); no transaction spans public calls. The #929 per-thread connection pattern is therefore the smallest compatible classification for all three stores.

## Why

Each store opted out of `sqlite3`'s default thread guard with `check_same_thread=False`, exposed that connection through a daemon-wide singleton, and provided zero serialization around connection use. That is unsafe by construction if call paths execute concurrently on different threads: disabling the guard makes serialization the caller's responsibility, but these callers had neither a lock nor per-thread ownership.

This is a code-level hardening change and part of #930. Per the corrected #927/#930 forensics, it does **not** claim that either Pi incident was a proven firing of this race; those incidents are underdetermined and the distinct external-in-place-open poisoning hazard is tracked separately.

## Impact

Each calling thread now owns its statement state and closes only its own connection. The public store APIs and on-disk schemas are unchanged. The hammers verify distinct connection identities, repeatedly parse the same shared rows while writes are in flight, reject all database/malformed errors, and assert exact final row counts.

## Validation

- three concurrency hammers: 10 consecutive passes (`30 passed`)
- affected store/API/session/scheduler/broker/autonomy/daemon/migration matrix: `816 passed`
- `ruff check .`
- `git diff --check`

Part of #930.

🤖 Opened by Kuzya