### PR TITLE
fix(scheduler): add host-local owner alert fallback (#985)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -10517,34 +10517,143 @@ npm run build</pre>
     async def _notify_owner_undelivered(
         agent_name: str, message: str
     ) -> bool:
-        """Send scheduler failures through canonical owner destinations."""
+        """Send scheduler failures through canonical and host-local fallbacks."""
         send_callback = broker.send_callback
         destinations = agents.get_owner_notification_destinations()
-        if not send_callback or not destinations:
+        if not send_callback:
             return False
-        last_error = "no configured destination accepted the alert"
-        for destination in destinations:
+
+        sender_names = [agent_name] + [
+            agent.name
+            for agent in agents.list(enabled_only=True)
+            if agent.name != agent_name
+        ]
+        attempted_routes: set[tuple[str, str, str, str]] = set()
+        failures: list[str] = []
+
+        async def _attempt(
+            sender_name: str,
+            platform: str,
+            account_id: str,
+            conversation_id: str,
+        ) -> bool:
+            route = (sender_name, platform, account_id, conversation_id)
+            if route in attempted_routes:
+                return False
+            attempted_routes.add(route)
             try:
                 result = await send_callback(
-                    agent_name,
-                    destination["platform"],
-                    destination["conversation_id"],
+                    sender_name,
+                    platform,
+                    conversation_id,
                     message,
-                    account_id=destination["account_id"],
+                    account_id=account_id,
                 )
                 if not (
                     isinstance(result, dict)
                     and result.get("sent") is True
                 ):
-                    raise RuntimeError(
-                        "send callback did not confirm delivery"
-                    )
+                    raise RuntimeError("send callback did not confirm delivery")
             except Exception as exc:
-                last_error = f"{type(exc).__name__}: {exc}"
-                continue
+                error = f"{type(exc).__name__}: {exc}"
+                failures.append(error)
+                _log(
+                    "api: OWNER_NOTIFY_DELIVERY_FAILURE for scheduler alert "
+                    f"agent '{agent_name}' via sender '{sender_name}' route "
+                    f"{platform}/{account_id}/{conversation_id}: {error}"
+                )
+                return False
             return True
+
+        for index, destination in enumerate(destinations):
+            platform = destination["platform"]
+            account_id = destination["account_id"]
+            conversation_id = destination["conversation_id"]
+            preferred_bound = bool(agents.get_raw_token_for_account(
+                agent_name, platform, account_id,
+            ))
+            sender_name = next((
+                candidate
+                for candidate in sender_names
+                if agents.get_raw_token_for_account(candidate, platform, account_id)
+            ), "")
+
+            if not preferred_bound:
+                error = (
+                    f"no {platform} token bound to destination account "
+                    f"{account_id} for preferred sender {agent_name}"
+                )
+                failures.append(error)
+                _log(
+                    "api: OWNER_NOTIFY_DELIVERY_FAILURE for scheduler alert "
+                    f"agent '{agent_name}' via sender '{agent_name}' route "
+                    f"{platform}/{account_id}/{conversation_id}: {error}"
+                )
+
+            if not sender_name:
+                continue
+            if index > 0 or sender_name != agent_name:
+                _log(
+                    "api: OWNER_NOTIFY_ROUTE_FALLBACK for scheduler alert "
+                    f"agent '{agent_name}': using canonical route "
+                    f"{platform}/{account_id}/{conversation_id} via local "
+                    f"sender '{sender_name}'"
+                )
+            if await _attempt(sender_name, platform, account_id, conversation_id):
+                return True
+
+        try:
+            default_conversation_id, default_platform = resolve_operator_chat(
+                get_setting=agents.get_setting,
+                list_all_approved_users=agents.list_all_approved_users,
+            )
+        except Exception as exc:
+            error = f"default owner channel resolution failed: {type(exc).__name__}: {exc}"
+            failures.append(error)
+            _log(
+                "api: OWNER_NOTIFY_DELIVERY_FAILURE for scheduler alert "
+                f"agent '{agent_name}': {error}"
+            )
+            default_conversation_id, default_platform = "", ""
+
+        default_sender = ""
+        default_account = ""
+        if default_conversation_id and default_platform:
+            for candidate in sender_names:
+                account_id = agents.get_token_account_id(candidate, default_platform)
+                if account_id and agents.get_raw_token_for_account(
+                    candidate, default_platform, account_id,
+                ):
+                    default_sender = candidate
+                    default_account = account_id
+                    break
+
+        if default_sender:
+            _log(
+                "api: OWNER_NOTIFY_ROUTE_FALLBACK for scheduler alert "
+                f"agent '{agent_name}': using daemon default owner channel "
+                f"{default_platform}/{default_account}/{default_conversation_id} "
+                f"via local sender '{default_sender}'"
+            )
+            if await _attempt(
+                default_sender,
+                default_platform,
+                default_account,
+                default_conversation_id,
+            ):
+                return True
+        elif default_conversation_id and default_platform:
+            error = f"no local token bound for default owner platform {default_platform}"
+            failures.append(error)
+            _log(
+                "api: OWNER_NOTIFY_DELIVERY_FAILURE for scheduler alert "
+                f"agent '{agent_name}' route {default_platform}/"
+                f"{default_conversation_id}: {error}"
+            )
+
+        last_error = failures[-1] if failures else "no owner alert route is configured"
         _log(
-            f"api: OWNER_NOTIFY_DELIVERY_FAILURE for scheduler alert "
+            "api: OWNER_NOTIFY_TERMINAL_FAILURE for scheduler alert "
             f"agent '{agent_name}': {last_error}"
         )
         return False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7775,6 +7775,10 @@ class TestBuildStreamingWakeContextReasonGating:
         """#949 alerting uses the durable #863 owner-notify configuration."""
         with tempfile.TemporaryDirectory() as tmpdir:
             app = self._make_app(os.path.join(tmpdir, "test.db"))
+            app.state.agents.register("dymok", model="sonnet")
+            app.state.agents.set_token(
+                "dymok", "telegram", "token", settings={"account_id": "acct-1"},
+            )
             app.state.agents.set_owner_notification_destinations([
                 {
                     "platform": "telegram",
@@ -7797,6 +7801,106 @@ class TestBuildStreamingWakeContextReasonGating:
                 "owner-dm",
                 "FIRED BUT UNDELIVERED test",
                 account_id="acct-1",
+            )
+
+    @pytest.mark.asyncio
+    async def test_scheduler_owner_alert_uses_exact_account_on_another_local_agent(
+        self, monkeypatch,
+    ):
+        """#985: an absent preferred binding falls back without hiding the rot."""
+        import pinky_daemon.api as api_mod
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            app.state.agents.register("geordi", model="sonnet")
+            app.state.agents.register("local-notifier", model="sonnet")
+            app.state.agents.set_token(
+                "local-notifier",
+                "telegram",
+                "token",
+                settings={"account_id": "brad-telegram"},
+            )
+            app.state.agents.set_owner_notification_destinations([
+                {
+                    "platform": "telegram",
+                    "account_id": "brad-telegram",
+                    "conversation_id": "owner-dm",
+                    "principal_id": "owner-user",
+                }
+            ])
+            send = AsyncMock(return_value={"sent": True})
+            app.state.broker._send_callback = send
+            logs: list[str] = []
+            monkeypatch.setattr(api_mod, "_log", logs.append)
+
+            delivered = await app.state.scheduler._owner_notify_callback(
+                "geordi", "FIRED BUT UNDELIVERED test"
+            )
+
+            assert delivered is True
+            send.assert_awaited_once_with(
+                "local-notifier",
+                "telegram",
+                "owner-dm",
+                "FIRED BUT UNDELIVERED test",
+                account_id="brad-telegram",
+            )
+            assert any("OWNER_NOTIFY_DELIVERY_FAILURE" in line for line in logs)
+            assert any(
+                "OWNER_NOTIFY_ROUTE_FALLBACK" in line and "local-notifier" in line
+                for line in logs
+            )
+
+    @pytest.mark.asyncio
+    async def test_scheduler_owner_alert_uses_default_channel_with_any_local_account(
+        self, monkeypatch,
+    ):
+        """#985: total canonical-binding absence falls back to the daemon default."""
+        import pinky_daemon.api as api_mod
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            app.state.agents.register("geordi", model="sonnet")
+            app.state.agents.set_token(
+                "geordi", "slack", "token", settings={"team_id": "T_PI"},
+            )
+            app.state.agents.set_setting("operator_chat_id", "D_OWNER")
+            app.state.agents.set_setting("operator_platform", "slack")
+            app.state.agents.set_owner_notification_destinations([
+                {
+                    "platform": "telegram",
+                    "account_id": "brad-telegram",
+                    "conversation_id": "telegram-owner-dm",
+                    "principal_id": "telegram-owner",
+                }
+            ])
+            send = AsyncMock(return_value={"sent": True})
+            app.state.broker._send_callback = send
+            logs: list[str] = []
+            monkeypatch.setattr(api_mod, "_log", logs.append)
+
+            delivered = await app.state.scheduler._owner_notify_callback(
+                "geordi", "FIRED BUT UNDELIVERED test"
+            )
+
+            assert delivered is True
+            send.assert_awaited_once_with(
+                "geordi",
+                "slack",
+                "D_OWNER",
+                "FIRED BUT UNDELIVERED test",
+                account_id="T_PI",
+            )
+            assert any(
+                "OWNER_NOTIFY_DELIVERY_FAILURE" in line
+                and "brad-telegram" in line
+                for line in logs
+            )
+            assert any(
+                "OWNER_NOTIFY_ROUTE_FALLBACK" in line
+                and "daemon default owner channel" in line
+                and "slack/T_PI/D_OWNER" in line
+                for line in logs
             )
 
     def test_central_wake_log_failure_does_not_advance_gate(self):


### PR DESCRIPTION
Fixes #985.

## What changed

- Preflight canonical owner destinations against local token bindings instead of waiting for an HTTP 409.
- If the affected agent lacks the exact account, send through another enabled local agent with that exact binding.
- If no canonical account exists locally, resolve the daemon default with `resolve_operator_chat()` and use any locally bound account for that platform.
- Emit `OWNER_NOTIFY_DELIVERY_FAILURE` for the original broken route even when fallback succeeds, log every `OWNER_NOTIFY_ROUTE_FALLBACK` hop, and retain a loud terminal failure event when no route delivers.
- Require a positive send receipt on every attempted route.

## Root cause and impact

Owner-notification destinations are global, while fleet hosts carry different outreach accounts. Pi agents chekov/geordi/quark have Slack bindings but no local `brad-telegram` binding, so scheduler alerts could fail silently with a 409. The fallback now preserves alert delivery without hiding the stale configuration.

This does not change approval notification state semantics; #982 remains out of scope and compatible with this routing behavior.

## Validation

- `PYTHONPATH=src PINKY_DREAM_TRANSPORT=sdk PINKY_AUTH_DENY_DEFAULT=shadow /Users/oleg/PinkyBot/.venv/bin/python -m pytest -q` — 4,569 passed, 4 skipped.
- `python3 -m ruff check .` — passed.
- Focused owner-alert regressions — 3 passed, including direct absent-binding inputs for both fallback hops.
- `git diff --check` — passed.

## Visual evidence

Screenshot/clip: N/A — daemon routing change with no UI surface.

---
🤖 Opened by Murzik