### PR TITLE
Make five more SQLite stores thread-local

### DIFF
--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -19,6 +19,7 @@ import os
 import re
 import sqlite3
 import sys
+import threading
 import time
 from collections.abc import Callable
 from datetime import date, datetime, timezone
@@ -92,7 +93,8 @@ class DreamRunner:
         signing_key_provider: Callable[[str], str | None] | None = None,
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._history_provider = history_provider
         # Optional () -> owner-profile dict, used to derive high-value entity
         # names for KG proactive-surfacing materiality. May be None.
@@ -104,8 +106,17 @@ class DreamRunner:
         # Optional agent_name -> per-agent signing key resolver for daemon-internal
         # API calls. Isolated agents cannot authenticate with the fleet-wide secret.
         self._signing_key_provider = signing_key_provider
-        self._db.execute("PRAGMA journal_mode=WAL")
         self._init_tables()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_tables(self) -> None:
         self._db.executescript("""
@@ -1303,3 +1314,14 @@ class DreamRunner:
             (agent_name, now, summary, last_message_ts),
         )
         self._db.commit()
+
+    def close(self) -> None:
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection

--- a/src/pinky_daemon/hooks.py
+++ b/src/pinky_daemon/hooks.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -122,8 +123,21 @@ class AuditStore:
 
     def __init__(self, db_path: str = "data/audit.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db_path = db_path
+        self._thread_local = threading.local()
+        self._init_tables()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            self._thread_local.connection = connection
+        return connection
+
+    def _init_tables(self) -> None:
         self._db.executescript("""
             CREATE TABLE IF NOT EXISTS audit_log (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -247,7 +261,15 @@ class AuditStore:
         return cursor.rowcount
 
     def close(self) -> None:
-        self._db.close()
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection
 
 
 # ── Hook Manager ─────────────────────────────────────────

--- a/src/pinky_daemon/presentation_store.py
+++ b/src/pinky_daemon/presentation_store.py
@@ -18,6 +18,7 @@ import re
 import secrets
 import sqlite3
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -126,10 +127,20 @@ class PresentationStore:
 
     def __init__(self, db_path: str = "data/presentations.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA foreign_keys=ON")
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._init_tables()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA foreign_keys=ON")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_tables(self) -> None:
         self._db.executescript("""
@@ -580,7 +591,15 @@ class PresentationStore:
         }
 
     def close(self) -> None:
-        self._db.close()
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection
 
 
 # ── Built-in template definitions ────────────────────────────────────────────

--- a/src/pinky_daemon/research_store.py
+++ b/src/pinky_daemon/research_store.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -136,10 +137,20 @@ class ResearchStore:
 
     def __init__(self, db_path: str = "data/research.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA foreign_keys=ON")
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._init_tables()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA foreign_keys=ON")
+            self._thread_local.connection = connection
+        return connection
 
     def _init_tables(self) -> None:
         self._db.executescript("""
@@ -587,4 +598,12 @@ class ResearchStore:
         )
 
     def close(self) -> None:
-        self._db.close()
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection

--- a/src/pinky_daemon/voice_store.py
+++ b/src/pinky_daemon/voice_store.py
@@ -15,6 +15,7 @@ import json
 import re
 import sqlite3
 import sys
+import threading
 import time
 import uuid
 from dataclasses import dataclass
@@ -217,12 +218,22 @@ class VoiceStore:
 
     def __init__(self, db_path: str = "data/voice_calls.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA foreign_keys=ON")
-        self._db.row_factory = sqlite3.Row
+        self._db_path = db_path
+        self._thread_local = threading.local()
         self._init_tables()
         self._migrate()
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """Return the calling thread's connection, creating it on first use."""
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is None:
+            connection = sqlite3.connect(self._db_path)
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA foreign_keys=ON")
+            connection.row_factory = sqlite3.Row
+            self._thread_local.connection = connection
+        return connection
 
     def _init_tables(self) -> None:
         self._db.executescript("""
@@ -686,3 +697,14 @@ class VoiceStore:
             f"UPDATE voice_call_artifact SET {sets} WHERE id = ?", vals
         )
         self._db.commit()
+
+    def close(self) -> None:
+        """Close the calling thread's connection, if it has opened one.
+
+        Connections opened by other threads belong to their thread-local state
+        and are released when those threads exit.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            connection.close()
+            del self._thread_local.connection

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from urllib.parse import urlsplit
 
@@ -23,6 +26,72 @@ class _FakeAgentConfig:
 
     def __init__(self, provider_key: str = "") -> None:
         self.provider_key = provider_key
+
+
+class TestDreamRunnerConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        runner = DreamRunner(db_path=str(tmp_path / "dream.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        runner._save_state("shared-agent", "Shared dream summary", 123.0)
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection = runner._db
+                connection_id = id(connection)
+                assert connection.execute(
+                    "PRAGMA journal_mode"
+                ).fetchone()[0].lower() == "wal"
+                assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
+                agent_name = f"worker-{worker_index}"
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    runner._save_state(
+                        agent_name,
+                        f"Hammer dream summary {marker}",
+                        float(round_index),
+                    )
+                    own = runner.get_state(agent_name)
+                    assert own["last_summary"] == f"Hammer dream summary {marker}"
+                    for _ in range(point_reads_per_round):
+                        point_read = runner.get_state("shared-agent")
+                        assert point_read["last_summary"] == "Shared dream summary"
+                        point_reads += 1
+                    snapshots.append(own)
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                runner.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            assert len(runner.list_states()) == worker_count + 1
+        finally:
+            runner.close()
 
 
 def _new_runner(**kwargs) -> tuple[DreamRunner, str]:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,94 @@
+"""Tests for agent hooks and their SQLite-backed audit store."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from pinky_daemon.hooks import AuditStore
+
+
+class TestAuditStoreConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        store = AuditStore(db_path=str(tmp_path / "audit.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        shared = store.log(
+            "shared-event",
+            agent_name="shared-agent",
+            session_id="shared-session",
+            tool_name="shared-tool",
+            tool_input_summary='{"kind": "shared-seed", "values": [1, 2]}',
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection = store._db
+                connection_id = id(connection)
+                assert connection.execute(
+                    "PRAGMA journal_mode"
+                ).fetchone()[0].lower() == "wal"
+                assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = store.log(
+                        "hammer",
+                        agent_name=f"worker-{worker_index}",
+                        session_id=marker,
+                        tool_name=f"hammer-tool-{marker}",
+                        tool_input_summary=f'{{"marker": "{marker}"}}',
+                    )
+                    own = store.get_log(session_id=marker, event="hammer", limit=1)
+                    assert own[0].id == created.id
+                    assert own[0].tool_name == f"hammer-tool-{marker}"
+                    for _ in range(point_reads_per_round):
+                        point_read = store.get_log(
+                            agent_name="shared-agent",
+                            session_id="shared-session",
+                            event="shared-event",
+                            limit=1,
+                        )
+                        assert point_read[0].id == shared.id
+                        assert point_read[0].tool_name == "shared-tool"
+                        assert point_read[0].tool_input_summary == (
+                            '{"kind": "shared-seed", "values": [1, 2]}'
+                        )
+                        point_reads += 1
+                    snapshots.append((created.to_dict(), own[0].to_dict()))
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            assert len(store.get_log(limit=worker_count * rounds + 1)) == (
+                worker_count * rounds + 1
+            )
+        finally:
+            store.close()

--- a/tests/test_presentation_store.py
+++ b/tests/test_presentation_store.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from pinky_daemon.presentation_store import PresentationStore
@@ -10,6 +14,87 @@ from pinky_daemon.presentation_store import PresentationStore
 @pytest.fixture
 def store(tmp_path):
     return PresentationStore(str(tmp_path / "presentations.db"))
+
+
+class TestPresentationStoreConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        presentation_store = PresentationStore(str(tmp_path / "presentations.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        shared = presentation_store.create(
+            "Shared presentation seed",
+            "<main>Shared point-read content</main>",
+            created_by="shared-agent",
+            tags=["shared", "point-read"],
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection = presentation_store._db
+                connection_id = id(connection)
+                assert connection.execute(
+                    "PRAGMA journal_mode"
+                ).fetchone()[0].lower() == "wal"
+                assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = presentation_store.create(
+                        f"Hammer Deck {marker}",
+                        f"<main>hammer-{marker}</main>",
+                        created_by=f"worker-{worker_index}",
+                        tags=["hammer", marker],
+                    )
+                    own = presentation_store.get_with_content(created.id)
+                    assert own is not None
+                    assert own.title == f"Hammer Deck {marker}"
+                    assert own.tags == ["hammer", marker]
+                    assert own.current_html == f"<main>hammer-{marker}</main>"
+                    for _ in range(point_reads_per_round):
+                        point_read = presentation_store.get_with_content(shared.id)
+                        assert point_read is not None
+                        assert point_read.title == "Shared presentation seed"
+                        assert point_read.tags == ["shared", "point-read"]
+                        assert point_read.current_html == (
+                            "<main>Shared point-read content</main>"
+                        )
+                        point_reads += 1
+                    snapshots.append((created.to_dict(), own.to_dict()))
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                presentation_store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            assert presentation_store.get_stats()["total"] == (
+                worker_count * rounds + 1
+            )
+        finally:
+            presentation_store.close()
 
 
 class TestVersioning:

--- a/tests/test_research_store.py
+++ b/tests/test_research_store.py
@@ -1,0 +1,90 @@
+"""Tests for the SQLite-backed research store."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from pinky_daemon.research_store import ResearchStore
+
+
+class TestResearchStoreConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        store = ResearchStore(db_path=str(tmp_path / "research.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        shared = store.create_topic(
+            "Shared research seed",
+            submitted_by="shared-agent",
+            tags=["shared", "point-read"],
+            scope="Shared row parsed by every worker",
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection = store._db
+                connection_id = id(connection)
+                assert connection.execute(
+                    "PRAGMA journal_mode"
+                ).fetchone()[0].lower() == "wal"
+                assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = store.create_topic(
+                        f"Hammer topic {marker}",
+                        submitted_by=f"worker-{worker_index}",
+                        tags=["hammer", marker],
+                        scope=f"scope-{marker}",
+                    )
+                    own = store.get_topic(created.id)
+                    assert own is not None
+                    assert own.title == f"Hammer topic {marker}"
+                    assert own.tags == ["hammer", marker]
+                    for _ in range(point_reads_per_round):
+                        point_read = store.get_topic(shared.id)
+                        assert point_read is not None
+                        assert point_read.title == "Shared research seed"
+                        assert point_read.tags == ["shared", "point-read"]
+                        assert point_read.scope == "Shared row parsed by every worker"
+                        point_reads += 1
+                    snapshots.append((created.to_dict(), own.to_dict()))
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            assert len(
+                store.list_topics(
+                    include_cancelled=True,
+                    limit=worker_count * rounds + 1,
+                )
+            ) == worker_count * rounds + 1
+        finally:
+            store.close()

--- a/tests/test_voice_store.py
+++ b/tests/test_voice_store.py
@@ -1,0 +1,95 @@
+"""Tests for the SQLite-backed voice store."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from pinky_daemon.voice_store import VoiceStore
+
+
+class TestVoiceStoreConcurrency:
+    def test_point_read_hammer_uses_thread_local_connections(self, tmp_path):
+        store = VoiceStore(db_path=str(tmp_path / "voice.db"))
+        worker_count = 12
+        rounds = 25
+        point_reads_per_round = 8
+        start = threading.Barrier(worker_count)
+        shared = store.create_call_request(
+            requested_by_agent="shared-agent",
+            target_name="Shared Target",
+            target_phone="415-555-0100",
+            goal="Verify shared point reads",
+            context={"kind": "shared-seed", "nested": {"valid": True}},
+        )
+
+        def hammer(worker_index):
+            point_reads = 0
+            snapshots = []
+            try:
+                start.wait(timeout=10)
+                connection = store._db
+                connection_id = id(connection)
+                assert connection.execute(
+                    "PRAGMA journal_mode"
+                ).fetchone()[0].lower() == "wal"
+                assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+                assert connection.row_factory is sqlite3.Row
+                for round_index in range(rounds):
+                    marker = f"{worker_index}-{round_index}"
+                    created = store.create_call_request(
+                        requested_by_agent=f"worker-{worker_index}",
+                        target_name=f"Hammer Target {marker}",
+                        target_phone="415-555-0101",
+                        goal=f"hammer-goal-{marker}",
+                        context={"marker": marker, "values": [worker_index, round_index]},
+                    )
+                    own = store.get_call_request(created.id)
+                    assert own is not None
+                    assert own.target_name == f"Hammer Target {marker}"
+                    assert own.to_dict()["context"] == {
+                        "marker": marker,
+                        "values": [worker_index, round_index],
+                    }
+                    for _ in range(point_reads_per_round):
+                        point_read = store.get_call_request(shared.id)
+                        assert point_read is not None
+                        assert point_read.target_name == "Shared Target"
+                        assert point_read.to_dict()["context"] == {
+                            "kind": "shared-seed",
+                            "nested": {"valid": True},
+                        }
+                        point_reads += 1
+                    snapshots.append((created.to_dict(), own.to_dict()))
+                return connection_id, snapshots, point_reads, None
+            except Exception as exc:
+                return None, snapshots, point_reads, exc
+            finally:
+                store.close()
+
+        try:
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                results = list(executor.map(hammer, range(worker_count)))
+
+            errors = [error for _, _, _, error in results if error is not None]
+            database_errors = [
+                error
+                for error in errors
+                if isinstance(error, sqlite3.DatabaseError)
+                or "malformed" in str(error).lower()
+            ]
+            assert database_errors == []
+            assert errors == []
+
+            connection_ids = [connection_id for connection_id, _, _, _ in results]
+            assert len(set(connection_ids)) == worker_count
+            assert sum(point_reads for _, _, point_reads, _ in results) == (
+                worker_count * rounds * point_reads_per_round
+            )
+            assert all(len(snapshots) == rounds for _, snapshots, _, _ in results)
+            assert len(
+                store.list_call_requests(limit=worker_count * rounds + 1)
+            ) == worker_count * rounds + 1
+        finally:
+            store.close()


### PR DESCRIPTION
## Summary

- replace the shared unserialized SQLite connections in `ResearchStore`, `AuditStore`, `VoiceStore`, `DreamRunner`, and `PresentationStore` with lazy per-thread connections backed by `threading.local()`
- preserve every store's prior per-connection pragmas and row behavior while restoring SQLite's default same-thread guard
- make `close()` caller-local, adding explicit lifecycle hooks to `VoiceStore` and `DreamRunner`
- add one 12-thread, 25-round, shared-row point-read-heavy concurrency hammer per selected store

## Call-site census and Batch 3 ranking

The remaining stores were ranked by distinct production consumer lanes first, with direct shared-instance traffic breaking ties. This tranche is:

1. **research store:** the API-composition instance is consumed independently by the research routes, presentation generation routes, project/task asset enrichment, and the API's KB-ingest callback.
2. **dream runner:** the same API instance serves wake-context summary/KG reads, manual dream/history routes, the scheduler's nightly callback, and post-dream worker-thread paths; `_surface_kg_insights()` uses this store from `asyncio.to_thread()`.
3. **audit store:** one instance receives all `SessionManager`/`SDKRunner` lifecycle and tool events through `HookManager`, serves activity/audit routes, and supplies direct health/dashboard reads.
4. **voice store:** production consumers are the voice routes, voice-engine dial/finalization helpers, and `Broker`'s owner approval command path (which creates an independent instance against the same database).
5. **presentation store:** one API instance is shared by presentation CRUD/generation routes and project/task linked-asset enrichment. It wins the next-count tie because both consumers perform direct CRUD/point reads against a long-lived shared instance.

The next census tier is plugin state/startup plus skill routes, outreach status plus outreach routes, and the federation helper consumers; app, hub, bearer-token, and signer stores have narrower production fan-out. `iMessageAdapter` is also deferred: unlike these five stores, it opens and closes a fresh read connection inside each query rather than retaining one daemon-wide connection, so it needs a separate classification/cleanup rather than this shared-store conversion.

## Threading classification

No selected caller establishes or asserts a safe single-thread ownership invariant.

The two hairiest contexts still fit the thread-local approach:

- `HookManager.fire()` may await arbitrary hook callbacks, but it does not open an audit-store transaction before those awaits. `AuditStore.log()` starts and commits all work inside one synchronous call.
- `DreamRunner.run_dream()` commits its own state writes before entering post-dream `asyncio.to_thread()` steps. The worker path's own dream-state reads/writes are synchronous and commit within their helper calls; no transaction or connection-scoped state crosses an `await` or public call.

All other selected multi-statement transactional work remains inside one synchronous call. A global lock would unnecessarily serialize independent SQLite connections, while a thread-affinity assert would reject supported shared composition and worker usage. The #929/#933 thread-local pattern is therefore the smallest compatible classification.

## Pragma and constraint parity

Every lazy connection exactly reapplies its store's old behavior:

- `ResearchStore`: WAL plus FK ON, tuple rows. Its brief-to-topic and review-to-brief/topic foreign keys remain actively enforced.
- `VoiceStore`: WAL plus FK ON and `sqlite3.Row`. Its session, event, and artifact references remain actively enforced.
- `AuditStore`: WAL only; FK enforcement remains at SQLite's default OFF, and its schema declares no FK clauses.
- `DreamRunner`: WAL only; FK enforcement remains at SQLite's default OFF, and its schema declares no FK clauses.
- `PresentationStore`: WAL plus FK ON, tuple rows. The version-to-presentation FK remains actively enforced; `research_topic_id` is only a nullable integer and declares no FK constraint.

No pragma, row-factory, or constraint semantics are silently flipped.

## Impact

Each calling thread now owns its SQLite statement state and closes only its own connection. Public CRUD behavior and on-disk schemas are unchanged. The hammers verify distinct connection identities, exact pragma/row parity, repeated parsing of the same shared rows while writes are in flight, zero database/malformed errors, and exact final row counts.

## Out of scope

The #932 reconnect-on-malformed self-heal remains a separate semantic change. This batch adds no retries, `busy_timeout`, quarantine/recreate, integrity checks, or deployment/runtime changes.

## Validation

- five concurrency hammers: 10 consecutive passes (`50 passed`)
- affected API/research/presentation/project/broker/voice/SDK/session/scheduler/dream matrix with `PINKY_DREAM_TRANSPORT=sdk`: `804 passed`
- post-commit five-hammer proof: `5 passed`
- `ruff check .`
- `git diff --check` and commit show/name checks

## Frozen audit object

- head: `492b12ab8ff426c54c84a6958696fcdf47d9ffb8`
- tree: `38b9261a7555497040e175d76d8f4488a914288e`
- base/parent: `9d0c61c2741d936a9f65a67bf6ee20c7db0bfdf1`
- stable patch-id: `c1b2df4b58a5824f40a529e7fc60962954f46410`

Part of #930.

🤖 Opened by Kuzya