### PR TITLE
feat(messaging): expose Slack threaded sends (#341)

### DIFF
--- a/src/pinky_messaging/server.py
+++ b/src/pinky_messaging/server.py
@@ -140,8 +140,14 @@ def create_server(
         prefer_large_media: bool = False,
         link_preview_above: bool = False,
         blocks: str = "",
+        reply_to: str = "",
     ) -> str:
-        """Send a standalone message to a chat/channel. Use chat IDs, not display names.
+        """Send a message to a chat/channel. Use chat IDs, not display names.
+
+        Slack threading: reply_to is the thread root ts. When an inbound header
+        includes thread_root_ts and is_thread_reply:true, default to replying in
+        that thread (thread() already does this for an inbound message_id). Omit
+        reply_to to explicitly break out of the thread and post at the channel root.
 
         Link-preview flags (Telegram): disable_link_preview suppresses the URL
         preview card; prefer_large_media forces a big thumbnail; link_preview_above
@@ -158,6 +164,7 @@ def create_server(
             "platform": platform,
             "chat_id": chat_id,
             "content": text,
+            "reply_to": reply_to,
             "parse_mode": parse_mode,
             "link_preview_options": _link_preview_options(
                 disable_link_preview, prefer_large_media, link_preview_above

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3607,6 +3607,33 @@ class TestAPI:
                 assert stored["metadata"] == {"direction": "outbound"}
                 assert send.call_args_list[1].kwargs["reply_to_message_id"] == 501
 
+    def test_broker_send_reply_to_reaches_slack_text_thread(self):
+        """#341: /broker/send reply_to reaches text send_message.thread_ts."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            with TestClient(app) as client:
+                client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+                app.state.agents.set_token("barsik", "slack", "xoxb-test")
+
+                with patch(
+                    "pinky_outreach.slack.SlackAdapter.send_message",
+                    return_value=SimpleNamespace(message_id="1711584001.000200"),
+                ) as send:
+                    response = client.post(
+                        "/broker/send",
+                        json={
+                            "agent_name": "barsik",
+                            "platform": "slack",
+                            "chat_id": "C123",
+                            "content": "reply in thread",
+                            "reply_to": "1711584000.000100",
+                        },
+                    )
+
+                assert response.status_code == 200, response.text
+                send.assert_called_once()
+                assert send.call_args.kwargs["thread_ts"] == "1711584000.000100"
+
     def test_broker_thread_fails_closed_on_chat_scoped_message_id_collision(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "test.db")

--- a/tests/test_messaging_server.py
+++ b/tests/test_messaging_server.py
@@ -59,6 +59,24 @@ class TestSend:
             )
         assert json.loads(result)["ok"] is True
 
+    def test_send_forwards_reply_to(self):
+        payload = {"ok": True, "message_id": "1711584001.000200"}
+        with patch(
+            "urllib.request.urlopen", return_value=_mock_response(payload),
+        ) as mock_open:
+            srv = _srv()
+            result = _tools(srv)["send"](
+                chat_id="C123",
+                platform="slack",
+                text="reply in thread",
+                reply_to="1711584000.000100",
+            )
+
+        assert json.loads(result)["ok"] is True
+        request = mock_open.call_args[0][0]
+        body = json.loads(request.data)
+        assert body["reply_to"] == "1711584000.000100"
+
     def test_send_http_error(self):
         import urllib.error
         err = urllib.error.HTTPError(


### PR DESCRIPTION
## What changed

- expose optional `reply_to` on the messaging MCP `send()` tool and forward it to `/broker/send`
- document the Slack default: preserve an inbound thread using the shipped `thread_root_ts` / `is_thread_reply` header fields, while omitting `reply_to` explicitly posts at channel root
- add focused coverage for both the MCP payload and the Slack text-send `thread_ts` path

This completes Task #341 scope items 1 and 4. Scope item 3 is intentionally untouched because #864 already shipped the inbound thread provenance header.

## Why

The broker and Slack adapter already supported threaded text replies, but the MCP `send()` surface omitted `reply_to`. Agents therefore could not intentionally preserve a Slack thread through that tool, and its documentation did not explain the threading default or channel-root override.

## Impact

Thread-aware agents can now reply through `send()` without losing Slack conversation context. Existing callers remain compatible because `reply_to` is optional and appended to the function signature.

## Live text-path proof

No deployment was needed: release 26.08.001 already exposes the broker path.

- channel: `support-beta` (`C0BGJE4LRD3`)
- root ts: `1785780383.099109`
- signed `POST /broker/send` with `reply_to=root`: HTTP 200
- reply ts: `1785780688.495989`
- independent Slack readback: reply `thread_ts=1785780383.099109`; root `reply_count=1`

This proves the deployed text path lands visibly in-thread; no `api.py` text-path repair was required.

## Checks

- `PYTHONPATH=src PINKY_SHARED_MCP=0 ... pytest -q`: 4,569 passed, 4 skipped
- focused messaging + broker provenance/text-path tests: 35 passed
- `python -m ruff check .`: passed
- `git diff --check`: passed

Screenshot/clip: N/A — this is an MCP tool-surface and broker plumbing change with no visual UI.

🤖 Opened by Murzik