### PR TITLE
Make four more SQLite stores thread-local

### DIFF
--- a/src/pinky_daemon/activity_store.py
+++ b/src/pinky_daemon/activity_store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 import time
 from pathlib import Path
 
@@ -18,9 +19,19 @@ class ActivityStore:
 
     def __init__(self, db_path: str = "data/activity.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._init_tables()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_tables(self) -> None:
         self._db.executescript("""
@@ -131,4 +142,12 @@ class ActivityStore:
         }
 
     def close(self) -> None:
-        self._db.close()
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection

--- a/src/pinky_daemon/skill_store.py
+++ b/src/pinky_daemon/skill_store.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -142,10 +143,20 @@ class SkillStore:
 
     def __init__(self, db_path: str = "data/skills.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA foreign_keys=ON")
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._init_tables()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA foreign_keys=ON")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_tables(self) -> None:
         self._db.executescript("""
@@ -639,7 +650,15 @@ class SkillStore:
         return cursor.rowcount > 0
 
     def close(self) -> None:
-        self._db.close()
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection
 
 
 def _deep_merge(base: dict, overrides: dict) -> dict:

--- a/src/pinky_daemon/trigger_store.py
+++ b/src/pinky_daemon/trigger_store.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import secrets
 import sqlite3
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -75,12 +76,22 @@ class TriggerStore:
 
     def __init__(self, db_path: str = "data/triggers.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA foreign_keys=ON")
-        self._db.row_factory = sqlite3.Row
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._init_table()
         self._migrate()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA foreign_keys=ON")
+            connection.row_factory = sqlite3.Row
+            self._thread_local.connection = connection
+        return connection
 
     def _init_table(self) -> None:
         self._db.executescript("""
@@ -303,3 +314,14 @@ class TriggerStore:
             (now,),
         ).fetchall()
         return [self._row_to_trigger(r) for r in rows]
+
+    def close(self) -> None:
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection

--- a/src/pinky_daemon/user_profile_store.py
+++ b/src/pinky_daemon/user_profile_store.py
@@ -13,6 +13,7 @@ to specific users' profiles via the visibility table.
 from __future__ import annotations
 
 import sqlite3
+import threading
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -79,9 +80,19 @@ class UserProfileStore:
 
     def __init__(self, db_path: str = "data/user_profiles.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._init_tables()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_tables(self) -> None:
         self._db.executescript("""
@@ -463,6 +474,17 @@ class UserProfileStore:
         )
         self._db.commit()
         return len(rows)
+
+    def close(self) -> None:
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection
 
     # ── Internal ─────────────────────────────────────────
 

--- a/tests/test_activity_store.py
+++ b/tests/test_activity_store.py
@@ -1,0 +1,93 @@
+"""Tests for the SQLite-backed activity store."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from pinky_daemon.activity_store import ActivityStore
+
+
+class TestActivityStoreConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        store = ActivityStore(db_path=str(tmp_path / "activity.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        store.log(
+            "shared-agent",
+            "shared-event",
+            "Shared point-read seed",
+            metadata={"kind": "shared-seed", "nested": {"valid": True}},
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection = store._db
+                connection_id = id(connection)
+                assert connection.execute(
+                    "PRAGMA journal_mode"
+                ).fetchone()[0].lower() == "wal"
+                assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
+                agent_name = f"worker-{worker_index}"
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = store.log(
+                        agent_name,
+                        "hammer",
+                        f"Hammer event {marker}",
+                        metadata={"marker": marker, "values": [worker_index, round_index]},
+                    )
+                    own = store.list(limit=1, agent_name=agent_name)
+                    assert own[0]["id"] == created["id"]
+                    assert own[0]["metadata"] == {
+                        "marker": marker,
+                        "values": [worker_index, round_index],
+                    }
+                    for _ in range(point_reads_per_round):
+                        shared = store.list(
+                            limit=1,
+                            agent_name="shared-agent",
+                            event_type="shared-event",
+                        )
+                        assert shared[0]["title"] == "Shared point-read seed"
+                        assert shared[0]["metadata"] == {
+                            "kind": "shared-seed",
+                            "nested": {"valid": True},
+                        }
+                        point_reads += 1
+                    snapshots.append((created, own[0]))
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            assert store.get_stats()["total"] == worker_count * rounds + 1
+        finally:
+            store.close()

--- a/tests/test_skill_store.py
+++ b/tests/test_skill_store.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -104,6 +107,93 @@ class TestSkillStore:
         assert d["description"] == "desc"
         assert d["skill_type"] == "builtin"
         assert d["enabled"] is True
+
+
+class TestSkillStoreConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        store = SkillStore(db_path=str(tmp_path / "skills.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        store.register(
+            "shared-skill",
+            description="Shared point-read seed",
+            mcp_server_config={
+                "command": "shared-command",
+                "env": {"SEED": "shared"},
+            },
+            tool_patterns=["mcp__shared__*"],
+            requires=["base-skill"],
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection = store._db
+                connection_id = id(connection)
+                assert connection.execute(
+                    "PRAGMA journal_mode"
+                ).fetchone()[0].lower() == "wal"
+                assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = store.register(
+                        f"hammer-{marker}",
+                        description=f"Hammer skill {marker}",
+                        config={"marker": marker},
+                        mcp_server_config={
+                            "command": "hammer",
+                            "args": [marker],
+                        },
+                        tool_patterns=[f"mcp__hammer__{marker}"],
+                    )
+                    own = store.get(created.name)
+                    assert own is not None
+                    assert own.config == {"marker": marker}
+                    assert own.mcp_server_config["args"] == [marker]
+                    for _ in range(point_reads_per_round):
+                        shared = store.get("shared-skill")
+                        assert shared is not None
+                        assert shared.mcp_server_config == {
+                            "command": "shared-command",
+                            "env": {"SEED": "shared"},
+                        }
+                        assert shared.tool_patterns == ["mcp__shared__*"]
+                        assert shared.requires == ["base-skill"]
+                        point_reads += 1
+                    snapshots.append((created.to_dict(), own.to_dict()))
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            assert len(store.list()) == worker_count * rounds + 1
+        finally:
+            store.close()
 
 
 class TestSessionSkills:

--- a/tests/test_trigger_store.py
+++ b/tests/test_trigger_store.py
@@ -4,7 +4,10 @@ Uses tmp_path for isolated SQLite databases — no external dependencies.
 """
 from __future__ import annotations
 
+import sqlite3
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from pinky_daemon.trigger_store import Trigger, TriggerStore
@@ -39,6 +42,87 @@ def _file_trigger(store: TriggerStore, name: str = "file1", agent: str = "barsik
         file_path="/tmp/watch.txt",
         condition="file_changed",
     )
+
+
+class TestTriggerStoreConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        store = _store(tmp_path)
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        shared = store.create(
+            "shared-agent",
+            "shared-trigger",
+            "url",
+            url="https://example.com/shared",
+            condition="json_path",
+            condition_value='{"path": "$.status", "equals": "ok"}',
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection = store._db
+                connection_id = id(connection)
+                assert connection.execute(
+                    "PRAGMA journal_mode"
+                ).fetchone()[0].lower() == "wal"
+                assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = store.create(
+                        f"worker-{worker_index}",
+                        f"hammer-{marker}",
+                        "url",
+                        url=f"https://example.com/{marker}",
+                        condition="status_change",
+                        condition_value=marker,
+                    )
+                    own = store.get(created.id)
+                    assert own is not None
+                    assert own.name == f"hammer-{marker}"
+                    assert own.condition_value == marker
+                    for _ in range(point_reads_per_round):
+                        point_read = store.get(shared.id)
+                        assert point_read is not None
+                        assert point_read.name == "shared-trigger"
+                        assert point_read.condition_value == (
+                            '{"path": "$.status", "equals": "ok"}'
+                        )
+                        point_reads += 1
+                    snapshots.append((created.to_dict(), own.to_dict()))
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            assert len(store.list()) == worker_count * rounds + 1
+        finally:
+            store.close()
 
 
 # ── Trigger.to_dict ────────────────────────────────────────────────────────────

--- a/tests/test_user_profile_store.py
+++ b/tests/test_user_profile_store.py
@@ -1,0 +1,98 @@
+"""Tests for the SQLite-backed user profile store."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from pinky_daemon.user_profile_store import ProfileEntry, UserProfileStore
+
+
+class TestUserProfileStoreConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        store = UserProfileStore(db_path=str(tmp_path / "user-profiles.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        shared_entry = store.upsert(
+            ProfileEntry(
+                chat_id="shared-chat",
+                category="preferences",
+                key="response_style",
+                value="Concise, with examples",
+                confidence=0.9,
+                source="manual",
+            )
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection = store._db
+                connection_id = id(connection)
+                assert connection.execute(
+                    "PRAGMA journal_mode"
+                ).fetchone()[0].lower() == "wal"
+                assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
+                chat_id = f"worker-{worker_index}"
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = store.upsert(
+                        ProfileEntry(
+                            chat_id=chat_id,
+                            category="patterns",
+                            key=f"hammer-{round_index}",
+                            value=marker,
+                            confidence=0.75,
+                            source="dream",
+                        )
+                    )
+                    own = store.get(created.id)
+                    assert own is not None
+                    assert own.chat_id == chat_id
+                    assert own.value == marker
+                    for _ in range(point_reads_per_round):
+                        shared = store.get(shared_entry.id)
+                        assert shared is not None
+                        assert shared.chat_id == "shared-chat"
+                        assert shared.value == "Concise, with examples"
+                        assert shared.confidence == 0.9
+                        assert shared.source == "manual"
+                        point_reads += 1
+                    snapshots.append((created.to_dict(), own.to_dict()))
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            assert store.stats() == {
+                "total_users": worker_count + 1,
+                "total_entries": worker_count * rounds + 1,
+            }
+        finally:
+            store.close()


### PR DESCRIPTION
## Summary

- replace the daemon-wide unserialized SQLite connections in `ActivityStore`, `SkillStore`, `TriggerStore`, and `UserProfileStore` with lazy per-thread connections backed by `threading.local()`
- preserve every store's prior per-connection setup, restore SQLite's default same-thread guard, and make `close()` caller-local; `TriggerStore` and `UserProfileStore` gain the same explicit lifecycle hook used by the earlier batches
- add one 12-thread, 25-round, shared-row point-read-heavy concurrency hammer per dispatched store

## Call-site census and Batch 2 selection

These are the four highest-traffic remaining stores by distinct production consumers:

- **activity store:** one API-composition instance is written by direct API lifecycle/admin paths, `Broker`, `AgentScheduler`, and the presentation, project/task, research, and activity route modules; it also serves feed/stat reads.
- **skill store:** one API-composition instance serves the skill routes and direct agent-skill APIs, and is reused by startup seeding/loading, plugin registration, prompt/tool-gate construction, MCP JSON generation, and per-agent materialization.
- **trigger store:** one API-composition instance is shared between trigger/webhook routes and the scheduler's URL-watcher loop.
- **user profile store:** the API instance is shared by profile routes and direct prompt/profile reads. Dream-tail and registry prompt paths also construct independent store instances in worker/caller threads. This fan-out outranks the remaining tail stores.

No caller establishes or asserts a safe single-thread ownership invariant. All multi-statement transactional work remains inside one synchronous public/internal call; no transaction spans public calls. The #929/#933 per-thread connection pattern is therefore the smallest compatible classification.

## Pragma and constraint parity

Every lazy connection reapplies its store's old behavior:

- `ActivityStore` and `UserProfileStore`: WAL only; foreign-key enforcement remains at SQLite's default OFF, and neither schema declares FK clauses.
- `SkillStore`: WAL plus FK ON; its `agent_skills`/`session_skills` references to `skills` remain actively enforced.
- `TriggerStore`: WAL plus FK ON and `sqlite3.Row`; its schema declares no FK clauses, so the preserved FK pragma is currently operationally inert rather than evidence of enforced constraints.

No pragma or constraint semantics are silently flipped.

## User-profile incident/stopgap interaction

`user_profiles.db` has the real corruption history tracked in #889. This batch removes unsafe statement sharing if a `UserProfileStore` instance crosses threads, but it does **not** claim that race was the proven root cause of those restart-correlated incidents.

The #899 dream-tail stopgap is still an open proposal; there is no merged quarantine/recovery connection hook for this conversion to alter. AgentRegistry's existing broad prompt-build guard is unchanged, and each dream profile/relationship writer continues to instantiate a fresh store wholly inside its own `asyncio.to_thread()` call. This PR adds no quarantine/recreate, retry/`busy_timeout`, quick-check, dream-tail step isolation, or shutdown/checkpoint behavior.

## Impact

Each calling thread owns its SQLite statement state and closes only its own connection. Public CRUD behavior and on-disk schemas are unchanged. The hammers verify distinct connection identities, exact pragma parity, repeated parsing of the same shared rows while writes are in flight, zero database/malformed errors, and exact final row counts.

## Out of scope

The #932 reconnect-on-malformed self-heal is a separate semantic change and is intentionally not folded into this batch.

## Validation

- four concurrency hammers: 10 consecutive passes (`40 passed`)
- affected store/API/broker/scheduler/daemon/dream/plugin/shared-MCP matrix with `PINKY_DREAM_TRANSPORT=sdk`: `872 passed`
- `ruff check .`
- `git diff --cached --check`

## Frozen audit object

- head: `ffc7b822688483f5f0850c1e6e965e396e3c4ddb`
- tree: `c98762b00ab9f54afb03225dadf76ddc3b78d944`
- base/parent: `28e57c1019c57ba50395dd3e2fecb77d8d85e0ca`
- stable patch-id: `0037e4d336aa604f216a82d402cdf5db8bb50d3d`

Part of #930.

🤖 Opened by Kuzya