### PR TITLE
fix(memory): don't take a write lock to backfill nothing on every open (#368)

### DIFF
--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -134,6 +134,18 @@ END;
 """
 
 
+# Rows that still need a review date. Shared by the guard and the UPDATE in
+# _migrate_backfill_review_schedule so the two can never drift apart: a guard
+# that is narrower than the write would skip work, a wider one would write when
+# there is nothing to do. salience >= 4 is protected — those stay NULL and are
+# never auto-reviewed.
+_NEEDS_REVIEW_DATE = """active = 1
+      AND next_review_date IS NULL
+      AND salience < 4
+      AND type != 'continuation'
+      AND no_recall = 0"""
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -230,19 +242,26 @@ class ReflectionStore:
             pass  # column already exists
 
     def _migrate_backfill_review_schedule(self) -> None:
-        """Backfill next_review_date for existing active memories on first run."""
+        """Give unscheduled active memories a review date, writing only if any exist.
+
+        Despite the "migration" name this is not one-shot: insert() leaves
+        next_review_date NULL, so this is also what makes newly created
+        memories reviewable. It must keep running on every open — it just must
+        not take a write lock when there is nothing to schedule, which is the
+        steady state and used to cost one write transaction per store opened
+        at daemon start. #368
+        """
         with self._lock:
-            # Only backfill rows that have NULL next_review_date AND salience < 4
-            # (salience >= 4 are protected and stay NULL = never auto-reviewed)
-            self._conn.execute("""
-                UPDATE reflections
-                SET next_review_date = date(created_at, '+30 days')
-                WHERE active = 1
-                  AND next_review_date IS NULL
-                  AND salience < 4
-                  AND type != 'continuation'
-                  AND no_recall = 0
-            """)
+            unscheduled = self._conn.execute(
+                f"SELECT 1 FROM reflections WHERE {_NEEDS_REVIEW_DATE} LIMIT 1"
+            ).fetchone()
+            if unscheduled is None:
+                return
+            self._conn.execute(
+                f"""UPDATE reflections
+                    SET next_review_date = date(created_at, '+30 days')
+                    WHERE {_NEEDS_REVIEW_DATE}"""
+            )
             self._conn.commit()
 
     def _migrate_create_memory_events(self) -> None:

--- a/tests/test_memory_backfill_review_writes.py
+++ b/tests/test_memory_backfill_review_writes.py
@@ -1,0 +1,109 @@
+"""Opening a ReflectionStore must not write when there is nothing to backfill (#368).
+
+_migrate_backfill_review_schedule ran an unconditional UPDATE on every open, so
+every component that constructs a store took a write lock at daemon start even
+on a database where every row was already scheduled.
+
+Careful: despite its "on first run" docstring, this UPDATE is load-bearing.
+insert() never sets next_review_date, so this is also what schedules *new*
+memories. Making it a one-time migration would silently stop the review system
+from ever picking up anything inserted later — hence the tests below pin the
+scheduling behaviour, not just the write.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from pinky_memory.store import ReflectionStore
+from pinky_memory.types import Reflection, ReflectionType
+
+
+def _trace_opens(monkeypatch) -> list[str]:
+    """Capture every SQL statement the next ReflectionStore(s) execute."""
+    seen: list[str] = []
+    real_connect = sqlite3.connect
+
+    def traced(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        conn.set_trace_callback(seen.append)
+        return conn
+
+    monkeypatch.setattr(sqlite3, "connect", traced)
+    return seen
+
+
+def _backfill_writes(seen: list[str]) -> list[str]:
+    return [
+        s
+        for s in seen
+        if s.strip().upper().startswith("UPDATE REFLECTIONS") and "next_review_date" in s
+    ]
+
+
+def _scheduled(db: Path, reflection_id: str) -> str | None:
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(
+            "SELECT next_review_date FROM reflections WHERE id = ?", (reflection_id,)
+        ).fetchone()
+        return row[0]
+    finally:
+        conn.close()
+
+
+def _seed(db: Path, **kwargs) -> str:
+    store = ReflectionStore(str(db))
+    try:
+        r = store.insert(
+            Reflection(
+                type=ReflectionType.fact,
+                content="il daemon riavvia il gateway",
+                **kwargs,
+            )
+        )
+        return r.id
+    finally:
+        store.close()
+
+
+class TestBackfillOnlyWritesWhenNeeded:
+    def test_reopening_a_fully_scheduled_db_writes_nothing(self, tmp_path, monkeypatch):
+        db = tmp_path / "memory.db"
+        _seed(db)
+        ReflectionStore(str(db)).close()  # this open does the backfill
+
+        seen = _trace_opens(monkeypatch)
+        ReflectionStore(str(db)).close()
+
+        writes = _backfill_writes(seen)
+        assert writes == [], f"reopen still takes a write lock to backfill nothing: {writes}"
+
+    def test_an_empty_db_writes_nothing(self, tmp_path, monkeypatch):
+        db = tmp_path / "memory.db"
+        ReflectionStore(str(db)).close()
+
+        seen = _trace_opens(monkeypatch)
+        ReflectionStore(str(db)).close()
+
+        assert _backfill_writes(seen) == []
+
+
+class TestBackfillStillSchedules:
+    def test_a_memory_inserted_later_is_scheduled_on_the_next_open(self, tmp_path):
+        """Load-bearing: insert() leaves next_review_date NULL, this fills it in."""
+        db = tmp_path / "memory.db"
+        rid = _seed(db)
+        assert _scheduled(db, rid) is None, "insert() unexpectedly schedules the review itself"
+
+        ReflectionStore(str(db)).close()
+
+        assert _scheduled(db, rid) is not None, "a new memory never became reviewable"
+
+    def test_protected_high_salience_memories_stay_unscheduled(self, tmp_path):
+        db = tmp_path / "memory.db"
+        rid = _seed(db, salience=5)
+
+        ReflectionStore(str(db)).close()
+
+        assert _scheduled(db, rid) is None, "a protected memory was pulled into the review cycle"


### PR DESCRIPTION
Fixes #368.

## Il problema

`_migrate_backfill_review_schedule` eseguiva la sua `UPDATE` in modo incondizionato a **ogni** apertura di `ReflectionStore`. Diversi componenti ne costruiscono uno all'avvio del daemon, quindi ognuno prendeva una transazione di scrittura anche quando nessuna riga aveva bisogno di essere schedulata — che e' lo stato normale a regime.

## Perche' NON e' stata resa una migrazione one-shot

Il nome del metodo e il vecchio docstring ("on first run") dicono migrazione una-tantum, ed e' la lettura che porterebbe naturalmente a un marker di versione dello schema. Sarebbe stato un errore silenzioso.

`insert()` non imposta mai `next_review_date` — le nuove righe restano `NULL`. Questa `UPDATE` e' quindi anche cio' che rende recensibile una memoria appena creata. Eseguirla una volta sola avrebbe fatto smettere al sistema di review di raccogliere qualunque cosa inserita in seguito, senza alcun errore visibile.

Quindi il comportamento resta identico: gira a ogni apertura. Cambia solo che non prende piu' il lock quando non c'e' niente da fare.

## Il fix

Una sonda read-only (`SELECT 1 ... LIMIT 1`) precede la `UPDATE`; si scrive solo se esiste davvero almeno una riga da schedulare.

Il predicato delle righe e' estratto in `_NEEDS_REVIEW_DATE`, condiviso da guardia e `UPDATE` cosi' i due non possono divergere: una guardia piu' stretta salterebbe lavoro reale, una piu' larga rimetterebbe la scrittura a vuoto che questa PR elimina.

Il docstring e' stato riscritto per dire cosa fa davvero il metodo, visto che quello vecchio era esattamente la premessa fuorviante.

## Test

Nuovo file `tests/test_memory_backfill_review_writes.py` (4 test):

- riaprire un DB gia' interamente schedulato non esegue alcuna scrittura di backfill
- lo stesso su un DB vuoto
- una memoria inserita dopo viene comunque schedulata alla successiva apertura (fissa il comportamento load-bearing descritto sopra)
- le memorie protette (`salience >= 4`) restano `NULL` e non entrano nel ciclo di review

Verifica eseguita:

- pre-fix: **2 failed** (la `UPDATE` parte anche su un DB vuoto), 2 passed — i 2 verdi sono le guardie di non-regressione, il loro compito e' passare da subito
- post-fix: **4 passed**
- non-regressione: **464 passed** su tutte e 10 le suite che toccano `pinky_memory` (`test_memory_store`, `test_memory_server`, `test_kg_*`, `test_memory_cross_agent`, `test_memory_heal_unembedded`, `test_shared_mcp`)
- `ruff check` pulito su entrambi i file

## Note

Branch basato su `origin/main`, come #979. Le due PR toccano hunk diversi dello stesso file e non hanno dipendenze d'ordine: si possono mergiare in qualunque sequenza.

---

🤖 Opened by Engineer