### PR TITLE
Export DB-composed agent instructions for V3 cutover

### DIFF
--- a/scripts/v3_export.py
+++ b/scripts/v3_export.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""V2 -> V3 memory/inventory exporter (PinkyBotV3 #16, pinky.import schema 1).
+
+Reads one agent's pinky-memory store (copy-then-read; never opens the live WAL
+in place) and emits the V3 import JSON. The V3 importer's dry-run is the
+authoritative validator for this output — run `pinky import dry-run <file>` on
+a V3 instance and treat every fatal as a bug HERE, not there.
+
+Contract notes encoded (V3 #16):
+- confidence: V2 reflections carry no confidence -> field omitted entirely
+  (the schema-13 validator fatals on non-int shapes; absent is legal).
+- createdAt: emitted as ISO-8601 UTC (epoch integers are fatal).
+- kind: V2 reflection types are a subset of V3 MEMORY_KINDS; emitted verbatim.
+- subject: V2 has no subject; synthesized from the first content line (<=200
+  chars). Deliberate, lossy-upward; flagged in the manifest notes.
+- project rows: distinct V2 `project` labels become V3 project records, and
+  their memories scope to them. Casing collisions (V2 labels are messy) are
+  pre-merged here because the V3 importer fatals on case-insensitive name
+  collisions (IMPORT_PROJECT_NAME_COLLISION).
+- supersedes: V2 id -> deterministic sourceKey reference.
+- inactive rows: skipped by default (--include-inactive to override); V2
+  "active=0" mixes superseded-with-successor and soft-forgotten, and the V3
+  tombstone model wants explicit intent, not a guess.
+- effective instructions: composed exclusively from V2 DB authority through
+  AgentRegistry.build_system_prompt(). The generated CLAUDE.md is hashed only
+  as drift evidence and is never used as an instruction source.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import sqlite3
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.skill_store import SkillStore
+
+SCHEMA_VERSION = 1
+# Mirror of PinkyBotV3 import-format.ts SECRET_STRING_PATTERNS (schema 13).
+# The importer fatals on first match with no row pointer, so we pre-flight
+# every row here and EXCLUDE matches with a named disposition report. Real
+# secrets found this way are incidents, not export rows.
+SECRET_PATTERNS = [
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(
+        r"\b(?:sk-[A-Za-z0-9_-]{16,}|xox[baprs]-[A-Za-z0-9-]{12,}|gh[pousr]_[A-Za-z0-9]{20,})\b"
+    ),
+    re.compile(r"\bAKIA[A-Z0-9]{16}\b"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b", re.I),
+    re.compile(
+        r"\b(?:password|passwd|token|api[_-]?key|client[_-]?secret)\s*[:=]\s*[\"\']?[^\s\"\',}]{4,}",
+        re.I,
+    ),
+    re.compile(r"\b\d{6,12}:[A-Za-z0-9_-]{30,}\b"),
+    re.compile(r"\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}\b"),
+]
+
+
+def secret_scan(data: dict) -> str | None:
+    for field in ("subject", "content", "context"):
+        value = data.get(field, "")
+        for index, pattern in enumerate(SECRET_PATTERNS):
+            if pattern.search(value):
+                return f"{field}:pattern{index}"
+    return None
+
+
+V3_MEMORY_KINDS = {
+    "fact",
+    "preference",
+    "decision",
+    "procedure",
+    "observation",
+    "summary",
+    "insight",
+    "project_state",
+    "interaction_pattern",
+    "continuation",
+}
+
+GENERATED_OUTPUT_KINDS = (
+    "CLAUDE_SETTINGS",
+    "CLAUDE_HOOKS",
+    "MCP_CONFIG",
+)
+
+
+def iso_utc(value) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc).isoformat()
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        try:
+            return datetime.fromtimestamp(float(text), tz=timezone.utc).isoformat()
+        except (ValueError, OverflowError):
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def canonical_now_utc() -> str:
+    """Return the V3 contract's canonical millisecond RFC 3339 form."""
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def synthesize_subject(content: str) -> str:
+    first = content.strip().splitlines()[0] if content.strip() else "untitled memory"
+    return first[:200] if first else "untitled memory"
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_text(value: str) -> str:
+    return sha256_bytes(value.encode("utf-8"))
+
+
+def stable_json_sha256(value) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return sha256_bytes(encoded)
+
+
+def _copy_sqlite_bundle(source: Path, target: Path) -> None:
+    """Copy a SQLite main file plus any live WAL sidecars into a private dir."""
+    if not source.is_file():
+        raise FileNotFoundError(f"SQLite source does not exist: {source}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    for suffix in ("-wal", "-shm"):
+        sidecar = source.with_name(source.name + suffix)
+        if sidecar.exists():
+            shutil.copy2(sidecar, target.with_name(target.name + suffix))
+
+
+def _hash_path_evidence(path: Path, *, fallback_glob: str | None = None) -> str:
+    """Hash one generated output or a canonical inventory of its tree."""
+    files: list[Path]
+    if path.is_file():
+        return sha256_bytes(path.read_bytes())
+    if path.is_dir():
+        files = sorted(item for item in path.rglob("*") if item.is_file())
+        root = path
+    elif fallback_glob is not None:
+        root = path.parent
+        files = sorted(item for item in root.glob(fallback_glob) if item.is_file())
+    else:
+        files = []
+        root = path.parent
+    evidence = {
+        "declaredPath": str(path),
+        "files": [
+            {
+                "path": item.relative_to(root).as_posix(),
+                "sha256": sha256_bytes(item.read_bytes()),
+            }
+            for item in files
+        ],
+        "status": "PRESENT" if files else "MISSING",
+    }
+    return stable_json_sha256(evidence)
+
+
+def _generated_output_evidence(agent_root: Path) -> list[dict]:
+    settings = agent_root / ".claude" / "settings.json"
+    hooks = agent_root / ".claude" / "hooks"
+    mcp = agent_root / ".mcp.json"
+    digests = {
+        "CLAUDE_SETTINGS": _hash_path_evidence(settings),
+        # Current V2 emits hook_*.py beside settings.json. V3's contract names
+        # the logical generated-output surface .claude/hooks, so bind the
+        # canonical hook file set when that directory is absent.
+        "CLAUDE_HOOKS": _hash_path_evidence(hooks, fallback_glob="hook*.py"),
+        "MCP_CONFIG": _hash_path_evidence(mcp),
+    }
+    paths = {
+        "CLAUDE_SETTINGS": settings,
+        "CLAUDE_HOOKS": hooks,
+        "MCP_CONFIG": mcp,
+    }
+    return [
+        {
+            "kind": kind,
+            "legacyPath": str(paths[kind]),
+            "classification": "GENERATED_OUTPUT",
+            "disposition": "REGENERATE_FROM_OWNER_AUTHORITY",
+            "evidenceSha256": digests[kind],
+        }
+        for kind in GENERATED_OUTPUT_KINDS
+    ]
+
+
+def _write_private_artifact(path: Path, text: str) -> None:
+    """Atomically replace path with UTF-8 text that is private from creation."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(text.encode("utf-8"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+        path.chmod(0o600)
+    finally:
+        if temporary_path.exists():
+            temporary_path.unlink()
+
+
+def export_agent_instructions(
+    agents_db_path: Path,
+    skills_db_path: Path,
+    user_profiles_db_path: Path,
+    agent_name: str,
+    snapshot_at: str,
+    authority_decision_id: str,
+    instructions_out_path: Path,
+    legacy_artifact_path: Path | None = None,
+) -> tuple[list[dict], dict]:
+    """Compose one agent's DB-authoritative instructions and inventory facts."""
+    invocation_root = Path.cwd()
+    target_path = instructions_out_path.resolve()
+    registry: AgentRegistry | None = None
+    skill_store: SkillStore | None = None
+    with tempfile.TemporaryDirectory() as tmp:
+        snapshot_root = Path(tmp)
+        agents_copy = snapshot_root / "agents.db"
+        skills_copy = snapshot_root / "skills.db"
+        profiles_copy = snapshot_root / "data" / "user_profiles.db"
+        _copy_sqlite_bundle(agents_db_path.resolve(), agents_copy)
+        _copy_sqlite_bundle(skills_db_path.resolve(), skills_copy)
+        if user_profiles_db_path.exists():
+            _copy_sqlite_bundle(user_profiles_db_path.resolve(), profiles_copy)
+
+        original_cwd = Path.cwd()
+        try:
+            # build_system_prompt() creates UserProfileStore with its normal
+            # relative path. Point that lookup at the copied snapshot, never
+            # the live DB, without introducing a second prompt composer.
+            os.chdir(snapshot_root)
+            registry = AgentRegistry(db_path=str(agents_copy))
+            skill_store = SkillStore(db_path=str(skills_copy))
+            agent = registry.get(agent_name)
+            if agent is None:
+                raise ValueError(f"Agent does not exist in registry: {agent_name}")
+            effective = registry.build_system_prompt(
+                agent_name,
+                skill_store=skill_store,
+            )
+            if not effective:
+                raise ValueError(f"DB composition is empty for agent: {agent_name}")
+            directives = [
+                {"directive": item.directive, "priority": item.priority}
+                for item in registry.get_directives(agent_name)
+            ]
+            skill_catalog = skill_store.materialize_for_agent(agent_name).get("catalog", [])
+            configured_root = Path(agent.working_dir or f"data/agents/{agent_name}")
+            agent_root = (
+                configured_root
+                if configured_root.is_absolute()
+                else invocation_root / configured_root
+            ).resolve()
+            soul = agent.soul
+            provider = (getattr(agent, "runtime", "") or "pinkybot-v2").strip()
+            driver = (getattr(agent, "transport", "") or provider).strip()
+        finally:
+            if skill_store is not None:
+                skill_store.close()
+            if registry is not None:
+                registry.close()
+            os.chdir(original_cwd)
+
+    legacy_path = (
+        legacy_artifact_path.resolve()
+        if legacy_artifact_path is not None
+        else (agent_root / "CLAUDE.md").resolve()
+    )
+    if legacy_path.name != "CLAUDE.md":
+        raise ValueError("Legacy instruction artifact must be named CLAUDE.md")
+    if not legacy_path.is_file():
+        raise FileNotFoundError(f"Legacy instruction artifact does not exist: {legacy_path}")
+    if target_path == legacy_path:
+        raise ValueError("Private target artifact must not overwrite legacy CLAUDE.md")
+    if not authority_decision_id.strip():
+        raise ValueError("An explicit instruction authority decision ID is required")
+
+    effective_sha = sha256_text(effective)
+    legacy_sha = sha256_bytes(legacy_path.read_bytes())
+    freshness = (
+        "MATCHES_DB_COMPOSITION" if legacy_sha == effective_sha else "DIFFERS_FROM_DB_COMPOSITION"
+    )
+    _write_private_artifact(target_path, effective)
+
+    agent_source_key = f"inventory:agent:{agent_name}"
+    instruction_source_key = f"inventory:instructions:{agent_name}"
+    scope = {"kind": "agent", "id": agent_name}
+    records = [
+        {
+            "kind": "inventory",
+            "sourceKey": agent_source_key,
+            "scope": scope,
+            "inventoryKind": "agent",
+            "name": agent_source_key,
+            "disposition": "preserve",
+            "details": {
+                "provider": provider,
+                "driver": driver,
+                "cwd": str(agent_root),
+                "commandRef": "claude-cli" if driver == "tmux" else driver,
+                "homeRef": str(agent_root),
+            },
+        },
+        {
+            "kind": "inventory",
+            "sourceKey": instruction_source_key,
+            "scope": scope,
+            "inventoryKind": "agent-instructions",
+            "name": instruction_source_key,
+            "disposition": "preserve",
+            "details": {
+                "agentSourceKey": agent_source_key,
+                "authorityKind": "V2_DB_COMPOSED",
+                "authorityDecisionId": authority_decision_id.strip(),
+                "compositionProtocol": "pinkybot-v2-agent-instructions",
+                "compositionVersion": 1,
+                "soulSha256": sha256_text(soul),
+                "directiveSetSha256": stable_json_sha256(directives),
+                "skillSetSha256": stable_json_sha256(skill_catalog),
+                "effectiveInstructionsSha256": effective_sha,
+                "sourceSnapshotBoundary": snapshot_at,
+                "legacyArtifactPath": str(legacy_path),
+                "legacyArtifactSha256": legacy_sha,
+                "legacyArtifactFreshness": freshness,
+                "targetPath": str(target_path),
+                "targetSha256": effective_sha,
+                "targetMode": "0600",
+                "ownerAgentId": agent_name,
+                "generatedOutputs": _generated_output_evidence(agent_root),
+            },
+        },
+    ]
+    return records, {
+        "artifact": str(target_path),
+        "effectiveInstructionsSha256": effective_sha,
+        "legacyArtifactSha256": legacy_sha,
+        "legacyArtifactFreshness": freshness,
+    }
+
+
+def export_agent(
+    db_path: Path,
+    agent_name: str,
+    host: str,
+    include_inactive: bool,
+    snapshot_at: str | None = None,
+) -> tuple[dict, dict]:
+    with tempfile.TemporaryDirectory() as tmp:
+        copy = Path(tmp) / "memory.db"
+        shutil.copy(db_path, copy)
+        wal = db_path.with_name(db_path.name + "-wal")
+        if wal.exists():
+            shutil.copy(wal, copy.with_name(copy.name + "-wal"))
+        conn = sqlite3.connect(f"file:{copy}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT id, type, content, context, project, salience, active,"
+            "       no_recall, supersedes, created_at"
+            "  FROM reflections ORDER BY created_at, id"
+        ).fetchall()
+        conn.close()
+
+    records: list[dict] = []
+    skipped: dict = {}
+    # V3 lineage chains reject forks (IMPORT_REFERENCE_FORK): where several
+    # rows claim the same supersedes parent, only the LATEST claimant keeps
+    # the link; earlier claimants import as standalone rows (link dropped,
+    # counted). V2 recorded exactly this shape at least once.
+    claimants: dict[str, list] = {}
+    for row in rows:
+        if row["supersedes"] and (include_inactive or row["active"]):
+            claimants.setdefault(row["supersedes"], []).append((row["created_at"], row["id"]))
+    fork_winners = {parent: max(entries)[1] for parent, entries in claimants.items()}
+    # Pre-merge project labels case-insensitively; first-seen casing wins.
+    canonical_projects: dict[str, str] = {}
+    for row in rows:
+        label = (row["project"] or "").strip()
+        if label:
+            canonical_projects.setdefault(label.lower(), label)
+
+    for folded, label in sorted(canonical_projects.items()):
+        records.append(
+            {
+                "kind": "project",
+                "sourceKey": f"project:{agent_name}:{folded}",
+                "scope": {"kind": "project", "id": label},
+                "data": {
+                    "name": label,
+                    "ownerAgent": agent_name,
+                    "purpose": f"V2 project label '{label}' (imported)",
+                },
+            }
+        )
+
+    for row in rows:
+        if not include_inactive and not row["active"]:
+            skipped["inactive"] = skipped.get("inactive", 0) + 1
+            continue
+        kind = (row["type"] or "").strip()
+        if kind not in V3_MEMORY_KINDS:
+            skipped[f"unknown-kind:{kind}"] = skipped.get(f"unknown-kind:{kind}", 0) + 1
+            continue
+        content = (row["content"] or "").strip()
+        if not content:
+            skipped["empty-content"] = skipped.get("empty-content", 0) + 1
+            continue
+        created = iso_utc(row["created_at"])
+        data: dict = {
+            "kind": kind,
+            "subject": synthesize_subject(content),
+            "content": content,
+            "salience": max(1, min(5, int(row["salience"] or 3))),
+        }
+        context = (row["context"] or "").strip()
+        if context:
+            data["context"] = context
+        if created:
+            data["createdAt"] = created
+        if row["no_recall"]:
+            data["noRecall"] = True
+        if row["supersedes"] and row["id"] == fork_winners.get(row["supersedes"], row["id"]):
+            data["supersedesSourceKey"] = f"memory:{agent_name}:{row['supersedes']}"
+        elif row["supersedes"]:
+            skipped["supersede-fork-link-dropped"] = (
+                skipped.get("supersede-fork-link-dropped", 0) + 1
+            )
+        flagged = secret_scan(data)
+        if flagged:
+            skipped[f"secret-flagged({flagged})"] = skipped.get(f"secret-flagged({flagged})", 0) + 1
+            rows_list = skipped.setdefault("secret-flagged-rows", [])
+            rows_list.append(f"memory:{agent_name}:{row['id']}")
+            continue
+        label = (row["project"] or "").strip()
+        scope = (
+            {"kind": "project", "id": canonical_projects[label.lower()]}
+            if label
+            else {"kind": "agent", "id": agent_name}
+        )
+        records.append(
+            {
+                "kind": "memory",
+                "sourceKey": f"memory:{agent_name}:{row['id']}",
+                "scope": scope,
+                "data": data,
+            }
+        )
+
+    # V3 rejects dangling supersede references (IMPORT_DANGLING_REFERENCE):
+    # a link may only point at a row that is itself in this export. Links to
+    # excluded parents (inactive, secret-flagged, invalid) are dropped-and-
+    # counted; the child still imports as a standalone row.
+    exported_keys = {record["sourceKey"] for record in records}
+    for record in records:
+        if record["kind"] != "memory":
+            continue
+        target = record["data"].get("supersedesSourceKey")
+        if target and target not in exported_keys:
+            del record["data"]["supersedesSourceKey"]
+            skipped["supersede-dangling-link-dropped"] = (
+                skipped.get("supersede-dangling-link-dropped", 0) + 1
+            )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": {
+            "system": "pinkybot-v2",
+            "host": host,
+            "authorityPath": str(db_path.resolve()),
+            "snapshotAt": snapshot_at or canonical_now_utc(),
+        },
+        "records": records,
+    }, skipped
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("db", type=Path)
+    ap.add_argument("agent")
+    ap.add_argument("--host", default="mini")
+    ap.add_argument("--include-inactive", action="store_true")
+    ap.add_argument("--agents-db", type=Path, default=Path("data/conversations_agents.db"))
+    ap.add_argument("--skills-db", type=Path, default=Path("data/conversations_skills.db"))
+    ap.add_argument("--user-profiles-db", type=Path, default=Path("data/user_profiles.db"))
+    ap.add_argument("--legacy-artifact", type=Path)
+    ap.add_argument("--instructions-out", type=Path)
+    ap.add_argument("--authority-decision-id", required=True)
+    ap.add_argument("-o", "--out", type=Path, required=True)
+    args = ap.parse_args()
+    snapshot_at = canonical_now_utc()
+    result, skipped = export_agent(
+        args.db,
+        args.agent,
+        args.host,
+        args.include_inactive,
+        snapshot_at,
+    )
+    instructions_out = (
+        args.instructions_out
+        if args.instructions_out is not None
+        else args.out.with_name(f"{args.out.stem}.{args.agent}.instructions.md")
+    )
+    instruction_records, instruction_summary = export_agent_instructions(
+        args.agents_db,
+        args.skills_db,
+        args.user_profiles_db,
+        args.agent,
+        snapshot_at,
+        args.authority_decision_id,
+        instructions_out,
+        args.legacy_artifact,
+    )
+    result["records"] = instruction_records + result["records"]
+    args.out.write_text(json.dumps(result, indent=1, ensure_ascii=False))
+    counts: dict[str, int] = {}
+    for record in result["records"]:
+        counts[record["kind"]] = counts.get(record["kind"], 0) + 1
+    print(
+        json.dumps(
+            {
+                "records": counts,
+                "skipped": skipped,
+                "notes": {
+                    "subject_synthesis": "first content line, <=200 chars",
+                    "confidence": "omitted (V2 reflections carry none)",
+                    "instruction_authority": "V2_DB_COMPOSED",
+                },
+                "instructions": instruction_summary,
+                "out": str(args.out),
+            },
+            indent=1,
+        )
+    )

--- a/tests/test_v3_export.py
+++ b/tests/test_v3_export.py
@@ -1,0 +1,202 @@
+"""Tests for the V2 -> V3 cutover exporter."""
+
+from __future__ import annotations
+
+import hashlib
+import stat
+from pathlib import Path
+
+import pytest
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.skill_store import SkillStore
+from pinky_daemon.user_profile_store import UserProfileStore
+from scripts.v3_export import export_agent_instructions
+
+SNAPSHOT_AT = "2026-08-05T12:34:56.789Z"
+INSTRUCTION_DETAIL_KEYS = {
+    "agentSourceKey",
+    "authorityDecisionId",
+    "authorityKind",
+    "compositionProtocol",
+    "compositionVersion",
+    "directiveSetSha256",
+    "effectiveInstructionsSha256",
+    "generatedOutputs",
+    "legacyArtifactFreshness",
+    "legacyArtifactPath",
+    "legacyArtifactSha256",
+    "ownerAgentId",
+    "skillSetSha256",
+    "soulSha256",
+    "sourceSnapshotBoundary",
+    "targetMode",
+    "targetPath",
+    "targetSha256",
+}
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+@pytest.fixture
+def v2_instruction_authority(tmp_path: Path) -> dict[str, Path]:
+    agent_root = tmp_path / "agent-home"
+    agents_db = tmp_path / "conversations_agents.db"
+    skills_db = tmp_path / "conversations_skills.db"
+    profiles_db = tmp_path / "user_profiles.db"
+
+    registry = AgentRegistry(db_path=str(agents_db))
+    registry.register(
+        "barsik",
+        soul="# Database Soul\nCurious and exact.",
+        boundaries="## Database Boundaries\nNever guess.",
+        working_dir=str(agent_root),
+        runtime="claude_code",
+        transport="tmux",
+    )
+    registry.add_directive("barsik", "Keep durable receipts", priority=90)
+    registry.set_owner_profile(
+        {
+            "name": "Oleg",
+            "timezone": "America/Los_Angeles",
+            "comm_style": "Direct",
+        }
+    )
+    registry.close()
+
+    skills = SkillStore(db_path=str(skills_db))
+    skills.register("calendar", description="Calendar operations")
+    skills.assign_to_agent("barsik", "calendar")
+    skills.close()
+
+    profiles = UserProfileStore(db_path=str(profiles_db))
+    profiles.close()
+
+    # These are generated artifacts and evidence only. In particular, the
+    # deliberately stale CLAUDE.md marker must never enter composed output.
+    legacy = agent_root / "CLAUDE.md"
+    legacy.write_text("STALE LEGACY INSTRUCTIONS — NEVER SOURCE THIS\n")
+    claude_dir = agent_root / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (claude_dir / "settings.json").write_text('{"hooks": {}}\n')
+    (claude_dir / "hook_alpha.py").write_text("print('hook')\n")
+    (agent_root / ".mcp.json").write_text('{"mcpServers": {}}\n')
+
+    return {
+        "root": agent_root,
+        "legacy": legacy,
+        "agents_db": agents_db,
+        "skills_db": skills_db,
+        "profiles_db": profiles_db,
+    }
+
+
+def _export(paths: dict[str, Path], target: Path) -> tuple[list[dict], dict]:
+    return export_agent_instructions(
+        paths["agents_db"],
+        paths["skills_db"],
+        paths["profiles_db"],
+        "barsik",
+        SNAPSHOT_AT,
+        "owner-decision:barsik:instructions-v1",
+        target,
+        paths["legacy"],
+    )
+
+
+def test_exports_db_composition_to_private_artifact(
+    v2_instruction_authority: dict[str, Path], tmp_path: Path
+) -> None:
+    paths = v2_instruction_authority
+    source_hashes = {
+        "agents": _sha256(paths["agents_db"]),
+        "skills": _sha256(paths["skills_db"]),
+        "profiles": _sha256(paths["profiles_db"]),
+    }
+    target = tmp_path / "private" / "barsik-instructions.md"
+
+    records, summary = _export(paths, target)
+
+    assert _sha256(paths["agents_db"]) == source_hashes["agents"]
+    assert _sha256(paths["skills_db"]) == source_hashes["skills"]
+    assert _sha256(paths["profiles_db"]) == source_hashes["profiles"]
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    composed = target.read_text()
+    assert "# Database Soul" in composed
+    assert "## Database Boundaries" in composed
+    assert "Keep durable receipts" in composed
+    assert "Equipped: calendar" in composed
+    assert "**Name:** Oleg" in composed
+    assert "STALE LEGACY INSTRUCTIONS" not in composed
+
+    agent_record, instruction_record = records
+    assert agent_record == {
+        "kind": "inventory",
+        "sourceKey": "inventory:agent:barsik",
+        "scope": {"kind": "agent", "id": "barsik"},
+        "inventoryKind": "agent",
+        "name": "inventory:agent:barsik",
+        "disposition": "preserve",
+        "details": {
+            "provider": "claude_code",
+            "driver": "tmux",
+            "cwd": str(paths["root"]),
+            "commandRef": "claude-cli",
+            "homeRef": str(paths["root"]),
+        },
+    }
+    assert instruction_record["sourceKey"] == "inventory:instructions:barsik"
+    assert instruction_record["name"] == instruction_record["sourceKey"]
+    assert instruction_record["scope"] == {"kind": "agent", "id": "barsik"}
+    assert instruction_record["inventoryKind"] == "agent-instructions"
+    assert instruction_record["disposition"] == "preserve"
+
+    details = instruction_record["details"]
+    assert set(details) == INSTRUCTION_DETAIL_KEYS
+    assert details["agentSourceKey"] == agent_record["sourceKey"]
+    assert details["authorityKind"] == "V2_DB_COMPOSED"
+    assert details["sourceSnapshotBoundary"] == SNAPSHOT_AT
+    assert details["ownerAgentId"] == "barsik"
+    assert details["targetPath"] == str(target)
+    assert details["targetMode"] == "0600"
+    assert details["targetSha256"] == _sha256(target)
+    assert details["effectiveInstructionsSha256"] == _sha256(target)
+    assert details["legacyArtifactSha256"] == _sha256(paths["legacy"])
+    assert details["legacyArtifactFreshness"] == "DIFFERS_FROM_DB_COMPOSITION"
+    assert [item["kind"] for item in details["generatedOutputs"]] == [
+        "CLAUDE_SETTINGS",
+        "CLAUDE_HOOKS",
+        "MCP_CONFIG",
+    ]
+    assert all(item["evidenceSha256"] != "0" * 64 for item in details["generatedOutputs"])
+    assert summary["artifact"] == str(target)
+    assert summary["legacyArtifactFreshness"] == "DIFFERS_FROM_DB_COMPOSITION"
+
+
+def test_freshness_matches_only_when_legacy_bytes_equal_db_composition(
+    v2_instruction_authority: dict[str, Path], tmp_path: Path
+) -> None:
+    paths = v2_instruction_authority
+    first_target = tmp_path / "first.md"
+    _export(paths, first_target)
+    paths["legacy"].write_bytes(first_target.read_bytes())
+
+    second_target = tmp_path / "second.md"
+    records, summary = _export(paths, second_target)
+
+    details = records[1]["details"]
+    assert details["legacyArtifactSha256"] == details["effectiveInstructionsSha256"]
+    assert details["legacyArtifactFreshness"] == "MATCHES_DB_COMPOSITION"
+    assert summary["legacyArtifactFreshness"] == "MATCHES_DB_COMPOSITION"
+
+
+def test_refuses_to_overwrite_legacy_artifact(v2_instruction_authority: dict[str, Path]) -> None:
+    paths = v2_instruction_authority
+    original = paths["legacy"].read_bytes()
+
+    with pytest.raises(ValueError, match="must not overwrite"):
+        _export(paths, paths["legacy"])
+
+    assert paths["legacy"].read_bytes() == original


### PR DESCRIPTION
## Summary

Adds the missing V2-side instruction export leg for the V3 cutover contract described in [PinkyBotV3#12](https://github.com/bradbrok/PinkyBotV3/issues/12#issuecomment-5188264727).

- composes effective instructions through `AgentRegistry.build_system_prompt()` from copied agent, skill, and user-profile databases
- never treats generated `data/agents/<name>/CLAUDE.md` as authority; it is read only as bytes for drift hashing
- writes the DB-composed artifact atomically with mode `0600`
- emits linked `agent` and `agent-instructions` inventory rows with the full resolver evidence contract, including composition-set hashes, generated-output classifications, target hash/mode, and exact freshness state
- requires an explicit owner authority-decision ID at export time

## Root cause

The existing cutover exporter covered memory/project rows only. V3 already fails closed unless completed import evidence contains one exact DB-composed instruction record and a retained private artifact, so V2 had no valid way to supply instruction authority.

## Validation

- `uv run ruff check scripts/v3_export.py tests/test_v3_export.py`
- `uv run ruff format --check scripts/v3_export.py tests/test_v3_export.py`
- `uv run pytest -q tests/test_v3_export.py tests/test_agent_registry.py` — 120 passed
- `git diff --check`
- real Barsik export: private artifact mode `0600`; DB-composed and legacy hashes differed, producing `DIFFERS_FROM_DB_COMPOSITION` as expected
- isolated PinkyBotV3 importer dry-run: 1,365 rows processed, 0 fatals; both inventory rows classified `INVENTORY_SUPPORTED`

The isolated target was intentionally empty, so existing memory/project rows remained omitted as unresolved scopes; that is the normal pre-agent qualification state and did not produce exporter fatals.