### PR TITLE
fix(sqlite): move the non-daemon stores off WAL to rollback journalling (#356)

### DIFF
--- a/src/pinky_daemon/activity_store.py
+++ b/src/pinky_daemon/activity_store.py
@@ -13,6 +13,8 @@ import threading
 import time
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 class ActivityStore:
     """SQLite-backed activity log."""
@@ -29,8 +31,7 @@ class ActivityStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="activity.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/agent_comms.py
+++ b/src/pinky_daemon/agent_comms.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 @dataclass
 class AgentMessage:
@@ -83,8 +85,7 @@ class AgentComms:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.row_factory = sqlite3.Row
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="agent_comms.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -6,6 +6,8 @@ import sqlite3
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 # Providers to include in analytics dashboards.
 # Only Anthropic/Claude usage — excludes Codex CLI (OpenAI) and other non-Anthropic providers.
 _ANTHROPIC_PROVIDERS = {"firstParty", "default", "anthropic", "bedrock", "vertex"}
@@ -77,10 +79,12 @@ class AnalyticsStore:
 
     def _init_db(self) -> None:
         with self._connect() as conn:
+            # Runs once per store construction, before any other connection is
+            # handed out. TRUNCATE is persisted in the database header, so the
+            # short-lived connections from _connect() inherit it.
+            configure_rollback_journal(conn, db_label="analytics.db")
             conn.executescript(
                 """
-                PRAGMA journal_mode=WAL;
-
                 CREATE TABLE IF NOT EXISTS analytics_session_facts (
                   session_id TEXT PRIMARY KEY,
                   agent_name TEXT NOT NULL,

--- a/src/pinky_daemon/app_store.py
+++ b/src/pinky_daemon/app_store.py
@@ -18,6 +18,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -78,7 +80,7 @@ class AppStore:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(self._db, db_label="apps.db")
         self._db.execute("PRAGMA foreign_keys=ON")
         self._init_tables()
 

--- a/src/pinky_daemon/conversation_store.py
+++ b/src/pinky_daemon/conversation_store.py
@@ -18,6 +18,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _fts5_phrase(query: str) -> str:
     """Escape a user query as quoted FTS5 phrase tokens (no operator syntax)."""
@@ -94,8 +96,7 @@ class ConversationStore:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.row_factory = sqlite3.Row
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="conversations.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -33,6 +33,7 @@ from pinky_daemon.auth import (
 )
 from pinky_daemon.dream_prompt import DREAM_SYSTEM_PROMPT
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig
+from pinky_daemon.sqlite_journal import configure_rollback_journal
 from pinky_daemon.tmux_dream_runner import TmuxDreamConfig, TmuxDreamRunner
 
 
@@ -114,8 +115,7 @@ class DreamRunner:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="dreams.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/hooks.py
+++ b/src/pinky_daemon/hooks.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -133,8 +135,7 @@ class AuditStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="audit.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/kb_store.py
+++ b/src/pinky_daemon/kb_store.py
@@ -34,6 +34,8 @@ from pathlib import Path
 
 import yaml
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -177,7 +179,7 @@ class KBStore:
 
     def _conn(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self.db_path))
-        conn.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(conn, db_label="kb.db")
         conn.execute("PRAGMA foreign_keys=ON")
         conn.row_factory = sqlite3.Row
         return conn

--- a/src/pinky_daemon/librarian_runner.py
+++ b/src/pinky_daemon/librarian_runner.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from pinky_daemon.kb_store import _FRONTMATTER_RE, KBStore, _content_hash
 from pinky_daemon.librarian_prompt import LIBRARIAN_SYSTEM_PROMPT
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig
+from pinky_daemon.sqlite_journal import configure_rollback_journal
 
 
 def _log(msg: str) -> None:
@@ -66,7 +67,7 @@ class LibrarianRunner:
 
     def _conn(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self._db_path))
-        conn.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(conn, db_label="librarian_state.db")
         conn.row_factory = sqlite3.Row
         return conn
 

--- a/src/pinky_daemon/mesh_store.py
+++ b/src/pinky_daemon/mesh_store.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 # -- Records -------------------------------------------------------------------
 
 
@@ -102,7 +104,7 @@ class MeshStore:
     def __init__(self, db_path: str = "data/mesh.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(self._db, db_label="mesh.db")
         self._db.execute("PRAGMA foreign_keys=ON")
         self._lock = threading.RLock()
         self._init_tables()

--- a/src/pinky_daemon/message_context_store.py
+++ b/src/pinky_daemon/message_context_store.py
@@ -9,6 +9,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 DEFAULT_RETENTION_DAYS = 30
 DEFAULT_MAX_PER_AGENT = 1000
 
@@ -30,8 +32,10 @@ class MessageContextStore:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         self._db.row_factory = sqlite3.Row
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA busy_timeout=5000")
+        # configure_rollback_journal also installs a 30s busy_timeout, which
+        # replaces the 5s this store used to set: rollback journalling
+        # serialises readers against the writer, so waiting longer is right.
+        configure_rollback_journal(self._db, db_label="message_context.db")
         self._create_schema()
         self._ensure_columns()
         self._ensure_identity_key()

--- a/src/pinky_daemon/outreach_config.py
+++ b/src/pinky_daemon/outreach_config.py
@@ -17,6 +17,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -53,7 +55,7 @@ class OutreachConfigStore:
     def __init__(self, db_path: str = "data/outreach_config.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(self._db, db_label="outreach_config.db")
         self._init_tables()
 
     def _init_tables(self) -> None:

--- a/src/pinky_daemon/plugin_manager.py
+++ b/src/pinky_daemon/plugin_manager.py
@@ -38,6 +38,8 @@ from typing import Any, Callable
 
 import yaml
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -139,7 +141,7 @@ class PluginContext:
                 data_dir.mkdir(parents=True, exist_ok=True)
                 self._db_path = str(data_dir / "plugins.db")
             self._db = sqlite3.connect(self._db_path, check_same_thread=False)
-            self._db.execute("PRAGMA journal_mode=WAL")
+            configure_rollback_journal(self._db, db_label="plugins.db")
         return self._db
 
     def create_table(self, table_name: str, schema: str) -> None:
@@ -296,7 +298,7 @@ class PluginManager:
         """Initialize the plugin state tracking table."""
         Path(self._state_db_path).parent.mkdir(parents=True, exist_ok=True)
         db = sqlite3.connect(self._state_db_path, check_same_thread=False)
-        db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(db, db_label="plugins.db")
         db.execute("""
             CREATE TABLE IF NOT EXISTS plugin_state (
                 name TEXT PRIMARY KEY,

--- a/src/pinky_daemon/presentation_store.py
+++ b/src/pinky_daemon/presentation_store.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -137,8 +139,7 @@ class PresentationStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="presentations.db")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/research_store.py
+++ b/src/pinky_daemon/research_store.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -147,8 +149,7 @@ class ResearchStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="research.db")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/session_store.py
+++ b/src/pinky_daemon/session_store.py
@@ -20,6 +20,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -71,8 +73,7 @@ class SessionStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="sessions.db")
             self._thread_local.connection = connection
         return connection
 
@@ -314,8 +315,7 @@ class SessionEventStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="sessions.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/skill_store.py
+++ b/src/pinky_daemon/skill_store.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -153,8 +155,7 @@ class SkillStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="skills.db")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/sqlite_journal.py
+++ b/src/pinky_daemon/sqlite_journal.py
@@ -1,0 +1,103 @@
+"""Shared SQLite journal-mode configuration for long-lived daemon stores.
+
+WAL mode is unsafe for the way this daemon holds SQLite open. Two properties
+combine badly:
+
+1. Every store opens the same database file once **per thread**
+   (``self._thread_local.connection``), so a single process holds several
+   independent connections to one file.
+2. POSIX record locks are owned per ``(process, inode)``, not per descriptor.
+   The moment *any* of those connections is closed — a worker thread ending, an
+   explicit ``_reset_connection()`` — the process drops **all** of its advisory
+   locks on that file, including the ones the surviving connections still rely
+   on.
+
+After that the daemon is invisible to other processes: the next external opener
+(a backup, an operator running ``sqlite3``, a script) sees an unlocked database,
+believes it is the sole connection, and on close checkpoints and **unlinks** the
+``-wal``/``-shm``. The daemon's surviving connections keep writing happily into
+the now-orphaned inode. Those writes are visible only through the daemon itself;
+every external reader sees data frozen at the last checkpoint, and the whole tail
+is lost when the process exits.
+
+That failure mode was observed in production on 2026-08-01: four stores
+(conversations, tasks, agent_comms, research) were left holding
+``...-wal (deleted)`` with 54 messages, 5 inbox rows and 2 tasks reachable only
+from the daemon's address space, while ``/proc/<pid>/locks`` showed the daemon
+holding no locks at all.
+
+Rollback (TRUNCATE) journalling sidesteps the whole class: committed data lives
+in the main database file, there is no ``-wal`` for anyone to unlink and no
+``-shm`` to map. It is the same remedy already applied to
+``conversations_agents.db`` (#797/#220), the skills DB and the dream runner —
+this module exists so those hand-rolled copies can converge on one
+implementation instead of drifting.
+
+Trade-off, deliberately accepted: rollback mode serialises readers against the
+writer. These stores are low-throughput control-plane data, and correctness of
+the write path matters more here than reader concurrency.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+
+class SqliteJournalConfigError(RuntimeError):
+    """A store connection could not be moved off WAL."""
+
+
+def configure_rollback_journal(
+    conn: sqlite3.Connection,
+    *,
+    db_label: str,
+    busy_ms: int = 30_000,
+    retries: int = 6,
+) -> str:
+    """Put ``conn`` in rollback (TRUNCATE) journal mode and confirm it took.
+
+    Must run BEFORE table init and before anything can spawn stdio children that
+    hold the database, so an existing WAL file is converted in place while the
+    daemon is still the only writer.
+
+    Any hot WAL content is checkpointed first, so nothing committed is stranded
+    when the wal-index is dropped. A busy database during that drain is
+    non-fatal — the mode switch below retries.
+
+    Fails LOUD: raises :class:`SqliteJournalConfigError` rather than silently
+    running on WAL, because a silent fallback is exactly the state that loses
+    writes.
+
+    Args:
+        conn: Connection to configure, before any table creation.
+        db_label: Human-readable database name, used in the error message.
+        busy_ms: ``busy_timeout`` applied to the connection.
+        retries: Bounded attempts before giving up.
+
+    Returns:
+        The effective journal mode, always ``"truncate"``.
+    """
+    conn.execute(f"PRAGMA busy_timeout={int(busy_ms)}")
+    last: str | None = None
+    for attempt in range(retries):
+        try:
+            cur = conn.execute("PRAGMA journal_mode").fetchone()
+            if cur and str(cur[0]).lower() == "wal":
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except sqlite3.OperationalError:
+            pass
+        try:
+            row = conn.execute("PRAGMA journal_mode=TRUNCATE").fetchone()
+            last = str(row[0]).lower() if row else None
+            if last == "truncate":
+                return last
+        except sqlite3.OperationalError as exc:
+            last = f"error:{exc}"
+        time.sleep(0.2 * (attempt + 1))
+
+    raise SqliteJournalConfigError(
+        f"{db_label} refused to leave WAL: journal_mode={last!r} after {retries} "
+        f"attempts — refusing to run on WAL, where an unlinked -wal silently "
+        f"strands committed writes in the daemon's address space (#797/#220)."
+    )

--- a/src/pinky_daemon/task_store.py
+++ b/src/pinky_daemon/task_store.py
@@ -22,6 +22,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -195,8 +197,7 @@ class TaskStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="tasks.db")
             connection.execute("PRAGMA foreign_keys=ON")
             self._thread_local.connection = connection
         return connection

--- a/src/pinky_daemon/trigger_store.py
+++ b/src/pinky_daemon/trigger_store.py
@@ -19,6 +19,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -87,8 +89,7 @@ class TriggerStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="triggers.db")
             connection.execute("PRAGMA foreign_keys=ON")
             connection.row_factory = sqlite3.Row
             self._thread_local.connection = connection

--- a/src/pinky_daemon/user_profile_store.py
+++ b/src/pinky_daemon/user_profile_store.py
@@ -18,6 +18,8 @@ import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 @dataclass
 class ProfileEntry:
@@ -90,8 +92,7 @@ class UserProfileStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="user_profiles.db")
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/voice_store.py
+++ b/src/pinky_daemon/voice_store.py
@@ -21,6 +21,8 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -229,8 +231,7 @@ class VoiceStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
-            connection.execute("PRAGMA busy_timeout=30000")
+            configure_rollback_journal(connection, db_label="voice_calls.db")
             connection.execute("PRAGMA foreign_keys=ON")
             connection.row_factory = sqlite3.Row
             self._thread_local.connection = connection

--- a/src/pinky_federation/state.py
+++ b/src/pinky_federation/state.py
@@ -43,6 +43,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 DEFAULT_DB_PATH = "data/federation/state.db"
 
 # Instance-key lifecycle states.
@@ -273,7 +275,7 @@ class FederationStateStore:
         self.db_path = db_path
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(self._db, db_label="federation state")
         self._db.execute("PRAGMA foreign_keys=ON")
         self._db.row_factory = sqlite3.Row
         self._create_schema()

--- a/src/pinky_hub/hub_store.py
+++ b/src/pinky_hub/hub_store.py
@@ -20,6 +20,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -100,7 +102,7 @@ class HubStore:
     def __init__(self, db_path: str = "data/hub.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(self._db, db_label="hub.db")
         self._db.execute("PRAGMA foreign_keys=ON")
         self._init_tables()
 

--- a/src/pinky_identity/bearer_tokens.py
+++ b/src/pinky_identity/bearer_tokens.py
@@ -70,6 +70,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
 from pinky_identity.fs_security import harden_secret_file
 from pinky_identity.keys import SignatureError
 
@@ -290,7 +291,7 @@ class BearerTokenStore:
             str(self._db_path), isolation_level=None, check_same_thread=False
         )
         self._db.row_factory = sqlite3.Row
-        self._db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(self._db, db_label="bearer tokens")
         self._db.execute("PRAGMA foreign_keys=ON")
         self._ensure_schema()
         harden_secret_file(self._db_path)

--- a/src/pinky_identity/signer_store.py
+++ b/src/pinky_identity/signer_store.py
@@ -21,7 +21,9 @@ Design rules (see ``docs/design/agent-asymmetric-identity.md`` and #461):
   cleanup so an attacker who somehow obtains a stale row plus the device
   key still can't impersonate a retired agent (the registry won't return
   the kid as active).
-- **WAL mode + journal_mode=WAL**, same as other PinkyBot SQLite stores.
+- **Rollback (TRUNCATE) journalling**, same as other PinkyBot SQLite
+  stores — see :mod:`pinky_daemon.sqlite_journal` for why WAL is unsafe
+  for the way this process holds SQLite open.
 - **No SQL injection surface.** All writes use parameterized queries; no
   string concatenation into SQL.
 - **Errors normalize to** :class:`pinky_identity.keystore.KeystoreError`
@@ -41,6 +43,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
 from pinky_identity.fs_security import harden_secret_file
 from pinky_identity.keys import SigningKeypair
 from pinky_identity.keystore import (
@@ -146,7 +149,7 @@ class EncryptedSignerStore:
             str(self._db_path), isolation_level=None, check_same_thread=False
         )
         self._db.row_factory = sqlite3.Row
-        self._db.execute("PRAGMA journal_mode=WAL")
+        configure_rollback_journal(self._db, db_label="signer store")
         self._db.execute("PRAGMA foreign_keys=ON")
         self._ensure_schema()
         harden_secret_file(self._db_path)

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from pinky_daemon.sqlite_journal import configure_rollback_journal
 from pinky_memory.ephemeral_guard import (
     guard_enabled,
     is_ephemeral_entity,
@@ -159,8 +160,7 @@ class ReflectionStore:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute("PRAGMA busy_timeout=5000")
+        configure_rollback_journal(self._conn, db_label="pinky memory")
         self._init_schema()
 
     def _init_schema(self) -> None:
@@ -2458,7 +2458,7 @@ class ReflectionStore:
                 return (False, str(exc))
 
     def reopen(self) -> None:
-        """Close and reopen the connection (triggers WAL recovery)."""
+        """Close and reopen the connection."""
         with self._lock:
             try:
                 self._conn.close()
@@ -2468,8 +2468,7 @@ class ReflectionStore:
                 logger.debug("close on reopen failed (already closed?): %s", e)
             self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
             self._conn.row_factory = sqlite3.Row
-            self._conn.execute("PRAGMA journal_mode=WAL")
-            self._conn.execute("PRAGMA busy_timeout=5000")
+            configure_rollback_journal(self._conn, db_label="pinky memory")
             # Reload sqlite-vec extension after reconnect
             self._vec_available = False
             self._init_vec()

--- a/tests/pinky_federation/test_state.py
+++ b/tests/pinky_federation/test_state.py
@@ -497,6 +497,7 @@ def test_tenant_signing_keys_fk_cascades_on_tenant_delete(store: FederationState
     assert rows == []
 
 
-def test_db_uses_wal_mode(store: FederationStateStore) -> None:
+def test_db_uses_rollback_journalling(store: FederationStateStore) -> None:
+    """WAL is unsafe here — see pinky_daemon.sqlite_journal for why."""
     mode = store._db.execute("PRAGMA journal_mode").fetchone()[0]  # noqa: SLF001
-    assert mode.lower() == "wal"
+    assert mode.lower() == "truncate"

--- a/tests/test_activity_store.py
+++ b/tests/test_activity_store.py
@@ -32,7 +32,7 @@ class TestActivityStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
                 agent_name = f"worker-{worker_index}"
                 for round_index in range(rounds):

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -46,7 +46,7 @@ class TestDreamRunnerConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
                 agent_name = f"worker-{worker_index}"
                 for round_index in range(rounds):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -33,7 +33,7 @@ class TestAuditStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
                 for round_index in range(rounds):
                     marker = f"{worker_index}-{round_index}"

--- a/tests/test_message_context_store.py
+++ b/tests/test_message_context_store.py
@@ -71,7 +71,7 @@ def test_context_survives_broker_restart_via_load_through(tmp_path):
     second_store.close()
 
 
-def test_store_uses_wal_and_self_heals_optional_columns(tmp_path):
+def test_store_uses_rollback_journal_and_self_heals_optional_columns(tmp_path):
     db_path = tmp_path / "message-context.db"
     legacy = sqlite3.connect(db_path)
     legacy.execute(
@@ -104,7 +104,9 @@ def test_store_uses_wal_and_self_heals_optional_columns(tmp_path):
         for row in store._db.execute("PRAGMA table_info(message_contexts)").fetchall()
     }
 
-    assert str(mode).lower() == "wal"
+    # Rollback journalling, not WAL: an unlinked -wal silently strands
+    # committed writes in the daemon's address space (#797/#220).
+    assert str(mode).lower() == "truncate"
     assert {"reply_to", "attachments_json", "metadata_json", "stored_at"} <= columns
     primary_key = tuple(
         row["name"]

--- a/tests/test_non_daemon_stores_no_wal.py
+++ b/tests/test_non_daemon_stores_no_wal.py
@@ -1,0 +1,105 @@
+"""The stores outside ``pinky_daemon`` must not run on WAL either.
+
+The orphaned-WAL failure mode documented in :mod:`pinky_daemon.sqlite_journal`
+is a property of *how the process holds SQLite open*, not of which package the
+store lives in. These four modules keep a long-lived
+``check_same_thread=False`` connection open for the life of the process —
+exactly the shape that loses committed writes when an outside opener unlinks
+the ``-wal``.
+
+The daemon stores are pinned by their own per-store tests; this file pins the
+remainder so the contract cannot regress package by package.
+"""
+
+from __future__ import annotations
+
+import secrets
+import sqlite3
+
+import pytest
+
+from pinky_hub.hub_store import HubStore
+from pinky_identity.bearer_tokens import BearerTokenStore
+from pinky_identity.keystore import DEVICE_KEY_BYTES, DeviceKey
+from pinky_identity.signer_store import EncryptedSignerStore
+from pinky_memory.store import ReflectionStore
+
+
+def _mode(conn: sqlite3.Connection) -> str:
+    return str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+
+
+def _mode_on_disk(path) -> str:
+    """Journal mode a *fresh* opener sees.
+
+    Only WAL is sticky in the database header; TRUNCATE is a per-connection
+    setting, so an independent connection reports the ``delete`` default. What
+    matters for this contract is simply that it is not ``wal``.
+    """
+    conn = sqlite3.connect(str(path))
+    try:
+        return str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def device_key():
+    return DeviceKey.from_bytes(secrets.token_bytes(DEVICE_KEY_BYTES))
+
+
+def test_hub_store_uses_rollback_journalling(tmp_path):
+    store = HubStore(db_path=str(tmp_path / "hub.db"))
+    assert _mode(store._db) == "truncate"  # noqa: SLF001
+
+
+def test_bearer_token_store_uses_rollback_journalling(tmp_path):
+    store = BearerTokenStore(db_path=tmp_path / "bearer.db")
+    assert _mode(store._db) == "truncate"  # noqa: SLF001
+
+
+def test_signer_store_uses_rollback_journalling(tmp_path, device_key):
+    store = EncryptedSignerStore(db_path=tmp_path / "signer.db", device_key=device_key)
+    assert _mode(store._db) == "truncate"  # noqa: SLF001
+
+
+def test_reflection_store_uses_rollback_journalling(tmp_path):
+    store = ReflectionStore(db_path=str(tmp_path / "reflections.db"))
+    assert _mode(store._conn) == "truncate"  # noqa: SLF001
+
+
+def test_reflection_store_reopen_does_not_fall_back_to_wal(tmp_path):
+    """``reopen()`` builds a fresh connection — it must configure it too."""
+    store = ReflectionStore(db_path=str(tmp_path / "reflections.db"))
+    store.reopen()
+    assert _mode(store._conn) == "truncate"  # noqa: SLF001
+
+
+def test_no_wal_sidecars_are_created(tmp_path):
+    """Rollback journalling leaves no ``-wal``/``-shm`` for anyone to unlink."""
+    path = tmp_path / "hub.db"
+    store = HubStore(db_path=str(path))
+    store.register_instance(
+        label="alpha", url="https://example.invalid", api_key="k"
+    )
+
+    assert not path.with_name(path.name + "-wal").exists()
+    assert not path.with_name(path.name + "-shm").exists()
+
+
+def test_existing_wal_database_is_converted_in_place(tmp_path):
+    """A store opened on a database left in WAL by an older build migrates it."""
+    path = tmp_path / "hub.db"
+    seed = sqlite3.connect(str(path))
+    try:
+        seed.execute("PRAGMA journal_mode=WAL")
+        seed.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
+        seed.commit()
+    finally:
+        seed.close()
+    assert _mode_on_disk(path) == "wal"
+
+    store = HubStore(db_path=str(path))
+
+    assert _mode(store._db) == "truncate"  # noqa: SLF001
+    assert _mode_on_disk(path) != "wal"

--- a/tests/test_presentation_store.py
+++ b/tests/test_presentation_store.py
@@ -39,7 +39,7 @@ class TestPresentationStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
                 for round_index in range(rounds):
                     marker = f"{worker_index}-{round_index}"

--- a/tests/test_research_store.py
+++ b/tests/test_research_store.py
@@ -32,7 +32,7 @@ class TestResearchStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
                 for round_index in range(rounds):
                     marker = f"{worker_index}-{round_index}"

--- a/tests/test_skill_store.py
+++ b/tests/test_skill_store.py
@@ -136,7 +136,7 @@ class TestSkillStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
                 for round_index in range(rounds):
                     marker = f"{worker_index}-{round_index}"

--- a/tests/test_sqlite_journal.py
+++ b/tests/test_sqlite_journal.py
@@ -14,14 +14,29 @@ from pathlib import Path
 
 import pytest
 
+from pinky_daemon.activity_store import ActivityStore
 from pinky_daemon.agent_comms import AgentComms
+from pinky_daemon.analytics_store import AnalyticsStore
+from pinky_daemon.app_store import AppStore
 from pinky_daemon.conversation_store import ConversationStore
+from pinky_daemon.hooks import AuditStore
+from pinky_daemon.kb_store import KBStore
+from pinky_daemon.librarian_runner import LibrarianRunner
+from pinky_daemon.mesh_store import MeshStore
+from pinky_daemon.message_context_store import MessageContextStore
+from pinky_daemon.outreach_config import OutreachConfigStore
+from pinky_daemon.plugin_manager import PluginManager
+from pinky_daemon.presentation_store import PresentationStore
 from pinky_daemon.research_store import ResearchStore
+from pinky_daemon.session_store import SessionEventStore, SessionStore
 from pinky_daemon.sqlite_journal import (
     SqliteJournalConfigError,
     configure_rollback_journal,
 )
 from pinky_daemon.task_store import TaskStore
+from pinky_daemon.trigger_store import TriggerStore
+from pinky_daemon.user_profile_store import UserProfileStore
+from pinky_daemon.voice_store import VoiceStore
 
 
 def _journal_mode(db_path: Path) -> str:
@@ -179,6 +194,18 @@ def test_fts5_shadow_tables_survive_the_wal_conversion(tmp_path):
         (TaskStore, "tasks.db", "_db"),
         (AgentComms, "agent_comms.db", "_conn"),
         (ResearchStore, "research.db", "_db"),
+        (ActivityStore, "activity.db", "_db"),
+        (AppStore, "apps.db", "_db"),
+        (AuditStore, "audit.db", "_db"),
+        (MeshStore, "mesh.db", "_db"),
+        (MessageContextStore, "message_context.db", "_db"),
+        (OutreachConfigStore, "outreach_config.db", "_db"),
+        (PresentationStore, "presentations.db", "_db"),
+        (SessionStore, "sessions.db", "_db"),
+        (SessionEventStore, "session_events.db", "_db"),
+        (TriggerStore, "triggers.db", "_db"),
+        (UserProfileStore, "user_profiles.db", "_db"),
+        (VoiceStore, "voice_calls.db", "_db"),
     ],
 )
 def test_stores_open_in_rollback_mode(tmp_path, factory, filename, conn_attr):
@@ -188,3 +215,46 @@ def test_stores_open_in_rollback_mode(tmp_path, factory, filename, conn_attr):
     assert getattr(store, conn_attr) is not None
     assert _journal_mode(db_path) != "wal"
     assert not (tmp_path / f"{filename}-wal").exists()
+
+
+def test_per_call_connection_stores_open_in_rollback_mode(tmp_path):
+    """Stores that open a fresh connection per call, not one long-lived handle.
+
+    These are just as exposed: two overlapping short connections in one process
+    still share POSIX locks, so whichever closes first drops the locks the other
+    is relying on.
+    """
+    kb = KBStore(data_dir=str(tmp_path / "kb"))
+    assert _journal_mode(Path(kb.db_path)) != "wal"
+    assert not Path(str(kb.db_path) + "-wal").exists()
+
+    librarian_db = tmp_path / "librarian_state.db"
+    LibrarianRunner(kb, db_path=str(librarian_db))
+    assert _journal_mode(librarian_db) != "wal"
+
+    analytics_db = tmp_path / "analytics.db"
+    AnalyticsStore(db_path=str(analytics_db))
+    assert _journal_mode(analytics_db) != "wal"
+
+    plugins_db = tmp_path / "plugins.db"
+    PluginManager(
+        db_path=str(plugins_db),
+        api_url="http://localhost:8888",
+        working_dir=str(tmp_path / "wd"),
+    )
+    assert _journal_mode(plugins_db) != "wal"
+
+
+def test_no_daemon_module_still_asks_for_wal():
+    """Guard against a new store landing back on WAL by copy-paste."""
+    src = Path(__file__).resolve().parents[1] / "src" / "pinky_daemon"
+    offenders = [
+        f"{path.relative_to(src)}:{n}"
+        for path in sorted(src.rglob("*.py"))
+        for n, line in enumerate(path.read_text().splitlines(), 1)
+        if "journal_mode=WAL" in line
+    ]
+    assert offenders == [], (
+        "these daemon modules still open SQLite in WAL mode — use "
+        f"configure_rollback_journal() instead: {offenders}"
+    )

--- a/tests/test_sqlite_journal.py
+++ b/tests/test_sqlite_journal.py
@@ -1,0 +1,190 @@
+"""Rollback-journal configuration for the long-lived daemon stores.
+
+Regression cover for the 2026-08-01 orphaned-WAL incident: WAL mode plus
+per-thread connections let an external process unlink the ``-wal`` out from
+under the daemon, stranding committed writes in its address space.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from pinky_daemon.agent_comms import AgentComms
+from pinky_daemon.conversation_store import ConversationStore
+from pinky_daemon.research_store import ResearchStore
+from pinky_daemon.sqlite_journal import (
+    SqliteJournalConfigError,
+    configure_rollback_journal,
+)
+from pinky_daemon.task_store import TaskStore
+
+
+def _journal_mode(db_path: Path) -> str:
+    """Journal mode seen by a *fresh* connection, i.e. what the file persists.
+
+    SQLite only records "WAL vs rollback" in the database header — it does not
+    persist *which* rollback mode. A new connection therefore reports the
+    compile-time default ("delete") even when the writer set TRUNCATE, so
+    callers assert on the family (``!= "wal"``), not on the exact value.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        return str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+    finally:
+        conn.close()
+
+
+def test_configure_returns_truncate_on_fresh_db(tmp_path):
+    conn = sqlite3.connect(tmp_path / "fresh.db")
+    assert configure_rollback_journal(conn, db_label="fresh.db") == "truncate"
+    conn.close()
+
+
+def test_converts_an_existing_wal_database_in_place(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    seed = sqlite3.connect(db_path)
+    seed.execute("PRAGMA journal_mode=WAL")
+    seed.execute("CREATE TABLE t (v TEXT)")
+    seed.execute("INSERT INTO t VALUES ('committed-under-wal')")
+    seed.commit()
+    seed.close()
+    assert _journal_mode(db_path) == "wal"
+
+    conn = sqlite3.connect(db_path)
+    assert configure_rollback_journal(conn, db_label="legacy.db") == "truncate"
+
+    # Content written under WAL survives the conversion — the helper checkpoints
+    # before dropping the wal-index.
+    assert conn.execute("SELECT v FROM t").fetchone()[0] == "committed-under-wal"
+    conn.close()
+    assert _journal_mode(db_path) != "wal"
+
+
+def test_leaves_no_wal_or_shm_sidecars(tmp_path):
+    """The whole point: no ``-wal``/``-shm`` for another process to unlink."""
+    db_path = tmp_path / "sidecars.db"
+    conn = sqlite3.connect(db_path)
+    configure_rollback_journal(conn, db_label="sidecars.db")
+    conn.execute("CREATE TABLE t (v TEXT)")
+    conn.execute("INSERT INTO t VALUES ('x')")
+    conn.commit()
+
+    assert not (tmp_path / "sidecars.db-wal").exists()
+    assert not (tmp_path / "sidecars.db-shm").exists()
+    conn.close()
+
+
+def test_committed_writes_are_visible_to_a_separate_process_handle(tmp_path):
+    """The incident symptom, inverted: an outside reader must see the write.
+
+    Under the orphaned WAL, ``sqlite3`` from outside saw data frozen at the last
+    checkpoint while the daemon reported success.
+    """
+    db_path = tmp_path / "visible.db"
+    daemon_conn = sqlite3.connect(db_path)
+    configure_rollback_journal(daemon_conn, db_label="visible.db")
+    daemon_conn.execute("CREATE TABLE t (v TEXT)")
+    daemon_conn.execute("INSERT INTO t VALUES ('written-by-daemon')")
+    daemon_conn.commit()
+
+    outsider = sqlite3.connect(db_path)
+    assert outsider.execute("SELECT v FROM t").fetchone()[0] == "written-by-daemon"
+    outsider.close()
+    daemon_conn.close()
+
+
+class _RefusesModeSwitch(sqlite3.Connection):
+    """A connection that always reports the database as locked for the switch.
+
+    ``sqlite3.Connection`` is a C type, so its ``execute`` cannot be
+    monkeypatched on an instance — subclassing via ``connect(factory=...)`` is
+    the way to simulate a database that will not leave WAL.
+    """
+
+    def execute(self, sql, *args):  # noqa: D102 - inherited contract
+        if "journal_mode=TRUNCATE" in sql:
+            raise sqlite3.OperationalError("database is locked")
+        return super().execute(sql, *args)
+
+
+def test_raises_rather_than_silently_staying_on_wal(tmp_path):
+    """A silent WAL fallback is the state that loses writes — it must fail loud."""
+    conn = sqlite3.connect(tmp_path / "stuck.db", factory=_RefusesModeSwitch)
+
+    with pytest.raises(SqliteJournalConfigError, match="refused to leave WAL"):
+        configure_rollback_journal(conn, db_label="stuck.db", retries=2)
+    conn.close()
+
+
+# Seeds a conversations.db under WAL and exits WITHOUT closing the connection,
+# leaving a hot -wal behind — the state conversation_store's checkpoint has to
+# survive. os._exit skips interpreter cleanup, so SQLite never checkpoints.
+_HOT_WAL_SEEDER = """
+import os, sys
+sys.path.insert(0, {src!r})
+import sqlite3
+from pinky_daemon.conversation_store import ConversationStore
+
+store = ConversationStore(db_path={db!r})
+store._conn.execute("PRAGMA journal_mode=WAL")
+store.append("s1", "user", "checkpointed under wal")
+store.append("s1", "agent", "hot in the wal file")
+assert store._conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+os._exit(0)
+"""
+
+
+def test_fts5_shadow_tables_survive_the_wal_conversion(tmp_path):
+    """conversation_store.py warns that checkpointing with live writers corrupts
+    the FTS5 shadow tables. Our checkpoint runs at connection open, before table
+    init and with no concurrent writer — this pins that it is in fact safe, on a
+    genuinely hot WAL rather than on the reasoning alone.
+    """
+    db_path = tmp_path / "conversations.db"
+    src = str(Path(__file__).resolve().parents[1] / "src")
+    seeded = subprocess.run(
+        [sys.executable, "-c", _HOT_WAL_SEEDER.format(src=src, db=str(db_path))],
+        capture_output=True,
+        text=True,
+    )
+    assert seeded.returncode == 0, seeded.stderr
+    assert db_path.with_name("conversations.db-wal").exists(), "no hot WAL to convert"
+
+    # Opening the store checkpoints the hot WAL and converts to rollback mode.
+    store = ConversationStore(db_path=str(db_path))
+
+    integrity = store._conn.execute(
+        "INSERT INTO messages_fts(messages_fts) VALUES('integrity-check')"
+    )
+    assert integrity is not None  # raises DatabaseError if the index is corrupt
+
+    # Both the checkpointed and the WAL-resident row are searchable...
+    assert len(store.search("checkpointed")) == 1
+    assert len(store.search("hot")) == 1
+    # ...and the triggers keep indexing after the conversion.
+    store.append("s1", "user", "indexed after the conversion")
+    assert len(store.search("conversion")) == 1
+    store.close()
+
+
+@pytest.mark.parametrize(
+    ("factory", "filename", "conn_attr"),
+    [
+        (ConversationStore, "conversations.db", "_conn"),
+        (TaskStore, "tasks.db", "_db"),
+        (AgentComms, "agent_comms.db", "_conn"),
+        (ResearchStore, "research.db", "_db"),
+    ],
+)
+def test_stores_open_in_rollback_mode(tmp_path, factory, filename, conn_attr):
+    db_path = tmp_path / filename
+    store = factory(db_path=str(db_path))
+    # Touch the lazy per-thread connection so the store actually opens.
+    assert getattr(store, conn_attr) is not None
+    assert _journal_mode(db_path) != "wal"
+    assert not (tmp_path / f"{filename}-wal").exists()

--- a/tests/test_trigger_store.py
+++ b/tests/test_trigger_store.py
@@ -69,7 +69,7 @@ class TestTriggerStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
                 for round_index in range(rounds):
                     marker = f"{worker_index}-{round_index}"

--- a/tests/test_user_profile_store.py
+++ b/tests/test_user_profile_store.py
@@ -36,7 +36,7 @@ class TestUserProfileStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
                 chat_id = f"worker-{worker_index}"
                 for round_index in range(rounds):

--- a/tests/test_voice_store.py
+++ b/tests/test_voice_store.py
@@ -33,7 +33,7 @@ class TestVoiceStoreConcurrency:
                 connection_id = id(connection)
                 assert connection.execute(
                     "PRAGMA journal_mode"
-                ).fetchone()[0].lower() == "wal"
+                ).fetchone()[0].lower() == "truncate"
                 assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
                 assert connection.row_factory is sqlite3.Row
                 for round_index in range(rounds):


### PR DESCRIPTION
> **Stacked on #968 — merge that first.** This branch is based on #968's head, not on `main`, because it imports `pinky_daemon.sqlite_journal`, which #968 introduces and `main` does not yet have. Until #968 merges, the diff below shows its three commits too; the only commit belonging to this PR is the last one. Rebase is not needed after #968 merges — GitHub will narrow the diff on its own.

Closes the SQLite reliability thread opened on 2026-08-01. `b5fad85`, `87e2a60` and `77f0662` converted the daemon stores; this converts the five that live outside `pinky_daemon` and were explicitly left out of scope there.

## What changes

`PRAGMA journal_mode=WAL` → `configure_rollback_journal()` in:

- `pinky_federation.state.FederationStateStore`
- `pinky_hub.hub_store.HubStore`
- `pinky_identity.bearer_tokens.BearerTokenStore`
- `pinky_identity.signer_store.EncryptedSignerStore`
- `pinky_memory.store.ReflectionStore` — both the constructor **and** `reopen()`, which built a second connection and would have silently reverted that file to WAL

These import the daemon's helper rather than growing four copies of it. `signer_store`'s security-notes docstring advertised WAL and now points at `sqlite_journal` instead. `ReflectionStore`'s two explicit `busy_timeout=5000` pragmas are dropped for the helper's 30000, matching #942.

## Why this is not the low-priority cleanup it was filed as

Checked what is actually on disk in production right now. Four of the five stores have **no database yet** — `data/federation/state.db`, `data/hub.db` and both `data/identity/*.db` are absent; those subsystems aren't in use. The fifth is very much in use:

**All nine per-agent `memory.db` files are on WAL with live `-wal`/`-shm` sidecars** — aiena, fixer, sentinel, engineer, satoshi, alter-ego, writer, seo-pro, segugio. Orphaned `-wal` under a running daemon is the exact signature of the 2026-08-01 incident, and this is the same database that needed a hot-patch on 2026-08-02 for a poisoned row. So in practice this PR is a `pinky_memory` fix that also future-proofs four dormant stores.

## Deploy note — please read before restarting prod

`configure_rollback_journal()` checkpoints any hot WAL and then **raises** `SqliteJournalConfigError` rather than silently staying on WAL (`sqlite_journal.py:85-100`). That is the right behaviour, but it means the first restart after this deploy converts nine live `memory.db` files in place.

`pinky_memory` runs as a per-agent MCP **subprocess**. If a subprocess from the old build still holds the WAL lock on a file the new one is converting, the checkpoint fails, the store raises, and that agent comes up with no memory instead of degrading quietly.

Mitigation: make sure the old MCP subprocesses are fully gone before the new ones start — a clean stop/start, not an overlapping rolling restart.

## Testing

- `tests/test_non_daemon_stores_no_wal.py` (new) — pins all five stores plus `reopen()`, asserts no `-wal`/`-shm` sidecars appear, and covers in-place migration of a database left in WAL by an older build
- `tests/pinky_federation/test_state.py` pinned `journal_mode == "wal"`; converted, as `77f0662` did for the daemon stores
- Targeted run: 71 passed (`test_non_daemon_stores_no_wal`, `test_sqlite_journal`, `pinky_federation/test_state`)
- Full suite: `4620 passed, 2 skipped` in 41:36 — run from an isolated worktree, never from the live checkout (these stores default to relative `db_path`s and would otherwise touch the production databases)

One caveat on that full-suite number, stated plainly: it was produced on the original base, before this branch was rebased onto #968's head to keep it clean of unrelated local commits. On the current base I have only re-run the 71 targeted tests, which pass. The change itself is byte-identical across both bases (`git diff` between them is empty), but the underlying base is not — it now includes #942 — so CI is the first full-suite run on this exact tree.

The on-disk assertion is `!= "wal"` rather than `== "truncate"` on purpose: only WAL is sticky in the database header, so an independent opener reports the `delete` default. Both are rollback modes with no `-wal` to unlink, which is the property that matters.

## Review note

`pinky_identity`, `pinky_hub`, `pinky_federation` and `pinky_memory` now import from `pinky_daemon.sqlite_journal`, so the MCP server packages take a dependency on the daemon package. `pinky_daemon/__init__.py` is a docstring and a version string, so this adds no import weight beyond `sqlite3` — but it is a new coupling direction and worth an explicit opinion from a reviewer rather than being buried in a commit message.

🤖 Opened by Engineer
