### PR TITLE
Confirm and serialize scheduler wake delivery

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -626,7 +626,8 @@ class AgentSchedule:
     prompt: str = ""  # Message to send to main session on wake
     timezone: str = "America/Los_Angeles"
     enabled: bool = True
-    last_run: float = 0.0
+    last_run: float = 0.0  # Scheduler decided to fire.
+    last_delivered: float = 0.0  # Session confirmed prompt acceptance.
     created_at: float = 0.0
     direct_send: bool = False  # If true, prompt is sent directly as a message (not as agent input)
     target_channel: str = ""  # Chat ID or channel for direct_send routing
@@ -642,6 +643,7 @@ class AgentSchedule:
             "timezone": self.timezone,
             "enabled": self.enabled,
             "last_run": self.last_run,
+            "last_delivered": self.last_delivered,
             "next_run": _cron_next_run(self.cron, self.timezone),
             "created_at": self.created_at,
             "direct_send": self.direct_send,
@@ -1242,6 +1244,7 @@ class AgentRegistry:
                 timezone TEXT NOT NULL DEFAULT 'America/Los_Angeles',
                 enabled INTEGER NOT NULL DEFAULT 1,
                 last_run REAL NOT NULL DEFAULT 0,
+                last_delivered REAL NOT NULL DEFAULT 0,
                 created_at REAL NOT NULL,
                 FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE
             );
@@ -1561,6 +1564,7 @@ class AgentRegistry:
             ("direct_send", "INTEGER NOT NULL DEFAULT 0"),
             ("target_channel", "TEXT NOT NULL DEFAULT ''"),
             ("one_shot", "INTEGER NOT NULL DEFAULT 0"),
+            ("last_delivered", "REAL NOT NULL DEFAULT 0"),
         ]
         for col, typedef in sched_migrations:
             if col not in sched_existing:
@@ -2965,7 +2969,7 @@ except Exception:
             return AgentSchedule(
                 id=cursor.lastrowid, agent_name=agent_name, name=name,
                 cron=cron, prompt=prompt, timezone=timezone,
-                enabled=True, last_run=0.0, created_at=now,
+                enabled=True, last_run=0.0, last_delivered=0.0, created_at=now,
                 direct_send=direct_send, target_channel=target_channel,
                 one_shot=one_shot,
             )
@@ -2975,15 +2979,15 @@ except Exception:
         return AgentSchedule(
             id=r[0], agent_name=r[1], name=r[2], cron=r[3],
             prompt=r[4], timezone=r[5], enabled=bool(r[6]),
-            last_run=r[7], created_at=r[8],
-            direct_send=bool(r[9]) if len(r) > 9 else False,
-            target_channel=r[10] if len(r) > 10 else "",
-            one_shot=bool(r[11]) if len(r) > 11 else False,
+            last_run=r[7], last_delivered=r[8], created_at=r[9],
+            direct_send=bool(r[10]) if len(r) > 10 else False,
+            target_channel=r[11] if len(r) > 11 else "",
+            one_shot=bool(r[12]) if len(r) > 12 else False,
         )
 
     def get_schedules(self, agent_name: str, *, enabled_only: bool = True) -> list[AgentSchedule]:
         """Get all schedules for an agent."""
-        sql = "SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run, created_at, direct_send, target_channel, one_shot FROM agent_schedules WHERE agent_name=?"
+        sql = "SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run, last_delivered, created_at, direct_send, target_channel, one_shot FROM agent_schedules WHERE agent_name=?"
         params: list = [agent_name]
         if enabled_only:
             sql += " AND enabled=1"
@@ -2993,7 +2997,7 @@ except Exception:
 
     def get_all_schedules(self, *, enabled_only: bool = True) -> list[AgentSchedule]:
         """Get all schedules across all agents."""
-        sql = "SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run, created_at, direct_send, target_channel, one_shot FROM agent_schedules"
+        sql = "SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run, last_delivered, created_at, direct_send, target_channel, one_shot FROM agent_schedules"
         if enabled_only:
             sql += " WHERE enabled=1"
         sql += " ORDER BY agent_name, created_at ASC"
@@ -3056,7 +3060,7 @@ except Exception:
                 return None
             row = self._db.execute(
                 """SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run,
-                          created_at, direct_send, target_channel, one_shot
+                          last_delivered, created_at, direct_send, target_channel, one_shot
                    FROM agent_schedules WHERE id=?""",
                 (schedule_id,),
             ).fetchone()
@@ -3097,10 +3101,21 @@ except Exception:
             return cursor.rowcount > 0
 
     def update_schedule_last_run(self, schedule_id: int, timestamp: float = 0.0) -> None:
-        """Record when a schedule last ran."""
+        """Record when the scheduler decided to fire a schedule."""
         ts = timestamp or time.time()
         self._db.execute(
             "UPDATE agent_schedules SET last_run=? WHERE id=?",
+            (ts, schedule_id),
+        )
+        self._db.commit()
+
+    def update_schedule_last_delivered(
+        self, schedule_id: int, timestamp: float = 0.0
+    ) -> None:
+        """Record when the session confirmed acceptance of a fired prompt."""
+        ts = timestamp or time.time()
+        self._db.execute(
+            "UPDATE agent_schedules SET last_delivered=? WHERE id=?",
             (ts, schedule_id),
         )
         self._db.commit()

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -10219,21 +10219,45 @@ npm run build</pre>
             "connected": ss.state == TransportSessionState.CONNECTED,
         }
 
-    async def _wake_callback(agent_name: str, session_id: str, prompt: str) -> None:
-        """Callback for the scheduler/autonomy to wake an agent."""
+    async def _wake_callback(agent_name: str, session_id: str, prompt: str):
+        """Queue a wake and return its exact per-prompt delivery receipt."""
         del session_id  # Streaming is now the canonical main runtime.
         ss = await _ensure_streaming_session(agent_name, label="main")
         if not ss:
             _log(f"scheduler: no streaming main session for {agent_name}, skipping wake")
-            return
-        await ss.send(prompt)
-        _log(f"scheduler: woke {agent_name} via streaming main")
+            return False
+
+        scheduler_send = getattr(ss, "send_scheduler_prompt", None)
+        if callable(scheduler_send):
+            receipt = await scheduler_send(prompt)
+            _log(
+                f"scheduler: queued confirmed-delivery wake for "
+                f"{agent_name} via streaming main"
+            )
+            return receipt
+
+        handed_off = await ss.send(prompt)
+        confirmed = bool(
+            handed_off
+            and getattr(ss, "injection_confirms_consumption", False)
+        )
+        if confirmed:
+            _log(
+                f"scheduler: wake accepted for {agent_name} via "
+                f"streaming main"
+            )
+        else:
+            _log(
+                f"scheduler: wake enqueue for {agent_name} did not "
+                f"provide a positive delivery receipt"
+            )
         # ``agent_wake`` is logged centrally via ``on_wake_delivered``
         # when the session's connect-time wake prompt lands. Logging
         # here would double-count for scheduled wakes that triggered
         # a cold-start (the connect already fired the callback) and
         # would mismark scheduled re-prompts (which aren't really new
         # wake events — the session was already awake). See Murzik P1#2.
+        return confirmed
 
     async def _dream_callback(agent_name: str, agent_config) -> None:
         """Callback for the scheduler to run nightly dream consolidation."""

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -122,7 +122,9 @@ class CodexSession:
         # CONNECTED; send is accepted only while CONNECTED).
         self._state_machine = StateMachine(owner_label=f"codex:{config.agent_name}")
         self._processing = False  # True while a codex exec is running
-        self._message_queue: asyncio.Queue[tuple[str, str, str, str]] = asyncio.Queue()
+        # Scheduler entries carry a fifth per-call delivery Future. Legacy
+        # four-tuples remain accepted for connect-time wakes and tests.
+        self._message_queue: asyncio.Queue[tuple] = asyncio.Queue()
         # Serializes _exec_codex between the worker and out-of-band callers
         # (idle_sleep's save turn): two concurrent execs would resume the same
         # codex thread and clobber the shared _current_proc / app-server
@@ -447,6 +449,39 @@ class CodexSession:
         is not consumption — ``injection_confirms_consumption`` is False, so
         the broker never confirms an inject off this value alone.
         """
+        return await self._queue_external_message(
+            prompt,
+            platform=platform,
+            chat_id=chat_id,
+            message_id=message_id,
+            agent_hint=agent_hint,
+        )
+
+    async def send_scheduler_prompt(
+        self, prompt: str
+    ) -> asyncio.Future[bool]:
+        """Queue a scheduler prompt and confirm when its exec turn starts."""
+        receipt: asyncio.Future[bool] = (
+            asyncio.get_running_loop().create_future()
+        )
+        queued = await self._queue_external_message(
+            prompt, scheduler_delivery=receipt
+        )
+        if not queued and not receipt.done():
+            receipt.set_result(False)
+        return receipt
+
+    async def _queue_external_message(
+        self,
+        prompt: str,
+        *,
+        platform: str = "",
+        chat_id: str = "",
+        message_id: str = "",
+        agent_hint: str = "",
+        scheduler_delivery: asyncio.Future[bool] | None = None,
+    ) -> bool:
+        """Apply external-send side effects and enqueue one Codex turn."""
         if self.state != SessionState.CONNECTED:
             _log(
                 f"codex[{self.agent_name}]: not connected "
@@ -477,7 +512,17 @@ class CodexSession:
                 _log(f"codex[{self.agent_name}]: conversation store append failed: {e}")
 
         queued_prompt = prompt + agent_hint if agent_hint else prompt
-        await self._message_queue.put((queued_prompt, platform, chat_id, message_id))
+        if scheduler_delivery is None:
+            queued = (queued_prompt, platform, chat_id, message_id)
+        else:
+            queued = (
+                queued_prompt,
+                platform,
+                chat_id,
+                message_id,
+                scheduler_delivery,
+            )
+        await self._message_queue.put(queued)
         _log(f"codex[{self.agent_name}]: queued message (chat={chat_id})")
         return True
 
@@ -491,11 +536,23 @@ class CodexSession:
             # the loop at the next iteration, and disconnect() cancels an
             # in-flight ``get``. (#206 — was ``while self._connected``.)
             while self.state == SessionState.CONNECTED:
-                prompt, platform, chat_id, message_id = await self._message_queue.get()
+                queued = await self._message_queue.get()
+                prompt, platform, chat_id, message_id = queued[:4]
+                scheduler_delivery = queued[4] if len(queued) > 4 else None
+                if (
+                    scheduler_delivery is not None
+                    and scheduler_delivery.cancelled()
+                ):
+                    continue
                 try:
                     self._processing = True
                     self._current_turn_seq = self._stats["turns"] + 1
                     async with self._exec_lock:
+                        if (
+                            scheduler_delivery is not None
+                            and not scheduler_delivery.done()
+                        ):
+                            scheduler_delivery.set_result(True)
                         result = await self._exec_codex(prompt)
 
                     # #591 P1#2 (Murzik round-2): fire the pending wake

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -460,7 +460,7 @@ class CodexSession:
     async def send_scheduler_prompt(
         self, prompt: str
     ) -> asyncio.Future[bool]:
-        """Queue a scheduler prompt and confirm when its exec turn starts."""
+        """Queue a scheduler prompt and confirm transport acceptance."""
         receipt: asyncio.Future[bool] = (
             asyncio.get_running_loop().create_future()
         )
@@ -470,6 +470,14 @@ class CodexSession:
         if not queued and not receipt.done():
             receipt.set_result(False)
         return receipt
+
+    @staticmethod
+    def _resolve_scheduler_delivery(
+        receipt: asyncio.Future[bool] | None, accepted: bool
+    ) -> None:
+        """Resolve an exact-turn receipt once, unless its waiter timed out."""
+        if receipt is not None and not receipt.done():
+            receipt.set_result(accepted)
 
     async def _queue_external_message(
         self,
@@ -548,12 +556,19 @@ class CodexSession:
                     self._processing = True
                     self._current_turn_seq = self._stats["turns"] + 1
                     async with self._exec_lock:
-                        if (
-                            scheduler_delivery is not None
-                            and not scheduler_delivery.done()
-                        ):
-                            scheduler_delivery.set_result(True)
-                        result = await self._exec_codex(prompt)
+                        if scheduler_delivery is None:
+                            result = await self._exec_codex(prompt)
+                        else:
+                            result = await self._exec_codex(
+                                prompt,
+                                scheduler_delivery=scheduler_delivery,
+                            )
+                        # The real implementations resolve True at their
+                        # transport acceptance edge. A replacement/mock that
+                        # returns without doing so has provided no receipt.
+                        self._resolve_scheduler_delivery(
+                            scheduler_delivery, False
+                        )
 
                     # #591 P1#2 (Murzik round-2): fire the pending wake
                     # callback after exec confirms delivery. Only on
@@ -661,10 +676,16 @@ class CodexSession:
                     self._current_turn_seq = 0
 
                 except Exception as e:
+                    self._resolve_scheduler_delivery(
+                        scheduler_delivery, False
+                    )
                     self._current_turn_seq = 0
                     self._stats["errors"] += 1
                     _log(f"codex[{self.agent_name}]: exec error: {e}")
                 finally:
+                    self._resolve_scheduler_delivery(
+                        scheduler_delivery, False
+                    )
                     self._processing = False
 
         except asyncio.CancelledError:
@@ -850,13 +871,22 @@ class CodexSession:
         cmd.append("-")
         return cmd
 
-    async def _exec_codex(self, prompt: str) -> CodexTurnResult:
+    async def _exec_codex(
+        self,
+        prompt: str,
+        *,
+        scheduler_delivery: asyncio.Future[bool] | None = None,
+    ) -> CodexTurnResult:
         """Run a single codex exec invocation and parse JSONL output.
 
         Streams stdout line-by-line for real-time activity tracking.
         """
         if self._use_app_server:
-            return await self._exec_codex_app_server(prompt)
+            if scheduler_delivery is None:
+                return await self._exec_codex_app_server(prompt)
+            return await self._exec_codex_app_server(
+                prompt, scheduler_delivery=scheduler_delivery
+            )
 
         result = CodexTurnResult()
 
@@ -901,6 +931,10 @@ class CodexSession:
             await proc.stdin.drain()
             proc.stdin.close()
             await proc.stdin.wait_closed()
+            # The exact prompt has crossed the exec transport boundary.
+            # Merely acquiring _exec_lock or spawning the process is not a
+            # receipt: stdin write+drain+EOF is the first observed acceptance.
+            self._resolve_scheduler_delivery(scheduler_delivery, True)
 
             # Stream stdout line-by-line for real-time activity tracking.
             # Defensive: skip-and-continue on a single oversized line rather
@@ -996,6 +1030,9 @@ class CodexSession:
                 except Exception:
                     pass
         finally:
+            # Spawn/write/protocol failures before the acceptance edge are
+            # terminal negative receipts.
+            self._resolve_scheduler_delivery(scheduler_delivery, False)
             self._current_proc = None
             if stderr_task is not None and not stderr_task.done():
                 stderr_task.cancel()
@@ -1105,7 +1142,12 @@ class CodexSession:
             return effort
         return None
 
-    async def _exec_codex_app_server(self, prompt: str) -> CodexTurnResult:
+    async def _exec_codex_app_server(
+        self,
+        prompt: str,
+        *,
+        scheduler_delivery: asyncio.Future[bool] | None = None,
+    ) -> CodexTurnResult:
         """Run a single turn over the long-lived app-server connection."""
         result = CodexTurnResult()
         try:
@@ -1124,6 +1166,7 @@ class CodexSession:
                 "session_id": self.id, "error": str(e),
             })
             await self._terminalize_dead("app-server connect failed")
+            self._resolve_scheduler_delivery(scheduler_delivery, False)
             return result
 
         client = self._app_client
@@ -1183,6 +1226,9 @@ class CodexSession:
             if effort:
                 turn_params["effort"] = effort
             await client.request("turn/start", turn_params)
+            # Successful turn/start response is the app-server's exact prompt
+            # acceptance edge. Thread start/resume alone is not sufficient.
+            self._resolve_scheduler_delivery(scheduler_delivery, True)
 
             # turn/start returns immediately; notifications drive the turn.
             # _on_appserver_notification resolves _turn_done on turn/completed.
@@ -1225,6 +1271,7 @@ class CodexSession:
             await self._teardown_app_server()
             await self._terminalize_dead("app-server turn exception")
         finally:
+            self._resolve_scheduler_delivery(scheduler_delivery, False)
             self._active_turn_result = None
             self._turn_done = None
 

--- a/src/pinky_daemon/daemon.py
+++ b/src/pinky_daemon/daemon.py
@@ -196,7 +196,11 @@ class Daemon:
                 data={"prompt": prompt, "session_id": session_id},
             )
             await self._autonomy.push_event(event)
-            return True
+            # This legacy daemon can observe only event-queue insertion here;
+            # the autonomy runner accepts the prompt later in another task.
+            # Enqueue is not a transport receipt, so fail closed rather than
+            # stamping last_delivered for an unconsumed pending event.
+            return False
 
         self._scheduler = AgentScheduler(
             self._registry,

--- a/src/pinky_daemon/daemon.py
+++ b/src/pinky_daemon/daemon.py
@@ -196,6 +196,7 @@ class Daemon:
                 data={"prompt": prompt, "session_id": session_id},
             )
             await self._autonomy.push_event(event)
+            return True
 
         self._scheduler = AgentScheduler(
             self._registry,

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -14,6 +14,7 @@ Supports standard 5-field cron: minute hour day month weekday.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import sys
 import time
@@ -170,9 +171,13 @@ class AgentScheduler:
         trigger_store=None,
         activity=None,
         tick_interval: int = 30,
+        schedule_delivery_timeout: float = 600.0,
     ) -> None:
         self._registry = registry
-        self._wake_callback = wake_callback  # async fn(agent_name, session_id, prompt)
+        # async fn(agent_name, session_id, prompt) -> bool | Awaitable[bool].
+        # An awaitable return is a per-prompt delivery receipt; same-agent
+        # schedules are not advanced until it resolves.
+        self._wake_callback = wake_callback
         self._heartbeat_callback = heartbeat_callback  # async fn(agent_name, session_id)
         self._direct_send_callback = direct_send_callback  # async fn(agent_name, platform, chat_id, message)
         self._auto_sleep_callback = auto_sleep_callback  # async fn(agent_name, reason)
@@ -189,6 +194,7 @@ class AgentScheduler:
         self._trigger_store = trigger_store  # TriggerStore | None
         self._activity = activity  # ActivityStore | None
         self._tick_interval = tick_interval
+        self._schedule_delivery_timeout = schedule_delivery_timeout
         self._running = False
         self._task: asyncio.Task | None = None
         self._last_clock_slot: dict[str, int] = {}  # agent_name -> last fired clock slot (minutes since midnight)
@@ -207,6 +213,12 @@ class AgentScheduler:
         # inline in the tick (same #702 class as dreams): one slot per
         # (agent_name, label) so a sleep spanning several ticks isn't refired.
         self._sleep_tasks: dict[tuple[str, str], asyncio.Task] = {}
+        # Schedule prompts run outside the tick loop so waiting for a busy
+        # agent cannot freeze every other cron/heartbeat check (#702 class).
+        # A per-agent lock preserves fire order across same-tick and later-tick
+        # cohorts while allowing unrelated agents to progress independently.
+        self._schedule_delivery_tasks: set[asyncio.Task] = set()
+        self._schedule_delivery_locks: dict[str, asyncio.Lock] = {}
         # Resurrection rate-limit: agent_name -> list[timestamp] of recent attempts.
         # Used by _check_heartbeats to cap how often we ping the heartbeat_callback
         # for a stuck agent (avoid thrashing on a persistently-broken session).
@@ -242,6 +254,13 @@ class AgentScheduler:
                     except asyncio.CancelledError:
                         pass
             task_map.clear()
+        delivery_tasks = list(self._schedule_delivery_tasks)
+        for task in delivery_tasks:
+            if not task.done():
+                task.cancel()
+        if delivery_tasks:
+            await asyncio.gather(*delivery_tasks, return_exceptions=True)
+        self._schedule_delivery_tasks.clear()
         _log("scheduler: stopped")
 
     async def _loop(self) -> None:
@@ -285,11 +304,12 @@ class AgentScheduler:
         await self._check_url_watchers(now)
 
     async def _check_schedules(self, now: float) -> None:
-        """Check all enabled schedules and fire any that match current time."""
+        """Stamp due schedules fired, then deliver each agent's cohort in order."""
         schedules = self._registry.get_all_schedules(enabled_only=True)
         if not schedules:
             return
 
+        due_by_agent: dict[str, list] = {}
         for schedule in schedules:
             try:
                 tz = ZoneInfo(schedule.timezone)
@@ -321,28 +341,128 @@ class AgentScheduler:
                     self._registry.toggle_schedule(schedule.id, False)
                     _log(f"scheduler: one-shot schedule '{schedule.name}' (#{schedule.id}) auto-disabled after firing")
 
-                if schedule.direct_send and schedule.target_channel and self._direct_send_callback:
-                    # Direct send mode: route message through broker, not as agent input
-                    try:
-                        await self._direct_send_callback(
-                            schedule.agent_name,
-                            "telegram",  # Default platform
-                            schedule.target_channel,
-                            schedule.prompt,
-                        )
-                        _log(f"scheduler: direct-sent to {schedule.target_channel} for {schedule.agent_name}")
-                    except Exception as e:
-                        _log(f"scheduler: direct send failed for {schedule.agent_name}: {e}")
-                elif self._wake_callback:
-                    try:
-                        main_session_id = f"{schedule.agent_name}-main"
-                        await self._wake_callback(
-                            schedule.agent_name,
-                            main_session_id,
-                            schedule.prompt or f"Scheduled wake: {schedule.name}",
-                        )
-                    except Exception as e:
-                        _log(f"scheduler: wake callback failed for {schedule.agent_name}: {e}")
+                due_by_agent.setdefault(schedule.agent_name, []).append(schedule)
+
+        for agent_name, due_schedules in due_by_agent.items():
+            task = asyncio.create_task(
+                self._deliver_schedule_group(agent_name, due_schedules)
+            )
+            self._schedule_delivery_tasks.add(task)
+            task.add_done_callback(self._schedule_delivery_done)
+
+        # Give callbacks that confirm immediately one loop turn without making
+        # a busy agent's bounded receipt wait part of the scheduler tick.
+        if due_by_agent:
+            await asyncio.sleep(0)
+
+    async def _deliver_schedule_group(
+        self, agent_name: str, schedules: list
+    ) -> None:
+        """Deliver one agent's due prompts serially, including receipt waits."""
+        lock = self._schedule_delivery_locks.setdefault(agent_name, asyncio.Lock())
+        async with lock:
+            for schedule in schedules:
+                await self._deliver_schedule(schedule)
+
+    async def _deliver_schedule(self, schedule) -> None:
+        """Attempt one fired schedule and record confirmed delivery separately."""
+        confirmed = False
+        failure_reason = "no delivery callback configured"
+
+        if (
+            schedule.direct_send
+            and schedule.target_channel
+            and self._direct_send_callback
+        ):
+            try:
+                await self._direct_send_callback(
+                    schedule.agent_name,
+                    "telegram",  # Default platform
+                    schedule.target_channel,
+                    schedule.prompt,
+                )
+                confirmed = True
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                failure_reason = f"direct send raised {type(e).__name__}: {e}"
+        elif self._wake_callback:
+            try:
+                confirmed = await asyncio.wait_for(
+                    self._wake_and_confirm(schedule),
+                    timeout=self._schedule_delivery_timeout,
+                )
+                if not confirmed:
+                    failure_reason = "wake callback returned no positive receipt"
+            except asyncio.TimeoutError:
+                failure_reason = (
+                    "delivery receipt timed out after "
+                    f"{self._schedule_delivery_timeout:g}s"
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                failure_reason = f"wake callback raised {type(e).__name__}: {e}"
+
+        if confirmed:
+            delivered_at = time.time()
+            self._registry.update_schedule_last_delivered(
+                schedule.id, delivered_at
+            )
+            if self._activity:
+                try:
+                    self._activity.log(
+                        schedule.agent_name,
+                        "schedule_delivered",
+                        f"Schedule '{schedule.name}' delivery confirmed",
+                    )
+                except Exception:
+                    pass
+            _log(
+                f"scheduler: delivery confirmed for schedule "
+                f"'{schedule.name}' (#{schedule.id}) for agent "
+                f"'{schedule.agent_name}'"
+            )
+            return
+
+        if self._activity:
+            try:
+                self._activity.log(
+                    schedule.agent_name,
+                    "schedule_undelivered",
+                    f"Schedule '{schedule.name}' fired but delivery was not confirmed",
+                )
+            except Exception:
+                pass
+        _log(
+            f"scheduler: FIRED BUT UNDELIVERED schedule "
+            f"'{schedule.name}' (#{schedule.id}) for agent "
+            f"'{schedule.agent_name}': {failure_reason}"
+        )
+
+    async def _wake_and_confirm(self, schedule) -> bool:
+        """Invoke the wake callback and await its exact per-prompt receipt."""
+        main_session_id = f"{schedule.agent_name}-main"
+        result = await self._wake_callback(
+            schedule.agent_name,
+            main_session_id,
+            schedule.prompt or f"Scheduled wake: {schedule.name}",
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        return result is True
+
+    def _schedule_delivery_done(self, task: asyncio.Task) -> None:
+        """Retire a delivery task and surface any unexpected cohort crash."""
+        self._schedule_delivery_tasks.discard(task)
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            _log(
+                f"scheduler: SCHEDULE DELIVERY TASK CRASHED with "
+                f"{type(error).__name__}: {error}"
+            )
 
     async def _check_heartbeats(self, now: float) -> None:
         """Check heartbeat health for all agents with heartbeat_interval > 0."""

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -360,32 +360,55 @@ class AgentScheduler:
     ) -> None:
         """Deliver one agent's due prompts serially, including receipt waits."""
         lock = self._schedule_delivery_locks.setdefault(agent_name, asyncio.Lock())
-        async with lock:
-            for schedule in schedules:
-                await self._deliver_schedule(schedule)
+        next_index = 0
+        try:
+            async with lock:
+                for next_index, schedule in enumerate(schedules):
+                    try:
+                        await self._deliver_schedule(schedule)
+                    except asyncio.CancelledError:
+                        self._record_schedule_undelivered(
+                            schedule, "delivery canceled before confirmation"
+                        )
+                        next_index += 1
+                        raise
+                    next_index += 1
+        except asyncio.CancelledError:
+            # All members of this cohort were stamped fired before this task
+            # was created. Cancellation (including stop()) must not make the
+            # current/tail schedules disappear from the audit trail. Keep this
+            # synchronous so shutdown remains fast.
+            for schedule in schedules[next_index:]:
+                self._record_schedule_undelivered(
+                    schedule, "delivery canceled before attempt"
+                )
+            raise
 
     async def _deliver_schedule(self, schedule) -> None:
         """Attempt one fired schedule and record confirmed delivery separately."""
         confirmed = False
         failure_reason = "no delivery callback configured"
 
-        if (
-            schedule.direct_send
-            and schedule.target_channel
-            and self._direct_send_callback
-        ):
-            try:
-                await self._direct_send_callback(
-                    schedule.agent_name,
-                    "telegram",  # Default platform
-                    schedule.target_channel,
-                    schedule.prompt,
-                )
-                confirmed = True
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                failure_reason = f"direct send raised {type(e).__name__}: {e}"
+        if schedule.direct_send:
+            if not schedule.target_channel:
+                failure_reason = "direct send has no target channel"
+            elif self._direct_send_callback is None:
+                failure_reason = "no direct send callback configured"
+            else:
+                try:
+                    await self._direct_send_callback(
+                        schedule.agent_name,
+                        "telegram",  # Default platform
+                        schedule.target_channel,
+                        schedule.prompt,
+                    )
+                    confirmed = True
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    failure_reason = (
+                        f"direct send raised {type(e).__name__}: {e}"
+                    )
         elif self._wake_callback:
             try:
                 confirmed = await asyncio.wait_for(
@@ -425,6 +448,12 @@ class AgentScheduler:
             )
             return
 
+        self._record_schedule_undelivered(schedule, failure_reason)
+
+    def _record_schedule_undelivered(
+        self, schedule, failure_reason: str
+    ) -> None:
+        """Loudly account one fired schedule without advancing delivery."""
         if self._activity:
             try:
                 self._activity.log(

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -465,6 +465,10 @@ class _ContextLockDeferral(Exception):  # noqa: N818
     """
 
 
+class _SchedulerDeliveryCancelled(Exception):  # noqa: N818
+    """A timed-out scheduler receipt cancelled this turn before paste."""
+
+
 @dataclass
 class TmuxCommandResult:
     """Outcome of one ``tmux ...`` invocation."""
@@ -827,6 +831,11 @@ class _QueuedTurn:
     # so a never-clearing wedge can't replay the same turn forever and grow
     # the deque unboundedly (the murzik #846 loop).
     replay_count: int = 0
+    # Scheduler-only receipt. A serialized scheduler turn waits for the
+    # pane to become idle before paste; successful paste resolves True,
+    # permanent failure resolves False, and receipt timeout cancels it.
+    scheduler_delivery: asyncio.Future[bool] | None = None
+    scheduler_serialized: bool = False
 
 
 @dataclass
@@ -3282,6 +3291,9 @@ class TmuxSession:
             evt = self._inflight_turn.completion_event
             if evt is not None and not evt.is_set():
                 evt.set()
+            delivery = self._inflight_turn.scheduler_delivery
+            if delivery is not None and not delivery.done():
+                delivery.set_result(False)
             self._inflight_turn = None
 
         # Stop the response tailer (PR8b). Tailer instance is retained
@@ -3340,6 +3352,46 @@ class TmuxSession:
         sets ``injection_confirms_consumption = False``, so the broker never
         confirms off this value alone.
         """
+        return await self._queue_external_turn(
+            prompt,
+            platform=platform,
+            chat_id=chat_id,
+            message_id=message_id,
+            agent_hint=agent_hint,
+        )
+
+    async def send_scheduler_prompt(
+        self, prompt: str
+    ) -> asyncio.Future[bool]:
+        """Queue a scheduler turn and return its exact pane-delivery receipt.
+
+        The worker does not paste this turn while another turn is in flight.
+        That idle gate preserves each same-tick prompt instead of relying on
+        Claude Code's lossy mid-turn input behavior.
+        """
+        loop = asyncio.get_running_loop()
+        receipt: asyncio.Future[bool] = loop.create_future()
+        queued = await self._queue_external_turn(
+            prompt,
+            scheduler_delivery=receipt,
+            scheduler_serialized=True,
+        )
+        if not queued and not receipt.done():
+            receipt.set_result(False)
+        return receipt
+
+    async def _queue_external_turn(
+        self,
+        prompt: str,
+        *,
+        platform: str = "",
+        chat_id: str = "",
+        message_id: str = "",
+        agent_hint: str = "",
+        scheduler_delivery: asyncio.Future[bool] | None = None,
+        scheduler_serialized: bool = False,
+    ) -> bool:
+        """Apply external-send side effects and enqueue one pane turn."""
         if self.state != SessionState.CONNECTED:
             _log(
                 f"tmux[{self.agent_name}]: not connected (state={self.state.value}), "
@@ -3367,6 +3419,8 @@ class TmuxSession:
             platform=platform,
             chat_id=chat_id,
             message_id=message_id,
+            scheduler_delivery=scheduler_delivery,
+            scheduler_serialized=scheduler_serialized,
         ))
         _log(f"tmux[{self.agent_name}]: queued message (chat={chat_id})")
         return True
@@ -5211,6 +5265,13 @@ class TmuxSession:
                     # the second/third/Nth pasted turn while the first
                     # is still running.
                     self._inflight_turn = None
+                except _SchedulerDeliveryCancelled:
+                    _log(
+                        f"tmux[{self.agent_name}]: scheduler delivery "
+                        f"cancelled before paste"
+                    )
+                    self._inflight_turn = None
+                    continue
                 except _ContextLockDeferral as e:
                     # Transient: lock file present. Don't touch
                     # _inflight_turn or any deque state — _deliver_turn
@@ -5290,6 +5351,11 @@ class TmuxSession:
                         and not turn.completion_event.is_set()
                     ):
                         turn.completion_event.set()
+                    if (
+                        turn.scheduler_delivery is not None
+                        and not turn.scheduler_delivery.done()
+                    ):
+                        turn.scheduler_delivery.set_result(False)
                     # The message is being dropped; tell the chat that
                     # sent it instead of leaving the user with dead
                     # silence (daemon-log-only failures are invisible
@@ -6166,6 +6232,40 @@ class TmuxSession:
         """
         return _TRANSPORT_LOCK_DIR / f"{self.agent_name}.lock"
 
+    async def _wait_for_scheduler_delivery_slot(
+        self, turn: _QueuedTurn
+    ) -> None:
+        """Wait until no pane turn is running before a scheduler paste."""
+        if not turn.scheduler_serialized:
+            return
+
+        while self._scheduler_pane_busy():
+            if (
+                turn.scheduler_delivery is not None
+                and turn.scheduler_delivery.cancelled()
+            ):
+                raise _SchedulerDeliveryCancelled
+            await asyncio.sleep(0.25)
+
+        if (
+            turn.scheduler_delivery is not None
+            and turn.scheduler_delivery.cancelled()
+        ):
+            raise _SchedulerDeliveryCancelled
+
+    def _scheduler_pane_busy(self) -> bool:
+        """Conservative busy verdict for safe scheduled-prompt injection."""
+        if self._inflight_metas or self._inflight_tool_calls:
+            return True
+        live_status_fn = getattr(self._config, "live_status_fn", None)
+        if live_status_fn is None:
+            return False
+        try:
+            live = live_status_fn() or {}
+        except Exception:
+            return False
+        return live.get("status") == "working"
+
     async def _deliver_turn(self, turn: _QueuedTurn) -> None:
         """Push one turn through to the tmux pane.
 
@@ -6231,8 +6331,15 @@ class TmuxSession:
         the wake prompt (broker calls ``send`` the moment ``state ==
         CONNECTED``, which fires before this wait would have ended).
         """
+        # #931: scheduled prompts are not steering messages. Mid-turn pastes
+        # can vanish after a successful tmux command, so wait for the pane's
+        # prior FIFO turn to complete before injecting this one. Do this before
+        # the context-lock check so a lock created during a long idle wait is
+        # still observed immediately before delivery.
+        await self._wait_for_scheduler_delivery_slot(turn)
+
         # Pulse-v2 safety primitive: context-lock check. Cheap fs stat;
-        # do this first so we bail before mutating any state. The lock
+        # do this before mutating any delivery state. The lock
         # being held is transient — Murzik #522 round-1: raise a typed
         # ``_ContextLockDeferral`` so the worker knows to PRESERVE the
         # inflight turn, sleep, and retry on the next iteration. Bare
@@ -6403,6 +6510,11 @@ class TmuxSession:
             self._turn_done.set()
             if turn.completion_event is not None and not turn.completion_event.is_set():
                 turn.completion_event.set()
+            if (
+                turn.scheduler_delivery is not None
+                and not turn.scheduler_delivery.done()
+            ):
+                turn.scheduler_delivery.set_result(False)
             # Task #90: detect dead-pane (tmux session killed externally,
             # tmux server crashed, etc.). Without this, the worker would
             # loop forever pasting into a non-existent pane. Schedule
@@ -6499,6 +6611,12 @@ class TmuxSession:
         # became the head — leave it alone (Murzik review point #1).
         if was_empty:
             self._head_started_at = time.time()
+
+        if (
+            turn.scheduler_delivery is not None
+            and not turn.scheduler_delivery.done()
+        ):
+            turn.scheduler_delivery.set_result(True)
 
         # Hint to the tailer that a turn is in flight — switches to the
         # active-poll cadence (200ms vs 2s) for low-latency response

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -832,10 +832,14 @@ class _QueuedTurn:
     # the deque unboundedly (the murzik #846 loop).
     replay_count: int = 0
     # Scheduler-only receipt. A serialized scheduler turn waits for the
-    # pane to become idle before paste; successful paste resolves True,
-    # permanent failure resolves False, and receipt timeout cancels it.
+    # pane to become explicitly idle before paste. True requires a matching
+    # transcript user row, or queue enqueue followed by dequeue; successful
+    # tmux keystrokes alone are not a receipt.
     scheduler_delivery: asyncio.Future[bool] | None = None
     scheduler_serialized: bool = False
+    pane_delivery_started: bool = False
+    pane_queue_enqueued: bool = False
+    transport_accepted: bool = False
 
 
 @dataclass
@@ -1187,6 +1191,16 @@ class TmuxSession:
         # Worker queue + task.
         self._message_queue: asyncio.Queue[_QueuedTurn] = asyncio.Queue()
         self._worker_task: asyncio.Task | None = None
+        # Scheduler turns use separate delivery tasks so their conservative
+        # idle wait can never occupy the ordinary worker's head-of-line.
+        self._scheduler_delivery_tasks: set[asyncio.Task] = set()
+        self._scheduler_delivery_lock = asyncio.Lock()
+        # Turns remain here after paste until their exact transcript receipt
+        # resolves. Raw queue-operation dequeue rows carry no content, so the
+        # companion deque preserves enqueue ordering across all pane turns.
+        self._scheduler_pending_turns: list[_QueuedTurn] = []
+        self._pane_queue_operations: deque[_QueuedTurn | None] = deque()
+        self._pane_dequeued_turns: deque[_QueuedTurn | None] = deque()
         # Background watchdog that ages the deque head against
         # ``_TURN_DONE_TIMEOUT_SEC`` and triggers ``force_restart`` when
         # a stop hook fails to land. Issue #560 replaces the per-iter
@@ -3232,6 +3246,23 @@ class TmuxSession:
         intent (idle_sleep / force_restart / explicit DEAD) by driving
         the state machine BEFORE calling disconnect.
         """
+        # Fail and cancel scheduler-only delivery tasks before tearing down the
+        # ordinary worker/pane. A pane shutdown is a terminal non-receipt.
+        for turn in list(self._scheduler_pending_turns):
+            delivery = turn.scheduler_delivery
+            if delivery is not None and not delivery.done():
+                delivery.set_result(False)
+        scheduler_tasks = list(self._scheduler_delivery_tasks)
+        for task in scheduler_tasks:
+            if not task.done():
+                task.cancel()
+        if scheduler_tasks:
+            await asyncio.gather(*scheduler_tasks, return_exceptions=True)
+        self._scheduler_delivery_tasks.clear()
+        self._scheduler_pending_turns.clear()
+        self._pane_queue_operations.clear()
+        self._pane_dequeued_turns.clear()
+
         # Cancel worker.
         if self._worker_task and not self._worker_task.done():
             self._worker_task.cancel()
@@ -3279,6 +3310,9 @@ class TmuxSession:
         for entry in drained:
             if entry.completion_event is not None and not entry.completion_event.is_set():
                 entry.completion_event.set()
+            delivery = entry.turn.scheduler_delivery
+            if delivery is not None and not delivery.done():
+                delivery.set_result(False)
 
         # Issue #547: also unblock ``_inflight_turn`` — the turn the
         # worker pulled from the queue but had NOT yet pasted (e.g.
@@ -3363,11 +3397,10 @@ class TmuxSession:
     async def send_scheduler_prompt(
         self, prompt: str
     ) -> asyncio.Future[bool]:
-        """Queue a scheduler turn and return its exact pane-delivery receipt.
+        """Start a scheduler turn and return its exact acceptance receipt.
 
-        The worker does not paste this turn while another turn is in flight.
-        That idle gate preserves each same-tick prompt instead of relying on
-        Claude Code's lossy mid-turn input behavior.
+        Scheduler idle waits run outside the ordinary message worker, so user
+        steering and inter-agent sends retain their mid-turn paste latency.
         """
         loop = asyncio.get_running_loop()
         receipt: asyncio.Future[bool] = loop.create_future()
@@ -3414,16 +3447,101 @@ class TmuxSession:
                 pass
 
         queued_prompt = prompt + agent_hint if agent_hint else prompt
-        await self._message_queue.put(_QueuedTurn(
+        turn = _QueuedTurn(
             prompt=queued_prompt,
             platform=platform,
             chat_id=chat_id,
             message_id=message_id,
             scheduler_delivery=scheduler_delivery,
             scheduler_serialized=scheduler_serialized,
-        ))
+        )
+        if scheduler_serialized:
+            self._scheduler_pending_turns.append(turn)
+            if scheduler_delivery is not None:
+                scheduler_delivery.add_done_callback(
+                    lambda _receipt, _turn=turn: self._scheduler_receipt_done(
+                        _turn
+                    )
+                )
+            task = asyncio.create_task(self._deliver_scheduler_turn(turn))
+            self._scheduler_delivery_tasks.add(task)
+            task.add_done_callback(
+                lambda done, _turn=turn: self._scheduler_delivery_done(
+                    done, _turn
+                )
+            )
+        else:
+            await self._message_queue.put(turn)
         _log(f"tmux[{self.agent_name}]: queued message (chat={chat_id})")
         return True
+
+    def _scheduler_receipt_done(self, turn: _QueuedTurn) -> None:
+        """Forget one receipt turn by identity, preserving equal duplicates."""
+        self._scheduler_pending_turns[:] = [
+            pending
+            for pending in self._scheduler_pending_turns
+            if pending is not turn
+        ]
+
+    def _scheduler_delivery_done(
+        self, task: asyncio.Task, turn: _QueuedTurn
+    ) -> None:
+        """Retire an out-of-band scheduler paste task and surface crashes."""
+        self._scheduler_delivery_tasks.discard(task)
+        if task.cancelled():
+            receipt = turn.scheduler_delivery
+            if receipt is not None and not receipt.done():
+                receipt.set_result(False)
+            return
+        error = task.exception()
+        if error is not None:
+            receipt = turn.scheduler_delivery
+            if receipt is not None and not receipt.done():
+                receipt.set_result(False)
+            _log(
+                f"tmux[{self.agent_name}]: SCHEDULER DELIVERY TASK CRASHED "
+                f"with {type(error).__name__}: {error}"
+            )
+
+    async def _deliver_scheduler_turn(self, turn: _QueuedTurn) -> None:
+        """Paste one scheduler turn without blocking ordinary sends."""
+        receipt = turn.scheduler_delivery
+        try:
+            async with self._scheduler_delivery_lock:
+                while self.state == SessionState.CONNECTED:
+                    if receipt is None or receipt.cancelled():
+                        return
+                    try:
+                        self._processing = True
+                        await self._deliver_turn(turn)
+                        self._stats["turns"] += 1
+                        return
+                    except _SchedulerDeliveryCancelled:
+                        return
+                    except _ContextLockDeferral as e:
+                        _log(
+                            f"tmux[{self.agent_name}]: scheduler turn deferred "
+                            f"(context lock); retrying in "
+                            f"{_TRANSIENT_RETRY_BACKOFF_SEC}s ({e})"
+                        )
+                        await asyncio.sleep(_TRANSIENT_RETRY_BACKOFF_SEC)
+                    except Exception as e:
+                        self._stats["errors"] += 1
+                        _log(
+                            f"tmux[{self.agent_name}]: scheduler turn "
+                            f"delivery raised: {e}"
+                        )
+                        if receipt is not None and not receipt.done():
+                            receipt.set_result(False)
+                        return
+                    finally:
+                        self._processing = False
+                if receipt is not None and not receipt.done():
+                    receipt.set_result(False)
+        except asyncio.CancelledError:
+            if receipt is not None and not receipt.done():
+                receipt.set_result(False)
+            raise
 
     async def _enqueue_internal_prompt(
         self,
@@ -4519,6 +4637,16 @@ class TmuxSession:
             return
 
         entry = self._inflight_metas.popleft()
+        self._pane_queue_operations = deque(
+            queued
+            for queued in self._pane_queue_operations
+            if queued is not entry.turn
+        )
+        self._pane_dequeued_turns = deque(
+            dequeued
+            for dequeued in self._pane_dequeued_turns
+            if dequeued is not entry.turn
+        )
         if (
             self._fresh_context_respawn_grace_until
             and self._fresh_context_respawn_epoch
@@ -4874,6 +5002,9 @@ class TmuxSession:
                 # the live window instead of freezing at the previous
                 # turn's value for the whole in-flight turn.
                 on_usage=self._on_transcript_usage,
+                # Scheduler receipts require an exact user/dequeue transcript
+                # observation; successful external-pane keystrokes are weaker.
+                on_entry=self._on_transcript_entry,
             )
             await self._tailer.start()
             if guessed is None:
@@ -5963,6 +6094,9 @@ class TmuxSession:
                         ev = m.completion_event
                         if ev is not None and not ev.is_set():
                             ev.set()
+                        delivery = m.turn.scheduler_delivery
+                        if delivery is not None and not delivery.done():
+                            delivery.set_result(False)
                     _log(
                         f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
                         f"but REPL is idle — reconciled {len(drained)} phantom "
@@ -6123,6 +6257,9 @@ class TmuxSession:
                             f"already-completed {kind} turn "
                             f"(completion_event set) — #846"
                         )
+                        delivery = t.scheduler_delivery
+                        if delivery is not None and not delivery.done():
+                            delivery.set_result(False)
                         return False
                     t.replay_count += 1
                     if replay_cap and t.replay_count > replay_cap:
@@ -6134,6 +6271,9 @@ class TmuxSession:
                         )
                         if ev is not None and not ev.is_set():
                             ev.set()
+                        delivery = t.scheduler_delivery
+                        if delivery is not None and not delivery.done():
+                            delivery.set_result(False)
                         return False
                     return True
 
@@ -6152,6 +6292,9 @@ class TmuxSession:
                             de = dropped.turn.completion_event
                             if de is not None and not de.is_set():
                                 de.set()
+                            delivery = dropped.turn.scheduler_delivery
+                            if delivery is not None and not delivery.done():
+                                delivery.set_result(False)
                         break
                     if _consider_replay(entry.turn, kind="tail"):
                         replay.append(entry.turn)
@@ -6193,6 +6336,9 @@ class TmuxSession:
                     and not head.completion_event.is_set()
                 ):
                     head.completion_event.set()
+                head_delivery = head.turn.scheduler_delivery
+                if head_delivery is not None and not head_delivery.done():
+                    head_delivery.set_result(False)
                 self._turn_done.set()
                 self._stats["errors"] += 1
                 self._stats["turn_timeouts"] = (
@@ -6255,16 +6401,119 @@ class TmuxSession:
 
     def _scheduler_pane_busy(self) -> bool:
         """Conservative busy verdict for safe scheduled-prompt injection."""
-        if self._inflight_metas or self._inflight_tool_calls:
+        if (
+            self._inflight_metas
+            or self._inflight_tool_calls
+            or self._inflight_turn is not None
+            or not self._message_queue.empty()
+        ):
             return True
         live_status_fn = getattr(self._config, "live_status_fn", None)
         if live_status_fn is None:
-            return False
+            return True
         try:
             live = live_status_fn() or {}
         except Exception:
-            return False
-        return live.get("status") == "working"
+            return True
+        if live.get("status") != "idle":
+            return True
+        last_updated = live.get("last_updated")
+        return not (
+            isinstance(last_updated, (int, float))
+            and not isinstance(last_updated, bool)
+            and last_updated > 0
+        )
+
+    @staticmethod
+    def _transcript_user_text(entry: dict) -> str | None:
+        """Extract a plain user prompt from either known transcript shape."""
+        message = entry.get("message") or {}
+        content = message.get("content") if isinstance(message, dict) else None
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            return None
+        text_parts = [
+            block.get("text", "")
+            for block in content
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "text"
+                and isinstance(block.get("text"), str)
+            )
+        ]
+        return "".join(text_parts) if text_parts else None
+
+    def _acceptance_candidates(self) -> list[_QueuedTurn]:
+        """Return known pane turns oldest-first, without duplicate objects."""
+        candidates = [entry.turn for entry in self._inflight_metas]
+        if self._inflight_turn is not None:
+            candidates.append(self._inflight_turn)
+        candidates.extend(self._scheduler_pending_turns)
+        unique: dict[int, _QueuedTurn] = {}
+        for turn in candidates:
+            unique.setdefault(id(turn), turn)
+        return sorted(unique.values(), key=lambda turn: turn.queued_at)
+
+    def _match_acceptance_turn(
+        self, prompt: str, *, for_enqueue: bool = False
+    ) -> _QueuedTurn | None:
+        """Match an exact transcript prompt to its oldest pending pane turn."""
+        for turn in self._acceptance_candidates():
+            if (
+                not turn.pane_delivery_started
+                or turn.transport_accepted
+                or turn.prompt != prompt
+            ):
+                continue
+            if for_enqueue and turn.pane_queue_enqueued:
+                continue
+            return turn
+        return None
+
+    @staticmethod
+    def _mark_transport_accepted(turn: _QueuedTurn | None) -> None:
+        """Resolve a scheduler receipt only on observed pane acceptance."""
+        if turn is None or turn.transport_accepted:
+            return
+        turn.transport_accepted = True
+        receipt = turn.scheduler_delivery
+        if receipt is not None and not receipt.done():
+            receipt.set_result(True)
+
+    def _on_transcript_entry(self, entry: dict) -> None:
+        """Consume transcript evidence strong enough for exact-turn receipts."""
+        entry_type = entry.get("type")
+        if entry_type == "queue-operation":
+            operation = entry.get("operation")
+            if operation == "enqueue":
+                content = entry.get("content")
+                turn = (
+                    self._match_acceptance_turn(content, for_enqueue=True)
+                    if isinstance(content, str)
+                    else None
+                )
+                if turn is not None:
+                    turn.pane_queue_enqueued = True
+                self._pane_queue_operations.append(turn)
+            elif operation == "dequeue" and self._pane_queue_operations:
+                turn = self._pane_queue_operations.popleft()
+                self._pane_dequeued_turns.append(turn)
+                self._mark_transport_accepted(turn)
+            return
+
+        if entry_type == "user":
+            prompt = self._transcript_user_text(entry)
+            if prompt is not None:
+                if self._pane_dequeued_turns:
+                    dequeued = self._pane_dequeued_turns[0]
+                    if dequeued is None or dequeued.prompt == prompt:
+                        self._pane_dequeued_turns.popleft()
+                        self._mark_transport_accepted(dequeued)
+                        return
+                self._mark_transport_accepted(
+                    self._match_acceptance_turn(prompt)
+                )
 
     async def _deliver_turn(self, turn: _QueuedTurn) -> None:
         """Push one turn through to the tmux pane.
@@ -6500,8 +6749,25 @@ class TmuxSession:
         # Held under the REPL-control lock so a live /effort or /model
         # apply (which sends, settles, and may confirm a dialog) can't
         # interleave with this paste — two send paths into one pane.
-        async with self._repl_control_lock:
-            result = await self._tmux.paste_text(turn.prompt, enter=True)
+        while True:
+            async with self._repl_control_lock:
+                # An ordinary send can win the REPL lock after the scheduler's
+                # outer idle wait. Recheck under the shared lock so a scheduler
+                # paste never races behind newly queued steering input.
+                if (
+                    turn.scheduler_serialized
+                    and self._scheduler_pane_busy()
+                ):
+                    retry_scheduler_gate = True
+                else:
+                    retry_scheduler_gate = False
+                    turn.pane_delivery_started = True
+                    result = await self._tmux.paste_text(
+                        turn.prompt, enter=True
+                    )
+            if not retry_scheduler_gate:
+                break
+            await self._wait_for_scheduler_delivery_slot(turn)
         if not result.ok:
             # Send failed — no response will arrive. Re-arm turn_done
             # (back-compat) and unblock any wait_for_completion caller
@@ -6611,12 +6877,6 @@ class TmuxSession:
         # became the head — leave it alone (Murzik review point #1).
         if was_empty:
             self._head_started_at = time.time()
-
-        if (
-            turn.scheduler_delivery is not None
-            and not turn.scheduler_delivery.done()
-        ):
-            turn.scheduler_delivery.set_result(True)
 
         # Hint to the tailer that a turn is in flight — switches to the
         # active-poll cadence (200ms vs 2s) for low-latency response

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -294,6 +294,7 @@ class TmuxTranscriptTailer:
         active_poll_sec: float = _ACTIVE_POLL_SEC,
         path_discovery: Callable[[], Path | None] | None = None,
         on_usage: Callable[[dict], None] | None = None,
+        on_entry: Callable[[dict], None] | None = None,
     ) -> None:
         self._path = Path(transcript_path)
         # #291: wall-clock when ``_path`` was last bound via an explicit
@@ -331,6 +332,9 @@ class TmuxTranscriptTailer:
         # transcript-swap race that ``_swap_generation`` guards around
         # turn callbacks.
         self._on_usage = on_usage
+        # Raw-entry hook used by TmuxSession to observe prompt acceptance.
+        # Sync so reading a chunk has no new suspension point.
+        self._on_entry = on_entry
 
         self._offset: int = 0
         # Bumped by every path-changing ``set_transcript_path``. Lets
@@ -729,6 +733,16 @@ class TmuxTranscriptTailer:
                     )
                     bytes_read += len(line) + 1
                     continue
+
+                if self._on_entry is not None:
+                    try:
+                        self._on_entry(dict(entry))
+                    except Exception as e:
+                        self._stats["callback_errors"] += 1
+                        _log(
+                            f"tmux_tailer[{self._agent_name}]: on_entry raised "
+                            f"({type(e).__name__}: {e}); continuing"
+                        )
 
                 closes_turn = False
                 prevented = False

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -365,6 +365,39 @@ class TestCodexSessionSendSignature:
         queued = await s._message_queue.get()
         assert queued[0] == "plain prompt"
 
+    @pytest.mark.asyncio
+    async def test_scheduler_receipt_waits_until_worker_starts_exact_turn(self):
+        """#931: a queued scheduler prompt is not delivered at enqueue time."""
+        s = self._make()
+        await _to_connected(s)
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        calls: list[str] = []
+
+        async def fake_exec(prompt: str) -> CodexTurnResult:
+            calls.append(prompt)
+            if prompt == "first":
+                first_started.set()
+                await release_first.wait()
+            return CodexTurnResult()
+
+        s._exec_codex = fake_exec  # type: ignore[assignment]
+        await s.send("first")
+        worker = asyncio.create_task(s._message_worker())
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+
+        second_receipt = await s.send_scheduler_prompt("second")
+        await asyncio.sleep(0.02)
+        assert not second_receipt.done()
+
+        release_first.set()
+        assert await asyncio.wait_for(second_receipt, timeout=1) is True
+        assert calls == ["first", "second"]
+
+        await _to_dead(s)
+        s._message_queue.put_nowait(("noop", "", "", ""))
+        await asyncio.wait_for(worker, timeout=1)
+
 
 class TestCodexSessionDisconnect:
     @pytest.mark.asyncio

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import sys
 import tempfile
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -374,11 +375,16 @@ class TestCodexSessionSendSignature:
         release_first = asyncio.Event()
         calls: list[str] = []
 
-        async def fake_exec(prompt: str) -> CodexTurnResult:
+        async def fake_exec(
+            prompt: str,
+            *,
+            scheduler_delivery: asyncio.Future[bool] | None = None,
+        ) -> CodexTurnResult:
             calls.append(prompt)
             if prompt == "first":
                 first_started.set()
                 await release_first.wait()
+            s._resolve_scheduler_delivery(scheduler_delivery, True)
             return CodexTurnResult()
 
         s._exec_codex = fake_exec  # type: ignore[assignment]
@@ -393,6 +399,27 @@ class TestCodexSessionSendSignature:
         release_first.set()
         assert await asyncio.wait_for(second_receipt, timeout=1) is True
         assert calls == ["first", "second"]
+
+        await _to_dead(s)
+        s._message_queue.put_nowait(("noop", "", "", ""))
+        await asyncio.wait_for(worker, timeout=1)
+
+    @pytest.mark.asyncio
+    async def test_scheduler_receipt_is_false_when_exec_fails_before_acceptance(
+        self,
+    ):
+        """A spawned/accepted turn, not _exec_lock acquisition, is the edge."""
+        s = self._make()
+        s._use_app_server = False
+        await _to_connected(s)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=OSError("spawn failed before acceptance")),
+        ):
+            receipt = await s.send_scheduler_prompt("scheduled")
+            worker = asyncio.create_task(s._message_worker())
+            assert await asyncio.wait_for(receipt, timeout=1) is False
 
         await _to_dead(s)
         s._message_queue.put_nowait(("noop", "", "", ""))
@@ -1268,10 +1295,14 @@ class TestCodexAppServerTurn:
         ]
         fake = _FakeAppClient(s, notifications)
         _patch_ensure(s, fake)
+        receipt = asyncio.get_running_loop().create_future()
 
-        result = await s._exec_codex_app_server("hi there")
+        result = await s._exec_codex_app_server(
+            "hi there", scheduler_delivery=receipt
+        )
 
         assert not result.failed
+        assert await receipt is True
         assert result.text_parts == ["hello"]
         assert result.input_tokens == 100
         assert result.output_tokens == 10
@@ -1366,6 +1397,28 @@ class TestCodexAppServerTurn:
         result = await s._exec_codex_app_server("hi")
         assert result.failed
         assert "spawn failed" in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_turn_start_failure_is_a_negative_scheduler_receipt(self):
+        s = _appserver_session()
+        fake = _FakeAppClient(s, [])
+        original_request = fake.request
+
+        async def fail_turn_start(method, params=None, *, timeout=600.0):
+            if method == "turn/start":
+                raise RuntimeError("turn rejected before acceptance")
+            return await original_request(method, params, timeout=timeout)
+
+        fake.request = fail_turn_start
+        _patch_ensure(s, fake)
+        receipt = asyncio.get_running_loop().create_future()
+
+        result = await s._exec_codex_app_server(
+            "scheduled", scheduler_delivery=receipt
+        )
+
+        assert result.failed
+        assert await receipt is False
 
 
 # -- Exec serialization / stderr drain / delta dedupe regressions ---------

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -488,3 +488,30 @@ class TestDaemon:
         assert stats["running"] is False
         assert stats["pollers"] == 0
         assert stats["messages_processed"] == 0
+
+    @pytest.mark.asyncio
+    async def test_legacy_schedule_enqueue_is_not_a_delivery_receipt(
+        self, tmp_path, capsys
+    ):
+        """A pending autonomy event must not advance last_delivered."""
+        config = DaemonConfig(working_dir=str(tmp_path))
+        with patch(
+            "pinky_daemon.claude_runner._find_claude_binary",
+            return_value="/usr/bin/claude",
+        ):
+            daemon = Daemon(config)
+        daemon._registry.register("oleg")
+        daemon._registry.add_schedule(
+            "oleg", "* * * * *", name="queued-only", prompt="scheduled"
+        )
+        schedule = daemon._registry.get_schedules("oleg")[0]
+        daemon._runner.run = AsyncMock()
+
+        await daemon._scheduler._deliver_schedule(schedule)
+        await asyncio.sleep(0)
+
+        stored = daemon._registry.get_schedules("oleg")[0]
+        assert daemon._autonomy.event_queue.pending_count("oleg") == 1
+        daemon._runner.run.assert_not_awaited()
+        assert stored.last_delivered == 0.0
+        assert "FIRED BUT UNDELIVERED" in capsys.readouterr().err

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -353,12 +353,28 @@ class TestAgentSchedules:
         registry.register("oleg")
         s = registry.add_schedule("oleg", "0 8 * * *")
         assert s.last_run == 0.0
+        assert s.last_delivered == 0.0
 
         now = time.time()
         registry.update_schedule_last_run(s.id, now)
 
         schedules = registry.get_schedules("oleg")
         assert schedules[0].last_run == pytest.approx(now, abs=0.1)
+        assert schedules[0].last_delivered == 0.0
+
+    def test_update_last_delivered_is_distinct_from_last_run(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule("oleg", "0 8 * * *")
+
+        delivered_at = time.time()
+        registry.update_schedule_last_delivered(schedule.id, delivered_at)
+
+        stored = registry.get_schedules("oleg")[0]
+        assert stored.last_run == 0.0
+        assert stored.last_delivered == pytest.approx(delivered_at, abs=0.1)
+        assert stored.to_dict()["last_delivered"] == pytest.approx(
+            delivered_at, abs=0.1
+        )
 
     def test_cascade_delete(self, registry):
         registry.register("oleg")
@@ -704,6 +720,99 @@ class TestScheduler:
         scheduler = AgentScheduler(registry)
         result = await scheduler.fire_now("oleg")
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_same_tick_prompts_wait_for_each_delivery_confirmation(
+        self, registry
+    ):
+        """A busy session must not swallow the tail of a same-tick cohort."""
+        registry.register("oleg")
+        registry.add_schedule(
+            "oleg", "* * * * *", name="first", prompt="first prompt"
+        )
+        registry.add_schedule(
+            "oleg", "* * * * *", name="second", prompt="second prompt"
+        )
+
+        busy = False
+        delivered: list[str] = []
+        events: list[str] = []
+
+        class Activity:
+            def log(self, agent_name, event_type, summary):
+                del agent_name, summary
+                events.append(event_type)
+
+        async def wake_cb(agent_name, session_id, prompt):
+            nonlocal busy
+            del agent_name, session_id
+            receipt = asyncio.get_running_loop().create_future()
+            if busy:
+                receipt.set_result(False)
+                return receipt
+
+            busy = True
+
+            def confirm_delivery():
+                nonlocal busy
+                delivered.append(prompt)
+                busy = False
+                receipt.set_result(True)
+
+            asyncio.get_running_loop().call_soon(confirm_delivery)
+            return receipt
+
+        scheduler = AgentScheduler(
+            registry, wake_callback=wake_cb, activity=Activity()
+        )
+        await scheduler._check_schedules(time.time())
+        await asyncio.sleep(0.05)
+
+        assert delivered == ["first prompt", "second prompt"]
+        schedules = registry.get_schedules("oleg")
+        assert all(schedule.last_run > 0 for schedule in schedules)
+        assert all(schedule.last_delivered > 0 for schedule in schedules)
+        assert events == [
+            "schedule_fired",
+            "schedule_fired",
+            "schedule_delivered",
+            "schedule_delivered",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unconfirmed_delivery_stays_fired_but_undelivered(
+        self, registry, capsys
+    ):
+        registry.register("oleg")
+        registry.add_schedule(
+            "oleg", "* * * * *", name="unconfirmed", prompt="prompt"
+        )
+        events: list[str] = []
+
+        class Activity:
+            def log(self, agent_name, event_type, summary):
+                del agent_name, summary
+                events.append(event_type)
+
+        async def wake_cb(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return asyncio.get_running_loop().create_future()
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            activity=Activity(),
+            schedule_delivery_timeout=0.01,
+        )
+        fired_at = time.time()
+        await scheduler._check_schedules(fired_at)
+        await asyncio.sleep(0.05)
+
+        stored = registry.get_schedules("oleg")[0]
+        assert stored.last_run == pytest.approx(fired_at)
+        assert stored.last_delivered == 0.0
+        assert events == ["schedule_fired", "schedule_undelivered"]
+        assert "FIRED BUT UNDELIVERED" in capsys.readouterr().err
 
 
 # ── Heartbeat Watchdog Resurrection (issue #338) ──────────────────────────

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -814,6 +814,80 @@ class TestScheduler:
         assert events == ["schedule_fired", "schedule_undelivered"]
         assert "FIRED BUT UNDELIVERED" in capsys.readouterr().err
 
+    @pytest.mark.asyncio
+    async def test_canceled_cohort_accounts_current_and_remaining_as_undelivered(
+        self, registry, capsys
+    ):
+        registry.register("oleg")
+        registry.add_schedule(
+            "oleg", "* * * * *", name="first", prompt="first"
+        )
+        registry.add_schedule(
+            "oleg", "* * * * *", name="second", prompt="second"
+        )
+        first_started = asyncio.Event()
+        attempts: list[str] = []
+        events: list[str] = []
+
+        class Activity:
+            def log(self, agent_name, event_type, summary):
+                del agent_name, summary
+                events.append(event_type)
+
+        async def wake_cb(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            first_started.set()
+            return asyncio.get_running_loop().create_future()
+
+        scheduler = AgentScheduler(
+            registry, wake_callback=wake_cb, activity=Activity()
+        )
+        await scheduler._check_schedules(time.time())
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+        await asyncio.wait_for(scheduler.stop(), timeout=1)
+
+        schedules = registry.get_schedules("oleg")
+        assert attempts == ["first"]
+        assert all(schedule.last_run > 0 for schedule in schedules)
+        assert all(schedule.last_delivered == 0 for schedule in schedules)
+        assert events == [
+            "schedule_fired",
+            "schedule_fired",
+            "schedule_undelivered",
+            "schedule_undelivered",
+        ]
+        assert capsys.readouterr().err.count("FIRED BUT UNDELIVERED") == 2
+
+    @pytest.mark.asyncio
+    async def test_misconfigured_direct_send_never_falls_back_to_agent_wake(
+        self, registry, capsys
+    ):
+        registry.register("oleg")
+        registry.add_schedule(
+            "oleg",
+            "* * * * *",
+            name="direct",
+            prompt="target prompt",
+            target_channel="12345",
+            direct_send=True,
+        )
+        wake_calls: list[str] = []
+
+        async def wake_cb(agent_name, session_id, prompt):
+            del agent_name, session_id
+            wake_calls.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=wake_cb)
+        schedule = registry.get_schedules("oleg")[0]
+        await scheduler._deliver_schedule(schedule)
+
+        stored = registry.get_schedules("oleg")[0]
+        assert wake_calls == []
+        assert stored.last_delivered == 0.0
+        assert "FIRED BUT UNDELIVERED" in capsys.readouterr().err
+
 
 # ── Heartbeat Watchdog Resurrection (issue #338) ──────────────────────────
 

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3572,6 +3572,60 @@ async def test_disconnect_clears_inflight_meta() -> None:
 
 
 @pytest.mark.asyncio
+async def test_scheduler_prompt_receipt_waits_for_idle_pane() -> None:
+    """#931: scheduler turns must never paste concurrently into a busy REPL."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+
+    first_receipt = await ss.send_scheduler_prompt("first")
+    first_turn = await ss._message_queue.get()
+    await ss._deliver_turn(first_turn)
+    assert await first_receipt is True
+    assert len(ss._inflight_metas) == 1
+
+    second_receipt = await ss.send_scheduler_prompt("second")
+    second_turn = await ss._message_queue.get()
+    second_delivery = asyncio.create_task(ss._deliver_turn(second_turn))
+    await asyncio.sleep(0.02)
+
+    assert tmux.paste_text.await_count == 1
+    assert not second_receipt.done()
+
+    await ss._handle_turn_complete(
+        TurnResponse(text="first done", stop_reason="end_turn")
+    )
+    await asyncio.wait_for(second_delivery, timeout=1)
+
+    assert await second_receipt is True
+    assert tmux.paste_text.await_count == 2
+    assert [call.args[0] for call in tmux.paste_text.await_args_list] == [
+        "first",
+        "second",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_prompt_receipt_waits_for_live_working_status() -> None:
+    """#931: pane status must gate prompts without local inflight metadata."""
+    live = {"status": "working"}
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: live
+
+    receipt = await ss.send_scheduler_prompt("scheduled")
+    turn = await ss._message_queue.get()
+    delivery = asyncio.create_task(ss._deliver_turn(turn))
+    await asyncio.sleep(0.02)
+
+    assert tmux.paste_text.await_count == 0
+    assert not receipt.done()
+
+    live["status"] = "idle"
+    await asyncio.wait_for(delivery, timeout=1)
+
+    assert await receipt is True
+    tmux.paste_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_multi_prompt_routing_no_cross_user_leak(tmp_path) -> None:
     """#560 / Pushok PR #496 round-1 Case 1 — preserved with concurrent
     dispatch: two ``send()`` calls in quick succession must route response

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3676,14 +3676,18 @@ async def test_scheduler_gate_fails_closed_without_trustworthy_idle(
     """Missing/error/non-idle status never permits a scheduler pane paste."""
     ss, tmux = _make_session(state=SessionState.CONNECTED)
     ss._config.live_status_fn = live_status_fn
+    ss._worker_task = asyncio.create_task(ss._message_worker())
+    receipt: asyncio.Future[bool] | None = None
+    try:
+        receipt = await ss.send_scheduler_prompt("scheduled")
+        await asyncio.sleep(0.02)
 
-    receipt = await ss.send_scheduler_prompt("scheduled")
-    await asyncio.sleep(0.02)
-
-    tmux.paste_text.assert_not_awaited()
-    assert not receipt.done()
-    receipt.cancel()
-    await ss.disconnect()
+        tmux.paste_text.assert_not_awaited()
+        assert not receipt.done()
+    finally:
+        if receipt is not None:
+            receipt.cancel()
+        await ss.disconnect()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3573,56 +3573,117 @@ async def test_disconnect_clears_inflight_meta() -> None:
 
 @pytest.mark.asyncio
 async def test_scheduler_prompt_receipt_waits_for_idle_pane() -> None:
-    """#931: scheduler turns must never paste concurrently into a busy REPL."""
+    """Successful pane keystrokes are not a scheduler delivery receipt."""
     ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
 
-    first_receipt = await ss.send_scheduler_prompt("first")
-    first_turn = await ss._message_queue.get()
-    await ss._deliver_turn(first_turn)
-    assert await first_receipt is True
+    receipt = await ss.send_scheduler_prompt("scheduled")
+    for _ in range(100):
+        if tmux.paste_text.await_count == 1:
+            break
+        await asyncio.sleep(0.01)
+
+    tmux.paste_text.assert_awaited_once_with("scheduled", enter=True)
+    assert not receipt.done()
     assert len(ss._inflight_metas) == 1
 
-    second_receipt = await ss.send_scheduler_prompt("second")
-    second_turn = await ss._message_queue.get()
-    second_delivery = asyncio.create_task(ss._deliver_turn(second_turn))
-    await asyncio.sleep(0.02)
-
-    assert tmux.paste_text.await_count == 1
-    assert not second_receipt.done()
-
-    await ss._handle_turn_complete(
-        TurnResponse(text="first done", stop_reason="end_turn")
-    )
-    await asyncio.wait_for(second_delivery, timeout=1)
-
-    assert await second_receipt is True
-    assert tmux.paste_text.await_count == 2
-    assert [call.args[0] for call in tmux.paste_text.await_args_list] == [
-        "first",
-        "second",
-    ]
+    ss._on_transcript_entry({
+        "type": "queue-operation",
+        "operation": "enqueue",
+        "content": "scheduled",
+    })
+    assert not receipt.done()
+    ss._on_transcript_entry({
+        "type": "queue-operation",
+        "operation": "dequeue",
+    })
+    assert await receipt is True
+    await ss.disconnect()
 
 
 @pytest.mark.asyncio
 async def test_scheduler_prompt_receipt_waits_for_live_working_status() -> None:
     """#931: pane status must gate prompts without local inflight metadata."""
-    live = {"status": "working"}
+    live = {"status": "working", "last_updated": _time.time()}
     ss, tmux = _make_session(state=SessionState.CONNECTED)
     ss._config.live_status_fn = lambda: live
 
     receipt = await ss.send_scheduler_prompt("scheduled")
-    turn = await ss._message_queue.get()
-    delivery = asyncio.create_task(ss._deliver_turn(turn))
     await asyncio.sleep(0.02)
 
     assert tmux.paste_text.await_count == 0
     assert not receipt.done()
 
     live["status"] = "idle"
-    await asyncio.wait_for(delivery, timeout=1)
+    live["last_updated"] = _time.time()
+    for _ in range(100):
+        if tmux.paste_text.await_count == 1:
+            break
+        await asyncio.sleep(0.01)
 
-    assert await receipt is True
     tmux.paste_text.assert_awaited_once()
+    assert not receipt.done()
+    ss._on_transcript_entry({
+        "type": "user",
+        "message": {"role": "user", "content": "scheduled"},
+    })
+    assert await receipt is True
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_idle_wait_does_not_block_ordinary_midturn_send() -> None:
+    """A waiting scheduler turn never owns the ordinary worker head-of-line."""
+    live = {"status": "working", "last_updated": _time.time()}
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: live
+    ss._worker_task = asyncio.create_task(ss._message_worker())
+
+    receipt = await ss.send_scheduler_prompt("scheduled")
+    await asyncio.sleep(0.02)
+    assert tmux.paste_text.await_count == 0
+
+    assert await ss.send("ordinary") is True
+    for _ in range(100):
+        if tmux.paste_text.await_count == 1:
+            break
+        await asyncio.sleep(0.01)
+
+    tmux.paste_text.assert_awaited_once_with("ordinary", enter=True)
+    assert not receipt.done()
+    receipt.cancel()
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "live_status_fn",
+    [
+        None,
+        lambda: {},
+        lambda: {"status": "thinking", "last_updated": _time.time()},
+        lambda: {"status": "tool_use", "last_updated": _time.time()},
+        lambda: {"status": "offline", "last_updated": _time.time()},
+        lambda: (_ for _ in ()).throw(RuntimeError("status failed")),
+    ],
+)
+async def test_scheduler_gate_fails_closed_without_trustworthy_idle(
+    live_status_fn,
+) -> None:
+    """Missing/error/non-idle status never permits a scheduler pane paste."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = live_status_fn
+
+    receipt = await ss.send_scheduler_prompt("scheduled")
+    await asyncio.sleep(0.02)
+
+    tmux.paste_text.assert_not_awaited()
+    assert not receipt.done()
+    receipt.cancel()
+    await ss.disconnect()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tmux_transcript.py
+++ b/tests/test_tmux_transcript.py
@@ -310,6 +310,31 @@ class TestTailerReadOnce:
         assert tailer.offset == 0
 
     @pytest.mark.asyncio
+    async def test_raw_entry_hook_observes_queue_acceptance_rows(
+        self, transcript
+    ):
+        cb = _Captor()
+        entries = [
+            {
+                "type": "queue-operation",
+                "operation": "enqueue",
+                "content": "scheduled",
+            },
+            {"type": "queue-operation", "operation": "dequeue"},
+            _user(text="scheduled"),
+        ]
+        seen: list[dict] = []
+        tailer = TmuxTranscriptTailer(
+            transcript, cb, on_entry=seen.append
+        )
+        _write_jsonl(transcript, entries)
+
+        await tailer.read_once()
+
+        assert seen == entries
+        assert cb.responses == []
+
+    @pytest.mark.asyncio
     async def test_nonexistent_file_no_error(self, tmp_path):
         cb = _Captor()
         tailer = TmuxTranscriptTailer(tmp_path / "does-not-exist.jsonl", cb)


### PR DESCRIPTION
Fixes #931.

## What changed

- Keep `last_run` as the scheduler's fired decision and add `last_delivered` as a distinct confirmed-acceptance timestamp.
- Record `schedule_fired`, `schedule_delivered`, and `schedule_undelivered` activity events separately.
- Deliver each agent's due schedule cohort serially, waiting for the exact prompt receipt before advancing to the next prompt.
- Keep receipt waits outside the scheduler tick and serialize them with a per-agent lock, so a busy agent cannot block unrelated scheduler work.
- Treat an unconfirmed/false/failed receipt as fired-but-undelivered. The bounded receipt window is 600 seconds and expiry logs a loud `FIRED BUT UNDELIVERED` line.
- Add scheduler-only transport receipts:
  - tmux waits until the pane is not locally in flight, not in a foreground tool call, and not reporting live `working`; successful paste resolves the receipt;
  - Codex resolves when the exact queued exec turn starts under its serialization lock;
  - transports whose normal injection explicitly confirms consumption retain that positive handoff path.
- Preserve ordinary tmux steering behavior; only scheduler prompts use the idle gate.

The optional creation-time collision warning is intentionally not included. Correctly identifying cron overlap beyond identical expressions/minutes is not a cheap local check, and the dispatched fix scope called for the two delivery mechanisms plus tests. No coalescing, journald, reconnect/self-heal, runtime, or deployment behavior is changed.

## Root cause

The scheduler already awaited each wake callback, but the callback returned after `send()` merely enqueued the prompt. Same-tick prompts 2-N could therefore be pasted into a session still processing prompt 1 and disappear while `last_run` falsely looked like delivery evidence.

## Regression evidence

The new same-tick test simulates that lossy busy-session behavior. Against current main before the fix it failed with only `["first prompt"]` delivered instead of both prompts. It passes with receipt-aware serialization and asserts fired and delivered state independently.

## Validation

- `ruff check .`
- `git diff HEAD^ --check`
- `PINKY_DREAM_TRANSPORT=sdk pytest -q tests/test_scheduler.py tests/test_codex_session.py` — 180 passed
- `PINKY_DREAM_TRANSPORT=sdk pytest -q tests/test_tmux_session.py` — 344 passed
- `PINKY_DREAM_TRANSPORT=sdk pytest -q tests/test_api.py tests/test_broker.py tests/test_daemon.py` — 508 passed (known FastAPI deprecations and shared-MCP port-8890 contention warnings only)
