### PR TITLE
Add native Buzz inbound persona routing

### DIFF
--- a/specs/buzz-native-platform.md
+++ b/specs/buzz-native-platform.md
@@ -1,0 +1,75 @@
+# Native Buzz platform operations
+
+Buzz chat is a native PinkyBot platform. Each enabled identity owns an
+authenticated Nostr relay subscription, and verified channel messages enter
+the agent's normal persona session like Telegram or Slack messages. `pinky acp`
+remains a separate harness/debug surface; it is not the Buzz chat transport.
+
+## Bind once, then talk
+
+Use the authenticated owner-control UI/API to bind the encrypted identity and
+its inbound policy in one `PUT /system/buzz-identities/{agent}` operation:
+
+```json
+{
+  "private_key": "<32-byte identity key as 64 lowercase hex>",
+  "relay_url": "wss://example.communities.buzz.xyz",
+  "community_id": "example",
+  "enabled": true,
+  "inbound": {
+    "owner_pubkey": "<out-of-band verified 64-hex owner pubkey>",
+    "channels": [
+      {"channel_id": "00000000-0000-4000-8000-000000000001", "label": "#general"}
+    ],
+    "approved_users": []
+  }
+}
+```
+
+The daemon derives all authority metadata from the signed owner session,
+encrypts the identity key, starts the poller immediately, and restores it on
+daemon restart. Never put a real private key in shell history, logs, agent
+context, or this file.
+
+Both inbound gates are default-deny and load-bearing:
+
+- The community, relay, and exact channel UUID must match the stored identity
+  policy. Relay membership/JOIN events never add an allowed channel.
+- The BIP340-verified full author pubkey must be the configured owner or an
+  explicitly approved user in that same community. Profiles, display names,
+  npub text, and first-message claims are never authority.
+
+Ordinary channel broadcasts have no `p` tag and remain eligible after both
+gates. If a `p` tag exists, it must be exactly one canonical self-pubkey tag;
+foreign, malformed, or duplicate tags suppress delivery. Only that exact tag
+sets `mentioned_self`; rendered `@name` text never does. Inbound kind-20002
+events are ignored and are never routed, retained, or replayed.
+
+## Health and owner-key rotation
+
+Check `/broker/status` for a running poller and
+`/agents/{agent}/health` for `checks.buzz_inbound.status == "connected"`.
+The daemon uses periodic authenticated `REQ`/`EOSE` probes, reconnects after a
+measured dead subscription, and notifies the owner. It also notifies after 14
+days without a verified event from the configured owner pubkey.
+
+An owner-key rotation is always an explicit authenticated owner-control
+replacement through `PUT /system/buzz-identities/{agent}/inbound`. Verify the
+new full x-only pubkey out of band, then replace `owner_pubkey`; do not approve a
+rotation claimed in a Buzz message. The update restarts the native poller and
+preserves only still-authorized pending messages.
+
+## Bridge retirement during the release cutover
+
+Do not stop the legacy bridge before the release containing native inbound is
+running. During that release's operator-controlled deployment:
+
+1. Confirm the native poller is connected and a verified, approved kind-9 from
+   an allowlisted channel reaches the persona's main session.
+2. Unload `com.barsik.buzz-bridge` and remove its LaunchAgent only after the
+   native health check passes.
+3. Confirm the old bridge stays stopped and that a second verified message
+   produces exactly one persona delivery.
+
+Rollback is to reload the legacy bridge only after stopping/disabling the
+native identity, so the two chat consumers never run concurrently.

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2862,6 +2862,7 @@ except Exception as exc:
         community_id: str,
         enabled: bool,
         owner_actor: str,
+        _commit: bool = True,
     ) -> dict:
         """Bind one identity from the authenticated owner-control route only.
 
@@ -2993,7 +2994,8 @@ except Exception as exc:
                             now,
                         ),
                     )
-                self._db.commit()
+                if _commit:
+                    self._db.commit()
             except sqlite3.IntegrityError as exc:
                 self._db.rollback()
                 raise ValueError("Buzz identity conflicts with an existing binding") from exc
@@ -3104,6 +3106,7 @@ except Exception as exc:
         channels: list[dict],
         approved_users: list[dict],
         owner_actor: str,
+        _commit: bool = True,
     ) -> dict:
         """Atomically replace one identity-scoped, default-deny inbound policy."""
         from pinky_daemon.buzz_identity import validate_buzz_owner_actor
@@ -3249,7 +3252,8 @@ except Exception as exc:
                     "DELETE FROM buzz_inbound_events WHERE agent=? AND event_id=?",
                     revoked_pending,
                 )
-                self._db.commit()
+                if _commit:
+                    self._db.commit()
             except Exception:
                 self._db.rollback()
                 raise
@@ -3257,6 +3261,46 @@ except Exception as exc:
         if policy is None:  # pragma: no cover - defensive after successful transaction
             raise RuntimeError("Buzz inbound policy write did not persist")
         return policy
+
+    def bind_buzz_identity_with_inbound_owner_control(
+        self,
+        agent_name: str,
+        *,
+        private_key: str,
+        relay_url: str,
+        community_id: str,
+        enabled: bool,
+        owner_pubkey: str,
+        channels: list[dict],
+        approved_users: list[dict],
+        owner_actor: str,
+    ) -> tuple[dict, dict]:
+        """Atomically bind an identity and its complete inbound policy."""
+        with self._rmw_lock:
+            try:
+                self._db.execute("BEGIN IMMEDIATE")
+                identity = self.bind_buzz_identity_owner_control(
+                    agent_name,
+                    private_key=private_key,
+                    relay_url=relay_url,
+                    community_id=community_id,
+                    enabled=enabled,
+                    owner_actor=owner_actor,
+                    _commit=False,
+                )
+                policy = self.configure_buzz_inbound_owner_control(
+                    agent_name,
+                    owner_pubkey=owner_pubkey,
+                    channels=channels,
+                    approved_users=approved_users,
+                    owner_actor=owner_actor,
+                    _commit=False,
+                )
+                self._db.commit()
+            except Exception:
+                self._db.rollback()
+                raise
+        return identity, policy
 
     def get_buzz_inbound_policy(self, agent_name: str) -> dict | None:
         row = self._db.execute(

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -32,6 +32,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from uuid import UUID
 
 from pinky_daemon.cron_utils import _field_matches
 from pinky_daemon.effort import is_ultracode
@@ -45,6 +46,37 @@ from pinky_daemon.effort import is_ultracode
 # the same guarantee the API layer enforces, and so CodeQL's taint analysis
 # sees an explicit sanitizer at the source-of-path-construction.
 _AGENT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+_BUZZ_HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+BUZZ_OWNER_SILENCE_DAYS = 14
+BUZZ_INBOUND_CLAIM_LEASE_SECONDS = 5 * 60
+
+
+def _validate_buzz_pubkey(value: str, *, field_name: str = "pubkey") -> str:
+    pubkey = str(value or "")
+    if not _BUZZ_HEX_64_RE.fullmatch(pubkey):
+        raise ValueError(f"Buzz {field_name} must be exactly 64 lowercase hex characters")
+    return pubkey
+
+
+def _validate_buzz_channel_id(value: str) -> str:
+    try:
+        canonical = str(UUID(str(value)))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise ValueError("Buzz channel_id must be a UUID") from exc
+    if canonical != str(value):
+        raise ValueError("Buzz channel_id must be a canonical lowercase UUID")
+    return canonical
+
+
+def _validate_buzz_annotation(value: str, *, field_name: str, limit: int) -> str:
+    annotation = str(value or "").strip()
+    if len(annotation) > limit or any(
+        ord(ch) < 32 or ord(ch) == 127 for ch in annotation
+    ):
+        raise ValueError(
+            f"Buzz {field_name} must be at most {limit} printable characters"
+        )
+    return annotation
 
 
 def _validate_agent_name(name: str) -> str:
@@ -1586,6 +1618,76 @@ class AgentRegistry:
                     )
                 )
             );
+
+            CREATE TABLE IF NOT EXISTS buzz_inbound_policies (
+                agent TEXT PRIMARY KEY NOT NULL,
+                community_id TEXT NOT NULL,
+                relay_url TEXT NOT NULL,
+                owner_pubkey TEXT NOT NULL
+                    CHECK(length(owner_pubkey)=64 AND owner_pubkey=lower(owner_pubkey)
+                          AND owner_pubkey NOT GLOB '*[^0-9a-f]*'),
+                owner_configured_at REAL NOT NULL,
+                owner_last_seen_at REAL NOT NULL DEFAULT 0,
+                owner_silence_notified_at REAL NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'configured',
+                last_connect_at REAL NOT NULL DEFAULT 0,
+                last_liveness_at REAL NOT NULL DEFAULT 0,
+                last_event_at REAL NOT NULL DEFAULT 0,
+                last_error TEXT NOT NULL DEFAULT '',
+                updated_by TEXT NOT NULL,
+                updated_at REAL NOT NULL,
+                FOREIGN KEY (agent) REFERENCES buzz_identities(agent) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS buzz_inbound_channels (
+                agent TEXT NOT NULL,
+                community_id TEXT NOT NULL,
+                relay_url TEXT NOT NULL,
+                channel_id TEXT NOT NULL,
+                label TEXT NOT NULL DEFAULT '',
+                created_at REAL NOT NULL,
+                FOREIGN KEY (agent) REFERENCES buzz_inbound_policies(agent) ON DELETE CASCADE,
+                PRIMARY KEY (agent, community_id, channel_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS buzz_inbound_principals (
+                agent TEXT NOT NULL,
+                community_id TEXT NOT NULL,
+                pubkey TEXT NOT NULL
+                    CHECK(length(pubkey)=64 AND pubkey=lower(pubkey)
+                          AND pubkey NOT GLOB '*[^0-9a-f]*'),
+                role TEXT NOT NULL CHECK(role IN ('owner', 'approved')),
+                display_name TEXT NOT NULL DEFAULT '',
+                approved_by TEXT NOT NULL,
+                approved_at REAL NOT NULL,
+                last_seen_at REAL NOT NULL DEFAULT 0,
+                FOREIGN KEY (agent) REFERENCES buzz_inbound_policies(agent) ON DELETE CASCADE,
+                PRIMARY KEY (agent, community_id, pubkey)
+            );
+
+            CREATE TABLE IF NOT EXISTS buzz_inbound_events (
+                agent TEXT NOT NULL,
+                event_id TEXT NOT NULL
+                    CHECK(length(event_id)=64 AND event_id=lower(event_id)
+                          AND event_id NOT GLOB '*[^0-9a-f]*'),
+                community_id TEXT NOT NULL,
+                channel_id TEXT NOT NULL,
+                author_pubkey TEXT NOT NULL,
+                kind INTEGER NOT NULL CHECK(kind=9),
+                event_created_at REAL NOT NULL,
+                event_json TEXT NOT NULL,
+                delivery_status TEXT NOT NULL DEFAULT 'pending'
+                    CHECK(delivery_status IN ('pending', 'delivered')),
+                claimed_at REAL NOT NULL DEFAULT 0,
+                delivered_at REAL NOT NULL DEFAULT 0,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT NOT NULL DEFAULT '',
+                FOREIGN KEY (agent) REFERENCES buzz_inbound_policies(agent) ON DELETE CASCADE,
+                PRIMARY KEY (agent, event_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_buzz_inbound_events_pending
+                ON buzz_inbound_events(agent, delivery_status, event_created_at);
         """)
         self._db.commit()
         self._migrate()
@@ -2991,6 +3093,462 @@ except Exception as exc:
         )
         self._db.commit()
         return cursor.rowcount > 0
+
+    # ── Buzz inbound authorization + durable delivery (#541 inc2) ─────
+
+    def configure_buzz_inbound_owner_control(
+        self,
+        agent_name: str,
+        *,
+        owner_pubkey: str,
+        channels: list[dict],
+        approved_users: list[dict],
+        owner_actor: str,
+    ) -> dict:
+        """Atomically replace one identity-scoped, default-deny inbound policy."""
+        from pinky_daemon.buzz_identity import validate_buzz_owner_actor
+
+        actor = validate_buzz_owner_actor(owner_actor)
+        owner = _validate_buzz_pubkey(owner_pubkey, field_name="owner_pubkey")
+        identity = self._db.execute(
+            "SELECT pubkey, relay_url, community_id FROM buzz_identities WHERE agent=?",
+            (agent_name,),
+        ).fetchone()
+        if not identity:
+            raise KeyError(f"Buzz identity not found for agent: {agent_name}")
+        if owner == identity[0]:
+            raise ValueError("Buzz owner_pubkey must not equal the agent identity pubkey")
+        if not channels:
+            raise ValueError("Buzz inbound channel allowlist must not be empty")
+        if len(channels) > 128 or len(approved_users) > 256:
+            raise ValueError("Buzz inbound policy exceeds configured bounds")
+
+        clean_channels: list[tuple[str, str]] = []
+        channel_ids: set[str] = set()
+        for item in channels:
+            channel = _validate_buzz_channel_id(item.get("channel_id", ""))
+            if channel in channel_ids:
+                raise ValueError("Buzz channel allowlist contains a duplicate channel_id")
+            channel_ids.add(channel)
+            label = _validate_buzz_annotation(
+                item.get("label", ""), field_name="channel label", limit=80
+            )
+            clean_channels.append((channel, label))
+
+        clean_users: list[tuple[str, str]] = []
+        user_pubkeys: set[str] = {owner}
+        for item in approved_users:
+            pubkey = _validate_buzz_pubkey(item.get("pubkey", ""))
+            if pubkey in user_pubkeys:
+                raise ValueError("Buzz approved principals contain a duplicate pubkey")
+            if pubkey == identity[0]:
+                raise ValueError("Buzz approved principal must not equal the agent identity")
+            user_pubkeys.add(pubkey)
+            display = _validate_buzz_annotation(
+                item.get("display_name", ""), field_name="display_name", limit=120
+            )
+            clean_users.append((pubkey, display))
+
+        relay_url = identity[1]
+        community_id = identity[2]
+        now = time.time()
+        with self._rmw_lock:
+            prior_policy = self._db.execute(
+                "SELECT owner_pubkey, owner_configured_at, owner_last_seen_at, "
+                "owner_silence_notified_at FROM buzz_inbound_policies WHERE agent=?",
+                (agent_name,),
+            ).fetchone()
+            prior_seen = {
+                row[0]: float(row[1])
+                for row in self._db.execute(
+                    "SELECT pubkey, last_seen_at FROM buzz_inbound_principals WHERE agent=?",
+                    (agent_name,),
+                ).fetchall()
+            }
+            same_owner = bool(prior_policy and prior_policy[0] == owner)
+            configured_at = float(prior_policy[1]) if same_owner else now
+            owner_seen = float(prior_policy[2]) if same_owner else 0.0
+            silence_notified = float(prior_policy[3]) if same_owner else 0.0
+            try:
+                self._db.execute(
+                    """INSERT INTO buzz_inbound_policies
+                       (agent, community_id, relay_url, owner_pubkey,
+                        owner_configured_at, owner_last_seen_at,
+                        owner_silence_notified_at, status, last_connect_at,
+                        last_liveness_at, last_event_at, last_error,
+                        updated_by, updated_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, 'configured', 0, 0, 0, '', ?, ?)
+                       ON CONFLICT(agent) DO UPDATE SET
+                         community_id=excluded.community_id,
+                         relay_url=excluded.relay_url,
+                         owner_pubkey=excluded.owner_pubkey,
+                         owner_configured_at=excluded.owner_configured_at,
+                         owner_last_seen_at=excluded.owner_last_seen_at,
+                         owner_silence_notified_at=excluded.owner_silence_notified_at,
+                         status='configured', last_error='',
+                         updated_by=excluded.updated_by, updated_at=excluded.updated_at""",
+                    (
+                        agent_name,
+                        community_id,
+                        relay_url,
+                        owner,
+                        configured_at,
+                        owner_seen,
+                        silence_notified,
+                        actor,
+                        now,
+                    ),
+                )
+                self._db.execute("DELETE FROM buzz_inbound_channels WHERE agent=?", (agent_name,))
+                self._db.execute("DELETE FROM buzz_inbound_principals WHERE agent=?", (agent_name,))
+                self._db.executemany(
+                    """INSERT INTO buzz_inbound_channels
+                       (agent, community_id, relay_url, channel_id, label, created_at)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    [
+                        (agent_name, community_id, relay_url, channel, label, now)
+                        for channel, label in clean_channels
+                    ],
+                )
+                principals = [(owner, "owner", "")] + [
+                    (pubkey, "approved", display) for pubkey, display in clean_users
+                ]
+                self._db.executemany(
+                    """INSERT INTO buzz_inbound_principals
+                       (agent, community_id, pubkey, role, display_name,
+                        approved_by, approved_at, last_seen_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    [
+                        (
+                            agent_name,
+                            community_id,
+                            pubkey,
+                            role,
+                            display,
+                            actor,
+                            now,
+                            prior_seen.get(pubkey, 0.0),
+                        )
+                        for pubkey, role, display in principals
+                    ],
+                )
+                # A policy replacement is an authorization-boundary change.
+                # Pending events whose channel or author was revoked must not
+                # become deliverable if that authority is added back later.
+                revoked_pending = [
+                    (agent_name, row[0])
+                    for row in self._db.execute(
+                        """SELECT event_id, channel_id, author_pubkey
+                           FROM buzz_inbound_events
+                           WHERE agent=? AND delivery_status='pending'""",
+                        (agent_name,),
+                    ).fetchall()
+                    if row[1] not in channel_ids or row[2] not in user_pubkeys
+                ]
+                self._db.executemany(
+                    "DELETE FROM buzz_inbound_events WHERE agent=? AND event_id=?",
+                    revoked_pending,
+                )
+                self._db.commit()
+            except Exception:
+                self._db.rollback()
+                raise
+        policy = self.get_buzz_inbound_policy(agent_name)
+        if policy is None:  # pragma: no cover - defensive after successful transaction
+            raise RuntimeError("Buzz inbound policy write did not persist")
+        return policy
+
+    def get_buzz_inbound_policy(self, agent_name: str) -> dict | None:
+        row = self._db.execute(
+            """SELECT agent, community_id, relay_url, owner_pubkey,
+                      owner_configured_at, owner_last_seen_at,
+                      owner_silence_notified_at, status, last_connect_at,
+                      last_liveness_at, last_event_at, last_error,
+                      updated_by, updated_at
+               FROM buzz_inbound_policies WHERE agent=?""",
+            (agent_name,),
+        ).fetchone()
+        if not row:
+            return None
+        channels = [
+            {"channel_id": item[0], "label": item[1]}
+            for item in self._db.execute(
+                "SELECT channel_id, label FROM buzz_inbound_channels "
+                "WHERE agent=? AND community_id=? AND relay_url=? ORDER BY channel_id",
+                (agent_name, row[1], row[2]),
+            ).fetchall()
+        ]
+        principal_rows = self._db.execute(
+            """SELECT pubkey, role, display_name, approved_by, approved_at, last_seen_at
+               FROM buzz_inbound_principals
+               WHERE agent=? AND community_id=? ORDER BY role DESC, pubkey""",
+            (agent_name, row[1]),
+        ).fetchall()
+        principals = [
+            {
+                "principal": f"buzz:{row[1]}:{item[0]}",
+                "pubkey": item[0],
+                "role": item[1],
+                "display_name": item[2],
+                "approved_by": item[3],
+                "approved_at": item[4],
+                "last_seen_at": item[5],
+            }
+            for item in principal_rows
+        ]
+        return {
+            "agent": row[0],
+            "community_id": row[1],
+            "relay_url": row[2],
+            "owner_pubkey": row[3],
+            "owner_principal": f"buzz:{row[1]}:{row[3]}",
+            "owner_configured_at": row[4],
+            "owner_last_seen_at": row[5],
+            "owner_silence_notified_at": row[6],
+            "owner_silence_days": BUZZ_OWNER_SILENCE_DAYS,
+            "channels": channels,
+            "approved_users": [item for item in principals if item["role"] == "approved"],
+            "principals": principals,
+            "status": row[7],
+            "last_connect_at": row[8],
+            "last_liveness_at": row[9],
+            "last_event_at": row[10],
+            "last_error": row[11],
+            "updated_by": row[12],
+            "updated_at": row[13],
+        }
+
+    def get_buzz_inbound_channel(
+        self, agent_name: str, community_id: str, relay_url: str, channel_id: str
+    ) -> dict | None:
+        row = self._db.execute(
+            """SELECT channel_id, label FROM buzz_inbound_channels
+               WHERE agent=? AND community_id=? AND relay_url=? AND channel_id=?""",
+            (agent_name, community_id, relay_url, channel_id),
+        ).fetchone()
+        return {"channel_id": row[0], "label": row[1]} if row else None
+
+    def get_buzz_inbound_principal(
+        self, agent_name: str, community_id: str, pubkey: str
+    ) -> dict | None:
+        row = self._db.execute(
+            """SELECT pubkey, role, display_name, approved_by, approved_at, last_seen_at
+               FROM buzz_inbound_principals
+               WHERE agent=? AND community_id=? AND pubkey=?""",
+            (agent_name, community_id, pubkey),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "principal": f"buzz:{community_id}:{row[0]}",
+            "pubkey": row[0],
+            "role": row[1],
+            "display_name": row[2],
+            "approved_by": row[3],
+            "approved_at": row[4],
+            "last_seen_at": row[5],
+        }
+
+    def note_buzz_inbound_principal_seen(
+        self, agent_name: str, community_id: str, pubkey: str, seen_at: float
+    ) -> None:
+        with self._rmw_lock:
+            self._db.execute(
+                """UPDATE buzz_inbound_principals
+                   SET last_seen_at=MAX(last_seen_at, ?)
+                   WHERE agent=? AND community_id=? AND pubkey=?""",
+                (seen_at, agent_name, community_id, pubkey),
+            )
+            self._db.execute(
+                """UPDATE buzz_inbound_policies
+                   SET owner_last_seen_at=MAX(owner_last_seen_at, ?),
+                       owner_silence_notified_at=0
+                   WHERE agent=? AND community_id=? AND owner_pubkey=?""",
+                (seen_at, agent_name, community_id, pubkey),
+            )
+            self._db.commit()
+
+    def buzz_owner_silence_alert_due(
+        self, agent_name: str, *, now: float | None = None
+    ) -> dict | None:
+        row = self._db.execute(
+            """SELECT community_id, owner_pubkey, owner_configured_at,
+                      owner_last_seen_at, owner_silence_notified_at
+               FROM buzz_inbound_policies WHERE agent=?""",
+            (agent_name,),
+        ).fetchone()
+        if not row:
+            return None
+        current = time.time() if now is None else float(now)
+        basis = float(row[3] or row[2])
+        if basis <= 0 or current - basis < BUZZ_OWNER_SILENCE_DAYS * 86400:
+            return None
+        if float(row[4]) >= basis:
+            return None
+        return {
+            "agent": agent_name,
+            "community_id": row[0],
+            "owner_principal": f"buzz:{row[0]}:{row[1]}",
+            "last_seen_at": float(row[3]),
+            "configured_at": float(row[2]),
+            "days": BUZZ_OWNER_SILENCE_DAYS,
+        }
+
+    def mark_buzz_owner_silence_notified(
+        self, agent_name: str, *, notified_at: float | None = None
+    ) -> None:
+        self._db.execute(
+            "UPDATE buzz_inbound_policies SET owner_silence_notified_at=? WHERE agent=?",
+            (time.time() if notified_at is None else float(notified_at), agent_name),
+        )
+        self._db.commit()
+
+    def begin_buzz_inbound_event_delivery(
+        self,
+        agent_name: str,
+        event: dict,
+        *,
+        community_id: str,
+        channel_id: str,
+        replay: bool = False,
+    ) -> bool:
+        """Claim one verified durable kind-9; ephemeral events never enter this table."""
+        if event.get("kind") != 9:
+            raise ValueError("only durable Buzz kind-9 events may be claimed")
+        event_id = _validate_buzz_pubkey(event.get("id", ""), field_name="event id")
+        author = _validate_buzz_pubkey(event.get("pubkey", ""))
+        payload = json.dumps(event, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        now = time.time()
+        with self._rmw_lock:
+            row = self._db.execute(
+                "SELECT delivery_status, claimed_at FROM buzz_inbound_events "
+                "WHERE agent=? AND event_id=?",
+                (agent_name, event_id),
+            ).fetchone()
+            if row:
+                if row[0] == "delivered" or not replay:
+                    return False
+                cursor = self._db.execute(
+                    """UPDATE buzz_inbound_events
+                       SET claimed_at=?, attempts=attempts+1, last_error=''
+                       WHERE agent=? AND event_id=? AND delivery_status='pending'
+                         AND (claimed_at=0 OR claimed_at<=?)""",
+                    (
+                        now,
+                        agent_name,
+                        event_id,
+                        now - BUZZ_INBOUND_CLAIM_LEASE_SECONDS,
+                    ),
+                )
+                self._db.commit()
+                return cursor.rowcount > 0
+            else:
+                self._db.execute(
+                    """INSERT INTO buzz_inbound_events
+                       (agent, event_id, community_id, channel_id, author_pubkey,
+                        kind, event_created_at, event_json, delivery_status,
+                        claimed_at, delivered_at, attempts, last_error)
+                       VALUES (?, ?, ?, ?, ?, 9, ?, ?, 'pending', ?, 0, 1, '')""",
+                    (
+                        agent_name,
+                        event_id,
+                        community_id,
+                        channel_id,
+                        author,
+                        float(event["created_at"]),
+                        payload,
+                        now,
+                    ),
+                )
+            self._db.commit()
+        return True
+
+    def list_pending_buzz_inbound_events(self, agent_name: str) -> list[dict]:
+        stale_before = time.time() - BUZZ_INBOUND_CLAIM_LEASE_SECONDS
+        rows = self._db.execute(
+            """SELECT event_json FROM buzz_inbound_events
+               WHERE agent=? AND delivery_status='pending'
+                 AND (claimed_at=0 OR claimed_at<=?)
+               ORDER BY event_created_at, event_id""",
+            (agent_name, stale_before),
+        ).fetchall()
+        result: list[dict] = []
+        for row in rows:
+            try:
+                event = json.loads(row[0])
+            except (TypeError, ValueError):
+                continue
+            if isinstance(event, dict):
+                result.append(event)
+        return result
+
+    def reset_buzz_inbound_event_claims_after_restart(self) -> int:
+        """Release claims whose owning daemon process can no longer exist."""
+        cursor = self._db.execute(
+            """UPDATE buzz_inbound_events SET claimed_at=0
+               WHERE delivery_status='pending' AND claimed_at!=0"""
+        )
+        self._db.commit()
+        return cursor.rowcount
+
+    def mark_buzz_inbound_event_delivered(self, agent_name: str, event_id: str) -> None:
+        now = time.time()
+        self._db.execute(
+            """UPDATE buzz_inbound_events
+               SET delivery_status='delivered', delivered_at=?, last_error='', event_json=''
+               WHERE agent=? AND event_id=? AND delivery_status='pending'""",
+            (now, agent_name, event_id),
+        )
+        self._db.commit()
+
+    def mark_buzz_inbound_event_retry(self, agent_name: str, event_id: str, reason: str) -> None:
+        self._db.execute(
+            """UPDATE buzz_inbound_events SET claimed_at=0, last_error=?
+               WHERE agent=? AND event_id=? AND delivery_status='pending'""",
+            (str(reason or "delivery_failed")[:160], agent_name, event_id),
+        )
+        self._db.commit()
+
+    def get_buzz_subscription_since(self, agent_name: str, *, now: float | None = None) -> int:
+        row = self._db.execute(
+            "SELECT MAX(event_created_at) FROM buzz_inbound_events WHERE agent=?",
+            (agent_name,),
+        ).fetchone()
+        if row and row[0]:
+            return max(0, int(float(row[0])) - 2)
+        current = time.time() if now is None else float(now)
+        return max(0, int(current) - 60)
+
+    def update_buzz_inbound_health(
+        self,
+        agent_name: str,
+        *,
+        status: str,
+        last_error: str = "",
+        connected_at: float | None = None,
+        liveness_at: float | None = None,
+        event_at: float | None = None,
+    ) -> None:
+        connected = float(connected_at) if connected_at is not None else None
+        liveness = float(liveness_at) if liveness_at is not None else None
+        event = float(event_at) if event_at is not None else None
+        self._db.execute(
+            """UPDATE buzz_inbound_policies
+               SET status=?, last_error=?,
+                   last_connect_at=COALESCE(MAX(last_connect_at, ?), last_connect_at),
+                   last_liveness_at=COALESCE(MAX(last_liveness_at, ?), last_liveness_at),
+                   last_event_at=COALESCE(MAX(last_event_at, ?), last_event_at)
+               WHERE agent=?""",
+            (
+                str(status or "unknown")[:40],
+                str(last_error or "")[:160],
+                connected,
+                liveness,
+                event,
+                agent_name,
+            ),
+        )
+        self._db.commit()
 
     def list(self, *, parent: str = "", group: str = "", enabled_only: bool = False,
              include_retired: bool = False) -> list[Agent]:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -63,6 +63,7 @@ from pinky_daemon.api_models import (
     AuthSetupRequest,
     BindBuzzIdentityRequest,
     CloneWorkerRequest,
+    ConfigureBuzzInboundRequest,
     ContainerizeRequest,
     ContextResponse,
     ConversationListResponse,
@@ -7612,6 +7613,55 @@ npm run build</pre>
 
     # ── Buzz identity owner control (#541 inc1) ────────────
 
+    app.state.buzz_poller_tasks = set()
+
+    async def _restart_buzz_poller(name: str) -> bool:
+        """Apply one identity's current owner policy without restarting the daemon."""
+        from pinky_daemon.buzz_inbound import BrokerBuzzPoller
+
+        for poller in list(_broker_pollers):
+            if isinstance(poller, BrokerBuzzPoller) and poller.agent_name == name:
+                poller.stop()
+                _broker_pollers.remove(poller)
+        identity = agents.get_buzz_identity(name)
+        policy = agents.get_buzz_inbound_policy(name)
+        if (
+            not identity
+            or not identity["enabled"]
+            or identity["status"] != "active"
+            or not policy
+            or not policy["channels"]
+            or not policy["principals"]
+        ):
+            return False
+        material = agents.get_buzz_signing_material(name)
+        if material is None:
+            return False
+        poller = BrokerBuzzPoller(
+            material,
+            broker,
+            agents,
+            _notify_owner_undelivered,
+        )
+        _broker_pollers.append(poller)
+        task = asyncio.create_task(poller.start())
+        app.state.buzz_poller_tasks.add(task)
+
+        def _release_buzz_task(done: asyncio.Task) -> None:
+            app.state.buzz_poller_tasks.discard(done)
+            if done.cancelled():
+                return
+            try:
+                exc = done.exception()
+            except Exception:
+                return
+            if exc is not None:
+                _log(f"api: Buzz poller task failed for {name} ({type(exc).__name__})")
+
+        task.add_done_callback(_release_buzz_task)
+        _log(f"api: native Buzz inbound poller started for {name}")
+        return True
+
     @app.get("/system/buzz-identities")
     async def list_buzz_identities(request: Request):
         """List redacted Buzz identities for the authenticated owner."""
@@ -7645,12 +7695,24 @@ npm run build</pre>
                 enabled=req.enabled,
                 owner_actor=actor,
             )
+            inbound_policy = None
+            if req.inbound is not None:
+                inbound_policy = agents.configure_buzz_inbound_owner_control(
+                    name,
+                    owner_pubkey=req.inbound.owner_pubkey,
+                    channels=[item.model_dump() for item in req.inbound.channels],
+                    approved_users=[
+                        item.model_dump() for item in req.inbound.approved_users
+                    ],
+                    owner_actor=actor,
+                )
         except KeyError as exc:
             raise HTTPException(404, str(exc)) from exc
         except ValueError as exc:
             status = 409 if "rotation" in str(exc) or "conflicts" in str(exc) else 400
             raise HTTPException(status, str(exc)) from exc
         _evict_platform_adapters(name, "buzz")
+        await _restart_buzz_poller(name)
         audit.log(
             "buzz_identity_bound",
             agent_name=name,
@@ -7666,7 +7728,56 @@ npm run build</pre>
                 separators=(",", ":"),
             ),
         )
+        if inbound_policy is not None:
+            return {**identity, "inbound": inbound_policy}
         return identity
+
+    @app.get("/system/buzz-identities/{name}/inbound")
+    async def get_buzz_inbound_policy(name: str, request: Request):
+        """Read the exact community-scoped inbound authorization policy."""
+        _owner_control_actor(request)
+        policy = agents.get_buzz_inbound_policy(name)
+        if policy is None:
+            raise HTTPException(404, "Buzz inbound policy not configured")
+        return policy
+
+    @app.put("/system/buzz-identities/{name}/inbound")
+    async def configure_buzz_inbound_policy(
+        name: str,
+        req: ConfigureBuzzInboundRequest,
+        request: Request,
+    ):
+        """Owner-control replace of both load-bearing Buzz inbound gates."""
+        actor = _owner_control_actor(request)
+        try:
+            policy = agents.configure_buzz_inbound_owner_control(
+                name,
+                owner_pubkey=req.owner_pubkey,
+                channels=[item.model_dump() for item in req.channels],
+                approved_users=[item.model_dump() for item in req.approved_users],
+                owner_actor=actor,
+            )
+        except KeyError as exc:
+            raise HTTPException(404, str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        started = await _restart_buzz_poller(name)
+        audit.log(
+            "buzz_inbound_policy_configured",
+            agent_name=name,
+            tool_name="owner_control",
+            tool_input_summary=json.dumps(
+                {
+                    "agent": name,
+                    "community_id": policy["community_id"],
+                    "channel_count": len(policy["channels"]),
+                    "approved_principal_count": len(policy["principals"]),
+                    "actor": actor,
+                },
+                separators=(",", ":"),
+            ),
+        )
+        return {**policy, "poller_started": started}
 
     @app.post("/system/buzz-identities/{name}/disable")
     async def disable_buzz_identity(name: str, request: Request):
@@ -7675,6 +7786,7 @@ npm run build</pre>
         if not agents.disable_buzz_identity(name):
             raise HTTPException(404, "Buzz identity not found")
         _evict_platform_adapters(name, "buzz")
+        await _restart_buzz_poller(name)
         audit.log(
             "buzz_identity_disabled",
             agent_name=name,
@@ -11339,6 +11451,12 @@ npm run build</pre>
                 "startup: Buzz platform registration REFUSED for "
                 f"{app.state.buzz_registration['refused']} identity(s)"
             )
+        released_buzz_claims = agents.reset_buzz_inbound_event_claims_after_restart()
+        if released_buzz_claims:
+            _log(
+                f"startup: released {released_buzz_claims} interrupted Buzz "
+                "inbound delivery claim(s)"
+            )
 
         # Start shared MCP server BEFORE agent sessions so SSE URLs are ready
         if SHARED_MCP_ENABLED:
@@ -11552,6 +11670,18 @@ npm run build</pre>
                     except Exception as e:
                         _log(f"startup: slack poller failed for {agent.name}: {e}")
 
+            # Buzz poller — native NIP-42 relay subscription. The helper is
+            # default-deny unless the encrypted identity AND both inbound
+            # authorization-gate tables are fully configured.
+            try:
+                if await _restart_buzz_poller(agent.name):
+                    _log(f"startup: Buzz inbound poller started for {agent.name}")
+            except Exception as e:
+                _log(
+                    f"startup: Buzz inbound poller refused for {agent.name}: "
+                    f"{type(e).__name__}"
+                )
+
             # iMessage poller — check if agent has imessage enabled in DB
             if agents.get_raw_token(agent.name, "imessage"):
                 try:
@@ -11720,6 +11850,11 @@ npm run build</pre>
         for poller in _broker_pollers:
             poller.stop()
         _broker_pollers.clear()
+        for task in list(app.state.buzz_poller_tasks):
+            task.cancel()
+        if app.state.buzz_poller_tasks:
+            await asyncio.gather(*app.state.buzz_poller_tasks, return_exceptions=True)
+        app.state.buzz_poller_tasks.clear()
         await autonomy.stop()
         await scheduler.stop()
         await watchdog.stop()
@@ -12804,9 +12939,37 @@ npm run build</pre>
             agent_name,
         )
         approval_backlog_health = agents.get_approval_backlog_health(agent_name)
+        buzz_poller = next(
+            (
+                poller
+                for poller in _broker_pollers
+                if getattr(poller, "agent_name", "") == agent_name
+                and getattr(poller, "health", {}).get("platform") == "buzz"
+            ),
+            None,
+        )
+        buzz_policy = agents.get_buzz_inbound_policy(agent_name)
+        buzz_identity = (
+            agents.get_buzz_identity(agent_name) if buzz_policy is not None else None
+        )
+        buzz_health = None
+        if buzz_poller is not None:
+            buzz_health = {**buzz_poller.health, "enabled": True}
+        elif buzz_policy is not None:
+            buzz_health = {
+                "platform": "buzz",
+                "agent": agent_name,
+                "enabled": bool(buzz_identity and buzz_identity["enabled"]),
+                "status": buzz_policy["status"],
+                "running": False,
+                "last_error": buzz_policy["last_error"],
+                "last_liveness_at": buzz_policy["last_liveness_at"],
+                "last_event_at": buzz_policy["last_event_at"],
+            }
         checks = {
             "approval_notifications": approval_notification_health,
             "approval_backlog": approval_backlog_health,
+            "buzz_inbound": buzz_health,
         }
 
         return {
@@ -12844,6 +13007,7 @@ npm run build</pre>
             issues.append("high_error_rate")
         approval_check = (checks or {}).get("approval_notifications", {})
         backlog_check = (checks or {}).get("approval_backlog", {})
+        buzz_check = (checks or {}).get("buzz_inbound") or {}
         if approval_check.get("failed"):
             issues.append("owner_notification_failed")
         elif approval_check.get("retrying"):
@@ -12854,6 +13018,10 @@ npm run build</pre>
             issues.append("approved_principal_blocked")
         elif backlog_check.get("pending_chats"):
             issues.append("approval_pending")
+        if buzz_check and buzz_check.get("enabled", True) and (
+            not buzz_check.get("running") or buzz_check.get("status") != "connected"
+        ):
+            issues.append("buzz_inbound_unhealthy")
 
         if not issues:
             return "healthy"

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7687,25 +7687,28 @@ npm run build</pre>
         """One-step owner-approved Buzz bind; raw key is immediately wrapped."""
         actor = _owner_control_actor(request)
         try:
-            identity = agents.bind_buzz_identity_owner_control(
-                name,
-                private_key=req.private_key,
-                relay_url=req.relay_url,
-                community_id=req.community_id,
-                enabled=req.enabled,
-                owner_actor=actor,
-            )
-            inbound_policy = None
             if req.inbound is not None:
-                inbound_policy = agents.configure_buzz_inbound_owner_control(
+                identity, inbound_policy = agents.bind_buzz_identity_with_inbound_owner_control(
                     name,
+                    private_key=req.private_key,
+                    relay_url=req.relay_url,
+                    community_id=req.community_id,
+                    enabled=req.enabled,
                     owner_pubkey=req.inbound.owner_pubkey,
                     channels=[item.model_dump() for item in req.inbound.channels],
-                    approved_users=[
-                        item.model_dump() for item in req.inbound.approved_users
-                    ],
+                    approved_users=[item.model_dump() for item in req.inbound.approved_users],
                     owner_actor=actor,
                 )
+            else:
+                identity = agents.bind_buzz_identity_owner_control(
+                    name,
+                    private_key=req.private_key,
+                    relay_url=req.relay_url,
+                    community_id=req.community_id,
+                    enabled=req.enabled,
+                    owner_actor=actor,
+                )
+                inbound_policy = None
         except KeyError as exc:
             raise HTTPException(404, str(exc)) from exc
         except ValueError as exc:

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import re
 from typing import Literal
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -17,6 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 # alerts on PR #510 that surfaced agent_registry.py's path construction.
 # Lowercase + digits + underscore + hyphen, starts with [a-z0-9], 1-63 chars.
 _AGENT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+_BUZZ_PUBKEY_RE = re.compile(r"^[0-9a-f]{64}$")
 
 # ── Session Models ───────────────────────────────────────────
 
@@ -568,6 +570,92 @@ class SetAgentTokenRequest(BaseModel):
     settings: dict = Field(default_factory=dict)
 
 
+class BuzzInboundChannelRequest(BaseModel):
+    """One exact Buzz channel admitted to an agent's persona session."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str
+    label: str = ""
+
+    @field_validator("channel_id")
+    @classmethod
+    def validate_channel_id(cls, value: str) -> str:
+        try:
+            canonical = str(UUID(str(value)))
+        except (TypeError, ValueError, AttributeError) as exc:
+            raise ValueError("Buzz channel_id must be a UUID") from exc
+        if canonical != str(value):
+            raise ValueError("Buzz channel_id must be a canonical lowercase UUID")
+        return canonical
+
+    @field_validator("label")
+    @classmethod
+    def validate_label(cls, value: str) -> str:
+        label = str(value or "").strip()
+        if len(label) > 80 or any(ord(ch) < 32 or ord(ch) == 127 for ch in label):
+            raise ValueError("Buzz channel label must be at most 80 printable characters")
+        return label
+
+
+class BuzzApprovedPrincipalRequest(BaseModel):
+    """One out-of-band approved Buzz author for one community."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pubkey: str
+    display_name: str = ""
+
+    @field_validator("pubkey")
+    @classmethod
+    def validate_pubkey(cls, value: str) -> str:
+        pubkey = str(value or "")
+        if not _BUZZ_PUBKEY_RE.fullmatch(pubkey):
+            raise ValueError("Buzz pubkey must be exactly 64 lowercase hex characters")
+        return pubkey
+
+    @field_validator("display_name")
+    @classmethod
+    def validate_display_name(cls, value: str) -> str:
+        display = str(value or "").strip()
+        if len(display) > 120 or any(ord(ch) < 32 or ord(ch) == 127 for ch in display):
+            raise ValueError("Buzz display_name must be at most 120 printable characters")
+        return display
+
+
+class ConfigureBuzzInboundRequest(BaseModel):
+    """Owner-only default-deny Buzz persona-routing policy."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    owner_pubkey: str
+    channels: list[BuzzInboundChannelRequest] = Field(min_length=1, max_length=128)
+    approved_users: list[BuzzApprovedPrincipalRequest] = Field(
+        default_factory=list,
+        max_length=256,
+    )
+
+    @field_validator("owner_pubkey")
+    @classmethod
+    def validate_owner_pubkey(cls, value: str) -> str:
+        pubkey = str(value or "")
+        if not _BUZZ_PUBKEY_RE.fullmatch(pubkey):
+            raise ValueError("Buzz owner_pubkey must be exactly 64 lowercase hex characters")
+        return pubkey
+
+    @model_validator(mode="after")
+    def validate_uniqueness(self):
+        channel_ids = [item.channel_id for item in self.channels]
+        if len(channel_ids) != len(set(channel_ids)):
+            raise ValueError("Buzz channel allowlist contains a duplicate channel_id")
+        pubkeys = [item.pubkey for item in self.approved_users]
+        if self.owner_pubkey in pubkeys:
+            raise ValueError("Buzz owner_pubkey must not be repeated in approved_users")
+        if len(pubkeys) != len(set(pubkeys)):
+            raise ValueError("Buzz approved_users contains a duplicate pubkey")
+        return self
+
+
 class BindBuzzIdentityRequest(BaseModel):
     """Owner-control request to bind one encrypted Buzz identity."""
 
@@ -577,6 +665,7 @@ class BindBuzzIdentityRequest(BaseModel):
     relay_url: str
     community_id: str
     enabled: bool = True
+    inbound: ConfigureBuzzInboundRequest | None = None
 
 
 class AddMcpServerRequest(BaseModel):

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1371,7 +1371,7 @@ class MessageBroker:
 
     async def dispatch_pre_authorized(
         self, agent_name: str, message: BrokerMessage,
-    ) -> None:
+    ) -> bool:
         """Dispatch a message whose sender is already authorized upstream.
 
         Bypasses the human-platform onboarding flow that ``handle_inbound``
@@ -1394,7 +1394,7 @@ class MessageBroker:
         platforms (sender/preview formatting). If a future caller wants
         broker-side activity logs, expose that as a separate flag.
         """
-        await self._route_streaming(agent_name, message)
+        return await self._route_streaming(agent_name, message)
 
     def _format_prompt(self, message: BrokerMessage) -> str:
         """Format a single message as a platform-aware prompt line."""
@@ -1417,7 +1417,18 @@ class MessageBroker:
             f" | thread_root_ts:{message.reply_to} | is_thread_reply:true"
             if message.reply_to else ""
         )
-        if message.is_group:
+        buzz_principal = message.metadata.get("buzz_verified_principal", "")
+        if message.platform == "buzz" and buzz_principal:
+            alias = self._registry.get_group_chat_alias(message.agent_name, message.chat_id)
+            display = alias or message.chat_title or message.chat_id
+            mentioned = "true" if message.metadata.get("buzz_mentioned_self") is True else "false"
+            header = (
+                f"[buzz | channel | {display} | "
+                f"display_name(untrusted):{message.sender_name} | "
+                f"principal:{buzz_principal} | mentioned_self:{mentioned} | "
+                f"{message.chat_id} | {ts}{msg_id}{thread_provenance}]"
+            )
+        elif message.is_group:
             alias = self._registry.get_group_chat_alias(message.agent_name, message.chat_id)
             display = alias or message.chat_title or message.chat_id
             header = f"[{message.platform} | group | {display} | {message.sender_name} | {message.chat_id} | {ts}{msg_id}{thread_provenance}]"

--- a/src/pinky_daemon/buzz_inbound.py
+++ b/src/pinky_daemon/buzz_inbound.py
@@ -1,0 +1,687 @@
+"""Native Buzz inbound verification, authorization, and relay supervision."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import secrets
+import sys
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Callable
+from uuid import UUID
+
+import websockets
+
+from pinky_daemon.broker import BrokerMessage
+from pinky_outreach.buzz import BuzzNostrSigner, verify_nostr_event
+
+_HEX_64 = frozenset("0123456789abcdef")
+_ALLOWED_KINDS = {9, 20002}
+_MAX_FRAME_BYTES = 128 * 1024
+_MAX_CONTENT_BYTES = 32 * 1024
+_MAX_TAGS = 64
+_MAX_TAG_PARTS = 4
+_MAX_TAG_PART_BYTES = 512
+_MAX_FUTURE_SECONDS = 5 * 60
+_RECENT_EVENT_IDS = 4096
+
+
+def _log(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+class BuzzInboundError(RuntimeError):
+    """Base inbound Buzz failure."""
+
+
+class BuzzInboundRejectedError(BuzzInboundError):
+    """An event failed strict schema, cryptographic, or target validation."""
+
+
+class BuzzInboundDeliveryError(BuzzInboundError):
+    """A verified/authorized durable event was not accepted by the persona."""
+
+
+class BuzzRelayProtocolError(BuzzInboundError):
+    """The relay failed the required NIP-42/NIP-01 protocol contract."""
+
+
+class BuzzRelayLivenessError(BuzzInboundError):
+    """The relay socket existed but failed an active EOSE liveness probe."""
+
+
+@dataclass(frozen=True)
+class ValidatedBuzzInboundEvent:
+    event: dict
+    channel_id: str
+    mentioned_self: bool
+    reply_to: str
+
+
+def _is_hex_64(value: object) -> bool:
+    return isinstance(value, str) and len(value) == 64 and not (set(value) - _HEX_64)
+
+
+def validate_buzz_inbound_event(
+    event: object,
+    *,
+    identity_pubkey: str,
+    now: float | None = None,
+) -> ValidatedBuzzInboundEvent:
+    """Strictly validate one event before either inbound authorization gate."""
+    if not isinstance(event, dict):
+        raise BuzzInboundRejectedError("event_not_object")
+    try:
+        encoded = json.dumps(event, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise BuzzInboundRejectedError("event_not_json") from exc
+    if len(encoded) > _MAX_FRAME_BYTES:
+        raise BuzzInboundRejectedError("event_too_large")
+    if not verify_nostr_event(event):
+        raise BuzzInboundRejectedError("event_signature_or_id_invalid")
+    if event["kind"] not in _ALLOWED_KINDS:
+        raise BuzzInboundRejectedError("event_kind_not_allowed")
+    if event["pubkey"] == identity_pubkey:
+        raise BuzzInboundRejectedError("self_event")
+    current = time.time() if now is None else float(now)
+    if event["created_at"] > int(current + _MAX_FUTURE_SECONDS):
+        raise BuzzInboundRejectedError("event_from_future")
+    if len(event["content"].encode("utf-8")) > _MAX_CONTENT_BYTES:
+        raise BuzzInboundRejectedError("content_too_large")
+    tags = event["tags"]
+    if len(tags) > _MAX_TAGS:
+        raise BuzzInboundRejectedError("too_many_tags")
+    if any(
+        len(tag) < 2
+        or len(tag) > _MAX_TAG_PARTS
+        or any(len(part.encode("utf-8")) > _MAX_TAG_PART_BYTES for part in tag)
+        for tag in tags
+    ):
+        raise BuzzInboundRejectedError("tag_bounds_invalid")
+
+    channel_tags = [tag for tag in tags if tag[0] == "h"]
+    if len(channel_tags) != 1 or len(channel_tags[0]) != 2:
+        raise BuzzInboundRejectedError("channel_tag_invalid")
+    channel_id = channel_tags[0][1]
+    try:
+        if str(UUID(channel_id)) != channel_id:
+            raise ValueError
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise BuzzInboundRejectedError("channel_tag_invalid") from exc
+
+    p_tags = [tag for tag in tags if tag[0] == "p"]
+    if len(p_tags) > 1:
+        raise BuzzInboundRejectedError("target_pubkey_duplicate")
+    if p_tags:
+        if len(p_tags[0]) != 2 or not _is_hex_64(p_tags[0][1]):
+            raise BuzzInboundRejectedError("target_pubkey_malformed")
+        if p_tags[0][1] != identity_pubkey:
+            # Conservative inc2 choice: a message explicitly addressed to a
+            # different identity never enters this persona. No-p broadcasts
+            # remain eligible after both load-bearing authorization gates.
+            raise BuzzInboundRejectedError("target_pubkey_foreign")
+
+    reply_tags: list[str] = []
+    for tag in tags:
+        if tag[0] != "e":
+            continue
+        if not _is_hex_64(tag[1]):
+            raise BuzzInboundRejectedError("reply_event_id_invalid")
+        if len(tag) == 4 and tag[3] == "reply":
+            reply_tags.append(tag[1])
+    if len(reply_tags) > 1:
+        raise BuzzInboundRejectedError("reply_tag_duplicate")
+
+    return ValidatedBuzzInboundEvent(
+        event=event,
+        channel_id=channel_id,
+        mentioned_self=bool(p_tags),
+        reply_to=reply_tags[0] if reply_tags else "",
+    )
+
+
+class BuzzInboundProcessor:
+    """Apply both DB-backed authorization gates before persona dispatch."""
+
+    def __init__(
+        self,
+        *,
+        registry,
+        broker,
+        agent_name: str,
+        identity_pubkey: str,
+        community_id: str,
+        relay_url: str,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._registry = registry
+        self._broker = broker
+        self.agent_name = agent_name
+        self.identity_pubkey = identity_pubkey
+        self.community_id = community_id
+        self.relay_url = relay_url
+        self._clock = clock
+        self._recent_order: deque[str] = deque()
+        self._recent_ids: set[str] = set()
+        self.stats = {
+            "delivered": 0,
+            "duplicates": 0,
+            "ephemeral_ignored": 0,
+            "rejected": 0,
+            "unlisted_channel": 0,
+            "unapproved_principal": 0,
+        }
+
+    def _remember(self, event_id: str) -> bool:
+        if event_id in self._recent_ids:
+            return False
+        self._recent_ids.add(event_id)
+        self._recent_order.append(event_id)
+        if len(self._recent_order) > _RECENT_EVENT_IDS:
+            self._recent_ids.discard(self._recent_order.popleft())
+        return True
+
+    async def process_event(self, event: object, *, replay: bool = False) -> str:
+        try:
+            validated = validate_buzz_inbound_event(
+                event,
+                identity_pubkey=self.identity_pubkey,
+                now=self._clock(),
+            )
+        except BuzzInboundRejectedError:
+            self.stats["rejected"] += 1
+            return "rejected"
+
+        event_id = validated.event["id"]
+        if not replay and not self._remember(event_id):
+            self.stats["duplicates"] += 1
+            return "duplicate"
+
+        # Gate A: exact identity community/relay plus exact channel UUID.
+        channel = self._registry.get_buzz_inbound_channel(
+            self.agent_name,
+            self.community_id,
+            self.relay_url,
+            validated.channel_id,
+        )
+        if channel is None:
+            self.stats["unlisted_channel"] += 1
+            return "unlisted_channel"
+
+        # Gate B: full, platform-qualified, community-scoped verified author.
+        author = self._registry.get_buzz_inbound_principal(
+            self.agent_name,
+            self.community_id,
+            validated.event["pubkey"],
+        )
+        if author is None:
+            self.stats["unapproved_principal"] += 1
+            return "unapproved_principal"
+
+        self._registry.note_buzz_inbound_principal_seen(
+            self.agent_name,
+            self.community_id,
+            author["pubkey"],
+            float(validated.event["created_at"]),
+        )
+
+        # kind-20002 is typing/diagnostic only. It never enters the durable
+        # event ledger, broker, conversation store, replay queue, or prompt.
+        if validated.event["kind"] == 20002:
+            self.stats["ephemeral_ignored"] += 1
+            return "ephemeral_ignored"
+
+        if not self._registry.begin_buzz_inbound_event_delivery(
+            self.agent_name,
+            validated.event,
+            community_id=self.community_id,
+            channel_id=validated.channel_id,
+            replay=replay,
+        ):
+            self.stats["duplicates"] += 1
+            return "duplicate"
+
+        principal = author["principal"]
+        display_name = author["display_name"] or f"Buzz user {author['pubkey'][:16]}"
+        message = BrokerMessage(
+            platform="buzz",
+            chat_id=validated.channel_id,
+            sender_name=display_name,
+            sender_id=principal,
+            content=validated.event["content"],
+            agent_name=self.agent_name,
+            timestamp=float(validated.event["created_at"]),
+            message_id=event_id,
+            chat_title=channel["label"],
+            is_group=True,
+            reply_to=validated.reply_to,
+            metadata={
+                "buzz_verified_event": {
+                    "verified": True,
+                    "event_id": event_id,
+                    "kind": 9,
+                    "author_pubkey": author["pubkey"],
+                    "channel_id": validated.channel_id,
+                },
+                "buzz_verified_principal": principal,
+                "buzz_display_name_untrusted": True,
+                "buzz_mentioned_self": validated.mentioned_self,
+            },
+        )
+        try:
+            accepted = await self._broker.dispatch_pre_authorized(self.agent_name, message)
+            if accepted is False:
+                raise BuzzInboundDeliveryError("persona_handoff_unavailable")
+        except Exception as exc:
+            self._registry.mark_buzz_inbound_event_retry(
+                self.agent_name,
+                event_id,
+                type(exc).__name__,
+            )
+            if isinstance(exc, BuzzInboundDeliveryError):
+                raise
+            raise BuzzInboundDeliveryError("persona_handoff_failed") from exc
+
+        self._registry.mark_buzz_inbound_event_delivered(self.agent_name, event_id)
+        self._registry.update_buzz_inbound_health(
+            self.agent_name,
+            status="connected",
+            event_at=self._clock(),
+        )
+        self.stats["delivered"] += 1
+        return "delivered"
+
+    async def replay_pending(self) -> int:
+        delivered = 0
+        for event in self._registry.list_pending_buzz_inbound_events(self.agent_name):
+            if await self.process_event(event, replay=True) == "delivered":
+                delivered += 1
+        return delivered
+
+
+class BrokerBuzzPoller:
+    """Supervised NIP-42 relay subscription for one encrypted Buzz identity."""
+
+    def __init__(
+        self,
+        signing_material,
+        broker,
+        registry,
+        owner_notify,
+        *,
+        heartbeat_interval: float = 60.0,
+        liveness_timeout: float = 15.0,
+        auth_timeout: float = 15.0,
+        reconnect_base: float = 1.0,
+        reconnect_max: float = 30.0,
+        connect_factory: Callable[..., Any] = websockets.connect,
+    ) -> None:
+        self._agent_name = signing_material.agent
+        self._pubkey = signing_material.pubkey
+        self._relay_url = signing_material.relay_url
+        self._community_id = signing_material.community_id
+        self._signer = BuzzNostrSigner(signing_material.private_key)
+        if not secrets.compare_digest(self._signer.pubkey, self._pubkey):
+            raise BuzzRelayProtocolError("signing material pubkey mismatch")
+        self._broker = broker
+        self._registry = registry
+        self._owner_notify = owner_notify
+        self._heartbeat_interval = max(0.05, float(heartbeat_interval))
+        self._liveness_timeout = max(0.05, float(liveness_timeout))
+        self._auth_timeout = max(0.05, float(auth_timeout))
+        self._reconnect_base = max(0.01, float(reconnect_base))
+        self._reconnect_max = max(self._reconnect_base, float(reconnect_max))
+        self._connect_factory = connect_factory
+        self._running = False
+        self._ws = None
+        self._poll_count = 0
+        self._consecutive_failures = 0
+        self._outage_notified = False
+        self._status = "stopped"
+        self._last_error = ""
+        self._last_liveness_at = 0.0
+        self._last_event_at = 0.0
+        self._processor = BuzzInboundProcessor(
+            registry=registry,
+            broker=broker,
+            agent_name=self._agent_name,
+            identity_pubkey=self._pubkey,
+            community_id=self._community_id,
+            relay_url=self._relay_url,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"BrokerBuzzPoller(agent={self._agent_name!r}, pubkey={self._pubkey!r}, "
+            f"community_id={self._community_id!r}, private_key=<redacted>)"
+        )
+
+    @property
+    def agent_name(self) -> str:
+        return self._agent_name
+
+    @property
+    def poll_count(self) -> int:
+        return self._poll_count
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    @property
+    def health(self) -> dict:
+        return {
+            "platform": "buzz",
+            "agent": self._agent_name,
+            "status": self._status,
+            "running": self._running,
+            "last_error": self._last_error,
+            "last_liveness_at": self._last_liveness_at,
+            "last_event_at": self._last_event_at,
+            "consecutive_failures": self._consecutive_failures,
+            "polls": self._poll_count,
+            **self._processor.stats,
+        }
+
+    async def start(self) -> None:
+        self._running = True
+        self._status = "starting"
+        delay = self._reconnect_base
+        while self._running:
+            try:
+                await self._run_connection()
+                if self._running:
+                    raise BuzzRelayProtocolError("relay_connection_ended")
+            except asyncio.CancelledError:
+                self._status = "stopped"
+                self._running = False
+                raise
+            except Exception as exc:  # noqa: BLE001 — supervisor owns reconnect policy
+                if not self._running:
+                    break
+                self._consecutive_failures += 1
+                if self._consecutive_failures == 1:
+                    # A completed authenticated/liveness handshake resets the
+                    # counter to zero, so the next unrelated outage starts at
+                    # the base delay instead of inheriting an old backoff.
+                    delay = self._reconnect_base
+                self._status = "reconnecting"
+                self._last_error = type(exc).__name__
+                self._registry.update_buzz_inbound_health(
+                    self._agent_name,
+                    status="reconnecting",
+                    last_error=self._last_error,
+                )
+                measured_dead = isinstance(exc, BuzzRelayLivenessError)
+                if measured_dead or self._consecutive_failures >= 3:
+                    await self._notify_outage_once(measured_dead=measured_dead)
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, self._reconnect_max)
+            else:  # pragma: no cover - _run_connection runs until stop/error
+                delay = self._reconnect_base
+        self._status = "stopped"
+        self._registry.update_buzz_inbound_health(
+            self._agent_name,
+            status="stopped",
+            last_error=self._last_error,
+        )
+
+    def stop(self) -> None:
+        self._running = False
+        self._status = "stopping"
+        if self._ws is not None:
+            try:
+                asyncio.get_running_loop().create_task(self._ws.close())
+            except RuntimeError:
+                pass
+
+    async def _run_connection(self) -> None:
+        policy = self._registry.get_buzz_inbound_policy(self._agent_name)
+        if not policy or not policy["channels"] or not policy["principals"]:
+            raise BuzzRelayProtocolError("inbound_policy_default_deny")
+        if policy["community_id"] != self._community_id or policy["relay_url"] != self._relay_url:
+            raise BuzzRelayProtocolError("inbound_policy_identity_scope_mismatch")
+        channels = [item["channel_id"] for item in policy["channels"]]
+        connect = self._connect_factory(
+            self._relay_url,
+            open_timeout=self._auth_timeout,
+            close_timeout=3,
+            ping_interval=min(self._heartbeat_interval, 20.0),
+            ping_timeout=self._liveness_timeout,
+            max_size=_MAX_FRAME_BYTES,
+            additional_headers={"User-Agent": "PinkyBot-Buzz/1.0"},
+        )
+        try:
+            async with connect as ws:
+                self._ws = ws
+                await self._run_authenticated_subscription(ws, channels)
+        finally:
+            self._ws = None
+
+    async def _run_authenticated_subscription(self, ws, channels: list[str]) -> None:
+        challenge_frame = await self._receive_frame(ws, timeout=self._auth_timeout)
+        if (
+            len(challenge_frame) != 2
+            or challenge_frame[0] != "AUTH"
+            or not isinstance(challenge_frame[1], str)
+        ):
+            raise BuzzRelayProtocolError("relay_missing_auth_challenge")
+        auth_event = self._signer.sign_relay_auth(
+            self._relay_url,
+            challenge_frame[1],
+        )
+        await self._send_frame(ws, ["AUTH", auth_event])
+        auth_result = await self._receive_frame(ws, timeout=self._auth_timeout)
+        if (
+            len(auth_result) < 3
+            or auth_result[0] != "OK"
+            or auth_result[1] != auth_event["id"]
+            or auth_result[2] is not True
+        ):
+            raise BuzzRelayProtocolError("relay_auth_refused")
+
+        await self._processor.replay_pending()
+        main_sub = f"pinky-{self._agent_name}-{secrets.token_hex(8)}"
+        since = self._registry.get_buzz_subscription_since(self._agent_name)
+        await self._send_frame(
+            ws,
+            [
+                "REQ",
+                main_sub,
+                {"kinds": [9, 20002], "#h": channels, "since": since},
+            ],
+        )
+        await self._wait_for_eose(
+            ws,
+            subscription_id=main_sub,
+            timeout=self._liveness_timeout,
+        )
+        now = time.time()
+        self._status = "connected"
+        self._last_error = ""
+        self._last_liveness_at = now
+        self._consecutive_failures = 0
+        self._outage_notified = False
+        self._registry.update_buzz_inbound_health(
+            self._agent_name,
+            status="connected",
+            connected_at=now,
+            liveness_at=now,
+        )
+        await self._check_owner_silence()
+
+        while self._running:
+            try:
+                frame = await self._receive_frame(
+                    ws,
+                    timeout=self._heartbeat_interval,
+                )
+            except asyncio.TimeoutError:
+                await self._active_liveness_probe(
+                    ws,
+                    channels,
+                    main_subscription=main_sub,
+                )
+                await self._processor.replay_pending()
+                await self._check_owner_silence()
+                continue
+            await self._handle_frame(
+                ws,
+                frame,
+                allowed_subscriptions={main_sub},
+            )
+
+    async def _active_liveness_probe(
+        self, ws, channels: list[str], *, main_subscription: str
+    ) -> None:
+        heartbeat_sub = f"pinky-live-{secrets.token_hex(8)}"
+        await self._send_frame(
+            ws,
+            [
+                "REQ",
+                heartbeat_sub,
+                {
+                    "kinds": [9, 20002],
+                    "#h": channels,
+                    "since": int(time.time()),
+                    "limit": 1,
+                },
+            ],
+        )
+        try:
+            await self._wait_for_eose(
+                ws,
+                subscription_id=heartbeat_sub,
+                timeout=self._liveness_timeout,
+                other_subscription=main_subscription,
+            )
+        except asyncio.TimeoutError as exc:
+            raise BuzzRelayLivenessError("relay_eose_heartbeat_timed_out") from exc
+        finally:
+            try:
+                await self._send_frame(ws, ["CLOSE", heartbeat_sub])
+            except Exception:
+                pass
+        now = time.time()
+        self._last_liveness_at = now
+        self._registry.update_buzz_inbound_health(
+            self._agent_name,
+            status="connected",
+            liveness_at=now,
+        )
+
+    async def _wait_for_eose(
+        self,
+        ws,
+        *,
+        subscription_id: str,
+        timeout: float,
+        other_subscription: str | None = None,
+    ) -> None:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise asyncio.TimeoutError
+            frame = await self._receive_frame(ws, timeout=remaining)
+            if len(frame) >= 2 and frame[0] == "EOSE" and frame[1] == subscription_id:
+                return
+            allowed = {subscription_id}
+            if other_subscription:
+                allowed.add(other_subscription)
+            await self._handle_frame(ws, frame, allowed_subscriptions=allowed)
+
+    async def _handle_frame(
+        self,
+        ws,
+        frame: list,
+        *,
+        allowed_subscriptions: set[str] | None,
+    ) -> None:
+        if not frame:
+            raise BuzzRelayProtocolError("relay_frame_empty")
+        kind = frame[0]
+        if kind == "EVENT":
+            if len(frame) != 3 or not isinstance(frame[1], str):
+                raise BuzzRelayProtocolError("relay_event_frame_invalid")
+            if allowed_subscriptions is not None and frame[1] not in allowed_subscriptions:
+                raise BuzzRelayProtocolError("relay_event_subscription_mismatch")
+            await self._processor.process_event(frame[2])
+            self._last_event_at = time.time()
+            return
+        if kind == "AUTH" and len(frame) == 2 and isinstance(frame[1], str):
+            auth_event = self._signer.sign_relay_auth(self._relay_url, frame[1])
+            await self._send_frame(ws, ["AUTH", auth_event])
+            return
+        if kind == "CLOSED" and (
+            allowed_subscriptions is None or (len(frame) >= 2 and frame[1] in allowed_subscriptions)
+        ):
+            raise BuzzRelayProtocolError("relay_subscription_closed")
+        if kind == "NOTICE":
+            raise BuzzRelayProtocolError("relay_notice")
+        # OK/EOSE for another request are control frames, not inbound content.
+
+    async def _receive_frame(self, ws, *, timeout: float) -> list:
+        raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+        self._poll_count += 1
+        if not isinstance(raw, str) or len(raw.encode("utf-8")) > _MAX_FRAME_BYTES:
+            raise BuzzRelayProtocolError("relay_frame_bounds_invalid")
+        try:
+            frame = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise BuzzRelayProtocolError("relay_frame_not_json") from exc
+        if not isinstance(frame, list) or not frame or not isinstance(frame[0], str):
+            raise BuzzRelayProtocolError("relay_frame_shape_invalid")
+        return frame
+
+    @staticmethod
+    async def _send_frame(ws, frame: list) -> None:
+        await ws.send(json.dumps(frame, separators=(",", ":"), ensure_ascii=False))
+
+    async def _check_owner_silence(self) -> None:
+        due = self._registry.buzz_owner_silence_alert_due(self._agent_name)
+        if not due:
+            return
+        message = (
+            f"BUZZ OWNER KEY SILENCE for {self._agent_name}: the configured owner "
+            f"principal {due['owner_principal']} has not been seen for at least "
+            f"{due['days']} days. If the owner rotated keys, use the documented "
+            "owner-control rotation procedure; never approve a first-message claim."
+        )
+        if await self._notify(message):
+            self._registry.mark_buzz_owner_silence_notified(self._agent_name)
+
+    async def _notify_outage_once(self, *, measured_dead: bool) -> None:
+        if self._outage_notified:
+            return
+        reason = "active EOSE liveness failed" if measured_dead else "repeated connection failures"
+        message = (
+            f"BUZZ INBOUND UNHEALTHY for {self._agent_name}: {reason}; "
+            f"the daemon is reconnecting and no unverified event is routed. "
+            f"error_type={self._last_error}"
+        )
+        if await self._notify(message):
+            self._outage_notified = True
+
+    async def _notify(self, message: str) -> bool:
+        try:
+            result = self._owner_notify(self._agent_name, message)
+            return bool(await result) if inspect.isawaitable(result) else bool(result)
+        except Exception as exc:  # noqa: BLE001 — supervision must survive alert failure
+            _log(f"buzz-inbound: owner-notify failed for {self._agent_name} ({type(exc).__name__})")
+            return False
+
+
+__all__ = [
+    "BrokerBuzzPoller",
+    "BuzzInboundDeliveryError",
+    "BuzzInboundProcessor",
+    "BuzzInboundRejectedError",
+    "BuzzRelayLivenessError",
+    "BuzzRelayProtocolError",
+    "ValidatedBuzzInboundEvent",
+    "validate_buzz_inbound_event",
+]

--- a/src/pinky_daemon/buzz_inbound.py
+++ b/src/pinky_daemon/buzz_inbound.py
@@ -70,6 +70,7 @@ def validate_buzz_inbound_event(
     *,
     identity_pubkey: str,
     now: float | None = None,
+    subscription_since: int | None = None,
 ) -> ValidatedBuzzInboundEvent:
     """Strictly validate one event before either inbound authorization gate."""
     if not isinstance(event, dict):
@@ -89,6 +90,10 @@ def validate_buzz_inbound_event(
     current = time.time() if now is None else float(now)
     if event["created_at"] > int(current + _MAX_FUTURE_SECONDS):
         raise BuzzInboundRejectedError("event_from_future")
+    if subscription_since is not None and event["created_at"] < int(subscription_since):
+        # A relay filter is advisory, not an authorization boundary. Enforce
+        # the exact REQ floor again before any gate, cache, or durable write.
+        raise BuzzInboundRejectedError("event_before_subscription_since")
     if len(event["content"].encode("utf-8")) > _MAX_CONTENT_BYTES:
         raise BuzzInboundRejectedError("content_too_large")
     tags = event["tags"]
@@ -184,16 +189,31 @@ class BuzzInboundProcessor:
             self._recent_ids.discard(self._recent_order.popleft())
         return True
 
-    async def process_event(self, event: object, *, replay: bool = False) -> str:
+    async def process_event(
+        self,
+        event: object,
+        *,
+        replay: bool = False,
+        subscription_since: int | None = None,
+    ) -> str:
         try:
             validated = validate_buzz_inbound_event(
                 event,
                 identity_pubkey=self.identity_pubkey,
                 now=self._clock(),
+                # Durable pending rows were admitted under an earlier live
+                # subscription and are the only sanctioned freshness bypass.
+                subscription_since=None if replay else subscription_since,
             )
         except BuzzInboundRejectedError:
             self.stats["rejected"] += 1
             return "rejected"
+
+        # kind-20002 is typing/diagnostic only. Return before the in-memory
+        # duplicate cache, either authorization lookup, or any durable write.
+        if validated.event["kind"] == 20002:
+            self.stats["ephemeral_ignored"] += 1
+            return "ephemeral_ignored"
 
         event_id = validated.event["id"]
         if not replay and not self._remember(event_id):
@@ -227,12 +247,6 @@ class BuzzInboundProcessor:
             author["pubkey"],
             float(validated.event["created_at"]),
         )
-
-        # kind-20002 is typing/diagnostic only. It never enters the durable
-        # event ledger, broker, conversation store, replay queue, or prompt.
-        if validated.event["kind"] == 20002:
-            self.stats["ephemeral_ignored"] += 1
-            return "ephemeral_ignored"
 
         if not self._registry.begin_buzz_inbound_event_delivery(
             self.agent_name,
@@ -436,6 +450,7 @@ class BrokerBuzzPoller:
             try:
                 asyncio.get_running_loop().create_task(self._ws.close())
             except RuntimeError:
+                # No running loop means an asynchronous close cannot be scheduled.
                 pass
 
     async def _run_connection(self) -> None:
@@ -498,6 +513,7 @@ class BrokerBuzzPoller:
             ws,
             subscription_id=main_sub,
             timeout=self._liveness_timeout,
+            subscription_since={main_sub: since},
         )
         now = time.time()
         self._status = "connected"
@@ -513,31 +529,41 @@ class BrokerBuzzPoller:
         )
         await self._check_owner_silence()
 
+        loop = asyncio.get_running_loop()
+        next_heartbeat = loop.time() + self._heartbeat_interval
         while self._running:
-            try:
-                frame = await self._receive_frame(
-                    ws,
-                    timeout=self._heartbeat_interval,
-                )
-            except asyncio.TimeoutError:
+            remaining = next_heartbeat - loop.time()
+            if remaining <= 0:
                 await self._active_liveness_probe(
                     ws,
                     channels,
                     main_subscription=main_sub,
+                    main_since=since,
                 )
+                next_heartbeat = loop.time() + self._heartbeat_interval
                 await self._processor.replay_pending()
                 await self._check_owner_silence()
+                continue
+            try:
+                frame = await self._receive_frame(ws, timeout=remaining)
+            except asyncio.TimeoutError:
                 continue
             await self._handle_frame(
                 ws,
                 frame,
-                allowed_subscriptions={main_sub},
+                subscription_since={main_sub: since},
             )
 
     async def _active_liveness_probe(
-        self, ws, channels: list[str], *, main_subscription: str
+        self,
+        ws,
+        channels: list[str],
+        *,
+        main_subscription: str,
+        main_since: int,
     ) -> None:
         heartbeat_sub = f"pinky-live-{secrets.token_hex(8)}"
+        heartbeat_since = int(time.time())
         await self._send_frame(
             ws,
             [
@@ -546,7 +572,7 @@ class BrokerBuzzPoller:
                 {
                     "kinds": [9, 20002],
                     "#h": channels,
-                    "since": int(time.time()),
+                    "since": heartbeat_since,
                     "limit": 1,
                 },
             ],
@@ -556,7 +582,10 @@ class BrokerBuzzPoller:
                 ws,
                 subscription_id=heartbeat_sub,
                 timeout=self._liveness_timeout,
-                other_subscription=main_subscription,
+                subscription_since={
+                    main_subscription: main_since,
+                    heartbeat_sub: heartbeat_since,
+                },
             )
         except asyncio.TimeoutError as exc:
             raise BuzzRelayLivenessError("relay_eose_heartbeat_timed_out") from exc
@@ -564,6 +593,7 @@ class BrokerBuzzPoller:
             try:
                 await self._send_frame(ws, ["CLOSE", heartbeat_sub])
             except Exception:
+                # Best-effort CLOSE must not hide the measured liveness result.
                 pass
         now = time.time()
         self._last_liveness_at = now
@@ -579,7 +609,7 @@ class BrokerBuzzPoller:
         *,
         subscription_id: str,
         timeout: float,
-        other_subscription: str | None = None,
+        subscription_since: dict[str, int],
     ) -> None:
         deadline = asyncio.get_running_loop().time() + timeout
         while True:
@@ -589,17 +619,18 @@ class BrokerBuzzPoller:
             frame = await self._receive_frame(ws, timeout=remaining)
             if len(frame) >= 2 and frame[0] == "EOSE" and frame[1] == subscription_id:
                 return
-            allowed = {subscription_id}
-            if other_subscription:
-                allowed.add(other_subscription)
-            await self._handle_frame(ws, frame, allowed_subscriptions=allowed)
+            await self._handle_frame(
+                ws,
+                frame,
+                subscription_since=subscription_since,
+            )
 
     async def _handle_frame(
         self,
         ws,
         frame: list,
         *,
-        allowed_subscriptions: set[str] | None,
+        subscription_since: dict[str, int] | None,
     ) -> None:
         if not frame:
             raise BuzzRelayProtocolError("relay_frame_empty")
@@ -607,17 +638,23 @@ class BrokerBuzzPoller:
         if kind == "EVENT":
             if len(frame) != 3 or not isinstance(frame[1], str):
                 raise BuzzRelayProtocolError("relay_event_frame_invalid")
-            if allowed_subscriptions is not None and frame[1] not in allowed_subscriptions:
+            if subscription_since is not None and frame[1] not in subscription_since:
                 raise BuzzRelayProtocolError("relay_event_subscription_mismatch")
-            await self._processor.process_event(frame[2])
-            self._last_event_at = time.time()
+            result = await self._processor.process_event(
+                frame[2],
+                subscription_since=(
+                    subscription_since[frame[1]] if subscription_since is not None else None
+                ),
+            )
+            if result == "delivered":
+                self._last_event_at = time.time()
             return
         if kind == "AUTH" and len(frame) == 2 and isinstance(frame[1], str):
             auth_event = self._signer.sign_relay_auth(self._relay_url, frame[1])
             await self._send_frame(ws, ["AUTH", auth_event])
             return
         if kind == "CLOSED" and (
-            allowed_subscriptions is None or (len(frame) >= 2 and frame[1] in allowed_subscriptions)
+            subscription_since is None or (len(frame) >= 2 and frame[1] in subscription_since)
         ):
             raise BuzzRelayProtocolError("relay_subscription_closed")
         if kind == "NOTICE":

--- a/src/pinky_outreach/buzz.py
+++ b/src/pinky_outreach/buzz.py
@@ -126,7 +126,7 @@ def verify_nostr_event(event: dict) -> bool:
         return False
 
 
-class _NostrSigner:
+class BuzzNostrSigner:
     """Small signing helper whose repr never contains the private scalar."""
 
     def __init__(self, private_key: bytes) -> None:
@@ -139,7 +139,7 @@ class _NostrSigner:
         self.pubkey = self._key.public_key_xonly.format().hex()
 
     def __repr__(self) -> str:
-        return f"_NostrSigner(pubkey={self.pubkey!r}, private_key=<redacted>)"
+        return f"BuzzNostrSigner(pubkey={self.pubkey!r}, private_key=<redacted>)"
 
     def sign_event(
         self,
@@ -168,6 +168,22 @@ class _NostrSigner:
             "content": content,
             "sig": self._key.sign_schnorr(bytes.fromhex(event_id)).hex(),
         }
+
+    def sign_relay_auth(self, relay_url: str, challenge: str) -> dict:
+        """Sign a NIP-42 transport-auth event; it is never channel-published."""
+        relay, _ = _validate_relay_url(relay_url)
+        if (
+            not isinstance(challenge, str)
+            or not challenge
+            or len(challenge) > 512
+            or any(ord(ch) < 32 or ord(ch) == 127 for ch in challenge)
+        ):
+            raise BuzzProtocolError("Buzz relay AUTH challenge is invalid")
+        return self.sign_event(
+            kind=22242,
+            tags=[["relay", relay], ["challenge", challenge]],
+            content="",
+        )
 
 
 def _validate_channel_id(channel_id: str) -> str:
@@ -209,7 +225,7 @@ class BuzzAdapter:
         timeout: float = 20.0,
         transport: httpx.BaseTransport | None = None,
     ) -> None:
-        self._signer = _NostrSigner(private_key)
+        self._signer = BuzzNostrSigner(private_key)
         self.relay_url, self._http_base = _validate_relay_url(relay_url)
         community = str(community_id or "").lower()
         if not _COMMUNITY_RE.fullmatch(community):
@@ -407,6 +423,7 @@ class BuzzAdapter:
 __all__ = [
     "BuzzAdapter",
     "BuzzError",
+    "BuzzNostrSigner",
     "BuzzProtocolError",
     "BuzzTransportError",
     "MentionNormalization",

--- a/tests/test_buzz_api.py
+++ b/tests/test_buzz_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import re
@@ -16,11 +17,14 @@ from pinky_daemon.agent_registry import AgentRegistry
 from pinky_daemon.api import create_api
 from pinky_daemon.auth import build_internal_auth_headers
 from pinky_daemon.broker import BrokerMessage
+from pinky_outreach.buzz import BuzzNostrSigner
 from pinky_outreach.types import Message, Platform
 
 PRIVATE_KEY = "11" * 32
 OTHER_PRIVATE_KEY = "22" * 32
 CHANNEL = "00000000-0000-4000-8000-000000000001"
+OWNER_PUBKEY = BuzzNostrSigner(bytes.fromhex("33" * 32)).pubkey
+APPROVED_PUBKEY = BuzzNostrSigner(bytes.fromhex("44" * 32)).pubkey
 
 
 @pytest.fixture(autouse=True)
@@ -35,6 +39,16 @@ def _body(**overrides):
         "relay_url": "wss://example.communities.buzz.xyz",
         "community_id": "example",
         "enabled": True,
+    }
+    body.update(overrides)
+    return body
+
+
+def _inbound_body(**overrides):
+    body = {
+        "owner_pubkey": OWNER_PUBKEY,
+        "channels": [{"channel_id": CHANNEL, "label": "#general"}],
+        "approved_users": [{"pubkey": APPROVED_PUBKEY, "display_name": "Brad"}],
     }
     body.update(overrides)
     return body
@@ -113,6 +127,7 @@ def test_arbitrary_or_caller_supplied_authority_cannot_enable(tmp_path):
             "relay_url",
             "community_id",
             "enabled",
+            "inbound",
         }
         assert schema["additionalProperties"] is False
         response = client.put(
@@ -213,6 +228,138 @@ def test_valid_internal_agent_auth_cannot_write_tos_authority(tmp_path):
         assert "owner session" in response.json()["detail"]
         assert PRIVATE_KEY not in response.text
         assert app.state.agents.get_buzz_identity("barsik") is None
+
+
+def test_one_step_bind_configures_inbound_gates_and_starts_native_poller(
+    tmp_path, monkeypatch
+):
+    async def idle_poller(self):  # noqa: ANN001
+        self._running = True
+        while self._running:
+            await asyncio.sleep(0.01)
+
+    monkeypatch.setattr(
+        "pinky_daemon.buzz_inbound.BrokerBuzzPoller.start",
+        idle_poller,
+    )
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+        response = client.put(
+            "/system/buzz-identities/barsik",
+            json=_body(inbound=_inbound_body()),
+        )
+
+        assert response.status_code == 200, response.text
+        policy = response.json()["inbound"]
+        assert policy["owner_principal"] == f"buzz:example:{OWNER_PUBKEY}"
+        assert policy["channels"] == [{"channel_id": CHANNEL, "label": "#general"}]
+        assert policy["approved_users"][0]["principal"] == (
+            f"buzz:example:{APPROVED_PUBKEY}"
+        )
+        assert policy["updated_by"] == "ui:admin"
+        fetched = client.get("/system/buzz-identities/barsik/inbound")
+        assert fetched.status_code == 200
+        assert fetched.json()["principals"] == policy["principals"]
+        status = client.get("/broker/status").json()
+        assert status["active_pollers"] == [
+            {"agent": "barsik", "polls": 0, "running": True}
+        ]
+
+        disabled = client.post("/system/buzz-identities/barsik/disable")
+        assert disabled.status_code == 200
+        health = client.get("/agents/barsik/health").json()
+        assert health["checks"]["buzz_inbound"]["enabled"] is False
+        assert health["recommendation"] != "degraded"
+
+
+def test_inbound_policy_rejects_caller_authority_and_internal_agent_auth(tmp_path):
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        client.post("/agents", json={"name": "barsik", "model": "sonnet"})
+        bound = client.put("/system/buzz-identities/barsik", json=_body())
+        assert bound.status_code == 200
+
+        forged = client.put(
+            "/system/buzz-identities/barsik/inbound",
+            json=_inbound_body(
+                updated_by="agent:forged",
+                updated_at=1,
+                owner_last_seen_at=1,
+                relay_url="wss://attacker.invalid",
+                community_id="attacker",
+            ),
+        )
+        assert forged.status_code == 422
+        assert app.state.agents.get_buzz_inbound_policy("barsik") is None
+
+        signing_key = app.state.agents.get_signing_key("barsik")
+        client.cookies.clear()
+        path = "/system/buzz-identities/barsik/inbound"
+        headers = build_internal_auth_headers(
+            signing_key,
+            agent_name="barsik",
+            method="PUT",
+            path=path,
+        )
+        denied = client.put(path, json=_inbound_body(), headers=headers)
+        assert denied.status_code == 403
+        assert "owner session" in denied.json()["detail"]
+        assert app.state.agents.get_buzz_inbound_policy("barsik") is None
+
+
+def test_daemon_restart_resumes_configured_native_buzz_poller(tmp_path, monkeypatch):
+    registry = AgentRegistry(
+        str(tmp_path / "conversations_agents.db"),
+        buzz_device_key_path=str(tmp_path / "identity" / ".device_key"),
+    )
+    registry.register("barsik", model="sonnet", working_dir=str(tmp_path / "barsik"))
+    registry.bind_buzz_identity_owner_control(
+        "barsik",
+        private_key=PRIVATE_KEY,
+        relay_url="wss://example.communities.buzz.xyz",
+        community_id="example",
+        enabled=True,
+        owner_actor="ui:admin",
+    )
+    registry.configure_buzz_inbound_owner_control(
+        "barsik",
+        owner_pubkey=OWNER_PUBKEY,
+        channels=[{"channel_id": CHANNEL, "label": "#general"}],
+        approved_users=[{"pubkey": APPROVED_PUBKEY, "display_name": "Brad"}],
+        owner_actor="ui:admin",
+    )
+    interrupted = BuzzNostrSigner(bytes.fromhex("44" * 32)).sign_event(
+        kind=9,
+        tags=[["h", CHANNEL]],
+        content="resume after kill -9",
+    )
+    assert registry.begin_buzz_inbound_event_delivery(
+        "barsik",
+        interrupted,
+        community_id="example",
+        channel_id=CHANNEL,
+    )
+    registry.close()
+
+    async def idle_poller(self):  # noqa: ANN001
+        self._running = True
+        while self._running:
+            await asyncio.sleep(0.01)
+
+    monkeypatch.setattr(
+        "pinky_daemon.buzz_inbound.BrokerBuzzPoller.start",
+        idle_poller,
+    )
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        assert client.get("/broker/status").json()["active_pollers"] == [
+            {"agent": "barsik", "polls": 0, "running": True}
+        ]
+        assert app.state.agents._db.execute(
+            "SELECT claimed_at FROM buzz_inbound_events WHERE event_id=?",
+            (interrupted["id"],),
+        ).fetchone()[0] == 0
 
 
 def test_broker_send_thread_and_react_route_to_native_buzz_adapter(tmp_path):

--- a/tests/test_buzz_api.py
+++ b/tests/test_buzz_api.py
@@ -273,6 +273,50 @@ def test_one_step_bind_configures_inbound_gates_and_starts_native_poller(
         assert health["recommendation"] != "degraded"
 
 
+def test_failed_one_step_bind_rolls_back_identity_and_policy_together(tmp_path):
+    app = _app(tmp_path)
+    agent_pubkey = BuzzNostrSigner(bytes.fromhex(PRIVATE_KEY)).pubkey
+    other_pubkey = BuzzNostrSigner(bytes.fromhex(OTHER_PRIVATE_KEY)).pubkey
+    with TestClient(app) as client:
+        for name in ("barsik", "murzik"):
+            created = client.post("/agents", json={"name": name, "model": "sonnet"})
+            assert created.status_code == 200
+
+        initial = client.put(
+            "/system/buzz-identities/barsik",
+            json=_body(enabled=False),
+        )
+        assert initial.status_code == 200
+        identity_before = app.state.agents._db.execute(
+            "SELECT * FROM buzz_identities WHERE agent='barsik'"
+        ).fetchone()
+
+        failed_rebind = client.put(
+            "/system/buzz-identities/barsik",
+            json=_body(enabled=True, inbound=_inbound_body(owner_pubkey=agent_pubkey)),
+        )
+        failed_first_bind = client.put(
+            "/system/buzz-identities/murzik",
+            json=_body(
+                private_key=OTHER_PRIVATE_KEY,
+                inbound=_inbound_body(owner_pubkey=other_pubkey),
+            ),
+        )
+
+        assert failed_rebind.status_code == 400
+        assert failed_first_bind.status_code == 400
+        assert (
+            app.state.agents._db.execute(
+                "SELECT * FROM buzz_identities WHERE agent='barsik'"
+            ).fetchone()
+            == identity_before
+        )
+        assert app.state.agents.get_buzz_identity("barsik")["enabled"] is False
+        assert app.state.agents.get_buzz_inbound_policy("barsik") is None
+        assert app.state.agents.get_buzz_identity("murzik") is None
+        assert app.state.agents.get_buzz_inbound_policy("murzik") is None
+
+
 def test_inbound_policy_rejects_caller_authority_and_internal_agent_auth(tmp_path):
     app = _app(tmp_path)
     with TestClient(app) as client:

--- a/tests/test_buzz_inbound.py
+++ b/tests/test_buzz_inbound.py
@@ -1,0 +1,406 @@
+"""Security and persona-routing tests for native Buzz inbound."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.broker import MessageBroker
+from pinky_daemon.buzz_inbound import (
+    BuzzInboundDeliveryError,
+    BuzzInboundProcessor,
+    BuzzInboundRejectedError,
+    validate_buzz_inbound_event,
+)
+from pinky_outreach.buzz import BuzzNostrSigner
+
+AGENT_KEY = "11" * 32
+OWNER_KEY = bytes.fromhex("33" * 32)
+USER_KEY = bytes.fromhex("44" * 32)
+STRANGER_KEY = bytes.fromhex("55" * 32)
+OWNER = BuzzNostrSigner(OWNER_KEY)
+USER = BuzzNostrSigner(USER_KEY)
+STRANGER = BuzzNostrSigner(STRANGER_KEY)
+CHANNEL = "00000000-0000-4000-8000-000000000001"
+OTHER_CHANNEL = "00000000-0000-4000-8000-000000000002"
+RELAY = "wss://example.communities.buzz.xyz"
+COMMUNITY = "example"
+
+
+class FakeBroker:
+    def __init__(self, *, accepted: bool = True) -> None:
+        self.accepted = accepted
+        self.calls: list[tuple[str, object]] = []
+
+    async def dispatch_pre_authorized(self, agent_name, message):  # noqa: ANN001
+        self.calls.append((agent_name, message))
+        return self.accepted
+
+
+@pytest.fixture
+def registry(tmp_path):
+    result = AgentRegistry(
+        str(tmp_path / "agents.db"),
+        buzz_device_key_path=str(tmp_path / "identity" / ".device_key"),
+    )
+    result.register("barsik", model="sonnet", working_dir=str(tmp_path / "barsik"))
+    identity = result.bind_buzz_identity_owner_control(
+        "barsik",
+        private_key=AGENT_KEY,
+        relay_url=RELAY,
+        community_id=COMMUNITY,
+        enabled=True,
+        owner_actor="ui:admin",
+    )
+    result.configure_buzz_inbound_owner_control(
+        "barsik",
+        owner_pubkey=OWNER.pubkey,
+        channels=[{"channel_id": CHANNEL, "label": "#general"}],
+        approved_users=[{"pubkey": USER.pubkey, "display_name": "Brad"}],
+        owner_actor="ui:admin",
+    )
+    yield result, identity["pubkey"]
+    result.close()
+
+
+def _processor(registry, identity_pubkey, broker=None):
+    return BuzzInboundProcessor(
+        registry=registry,
+        broker=broker or FakeBroker(),
+        agent_name="barsik",
+        identity_pubkey=identity_pubkey,
+        community_id=COMMUNITY,
+        relay_url=RELAY,
+    )
+
+
+def _event(
+    signer: BuzzNostrSigner = USER,
+    *,
+    kind: int = 9,
+    channel: str = CHANNEL,
+    content: str = "hello",
+    p_tags: list[str] | None = None,
+    created_at: int | None = None,
+):
+    tags = [["h", channel]]
+    for pubkey in p_tags or []:
+        tags.append(["p", pubkey])
+    return signer.sign_event(
+        kind=kind,
+        tags=tags,
+        content=content,
+        created_at=created_at,
+    )
+
+
+def test_policy_is_identity_scoped_default_deny_and_owner_issued(registry):
+    store, identity_pubkey = registry
+    policy = store.get_buzz_inbound_policy("barsik")
+
+    assert policy["community_id"] == COMMUNITY
+    assert policy["relay_url"] == RELAY
+    assert policy["channels"] == [{"channel_id": CHANNEL, "label": "#general"}]
+    assert policy["owner_principal"] == f"buzz:{COMMUNITY}:{OWNER.pubkey}"
+    assert policy["updated_by"] == "ui:admin"
+    assert policy["owner_silence_days"] == 14
+    assert {item["principal"] for item in policy["principals"]} == {
+        f"buzz:{COMMUNITY}:{OWNER.pubkey}",
+        f"buzz:{COMMUNITY}:{USER.pubkey}",
+    }
+    assert store.get_buzz_inbound_channel("barsik", COMMUNITY, RELAY, OTHER_CHANNEL) is None
+    assert store.get_buzz_inbound_principal("barsik", COMMUNITY, STRANGER.pubkey) is None
+    assert identity_pubkey not in {item["pubkey"] for item in policy["principals"]}
+
+
+def test_policy_replace_is_owner_controlled_and_preserves_seen_same_principal(registry):
+    store, _ = registry
+    store.note_buzz_inbound_principal_seen("barsik", COMMUNITY, OWNER.pubkey, 1234)
+    with pytest.raises(ValueError, match="owner approval actor"):
+        store.configure_buzz_inbound_owner_control(
+            "barsik",
+            owner_pubkey=OWNER.pubkey,
+            channels=[{"channel_id": CHANNEL, "label": "#general"}],
+            approved_users=[],
+            owner_actor="agent:forged",
+        )
+
+    policy = store.configure_buzz_inbound_owner_control(
+        "barsik",
+        owner_pubkey=OWNER.pubkey,
+        channels=[{"channel_id": OTHER_CHANNEL, "label": "#ops"}],
+        approved_users=[],
+        owner_actor="ui:admin",
+    )
+    assert policy["channels"] == [{"channel_id": OTHER_CHANNEL, "label": "#ops"}]
+    assert policy["owner_last_seen_at"] == 1234
+    assert store.get_buzz_inbound_channel("barsik", COMMUNITY, RELAY, CHANNEL) is None
+
+
+@pytest.mark.asyncio
+async def test_verified_no_p_broadcast_reaches_persona_with_full_principal(registry):
+    store, identity_pubkey = registry
+    broker = FakeBroker()
+    processor = _processor(store, identity_pubkey, broker)
+    event = _event(content="ordinary channel message")
+
+    assert await processor.process_event(event) == "delivered"
+    assert len(broker.calls) == 1
+    message = broker.calls[0][1]
+    assert message.agent_name == "barsik"
+    assert message.chat_id == CHANNEL
+    assert message.is_group is True
+    assert message.sender_id == f"buzz:{COMMUNITY}:{USER.pubkey}"
+    assert message.metadata["buzz_mentioned_self"] is False
+    assert message.metadata["buzz_display_name_untrusted"] is True
+    assert message.metadata["buzz_verified_event"] == {
+        "verified": True,
+        "event_id": event["id"],
+        "kind": 9,
+        "author_pubkey": USER.pubkey,
+        "channel_id": CHANNEL,
+    }
+
+    formatter = object.__new__(MessageBroker)
+    formatter._registry = store
+    prompt = MessageBroker._format_prompt(formatter, message)
+    assert "[buzz | channel | #general" in prompt
+    assert "display_name(untrusted):Brad" in prompt
+    assert f"principal:buzz:{COMMUNITY}:{USER.pubkey}" in prompt
+    assert "mentioned_self:false" in prompt
+
+
+@pytest.mark.asyncio
+async def test_only_exact_single_self_p_tag_sets_mentioned_self(registry):
+    store, identity_pubkey = registry
+    broker = FakeBroker()
+    processor = _processor(store, identity_pubkey, broker)
+
+    exact = _event(content="ping", p_tags=[identity_pubkey])
+    foreign = _event(content="foreign", p_tags=[STRANGER.pubkey])
+    duplicate = USER.sign_event(
+        kind=9,
+        tags=[["h", CHANNEL], ["p", identity_pubkey], ["p", identity_pubkey]],
+        content="duplicate",
+    )
+    display_only = _event(content="@Barsik in display text only")
+
+    assert await processor.process_event(exact) == "delivered"
+    assert broker.calls[-1][1].metadata["buzz_mentioned_self"] is True
+    assert await processor.process_event(foreign) == "rejected"
+    assert await processor.process_event(duplicate) == "rejected"
+    assert await processor.process_event(display_only) == "delivered"
+    assert broker.calls[-1][1].metadata["buzz_mentioned_self"] is False
+    assert len(broker.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_both_gates_signature_self_and_dedupe_fail_closed(registry):
+    store, identity_pubkey = registry
+    broker = FakeBroker()
+    processor = _processor(store, identity_pubkey, broker)
+
+    unlisted = _event(channel=OTHER_CHANNEL)
+    unapproved = _event(signer=STRANGER)
+    invalid = _event(content="signed")
+    invalid["content"] = "tampered"
+    self_event = BuzzNostrSigner(bytes.fromhex(AGENT_KEY)).sign_event(
+        kind=9,
+        tags=[["h", CHANNEL]],
+        content="self",
+    )
+    valid = _event(content="once")
+
+    assert await processor.process_event(unlisted) == "unlisted_channel"
+    assert await processor.process_event(unapproved) == "unapproved_principal"
+    assert await processor.process_event(invalid) == "rejected"
+    assert await processor.process_event(self_event) == "rejected"
+    assert await processor.process_event(valid) == "delivered"
+    assert await processor.process_event(valid) == "duplicate"
+    assert len(broker.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_membership_events_never_expand_channels_or_reach_persona(registry):
+    store, identity_pubkey = registry
+    broker = FakeBroker()
+    processor = _processor(store, identity_pubkey, broker)
+    before = store.get_buzz_inbound_policy("barsik")["channels"]
+    membership = USER.sign_event(
+        kind=30000,
+        tags=[["h", OTHER_CHANNEL]],
+        content="join",
+    )
+
+    assert await processor.process_event(membership) == "rejected"
+    assert broker.calls == []
+    assert store.get_buzz_inbound_policy("barsik")["channels"] == before
+    assert store.get_buzz_inbound_channel("barsik", COMMUNITY, RELAY, OTHER_CHANNEL) is None
+
+
+@pytest.mark.asyncio
+async def test_community_scope_is_part_of_both_authorization_gates(registry):
+    store, identity_pubkey = registry
+    broker = FakeBroker()
+    wrong_community = BuzzInboundProcessor(
+        registry=store,
+        broker=broker,
+        agent_name="barsik",
+        identity_pubkey=identity_pubkey,
+        community_id="other-community",
+        relay_url=RELAY,
+    )
+
+    assert await wrong_community.process_event(_event()) == "unlisted_channel"
+    assert broker.calls == []
+
+
+@pytest.mark.asyncio
+async def test_kind_20002_is_verified_but_never_retained_or_dispatched(registry):
+    store, identity_pubkey = registry
+    broker = FakeBroker()
+    processor = _processor(store, identity_pubkey, broker)
+    ephemeral = _event(kind=20002, content="")
+
+    assert await processor.process_event(ephemeral) == "ephemeral_ignored"
+    assert broker.calls == []
+    assert store._db.execute("SELECT COUNT(*) FROM buzz_inbound_events").fetchone()[0] == 0
+    with pytest.raises(ValueError, match="kind-9"):
+        store.begin_buzz_inbound_event_delivery(
+            "barsik",
+            ephemeral,
+            community_id=COMMUNITY,
+            channel_id=CHANNEL,
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        store._db.execute(
+            """INSERT INTO buzz_inbound_events
+               (agent, event_id, community_id, channel_id, author_pubkey, kind,
+                event_created_at, event_json, claimed_at, attempts)
+               VALUES (?, ?, ?, ?, ?, 20002, ?, '{}', 1, 1)""",
+            (
+                "barsik",
+                ephemeral["id"],
+                COMMUNITY,
+                CHANNEL,
+                USER.pubkey,
+                ephemeral["created_at"],
+            ),
+        )
+    store._db.rollback()
+
+
+@pytest.mark.asyncio
+async def test_pending_kind9_replays_after_failed_handoff_without_replaying_delivered(registry):
+    store, identity_pubkey = registry
+    event = _event(content="survive restart")
+    failing = _processor(store, identity_pubkey, FakeBroker(accepted=False))
+
+    with pytest.raises(BuzzInboundDeliveryError):
+        await failing.process_event(event)
+    row = store._db.execute(
+        "SELECT delivery_status, attempts, last_error FROM buzz_inbound_events"
+    ).fetchone()
+    assert row == ("pending", 1, "BuzzInboundDeliveryError")
+
+    success_broker = FakeBroker()
+    resumed = _processor(store, identity_pubkey, success_broker)
+    assert await resumed.replay_pending() == 1
+    assert len(success_broker.calls) == 1
+    assert await resumed.process_event(event) == "duplicate"
+    assert store._db.execute(
+        "SELECT delivery_status, attempts, event_json FROM buzz_inbound_events"
+    ).fetchone() == ("delivered", 2, "")
+
+
+def test_pending_claim_is_fenced_and_released_only_after_process_restart(registry):
+    store, _ = registry
+    event = _event(content="single claimant")
+    assert store.begin_buzz_inbound_event_delivery(
+        "barsik",
+        event,
+        community_id=COMMUNITY,
+        channel_id=CHANNEL,
+    )
+    store.mark_buzz_inbound_event_retry("barsik", event["id"], "handoff_failed")
+
+    assert store.begin_buzz_inbound_event_delivery(
+        "barsik",
+        event,
+        community_id=COMMUNITY,
+        channel_id=CHANNEL,
+        replay=True,
+    )
+    assert not store.begin_buzz_inbound_event_delivery(
+        "barsik",
+        event,
+        community_id=COMMUNITY,
+        channel_id=CHANNEL,
+        replay=True,
+    )
+    assert store.list_pending_buzz_inbound_events("barsik") == []
+
+    assert store.reset_buzz_inbound_event_claims_after_restart() == 1
+    assert store.list_pending_buzz_inbound_events("barsik") == [event]
+
+
+@pytest.mark.asyncio
+async def test_policy_replace_discards_pending_events_with_revoked_authority(registry):
+    store, identity_pubkey = registry
+    pending = _event(content="must not survive revocation")
+    processor = _processor(store, identity_pubkey, FakeBroker(accepted=False))
+    with pytest.raises(BuzzInboundDeliveryError):
+        await processor.process_event(pending)
+    assert store.list_pending_buzz_inbound_events("barsik") == [pending]
+
+    store.configure_buzz_inbound_owner_control(
+        "barsik",
+        owner_pubkey=OWNER.pubkey,
+        channels=[{"channel_id": OTHER_CHANNEL, "label": "#ops"}],
+        approved_users=[],
+        owner_actor="ui:admin",
+    )
+
+    assert store.list_pending_buzz_inbound_events("barsik") == []
+    assert (
+        store._db.execute(
+            "SELECT COUNT(*) FROM buzz_inbound_events WHERE event_id=?",
+            (pending["id"],),
+        ).fetchone()[0]
+        == 0
+    )
+
+
+def test_owner_rotation_silence_guard_is_durable_and_resets_on_verified_seen(registry):
+    store, _ = registry
+    policy = store.get_buzz_inbound_policy("barsik")
+    due_at = policy["owner_configured_at"] + 15 * 86400
+
+    due = store.buzz_owner_silence_alert_due("barsik", now=due_at)
+    assert due["owner_principal"] == f"buzz:{COMMUNITY}:{OWNER.pubkey}"
+    store.mark_buzz_owner_silence_notified("barsik", notified_at=due_at)
+    assert store.buzz_owner_silence_alert_due("barsik", now=due_at + 10) is None
+
+    store.note_buzz_inbound_principal_seen("barsik", COMMUNITY, OWNER.pubkey, due_at + 20)
+    assert store.buzz_owner_silence_alert_due("barsik", now=due_at + 20 + 13 * 86400) is None
+    assert store.buzz_owner_silence_alert_due("barsik", now=due_at + 20 + 15 * 86400) is not None
+
+
+def test_strict_bounds_future_and_malformed_tags_are_rejected(registry):
+    _, identity_pubkey = registry
+    now = int(time.time())
+    future = _event(created_at=now + 301)
+    malformed_h = USER.sign_event(kind=9, tags=[["h", CHANNEL, "extra"]], content="x")
+    noncanonical_h = USER.sign_event(
+        kind=9,
+        tags=[["h", "AAAAAAAA-0000-4000-8000-000000000001"]],
+        content="x",
+    )
+    malformed_p = USER.sign_event(kind=9, tags=[["h", CHANNEL], ["p", "ABC"]], content="x")
+
+    for event in (future, malformed_h, noncanonical_h, malformed_p):
+        with pytest.raises(BuzzInboundRejectedError):
+            validate_buzz_inbound_event(event, identity_pubkey=identity_pubkey, now=now)

--- a/tests/test_buzz_inbound.py
+++ b/tests/test_buzz_inbound.py
@@ -264,9 +264,15 @@ async def test_kind_20002_is_verified_but_never_retained_or_dispatched(registry)
     broker = FakeBroker()
     processor = _processor(store, identity_pubkey, broker)
     ephemeral = _event(kind=20002, content="")
+    policy_before = store.get_buzz_inbound_policy("barsik")
+    changes_before = store._db.total_changes
 
     assert await processor.process_event(ephemeral) == "ephemeral_ignored"
+    assert await processor.process_event(ephemeral) == "ephemeral_ignored"
     assert broker.calls == []
+    assert processor._recent_ids == set()
+    assert store.get_buzz_inbound_policy("barsik") == policy_before
+    assert store._db.total_changes == changes_before
     assert store._db.execute("SELECT COUNT(*) FROM buzz_inbound_events").fetchone()[0] == 0
     with pytest.raises(ValueError, match="kind-9"):
         store.begin_buzz_inbound_event_delivery(
@@ -291,6 +297,33 @@ async def test_kind_20002_is_verified_but_never_retained_or_dispatched(registry)
             ),
         )
     store._db.rollback()
+
+
+@pytest.mark.asyncio
+async def test_subscription_floor_rejects_stale_relay_event_but_pending_replay_is_allowed(
+    registry,
+):
+    store, identity_pubkey = registry
+    now = int(time.time())
+    stale = _event(content="historic signed command", created_at=now - 86400)
+    broker = FakeBroker()
+    processor = _processor(store, identity_pubkey, broker)
+
+    assert await processor.process_event(stale, subscription_since=now - 60) == "rejected"
+    assert broker.calls == []
+    assert store._db.execute("SELECT COUNT(*) FROM buzz_inbound_events").fetchone()[0] == 0
+
+    # Only the daemon's already-verified durable retry ledger may bypass a
+    # newly computed relay subscription floor after restart/reconnect.
+    assert store.begin_buzz_inbound_event_delivery(
+        "barsik",
+        stale,
+        community_id=COMMUNITY,
+        channel_id=CHANNEL,
+    )
+    store.mark_buzz_inbound_event_retry("barsik", stale["id"], "interrupted")
+    assert await processor.replay_pending() == 1
+    assert [call[1].content for call in broker.calls] == ["historic signed command"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_buzz_inbound_poller.py
+++ b/tests/test_buzz_inbound_poller.py
@@ -1,0 +1,266 @@
+"""Integrated NIP-42/REQ/liveness tests for the production Buzz poller."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+import websockets
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.buzz_inbound import BrokerBuzzPoller
+from pinky_outreach.buzz import BuzzNostrSigner, verify_nostr_event
+
+AGENT_KEY = "11" * 32
+OWNER = BuzzNostrSigner(bytes.fromhex("33" * 32))
+USER = BuzzNostrSigner(bytes.fromhex("44" * 32))
+CHANNEL = "00000000-0000-4000-8000-000000000001"
+COMMUNITY = "example"
+
+
+class FakeBroker:
+    def __init__(self) -> None:
+        self.calls = []
+        self.delivered = asyncio.Event()
+
+    async def dispatch_pre_authorized(self, agent_name, message):  # noqa: ANN001
+        self.calls.append((agent_name, message))
+        self.delivered.set()
+        return True
+
+
+def _registry(tmp_path, relay_url: str):
+    store = AgentRegistry(
+        str(tmp_path / "agents.db"),
+        buzz_device_key_path=str(tmp_path / "identity" / ".device_key"),
+    )
+    store.register("barsik", model="sonnet", working_dir=str(tmp_path / "barsik"))
+    store.bind_buzz_identity_owner_control(
+        "barsik",
+        private_key=AGENT_KEY,
+        relay_url=relay_url,
+        community_id=COMMUNITY,
+        enabled=True,
+        owner_actor="ui:admin",
+    )
+    store.configure_buzz_inbound_owner_control(
+        "barsik",
+        owner_pubkey=OWNER.pubkey,
+        channels=[{"channel_id": CHANNEL, "label": "#general"}],
+        approved_users=[{"pubkey": USER.pubkey, "display_name": "Brad"}],
+        owner_actor="ui:admin",
+    )
+    return store
+
+
+async def _authenticate(ws, relay_url: str, captured: list[list]) -> list:
+    challenge = "challenge-" + "ab" * 16
+    await ws.send(json.dumps(["AUTH", challenge]))
+    frame = json.loads(await ws.recv())
+    captured.append(frame)
+    assert frame[0] == "AUTH"
+    event = frame[1]
+    assert verify_nostr_event(event)
+    assert event["kind"] == 22242
+    assert event["content"] == ""
+    assert event["tags"] == [["relay", relay_url], ["challenge", challenge]]
+    await ws.send(json.dumps(["OK", event["id"], True, "authenticated"]))
+    return event
+
+
+@pytest.mark.asyncio
+async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_health(
+    tmp_path,
+):
+    captured: list[list] = []
+    initial_filter = {}
+    heartbeat_seen = asyncio.Event()
+    relay_url = ""
+
+    durable = USER.sign_event(kind=9, tags=[["h", CHANNEL]], content="hello from Brad")
+    ephemeral = USER.sign_event(kind=20002, tags=[["h", CHANNEL]], content="")
+
+    async def handler(ws):  # noqa: ANN001
+        await _authenticate(ws, relay_url, captured)
+        main = json.loads(await ws.recv())
+        captured.append(main)
+        assert main[0] == "REQ"
+        initial_filter.update(main[2])
+        await ws.send(json.dumps(["EVENT", main[1], ephemeral]))
+        await ws.send(json.dumps(["EVENT", main[1], durable]))
+        await ws.send(json.dumps(["EOSE", main[1]]))
+        while True:
+            try:
+                frame = json.loads(await ws.recv())
+            except websockets.ConnectionClosed:
+                return
+            captured.append(frame)
+            if frame[0] == "REQ":
+                heartbeat_seen.set()
+                await ws.send(json.dumps(["EOSE", frame[1]]))
+
+    async with websockets.serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        relay_url = f"ws://127.0.0.1:{port}"
+        store = _registry(tmp_path, relay_url)
+        broker = FakeBroker()
+        notices = []
+
+        async def notify(agent, message):  # noqa: ANN001
+            notices.append((agent, message))
+            return True
+
+        material = store.get_buzz_signing_material("barsik")
+        poller = BrokerBuzzPoller(
+            material,
+            broker,
+            store,
+            notify,
+            heartbeat_interval=0.05,
+            liveness_timeout=0.3,
+            reconnect_base=0.01,
+            reconnect_max=0.02,
+        )
+        task = asyncio.create_task(poller.start())
+        await asyncio.wait_for(broker.delivered.wait(), timeout=2)
+        await asyncio.wait_for(heartbeat_seen.wait(), timeout=2)
+        poller.stop()
+        await asyncio.wait_for(task, timeout=2)
+
+        assert initial_filter["kinds"] == [9, 20002]
+        assert initial_filter["#h"] == [CHANNEL]
+        assert isinstance(initial_filter["since"], int)
+        assert len(broker.calls) == 1
+        assert broker.calls[0][1].content == "hello from Brad"
+        assert poller.health["delivered"] == 1
+        assert poller.health["ephemeral_ignored"] == 1
+        assert notices == []
+        assert store._db.execute(
+            "SELECT event_id, kind, delivery_status FROM buzz_inbound_events"
+        ).fetchall() == [(durable["id"], 9, "delivered")]
+        assert all(frame[0] in {"AUTH", "REQ", "CLOSE"} for frame in captured)
+        assert not any(frame[0] == "EVENT" for frame in captured)
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_socket_open_without_eose_heartbeat_pages_owner_and_reconnects(tmp_path):
+    relay_url = ""
+    notified = asyncio.Event()
+    notices = []
+    connections = 0
+
+    async def handler(ws):  # noqa: ANN001
+        nonlocal connections
+        connections += 1
+        await _authenticate(ws, relay_url, [])
+        main = json.loads(await ws.recv())
+        await ws.send(json.dumps(["EOSE", main[1]]))
+        # Keep the TCP/WebSocket open but intentionally never answer the next
+        # heartbeat REQ. This is the exact socket-open/subscription-dead seam.
+        try:
+            while True:
+                await ws.recv()
+        except websockets.ConnectionClosed:
+            return
+
+    async with websockets.serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        relay_url = f"ws://127.0.0.1:{port}"
+        store = _registry(tmp_path, relay_url)
+
+        async def notify(agent, message):  # noqa: ANN001
+            notices.append((agent, message))
+            notified.set()
+            return True
+
+        poller = BrokerBuzzPoller(
+            store.get_buzz_signing_material("barsik"),
+            FakeBroker(),
+            store,
+            notify,
+            heartbeat_interval=0.05,
+            liveness_timeout=0.08,
+            reconnect_base=0.01,
+            reconnect_max=0.02,
+        )
+        task = asyncio.create_task(poller.start())
+        await asyncio.wait_for(notified.wait(), timeout=2)
+
+        assert connections >= 1
+        assert notices[0][0] == "barsik"
+        assert "active EOSE liveness failed" in notices[0][1]
+        assert poller.health["last_error"] == "BuzzRelayLivenessError"
+        poller.stop()
+        await asyncio.wait_for(task, timeout=2)
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_restart_replays_overlap_but_dedupes_delivered_event(tmp_path):
+    relay_url = ""
+    connection_number = 0
+    first = USER.sign_event(kind=9, tags=[["h", CHANNEL]], content="first")
+    second = USER.sign_event(kind=9, tags=[["h", CHANNEL]], content="second")
+
+    async def handler(ws):  # noqa: ANN001
+        nonlocal connection_number
+        connection_number += 1
+        this_connection = connection_number
+        await _authenticate(ws, relay_url, [])
+        main = json.loads(await ws.recv())
+        await ws.send(json.dumps(["EVENT", main[1], first]))
+        if this_connection >= 2:
+            await ws.send(json.dumps(["EVENT", main[1], second]))
+        await ws.send(json.dumps(["EOSE", main[1]]))
+        try:
+            while True:
+                await ws.recv()
+        except websockets.ConnectionClosed:
+            return
+
+    async with websockets.serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        relay_url = f"ws://127.0.0.1:{port}"
+        store = _registry(tmp_path, relay_url)
+        broker = FakeBroker()
+
+        async def notify(_agent, _message):
+            return True
+
+        first_poller = BrokerBuzzPoller(
+            store.get_buzz_signing_material("barsik"),
+            broker,
+            store,
+            notify,
+            heartbeat_interval=10,
+            liveness_timeout=1,
+        )
+        first_task = asyncio.create_task(first_poller.start())
+        await asyncio.wait_for(broker.delivered.wait(), timeout=2)
+        first_poller.stop()
+        await asyncio.wait_for(first_task, timeout=2)
+
+        broker.delivered.clear()
+        second_poller = BrokerBuzzPoller(
+            store.get_buzz_signing_material("barsik"),
+            broker,
+            store,
+            notify,
+            heartbeat_interval=10,
+            liveness_timeout=1,
+        )
+        second_task = asyncio.create_task(second_poller.start())
+        await asyncio.wait_for(broker.delivered.wait(), timeout=2)
+        second_poller.stop()
+        await asyncio.wait_for(second_task, timeout=2)
+
+        assert [call[1].content for call in broker.calls] == ["first", "second"]
+        assert (
+            store._db.execute(
+                "SELECT COUNT(*) FROM buzz_inbound_events WHERE delivery_status='delivered'"
+            ).fetchone()[0]
+            == 2
+        )
+        store.close()

--- a/tests/test_buzz_inbound_poller.py
+++ b/tests/test_buzz_inbound_poller.py
@@ -198,6 +198,136 @@ async def test_socket_open_without_eose_heartbeat_pages_owner_and_reconnects(tmp
 
 
 @pytest.mark.asyncio
+async def test_control_frame_trickle_cannot_starve_periodic_eose_probe(tmp_path):
+    relay_url = ""
+    heartbeat_seen = asyncio.Event()
+    heartbeat_closed = asyncio.Event()
+    captured: list[list] = []
+
+    async def handler(ws):  # noqa: ANN001
+        await _authenticate(ws, relay_url, captured)
+        main = json.loads(await ws.recv())
+        captured.append(main)
+        await ws.send(json.dumps(["EOSE", main[1]]))
+        counter = 0
+        try:
+            while True:
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=0.01)
+                except asyncio.TimeoutError:
+                    # Alternate an ignorable OK with an unknown control shape.
+                    # Neither proves the subscription is alive.
+                    frame = (
+                        ["OK", "00" * 32, True, "control trickle"]
+                        if counter % 2 == 0
+                        else ["IGNORED", counter]
+                    )
+                    counter += 1
+                    await ws.send(json.dumps(frame))
+                    continue
+                frame = json.loads(raw)
+                captured.append(frame)
+                if frame[0] == "REQ":
+                    heartbeat_seen.set()
+                    await ws.send(json.dumps(["EOSE", frame[1]]))
+                elif frame[0] == "CLOSE":
+                    heartbeat_closed.set()
+        except websockets.ConnectionClosed:
+            return
+
+    async with websockets.serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        relay_url = f"ws://127.0.0.1:{port}"
+        store = _registry(tmp_path, relay_url)
+        notices = []
+
+        async def notify(agent, message):  # noqa: ANN001
+            notices.append((agent, message))
+            return True
+
+        poller = BrokerBuzzPoller(
+            store.get_buzz_signing_material("barsik"),
+            FakeBroker(),
+            store,
+            notify,
+            heartbeat_interval=0.05,
+            liveness_timeout=0.3,
+        )
+        task = asyncio.create_task(poller.start())
+        await asyncio.wait_for(heartbeat_seen.wait(), timeout=2)
+        await asyncio.wait_for(heartbeat_closed.wait(), timeout=2)
+        poller.stop()
+        await asyncio.wait_for(task, timeout=2)
+
+        assert any(frame[0] == "REQ" and frame[1].startswith("pinky-live-") for frame in captured)
+        assert poller.health["last_liveness_at"] > 0
+        assert notices == []
+        assert not any(frame[0] == "EVENT" for frame in captured)
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_real_relay_event_older_than_req_since_is_rejected_client_side(tmp_path):
+    relay_url = ""
+    subscription_filter = {}
+
+    async def handler(ws):  # noqa: ANN001
+        await _authenticate(ws, relay_url, [])
+        main = json.loads(await ws.recv())
+        subscription_filter.update(main[2])
+        stale = USER.sign_event(
+            kind=9,
+            tags=[["h", CHANNEL]],
+            content="historic signed command",
+            created_at=main[2]["since"] - 86340,
+        )
+        fresh = USER.sign_event(
+            kind=9,
+            tags=[["h", CHANNEL]],
+            content="current signed command",
+            created_at=main[2]["since"],
+        )
+        await ws.send(json.dumps(["EVENT", main[1], stale]))
+        await ws.send(json.dumps(["EVENT", main[1], fresh]))
+        await ws.send(json.dumps(["EOSE", main[1]]))
+        try:
+            while True:
+                await ws.recv()
+        except websockets.ConnectionClosed:
+            return
+
+    async with websockets.serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        relay_url = f"ws://127.0.0.1:{port}"
+        store = _registry(tmp_path, relay_url)
+        broker = FakeBroker()
+
+        async def notify(_agent, _message):
+            return True
+
+        poller = BrokerBuzzPoller(
+            store.get_buzz_signing_material("barsik"),
+            broker,
+            store,
+            notify,
+            heartbeat_interval=10,
+            liveness_timeout=1,
+        )
+        task = asyncio.create_task(poller.start())
+        await asyncio.wait_for(broker.delivered.wait(), timeout=2)
+        poller.stop()
+        await asyncio.wait_for(task, timeout=2)
+
+        assert isinstance(subscription_filter["since"], int)
+        assert [call[1].content for call in broker.calls] == ["current signed command"]
+        assert poller.health["rejected"] == 1
+        assert store._db.execute(
+            "SELECT event_created_at, delivery_status FROM buzz_inbound_events"
+        ).fetchall() == [(float(subscription_filter["since"]), "delivered")]
+        store.close()
+
+
+@pytest.mark.asyncio
 async def test_restart_replays_overlap_but_dedupes_delivered_event(tmp_path):
     relay_url = ""
     connection_number = 0


### PR DESCRIPTION
## Outcome

Adds Buzz inbound as a native PinkyBot chat platform. A verified, explicitly approved kind-9 from an allowlisted channel now reaches the agent's normal persona session exactly like Telegram or Slack; agents continue replying through the existing generic `send` / `thread` surfaces.

Built from the FINAL v5 security spec at SHA-256 `33e86969d9189c6f113546e5d26b893feb419b83d4c1d9fbcc66d3ff3f54e21e`.

## What changed

- Adds per-identity native NIP-42 WebSocket supervision with standard Nostr `REQ` subscriptions, reconnect/backoff, monotonic periodic authenticated `REQ`/EOSE liveness probes, durable health, and owner notification.
- Treats relay `since` filters as advisory and enforces the exact subscription floor client-side before any cache, authorization lookup, durable write, or persona turn. Only events already present in the local pending-delivery ledger may replay across a newer subscription floor.
- Adds the two load-bearing, DB-backed gates before persona dispatch: exact identity community/relay + per-agent channel UUID allowlist, then a BIP340-verified full `buzz:<community>:<64-hex-pubkey>` owner/approved principal.
- Adds strict event schema/bounds, canonical ID and Schnorr verification, non-self enforcement, event-ID dedupe, durable kind-9 retry/claim fencing, restart claim release, and policy-revocation cleanup.
- Routes accepted messages into the normal main/group persona path with the full verified principal adjacent to an explicitly untrusted display annotation.
- Ignores kind-20002 immediately after cryptographic/schema validation: no persona turn, authorization lookup, duplicate cache, principal timestamp, durable row, replay, prompt, or conversation retention.
- Makes the one-operation identity + inbound-policy bind a single database transaction, so any derived policy conflict rolls back both new and existing identity state. The separate owner-only policy replacement route remains available for channel/user changes and out-of-band owner-key rotation.
- Documents native health, rotation, ACP-as-harness-only, and the release-time legacy bridge cutover.

## Spec interpretation made explicit

For ordinary channel broadcasts, a self `p` tag is optional. A no-`p` kind-9 remains eligible only after both load-bearing gates and is always a group/channel message with `mentioned_self=false`.

If any `p` tag is present, this increment requires exactly one canonical self-pubkey tag. Foreign, malformed, or duplicate `p` tags suppress delivery; only the exact self tag sets `mentioned_self`, and rendered `@name` text never does.

The foreign-`p` suppression is the conservative inc2 choice. Slack parity could instead deliver a foreign-targeted channel message with `mentioned_self=false`; revisit that only when inc3 introduces real multi-agent Buzz channels.

## Relay compatibility evidence

Read-only live-rig probes confirmed:

- NIP-98 query returned both of Brad's BIP340-verified kind-9 forms in #general: one exact self-`p` message and one no-`p` broadcast.
- A plain WebSocket received the relay AUTH challenge; a signed NIP-42 kind-22242 AUTH was accepted; a standard `REQ` returned both kind-9 events followed by EOSE.
- The local production-WebSocket integration sends only AUTH/REQ/CLOSE application frames. No live channel EVENT publication was performed.

## Validation

- All Buzz tests: `60 passed`
- Focused inbound/API/poller tests: `30 passed`
- Exact adversarial round-2 regressions: `5 passed` (stale relay replay + pending-ledger exception, control-frame liveness trickle, kind-20002 zero mutation, and new/existing identity atomic rollback)
- Registry/database-security/auth overlap: `215 passed` under the repository's intended `PINKY_AUTH_DENY_DEFAULT=shadow`, `PINKY_SHARED_MCP=0` test environment
- Broker/messaging overlap: `107 passed`
- Daemon/poller overlap: `85 passed`
- Broad local round-2 run: `828 passed, 2 skipped, 1 deselected` before interrupting unrelated host-environment seams. This machine's global dream transport selected the real logged-in tmux/Claude path instead of the test's patched SDK path; that selector passed independently with `PINKY_DREAM_TRANSPORT=sdk`. Exact-head GitHub CI is the authoritative full-suite gate.
- Ruff, `git diff --check`, `uv lock --check`, `uv pip check`, source compile, sdist build, and wheel build passed.

Screenshot/clip: N/A — daemon relay/routing and owner-control plumbing only; no visual UI surface changed.

## Boundaries

No production identity was bound or changed, no live Buzz channel event was published, the legacy bridge/LaunchAgent was not touched, and nothing was deployed. Bridge retirement is an operator-controlled release step after native health verification. This draft does not authorize merge or deploy.

---
🤖 Opened by Kuzya
