### PR TITLE
export V2 approval-gate state as deferred V3 principal proposals (#516 / V3#12 item 4)

### DIFF
--- a/scripts/v3_export.py
+++ b/scripts/v3_export.py
@@ -677,12 +677,12 @@ def export_messaging_continuity(
             raise ValueError(
                 "Lease-stop record must contain an 'activeChats' list"
             )
-        lease_stop_ids = set()
+        lease_entries: dict[str, dict] = {}
         for entry in active_chats:
             chat_id = str(entry.get("chatId", "")).strip()
             if not chat_id:
                 raise ValueError("Lease-stop activeChats entry lacks chatId")
-            lease_stop_ids.add(chat_id)
+            lease_entries[chat_id] = entry
             if chat_id in {p["externalPrincipalId"] for p in proposals}:
                 continue
             proposals.append({
@@ -697,15 +697,37 @@ def export_messaging_continuity(
                 "proposedRole": "UNASSIGNED_PENDING_OWNER_DECISION",
                 "gateSource": "lease-stop-record",
             })
+        # The record settles provenance, not just membership (review round
+        # 3): a lease platform RESOLVES a V2-unresolved row, and a
+        # disagreement with a V2-resolved row is a CONFLICT the owner must
+        # see — silently calling either side "confirmed" hides exactly the
+        # divergence this input exists to expose.
         for p in proposals:
             if p["gateSource"] == "lease-stop-record":
                 p["leaseStop"] = "only-in-lease-stop"
-            else:
+                continue
+            entry = lease_entries.get(p["externalPrincipalId"])
+            if entry is None:
+                p["leaseStop"] = "absent-at-lease-stop"
+                continue
+            lease_platform = str(entry.get("platform", "")).strip()
+            if not lease_platform:
+                p["leaseStop"] = "confirmed"
+            elif p["platformSource"] == PLATFORM_SOURCE_UNRESOLVED:
+                p["platform"] = lease_platform
+                p["platformSource"] = "lease-stop-record"
+                p["leaseStop"] = "resolved-by-lease-stop"
+            elif p["platform"] != lease_platform:
+                # Keep V2's value in provider; the conflict marker carries
+                # both sides so the owner decides, not the exporter.
                 p["leaseStop"] = (
-                    "confirmed"
-                    if p["externalPrincipalId"] in lease_stop_ids
-                    else "absent-at-lease-stop"
+                    f"platform-conflict(v2={p['platform']},"
+                    f"lease={lease_platform})"
                 )
+            else:
+                p["leaseStop"] = "confirmed"
+            if not p["displayName"] and entry.get("title"):
+                p["displayName"] = str(entry["title"])
         lease_stop_status = "reconciled"
     else:
         for p in proposals:
@@ -757,6 +779,9 @@ def export_messaging_continuity(
     unresolved = [p for p in proposals if p["platformSource"] == PLATFORM_SOURCE_UNRESOLVED]
     held_total = sum(p["heldPendingInbound"] for p in proposals)
     lease_stop_only = [p for p in proposals if p["gateSource"] == "lease-stop-record"]
+    platform_conflicts = [
+        p for p in proposals if str(p["leaseStop"]).startswith("platform-conflict")
+    ]
     lines = [
         f"# Phase-5 principal proposal — {agent_name} ({snapshot_at})",
         "",
@@ -787,6 +812,7 @@ def export_messaging_continuity(
         f"- [ ] {len(unresolved)} unresolved-platform row(s) settled against the lease-stop record.",
         f"- [ ] {held_total} gate-pending inbound message(s) drained/classified before old-lease stop.",
         f"- [ ] {len(lease_stop_only)} lease-stop-only chat(s) (active at stop, unknown to V2 tables) decided.",
+        f"- [ ] {len(platform_conflicts)} platform conflict(s) (V2 vs lease-stop disagree) decided.",
         "- [ ] NEGATIVE CONTROL after enable: a known-unapproved chat id still gets the",
         "      generic denial — the gate itself must survive the migration, not just the approvals.",
     ]
@@ -801,6 +827,7 @@ def export_messaging_continuity(
             1 for p in proposals if p["gateStatus"] == "pending-inbound-without-gate-row"
         ),
         "leaseStopOnly": len(lease_stop_only),
+        "platformConflicts": len(platform_conflicts),
         "leaseStopStatus": lease_stop_status,
     }
     return records, summary, "\n".join(lines) + "\n"

--- a/scripts/v3_export.py
+++ b/scripts/v3_export.py
@@ -538,12 +538,15 @@ def _principal_key_component(chat_id: str) -> str:
     """Return a V3 source-key-safe component for an arbitrary V2 chat id.
 
     Realistic V2 identities include +phone, whitespace, and Unicode, all of
-    which fatal V3's SOURCE_KEY_INVALID. Clean ids stay readable; anything
-    else becomes a stable tagged digest, with the raw id preserved in
-    conversationRef/legacyId.
+    which fatal V3's SOURCE_KEY_INVALID. Clean ids stay readable under a
+    ``raw-`` prefix; anything else becomes a stable ``sha256-`` digest. The
+    prefixes make the two namespaces disjoint BY CONSTRUCTION — a raw id
+    that happens to look like a digest can never collide with a hashed one
+    (review round 2 found exactly that SOURCE_KEY_DUPLICATE). Raw ids are
+    preserved in conversationRef/legacyId either way.
     """
     if _SAFE_SOURCE_KEY_COMPONENT.fullmatch(chat_id):
-        return chat_id
+        return f"raw-{chat_id}"
     return f"sha256-{sha256_text(chat_id)[:24]}"
 
 
@@ -554,7 +557,10 @@ def _md_cell(value) -> str:
     rows in the artifact the owner signs off against.
     """
     text = str(value)
-    text = "".join(ch for ch in text if ch >= " " or ch == "\t")
+    text = "".join(
+        ch for ch in text
+        if (ord(ch) >= 0x20 and not (0x7F <= ord(ch) <= 0x9F)) or ch == "\t"
+    )
     return text.replace("\\", "\\\\").replace("|", "\\|").replace("\t", " ")
 
 

--- a/scripts/v3_export.py
+++ b/scripts/v3_export.py
@@ -502,6 +502,183 @@ def export_agent(
     }, skipped
 
 
+# V2's approval gate is keyed by (agent_name, chat_id) with NO platform column
+# (agent_registry.approved_users), while V3 principals bind per connector. The
+# platform is therefore RESOLVED here, never assumed: group_chats rows carry an
+# explicit platform; DM ids fall back to a shape heuristic; anything else is
+# UNRESOLVED and must be settled by the owner at Phase-5 qualification against
+# the old-lease-stop record. Every proposal row ships disposition
+# "defer-with-owner-approval" so the V3 dry-run classifies it
+# INVENTORY_DEFERRED_OWNER_APPROVAL — visible for the ceremony, never imported
+# as an enabled principal.
+PLATFORM_SOURCE_GROUP_TABLE = "group_chats"
+PLATFORM_SOURCE_ID_SHAPE = "id-shape-heuristic"
+PLATFORM_SOURCE_UNRESOLVED = "unresolved"
+
+
+def _resolve_platform(chat_id: str, group_platforms: dict[str, str]) -> tuple[str, str]:
+    if chat_id in group_platforms:
+        return group_platforms[chat_id], PLATFORM_SOURCE_GROUP_TABLE
+    text = chat_id.strip()
+    if text in ("web", "admin"):
+        return "web", PLATFORM_SOURCE_ID_SHAPE
+    if re.fullmatch(r"-\d{1,16}", text):
+        return "telegram", PLATFORM_SOURCE_ID_SHAPE
+    if re.fullmatch(r"\d{17,20}", text):
+        return "discord", PLATFORM_SOURCE_ID_SHAPE
+    if re.fullmatch(r"\d{1,13}", text):
+        return "telegram", PLATFORM_SOURCE_ID_SHAPE
+    return "unknown", PLATFORM_SOURCE_UNRESOLVED
+
+
+def export_messaging_continuity(
+    agents_db_path: Path,
+    agent_name: str,
+    snapshot_at: str,
+) -> tuple[list[dict], dict, str]:
+    """Propose the V3 connector-principal set from V2 gate + group state.
+
+    Returns (records, summary, proposal_markdown). Records carry
+    disposition "defer-with-owner-approval" by design: enabling principals
+    is the Phase-5 owner ceremony's decision, not an import side effect.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        copy = Path(tmp) / "agents.db"
+        _copy_sqlite_bundle(agents_db_path.resolve(), copy)
+        conn = sqlite3.connect(f"file:{copy}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        approved = conn.execute(
+            "SELECT chat_id, display_name, status, approved_by, timezone"
+            "  FROM approved_users WHERE agent_name=? ORDER BY created_at, id",
+            (agent_name,),
+        ).fetchall()
+        groups = conn.execute(
+            "SELECT chat_id, platform, chat_title, alias, chat_type, active"
+            "  FROM group_chats WHERE agent_name=? ORDER BY joined_at, id",
+            (agent_name,),
+        ).fetchall()
+        held = {
+            row["chat_id"]: row["held"]
+            for row in conn.execute(
+                "SELECT chat_id, COUNT(*) AS held FROM pending_messages"
+                "  WHERE agent_name=? GROUP BY chat_id",
+                (agent_name,),
+            ).fetchall()
+        }
+        conn.close()
+
+    group_platforms = {row["chat_id"]: row["platform"] for row in groups}
+    group_meta = {row["chat_id"]: row for row in groups}
+    approved_ids = {row["chat_id"] for row in approved}
+
+    proposals: list[dict] = []
+    for row in approved:
+        platform, source = _resolve_platform(row["chat_id"], group_platforms)
+        meta = group_meta.get(row["chat_id"])
+        proposals.append({
+            "externalPrincipalId": row["chat_id"],
+            "platform": platform,
+            "platformSource": source,
+            "displayName": row["display_name"] or (meta["chat_title"] if meta else ""),
+            "gateStatus": row["status"],
+            "approvedBy": row["approved_by"],
+            "isGroup": meta is not None and meta["chat_type"] != "dm",
+            "heldPendingInbound": held.get(row["chat_id"], 0),
+            "proposedRole": "UNASSIGNED_PENDING_OWNER_DECISION",
+            "gateSource": "approved_users",
+        })
+    # Active groups the gate table never recorded are the V2 "orphaned group"
+    # failure class in the making — surface them rather than silently dropping.
+    for row in groups:
+        if row["chat_id"] in approved_ids or not row["active"]:
+            continue
+        proposals.append({
+            "externalPrincipalId": row["chat_id"],
+            "platform": row["platform"],
+            "platformSource": PLATFORM_SOURCE_GROUP_TABLE,
+            "displayName": row["chat_title"] or row["alias"],
+            "gateStatus": "group-active-without-gate-row",
+            "approvedBy": "",
+            "isGroup": True,
+            "heldPendingInbound": held.get(row["chat_id"], 0),
+            "proposedRole": "UNASSIGNED_PENDING_OWNER_DECISION",
+            "gateSource": "group_chats",
+        })
+
+    # The connector-binding detail schema is a FATAL-enforced allowlist of
+    # bounded identity refs plus the common keys (import-format.ts
+    # INVENTORY_DETAIL_KEYS) — verified against the real inspector, which
+    # rejected the first draft's free-form fields. Rich provenance lives in
+    # the ceremony proposal document; the ledger row carries only bounded
+    # facts, with the human-facing fields folded into `notes`.
+    scope = {"kind": "agent", "id": agent_name}
+    records = [
+        {
+            "kind": "inventory",
+            "sourceKey": f"inventory:connector-principal:{agent_name}:{item['externalPrincipalId']}",
+            "scope": scope,
+            "inventoryKind": "connector-binding",
+            "name": f"inventory:connector-principal:{agent_name}:{item['externalPrincipalId']}",
+            "disposition": "defer-with-owner-approval",
+            "details": {
+                "provider": item["platform"],
+                "conversationRef": item["externalPrincipalId"],
+                "agentRef": agent_name,
+                "legacyId": item["externalPrincipalId"],
+                "status": item["gateStatus"],
+                "notes": (
+                    f"display={item['displayName'] or '-'};"
+                    f" platformSource={item['platformSource']};"
+                    f" group={'yes' if item['isGroup'] else 'no'};"
+                    f" heldPendingInbound={item['heldPendingInbound']};"
+                    f" approvedBy={item['approvedBy'] or '-'};"
+                    f" gateSource={item['gateSource']};"
+                    f" role=PENDING_OWNER_DECISION;"
+                    f" snapshotAt={snapshot_at}"
+                ),
+            },
+        }
+        for item in proposals
+    ]
+
+    unresolved = [p for p in proposals if p["platformSource"] == PLATFORM_SOURCE_UNRESOLVED]
+    held_total = sum(p["heldPendingInbound"] for p in proposals)
+    lines = [
+        f"# Phase-5 principal proposal — {agent_name} ({snapshot_at})",
+        "",
+        "Every row requires an explicit owner enable at qualification; nothing",
+        "below is imported as an enabled principal. Cross-check against the",
+        "old-lease-stop record (active chats/topics/senders) before enabling.",
+        "",
+        "| principal id | platform (source) | name | gate status | group | held inbound |",
+        "|---|---|---|---|---|---|",
+    ]
+    for p in proposals:
+        lines.append(
+            f"| {p['externalPrincipalId']} | {p['platform']} ({p['platformSource']}) "
+            f"| {p['displayName']} | {p['gateStatus']} | {p['isGroup']} "
+            f"| {p['heldPendingInbound']} |"
+        )
+    lines += [
+        "",
+        "## Ceremony checklist",
+        "- [ ] Every expected chat above is present (owner DM + all groups).",
+        f"- [ ] {len(unresolved)} unresolved-platform row(s) settled against the lease-stop record.",
+        f"- [ ] {held_total} gate-pending inbound message(s) drained/classified before old-lease stop.",
+        "- [ ] NEGATIVE CONTROL after enable: a known-unapproved chat id still gets the",
+        "      generic denial — the gate itself must survive the migration, not just the approvals.",
+    ]
+    summary = {
+        "proposals": len(proposals),
+        "unresolvedPlatform": len(unresolved),
+        "heldPendingInbound": held_total,
+        "groupsWithoutGateRow": sum(
+            1 for p in proposals if p["gateStatus"] == "group-active-without-gate-row"
+        ),
+    }
+    return records, summary, "\n".join(lines) + "\n"
+
+
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("db", type=Path)
@@ -539,7 +716,14 @@ if __name__ == "__main__":
         instructions_out,
         args.legacy_artifact,
     )
-    result["records"] = instruction_records + result["records"]
+    continuity_records, continuity_summary, proposal_doc = export_messaging_continuity(
+        args.agents_db,
+        args.agent,
+        snapshot_at,
+    )
+    proposal_out = args.out.with_name(f"{args.out.stem}.{args.agent}.principals.md")
+    proposal_out.write_text(proposal_doc)
+    result["records"] = instruction_records + continuity_records + result["records"]
     args.out.write_text(json.dumps(result, indent=1, ensure_ascii=False))
     counts: dict[str, int] = {}
     for record in result["records"]:
@@ -555,6 +739,7 @@ if __name__ == "__main__":
                     "instruction_authority": "V2_DB_COMPOSED",
                 },
                 "instructions": instruction_summary,
+                "messagingContinuity": {**continuity_summary, "proposal": str(proposal_out)},
                 "out": str(args.out),
             },
             indent=1,

--- a/scripts/v3_export.py
+++ b/scripts/v3_export.py
@@ -531,16 +531,50 @@ def _resolve_platform(chat_id: str, group_platforms: dict[str, str]) -> tuple[st
     return "unknown", PLATFORM_SOURCE_UNRESOLVED
 
 
+_SAFE_SOURCE_KEY_COMPONENT = re.compile(r"[A-Za-z0-9._:@-]{1,80}")
+
+
+def _principal_key_component(chat_id: str) -> str:
+    """Return a V3 source-key-safe component for an arbitrary V2 chat id.
+
+    Realistic V2 identities include +phone, whitespace, and Unicode, all of
+    which fatal V3's SOURCE_KEY_INVALID. Clean ids stay readable; anything
+    else becomes a stable tagged digest, with the raw id preserved in
+    conversationRef/legacyId.
+    """
+    if _SAFE_SOURCE_KEY_COMPONENT.fullmatch(chat_id):
+        return chat_id
+    return f"sha256-{sha256_text(chat_id)[:24]}"
+
+
+def _md_cell(value) -> str:
+    """Escape a DB-sourced value for the owner-decision Markdown table.
+
+    A crafted display name containing pipes/newlines could otherwise forge
+    rows in the artifact the owner signs off against.
+    """
+    text = str(value)
+    text = "".join(ch for ch in text if ch >= " " or ch == "\t")
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\t", " ")
+
+
 def export_messaging_continuity(
     agents_db_path: Path,
     agent_name: str,
     snapshot_at: str,
+    lease_stop_record_path: Path | None = None,
 ) -> tuple[list[dict], dict, str]:
     """Propose the V3 connector-principal set from V2 gate + group state.
 
     Returns (records, summary, proposal_markdown). Records carry
     disposition "defer-with-owner-approval" by design: enabling principals
     is the Phase-5 owner ceremony's decision, not an import side effect.
+
+    ``lease_stop_record_path`` is the Phase-5 step-2 old-lease-stop record
+    (``{"activeChats": [{"chatId": ..., "platform": ..., "title": ...}]}``).
+    When present, chats active at lease stop but absent from every V2 table
+    are surfaced as their own status instead of relying on the operator's
+    manual cross-check; pre-cutover exports may omit it.
     """
     with tempfile.TemporaryDirectory() as tmp:
         copy = Path(tmp) / "agents.db"
@@ -557,11 +591,13 @@ def export_messaging_continuity(
             "  FROM group_chats WHERE agent_name=? ORDER BY joined_at, id",
             (agent_name,),
         ).fetchall()
+        # delivered=1 rows are retained delivery HISTORY (V2 checkpoints, not
+        # deletes); counting them ordered phantom drains in review round 1.
         held = {
             row["chat_id"]: row["held"]
             for row in conn.execute(
                 "SELECT chat_id, COUNT(*) AS held FROM pending_messages"
-                "  WHERE agent_name=? GROUP BY chat_id",
+                "  WHERE agent_name=? AND delivered=0 GROUP BY chat_id",
                 (agent_name,),
             ).fetchall()
         }
@@ -604,6 +640,70 @@ def export_messaging_continuity(
             "proposedRole": "UNASSIGNED_PENDING_OWNER_DECISION",
             "gateSource": "group_chats",
         })
+    # Undelivered inbound from senders with NO gate row and NO group row is
+    # the NORMAL gate-held shape (a stranger's message is why the gate
+    # exists) — round 1 silently dropped exactly this class.
+    covered = {p["externalPrincipalId"] for p in proposals}
+    for chat_id, count in sorted(held.items()):
+        if chat_id in covered:
+            continue
+        platform, source = _resolve_platform(chat_id, group_platforms)
+        proposals.append({
+            "externalPrincipalId": chat_id,
+            "platform": platform,
+            "platformSource": source,
+            "displayName": "",
+            "gateStatus": "pending-inbound-without-gate-row",
+            "approvedBy": "",
+            "isGroup": False,
+            "heldPendingInbound": count,
+            "proposedRole": "UNASSIGNED_PENDING_OWNER_DECISION",
+            "gateSource": "pending_messages",
+        })
+
+    # Phase-5 continuity hole closure: anything alive at old-lease stop but
+    # unknown to every V2 table must confront the owner explicitly.
+    lease_stop_status = "no-record"
+    if lease_stop_record_path is not None:
+        lease_stop = json.loads(lease_stop_record_path.read_text())
+        active_chats = lease_stop.get("activeChats")
+        if not isinstance(active_chats, list):
+            raise ValueError(
+                "Lease-stop record must contain an 'activeChats' list"
+            )
+        lease_stop_ids = set()
+        for entry in active_chats:
+            chat_id = str(entry.get("chatId", "")).strip()
+            if not chat_id:
+                raise ValueError("Lease-stop activeChats entry lacks chatId")
+            lease_stop_ids.add(chat_id)
+            if chat_id in {p["externalPrincipalId"] for p in proposals}:
+                continue
+            proposals.append({
+                "externalPrincipalId": chat_id,
+                "platform": str(entry.get("platform", "unknown")),
+                "platformSource": "lease-stop-record",
+                "displayName": str(entry.get("title", "")),
+                "gateStatus": "active-without-v2-state",
+                "approvedBy": "",
+                "isGroup": bool(entry.get("isGroup", False)),
+                "heldPendingInbound": held.get(chat_id, 0),
+                "proposedRole": "UNASSIGNED_PENDING_OWNER_DECISION",
+                "gateSource": "lease-stop-record",
+            })
+        for p in proposals:
+            if p["gateSource"] == "lease-stop-record":
+                p["leaseStop"] = "only-in-lease-stop"
+            else:
+                p["leaseStop"] = (
+                    "confirmed"
+                    if p["externalPrincipalId"] in lease_stop_ids
+                    else "absent-at-lease-stop"
+                )
+        lease_stop_status = "reconciled"
+    else:
+        for p in proposals:
+            p["leaseStop"] = "no-record"
 
     # The connector-binding detail schema is a FATAL-enforced allowlist of
     # bounded identity refs plus the common keys (import-format.ts
@@ -615,10 +715,16 @@ def export_messaging_continuity(
     records = [
         {
             "kind": "inventory",
-            "sourceKey": f"inventory:connector-principal:{agent_name}:{item['externalPrincipalId']}",
+            "sourceKey": (
+                f"inventory:connector-principal:{agent_name}:"
+                f"{_principal_key_component(item['externalPrincipalId'])}"
+            ),
             "scope": scope,
             "inventoryKind": "connector-binding",
-            "name": f"inventory:connector-principal:{agent_name}:{item['externalPrincipalId']}",
+            "name": (
+                f"inventory:connector-principal:{agent_name}:"
+                f"{_principal_key_component(item['externalPrincipalId'])}"
+            ),
             "disposition": "defer-with-owner-approval",
             "details": {
                 "provider": item["platform"],
@@ -633,6 +739,7 @@ def export_messaging_continuity(
                     f" heldPendingInbound={item['heldPendingInbound']};"
                     f" approvedBy={item['approvedBy'] or '-'};"
                     f" gateSource={item['gateSource']};"
+                    f" leaseStop={item['leaseStop']};"
                     f" role=PENDING_OWNER_DECISION;"
                     f" snapshotAt={snapshot_at}"
                 ),
@@ -643,21 +750,29 @@ def export_messaging_continuity(
 
     unresolved = [p for p in proposals if p["platformSource"] == PLATFORM_SOURCE_UNRESOLVED]
     held_total = sum(p["heldPendingInbound"] for p in proposals)
+    lease_stop_only = [p for p in proposals if p["gateSource"] == "lease-stop-record"]
     lines = [
         f"# Phase-5 principal proposal — {agent_name} ({snapshot_at})",
         "",
         "Every row requires an explicit owner enable at qualification; nothing",
-        "below is imported as an enabled principal. Cross-check against the",
-        "old-lease-stop record (active chats/topics/senders) before enabling.",
+        "below is imported as an enabled principal.",
+        (
+            "Lease-stop record: RECONCILED below."
+            if lease_stop_status == "reconciled"
+            else "Lease-stop record: NOT provided — cross-check active"
+            " chats/topics/senders manually before enabling."
+        ),
         "",
-        "| principal id | platform (source) | name | gate status | group | held inbound |",
-        "|---|---|---|---|---|---|",
+        "| principal id | platform (source) | name | gate status | group | held inbound | lease stop |",
+        "|---|---|---|---|---|---|---|",
     ]
     for p in proposals:
         lines.append(
-            f"| {p['externalPrincipalId']} | {p['platform']} ({p['platformSource']}) "
-            f"| {p['displayName']} | {p['gateStatus']} | {p['isGroup']} "
-            f"| {p['heldPendingInbound']} |"
+            f"| {_md_cell(p['externalPrincipalId'])} "
+            f"| {_md_cell(p['platform'])} ({_md_cell(p['platformSource'])}) "
+            f"| {_md_cell(p['displayName'])} | {_md_cell(p['gateStatus'])} "
+            f"| {p['isGroup']} | {p['heldPendingInbound']} "
+            f"| {_md_cell(p['leaseStop'])} |"
         )
     lines += [
         "",
@@ -665,6 +780,7 @@ def export_messaging_continuity(
         "- [ ] Every expected chat above is present (owner DM + all groups).",
         f"- [ ] {len(unresolved)} unresolved-platform row(s) settled against the lease-stop record.",
         f"- [ ] {held_total} gate-pending inbound message(s) drained/classified before old-lease stop.",
+        f"- [ ] {len(lease_stop_only)} lease-stop-only chat(s) (active at stop, unknown to V2 tables) decided.",
         "- [ ] NEGATIVE CONTROL after enable: a known-unapproved chat id still gets the",
         "      generic denial — the gate itself must survive the migration, not just the approvals.",
     ]
@@ -675,6 +791,11 @@ def export_messaging_continuity(
         "groupsWithoutGateRow": sum(
             1 for p in proposals if p["gateStatus"] == "group-active-without-gate-row"
         ),
+        "pendingWithoutGateRow": sum(
+            1 for p in proposals if p["gateStatus"] == "pending-inbound-without-gate-row"
+        ),
+        "leaseStopOnly": len(lease_stop_only),
+        "leaseStopStatus": lease_stop_status,
     }
     return records, summary, "\n".join(lines) + "\n"
 
@@ -691,6 +812,7 @@ if __name__ == "__main__":
     ap.add_argument("--legacy-artifact", type=Path)
     ap.add_argument("--instructions-out", type=Path)
     ap.add_argument("--authority-decision-id", required=True)
+    ap.add_argument("--lease-stop-record", type=Path)
     ap.add_argument("-o", "--out", type=Path, required=True)
     args = ap.parse_args()
     snapshot_at = canonical_now_utc()
@@ -720,6 +842,7 @@ if __name__ == "__main__":
         args.agents_db,
         args.agent,
         snapshot_at,
+        lease_stop_record_path=args.lease_stop_record,
     )
     proposal_out = args.out.with_name(f"{args.out.stem}.{args.agent}.principals.md")
     proposal_out.write_text(proposal_doc)

--- a/tests/test_v3_export.py
+++ b/tests/test_v3_export.py
@@ -400,12 +400,22 @@ def test_no_lease_stop_record_keeps_manual_crosscheck(
 @pytest.mark.parametrize(
     ("chat_id", "expected"),
     [
-        ("6770805286", "6770805286"),
-        ("-5270435808", "-5270435808"),
+        ("6770805286", "raw-6770805286"),
+        ("-5270435808", "raw--5270435808"),
     ],
 )
 def test_clean_ids_stay_readable_in_source_keys(chat_id: str, expected: str) -> None:
     assert _principal_key_component(chat_id) == expected
+
+
+def test_digest_shaped_raw_id_cannot_collide_with_hashed_id() -> None:
+    hostile = "+14155550123"
+    digest_component = _principal_key_component(hostile)
+    assert digest_component.startswith("sha256-")
+    # An attacker-controlled RAW id crafted to equal the digest component.
+    crafted_raw = digest_component
+    assert _principal_key_component(crafted_raw) == f"raw-{crafted_raw}"
+    assert _principal_key_component(crafted_raw) != digest_component
 
 
 @pytest.mark.parametrize(
@@ -439,6 +449,7 @@ def test_md_cell_strips_control_and_escapes() -> None:
     assert _md_cell("a\nb\rc") == "abc"
     assert _md_cell("a\\|b") == "a\\\\\\|b"
     assert _md_cell("tab\there") == "tab here"
+    assert _md_cell("a\x7fb\x85c\x9fd") == "abcd"
 
 
 @pytest.mark.parametrize(
@@ -446,8 +457,11 @@ def test_md_cell_strips_control_and_escapes() -> None:
     [
         ("9" * 13, "telegram", PLATFORM_SOURCE_ID_SHAPE),
         ("9" * 14, "unknown", PLATFORM_SOURCE_UNRESOLVED),
+        ("9" * 15, "unknown", PLATFORM_SOURCE_UNRESOLVED),
         ("9" * 16, "unknown", PLATFORM_SOURCE_UNRESOLVED),
         ("9" * 17, "discord", PLATFORM_SOURCE_ID_SHAPE),
+        ("9" * 18, "discord", PLATFORM_SOURCE_ID_SHAPE),
+        ("9" * 19, "discord", PLATFORM_SOURCE_ID_SHAPE),
         ("9" * 20, "discord", PLATFORM_SOURCE_ID_SHAPE),
         ("9" * 21, "unknown", PLATFORM_SOURCE_UNRESOLVED),
         ("-" + "9" * 16, "telegram", PLATFORM_SOURCE_ID_SHAPE),

--- a/tests/test_v3_export.py
+++ b/tests/test_v3_export.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import re
 import stat
 from pathlib import Path
 
@@ -304,3 +306,153 @@ def test_group_platform_row_beats_id_heuristic(v2_messaging_state: Path) -> None
     by_id = {r["details"]["conversationRef"]: r["details"] for r in records}
     assert f"platformSource={PLATFORM_SOURCE_GROUP_TABLE}" in by_id["-5270435808"]["notes"]
     assert "group=yes" in by_id["-5270435808"]["notes"]
+
+
+# ── review round-2 regressions (murzik gauntlet findings 1-5) ────────────────
+
+from scripts.v3_export import _md_cell, _principal_key_component  # noqa: E402
+
+
+@pytest.fixture
+def v2_gate_edge_state(tmp_path: Path) -> Path:
+    agents_db = tmp_path / "conversations_agents.db"
+    registry = AgentRegistry(db_path=str(agents_db))
+    registry.register("barsik", soul="soul", working_dir=str(tmp_path / "home"))
+    registry.approve_user("barsik", "6770805286", display_name="Brad")
+    # Finding 1: delivered history must NOT count as held.
+    msg_id = registry.queue_pending_message(
+        "barsik", "telegram", "6770805286", "Brad", "old delivered message"
+    )
+    registry.mark_pending_message_delivered(msg_id)
+    # Finding 2: a stranger's undelivered message — NO gate row, NO group row —
+    # is the normal gate-held shape and must surface, not vanish.
+    registry.queue_pending_message(
+        "barsik", "telegram", "5551234567", "Stranger", "hello, still waiting"
+    )
+    # Finding 5: hostile display name aimed at the ceremony Markdown.
+    registry.approve_user(
+        "barsik", "-5999999999",
+        display_name="Evil | forged | row\n| fake | Brad | row |",
+    )
+    registry.upsert_group_chat("barsik", "-5999999999", chat_title="Hostile Group")
+    registry.close()
+    return agents_db
+
+
+def test_delivered_history_is_not_held(v2_gate_edge_state: Path) -> None:
+    records, summary, _doc = export_messaging_continuity(
+        v2_gate_edge_state, "barsik", SNAPSHOT_AT
+    )
+    by_ref = {r["details"]["conversationRef"]: r["details"] for r in records}
+    assert "heldPendingInbound=0" in by_ref["6770805286"]["notes"]
+    assert summary["heldPendingInbound"] == 1  # only the stranger's row
+
+
+def test_orphan_undelivered_pending_surfaces_exactly_once(
+    v2_gate_edge_state: Path,
+) -> None:
+    records, summary, doc = export_messaging_continuity(
+        v2_gate_edge_state, "barsik", SNAPSHOT_AT
+    )
+    orphan_rows = [
+        r for r in records
+        if r["details"]["status"] == "pending-inbound-without-gate-row"
+    ]
+    assert [r["details"]["conversationRef"] for r in orphan_rows] == ["5551234567"]
+    assert "heldPendingInbound=1" in orphan_rows[0]["details"]["notes"]
+    assert summary["pendingWithoutGateRow"] == 1
+    assert "5551234567" in doc
+
+
+def test_lease_stop_reconciliation_surfaces_unknown_chats(
+    v2_gate_edge_state: Path, tmp_path: Path
+) -> None:
+    record = tmp_path / "lease-stop.json"
+    record.write_text(json.dumps({
+        "activeChats": [
+            {"chatId": "6770805286", "platform": "telegram", "title": "Brad"},
+            {"chatId": "40404040", "platform": "telegram", "title": "Ghost Chat"},
+        ]
+    }))
+    records, summary, doc = export_messaging_continuity(
+        v2_gate_edge_state, "barsik", SNAPSHOT_AT, lease_stop_record_path=record
+    )
+    by_ref = {r["details"]["conversationRef"]: r["details"] for r in records}
+    assert by_ref["40404040"]["status"] == "active-without-v2-state"
+    assert "leaseStop=only-in-lease-stop" in by_ref["40404040"]["notes"]
+    assert "leaseStop=confirmed" in by_ref["6770805286"]["notes"]
+    assert "leaseStop=absent-at-lease-stop" in by_ref["-5999999999"]["notes"]
+    assert summary["leaseStopOnly"] == 1
+    assert summary["leaseStopStatus"] == "reconciled"
+    assert "1 lease-stop-only chat(s)" in doc
+
+
+def test_no_lease_stop_record_keeps_manual_crosscheck(
+    v2_gate_edge_state: Path,
+) -> None:
+    _records, summary, doc = export_messaging_continuity(
+        v2_gate_edge_state, "barsik", SNAPSHOT_AT
+    )
+    assert summary["leaseStopStatus"] == "no-record"
+    assert "NOT provided" in doc
+
+
+@pytest.mark.parametrize(
+    ("chat_id", "expected"),
+    [
+        ("6770805286", "6770805286"),
+        ("-5270435808", "-5270435808"),
+    ],
+)
+def test_clean_ids_stay_readable_in_source_keys(chat_id: str, expected: str) -> None:
+    assert _principal_key_component(chat_id) == expected
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["+14155550123", "chat id with spaces", "чат-юникод", "x" * 200, "a|b\nc"],
+)
+def test_unsafe_ids_get_stable_tagged_digest_keys(hostile: str) -> None:
+    key = _principal_key_component(hostile)
+    assert key.startswith("sha256-")
+    assert re.fullmatch(r"sha256-[0-9a-f]{24}", key)
+    assert key == _principal_key_component(hostile)  # stable
+
+
+def test_hostile_display_name_cannot_forge_markdown_rows(
+    v2_gate_edge_state: Path,
+) -> None:
+    _records, _summary, doc = export_messaging_continuity(
+        v2_gate_edge_state, "barsik", SNAPSHOT_AT
+    )
+    forged = [
+        line for line in doc.splitlines()
+        if line.startswith("|") and "fake" in line and line.count("|") >= 7
+        and "Evil" not in line
+    ]
+    assert forged == [], forged
+    assert "Evil \\| forged \\| row" in doc
+
+
+def test_md_cell_strips_control_and_escapes() -> None:
+    assert _md_cell("a|b") == "a\\|b"
+    assert _md_cell("a\nb\rc") == "abc"
+    assert _md_cell("a\\|b") == "a\\\\\\|b"
+    assert _md_cell("tab\there") == "tab here"
+
+
+@pytest.mark.parametrize(
+    ("chat_id", "platform", "source"),
+    [
+        ("9" * 13, "telegram", PLATFORM_SOURCE_ID_SHAPE),
+        ("9" * 14, "unknown", PLATFORM_SOURCE_UNRESOLVED),
+        ("9" * 16, "unknown", PLATFORM_SOURCE_UNRESOLVED),
+        ("9" * 17, "discord", PLATFORM_SOURCE_ID_SHAPE),
+        ("9" * 20, "discord", PLATFORM_SOURCE_ID_SHAPE),
+        ("9" * 21, "unknown", PLATFORM_SOURCE_UNRESOLVED),
+        ("-" + "9" * 16, "telegram", PLATFORM_SOURCE_ID_SHAPE),
+        ("-" + "9" * 17, "unknown", PLATFORM_SOURCE_UNRESOLVED),
+    ],
+)
+def test_platform_heuristic_edges_frozen(chat_id: str, platform: str, source: str) -> None:
+    assert _resolve_platform(chat_id, {}) == (platform, source)

--- a/tests/test_v3_export.py
+++ b/tests/test_v3_export.py
@@ -387,6 +387,39 @@ def test_lease_stop_reconciliation_surfaces_unknown_chats(
     assert "1 lease-stop-only chat(s)" in doc
 
 
+def test_lease_platform_resolves_unresolved_and_conflicts_surface(
+    tmp_path: Path,
+) -> None:
+    agents_db = tmp_path / "agents.db"
+    registry = AgentRegistry(db_path=str(agents_db))
+    registry.register("barsik", soul="soul", working_dir=str(tmp_path / "home"))
+    registry.approve_user("barsik", "9" * 14, display_name="Unresolvable")
+    registry.approve_user("barsik", "6770805286", display_name="Brad")
+    registry.close()
+    record = tmp_path / "lease-stop.json"
+    record.write_text(json.dumps({"activeChats": [
+        {"chatId": "9" * 14, "platform": "telegram"},
+        {"chatId": "6770805286", "platform": "discord"},
+    ]}))
+    records, summary, doc = export_messaging_continuity(
+        agents_db, "barsik", SNAPSHOT_AT, lease_stop_record_path=record
+    )
+    by_ref = {r["details"]["conversationRef"]: r["details"] for r in records}
+    # Unresolved V2 row: lease platform APPLIES and provenance says so.
+    assert by_ref["9" * 14]["provider"] == "telegram"
+    assert "platformSource=lease-stop-record" in by_ref["9" * 14]["notes"]
+    assert "leaseStop=resolved-by-lease-stop" in by_ref["9" * 14]["notes"]
+    assert summary["unresolvedPlatform"] == 0
+    # Resolved V2 row disagreeing with lease: V2 value kept, conflict surfaced.
+    assert by_ref["6770805286"]["provider"] == "telegram"
+    assert (
+        "leaseStop=platform-conflict(v2=telegram,lease=discord)"
+        in by_ref["6770805286"]["notes"]
+    )
+    assert summary["platformConflicts"] == 1
+    assert "1 platform conflict(s)" in doc
+
+
 def test_no_lease_stop_record_keeps_manual_crosscheck(
     v2_gate_edge_state: Path,
 ) -> None:

--- a/tests/test_v3_export.py
+++ b/tests/test_v3_export.py
@@ -200,3 +200,107 @@ def test_refuses_to_overwrite_legacy_artifact(v2_instruction_authority: dict[str
         _export(paths, paths["legacy"])
 
     assert paths["legacy"].read_bytes() == original
+
+
+# ── messaging continuity (task #516 / V3#12 item 4) ──────────────────────────
+
+from scripts.v3_export import (  # noqa: E402
+    PLATFORM_SOURCE_GROUP_TABLE,
+    PLATFORM_SOURCE_ID_SHAPE,
+    PLATFORM_SOURCE_UNRESOLVED,
+    _resolve_platform,
+    export_messaging_continuity,
+)
+
+
+@pytest.fixture
+def v2_messaging_state(tmp_path: Path) -> Path:
+    agents_db = tmp_path / "conversations_agents.db"
+    registry = AgentRegistry(db_path=str(agents_db))
+    registry.register("barsik", soul="soul", working_dir=str(tmp_path / "home"))
+    registry.approve_user("barsik", "6770805286", display_name="Brad", approved_by="owner")
+    registry.approve_user("barsik", "-5270435808", display_name="B & Barsik", approved_by="owner")
+    registry.approve_user(
+        "barsik", "754027672526389310", display_name="bradbrok", approved_by="owner"
+    )
+    registry.approve_user("barsik", "web", display_name="Console", approved_by="owner")
+    # A gate-approved group with an explicit platform row.
+    registry.upsert_group_chat(
+        "barsik", "-5270435808", chat_title="B & Barsik, Yulia", platform="telegram"
+    )
+    # The orphaned-group failure class: active group, NO approved_users row.
+    registry.upsert_group_chat(
+        "barsik", "-5476255431", chat_title="B, Barsik and Yulia", platform="telegram"
+    )
+    # Gate-pending inbound that must be drained before old-lease stop.
+    registry.queue_pending_message(
+        "barsik", "telegram", "999999999999999", "Stranger", "hello?"
+    )
+    registry.approve_user("barsik", "999999999999999", display_name="Fourteen Digits")
+    registry.close()
+    return agents_db
+
+
+def test_platform_resolution_provenance() -> None:
+    groups = {"-5476255431": "telegram"}
+    assert _resolve_platform("-5476255431", groups) == ("telegram", PLATFORM_SOURCE_GROUP_TABLE)
+    assert _resolve_platform("6770805286", {}) == ("telegram", PLATFORM_SOURCE_ID_SHAPE)
+    assert _resolve_platform("-5270435808", {}) == ("telegram", PLATFORM_SOURCE_ID_SHAPE)
+    assert _resolve_platform("754027672526389310", {}) == ("discord", PLATFORM_SOURCE_ID_SHAPE)
+    assert _resolve_platform("web", {}) == ("web", PLATFORM_SOURCE_ID_SHAPE)
+    assert _resolve_platform("999999999999999", {})[1] == PLATFORM_SOURCE_UNRESOLVED
+    assert _resolve_platform("ferry://pi/geordi", {})[1] == PLATFORM_SOURCE_UNRESOLVED
+
+
+def test_every_proposal_is_deferred_never_imported(v2_messaging_state: Path) -> None:
+    records, summary, doc = export_messaging_continuity(
+        v2_messaging_state, "barsik", SNAPSHOT_AT
+    )
+    assert records, "expected at least one proposal record"
+    assert all(r["disposition"] == "defer-with-owner-approval" for r in records)
+    assert all(r["inventoryKind"] == "connector-binding" for r in records)
+    assert all(r["scope"] == {"kind": "agent", "id": "barsik"} for r in records)
+    allowed = {
+        "provider", "accountRef", "appRef", "botRef", "communityRef",
+        "conversationRef", "channelRef", "agentRef", "endpointRef", "secretRef",
+        "legacyId", "notes", "reason", "replacement", "status", "version",
+    }
+    for r in records:
+        assert set(r["details"]) <= allowed, set(r["details"]) - allowed
+        assert "role=PENDING_OWNER_DECISION" in r["details"]["notes"]
+    assert "NEGATIVE CONTROL" in doc
+
+
+def test_orphaned_active_group_is_surfaced_not_dropped(v2_messaging_state: Path) -> None:
+    records, summary, _doc = export_messaging_continuity(
+        v2_messaging_state, "barsik", SNAPSHOT_AT
+    )
+    orphans = [
+        r for r in records
+        if r["details"]["status"] == "group-active-without-gate-row"
+    ]
+    assert [r["details"]["conversationRef"] for r in orphans] == ["-5476255431"]
+    assert summary["groupsWithoutGateRow"] == 1
+
+
+def test_held_pending_inbound_counted_and_unresolved_flagged(
+    v2_messaging_state: Path,
+) -> None:
+    records, summary, doc = export_messaging_continuity(
+        v2_messaging_state, "barsik", SNAPSHOT_AT
+    )
+    by_id = {r["details"]["conversationRef"]: r["details"] for r in records}
+    assert "heldPendingInbound=1" in by_id["999999999999999"]["notes"]
+    assert f"platformSource={PLATFORM_SOURCE_UNRESOLVED}" in by_id["999999999999999"]["notes"]
+    assert summary["heldPendingInbound"] == 1
+    assert summary["unresolvedPlatform"] == 1
+    assert "1 gate-pending inbound" in doc
+
+
+def test_group_platform_row_beats_id_heuristic(v2_messaging_state: Path) -> None:
+    records, _summary, _doc = export_messaging_continuity(
+        v2_messaging_state, "barsik", SNAPSHOT_AT
+    )
+    by_id = {r["details"]["conversationRef"]: r["details"] for r in records}
+    assert f"platformSource={PLATFORM_SOURCE_GROUP_TABLE}" in by_id["-5270435808"]["notes"]
+    assert "group=yes" in by_id["-5270435808"]["notes"]


### PR DESCRIPTION
## Summary

Third exporter leg: V2 messaging-continuity state → V3 connector-principal proposals for the Phase-5 lease-transfer ceremony.

- `approved_users` is platform-blind; platform is **resolved, never assumed** — `group_chats` rows authoritative, DM id-shape heuristic second (edges frozen parametrically: 1–13 telegram, 14–16 unresolved, 17–20 discord, 21+ unresolved, negative 16/17 boundary). `UNRESOLVED` is settled by the lease-stop record when one is provided, else by the owner at qualification.
- Active groups with no gate row surface as `group-active-without-gate-row`; **undelivered pending inbound with no gate/group parent — the normal stranger-at-the-gate shape — surfaces as `pending-inbound-without-gate-row`** instead of vanishing.
- Held counts filter `delivered=0` (V2 retains delivery history); **live Mini numbers: 13 proposals / 8 genuinely held** (an earlier draft misread 21 by counting history).
- Optional `--lease-stop-record` reconciles the Phase-5 step-2 record when present — membership AND provenance: lease-stop-only chats → `active-without-v2-state`; a lease platform **resolves** V2-unresolved rows (`leaseStop=resolved-by-lease-stop`); a disagreement with a V2-resolved row keeps V2's value and surfaces `platform-conflict(v2=…,lease=…)` with its own summary count and checklist line. Without the record, the ceremony doc keeps the manual cross-check explicit.
- Source keys: `raw-<id>` when schema-legal, `sha256-<24hex>` otherwise — **disjoint namespaces by construction** (collision regression uses an attacker-crafted digest-shaped raw id); raw ids preserved in `conversationRef`/`legacyId`.
- Ceremony Markdown escapes pipes/backslashes and strips C0+DEL+C1 controls from every DB-sourced cell; a hostile-display-name regression forges a row and asserts it stays inert.
- Every row: `inventoryKind: connector-binding`, `disposition: defer-with-owner-approval` → `INVENTORY_DEFERRED_OWNER_APPROVAL`, never auto-imported; details conform to the fatal-enforced allowlist.

## Validation

- `ruff` clean; **34/34 tests**.
- Real-data run against the live Mini `agents.db` (copy-then-read) + V3 `inspectPinkyImportManifest`: `ok: true`, **0 fatals**, 13× `INVENTORY_DEFERRED_OWNER_APPROVAL` — re-verified after every review round; lease-reconciliation manifests independently verified (3 deferred / 0 fatals).

Review: murzik gauntlet rounds 1–4 produced seven findings across three rounds — held-count inflation, orphan pending drop, missing lease-stop input, source-key fatality, Markdown forgery, key-namespace collision, and membership-only lease reconciliation — all addressed with frozen regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Opened by Barsik