### PR TITLE
Add first-class Buzz outbound support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dependencies = [
     # include its SDK and async transport without relying on an optional extra.
     "slack-sdk>=3.0",
     "aiohttp>=3.9",
+    # Native Buzz/Nostr outbound signing. This is a daemon runtime path, so it
+    # must survive a base-install venv heal rather than living only in an extra.
+    "coincurve>=21.0",
 ]
 
 [project.optional-dependencies]
@@ -60,6 +63,8 @@ telegram = ["python-telegram-bot[webhooks]>=21.0"]
 discord = ["discord.py>=2.3"]
 # Backward-compatible no-op while hosts migrate off `uv run --extra slack`.
 slack = []
+# Backward-compatible named extra; required Buzz deps live in the base install.
+buzz = []
 google = ["google-auth>=2.0", "google-api-python-client>=2.0"]
 calendar = [
     "google-api-python-client>=2.0",
@@ -74,7 +79,7 @@ web = ["camoufox>=0.4", "markdownify>=1.0", "beautifulsoup4>=4.12"]
 voice = ["twilio>=9.0", "anthropic>=0.98"]
 local-embeddings = ["sentence-transformers>=2.0"]
 all = [
-    "pinky-ai[telegram,discord,slack,google,calendar,voice]",
+    "pinky-ai[telegram,discord,slack,buzz,google,calendar,voice]",
 ]
 dev = [
     "pytest>=9.0",

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1845,6 +1845,14 @@ class AgentRegistry:
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_buzz_identities_pubkey "
             "ON buzz_identities(pubkey) WHERE pubkey != ''"
         )
+        self._db.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_buzz_identities_approval_ref "
+            "ON buzz_identities(tos_approval_ref) WHERE tos_approval_ref != ''"
+        )
+        self._db.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_buzz_identities_tos_receipt "
+            "ON buzz_identities(tos_receipt) WHERE tos_receipt != ''"
+        )
 
         # Seed main_agent default: if unset, adopt the oldest enabled agent.
         # New installs get their main agent auto-assigned at create time (see
@@ -2751,21 +2759,22 @@ except Exception as exc:
         relay_url: str,
         community_id: str,
         enabled: bool,
-        tos_receipt: str,
-        tos_approved_by: str,
-        tos_approved_at: float,
-        tos_approval_ref: str,
+        owner_actor: str,
     ) -> dict:
         """Bind one identity from the authenticated owner-control route only.
 
-        The HTTP composition root derives the actor, timestamp, and approval
-        reference. There is intentionally no generic token/settings mutation
-        path for these authority columns.
+        The HTTP composition root derives only the authenticated owner actor.
+        Receipt, timestamp, and reference are generated here and bound to the
+        exact identity/policy/scope; callers cannot supply authority bytes.
         """
-        import hashlib
         from urllib.parse import urlsplit
 
-        from pinky_daemon.buzz_identity import wrap_buzz_private_key
+        from pinky_daemon.buzz_identity import (
+            issue_buzz_owner_approval,
+            validate_buzz_owner_actor,
+            validate_buzz_owner_approval,
+            wrap_buzz_private_key,
+        )
         from pinky_identity.keystore import DeviceKey
 
         agent = _validate_agent_name(agent_name)
@@ -2785,25 +2794,13 @@ except Exception as exc:
         community = str(community_id or "").strip().lower()
         if not re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,62}", community):
             raise ValueError("Buzz community_id is invalid")
-        receipt = str(tos_receipt or "").strip()
-        approver = str(tos_approved_by or "").strip()
-        approval_ref = str(tos_approval_ref or "").strip()
-        approved_at = float(tos_approved_at or 0)
-        if not receipt or len(receipt.encode("utf-8")) > 8192:
-            raise ValueError("Buzz ToS receipt is required and must be at most 8192 bytes")
-        if not approver or len(approver) > 128 or approved_at <= 0:
-            raise ValueError("Buzz ToS approval authority is invalid")
-        expected_digest = hashlib.sha256(receipt.encode("utf-8")).hexdigest()
-        if not re.fullmatch(
-            r"owner-control:[0-9a-f]{32}:sha256:[0-9a-f]{64}", approval_ref
-        ) or not approval_ref.endswith(expected_digest):
-            raise ValueError("Buzz ToS approval reference does not match its receipt")
+        approver = validate_buzz_owner_actor(owner_actor)
 
         # Refuse accidental secret duplication into any durable text column.
         secret_text = str(private_key or "").strip().lower()
         if secret_text and any(
             secret_text in value.lower()
-            for value in (relay, community, receipt, approver, approval_ref)
+            for value in (relay, community, approver)
         ):
             raise ValueError("Buzz private key must not appear in identity metadata")
 
@@ -2817,18 +2814,31 @@ except Exception as exc:
         status = "active" if enabled else "disabled"
         with self._rmw_lock:
             existing = self._db.execute(
-                "SELECT pubkey, tos_receipt FROM buzz_identities WHERE agent=?",
+                "SELECT pubkey, relay_url, community_id, tos_receipt, "
+                "tos_approved_by, tos_approved_at, tos_approval_ref "
+                "FROM buzz_identities WHERE agent=?",
                 (agent,),
             ).fetchone()
             if existing and (
                 not secrets.compare_digest(existing[0], envelope.pubkey)
-                or not secrets.compare_digest(existing[1], receipt)
+                or not secrets.compare_digest(existing[1], relay)
+                or not secrets.compare_digest(existing[2], community)
             ):
                 raise ValueError(
-                    "Buzz identity or ToS receipt rotation requires an explicit rotation operation"
+                    "Buzz identity or approval scope rotation requires an explicit rotation operation"
                 )
             try:
                 if existing:
+                    validate_buzz_owner_approval(
+                        agent=agent,
+                        pubkey=existing[0],
+                        relay_url=existing[1],
+                        community_id=existing[2],
+                        receipt=existing[3],
+                        approved_by=existing[4],
+                        approved_at=existing[5],
+                        approval_ref=existing[6],
+                    )
                     # Same identity + same immutable receipt: safe idempotent
                     # re-bind. Preserve the original authority actor/timestamp/ref.
                     self._db.execute(
@@ -2849,6 +2859,13 @@ except Exception as exc:
                         ),
                     )
                 else:
+                    approval = issue_buzz_owner_approval(
+                        owner_actor=approver,
+                        agent=agent,
+                        pubkey=envelope.pubkey,
+                        relay_url=relay,
+                        community_id=community,
+                    )
                     self._db.execute(
                         """INSERT INTO buzz_identities (
                                agent, pubkey, wrap_version, nonce, ciphertext,
@@ -2866,10 +2883,10 @@ except Exception as exc:
                             community,
                             int(enabled),
                             status,
-                            receipt,
-                            approver,
-                            approved_at,
-                            approval_ref,
+                            approval.receipt,
+                            approval.approved_by,
+                            approval.approved_at,
+                            approval.approval_ref,
                             now,
                             now,
                         ),
@@ -2891,6 +2908,7 @@ except Exception as exc:
             BuzzKeyEnvelope,
             BuzzSigningMaterial,
             unwrap_buzz_private_key,
+            validate_buzz_owner_approval,
         )
         from pinky_identity.keystore import DeviceKey
 
@@ -2903,10 +2921,17 @@ except Exception as exc:
         ).fetchone()
         if not row or not row[7] or row[8] != "active":
             return None
-        if not row[9] or not row[10] or not row[11] or not row[12]:
-            self.mark_buzz_identity_unhealthy(agent_name, "missing_tos_authority")
-            raise BuzzIdentityUnhealthyError("Buzz identity lacks ToS authority")
         try:
+            validate_buzz_owner_approval(
+                agent=row[0],
+                pubkey=row[1],
+                relay_url=row[5],
+                community_id=row[6],
+                receipt=row[9],
+                approved_by=row[10],
+                approved_at=row[11],
+                approval_ref=row[12],
+            )
             envelope = BuzzKeyEnvelope(
                 agent=row[0],
                 pubkey=row[1],

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1213,12 +1213,22 @@ def _configure_agents_db_connection(
 class AgentRegistry:
     """SQLite-backed agent registry."""
 
-    def __init__(self, db_path: str = "data/agents.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/agents.db",
+        *,
+        buzz_device_key_path: str | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         # Absolute path retained so callers (e.g. _write_mcp_json) can hand
         # stdio MCP subprocesses an explicit DB location for request-time
         # signing-key lookup (#641) rather than relying on their cwd.
         self._db_path = str(Path(db_path).resolve())
+        self._buzz_device_key_path = str(
+            Path(buzz_device_key_path).resolve()
+            if buzz_device_key_path
+            else Path(self._db_path).parent / "identity" / ".device_key"
+        )
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         # #797/#220: the agents DB runs in ROLLBACK (TRUNCATE) journal mode, NOT
         # WAL. The WAL wal-index (-shm) is always mmap'd; under the long-lived
@@ -1548,6 +1558,34 @@ class AgentRegistry:
                 signing_key TEXT NOT NULL,
                 created_at REAL NOT NULL DEFAULT 0
             );
+
+            CREATE TABLE IF NOT EXISTS buzz_identities (
+                agent TEXT PRIMARY KEY NOT NULL,
+                pubkey TEXT NOT NULL
+                    CHECK(length(pubkey)=64 AND pubkey=lower(pubkey)
+                          AND pubkey NOT GLOB '*[^0-9a-f]*'),
+                wrap_version INTEGER NOT NULL,
+                nonce BLOB NOT NULL,
+                ciphertext BLOB NOT NULL,
+                relay_url TEXT NOT NULL,
+                community_id TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 0 CHECK(enabled IN (0, 1)),
+                status TEXT NOT NULL DEFAULT 'disabled',
+                last_error TEXT NOT NULL DEFAULT '',
+                tos_receipt TEXT NOT NULL,
+                tos_approved_by TEXT NOT NULL,
+                tos_approved_at REAL NOT NULL,
+                tos_approval_ref TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                FOREIGN KEY (agent) REFERENCES agents(name) ON DELETE CASCADE,
+                CHECK(
+                    enabled=0 OR (
+                        tos_receipt != '' AND tos_approved_by != ''
+                        AND tos_approved_at > 0 AND tos_approval_ref != ''
+                    )
+                )
+            );
         """)
         self._db.commit()
         self._migrate()
@@ -1775,6 +1813,38 @@ class AgentRegistry:
                 "ADD COLUMN high_signal_alerted_at REAL NOT NULL DEFAULT 0"
             )
             _log("agent_registry: migrated — added high_signal_alerted_at to approval_requests")
+
+        # Buzz identity storage is forward-migrated column-by-column rather
+        # than relying only on CREATE TABLE. This keeps fleet-local DBs safe if
+        # an increment adds lifecycle metadata after the first rollout.
+        buzz_existing = {
+            row[1] for row in self._db.execute("PRAGMA table_info(buzz_identities)").fetchall()
+        }
+        buzz_migrations = [
+            ("pubkey", "TEXT NOT NULL DEFAULT ''"),
+            ("wrap_version", "INTEGER NOT NULL DEFAULT 1"),
+            ("nonce", "BLOB NOT NULL DEFAULT X''"),
+            ("ciphertext", "BLOB NOT NULL DEFAULT X''"),
+            ("relay_url", "TEXT NOT NULL DEFAULT ''"),
+            ("community_id", "TEXT NOT NULL DEFAULT ''"),
+            ("enabled", "INTEGER NOT NULL DEFAULT 0"),
+            ("status", "TEXT NOT NULL DEFAULT 'disabled'"),
+            ("last_error", "TEXT NOT NULL DEFAULT ''"),
+            ("tos_receipt", "TEXT NOT NULL DEFAULT ''"),
+            ("tos_approved_by", "TEXT NOT NULL DEFAULT ''"),
+            ("tos_approved_at", "REAL NOT NULL DEFAULT 0"),
+            ("tos_approval_ref", "TEXT NOT NULL DEFAULT ''"),
+            ("created_at", "REAL NOT NULL DEFAULT 0"),
+            ("updated_at", "REAL NOT NULL DEFAULT 0"),
+        ]
+        for col, typedef in buzz_migrations:
+            if col not in buzz_existing:
+                self._db.execute(f"ALTER TABLE buzz_identities ADD COLUMN {col} {typedef}")
+                _log(f"agent_registry: migrated — added {col} to buzz_identities")
+        self._db.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_buzz_identities_pubkey "
+            "ON buzz_identities(pubkey) WHERE pubkey != ''"
+        )
 
         # Seed main_agent default: if unset, adopt the oldest enabled agent.
         # New installs get their main agent auto-assigned at create time (see
@@ -2627,6 +2697,275 @@ except Exception as exc:
                 _log(f"agent_registry: skipped signing-key backfill for {name!r}: {e}")
         if generated:
             _log(f"agent_registry: backfilled signing keys for {generated} agent(s)")
+
+    # ── Buzz identities (#541 inc1) ────────────────────────────────────
+
+    @staticmethod
+    def _buzz_identity_dict(row) -> dict:
+        """Public identity DTO. Secret envelope and receipt stay daemon-only."""
+        return {
+            "agent": row[0],
+            "pubkey": row[1],
+            "wrap_version": row[2],
+            "relay_url": row[3],
+            "community_id": row[4],
+            "enabled": bool(row[5]),
+            "status": row[6],
+            "last_error": row[7],
+            "tos_approved": bool(row[8] and row[9] and row[10]),
+            "tos_approved_by": row[8],
+            "tos_approved_at": row[9],
+            "tos_approval_ref": row[10],
+            "created_at": row[11],
+            "updated_at": row[12],
+        }
+
+    def get_buzz_identity(self, agent_name: str) -> dict | None:
+        """Return public Buzz identity state without receipt or key envelope."""
+        row = self._db.execute(
+            "SELECT agent, pubkey, wrap_version, relay_url, community_id, enabled, "
+            "status, last_error, tos_approved_by, tos_approved_at, "
+            "tos_approval_ref, created_at, updated_at "
+            "FROM buzz_identities WHERE agent=?",
+            (agent_name,),
+        ).fetchone()
+        return self._buzz_identity_dict(row) if row else None
+
+    def list_buzz_identities(self, *, enabled_only: bool = False) -> list[dict]:
+        """List public Buzz identity state, never encrypted or raw secret fields."""
+        sql = (
+            "SELECT agent, pubkey, wrap_version, relay_url, community_id, enabled, "
+            "status, last_error, tos_approved_by, tos_approved_at, "
+            "tos_approval_ref, created_at, updated_at FROM buzz_identities"
+        )
+        if enabled_only:
+            sql += " WHERE enabled=1"
+        sql += " ORDER BY agent"
+        return [self._buzz_identity_dict(row) for row in self._db.execute(sql).fetchall()]
+
+    def bind_buzz_identity_owner_control(
+        self,
+        agent_name: str,
+        *,
+        private_key: str,
+        relay_url: str,
+        community_id: str,
+        enabled: bool,
+        tos_receipt: str,
+        tos_approved_by: str,
+        tos_approved_at: float,
+        tos_approval_ref: str,
+    ) -> dict:
+        """Bind one identity from the authenticated owner-control route only.
+
+        The HTTP composition root derives the actor, timestamp, and approval
+        reference. There is intentionally no generic token/settings mutation
+        path for these authority columns.
+        """
+        import hashlib
+        from urllib.parse import urlsplit
+
+        from pinky_daemon.buzz_identity import wrap_buzz_private_key
+        from pinky_identity.keystore import DeviceKey
+
+        agent = _validate_agent_name(agent_name)
+        if not self.get(agent):
+            raise KeyError(f"Agent '{agent}' not found")
+        relay = str(relay_url or "").strip()
+        parsed = urlsplit(relay)
+        if (
+            parsed.scheme not in {"ws", "wss"}
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("Buzz relay_url must be a plain ws:// or wss:// URL")
+        community = str(community_id or "").strip().lower()
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,62}", community):
+            raise ValueError("Buzz community_id is invalid")
+        receipt = str(tos_receipt or "").strip()
+        approver = str(tos_approved_by or "").strip()
+        approval_ref = str(tos_approval_ref or "").strip()
+        approved_at = float(tos_approved_at or 0)
+        if not receipt or len(receipt.encode("utf-8")) > 8192:
+            raise ValueError("Buzz ToS receipt is required and must be at most 8192 bytes")
+        if not approver or len(approver) > 128 or approved_at <= 0:
+            raise ValueError("Buzz ToS approval authority is invalid")
+        expected_digest = hashlib.sha256(receipt.encode("utf-8")).hexdigest()
+        if not re.fullmatch(
+            r"owner-control:[0-9a-f]{32}:sha256:[0-9a-f]{64}", approval_ref
+        ) or not approval_ref.endswith(expected_digest):
+            raise ValueError("Buzz ToS approval reference does not match its receipt")
+
+        # Refuse accidental secret duplication into any durable text column.
+        secret_text = str(private_key or "").strip().lower()
+        if secret_text and any(
+            secret_text in value.lower()
+            for value in (relay, community, receipt, approver, approval_ref)
+        ):
+            raise ValueError("Buzz private key must not appear in identity metadata")
+
+        device_key = DeviceKey.load_or_create(self._buzz_device_key_path)
+        envelope = wrap_buzz_private_key(
+            private_key,
+            agent=agent,
+            device_key=device_key,
+        )
+        now = time.time()
+        status = "active" if enabled else "disabled"
+        with self._rmw_lock:
+            existing = self._db.execute(
+                "SELECT pubkey, tos_receipt FROM buzz_identities WHERE agent=?",
+                (agent,),
+            ).fetchone()
+            if existing and (
+                not secrets.compare_digest(existing[0], envelope.pubkey)
+                or not secrets.compare_digest(existing[1], receipt)
+            ):
+                raise ValueError(
+                    "Buzz identity or ToS receipt rotation requires an explicit rotation operation"
+                )
+            try:
+                if existing:
+                    # Same identity + same immutable receipt: safe idempotent
+                    # re-bind. Preserve the original authority actor/timestamp/ref.
+                    self._db.execute(
+                        """UPDATE buzz_identities
+                           SET wrap_version=?, nonce=?, ciphertext=?, relay_url=?,
+                               community_id=?, enabled=?, status=?, last_error='',
+                               updated_at=? WHERE agent=?""",
+                        (
+                            envelope.wrap_version,
+                            envelope.nonce,
+                            envelope.ciphertext,
+                            relay,
+                            community,
+                            int(enabled),
+                            status,
+                            now,
+                            agent,
+                        ),
+                    )
+                else:
+                    self._db.execute(
+                        """INSERT INTO buzz_identities (
+                               agent, pubkey, wrap_version, nonce, ciphertext,
+                               relay_url, community_id, enabled, status, last_error,
+                               tos_receipt, tos_approved_by, tos_approved_at,
+                               tos_approval_ref, created_at, updated_at
+                           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?)""",
+                        (
+                            agent,
+                            envelope.pubkey,
+                            envelope.wrap_version,
+                            envelope.nonce,
+                            envelope.ciphertext,
+                            relay,
+                            community,
+                            int(enabled),
+                            status,
+                            receipt,
+                            approver,
+                            approved_at,
+                            approval_ref,
+                            now,
+                            now,
+                        ),
+                    )
+                self._db.commit()
+            except sqlite3.IntegrityError as exc:
+                self._db.rollback()
+                raise ValueError("Buzz identity conflicts with an existing binding") from exc
+        result = self.get_buzz_identity(agent)
+        if result is None:  # pragma: no cover - defensive after successful write
+            raise RuntimeError("Buzz identity write did not persist")
+        return result
+
+    def get_buzz_signing_material(self, agent_name: str):
+        """Unwrap one active identity or disable it on any integrity failure."""
+        from pinky_daemon.buzz_identity import (
+            BuzzDependencyError,
+            BuzzIdentityUnhealthyError,
+            BuzzKeyEnvelope,
+            BuzzSigningMaterial,
+            unwrap_buzz_private_key,
+        )
+        from pinky_identity.keystore import DeviceKey
+
+        row = self._db.execute(
+            """SELECT agent, pubkey, wrap_version, nonce, ciphertext, relay_url,
+                      community_id, enabled, status, tos_receipt, tos_approved_by,
+                      tos_approved_at, tos_approval_ref
+               FROM buzz_identities WHERE agent=?""",
+            (agent_name,),
+        ).fetchone()
+        if not row or not row[7] or row[8] != "active":
+            return None
+        if not row[9] or not row[10] or not row[11] or not row[12]:
+            self.mark_buzz_identity_unhealthy(agent_name, "missing_tos_authority")
+            raise BuzzIdentityUnhealthyError("Buzz identity lacks ToS authority")
+        try:
+            envelope = BuzzKeyEnvelope(
+                agent=row[0],
+                pubkey=row[1],
+                wrap_version=row[2],
+                nonce=bytes(row[3]),
+                ciphertext=bytes(row[4]),
+            )
+            device_key = DeviceKey.load_or_create(self._buzz_device_key_path)
+            private_key = unwrap_buzz_private_key(envelope, device_key=device_key)
+        except BuzzDependencyError:
+            self.mark_buzz_dependency_refused(agent_name, "missing_runtime_dependency")
+            raise
+        except Exception as exc:
+            self.mark_buzz_identity_unhealthy(agent_name, type(exc).__name__)
+            raise BuzzIdentityUnhealthyError("Buzz identity is unhealthy and was disabled") from exc
+        return BuzzSigningMaterial(
+            agent=row[0],
+            pubkey=row[1],
+            private_key=private_key,
+            relay_url=row[5],
+            community_id=row[6],
+        )
+
+    def mark_buzz_identity_unhealthy(self, agent_name: str, reason: str) -> None:
+        """Disable an identity after AEAD/KEK/public-key integrity failure."""
+        self._db.execute(
+            "UPDATE buzz_identities SET enabled=0, status='unhealthy', "
+            "last_error=?, updated_at=? WHERE agent=?",
+            (str(reason or "integrity_failure")[:160], time.time(), agent_name),
+        )
+        self._db.commit()
+
+    def mark_buzz_dependency_refused(self, agent_name: str, reason: str) -> None:
+        """Refuse registration without destroying an otherwise valid identity."""
+        self._db.execute(
+            "UPDATE buzz_identities SET status='dependency_refused', "
+            "last_error=?, updated_at=? WHERE agent=? AND enabled=1",
+            (str(reason or "missing_runtime_dependency")[:160], time.time(), agent_name),
+        )
+        self._db.commit()
+
+    def mark_buzz_dependency_ready(self, agent_name: str) -> None:
+        """Restore an enabled dependency-refused identity after venv healing."""
+        self._db.execute(
+            "UPDATE buzz_identities SET status='active', last_error='', updated_at=? "
+            "WHERE agent=? AND enabled=1 AND status='dependency_refused'",
+            (time.time(), agent_name),
+        )
+        self._db.commit()
+
+    def disable_buzz_identity(self, agent_name: str) -> bool:
+        """Owner-control lifecycle operation; encrypted material remains recoverable."""
+        cursor = self._db.execute(
+            "UPDATE buzz_identities SET enabled=0, status='disabled', "
+            "last_error='', updated_at=? WHERE agent=?",
+            (time.time(), agent_name),
+        )
+        self._db.commit()
+        return cursor.rowcount > 0
 
     def list(self, *, parent: str = "", group: str = "", enabled_only: bool = False,
              include_retired: bool = False) -> list[Agent]:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -61,6 +61,7 @@ from pinky_daemon.api_models import (
     AssignSkillRequest,
     AuthLoginRequest,
     AuthSetupRequest,
+    BindBuzzIdentityRequest,
     CloneWorkerRequest,
     ContainerizeRequest,
     ContextResponse,
@@ -1780,6 +1781,27 @@ def create_api(
         if key in _platform_adapters:
             return _platform_adapters[key]
 
+        if platform == "buzz":
+            from pinky_outreach.buzz_dependency import missing_buzz_dependencies
+
+            missing = missing_buzz_dependencies()
+            if missing:
+                agents.mark_buzz_dependency_refused(agent_name, f"missing:{','.join(missing)}")
+                return None
+            agents.mark_buzz_dependency_ready(agent_name)
+            material = agents.get_buzz_signing_material(agent_name)
+            if material is None:
+                return None
+            from pinky_outreach.buzz import BuzzAdapter
+
+            adapter = BuzzAdapter(
+                material.private_key,
+                relay_url=material.relay_url,
+                community_id=material.community_id,
+            )
+            _platform_adapters[key] = adapter
+            return adapter
+
         token = (
             agents.get_raw_token_for_account(agent_name, platform, account_id)
             if account_id
@@ -1807,7 +1829,12 @@ def create_api(
         """Drop generic and account-bound adapters after token mutation."""
         for key in list(_platform_adapters):
             if len(key) >= 2 and key[0] == agent_name and key[1] == platform:
-                _platform_adapters.pop(key, None)
+                adapter = _platform_adapters.pop(key, None)
+                if platform == "buzz" and adapter is not None:
+                    try:
+                        adapter.close()
+                    except Exception:
+                        pass
 
     def _get_imessage_adapter(agent_name: str = ""):
         """Get or create the iMessage adapter for an agent."""
@@ -1864,6 +1891,23 @@ def create_api(
             raise HTTPException(404, f"Message context '{message_id}' not found for {agent_name}")
         return ctx
 
+    def _buzz_reply_metadata(ctx) -> dict | None:
+        """Copy only verified public routing fields from durable context."""
+        if ctx.platform != "buzz" or not isinstance(ctx.metadata, dict):
+            return None
+        candidate = ctx.metadata.get("buzz_verified_event")
+        if not isinstance(candidate, dict):
+            return None
+        return {
+            "buzz_verified_event": {
+                "verified": candidate.get("verified"),
+                "event_id": candidate.get("event_id"),
+                "kind": candidate.get("kind"),
+                "author_pubkey": candidate.get("author_pubkey"),
+                "channel_id": candidate.get("channel_id"),
+            }
+        }
+
     def _extract_message_id(result) -> str:
         """Extract a message ID from a platform adapter response."""
         if hasattr(result, "message_id"):
@@ -1900,6 +1944,7 @@ def create_api(
         link_preview_options: dict | None = None,
         quote: str = "",
         blocks: str = "",
+        reply_metadata: dict | None = None,
     ) -> SimpleNamespace:
         """Send a text message and return SimpleNamespace(message_id=...).
 
@@ -2047,6 +2092,15 @@ def create_api(
             )
             return SimpleNamespace(message_id=_extract_message_id(result))
 
+        if platform == "buzz":
+            result = adapter.send_message(
+                chat_id,
+                content,
+                reply_to=reply_to or None,
+                reply_metadata=reply_metadata,
+            )
+            return SimpleNamespace(message_id=_extract_message_id(result))
+
         raise HTTPException(400, f"Unsupported platform: {platform}")
 
     def _send_file_message(
@@ -2143,6 +2197,7 @@ def create_api(
         link_preview_options: dict | None = None,
         quote: str = "",
         blocks: str = "",
+        reply_metadata: dict | None = None,
     ) -> dict:
         """Send a message back to the platform on behalf of an agent."""
         if account_id and not agents.get_raw_token_for_account(
@@ -2169,6 +2224,7 @@ def create_api(
                     link_preview_options=link_preview_options,
                     quote=quote,
                     blocks=blocks,
+                    reply_metadata=reply_metadata,
                 ),
             )
             # Once an outbound message lands, the typing indicator becomes noise —
@@ -2197,7 +2253,7 @@ def create_api(
         # Plain sends keep key_extra="" — their historical dedupe behaviour is
         # unchanged. The dict is serialized (never used raw) so the key stays
         # hashable.
-        if account_id or parse_mode or link_preview_options or quote or blocks:
+        if account_id or parse_mode or link_preview_options or quote or blocks or reply_metadata:
             key_extra = json.dumps(
                 {
                     "acct": account_id or "",
@@ -2205,6 +2261,7 @@ def create_api(
                     "lpo": link_preview_options or None,
                     "q": quote or "",
                     "blk": blocks or "",
+                    "reply_meta": reply_metadata or None,
                 },
                 sort_keys=True, separators=(",", ":"),
             )
@@ -2232,6 +2289,8 @@ def create_api(
                 if platform == "discord":
                     await loop.run_in_executor(None, lambda: adapter.add_reaction(chat_id, message_id, emoji))
                 elif platform == "slack":
+                    await loop.run_in_executor(None, lambda: adapter.add_reaction(chat_id, message_id, emoji))
+                elif platform == "buzz":
                     await loop.run_in_executor(None, lambda: adapter.add_reaction(chat_id, message_id, emoji))
                 return
             except Exception as e:
@@ -4778,6 +4837,23 @@ def create_api(
         if not secret:
             return False
         return bool(verify_session_cookie(secret, request.cookies.get(SESSION_COOKIE_NAME, "")))
+
+    def _owner_control_actor(request: Request) -> str:
+        """Require a browser owner session and derive its authority principal.
+
+        Valid internal agent HMAC auth intentionally does not satisfy this
+        gate: Buzz ToS provenance is owner control, never minting/agent data.
+        """
+        secret = _session_secret()
+        session = (
+            verify_session_cookie(secret, request.cookies.get(SESSION_COOKIE_NAME, ""))
+            if secret
+            else None
+        )
+        if not session:
+            raise HTTPException(403, "authenticated owner session required")
+        user = re.sub(r"[^a-zA-Z0-9_.-]", "_", str(session.get("user") or "admin"))
+        return f"ui:{user[:120]}"
 
     def _needs_browser_api_auth(request: Request) -> bool:
         path = request.url.path
@@ -7534,6 +7610,87 @@ npm run build</pre>
             raise HTTPException(404, "Directive not found")
         return {"id": directive_id, "active": active}
 
+    # ── Buzz identity owner control (#541 inc1) ────────────
+
+    @app.get("/system/buzz-identities")
+    async def list_buzz_identities(request: Request):
+        """List redacted Buzz identities for the authenticated owner."""
+        _owner_control_actor(request)
+        identities = agents.list_buzz_identities()
+        return {"identities": identities, "count": len(identities)}
+
+    @app.get("/system/buzz-identities/{name}")
+    async def get_buzz_identity(name: str, request: Request):
+        """Read one redacted Buzz identity for the authenticated owner."""
+        _owner_control_actor(request)
+        identity = agents.get_buzz_identity(name)
+        if identity is None:
+            raise HTTPException(404, "Buzz identity not found")
+        return identity
+
+    @app.put("/system/buzz-identities/{name}")
+    async def bind_buzz_identity(
+        name: str,
+        req: BindBuzzIdentityRequest,
+        request: Request,
+    ):
+        """One-step owner-approved Buzz bind; raw key is immediately wrapped."""
+        actor = _owner_control_actor(request)
+        receipt = req.tos_receipt.strip()
+        approval_ref = (
+            f"owner-control:{uuid.uuid4().hex}:sha256:"
+            f"{hashlib.sha256(receipt.encode('utf-8')).hexdigest()}"
+        )
+        try:
+            identity = agents.bind_buzz_identity_owner_control(
+                name,
+                private_key=req.private_key,
+                relay_url=req.relay_url,
+                community_id=req.community_id,
+                enabled=req.enabled,
+                tos_receipt=receipt,
+                tos_approved_by=actor,
+                tos_approved_at=time.time(),
+                tos_approval_ref=approval_ref,
+            )
+        except KeyError as exc:
+            raise HTTPException(404, str(exc)) from exc
+        except ValueError as exc:
+            status = 409 if "rotation" in str(exc) or "conflicts" in str(exc) else 400
+            raise HTTPException(status, str(exc)) from exc
+        _evict_platform_adapters(name, "buzz")
+        audit.log(
+            "buzz_identity_bound",
+            agent_name=name,
+            tool_name="owner_control",
+            tool_input_summary=json.dumps(
+                {
+                    "agent": name,
+                    "pubkey": identity["pubkey"],
+                    "community_id": identity["community_id"],
+                    "enabled": identity["enabled"],
+                    "tos_approval_ref": identity["tos_approval_ref"],
+                },
+                separators=(",", ":"),
+            ),
+        )
+        return identity
+
+    @app.post("/system/buzz-identities/{name}/disable")
+    async def disable_buzz_identity(name: str, request: Request):
+        """Disable outbound Buzz without deleting the encrypted authority row."""
+        actor = _owner_control_actor(request)
+        if not agents.disable_buzz_identity(name):
+            raise HTTPException(404, "Buzz identity not found")
+        _evict_platform_adapters(name, "buzz")
+        audit.log(
+            "buzz_identity_disabled",
+            agent_name=name,
+            tool_name="owner_control",
+            tool_input_summary=json.dumps({"agent": name, "actor": actor}),
+        )
+        return agents.get_buzz_identity(name)
+
     # ── Agent Tokens ────────────────────────────────────────
 
     @app.put("/agents/{name}/tokens/{platform}")
@@ -8424,7 +8581,11 @@ npm run build</pre>
         _deny_isolated_cross_actor(request, agent_name)
 
         ctx = _resolve_message_context(agent_name, source_message_id)
-        effective_thread_root = ctx.reply_to or ctx.message_id
+        # Buzz/Nostr's reply marker targets the exact source event. Slack's
+        # thread_ts model instead collapses child replies to their stored root.
+        effective_thread_root = (
+            ctx.message_id if ctx.platform == "buzz" else ctx.reply_to or ctx.message_id
+        )
         voice_settings = _get_voice_reply_settings(agent_name, ctx.platform)
 
         if ctx.source_was_voice and voice_settings:
@@ -8465,6 +8626,7 @@ npm run build</pre>
             parse_mode=parse_mode,
             link_preview_options=link_preview_options,
             quote=quote,
+            reply_metadata=_buzz_reply_metadata(ctx),
         )
         _record_outbound_message(
             agent_name,
@@ -11171,6 +11333,20 @@ npm run build</pre>
                     )
             except Exception as exc:  # never let log rotation abort startup
                 _log(f"startup: log rotation not started ({exc})")
+
+        # Buzz is a required-dependency outbound platform. A broken/partially
+        # healed venv must refuse every enabled identity and page the owner;
+        # silently leaving send() registered but non-functional is unsafe.
+        from pinky_daemon.buzz_runtime import register_buzz_outbound_platforms
+
+        app.state.buzz_registration = await register_buzz_outbound_platforms(
+            agents, _notify_owner_undelivered
+        )
+        if app.state.buzz_registration["refused"]:
+            _log(
+                "startup: Buzz platform registration REFUSED for "
+                f"{app.state.buzz_registration['refused']} identity(s)"
+            )
 
         # Start shared MCP server BEFORE agent sessions so SSE URLs are ready
         if SHARED_MCP_ENABLED:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7636,11 +7636,6 @@ npm run build</pre>
     ):
         """One-step owner-approved Buzz bind; raw key is immediately wrapped."""
         actor = _owner_control_actor(request)
-        receipt = req.tos_receipt.strip()
-        approval_ref = (
-            f"owner-control:{uuid.uuid4().hex}:sha256:"
-            f"{hashlib.sha256(receipt.encode('utf-8')).hexdigest()}"
-        )
         try:
             identity = agents.bind_buzz_identity_owner_control(
                 name,
@@ -7648,10 +7643,7 @@ npm run build</pre>
                 relay_url=req.relay_url,
                 community_id=req.community_id,
                 enabled=req.enabled,
-                tos_receipt=receipt,
-                tos_approved_by=actor,
-                tos_approved_at=time.time(),
-                tos_approval_ref=approval_ref,
+                owner_actor=actor,
             )
         except KeyError as exc:
             raise HTTPException(404, str(exc)) from exc

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Agent names appear in filesystem paths (data/agents/{name}/, hook scripts,
 # settings.json, .mcp.json) and database queries. Restrict to a safe character
@@ -571,10 +571,11 @@ class SetAgentTokenRequest(BaseModel):
 class BindBuzzIdentityRequest(BaseModel):
     """Owner-control request to bind one encrypted Buzz identity."""
 
+    model_config = ConfigDict(extra="forbid")
+
     private_key: str
     relay_url: str
     community_id: str
-    tos_receipt: str
     enabled: bool = True
 
 

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -568,6 +568,16 @@ class SetAgentTokenRequest(BaseModel):
     settings: dict = Field(default_factory=dict)
 
 
+class BindBuzzIdentityRequest(BaseModel):
+    """Owner-control request to bind one encrypted Buzz identity."""
+
+    private_key: str
+    relay_url: str
+    community_id: str
+    tos_receipt: str
+    enabled: bool = True
+
+
 class AddMcpServerRequest(BaseModel):
     """Add a custom MCP server to an agent."""
 

--- a/src/pinky_daemon/buzz_identity.py
+++ b/src/pinky_daemon/buzz_identity.py
@@ -1,0 +1,201 @@
+"""Encrypted-at-rest Buzz (Nostr/secp256k1) identity primitives.
+
+The agent registry owns lifecycle and persistence.  This module owns only the
+secret envelope and deliberately has no DTO or logging surface for raw key
+material.
+"""
+
+from __future__ import annotations
+
+import hmac
+import re
+import secrets
+from dataclasses import dataclass
+
+from nacl.bindings import (
+    crypto_aead_xchacha20poly1305_ietf_decrypt,
+    crypto_aead_xchacha20poly1305_ietf_encrypt,
+    crypto_aead_xchacha20poly1305_ietf_NPUBBYTES,
+)
+
+from pinky_identity.keystore import DeviceKey
+
+BUZZ_WRAP_VERSION = 1
+BUZZ_PRIVATE_KEY_BYTES = 32
+_BUZZ_AAD_PREFIX = b"pinky-identity/v1/buzz-secp256k1"
+_HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class BuzzIdentityError(ValueError):
+    """Base error for invalid or unusable Buzz identity material."""
+
+
+class BuzzIdentityUnhealthyError(BuzzIdentityError):
+    """The stored envelope cannot be trusted or decrypted."""
+
+
+class BuzzDependencyError(BuzzIdentityError):
+    """A required Buzz runtime dependency is missing."""
+
+
+@dataclass(frozen=True)
+class BuzzKeyEnvelope:
+    """Encrypted private-key envelope; repr never exposes secret bytes."""
+
+    agent: str
+    pubkey: str
+    wrap_version: int
+    nonce: bytes
+    ciphertext: bytes
+
+    def __repr__(self) -> str:
+        return (
+            f"BuzzKeyEnvelope(agent={self.agent!r}, pubkey={self.pubkey!r}, "
+            f"wrap_version={self.wrap_version}, "
+            f"ciphertext=<{len(self.ciphertext)} bytes redacted>)"
+        )
+
+
+@dataclass(frozen=True)
+class BuzzSigningMaterial:
+    """Internal-only unwrapped identity handed directly to the sender."""
+
+    agent: str
+    pubkey: str
+    private_key: bytes
+    relay_url: str
+    community_id: str
+
+    def __repr__(self) -> str:
+        return (
+            f"BuzzSigningMaterial(agent={self.agent!r}, pubkey={self.pubkey!r}, "
+            f"relay_url={self.relay_url!r}, community_id={self.community_id!r}, "
+            "private_key=<redacted>)"
+        )
+
+
+def _coincurve():
+    try:
+        import coincurve
+    except ImportError as exc:  # pragma: no cover - exercised by boot dependency probe
+        raise BuzzDependencyError("Buzz secp256k1 dependency is unavailable") from exc
+    return coincurve
+
+
+def normalize_private_key(value: str | bytes) -> bytes:
+    """Return one valid 32-byte secp256k1 secret without echoing bad input."""
+    if isinstance(value, bytes):
+        raw = bytes(value)
+    elif isinstance(value, str) and _HEX_64_RE.fullmatch(value.strip().lower()):
+        raw = bytes.fromhex(value.strip())
+    else:
+        raise BuzzIdentityError("Buzz private key must be 64 hexadecimal characters")
+    if len(raw) != BUZZ_PRIVATE_KEY_BYTES:
+        raise BuzzIdentityError("Buzz private key must be 32 bytes")
+    try:
+        _coincurve().PrivateKey(raw)
+    except Exception as exc:
+        raise BuzzIdentityError("Buzz private key is not a valid secp256k1 scalar") from exc
+    return raw
+
+
+def derive_xonly_pubkey(private_key: str | bytes) -> str:
+    """Derive the canonical lowercase 64-hex BIP340 x-only public key."""
+    raw = normalize_private_key(private_key)
+    return _coincurve().PrivateKey(raw).public_key_xonly.format().hex()
+
+
+def _aad(*, agent: str, pubkey: str, wrap_version: int) -> bytes:
+    if not agent or not _HEX_64_RE.fullmatch(pubkey):
+        raise BuzzIdentityError("invalid Buzz envelope identity metadata")
+    return (
+        _BUZZ_AAD_PREFIX
+        + b"|v="
+        + str(wrap_version).encode("ascii")
+        + b"|agent="
+        + agent.encode("utf-8")
+        + b"|pubkey="
+        + pubkey.encode("ascii")
+    )
+
+
+def wrap_buzz_private_key(
+    private_key: str | bytes,
+    *,
+    agent: str,
+    device_key: DeviceKey,
+) -> BuzzKeyEnvelope:
+    """Encrypt a Buzz private key with identity-bound XChaCha20-Poly1305 AAD."""
+    if not isinstance(device_key, DeviceKey):
+        raise TypeError("device_key must be a DeviceKey")
+    raw = normalize_private_key(private_key)
+    pubkey = derive_xonly_pubkey(raw)
+    nonce = secrets.token_bytes(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES)
+    ciphertext = crypto_aead_xchacha20poly1305_ietf_encrypt(
+        raw,
+        _aad(agent=agent, pubkey=pubkey, wrap_version=BUZZ_WRAP_VERSION),
+        nonce,
+        device_key.material_insecure(),
+    )
+    return BuzzKeyEnvelope(
+        agent=agent,
+        pubkey=pubkey,
+        wrap_version=BUZZ_WRAP_VERSION,
+        nonce=nonce,
+        ciphertext=ciphertext,
+    )
+
+
+def unwrap_buzz_private_key(
+    envelope: BuzzKeyEnvelope,
+    *,
+    device_key: DeviceKey,
+) -> bytes:
+    """Decrypt and cross-check a stored Buzz secret.
+
+    AAD binds the secret to both the owning agent and stored public key.  The
+    explicit constant-time derived-key comparison is retained even though a
+    metadata substitution should already fail AEAD authentication.
+    """
+    if not isinstance(envelope, BuzzKeyEnvelope):
+        raise TypeError("envelope must be a BuzzKeyEnvelope")
+    if not isinstance(device_key, DeviceKey):
+        raise TypeError("device_key must be a DeviceKey")
+    if envelope.wrap_version != BUZZ_WRAP_VERSION:
+        raise BuzzIdentityUnhealthyError(f"unsupported Buzz wrap version {envelope.wrap_version}")
+    try:
+        raw = crypto_aead_xchacha20poly1305_ietf_decrypt(
+            envelope.ciphertext,
+            _aad(
+                agent=envelope.agent,
+                pubkey=envelope.pubkey,
+                wrap_version=envelope.wrap_version,
+            ),
+            envelope.nonce,
+            device_key.material_insecure(),
+        )
+    except Exception as exc:
+        raise BuzzIdentityUnhealthyError("Buzz identity envelope authentication failed") from exc
+    try:
+        derived = derive_xonly_pubkey(raw)
+    except BuzzIdentityError as exc:
+        raise BuzzIdentityUnhealthyError("Buzz identity decrypted to an invalid key") from exc
+    if not hmac.compare_digest(derived, envelope.pubkey):
+        raise BuzzIdentityUnhealthyError(
+            "Buzz identity public key does not match the decrypted private key"
+        )
+    return raw
+
+
+__all__ = [
+    "BUZZ_WRAP_VERSION",
+    "BuzzDependencyError",
+    "BuzzIdentityError",
+    "BuzzIdentityUnhealthyError",
+    "BuzzKeyEnvelope",
+    "BuzzSigningMaterial",
+    "derive_xonly_pubkey",
+    "normalize_private_key",
+    "unwrap_buzz_private_key",
+    "wrap_buzz_private_key",
+]

--- a/src/pinky_daemon/buzz_identity.py
+++ b/src/pinky_daemon/buzz_identity.py
@@ -7,9 +7,12 @@ material.
 
 from __future__ import annotations
 
+import hashlib
 import hmac
+import json
 import re
 import secrets
+import time
 from dataclasses import dataclass
 
 from nacl.bindings import (
@@ -22,8 +25,12 @@ from pinky_identity.keystore import DeviceKey
 
 BUZZ_WRAP_VERSION = 1
 BUZZ_PRIVATE_KEY_BYTES = 32
+BUZZ_TOS_POLICY = "buzz-tos-and-18-plus"
+BUZZ_TOS_POLICY_VERSION = 1
 _BUZZ_AAD_PREFIX = b"pinky-identity/v1/buzz-secp256k1"
 _HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+_OWNER_ACTOR_RE = re.compile(r"^ui:[a-zA-Z0-9_.-]{1,120}$")
+_APPROVAL_REF_RE = re.compile(r"^owner-control:[0-9a-f]{32}:sha256:[0-9a-f]{64}$")
 
 
 class BuzzIdentityError(ValueError):
@@ -72,6 +79,111 @@ class BuzzSigningMaterial:
             f"relay_url={self.relay_url!r}, community_id={self.community_id!r}, "
             "private_key=<redacted>)"
         )
+
+
+@dataclass(frozen=True)
+class BuzzOwnerApproval:
+    """Server-issued authority record for one exact Buzz identity binding."""
+
+    receipt: str
+    approved_by: str
+    approved_at: float
+    approval_ref: str
+
+
+def canonical_buzz_tos_receipt(
+    *,
+    agent: str,
+    pubkey: str,
+    relay_url: str,
+    community_id: str,
+) -> str:
+    """Build the canonical, identity-scoped receipt for an owner bind action."""
+    if not agent or not _HEX_64_RE.fullmatch(pubkey):
+        raise BuzzIdentityError("invalid Buzz approval identity metadata")
+    return json.dumps(
+        {
+            "action": "buzz.identity.bind",
+            "agent": agent,
+            "community_id": community_id,
+            "policy": BUZZ_TOS_POLICY,
+            "policy_version": BUZZ_TOS_POLICY_VERSION,
+            "pubkey": pubkey,
+            "relay_url": relay_url,
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def validate_buzz_owner_actor(owner_actor: str) -> str:
+    """Validate the trusted owner principal derived by the HTTP session gate."""
+    actor = str(owner_actor or "").strip()
+    if not _OWNER_ACTOR_RE.fullmatch(actor):
+        raise BuzzIdentityError("Buzz owner approval actor is invalid")
+    return actor
+
+
+def issue_buzz_owner_approval(
+    *,
+    owner_actor: str,
+    agent: str,
+    pubkey: str,
+    relay_url: str,
+    community_id: str,
+) -> BuzzOwnerApproval:
+    """Issue fresh provenance for one authenticated owner action.
+
+    The API caller supplies none of these bytes. The trusted route derives the
+    actor from its session, while this function derives the receipt, time, and
+    single-use reference inside the daemon.
+    """
+    actor = validate_buzz_owner_actor(owner_actor)
+    receipt = canonical_buzz_tos_receipt(
+        agent=agent,
+        pubkey=pubkey,
+        relay_url=relay_url,
+        community_id=community_id,
+    )
+    digest = hashlib.sha256(receipt.encode("utf-8")).hexdigest()
+    return BuzzOwnerApproval(
+        receipt=receipt,
+        approved_by=actor,
+        approved_at=time.time(),
+        approval_ref=f"owner-control:{secrets.token_hex(16)}:sha256:{digest}",
+    )
+
+
+def validate_buzz_owner_approval(
+    *,
+    agent: str,
+    pubkey: str,
+    relay_url: str,
+    community_id: str,
+    receipt: str,
+    approved_by: str,
+    approved_at: float,
+    approval_ref: str,
+) -> None:
+    """Validate stored provenance against its exact identity and policy scope."""
+    expected = canonical_buzz_tos_receipt(
+        agent=agent,
+        pubkey=pubkey,
+        relay_url=relay_url,
+        community_id=community_id,
+    )
+    if not hmac.compare_digest(str(receipt or ""), expected):
+        raise BuzzIdentityUnhealthyError("Buzz owner approval receipt is invalid")
+    actor = str(approved_by or "")
+    if not _OWNER_ACTOR_RE.fullmatch(actor) or float(approved_at or 0) <= 0:
+        raise BuzzIdentityUnhealthyError("Buzz owner approval provenance is invalid")
+    ref = str(approval_ref or "")
+    expected_digest = hashlib.sha256(expected.encode("utf-8")).hexdigest()
+    if not _APPROVAL_REF_RE.fullmatch(ref) or not hmac.compare_digest(
+        ref.rsplit(":", 1)[-1], expected_digest
+    ):
+        raise BuzzIdentityUnhealthyError("Buzz owner approval reference is invalid")
 
 
 def _coincurve():
@@ -188,14 +300,21 @@ def unwrap_buzz_private_key(
 
 
 __all__ = [
+    "BUZZ_TOS_POLICY",
+    "BUZZ_TOS_POLICY_VERSION",
     "BUZZ_WRAP_VERSION",
     "BuzzDependencyError",
     "BuzzIdentityError",
     "BuzzIdentityUnhealthyError",
     "BuzzKeyEnvelope",
+    "BuzzOwnerApproval",
     "BuzzSigningMaterial",
+    "canonical_buzz_tos_receipt",
     "derive_xonly_pubkey",
+    "issue_buzz_owner_approval",
     "normalize_private_key",
     "unwrap_buzz_private_key",
+    "validate_buzz_owner_actor",
+    "validate_buzz_owner_approval",
     "wrap_buzz_private_key",
 ]

--- a/src/pinky_daemon/buzz_runtime.py
+++ b/src/pinky_daemon/buzz_runtime.py
@@ -1,0 +1,50 @@
+"""Buzz outbound registration gate used during daemon startup."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+
+from pinky_outreach.buzz_dependency import missing_buzz_dependencies
+
+
+def _log(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+async def register_buzz_outbound_platforms(registry, owner_notify) -> dict:
+    """Refuse enabled Buzz identities loudly when runtime deps are missing."""
+    identities = registry.list_buzz_identities(enabled_only=True)
+    if not identities:
+        return {"registered": 0, "refused": 0, "missing_dependencies": []}
+    missing = missing_buzz_dependencies()
+    if not missing:
+        for identity in identities:
+            registry.mark_buzz_dependency_ready(identity["agent"])
+        return {"registered": len(identities), "refused": 0, "missing_dependencies": []}
+
+    names = ", ".join(missing)
+    for identity in identities:
+        agent = identity["agent"]
+        registry.mark_buzz_dependency_refused(agent, f"missing:{names}")
+        message = (
+            f"BUZZ PLATFORM REFUSED for {agent}: required daemon dependencies "
+            f"are missing ({names}). Run the normal dependency heal/update; "
+            "the identity remains encrypted and will re-register after restart."
+        )
+        delivered = False
+        try:
+            result = owner_notify(agent, message)
+            delivered = bool(await result) if inspect.isawaitable(result) else bool(result)
+        except Exception as exc:  # noqa: BLE001 — refusal must survive alert failure
+            _log(f"buzz-startup: owner-notify failed for {agent} ({type(exc).__name__})")
+        if not delivered:
+            _log(f"buzz-startup: OWNER_NOTIFY_FAILED for refused identity {agent}")
+    return {
+        "registered": 0,
+        "refused": len(identities),
+        "missing_dependencies": list(missing),
+    }
+
+
+__all__ = ["register_buzz_outbound_platforms"]

--- a/src/pinky_outreach/buzz.py
+++ b/src/pinky_outreach/buzz.py
@@ -1,0 +1,416 @@
+"""Native Buzz outbound adapter using signed Nostr events and NIP-98 HTTP auth."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+import secrets
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from urllib.parse import urlsplit, urlunsplit
+
+import coincurve
+import httpx
+
+from pinky_outreach.types import Message, Platform
+
+_HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+_COMMUNITY_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+_ASCII_AT_WORD_RE = re.compile(r"@(?=\w)", flags=re.UNICODE)
+_MAX_REWRITE_POSITIONS = 32
+_REFERENCE_EVENT_PREFIX = 16
+_MAX_REFERENCE_LINE = 192
+
+
+class BuzzError(RuntimeError):
+    """Base Buzz adapter failure."""
+
+
+class BuzzProtocolError(BuzzError):
+    """Buzz returned or was given an invalid protocol object."""
+
+
+class BuzzTransportError(BuzzError):
+    """Buzz relay transport failed."""
+
+
+@dataclass(frozen=True)
+class MentionNormalization:
+    content: str
+    rewrite_count: int
+    positions: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class VerifiedReplyMetadata:
+    event_id: str
+    kind: int
+    author_pubkey: str
+    channel_id: str
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def normalize_buzz_mentions(content: str) -> MentionNormalization:
+    """Replace every parser-matching ASCII ``@word`` introducer visibly.
+
+    This intentionally also covers emails and inline/fenced code: Buzz parses
+    the final wire string, not Markdown semantics, so those contexts cannot be
+    exempted safely.
+    """
+    if not isinstance(content, str):
+        raise TypeError("Buzz content must be a string")
+    positions = tuple(match.start() for match in _ASCII_AT_WORD_RE.finditer(content))
+    return MentionNormalization(
+        content=_ASCII_AT_WORD_RE.sub("＠", content),
+        rewrite_count=len(positions),
+        positions=positions[:_MAX_REWRITE_POSITIONS],
+    )
+
+
+def _canonical_event_bytes(
+    *, pubkey: str, created_at: int, kind: int, tags: list[list[str]], content: str
+) -> bytes:
+    return json.dumps(
+        [0, pubkey, created_at, kind, tags, content],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def verify_nostr_event(event: dict) -> bool:
+    """Strictly recompute and BIP340-verify one Nostr event."""
+    try:
+        required = {"id", "pubkey", "created_at", "kind", "tags", "content", "sig"}
+        if set(event) != required:
+            return False
+        if not _HEX_64_RE.fullmatch(event["id"]):
+            return False
+        if not _HEX_64_RE.fullmatch(event["pubkey"]):
+            return False
+        if not isinstance(event["created_at"], int) or isinstance(event["created_at"], bool):
+            return False
+        if not isinstance(event["kind"], int) or isinstance(event["kind"], bool):
+            return False
+        if not isinstance(event["content"], str) or not isinstance(event["tags"], list):
+            return False
+        if not isinstance(event["sig"], str) or len(event["sig"]) != 128:
+            return False
+        if any(
+            not isinstance(tag, list) or any(not isinstance(part, str) for part in tag)
+            for tag in event["tags"]
+        ):
+            return False
+        computed = hashlib.sha256(
+            _canonical_event_bytes(
+                pubkey=event["pubkey"],
+                created_at=event["created_at"],
+                kind=event["kind"],
+                tags=event["tags"],
+                content=event["content"],
+            )
+        ).hexdigest()
+        if not secrets.compare_digest(computed, event["id"]):
+            return False
+        return coincurve.PublicKeyXOnly(bytes.fromhex(event["pubkey"])).verify(
+            bytes.fromhex(event["sig"]), bytes.fromhex(computed)
+        )
+    except Exception:
+        return False
+
+
+class _NostrSigner:
+    """Small signing helper whose repr never contains the private scalar."""
+
+    def __init__(self, private_key: bytes) -> None:
+        if not isinstance(private_key, bytes) or len(private_key) != 32:
+            raise BuzzProtocolError("Buzz private key must be 32 bytes")
+        try:
+            self._key = coincurve.PrivateKey(private_key)
+        except Exception as exc:
+            raise BuzzProtocolError("Buzz private key is not a valid secp256k1 scalar") from exc
+        self.pubkey = self._key.public_key_xonly.format().hex()
+
+    def __repr__(self) -> str:
+        return f"_NostrSigner(pubkey={self.pubkey!r}, private_key=<redacted>)"
+
+    def sign_event(
+        self,
+        *,
+        kind: int,
+        tags: list[list[str]],
+        content: str,
+        created_at: int | None = None,
+    ) -> dict:
+        timestamp = int(time.time()) if created_at is None else int(created_at)
+        event_id = hashlib.sha256(
+            _canonical_event_bytes(
+                pubkey=self.pubkey,
+                created_at=timestamp,
+                kind=kind,
+                tags=tags,
+                content=content,
+            )
+        ).hexdigest()
+        return {
+            "id": event_id,
+            "pubkey": self.pubkey,
+            "created_at": timestamp,
+            "kind": kind,
+            "tags": tags,
+            "content": content,
+            "sig": self._key.sign_schnorr(bytes.fromhex(event_id)).hex(),
+        }
+
+
+def _validate_channel_id(channel_id: str) -> str:
+    try:
+        parsed = uuid.UUID(str(channel_id))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise BuzzProtocolError("Buzz chat_id must be a channel UUID") from exc
+    canonical = str(parsed)
+    if canonical != str(channel_id).lower():
+        raise BuzzProtocolError("Buzz chat_id must be a canonical channel UUID")
+    return canonical
+
+
+def _validate_relay_url(relay_url: str) -> tuple[str, str]:
+    parsed = urlsplit(relay_url)
+    if (
+        parsed.scheme not in {"wss", "ws"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise BuzzProtocolError("Buzz relay_url must be a plain ws:// or wss:// URL")
+    http_scheme = "https" if parsed.scheme == "wss" else "http"
+    base = urlunsplit((http_scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+    return relay_url, base
+
+
+class BuzzAdapter:
+    """Synchronous outbound adapter used from the broker executor."""
+
+    def __init__(
+        self,
+        private_key: bytes,
+        *,
+        relay_url: str,
+        community_id: str,
+        timeout: float = 20.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._signer = _NostrSigner(private_key)
+        self.relay_url, self._http_base = _validate_relay_url(relay_url)
+        community = str(community_id or "").lower()
+        if not _COMMUNITY_RE.fullmatch(community):
+            raise BuzzProtocolError("Buzz community_id is invalid")
+        self.community_id = community
+        self._client = httpx.Client(timeout=timeout, transport=transport)
+
+    @property
+    def pubkey(self) -> str:
+        return self._signer.pubkey
+
+    def __repr__(self) -> str:
+        return (
+            f"BuzzAdapter(pubkey={self.pubkey!r}, relay_url={self.relay_url!r}, "
+            f"community_id={self.community_id!r}, private_key=<redacted>)"
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    def _authorization(self, url: str, body: bytes) -> str:
+        auth = self._signer.sign_event(
+            kind=27235,
+            tags=[
+                ["u", url],
+                ["method", "POST"],
+                ["nonce", secrets.token_hex(16)],
+                ["payload", hashlib.sha256(body).hexdigest()],
+            ],
+            content="",
+        )
+        encoded = base64.b64encode(
+            json.dumps(auth, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        ).decode("ascii")
+        return f"Nostr {encoded}"
+
+    def _post(self, path: str, payload: object) -> object:
+        url = f"{self._http_base}{path}"
+        body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        try:
+            response = self._client.post(
+                url,
+                content=body,
+                headers={
+                    "Authorization": self._authorization(url, body),
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                    "User-Agent": "PinkyBot-Buzz/1.0",
+                },
+            )
+            response.raise_for_status()
+            return response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            raise BuzzTransportError(
+                f"Buzz relay request failed for {path} ({type(exc).__name__})"
+            ) from exc
+
+    def _query_reply(self, event_id: str, channel_id: str) -> VerifiedReplyMetadata:
+        if not _HEX_64_RE.fullmatch(event_id):
+            raise BuzzProtocolError("Buzz reply target must be a 64-hex event id")
+        result = self._post("/query", [{"ids": [event_id], "limit": 1}])
+        if not isinstance(result, list) or len(result) != 1 or not isinstance(result[0], dict):
+            raise BuzzProtocolError("Buzz reply target was not found uniquely")
+        event = result[0]
+        if not verify_nostr_event(event) or event["id"] != event_id:
+            raise BuzzProtocolError("Buzz reply target failed event verification")
+        channels = [tag[1] for tag in event["tags"] if len(tag) >= 2 and tag[0] == "h"]
+        if channels != [channel_id]:
+            raise BuzzProtocolError("Buzz reply target belongs to a different channel")
+        return VerifiedReplyMetadata(
+            event_id=event["id"],
+            kind=event["kind"],
+            author_pubkey=event["pubkey"],
+            channel_id=channel_id,
+        )
+
+    @staticmethod
+    def _stored_reply_metadata(
+        metadata: dict | None,
+        *,
+        event_id: str,
+        channel_id: str,
+    ) -> VerifiedReplyMetadata | None:
+        if not metadata:
+            return None
+        candidate = metadata.get("buzz_verified_event")
+        if not isinstance(candidate, dict) or candidate.get("verified") is not True:
+            return None
+        author = str(candidate.get("author_pubkey") or "").lower()
+        stored_event = str(candidate.get("event_id") or "").lower()
+        stored_channel = str(candidate.get("channel_id") or "").lower()
+        kind = candidate.get("kind")
+        if (
+            stored_event != event_id
+            or stored_channel != channel_id
+            or not _HEX_64_RE.fullmatch(author)
+            or not isinstance(kind, int)
+            or isinstance(kind, bool)
+        ):
+            raise BuzzProtocolError("stored Buzz reply metadata is invalid")
+        return VerifiedReplyMetadata(
+            event_id=stored_event,
+            kind=kind,
+            author_pubkey=author,
+            channel_id=stored_channel,
+        )
+
+    def _publish(self, *, kind: int, tags: list[list[str]], content: str) -> tuple[dict, int]:
+        normalized = normalize_buzz_mentions(content)
+        event = self._signer.sign_event(kind=kind, tags=tags, content=normalized.content)
+        if normalized.rewrite_count:
+            _log(
+                "buzz-normalize: "
+                f"event_id={event['id']} rewrites={normalized.rewrite_count} "
+                "rule=ascii-at-word-to-fullwidth reason=buzz-parser-safety "
+                f"positions={list(normalized.positions)}"
+            )
+        self._post("/events", event)
+        return event, normalized.rewrite_count
+
+    def send_message(
+        self,
+        channel_id: str,
+        content: str,
+        *,
+        reply_to: str | None = None,
+        reply_metadata: dict | None = None,
+    ) -> Message:
+        channel = _validate_channel_id(channel_id)
+        tags: list[list[str]] = [["h", channel]]
+        final_content = content
+        if reply_to:
+            target_id = str(reply_to).lower()
+            if not _HEX_64_RE.fullmatch(target_id):
+                raise BuzzProtocolError("Buzz reply target must be a 64-hex event id")
+            stored_target = self._stored_reply_metadata(
+                reply_metadata,
+                event_id=target_id,
+                channel_id=channel,
+            )
+            target = stored_target
+            if target is None:
+                target = self._query_reply(target_id, channel)
+            if target.kind == 20002:
+                if stored_target is None:
+                    raise BuzzProtocolError(
+                        "ephemeral Buzz replies require verified stored metadata"
+                    )
+                # Reference-only: no raw ephemeral content is accepted or read.
+                reference = (
+                    f"[reply to ephemeral {target.event_id[:_REFERENCE_EVENT_PREFIX]} "
+                    f"by buzz:{self.community_id}:{target.author_pubkey}]"
+                )
+                if "\n" in reference or len(reference) > _MAX_REFERENCE_LINE:
+                    raise BuzzProtocolError("Buzz ephemeral reference metadata is too long")
+                final_content = f"{reference}\n{content}"
+            elif target.kind == 9:
+                tags.append(["e", target.event_id, "", "reply"])
+            else:
+                raise BuzzProtocolError(f"Buzz event kind {target.kind} cannot be replied to")
+        event, rewrites = self._publish(kind=9, tags=tags, content=final_content)
+        return Message(
+            platform=Platform.buzz,
+            chat_id=channel,
+            sender=self.pubkey,
+            content="",
+            timestamp=datetime.now(timezone.utc),
+            message_id=event["id"],
+            reply_to=str(reply_to or ""),
+            is_outbound=True,
+            metadata={"mention_normalized": bool(rewrites), "rewrite_count": rewrites},
+        )
+
+    def add_reaction(self, channel_id: str, event_id: str, emoji: str) -> Message:
+        channel = _validate_channel_id(channel_id)
+        target = str(event_id or "").lower()
+        if not _HEX_64_RE.fullmatch(target):
+            raise BuzzProtocolError("Buzz reaction target must be a 64-hex event id")
+        if not isinstance(emoji, str) or not emoji.strip() or "\n" in emoji:
+            raise BuzzProtocolError("Buzz reaction emoji must be one non-empty line")
+        event, rewrites = self._publish(kind=7, tags=[["e", target]], content=emoji.strip())
+        return Message(
+            platform=Platform.buzz,
+            chat_id=channel,
+            sender=self.pubkey,
+            content="",
+            timestamp=datetime.now(timezone.utc),
+            message_id=event["id"],
+            reply_to=target,
+            is_outbound=True,
+            metadata={"mention_normalized": bool(rewrites), "rewrite_count": rewrites},
+        )
+
+
+__all__ = [
+    "BuzzAdapter",
+    "BuzzError",
+    "BuzzProtocolError",
+    "BuzzTransportError",
+    "MentionNormalization",
+    "VerifiedReplyMetadata",
+    "normalize_buzz_mentions",
+    "verify_nostr_event",
+]

--- a/src/pinky_outreach/buzz_dependency.py
+++ b/src/pinky_outreach/buzz_dependency.py
@@ -1,0 +1,27 @@
+"""Lightweight Buzz dependency probe safe to import in a broken venv."""
+
+from __future__ import annotations
+
+import importlib
+
+BUZZ_REQUIRED_IMPORTS = ("coincurve", "httpx", "nacl", "websockets")
+
+
+def missing_buzz_dependencies() -> tuple[str, ...]:
+    """Return dependencies that cannot actually be imported at boot.
+
+    ``find_spec`` alone is insufficient for native wheels: a package can be
+    present while its extension or shared library still fails to load.  Probe
+    the required modules themselves, while keeping the Buzz adapter unimported
+    so a broken dependency becomes a loud refusal instead of a daemon crash.
+    """
+    missing: list[str] = []
+    for name in BUZZ_REQUIRED_IMPORTS:
+        try:
+            importlib.import_module(name)
+        except Exception:  # noqa: BLE001 — broken native wheels count as missing
+            missing.append(name)
+    return tuple(missing)
+
+
+__all__ = ["BUZZ_REQUIRED_IMPORTS", "missing_buzz_dependencies"]

--- a/src/pinky_outreach/types.py
+++ b/src/pinky_outreach/types.py
@@ -11,6 +11,7 @@ class Platform(str, Enum):
     telegram = "telegram"
     discord = "discord"
     slack = "slack"
+    buzz = "buzz"
     imessage = "imessage"
     email = "email"
     whatsapp = "whatsapp"

--- a/tests/test_buzz_api.py
+++ b/tests/test_buzz_api.py
@@ -1,0 +1,251 @@
+"""API/broker integration coverage for Buzz inc1."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.api import create_api
+from pinky_daemon.auth import build_internal_auth_headers
+from pinky_daemon.broker import BrokerMessage
+from pinky_outreach.types import Message, Platform
+
+PRIVATE_KEY = "11" * 32
+RECEIPT = "telegram:6770805286:15921|buzz-tos-and-18-plus-approved"
+CHANNEL = "00000000-0000-4000-8000-000000000001"
+
+
+@pytest.fixture(autouse=True)
+def _disable_shared_mcp(monkeypatch):
+    """API tests don't need the process-global shared MCP listener."""
+    monkeypatch.setattr("pinky_daemon.api.SHARED_MCP_ENABLED", False)
+
+
+def _body(**overrides):
+    body = {
+        "private_key": PRIVATE_KEY,
+        "relay_url": "wss://example.communities.buzz.xyz",
+        "community_id": "example",
+        "tos_receipt": RECEIPT,
+        "enabled": True,
+    }
+    body.update(overrides)
+    return body
+
+
+def _app(tmp_path):
+    return create_api(
+        max_sessions=10,
+        default_working_dir=str(tmp_path),
+        db_path=str(tmp_path / "conversations.db"),
+    )
+
+
+def _register_and_bind(client: TestClient):
+    created = client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+    assert created.status_code == 200, created.text
+    bound = client.put("/system/buzz-identities/barsik", json=_body())
+    assert bound.status_code == 200, bound.text
+    return bound
+
+
+def test_owner_bind_is_one_step_server_derived_and_redacted(tmp_path):
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+        response = client.put(
+            "/system/buzz-identities/barsik",
+            json=_body(
+                tos_approved_by="agent:forged",
+                tos_approved_at=1,
+                tos_approval_ref="forged",
+            ),
+        )
+
+        assert response.status_code == 200, response.text
+        identity = response.json()
+        assert identity["enabled"] is True
+        assert identity["status"] == "active"
+        assert identity["tos_approved_by"] == "ui:admin"
+        assert identity["tos_approved_at"] > 0
+        assert re.fullmatch(
+            r"owner-control:[0-9a-f]{32}:sha256:[0-9a-f]{64}",
+            identity["tos_approval_ref"],
+        )
+        assert identity["tos_approval_ref"].endswith(hashlib.sha256(RECEIPT.encode()).hexdigest())
+        assert PRIVATE_KEY not in response.text
+        assert RECEIPT not in response.text
+        assert "ciphertext" not in identity
+        assert "nonce" not in identity
+
+        listed = client.get("/system/buzz-identities").text
+        assert PRIVATE_KEY not in listed
+        assert RECEIPT not in listed
+
+    agents_db = tmp_path / "conversations_agents.db"
+    audit_db = tmp_path / "conversations_audit.db"
+    assert PRIVATE_KEY.encode() not in agents_db.read_bytes()
+    assert PRIVATE_KEY.encode() not in audit_db.read_bytes()
+    assert RECEIPT.encode() not in audit_db.read_bytes()
+
+
+def test_valid_internal_agent_auth_cannot_write_tos_authority(tmp_path):
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+        signing_key = app.state.agents.get_signing_key("barsik")
+        client.cookies.clear()
+        headers = build_internal_auth_headers(
+            signing_key,
+            agent_name="barsik",
+            method="PUT",
+            path="/system/buzz-identities/barsik",
+        )
+
+        response = client.put(
+            "/system/buzz-identities/barsik",
+            json=_body(),
+            headers=headers,
+        )
+
+        assert response.status_code == 403
+        assert "owner session" in response.json()["detail"]
+        assert PRIVATE_KEY not in response.text
+        assert app.state.agents.get_buzz_identity("barsik") is None
+
+
+def test_broker_send_thread_and_react_route_to_native_buzz_adapter(tmp_path):
+    app = _app(tmp_path)
+    parent = "22" * 32
+    author = "33" * 32
+    with TestClient(app) as client:
+        _register_and_bind(client)
+        app.state.broker.remember_message_context(
+            BrokerMessage(
+                platform="buzz",
+                chat_id=CHANNEL,
+                sender_name="Brad",
+                sender_id=author,
+                content="ephemeral metadata only",
+                agent_name="barsik",
+                message_id=parent,
+                reply_to="aa" * 32,
+                is_group=True,
+                metadata={
+                    "buzz_verified_event": {
+                        "verified": True,
+                        "event_id": parent,
+                        "kind": 20002,
+                        "author_pubkey": author,
+                        "channel_id": CHANNEL,
+                    },
+                    "content": "raw ephemeral body must never be forwarded",
+                },
+            )
+        )
+        sent_message = Message(
+            platform=Platform.buzz,
+            chat_id=CHANNEL,
+            sender="44" * 32,
+            content="",
+            timestamp=datetime.now(timezone.utc),
+            message_id="55" * 32,
+            is_outbound=True,
+        )
+
+        with (
+            patch(
+                "pinky_outreach.buzz.BuzzAdapter.send_message",
+                return_value=sent_message,
+            ) as send,
+            patch(
+                "pinky_outreach.buzz.BuzzAdapter.add_reaction",
+                return_value=SimpleNamespace(message_id="66" * 32),
+            ) as react,
+        ):
+            root = client.post(
+                "/broker/send",
+                json={
+                    "agent_name": "barsik",
+                    "platform": "buzz",
+                    "chat_id": CHANNEL,
+                    "content": "hello",
+                },
+            )
+            thread = client.post(
+                "/broker/thread",
+                json={
+                    "agent_name": "barsik",
+                    "message_id": parent,
+                    "content": "reply",
+                },
+            )
+            reaction = client.post(
+                "/broker/react",
+                json={
+                    "agent_name": "barsik",
+                    "message_id": parent,
+                    "emoji": "👍",
+                },
+            )
+
+        assert root.status_code == 200, root.text
+        assert root.json()["message_id"] == "55" * 32
+        assert thread.status_code == 200, thread.text
+        assert reaction.status_code == 200, reaction.text
+        assert send.call_count == 2
+        assert send.call_args_list[0].kwargs == {
+            "reply_to": None,
+            "reply_metadata": None,
+        }
+        assert send.call_args_list[1].kwargs["reply_to"] == parent
+        assert (
+            send.call_args_list[1].kwargs["reply_metadata"]["buzz_verified_event"]["kind"] == 20002
+        )
+        assert "content" not in send.call_args_list[1].kwargs["reply_metadata"]
+        react.assert_called_once_with(CHANNEL, parent, "👍")
+
+
+def test_startup_refuses_enabled_identity_when_buzz_dependency_is_missing(tmp_path, monkeypatch):
+    conversation_db = tmp_path / "conversations.db"
+    registry = AgentRegistry(
+        str(tmp_path / "conversations_agents.db"),
+        buzz_device_key_path=str(tmp_path / "identity" / ".device_key"),
+    )
+    registry.register("barsik", model="sonnet", working_dir=str(tmp_path / "barsik"))
+    digest = hashlib.sha256(RECEIPT.encode()).hexdigest()
+    registry.bind_buzz_identity_owner_control(
+        "barsik",
+        private_key=PRIVATE_KEY,
+        relay_url="wss://example.communities.buzz.xyz",
+        community_id="example",
+        enabled=True,
+        tos_receipt=RECEIPT,
+        tos_approved_by="ui:admin",
+        tos_approved_at=1234.5,
+        tos_approval_ref=f"owner-control:{'a' * 32}:sha256:{digest}",
+    )
+    registry.close()
+    monkeypatch.setattr(
+        "pinky_daemon.buzz_runtime.missing_buzz_dependencies",
+        lambda: ("coincurve",),
+    )
+
+    app = create_api(
+        max_sessions=10,
+        default_working_dir=str(tmp_path),
+        db_path=str(conversation_db),
+    )
+    with TestClient(app):
+        assert app.state.buzz_registration["refused"] == 1
+        identity = app.state.agents.get_buzz_identity("barsik")
+        assert identity["enabled"] is True
+        assert identity["status"] == "dependency_refused"
+        assert app.state.agents.get_buzz_signing_material("barsik") is None

--- a/tests/test_buzz_api.py
+++ b/tests/test_buzz_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -18,7 +19,7 @@ from pinky_daemon.broker import BrokerMessage
 from pinky_outreach.types import Message, Platform
 
 PRIVATE_KEY = "11" * 32
-RECEIPT = "telegram:6770805286:15921|buzz-tos-and-18-plus-approved"
+OTHER_PRIVATE_KEY = "22" * 32
 CHANNEL = "00000000-0000-4000-8000-000000000001"
 
 
@@ -33,7 +34,6 @@ def _body(**overrides):
         "private_key": PRIVATE_KEY,
         "relay_url": "wss://example.communities.buzz.xyz",
         "community_id": "example",
-        "tos_receipt": RECEIPT,
         "enabled": True,
     }
     body.update(overrides)
@@ -56,18 +56,11 @@ def _register_and_bind(client: TestClient):
     return bound
 
 
-def test_owner_bind_is_one_step_server_derived_and_redacted(tmp_path):
+def test_owner_bind_generates_identity_scoped_authority_and_redacts_it(tmp_path):
     app = _app(tmp_path)
     with TestClient(app) as client:
         client.post("/agents", json={"name": "barsik", "model": "sonnet"})
-        response = client.put(
-            "/system/buzz-identities/barsik",
-            json=_body(
-                tos_approved_by="agent:forged",
-                tos_approved_at=1,
-                tos_approval_ref="forged",
-            ),
-        )
+        response = client.put("/system/buzz-identities/barsik", json=_body())
 
         assert response.status_code == 200, response.text
         identity = response.json()
@@ -79,21 +72,122 @@ def test_owner_bind_is_one_step_server_derived_and_redacted(tmp_path):
             r"owner-control:[0-9a-f]{32}:sha256:[0-9a-f]{64}",
             identity["tos_approval_ref"],
         )
-        assert identity["tos_approval_ref"].endswith(hashlib.sha256(RECEIPT.encode()).hexdigest())
         assert PRIVATE_KEY not in response.text
-        assert RECEIPT not in response.text
         assert "ciphertext" not in identity
         assert "nonce" not in identity
 
+        receipt = app.state.agents._db.execute(
+            "SELECT tos_receipt FROM buzz_identities WHERE agent='barsik'"
+        ).fetchone()[0]
+        assert json.loads(receipt) == {
+            "action": "buzz.identity.bind",
+            "agent": "barsik",
+            "community_id": "example",
+            "policy": "buzz-tos-and-18-plus",
+            "policy_version": 1,
+            "pubkey": identity["pubkey"],
+            "relay_url": "wss://example.communities.buzz.xyz",
+        }
+        assert identity["tos_approval_ref"].endswith(hashlib.sha256(receipt.encode()).hexdigest())
+
         listed = client.get("/system/buzz-identities").text
         assert PRIVATE_KEY not in listed
-        assert RECEIPT not in listed
+        assert receipt not in listed
 
     agents_db = tmp_path / "conversations_agents.db"
     audit_db = tmp_path / "conversations_audit.db"
     assert PRIVATE_KEY.encode() not in agents_db.read_bytes()
     assert PRIVATE_KEY.encode() not in audit_db.read_bytes()
-    assert RECEIPT.encode() not in audit_db.read_bytes()
+    assert receipt.encode() not in audit_db.read_bytes()
+
+
+def test_arbitrary_or_caller_supplied_authority_cannot_enable(tmp_path):
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+        schema = client.get("/openapi.json").json()["components"]["schemas"][
+            "BindBuzzIdentityRequest"
+        ]
+        assert set(schema["properties"]) == {
+            "private_key",
+            "relay_url",
+            "community_id",
+            "enabled",
+        }
+        assert schema["additionalProperties"] is False
+        response = client.put(
+            "/system/buzz-identities/barsik",
+            json=_body(
+                tos_receipt="THIS IS ARBITRARY CALLER TEXT, NOT A RESOLVED APPROVAL RECORD",
+                tos_approved_by="agent:forged",
+                tos_approved_at=1,
+                tos_approval_ref="forged",
+            ),
+        )
+
+        assert response.status_code == 422
+        assert app.state.agents.get_buzz_identity("barsik") is None
+        assert PRIVATE_KEY not in response.text
+
+
+def test_one_approval_cannot_enable_a_second_identity(tmp_path):
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        for name in ("barsik", "murzik"):
+            response = client.post("/agents", json={"name": name, "model": "sonnet"})
+            assert response.status_code == 200
+        first = client.put("/system/buzz-identities/barsik", json=_body())
+        assert first.status_code == 200
+        first_state = first.json()
+        first_receipt = app.state.agents._db.execute(
+            "SELECT tos_receipt FROM buzz_identities WHERE agent='barsik'"
+        ).fetchone()[0]
+
+        replay = client.put(
+            "/system/buzz-identities/murzik",
+            json=_body(
+                private_key=OTHER_PRIVATE_KEY,
+                tos_receipt=first_receipt,
+                tos_approved_by=first_state["tos_approved_by"],
+                tos_approved_at=first_state["tos_approved_at"],
+                tos_approval_ref=first_state["tos_approval_ref"],
+            ),
+        )
+        assert replay.status_code == 422
+        assert app.state.agents.get_buzz_identity("murzik") is None
+
+        second = client.put(
+            "/system/buzz-identities/murzik",
+            json=_body(private_key=OTHER_PRIVATE_KEY),
+        )
+        assert second.status_code == 200
+        second_state = second.json()
+        second_receipt = app.state.agents._db.execute(
+            "SELECT tos_receipt FROM buzz_identities WHERE agent='murzik'"
+        ).fetchone()[0]
+        assert second_state["tos_approval_ref"] != first_state["tos_approval_ref"]
+        assert second_receipt != first_receipt
+        assert json.loads(second_receipt)["agent"] == "murzik"
+        assert json.loads(second_receipt)["pubkey"] == second_state["pubkey"]
+
+
+def test_rebind_preserves_immutable_server_authority(tmp_path):
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        first = _register_and_bind(client).json()
+        before = app.state.agents._db.execute(
+            "SELECT tos_receipt, tos_approved_by, tos_approved_at, tos_approval_ref "
+            "FROM buzz_identities WHERE agent='barsik'"
+        ).fetchone()
+
+        rebound = client.put("/system/buzz-identities/barsik", json=_body())
+        assert rebound.status_code == 200
+        after = app.state.agents._db.execute(
+            "SELECT tos_receipt, tos_approved_by, tos_approved_at, tos_approval_ref "
+            "FROM buzz_identities WHERE agent='barsik'"
+        ).fetchone()
+        assert after == before
+        assert rebound.json()["tos_approval_ref"] == first["tos_approval_ref"]
 
 
 def test_valid_internal_agent_auth_cannot_write_tos_authority(tmp_path):
@@ -220,17 +314,13 @@ def test_startup_refuses_enabled_identity_when_buzz_dependency_is_missing(tmp_pa
         buzz_device_key_path=str(tmp_path / "identity" / ".device_key"),
     )
     registry.register("barsik", model="sonnet", working_dir=str(tmp_path / "barsik"))
-    digest = hashlib.sha256(RECEIPT.encode()).hexdigest()
     registry.bind_buzz_identity_owner_control(
         "barsik",
         private_key=PRIVATE_KEY,
         relay_url="wss://example.communities.buzz.xyz",
         community_id="example",
         enabled=True,
-        tos_receipt=RECEIPT,
-        tos_approved_by="ui:admin",
-        tos_approved_at=1234.5,
-        tos_approval_ref=f"owner-control:{'a' * 32}:sha256:{digest}",
+        owner_actor="ui:admin",
     )
     registry.close()
     monkeypatch.setattr(

--- a/tests/test_buzz_identity.py
+++ b/tests/test_buzz_identity.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-import hashlib
+import json
 import sqlite3
 
 import pytest
 
 from pinky_daemon.agent_registry import AgentRegistry
 from pinky_daemon.buzz_identity import (
+    BUZZ_TOS_POLICY,
+    BUZZ_TOS_POLICY_VERSION,
     BuzzIdentityUnhealthyError,
     BuzzKeyEnvelope,
     unwrap_buzz_private_key,
@@ -18,12 +20,6 @@ from pinky_identity.keystore import DeviceKey
 
 PRIVATE_KEY = "11" * 32
 OTHER_PRIVATE_KEY = "22" * 32
-TOS_RECEIPT = "telegram:6770805286:15921|buzz-tos-and-18-plus-approved"
-
-
-def _approval_ref(receipt: str = TOS_RECEIPT) -> str:
-    digest = hashlib.sha256(receipt.encode()).hexdigest()
-    return f"owner-control:{'a' * 32}:sha256:{digest}"
 
 
 @pytest.fixture
@@ -43,10 +39,7 @@ def _bind(registry: AgentRegistry, **overrides) -> dict:
         "relay_url": "wss://example.communities.buzz.xyz",
         "community_id": "example",
         "enabled": True,
-        "tos_receipt": TOS_RECEIPT,
-        "tos_approved_by": "ui:admin",
-        "tos_approved_at": 1234.5,
-        "tos_approval_ref": _approval_ref(),
+        "owner_actor": "ui:admin",
     }
     values.update(overrides)
     return registry.bind_buzz_identity_owner_control("barsik", **values)
@@ -65,14 +58,30 @@ def test_private_key_is_encrypted_and_absent_from_public_surfaces(registry, tmp_
     columns = {row[1] for row in registry._db.execute("PRAGMA table_info(buzz_identities)")}
     assert "private_key" not in columns
     assert "secret_key" not in columns
+    unique_indexes = {
+        row[1] for row in registry._db.execute("PRAGMA index_list(buzz_identities)") if row[2]
+    }
+    assert "idx_buzz_identities_pubkey" in unique_indexes
+    assert "idx_buzz_identities_approval_ref" in unique_indexes
+    assert "idx_buzz_identities_tos_receipt" in unique_indexes
     assert public["tos_approved"] is True
 
     row = registry._db.execute(
-        "SELECT nonce, ciphertext FROM buzz_identities WHERE agent='barsik'"
+        "SELECT nonce, ciphertext, tos_receipt FROM buzz_identities WHERE agent='barsik'"
     ).fetchone()
     assert len(row[0]) == 24
     assert len(row[1]) == 48
     assert row[1] != bytes.fromhex(PRIVATE_KEY)
+    receipt = json.loads(row[2])
+    assert receipt == {
+        "action": "buzz.identity.bind",
+        "agent": "barsik",
+        "community_id": "example",
+        "policy": BUZZ_TOS_POLICY,
+        "policy_version": BUZZ_TOS_POLICY_VERSION,
+        "pubkey": public["pubkey"],
+        "relay_url": "wss://example.communities.buzz.xyz",
+    }
 
     material = registry.get_buzz_signing_material("barsik")
     assert material.private_key == bytes.fromhex(PRIVATE_KEY)
@@ -151,21 +160,29 @@ def test_wrong_device_kek_disables_identity(registry, tmp_path):
         other.close()
 
 
-def test_enable_refuses_missing_tos_authority(registry):
-    with pytest.raises(ValueError, match="ToS receipt"):
-        _bind(registry, tos_receipt="", tos_approval_ref=_approval_ref(""))
+def test_enable_refuses_untrusted_owner_actor(registry):
+    with pytest.raises(ValueError, match="owner approval actor"):
+        _bind(registry, owner_actor="agent:forged")
     assert registry.get_buzz_identity("barsik") is None
 
 
-def test_tos_receipt_is_immutable_without_explicit_rotation(registry):
+def test_server_generated_tos_receipt_is_immutable_without_explicit_rotation(registry):
     original = _bind(registry)
-    replacement = "a different owner receipt"
+    stored_receipt = registry._db.execute(
+        "SELECT tos_receipt FROM buzz_identities WHERE agent='barsik'"
+    ).fetchone()[0]
+    rebound = _bind(registry, owner_actor="ui:different-owner")
+    assert rebound["tos_approval_ref"] == original["tos_approval_ref"]
+    assert rebound["tos_approved_by"] == original["tos_approved_by"]
+    assert (
+        registry._db.execute(
+            "SELECT tos_receipt FROM buzz_identities WHERE agent='barsik'"
+        ).fetchone()[0]
+        == stored_receipt
+    )
+
     with pytest.raises(ValueError, match="rotation"):
-        _bind(
-            registry,
-            tos_receipt=replacement,
-            tos_approval_ref=_approval_ref(replacement),
-        )
+        _bind(registry, community_id="different")
     assert registry.get_buzz_identity("barsik")["tos_approval_ref"] == original["tos_approval_ref"]
 
 
@@ -173,6 +190,56 @@ def test_identity_rotation_is_not_implicit(registry):
     _bind(registry)
     with pytest.raises(ValueError, match="rotation"):
         _bind(registry, private_key=OTHER_PRIVATE_KEY)
+
+
+def test_one_approval_reference_cannot_be_reused_for_a_second_identity(registry, tmp_path):
+    _bind(registry)
+    registry.register("murzik", model="sonnet", working_dir=str(tmp_path / "murzik"))
+    source = registry._db.execute(
+        "SELECT tos_receipt, tos_approved_by, tos_approved_at, tos_approval_ref "
+        "FROM buzz_identities WHERE agent='barsik'"
+    ).fetchone()
+
+    with pytest.raises(sqlite3.IntegrityError):
+        registry._db.execute(
+            """INSERT INTO buzz_identities (
+                   agent, pubkey, wrap_version, nonce, ciphertext, relay_url,
+                   community_id, enabled, status, last_error, tos_receipt,
+                   tos_approved_by, tos_approved_at, tos_approval_ref,
+                   created_at, updated_at
+               ) VALUES (?, ?, 1, X'00', X'00', ?, ?, 1, 'active', '',
+                         ?, ?, ?, ?, 1, 1)""",
+            (
+                "murzik",
+                "f" * 64,
+                "wss://example.communities.buzz.xyz",
+                "example",
+                *source,
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [
+        ("tos_receipt", "arbitrary caller text"),
+        ("tos_approved_by", "agent:forged"),
+        ("tos_approval_ref", "owner-control:" + "b" * 32 + ":sha256:" + "c" * 64),
+    ],
+)
+def test_tampered_owner_authority_disables_identity(registry, column, value):
+    _bind(registry)
+    registry._db.execute(
+        f"UPDATE buzz_identities SET {column}=? WHERE agent='barsik'",
+        (value,),
+    )
+    registry._db.commit()
+
+    with pytest.raises(BuzzIdentityUnhealthyError):
+        registry.get_buzz_signing_material("barsik")
+    state = registry.get_buzz_identity("barsik")
+    assert state["enabled"] is False
+    assert state["status"] == "unhealthy"
 
 
 def test_legacy_buzz_table_gets_all_forward_columns(tmp_path):

--- a/tests/test_buzz_identity.py
+++ b/tests/test_buzz_identity.py
@@ -1,0 +1,207 @@
+"""Security and migration tests for encrypted Buzz identities."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+
+import pytest
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.buzz_identity import (
+    BuzzIdentityUnhealthyError,
+    BuzzKeyEnvelope,
+    unwrap_buzz_private_key,
+    wrap_buzz_private_key,
+)
+from pinky_identity.keystore import DeviceKey
+
+PRIVATE_KEY = "11" * 32
+OTHER_PRIVATE_KEY = "22" * 32
+TOS_RECEIPT = "telegram:6770805286:15921|buzz-tos-and-18-plus-approved"
+
+
+def _approval_ref(receipt: str = TOS_RECEIPT) -> str:
+    digest = hashlib.sha256(receipt.encode()).hexdigest()
+    return f"owner-control:{'a' * 32}:sha256:{digest}"
+
+
+@pytest.fixture
+def registry(tmp_path):
+    result = AgentRegistry(
+        str(tmp_path / "agents.db"),
+        buzz_device_key_path=str(tmp_path / "identity" / ".device_key"),
+    )
+    result.register("barsik", model="sonnet", working_dir=str(tmp_path / "barsik"))
+    yield result
+    result.close()
+
+
+def _bind(registry: AgentRegistry, **overrides) -> dict:
+    values = {
+        "private_key": PRIVATE_KEY,
+        "relay_url": "wss://example.communities.buzz.xyz",
+        "community_id": "example",
+        "enabled": True,
+        "tos_receipt": TOS_RECEIPT,
+        "tos_approved_by": "ui:admin",
+        "tos_approved_at": 1234.5,
+        "tos_approval_ref": _approval_ref(),
+    }
+    values.update(overrides)
+    return registry.bind_buzz_identity_owner_control("barsik", **values)
+
+
+def test_private_key_is_encrypted_and_absent_from_public_surfaces(registry, tmp_path):
+    public = _bind(registry)
+    raw_db = (tmp_path / "agents.db").read_bytes()
+
+    assert PRIVATE_KEY.encode() not in raw_db
+    assert b"nsec1" not in raw_db
+    assert "private_key" not in public
+    assert "nonce" not in public
+    assert "ciphertext" not in public
+    assert "tos_receipt" not in public
+    columns = {row[1] for row in registry._db.execute("PRAGMA table_info(buzz_identities)")}
+    assert "private_key" not in columns
+    assert "secret_key" not in columns
+    assert public["tos_approved"] is True
+
+    row = registry._db.execute(
+        "SELECT nonce, ciphertext FROM buzz_identities WHERE agent='barsik'"
+    ).fetchone()
+    assert len(row[0]) == 24
+    assert len(row[1]) == 48
+    assert row[1] != bytes.fromhex(PRIVATE_KEY)
+
+    material = registry.get_buzz_signing_material("barsik")
+    assert material.private_key == bytes.fromhex(PRIVATE_KEY)
+    assert PRIVATE_KEY not in repr(material)
+
+
+@pytest.mark.parametrize("column", ["nonce", "ciphertext", "pubkey"])
+def test_tampered_envelope_or_pubkey_disables_identity(registry, column):
+    _bind(registry)
+    if column == "pubkey":
+        value = "f" * 64
+    else:
+        original = registry._db.execute(
+            f"SELECT {column} FROM buzz_identities WHERE agent='barsik'"
+        ).fetchone()[0]
+        tampered = bytearray(original)
+        tampered[0] ^= 1
+        value = bytes(tampered)
+    registry._db.execute(f"UPDATE buzz_identities SET {column}=? WHERE agent='barsik'", (value,))
+    registry._db.commit()
+
+    with pytest.raises(BuzzIdentityUnhealthyError):
+        registry.get_buzz_signing_material("barsik")
+
+    state = registry.get_buzz_identity("barsik")
+    assert state["enabled"] is False
+    assert state["status"] == "unhealthy"
+
+
+def test_malformed_blob_type_also_disables_identity(registry):
+    _bind(registry)
+    registry._db.execute("UPDATE buzz_identities SET ciphertext='not-a-blob' WHERE agent='barsik'")
+    registry._db.commit()
+
+    with pytest.raises(BuzzIdentityUnhealthyError):
+        registry.get_buzz_signing_material("barsik")
+    assert registry.get_buzz_identity("barsik")["status"] == "unhealthy"
+
+
+def test_aad_is_bound_to_agent_and_pubkey():
+    key = DeviceKey.from_bytes(b"k" * 32)
+    wrapped = wrap_buzz_private_key(PRIVATE_KEY, agent="barsik", device_key=key)
+    foreign_agent = BuzzKeyEnvelope(
+        agent="murzik",
+        pubkey=wrapped.pubkey,
+        wrap_version=wrapped.wrap_version,
+        nonce=wrapped.nonce,
+        ciphertext=wrapped.ciphertext,
+    )
+    foreign_pubkey = BuzzKeyEnvelope(
+        agent=wrapped.agent,
+        pubkey="f" * 64,
+        wrap_version=wrapped.wrap_version,
+        nonce=wrapped.nonce,
+        ciphertext=wrapped.ciphertext,
+    )
+
+    with pytest.raises(BuzzIdentityUnhealthyError):
+        unwrap_buzz_private_key(foreign_agent, device_key=key)
+    with pytest.raises(BuzzIdentityUnhealthyError):
+        unwrap_buzz_private_key(foreign_pubkey, device_key=key)
+
+
+def test_wrong_device_kek_disables_identity(registry, tmp_path):
+    _bind(registry)
+    registry.close()
+    other = AgentRegistry(
+        str(tmp_path / "agents.db"),
+        buzz_device_key_path=str(tmp_path / "other-identity" / ".device_key"),
+    )
+    try:
+        with pytest.raises(BuzzIdentityUnhealthyError):
+            other.get_buzz_signing_material("barsik")
+        assert other.get_buzz_identity("barsik")["status"] == "unhealthy"
+    finally:
+        other.close()
+
+
+def test_enable_refuses_missing_tos_authority(registry):
+    with pytest.raises(ValueError, match="ToS receipt"):
+        _bind(registry, tos_receipt="", tos_approval_ref=_approval_ref(""))
+    assert registry.get_buzz_identity("barsik") is None
+
+
+def test_tos_receipt_is_immutable_without_explicit_rotation(registry):
+    original = _bind(registry)
+    replacement = "a different owner receipt"
+    with pytest.raises(ValueError, match="rotation"):
+        _bind(
+            registry,
+            tos_receipt=replacement,
+            tos_approval_ref=_approval_ref(replacement),
+        )
+    assert registry.get_buzz_identity("barsik")["tos_approval_ref"] == original["tos_approval_ref"]
+
+
+def test_identity_rotation_is_not_implicit(registry):
+    _bind(registry)
+    with pytest.raises(ValueError, match="rotation"):
+        _bind(registry, private_key=OTHER_PRIVATE_KEY)
+
+
+def test_legacy_buzz_table_gets_all_forward_columns(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    with sqlite3.connect(db_path) as db:
+        db.execute("CREATE TABLE buzz_identities (agent TEXT PRIMARY KEY)")
+    registry = AgentRegistry(
+        str(db_path),
+        buzz_device_key_path=str(tmp_path / "identity" / ".device_key"),
+    )
+    try:
+        columns = {row[1] for row in registry._db.execute("PRAGMA table_info(buzz_identities)")}
+        assert {
+            "agent",
+            "pubkey",
+            "wrap_version",
+            "nonce",
+            "ciphertext",
+            "relay_url",
+            "community_id",
+            "enabled",
+            "status",
+            "last_error",
+            "tos_receipt",
+            "tos_approved_by",
+            "tos_approved_at",
+            "tos_approval_ref",
+            "created_at",
+            "updated_at",
+        } <= columns
+    finally:
+        registry.close()

--- a/tests/test_buzz_outbound.py
+++ b/tests/test_buzz_outbound.py
@@ -1,0 +1,174 @@
+"""Wire-shape and content-safety tests for the native Buzz sender."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+
+import httpx
+import pytest
+
+from pinky_outreach.buzz import BuzzAdapter, BuzzProtocolError, verify_nostr_event
+
+PRIVATE_KEY = bytes.fromhex("11" * 32)
+OTHER_PRIVATE_KEY = bytes.fromhex("22" * 32)
+CHANNEL = "00000000-0000-4000-8000-000000000001"
+
+
+def _capturing_adapter(*, query_events=None):
+    captured: list[dict] = []
+    query_events = list(query_events or [])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        captured.append({"path": request.url.path, "body": body, "headers": request.headers})
+        if request.url.path == "/query":
+            return httpx.Response(200, json=query_events)
+        return httpx.Response(200, json={"accepted": True})
+
+    adapter = BuzzAdapter(
+        PRIVATE_KEY,
+        relay_url="wss://example.communities.buzz.xyz",
+        community_id="example",
+        transport=httpx.MockTransport(handler),
+    )
+    return adapter, captured
+
+
+def _signed_parent(*, kind: int, content: str = "parent") -> dict:
+    adapter = BuzzAdapter(
+        OTHER_PRIVATE_KEY,
+        relay_url="wss://example.communities.buzz.xyz",
+        community_id="example",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json={})),
+    )
+    return adapter._signer.sign_event(
+        kind=kind,
+        tags=[["h", CHANNEL]],
+        content=content,
+        created_at=1_700_000_000,
+    )
+
+
+def _posted_event(captured: list[dict]) -> dict:
+    return next(item["body"] for item in captured if item["path"] == "/events")
+
+
+def test_send_uses_cli_compatible_kind9_h_tag_and_nip98():
+    adapter, captured = _capturing_adapter()
+    result = adapter.send_message(CHANNEL, "hello")
+
+    request = captured[0]
+    event = request["body"]
+    assert request["path"] == "/events"
+    assert event["kind"] == 9
+    assert event["tags"] == [["h", CHANNEL]]
+    assert event["content"] == "hello"
+    assert verify_nostr_event(event)
+    assert result.message_id == event["id"]
+
+    scheme, token = request["headers"]["authorization"].split(" ", 1)
+    auth = json.loads(base64.b64decode(token))
+    assert scheme == "Nostr"
+    assert auth["kind"] == 27235
+    assert verify_nostr_event(auth)
+    assert [tag[0] for tag in auth["tags"]] == ["u", "method", "nonce", "payload"]
+    payload_tag = next(tag[1] for tag in auth["tags"] if tag[0] == "payload")
+    canonical_body = json.dumps(event, separators=(",", ":"), ensure_ascii=False).encode()
+    assert payload_tag == hashlib.sha256(canonical_body).hexdigest()
+
+
+def test_thread_uses_four_field_reply_marker_after_parent_verification():
+    parent = _signed_parent(kind=9)
+    adapter, captured = _capturing_adapter(query_events=[parent])
+    adapter.send_message(CHANNEL, "thread reply", reply_to=parent["id"])
+
+    assert captured[0]["path"] == "/query"
+    event = _posted_event(captured)
+    assert event["tags"] == [
+        ["h", CHANNEL],
+        ["e", parent["id"], "", "reply"],
+    ]
+    assert verify_nostr_event(event)
+
+
+def test_ephemeral_reply_uses_verified_stored_reference_only_and_no_e_tag():
+    parent = _signed_parent(kind=20002, content="RAW EPHEMERAL @secret MUST NOT PERSIST")
+    adapter, captured = _capturing_adapter()
+    metadata = {
+        "buzz_verified_event": {
+            "verified": True,
+            "event_id": parent["id"],
+            "kind": 20002,
+            "author_pubkey": parent["pubkey"],
+            "channel_id": CHANNEL,
+            # Deliberately ignored even if a future context carries it.
+            "content": parent["content"],
+        }
+    }
+    adapter.send_message(
+        CHANNEL,
+        "answer @owner",
+        reply_to=parent["id"],
+        reply_metadata=metadata,
+    )
+
+    assert [item["path"] for item in captured] == ["/events"]
+    event = _posted_event(captured)
+    assert event["tags"] == [["h", CHANNEL]]
+    assert "RAW EPHEMERAL" not in event["content"]
+    assert parent["id"][:16] in event["content"]
+    assert f"buzz:example:{parent['pubkey']}" in event["content"]
+    assert "＠owner" in event["content"]
+    assert "\n" in event["content"]
+    assert verify_nostr_event(event)
+
+
+def test_ephemeral_reply_without_stored_metadata_refuses_before_publish():
+    parent = _signed_parent(kind=20002, content="do not retain")
+    adapter, captured = _capturing_adapter(query_events=[parent])
+    with pytest.raises(BuzzProtocolError, match="verified stored metadata"):
+        adapter.send_message(CHANNEL, "reply", reply_to=parent["id"])
+    assert [item["path"] for item in captured] == ["/query"]
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("@alice start", "＠alice start"),
+        ("middle @alice token", "middle ＠alice token"),
+        ("@alice and @bob", "＠alice and ＠bob"),
+        ("mail alice@example.com", "mail alice＠example.com"),
+        ("inline `@code`", "inline `＠code`"),
+        ("fenced ```\n@code\n```", "fenced ```\n＠code\n```"),
+        ("Unicode @Мария and ＠kept", "Unicode ＠Мария and ＠kept"),
+    ],
+)
+def test_normalization_is_applied_to_final_signed_wire_content(source, expected, capsys):
+    adapter, captured = _capturing_adapter()
+    result = adapter.send_message(CHANNEL, source)
+
+    event = _posted_event(captured)
+    assert event["content"] == expected
+    assert re.search(r"@(?=\w)", event["content"], flags=re.UNICODE) is None
+    assert verify_nostr_event(event)
+    assert result.metadata["mention_normalized"] is True
+    logs = capsys.readouterr().err
+    assert "rule=ascii-at-word-to-fullwidth" in logs
+    assert source not in logs
+    assert expected not in logs
+
+
+def test_reaction_uses_kind7_e_tag():
+    adapter, captured = _capturing_adapter()
+    target = "33" * 32
+    result = adapter.add_reaction(CHANNEL, target, "👍")
+
+    event = _posted_event(captured)
+    assert event["kind"] == 7
+    assert event["tags"] == [["e", target]]
+    assert event["content"] == "👍"
+    assert verify_nostr_event(event)
+    assert result.reply_to == target

--- a/tests/test_buzz_runtime.py
+++ b/tests/test_buzz_runtime.py
@@ -1,0 +1,78 @@
+"""Boot dependency refusal tests for Buzz platform registration."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pinky_daemon.buzz_runtime import register_buzz_outbound_platforms
+from pinky_outreach.buzz_dependency import missing_buzz_dependencies
+
+
+class _Registry:
+    def __init__(self):
+        self.refused = []
+        self.ready = []
+
+    def list_buzz_identities(self, *, enabled_only=False):
+        assert enabled_only is True
+        return [{"agent": "barsik"}]
+
+    def mark_buzz_dependency_refused(self, agent, reason):
+        self.refused.append((agent, reason))
+
+    def mark_buzz_dependency_ready(self, agent):
+        self.ready.append(agent)
+
+
+def test_dependency_probe_detects_present_but_unloadable_native_module(monkeypatch):
+    def fake_import(name):
+        if name == "coincurve":
+            raise OSError("native extension could not load")
+        return object()
+
+    monkeypatch.setattr("pinky_outreach.buzz_dependency.importlib.import_module", fake_import)
+
+    assert missing_buzz_dependencies() == ("coincurve",)
+
+
+@pytest.mark.asyncio
+async def test_missing_dependency_refuses_registration_and_notifies_owner(monkeypatch):
+    registry = _Registry()
+    notify = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "pinky_daemon.buzz_runtime.missing_buzz_dependencies",
+        lambda: ("coincurve",),
+    )
+
+    result = await register_buzz_outbound_platforms(registry, notify)
+
+    assert result == {
+        "registered": 0,
+        "refused": 1,
+        "missing_dependencies": ["coincurve"],
+    }
+    assert registry.refused == [("barsik", "missing:coincurve")]
+    assert registry.ready == []
+    notify.assert_awaited_once()
+    assert "REFUSED" in notify.await_args.args[1]
+    assert "coincurve" in notify.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_healed_dependencies_restore_registration(monkeypatch):
+    registry = _Registry()
+    notify = AsyncMock()
+    monkeypatch.setattr(
+        "pinky_daemon.buzz_runtime.missing_buzz_dependencies",
+        lambda: (),
+    )
+
+    result = await register_buzz_outbound_platforms(registry, notify)
+
+    assert result["registered"] == 1
+    assert result["refused"] == 0
+    assert registry.ready == ["barsik"]
+    assert registry.refused == []
+    notify.assert_not_awaited()

--- a/tests/test_packaging_dependencies.py
+++ b/tests/test_packaging_dependencies.py
@@ -17,5 +17,16 @@ def test_slack_socket_mode_dependencies_are_in_base_install() -> None:
     assert project["optional-dependencies"]["slack"] == []
 
 
+def test_buzz_dependencies_are_in_base_install() -> None:
+    project = _project()
+
+    assert "coincurve>=21.0" in project["dependencies"]
+    assert "httpx>=0.28" in project["dependencies"]
+    assert "websockets>=15.0" in project["dependencies"]
+    assert "pynacl>=1.5" in project["dependencies"]
+    assert project["optional-dependencies"]["buzz"] == []
+    assert "buzz" in project["optional-dependencies"]["all"][0]
+
+
 def test_claude_agent_sdk_excludes_allowed_tools_injection_versions() -> None:
     assert "claude-agent-sdk>=0.2.129,<0.3" in _project()["dependencies"]

--- a/uv.lock
+++ b/uv.lock
@@ -549,6 +549,44 @@ wheels = [
 ]
 
 [[package]]
+name = "coincurve"
+version = "21.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/a2/f2a38eb05b747ed3e54e1be33be339d4a14c1f5cc6a6e2b342b5e8160d51/coincurve-21.0.0.tar.gz", hash = "sha256:8b37ce4265a82bebf0e796e21a769e56fdbf8420411ccbe3fafee4ed75b6a6e5", size = 128986, upload-time = "2025-03-08T15:31:24.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/5a/9aaa096d830b5d1386335759e73038a5352f8cd670efed55d242f92d0bce/coincurve-21.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:65ec42cab9c60d587fb6275c71f0ebc580625c377a894c4818fb2a2b583a184b", size = 1390936, upload-time = "2025-03-08T15:30:14.716Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e4/37dd30ed171432e32c075a03237915c0e69a5a524a807f380d910b276a2a/coincurve-21.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5828cd08eab928db899238874d1aab12fa1236f30fe095a3b7e26a5fc81df0a3", size = 1384762, upload-time = "2025-03-08T15:30:16.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/fd/78870f4babed4981feb9b97b3189aec0f01a1a24be8a1ac04807dc68aa0d/coincurve-21.0.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54de1cac75182de9f71ce41415faafcaf788303e21cbd0188064e268d61625e5", size = 1597025, upload-time = "2025-03-08T15:30:18.566Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/fb/b4850f8afc941655ef4c1204b50f9e21f841c6a64aa83a559277ca305cbd/coincurve-21.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07cda058d9394bea30d57a92fdc18ee3ca6b5bc8ef776a479a2ffec917105836", size = 1603987, upload-time = "2025-03-08T15:30:20.65Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/b7/df41dbcec3f70e383fa024949ce8956ff3b2a1b9eac330fba18c2115eece/coincurve-21.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9070804d7c71badfe4f0bf19b728cfe7c70c12e733938ead6b1db37920b745c0", size = 1604762, upload-time = "2025-03-08T15:30:22.271Z" },
+    { url = "https://files.pythonhosted.org/packages/70/84/1b2437fc22590073eefb3da0418648b2d5b768951ef851822be8c164b998/coincurve-21.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:669ab5db393637824b226de058bb7ea0cb9a0236e1842d7b22f74d4a8a1f1ff1", size = 1637469, upload-time = "2025-03-08T15:30:24.305Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/4b/893763b3964b3044071a450fdada4c5024dc16f7644258a7bd06cf41e2ba/coincurve-21.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3bcd538af097b3914ec3cb654262e72e224f95f2e9c1eb7fbd75d843ae4e528e", size = 1601177, upload-time = "2025-03-08T15:30:25.805Z" },
+    { url = "https://files.pythonhosted.org/packages/77/45/d2f42159cb461f5b070ff848244f1b83f3ea9ec3a3435368f9be33e4e276/coincurve-21.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45b6a5e6b5536e1f46f729829d99ce1f8f847308d339e8880fe7fa1646935c10", size = 1635597, upload-time = "2025-03-08T15:30:28.113Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/7c/528cff0aa17acd6c64b10c4bd8bb0adb6c96420be4e170916150537f36f6/coincurve-21.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:87597cf30dfc05fa74218810776efacf8816813ab9fa6ea1490f94e9f8b15e77", size = 1328626, upload-time = "2025-03-08T15:30:29.757Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/91/845b00da05b132e7bb3f3d1c4c301c195b39a9dc8f9962295ff340a27f18/coincurve-21.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:b992d1b1dac85d7f542d9acbcf245667438839484d7f2b032fd032256bcd778e", size = 1325365, upload-time = "2025-03-08T15:30:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/61/a2d9e109f99b6f5e65e653ac998b0944c5b82c568ac142fcbb381a4803be/coincurve-21.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f60ad56113f08e8c540bb89f4f35f44d434311433195ffff22893ccfa335070c", size = 1391948, upload-time = "2025-03-08T15:30:32.899Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5a/2da75ee00a722ef1fa068ada3bc34c564595ead86fef573434e2f0cb0a5c/coincurve-21.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1cb1cd19fb0be22e68ecb60ad950b41f18b9b02eebeffaac9391dc31f74f08f2", size = 1384958, upload-time = "2025-03-08T15:30:34.705Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/50/6bf0bf7e8a9a9dd419ecc1e479dcb9fbfe657029276ad703806a25a2bef2/coincurve-21.0.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05d7e255a697b3475d7ae7640d3bdef3d5bc98ce9ce08dd387f780696606c33b", size = 1606576, upload-time = "2025-03-08T15:30:36.796Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ab/9e89908fdd09ad522938085587aaa821b022f4def16c286c5580cfc85811/coincurve-21.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a366c314df7217e3357bb8c7d2cda540b0bce180705f7a0ce2d1d9e28f62ad4", size = 1613642, upload-time = "2025-03-08T15:30:38.416Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/75/050b6fd08978de85a7b480f0f220ab6a30967c0910119f3096a8dd40befc/coincurve-21.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b04778b75339c6e46deb9ae3bcfc2250fbe48d1324153e4310fc4996e135715", size = 1616974, upload-time = "2025-03-08T15:30:39.939Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/62/2740ba0cafebf45708633635fecadcbe582d7a3ed1ce8b4637921feceaf8/coincurve-21.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8efcbdcd50cc219989a2662e6c6552f455efc000a15dd6ab3ebf4f9b187f41a3", size = 1644133, upload-time = "2025-03-08T15:30:41.733Z" },
+    { url = "https://files.pythonhosted.org/packages/94/14/1f27c3048c4084fa85ef65f42a4ca631f2b184336e6d9446fecec20e0a7f/coincurve-21.0.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6df44b4e3b7acdc1453ade52a52e3f8a5b53ecdd5a06bd200f1ec4b4e250f7d9", size = 1619918, upload-time = "2025-03-08T15:30:43.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/22/7ec3ec4c8e7764daa25767d6674cb5741ea2d9b39ff758e9918d22a4b49b/coincurve-21.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bcc0831f07cb75b91c35c13b1362e7b9dc76c376b27d01ff577bec52005e22a8", size = 1645797, upload-time = "2025-03-08T15:30:44.974Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/60/87982b7499943ab12605df7b14f6001fff331aca0881b260682461e2309d/coincurve-21.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:5dd7b66b83b143f3ad3861a68fc0279167a0bae44fe3931547400b7a200e90b1", size = 1329255, upload-time = "2025-03-08T15:30:46.4Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c0/65b60b371579570931daca8a3f67debfc1482908b8ed03432297274a27da/coincurve-21.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:78dbe439e8cb22389956a4f2f2312813b4bd0531a0b691d4f8e868c7b366555d", size = 1325973, upload-time = "2025-03-08T15:30:48.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/cce55adaec37a588eb24b67da8eb68926546458e12ed2c4c2a21deb93d4c/coincurve-21.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9df5ceb5de603b9caf270629996710cf5ed1d43346887bc3895a11258644b65b", size = 1391762, upload-time = "2025-03-08T15:30:49.586Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/7a/628a30281d246ce98aea56592e0c8e79b03a93ee8b85d688db3388130c2d/coincurve-21.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:154467858d23c48f9e5ab380433bc2625027b50617400e2984cc16f5799ab601", size = 1384921, upload-time = "2025-03-08T15:30:51.103Z" },
+    { url = "https://files.pythonhosted.org/packages/61/cc/719c5da31e6ba07e438abcf962f7a365eb69a06a0621ca4f2a484f344e09/coincurve-21.0.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f57f07c44d14d939bed289cdeaba4acb986bba9f729a796b6a341eab1661eedc", size = 1606559, upload-time = "2025-03-08T15:30:53.218Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ee/dd14237013d732e7fc3248c0c33a1d36b88b5378dfa3e624a50a23fb6f19/coincurve-21.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fb03e3a388a93d31ed56a442bdec7983ea404490e21e12af76fb1dbf097082a", size = 1613684, upload-time = "2025-03-08T15:30:55.087Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/05/eaa7f36a03376ced1c19e0cb563341cc83fe48f5734b2effe8f16d0ee0ab/coincurve-21.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d09ba4fd9d26b00b06645fcd768c5ad44832a1fa847ebe8fb44970d3204c3cb7", size = 1617001, upload-time = "2025-03-08T15:30:57.036Z" },
+    { url = "https://files.pythonhosted.org/packages/39/32/fc75f1dd914ac95eb2704425c7ca1a9f509f982e15d05e0ca895b9e6ea9c/coincurve-21.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1a1e7ee73bc1b3bcf14c7b0d1f44e6485785d3b53ef7b16173c36d3cefa57f93", size = 1643924, upload-time = "2025-03-08T15:30:58.737Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/4b/8c6e65b5755e26fc02077803879747615c1c327047328d1784bccb4ff4c3/coincurve-21.0.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ad05952b6edc593a874df61f1bc79db99d716ec48ba4302d699e14a419fe6f51", size = 1619964, upload-time = "2025-03-08T15:31:00.275Z" },
+    { url = "https://files.pythonhosted.org/packages/64/bc/d0a743305ff9fa26e72b4c77b534d5958ec8030b3772555a7172a0c134e5/coincurve-21.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d2bf350ced38b73db9efa1ff8fd16a67a1cb35abb2dda50d89661b531f03fd3", size = 1645526, upload-time = "2025-03-08T15:31:01.952Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/44/ab082e2dc8c9a45774f1bb9961f58b43c0882b866f5c469ead932d45a35d/coincurve-21.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:54d9500c56d5499375e579c3917472ffcf804c3584dd79052a79974280985c74", size = 1329285, upload-time = "2025-03-08T15:31:03.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/94/407f6fc811310f15b1fc7255f436f6a9040854213beeb10093f56b5b7fd3/coincurve-21.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:773917f075ec4b94a7a742637d303a3a082616a115c36568eb6c873a8d950d18", size = 1326027, upload-time = "2025-03-08T15:31:05.318Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2202,6 +2240,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "claude-agent-sdk" },
+    { name = "coincurve" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "http-message-signatures" },
@@ -2291,6 +2330,7 @@ requires-dist = [
     { name = "caldav", marker = "extra == 'calendar'", specifier = ">=1.3" },
     { name = "camoufox", marker = "extra == 'web'", specifier = ">=0.4" },
     { name = "claude-agent-sdk", specifier = ">=0.2.129,<0.3" },
+    { name = "coincurve", specifier = ">=21.0" },
     { name = "cryptography", specifier = ">=41.0" },
     { name = "cryptography", marker = "extra == 'calendar'", specifier = ">=41.0" },
     { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.3" },
@@ -2310,7 +2350,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.2" },
     { name = "openai", specifier = ">=2.30" },
     { name = "pillow", specifier = ">=10.0" },
-    { name = "pinky-ai", extras = ["telegram", "discord", "slack", "google", "calendar", "voice"], marker = "extra == 'all'" },
+    { name = "pinky-ai", extras = ["telegram", "discord", "slack", "buzz", "google", "calendar", "voice"], marker = "extra == 'all'" },
     { name = "pydantic", specifier = ">=2.12" },
     { name = "pynacl", specifier = ">=1.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0" },
@@ -2326,7 +2366,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.44" },
     { name = "websockets", specifier = ">=15.0" },
 ]
-provides-extras = ["acp", "telegram", "discord", "slack", "google", "calendar", "web", "voice", "local-embeddings", "all", "dev"]
+provides-extras = ["acp", "telegram", "discord", "slack", "buzz", "google", "calendar", "web", "voice", "local-embeddings", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Outcome

Adds the first native Buzz outbound increment while keeping the operator path to one owner-controlled bind. Bound agents can use the existing generic `send`, `thread`, and `react` surfaces; no agent-facing Buzz configuration surface or parallel messaging API is introduced.

Built from the FINAL v5 security spec at SHA-256 `33e86969d9189c6f113546e5d26b893feb419b83d4c1d9fbcc66d3ff3f54e21e`.

## What changed

- Adds `buzz_identities` to the agent registry with canonical unique x-only pubkeys, immutable owner-derived ToS authority provenance, and XChaCha20-Poly1305 private-key envelopes bound by AAD to agent + stored pubkey.
- Adds one owner-session-only bind operation plus redacted list/read/disable lifecycle routes. Internal agent HMAC cannot mint or modify the authority record.
- Adds a native Nostr/NIP-98 Buzz adapter integrated into generic `send`, `thread`, and `react` broker routes.
- Normalizes every parser-matching ASCII `@word` in the final composed payload before signing, with metadata-only rewrite logs.
- Implements the kind-20002 reference-only top-level reply fallback from verified stored metadata; raw ephemeral content is never read into the fallback.
- Makes Buzz signing/runtime dependencies base-install requirements and refuses registration with owner notification if an installed module cannot actually load.

## Relay compatibility burn-down

Read-only probes against the live Buzz rig confirmed:

- plain-client WebSocket NIP-42 authentication and a verified kind-9 subscription event;
- NIP-98 `POST /query` returning a BIP340-verified event through this native adapter;
- the existing CLI wire shapes for send/thread/react: kind 9 + `h`, four-field reply `e`, and kind 7 reaction `e`.

No live `/events` publication was performed.

## Validation

- Buzz-focused suite: `33 passed`
- Existing broker/messaging overlap: `25 passed`
- Registry/database-security/auth overlap: `215 passed`
- Environmental dream-runner failure rerun with intended SDK/shared-MCP overrides: `1 passed`
- Broad partial run before stopping the environment-driven slow block: `833 passed, 2 skipped`; its one failure was the same shell-forced tmux/shared-port case above
- Ruff, `git diff --check`, `uv lock --check`, `uv pip check`, source compile, sdist build, and wheel build passed

## Boundaries

This is outbound increment 1 only. Inbound-as-native-chat remains increment 2. No production identity was bound, no live channel event was posted, and this draft does not authorize merge or deploy.
