### PR TITLE
Heal stale WAL generation in task_store reads (#889)

### DIFF
--- a/src/pinky_daemon/task_store.py
+++ b/src/pinky_daemon/task_store.py
@@ -200,6 +200,45 @@ class TaskStore:
             self._thread_local.connection = connection
         return connection
 
+    def _reset_connection(self) -> None:
+        """Drop the calling thread's cached connection so the next access reopens it.
+
+        Recovers from a stale WAL generation (see #889): the database file is intact
+        (integrity_check passes from a separate process) but this long-lived handle's
+        page cache still references a WAL that was checkpointed/reset underneath it,
+        which surfaces as "database disk image is malformed" on every statement.
+        Reopening rebinds to the current generation; the file itself is never touched.
+        """
+        connection = getattr(self._thread_local, "connection", None)
+        if connection is not None:
+            try:
+                connection.close()
+            except sqlite3.Error:
+                pass
+            self._thread_local.connection = None
+
+    def _read(self, sql: str, params=()) -> list:
+        """Run a read-only query, healing a stale connection once (see #889).
+
+        On DatabaseError the thread-local handle is dropped and reopened, then the
+        query is retried exactly once. This is safe for reads: the error fires before
+        any row is produced, so a retry cannot double-apply anything. Write paths are
+        deliberately NOT routed through here — a blind retry could re-apply a
+        statement that had partially landed before the handle went bad; hardening the
+        write path is a separate, deliberate pass.
+        """
+        try:
+            return self._db.execute(sql, params).fetchall()
+        except sqlite3.DatabaseError as exc:
+            _log(f"task_store: read hit stale handle ({exc}); reopening connection, retry 1/1")
+            self._reset_connection()
+            return self._db.execute(sql, params).fetchall()
+
+    def _read_one(self, sql: str, params=()):
+        """Single-row variant of :meth:`_read` (see #889). Returns the first row or None."""
+        rows = self._read(sql, params)
+        return rows[0] if rows else None
+
     def _init_tables(self) -> None:
         self._db.executescript("""
             CREATE TABLE IF NOT EXISTS projects (
@@ -340,9 +379,7 @@ class TaskStore:
 
     def get(self, task_id: int) -> Task | None:
         """Get a task by ID."""
-        row = self._db.execute(
-            "SELECT * FROM tasks WHERE id=?", (task_id,)
-        ).fetchone()
+        row = self._read_one("SELECT * FROM tasks WHERE id=?", (task_id,))
         if not row:
             return None
         return self._row_to_task(row)
@@ -442,7 +479,7 @@ class TaskStore:
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         params.append(limit)
 
-        rows = self._db.execute(
+        rows = self._read(
             f"""SELECT * FROM tasks {where}
                 ORDER BY
                     CASE priority WHEN 'urgent' THEN 0 WHEN 'high' THEN 1
@@ -450,7 +487,7 @@ class TaskStore:
                     created_at DESC
                 LIMIT ?""",
             params,
-        ).fetchall()
+        )
 
         return [self._row_to_task(r) for r in rows]
 
@@ -460,18 +497,16 @@ class TaskStore:
 
     def count_by_status(self) -> dict[str, int]:
         """Get task counts grouped by status."""
-        rows = self._db.execute(
-            "SELECT status, COUNT(*) FROM tasks GROUP BY status"
-        ).fetchall()
+        rows = self._read("SELECT status, COUNT(*) FROM tasks GROUP BY status")
         return {r[0]: r[1] for r in rows}
 
     def count_by_agent(self) -> dict[str, int]:
         """Get active task counts grouped by assigned agent."""
-        rows = self._db.execute(
+        rows = self._read(
             """SELECT assigned_agent, COUNT(*) FROM tasks
                WHERE status NOT IN ('completed', 'cancelled') AND assigned_agent != ''
                GROUP BY assigned_agent"""
-        ).fetchall()
+        )
         return {r[0]: r[1] for r in rows}
 
     # ── Helpers ────────────────────────────────────────────
@@ -537,10 +572,10 @@ class TaskStore:
 
     def get_project(self, project_id: int) -> Project | None:
         """Get a project by ID."""
-        row = self._db.execute(
+        row = self._read_one(
             f"SELECT {self._P_COLS} FROM projects WHERE id=?",
             (project_id,),
-        ).fetchone()
+        )
         if not row:
             return None
         return self._row_to_project(row)
@@ -548,13 +583,13 @@ class TaskStore:
     def list_projects(self, *, include_archived: bool = False) -> list[Project]:
         """List all projects."""
         if include_archived:
-            rows = self._db.execute(
+            rows = self._read(
                 f"SELECT {self._P_COLS} FROM projects ORDER BY updated_at DESC"
-            ).fetchall()
+            )
         else:
-            rows = self._db.execute(
+            rows = self._read(
                 f"SELECT {self._P_COLS} FROM projects WHERE status != 'archived' ORDER BY updated_at DESC"
-            ).fetchall()
+            )
         return [self._row_to_project(r) for r in rows]
 
     def update_project(self, project_id: int, **kwargs) -> Project | None:
@@ -618,11 +653,11 @@ class TaskStore:
 
     def get_milestone(self, milestone_id: int) -> Milestone | None:
         """Get a milestone by ID."""
-        row = self._db.execute(
+        row = self._read_one(
             "SELECT id, project_id, name, description, due_date, status, created_at, updated_at"
             " FROM milestones WHERE id=?",
             (milestone_id,),
-        ).fetchone()
+        )
         if not row:
             return None
         return Milestone(
@@ -632,11 +667,11 @@ class TaskStore:
 
     def list_milestones(self, project_id: int) -> list[Milestone]:
         """List all milestones for a project."""
-        rows = self._db.execute(
+        rows = self._read(
             "SELECT id, project_id, name, description, due_date, status, created_at, updated_at"
             " FROM milestones WHERE project_id=? ORDER BY due_date ASC, created_at ASC",
             (project_id,),
-        ).fetchall()
+        )
         return [
             Milestone(
                 id=r[0], project_id=r[1], name=r[2], description=r[3],
@@ -706,11 +741,11 @@ class TaskStore:
 
     def get_sprint(self, sprint_id: int) -> Sprint | None:
         """Get a sprint by ID."""
-        row = self._db.execute(
+        row = self._read_one(
             "SELECT id, project_id, name, goal, start_date, end_date, status, created_at, updated_at"
             " FROM sprints WHERE id=?",
             (sprint_id,),
-        ).fetchone()
+        )
         if not row:
             return None
         return self._row_to_sprint(row)
@@ -718,17 +753,17 @@ class TaskStore:
     def list_sprints(self, project_id: int, include_completed: bool = False) -> list[Sprint]:
         """List sprints for a project."""
         if include_completed:
-            rows = self._db.execute(
+            rows = self._read(
                 "SELECT id, project_id, name, goal, start_date, end_date, status, created_at, updated_at"
                 " FROM sprints WHERE project_id=? ORDER BY created_at DESC",
                 (project_id,),
-            ).fetchall()
+            )
         else:
-            rows = self._db.execute(
+            rows = self._read(
                 "SELECT id, project_id, name, goal, start_date, end_date, status, created_at, updated_at"
                 " FROM sprints WHERE project_id=? AND status != 'completed' ORDER BY created_at DESC",
                 (project_id,),
-            ).fetchall()
+            )
         return [self._row_to_sprint(r) for r in rows]
 
     def update_sprint(self, sprint_id: int, **kwargs) -> Sprint | None:
@@ -776,10 +811,10 @@ class TaskStore:
 
     def count_tasks_by_sprint(self, sprint_id: int) -> dict:
         """Return total and completed task counts for a sprint."""
-        rows = self._db.execute(
+        rows = self._read(
             "SELECT status, COUNT(*) FROM tasks WHERE sprint_id=? GROUP BY status",
             (sprint_id,),
-        ).fetchall()
+        )
         counts = {r[0]: r[1] for r in rows}
         total = sum(counts.values())
         completed = counts.get("completed", 0) + counts.get("cancelled", 0)
@@ -797,10 +832,10 @@ class TaskStore:
         if not sprint:
             return []
 
-        rows = self._db.execute(
+        rows = self._read(
             "SELECT status, updated_at FROM tasks WHERE sprint_id=?",
             (sprint_id,),
-        ).fetchall()
+        )
 
         total = len(rows)
         if not total:
@@ -853,19 +888,19 @@ class TaskStore:
 
     def count_tasks_by_milestone(self, project_id: int) -> dict[int, int]:
         """Return task counts keyed by milestone_id for a project."""
-        rows = self._db.execute(
+        rows = self._read(
             "SELECT milestone_id, COUNT(*) FROM tasks WHERE project_id=? GROUP BY milestone_id",
             (project_id,),
-        ).fetchall()
+        )
         return {r[0]: r[1] for r in rows}
 
     def count_completed_tasks_by_milestone(self, project_id: int) -> dict[int, int]:
         """Return completed task counts keyed by milestone_id for a project."""
-        rows = self._db.execute(
+        rows = self._read(
             "SELECT milestone_id, COUNT(*) FROM tasks"
             " WHERE project_id=? AND status IN ('completed', 'cancelled') GROUP BY milestone_id",
             (project_id,),
-        ).fetchall()
+        )
         return {r[0]: r[1] for r in rows}
 
     # ── Comments ───────────────────────────────────────────
@@ -883,10 +918,10 @@ class TaskStore:
 
     def get_comments(self, task_id: int, *, limit: int = 50) -> list[TaskComment]:
         """Get comments for a task, newest first."""
-        rows = self._db.execute(
+        rows = self._read(
             "SELECT id, task_id, author, content, created_at FROM task_comments WHERE task_id=? ORDER BY created_at DESC LIMIT ?",
             (task_id, limit),
-        ).fetchall()
+        )
         return [
             TaskComment(id=r[0], task_id=r[1], author=r[2], content=r[3], created_at=r[4])
             for r in rows

--- a/src/pinky_daemon/task_store.py
+++ b/src/pinky_daemon/task_store.py
@@ -220,16 +220,24 @@ class TaskStore:
     def _read(self, sql: str, params=()) -> list:
         """Run a read-only query, healing a stale connection once (see #889).
 
-        On DatabaseError the thread-local handle is dropped and reopened, then the
-        query is retried exactly once. This is safe for reads: the error fires before
-        any row is produced, so a retry cannot double-apply anything. Write paths are
-        deliberately NOT routed through here — a blind retry could re-apply a
-        statement that had partially landed before the handle went bad; hardening the
-        write path is a separate, deliberate pass.
+        On DatabaseError outside a transaction, the thread-local handle is dropped
+        and reopened, then the query is retried exactly once. This is safe for reads:
+        the error fires before any row is produced, so a retry cannot double-apply
+        anything. Inside a transaction the error propagates without resetting the
+        handle, because closing it would silently roll back pending writes. Write
+        paths are deliberately NOT routed through here — a blind retry could re-apply
+        a statement that had partially landed before the handle went bad; hardening
+        the write path is a separate, deliberate pass.
         """
         try:
             return self._db.execute(sql, params).fetchall()
         except sqlite3.DatabaseError as exc:
+            if self._db.in_transaction:
+                _log(
+                    f"task_store: read failed inside transaction ({exc}); "
+                    "propagating without reopening connection"
+                )
+                raise
             _log(f"task_store: read hit stale handle ({exc}); reopening connection, retry 1/1")
             self._reset_connection()
             return self._db.execute(sql, params).fetchall()

--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -365,6 +365,83 @@ class TestTaskConcurrency:
             store.close()
 
 
+class _StaleOnce:
+    """Wraps a real connection but raises 'database disk image is malformed' on the
+    first execute — simulating a thread-local handle whose WAL generation was
+    checkpointed/reset underneath it (#889). Later calls delegate normally.
+    """
+
+    def __init__(self, conn):
+        self._conn = conn
+        self._raised = False
+
+    def execute(self, *args, **kwargs):
+        if not self._raised:
+            self._raised = True
+            raise sqlite3.DatabaseError("database disk image is malformed")
+        return self._conn.execute(*args, **kwargs)
+
+    def close(self):
+        self._conn.close()
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+class TestStaleConnectionRecovery:
+    """#889 — the file is intact but the long-lived handle is stale; reads self-heal
+    by dropping and reopening the thread-local connection and retrying once.
+    """
+
+    def test_list_reopens_and_retries_on_malformed(self, store):
+        store.create("alpha", assigned_agent="onesie", status="pending")
+        poisoned = _StaleOnce(store._db)  # materialize a healthy conn, then poison it
+        store._thread_local.connection = poisoned
+
+        tasks = store.list(assigned_agent="onesie", status="pending")
+
+        assert [t.title for t in tasks] == ["alpha"]
+        # the poisoned handle was dropped; a fresh real connection is now in place
+        assert store._thread_local.connection is not poisoned
+        assert not isinstance(store._thread_local.connection, _StaleOnce)
+
+    def test_get_one_recovers(self, store):
+        created = store.create("beta")
+        store._thread_local.connection = _StaleOnce(store._db)
+
+        got = store.get(created.id)
+
+        assert got is not None
+        assert got.title == "beta"
+
+    def test_retry_is_bounded_to_once(self, store):
+        """If the handle stays broken, the error propagates (no infinite retry)."""
+        store.create("gamma")
+
+        class AlwaysMalformed:
+            def execute(self, *a, **k):
+                raise sqlite3.DatabaseError("database disk image is malformed")
+
+            def close(self):
+                pass
+
+        store._thread_local.connection = AlwaysMalformed()
+        # first attempt raises -> reset -> _db reopens a *real* connection, which
+        # succeeds; to prove the bound, force reopen to also yield a broken handle.
+        store._reset_connection()
+        store._thread_local.connection = AlwaysMalformed()
+        original_reset = store._reset_connection
+        store._reset_connection = lambda: setattr(
+            store._thread_local, "connection", AlwaysMalformed()
+        )
+        try:
+            with pytest.raises(sqlite3.DatabaseError):
+                store.list()
+        finally:
+            store._reset_connection = original_reset
+            store._reset_connection()
+
+
 class TestTaskAPI:
     def _make_client(self):
         fd, path = tempfile.mkstemp(suffix=".db")

--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -419,6 +419,8 @@ class TestStaleConnectionRecovery:
         store.create("gamma")
 
         class AlwaysMalformed:
+            in_transaction = False
+
             def execute(self, *a, **k):
                 raise sqlite3.DatabaseError("database disk image is malformed")
 
@@ -440,6 +442,43 @@ class TestStaleConnectionRecovery:
         finally:
             store._reset_connection = original_reset
             store._reset_connection()
+
+    def test_mid_transaction_read_failure_does_not_reset_or_activate_two_sprints(
+        self, store
+    ):
+        project = store.create_project("transaction guard")
+        current = store.create_sprint(project.id, "current")
+        target = store.create_sprint(project.id, "target")
+        store.update_sprint(current.id, status="active")
+
+        class FailReadInTransaction:
+            def __init__(self, conn):
+                self._conn = conn
+                self.close_calls = 0
+
+            def execute(self, sql, *args, **kwargs):
+                if self._conn.in_transaction and sql.lstrip().upper().startswith("SELECT"):
+                    raise sqlite3.DatabaseError("database disk image is malformed")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            def close(self):
+                self.close_calls += 1
+                self._conn.close()
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+        poisoned = FailReadInTransaction(store._db)
+        store._thread_local.connection = poisoned
+
+        with pytest.raises(sqlite3.DatabaseError, match="malformed"):
+            store.start_sprint(target.id)
+
+        assert store._thread_local.connection is poisoned
+        assert poisoned.close_calls == 0
+        with sqlite3.connect(store._db_path) as observer:
+            statuses = dict(observer.execute("SELECT id, status FROM sprints"))
+        assert statuses == {current.id: "active", target.id: "planned"}
 
 
 class TestTaskAPI:


### PR DESCRIPTION
## The bug

`TaskStore` keeps a long-lived thread-local sqlite handle. That handle can end up bound to a WAL generation that was checkpointed away underneath it. Once that happens, **every statement on that handle raises `database disk image is malformed` even though the database file is intact** — `integrity_check` passes from a separate process.

Live impact on the TOD fleet: `GET /tasks` 500s and `get_next_task()` fails until the daemon is restarted. The restart both masks the cause and eats queued scheduled work, so the failure looks transient and its evidence disappears. Onesie hit it twice in one night.

Same family as #889 and the earlier deleted-WAL split-brain incident.

## The fix

Route the SELECT paths through `_read` / `_read_one`. On `sqlite3.DatabaseError`: drop the thread-local handle, reopen, retry **exactly once**.

Why reads are safe to retry: the error fires before any row is produced, so a retry cannot double-apply anything.

**Write paths are deliberately untouched.** A blind retry could re-apply a statement that had partially landed before the handle went bad. Hardening writes is a separate, deliberate pass — verified in this diff: zero INSERT/UPDATE/DELETE call sites were rerouted.

Failure behavior is preserved, not papered over:
- The retry is bounded to one attempt, so a genuinely corrupt database still raises rather than looping.
- Every heal is logged (`task_store: read hit stale handle (...); reopening connection, retry 1/1`), so self-healing doesn't hide the incident rate — this class of fix is only acceptable if it stays loud.

## Provenance and verification

Found, diagnosed, and patched by **angel** (TOD fleet) after Onesie routed the incident to it. Angel could not run `pytest` or `ruff` on that box (neither is in its venv) and validated via a standalone harness instead — so it explicitly did not claim CI-grade verification, and did not push or open this PR itself.

Verified by me on the Mini against current `main` (`efbb09d`):
- Patch applies clean to `main` (angel checked it against `1bbe3d3`; two merges have landed since).
- `ruff check` — clean.
- `pytest tests/test_task_store.py` — **48 passed**.
- The three new recovery tests were run in isolation and read for substance rather than counted: they poison the thread-local handle with a stub that raises `malformed` once, prove `list()` and `get()` return correct data afterward, assert the poisoned handle was actually replaced, and — for the bound — force the *reopen* to also yield a broken handle so the error must propagate. That last one is the test that makes the "no infinite retry" claim real.
- Full-suite result appended below before this leaves draft.

## Review notes

The judgment call worth a second opinion: `sqlite3.DatabaseError` is broad — it also covers `OperationalError` (e.g. `database is locked`). Such an error would trigger a drop-and-reopen that cannot clear a lock, then one retry, then propagate. Wasteful but not harmful, and the alternative (matching on the message string) is more brittle. Flagging it rather than changing it.

Closes the read-path half of #889.

🤖 Opened by Barsik
