### PR TITLE
fix(scheduler): duplicate-execution guard — timeout decisions read transport execution state, not receipt state

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -10502,6 +10502,18 @@ npm run build</pre>
             or stats.get("inflight_active") is True
         )
 
+    def _scheduler_wake_inflight(agent_name: str, prompt: str) -> bool:
+        """Per-turn execution state: is this wake pasted with an open receipt?
+
+        Transports without the probe (e.g. Codex sessions) fall through to
+        False, preserving their pre-probe timeout behavior.
+        """
+        ss = broker._get_streaming_session(agent_name)
+        probe = getattr(ss, "scheduler_wake_inflight", None) if ss else None
+        if not callable(probe):
+            return False
+        return probe(prompt) is True
+
     async def _notify_owner_undelivered(
         agent_name: str, message: str
     ) -> bool:
@@ -10548,6 +10560,7 @@ npm run build</pre>
         streaming_sessions_fn=lambda: broker._streaming,
         comms_cleanup_fn=comms.cleanup_expired,
         delivery_busy_fn=_scheduler_delivery_busy,
+        delivery_inflight_fn=_scheduler_wake_inflight,
         owner_notify_callback=_notify_owner_undelivered,
         trigger_store=trigger_store,
         activity=activity,

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -169,6 +169,7 @@ class AgentScheduler:
         is_resurrectable_fn=None,
         comms_cleanup_fn=None,
         delivery_busy_fn=None,
+        delivery_inflight_fn=None,
         owner_notify_callback=None,
         trigger_store=None,
         activity=None,
@@ -197,6 +198,16 @@ class AgentScheduler:
         # positive busy-not-wedged evidence, so a pending scheduler receipt
         # must keep waiting instead of expiring behind a healthy long turn.
         self._delivery_busy_fn = delivery_busy_fn
+        # fn(agent_name, prompt) -> bool. True means THIS wake's prompt has
+        # already been pasted to the transport with its receipt unresolved.
+        # Past that point a cancel cannot recall the prompt — the pane will
+        # execute it regardless — so declaring the wake undelivered and
+        # re-persisting it would mint a phantom outbox row whose later
+        # replay is a DUPLICATE EXECUTION. The receipt wait must extend
+        # instead. Distinct from delivery_busy_fn: that reads watchdog
+        # liveness (can blip false between turns at the timeout boundary);
+        # this reads the turn's own transport execution state.
+        self._delivery_inflight_fn = delivery_inflight_fn
         # async fn(agent_name, text) -> bool. FIRED BUT UNDELIVERED must leave
         # journald and reach the owner through an out-of-band transport.
         self._owner_notify_callback = owner_notify_callback
@@ -625,6 +636,17 @@ class AgentScheduler:
                             "reports busy-not-wedged; extending delivery timeout"
                         )
                         continue
+                    if self._wake_prompt_inflight(schedule):
+                        _log(
+                            f"scheduler: receipt still pending for schedule "
+                            f"'{schedule.name}' (#{schedule.id}) for agent "
+                            f"'{schedule.agent_name}', but its prompt is "
+                            "already pasted to the transport — a cancel "
+                            "cannot recall it, and declaring undelivered "
+                            "would re-persist a wake that is about to "
+                            "execute (duplicate execution); extending"
+                        )
+                        continue
                     delivery.cancel()
                     await asyncio.gather(delivery, return_exceptions=True)
                     raise
@@ -785,6 +807,35 @@ class AgentScheduler:
                 f"(#{pending.schedule_id}) for agent '{agent_name}'"
             )
 
+    @staticmethod
+    def _wake_prompt(schedule) -> str:
+        """The exact prompt text a schedule's wake delivers to the transport."""
+        return schedule.prompt or f"Scheduled wake: {schedule.name}"
+
+    def _wake_prompt_inflight(self, schedule) -> bool:
+        """True when this wake's prompt is pasted with its receipt unresolved.
+
+        Reads the transport's per-turn execution state via
+        ``delivery_inflight_fn``, failing closed (False) so a missing or
+        broken probe degrades to the pre-probe behavior rather than
+        extending forever.
+        """
+        if self._delivery_inflight_fn is None:
+            return False
+        try:
+            return (
+                self._delivery_inflight_fn(
+                    schedule.agent_name, self._wake_prompt(schedule)
+                )
+                is True
+            )
+        except Exception as exc:
+            _log(
+                f"scheduler: wake-inflight check failed for "
+                f"'{schedule.agent_name}': {type(exc).__name__}: {exc}"
+            )
+            return False
+
     async def _wake_and_confirm(
         self,
         schedule,
@@ -798,7 +849,7 @@ class AgentScheduler:
         result = await self._wake_callback(
             schedule.agent_name,
             main_session_id,
-            schedule.prompt or f"Scheduled wake: {schedule.name}",
+            self._wake_prompt(schedule),
         )
         if inspect.isawaitable(result):
             result = await result

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -207,6 +207,17 @@ class AgentScheduler:
         # instead. Distinct from delivery_busy_fn: that reads watchdog
         # liveness (can blip false between turns at the timeout boundary);
         # this reads the turn's own transport execution state.
+        #
+        # The extension is DELIBERATELY unbounded while the probe keeps
+        # reporting pasted-unresolved: in that state any timeout action
+        # either drops the wake or duplicates it, so the scheduler holds.
+        # The hold ends when the receipt resolves (acceptance observed),
+        # the session leaves CONNECTED (receipt resolves False), or a
+        # force_restart resets the turn's pasted flag (probe reads False
+        # and the durable cancel+persist path resumes). Operational cost
+        # while held: same-agent schedule cohorts queue behind the
+        # per-agent delivery lock — surfaced by the "extending" log line
+        # each timeout period (Murzik review, PR #983).
         self._delivery_inflight_fn = delivery_inflight_fn
         # async fn(agent_name, text) -> bool. FIRED BUT UNDELIVERED must leave
         # journald and reach the owner through an out-of-band transport.

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3492,11 +3492,25 @@ class TmuxSession:
         execution. Prompt-text matching mirrors ``_match_acceptance_turn``:
         scheduler turns are enqueued without an agent hint, so the queued
         prompt is the schedule's exact wake prompt.
+
+        Scans ``_acceptance_candidates()`` — NOT just
+        ``_scheduler_pending_turns`` — because the #943 watchdog
+        unaccepted-head path removes a preserved scheduler head from the
+        pending list and requeues it through the ordinary worker; after the
+        post-restart repaste that turn lives in ``_inflight_turn`` /
+        ``_inflight_metas`` only. Scanning the narrow list would report
+        False for exactly that pasted-with-open-receipt replay and re-open
+        the duplicate path (Murzik review, PR #983). While the replayed
+        turn is still queued-unpasted, ``pane_delivery_started`` is False
+        (reset by the watchdog) and a cancel remains safe: the shared
+        in-lock cancelled-receipt check covers the ordinary worker's paste
+        path too.
         """
-        for turn in self._scheduler_pending_turns:
+        for turn in self._acceptance_candidates():
             receipt = turn.scheduler_delivery
             if (
-                receipt is not None
+                turn.scheduler_serialized
+                and receipt is not None
                 and not receipt.done()
                 and turn.pane_delivery_started
                 and turn.prompt == prompt

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3481,6 +3481,29 @@ class TmuxSession:
             receipt.set_result(False)
         return receipt
 
+    def scheduler_wake_inflight(self, prompt: str) -> bool:
+        """True when this prompt is pasted to the pane with an unresolved receipt.
+
+        The scheduler consults this at its receipt-timeout boundary. Once
+        ``pane_delivery_started`` is set the prompt is physically in (or
+        entering) the pane and cancellation cannot recall it — the REPL will
+        execute it regardless — so timing out and re-persisting the wake
+        would mint an outbox row whose later replay duplicates the
+        execution. Prompt-text matching mirrors ``_match_acceptance_turn``:
+        scheduler turns are enqueued without an agent hint, so the queued
+        prompt is the schedule's exact wake prompt.
+        """
+        for turn in self._scheduler_pending_turns:
+            receipt = turn.scheduler_delivery
+            if (
+                receipt is not None
+                and not receipt.done()
+                and turn.pane_delivery_started
+                and turn.prompt == prompt
+            ):
+                return True
+        return False
+
     async def _queue_external_turn(
         self,
         prompt: str,
@@ -7247,6 +7270,19 @@ class TmuxSession:
         # interleave with this paste — two send paths into one pane.
         while True:
             async with self._repl_control_lock:
+                # A scheduler-side cancel can land while this task awaits the
+                # REPL lock; pasting after that point would execute a turn
+                # whose wake was already re-persisted as undelivered — the
+                # replay then duplicates the execution. Last-instant check
+                # under the lock: past ``pane_delivery_started = True`` the
+                # scheduler's inflight probe takes over and blocks the cancel
+                # instead.
+                if (
+                    turn.scheduler_serialized
+                    and turn.scheduler_delivery is not None
+                    and turn.scheduler_delivery.cancelled()
+                ):
+                    raise _SchedulerDeliveryCancelled
                 # An ordinary send can win the REPL lock after the scheduler's
                 # outer idle wait. Recheck under the shared lock so a scheduler
                 # paste never races behind newly queued steering input.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -929,6 +929,107 @@ class TestScheduler:
         assert "busy-not-wedged; extending" in capsys.readouterr().err
 
     @pytest.mark.asyncio
+    async def test_pasted_wake_extends_timeout_instead_of_cancelling(
+        self, registry, capsys
+    ):
+        """A pasted-but-unaccepted wake must extend, never re-persist.
+
+        Reproduces the 2026-08-01 duplicate-execution incident: the 600s
+        receipt timeout hit while the prompt was already pasted to the pane
+        (watchdog liveness blipped false between turns). Cancelling there
+        cannot recall the paste — the REPL executes it anyway — so the
+        re-persisted outbox row replays a wake that already ran. The
+        transport execution-state probe must block the cancel.
+        """
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="sweep", prompt="run the sweep"
+        )
+        receipt = asyncio.get_running_loop().create_future()
+        probes: list[tuple[str, str]] = []
+
+        async def wake_cb(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            # Acceptance lands well after several timeout boundaries.
+            asyncio.get_running_loop().call_later(
+                0.05, receipt.set_result, True
+            )
+            return receipt
+
+        def inflight_fn(agent_name, prompt):
+            probes.append((agent_name, prompt))
+            return True  # prompt is pasted, receipt open
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            delivery_busy_fn=lambda agent_name: False,  # liveness blip
+            delivery_inflight_fn=inflight_fn,
+            schedule_delivery_timeout=0.01,
+        )
+        await scheduler._deliver_schedule(schedule)
+
+        assert probes and set(probes) == {("oleg", "run the sweep")}
+        assert registry.get_schedules("oleg")[0].last_delivered > 0
+        assert registry.list_pending_schedule_wakes("oleg") == []
+        assert "already pasted to the transport" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_unpasted_wake_still_persists_on_timeout(self, registry):
+        """Probe False (never pasted) keeps the durable-persist behavior."""
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="queued-only", prompt="never pasted"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+
+        async def no_receipt(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return asyncio.get_running_loop().create_future()
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=no_receipt,
+            delivery_inflight_fn=lambda agent_name, prompt: False,
+            schedule_delivery_timeout=0.01,
+        )
+        await scheduler._deliver_schedule(schedule)
+
+        pending = registry.list_pending_schedule_wakes("oleg")
+        assert [wake.prompt for wake in pending] == ["never pasted"]
+
+    @pytest.mark.asyncio
+    async def test_inflight_probe_failure_fails_closed(self, registry):
+        """A broken probe degrades to the pre-probe cancel path, loudly."""
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="broken-probe", prompt="probe breaks"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+
+        async def no_receipt(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return asyncio.get_running_loop().create_future()
+
+        def broken(agent_name, prompt):
+            raise RuntimeError("probe transport gone")
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=no_receipt,
+            delivery_inflight_fn=broken,
+            schedule_delivery_timeout=0.01,
+        )
+        await scheduler._deliver_schedule(schedule)
+
+        pending = registry.list_pending_schedule_wakes("oleg")
+        assert [wake.prompt for wake in pending] == ["probe breaks"]
+
+    @pytest.mark.asyncio
     async def test_undelivered_alerts_owner_and_replays_on_next_boot(
         self, registry
     ):

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3727,6 +3727,43 @@ async def test_scheduler_cancel_before_paste_never_pastes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_scheduler_cancel_during_repl_lock_wait_never_pastes() -> None:
+    """Murzik review (PR #983): the IN-LOCK cancelled-receipt check must fire.
+
+    The slot-wait check catches a cancel that lands while the pane is busy;
+    this test targets the residual race AFTER the outer idle gate: the
+    delivery task is parked on ``_repl_control_lock`` when the cancel lands,
+    so only the check inside the lock stands between the cancel and a paste
+    of an already-re-persisted wake.
+    """
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+
+    await ss._repl_control_lock.acquire()
+    try:
+        receipt = await ss.send_scheduler_prompt("scheduled")
+        # Idle pane → the delivery task passes the outer slot gate and its
+        # final pre-lock cancelled check, then parks on the held lock.
+        await asyncio.sleep(0.3)
+        assert tmux.paste_text.await_count == 0
+        receipt.cancel()
+    finally:
+        ss._repl_control_lock.release()
+
+    # The task acquires the lock, sees the cancelled receipt inside it, and
+    # must abort without ever pasting.
+    for _ in range(50):
+        if not ss._scheduler_delivery_tasks:
+            break
+        await asyncio.sleep(0.01)
+    assert tmux.paste_text.await_count == 0
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_watchdog_force_restart_replays_unaccepted_scheduler_head(
     monkeypatch,
 ) -> None:

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3789,6 +3789,12 @@ async def test_watchdog_force_restart_replays_unaccepted_scheduler_head(
     assert original.replay_count == 1
     assert not original.transport_accepted
     assert not receipt.done(), "force_restart must preserve the exact receipt"
+    # Murzik review (PR #983): the replayed head now lives outside
+    # _scheduler_pending_turns (the watchdog removed it and requeued via the
+    # ordinary worker) but it is pasted with an open receipt — the inflight
+    # probe must still see it, or the scheduler's timeout path re-opens the
+    # cancel+persist duplicate hole for exactly this turn.
+    assert ss.scheduler_wake_inflight("one-shot scheduled wake") is True
 
     ss._on_transcript_entry({
         "type": "user",

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3668,6 +3668,65 @@ async def test_scheduler_prompt_receipt_waits_for_live_working_status() -> None:
 
 
 @pytest.mark.asyncio
+async def test_scheduler_wake_inflight_probe_tracks_pasted_turn() -> None:
+    """The probe reports pasted-with-open-receipt, per exact prompt."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+
+    receipt = await ss.send_scheduler_prompt("scheduled")
+    for _ in range(100):
+        if tmux.paste_text.await_count == 1:
+            break
+        await asyncio.sleep(0.01)
+
+    assert ss.scheduler_wake_inflight("scheduled") is True
+    assert ss.scheduler_wake_inflight("some other prompt") is False
+
+    ss._on_transcript_entry({
+        "type": "queue-operation",
+        "operation": "enqueue",
+        "content": "scheduled",
+    })
+    ss._on_transcript_entry({
+        "type": "queue-operation",
+        "operation": "dequeue",
+    })
+    assert await receipt is True
+    assert ss.scheduler_wake_inflight("scheduled") is False
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_cancel_before_paste_never_pastes() -> None:
+    """A queued-unpasted turn reports not-inflight and honors a cancel.
+
+    This is the safe half of the timeout split: while the prompt has not
+    been pasted, the probe returns False (so the scheduler may cancel and
+    durably persist the wake) and the cancelled turn must never reach the
+    pane afterwards — otherwise the persisted row replays a wake that also
+    executed (the 2026-08-01 duplicate-execution incident).
+    """
+    live = {"status": "working", "last_updated": _time.time()}
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: live
+
+    receipt = await ss.send_scheduler_prompt("scheduled")
+    await asyncio.sleep(0.02)
+    assert tmux.paste_text.await_count == 0
+    assert ss.scheduler_wake_inflight("scheduled") is False
+
+    receipt.cancel()
+    live["status"] = "idle"
+    live["last_updated"] = _time.time()
+    await asyncio.sleep(0.35)  # > slot-wait poll interval
+    assert tmux.paste_text.await_count == 0
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_watchdog_force_restart_replays_unaccepted_scheduler_head(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## The bug (confirmed live, 2026-08-01)

`_wait_for_wake_confirmation` cancels the delivery waiter and durably re-persists the wake whenever the 600s receipt timeout fires and the watchdog liveness signal reads false at that instant. But **a cancel cannot recall a prompt that is already pasted to the pane** — the REPL executes it regardless, acceptance resolves into a cancelled future, and the re-persisted outbox row later replays a wake that already ran. Evidence from a fleet host's work log: **three executed runs of a cron against two executable fires** in one congestion window (plus 53 FIRED-BUT-UNDELIVERED re-persists that day).

## The fix — guard on execution state

The timeout decision now splits on the transport's own per-turn state:

| Turn state at timeout | Old behavior | New behavior |
|---|---|---|
| Pasted, receipt open | cancel + re-persist → **duplicate** | **extend** (with its own log line) |
| Queued, never pasted | cancel + re-persist | unchanged — and provably safe: a cancelled queued turn never reaches the pane |

- `TmuxAgentSession.scheduler_wake_inflight(prompt)` — True while a scheduler turn with this exact prompt is pasted (`pane_delivery_started`) with an unresolved receipt; prompt matching mirrors `_match_acceptance_turn`.
- Scheduler gains `delivery_inflight_fn` (wired in `api.py`), consulted after the existing busy-not-wedged check; fails closed to pre-probe behavior on missing/broken probe (Codex transport unchanged).
- Residual pre-paste race closed: a cancel landing while the delivery task awaits the REPL control lock now raises `_SchedulerDeliveryCancelled` inside the lock instead of pasting a cancelled turn.

## Relationship to PR #981 (drain fix — currently draft)

With this guard, outbox rows exist only for wakes that provably never reached the pane — the precondition that makes #981's proven-live drain safe. **Merge order: this first, then #981.**

## Tests

- `test_scheduler.py`: pasted→extend (repro of the live incident), unpasted→persist (regression), broken-probe→fail-closed. 110 passed.
- `test_tmux_session.py`: probe tracks pasted/open-receipt per exact prompt; cancelled queued turn never pastes. 16 scheduler-path tests passed.
- Full local suite green except 7 pre-existing collection errors identical on plain main (local-env deps); CI is authoritative.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Root-caused by Angel (fleet agent, from production logs); implemented by Barsik