### PR TITLE
Prevent stale-status restart loops and preserve queued wakes

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1809,13 +1809,46 @@ class AgentRegistry:
 
         hook_template = '''\
 #!/usr/bin/env python3
-import hashlib, hmac, base64, time, urllib.request, json, os, sys
+import hashlib, hmac, base64, time, urllib.request, json, os, subprocess, sys, tempfile
+
+agent = "{agent_name}"
+status = "{status}"
+
+def emit_failure(literal, detail):
+    message = "%s agent=%s status=%s error=%s" % (literal, agent, status, detail)
+    # The hook runs inside a tmux pane, whose stderr is not guaranteed to
+    # reach the daemon's systemd journal. Send failures to the host logger as
+    # the durable operator receipt, with stderr as a portable fallback.
+    try:
+        subprocess.run(
+            ["logger", "-t", "pinkybot-status-hook", message],
+            timeout=1,
+            check=False,
+        )
+    except Exception:
+        pass
+    print(message, file=sys.stderr, flush=True)
 
 secret = os.environ.get("PINKY_AGENT_KEY", "").strip() or os.environ.get("PINKY_SESSION_SECRET", "").strip()
 if not secret:
+    # One durable receipt per tmux/Claude session. Hook commands are separate
+    # subprocesses, so an O_EXCL marker keyed by their inherited session ID is
+    # the cheap cross-invocation once guard.
+    marker = os.path.join(
+        tempfile.gettempdir(),
+        "pinkybot-status-hook-%s-%s.missing-secret" % (agent, os.getsid(0)),
+    )
+    try:
+        fd = os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        pass
+    except Exception as exc:
+        emit_failure("STATUS_HOOK_SECRET_MISSING", "marker: %s" % exc)
+    else:
+        os.close(fd)
+        emit_failure("STATUS_HOOK_SECRET_MISSING", "no signing key in hook env")
     sys.exit(0)
 
-agent = "{agent_name}"
 path = "/agents/{agent_name}/status"
 ts = int(time.time())
 payload = f"{{agent}}\\nPOST\\n{{path}}\\n{{ts}}".encode()
@@ -1833,8 +1866,11 @@ req.add_header("x-pinky-timestamp", str(ts))
 req.add_header("x-pinky-signature", sig)
 try:
     urllib.request.urlopen(req, timeout=2)
-except Exception:
-    pass
+except Exception as exc:
+    emit_failure(
+        "STATUS_HOOK_POST_FAILURE",
+        "%s: %s" % (type(exc).__name__, exc),
+    )
 '''
         working_path = claude_dir / "hook_working.py"
         idle_path = claude_dir / "hook_idle.py"
@@ -1962,8 +1998,10 @@ except Exception:
             f"python3 {shlex.quote(str(verify_effort_path))}"
             f' "$CLAUDE_PROJECT_DIR" 2>/dev/null || true'
         )
-        working_cmd = f"python3 {shlex.quote(str(working_path))} 2>/dev/null || true"
-        idle_cmd = f"python3 {shlex.quote(str(idle_path))} 2>/dev/null || true"
+        # Do not suppress stderr: STATUS_HOOK_POST_FAILURE is a release
+        # receipt when the direct POST (and possibly host logger) fails.
+        working_cmd = f"python3 {shlex.quote(str(working_path))} || true"
+        idle_cmd = f"python3 {shlex.quote(str(idle_path))} || true"
         tmux_wake_cmd = f"python3 {shlex.quote(str(tmux_wake_path))} 2>/dev/null || true"
         tmux_session_start_cmd = (
             f"python3 {shlex.quote(str(tmux_session_start_path))} 2>/dev/null || true"
@@ -2060,6 +2098,21 @@ except Exception:
         changed = False
         hooks = data.setdefault("hooks", {})
 
+        # Working/idle status hooks predate the managed merge path.  Existing
+        # settings.json files could therefore retain SessionStart/tmux hooks
+        # while silently missing the only writers of live_status.  Repair both
+        # on every workspace sync, just like the newer managed hooks.
+        changed |= AgentRegistry._merge_hook_into_event(
+            hooks, "PreToolUse",
+            needle=str(working_path),
+            command=working_cmd,
+        )
+        changed |= AgentRegistry._merge_hook_into_event(
+            hooks, "Stop",
+            needle=str(idle_path),
+            command=idle_cmd,
+        )
+
         # verify_effort hook → PreToolUse bucket
         changed |= AgentRegistry._merge_hook_into_event(
             hooks, "PreToolUse",
@@ -2124,7 +2177,15 @@ except Exception:
         for entry in event_list:
             for h in entry.get("hooks", []):
                 if needle in (h.get("command") or ""):
-                    return False
+                    if h.get("type") == "command" and h.get("command") == command:
+                        return False
+                    # PinkyBot-managed hook paths are the identity.  Upgrade
+                    # stale command wrappers in place (for example, remove the
+                    # historical ``2>/dev/null`` status-hook sink) instead of
+                    # treating any path match as permanently current.
+                    h["type"] = "command"
+                    h["command"] = command
+                    return True
 
         target_bucket = None
         for entry in event_list:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -199,6 +199,27 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+_STATUS_HOOK_RECEIPT_LOG_INTERVAL_SEC = 60.0
+
+
+def _read_persisted_agent_working_status(
+    registry: AgentRegistry, agent_name: str,
+) -> dict | None:
+    """Read the hook-written working status directly from SQLite.
+
+    The inflight watchdog calls this at verdict time.  Do not substitute the
+    process-local live-status map here: that map was observed fossilized while
+    the committed hook-written agent record remained current (#943).
+    """
+    agent = registry.get(agent_name)
+    if agent is None:
+        return None
+    return {
+        "status": agent.working_status or "idle",
+        "last_updated": agent.working_status_updated_at,
+    }
+
+
 class _ResponseSentHandoffMiddleware:
     """Run a registered handoff only after the outer response send returns.
 
@@ -1702,6 +1723,7 @@ def create_api(
     # In-memory live status for agents (updated by POST /agents/{name}/status).
     # Keys are agent names; values are dicts with status/tool_name/detail/last_updated.
     _agent_live_status: dict[str, dict] = {}
+    _agent_status_receipt_logged_at: dict[str, float] = {}
 
     # Per-agent cost milestone tracking — set of already-fired thresholds (USD).
     _agent_cost_milestones: dict[str, set[float]] = {}
@@ -3653,7 +3675,12 @@ def create_api(
             wake_context_builder=_build_streaming_wake_context,
             on_wake_delivered=_log_agent_wake_event,
             restart_guard=lambda session, _agent_name=agent_name: _get_streaming_restart_guard(_agent_name, session),
-            live_status_fn=lambda _agent_name=agent_name: _agent_live_status.get(_agent_name),
+            # #943: verdict-time fresh read of the persisted field that the
+            # working/idle hooks update.  The in-memory map is non-authoritative
+            # and was observed fossilized while this record remained current.
+            live_status_fn=lambda _agent_name=agent_name: (
+                _read_persisted_agent_working_status(agents, _agent_name)
+            ),
             # #846 — expose watchdog_config.enabled to the tmux inflight
             # watchdog so it honors the same operator kill-switch the daemon
             # SessionWatchdog already respects. Deferred (called per watchdog
@@ -6363,12 +6390,24 @@ npm run build</pre>
         agents.set_working_status(name, db_status)
 
         # Update live in-memory status (fine-grained: thinking, tool_use, etc.)
+        receipt_at = time.time()
         _agent_live_status[name] = {
             "status": new_status,
             "tool_name": req.tool_name,
             "detail": req.detail,
-            "last_updated": time.time(),
+            "last_updated": receipt_at,
         }
+        last_receipt_log = _agent_status_receipt_logged_at.get(name, 0.0)
+        if (
+            last_receipt_log <= 0
+            or receipt_at - last_receipt_log
+            >= _STATUS_HOOK_RECEIPT_LOG_INTERVAL_SEC
+        ):
+            _log(
+                f"STATUS_HOOK_RECEIPT agent={name} "
+                f"status={new_status} received_at={receipt_at:.6f}"
+            )
+            _agent_status_receipt_logged_at[name] = receipt_at
 
         # Only log meaningful state transitions to activity (not every tool tick)
         if new_status in ("idle", "working", "offline"):

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1366,6 +1366,10 @@ class TmuxSession:
         self._fresh_context_respawn_grace_until: float = 0.0
         self._fresh_context_respawn_epoch_seq: int = 0
         self._fresh_context_respawn_epoch: int = 0
+        # Daemon-clock lower bound for status evidence belonging to the
+        # currently-running tmux/Claude process.  Status evidence older than
+        # this launch is unknown, never restart proof.
+        self._current_session_started_at: float = 0.0
 
         # Issue #563 — "first transcript bind" tracking. Set to True in
         # ``_start_tailer`` after the tailer is constructed; consumed
@@ -2760,6 +2764,9 @@ class TmuxSession:
             # before the REPL launches. No-ops for local agents.
             await self._seed_container_trust(cwd)
             await self._seed_container_home_creds()
+            # Stamp before process creation so even an immediate current-
+            # session hook POST is correctly considered fresh.
+            session_started_at = time.time()
             result = await self._tmux.new_session(
                 cwd=cwd,
                 command=claude_cmd,
@@ -2770,6 +2777,7 @@ class TmuxSession:
                     f"tmux new-session failed: rc={result.returncode} "
                     f"stderr={result.stderr.strip()!r}"
                 )
+            self._current_session_started_at = session_started_at
 
         try:
             await asyncio.wait_for(_spawn(), timeout=_COLD_START_TIMEOUT_SEC)
@@ -5801,6 +5809,8 @@ class TmuxSession:
                             input, so the lingering meta(s) are phantom (a
                             paste with no matching stop_hook). Reconcile, don't
                             restart.
+          - ``"unknown"`` — live_status predates this tmux process and cannot
+                            prove either idle or wedged; veto restart.
           - ``"wedged"``  — aged out, transcript quiet, REPL not idle →
                             genuinely stuck; force_restart.
 
@@ -5849,6 +5859,14 @@ class TmuxSession:
                 live = fn()
             except Exception:
                 live = None
+        live_last_updated = live.get("last_updated") if live else None
+        if (
+            self._current_session_started_at > 0
+            and isinstance(live_last_updated, (int, float))
+            and not isinstance(live_last_updated, bool)
+            and live_last_updated < self._current_session_started_at
+        ):
+            return "unknown"
         if live and live.get("status") == "idle":
             last_updated = live.get("last_updated") or 0.0
             # Floor the idle-freshness check at when the current head was
@@ -5990,19 +6008,16 @@ class TmuxSession:
         window once it's the head — a queued turn doesn't get
         force_restarted for ageing while ANOTHER turn was running.
 
-        **Tail requeue on timeout** (Murzik review on PR #561).
-        When the head wedges, ONLY the head is abandoned — its
-        ``completion_event`` fires (signal of "definitively failed"),
-        but its prompt is NOT replayed. Tail entries (B, C, ... that
-        were already dispatched into Claude Code's native queue but
-        never got to run because A wedged) carry intact prompts +
-        completion_events; we requeue them at the FRONT of
-        ``_message_queue`` in FIFO order so the new worker (spawned
-        by force_restart's disconnect→connect cycle) re-dispatches
-        them after the restart. Their ``completion_event`` stays
-        UNSET so a ``wait_for_completion=True`` caller still waits
-        for the actual rerun, not for a phantom "completion" the
-        watchdog falsely signaled.
+        **Undelivered requeue on timeout** (#943, extending Murzik's PR #561
+        tail-requeue contract). A head with no transcript acceptance receipt
+        is replayed first: it was pasted but never observed reaching the REPL.
+        An accepted head is still abandoned to avoid duplicating partial,
+        potentially side-effecting work. Tail entries (B, C, ... already
+        dispatched into Claude Code's native queue but not yet run) carry
+        intact prompts + completion events; they are requeued at the FRONT of
+        ``_message_queue`` in FIFO order so the new worker re-dispatches them
+        after restart. Replayed completion events stay UNSET so a
+        ``wait_for_completion=True`` caller still waits for the actual rerun.
 
         Also covers the worker's in-hand-but-not-pasted turn (e.g.
         mid context-lock retry) — that turn's meta isn't in the deque
@@ -6105,6 +6120,38 @@ class TmuxSession:
                     log_watchdog_decision(
                         watchdog="inflight", agent=self.agent_name,
                         decision="reconcile", reason="idle_phantom",
+                        state=self.state.value, progress_stale_s=age,
+                        inflight_turns=depth, inflight_active=False,
+                    )
+                    continue
+                if verdict == "unknown":
+                    # #943: a process-local live-status reader can fossilize
+                    # across session recreation.  A value predating THIS tmux
+                    # process is not evidence that an idle/static pane is
+                    # wedged. Fail toward no-restart, extend the decision
+                    # window, and emit a distinctive release receipt once per
+                    # timeout window.
+                    self._head_started_at = now
+                    self._inflight_pane_ext_anchor = None
+                    live = None
+                    live_status_fn = getattr(self._config, "live_status_fn", None)
+                    if live_status_fn is not None:
+                        try:
+                            live = live_status_fn()
+                        except Exception:
+                            live = None
+                    _log(
+                        f"tmux[{self.agent_name}]: "
+                        f"WATCHDOG_STALE_LIVE_STATUS_VETO "
+                        f"live_last_updated="
+                        f"{live.get('last_updated') if live else None} "
+                        f"session_started_at={self._current_session_started_at} "
+                        f"— input unknown; NOT restarting "
+                        f"(deque depth={depth})"
+                    )
+                    log_watchdog_decision(
+                        watchdog="inflight", agent=self.agent_name,
+                        decision="skip", reason="stale_live_status_veto",
                         state=self.state.value, progress_stale_s=age,
                         inflight_turns=depth, inflight_active=False,
                     )
@@ -6278,6 +6325,38 @@ class TmuxSession:
                     return True
 
                 replay: list[_QueuedTurn] = []
+                # A head with no transcript queue-dequeue/user-row receipt was
+                # pasted but never observed as accepted by the REPL.  It is an
+                # undelivered item, not failed in-progress work: preserve it
+                # across force_restart ahead of the later tail/in-hand turns.
+                # Accepted heads retain the historical abandon behavior to
+                # avoid duplicating side effects after partial processing.
+                head_replayed = False
+                if not head.turn.transport_accepted and _consider_replay(
+                    head.turn, kind="unaccepted_head"
+                ):
+                    # A scheduler turn was originally pasted by its dedicated
+                    # out-of-band delivery task and remains listed only until
+                    # the transcript acceptance receipt resolves.  Detach it
+                    # before force_restart→disconnect so that teardown neither
+                    # resolves the still-valid receipt False nor treats this
+                    # preserved turn as an abandoned scheduler delivery.  The
+                    # ordinary replay worker keeps scheduler_serialized=True;
+                    # its slot check explicitly excludes that same in-hand
+                    # replay candidate, while still waiting behind earlier
+                    # work.
+                    if head.turn.scheduler_serialized:
+                        self._scheduler_pending_turns[:] = [
+                            pending
+                            for pending in self._scheduler_pending_turns
+                            if pending is not head.turn
+                        ]
+                    # Any enqueue/dequeue evidence belonged to the killed pane.
+                    # Re-arm exact matching for the replacement paste.
+                    head.turn.pane_delivery_started = False
+                    head.turn.pane_queue_enqueued = False
+                    replay.append(head.turn)
+                    head_replayed = True
                 tail_replayed = 0
                 for i, entry in enumerate(tail_entries):
                     if tail_cap and tail_replayed >= tail_cap:
@@ -6322,22 +6401,29 @@ class TmuxSession:
                         f"{len(replay)} turn(s) for replay after "
                         f"force_restart (tail={tail_replayed}/"
                         f"{len(tail_entries)}, "
+                        f"unaccepted_head={'yes' if head_replayed else 'no'}, "
                         f"in_hand={'yes' if in_hand else 'no'})"
                     )
 
-                # HEAD ONLY: fire its completion_event. Head was
-                # definitively abandoned (its prompt is NOT replayed —
-                # the wedge invalidated whatever progress it made).
+                # ACCEPTED HEAD ONLY: fire its completion_event. An unaccepted
+                # head is replayed with its event still unset; accepted work
+                # may have made partial side-effecting progress and remains
+                # definitively abandoned to avoid duplicate execution.
                 # Tail entries' events stay UNSET so wait_for_completion
                 # callers wait for the actual rerun, not the watchdog
                 # itself. Critical contract — Murzik review on PR #561.
                 if (
-                    head.completion_event is not None
+                    not head_replayed
+                    and head.completion_event is not None
                     and not head.completion_event.is_set()
                 ):
                     head.completion_event.set()
                 head_delivery = head.turn.scheduler_delivery
-                if head_delivery is not None and not head_delivery.done():
+                if (
+                    not head_replayed
+                    and head_delivery is not None
+                    and not head_delivery.done()
+                ):
                     head_delivery.set_result(False)
                 self._turn_done.set()
                 self._stats["errors"] += 1
@@ -6385,7 +6471,7 @@ class TmuxSession:
         if not turn.scheduler_serialized:
             return
 
-        while self._scheduler_pane_busy():
+        while self._scheduler_pane_busy(turn):
             if (
                 turn.scheduler_delivery is not None
                 and turn.scheduler_delivery.cancelled()
@@ -6399,12 +6485,31 @@ class TmuxSession:
         ):
             raise _SchedulerDeliveryCancelled
 
-    def _scheduler_pane_busy(self) -> bool:
-        """Conservative busy verdict for safe scheduled-prompt injection."""
+    def _scheduler_pane_busy(
+        self, candidate: _QueuedTurn | None = None
+    ) -> bool:
+        """Conservative busy verdict for safe scheduled-prompt injection.
+
+        ``candidate`` is normally delivered by an out-of-band scheduler task,
+        so ordinary in-hand/queued work remains ahead of it.  After #943
+        preserves an unaccepted scheduler head across force_restart, the
+        ordinary replay worker itself holds that candidate.  Exclude only that
+        identity (and queue items necessarily behind it) to avoid a self-wait;
+        all earlier pane work and live-idle evidence still gate the paste.
+        """
+        candidate_in_worker = (
+            candidate is not None and self._inflight_turn is candidate
+        )
         if (
             self._inflight_tool_calls
-            or self._inflight_turn is not None
-            or not self._message_queue.empty()
+            or (
+                self._inflight_turn is not None
+                and not candidate_in_worker
+            )
+            or (
+                not self._message_queue.empty()
+                and not candidate_in_worker
+            )
         ):
             return True
         live_status_fn = getattr(self._config, "live_status_fn", None)
@@ -6772,7 +6877,7 @@ class TmuxSession:
                 # paste never races behind newly queued steering input.
                 if (
                     turn.scheduler_serialized
-                    and self._scheduler_pane_busy()
+                    and self._scheduler_pane_busy(turn)
                 ):
                     retry_scheduler_gate = True
                 else:

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -71,6 +71,12 @@ _FALLBACK_POLL_SEC = 2.0
 # to do on a hot file.
 _ACTIVE_POLL_SEC = 0.2
 
+# A freshly-bound transcript path may be reported before Claude Code creates
+# the JSONL.  During that brief gap discovery keeps returning the previous
+# session's stale file.  Keep the #291 guard, but rate-limit its operator log
+# so active polling cannot flood the journal at 5 lines/second.
+_STALE_DISCOVERY_LOG_INTERVAL_SEC = 30.0
+
 # Max bytes read per ``_read_and_dispatch`` invocation. Bounds memory if the
 # transcript path ever points at something pathologically large (per
 # Pushok's PR #496 round-1 Case 4a: the daemon endpoint's docstring claims
@@ -348,6 +354,7 @@ class TmuxTranscriptTailer:
         self._wake_event = asyncio.Event()
         self._task: asyncio.Task | None = None
         self._stopped = False
+        self._last_stale_discovery_log_at = 0.0
         self._stats = {
             "turns_fired": 0,
             "lines_read": 0,
@@ -635,12 +642,19 @@ class TmuxTranscriptTailer:
         except OSError:
             return
         if discovered_mtime < self._path_bound_at:
-            _log(
-                f"tmux_tailer[{self._agent_name}]: self-heal SKIP stale "
-                f"discovery {discovered} (mtime {discovered_mtime:.0f} predates "
-                f"bind {self._path_bound_at:.0f}) — awaiting bound path to "
-                f"materialise (#291)"
-            )
+            monotonic_now = time.monotonic()
+            if (
+                self._last_stale_discovery_log_at == 0.0
+                or monotonic_now - self._last_stale_discovery_log_at
+                >= _STALE_DISCOVERY_LOG_INTERVAL_SEC
+            ):
+                _log(
+                    f"tmux_tailer[{self._agent_name}]: self-heal SKIP stale "
+                    f"discovery {discovered} (mtime {discovered_mtime:.0f} "
+                    f"predates bind {self._path_bound_at:.0f}) — awaiting "
+                    f"bound path to materialise (#291)"
+                )
+                self._last_stale_discovery_log_at = monotonic_now
             self._stats["self_heal_stale_skips"] += 1
             return
         _log(

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 import threading
@@ -330,6 +331,91 @@ class TestSigningKeys:
 
         assert (working.read_text(), idle.read_text()) == before
         assert (working.stat().st_mtime_ns, idle.stat().st_mtime_ns) == before_mtimes
+
+    def test_existing_settings_repair_missing_status_hook_entries(self, tmp_path):
+        """#943: a workspace can retain SessionStart while losing the
+        working/idle hooks. Every sync must restore both live-status writers."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        settings_path = claude_dir / "settings.json"
+        settings_path.write_text(json.dumps({
+            "hooks": {
+                "SessionStart": [{
+                    "matcher": ".*",
+                    "hooks": [{"type": "command", "command": "echo retained"}],
+                }],
+            },
+        }))
+
+        AgentRegistry._setup_hooks(tmp_path, "dymok")
+
+        hooks = json.loads(settings_path.read_text())["hooks"]
+        working_path = str((claude_dir / "hook_working.py").resolve())
+        idle_path = str((claude_dir / "hook_idle.py").resolve())
+        pre_tool_commands = [
+            hook["command"]
+            for bucket in hooks["PreToolUse"]
+            for hook in bucket["hooks"]
+        ]
+        stop_commands = [
+            hook["command"]
+            for bucket in hooks["Stop"]
+            for hook in bucket["hooks"]
+        ]
+        assert sum(working_path in command for command in pre_tool_commands) == 1
+        assert sum(idle_path in command for command in stop_commands) == 1
+
+    def test_status_hook_failures_are_loud_and_stale_wrappers_upgrade(
+        self, tmp_path,
+    ):
+        """#943: managed status POST failures must reach logger/stderr, and an
+        existing 2>/dev/null wrapper must be upgraded rather than accepted."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        working_path = (claude_dir / "hook_working.py").resolve()
+        idle_path = (claude_dir / "hook_idle.py").resolve()
+        settings_path = claude_dir / "settings.json"
+        settings_path.write_text(json.dumps({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": ".*",
+                    "hooks": [{
+                        "type": "command",
+                        "command": f"python3 {working_path} 2>/dev/null || true",
+                    }],
+                }],
+                "Stop": [{
+                    "matcher": ".*",
+                    "hooks": [{
+                        "type": "command",
+                        "command": f"python3 {idle_path} 2>/dev/null || true",
+                    }],
+                }],
+            },
+        }))
+
+        AgentRegistry._setup_hooks(tmp_path, "dymok")
+
+        for path in (working_path, idle_path):
+            source = path.read_text()
+            compile(source, str(path), "exec")
+            assert "STATUS_HOOK_POST_FAILURE" in source
+            assert "STATUS_HOOK_SECRET_MISSING" in source
+            assert "os.O_CREAT | os.O_EXCL | os.O_WRONLY" in source
+            assert "os.getsid(0)" in source
+            assert '["logger", "-t", "pinkybot-status-hook", message]' in source
+            assert "print(message, file=sys.stderr, flush=True)" in source
+
+        hooks = json.loads(settings_path.read_text())["hooks"]
+        managed_commands = [
+            hook["command"]
+            for event in ("PreToolUse", "Stop")
+            for bucket in hooks[event]
+            for hook in bucket["hooks"]
+            if str(working_path) in hook["command"] or str(idle_path) in hook["command"]
+        ]
+        assert len(managed_commands) == 2
+        assert all("2>/dev/null" not in command for command in managed_commands)
 
     def test_backfill_skips_malformed_name_without_bricking(self, registry):
         # A legacy/non-conforming agent name must not brick boot: the per-row

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -173,6 +173,45 @@ class TestPostAgentStatus:
         assert resp.status_code == 200
         assert resp.json()["status"] == "working"
 
+    def test_status_receipt_log_is_distinctive_and_rate_limited_per_agent(
+        self, capsys,
+    ):
+        client = self._client_with_agent()
+        client.post("/agents/arty/status", json={"status": "working"})
+        client.post("/agents/arty/status", json={"status": "idle"})
+        client.post("/agents", json={"name": "beth", "model": "sonnet"})
+        client.post("/agents/beth/status", json={"status": "working"})
+
+        receipt_lines = [
+            line
+            for line in capsys.readouterr().err.splitlines()
+            if "STATUS_HOOK_RECEIPT" in line
+        ]
+        assert len(receipt_lines) == 2
+        assert any("agent=arty" in line for line in receipt_lines)
+        assert any("agent=beth" in line for line in receipt_lines)
+
+    def test_watchdog_reader_observes_hook_updates_across_registry_connections(
+        self,
+    ):
+        """#943: the watchdog source is SQLite, not a process-local snapshot."""
+        from pinky_daemon.agent_registry import AgentRegistry
+        from pinky_daemon.api import _read_persisted_agent_working_status
+
+        client = self._client_with_agent()
+        observer = AgentRegistry(db_path=self._db.replace(".db", "_agents.db"))
+        try:
+            client.post("/agents/arty/status", json={"status": "working"})
+            working = _read_persisted_agent_working_status(observer, "arty")
+            client.post("/agents/arty/status", json={"status": "idle"})
+            idle = _read_persisted_agent_working_status(observer, "arty")
+
+            assert working is not None and working["status"] == "working"
+            assert idle is not None and idle["status"] == "idle"
+            assert idle["last_updated"] >= working["last_updated"] > 0
+        finally:
+            observer.close()
+
     def test_thinking_status(self):
         client = self._client_with_agent()
         resp = client.post("/agents/arty/status", json={"status": "thinking"})

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -47,6 +47,7 @@ def _seed_inflight(
     completion_event: asyncio.Event | None = None,
     prompt: str = "",
     fresh_context_epoch: int = 0,
+    transport_accepted: bool = True,
 ) -> _InflightMeta:
     """Append one ``_InflightMeta`` entry to ``ss._inflight_metas``.
 
@@ -68,6 +69,7 @@ def _seed_inflight(
         message_id=m.get("message_id", ""),
         internal=internal,
         completion_event=completion_event,
+        transport_accepted=transport_accepted,
     )
     entry = _InflightMeta(
         meta=m,
@@ -3635,6 +3637,81 @@ async def test_scheduler_prompt_receipt_waits_for_live_working_status() -> None:
 
 
 @pytest.mark.asyncio
+async def test_watchdog_force_restart_replays_unaccepted_scheduler_head(
+    monkeypatch,
+) -> None:
+    """#943 / Murzik terminal block: a serialized scheduler head must keep its
+    pending receipt, cross a real force_restart, and repaste without waiting on
+    itself in the ordinary replay worker."""
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.02)
+
+    live = {"status": "idle", "last_updated": _time.time()}
+    ss, tmux = _make_session()
+    ss._config.live_status_fn = lambda: live
+    ss._transcript_recently_grew = lambda *_args: False
+    ss._background_tasks_recently_active = lambda *_args: False
+    ss._foreground_tool_in_flight = lambda *_args: False
+    ss._pane_is_animating = AsyncMock(return_value=False)
+
+    async def _spawn_with_current_idle(*_args, **_kwargs):
+        live.update(status="idle", last_updated=_time.time())
+        return _ok()
+
+    tmux.new_session = AsyncMock(side_effect=_spawn_with_current_idle)
+    await ss.connect()
+
+    receipt = await ss.send_scheduler_prompt("one-shot scheduled wake")
+    for _ in range(100):
+        if tmux.paste_text.await_count == 1 and ss._inflight_metas:
+            break
+        await asyncio.sleep(0.01)
+    assert tmux.paste_text.await_count == 1
+    assert len(ss._inflight_metas) == 1
+    original = ss._inflight_metas[0].turn
+    assert original.scheduler_serialized is True
+    assert not original.transport_accepted
+    assert not receipt.done()
+
+    # Freeze the current pane in a fresh "working" state so the watchdog takes
+    # its real wedged→force_restart recovery path.
+    live.update(status="working", last_updated=_time.time())
+    ss._head_started_at = 0.0
+
+    for _ in range(300):
+        if (
+            tmux.new_session.await_count >= 2
+            and tmux.paste_text.await_count >= 2
+            and len(ss._inflight_metas) == 1
+            and ss._inflight_metas[0].turn is original
+            and ss._inflight_turn is None
+        ):
+            break
+        await asyncio.sleep(0.01)
+
+    assert ss.state == SessionState.CONNECTED
+    assert tmux.new_session.await_count == 2
+    assert [
+        call.args[0] for call in tmux.paste_text.await_args_list
+    ] == ["one-shot scheduled wake", "one-shot scheduled wake"]
+    assert len(ss._inflight_metas) == 1
+    assert ss._inflight_metas[0].turn is original
+    assert original.replay_count == 1
+    assert not original.transport_accepted
+    assert not receipt.done(), "force_restart must preserve the exact receipt"
+
+    ss._on_transcript_entry({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": "one-shot scheduled wake",
+        },
+    })
+    assert await receipt is True
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("steering_starts_before_stop", [True, False])
 async def test_second_scheduler_prompt_delivers_after_first_receipt_and_stop(
     steering_starts_before_stop: bool,
@@ -3980,8 +4057,9 @@ async def test_worker_force_restarts_on_turn_done_timeout(monkeypatch) -> None:
     assert ss._has_completed_turn is False
     assert force_restart_results == [True]
     guard.assert_not_called()
-    # Deque was drained by the watchdog's force_restart path.
-    assert len(ss._inflight_metas) == 0
+    # #943: the prompt had no transcript acceptance receipt, so the restart
+    # must preserve exactly one copy (queued or already re-dispatched).
+    assert len(ss._inflight_metas) + ss._message_queue.qsize() == 1
 
     await ss.disconnect()
 
@@ -6672,6 +6750,19 @@ class TestForceFreshContextOnce:
             "a prior transcript exists"
         )
 
+    def test_prior_transcript_is_informational_on_force_fresh_build(self):
+        """#943 Fix-C adjudication: prior history may exist, but a force-fresh
+        context_restart passes neither --continue nor a transcript argument."""
+        ss, _ = _make_session()
+        ss._has_prior_transcript = lambda: True
+        ss._config.force_fresh_context_once = True
+
+        cmd = ss._build_claude_cmd()
+
+        assert ss._last_launch_had_prior_transcript is True
+        assert ss._last_launch_used_continue is False
+        assert "--continue" not in shlex.split(cmd)
+
     def test_build_claude_cmd_records_launch_mode_on_session(self):
         ss, _ = _make_session()
         ss._has_prior_transcript = lambda: True
@@ -8008,6 +8099,95 @@ class TestInflightDequeConcurrentDispatch:
         # Stats updated.
         assert ss._stats.get("turn_timeouts", 0) == 1
 
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_requeues_unaccepted_head_across_force_restart(
+        self, monkeypatch,
+    ):
+        """#943: a pasted head with no transcript acceptance receipt is
+        undelivered and must survive the discarding force_restart boundary."""
+        from pinky_daemon import tmux_session as _ts
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.02)
+
+        ss, _ = _make_session()
+        await ss.connect()
+        assert ss._worker_task is not None
+        ss._worker_task.cancel()
+        try:
+            await ss._worker_task
+        except asyncio.CancelledError:
+            pass
+
+        force_called = asyncio.Event()
+
+        async def _stub_force_restart(*, bypass_guard: bool = False):
+            force_called.set()
+            return True
+
+        ss.force_restart = _stub_force_restart
+        completion = asyncio.Event()
+        original = _seed_inflight(
+            ss,
+            prompt="one-shot wake payload",
+            completion_event=completion,
+            transport_accepted=False,
+        ).turn
+        ss._head_started_at = 0.0
+
+        try:
+            await asyncio.wait_for(force_called.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pytest.fail("watchdog must schedule force_restart")
+
+        assert ss._message_queue.qsize() == 1
+        replay = ss._message_queue.get_nowait()
+        assert replay is original
+        assert replay.prompt == "one-shot wake payload"
+        assert replay.replay_count == 1
+        assert not completion.is_set(), (
+            "unaccepted head completion waits for the replay, not restart"
+        )
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_vetoes_frozen_pre_session_live_status(
+        self, monkeypatch, capsys,
+    ):
+        """#943: frozen live_last_updated + a static/idle pane is unknown
+        evidence and must never trigger force_restart."""
+        from pinky_daemon import tmux_session as _ts
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.02)
+
+        ss, _ = _make_session()
+        await ss.connect()
+        ss._transcript_recently_grew = lambda *_args: False
+        ss._background_tasks_recently_active = lambda *_args: False
+        ss._foreground_tool_in_flight = lambda *_args: False
+        ss._pane_is_animating = AsyncMock(return_value=False)
+        ss._config.live_status_fn = lambda: {
+            "status": "working",
+            "last_updated": ss._current_session_started_at - 1.0,
+        }
+        _seed_inflight(ss, prompt="wake")
+        ss._head_started_at = 0.0
+
+        restarted = asyncio.Event()
+
+        async def _must_not_restart(*, bypass_guard: bool = False):
+            restarted.set()
+            return True
+
+        ss.force_restart = _must_not_restart
+        await asyncio.sleep(0.15)
+
+        assert not restarted.is_set()
+        assert len(ss._inflight_metas) == 1
+        assert ss._head_started_at is not None and ss._head_started_at > 0
+        assert ss._pane_is_animating.await_count == 0
+        assert "WATCHDOG_STALE_LIVE_STATUS_VETO" in capsys.readouterr().err
         await ss.disconnect()
 
     @pytest.mark.asyncio

--- a/tests/test_tmux_transcript.py
+++ b/tests/test_tmux_transcript.py
@@ -1173,6 +1173,31 @@ class TestSelfHealDiscovery:
         assert tailer.stats["self_heal_stale_skips"] == 1
 
     @pytest.mark.asyncio
+    async def test_stale_discovery_skip_log_is_rate_limited(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        """#943: active polling must not flood the journal with #291 skips."""
+        cb = _Captor()
+        old = tmp_path / "old-session.jsonl"
+        _write_jsonl(old, [_assistant(text="old"), _stop_hook_summary()])
+        os.utime(old, (time.time() - 3600, time.time() - 3600))
+        fresh = tmp_path / "fresh-session.jsonl"
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl", cb,
+            path_discovery=lambda: old,
+        )
+        tailer.set_transcript_path(fresh)
+        monkeypatch.setattr(
+            "pinky_daemon.tmux_transcript.time.monotonic", lambda: 100.0,
+        )
+
+        tailer._try_self_heal_repoint()
+        tailer._try_self_heal_repoint()
+
+        assert tailer.stats["self_heal_stale_skips"] == 2
+        assert capsys.readouterr().err.count("self-heal SKIP stale discovery") == 1
+
+    @pytest.mark.asyncio
     async def test_self_heal_strict_floor_blocks_recent_previous_session(self, tmp_path):
         """#291: the floor is STRICT (no slack). The clobber target is often the
         *immediately* preceding session, whose last write can be only seconds


### PR DESCRIPTION
Addresses #943.

## What

- Read `working_status` and `working_status_updated_at` fresh from the authoritative `AgentRegistry` record whenever the tmux watchdog asks for live status, instead of consulting the non-authoritative process-local live-status map.
- Treat status evidence older than the current tmux/Claude process as unknown and veto restart with the distinctive `WATCHDOG_STALE_LIVE_STATUS_VETO` receipt.
- Preserve and replay an inflight head across `force_restart` when no transcript acceptance receipt exists. Accepted heads retain the existing no-replay behavior to avoid duplicating partial side effects; replay caps remain enforced.
- Preserve the exact pending receipt for a serialized scheduler head across restart. Detach that preserved identity from teardown, reset killed-pane acceptance evidence, and let the ordinary replay worker exclude only its own candidate from scheduler slot gating while still waiting behind earlier pane work.
- Bracket status delivery with a per-agent, one-minute-rate-limited `STATUS_HOOK_RECEIPT` daemon log and loud `STATUS_HOOK_SECRET_MISSING` / `STATUS_HOOK_POST_FAILURE` hook logs via host logger plus stderr.
- Repair/upgrade managed working and idle hook entries idempotently, including removal of the historical stderr sink.
- Rate-limit the companion `#291` stale-discovery skip log so active tailer polling cannot flood the journal.
- Leave context-restart command selection unchanged. A regression confirms force-fresh remains fresh even when prior transcript history exists: no `--continue` or transcript argument is passed.

## Why

Pi watchdog verdicts repeatedly cited a fossilized process-local status timestamp even while signed self-reads proved the hook-written `working_status_updated_at` record was current. Those false wedge verdicts triggered repeated `force_restart` cycles, and the restart boundary discarded dispatched prompts that had never been accepted by the transcript transport.

The authoritative verdict-time read fixes that reader-side root cause. The stale-age veto prevents any future fossil from authorizing a restart, and the replay contract prevents an unaccepted wake from disappearing if recovery is still required. Serialized scheduler replays retain both their receipt and non-steering delivery semantics without self-blocking in the worker.

## Impact and safety

- Fail toward no restart when status evidence belongs to an older process.
- Replay only turns with no transport-acceptance receipt; never replay a head already observed accepted.
- Keep scheduler receipts pending until the replacement paste receives exact transcript acceptance.
- Existing replay amplification limits and FIFO ordering remain intact.
- No execution, vendor, credential, release, or deployment surface is added.
- Rollout verification uses API behavior and distinctive journal receipts only. It must not open a daemon-held SQLite database externally, including read-only mode.

## Checks

- Python 3.11.15 focused #943 contracts: 50/50 passed; final core rerun 5/5 passed.
- Murzik blocker counterexample across real `force_restart`: 1/1 passed on the replacement implementation.
- Scheduler/replay regression set: 15/15 passed.
- Affected status/registry/tmux files at the replacement head: 574/574 passed.
- Broad pre-review repository run: 4512 passed, 3 skipped; two unrelated nodes were diverted by local fleet overrides (`PINKY_DREAM_TRANSPORT=tmux`, `PINKY_AUTH_DENY_DEFAULT=1`) and both passed 2/2 when rerun under CI-default values.
- `uv run --frozen ruff check .`
- `uv lock --check`
- `uv run --frozen python -m compileall -q src tests`
- generated status-hook sources compiled by regression test
- `git diff --check`

Normal GitHub CI and an exact-SHA Murzik terminal gauntlet are required before merge. Barsik owns release and fleet rollout after merge; this lane does not deploy.