### PR TITLE
fix(sqlite): add PRAGMA busy_timeout=30000 to all thread-local store connections

### DIFF
--- a/src/pinky_daemon/activity_store.py
+++ b/src/pinky_daemon/activity_store.py
@@ -30,6 +30,7 @@ class ActivityStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/agent_comms.py
+++ b/src/pinky_daemon/agent_comms.py
@@ -84,6 +84,7 @@ class AgentComms:
             connection = sqlite3.connect(self._db_path)
             connection.row_factory = sqlite3.Row
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/conversation_store.py
+++ b/src/pinky_daemon/conversation_store.py
@@ -95,6 +95,7 @@ class ConversationStore:
             connection = sqlite3.connect(self._db_path)
             connection.row_factory = sqlite3.Row
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -115,6 +115,7 @@ class DreamRunner:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/hooks.py
+++ b/src/pinky_daemon/hooks.py
@@ -134,6 +134,7 @@ class AuditStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/presentation_store.py
+++ b/src/pinky_daemon/presentation_store.py
@@ -138,6 +138,7 @@ class PresentationStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/research_store.py
+++ b/src/pinky_daemon/research_store.py
@@ -148,6 +148,7 @@ class ResearchStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/session_store.py
+++ b/src/pinky_daemon/session_store.py
@@ -72,6 +72,7 @@ class SessionStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             self._thread_local.connection = connection
         return connection
 
@@ -314,6 +315,7 @@ class SessionEventStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/skill_store.py
+++ b/src/pinky_daemon/skill_store.py
@@ -154,6 +154,7 @@ class SkillStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/task_store.py
+++ b/src/pinky_daemon/task_store.py
@@ -196,6 +196,7 @@ class TaskStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/trigger_store.py
+++ b/src/pinky_daemon/trigger_store.py
@@ -88,6 +88,7 @@ class TriggerStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
             connection.row_factory = sqlite3.Row
             self._thread_local.connection = connection

--- a/src/pinky_daemon/user_profile_store.py
+++ b/src/pinky_daemon/user_profile_store.py
@@ -91,6 +91,7 @@ class UserProfileStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/voice_store.py
+++ b/src/pinky_daemon/voice_store.py
@@ -230,6 +230,7 @@ class VoiceStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
             connection.row_factory = sqlite3.Row
             self._thread_local.connection = connection


### PR DESCRIPTION
## Summary

- The default `sqlite3.connect()` busy timeout (5 s) isn't enough when multiple FastAPI worker threads write to the same database concurrently: the serialised write queue can exceed 5 s under moderate load or on slower disks (Pi, constrained containers, remote execution environments).
- Adds `PRAGMA busy_timeout=30000` (30 s) right after `PRAGMA journal_mode=WAL` on every per-thread connection opened by the 13 stores converted to thread-local connections in #929/#933/#934/#937.
- Caught by `test_mixed_crud_hammer_uses_thread_local_connections` failing reproducibly with `OperationalError('database is locked')` across 10/12 worker threads. Test now passes (57 s wall-clock for 12 threads × 25 write rounds).

**Files changed:** activity_store, agent_comms, conversation_store, dream_runner, hooks, presentation_store, research_store, session_store (both store classes), skill_store, task_store, trigger_store, user_profile_store, voice_store — one line added per `_db` property.

## Test plan

- [x] `test_mixed_crud_hammer_uses_thread_local_connections` — was failing, now passes
- [x] `tests/pinky_federation/` (152 tests) — still passing
- [x] `ruff check` clean on all changed files
- [ ] Full CI run on push

---
_Generated by [Claude Code](https://claude.ai/code/session_019E6DxbrbMeuTFwTTBVEqbC)_