### PR TITLE
fix(scheduler): persist exact-fire acceptance receipts

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -654,7 +654,12 @@ class AgentSchedule:
 
 @dataclass
 class PendingScheduleWake:
-    """A fired scheduler prompt awaiting confirmed transport acceptance."""
+    """One durable exact-fire scheduler ledger record.
+
+    The historical class name is retained because active rows are also the
+    replay outbox.  ``accepted_at`` and ``parked_at`` make the terminal state
+    explicit without deleting the forensic receipt.
+    """
 
     id: int = 0
     schedule_id: int = 0
@@ -665,11 +670,40 @@ class PendingScheduleWake:
     created_at: float = 0.0
     attempts: int = 0
     parked_at: float = 0.0
+    accepted_at: float = 0.0
+    failed_at: float = 0.0
+    last_error: str = ""
 
     @property
     def name(self) -> str:
         """Match the ``AgentSchedule`` interface used by receipt waiting."""
         return self.schedule_name
+
+    @property
+    def ledger_state(self) -> str:
+        """Return the exact operational outcome used by fleet health."""
+        if self.accepted_at > 0:
+            return "receipted-ran-once"
+        if self.parked_at > 0:
+            return "quarantined"
+        return "pending"
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "schedule_id": self.schedule_id,
+            "agent_name": self.agent_name,
+            "schedule_name": self.schedule_name,
+            "prompt": self.prompt,
+            "fired_at": self.fired_at,
+            "created_at": self.created_at,
+            "attempts": self.attempts,
+            "parked_at": self.parked_at,
+            "accepted_at": self.accepted_at,
+            "failed_at": self.failed_at,
+            "last_error": self.last_error,
+            "state": self.ledger_state,
+        }
 
 
 class ScheduleNameConflictError(ValueError):
@@ -1279,6 +1313,9 @@ class AgentRegistry:
                 created_at REAL NOT NULL,
                 attempts INTEGER NOT NULL DEFAULT 0,
                 parked_at REAL NOT NULL DEFAULT 0,
+                accepted_at REAL NOT NULL DEFAULT 0,
+                failed_at REAL NOT NULL DEFAULT 0,
+                last_error TEXT NOT NULL DEFAULT '',
                 FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
                 UNIQUE(schedule_id, fired_at)
             );
@@ -1619,6 +1656,9 @@ class AgentRegistry:
         wake_migrations = [
             ("attempts", "INTEGER NOT NULL DEFAULT 0"),
             ("parked_at", "REAL NOT NULL DEFAULT 0"),
+            ("accepted_at", "REAL NOT NULL DEFAULT 0"),
+            ("failed_at", "REAL NOT NULL DEFAULT 0"),
+            ("last_error", "TEXT NOT NULL DEFAULT ''"),
         ]
         for col, typedef in wake_migrations:
             if col not in wake_existing:
@@ -1629,6 +1669,13 @@ class AgentRegistry:
                     "agent_registry: migrated — added "
                     f"{col} to pending_schedule_wakes"
                 )
+        self._db.execute(
+            """CREATE INDEX IF NOT EXISTS idx_schedule_wake_ledger_state
+               ON pending_schedule_wakes(
+                   agent_name, accepted_at, parked_at, fired_at
+               )"""
+        )
+        self._db.commit()
 
         # Migrate agent_heartbeats table
         hb_existing = {
@@ -3284,6 +3331,66 @@ except Exception as exc:
         )
         self._db.commit()
 
+    def claim_schedule_fire(
+        self,
+        schedule_id: int,
+        *,
+        timestamp: float,
+        expected_last_run: float,
+        agent_name: str,
+        schedule_name: str,
+        prompt: str,
+    ) -> tuple[bool, PendingScheduleWake | None]:
+        """Atomically claim one fire and create its durable ledger/outbox row.
+
+        A crash must never leave ``last_run`` advanced without an exact-fire
+        row that startup can classify.  This transaction closes that earlier
+        fire-claim/outbox gap while preserving the compare-and-swap race guard.
+        """
+        if timestamp <= 0:
+            raise ValueError("timestamp must be a positive exact-fire timestamp")
+        created_at = time.time()
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                """UPDATE agent_schedules SET last_run=?
+                   WHERE id=? AND last_run=?""",
+                (timestamp, schedule_id, expected_last_run),
+            )
+            if cursor.rowcount == 0:
+                self._db.commit()
+                return False, None
+            self._db.execute(
+                """INSERT OR IGNORE INTO pending_schedule_wakes (
+                       schedule_id, agent_name, schedule_name, prompt,
+                       fired_at, created_at
+                   ) VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    schedule_id,
+                    agent_name,
+                    schedule_name,
+                    prompt,
+                    timestamp,
+                    created_at,
+                ),
+            )
+            row = self._select_schedule_wake_by_fire(
+                schedule_id, timestamp
+            )
+            self._db.commit()
+        return True, PendingScheduleWake(*row)
+
+    def _select_schedule_wake_by_fire(
+        self, schedule_id: int, fired_at: float
+    ):
+        return self._db.execute(
+            """SELECT id, schedule_id, agent_name, schedule_name, prompt,
+                      fired_at, created_at, attempts, parked_at, accepted_at,
+                      failed_at, last_error
+               FROM pending_schedule_wakes
+               WHERE schedule_id=? AND fired_at=?""",
+            (schedule_id, fired_at),
+        ).fetchone()
+
     def persist_schedule_wake(
         self,
         schedule_id: int,
@@ -3321,7 +3428,8 @@ except Exception as exc:
             created = cursor.rowcount > 0
             row = self._db.execute(
                 """SELECT id, schedule_id, agent_name, schedule_name, prompt,
-                          fired_at, created_at, attempts, parked_at
+                          fired_at, created_at, attempts, parked_at, accepted_at,
+                          failed_at, last_error
                    FROM pending_schedule_wakes
                    WHERE schedule_id=? AND fired_at=?""",
                 (schedule_id, fired_at),
@@ -3337,18 +3445,20 @@ except Exception as exc:
     ) -> list[PendingScheduleWake]:
         """Return pending scheduler wakes oldest-first.
 
-        Parked rows are dead letters and are excluded by default. Pass
-        ``include_parked=True`` to inspect them. For now, deleting a parked row
-        manually is the only supported way to unpark it.
+        Accepted receipts are always excluded. Quarantined rows are excluded
+        by default; pass ``include_parked=True`` to inspect those terminal
+        records alongside the active replay outbox.
         """
         sql = """SELECT id, schedule_id, agent_name, schedule_name, prompt,
-                        fired_at, created_at, attempts, parked_at
+                        fired_at, created_at, attempts, parked_at, accepted_at,
+                        failed_at, last_error
                  FROM pending_schedule_wakes"""
         conditions: list[str] = []
         params: list = []
         if agent_name is not None:
             conditions.append("agent_name=?")
             params.append(agent_name)
+        conditions.append("accepted_at=0")
         if not include_parked:
             conditions.append("parked_at=0")
         if conditions:
@@ -3356,6 +3466,82 @@ except Exception as exc:
         sql += " ORDER BY fired_at ASC, id ASC"
         rows = self._db.execute(sql, params).fetchall()
         return [PendingScheduleWake(*row) for row in rows]
+
+    def list_schedule_wake_ledger(
+        self,
+        agent_name: str | None = None,
+        *,
+        state: str | None = None,
+        fired_after: float = 0.0,
+        limit: int = 200,
+    ) -> list[PendingScheduleWake]:
+        """Return queryable exact-fire outcomes newest-first for fleet health."""
+        if state not in {
+            None,
+            "pending",
+            "receipted-ran-once",
+            "quarantined",
+        }:
+            raise ValueError(f"invalid scheduler wake ledger state: {state}")
+        sql = """SELECT id, schedule_id, agent_name, schedule_name, prompt,
+                        fired_at, created_at, attempts, parked_at, accepted_at,
+                        failed_at, last_error
+                 FROM pending_schedule_wakes"""
+        conditions: list[str] = []
+        params: list = []
+        if agent_name is not None:
+            conditions.append("agent_name=?")
+            params.append(agent_name)
+        if fired_after > 0:
+            conditions.append("fired_at>=?")
+            params.append(fired_after)
+        if state == "pending":
+            conditions.extend(("accepted_at=0", "parked_at=0"))
+        elif state == "receipted-ran-once":
+            conditions.append("accepted_at>0")
+        elif state == "quarantined":
+            conditions.extend(("accepted_at=0", "parked_at>0"))
+        if conditions:
+            sql += " WHERE " + " AND ".join(conditions)
+        sql += " ORDER BY fired_at DESC, id DESC LIMIT ?"
+        params.append(max(1, min(int(limit), 1000)))
+        rows = self._db.execute(sql, params).fetchall()
+        return [PendingScheduleWake(*row) for row in rows]
+
+    def get_schedule_wake_by_fire(
+        self, schedule_id: int, fired_at: float
+    ) -> PendingScheduleWake | None:
+        """Return one exact-fire ledger row regardless of terminal state."""
+        row = self._select_schedule_wake_by_fire(schedule_id, fired_at)
+        return PendingScheduleWake(*row) if row is not None else None
+
+    def record_schedule_wake_failure(
+        self, schedule_id: int, fired_at: float, reason: str
+    ) -> tuple[PendingScheduleWake | None, bool]:
+        """Record a negative hint unless durable terminal evidence exists.
+
+        Returns the current row and whether this was its first negative hint.
+        A retained accepted receipt always wins over a cancelled/stale Future.
+        """
+        timestamp = time.time()
+        with self._rmw_lock:
+            row = self._select_schedule_wake_by_fire(schedule_id, fired_at)
+            if row is None:
+                return None, False
+            current = PendingScheduleWake(*row)
+            if current.accepted_at > 0 or current.parked_at > 0:
+                return current, False
+            first_failure = current.failed_at == 0
+            self._db.execute(
+                """UPDATE pending_schedule_wakes
+                   SET failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
+                       last_error=?
+                   WHERE id=? AND accepted_at=0 AND parked_at=0""",
+                (timestamp, reason, current.id),
+            )
+            row = self._select_schedule_wake_by_fire(schedule_id, fired_at)
+            self._db.commit()
+        return PendingScheduleWake(*row), first_failure
 
     def increment_pending_schedule_wake_attempts(
         self, pending_id: int
@@ -3379,16 +3565,22 @@ except Exception as exc:
         return int(row[0])
 
     def park_pending_schedule_wake(
-        self, pending_id: int, *, parked_at: float = 0.0
+        self,
+        pending_id: int,
+        *,
+        parked_at: float = 0.0,
+        reason: str = "delivery attempts exhausted",
     ) -> bool:
-        """Atomically move an active wake to dead-letter parked state once."""
+        """Atomically move an active wake to terminal quarantine once."""
         timestamp = parked_at or time.time()
         with self._rmw_lock:
             cursor = self._db.execute(
                 """UPDATE pending_schedule_wakes
-                   SET parked_at=?
-                   WHERE id=? AND parked_at=0""",
-                (timestamp, pending_id),
+                   SET parked_at=?,
+                       failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
+                       last_error=?
+                   WHERE id=? AND parked_at=0 AND accepted_at=0""",
+                (timestamp, timestamp, reason, pending_id),
             )
             self._db.commit()
         return cursor.rowcount > 0
@@ -3396,25 +3588,33 @@ except Exception as exc:
     def confirm_pending_schedule_wake(
         self, pending_id: int, *, delivered_at: float = 0.0
     ) -> bool:
-        """Atomically stamp the schedule delivered and retire its outbox row."""
+        """Atomically retain a positive receipt and retire it from replay."""
         timestamp = delivered_at or time.time()
         with self._rmw_lock:
             row = self._db.execute(
-                "SELECT schedule_id FROM pending_schedule_wakes WHERE id=?",
+                """SELECT schedule_id, accepted_at
+                   FROM pending_schedule_wakes WHERE id=?""",
                 (pending_id,),
             ).fetchone()
             if row is None:
                 return False
             self._db.execute(
-                "UPDATE agent_schedules SET last_delivered=? WHERE id=?",
+                """UPDATE agent_schedules
+                   SET last_delivered=MAX(last_delivered, ?)
+                   WHERE id=?""",
                 (timestamp, row[0]),
             )
-            cursor = self._db.execute(
-                "DELETE FROM pending_schedule_wakes WHERE id=?",
-                (pending_id,),
+            self._db.execute(
+                """UPDATE pending_schedule_wakes
+                   SET accepted_at=CASE
+                           WHEN accepted_at=0 THEN ? ELSE accepted_at END,
+                       parked_at=0,
+                       last_error=''
+                   WHERE id=?""",
+                (timestamp, pending_id),
             )
             self._db.commit()
-        return cursor.rowcount > 0
+        return True
 
     def confirm_pending_schedule_wake_by_fire(
         self,
@@ -3423,34 +3623,40 @@ except Exception as exc:
         *,
         delivered_at: float = 0.0,
     ) -> bool:
-        """Atomically confirm and retire the outbox row for one exact fire."""
+        """Atomically persist acceptance for one exact fire before replay."""
         timestamp = delivered_at or time.time()
         with self._rmw_lock:
             row = self._db.execute(
-                """SELECT id FROM pending_schedule_wakes
+                """SELECT id, accepted_at FROM pending_schedule_wakes
                    WHERE schedule_id=? AND fired_at=?""",
                 (schedule_id, fired_at),
             ).fetchone()
             if row is None:
                 return False
             self._db.execute(
-                "UPDATE agent_schedules SET last_delivered=? WHERE id=?",
+                """UPDATE agent_schedules
+                   SET last_delivered=MAX(last_delivered, ?)
+                   WHERE id=?""",
                 (timestamp, schedule_id),
             )
-            cursor = self._db.execute(
-                """DELETE FROM pending_schedule_wakes
+            self._db.execute(
+                """UPDATE pending_schedule_wakes
+                   SET accepted_at=CASE
+                           WHEN accepted_at=0 THEN ? ELSE accepted_at END,
+                       parked_at=0,
+                       last_error=''
                    WHERE schedule_id=? AND fired_at=?""",
-                (schedule_id, fired_at),
+                (timestamp, schedule_id, fired_at),
             )
             self._db.commit()
-        retired = cursor.rowcount > 0
-        if retired:
+        newly_receipted = float(row[1]) == 0
+        if newly_receipted:
             _log(
-                "agent_registry: PERSISTED_WAKE_RETIRED_ON_LATE_CONFIRM "
+                "agent_registry: SCHEDULE_WAKE_RECEIPTED "
                 f"pending #{row[0]}, schedule #{schedule_id}, "
                 f"fired_at={fired_at}"
             )
-        return retired
+        return True
 
     def discard_pending_schedule_wake(self, pending_id: int) -> bool:
         """Retire a pending wake without marking its schedule delivered."""

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -16,6 +16,7 @@ import asyncio
 import contextlib
 import hashlib
 import hmac
+import inspect
 import json
 import os
 import re
@@ -10091,6 +10092,28 @@ npm run build</pre>
             "count": len(schedules),
         }
 
+    @app.get("/scheduler/wake-ledger")
+    async def list_scheduler_wake_ledger(
+        agent_name: str | None = None,
+        state: str | None = None,
+        fired_after: float = 0.0,
+        limit: int = 200,
+    ):
+        """Query exact-fire scheduler outcomes without interpreting logs."""
+        try:
+            rows = agents.list_schedule_wake_ledger(
+                agent_name,
+                state=state,
+                fired_after=fired_after,
+                limit=limit,
+            )
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        return {
+            "records": [row.to_dict() for row in rows],
+            "count": len(rows),
+        }
+
     # ── Heartbeat Endpoints ────────────────────────────────
 
     @app.post("/agents/{agent_name}/heartbeat")
@@ -10329,7 +10352,13 @@ npm run build</pre>
             "connected": ss.state == TransportSessionState.CONNECTED,
         }
 
-    async def _wake_callback(agent_name: str, session_id: str, prompt: str):
+    async def _wake_callback(
+        agent_name: str,
+        session_id: str,
+        prompt: str,
+        *,
+        schedule_receipt=None,
+    ):
         """Queue a wake and return its exact per-prompt delivery receipt."""
         del session_id  # Streaming is now the canonical main runtime.
         ss = await _ensure_streaming_session(agent_name, label="main")
@@ -10339,7 +10368,17 @@ npm run build</pre>
 
         scheduler_send = getattr(ss, "send_scheduler_prompt", None)
         if callable(scheduler_send):
-            receipt = await scheduler_send(prompt)
+            scheduler_kwargs = {}
+            if schedule_receipt is not None:
+                try:
+                    signature = inspect.signature(scheduler_send)
+                    if "on_accept" in signature.parameters:
+                        scheduler_kwargs["on_accept"] = (
+                            schedule_receipt.accept
+                        )
+                except (TypeError, ValueError):
+                    pass
+            receipt = await scheduler_send(prompt, **scheduler_kwargs)
             _log(
                 f"scheduler: queued confirmed-delivery wake for "
                 f"{agent_name} via streaming main"
@@ -10352,6 +10391,21 @@ npm run build</pre>
             and getattr(ss, "injection_confirms_consumption", False)
         )
         if confirmed:
+            if schedule_receipt is not None:
+                try:
+                    persisted = schedule_receipt.accept()
+                except Exception as exc:
+                    persisted = False
+                    _log(
+                        "scheduler: SCHEDULER_RECEIPT_PERSIST_FAILURE "
+                        f"for {agent_name}: {type(exc).__name__}: {exc}"
+                    )
+                if persisted is not True:
+                    _log(
+                        "scheduler: SCHEDULER_RECEIPT_PERSIST_FAILURE "
+                        f"for {agent_name}: no durable positive evidence; "
+                        "suppressing unsafe replay"
+                    )
             _log(
                 f"scheduler: wake accepted for {agent_name} via "
                 f"streaming main"

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -458,14 +458,16 @@ class CodexSession:
         )
 
     async def send_scheduler_prompt(
-        self, prompt: str
+        self, prompt: str, *, on_accept=None
     ) -> asyncio.Future[bool]:
         """Queue a scheduler prompt and confirm transport acceptance."""
         receipt: asyncio.Future[bool] = (
             asyncio.get_running_loop().create_future()
         )
         queued = await self._queue_external_message(
-            prompt, scheduler_delivery=receipt
+            prompt,
+            scheduler_delivery=receipt,
+            scheduler_accept=on_accept,
         )
         if not queued and not receipt.done():
             receipt.set_result(False)
@@ -479,6 +481,32 @@ class CodexSession:
         if receipt is not None and not receipt.done():
             receipt.set_result(accepted)
 
+    def _accept_scheduler_delivery(
+        self,
+        receipt: asyncio.Future[bool] | None,
+        scheduler_accept=None,
+    ) -> None:
+        """Persist the exact-fire receipt before resolving the Future True."""
+        if scheduler_accept is not None:
+            try:
+                persisted = scheduler_accept()
+            except Exception as exc:
+                persisted = False
+                _log(
+                    f"codex[{self.agent_name}]: "
+                    "SCHEDULER_RECEIPT_PERSIST_FAILURE after exact transport "
+                    f"acceptance ({type(exc).__name__}: {exc})"
+                )
+            if persisted is not True:
+                # The turn is already accepted. A negative receipt would make
+                # replay more dangerous than the durability degradation.
+                _log(
+                    f"codex[{self.agent_name}]: "
+                    "SCHEDULER_RECEIPT_PERSIST_FAILURE returned no durable "
+                    "positive evidence; suppressing unsafe replay"
+                )
+        self._resolve_scheduler_delivery(receipt, True)
+
     async def _queue_external_message(
         self,
         prompt: str,
@@ -488,6 +516,7 @@ class CodexSession:
         message_id: str = "",
         agent_hint: str = "",
         scheduler_delivery: asyncio.Future[bool] | None = None,
+        scheduler_accept=None,
     ) -> bool:
         """Apply external-send side effects and enqueue one Codex turn."""
         if self.state != SessionState.CONNECTED:
@@ -529,6 +558,7 @@ class CodexSession:
                 chat_id,
                 message_id,
                 scheduler_delivery,
+                scheduler_accept,
             )
         await self._message_queue.put(queued)
         _log(f"codex[{self.agent_name}]: queued message (chat={chat_id})")
@@ -547,6 +577,7 @@ class CodexSession:
                 queued = await self._message_queue.get()
                 prompt, platform, chat_id, message_id = queued[:4]
                 scheduler_delivery = queued[4] if len(queued) > 4 else None
+                scheduler_accept = queued[5] if len(queued) > 5 else None
                 if (
                     scheduler_delivery is not None
                     and scheduler_delivery.cancelled()
@@ -558,6 +589,12 @@ class CodexSession:
                     async with self._exec_lock:
                         if scheduler_delivery is None:
                             result = await self._exec_codex(prompt)
+                        elif scheduler_accept is not None:
+                            result = await self._exec_codex(
+                                prompt,
+                                scheduler_delivery=scheduler_delivery,
+                                scheduler_accept=scheduler_accept,
+                            )
                         else:
                             result = await self._exec_codex(
                                 prompt,
@@ -876,6 +913,7 @@ class CodexSession:
         prompt: str,
         *,
         scheduler_delivery: asyncio.Future[bool] | None = None,
+        scheduler_accept=None,
     ) -> CodexTurnResult:
         """Run a single codex exec invocation and parse JSONL output.
 
@@ -885,7 +923,9 @@ class CodexSession:
             if scheduler_delivery is None:
                 return await self._exec_codex_app_server(prompt)
             return await self._exec_codex_app_server(
-                prompt, scheduler_delivery=scheduler_delivery
+                prompt,
+                scheduler_delivery=scheduler_delivery,
+                scheduler_accept=scheduler_accept,
             )
 
         result = CodexTurnResult()
@@ -934,7 +974,9 @@ class CodexSession:
             # The exact prompt has crossed the exec transport boundary.
             # Merely acquiring _exec_lock or spawning the process is not a
             # receipt: stdin write+drain+EOF is the first observed acceptance.
-            self._resolve_scheduler_delivery(scheduler_delivery, True)
+            self._accept_scheduler_delivery(
+                scheduler_delivery, scheduler_accept
+            )
 
             # Stream stdout line-by-line for real-time activity tracking.
             # Defensive: skip-and-continue on a single oversized line rather
@@ -1147,6 +1189,7 @@ class CodexSession:
         prompt: str,
         *,
         scheduler_delivery: asyncio.Future[bool] | None = None,
+        scheduler_accept=None,
     ) -> CodexTurnResult:
         """Run a single turn over the long-lived app-server connection."""
         result = CodexTurnResult()
@@ -1228,7 +1271,9 @@ class CodexSession:
             await client.request("turn/start", turn_params)
             # Successful turn/start response is the app-server's exact prompt
             # acceptance edge. Thread start/resume alone is not sufficient.
-            self._resolve_scheduler_delivery(scheduler_delivery, True)
+            self._accept_scheduler_delivery(
+                scheduler_delivery, scheduler_accept
+            )
 
             # turn/start returns immediately; notifications drive the turn.
             # _on_appserver_notification resolves _turn_done on turn/completed.

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -149,6 +149,33 @@ def next_cron_description(cron_expr: str) -> str:
 
 # ── Scheduler ────────────────────────────────────────────────
 
+
+class ScheduleWakeReceipt:
+    """Capability that durably accepts one exact scheduler fire.
+
+    The transport calls ``accept`` at its real acceptance edge and only then
+    resolves the process-local Future.  This ordering is the load-bearing
+    crash-gap guarantee for issue #991.
+    """
+
+    def __init__(
+        self,
+        registry: AgentRegistry,
+        schedule_id: int,
+        fired_at: float,
+    ) -> None:
+        self.schedule_id = schedule_id
+        self.fired_at = fired_at
+        self._registry = registry
+
+    def accept(self) -> bool:
+        """Commit the positive receipt synchronously and idempotently."""
+        return self._registry.confirm_pending_schedule_wake_by_fire(
+            self.schedule_id,
+            self.fired_at,
+            delivered_at=time.time(),
+        )
+
 class AgentScheduler:
     """Background scheduler for agent wake schedules and heartbeats.
 
@@ -184,7 +211,10 @@ class AgentScheduler:
         schedule_delivery_timeout: float = 600.0,
     ) -> None:
         self._registry = registry
-        # async fn(agent_name, session_id, prompt) -> bool | Awaitable[bool].
+        # async fn(agent_name, session_id, prompt, *, schedule_receipt=None)
+        # -> bool | Awaitable[bool]. Production API callbacks accept the
+        # optional durable receipt capability; legacy/test callbacks retain
+        # the original three-argument contract.
         # An awaitable return is a per-prompt delivery receipt; same-agent
         # schedules are not advanced until it resolves.
         self._wake_callback = wake_callback
@@ -383,11 +413,26 @@ class AgentScheduler:
                     continue
 
             if cron_matches(schedule.cron, dt):
-                claimed = self._registry.update_schedule_last_run(
-                    schedule.id,
-                    now,
-                    expected_last_run=schedule.last_run,
-                )
+                if schedule.direct_send:
+                    claimed = self._registry.update_schedule_last_run(
+                        schedule.id,
+                        now,
+                        expected_last_run=schedule.last_run,
+                    )
+                else:
+                    claimed, _ledger_row = (
+                        self._registry.claim_schedule_fire(
+                            schedule.id,
+                            timestamp=now,
+                            expected_last_run=schedule.last_run,
+                            agent_name=schedule.agent_name,
+                            schedule_name=schedule.name,
+                            prompt=(
+                                schedule.prompt
+                                or f"Scheduled wake: {schedule.name}"
+                            ),
+                        )
+                    )
                 if not claimed:
                     _log(
                         f"scheduler: lost last_run claim race for "
@@ -512,6 +557,18 @@ class AgentScheduler:
         confirmed = False
         failure_reason = "no delivery callback configured"
 
+        # Direct unit/in-process callers can bypass ``_check_schedules``. Keep
+        # their exact fire represented too; production fires already have this
+        # row from the atomic claim transaction above.
+        if not schedule.direct_send and schedule.last_run > 0:
+            self._registry.persist_schedule_wake(
+                schedule.id,
+                agent_name=schedule.agent_name,
+                schedule_name=schedule.name,
+                prompt=self._wake_prompt(schedule),
+                fired_at=schedule.last_run,
+            )
+
         if schedule.direct_send:
             if attempt_started is not None:
                 attempt_started.set()
@@ -555,14 +612,14 @@ class AgentScheduler:
 
         if confirmed:
             delivered_at = time.time()
-            retired_pending = (
+            receipted_pending = (
                 self._registry.confirm_pending_schedule_wake_by_fire(
                     schedule.id,
                     schedule.last_run,
                     delivered_at=delivered_at,
                 )
             )
-            if not retired_pending:
+            if not receipted_pending:
                 self._registry.update_schedule_last_delivered(
                     schedule.id, delivered_at
                 )
@@ -596,7 +653,7 @@ class AgentScheduler:
         alert_this_failure = True
         if not schedule.direct_send:
             try:
-                _, created = self._registry.persist_schedule_wake(
+                row, _created = self._registry.persist_schedule_wake(
                     schedule.id,
                     agent_name=schedule.agent_name,
                     schedule_name=schedule.name,
@@ -607,7 +664,31 @@ class AgentScheduler:
                     fired_at=schedule.last_run,
                 )
                 persisted = True
-                alert_this_failure = created
+                row, alert_this_failure = (
+                    self._registry.record_schedule_wake_failure(
+                        schedule.id,
+                        schedule.last_run,
+                        failure_reason,
+                    )
+                )
+                if row is not None and row.accepted_at > 0:
+                    _log(
+                        f"scheduler: durable receipt won teardown race for "
+                        f"schedule '{schedule.name}' (#{schedule.id}) for "
+                        f"agent '{schedule.agent_name}' "
+                        f"(fired_at={schedule.last_run}); suppressing stale "
+                        "negative delivery verdict"
+                    )
+                    return
+                if row is not None and row.parked_at > 0:
+                    _log(
+                        f"scheduler: schedule '{schedule.name}' "
+                        f"(#{schedule.id}) for agent "
+                        f"'{schedule.agent_name}' is already quarantined "
+                        f"(fired_at={schedule.last_run}); suppressing "
+                        "duplicate undelivered verdict"
+                    )
+                    return
             except Exception as exc:
                 _log(
                     f"scheduler: SCHEDULER_WAKE_PERSIST_FAILURE schedule "
@@ -768,7 +849,7 @@ class AgentScheduler:
         task.add_done_callback(_done)
 
     async def _replay_pending_for_agent(self, agent_name: str) -> None:
-        """Deliver one agent's persisted wakes FIFO and retire exact successes."""
+        """Deliver one agent's persisted wakes FIFO and receipt exact successes."""
         lock = self._schedule_delivery_locks.setdefault(agent_name, asyncio.Lock())
         async with lock:
             await self._replay_pending_locked(agent_name)
@@ -802,8 +883,8 @@ class AgentScheduler:
                 f"#{pending.id} for schedule '{pending.schedule_name}' "
                 f"(#{pending.schedule_id}) on agent '{pending.agent_name}' "
                 f"reached {attempts} unconfirmed delivery attempts. Replay "
-                "is stopped for this row to prevent a storm; delete the row "
-                "manually to unpark it."
+                "is stopped to prevent a storm; the exact fire remains in "
+                "the ledger as a queryable quarantine."
             ),
         )
         return True
@@ -824,14 +905,15 @@ class AgentScheduler:
             elif not current_schedule.enabled and not current_schedule.one_shot:
                 zombie_reason = "schedule disabled"
             if zombie_reason:
-                retired = self._registry.discard_pending_schedule_wake(
-                    pending.id
+                quarantined = self._registry.park_pending_schedule_wake(
+                    pending.id,
+                    reason=f"terminal replay policy: {zombie_reason}",
                 )
                 _log(
-                    f"scheduler: PERSISTED_WAKE_ZOMBIE_DROPPED pending "
+                    f"scheduler: PERSISTED_WAKE_ZOMBIE_QUARANTINED pending "
                     f"#{pending.id}, schedule #{pending.schedule_id} for "
                     f"agent '{pending.agent_name}': {zombie_reason}; "
-                    f"outbox_retired={retired}"
+                    f"quarantined={quarantined}"
                 )
                 continue
             if pending.parked_at == 0:
@@ -871,7 +953,7 @@ class AgentScheduler:
             ):
                 _log(
                     f"scheduler: persisted wake #{pending.id} for "
-                    f"'{agent_name}' was confirmed but outbox retirement "
+                    f"'{agent_name}' was confirmed but receipt persistence "
                     "did not match a row"
                 )
                 break
@@ -934,10 +1016,27 @@ class AgentScheduler:
         if attempt_started is not None:
             attempt_started.set()
         main_session_id = f"{schedule.agent_name}-main"
+        fired_at = (
+            schedule.fired_at
+            if hasattr(schedule, "fired_at")
+            else schedule.last_run
+        )
+        receipt = ScheduleWakeReceipt(
+            self._registry, schedule.id, fired_at
+        )
+        callback_kwargs = {}
+        try:
+            signature = inspect.signature(self._wake_callback)
+            if "schedule_receipt" in signature.parameters:
+                callback_kwargs["schedule_receipt"] = receipt
+        except (TypeError, ValueError):
+            # Opaque callables keep the historical three-argument contract.
+            pass
         result = await self._wake_callback(
             schedule.agent_name,
             main_session_id,
             self._wake_prompt(schedule),
+            **callback_kwargs,
         )
         if inspect.isawaitable(result):
             result = await result

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -862,6 +862,10 @@ class _QueuedTurn:
     # transcript user row, or queue enqueue followed by dequeue; successful
     # tmux keystrokes alone are not a receipt.
     scheduler_delivery: asyncio.Future[bool] | None = None
+    # Exact-fire durable acceptance callback. It MUST run successfully before
+    # ``scheduler_delivery`` resolves True; otherwise a process death can lose
+    # the only positive evidence and replay work that already entered the pane.
+    scheduler_accept: object = None  # Callable() -> bool
     scheduler_serialized: bool = False
     pane_delivery_started: bool = False
     pane_queue_enqueued: bool = False
@@ -3463,7 +3467,7 @@ class TmuxSession:
         )
 
     async def send_scheduler_prompt(
-        self, prompt: str
+        self, prompt: str, *, on_accept=None
     ) -> asyncio.Future[bool]:
         """Start a scheduler turn and return its exact acceptance receipt.
 
@@ -3475,6 +3479,7 @@ class TmuxSession:
         queued = await self._queue_external_turn(
             prompt,
             scheduler_delivery=receipt,
+            scheduler_accept=on_accept,
             scheduler_serialized=True,
         )
         if not queued and not receipt.done():
@@ -3527,6 +3532,7 @@ class TmuxSession:
         message_id: str = "",
         agent_hint: str = "",
         scheduler_delivery: asyncio.Future[bool] | None = None,
+        scheduler_accept=None,
         scheduler_serialized: bool = False,
     ) -> bool:
         """Apply external-send side effects and enqueue one pane turn."""
@@ -3558,6 +3564,7 @@ class TmuxSession:
             chat_id=chat_id,
             message_id=message_id,
             scheduler_delivery=scheduler_delivery,
+            scheduler_accept=scheduler_accept,
             scheduler_serialized=scheduler_serialized,
         )
         if scheduler_serialized:
@@ -6803,6 +6810,26 @@ class TmuxSession:
         # callback has an entry to pop. _finish_turn_delivery is idempotent.
         if self._wake_requires_submission_receipt(turn):
             self._finish_turn_delivery(turn, fire_on_delivered=False)
+        if turn.scheduler_accept is not None:
+            try:
+                persisted = turn.scheduler_accept()
+            except Exception as exc:
+                persisted = False
+                _log(
+                    f"tmux[{self.agent_name}]: "
+                    "SCHEDULER_RECEIPT_PERSIST_FAILURE after exact transport "
+                    f"acceptance ({type(exc).__name__}: {exc})"
+                )
+            if persisted is not True:
+                # The prompt is already accepted and cannot safely be replayed.
+                # Resolve the in-process receipt positively so the scheduler
+                # gets one more chance to persist before shutdown, while the
+                # loud log makes the degraded durability visible.
+                _log(
+                    f"tmux[{self.agent_name}]: "
+                    "SCHEDULER_RECEIPT_PERSIST_FAILURE returned no durable "
+                    "positive evidence; suppressing unsafe replay"
+                )
         turn.transport_accepted = True
         for receipt in (turn.scheduler_delivery, turn.submission_receipt):
             if receipt is not None and not receipt.done():
@@ -7185,11 +7212,10 @@ class TmuxSession:
                     gate_subtype = "timeout"
                     _log(
                         f"tmux[{self.agent_name}]: wake-prompt readiness "
-                        f"gate TIMEOUT after {_SESSION_READY_GATE_TIMEOUT_SEC}s "
-                        f"— proceeding with paste anyway "
-                        f"(reason={turn.reason}). Hook may have failed to "
-                        f"fire; check the agent's "
-                        f".claude/hook_tmux_session_start.py."
+                        f"gate still pending after "
+                        f"{_SESSION_READY_GATE_TIMEOUT_SEC}s — proceeding "
+                        f"with paste; exact transcript receipt remains the "
+                        f"delivery verdict (reason={turn.reason})"
                     )
 
             if self._analytics_store:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5340,6 +5340,40 @@ class TestAgentScheduleEndpoints:
 
         assert response.status_code == 400
 
+    def test_wake_ledger_endpoint_filters_queryable_receipts(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        created = self._create_schedule(
+            client,
+            direct_send=False,
+            target_channel="",
+        ).json()
+        registry = client.app.state.agents
+        row, _ = registry.persist_schedule_wake(
+            created["id"],
+            agent_name="alice",
+            schedule_name="morning",
+            prompt="Original",
+            fired_at=100.0,
+        )
+        assert registry.confirm_pending_schedule_wake(
+            row.id, delivered_at=110.0
+        )
+
+        response = client.get(
+            "/scheduler/wake-ledger",
+            params={
+                "agent_name": "alice",
+                "state": "receipted-ran-once",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 1
+        assert body["records"][0]["state"] == "receipted-ran-once"
+        assert body["records"][0]["fired_at"] == 100.0
+
 
 # ── Agent CRUD ───────────────────────────────────────────────
 

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -1296,12 +1296,20 @@ class TestCodexAppServerTurn:
         fake = _FakeAppClient(s, notifications)
         _patch_ensure(s, fake)
         receipt = asyncio.get_running_loop().create_future()
+        acceptance_order: list[bool] = []
+
+        def persist_exact_fire() -> bool:
+            acceptance_order.append(receipt.done())
+            return True
 
         result = await s._exec_codex_app_server(
-            "hi there", scheduler_delivery=receipt
+            "hi there",
+            scheduler_delivery=receipt,
+            scheduler_accept=persist_exact_fire,
         )
 
         assert not result.failed
+        assert acceptance_order == [False]
         assert await receipt is True
         assert result.text_parts == ["hello"]
         assert result.input_tokens == 100

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -436,6 +436,64 @@ class TestAgentSchedules:
         stored = registry.get_schedules("oleg")[0]
         assert stored.last_delivered == pytest.approx(delivered_at)
 
+    def test_schedule_wake_ledger_exposes_exact_terminal_states(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="ledger", prompt="run it"
+        )
+        accepted, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="ledger",
+            prompt="accepted",
+            fired_at=100.0,
+        )
+        quarantined, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="ledger",
+            prompt="quarantined",
+            fired_at=200.0,
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="ledger",
+            prompt="pending",
+            fired_at=300.0,
+        )
+
+        assert registry.confirm_pending_schedule_wake(
+            accepted.id, delivered_at=150.0
+        )
+        assert registry.park_pending_schedule_wake(
+            quarantined.id,
+            parked_at=250.0,
+            reason="explicit misfire quarantine",
+        )
+
+        assert [
+            row.ledger_state for row in registry.list_schedule_wake_ledger("oleg")
+        ] == ["pending", "quarantined", "receipted-ran-once"]
+        assert [
+            row.prompt
+            for row in registry.list_schedule_wake_ledger(
+                "oleg", state="receipted-ran-once"
+            )
+        ] == ["accepted"]
+        assert registry.list_schedule_wake_ledger(
+            "oleg", state="quarantined"
+        )[0].last_error == "explicit misfire quarantine"
+        assert [
+            row.prompt
+            for row in registry.list_schedule_wake_ledger(
+                "oleg", fired_after=150.0
+            )
+        ] == ["pending", "quarantined"]
+        assert [row.prompt for row in registry.list_pending_schedule_wakes("oleg")] == [
+            "pending"
+        ]
+
     def test_confirm_pending_wake_by_fire_missing_is_harmless(
         self, registry, capsys
     ):
@@ -479,7 +537,7 @@ class TestAgentSchedules:
         ) == []
         assert registry.get_schedules("oleg")[0].last_delivered == 200.0
         captured = capsys.readouterr().err
-        assert "PERSISTED_WAKE_RETIRED_ON_LATE_CONFIRM" in captured
+        assert "SCHEDULE_WAKE_RECEIPTED" in captured
         assert f"pending #{pending.id}, schedule #{schedule.id}" in captured
 
     def test_pending_wake_columns_migrate_idempotently_on_existing_db(self):
@@ -513,6 +571,9 @@ class TestAgentSchedules:
             ]
             assert columns.count("attempts") == 1
             assert columns.count("parked_at") == 1
+            assert columns.count("accepted_at") == 1
+            assert columns.count("failed_at") == 1
+            assert columns.count("last_error") == 1
         finally:
             reopened.close()
             os.unlink(path)
@@ -958,27 +1019,37 @@ class TestScheduler:
         )
         wake_calls: list[str] = []
         events: list[str] = []
-        real_update = registry.update_schedule_last_run
+        real_claim = registry.claim_schedule_fire
         competing_claim_made = False
 
         def lose_to_competing_claim(
             schedule_id,
-            timestamp=0.0,
             *,
-            expected_last_run=None,
+            timestamp,
+            expected_last_run,
+            agent_name,
+            schedule_name,
+            prompt,
         ):
             nonlocal competing_claim_made
-            if expected_last_run is not None and not competing_claim_made:
+            if not competing_claim_made:
                 competing_claim_made = True
-                assert real_update(
+                claimed, _row = real_claim(
                     schedule_id,
-                    timestamp,
+                    timestamp=timestamp,
                     expected_last_run=expected_last_run,
-                ) is True
-            return real_update(
+                    agent_name=agent_name,
+                    schedule_name=schedule_name,
+                    prompt=prompt,
+                )
+                assert claimed is True
+            return real_claim(
                 schedule_id,
-                timestamp,
+                timestamp=timestamp,
                 expected_last_run=expected_last_run,
+                agent_name=agent_name,
+                schedule_name=schedule_name,
+                prompt=prompt,
             )
 
         class Activity:
@@ -993,7 +1064,7 @@ class TestScheduler:
 
         monkeypatch.setattr(
             registry,
-            "update_schedule_last_run",
+            "claim_schedule_fire",
             lose_to_competing_claim,
         )
         scheduler = AgentScheduler(
@@ -1097,12 +1168,132 @@ class TestScheduler:
         ) == []
         assert registry.get_schedules("oleg")[0].last_delivered > 0
         captured = capsys.readouterr().err
-        assert "PERSISTED_WAKE_RETIRED_ON_LATE_CONFIRM" in captured
+        assert "SCHEDULE_WAKE_RECEIPTED" in captured
         assert f"pending #{pending[0].id}, schedule #{schedule.id}" in captured
 
         scheduler.replay_pending_for_agent("oleg")
         await scheduler._pending_replay_tasks["oleg"]
         assert attempts == ["run once"]
+
+    @pytest.mark.asyncio
+    async def test_kill_after_durable_accept_before_future_resolve_never_replays(
+        self, capsys
+    ):
+        """Exercise the exact #991 crash seam, not a nearby timeout.
+
+        The callback commits ``accepted_at`` and then deliberately returns an
+        unresolved Future. Cancelling the delivery group models daemon death
+        before AgentScheduler can observe/confirm that Future. A reopened
+        scheduler must read the retained receipt and perform zero replay.
+        """
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        first = AgentRegistry(db_path=path)
+        first.register("oleg")
+        schedule = first.add_schedule(
+            "oleg", "* * * * *", name="crash-seam", prompt="run once"
+        )
+        fired_at = time.time()
+        claimed, row = first.claim_schedule_fire(
+            schedule.id,
+            timestamp=fired_at,
+            expected_last_run=schedule.last_run,
+            agent_name="oleg",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+        )
+        assert claimed is True and row is not None
+        schedule.last_run = fired_at
+        accepted_before_future = asyncio.Event()
+        process_local_receipt = asyncio.get_running_loop().create_future()
+
+        async def accept_then_stall(
+            agent_name,
+            session_id,
+            prompt,
+            *,
+            schedule_receipt,
+        ):
+            del agent_name, session_id, prompt
+            assert not process_local_receipt.done()
+            assert schedule_receipt.accept() is True
+            committed = first.get_schedule_wake_by_fire(
+                schedule.id, fired_at
+            )
+            assert committed is not None
+            assert committed.ledger_state == "receipted-ran-once"
+            assert not process_local_receipt.done()
+            accepted_before_future.set()
+            return process_local_receipt
+
+        first_scheduler = AgentScheduler(
+            first, wake_callback=accept_then_stall
+        )
+        delivery = asyncio.create_task(
+            first_scheduler._deliver_schedule_group("oleg", [schedule])
+        )
+        await asyncio.wait_for(accepted_before_future.wait(), timeout=1)
+        assert not delivery.done()
+
+        delivery.cancel()
+        await asyncio.gather(delivery, return_exceptions=True)
+        assert first.list_pending_schedule_wakes("oleg") == []
+        assert "FIRED BUT UNDELIVERED" not in capsys.readouterr().err
+
+        uncertain = first.add_schedule(
+            "oleg",
+            "0 0 1 1 *",
+            name="unconfirmed-at-kill",
+            prompt="quarantine me",
+        )
+        uncertain_fire = fired_at - 1
+        uncertain_claimed, _ = first.claim_schedule_fire(
+            uncertain.id,
+            timestamp=uncertain_fire,
+            expected_last_run=uncertain.last_run,
+            agent_name="oleg",
+            schedule_name=uncertain.name,
+            prompt=uncertain.prompt,
+        )
+        assert uncertain_claimed is True
+        first.close()
+
+        reopened = AgentRegistry(db_path=path)
+        replay_attempts: list[str] = []
+
+        async def replay_only_unconfirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            replay_attempts.append(prompt)
+            return False
+
+        try:
+            restarted = AgentScheduler(
+                reopened,
+                wake_callback=replay_only_unconfirmed,
+                tick_interval=3600,
+            )
+            restarted.PERSISTED_WAKE_ATTEMPT_CAP = 1
+            await restarted.start()
+            await asyncio.wait_for(
+                restarted._pending_replay_tasks["oleg"], timeout=1
+            )
+            await restarted.stop()
+
+            assert replay_attempts == ["quarantine me"]
+            ledger = reopened.list_schedule_wake_ledger(
+                "oleg", state="receipted-ran-once"
+            )
+            assert len(ledger) == 1
+            assert ledger[0].fired_at == fired_at
+            quarantined = reopened.list_schedule_wake_ledger(
+                "oleg", state="quarantined"
+            )
+            assert len(quarantined) == 1
+            assert quarantined[0].fired_at == uncertain_fire
+            assert reopened.list_pending_schedule_wakes("oleg") == []
+        finally:
+            reopened.close()
+            os.unlink(path)
 
     @pytest.mark.asyncio
     async def test_overlapping_fires_keep_distinct_exact_outbox_rows(
@@ -1598,7 +1789,7 @@ class TestScheduler:
         assert parked[0].parked_at > 0
         assert len(alerts) == 1
         assert alerts[0][0] == "oleg"
-        assert "delete the row manually" in alerts[0][1]
+        assert "queryable quarantine" in alerts[0][1]
         assert capsys.readouterr().err.count("PERSISTED_WAKE_PARKED") == 1
 
         drain_triggers: list[str] = []
@@ -1684,12 +1875,14 @@ class TestScheduler:
         assert attempts == ["stuck head"]
         assert [
             pending.prompt
-            for pending in registry.list_pending_schedule_wakes(
-                "oleg", include_parked=True
-            )
+            for pending in registry.list_pending_schedule_wakes("oleg")
         ] == ["stuck head"]
+        quarantined = registry.list_schedule_wake_ledger(
+            "oleg", state="quarantined"
+        )
+        assert [row.prompt for row in quarantined] == ["never deliver"]
         error_log = capsys.readouterr().err
-        assert "PERSISTED_WAKE_ZOMBIE_DROPPED" in error_log
+        assert "PERSISTED_WAKE_ZOMBIE_QUARANTINED" in error_log
         assert f"schedule #{zombie.id}" in error_log
 
     @pytest.mark.asyncio
@@ -1738,7 +1931,7 @@ class TestScheduler:
 
         assert attempts == ["live one", "live two"]
         assert registry.list_pending_schedule_wakes("oleg") == []
-        assert "PERSISTED_WAKE_ZOMBIE_DROPPED" in capsys.readouterr().err
+        assert "PERSISTED_WAKE_ZOMBIE_QUARANTINED" in capsys.readouterr().err
 
     @pytest.mark.asyncio
     async def test_new_cron_fire_does_not_replay_backlog_into_old_session(
@@ -1867,8 +2060,11 @@ class TestScheduler:
         assert attempts == []
         assert registry.list_pending_schedule_wakes("oleg") == []
         error_log = capsys.readouterr().err
-        assert "PERSISTED_WAKE_ZOMBIE_DROPPED" in error_log
+        assert "PERSISTED_WAKE_ZOMBIE_QUARANTINED" in error_log
         assert reason in error_log
+        assert registry.list_schedule_wake_ledger(
+            "oleg", state="quarantined"
+        )[0].last_error.endswith(reason)
 
     @pytest.mark.asyncio
     async def test_disabled_one_shot_replays_once_across_scheduler_restart(

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -9322,6 +9322,30 @@ class TestWakeSubmissionVerification:
         assert fires == ["delivered"]
 
     @pytest.mark.asyncio
+    async def test_scheduler_acceptance_persists_before_future_resolves(
+        self,
+    ) -> None:
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        receipt = asyncio.get_running_loop().create_future()
+        ordering: list[bool] = []
+
+        def persist_exact_fire() -> bool:
+            ordering.append(receipt.done())
+            return True
+
+        turn = _QueuedTurn(
+            prompt="scheduled exact fire",
+            scheduler_delivery=receipt,
+            scheduler_accept=persist_exact_fire,
+            scheduler_serialized=True,
+        )
+
+        ss._mark_transport_accepted(turn)
+
+        assert ordering == [False]
+        assert await receipt is True
+
+    @pytest.mark.asyncio
     async def test_missing_receipt_retries_enter_only_then_verifies(
         self, monkeypatch,
     ) -> None:


### PR DESCRIPTION
## Summary

- atomically claim each non-direct scheduler fire and create its durable exact-fire ledger/outbox row in the same SQLite transaction
- carry `(schedule_id, fired_at)` through the API into tmux and Codex, committing `accepted_at` at the real transport acceptance edge **before** resolving the process-local Future
- retain accepted and quarantined rows as forensic outcomes while active replay queries exclude them
- let durable acceptance win teardown races, preventing both false `FIRED BUT UNDELIVERED` verdicts and replay of work that already entered the agent
- expose `GET /scheduler/wake-ledger` with agent/state/time filters for direct fleet-health queries
- classify attempt-cap and zombie outcomes as queryable quarantines; soften the cold-boot readiness timeout message so it remains a timing observation rather than a false hook-failure verdict

## Audit finding

The positive receipt was previously only an in-memory Future. tmux/Codex resolved it at transport acceptance, but `AgentScheduler` wrote durable state later. Teardown or process death in that interval could resolve/log negative state or leave an outbox row that replayed work which had already run. Conversely, successful rows were deleted, so `last_delivered` and log strings could not prove the outcome of an exact fire.

Evidence: [08-04 replay incident](https://github.com/bradbrok/PinkyBot/issues/991#issuecomment-5187881729), [TOD false-loss incident](https://github.com/bradbrok/PinkyBot/issues/991#issuecomment-5189811353).

## Misfire policy decision

Fire age is not treated as confirmation. Retiring anything older than its cron period would silently lose imperative one-shots and misclassify late success. This repair is confirmation-state-first. Age can become a guardrail only when a schedule has an explicit V3-style `SKIP`, `FIRE_ONCE`, or `QUARANTINE` policy ([V3 policy map](https://github.com/bradbrok/PinkyBotV3/issues/12#issuecomment-5188236401)).

## Crash-seam drill

The regression commits `accepted_at` while the Future is deliberately still unresolved, kills the delivery group in that exact post-accept/pre-scheduler-confirm window, reopens the database, and starts a new scheduler. The accepted fire is never replayed or logged lost. A second unconfirmed fire is replayed to its cap and ends quarantined. The final ledger contains exactly one `receipted-ran-once` and one `quarantined` terminal record, with no active outbox rows.

## Validation

- `uv run ruff check .`
- `129 passed` — scheduler/registry, including schema migration and crash-seam drill
- `382 passed` — tmux transport
- `89 passed` — Codex transport
- `15 passed` — focused API/ledger/owner-alert slice
- `git diff --check`

A broader local run reached 773 passing tests before the pre-existing manual-dream test escaped its SDK mock into a real tmux dream because the shared MCP port was already occupied; that environmental failure is unrelated to this patch.

Fixes #991