### PR TITLE
Fix Buzz live inbound on production relay

### DIFF
--- a/src/pinky_daemon/buzz_inbound.py
+++ b/src/pinky_daemon/buzz_inbound.py
@@ -506,7 +506,11 @@ class BrokerBuzzPoller:
             [
                 "REQ",
                 main_sub,
-                {"kinds": [9, 20002], "#h": channels, "since": since},
+                # The production Buzz relay does not live-fanout events to a
+                # subscription whose filter carries ``since``.  Keep the wire
+                # subscription open-ended and enforce this exact floor in the
+                # client before any cache, authorization gate, or durable write.
+                {"kinds": [9, 20002], "#h": channels},
             ],
         )
         await self._wait_for_eose(

--- a/tests/test_buzz_inbound_poller.py
+++ b/tests/test_buzz_inbound_poller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 
 import pytest
 import websockets
@@ -69,6 +70,50 @@ async def _authenticate(ws, relay_url: str, captured: list[list]) -> list:
     return event
 
 
+class SinceBlindLiveRelayRig:
+    """Model Buzz: stored queries work, but wire-``since`` disables live push."""
+
+    def __init__(self, *, stored_events: list[dict], live_event: dict) -> None:
+        self.relay_url = ""
+        self.stored_events = stored_events
+        self.live_event = live_event
+        self.captured: list[list] = []
+        self.main_filter: dict = {}
+        self.stored_batch_sent = asyncio.Event()
+        self.release_live_event = asyncio.Event()
+        self.live_event_pushed = asyncio.Event()
+
+    async def handler(self, ws) -> None:  # noqa: ANN001
+        await _authenticate(ws, self.relay_url, self.captured)
+        main = json.loads(await ws.recv())
+        self.captured.append(main)
+        assert main[0] == "REQ"
+        self.main_filter.update(main[2])
+
+        # Stored-query delivery works for every filter shape on the real
+        # relay, including filters with ``since``.  A no-since main REQ can
+        # therefore receive the channel's full history before EOSE.
+        for event in self.stored_events:
+            await ws.send(json.dumps(["EVENT", main[1], event]))
+        await ws.send(json.dumps(["EOSE", main[1]]))
+        self.stored_batch_sent.set()
+
+        await self.release_live_event.wait()
+        # This is the production quirk isolated by the live probe matrix.
+        if "since" not in self.main_filter:
+            await ws.send(json.dumps(["EVENT", main[1], self.live_event]))
+            self.live_event_pushed.set()
+
+        try:
+            while True:
+                frame = json.loads(await ws.recv())
+                self.captured.append(frame)
+                if frame[0] == "REQ":
+                    await ws.send(json.dumps(["EOSE", frame[1]]))
+        except websockets.ConnectionClosed:
+            return
+
+
 @pytest.mark.asyncio
 async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_health(
     tmp_path,
@@ -130,7 +175,7 @@ async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_h
 
         assert initial_filter["kinds"] == [9, 20002]
         assert initial_filter["#h"] == [CHANNEL]
-        assert isinstance(initial_filter["since"], int)
+        assert "since" not in initial_filter
         assert len(broker.calls) == 1
         assert broker.calls[0][1].content == "hello from Brad"
         assert poller.health["delivered"] == 1
@@ -139,6 +184,16 @@ async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_h
         assert store._db.execute(
             "SELECT event_id, kind, delivery_status FROM buzz_inbound_events"
         ).fetchall() == [(durable["id"], 9, "delivered")]
+        heartbeat_filters = [
+            frame[2]
+            for frame in captured
+            if frame[0] == "REQ" and frame[1].startswith("pinky-live-")
+        ]
+        assert heartbeat_filters
+        assert all(
+            isinstance(item["since"], int) and item["limit"] == 1
+            for item in heartbeat_filters
+        )
         assert all(frame[0] in {"AUTH", "REQ", "CLOSE"} for frame in captured)
         assert not any(frame[0] == "EVENT" for frame in captured)
         store.close()
@@ -267,9 +322,13 @@ async def test_control_frame_trickle_cannot_starve_periodic_eose_probe(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_real_relay_event_older_than_req_since_is_rejected_client_side(tmp_path):
+async def test_wire_subscription_omits_since_but_client_floor_rejects_stale_event(
+    tmp_path,
+    monkeypatch,
+):
     relay_url = ""
     subscription_filter = {}
+    subscription_floor = int(time.time()) - 60
 
     async def handler(ws):  # noqa: ANN001
         await _authenticate(ws, relay_url, [])
@@ -279,13 +338,13 @@ async def test_real_relay_event_older_than_req_since_is_rejected_client_side(tmp
             kind=9,
             tags=[["h", CHANNEL]],
             content="historic signed command",
-            created_at=main[2]["since"] - 86340,
+            created_at=subscription_floor - 86340,
         )
         fresh = USER.sign_event(
             kind=9,
             tags=[["h", CHANNEL]],
             content="current signed command",
-            created_at=main[2]["since"],
+            created_at=subscription_floor,
         )
         await ws.send(json.dumps(["EVENT", main[1], stale]))
         await ws.send(json.dumps(["EVENT", main[1], fresh]))
@@ -300,6 +359,11 @@ async def test_real_relay_event_older_than_req_since_is_rejected_client_side(tmp
         port = server.sockets[0].getsockname()[1]
         relay_url = f"ws://127.0.0.1:{port}"
         store = _registry(tmp_path, relay_url)
+        monkeypatch.setattr(
+            store,
+            "get_buzz_subscription_since",
+            lambda _agent_name: subscription_floor,
+        )
         broker = FakeBroker()
 
         async def notify(_agent, _message):
@@ -318,12 +382,96 @@ async def test_real_relay_event_older_than_req_since_is_rejected_client_side(tmp
         poller.stop()
         await asyncio.wait_for(task, timeout=2)
 
-        assert isinstance(subscription_filter["since"], int)
+        assert "since" not in subscription_filter
         assert [call[1].content for call in broker.calls] == ["current signed command"]
         assert poller.health["rejected"] == 1
         assert store._db.execute(
             "SELECT event_created_at, delivery_status FROM buzz_inbound_events"
-        ).fetchall() == [(float(subscription_filter["since"]), "delivered")]
+        ).fetchall() == [(float(subscription_floor), "delivered")]
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_since_blind_relay_live_push_survives_large_stale_eose_burst(
+    tmp_path,
+    monkeypatch,
+):
+    subscription_floor = int(time.time()) - 60
+    stale_events = [
+        USER.sign_event(
+            kind=9,
+            tags=[["h", CHANNEL]],
+            content=f"historic signed command {index}",
+            created_at=subscription_floor - 86400 - index,
+        )
+        for index in range(256)
+    ]
+    # Repeat part of the history burst. Rejected pre-floor events must not
+    # consume the recent-ID cache or reach durable dedupe state.
+    stored_burst = [*stale_events, *stale_events[:32]]
+    live_event = USER.sign_event(
+        kind=9,
+        tags=[["h", CHANNEL]],
+        content="live event after EOSE",
+        created_at=subscription_floor,
+    )
+    rig = SinceBlindLiveRelayRig(stored_events=stored_burst, live_event=live_event)
+
+    async with websockets.serve(rig.handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        rig.relay_url = f"ws://127.0.0.1:{port}"
+        store = _registry(tmp_path, rig.relay_url)
+        monkeypatch.setattr(
+            store,
+            "get_buzz_subscription_since",
+            lambda _agent_name: subscription_floor,
+        )
+        broker = FakeBroker()
+
+        async def notify(_agent, _message):
+            return True
+
+        poller = BrokerBuzzPoller(
+            store.get_buzz_signing_material("barsik"),
+            broker,
+            store,
+            notify,
+            heartbeat_interval=10,
+            liveness_timeout=2,
+        )
+        task = asyncio.create_task(poller.start())
+        await asyncio.wait_for(rig.stored_batch_sent.wait(), timeout=2)
+
+        for _ in range(200):
+            if poller.health["status"] == "connected":
+                break
+            await asyncio.sleep(0.01)
+        assert poller.health["status"] == "connected"
+
+        assert rig.main_filter == {"kinds": [9, 20002], "#h": [CHANNEL]}
+        assert poller.health["rejected"] == len(stored_burst)
+        assert poller._processor._recent_ids == set()
+        assert broker.calls == []
+        assert store._db.execute(
+            "SELECT COUNT(*) FROM buzz_inbound_events"
+        ).fetchone()[0] == 0
+        assert store._db.execute(
+            "SELECT last_seen_at FROM buzz_inbound_principals WHERE agent='barsik'"
+        ).fetchall() == [(0.0,), (0.0,)]
+
+        rig.release_live_event.set()
+        await asyncio.wait_for(rig.live_event_pushed.wait(), timeout=2)
+        await asyncio.wait_for(broker.delivered.wait(), timeout=2)
+        poller.stop()
+        await asyncio.wait_for(task, timeout=2)
+
+        assert [call[1].content for call in broker.calls] == ["live event after EOSE"]
+        assert poller.health["delivered"] == 1
+        assert poller._processor._recent_ids == {live_event["id"]}
+        assert store._db.execute(
+            "SELECT event_id, delivery_status FROM buzz_inbound_events"
+        ).fetchall() == [(live_event["id"], "delivered")]
+        assert not any(frame[0] == "EVENT" for frame in rig.captured)
         store.close()
 
 


### PR DESCRIPTION
## Summary

- remove `since` from the native Buzz main subscription REQ so the production relay live-pushes new channel events
- retain the exact computed subscription floor in client-side validation before the recent-ID cache, authorization gates, or durable writes
- keep heartbeat REQs unchanged with `since` and `limit: 1`
- model the production relay's since-blind live-fanout behavior in the WebSocket rig
- cover a 288-frame pre-EOSE stale history burst, proving zero broker turns, zero inbound-event rows, unchanged principal-seen state, and no recent-ID cache consumption before the live event

## Root cause

The production Buzz relay returns stored events for subscriptions with or without `since`, but it does not live-push newly published events to any subscription whose filter contains `since`. The inc2 main subscription therefore authenticated and reached EOSE, then remained silent forever.

The main REQ is now open-ended on the wire. The existing client-side floor remains the freshness authority, so historical events streamed before EOSE are rejected before cache, policy gates, ledger writes, or persona dispatch. Active liveness probes keep their stored-query `since + limit` semantics.

## Validation

- `61 passed`: all Buzz tests
- `220 passed`: agent registry, DB security, and auth under `PINKY_AUTH_DENY_DEFAULT=shadow`
- `123 passed`: broker and messaging overlap
- `91 passed`: daemon and poller overlap
- full Ruff check passed
- `git diff --check` passed
- `uv lock --check` passed
- `uv pip check` passed
- `compileall` passed
- sdist and wheel builds passed

Exact local tuple before publication:

- base: `cd3ca1c7dbdf180ccc801abcc76b34056a92e06f`
- head: `60958b32df7762108ed0c7f65f9f04e171d54a78`
- tree: `e97a18302222093833754791be9add0c0f1a4511`

Draft only. Merge, release `26.08.011`, and deployment remain operator-controlled.
