### PR TITLE
fix(scheduler): non allertare l'owner su wake non consegnato se l'agente è vivo

### DIFF
--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -35,6 +35,12 @@ _PROVEN_LIVE_HEARTBEAT_STATUSES = frozenset(
     {"alive", "ok", "busy", "finishing"}
 )
 
+# How recent an agent-origin heartbeat must be to suppress the owner alert on
+# an unconfirmed schedule delivery. Deliberately short: it must cover "the
+# agent was demonstrably running while the receipt window elapsed", not "the
+# agent was up at some point today".
+_UNDELIVERED_ALERT_LIVENESS_WINDOW = 120.0
+
 
 # ── Rate Limit Gating ───────────────────────────────────────
 
@@ -709,6 +715,18 @@ class AgentScheduler:
             f"'{schedule.name}' (#{schedule.id}) for agent "
             f"'{schedule.agent_name}': {failure_reason}"
         )
+        if alert_this_failure and self._agent_recently_proved_live(
+            schedule.agent_name
+        ):
+            _log(
+                f"scheduler: agent '{schedule.agent_name}' posted an "
+                f"agent-origin heartbeat within "
+                f"{_UNDELIVERED_ALERT_LIVENESS_WINDOW:g}s of schedule "
+                f"'{schedule.name}' (#{schedule.id}) going unconfirmed; "
+                "suppressing owner alert (the persisted wake replays on its "
+                "own)"
+            )
+            alert_this_failure = False
         if alert_this_failure:
             recovery = (
                 " The wake was persisted for the agent's next session."
@@ -771,6 +789,32 @@ class AgentScheduler:
             delivery.cancel()
             await asyncio.gather(delivery, return_exceptions=True)
             raise
+
+    def _agent_recently_proved_live(self, agent_name: str) -> bool:
+        """Return True if the agent itself said it was alive very recently.
+
+        Reads ``get_latest_agent_heartbeat`` — NOT ``get_latest_heartbeat`` —
+        because the latter includes the synthetic ``server_presence`` rows this
+        scheduler writes when it sees a CONNECTED transport. The dominant cause
+        of an unconfirmed wake is exactly "transport CONNECTED but reader loop
+        wedged on an LLM call", so using ``get_latest_heartbeat`` would accept
+        the daemon's own writing as proof of life and hide a real crash.
+
+        Fails closed: any error, missing row, or non-agent-authored status
+        leaves the alert in place. This never widens the delivery timeout — a
+        genuinely dead agent still pages the owner.
+        """
+        try:
+            hb = self._registry.get_latest_agent_heartbeat(agent_name)
+        except Exception as exc:
+            _log(
+                f"scheduler: liveness lookup failed for '{agent_name}': "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return False
+        if hb is None or hb.status not in _PROVEN_LIVE_HEARTBEAT_STATUSES:
+            return False
+        return (time.time() - hb.timestamp) <= _UNDELIVERED_ALERT_LIVENESS_WINDOW
 
     def _agent_busy_not_wedged(self, agent_name: str) -> bool:
         """Read the transport's live positive-liveness signal, failing closed."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1523,6 +1523,126 @@ class TestScheduler:
         assert registry.get_schedules("oleg")[0].last_delivered > 0
 
     @pytest.mark.asyncio
+    async def test_undelivered_skips_owner_alert_when_agent_proved_live(
+        self, registry
+    ):
+        """A recent agent-authored heartbeat means the agent is alive and the
+        wake will replay on its own — the owner does not need paging."""
+        registry.register("oleg")
+        registry.record_heartbeat("oleg", session_id="s1", status="busy")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="live", prompt="live prompt"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        alerts: list[tuple[str, str]] = []
+
+        async def no_receipt(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return asyncio.get_running_loop().create_future()
+
+        async def owner_notify(agent_name, message):
+            alerts.append((agent_name, message))
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=no_receipt,
+            owner_notify_callback=owner_notify,
+            schedule_delivery_timeout=0.01,
+        )
+        await scheduler._deliver_schedule(schedule)
+        await asyncio.sleep(0)
+
+        assert alerts == []
+        # Durable recovery is unchanged: the wake still replays next boot.
+        pending = registry.list_pending_schedule_wakes("oleg")
+        assert [wake.prompt for wake in pending] == ["live prompt"]
+
+    @pytest.mark.asyncio
+    async def test_undelivered_alerts_when_only_server_presence_is_fresh(
+        self, registry
+    ):
+        """A fresh ``server_presence`` row is the scheduler's own writing, not
+        the agent's — it must never suppress the alert (wedged reader loop)."""
+        registry.register("oleg")
+        registry.record_heartbeat(
+            "oleg",
+            session_id="s1",
+            status="alive",
+            metadata={"source": "server_presence"},
+        )
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="wedged", prompt="wedged prompt"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        alerts: list[tuple[str, str]] = []
+
+        async def no_receipt(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return asyncio.get_running_loop().create_future()
+
+        async def owner_notify(agent_name, message):
+            alerts.append((agent_name, message))
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=no_receipt,
+            owner_notify_callback=owner_notify,
+            schedule_delivery_timeout=0.01,
+        )
+        await scheduler._deliver_schedule(schedule)
+        await asyncio.sleep(0)
+
+        assert len(alerts) == 1
+        assert "FIRED BUT UNDELIVERED" in alerts[0][1]
+
+    @pytest.mark.asyncio
+    async def test_undelivered_alerts_when_agent_heartbeat_is_stale(
+        self, registry
+    ):
+        """An agent-authored heartbeat older than the liveness window proves
+        nothing about now — the owner still gets paged."""
+        registry.register("oleg")
+        registry.record_heartbeat("oleg", session_id="s1", status="busy")
+        registry._db.execute(
+            "UPDATE agent_heartbeats SET timestamp = ? WHERE agent_name = ?",
+            (time.time() - 3600, "oleg"),
+        )
+        registry._db.commit()
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="old", prompt="old prompt"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        alerts: list[tuple[str, str]] = []
+
+        async def no_receipt(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return asyncio.get_running_loop().create_future()
+
+        async def owner_notify(agent_name, message):
+            alerts.append((agent_name, message))
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=no_receipt,
+            owner_notify_callback=owner_notify,
+            schedule_delivery_timeout=0.01,
+        )
+        await scheduler._deliver_schedule(schedule)
+        await asyncio.sleep(0)
+
+        assert len(alerts) == 1
+        assert "FIRED BUT UNDELIVERED" in alerts[0][1]
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("status", ["alive", "ok", "busy", "finishing"])
     async def test_fresh_heartbeat_drains_stranded_outbox(
         self, registry, status


### PR DESCRIPTION
## Problema

Quando un wake schedulato non ottiene la ricevuta di consegna entro il timeout, `_record_schedule_undelivered` paga l'owner con `🚨 FIRED BUT UNDELIVERED` — anche quando l'agente è palesemente vivo e sta solo elaborando (turno lungo, chiamata LLM in corso). In quel caso il wake è già stato persistito e viene rigiocato da solo alla sessione successiva: l'alert è puro rumore per l'owner.

## Fix

In `_record_schedule_undelivered`, prima di `_queue_owner_alert`, si controlla se l'agente ha dato segni di vita negli ultimi **120s**. Se sì, si sopprime **solo l'alert owner**.

Restano invariati:
- il log `FIRED BUT UNDELIVERED` su stderr (la diagnostica non si perde);
- l'activity `schedule_undelivered`;
- la persistenza durevole del wake e il replay al boot successivo;
- il timeout di consegna dei 600s — **deliberatamente non toccato**: alzarlo nasconderebbe crash reali.

Un agente davvero morto continua a pagare l'owner esattamente come prima.

## Scelta della fonte dati (deviazione motivata rispetto al suggerimento iniziale)

Il suggerimento era di usare la stessa fonte di `_reconcile_server_liveness` / `_check_heartbeats`, cioè `get_latest_heartbeat()` + `agent.last_seen_at`. Ho usato invece **`registry.get_latest_agent_heartbeat()`**, per due ragioni:

1. **`get_latest_heartbeat()` include le righe sintetiche `metadata.source='server_presence'`** che lo scheduler scrive da sé quando vede il transport `CONNECTED`. Ma il modo di fallire tipico di "FIRED BUT UNDELIVERED" è proprio *"transport CONNECTED ma reader loop bloccato su una chiamata LLM"*: userei come prova di vita una riga scritta dal daemon stesso e nasconderei il crash. È esattamente la distinzione documentata nel docstring di `get_latest_agent_heartbeat` (review Murzik di #573, endpoint force-restart #103).
2. **`last_seen_at` è stampato su consegna inbound riuscita** (`broker.py:1738`), non su risposta dell'agente. Usarlo sarebbe circolare: la consegna del wake stessa potrebbe averlo appena aggiornato, sopprimendo ogni alert.

`get_latest_agent_heartbeat` applica due tagli — esclude `server_presence` ed esclude `stale`/`dead` — cioè restituisce esattamente "l'agente ha detto lui di essere vivo". È già la convenzione del repo per la domanda "l'agente è davvero responsivo?". Il controllo aggiuntivo su `_PROVEN_LIVE_HEARTBEAT_STATUSES` (`alive`/`ok`/`busy`/`finishing`) e il **fail-closed** su riga assente o errore di lettura completano la garanzia: in dubbio, l'alert parte.

## Test (TDD)

Tre nuovi test in `tests/test_scheduler.py`:

- `test_undelivered_skips_owner_alert_when_agent_proved_live` — heartbeat `busy` recente → nessun alert, ma il wake resta persistito e replayabile. **Scritto per primo, verificato rosso** prima del fix.
- `test_undelivered_alerts_when_only_server_presence_is_fresh` — guardia: una riga `server_presence` fresca **non** sopprime l'alert.
- `test_undelivered_alerts_when_agent_heartbeat_is_stale` — guardia: heartbeat agent-origin di un'ora fa → alert regolare.

Suite: `tests/test_scheduler.py` 132 passed; `test_daemon.py`/`test_api.py` filtrati su schedule/undelivered verdi; `ruff check` pulito.

🤖 Opened by Engineer
