### PR TITLE
pinky_memory: reflect() falls back to 'fact' on invalid type instead of crashing

### DIFF
--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -32,6 +32,18 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+def _parse_reflection_type(type_str: str) -> ReflectionType:
+    """Coerce a caller-supplied type to ReflectionType, defaulting to `fact`
+    on an unrecognized value instead of raising. Callers (including dream
+    runs) occasionally pass a plausible-sounding but invalid type; failing
+    hard here previously aborted the entire dream run (#session_log bug)."""
+    try:
+        return ReflectionType(type_str)
+    except ValueError:
+        _log(f"reflect: invalid type={type_str!r}, defaulting to 'fact'")
+        return ReflectionType.fact
+
+
 # Strict agent-name slug for cross-agent memory targets (#614/#145). Mirrors
 # the trust-boundary slug discipline tracked in #105 — defends the
 # store-factory path resolution against traversal / injection even though the
@@ -369,7 +381,7 @@ def create_server(
         """
         input_data = ReflectInput(
             content=content,
-            type=ReflectionType(type),
+            type=_parse_reflection_type(type),
             context=context,
             project=project,
             salience=salience,
@@ -430,7 +442,7 @@ def create_server(
             s = _resolve_target_store(target_agent)
             input_data = ReflectInput(
                 content=content,
-                type=ReflectionType(type),
+                type=_parse_reflection_type(type),
                 context=context,
                 project=project,
                 salience=salience,

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -189,6 +189,16 @@ class TestReflect:
         assert result["salience"] == 5
         assert result["type"] == "project_state"
 
+    def test_reflect_invalid_type_falls_back_to_fact(self, srv):
+        """Regression: an unrecognized type (e.g. dream-hallucinated 'session_log')
+        must not raise — it previously crashed the whole dream run."""
+        result = json.loads(_tools(srv)["reflect"](
+            content="something the dream agent decided to call session_log",
+            type="session_log",
+        ))
+        assert result["stored"] is True
+        assert result["type"] == "fact"
+
     def test_reflect_supersedes(self, srv, store):
         # First memory
         r1 = json.loads(_tools(srv)["reflect"](content="old fact", type="fact"))


### PR DESCRIPTION
## Problem

`reflect()` and `reflect_for()` in `src/pinky_memory/server.py` built their `ReflectInput` with a bare `ReflectionType(type)`. A caller passing an unrecognized value raised an unhandled `ValueError`.

This is not hypothetical: dream runs occasionally invent a plausible-sounding but invalid type (observed in the wild: `session_log`). Because the exception propagated out of the tool call, a single bad memory write aborted the **entire dream run** rather than failing just that one write.

## Fix

Add `_parse_reflection_type()`, which coerces the caller-supplied string to a `ReflectionType` and falls back to `fact` on an unrecognized value, logging the coercion to stderr. Both `reflect()` and `reflect_for()` now use it.

The failure mode goes from "lose the whole dream run" to "one memory is filed as `fact` and the log says why".

## Testing

- Added `test_reflect_invalid_type_falls_back_to_fact` — regression test passing `type="session_log"`, asserting the write succeeds and lands as `fact`.
- `pytest tests/test_memory_server.py` → **64 passed**
- `ruff check` on both touched files → clean

## Notes

- +24/-2 across 2 files, additive and behavior-preserving for every valid type.
- Valid types are unaffected; only the previously-crashing path changes.

🤖 Opened by Engineer