### PR TITLE
Bind purchase approvals to requester identity

### DIFF
--- a/specs/slack-purchase-approval.md
+++ b/specs/slack-purchase-approval.md
@@ -15,7 +15,8 @@ security boundary.
 
 The daemon has **no MCP client** — it cannot call `approve_purchase` directly
 (arch map, #249). So after the gate passes, the daemon injects a synthetic
-instruction to the owning agent (chekov), which calls the purchasing MCP. (B1.)
+instruction to the owning requester agent (Chekov or Geordi), which calls its
+isolated purchasing MCP. (B1.)
 
 ## Flow
 
@@ -39,23 +40,27 @@ instruction to the owning agent (chekov), which calls the purchasing MCP. (B1.)
       blank id, an unconfigured allowlist, or any error → **deny**. Unauthorized
       clicks get an ephemeral refusal and never reach the agent.
    c. Authorized → **mint a daemon-signed approval token**
-      (`HMAC-SHA256(secret, decision \n pending_id \n clicker_id \n expires)`,
-      ~15-min TTL) and inject a synthetic instruction to the owning agent telling
-      it to call `approve_purchase`/`reject_purchase` for that exact `pending_id`
-      with the verified `clicker_id` **and the token + expiry**. Update the card
-      via `response_url` ("Approved/Rejected by X", buttons removed). If no secret
-      is configured, or the agent is unreachable, fail-closed (ephemeral note;
-      card keeps its buttons).
+      (`HMAC-SHA256(secret, decision \n pending_id \n requester \n clicker_id
+      \n expires)`, ~15-min TTL). `requester` comes from the poller's
+      infrastructure-owned `self._agent_name`, never from the Slack payload or
+      an LLM argument. Inject a synthetic instruction to that same owning agent
+      telling it to call `approve_purchase`/`reject_purchase` for the exact
+      `pending_id` with the verified `clicker_id` **and the token + expiry**.
+      Update the card via `response_url` ("Approved/Rejected by X", buttons
+      removed). If no secret is configured, or the agent is unreachable,
+      fail-closed (ephemeral note; card keeps its buttons).
 5. The agent calls the MCP tool, relaying the token. The MCP verifies it before
-   any state change, then the agent posts the cart link / confirmation.
+   any state change. The MCP first loads the proposal's persisted requester and
+   verifies that exact tuple. The owning agent then posts the returned public
+   purchase links / confirmation.
 
 ## Enforcement layers (defense in depth)
 
 1. **Daemon-signed token (authoritative).** The state transition (pending →
    approved | rejected) requires an HMAC token only the daemon can mint, and only
    after the verified-clicker gate (below) passes. The MCP verifies the token
-   (shared secret, exact `decision`/`pending_id`/`approver`/`expiry` tuple, not
-   expired) before touching the store. **An LLM cannot forge it**, so no prompt
+   (shared secret, exact `decision`/`pending_id`/`requester`/`approver`/`expiry`
+   tuple, not expired) before touching the store. **An LLM cannot forge it**, so no prompt
    path — including the legacy "type `approve`" text path — can drive the agent
    into approving an order that was never clicked by a verified, allowlisted
    approver. Fail-closed: missing secret / missing / invalid / expired token →
@@ -72,15 +77,20 @@ The shared secret lives in two places that must match: the daemon's
 `POS_PURCHASING_APPROVAL_SECRET` env (verifier). Either side unset → no approvals
 (fail-closed).
 
+4. **Requester isolation.** The daemon signs the owning poller's
+   `self._agent_name`; the MCP compares it to the stored proposal requester and
+   its process `--agent` identity. A Chekov token cannot authorize a Geordi
+   proposal, and neither model can choose or override requester identity.
+
 ## Phase 2 (pay-on-approval)
 
-`approve_purchase` returns only an Amazon cart link today — **no money moves**.
+`approve_purchase` returns only public cart/product/quote links today — **no money moves**.
 Phase 2 adds real payment via the Amazon Business API. The token already proves a
 verified click; phase 2 extends it so the *payment* step is bound to the same
 proof (and may add a daemon-recorded click ledger for non-repudiation). **Do not
 enable real payment before that exists.**
 
-## Deploy prerequisites (Pi / chekov)
+## Deploy prerequisites (isolated Pi requesters)
 
 1. **Slack app**: enable *Interactivity & Shortcuts* (Socket Mode is already on,
    so no Request URL and no reinstall needed). Without it, clicks deliver no
@@ -88,10 +98,13 @@ enable real payment before that exists.**
 2. **Shared approval secret** (fail-closed, else every approval is refused):
    generate one secret and set it on BOTH sides —
    `registry.set_purchase_approval_secret("<secret>")` (daemon) **and**
-   `POS_PURCHASING_APPROVAL_SECRET=<same secret>` in chekov's pos-spec-purchasing
-   MCP env. They must be identical.
+   `POS_PURCHASING_APPROVAL_SECRET=<same secret>` in each requester's isolated
+   pos-spec-purchasing MCP env. They must be identical.
 3. **Seed the approver allowlist** (fail-closed):
    `registry.set_purchase_approvers(["U7W8RJGP5"])` (Brad). Stored in
    `system_settings.purchase_approver_slack_ids`. Optionally also set
    `POS_PURCHASING_APPROVERS` on the MCP env (secondary check).
-4. Restart is on the **Pi** (chekov's Slack poller). Heads-up to Brad first.
+4. Chekov and Geordi each use their own explicit `--agent` and SQLite state
+   path. They may share a read-only catalog, but never a requester identity or
+   pending-order database.
+5. Restart is on the applicable **Pi tenant**. Heads-up to Brad first.

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -1145,6 +1145,7 @@ class BrokerSlackPoller:
             secret,
             decision=token_decision,
             pending_id=pending_id,
+            requester=self._agent_name,
             approver=clicker_id,
             expires=token_expires,
         )
@@ -1155,9 +1156,10 @@ class BrokerSlackPoller:
             instruction = (
                 f"Call approve_purchase(pending_id='{pending_id}', approver='{clicker_id}', "
                 f"approval_token='{token}', token_expires={token_expires}). "
-                f"If it returns ok, post the returned cart_link and instruction to channel "
-                f"{channel} so the human can place the order on Amazon. Approve ONLY this "
-                "pending_id; do not approve anything else."
+                f"If it returns ok, post the returned purchase_links and instruction to "
+                f"channel {channel} so the human can verify live prices and complete the "
+                f"vendor checkout or quote. Approve ONLY this pending_id; do not approve "
+                "anything else."
             )
         else:
             instruction = (
@@ -1169,8 +1171,10 @@ class BrokerSlackPoller:
         msg = (
             f"[purchase-approval] VERIFIED Slack approver {clicker_name} (id={clicker_id}) "
             f"clicked {decision.upper()} on purchase pending_id=`{pending_id}` in channel "
-            f"{channel}. The daemon has already verified the clicker's identity and confirmed "
-            f"they are an allowlisted purchase approver, so this {decision} is authorized.\n"
+            f"{channel}. Requester identity is infrastructure-bound to `{self._agent_name}` "
+            "and included in the signed token. The daemon has already verified the clicker's "
+            f"identity and confirmed they are an allowlisted purchase approver, so this "
+            f"{decision} is authorized.\n"
             + instruction
         )
 

--- a/src/pinky_daemon/purchase_approval.py
+++ b/src/pinky_daemon/purchase_approval.py
@@ -12,8 +12,8 @@ CROSS-REPO CONTRACT — the canonical signing string and HMAC MUST stay
 byte-for-byte identical to the verifier in
 pos-spec-purchasing/src/pos_spec_purchasing/approval.py. The golden vector
   secret="testsecret", decision="approve", pending_id="abc123",
-  approver="U7W8RJGP5", expires=1700000000
-  -> 8226a7515254d1640bc320eb2f9a57ca45cddcc8b920eaffa7044b82dbee0f3e
+  requester="chekov", approver="U7W8RJGP5", expires=1700000000
+  -> 17a128f65d20f93ef3080876906cb3f03968e55fefd1710bf734bae0dbf3f2dc
 is locked by tests in BOTH repos; changing the scheme breaks the gate.
 """
 
@@ -32,8 +32,14 @@ TOKEN_TTL_SECONDS = 900
 
 
 def make_approval_token(
-    secret: str, *, decision: str, pending_id: str, approver: str, expires: int
+    secret: str,
+    *,
+    decision: str,
+    pending_id: str,
+    requester: str,
+    approver: str,
+    expires: int,
 ) -> str:
-    """Return the HMAC-SHA256 hex token over the canonical decision tuple."""
-    msg = "\n".join([decision, pending_id, approver, str(int(expires))])
+    """Return HMAC-SHA256 over the requester-bound decision tuple."""
+    msg = "\n".join([decision, pending_id, requester, approver, str(int(expires))])
     return hmac.new(secret.encode("utf-8"), msg.encode("utf-8"), hashlib.sha256).hexdigest()

--- a/tests/test_slack_purchase_approval.py
+++ b/tests/test_slack_purchase_approval.py
@@ -31,7 +31,7 @@ SECRET = "test-secret"
 
 def _make_poller(
     *, approver_ok=True, inject_ok=True, registry_raises=False, registry=None,
-    approval_secret=SECRET,
+    approval_secret=SECRET, agent_name="chekov",
 ):
     adapter = MagicMock()
     adapter.bot_token = "xoxb-test"
@@ -52,7 +52,7 @@ def _make_poller(
         registry.get_purchase_approval_secret.return_value = approval_secret
 
     poller = BrokerSlackPoller(
-        adapter, "chekov", broker,
+        adapter, agent_name, broker,
         registry=(None if registry is False else registry),
         app_token="xapp-test",
     )
@@ -207,9 +207,14 @@ class TestApprovalToken:
         _f, _t, msg = poller._broker.inject_agent_message.call_args[0]
         token = re.search(r"approval_token='([0-9a-f]+)'", msg).group(1)
         expires = int(re.search(r"token_expires=(\d+)", msg).group(1))
-        # The minted token must verify for exactly (approve, PID, clicker, expires).
+        # Token binds the exact decision, proposal, requester, clicker, and expiry.
         expected = make_approval_token(
-            SECRET, decision="approve", pending_id=PID, approver=BRAD, expires=expires
+            SECRET,
+            decision="approve",
+            pending_id=PID,
+            requester="chekov",
+            approver=BRAD,
+            expires=expires,
         )
         assert token == expected
 
@@ -221,7 +226,43 @@ class TestApprovalToken:
         token = re.search(r"approval_token='([0-9a-f]+)'", msg).group(1)
         expires = int(re.search(r"token_expires=(\d+)", msg).group(1))
         assert token == make_approval_token(
-            SECRET, decision="reject", pending_id=PID, approver=BRAD, expires=expires
+            SECRET,
+            decision="reject",
+            pending_id=PID,
+            requester="chekov",
+            approver=BRAD,
+            expires=expires,
+        )
+
+    @pytest.mark.asyncio
+    async def test_geordi_token_is_requester_bound(self):
+        poller = _make_poller(
+            approver_ok=True,
+            inject_ok=True,
+            approval_secret=SECRET,
+            agent_name="geordi",
+        )
+        await poller._handle_interactive(_interactive(_PURCHASE_APPROVE_ACTION_ID))
+        _f, target, msg = poller._broker.inject_agent_message.call_args[0]
+        assert target == "geordi"
+        assert "infrastructure-bound to `geordi`" in msg
+        token = re.search(r"approval_token='([0-9a-f]+)'", msg).group(1)
+        expires = int(re.search(r"token_expires=(\d+)", msg).group(1))
+        assert token == make_approval_token(
+            SECRET,
+            decision="approve",
+            pending_id=PID,
+            requester="geordi",
+            approver=BRAD,
+            expires=expires,
+        )
+        assert token != make_approval_token(
+            SECRET,
+            decision="approve",
+            pending_id=PID,
+            requester="chekov",
+            approver=BRAD,
+            expires=expires,
         )
 
     @pytest.mark.asyncio
@@ -238,8 +279,8 @@ class TestApprovalToken:
         # Locked cross-repo contract — must equal pos-spec-purchasing's verifier.
         assert make_approval_token(
             "testsecret", decision="approve", pending_id="abc123",
-            approver="U7W8RJGP5", expires=1700000000,
-        ) == "8226a7515254d1640bc320eb2f9a57ca45cddcc8b920eaffa7044b82dbee0f3e"
+            requester="chekov", approver="U7W8RJGP5", expires=1700000000,
+        ) == "17a128f65d20f93ef3080876906cb3f03968e55fefd1710bf734bae0dbf3f2dc"
 
 
 class TestStripEmoji:


### PR DESCRIPTION
## Summary

- add the infrastructure-owned requester to the canonical purchase-approval tuple: `decision, pending_id, requester, approver, expires`
- mint `requester` only from the Slack poller's `self._agent_name`, never from Slack/model text
- keep routing the verified decision to that same owning requester
- update the synthetic approval instruction for multi-vendor `purchase_links` and explicit human live-price verification
- lock the new cross-repo golden vector and prove Geordi's token differs from Chekov's
- update the Phase-1 security/deploy specification for isolated requester state

## Why

The purchasing verifier persists requester identity on the proposal. Signing that identity prevents a Chekov-minted token from authorizing a Geordi record, even though both requesters use the same human approver gate and may share the approval secret.

## Deployment

This signer change can merge independently, but deployment remains held until the matching pos-spec-purchasing verifier is installed. No daemon/runtime/fleet deployment is part of this PR.

## Validation

- `PINKY_DREAM_TRANSPORT=sdk python3 -m pytest -q tests/test_slack_purchase_approval.py tests/test_slack_poller.py tests/test_poller_delivery.py tests/test_slack.py tests/test_slack_text_refs.py` — 107 passed
- `ruff check .`
- cross-repo golden-token equality + Chekov/Geordi requester discrimination
- `git diff --check`

## Frozen object

- head: `81f9576704a8e4f78fde5614b09b6b9063ff4e0e`
- tree: `c073b3c0ae551834835d17659969dd484d036287`
- base/parent: `9d0c61c2741d936a9f65a67bf6ee20c7db0bfdf1`
- stable patch-id: `f937c48875842761f448d01671085d15a6c95386`

🤖 Opened by Kuzya