### PR TITLE
fix(scheduler): retire late-confirmed persisted wakes

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -3381,6 +3381,42 @@ except Exception as exc:
             self._db.commit()
         return cursor.rowcount > 0
 
+    def confirm_pending_schedule_wake_by_fire(
+        self,
+        schedule_id: int,
+        fired_at: float,
+        *,
+        delivered_at: float = 0.0,
+    ) -> bool:
+        """Atomically confirm and retire the outbox row for one exact fire."""
+        timestamp = delivered_at or time.time()
+        with self._rmw_lock:
+            row = self._db.execute(
+                """SELECT id FROM pending_schedule_wakes
+                   WHERE schedule_id=? AND fired_at=?""",
+                (schedule_id, fired_at),
+            ).fetchone()
+            if row is None:
+                return False
+            self._db.execute(
+                "UPDATE agent_schedules SET last_delivered=? WHERE id=?",
+                (timestamp, schedule_id),
+            )
+            cursor = self._db.execute(
+                """DELETE FROM pending_schedule_wakes
+                   WHERE schedule_id=? AND fired_at=?""",
+                (schedule_id, fired_at),
+            )
+            self._db.commit()
+        retired = cursor.rowcount > 0
+        if retired:
+            _log(
+                "agent_registry: PERSISTED_WAKE_RETIRED_ON_LATE_CONFIRM "
+                f"pending #{row[0]}, schedule #{schedule_id}, "
+                f"fired_at={fired_at}"
+            )
+        return retired
+
     def discard_pending_schedule_wake(self, pending_id: int) -> bool:
         """Retire a pending wake without marking its schedule delivered."""
         cursor = self._db.execute(

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -545,9 +545,17 @@ class AgentScheduler:
 
         if confirmed:
             delivered_at = time.time()
-            self._registry.update_schedule_last_delivered(
-                schedule.id, delivered_at
+            retired_pending = (
+                self._registry.confirm_pending_schedule_wake_by_fire(
+                    schedule.id,
+                    schedule.last_run,
+                    delivered_at=delivered_at,
+                )
             )
+            if not retired_pending:
+                self._registry.update_schedule_last_delivered(
+                    schedule.id, delivered_at
+                )
             if self._activity:
                 try:
                     self._activity.log(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -413,6 +413,52 @@ class TestAgentSchedules:
         stored = registry.get_schedules("oleg")[0]
         assert stored.last_delivered == pytest.approx(delivered_at)
 
+    def test_confirm_pending_wake_by_fire_missing_is_harmless(
+        self, registry, capsys
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "0 8 * * *", name="morning", prompt="check mail"
+        )
+
+        assert registry.confirm_pending_schedule_wake_by_fire(
+            schedule.id, 100.0, delivered_at=200.0
+        ) is False
+
+        assert registry.get_schedules("oleg")[0].last_delivered == 0.0
+        captured = capsys.readouterr().err
+        assert "PERSISTED_WAKE_RETIRED_ON_LATE_CONFIRM" not in captured
+
+    def test_confirm_pending_wake_by_fire_retires_parked_row(
+        self, registry, capsys
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "0 8 * * *", name="morning", prompt="check mail"
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="morning",
+            prompt="check mail",
+            fired_at=100.0,
+        )
+        assert registry.park_pending_schedule_wake(
+            pending.id, parked_at=150.0
+        ) is True
+
+        assert registry.confirm_pending_schedule_wake_by_fire(
+            schedule.id, 100.0, delivered_at=200.0
+        ) is True
+
+        assert registry.list_pending_schedule_wakes(
+            "oleg", include_parked=True
+        ) == []
+        assert registry.get_schedules("oleg")[0].last_delivered == 200.0
+        captured = capsys.readouterr().err
+        assert "PERSISTED_WAKE_RETIRED_ON_LATE_CONFIRM" in captured
+        assert f"pending #{pending.id}, schedule #{schedule.id}" in captured
+
     def test_pending_wake_columns_migrate_idempotently_on_existing_db(self):
         fd, path = tempfile.mkstemp(suffix=".db")
         os.close(fd)
@@ -889,6 +935,54 @@ class TestScheduler:
         ]
         assert events == ["schedule_fired", "schedule_undelivered"]
         assert "FIRED BUT UNDELIVERED" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_late_primary_confirm_retires_persisted_wake(
+        self, registry, capsys
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="late", prompt="run once"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+
+        async def no_receipt(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return asyncio.get_running_loop().create_future()
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=no_receipt,
+            schedule_delivery_timeout=0.01,
+        )
+        await scheduler._deliver_schedule(schedule)
+        pending = registry.list_pending_schedule_wakes("oleg")
+        assert len(pending) == 1
+
+        attempts: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        scheduler._wake_callback = confirmed
+        await scheduler._deliver_schedule(schedule)
+
+        assert attempts == ["run once"]
+        assert registry.list_pending_schedule_wakes(
+            "oleg", include_parked=True
+        ) == []
+        assert registry.get_schedules("oleg")[0].last_delivered > 0
+        captured = capsys.readouterr().err
+        assert "PERSISTED_WAKE_RETIRED_ON_LATE_CONFIRM" in captured
+        assert f"pending #{pending[0].id}, schedule #{schedule.id}" in captured
+
+        scheduler.replay_pending_for_agent("oleg")
+        await scheduler._pending_replay_tasks["oleg"]
+        assert attempts == ["run once"]
 
     @pytest.mark.asyncio
     async def test_overlapping_fires_keep_distinct_exact_outbox_rows(


### PR DESCRIPTION
## What changed

- add `confirm_pending_schedule_wake_by_fire(schedule_id, fired_at, *, delivered_at)` to atomically stamp `last_delivered` and delete the exact persisted fire under the registry RMW lock
- make the primary `_deliver_schedule` confirmation branch use that keyed retirement, falling back to the existing delivery stamp when no row was persisted
- retire active or parked rows alike and log `PERSISTED_WAKE_RETIRED_ON_LATE_CONFIRM` with the durable row and schedule IDs only when a row matched

## Why / root cause

The primary delivery path could persist an outbox row after an unconfirmed receipt, then later confirm that same schedule fire without retiring the row. Only replay called the ID-keyed confirmation method, so every later replay boundary could deliver an already-executed wake again.

Live evidence on the Pi box showed one fire persisted at 15:41:16, a primary-path confirmation at 15:43:07, and the still-live row replaying and retiring only at 15:46:06. This change keys the late primary confirmation to the same immutable `(schedule_id, schedule.last_run)` pair used when the fire was persisted.

## Impact

A late positive receipt on the primary path now completes the durable outbox lifecycle immediately. Ordinary confirmations with no persisted row behave as before, and parked dead letters are removed when the exact fire is conclusively confirmed.

Receipt waiting, matching, and acceptance semantics are unchanged.

## Out of scope follow-up

The same live trace also contains a second primary-path confirmation for the same firing 28 seconds after the first. A read-only caller scan found one production chain only: `_check_schedules` → `_deliver_schedule_group` → `_deliver_schedule`. That narrows the separate defect to duplicate cohort dispatch or scheduler-instance/read-visibility behavior; this PR intentionally does not change that path.

## Checks

- focused late-confirm regressions: 3 passed
- `uv run pytest -q tests/test_scheduler.py`: 124 passed
- `uv run pytest -q tests/test_agent_registry.py`: 117 passed
- `uv run ruff check .`: passed
- `git diff --check`: passed

Refs #991

🤖 Opened by Murzik