### PR TITLE
fix(scheduler): bound persisted wake replay storms

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -663,6 +663,8 @@ class PendingScheduleWake:
     prompt: str = ""
     fired_at: float = 0.0
     created_at: float = 0.0
+    attempts: int = 0
+    parked_at: float = 0.0
 
     @property
     def name(self) -> str:
@@ -1275,6 +1277,8 @@ class AgentRegistry:
                 prompt TEXT NOT NULL DEFAULT '',
                 fired_at REAL NOT NULL,
                 created_at REAL NOT NULL,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                parked_at REAL NOT NULL DEFAULT 0,
                 FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
                 UNIQUE(schedule_id, fired_at)
             );
@@ -1602,6 +1606,27 @@ class AgentRegistry:
             if col not in sched_existing:
                 self._db.execute(f"ALTER TABLE agent_schedules ADD COLUMN {col} {typedef}")
                 _log(f"agent_registry: migrated — added {col} to agent_schedules")
+
+        # Migrate pending_schedule_wakes table
+        wake_existing = {
+            row[1]
+            for row in self._db.execute(
+                "PRAGMA table_info(pending_schedule_wakes)"
+            ).fetchall()
+        }
+        wake_migrations = [
+            ("attempts", "INTEGER NOT NULL DEFAULT 0"),
+            ("parked_at", "REAL NOT NULL DEFAULT 0"),
+        ]
+        for col, typedef in wake_migrations:
+            if col not in wake_existing:
+                self._db.execute(
+                    f"ALTER TABLE pending_schedule_wakes ADD COLUMN {col} {typedef}"
+                )
+                _log(
+                    "agent_registry: migrated — added "
+                    f"{col} to pending_schedule_wakes"
+                )
 
         # Migrate agent_heartbeats table
         hb_existing = {
@@ -3261,7 +3286,7 @@ except Exception as exc:
             created = cursor.rowcount > 0
             row = self._db.execute(
                 """SELECT id, schedule_id, agent_name, schedule_name, prompt,
-                          fired_at, created_at
+                          fired_at, created_at, attempts, parked_at
                    FROM pending_schedule_wakes
                    WHERE schedule_id=? AND fired_at=?""",
                 (schedule_id, fired_at),
@@ -3270,19 +3295,68 @@ except Exception as exc:
         return PendingScheduleWake(*row), created
 
     def list_pending_schedule_wakes(
-        self, agent_name: str | None = None
+        self,
+        agent_name: str | None = None,
+        *,
+        include_parked: bool = False,
     ) -> list[PendingScheduleWake]:
-        """Return pending scheduler wakes oldest-first."""
+        """Return pending scheduler wakes oldest-first.
+
+        Parked rows are dead letters and are excluded by default. Pass
+        ``include_parked=True`` to inspect them. For now, deleting a parked row
+        manually is the only supported way to unpark it.
+        """
         sql = """SELECT id, schedule_id, agent_name, schedule_name, prompt,
-                        fired_at, created_at
+                        fired_at, created_at, attempts, parked_at
                  FROM pending_schedule_wakes"""
-        params: tuple = ()
+        conditions: list[str] = []
+        params: list = []
         if agent_name is not None:
-            sql += " WHERE agent_name=?"
-            params = (agent_name,)
+            conditions.append("agent_name=?")
+            params.append(agent_name)
+        if not include_parked:
+            conditions.append("parked_at=0")
+        if conditions:
+            sql += " WHERE " + " AND ".join(conditions)
         sql += " ORDER BY fired_at ASC, id ASC"
         rows = self._db.execute(sql, params).fetchall()
         return [PendingScheduleWake(*row) for row in rows]
+
+    def increment_pending_schedule_wake_attempts(
+        self, pending_id: int
+    ) -> int | None:
+        """Persist one delivery attempt and return its new count."""
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                """UPDATE pending_schedule_wakes
+                   SET attempts=attempts + 1
+                   WHERE id=? AND parked_at=0""",
+                (pending_id,),
+            )
+            if cursor.rowcount == 0:
+                self._db.commit()
+                return None
+            row = self._db.execute(
+                "SELECT attempts FROM pending_schedule_wakes WHERE id=?",
+                (pending_id,),
+            ).fetchone()
+            self._db.commit()
+        return int(row[0])
+
+    def park_pending_schedule_wake(
+        self, pending_id: int, *, parked_at: float = 0.0
+    ) -> bool:
+        """Atomically move an active wake to dead-letter parked state once."""
+        timestamp = parked_at or time.time()
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                """UPDATE pending_schedule_wakes
+                   SET parked_at=?
+                   WHERE id=? AND parked_at=0""",
+                (timestamp, pending_id),
+            )
+            self._db.commit()
+        return cursor.rowcount > 0
 
     def confirm_pending_schedule_wake(
         self, pending_id: int, *, delivered_at: float = 0.0

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -31,6 +31,11 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+_PROVEN_LIVE_HEARTBEAT_STATUSES = frozenset(
+    {"alive", "ok", "busy", "finishing"}
+)
+
+
 # ── Rate Limit Gating ───────────────────────────────────────
 
 _RATE_LIMIT_FILE = "/tmp/claude-rate-limits.json"
@@ -154,6 +159,8 @@ class AgentScheduler:
     Also supports auto-sleep: agents are put to sleep after a configurable
     number of hours with no activity.
     """
+
+    PERSISTED_WAKE_ATTEMPT_CAP = 5
 
     def __init__(
         self,
@@ -748,10 +755,48 @@ class AgentScheduler:
         async with lock:
             await self._replay_pending_locked(agent_name)
 
+    def _park_pending_wake_if_capped(self, pending, attempts: int) -> bool:
+        """Park one capped wake once and emit its single owner alert."""
+        if attempts < self.PERSISTED_WAKE_ATTEMPT_CAP:
+            return False
+        try:
+            parked = self._registry.park_pending_schedule_wake(pending.id)
+        except Exception as exc:
+            _log(
+                f"scheduler: PERSISTED_WAKE_PARK_FAILURE pending "
+                f"#{pending.id}, schedule '{pending.schedule_name}' "
+                f"(#{pending.schedule_id}) for agent '{pending.agent_name}': "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return False
+        if not parked:
+            return False
+        _log(
+            f"scheduler: PERSISTED_WAKE_PARKED pending #{pending.id}, "
+            f"schedule '{pending.schedule_name}' (#{pending.schedule_id}), "
+            f"fired_at={pending.fired_at}, attempts={attempts} for agent "
+            f"'{pending.agent_name}'"
+        )
+        self._queue_owner_alert(
+            pending.agent_name,
+            (
+                "🚨 PERSISTED WAKE PARKED: outbox row "
+                f"#{pending.id} for schedule '{pending.schedule_name}' "
+                f"(#{pending.schedule_id}) on agent '{pending.agent_name}' "
+                f"reached {attempts} unconfirmed delivery attempts. Replay "
+                "is stopped for this row to prevent a storm; delete the row "
+                "manually to unpark it."
+            ),
+        )
+        return True
+
     async def _replay_pending_locked(self, agent_name: str) -> None:
-        """Replay FIFO pending wakes while the caller holds the agent lock."""
-        pending_wakes = self._registry.list_pending_schedule_wakes(agent_name)
-        for pending in pending_wakes:
+        """Reap all zombies, then replay active wakes FIFO under the agent lock."""
+        all_pending_wakes = self._registry.list_pending_schedule_wakes(
+            agent_name, include_parked=True
+        )
+        pending_wakes = []
+        for pending in all_pending_wakes:
             current_schedule = self._registry.get_schedule(pending.schedule_id)
             zombie_reason = ""
             if current_schedule is None:
@@ -771,6 +816,18 @@ class AgentScheduler:
                     f"outbox_retired={retired}"
                 )
                 continue
+            if pending.parked_at == 0:
+                pending_wakes.append(pending)
+
+        for pending in pending_wakes:
+            if pending.attempts >= self.PERSISTED_WAKE_ATTEMPT_CAP:
+                self._park_pending_wake_if_capped(pending, pending.attempts)
+                break
+            attempts = self._registry.increment_pending_schedule_wake_attempts(
+                pending.id
+            )
+            if attempts is None:
+                continue
             try:
                 confirmed = await self._wait_for_wake_confirmation(pending)
             except asyncio.CancelledError:
@@ -781,12 +838,14 @@ class AgentScheduler:
                     f"'{agent_name}' remains pending after replay: "
                     f"{type(exc).__name__}: {exc}"
                 )
+                self._park_pending_wake_if_capped(pending, attempts)
                 break
             if not confirmed:
                 _log(
                     f"scheduler: persisted wake #{pending.id} for "
                     f"'{agent_name}' remains pending: no positive receipt"
                 )
+                self._park_pending_wake_if_capped(pending, attempts)
                 break
             delivered_at = time.time()
             if not self._registry.confirm_pending_schedule_wake(
@@ -930,16 +989,14 @@ class AgentScheduler:
                         message_count=hb.message_count,
                         metadata={"reason": f"heartbeat overdue by {int(age - agent.heartbeat_interval)}s"},
                     )
-            elif hb.status == "alive":
-                # Fresh AND alive: the session ran a tool and reported in, so
-                # it is processing NOW. That is proof-of-life the durable wake
-                # outbox can safely drain against. The status gate matters:
-                # this scheduler itself writes "stale"/"dead" rows with
-                # CURRENT timestamps (above), so on the next tick those
-                # non-live rows are temporally fresh — draining on age alone
-                # would cold-start a dead or deliberately non-resurrectable
-                # runtime through the wake callback, bypassing the
-                # proven-live-only policy (Murzik review, PR #981).
+            elif hb.status in _PROVEN_LIVE_HEARTBEAT_STATUSES:
+                # Fresh agent/hook activity is transport-observed execution
+                # evidence: SDK hooks write "alive" and tmux-rails agents POST
+                # "ok"/"busy"/"finishing" themselves while running. This
+                # scheduler's own current-timestamp writes use only
+                # "stale"/"dead", which remain excluded, so accepting the full
+                # agent-authored vocabulary preserves #981's proven-live-only
+                # policy and never drains on scheduler-authored or aged rows.
                 self._drain_outbox_if_pending(agent.name)
 
     def _drain_outbox_if_pending(self, agent_name: str) -> None:
@@ -957,10 +1014,11 @@ class AgentScheduler:
         contract: replay still happens only at a proven-live boundary.
 
         Idempotent and self-limiting: skips when a replay is already in flight,
-        only reads the (indexed) outbox for a genuinely-live agent, and the
-        FIFO replay's per-prompt receipt gate leaves rows pending if the
-        session cannot accept them. So this never double-delivers and never
-        drains into a dead transport.
+        only reads the (indexed) outbox for a genuinely-live agent, and excludes
+        parked dead letters from its pending check. FIFO receipt failures remain
+        pending only through the bounded attempt cap, preventing one
+        never-confirming row from spawning replay tasks forever while preserving
+        the proven-live-only drain policy.
         """
         existing = self._pending_replay_tasks.get(agent_name)
         if existing is not None and not existing.done():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1199,7 +1199,9 @@ class TestScheduler:
         )
         # Temporally fresh, but the status says the session is not live —
         # exactly what the scheduler's own bookkeeping writes.
-        registry.record_heartbeat("oleg", session_id="oleg-main", status=status)
+        heartbeat = registry.record_heartbeat(
+            "oleg", session_id="oleg-main", status=status
+        )
 
         attempts: list[str] = []
 
@@ -1213,7 +1215,7 @@ class TestScheduler:
             wake_callback=confirmed,
             streaming_sessions_fn=lambda: {},
         )
-        await scheduler._check_heartbeats(time.time())
+        await scheduler._check_heartbeats(heartbeat.timestamp + 1)
         replay_task = scheduler._pending_replay_tasks.get("oleg")
         if replay_task is not None:
             await replay_task

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sqlite3
 import tempfile
 import threading
 import time
@@ -411,6 +412,41 @@ class TestAgentSchedules:
         assert registry.list_pending_schedule_wakes("oleg") == []
         stored = registry.get_schedules("oleg")[0]
         assert stored.last_delivered == pytest.approx(delivered_at)
+
+    def test_pending_wake_columns_migrate_idempotently_on_existing_db(self):
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        legacy = sqlite3.connect(path)
+        legacy.execute(
+            """CREATE TABLE pending_schedule_wakes (
+                   id INTEGER PRIMARY KEY AUTOINCREMENT,
+                   schedule_id INTEGER NOT NULL,
+                   agent_name TEXT NOT NULL,
+                   schedule_name TEXT NOT NULL DEFAULT '',
+                   prompt TEXT NOT NULL DEFAULT '',
+                   fired_at REAL NOT NULL,
+                   created_at REAL NOT NULL,
+                   UNIQUE(schedule_id, fired_at)
+               )"""
+        )
+        legacy.commit()
+        legacy.close()
+
+        first = AgentRegistry(db_path=path)
+        first.close()
+        reopened = AgentRegistry(db_path=path)
+        try:
+            columns = [
+                row[1]
+                for row in reopened._db.execute(
+                    "PRAGMA table_info(pending_schedule_wakes)"
+                ).fetchall()
+            ]
+            assert columns.count("attempts") == 1
+            assert columns.count("parked_at") == 1
+        finally:
+            reopened.close()
+            os.unlink(path)
 
     def test_cascade_delete(self, registry):
         registry.register("oleg")
@@ -1082,7 +1118,10 @@ class TestScheduler:
         assert registry.get_schedules("oleg")[0].last_delivered > 0
 
     @pytest.mark.asyncio
-    async def test_fresh_heartbeat_drains_stranded_outbox(self, registry):
+    @pytest.mark.parametrize("status", ["alive", "ok", "busy", "finishing"])
+    async def test_fresh_heartbeat_drains_stranded_outbox(
+        self, registry, status
+    ):
         """A session revived by a heartbeat (no confirmed wake) still replays.
 
         Reproduces the 2026-08-01 live incident: a context_restart whose
@@ -1107,7 +1146,7 @@ class TestScheduler:
         )
         # Session is provably alive again: a fresh heartbeat, exactly as
         # the live incident's reviving heartbeat proved — but NO confirmed wake landed.
-        registry.record_heartbeat("oleg", session_id="oleg-main", status="alive")
+        registry.record_heartbeat("oleg", session_id="oleg-main", status=status)
 
         attempts: list[str] = []
 
@@ -1175,6 +1214,46 @@ class TestScheduler:
             streaming_sessions_fn=lambda: {},
         )
         await scheduler._check_heartbeats(time.time())
+        replay_task = scheduler._pending_replay_tasks.get("oleg")
+        if replay_task is not None:
+            await replay_task
+
+        assert attempts == []
+        assert [
+            wake.prompt for wake in registry.list_pending_schedule_wakes("oleg")
+        ] == ["morning inbox"]
+
+    @pytest.mark.asyncio
+    async def test_aged_agent_heartbeat_never_drains(self, registry):
+        registry.register("oleg", heartbeat_interval=60)
+        schedule = registry.add_schedule(
+            "oleg", "0 8 * * *", name="inbox", prompt="morning inbox"
+        )
+        fired_at = time.time() - 300
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="inbox",
+            prompt="morning inbox",
+            fired_at=fired_at,
+        )
+        heartbeat = registry.record_heartbeat(
+            "oleg", session_id="oleg-main", status="ok"
+        )
+        attempts: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            streaming_sessions_fn=lambda: {},
+        )
+        await scheduler._check_heartbeats(heartbeat.timestamp + 61)
         replay_task = scheduler._pending_replay_tasks.get("oleg")
         if replay_task is not None:
             await replay_task
@@ -1254,6 +1333,148 @@ class TestScheduler:
             pending.prompt
             for pending in registry.list_pending_schedule_wakes("oleg")
         ] == ["oldest", "newer"]
+
+    @pytest.mark.asyncio
+    async def test_replay_failure_cap_parks_alerts_once_and_stops_drain(
+        self, registry, monkeypatch, capsys
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="storm-head", prompt="retry me"
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="storm-head",
+            prompt="retry me",
+            fired_at=100.0,
+        )
+        attempts: list[str] = []
+        alerts: list[tuple[str, str]] = []
+
+        async def unconfirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return False
+
+        async def owner_notify(agent_name, message):
+            alerts.append((agent_name, message))
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=unconfirmed,
+            owner_notify_callback=owner_notify,
+        )
+        for _ in range(scheduler.PERSISTED_WAKE_ATTEMPT_CAP):
+            scheduler.replay_pending_for_agent("oleg")
+            await scheduler._pending_replay_tasks["oleg"]
+            await asyncio.sleep(0)
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+
+        assert attempts == ["retry me"] * scheduler.PERSISTED_WAKE_ATTEMPT_CAP
+        assert registry.list_pending_schedule_wakes("oleg") == []
+        parked = registry.list_pending_schedule_wakes(
+            "oleg", include_parked=True
+        )
+        assert len(parked) == 1
+        assert parked[0].attempts == scheduler.PERSISTED_WAKE_ATTEMPT_CAP
+        assert parked[0].parked_at > 0
+        assert len(alerts) == 1
+        assert alerts[0][0] == "oleg"
+        assert "delete the row manually" in alerts[0][1]
+        assert capsys.readouterr().err.count("PERSISTED_WAKE_PARKED") == 1
+
+        drain_triggers: list[str] = []
+        monkeypatch.setattr(
+            scheduler, "replay_pending_for_agent", drain_triggers.append
+        )
+        scheduler._drain_outbox_if_pending("oleg")
+        assert drain_triggers == []
+
+    @pytest.mark.asyncio
+    async def test_confirmed_fifth_replay_retires_instead_of_parking(
+        self, registry
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="eventual", prompt="confirm me"
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="eventual",
+            prompt="confirm me",
+            fired_at=100.0,
+        )
+        for expected in range(1, AgentScheduler.PERSISTED_WAKE_ATTEMPT_CAP):
+            assert (
+                registry.increment_pending_schedule_wake_attempts(pending.id)
+                == expected
+            )
+        attempts: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=confirmed)
+        scheduler.replay_pending_for_agent("oleg")
+        await scheduler._pending_replay_tasks["oleg"]
+
+        assert attempts == ["confirm me"]
+        assert registry.list_pending_schedule_wakes(
+            "oleg", include_parked=True
+        ) == []
+
+    @pytest.mark.asyncio
+    async def test_zombie_behind_stuck_head_is_reaped_before_delivery(
+        self, registry, capsys
+    ):
+        registry.register("oleg")
+        stuck = registry.add_schedule(
+            "oleg", "* * * * *", name="stuck", prompt="stuck head"
+        )
+        zombie = registry.add_schedule(
+            "oleg", "* * * * *", name="zombie", prompt="never deliver"
+        )
+        registry.persist_schedule_wake(
+            stuck.id,
+            agent_name="oleg",
+            schedule_name="stuck",
+            prompt="stuck head",
+            fired_at=100.0,
+        )
+        registry.persist_schedule_wake(
+            zombie.id,
+            agent_name="oleg",
+            schedule_name="zombie",
+            prompt="never deliver",
+            fired_at=200.0,
+        )
+        registry.remove_schedule(zombie.id)
+        attempts: list[str] = []
+
+        async def unconfirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return False
+
+        scheduler = AgentScheduler(registry, wake_callback=unconfirmed)
+        scheduler.replay_pending_for_agent("oleg")
+        await scheduler._pending_replay_tasks["oleg"]
+
+        assert attempts == ["stuck head"]
+        assert [
+            pending.prompt
+            for pending in registry.list_pending_schedule_wakes(
+                "oleg", include_parked=True
+            )
+        ] == ["stuck head"]
+        error_log = capsys.readouterr().err
+        assert "PERSISTED_WAKE_ZOMBIE_DROPPED" in error_log
+        assert f"schedule #{zombie.id}" in error_log
 
     @pytest.mark.asyncio
     async def test_terminal_zombie_head_retires_and_fifo_advances(


### PR DESCRIPTION
## What changed

- migrate `pending_schedule_wakes` with persisted `attempts` and `parked_at` columns for both new and existing databases
- persist the attempt count before every replay delivery; after 5 unconfirmed outcomes, park the row, log `PERSISTED_WAKE_PARKED` with the durable row/schedule/fire metadata, and queue one owner alert
- exclude parked dead letters from default outbox listings and proven-live pending checks so a fully parked outbox stops spawning drain tasks; manual row deletion is the documented unpark path
- sweep every pending row for deleted, reassigned, or disabled non-one-shot schedules before the FIFO delivery loop, so a stuck head cannot protect zombies behind it
- accept the full fresh agent-authored heartbeat vocabulary (`alive|ok|busy|finishing`) as proven-live drain evidence while continuing to exclude scheduler-authored `stale|dead` and aged rows

## Why / root cause

The proven-live replay path retained an unconfirmed FIFO head forever. Every later drain trigger pasted that same wake again, while the break-at-head behavior prevented zombie checks from reaching stale rows behind it. Tmux-rails agents also persist self-reported heartbeat statuses such as `ok` and `busy`, but the drain gate accepted only the SDK hook's `alive`, making the heartbeat drain branch structurally unreachable for those agents without separate server-liveness evidence.

## Impact

Replay failures are bounded at five transport attempts per durable row, parked heads alert the owner once instead of replay-storming indefinitely, and zombie rows are reaped independently of FIFO delivery progress. Fresh tmux agent activity can now trigger the existing proven-live-only drain without admitting scheduler-authored or stale evidence.

Receipt matching/confirmation semantics and the #981 proven-live-only drain policy are unchanged.

## Checks

- `uv run pytest -q tests/test_scheduler.py`: 121 passed
- `uv run pytest -q tests/test_agent_registry.py`: 117 passed
- focused #991 regressions: 11 passed
- `uv run ruff check .`: passed
- `git diff --check`: passed
- repository-wide run attempted in the synced Python 3.11 environment; the live daemon already owning `127.0.0.1:8890` caused one unrelated manual-dream test to escape its SDK mock into the tmux path (825 passed, 1 failed, 2 skipped before the changed-code run was stopped)

Refs #991

🤖 Opened by Murzik