### PR TITLE
Add Pinky ACP daemon connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,acp]"
 
       - name: Run tests
         run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+acp = ["agent-client-protocol>=0.11,<0.12", "httpx"]
 telegram = ["python-telegram-bot[webhooks]>=21.0"]
 discord = ["discord.py>=2.3"]
 # slack-sdk's async Socket Mode client (slack_sdk.socket_mode.aiohttp) needs aiohttp.

--- a/src/pinky_cli/__main__.py
+++ b/src/pinky_cli/__main__.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
+import os
 import sys
 
 
@@ -49,6 +51,22 @@ def main() -> None:
         help="Working directory (where CLAUDE.md lives)",
     )
 
+    # ACP daemon-backed stdio connector
+    acp_parser = subparsers.add_parser(
+        "acp",
+        help="Run an ACP stdio connector backed by the Pinky daemon",
+    )
+    acp_parser.add_argument(
+        "--agent",
+        default=os.environ.get("PINKY_AGENT"),
+        help="Agent identity (or PINKY_AGENT)",
+    )
+    acp_parser.add_argument(
+        "--daemon-url",
+        default=os.environ.get("PINKY_DAEMON_URL", "http://127.0.0.1:8888"),
+        help="Pinky daemon URL (or PINKY_DAEMON_URL)",
+    )
+
     args = parser.parse_args()
 
     if args.command == "init":
@@ -70,6 +88,16 @@ def main() -> None:
             "--working-dir", args.working_dir,
         ]
         daemon_main()
+    elif args.command == "acp":
+        if not args.agent:
+            acp_parser.error("--agent is required when PINKY_AGENT is not set")
+        from pinky_cli.acp import run_acp
+
+        try:
+            asyncio.run(run_acp(args.agent, args.daemon_url))
+        except (RuntimeError, ValueError) as exc:
+            print(f"[pinky-acp] {exc}", file=sys.stderr, flush=True)
+            sys.exit(2)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/pinky_cli/acp.py
+++ b/src/pinky_cli/acp.py
@@ -70,6 +70,12 @@ def _effective_permission_mode(agent_config: dict[str, Any]) -> str:
     """Choose an ACP-specific daemon policy without inheriting unsafe bypass."""
     agent_name = str(agent_config.get("name", "unknown"))
     override = os.environ.get("PINKY_ACP_PERMISSION_MODE", "")
+    if override == "bypassPermissions":
+        _stderr(
+            f"agent '{agent_name}' bypassPermissions is not permitted on the ACP "
+            "surface (owner policy); using dontAsk"
+        )
+        return "dontAsk"
     if override:
         _stderr(
             f"agent '{agent_name}' ACP permission mode is '{override}' from "
@@ -82,14 +88,13 @@ def _effective_permission_mode(agent_config: dict[str, Any]) -> str:
     if configured == "bypassPermissions":
         _stderr(
             f"agent '{agent_name}' is configured bypassPermissions; ACP surface "
-            "downgrades to dontAsk — set PINKY_ACP_PERMISSION_MODE to "
-            "override deliberately"
+            "downgrades to dontAsk"
         )
         return "dontAsk"
     if not configured:
         _stderr(
             f"agent '{agent_name}' has no configured permission mode; ACP surface "
-            "uses dontAsk — set PINKY_ACP_PERMISSION_MODE to override deliberately"
+            "uses dontAsk"
         )
         return "dontAsk"
 

--- a/src/pinky_cli/acp.py
+++ b/src/pinky_cli/acp.py
@@ -31,6 +31,17 @@ else:
 DEFAULT_KEEPALIVE_INTERVAL = 60.0
 DEFAULT_BUSY_RETRIES = 10
 DEFAULT_BUSY_RETRY_DELAY = 1.0
+ACP_DEFAULT_ALLOWED_TOOLS = [
+    "Bash",
+    "Read",
+    "Glob",
+    "Grep",
+    "Edit",
+    "Write",
+    "mcp__pinky-memory__*",
+    "mcp__pinky-messaging__*",
+    "mcp__pinky-self__*",
+]
 _AGENT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
 _AgentBase = acp.Agent if acp is not None else object
 
@@ -53,6 +64,39 @@ def _require_acp() -> None:
 
 def _stderr(message: str) -> None:
     print(f"[pinky-acp] {message}", file=sys.stderr, flush=True)
+
+
+def _effective_permission_mode(agent_config: dict[str, Any]) -> str:
+    """Choose an ACP-specific daemon policy without inheriting unsafe bypass."""
+    agent_name = str(agent_config.get("name", "unknown"))
+    override = os.environ.get("PINKY_ACP_PERMISSION_MODE", "")
+    if override:
+        _stderr(
+            f"agent '{agent_name}' ACP permission mode is '{override}' from "
+            "PINKY_ACP_PERMISSION_MODE"
+        )
+        return override
+
+    configured = agent_config.get("permission_mode", "")
+    configured = configured if isinstance(configured, str) else ""
+    if configured == "bypassPermissions":
+        _stderr(
+            f"agent '{agent_name}' is configured bypassPermissions; ACP surface "
+            "downgrades to dontAsk — set PINKY_ACP_PERMISSION_MODE to "
+            "override deliberately"
+        )
+        return "dontAsk"
+    if not configured:
+        _stderr(
+            f"agent '{agent_name}' has no configured permission mode; ACP surface "
+            "uses dontAsk — set PINKY_ACP_PERMISSION_MODE to override deliberately"
+        )
+        return "dontAsk"
+
+    _stderr(
+        f"agent '{agent_name}' ACP permission mode is '{configured}' from agent config"
+    )
+    return configured
 
 
 def _project_root() -> Path:
@@ -149,16 +193,36 @@ class DaemonClient:
         working_dir: Path,
     ) -> str:
         requested_id = f"acp-{self.agent_name}-{uuid4().hex[:12]}"
+        permission_mode = _effective_permission_mode(config)
+        configured_allowed_tools = config.get("allowed_tools", [])
+        if not isinstance(configured_allowed_tools, list):
+            configured_allowed_tools = []
+        allowed_tools = configured_allowed_tools
+        if permission_mode == "dontAsk":
+            source = "agent-config"
+            if not allowed_tools:
+                allowed_tools = list(ACP_DEFAULT_ALLOWED_TOOLS)
+                source = "acp-default"
+            _stderr(
+                f"agent '{self.agent_name}' ACP session uses dontAsk with {source} "
+                f"allowed_tools: {', '.join(allowed_tools)}"
+            )
+            if "Bash" not in allowed_tools:
+                _stderr(
+                    f"warning: agent '{self.agent_name}' ACP allowlist lacks Bash; "
+                    "the Buzz CLI reply path will be denied"
+                )
         body = {
             "session_id": requested_id,
             "model": config.get("model", ""),
             "working_dir": str(working_dir),
-            "allowed_tools": config.get("allowed_tools", []),
+            "allowed_tools": allowed_tools,
+            "disallowed_tools": config.get("disallowed_tools", []),
             "max_turns": config.get("max_turns", 0),
             "timeout": config.get("timeout", 300.0),
             "restart_threshold_pct": config.get("restart_threshold_pct", 80.0),
             "auto_restart": config.get("auto_restart", True),
-            "permission_mode": config.get("permission_mode", ""),
+            "permission_mode": permission_mode,
         }
         response = await self._request("POST", "/sessions", json=body)
         response.raise_for_status()
@@ -320,7 +384,7 @@ class PinkyAcpAgent(_AgentBase):
         finally:
             keepalive_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await keepalive_task
+                _ = await keepalive_task
             active = self._cancel_events.get(session_id)
             if active is not None:
                 active.discard(cancel_event)

--- a/src/pinky_cli/acp.py
+++ b/src/pinky_cli/acp.py
@@ -1,0 +1,414 @@
+"""ACP stdio proxy backed by PinkyBot daemon sessions.
+
+Stdout belongs exclusively to the Agent Client Protocol transport. Diagnostics
+from this module must always go to stderr.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import httpx
+
+from pinky_daemon.auth import build_internal_auth_headers
+
+try:
+    import acp
+except ModuleNotFoundError as exc:  # Optional dependency; base installs stay usable.
+    acp = None  # type: ignore[assignment]
+    _ACP_IMPORT_ERROR: ModuleNotFoundError | None = exc
+else:
+    _ACP_IMPORT_ERROR = None
+
+
+DEFAULT_KEEPALIVE_INTERVAL = 60.0
+DEFAULT_BUSY_RETRIES = 10
+DEFAULT_BUSY_RETRY_DELAY = 1.0
+_AGENT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+_AgentBase = acp.Agent if acp is not None else object
+
+
+class AcpDependencyError(RuntimeError):
+    """Raised when ``pinky acp`` is used without its optional dependency."""
+
+
+class DaemonBusyError(RuntimeError):
+    """Raised after the bounded daemon busy retry window is exhausted."""
+
+
+def _require_acp() -> None:
+    if acp is None:
+        raise AcpDependencyError(
+            "pinky acp requires the optional ACP dependencies; "
+            "install with `pip install 'pinky-ai[acp]'`"
+        ) from _ACP_IMPORT_ERROR
+
+
+def _stderr(message: str) -> None:
+    print(f"[pinky-acp] {message}", file=sys.stderr, flush=True)
+
+
+def _project_root() -> Path:
+    """Resolve the PinkyBot checkout independently of the ACP client's cwd."""
+    configured = os.environ.get("PINKY_PROJECT_ROOT", "").strip()
+    candidates = []
+    if configured:
+        candidates.append(Path(configured))
+    candidates.extend(
+        [
+            Path(sys.prefix).resolve().parent,
+            Path(__file__).resolve().parents[2],
+        ]
+    )
+    for candidate in candidates:
+        if (candidate / "pyproject.toml").is_file() or (candidate / ".env").is_file():
+            return candidate.resolve()
+    return Path(__file__).resolve().parents[2]
+
+
+def _read_session_secret(project_root: Path) -> str:
+    """Read the daemon signing secret from the environment or checkout .env."""
+    secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+    if secret:
+        return secret
+
+    env_path = project_root / ".env"
+    if not env_path.is_file():
+        return ""
+    for raw_line in env_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        if key.strip() == "PINKY_SESSION_SECRET":
+            return value.strip().strip("\"'")
+    return ""
+
+
+class DaemonClient:
+    """Small signed-httpx client for the daemon's manager session API."""
+
+    def __init__(
+        self,
+        *,
+        daemon_url: str,
+        agent_name: str,
+        secret: str,
+        busy_retries: int = DEFAULT_BUSY_RETRIES,
+        busy_retry_delay: float = DEFAULT_BUSY_RETRY_DELAY,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self.agent_name = agent_name
+        self.secret = secret
+        self.busy_retries = busy_retries
+        self.busy_retry_delay = busy_retry_delay
+        self._client = httpx.AsyncClient(
+            base_url=daemon_url.rstrip("/"),
+            timeout=httpx.Timeout(7200.0, connect=10.0),
+            transport=transport,
+        )
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        headers = build_internal_auth_headers(
+            self.secret,
+            agent_name=self.agent_name,
+            method=method,
+            path=path,
+        )
+        return await self._client.request(method, path, json=json, headers=headers)
+
+    async def get_agent(self) -> dict[str, Any]:
+        path = f"/agents/{self.agent_name}"
+        response = await self._request("GET", path)
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError("daemon returned an invalid agent configuration")
+        return payload
+
+    async def create_session(
+        self,
+        *,
+        config: dict[str, Any],
+        working_dir: Path,
+    ) -> str:
+        requested_id = f"acp-{self.agent_name}-{uuid4().hex[:12]}"
+        body = {
+            "session_id": requested_id,
+            "model": config.get("model", ""),
+            "working_dir": str(working_dir),
+            "allowed_tools": config.get("allowed_tools", []),
+            "max_turns": config.get("max_turns", 0),
+            "timeout": config.get("timeout", 300.0),
+            "restart_threshold_pct": config.get("restart_threshold_pct", 80.0),
+            "auto_restart": config.get("auto_restart", True),
+            "permission_mode": config.get("permission_mode", ""),
+        }
+        response = await self._request("POST", "/sessions", json=body)
+        response.raise_for_status()
+        payload = response.json()
+        session_id = payload.get("id") if isinstance(payload, dict) else None
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError("daemon did not return a session id")
+        return session_id
+
+    async def send_message(self, session_id: str, content: str) -> str:
+        path = f"/sessions/{session_id}/message"
+        for retry in range(self.busy_retries + 1):
+            response = await self._request("POST", path, json={"content": content})
+            if response.status_code != 409:
+                response.raise_for_status()
+                payload = response.json()
+                if not isinstance(payload, dict):
+                    raise ValueError("daemon returned an invalid message response")
+                error = payload.get("error")
+                if error:
+                    raise RuntimeError(f"daemon turn failed: {error}")
+                result = payload.get("content", "")
+                if not isinstance(result, str):
+                    raise ValueError("daemon returned non-text message content")
+                return result
+            if retry == self.busy_retries:
+                break
+            await asyncio.sleep(self.busy_retry_delay)
+        raise DaemonBusyError(
+            f"daemon session remained busy after {self.busy_retries + 1} attempts"
+        )
+
+
+class PinkyAcpAgent(_AgentBase):
+    """ACP agent backed by dedicated PinkyBot daemon sessions."""
+
+    def __init__(
+        self,
+        *,
+        agent_name: str,
+        daemon: DaemonClient,
+        project_root: Path,
+        keepalive_interval: float = DEFAULT_KEEPALIVE_INTERVAL,
+    ) -> None:
+        _require_acp()
+        if not _AGENT_NAME_RE.fullmatch(agent_name):
+            raise ValueError("agent name must be lowercase alphanumeric, underscore, or hyphen")
+        self.agent_name = agent_name
+        self.daemon = daemon
+        self.project_root = project_root.resolve()
+        self.working_dir = self.project_root / "data" / "agents" / agent_name
+        self.keepalive_interval = keepalive_interval
+        self._conn: Any = None
+        self._sessions: set[str] = set()
+        self._cancel_events: dict[str, set[asyncio.Event]] = {}
+        self._detached_tasks: set[asyncio.Task[Any]] = set()
+
+    def on_connect(self, conn: Any) -> None:
+        self._conn = conn
+
+    async def close(self) -> None:
+        for task in tuple(self._detached_tasks):
+            task.cancel()
+        if self._detached_tasks:
+            await asyncio.gather(*self._detached_tasks, return_exceptions=True)
+        await self.daemon.close()
+
+    async def initialize(self, protocol_version: int, **kwargs: Any) -> Any:
+        del protocol_version, kwargs
+        return acp.InitializeResponse(
+            protocolVersion=1,
+            agentCapabilities=acp.schema.AgentCapabilities(
+                loadSession=False,
+                promptCapabilities=acp.schema.PromptCapabilities(embeddedContext=True),
+                mcpCapabilities=acp.schema.McpCapabilities(http=False, sse=False),
+            ),
+            authMethods=[],
+        )
+
+    async def new_session(
+        self,
+        cwd: str,
+        additional_directories: list[str] | None = None,
+        mcp_servers: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        del cwd, additional_directories, kwargs
+        if mcp_servers:
+            _stderr(
+                f"warning: ignoring {len(mcp_servers)} client MCP server(s); "
+                "daemon-managed .mcp.json remains authoritative"
+            )
+        config = await self.daemon.get_agent()
+        session_id = await self.daemon.create_session(
+            config=config,
+            working_dir=self.working_dir,
+        )
+        self._sessions.add(session_id)
+        self._cancel_events.setdefault(session_id, set())
+        return acp.NewSessionResponse(sessionId=session_id)
+
+    async def prompt(
+        self,
+        session_id: str,
+        prompt: list[Any],
+        **kwargs: Any,
+    ) -> Any:
+        del kwargs
+        if session_id not in self._sessions:
+            await self._message(session_id, "Unknown ACP session; create a new session first.")
+            return acp.PromptResponse(stopReason="refusal")
+
+        content = flatten_content_blocks(prompt)
+        cancel_event = asyncio.Event()
+        self._cancel_events.setdefault(session_id, set()).add(cancel_event)
+        send_task = asyncio.create_task(
+            self.daemon.send_message(session_id, content),
+            name=f"pinky-acp.send.{session_id}",
+        )
+        cancel_task = asyncio.create_task(
+            cancel_event.wait(),
+            name=f"pinky-acp.cancel-wait.{session_id}",
+        )
+        keepalive_task = asyncio.create_task(
+            self._keepalive(session_id, cancel_event),
+            name=f"pinky-acp.keepalive.{session_id}",
+        )
+        try:
+            done, _ = await asyncio.wait(
+                {send_task, cancel_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if cancel_task in done or cancel_event.is_set():
+                self._detach(send_task)
+                return acp.PromptResponse(stopReason="cancelled")
+
+            cancel_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await cancel_task
+            try:
+                response_text = await send_task
+            except Exception as exc:
+                _stderr(f"prompt failed for {session_id}: {exc}")
+                await self._message(
+                    session_id,
+                    "PinkyBot could not complete this turn through the daemon. "
+                    f"{exc}",
+                )
+                return acp.PromptResponse(stopReason="refusal")
+
+            if cancel_event.is_set():
+                return acp.PromptResponse(stopReason="cancelled")
+            await self._message(session_id, response_text)
+            return acp.PromptResponse(stopReason="end_turn")
+        except asyncio.CancelledError:
+            cancel_task.cancel()
+            self._detach(send_task)
+            raise
+        finally:
+            keepalive_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await keepalive_task
+            active = self._cancel_events.get(session_id)
+            if active is not None:
+                active.discard(cancel_event)
+
+    async def cancel(self, session_id: str, **kwargs: Any) -> None:
+        del kwargs
+        for event in tuple(self._cancel_events.get(session_id, ())):
+            event.set()
+
+    async def _message(self, session_id: str, text: str) -> None:
+        await self._conn.session_update(
+            session_id=session_id,
+            update=acp.update_agent_message(acp.text_block(text)),
+        )
+
+    async def _keepalive(self, session_id: str, cancel_event: asyncio.Event) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self.keepalive_interval)
+                if cancel_event.is_set():
+                    return
+                await self._conn.session_update(
+                    session_id=session_id,
+                    update=acp.update_agent_thought(acp.text_block("Still working…")),
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            _stderr(f"keepalive stopped for {session_id}: {exc}")
+
+    def _detach(self, task: asyncio.Task[Any]) -> None:
+        if task.done():
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                task.result()
+            return
+        self._detached_tasks.add(task)
+
+        def _finished(done: asyncio.Task[Any]) -> None:
+            self._detached_tasks.discard(done)
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                done.result()
+
+        task.add_done_callback(_finished)
+
+
+def flatten_content_blocks(blocks: list[Any]) -> str:
+    """Flatten ACP prompt content into the daemon's text-only request shape."""
+    parts: list[str] = []
+    for block in blocks:
+        block_type = getattr(block, "type", "")
+        if block_type == "text":
+            parts.append(block.text)
+        elif block_type == "resource":
+            resource = block.resource
+            text = getattr(resource, "text", None)
+            if isinstance(text, str):
+                parts.append(text)
+            else:
+                parts.append(f"[embedded resource: {resource.uri}]")
+        elif block_type == "resource_link":
+            parts.append(f"[{block.name}: {block.uri}]")
+        elif block_type in {"image", "audio"}:
+            uri = getattr(block, "uri", None)
+            detail = uri or getattr(block, "mime_type", "unknown")
+            parts.append(f"[{block_type}: {detail}]")
+    return "\n".join(parts)
+
+
+async def run_acp(agent_name: str, daemon_url: str) -> None:
+    """Run the ACP JSON-RPC server over stdin/stdout."""
+    _require_acp()
+    project_root = _project_root()
+    secret = _read_session_secret(project_root)
+    if not secret:
+        raise RuntimeError(
+            "PINKY_SESSION_SECRET is required in the environment or PinkyBot .env"
+        )
+    daemon = DaemonClient(
+        daemon_url=daemon_url,
+        agent_name=agent_name,
+        secret=secret,
+    )
+    agent = PinkyAcpAgent(
+        agent_name=agent_name,
+        daemon=daemon,
+        project_root=project_root,
+    )
+    try:
+        await acp.run_agent(agent)
+    finally:
+        await agent.close()

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -5246,6 +5246,7 @@ npm run build</pre>
             soul=soul_text,
             working_dir=working_dir,
             allowed_tools=req.allowed_tools,
+            disallowed_tools=req.disallowed_tools,
             max_turns=req.max_turns,
             timeout=req.timeout,
             system_prompt=system_prompt,

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -35,6 +35,7 @@ class CreateSessionRequest(BaseModel):
         "Glob",
         "Grep",
     ])
+    disallowed_tools: list[str] = Field(default_factory=list)
     max_turns: int = 0
     timeout: float = 300.0
     system_prompt: str = ""

--- a/src/pinky_daemon/sessions.py
+++ b/src/pinky_daemon/sessions.py
@@ -283,6 +283,7 @@ class Session:
                     working_dir=working_dir,
                     model=model or None,
                     max_turns=max_turns,
+                    permission_mode=permission_mode or "bypassPermissions",
                     allowed_tools=self.allowed_tools,
                     disallowed_tools=getattr(self, "disallowed_tools", []),
                     mcp_servers=mcp_servers,

--- a/tests/test_acp_proxy.py
+++ b/tests/test_acp_proxy.py
@@ -245,7 +245,7 @@ async def test_empty_agent_mode_uses_dont_ask_and_acp_default_allowlist(
 
 
 @pytest.mark.asyncio
-async def test_acp_permission_env_override_allows_deliberate_bypass(
+async def test_acp_permission_env_override_refuses_bypass(
     tmp_path, monkeypatch, capsys
 ):
     monkeypatch.setenv("PINKY_ACP_PERMISSION_MODE", "bypassPermissions")
@@ -263,9 +263,35 @@ async def test_acp_permission_env_override_allows_deliberate_bypass(
 
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert create_bodies[0]["permission_mode"] == "bypassPermissions"
+    assert create_bodies[0]["permission_mode"] == "dontAsk"
+    assert (
+        "bypassPermissions is not permitted on the ACP surface (owner policy); "
+        "using dontAsk"
+    ) in captured.err
+
+
+@pytest.mark.asyncio
+async def test_acp_permission_env_override_honors_non_bypass_mode(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("PINKY_ACP_PERMISSION_MODE", "default")
+    create_bodies: list[dict[str, Any]] = []
+    config = {**_agent_config(), "permission_mode": "bypassPermissions"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _response(200, config)
+        create_bodies.append(json.loads(request.content))
+        return _response(200, {"id": "daemon-session"})
+
+    agent, _, _ = await _new_agent(tmp_path, handler)
+    await agent.close()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert create_bodies[0]["permission_mode"] == "default"
     assert "PINKY_ACP_PERMISSION_MODE" in captured.err
-    assert "downgrades to dontAsk" not in captured.err
+    assert "not permitted on the ACP surface" not in captured.err
 
 
 @pytest.mark.asyncio

--- a/tests/test_acp_proxy.py
+++ b/tests/test_acp_proxy.py
@@ -12,7 +12,12 @@ from typing import Any
 import httpx
 import pytest
 
-from pinky_cli.acp import DaemonClient, PinkyAcpAgent, _read_session_secret
+from pinky_cli.acp import (
+    ACP_DEFAULT_ALLOWED_TOOLS,
+    DaemonClient,
+    PinkyAcpAgent,
+    _read_session_secret,
+)
 
 acp = pytest.importorskip("acp")
 
@@ -33,6 +38,7 @@ def _agent_config() -> dict[str, Any]:
         "name": "tester",
         "model": "sonnet",
         "allowed_tools": ["Read", "Bash"],
+        "disallowed_tools": ["WebSearch", "Write"],
         "permission_mode": "plan",
         "max_turns": 17,
         "timeout": 901.0,
@@ -116,7 +122,10 @@ async def test_subprocess_handshake_env_fallbacks_and_stdout_hygiene(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_new_and_prompt_happy_path_uses_agent_identity_and_policy(tmp_path):
+async def test_new_and_prompt_happy_path_uses_agent_identity_and_policy(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("PINKY_ACP_PERMISSION_MODE", raising=False)
     requests: list[tuple[str, str, dict[str, Any], httpx.Headers]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -158,6 +167,7 @@ async def test_new_and_prompt_happy_path_uses_agent_identity_and_policy(tmp_path
     assert create_body["working_dir"] != "/client/cwd"
     assert create_body["model"] == "sonnet"
     assert create_body["allowed_tools"] == ["Read", "Bash"]
+    assert create_body["disallowed_tools"] == ["WebSearch", "Write"]
     assert create_body["permission_mode"] == "plan"
     assert create_body["permission_mode"] != "bypassPermissions"
     assert create_body["max_turns"] == 17
@@ -174,6 +184,88 @@ async def test_new_and_prompt_happy_path_uses_agent_identity_and_policy(tmp_path
         assert headers["x-pinky-agent"] == "tester"
         assert headers["x-pinky-signature"]
         assert headers["x-pinky-timestamp"]
+
+
+@pytest.mark.asyncio
+async def test_bypass_agent_defaults_acp_surface_to_dont_ask(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.delenv("PINKY_ACP_PERMISSION_MODE", raising=False)
+    create_bodies: list[dict[str, Any]] = []
+    config = {
+        **_agent_config(),
+        "allowed_tools": ["Read"],
+        "permission_mode": "bypassPermissions",
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _response(200, config)
+        create_bodies.append(json.loads(request.content))
+        return _response(200, {"id": "daemon-session"})
+
+    agent, _, _ = await _new_agent(tmp_path, handler)
+    await agent.close()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert create_bodies[0]["permission_mode"] == "dontAsk"
+    assert create_bodies[0]["allowed_tools"] == ["Read"]
+    assert "configured bypassPermissions" in captured.err
+    assert "ACP surface downgrades to dontAsk" in captured.err
+    assert "agent-config allowed_tools: Read" in captured.err
+    assert "ACP allowlist lacks Bash" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_empty_agent_mode_uses_dont_ask_and_acp_default_allowlist(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.delenv("PINKY_ACP_PERMISSION_MODE", raising=False)
+    create_bodies: list[dict[str, Any]] = []
+    config = {**_agent_config(), "allowed_tools": [], "permission_mode": ""}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _response(200, config)
+        create_bodies.append(json.loads(request.content))
+        return _response(200, {"id": "daemon-session"})
+
+    agent, _, _ = await _new_agent(tmp_path, handler)
+    await agent.close()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert create_bodies[0]["permission_mode"] == "dontAsk"
+    assert create_bodies[0]["allowed_tools"] == ACP_DEFAULT_ALLOWED_TOOLS
+    assert "has no configured permission mode" in captured.err
+    assert "ACP surface uses dontAsk" in captured.err
+    assert "acp-default allowed_tools" in captured.err
+    assert "ACP allowlist lacks Bash" not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_acp_permission_env_override_allows_deliberate_bypass(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("PINKY_ACP_PERMISSION_MODE", "bypassPermissions")
+    create_bodies: list[dict[str, Any]] = []
+    config = {**_agent_config(), "permission_mode": "bypassPermissions"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _response(200, config)
+        create_bodies.append(json.loads(request.content))
+        return _response(200, {"id": "daemon-session"})
+
+    agent, _, _ = await _new_agent(tmp_path, handler)
+    await agent.close()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert create_bodies[0]["permission_mode"] == "bypassPermissions"
+    assert "PINKY_ACP_PERMISSION_MODE" in captured.err
+    assert "downgrades to dontAsk" not in captured.err
 
 
 @pytest.mark.asyncio

--- a/tests/test_acp_proxy.py
+++ b/tests/test_acp_proxy.py
@@ -1,0 +1,330 @@
+"""Protocol and daemon boundary tests for the optional ACP stdio connector."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from pinky_cli.acp import DaemonClient, PinkyAcpAgent, _read_session_secret
+
+acp = pytest.importorskip("acp")
+
+
+class RecordingClient(acp.Client):
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, Any]] = []
+
+    async def session_update(
+        self, session_id: str, update: Any, **kwargs: Any
+    ) -> None:
+        del kwargs
+        self.updates.append((session_id, update))
+
+
+def _agent_config() -> dict[str, Any]:
+    return {
+        "name": "tester",
+        "model": "sonnet",
+        "allowed_tools": ["Read", "Bash"],
+        "permission_mode": "plan",
+        "max_turns": 17,
+        "timeout": 901.0,
+        "restart_threshold_pct": 73.0,
+        "auto_restart": False,
+    }
+
+
+def _response(status: int, payload: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(status, json=payload)
+
+
+def _client(
+    handler: Any,
+    *,
+    busy_retries: int = 2,
+    busy_retry_delay: float = 0.0,
+) -> DaemonClient:
+    return DaemonClient(
+        daemon_url="http://daemon.test",
+        agent_name="tester",
+        secret="signed-test-secret",
+        busy_retries=busy_retries,
+        busy_retry_delay=busy_retry_delay,
+        transport=httpx.MockTransport(handler),
+    )
+
+
+async def _new_agent(
+    tmp_path: Path,
+    handler: Any,
+    *,
+    keepalive_interval: float = 60.0,
+    busy_retries: int = 2,
+) -> tuple[PinkyAcpAgent, RecordingClient, str]:
+    daemon = _client(handler, busy_retries=busy_retries)
+    agent = PinkyAcpAgent(
+        agent_name="tester",
+        daemon=daemon,
+        project_root=tmp_path,
+        keepalive_interval=keepalive_interval,
+    )
+    recorder = RecordingClient()
+    agent.on_connect(recorder)
+    session = await agent.new_session(cwd="/client/cwd")
+    return agent, recorder, session.session_id
+
+
+@pytest.mark.asyncio
+async def test_subprocess_handshake_env_fallbacks_and_stdout_hygiene(tmp_path):
+    recorder = RecordingClient()
+    env = {
+        **os.environ,
+        "PINKY_AGENT": "tester",
+        "PINKY_DAEMON_URL": "http://daemon.invalid",
+        "PINKY_PROJECT_ROOT": str(tmp_path),
+        "PINKY_SESSION_SECRET": "signed-test-secret",
+    }
+
+    async with acp.spawn_agent_process(
+        recorder,
+        sys.executable,
+        "-m",
+        "pinky_cli",
+        "acp",
+        env=env,
+    ) as (connection, process):
+        response = await connection.initialize(protocol_version=2)
+
+        assert response.protocol_version == 1
+        assert response.auth_methods == []
+        capabilities = response.agent_capabilities
+        assert capabilities.load_session is False
+        assert capabilities.mcp_capabilities.http is False
+        assert capabilities.mcp_capabilities.sse is False
+        assert capabilities.prompt_capabilities.embedded_context is True
+        assert process.returncode is None
+
+    assert process.stderr is not None
+    assert await process.stderr.read() == b""
+
+
+@pytest.mark.asyncio
+async def test_new_and_prompt_happy_path_uses_agent_identity_and_policy(tmp_path):
+    requests: list[tuple[str, str, dict[str, Any], httpx.Headers]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else {}
+        requests.append((request.method, request.url.path, body, request.headers))
+        if request.method == "GET":
+            return _response(200, _agent_config())
+        if request.url.path == "/sessions":
+            return _response(200, {"id": "daemon-session"})
+        return _response(
+            200,
+            {"content": "daemon answer", "error": "", "role": "assistant"},
+        )
+
+    agent, recorder, session_id = await _new_agent(tmp_path, handler)
+    embedded = acp.schema.EmbeddedResourceContentBlock(
+        type="resource",
+        resource=acp.schema.TextResourceContents(
+            uri="file:///context.txt",
+            text="embedded context",
+        ),
+    )
+    try:
+        result = await agent.prompt(
+            session_id,
+            [acp.text_block("user prompt"), embedded],
+        )
+    finally:
+        await agent.close()
+
+    assert result.stop_reason == "end_turn"
+    assert [(update.session_update, update.content.text) for _, update in recorder.updates] == [
+        ("agent_message_chunk", "daemon answer")
+    ]
+    create = requests[1]
+    assert create[:2] == ("POST", "/sessions")
+    create_body = create[2]
+    assert create_body["working_dir"] == str(tmp_path / "data" / "agents" / "tester")
+    assert create_body["working_dir"] != "/client/cwd"
+    assert create_body["model"] == "sonnet"
+    assert create_body["allowed_tools"] == ["Read", "Bash"]
+    assert create_body["permission_mode"] == "plan"
+    assert create_body["permission_mode"] != "bypassPermissions"
+    assert create_body["max_turns"] == 17
+    assert create_body["timeout"] == 901.0
+    assert create_body["restart_threshold_pct"] == 73.0
+    assert create_body["auto_restart"] is False
+    message = requests[2]
+    assert message[:3] == (
+        "POST",
+        "/sessions/daemon-session/message",
+        {"content": "user prompt\nembedded context"},
+    )
+    for _, _, _, headers in requests:
+        assert headers["x-pinky-agent"] == "tester"
+        assert headers["x-pinky-signature"]
+        assert headers["x-pinky-timestamp"]
+
+
+@pytest.mark.asyncio
+async def test_prompt_emits_keepalive_while_daemon_turn_is_running(tmp_path):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _response(200, _agent_config())
+        if request.url.path == "/sessions":
+            return _response(200, {"id": "daemon-session"})
+        started.set()
+        await release.wait()
+        return _response(200, {"content": "finished", "error": ""})
+
+    agent, recorder, session_id = await _new_agent(
+        tmp_path,
+        handler,
+        keepalive_interval=0.01,
+    )
+    prompt_task = asyncio.create_task(agent.prompt(session_id, [acp.text_block("slow")]))
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1)
+        while not recorder.updates:
+            await asyncio.sleep(0.005)
+        release.set()
+        result = await asyncio.wait_for(prompt_task, timeout=1)
+    finally:
+        release.set()
+        await agent.close()
+
+    assert result.stop_reason == "end_turn"
+    assert recorder.updates[0][1].session_update == "agent_thought_chunk"
+    assert recorder.updates[0][1].content.text == "Still working…"
+    assert recorder.updates[-1][1].session_update == "agent_message_chunk"
+    assert recorder.updates[-1][1].content.text == "finished"
+
+
+@pytest.mark.asyncio
+async def test_cancel_detaches_inflight_daemon_turn_and_returns_cancelled(tmp_path):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _response(200, _agent_config())
+        if request.url.path == "/sessions":
+            return _response(200, {"id": "daemon-session"})
+        started.set()
+        await release.wait()
+        return _response(200, {"content": "late answer", "error": ""})
+
+    agent, recorder, session_id = await _new_agent(tmp_path, handler)
+    prompt_task = asyncio.create_task(agent.prompt(session_id, [acp.text_block("cancel me")]))
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await agent.cancel(session_id)
+        result = await asyncio.wait_for(prompt_task, timeout=1)
+        assert agent._detached_tasks
+        release.set()
+        while agent._detached_tasks:
+            await asyncio.sleep(0)
+    finally:
+        release.set()
+        await agent.close()
+
+    assert result.stop_reason == "cancelled"
+    assert recorder.updates == []
+
+
+@pytest.mark.asyncio
+async def test_busy_response_retries_boundedly_without_protocol_error(tmp_path):
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        if request.method == "GET":
+            return _response(200, _agent_config())
+        if request.url.path == "/sessions":
+            return _response(200, {"id": "daemon-session"})
+        attempts += 1
+        if attempts < 3:
+            return _response(409, {"detail": "busy"})
+        return _response(200, {"content": "after busy", "error": ""})
+
+    agent, recorder, session_id = await _new_agent(tmp_path, handler, busy_retries=2)
+    try:
+        result = await agent.prompt(session_id, [acp.text_block("overlap")])
+    finally:
+        await agent.close()
+
+    assert attempts == 3
+    assert result.stop_reason == "end_turn"
+    assert recorder.updates[0][1].content.text == "after busy"
+
+
+@pytest.mark.asyncio
+async def test_busy_retry_exhaustion_returns_protocol_refusal(tmp_path):
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        if request.method == "GET":
+            return _response(200, _agent_config())
+        if request.url.path == "/sessions":
+            return _response(200, {"id": "daemon-session"})
+        attempts += 1
+        return _response(409, {"detail": "busy"})
+
+    agent, recorder, session_id = await _new_agent(tmp_path, handler, busy_retries=2)
+    try:
+        result = await agent.prompt(session_id, [acp.text_block("overlap")])
+    finally:
+        await agent.close()
+
+    assert attempts == 3
+    assert result.stop_reason == "refusal"
+    assert len(recorder.updates) == 1
+    assert recorder.updates[0][1].session_update == "agent_message_chunk"
+    assert "remained busy after 3 attempts" in recorder.updates[0][1].content.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_servers_warn_to_stderr_and_are_ignored(tmp_path, capsys):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return _response(200, _agent_config())
+        return _response(200, {"id": "daemon-session"})
+
+    daemon = _client(handler)
+    agent = PinkyAcpAgent(
+        agent_name="tester",
+        daemon=daemon,
+        project_root=tmp_path,
+    )
+    agent.on_connect(RecordingClient())
+    try:
+        await agent.new_session(cwd="/client/cwd", mcp_servers=[object()])
+    finally:
+        await agent.close()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "ignoring 1 client MCP server" in captured.err
+
+
+def test_session_secret_environment_then_dotenv(tmp_path, monkeypatch):
+    monkeypatch.delenv("PINKY_SESSION_SECRET", raising=False)
+    (tmp_path / ".env").write_text("OTHER=value\nPINKY_SESSION_SECRET='from-dotenv'\n")
+    assert _read_session_secret(tmp_path) == "from-dotenv"
+
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "from-environment")
+    assert _read_session_secret(tmp_path) == "from-environment"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,6 +109,19 @@ class TestSession:
         assert d["state"] == "idle"
         assert isinstance(d["created_at"], float)
 
+    def test_sdk_runner_receives_requested_permission_mode(self, monkeypatch, tmp_path):
+        from pinky_daemon import sdk_runner
+
+        monkeypatch.setattr(sdk_runner, "sdk_available", lambda: True)
+        session = Session(
+            session_id="permission-boundary",
+            working_dir=str(tmp_path),
+            permission_mode="plan",
+        )
+
+        assert session._runner_type == "sdk"
+        assert session._runner._config.permission_mode == "plan"
+
     @pytest.mark.asyncio
     async def test_send_message(self):
         session = Session(session_id="test")
@@ -993,6 +1006,27 @@ class TestAPI:
         resp = client.post("/sessions", json={"session_id": "my-session"})
         assert resp.status_code == 200
         assert resp.json()["id"] == "my-session"
+
+    def test_create_session_threads_tool_denials_to_sdk_runner(self, monkeypatch):
+        from pinky_daemon import sdk_runner
+
+        monkeypatch.setattr(sdk_runner, "sdk_available", lambda: True)
+        client = self._make_client()
+        resp = client.post(
+            "/sessions",
+            json={
+                "session_id": "policy-boundary",
+                "permission_mode": "acceptEdits",
+                "disallowed_tools": ["Bash", "Write"],
+            },
+        )
+
+        assert resp.status_code == 200
+        session = client.app.state.manager.get("policy-boundary")
+        assert session is not None
+        assert session.disallowed_tools == ["Bash", "Write"]
+        assert session._runner._config.permission_mode == "acceptEdits"
+        assert session._runner._config.disallowed_tools == ["Bash", "Write"]
 
     def test_get_heartbeat_settings_includes_prompt(self):
         client = self._make_client()

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a3/0af4ac4cdb943d0daffd214c02dc5f79596d71d1db40248ee4d54ac596b2/agent_client_protocol-0.11.1.tar.gz", hash = "sha256:96b02a94de53e05ec20f64cedd1b83744b64f3f94dd2b82ae5d0af88388239ea", size = 100326, upload-time = "2026-07-27T18:47:29.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/28/cc93079c418b03de7a778cabbf66ceac5add98592f5daf30cf6f4b8f9096/agent_client_protocol-0.11.1-py3-none-any.whl", hash = "sha256:42790f0a25b8fd24f5c9b27b7e0c34123fc1a980024ad8ef965d1d169a5e42d4", size = 68122, upload-time = "2026-07-27T18:47:28.27Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2207,6 +2219,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+acp = [
+    { name = "agent-client-protocol" },
+    { name = "httpx" },
+]
 all = [
     { name = "aiohttp" },
     { name = "anthropic" },
@@ -2272,6 +2288,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.11,<0.12" },
     { name = "aiohttp", marker = "extra == 'slack'", specifier = ">=3.9" },
     { name = "anthropic", marker = "extra == 'voice'", specifier = ">=0.98" },
     { name = "beautifulsoup4", marker = "extra == 'web'", specifier = ">=4.12" },
@@ -2290,6 +2307,7 @@ requires-dist = [
     { name = "google-auth-oauthlib", marker = "extra == 'calendar'", specifier = ">=1.0" },
     { name = "http-message-signatures", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.28" },
+    { name = "httpx", marker = "extra == 'acp'" },
     { name = "icalendar", marker = "extra == 'calendar'", specifier = ">=5.0" },
     { name = "markdownify", marker = "extra == 'web'", specifier = ">=1.0" },
     { name = "mcp", specifier = ">=1.27,<2.0" },
@@ -2312,7 +2330,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.44" },
     { name = "websockets", specifier = ">=15.0" },
 ]
-provides-extras = ["telegram", "discord", "slack", "google", "calendar", "web", "voice", "local-embeddings", "all", "dev"]
+provides-extras = ["acp", "telegram", "discord", "slack", "google", "calendar", "web", "voice", "local-embeddings", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Outcome

Adds `pinky acp`, a protocol-clean stdio connector that lets a configured PinkyBot agent run as a Buzz Custom harness while delegating turns to dedicated daemon manager sessions. It also closes the pre-existing daemon gap that accepted manager-session permission policy without propagating it to the SDK runner.

## What changed

- Add `PinkyAcpAgent` on the official Zed ACP Python SDK and a signed async `DaemonClient`.
- Negotiate ACP protocol version 1 with load-session and HTTP/SSE MCP capabilities disabled and no auth methods.
- Map `session/new` to generic `POST /sessions`, rooted at `data/agents/{agent}` rather than the ACP client's cwd.
- Copy model, allowed/disallowed tools, turn limits, timeout, restart settings, and the ACP-effective permission mode into the daemon session.
- Propagate manager-session `permission_mode` into `SDKRunnerConfig`; unset non-ACP callers retain the existing `bypassPermissions` behavior.
- Add `disallowed_tools` to `CreateSessionRequest` and thread it through `POST /sessions` to `SDKRunnerConfig`.
- Flatten prompt content blocks into daemon text, return one `agent_message_chunk`, and finish with `end_turn`.
- Emit thought-chunk keepalives every 60 seconds during long turns.
- Implement cancel-as-detach with `stopReason: cancelled`; the daemon turn is intentionally not interrupted until a daemon cancel endpoint exists.
- Retry daemon 409/busy responses through a bounded wait. Exhaustion becomes an ACP refusal/message, never a JSON-RPC handler error.
- Warn to stderr and ignore client MCP servers; daemon-managed `.mcp.json` stays authoritative.
- Read `PINKY_SESSION_SECRET` from the environment or checkout `.env`, and HMAC-sign every daemon call.
- Add the `acp` optional extra and install it in CI so connector tests execute.

## ACP policy boundary

Stdout is exclusively ACP JSON-RPC; all diagnostics and policy disclosures go to stderr.

- By owner ruling, Buzz stays secured: `bypassPermissions` is prohibited on the ACP surface from every source. Agent-config bypass is downgraded to `dontAsk`; `PINKY_ACP_PERMISSION_MODE=bypassPermissions` is refused with an owner-policy stderr disclosure and also resolves to `dontAsk`.
- A non-empty `PINKY_ACP_PERMISSION_MODE` may select any non-bypass mode verbatim. Without such an override, an empty agent mode is sanitized to `dontAsk`, which denies calls not pre-approved by allow rules.
- Under `dontAsk`, a non-empty agent `allowed_tools` list is preserved. If it is empty, ACP supplies: `Bash`, `Read`, `Glob`, `Grep`, `Edit`, `Write`, and the pinky memory/messaging/self MCP namespaces.
- A strict-mode allowlist without `Bash` emits a stderr warning that Buzz's CLI reply path will be denied.
- `disallowed_tools` is carried separately and removes tools from availability.

The rail is tool-granular: allowing `Bash` auto-approves all shell commands, not only `buzz messages send`; command-level policy is unavailable at this layer.

## Blast-radius audit

Production manager-backed creation has four entry shapes:

1. Generic `POST /sessions` passes the request mode. Omitted/empty remains bypass for compatibility; explicit modes are now enforced.
2. Clone-worker creation passes `agent.permission_mode`.
3. `POST /agents/{name}/sessions` passes `agent.permission_mode`.
4. Persisted restore passes the stored mode.

The current configured-agent snapshot has no `default` or `plan` modes and zero active manager sessions, so no live headless path flips into an interactive prompting mode.

- `auto`: kotik, kuzya, mora, ryzhik, solik, vaska. Their future SDK manager sessions now receive `auto`, whose SDK behavior is classifier approval/denial rather than prompting.
- `bypassPermissions`: barsik, dymok, murzik, persik, pushok. Non-ACP manager behavior is unchanged; ACP always sanitizes these to `dontAsk`.

No other production `manager.create` or direct manager `Session(...)` call sites were found.

## Known v0 limitations

- Generic `POST /sessions` does not resolve `provider_ref`/provider credentials and carries no `agent_name` attribution. ACP v0 is unsupported for provider-backed/isolated agents. The current direct-provider set is kuzya, murzik, ryzhik, and solik; no current agent uses `provider_ref`.
- The connector deliberately does not use `POST /agents/{name}/sessions`: that route rewrites the live agent's `CLAUDE.md` and `.mcp.json` from DB state, which is unsafe while DB-vs-disk reconciliation remains open in #955. A no-rewrite agent-aware creation path is follow-up work.
- A daemon-side approved-channel allowlist is tracked in #959 and is intentionally follow-up scope pending real-relay E2E confirmation of the channel identity Buzz sends in `session/new`.
- Cancel detaches locally; it does not cancel the daemon turn.

## Verification

Exact replacement head: `053e2ca2f2f119416ba6f8c0206787042fc19f4a`.

- Python 3.11: final ACP policy plus CLI plus API runner boundary — 23 passed.
- Python 3.11: SDK runner plus session store — 42 passed.
- Python 3.11: `TestSession` + `TestAPI` — 139 passed; the sole failure is the unchanged manual-dream test selecting real local tmux/Claude while shared MCP port 8890 is occupied by the running daemon. This is the same pre-existing local-environment failure previously classified on this PR.
- Real ACP subprocess handshake over stdio; daemon boundaries use `httpx.MockTransport`.
- Regressions assert requested mode reaches `SDKRunnerConfig`, `disallowed_tools` reaches it end-to-end from `POST /sessions`, bypass/empty ACP policy resolves to strict mode, defaults are injected only for an empty strict-mode allowlist, non-empty agent policy is preserved, missing Bash warns, the env bypass override is refused by owner policy, and non-bypass env overrides remain verbatim.
- Ruff, lock check, compileall, and `git diff --check` clean.
- Base-only wheel verification remains valid: `pinky --help` works; invoking `pinky acp` without the optional extra exits 2 with actionable stderr and empty stdout.

## Provenance

Implemented by Kuzya from Barsik's Buzz/ACP research brief and task #496 specification. Daemon enforcement and ACP policy corrections incorporate Murzik's review findings and Barsik's final policy direction.

🤖 Opened by Kuzya