### PR TITLE
fix(scheduler): drain stranded wake outbox on proven-live heartbeat

### DIFF
--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -832,6 +832,9 @@ class AgentScheduler:
 
             hb = self._registry.get_latest_heartbeat(agent.name)
             if self._reconcile_server_liveness(agent, hb, now, streaming_sessions):
+                # Server-side transport evidence proves this agent is live —
+                # a safe boot boundary to drain any stranded wake outbox.
+                self._drain_outbox_if_pending(agent.name)
                 continue
             if not hb:
                 # No heartbeat ever recorded — mark stale
@@ -865,6 +868,49 @@ class AgentScheduler:
                         message_count=hb.message_count,
                         metadata={"reason": f"heartbeat overdue by {int(age - agent.heartbeat_interval)}s"},
                     )
+            else:
+                # Fresh heartbeat: the session ran a tool and reported in, so
+                # it is processing NOW. That is proof-of-life the durable wake
+                # outbox can safely drain against.
+                self._drain_outbox_if_pending(agent.name)
+
+    def _drain_outbox_if_pending(self, agent_name: str) -> None:
+        """Replay a proven-live agent's stranded wake outbox.
+
+        The durable outbox otherwise drains only at daemon ``start()`` or on a
+        confirmed wake-prompt turn (``on_wake_delivered``). A session revived
+        WITHOUT such a turn — e.g. a ``context_restart`` whose orientation wake
+        never produced an exact receipt, then kept alive by heartbeats — stays
+        alive yet never replays, stranding every cron it missed while dark
+        (live incident 2026-08-01: 20 rows still pending after a mid-day heartbeat, all
+        fired 06:00–10:15 into the gap). ``_check_heartbeats`` calls this once
+        it has proof the session is live, closing that gap without touching the
+        deliberate "a new cron fire never replays backlog into the old session"
+        contract: replay still happens only at a proven-live boundary.
+
+        Idempotent and self-limiting: skips when a replay is already in flight,
+        only reads the (indexed) outbox for a genuinely-live agent, and the
+        FIFO replay's per-prompt receipt gate leaves rows pending if the
+        session cannot accept them. So this never double-delivers and never
+        drains into a dead transport.
+        """
+        existing = self._pending_replay_tasks.get(agent_name)
+        if existing is not None and not existing.done():
+            return
+        try:
+            if not self._registry.list_pending_schedule_wakes(agent_name):
+                return
+        except Exception as exc:
+            _log(
+                f"scheduler: outbox drain check failed for '{agent_name}': "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return
+        _log(
+            f"scheduler: proven-live agent '{agent_name}' has a stranded wake "
+            "outbox; triggering durable replay"
+        )
+        self.replay_pending_for_agent(agent_name)
 
     # Resurrection cap: at most this many attempts per RESURRECTION_WINDOW_SECONDS
     # per agent. Prevents thrashing on a persistently-broken session while still

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -930,10 +930,16 @@ class AgentScheduler:
                         message_count=hb.message_count,
                         metadata={"reason": f"heartbeat overdue by {int(age - agent.heartbeat_interval)}s"},
                     )
-            else:
-                # Fresh heartbeat: the session ran a tool and reported in, so
+            elif hb.status == "alive":
+                # Fresh AND alive: the session ran a tool and reported in, so
                 # it is processing NOW. That is proof-of-life the durable wake
-                # outbox can safely drain against.
+                # outbox can safely drain against. The status gate matters:
+                # this scheduler itself writes "stale"/"dead" rows with
+                # CURRENT timestamps (above), so on the next tick those
+                # non-live rows are temporally fresh — draining on age alone
+                # would cold-start a dead or deliberately non-resurrectable
+                # runtime through the wake callback, bypassing the
+                # proven-live-only policy (Murzik review, PR #981).
                 self._drain_outbox_if_pending(agent.name)
 
     def _drain_outbox_if_pending(self, agent_name: str) -> None:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -981,6 +981,56 @@ class TestScheduler:
         assert registry.get_schedules("oleg")[0].last_delivered > 0
 
     @pytest.mark.asyncio
+    async def test_fresh_heartbeat_drains_stranded_outbox(self, registry):
+        """A session revived by a heartbeat (no confirmed wake) still replays.
+
+        Reproduces the 2026-08-01 live incident: a context_restart whose
+        orientation wake never produced a receipt left the session alive but
+        never fired on_wake_delivered, so the durable outbox — the only two
+        triggers being daemon start() and on_wake_delivered — never drained.
+        _check_heartbeats must treat a fresh heartbeat as the proof-of-life
+        boundary and replay the backlog.
+        """
+        registry.register("oleg", heartbeat_interval=60)
+        schedule = registry.add_schedule(
+            "oleg", "0 8 * * *", name="inbox", prompt="morning inbox"
+        )
+        fired_at = time.time() - 300
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="inbox",
+            prompt="morning inbox",
+            fired_at=fired_at,
+        )
+        # Session is provably alive again: a fresh heartbeat, exactly as
+        # the live incident's reviving heartbeat proved — but NO confirmed wake landed.
+        registry.record_heartbeat("oleg", session_id="oleg-main", status="alive")
+
+        attempts: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        # streaming_sessions_fn returns {} so server-liveness does not short
+        # -circuit — the fresh-heartbeat branch is what must drain the outbox.
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            streaming_sessions_fn=lambda: {},
+        )
+        await scheduler._check_heartbeats(time.time())
+        replay_task = scheduler._pending_replay_tasks.get("oleg")
+        assert replay_task is not None, "fresh heartbeat did not trigger replay"
+        await replay_task
+
+        assert attempts == ["morning inbox"]
+        assert registry.list_pending_schedule_wakes("oleg") == []
+
+    @pytest.mark.asyncio
     async def test_persisted_fifo_replays_before_new_schedule_cohort(
         self, registry
     ):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1132,6 +1132,59 @@ class TestScheduler:
         assert registry.list_pending_schedule_wakes("oleg") == []
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", ["stale", "dead"])
+    async def test_fresh_but_non_alive_heartbeat_never_drains(
+        self, registry, status
+    ):
+        """A temporally-fresh stale/dead heartbeat row is NOT proof-of-life.
+
+        The scheduler itself writes "stale"/"dead" rows with current
+        timestamps, so on the next tick those rows pass the age check while
+        the session is provably NOT live. Draining there would cold-start a
+        dead (or deliberately non-resurrectable) runtime through the wake
+        callback, bypassing the proven-live-only policy (Murzik review,
+        PR #981). The pending row must be retained untouched.
+        """
+        registry.register("oleg", heartbeat_interval=60)
+        schedule = registry.add_schedule(
+            "oleg", "0 8 * * *", name="inbox", prompt="morning inbox"
+        )
+        fired_at = time.time() - 300
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="inbox",
+            prompt="morning inbox",
+            fired_at=fired_at,
+        )
+        # Temporally fresh, but the status says the session is not live —
+        # exactly what the scheduler's own bookkeeping writes.
+        registry.record_heartbeat("oleg", session_id="oleg-main", status=status)
+
+        attempts: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            streaming_sessions_fn=lambda: {},
+        )
+        await scheduler._check_heartbeats(time.time())
+        replay_task = scheduler._pending_replay_tasks.get("oleg")
+        if replay_task is not None:
+            await replay_task
+
+        assert attempts == []
+        assert [
+            wake.prompt for wake in registry.list_pending_schedule_wakes("oleg")
+        ] == ["morning inbox"]
+
+    @pytest.mark.asyncio
     async def test_persisted_fifo_replays_before_new_schedule_cohort(
         self, registry
     ):


### PR DESCRIPTION
## Gate satisfied

This PR was drafted behind a hard ordering constraint: it must land AFTER the exec-idempotency guard. That guard is now **merged** (#983, d1bcc2f) and this branch carries it (main merged in at 279b133; combined scheduler suite 111 passed). With #983 in place, outbox rows exist only for wakes that provably never reached the pane — which makes this PR's proven-live drain safe.

**Deploy note:** rows minted BEFORE #983 on any host may still be phantoms; the deploy runbook audits pending_schedule_wakes per host before this drain goes live.

## What

The durable schedule-wake outbox (`pending_schedule_wakes`) only replays at daemon `start()` or on a confirmed wake-prompt turn (`on_wake_delivered`). A session revived WITHOUT such a turn — a `context_restart` whose orientation wake never produced an exact receipt, then kept alive by heartbeats — stays alive yet never replays, so every cron it fired into the dark stays stranded indefinitely.

Live incident 2026-08-01: a post-midnight `context_restart` left a session dark until a mid-day heartbeat; 20 wakes fired across the morning were persisted but never drained, while `last_run` (stamped at fire) kept the schedule list looking healthy.

## How

`_check_heartbeats` already establishes proof-of-life two ways (server-side transport evidence via `_reconcile_server_liveness`, and a fresh agent heartbeat). Both are safe boot boundaries — drain the outbox there via a new idempotent `_drain_outbox_if_pending()`. Preserves the deliberate "a new cron fire never replays backlog into the old session" contract: replay still fires only at a proven-live boundary, skips when one is already in flight, and the FIFO per-prompt receipt gate still applies.

## Tests

New test reproduces the incident's exact case (heartbeat-revived session, no confirmed wake). `tests/test_scheduler.py`: 108 passed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Authored by Angel (fleet agent) — relayed and pushed by Barsik

