### PR TITLE
fix(sqlite): move every long-lived daemon store off WAL to rollback journalling

### DIFF
--- a/src/pinky_daemon/activity_store.py
+++ b/src/pinky_daemon/activity_store.py
@@ -13,6 +13,8 @@ import threading
 import time
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 class ActivityStore:
     """SQLite-backed activity log."""
@@ -29,8 +31,7 @@ class ActivityStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="activity.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/agent_comms.py
+++ b/src/pinky_daemon/agent_comms.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 @dataclass
 class AgentMessage:
@@ -83,8 +85,7 @@ class AgentComms:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.row_factory = sqlite3.Row
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="agent_comms.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -6,6 +6,8 @@ import sqlite3
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 # Providers to include in analytics dashboards.
 # Only Anthropic/Claude usage — excludes Codex CLI (OpenAI) and other non-Anthropic providers.
 _ANTHROPIC_PROVIDERS = {"firstParty", "default", "anthropic", "bedrock", "vertex"}
@@ -77,10 +79,12 @@ class AnalyticsStore:
 
     def _init_db(self) -> None:
         with self._connect() as conn:
+            # Runs once per store construction, before any other connection is
+            # handed out. TRUNCATE is persisted in the database header, so the
+            # short-lived connections from _connect() inherit it.
+            configure_rollback_journal(conn, db_label="analytics.db")
             conn.executescript(
                 """
-                PRAGMA journal_mode=WAL;
-
                 CREATE TABLE IF NOT EXISTS analytics_session_facts (
                   session_id TEXT PRIMARY KEY,
                   agent_name TEXT NOT NULL,

--- a/src/pinky_daemon/app_store.py
+++ b/src/pinky_daemon/app_store.py
@@ -18,6 +18,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -78,7 +80,7 @@ class AppStore:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(self._db, db_label="apps.db")
         self._db.execute("PRAGMA foreign_keys=ON")
         self._init_tables()
 

--- a/src/pinky_daemon/conversation_store.py
+++ b/src/pinky_daemon/conversation_store.py
@@ -18,6 +18,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _fts5_phrase(query: str) -> str:
     """Escape a user query as quoted FTS5 phrase tokens (no operator syntax)."""
@@ -94,8 +96,7 @@ class ConversationStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.row_factory = sqlite3.Row
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="conversations.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -33,6 +33,7 @@ from pinky_daemon.auth import (
 )
 from pinky_daemon.dream_prompt import DREAM_SYSTEM_PROMPT
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig
+from pinky_daemon.sqlite_journal import configure_rollback_journal
 from pinky_daemon.tmux_dream_runner import TmuxDreamConfig, TmuxDreamRunner
 
 
@@ -114,8 +115,7 @@ class DreamRunner:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="dreams.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/hooks.py
+++ b/src/pinky_daemon/hooks.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -133,8 +135,7 @@ class AuditStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="audit.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/kb_store.py
+++ b/src/pinky_daemon/kb_store.py
@@ -34,6 +34,8 @@ from pathlib import Path
 
 import yaml
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -177,7 +179,7 @@ class KBStore:
 
     def _conn(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self.db_path))
-        conn.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(conn, db_label="kb.db")
         conn.execute("PRAGMA foreign_keys=ON")
         conn.row_factory = sqlite3.Row
         return conn

--- a/src/pinky_daemon/librarian_runner.py
+++ b/src/pinky_daemon/librarian_runner.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from pinky_daemon.kb_store import _FRONTMATTER_RE, KBStore, _content_hash
 from pinky_daemon.librarian_prompt import LIBRARIAN_SYSTEM_PROMPT
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig
+from pinky_daemon.sqlite_journal import configure_rollback_journal
 
 
 def _log(msg: str) -> None:
@@ -66,7 +67,7 @@ class LibrarianRunner:
 
     def _conn(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self._db_path))
-        conn.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(conn, db_label="librarian_state.db")
         conn.row_factory = sqlite3.Row
         return conn
 

--- a/src/pinky_daemon/mesh_store.py
+++ b/src/pinky_daemon/mesh_store.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 # -- Records -------------------------------------------------------------------
 
 
@@ -102,7 +104,7 @@ class MeshStore:
     def __init__(self, db_path: str = "data/mesh.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(self._db, db_label="mesh.db")
         self._db.execute("PRAGMA foreign_keys=ON")
         self._lock = threading.RLock()
         self._init_tables()

--- a/src/pinky_daemon/message_context_store.py
+++ b/src/pinky_daemon/message_context_store.py
@@ -9,6 +9,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 DEFAULT_RETENTION_DAYS = 30
 DEFAULT_MAX_PER_AGENT = 1000
 
@@ -30,8 +32,10 @@ class MessageContextStore:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         self._db.row_factory = sqlite3.Row
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA busy_timeout=5000")
+        # configure_rollback_journal also installs a 30s busy_timeout, which
+        # replaces the 5s this store used to set: rollback journalling
+        # serialises readers against the writer, so waiting longer is right.
+        configure_rollback_journal(self._db, db_label="message_context.db")
         self._create_schema()
         self._ensure_columns()
         self._ensure_identity_key()

--- a/src/pinky_daemon/outreach_config.py
+++ b/src/pinky_daemon/outreach_config.py
@@ -17,6 +17,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -53,7 +55,7 @@ class OutreachConfigStore:
     def __init__(self, db_path: str = "data/outreach_config.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(self._db, db_label="outreach_config.db")
         self._init_tables()
 
     def _init_tables(self) -> None:

--- a/src/pinky_daemon/plugin_manager.py
+++ b/src/pinky_daemon/plugin_manager.py
@@ -38,6 +38,8 @@ from typing import Any, Callable
 
 import yaml
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -139,7 +141,7 @@ class PluginContext:
                 data_dir.mkdir(parents=True, exist_ok=True)
                 self._db_path = str(data_dir / "plugins.db")
             self._db = sqlite3.connect(self._db_path, check_same_thread=False)
-            self._db.execute("PRAGMA journal_mode=WAL")
+            configure_rollback_journal(self._db, db_label="plugins.db")
         return self._db
 
     def create_table(self, table_name: str, schema: str) -> None:
@@ -296,7 +298,7 @@ class PluginManager:
         """Initialize the plugin state tracking table."""
         Path(self._state_db_path).parent.mkdir(parents=True, exist_ok=True)
         db = sqlite3.connect(self._state_db_path, check_same_thread=False)
-        db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(db, db_label="plugins.db")
         db.execute("""
             CREATE TABLE IF NOT EXISTS plugin_state (
                 name TEXT PRIMARY KEY,

--- a/src/pinky_daemon/presentation_store.py
+++ b/src/pinky_daemon/presentation_store.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -137,8 +139,7 @@ class PresentationStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="presentations.db")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/research_store.py
+++ b/src/pinky_daemon/research_store.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -147,8 +149,7 @@ class ResearchStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="research.db")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/session_store.py
+++ b/src/pinky_daemon/session_store.py
@@ -20,6 +20,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -71,8 +73,7 @@ class SessionStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="sessions.db")
             self._thread_local.connection = connection
         return connection
 
@@ -314,8 +315,7 @@ class SessionEventStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="sessions.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/skill_store.py
+++ b/src/pinky_daemon/skill_store.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -153,8 +155,7 @@ class SkillStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="skills.db")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/sqlite_journal.py
+++ b/src/pinky_daemon/sqlite_journal.py
@@ -1,0 +1,103 @@
+"""Shared SQLite journal-mode configuration for long-lived daemon stores.
+
+WAL mode is unsafe for the way this daemon holds SQLite open. Two properties
+combine badly:
+
+1. Every store opens the same database file once **per thread**
+   (``self._thread_local.connection``), so a single process holds several
+   independent connections to one file.
+2. POSIX record locks are owned per ``(process, inode)``, not per descriptor.
+   The moment *any* of those connections is closed — a worker thread ending, an
+   explicit ``_reset_connection()`` — the process drops **all** of its advisory
+   locks on that file, including the ones the surviving connections still rely
+   on.
+
+After that the daemon is invisible to other processes: the next external opener
+(a backup, an operator running ``sqlite3``, a script) sees an unlocked database,
+believes it is the sole connection, and on close checkpoints and **unlinks** the
+``-wal``/``-shm``. The daemon's surviving connections keep writing happily into
+the now-orphaned inode. Those writes are visible only through the daemon itself;
+every external reader sees data frozen at the last checkpoint, and the whole tail
+is lost when the process exits.
+
+That failure mode was observed in production on 2026-08-01: four stores
+(conversations, tasks, agent_comms, research) were left holding
+``...-wal (deleted)`` with 54 messages, 5 inbox rows and 2 tasks reachable only
+from the daemon's address space, while ``/proc/<pid>/locks`` showed the daemon
+holding no locks at all.
+
+Rollback (TRUNCATE) journalling sidesteps the whole class: committed data lives
+in the main database file, there is no ``-wal`` for anyone to unlink and no
+``-shm`` to map. It is the same remedy already applied to
+``conversations_agents.db`` (#797/#220), the skills DB and the dream runner —
+this module exists so those hand-rolled copies can converge on one
+implementation instead of drifting.
+
+Trade-off, deliberately accepted: rollback mode serialises readers against the
+writer. These stores are low-throughput control-plane data, and correctness of
+the write path matters more here than reader concurrency.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+
+class SqliteJournalConfigError(RuntimeError):
+    """A store connection could not be moved off WAL."""
+
+
+def configure_rollback_journal(
+    conn: sqlite3.Connection,
+    *,
+    db_label: str,
+    busy_ms: int = 30_000,
+    retries: int = 6,
+) -> str:
+    """Put ``conn`` in rollback (TRUNCATE) journal mode and confirm it took.
+
+    Must run BEFORE table init and before anything can spawn stdio children that
+    hold the database, so an existing WAL file is converted in place while the
+    daemon is still the only writer.
+
+    Any hot WAL content is checkpointed first, so nothing committed is stranded
+    when the wal-index is dropped. A busy database during that drain is
+    non-fatal — the mode switch below retries.
+
+    Fails LOUD: raises :class:`SqliteJournalConfigError` rather than silently
+    running on WAL, because a silent fallback is exactly the state that loses
+    writes.
+
+    Args:
+        conn: Connection to configure, before any table creation.
+        db_label: Human-readable database name, used in the error message.
+        busy_ms: ``busy_timeout`` applied to the connection.
+        retries: Bounded attempts before giving up.
+
+    Returns:
+        The effective journal mode, always ``"truncate"``.
+    """
+    conn.execute(f"PRAGMA busy_timeout={int(busy_ms)}")
+    last: str | None = None
+    for attempt in range(retries):
+        try:
+            cur = conn.execute("PRAGMA journal_mode").fetchone()
+            if cur and str(cur[0]).lower() == "wal":
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except sqlite3.OperationalError:
+            pass
+        try:
+            row = conn.execute("PRAGMA journal_mode=TRUNCATE").fetchone()
+            last = str(row[0]).lower() if row else None
+            if last == "truncate":
+                return last
+        except sqlite3.OperationalError as exc:
+            last = f"error:{exc}"
+        time.sleep(0.2 * (attempt + 1))
+
+    raise SqliteJournalConfigError(
+        f"{db_label} refused to leave WAL: journal_mode={last!r} after {retries} "
+        f"attempts — refusing to run on WAL, where an unlinked -wal silently "
+        f"strands committed writes in the daemon's address space (#797/#220)."
+    )

--- a/src/pinky_daemon/task_store.py
+++ b/src/pinky_daemon/task_store.py
@@ -22,6 +22,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -195,8 +197,7 @@ class TaskStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="tasks.db")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/trigger_store.py
+++ b/src/pinky_daemon/trigger_store.py
@@ -19,6 +19,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -87,8 +89,7 @@ class TriggerStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="triggers.db")
             connection.execute("PRAGMA foreign_keys=ON")
             connection.row_factory = sqlite3.Row
             self._thread_local.connection = connection

--- a/src/pinky_daemon/user_profile_store.py
+++ b/src/pinky_daemon/user_profile_store.py
@@ -18,6 +18,8 @@ import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 @dataclass
 class ProfileEntry:
@@ -90,8 +92,7 @@ class UserProfileStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="user_profiles.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/voice_store.py
+++ b/src/pinky_daemon/voice_store.py
@@ -21,6 +21,8 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -229,8 +231,7 @@ class VoiceStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="voice_calls.db")
             connection.execute("PRAGMA foreign_keys=ON")
             connection.row_factory = sqlite3.Row
             self._thread_local.connection = connection

--- a/tests/test_activity_store.py
+++ b/tests/test_activity_store.py
@@ -32,7 +32,7 @@ class TestActivityStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
                 agent_name = f"worker-{worker_index}"
                 for round_index in range(rounds):

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -46,7 +46,7 @@ class TestDreamRunnerConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
                 agent_name = f"worker-{worker_index}"
                 for round_index in range(rounds):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -33,7 +33,7 @@ class TestAuditStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
                 for round_index in range(rounds):
                     marker = f"{worker_index}-{round_index}"

--- a/tests/test_message_context_store.py
+++ b/tests/test_message_context_store.py
@@ -71,7 +71,7 @@ def test_context_survives_broker_restart_via_load_through(tmp_path):
     second_store.close()
 
 
-def test_store_uses_wal_and_self_heals_optional_columns(tmp_path):
+def test_store_uses_rollback_journal_and_self_heals_optional_columns(tmp_path):
     db_path = tmp_path / "message-context.db"
     legacy = sqlite3.connect(db_path)
     legacy.execute(
@@ -104,7 +104,9 @@ def test_store_uses_wal_and_self_heals_optional_columns(tmp_path):
         for row in store._db.execute("PRAGMA table_info(message_contexts)").fetchall()
     }
 
-    assert str(mode).lower() == "wal"
+    # Rollback journalling, not WAL: an unlinked -wal silently strands
+    # committed writes in the daemon's address space (#797/#220).
+    assert str(mode).lower() == "truncate"
     assert {"reply_to", "attachments_json", "metadata_json", "stored_at"} <= columns
     primary_key = tuple(
         row["name"]

--- a/tests/test_presentation_store.py
+++ b/tests/test_presentation_store.py
@@ -39,7 +39,7 @@ class TestPresentationStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
                 for round_index in range(rounds):
                     marker = f"{worker_index}-{round_index}"

--- a/tests/test_research_store.py
+++ b/tests/test_research_store.py
@@ -32,7 +32,7 @@ class TestResearchStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
                 for round_index in range(rounds):
                     marker = f"{worker_index}-{round_index}"

--- a/tests/test_skill_store.py
+++ b/tests/test_skill_store.py
@@ -136,7 +136,7 @@ class TestSkillStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
                 for round_index in range(rounds):
                     marker = f"{worker_index}-{round_index}"

--- a/tests/test_sqlite_journal.py
+++ b/tests/test_sqlite_journal.py
@@ -14,14 +14,29 @@ from pathlib import Path
 
 import pytest
 
+from pinky_daemon.activity_store import ActivityStore
 from pinky_daemon.agent_comms import AgentComms
+from pinky_daemon.analytics_store import AnalyticsStore
+from pinky_daemon.app_store import AppStore
 from pinky_daemon.conversation_store import ConversationStore
+from pinky_daemon.hooks import AuditStore
+from pinky_daemon.kb_store import KBStore
+from pinky_daemon.librarian_runner import LibrarianRunner
+from pinky_daemon.mesh_store import MeshStore
+from pinky_daemon.message_context_store import MessageContextStore
+from pinky_daemon.outreach_config import OutreachConfigStore
+from pinky_daemon.plugin_manager import PluginManager
+from pinky_daemon.presentation_store import PresentationStore
 from pinky_daemon.research_store import ResearchStore
+from pinky_daemon.session_store import SessionEventStore, SessionStore
 from pinky_daemon.sqlite_journal import (
     SqliteJournalConfigError,
     configure_rollback_journal,
 )
 from pinky_daemon.task_store import TaskStore
+from pinky_daemon.trigger_store import TriggerStore
+from pinky_daemon.user_profile_store import UserProfileStore
+from pinky_daemon.voice_store import VoiceStore
 
 
 def _journal_mode(db_path: Path) -> str:
@@ -179,6 +194,18 @@ def test_fts5_shadow_tables_survive_the_wal_conversion(tmp_path):
         (TaskStore, "tasks.db", "_db"),
         (AgentComms, "agent_comms.db", "_conn"),
         (ResearchStore, "research.db", "_db"),
+        (ActivityStore, "activity.db", "_db"),
+        (AppStore, "apps.db", "_db"),
+        (AuditStore, "audit.db", "_db"),
+        (MeshStore, "mesh.db", "_db"),
+        (MessageContextStore, "message_context.db", "_db"),
+        (OutreachConfigStore, "outreach_config.db", "_db"),
+        (PresentationStore, "presentations.db", "_db"),
+        (SessionStore, "sessions.db", "_db"),
+        (SessionEventStore, "session_events.db", "_db"),
+        (TriggerStore, "triggers.db", "_db"),
+        (UserProfileStore, "user_profiles.db", "_db"),
+        (VoiceStore, "voice_calls.db", "_db"),
     ],
 )
 def test_stores_open_in_rollback_mode(tmp_path, factory, filename, conn_attr):
@@ -188,3 +215,46 @@ def test_stores_open_in_rollback_mode(tmp_path, factory, filename, conn_attr):
     assert getattr(store, conn_attr) is not None
     assert _journal_mode(db_path) != "wal"
     assert not (tmp_path / f"{filename}-wal").exists()
+
+
+def test_per_call_connection_stores_open_in_rollback_mode(tmp_path):
+    """Stores that open a fresh connection per call, not one long-lived handle.
+
+    These are just as exposed: two overlapping short connections in one process
+    still share POSIX locks, so whichever closes first drops the locks the other
+    is relying on.
+    """
+    kb = KBStore(data_dir=str(tmp_path / "kb"))
+    assert _journal_mode(Path(kb.db_path)) != "wal"
+    assert not Path(str(kb.db_path) + "-wal").exists()
+
+    librarian_db = tmp_path / "librarian_state.db"
+    LibrarianRunner(kb, db_path=str(librarian_db))
+    assert _journal_mode(librarian_db) != "wal"
+
+    analytics_db = tmp_path / "analytics.db"
+    AnalyticsStore(db_path=str(analytics_db))
+    assert _journal_mode(analytics_db) != "wal"
+
+    plugins_db = tmp_path / "plugins.db"
+    PluginManager(
+        db_path=str(plugins_db),
+        api_url="http://localhost:8888",
+        working_dir=str(tmp_path / "wd"),
+    )
+    assert _journal_mode(plugins_db) != "wal"
+
+
+def test_no_daemon_module_still_asks_for_wal():
+    """Guard against a new store landing back on WAL by copy-paste."""
+    src = Path(__file__).resolve().parents[1] / "src" / "pinky_daemon"
+    offenders = [
+        f"{path.relative_to(src)}:{n}"
+        for path in sorted(src.rglob("*.py"))
+        for n, line in enumerate(path.read_text().splitlines(), 1)
+        if "journal_mode=WAL" in line
+    ]
+    assert offenders == [], (
+        "these daemon modules still open SQLite in WAL mode — use "
+        f"configure_rollback_journal() instead: {offenders}"
+    )

--- a/tests/test_sqlite_journal.py
+++ b/tests/test_sqlite_journal.py
@@ -1,0 +1,190 @@
+"""Rollback-journal configuration for the long-lived daemon stores.
+
+Regression cover for the 2026-08-01 orphaned-WAL incident: WAL mode plus
+per-thread connections let an external process unlink the ``-wal`` out from
+under the daemon, stranding committed writes in its address space.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from pinky_daemon.agent_comms import AgentComms
+from pinky_daemon.conversation_store import ConversationStore
+from pinky_daemon.research_store import ResearchStore
+from pinky_daemon.sqlite_journal import (
+    SqliteJournalConfigError,
+    configure_rollback_journal,
+)
+from pinky_daemon.task_store import TaskStore
+
+
+def _journal_mode(db_path: Path) -> str:
+    """Journal mode seen by a *fresh* connection, i.e. what the file persists.
+
+    SQLite only records "WAL vs rollback" in the database header — it does not
+    persist *which* rollback mode. A new connection therefore reports the
+    compile-time default ("delete") even when the writer set TRUNCATE, so
+    callers assert on the family (``!= "wal"``), not on the exact value.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        return str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+    finally:
+        conn.close()
+
+
+def test_configure_returns_truncate_on_fresh_db(tmp_path):
+    conn = sqlite3.connect(tmp_path / "fresh.db")
+    assert configure_rollback_journal(conn, db_label="fresh.db") == "truncate"
+    conn.close()
+
+
+def test_converts_an_existing_wal_database_in_place(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    seed = sqlite3.connect(db_path)
+    seed.execute("PRAGMA journal_mode=WAL")
+    seed.execute("CREATE TABLE t (v TEXT)")
+    seed.execute("INSERT INTO t VALUES ('committed-under-wal')")
+    seed.commit()
+    seed.close()
+    assert _journal_mode(db_path) == "wal"
+
+    conn = sqlite3.connect(db_path)
+    assert configure_rollback_journal(conn, db_label="legacy.db") == "truncate"
+
+    # Content written under WAL survives the conversion — the helper checkpoints
+    # before dropping the wal-index.
+    assert conn.execute("SELECT v FROM t").fetchone()[0] == "committed-under-wal"
+    conn.close()
+    assert _journal_mode(db_path) != "wal"
+
+
+def test_leaves_no_wal_or_shm_sidecars(tmp_path):
+    """The whole point: no ``-wal``/``-shm`` for another process to unlink."""
+    db_path = tmp_path / "sidecars.db"
+    conn = sqlite3.connect(db_path)
+    configure_rollback_journal(conn, db_label="sidecars.db")
+    conn.execute("CREATE TABLE t (v TEXT)")
+    conn.execute("INSERT INTO t VALUES ('x')")
+    conn.commit()
+
+    assert not (tmp_path / "sidecars.db-wal").exists()
+    assert not (tmp_path / "sidecars.db-shm").exists()
+    conn.close()
+
+
+def test_committed_writes_are_visible_to_a_separate_process_handle(tmp_path):
+    """The incident symptom, inverted: an outside reader must see the write.
+
+    Under the orphaned WAL, ``sqlite3`` from outside saw data frozen at the last
+    checkpoint while the daemon reported success.
+    """
+    db_path = tmp_path / "visible.db"
+    daemon_conn = sqlite3.connect(db_path)
+    configure_rollback_journal(daemon_conn, db_label="visible.db")
+    daemon_conn.execute("CREATE TABLE t (v TEXT)")
+    daemon_conn.execute("INSERT INTO t VALUES ('written-by-daemon')")
+    daemon_conn.commit()
+
+    outsider = sqlite3.connect(db_path)
+    assert outsider.execute("SELECT v FROM t").fetchone()[0] == "written-by-daemon"
+    outsider.close()
+    daemon_conn.close()
+
+
+class _RefusesModeSwitch(sqlite3.Connection):
+    """A connection that always reports the database as locked for the switch.
+
+    ``sqlite3.Connection`` is a C type, so its ``execute`` cannot be
+    monkeypatched on an instance — subclassing via ``connect(factory=...)`` is
+    the way to simulate a database that will not leave WAL.
+    """
+
+    def execute(self, sql, *args):  # noqa: D102 - inherited contract
+        if "journal_mode=TRUNCATE" in sql:
+            raise sqlite3.OperationalError("database is locked")
+        return super().execute(sql, *args)
+
+
+def test_raises_rather_than_silently_staying_on_wal(tmp_path):
+    """A silent WAL fallback is the state that loses writes — it must fail loud."""
+    conn = sqlite3.connect(tmp_path / "stuck.db", factory=_RefusesModeSwitch)
+
+    with pytest.raises(SqliteJournalConfigError, match="refused to leave WAL"):
+        configure_rollback_journal(conn, db_label="stuck.db", retries=2)
+    conn.close()
+
+
+# Seeds a conversations.db under WAL and exits WITHOUT closing the connection,
+# leaving a hot -wal behind — the state conversation_store's checkpoint has to
+# survive. os._exit skips interpreter cleanup, so SQLite never checkpoints.
+_HOT_WAL_SEEDER = """
+import os, sys
+sys.path.insert(0, {src!r})
+import sqlite3
+from pinky_daemon.conversation_store import ConversationStore
+
+store = ConversationStore(db_path={db!r})
+store._conn.execute("PRAGMA journal_mode=WAL")
+store.append("s1", "user", "checkpointed under wal")
+store.append("s1", "agent", "hot in the wal file")
+assert store._conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+os._exit(0)
+"""
+
+
+def test_fts5_shadow_tables_survive_the_wal_conversion(tmp_path):
+    """conversation_store.py warns that checkpointing with live writers corrupts
+    the FTS5 shadow tables. Our checkpoint runs at connection open, before table
+    init and with no concurrent writer — this pins that it is in fact safe, on a
+    genuinely hot WAL rather than on the reasoning alone.
+    """
+    db_path = tmp_path / "conversations.db"
+    src = str(Path(__file__).resolve().parents[1] / "src")
+    seeded = subprocess.run(
+        [sys.executable, "-c", _HOT_WAL_SEEDER.format(src=src, db=str(db_path))],
+        capture_output=True,
+        text=True,
+    )
+    assert seeded.returncode == 0, seeded.stderr
+    assert db_path.with_name("conversations.db-wal").exists(), "no hot WAL to convert"
+
+    # Opening the store checkpoints the hot WAL and converts to rollback mode.
+    store = ConversationStore(db_path=str(db_path))
+
+    integrity = store._conn.execute(
+        "INSERT INTO messages_fts(messages_fts) VALUES('integrity-check')"
+    )
+    assert integrity is not None  # raises DatabaseError if the index is corrupt
+
+    # Both the checkpointed and the WAL-resident row are searchable...
+    assert len(store.search("checkpointed")) == 1
+    assert len(store.search("hot")) == 1
+    # ...and the triggers keep indexing after the conversion.
+    store.append("s1", "user", "indexed after the conversion")
+    assert len(store.search("conversion")) == 1
+    store.close()
+
+
+@pytest.mark.parametrize(
+    ("factory", "filename", "conn_attr"),
+    [
+        (ConversationStore, "conversations.db", "_conn"),
+        (TaskStore, "tasks.db", "_db"),
+        (AgentComms, "agent_comms.db", "_conn"),
+        (ResearchStore, "research.db", "_db"),
+    ],
+)
+def test_stores_open_in_rollback_mode(tmp_path, factory, filename, conn_attr):
+    db_path = tmp_path / filename
+    store = factory(db_path=str(db_path))
+    # Touch the lazy per-thread connection so the store actually opens.
+    assert getattr(store, conn_attr) is not None
+    assert _journal_mode(db_path) != "wal"
+    assert not (tmp_path / f"{filename}-wal").exists()

--- a/tests/test_trigger_store.py
+++ b/tests/test_trigger_store.py
@@ -69,7 +69,7 @@ class TestTriggerStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
                 for round_index in range(rounds):
                     marker = f"{worker_index}-{round_index}"

--- a/tests/test_user_profile_store.py
+++ b/tests/test_user_profile_store.py
@@ -36,7 +36,7 @@ class TestUserProfileStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
                 chat_id = f"worker-{worker_index}"
                 for round_index in range(rounds):

--- a/tests/test_voice_store.py
+++ b/tests/test_voice_store.py
@@ -33,7 +33,7 @@ class TestVoiceStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
                 assert connection.row_factory is sqlite3.Row
                 for round_index in range(rounds):


### PR DESCRIPTION
## Why

Production incident on **2026-08-01**: four daemon stores (`conversations`, `tasks`, `agent_comms`, `research`) were found holding `…-wal (deleted)`, with 54 messages, 5 inbox rows and 2 tasks reachable **only** from the daemon's address space. `/proc/<pid>/locks` showed the daemon holding no locks at all.

The failure mode is structural, not a one-off:

1. Every store opens the same database file **once per thread** (`self._thread_local.connection`), so one process holds several independent connections to one inode.
2. POSIX record locks are owned per `(process, inode)`, not per descriptor. The moment *any* of those connections closes — a worker thread ending, an explicit `_reset_connection()` — the process drops **all** of its advisory locks on that file, including the ones the surviving connections still rely on.
3. The daemon is then invisible to other processes. The next external opener (a backup, an operator running `sqlite3`, a script) sees an unlocked database, believes it is the sole connection, and on close checkpoints and **unlinks** the `-wal`/`-shm`.
4. The daemon's surviving connections keep writing into the now-orphaned inode. Those writes are visible only through the daemon; every external reader sees data frozen at the last checkpoint, and the whole tail is lost when the process exits.

Note that #956's `_reset_connection()` healing closes a connection — i.e. it is itself a trigger for step 2. That pattern is untouched here; under rollback journalling there is no `-wal` for anyone to unlink, so the trigger no longer has a payload.

## What

New module `src/pinky_daemon/sqlite_journal.py` with `configure_rollback_journal(conn, db_label=…)`:

- checkpoints any hot WAL **first**, so nothing committed is stranded when the wal-index is dropped;
- switches to `journal_mode=TRUNCATE` with bounded retries and `busy_timeout` (default 30s, same value as #942);
- **fails loud** (`SqliteJournalConfigError`) rather than silently running on WAL — a silent fallback is exactly the state that loses writes.

It is called from the thread-local connection factory of every long-lived daemon store, so *each* per-thread connection is configured, not just the first:

`activity`, `agent_comms`, `apps`, `audit` (`hooks.AuditStore`), `conversations`, `dreams`, `mesh`, `message_context`, `outreach_config`, `presentations`, `research`, `sessions` (×2), `skills`, `tasks`, `triggers`, `user_profiles`, `voice_calls` — plus the per-call connections in `kb_store`, `librarian_runner`, `analytics_store` and `plugin_manager` (×2).

This converges the hand-rolled copies already living in `conversations_agents.db` (#797/#220) on one implementation instead of letting them drift.

`dreams.db` and `skills.db` are included: the module docstring notes them as already-remedied, but the thread-local refactor put both back on `PRAGMA journal_mode=WAL` in their connection factory. This restores them.

**Trade-off, deliberately accepted:** rollback mode serialises readers against the writer. These are low-throughput control-plane stores; correctness of the write path matters more here than reader concurrency.

## Out of scope

Still on WAL, untouched by this PR: `pinky_identity` (2 sites), `pinky_hub`, `pinky_federation`, `pinky_memory` (2 sites). Worth a follow-up.

## Tests

- New `tests/test_sqlite_journal.py`: mode conversion, hot-WAL drain, retry/fail-loud behaviour, and a subprocess test pinning that the FTS5 shadow tables in `conversations.db` survive the checkpoint on a genuinely hot WAL (not just on the reasoning).
- The existing per-store concurrency hammers now assert `truncate` instead of `wal` on each thread-local connection.

🤖 Opened by Engineer
