### PR TITLE
Codex gate: retire coalesced FIFO metas at task-close; bounded idle-pane exit for lost submits (#1006 regression)

### DIFF
--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -46,7 +46,10 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import shlex
+import time
+from collections import deque
 from pathlib import Path
 
 from pinky_daemon.codex_tmux_transcript import (
@@ -58,6 +61,7 @@ from pinky_daemon.tmux_session import (
     _PLACEHOLDER_TRANSCRIPT_PATH,
     TmuxSession,
     _log,
+    _SchedulerDeliveryCancelled,
     _TmuxControl,
 )
 
@@ -70,6 +74,15 @@ _CODEX_ENTER_DELAY_MS = 4000
 # Cold-start NUX-dismissal budget (update-available + trust prompts).
 _CODEX_NUX_TIMEOUT_SEC = 25.0
 _CODEX_NUX_POLL_SEC = 0.5
+
+# A task-close can leave accepted FIFO metadata behind when several native
+# queue pastes were consumed by one Codex turn.  If an unaccepted paste is left
+# instead (for example, its submit Enter was lost), require two matching live
+# pane reads before reconciling it.  The literal Codex 0.146.1 production
+# discriminator is ``esc to interrupt`` while busy; an agent-cwd footer proves
+# a capture without that literal is rendered rather than empty/garbled.
+_CODEX_IDLE_CONFIRM_SEC = 0.25
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class _CodexTmuxControl(_TmuxControl):
@@ -145,6 +158,7 @@ class CodexTmuxSession(TmuxSession):
         self._openai_api_key = config.provider_key or os.environ.get("OPENAI_API_KEY", "")
         self._reasoning_effort = config.thinking_effort or "medium"
         self._codex_mcp_servers = config.mcp_servers or {}
+        self._codex_last_scheduler_gate_signature: tuple[bool, ...] | None = None
 
     # ── seam: session name ──────────────────────────────────────────────────
     def _build_session_name(self) -> str:
@@ -327,6 +341,25 @@ class CodexTmuxSession(TmuxSession):
         await super()._start_tailer()
 
     # ── seam: scheduler queued-route delivery (#1006) ──────────────────────
+    def _codex_scheduler_evidence(self, candidate=None) -> tuple[bool, ...]:
+        """Return the five Codex-owned scheduler gate inputs, in log order."""
+        candidate_in_worker = (
+            candidate is not None and self._inflight_turn is candidate
+        )
+        return (
+            bool(self._inflight_tool_calls),
+            bool(
+                self._inflight_turn is not None
+                and not candidate_in_worker
+            ),
+            bool(
+                not self._message_queue.empty()
+                and not candidate_in_worker
+            ),
+            bool(self._inflight_metas),
+            bool(getattr(self._tailer, "_active", False)),
+        )
+
     def _scheduler_pane_busy(self, candidate=None) -> bool:
         """Use Codex-local turn state instead of Claude hook status.
 
@@ -341,23 +374,150 @@ class CodexTmuxSession(TmuxSession):
         The inherited scheduler task, REPL lock, logs, exact receipt, and
         retirement paths remain unchanged.
         """
-        candidate_in_worker = (
-            candidate is not None and self._inflight_turn is candidate
+        evidence = self._codex_scheduler_evidence(candidate)
+        busy = any(evidence)
+        signature = (*evidence, busy)
+        if signature != self._codex_last_scheduler_gate_signature:
+            self._codex_last_scheduler_gate_signature = signature
+            tools, in_hand, queued, metas, tailer_active = evidence
+            _log(
+                f"tmux[{self.agent_name}]: CODEX_SCHEDULER_GATE "
+                f"tools={tools} in_hand={in_hand} queued={queued} "
+                f"metas={metas} tailer_active={tailer_active} busy={busy} "
+                f"meta_depth={len(self._inflight_metas)} "
+                f"queue_depth={self._message_queue.qsize()}"
+            )
+        return busy
+
+    def _codex_gate_blocked_only_by_metas(self, candidate=None) -> bool:
+        tools, in_hand, queued, metas, tailer_active = (
+            self._codex_scheduler_evidence(candidate)
         )
-        if (
-            self._inflight_tool_calls
-            or (
-                self._inflight_turn is not None
-                and not candidate_in_worker
+        if not (metas and not any((tools, in_hand, queued, tailer_active))):
+            return False
+        # Exact scheduler/wake receipts remain authoritative. Pane-idle proof
+        # may retire ordinary lost-submit metadata, but it must not turn a
+        # pasted-without-receipt exact fire into a negative result and replay.
+        return all(
+            all(
+                receipt is None or receipt.done()
+                for receipt in (
+                    meta.turn.scheduler_delivery,
+                    meta.turn.submission_receipt,
+                )
             )
-            or (
-                not self._message_queue.empty()
-                and not candidate_in_worker
+            for meta in self._inflight_metas
+        )
+
+    @staticmethod
+    def _codex_pane_is_explicitly_idle(snapshot: str, agent_name: str) -> bool:
+        """Recognize the literal Codex no-busy-marker + footer pane shape.
+
+        The composer placeholder persists while Codex is working, so it is not
+        evidence either way. ``esc to interrupt`` is the observed Codex busy
+        literal and always vetoes idle. The model/cwd footer is required so an
+        empty, truncated, or garbled capture fails closed as unknown/busy.
+        """
+        if not snapshot or "esc to interrupt" in snapshot:
+            return False
+        plain_lines = [
+            _ANSI_RE.sub("", raw).strip()
+            for raw in snapshot.splitlines()
+        ]
+        return any(
+            " · " in line and line.rstrip("/").endswith(f"/{agent_name}")
+            for line in plain_lines
+        )
+
+    async def _codex_capture_explicit_idle(self) -> bool:
+        try:
+            result = await self._tmux.capture_pane(lines=12, escapes=True)
+        except Exception:
+            return False
+        return bool(
+            result.ok
+            and self._codex_pane_is_explicitly_idle(
+                result.stdout or "", self.agent_name
             )
-            or self._inflight_metas
-        ):
-            return True
-        return bool(getattr(self._tailer, "_active", False))
+        )
+
+    def _reconcile_codex_phantom_metas(self, metas, *, reason: str) -> int:
+        """Remove proven historical Codex FIFO entries without a restart."""
+        stale = list(metas)
+        if not stale:
+            return 0
+        stale_ids = {id(meta) for meta in stale}
+        stale_turn_ids = {id(meta.turn) for meta in stale}
+        kept = [
+            meta for meta in self._inflight_metas
+            if id(meta) not in stale_ids
+        ]
+        self._inflight_metas.clear()
+        self._inflight_metas.extend(kept)
+        self._pane_queue_operations = deque(
+            turn for turn in self._pane_queue_operations
+            if turn is None or id(turn) not in stale_turn_ids
+        )
+        self._pane_dequeued_turns = deque(
+            turn for turn in self._pane_dequeued_turns
+            if turn is None or id(turn) not in stale_turn_ids
+        )
+        for meta in stale:
+            event = meta.completion_event
+            if event is not None and not event.is_set():
+                event.set()
+            delivery = meta.turn.scheduler_delivery
+            if delivery is not None and not delivery.done():
+                delivery.set_result(bool(meta.turn.transport_accepted))
+        self._head_started_at = time.time() if kept else None
+        self._inflight_pane_ext_anchor = None
+        _log(
+            f"tmux[{self.agent_name}]: CODEX_PHANTOM_META_RECONCILE "
+            f"reason={reason} reconciled={len(stale)} remaining={len(kept)}"
+        )
+        return len(stale)
+
+    async def _wait_for_scheduler_delivery_slot(self, turn) -> None:
+        """Wait for Codex work, with a literal idle-pane stale-meta exit."""
+        if not turn.scheduler_serialized:
+            return
+        while self._scheduler_pane_busy(turn):
+            delivery = turn.scheduler_delivery
+            if delivery is not None and delivery.cancelled():
+                raise _SchedulerDeliveryCancelled
+            if self._codex_gate_blocked_only_by_metas(turn):
+                first_idle = await self._codex_capture_explicit_idle()
+                if first_idle:
+                    await asyncio.sleep(_CODEX_IDLE_CONFIRM_SEC)
+                    if (
+                        self._codex_gate_blocked_only_by_metas(turn)
+                        and await self._codex_capture_explicit_idle()
+                    ):
+                        self._reconcile_codex_phantom_metas(
+                            list(self._inflight_metas),
+                            reason="explicit_idle_pane",
+                        )
+                        continue
+            await asyncio.sleep(0.25)
+        delivery = turn.scheduler_delivery
+        if delivery is not None and delivery.cancelled():
+            raise _SchedulerDeliveryCancelled
+
+    async def _handle_turn_complete(self, response) -> None:
+        """Retire Codex metas coalesced into the just-closed rollout turn."""
+        await super()._handle_turn_complete(response)
+        # ``on_entry`` runs before the tailer feeds the following task_complete.
+        # Therefore any remaining turn already transport-accepted at this exact
+        # callback boundary was accepted inside the turn that just closed. It
+        # cannot own a future task_complete; leaving it behind is the #1006
+        # stale-busy recurrence.
+        coalesced = [
+            meta for meta in self._inflight_metas
+            if meta.turn.transport_accepted
+        ]
+        self._reconcile_codex_phantom_metas(
+            coalesced, reason="accepted_before_task_close"
+        )
 
     def _on_transcript_entry(self, entry: dict) -> None:
         """Map Codex rollout acceptance onto the shared exact-receipt path."""

--- a/tests/test_codex_tmux_session.py
+++ b/tests/test_codex_tmux_session.py
@@ -388,6 +388,162 @@ async def test_codex_acceptance_reserves_meta_before_same_read_completion():
     assert len(ss._inflight_metas) == 0
 
 
+@pytest.mark.asyncio
+async def test_coalesced_multi_message_turn_releases_waiting_scheduler_wake(
+    capsys,
+):
+    """#1006 regression: rapid ordinary pastes can be accepted inside one
+    Codex rollout turn, which emits one task_complete.  The extra accepted meta
+    must not keep a mid-turn scheduler wake parked after the pane becomes idle.
+    """
+    tmux = _mock_tmux()
+    ss = _session(tmux=tmux)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._tailer = MagicMock()
+    ss._tailer._active = True
+    ss._worker_task = asyncio.create_task(ss._message_worker())
+    receipt = None
+    try:
+        assert await ss.send("cluster A") is True
+        assert await ss.send("cluster B") is True
+        for _ in range(100):
+            if tmux.paste_text.await_count == 2:
+                break
+            await asyncio.sleep(0.01)
+        assert tmux.paste_text.await_count == 2
+        assert len(ss._inflight_metas) == 2
+
+        for prompt in ("cluster A", "cluster B"):
+            ss._on_transcript_entry({
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": prompt},
+            })
+        assert all(meta.turn.transport_accepted for meta in ss._inflight_metas)
+
+        receipt = await ss.send_scheduler_prompt("wake after cluster")
+        await asyncio.sleep(0.02)
+        assert tmux.paste_text.await_count == 2
+
+        # The real tailer flips this before invoking _handle_turn_complete.
+        ss._tailer._active = False
+        await ss._handle_turn_complete(
+            TurnResponse(text="cluster complete", stop_reason="task_complete")
+        )
+
+        for _ in range(100):
+            if tmux.paste_text.await_count == 3:
+                break
+            await asyncio.sleep(0.01)
+        assert tmux.paste_text.await_count == 3
+        assert tmux.paste_text.await_args_list[-1].args == (
+            "wake after cluster",
+        )
+        logs = capsys.readouterr().err
+        assert (
+            "CODEX_SCHEDULER_GATE tools=False in_hand=False queued=False "
+            "metas=True tailer_active=True busy=True"
+        ) in logs
+        assert "reason=accepted_before_task_close reconciled=1" in logs
+    finally:
+        if receipt is not None and not receipt.done():
+            receipt.cancel()
+        await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_unaccepted_meta_reconciles_only_after_two_explicit_idle_reads(
+    monkeypatch,
+):
+    """A lost submit leaves a pasted/unaccepted meta.  Two literal Codex idle
+    pane reads release it; one read or a busy footer never does."""
+    import pinky_daemon.codex_tmux_session as codex_tmux_session
+
+    monkeypatch.setattr(codex_tmux_session, "_CODEX_IDLE_CONFIRM_SEC", 0.001)
+    tmux = _mock_tmux()
+    idle = (
+        "\x1b[2m• \x1b[0mNo action needed.\n\n"
+        "\x1b[1m›\x1b[0m \x1b[2mExplain this codebase\x1b[0m\n\n"
+        "  \x1b[38;2;246;226;183mgpt-5.6-sol xhigh\x1b[2m\x1b[39m "
+        "· \x1b[0m\x1b[38;2;171;223;167m~/PinkyBot/data/agents/murzik"
+        "\x1b[39m\n"
+    )
+    tmux.capture_pane = AsyncMock(side_effect=[_ok(idle), _ok(idle)])
+    ss = _session(tmux=tmux)
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._tailer = MagicMock()
+    ss._tailer._active = False
+    stale = _QueuedTurn(prompt="lost ordinary paste")
+    stale.pane_delivery_started = True
+    ss._finish_turn_delivery(stale)
+    ss._tailer._active = False
+
+    receipt = await ss.send_scheduler_prompt("wake after lost paste")
+    try:
+        for _ in range(100):
+            if tmux.paste_text.await_count == 1:
+                break
+            await asyncio.sleep(0.01)
+        assert tmux.capture_pane.await_count == 2
+        assert all(
+            awaited.kwargs == {"lines": 12, "escapes": True}
+            for awaited in tmux.capture_pane.await_args_list
+        )
+        tmux.paste_text.assert_awaited_once_with(
+            "wake after lost paste", enter=True
+        )
+        assert all(
+            meta.turn.prompt != "lost ordinary paste"
+            for meta in ss._inflight_metas
+        )
+    finally:
+        if not receipt.done():
+            receipt.cancel()
+        await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_idle_override_never_retires_unresolved_exact_receipt():
+    """Pane appearance cannot negate an already-pasted exact-fire contract."""
+    ss = _session()
+    ss._state_machine._state = SessionState.CONNECTED
+    ss._tailer = MagicMock()
+    ss._tailer._active = False
+    receipt = asyncio.get_running_loop().create_future()
+    exact = _QueuedTurn(
+        prompt="exact fire",
+        scheduler_delivery=receipt,
+        scheduler_serialized=True,
+    )
+    exact.pane_delivery_started = True
+    ss._finish_turn_delivery(exact)
+    ss._tailer._active = False
+
+    assert ss._codex_gate_blocked_only_by_metas() is False
+    assert len(ss._inflight_metas) == 1
+    assert not receipt.done()
+    receipt.cancel()
+
+
+def test_codex_explicit_idle_classifier_requires_footer_and_no_busy_literal():
+    footer = (
+        "  \x1b[38;2;246;226;183mgpt-5.6-sol xhigh\x1b[2m\x1b[39m "
+        "· \x1b[0m\x1b[38;2;171;223;167m~/PinkyBot/data/agents/murzik"
+        "\x1b[39m\n"
+    )
+    idle = "\x1b[1m›\x1b[0m \x1b[2mExplain this codebase\x1b[0m\n" + footer
+    busy = (
+        "• Working (2m 54s • esc to interrupt)\n"
+        + idle
+    )
+    no_footer = "\x1b[1m›\x1b[0m \x1b[2mExplain this codebase\x1b[0m\n"
+
+    assert CodexTmuxSession._codex_pane_is_explicitly_idle(idle, "murzik")
+    assert not CodexTmuxSession._codex_pane_is_explicitly_idle(busy, "murzik")
+    assert not CodexTmuxSession._codex_pane_is_explicitly_idle(
+        no_footer, "murzik"
+    )
+
+
 # ── StopFailure hook is a no-op for codex (#795 P2) ─────────────────────────
 @pytest.mark.asyncio
 async def test_handle_stop_failure_is_noop_for_codex():


### PR DESCRIPTION
## Summary

- reconcile every accepted Codex FIFO meta still present at the exact `task_complete` callback boundary, retiring native-queue messages coalesced into the turn that just closed
- add a bounded exit for ordinary lost-submit metas: two ANSI pane reads 250 ms apart must show the rendered agent footer and no literal `esc to interrupt`
- keep unresolved scheduler and submission exact receipts structurally ineligible for pane reconciliation, preserving at-least-once replay semantics
- purge associated pane bookkeeping and reset anchors when phantom metas retire
- emit state-change-only `CODEX_SCHEDULER_GATE` and reasoned `CODEX_PHANTOM_META_RECONCILE` diagnostics with gate inputs and queue depths

## Root cause

The #1006 Codex scheduler-gate fix correctly began tracking rollout `user_message` acceptance, but Codex can accept several injected messages inside one rollout task and then emit only one `task_complete`. The inherited FIFO completion path retires one inflight meta per task close, leaving additional accepted metas behind. Because the Codex gate treats any remaining inflight meta as current work, one coalesced turn could leave scheduler delivery permanently busy even after the pane returned idle.

## Safety and impact

At the task-close callback, transcript entry handling has already observed every acceptance belonging to that task. An accepted meta still present there cannot own a future `task_complete`, so it is causally safe to retire.

The pane fallback is narrower and fail-closed: it applies only when metas are the sole blocker, every scheduler/submission receipt is done or absent, both captures succeed and classify explicitly idle, and the busy literal is absent. Empty, garbled, erroring, or busy captures preserve the block. Lost ordinary submissions resolve honestly as `False`, allowing the existing upstream at-least-once contract to recover them.

This remains Codex-only. Shared `TmuxSession` / Claude Code production and test files are byte-untouched.

## Regression evidence

The exact regression drives two ordinary Codex messages into one rollout task, observes both `user_message` acceptances, closes the task once, and proves the waiting scheduler wake then pastes. Additional regressions cover the two-read idle requirement, busy/footer classification, and the unresolved exact-receipt veto.

## Validation

- Codex session + transcript suites: 86 passed / 1 skipped
- shared tmux suite: 382 passed
- exact new regressions: passed
- Ruff, `git diff --check`, and targeted bytecode compilation: passed
- broader run reached 659 passed / 2 skipped before the unrelated environment-sensitive manual-dream test selected live tmux while port 8890 was occupied

## Frozen identity

- base: `50aa38a2984710a28db05b7bc82e1ae000335b8c`
- head: `6d2dba489af10c1ff69b5525c6591485d82e4499`
- tree: `8395cf0bd2f34842ab75041536a424fa1c1a52d8`
- review: Barsik passed tree `8395cf0bd2f34842ab75041536a424fa1c1a52d8`; ancestry-only reparent verified zero content delta

Regression follow-up to #1006 and #1007.

---

🤖 Opened by Murzik