### PR TITLE
Fix scheduler starvation after coalesced tmux turns

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -6402,8 +6402,7 @@ class TmuxSession:
     def _scheduler_pane_busy(self) -> bool:
         """Conservative busy verdict for safe scheduled-prompt injection."""
         if (
-            self._inflight_metas
-            or self._inflight_tool_calls
+            self._inflight_tool_calls
             or self._inflight_turn is not None
             or not self._message_queue.empty()
         ):
@@ -6418,11 +6417,28 @@ class TmuxSession:
         if live.get("status") != "idle":
             return True
         last_updated = live.get("last_updated")
-        return not (
+        if not (
             isinstance(last_updated, (int, float))
             and not isinstance(last_updated, bool)
             and last_updated > 0
-        )
+        ):
+            return True
+
+        # Claude Code can consume several pane pastes in one native queued turn
+        # and emit one final Stop hook. That leaves extra routing metas even
+        # though the pane is explicitly idle. Trust that idle only when it was
+        # reported after every successful paste; an idle row older than any
+        # local inflight meta still fails closed.
+        for entry in self._inflight_metas:
+            dispatched_at = getattr(entry, "dispatched_at", None)
+            if not (
+                isinstance(dispatched_at, (int, float))
+                and not isinstance(dispatched_at, bool)
+                and dispatched_at > 0
+                and last_updated >= dispatched_at
+            ):
+                return True
+        return False
 
     @staticmethod
     def _transcript_user_text(entry: dict) -> str | None:

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3635,6 +3635,90 @@ async def test_scheduler_prompt_receipt_waits_for_live_working_status() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("steering_starts_before_stop", [True, False])
+async def test_second_scheduler_prompt_delivers_after_first_receipt_and_stop(
+    steering_starts_before_stop: bool,
+) -> None:
+    """Midturn native-queue steering must not starve the next scheduler turn."""
+    live = {"status": "idle", "last_updated": _time.time()}
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: live
+    ss._worker_task = asyncio.create_task(ss._message_worker())
+    second_receipt: asyncio.Future[bool] | None = None
+    try:
+        first_receipt = await ss.send_scheduler_prompt("first scheduled")
+        for _ in range(100):
+            if tmux.paste_text.await_count == 1:
+                break
+            await asyncio.sleep(0.01)
+        tmux.paste_text.assert_awaited_once_with(
+            "first scheduled", enter=True
+        )
+
+        ss._on_transcript_entry({
+            "type": "user",
+            "message": {"role": "user", "content": "first scheduled"},
+        })
+        assert await first_receipt is True
+
+        # Faithfully model Claude Code's native queue: steering can be pasted
+        # while the scheduled turn is active. It may coalesce into that model
+        # turn (the live #939 shape) or remain queued across its final Stop.
+        assert await ss.send("ordinary steering") is True
+        for _ in range(100):
+            if tmux.paste_text.await_count == 2:
+                break
+            await asyncio.sleep(0.01)
+        assert tmux.paste_text.await_args_list[-1].args == (
+            "ordinary steering",
+        )
+        if steering_starts_before_stop:
+            ss._on_transcript_entry({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": "ordinary steering",
+                },
+            })
+
+        live.update(status="idle", last_updated=_time.time())
+        await ss._handle_turn_complete(
+            TurnResponse(text="first complete", stop_reason="end_turn")
+        )
+
+        second_receipt = await ss.send_scheduler_prompt("second scheduled")
+        for _ in range(100):
+            if tmux.paste_text.await_count == 3:
+                break
+            await asyncio.sleep(0.01)
+        assert tmux.paste_text.await_count == 3
+        assert tmux.paste_text.await_args_list[-1].args == (
+            "second scheduled",
+        )
+
+        if not steering_starts_before_stop:
+            # The pre-existing native-queue turn starts first. Exact prompt
+            # matching must not misattribute it as the scheduler receipt.
+            ss._on_transcript_entry({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": "ordinary steering",
+                },
+            })
+            assert not second_receipt.done()
+        ss._on_transcript_entry({
+            "type": "user",
+            "message": {"role": "user", "content": "second scheduled"},
+        })
+        assert await second_receipt is True
+    finally:
+        if second_receipt is not None and not second_receipt.done():
+            second_receipt.cancel()
+        await ss.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_scheduler_idle_wait_does_not_block_ordinary_midturn_send() -> None:
     """A waiting scheduler turn never owns the ordinary worker head-of-line."""
     live = {"status": "working", "last_updated": _time.time()}
@@ -3656,6 +3740,25 @@ async def test_scheduler_idle_wait_does_not_block_ordinary_midturn_send() -> Non
     assert not receipt.done()
     receipt.cancel()
     await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_gate_rejects_idle_older_than_local_pane_paste() -> None:
+    """Stale idle evidence never overrides genuinely in-flight pane work."""
+    live = {"status": "idle", "last_updated": _time.time()}
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: live
+    _seed_inflight(ss, prompt="still active")
+
+    receipt = await ss.send_scheduler_prompt("scheduled")
+    try:
+        await asyncio.sleep(0.02)
+
+        tmux.paste_text.assert_not_awaited()
+        assert not receipt.done()
+    finally:
+        receipt.cancel()
+        await ss.disconnect()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #939.

## What changed

- Let explicit live `idle` evidence override only stale **pasted** tmux inflight metadata when the idle timestamp is at or after every successful pane paste.
- Keep pending queue entries, an in-hand ordinary turn, foreground tool state, and stale/missing/invalid/non-idle evidence as unconditional busy verdicts.
- Add a stateful two-delivery regression plus a stale-idle negative regression.

## Root cause

On live 26.07.024, the first post-restart scheduler heartbeat was accepted as an exact transcript user row. Ordinary steering was then pasted while that heartbeat turn was active. Claude Code consumed the native queued steering in the same model turn and emitted one final Stop hook for two pane pastes.

Tmux records one `_inflight_metas` entry per paste, but the Stop callback retires one entry. The steering entry therefore remained as a phantom. `_scheduler_pane_busy()` treated any local inflight entry as permanently busy even though the later Stop hook had reported explicit idle after every paste. Subsequent scheduler turns never pasted and timed out loudly after 600 seconds. The per-agent delivery lock was not leaked.

## Safety and #935 invariants

The change keeps the confirmed-delivery vocabulary intact:

1. `last_run` and `last_delivered` remain separate; undelivered wakes still fail loudly.
2. Scheduler receipt `True` still requires exact transcript acceptance, never successful tmux keystrokes alone.
3. Per-agent scheduler delivery order and lock serialization are unchanged.
4. Ordinary midturn steering remains outside the scheduler idle wait.
5. Pending queue, in-hand turn, and tool state remain hard busy vetoes.
6. Missing, invalid, erroring, non-idle, or idle evidence older than a local paste still fails closed.

A native-queued prompt may remain unstarted across the prior turn's Stop/idle window. In that case, the fresh idle permits only another paste into Claude Code's native serialized queue. The parameterized regression starts the pre-existing ordinary prompt first and proves scheduler receipt 2 remains unresolved until scheduler prompt 2's own exact user row. If acceptance never appears, the existing bounded loud timeout remains authoritative.

## Regression evidence

`test_second_scheduler_prompt_delivers_after_first_receipt_and_stop` performs two sequential confirmed scheduler deliveries after the first receipt completes and covers both native-queue outcomes:

- steering starts/coalesces before the first Stop (the live #939 shape);
- steering remains pasted-but-unstarted across Stop, then starts before scheduler prompt 2.

With the final test patch applied to exact bug source `9d0c61c2741d936a9f65a67bf6ee20c7db0bfdf1`, both parameter cases fail deterministically because `paste_text.await_count` remains 2 instead of reaching 3. Both pass with this fix.

## Validation

- `ruff check .`
- `git diff --check`
- `git show --check HEAD`
- `PINKY_DREAM_TRANSPORT=sdk pytest -q tests/test_tmux_session.py -k scheduler` — 12 passed
- `PINKY_DREAM_TRANSPORT=sdk pytest -q tests/test_scheduler.py tests/test_codex_session.py` — 184 passed
- `PINKY_DREAM_TRANSPORT=sdk pytest -q tests/test_tmux_session.py` — 354 passed

🤖 Opened by Kuzya