### PR TITLE
fix(deps): install Slack runtime dependencies by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "fastapi>=0.135",
     "uvicorn>=0.44",
     "websockets>=15.0",
-    "claude-agent-sdk>=0.2.126,<0.3",
+    "claude-agent-sdk>=0.2.127,<0.3",
     "Pillow>=10.0",
     # Federation crypto (sealed_box_v1): X25519, Ed25519, HKDF, XChaCha20-Poly1305.
     "cryptography>=41.0",
@@ -48,14 +48,18 @@ dependencies = [
     # http-message-signatures and is already a transitive dependency.
     "http-message-signatures>=2.0",
     "requests>=2.32",
+    # Slack Socket Mode is a daemon runtime path, so clean base installs must
+    # include its SDK and async transport without relying on an optional extra.
+    "slack-sdk>=3.0",
+    "aiohttp>=3.9",
 ]
 
 [project.optional-dependencies]
 acp = ["agent-client-protocol>=0.11,<0.12", "httpx"]
 telegram = ["python-telegram-bot[webhooks]>=21.0"]
 discord = ["discord.py>=2.3"]
-# slack-sdk's async Socket Mode client (slack_sdk.socket_mode.aiohttp) needs aiohttp.
-slack = ["slack-sdk>=3.0", "aiohttp>=3.9"]
+# Backward-compatible no-op while hosts migrate off `uv run --extra slack`.
+slack = []
 google = ["google-auth>=2.0", "google-api-python-client>=2.0"]
 calendar = [
     "google-api-python-client>=2.0",

--- a/tests/test_packaging_dependencies.py
+++ b/tests/test_packaging_dependencies.py
@@ -1,0 +1,21 @@
+"""Packaging contracts for dependencies required by daemon runtime paths."""
+
+import tomllib
+from pathlib import Path
+
+
+def _project() -> dict:
+    pyproject = Path(__file__).parents[1] / "pyproject.toml"
+    return tomllib.loads(pyproject.read_text())["project"]
+
+
+def test_slack_socket_mode_dependencies_are_in_base_install() -> None:
+    project = _project()
+
+    assert "slack-sdk>=3.0" in project["dependencies"]
+    assert "aiohttp>=3.9" in project["dependencies"]
+    assert project["optional-dependencies"]["slack"] == []
+
+
+def test_claude_agent_sdk_excludes_pretooluse_bypass_version() -> None:
+    assert "claude-agent-sdk>=0.2.127,<0.3" in _project()["dependencies"]

--- a/uv.lock
+++ b/uv.lock
@@ -520,20 +520,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.126"
+version = "0.2.128"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/33/30d51e1c53bb834fc4d51a39560c2e0cee0627767b2cc3b2001eb3b4ddb4/claude_agent_sdk-0.2.126.tar.gz", hash = "sha256:b0077f8da92f402032ec91b27499eb896aa97a9d78150ccd4a7840d39e70b9de", size = 304715, upload-time = "2026-07-22T21:40:34.678Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/e8/3a9622b31f9ee22274e13a620e5e75ac38454d14538391b2fe3bc7eb76dc/claude_agent_sdk-0.2.128.tar.gz", hash = "sha256:2ac7b2b3bc56ae9037fd284c8690d3dafab9493ecd28d8974bba79a418e1b800", size = 309369, upload-time = "2026-07-25T01:48:25.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/27/2624f73d65c24e2f2ebf8f4ef95f98a71bf382f3f622c439f096af8a66e8/claude_agent_sdk-0.2.126-py3-none-macosx_11_0_arm64.whl", hash = "sha256:edac88522b6fca74f1a84aa0d0f29caad4adda8aed04c3f08b86836e06c6c271", size = 74592742, upload-time = "2026-07-22T21:40:38.469Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/38/d774167d45c238f69a49734154236d1632ef7204153eafd13c126add32a3/claude_agent_sdk-0.2.126-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:8dd73c1a193afa133241d7346e89e5b60ebf45f6a8f2cc38c84c8aad794af61e", size = 79619741, upload-time = "2026-07-22T21:40:42.25Z" },
-    { url = "https://files.pythonhosted.org/packages/01/f4/786a8c67b53677af27fdbe3b3a80ee57c38ca18f95d44ec03567f97a7495/claude_agent_sdk-0.2.126-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:239e6073486488ce78fe88681c05e819562f5c5e567f02574492c3be3d35684b", size = 84165405, upload-time = "2026-07-22T21:40:46.331Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/42/76603fcd11ab51713ec0138c21ffbb82f5f1afcab9f73729e7e23a19e055/claude_agent_sdk-0.2.126-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:79caa03c6612e268bee93e95170d6b9ffdfa4bb21373a2e9ba7a439d3fb2e8e8", size = 85204584, upload-time = "2026-07-22T21:40:50.769Z" },
-    { url = "https://files.pythonhosted.org/packages/01/95/2d6685e502a7708473f03710f34f2ad6d7b3968fdd6cc90091e4f341c34d/claude_agent_sdk-0.2.126-py3-none-win_amd64.whl", hash = "sha256:201299609bb045e7ca8c7d3ff5e8d5900da2dcf3faad742990efe659e4c215ae", size = 85114596, upload-time = "2026-07-22T21:40:55.532Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ff/03613a38a84285cd85f114fc26d4431f545d2b3b344eb8f69f9b0f18f3c6/claude_agent_sdk-0.2.128-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e47ee95be68cb07612fd5288a40f3307763da5a5adf66d6e03ea49dc0495c9c", size = 75183825, upload-time = "2026-07-25T01:48:30.45Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/df/2adbd3077f1a1cada39cd1508990d4008a8ac9ec74c801b24b1b302348b0/claude_agent_sdk-0.2.128-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:55e8fa28918af5620f391692efe80527ad9f2294cec14dadeea93c5161dbefc4", size = 80305667, upload-time = "2026-07-25T01:48:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/776a41af67a53d794b420dcd2f1075b585ed3725faa9827164f4a2e945dd/claude_agent_sdk-0.2.128-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:6c10cc1c5403b2b0b3d8deb79ad5271a8e49b9db6460193599b91f49f16b4cf7", size = 84617823, upload-time = "2026-07-25T01:48:39.297Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1c/37044abbddf2141c4eeb6cc8e15a486491549a27283029d73db2c4f3c3b7/claude_agent_sdk-0.2.128-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:cc4a0f20337e227fe16f00edf7cbe109349707adb440fe51ca6c44f9f8d7d21a", size = 85663462, upload-time = "2026-07-25T01:48:43.982Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c9/ffbd8113080f87a4cd7bbfc8b00a974ea7189e3f666b5d7a2903dec7b74f/claude_agent_sdk-0.2.128-py3-none-win_amd64.whl", hash = "sha256:37b87c8e75daa2a6dc74da6d788e0981a2e5e3a6be80cfa4c287abce2bf70e0b", size = 85566882, upload-time = "2026-07-25T01:48:48.635Z" },
 ]
 
 [[package]]
@@ -2200,6 +2200,7 @@ name = "pinky-ai"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiohttp" },
     { name = "claude-agent-sdk" },
     { name = "cryptography" },
     { name = "fastapi" },
@@ -2213,6 +2214,7 @@ dependencies = [
     { name = "pynacl" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "slack-sdk" },
     { name = "sqlite-vec" },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -2224,7 +2226,6 @@ acp = [
     { name = "httpx" },
 ]
 all = [
-    { name = "aiohttp" },
     { name = "anthropic" },
     { name = "caldav" },
     { name = "cryptography" },
@@ -2235,7 +2236,6 @@ all = [
     { name = "google-auth-oauthlib" },
     { name = "icalendar" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
-    { name = "slack-sdk" },
     { name = "twilio" },
 ]
 calendar = [
@@ -2262,10 +2262,6 @@ google = [
 local-embeddings = [
     { name = "sentence-transformers" },
 ]
-slack = [
-    { name = "aiohttp" },
-    { name = "slack-sdk" },
-]
 telegram = [
     { name = "python-telegram-bot", extra = ["webhooks"] },
 ]
@@ -2289,12 +2285,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.11,<0.12" },
-    { name = "aiohttp", marker = "extra == 'slack'", specifier = ">=3.9" },
+    { name = "aiohttp", specifier = ">=3.9" },
     { name = "anthropic", marker = "extra == 'voice'", specifier = ">=0.98" },
     { name = "beautifulsoup4", marker = "extra == 'web'", specifier = ">=4.12" },
     { name = "caldav", marker = "extra == 'calendar'", specifier = ">=1.3" },
     { name = "camoufox", marker = "extra == 'web'", specifier = ">=0.4" },
-    { name = "claude-agent-sdk", specifier = ">=0.2.126,<0.3" },
+    { name = "claude-agent-sdk", specifier = ">=0.2.127,<0.3" },
     { name = "cryptography", specifier = ">=41.0" },
     { name = "cryptography", marker = "extra == 'calendar'", specifier = ">=41.0" },
     { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.3" },
@@ -2324,7 +2320,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11" },
     { name = "sentence-transformers", marker = "extra == 'local-embeddings'", specifier = ">=2.0" },
-    { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.0" },
+    { name = "slack-sdk", specifier = ">=3.0" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
     { name = "twilio", marker = "extra == 'voice'", specifier = ">=9.0" },
     { name = "uvicorn", specifier = ">=0.44" },


### PR DESCRIPTION
## What changed

- move `slack-sdk>=3.0` and `aiohttp>=3.9` from the optional Slack extra into PinkyBot's base dependencies
- retain `slack = []` as a temporary compatibility no-op for hosts still launching with `uv run --extra slack`
- raise the `claude-agent-sdk` floor from `>=0.2.126` to `>=0.2.127` so fresh installs exclude the PreToolUse-bypass-affected release
- refresh `uv.lock` (resolving `claude-agent-sdk 0.2.128`)
- add packaging contract tests for both dependency guarantees

This completes internal Tasks #226 and #456 and the fresh-install follow-up left by #915.

## Why / root cause

Slack Socket Mode is a daemon runtime path, but #801 declared its SDK and aiohttp transport only under an optional extra. Normal `uv run` release syncs install base dependencies, so inbound Slack silently failed on a clean host unless a per-machine systemd override supplied `--extra slack`. The poller tests mocked `slack_sdk` imports, which kept CI green while the deploy artifact was incomplete.

Separately, the production venv was upgraded past the affected Claude Agent SDK, but `pyproject.toml` still allowed a fresh environment to resolve 0.2.126.

## Impact

Clean base installs now contain the real Slack Socket Mode client and transport. The Pi's stopgap systemd override can be removed during deploy verification; the empty compatibility extra prevents the old launch command from breaking during that transition.

## Clean-install proof

Created a brand-new Python 3.11 virtualenv outside the repository, then installed the project with:

```
uv pip install --python <clean-venv>/bin/python .
```

No `--extra`, dev dependencies, editable workspace path, or mocked modules were used. From that environment:

```
pinky-ai=0.1.0
claude-agent-sdk=0.2.128
slack-sdk=3.43.0
aiohttp=3.14.3
SocketModeClient BrokerSlackPoller
```

Also verified `uv sync --extra slack --dry-run` accepts the compatibility extra while resolving Slack dependencies from base requirements.

## Checks

- full suite: 4,571 passed, 4 skipped
- focused packaging + Slack poller suite: 25 passed
- `uv lock --check`: passed
- `python -m ruff check .`: passed
- `git diff --check`: passed

Screenshot/clip: N/A — dependency metadata and clean-install behavior have no visual UI.

🤖 Opened by Murzik