### PR TITLE
Clean up Buzz envelopes and auto-register memberships

### DIFF
--- a/specs/buzz-native-platform.md
+++ b/specs/buzz-native-platform.md
@@ -15,6 +15,7 @@ its inbound policy in one `PUT /system/buzz-identities/{agent}` operation:
   "private_key": "<32-byte identity key as 64 lowercase hex>",
   "relay_url": "wss://example.communities.buzz.xyz",
   "community_id": "example",
+  "relay_signing_pubkey": "<operator-verified NIP-11 self key as 64 lowercase hex>",
   "enabled": true,
   "inbound": {
     "owner_pubkey": "<out-of-band verified 64-hex owner pubkey>",
@@ -34,7 +35,12 @@ context, or this file.
 Both inbound gates are default-deny and load-bearing:
 
 - The community, relay, and exact channel UUID must match the stored identity
-  policy. Relay membership/JOIN events never add an allowed channel.
+  policy. Kind-44100/44101 membership notifications may deliberately add or
+  remove a channel only after the event's BIP340 signature verifies and its
+  signer exactly matches the per-identity, operator-pinned relay authority
+  (the relay's independently verified NIP-11 `self` key). A missing pin disables
+  membership processing; a mismatched signer is rejected and logged. Neither
+  case may mutate channel authorization or live subscriptions.
 - The BIP340-verified full author pubkey must be the configured owner or an
   explicitly approved user in that same community. Profiles, display names,
   npub text, and first-message claims are never authority.
@@ -44,6 +50,13 @@ gates. If a `p` tag exists, it must be exactly one canonical self-pubkey tag;
 foreign, malformed, or duplicate tags suppress delivery. Only that exact tag
 sets `mentioned_self`; rendered `@name` text never does. Inbound kind-20002
 events are ignored and are never routed, retained, or replayed.
+
+The authenticated connection opens one additional exact-`#p` subscription for
+kinds 44100/44101. Kind 1059 is deliberately excluded until PinkyBot implements
+NIP-17 gift-wrap parsing and NIP-44 decryption end to end; subscribing before it
+can decrypt would falsely advertise working DM delivery while discarding DMs.
+Relay-authority rotation is operator-controlled and out of scope for automatic
+discovery: an old or absent pin fails closed and loudly until explicitly re-pinned.
 
 ## Health and owner-key rotation
 

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -47,6 +47,9 @@ from pinky_daemon.effort import is_ultracode
 # sees an explicit sanitizer at the source-of-path-construction.
 _AGENT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
 _BUZZ_HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+_BARSIK_BUZZ_RELAY_SIGNING_PUBKEY = (
+    "12f6870117eff1a6318bd38c82a65d51dd19879b7489f57247114d0ee8a96de3"
+)
 BUZZ_OWNER_SILENCE_DAYS = 14
 BUZZ_INBOUND_CLAIM_LEASE_SECONDS = 5 * 60
 
@@ -1614,6 +1617,14 @@ class AgentRegistry:
                 ciphertext BLOB NOT NULL,
                 relay_url TEXT NOT NULL,
                 community_id TEXT NOT NULL,
+                relay_signing_pubkey TEXT NOT NULL DEFAULT ''
+                    CHECK(
+                        relay_signing_pubkey='' OR (
+                            length(relay_signing_pubkey)=64
+                            AND relay_signing_pubkey=lower(relay_signing_pubkey)
+                            AND relay_signing_pubkey NOT GLOB '*[^0-9a-f]*'
+                        )
+                    ),
                 enabled INTEGER NOT NULL DEFAULT 0 CHECK(enabled IN (0, 1)),
                 status TEXT NOT NULL DEFAULT 'disabled',
                 last_error TEXT NOT NULL DEFAULT '',
@@ -1935,6 +1946,7 @@ class AgentRegistry:
         buzz_existing = {
             row[1] for row in self._db.execute("PRAGMA table_info(buzz_identities)").fetchall()
         }
+        relay_signing_pubkey_added = "relay_signing_pubkey" not in buzz_existing
         buzz_migrations = [
             ("pubkey", "TEXT NOT NULL DEFAULT ''"),
             ("wrap_version", "INTEGER NOT NULL DEFAULT 1"),
@@ -1942,6 +1954,7 @@ class AgentRegistry:
             ("ciphertext", "BLOB NOT NULL DEFAULT X''"),
             ("relay_url", "TEXT NOT NULL DEFAULT ''"),
             ("community_id", "TEXT NOT NULL DEFAULT ''"),
+            ("relay_signing_pubkey", "TEXT NOT NULL DEFAULT ''"),
             ("enabled", "INTEGER NOT NULL DEFAULT 0"),
             ("status", "TEXT NOT NULL DEFAULT 'disabled'"),
             ("last_error", "TEXT NOT NULL DEFAULT ''"),
@@ -1956,6 +1969,17 @@ class AgentRegistry:
             if col not in buzz_existing:
                 self._db.execute(f"ALTER TABLE buzz_identities ADD COLUMN {col} {typedef}")
                 _log(f"agent_registry: migrated — added {col} to buzz_identities")
+        if relay_signing_pubkey_added:
+            # One-time deployment migration for the operator-verified production
+            # authority. New/future identities receive their own explicit pin at
+            # provisioning; migrations never fetch NIP-11 or trust network data.
+            cursor = self._db.execute(
+                "UPDATE buzz_identities SET relay_signing_pubkey=? "
+                "WHERE agent='barsik' AND relay_signing_pubkey=''",
+                (_BARSIK_BUZZ_RELAY_SIGNING_PUBKEY,),
+            )
+            if cursor.rowcount:
+                _log("agent_registry: seeded barsik Buzz relay signing authority")
         self._db.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_buzz_identities_pubkey "
             "ON buzz_identities(pubkey) WHERE pubkey != ''"
@@ -2870,22 +2894,24 @@ except Exception as exc:
             "wrap_version": row[2],
             "relay_url": row[3],
             "community_id": row[4],
-            "enabled": bool(row[5]),
-            "status": row[6],
-            "last_error": row[7],
-            "tos_approved": bool(row[8] and row[9] and row[10]),
-            "tos_approved_by": row[8],
-            "tos_approved_at": row[9],
-            "tos_approval_ref": row[10],
-            "created_at": row[11],
-            "updated_at": row[12],
+            "relay_signing_pubkey": row[5],
+            "enabled": bool(row[6]),
+            "status": row[7],
+            "last_error": row[8],
+            "tos_approved": bool(row[9] and row[10] and row[11]),
+            "tos_approved_by": row[9],
+            "tos_approved_at": row[10],
+            "tos_approval_ref": row[11],
+            "created_at": row[12],
+            "updated_at": row[13],
         }
 
     def get_buzz_identity(self, agent_name: str) -> dict | None:
         """Return public Buzz identity state without receipt or key envelope."""
         row = self._db.execute(
-            "SELECT agent, pubkey, wrap_version, relay_url, community_id, enabled, "
-            "status, last_error, tos_approved_by, tos_approved_at, "
+            "SELECT agent, pubkey, wrap_version, relay_url, community_id, "
+            "relay_signing_pubkey, enabled, status, last_error, "
+            "tos_approved_by, tos_approved_at, "
             "tos_approval_ref, created_at, updated_at "
             "FROM buzz_identities WHERE agent=?",
             (agent_name,),
@@ -2895,8 +2921,9 @@ except Exception as exc:
     def list_buzz_identities(self, *, enabled_only: bool = False) -> list[dict]:
         """List public Buzz identity state, never encrypted or raw secret fields."""
         sql = (
-            "SELECT agent, pubkey, wrap_version, relay_url, community_id, enabled, "
-            "status, last_error, tos_approved_by, tos_approved_at, "
+            "SELECT agent, pubkey, wrap_version, relay_url, community_id, "
+            "relay_signing_pubkey, enabled, status, last_error, "
+            "tos_approved_by, tos_approved_at, "
             "tos_approval_ref, created_at, updated_at FROM buzz_identities"
         )
         if enabled_only:
@@ -2911,6 +2938,7 @@ except Exception as exc:
         private_key: str,
         relay_url: str,
         community_id: str,
+        relay_signing_pubkey: str,
         enabled: bool,
         owner_actor: str,
         _commit: bool = True,
@@ -2948,13 +2976,17 @@ except Exception as exc:
         community = str(community_id or "").strip().lower()
         if not re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,62}", community):
             raise ValueError("Buzz community_id is invalid")
+        relay_signer = _validate_buzz_pubkey(
+            relay_signing_pubkey,
+            field_name="relay_signing_pubkey",
+        )
         approver = validate_buzz_owner_actor(owner_actor)
 
         # Refuse accidental secret duplication into any durable text column.
         secret_text = str(private_key or "").strip().lower()
         if secret_text and any(
             secret_text in value.lower()
-            for value in (relay, community, approver)
+            for value in (relay, community, relay_signer, approver)
         ):
             raise ValueError("Buzz private key must not appear in identity metadata")
 
@@ -2968,7 +3000,7 @@ except Exception as exc:
         status = "active" if enabled else "disabled"
         with self._rmw_lock:
             existing = self._db.execute(
-                "SELECT pubkey, relay_url, community_id, tos_receipt, "
+                "SELECT pubkey, relay_url, community_id, relay_signing_pubkey, tos_receipt, "
                 "tos_approved_by, tos_approved_at, tos_approval_ref "
                 "FROM buzz_identities WHERE agent=?",
                 (agent,),
@@ -2981,6 +3013,12 @@ except Exception as exc:
                 raise ValueError(
                     "Buzz identity or approval scope rotation requires an explicit rotation operation"
                 )
+            if existing and existing[3] and not secrets.compare_digest(
+                existing[3], relay_signer
+            ):
+                raise ValueError(
+                    "Buzz relay signing authority rotation requires an explicit rotation operation"
+                )
             try:
                 if existing:
                     validate_buzz_owner_approval(
@@ -2988,17 +3026,17 @@ except Exception as exc:
                         pubkey=existing[0],
                         relay_url=existing[1],
                         community_id=existing[2],
-                        receipt=existing[3],
-                        approved_by=existing[4],
-                        approved_at=existing[5],
-                        approval_ref=existing[6],
+                        receipt=existing[4],
+                        approved_by=existing[5],
+                        approved_at=existing[6],
+                        approval_ref=existing[7],
                     )
                     # Same identity + same immutable receipt: safe idempotent
                     # re-bind. Preserve the original authority actor/timestamp/ref.
                     self._db.execute(
                         """UPDATE buzz_identities
                            SET wrap_version=?, nonce=?, ciphertext=?, relay_url=?,
-                               community_id=?, enabled=?, status=?, last_error='',
+                               community_id=?, relay_signing_pubkey=?, enabled=?, status=?, last_error='',
                                updated_at=? WHERE agent=?""",
                         (
                             envelope.wrap_version,
@@ -3006,6 +3044,7 @@ except Exception as exc:
                             envelope.ciphertext,
                             relay,
                             community,
+                            relay_signer,
                             int(enabled),
                             status,
                             now,
@@ -3023,10 +3062,11 @@ except Exception as exc:
                     self._db.execute(
                         """INSERT INTO buzz_identities (
                                agent, pubkey, wrap_version, nonce, ciphertext,
-                               relay_url, community_id, enabled, status, last_error,
+                               relay_url, community_id, relay_signing_pubkey,
+                               enabled, status, last_error,
                                tos_receipt, tos_approved_by, tos_approved_at,
                                tos_approval_ref, created_at, updated_at
-                           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?)""",
+                           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?)""",
                         (
                             agent,
                             envelope.pubkey,
@@ -3035,6 +3075,7 @@ except Exception as exc:
                             envelope.ciphertext,
                             relay,
                             community,
+                            relay_signer,
                             int(enabled),
                             status,
                             approval.receipt,
@@ -3069,12 +3110,12 @@ except Exception as exc:
 
         row = self._db.execute(
             """SELECT agent, pubkey, wrap_version, nonce, ciphertext, relay_url,
-                      community_id, enabled, status, tos_receipt, tos_approved_by,
-                      tos_approved_at, tos_approval_ref
+                      community_id, relay_signing_pubkey, enabled, status,
+                      tos_receipt, tos_approved_by, tos_approved_at, tos_approval_ref
                FROM buzz_identities WHERE agent=?""",
             (agent_name,),
         ).fetchone()
-        if not row or not row[7] or row[8] != "active":
+        if not row or not row[8] or row[9] != "active":
             return None
         try:
             validate_buzz_owner_approval(
@@ -3082,10 +3123,10 @@ except Exception as exc:
                 pubkey=row[1],
                 relay_url=row[5],
                 community_id=row[6],
-                receipt=row[9],
-                approved_by=row[10],
-                approved_at=row[11],
-                approval_ref=row[12],
+                receipt=row[10],
+                approved_by=row[11],
+                approved_at=row[12],
+                approval_ref=row[13],
             )
             envelope = BuzzKeyEnvelope(
                 agent=row[0],
@@ -3108,6 +3149,7 @@ except Exception as exc:
             private_key=private_key,
             relay_url=row[5],
             community_id=row[6],
+            relay_signing_pubkey=row[7],
         )
 
     def mark_buzz_identity_unhealthy(self, agent_name: str, reason: str) -> None:
@@ -3320,6 +3362,7 @@ except Exception as exc:
         private_key: str,
         relay_url: str,
         community_id: str,
+        relay_signing_pubkey: str,
         enabled: bool,
         owner_pubkey: str,
         channels: list[dict],
@@ -3335,6 +3378,7 @@ except Exception as exc:
                     private_key=private_key,
                     relay_url=relay_url,
                     community_id=community_id,
+                    relay_signing_pubkey=relay_signing_pubkey,
                     enabled=enabled,
                     owner_actor=owner_actor,
                     _commit=False,

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1455,6 +1455,17 @@ class AgentRegistry:
                 UNIQUE(agent_name, chat_id)
             );
 
+            CREATE TABLE IF NOT EXISTS verified_contacts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_name TEXT NOT NULL,
+                platform TEXT NOT NULL,
+                principal TEXT NOT NULL,
+                name TEXT NOT NULL,
+                role TEXT NOT NULL DEFAULT '',
+                added_at REAL NOT NULL,
+                UNIQUE(agent_name, platform, principal)
+            );
+
             CREATE TABLE IF NOT EXISTS agent_costs (
                 agent_name TEXT NOT NULL,
                 cost_usd REAL NOT NULL DEFAULT 0,
@@ -1515,6 +1526,8 @@ class AgentRegistry:
                 ON approval_requests(gate_state, notification_state, next_retry_at);
             CREATE INDEX IF NOT EXISTS idx_group_chats_agent
                 ON group_chats(agent_name);
+            CREATE INDEX IF NOT EXISTS idx_verified_contacts_agent
+                ON verified_contacts(agent_name);
             CREATE INDEX IF NOT EXISTS idx_streaming_session_labels_agent
                 ON streaming_session_labels(agent_name);
             CREATE INDEX IF NOT EXISTS idx_mcp_servers_agent
@@ -1956,6 +1969,11 @@ class AgentRegistry:
             "ON buzz_identities(tos_receipt) WHERE tos_receipt != ''"
         )
 
+        # Deployment seed for the explicitly verified owner principal in #545.
+        # The registry and all runtime lookups remain agent-keyed; this is only
+        # the caller-specified bootstrap row and never auto-learns from traffic.
+        self._seed_verified_contacts()
+
         # Seed main_agent default: if unset, adopt the oldest enabled agent.
         # New installs get their main agent auto-assigned at create time (see
         # ``register``); this migration covers pre-existing installs whose
@@ -1974,6 +1992,34 @@ class AgentRegistry:
 
         # Seed default models
         self._seed_models()
+
+    def _seed_verified_contacts(self) -> None:
+        """Install caller-specified verified contacts when their agent exists."""
+        marker = "migration:verified_contacts_brad_owner_seed_v1"
+        if self.get_setting(marker) == "1":
+            return
+        if self._db.execute("SELECT 1 FROM agents WHERE name='barsik'").fetchone() is None:
+            return
+        cursor = self._db.execute(
+            """INSERT INTO verified_contacts
+               (agent_name, platform, principal, name, role, added_at)
+               VALUES ('barsik', 'buzz', ?, 'Brad', 'owner', ?)
+               ON CONFLICT(agent_name, platform, principal) DO UPDATE SET
+                 name='Brad', role='owner'""",
+            (
+                "buzz:posspecialists:"
+                "90425c785cf23b60e57300658a7f4855938b3c2f661b3ef33acdb54831fcb44b",
+                time.time(),
+            ),
+        )
+        self._db.execute(
+            """INSERT INTO system_settings (key, value) VALUES (?, '1')
+               ON CONFLICT(key) DO UPDATE SET value='1'""",
+            (marker,),
+        )
+        self._db.commit()
+        if cursor.rowcount:
+            _log("agent_registry: seeded barsik Buzz owner verified contact")
 
     def _backfill_runtime_from_provider_url(self) -> None:
         """One-shot migration from legacy provider_url runtime selection."""
@@ -2615,6 +2661,7 @@ except Exception as exc:
             # Preserve register()'s historical signing-key backfill contract
             # for legacy rows even though the field mutation is delegated.
             self.get_or_create_signing_key(name)
+            self._seed_verified_contacts()
             return updated
         else:
             # Set up workspace — always store absolute path for portability.
@@ -2724,6 +2771,10 @@ except Exception as exc:
         # Ensure the agent has a per-agent signing key (#623). Idempotent —
         # returns the existing key on re-registration / update.
         self.get_or_create_signing_key(name)
+        # Fresh databases initialize before any agents exist. Retry the
+        # caller-specified bootstrap after registration so the seed ships for
+        # both upgrades and new installs without weakening the unique key.
+        self._seed_verified_contacts()
 
         return self.get(name)  # type: ignore
 
@@ -3371,6 +3422,68 @@ except Exception as exc:
             (agent_name, community_id, relay_url, channel_id),
         ).fetchone()
         return {"channel_id": row[0], "label": row[1]} if row else None
+
+    def upsert_buzz_inbound_channel_from_membership(
+        self,
+        agent_name: str,
+        community_id: str,
+        relay_url: str,
+        channel_id: str,
+        *,
+        label: str = "",
+    ) -> dict:
+        """Admit one relay-notified membership into the scoped inbound gate."""
+        channel = _validate_buzz_channel_id(channel_id)
+        clean_label = _validate_buzz_annotation(label, field_name="channel label", limit=80)
+        with self._rmw_lock:
+            policy = self._db.execute(
+                """SELECT 1 FROM buzz_inbound_policies
+                   WHERE agent=? AND community_id=? AND relay_url=?""",
+                (agent_name, community_id, relay_url),
+            ).fetchone()
+            if policy is None:
+                raise ValueError("Buzz membership notification is outside the inbound policy scope")
+            self._db.execute(
+                """INSERT INTO buzz_inbound_channels
+                   (agent, community_id, relay_url, channel_id, label, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(agent, community_id, channel_id) DO UPDATE SET
+                     relay_url=excluded.relay_url,
+                     label=CASE WHEN excluded.label != '' THEN excluded.label
+                                ELSE buzz_inbound_channels.label END""",
+                (agent_name, community_id, relay_url, channel, clean_label, time.time()),
+            )
+            self._db.commit()
+        result = self.get_buzz_inbound_channel(
+            agent_name, community_id, relay_url, channel
+        )
+        if result is None:  # pragma: no cover - defensive after successful write
+            raise RuntimeError("Buzz membership channel write did not persist")
+        return result
+
+    def remove_buzz_inbound_channel_from_membership(
+        self,
+        agent_name: str,
+        community_id: str,
+        relay_url: str,
+        channel_id: str,
+    ) -> bool:
+        """Revoke a relay-notified membership and any undelivered channel rows."""
+        channel = _validate_buzz_channel_id(channel_id)
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                """DELETE FROM buzz_inbound_channels
+                   WHERE agent=? AND community_id=? AND relay_url=? AND channel_id=?""",
+                (agent_name, community_id, relay_url, channel),
+            )
+            self._db.execute(
+                """DELETE FROM buzz_inbound_events
+                   WHERE agent=? AND community_id=? AND channel_id=?
+                     AND delivery_status='pending'""",
+                (agent_name, community_id, channel),
+            )
+            self._db.commit()
+        return cursor.rowcount > 0
 
     def get_buzz_inbound_principal(
         self, agent_name: str, community_id: str, pubkey: str
@@ -5759,7 +5872,13 @@ except Exception as exc:
                (agent_name, platform, chat_id, chat_title, chat_type, member_count, joined_at)
                VALUES (?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT (agent_name, chat_id)
-               DO UPDATE SET chat_title=excluded.chat_title,
+               DO UPDATE SET platform=CASE WHEN excluded.platform='buzz'
+                                            THEN excluded.platform
+                                            ELSE group_chats.platform END,
+                            chat_title=CASE WHEN excluded.platform='buzz'
+                                                 AND excluded.chat_title=''
+                                            THEN group_chats.chat_title
+                                            ELSE excluded.chat_title END,
                             chat_type=excluded.chat_type,
                             member_count=excluded.member_count,
                             active=1""",
@@ -5827,6 +5946,93 @@ except Exception as exc:
         cursor = self._db.execute(
             "UPDATE group_chats SET active=0 WHERE agent_name=? AND chat_id=?",
             (agent_name, chat_id),
+        )
+        self._db.commit()
+        return cursor.rowcount > 0
+
+    # ── Verified Contacts ────────────────────────────────────
+
+    @staticmethod
+    def _verified_contact_dict(row) -> dict:
+        return {
+            "id": row[0],
+            "agent_name": row[1],
+            "platform": row[2],
+            "principal": row[3],
+            "name": row[4],
+            "role": row[5],
+            "added_at": row[6],
+        }
+
+    def get_verified_contact(
+        self, agent_name: str, platform: str, principal: str
+    ) -> dict | None:
+        """Return one explicitly registered contact, never traffic-derived."""
+        row = self._db.execute(
+            """SELECT id, agent_name, platform, principal, name, role, added_at
+               FROM verified_contacts
+               WHERE agent_name=? AND platform=? AND principal=?""",
+            (agent_name, platform, principal),
+        ).fetchone()
+        return self._verified_contact_dict(row) if row else None
+
+    def upsert_verified_contact(
+        self,
+        agent_name: str,
+        platform: str,
+        principal: str,
+        name: str,
+        role: str = "",
+    ) -> dict:
+        """Create or replace an explicit principal-to-name trust decision."""
+        agent = _validate_agent_name(agent_name)
+        clean_platform = str(platform or "").strip().lower()
+        clean_principal = str(principal or "").strip()
+        clean_name = str(name or "").strip()
+        clean_role = str(role or "").strip().lower()
+        if not clean_platform or len(clean_platform) > 64:
+            raise ValueError("verified contact platform must be 1-64 characters")
+        if not clean_principal or len(clean_principal) > 512:
+            raise ValueError("verified contact principal must be 1-512 characters")
+        if not clean_name or len(clean_name) > 120 or any(
+            ord(ch) < 32 or ord(ch) == 127 for ch in clean_name
+        ):
+            raise ValueError("verified contact name must be 1-120 printable characters")
+        if clean_role not in {"", "owner", "agent"}:
+            raise ValueError("verified contact role must be owner, agent, or empty")
+        now = time.time()
+        self._db.execute(
+            """INSERT INTO verified_contacts
+               (agent_name, platform, principal, name, role, added_at)
+               VALUES (?, ?, ?, ?, ?, ?)
+               ON CONFLICT(agent_name, platform, principal) DO UPDATE SET
+                 name=excluded.name, role=excluded.role, added_at=excluded.added_at""",
+            (agent, clean_platform, clean_principal, clean_name, clean_role, now),
+        )
+        self._db.commit()
+        result = self.get_verified_contact(agent, clean_platform, clean_principal)
+        if result is None:  # pragma: no cover - defensive after successful write
+            raise RuntimeError("verified contact write did not persist")
+        return result
+
+    def list_verified_contacts(self, agent_name: str) -> list[dict]:
+        """List explicitly registered contacts for one agent."""
+        rows = self._db.execute(
+            """SELECT id, agent_name, platform, principal, name, role, added_at
+               FROM verified_contacts WHERE agent_name=?
+               ORDER BY platform, name COLLATE NOCASE, principal""",
+            (agent_name,),
+        ).fetchall()
+        return [self._verified_contact_dict(row) for row in rows]
+
+    def delete_verified_contact(
+        self, agent_name: str, platform: str, principal: str
+    ) -> bool:
+        """Delete one explicit verified-contact trust decision."""
+        cursor = self._db.execute(
+            """DELETE FROM verified_contacts
+               WHERE agent_name=? AND platform=? AND principal=?""",
+            (agent_name, str(platform or "").strip().lower(), str(principal or "").strip()),
         )
         self._db.commit()
         return cursor.rowcount > 0

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -33,6 +33,7 @@ from typing import Any, Literal
 from fastapi import (
     FastAPI,
     HTTPException,
+    Query,
     Request,
     Response,
     UploadFile,
@@ -8492,6 +8493,44 @@ npm run build</pre>
         if not agents.deactivate_group_chat(name, chat_id):
             raise HTTPException(404, "Group chat not found")
         return {"deactivated": True, "chat_id": chat_id}
+
+    # ── Verified Contacts ──────────────────────────────────
+
+    @app.get("/agents/{name}/verified-contacts")
+    async def list_verified_contacts(name: str):
+        """List explicit principal-to-name trust decisions for an agent."""
+        if not agents.get(name):
+            raise HTTPException(404, f"Agent '{name}' not found")
+        contacts = agents.list_verified_contacts(name)
+        return {"agent": name, "verified_contacts": contacts, "count": len(contacts)}
+
+    @app.put("/agents/{name}/verified-contacts")
+    async def upsert_verified_contact(
+        name: str,
+        platform: str,
+        principal: str,
+        contact_name: str = Query(..., alias="name"),
+        role: str = "",
+    ):
+        """Upsert one explicit verified contact."""
+        if not agents.get(name):
+            raise HTTPException(404, f"Agent '{name}' not found")
+        try:
+            contact = agents.upsert_verified_contact(
+                name, platform, principal, contact_name, role
+            )
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        return {"updated": True, "verified_contact": contact}
+
+    @app.delete("/agents/{name}/verified-contacts")
+    async def delete_verified_contact(name: str, platform: str, principal: str):
+        """Delete one explicit verified contact."""
+        if not agents.get(name):
+            raise HTTPException(404, f"Agent '{name}' not found")
+        if not agents.delete_verified_contact(name, platform, principal):
+            raise HTTPException(404, "Verified contact not found")
+        return {"deleted": True, "platform": platform, "principal": principal}
 
     # ── Channel → Session Assignment ──────────────────────
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7694,6 +7694,7 @@ npm run build</pre>
                     private_key=req.private_key,
                     relay_url=req.relay_url,
                     community_id=req.community_id,
+                    relay_signing_pubkey=req.relay_signing_pubkey,
                     enabled=req.enabled,
                     owner_pubkey=req.inbound.owner_pubkey,
                     channels=[item.model_dump() for item in req.inbound.channels],
@@ -7706,6 +7707,7 @@ npm run build</pre>
                     private_key=req.private_key,
                     relay_url=req.relay_url,
                     community_id=req.community_id,
+                    relay_signing_pubkey=req.relay_signing_pubkey,
                     enabled=req.enabled,
                     owner_actor=actor,
                 )

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -664,8 +664,19 @@ class BindBuzzIdentityRequest(BaseModel):
     private_key: str
     relay_url: str
     community_id: str
+    relay_signing_pubkey: str
     enabled: bool = True
     inbound: ConfigureBuzzInboundRequest | None = None
+
+    @field_validator("relay_signing_pubkey")
+    @classmethod
+    def validate_relay_signing_pubkey(cls, value: str) -> str:
+        pubkey = str(value or "")
+        if not _BUZZ_PUBKEY_RE.fullmatch(pubkey):
+            raise ValueError(
+                "Buzz relay_signing_pubkey must be exactly 64 lowercase hex characters"
+            )
+        return pubkey
 
 
 class AddMcpServerRequest(BaseModel):

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1422,11 +1422,53 @@ class MessageBroker:
             alias = self._registry.get_group_chat_alias(message.agent_name, message.chat_id)
             display = alias or message.chat_title or message.chat_id
             mentioned = "true" if message.metadata.get("buzz_mentioned_self") is True else "false"
+            contact = None
+            contact_lookup_failed = False
+            try:
+                contact = self._registry.get_verified_contact(
+                    message.agent_name, "buzz", buzz_principal
+                )
+            except Exception:
+                # Fail closed on trust but open on rendering: an absent legacy
+                # table or lookup failure must preserve the full-principal
+                # untrusted header instead of crashing inbound delivery.
+                contact_lookup_failed = True
+            if contact is not None:
+                role = f" ({contact['role']})" if contact.get("role") else ""
+                fingerprint = buzz_principal.rsplit(":", 1)[-1][:12]
+                sender = f"from:{contact['name']}{role} principal:{fingerprint}…"
+            else:
+                collision = ""
+                if not contact_lookup_failed:
+                    try:
+                        collision = next(
+                            (
+                                item["name"]
+                                for item in self._registry.list_verified_contacts(
+                                    message.agent_name
+                                )
+                                if item["name"].casefold() == message.sender_name.casefold()
+                            ),
+                            "",
+                        )
+                    except Exception:
+                        pass
+                trust_label = (
+                    f"untrusted+collides:{collision}" if collision else "untrusted"
+                )
+                sender = (
+                    f"display_name({trust_label}):{message.sender_name} | "
+                    f"principal:{buzz_principal}"
+                )
+            # When no name is available the full raw ID already occupies the
+            # display slot; do not print it a second time. Named channels keep
+            # the explicit chat_id field required by send()/thread().
+            chat_id = (
+                f" | chat_id:{message.chat_id}" if display != message.chat_id else ""
+            )
             header = (
-                f"[buzz | channel | {display} | "
-                f"display_name(untrusted):{message.sender_name} | "
-                f"principal:{buzz_principal} | mentioned_self:{mentioned} | "
-                f"{message.chat_id} | {ts}{msg_id}{thread_provenance}]"
+                f"[buzz | {display} | {sender} | mentioned_self:{mentioned}"
+                f"{chat_id} | {ts}{msg_id}{thread_provenance}]"
             )
         elif message.is_group:
             alias = self._registry.get_group_chat_alias(message.agent_name, message.chat_id)

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -1428,10 +1428,14 @@ class MessageBroker:
                 contact = self._registry.get_verified_contact(
                     message.agent_name, "buzz", buzz_principal
                 )
-            except Exception:
+            except Exception as exc:
                 # Fail closed on trust but open on rendering: an absent legacy
                 # table or lookup failure must preserve the full-principal
                 # untrusted header instead of crashing inbound delivery.
+                _log(
+                    "broker: WARNING verified-contact lookup failed for "
+                    f"{message.agent_name} ({type(exc).__name__}); rendering untrusted"
+                )
                 contact_lookup_failed = True
             if contact is not None:
                 role = f" ({contact['role']})" if contact.get("role") else ""
@@ -1451,8 +1455,15 @@ class MessageBroker:
                             ),
                             "",
                         )
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        # Collision enrichment is optional. Preserve the explicit
+                        # untrusted/full-principal fallback, but make registry
+                        # degradation observable instead of silently hiding it.
+                        _log(
+                            "broker: WARNING verified-contact collision lookup failed for "
+                            f"{message.agent_name} ({type(exc).__name__}); "
+                            "rendering untrusted"
+                        )
                 trust_label = (
                     f"untrusted+collides:{collision}" if collision else "untrusted"
                 )

--- a/src/pinky_daemon/buzz_identity.py
+++ b/src/pinky_daemon/buzz_identity.py
@@ -72,6 +72,7 @@ class BuzzSigningMaterial:
     private_key: bytes
     relay_url: str
     community_id: str
+    relay_signing_pubkey: str
 
     def __repr__(self) -> str:
         return (

--- a/src/pinky_daemon/buzz_inbound.py
+++ b/src/pinky_daemon/buzz_inbound.py
@@ -20,6 +20,7 @@ from pinky_outreach.buzz import BuzzNostrSigner, verify_nostr_event
 
 _HEX_64 = frozenset("0123456789abcdef")
 _ALLOWED_KINDS = {9, 20002}
+_MEMBERSHIP_KINDS = {44100, 44101}
 _MAX_FRAME_BYTES = 128 * 1024
 _MAX_CONTENT_BYTES = 32 * 1024
 _MAX_TAGS = 64
@@ -61,8 +62,87 @@ class ValidatedBuzzInboundEvent:
     reply_to: str
 
 
+@dataclass(frozen=True)
+class ValidatedBuzzMembershipEvent:
+    event: dict
+    channel_id: str
+    chat_title: str
+
+
 def _is_hex_64(value: object) -> bool:
     return isinstance(value, str) and len(value) == 64 and not (set(value) - _HEX_64)
+
+
+def validate_buzz_membership_event(
+    event: object,
+    *,
+    identity_pubkey: str,
+    now: float | None = None,
+) -> ValidatedBuzzMembershipEvent:
+    """Validate one relay-delivered, identity-targeted membership notification.
+
+    Buzz only admits relay-signed 44100/44101 events. The configured relay is
+    therefore the authority for the signer identity; locally we still verify
+    the Nostr signature and require one exact ``p`` target plus one canonical
+    channel ``h`` tag before changing subscriptions or authorization state.
+    """
+    if not isinstance(event, dict):
+        raise BuzzInboundRejectedError("membership_event_not_object")
+    try:
+        encoded = json.dumps(event, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise BuzzInboundRejectedError("membership_event_not_json") from exc
+    if len(encoded) > _MAX_FRAME_BYTES:
+        raise BuzzInboundRejectedError("membership_event_too_large")
+    if not verify_nostr_event(event):
+        raise BuzzInboundRejectedError("membership_signature_or_id_invalid")
+    if event["kind"] not in _MEMBERSHIP_KINDS:
+        raise BuzzInboundRejectedError("membership_kind_not_allowed")
+    current = time.time() if now is None else float(now)
+    if event["created_at"] > int(current + _MAX_FUTURE_SECONDS):
+        raise BuzzInboundRejectedError("membership_event_from_future")
+    tags = event["tags"]
+    if len(tags) > _MAX_TAGS:
+        raise BuzzInboundRejectedError("membership_too_many_tags")
+    if any(
+        len(tag) < 2
+        or len(tag) > _MAX_TAG_PARTS
+        or any(len(part.encode("utf-8")) > _MAX_TAG_PART_BYTES for part in tag)
+        for tag in tags
+    ):
+        raise BuzzInboundRejectedError("membership_tag_bounds_invalid")
+
+    p_tags = [tag for tag in tags if tag[0] == "p"]
+    if (
+        len(p_tags) != 1
+        or len(p_tags[0]) != 2
+        or not _is_hex_64(p_tags[0][1])
+        or p_tags[0][1] != identity_pubkey
+    ):
+        raise BuzzInboundRejectedError("membership_target_invalid")
+    channel_tags = [tag for tag in tags if tag[0] == "h"]
+    if len(channel_tags) != 1 or len(channel_tags[0]) != 2:
+        raise BuzzInboundRejectedError("membership_channel_invalid")
+    channel_id = channel_tags[0][1]
+    try:
+        if str(UUID(channel_id)) != channel_id:
+            raise ValueError
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise BuzzInboundRejectedError("membership_channel_invalid") from exc
+
+    name_tags = [tag for tag in tags if tag[0] == "name"]
+    if len(name_tags) > 1 or any(len(tag) != 2 for tag in name_tags):
+        raise BuzzInboundRejectedError("membership_name_invalid")
+    chat_title = name_tags[0][1].strip() if name_tags else ""
+    if len(chat_title) > 80 or any(
+        ord(ch) < 32 or ord(ch) == 127 for ch in chat_title
+    ):
+        raise BuzzInboundRejectedError("membership_name_invalid")
+    return ValidatedBuzzMembershipEvent(
+        event=event,
+        channel_id=channel_id,
+        chat_title=chat_title,
+    )
 
 
 def validate_buzz_inbound_event(
@@ -231,6 +311,16 @@ class BuzzInboundProcessor:
             self.stats["unlisted_channel"] += 1
             return "unlisted_channel"
 
+        # Buzz has no Telegram-style join callback. Ensure every authorized
+        # first inbound creates the row that alias management expects.
+        self._registry.upsert_group_chat(
+            self.agent_name,
+            validated.channel_id,
+            chat_title=channel["label"],
+            chat_type="channel",
+            platform="buzz",
+        )
+
         # Gate B: full, platform-qualified, community-scoped verified author.
         author = self._registry.get_buzz_inbound_principal(
             self.agent_name,
@@ -357,6 +447,7 @@ class BrokerBuzzPoller:
         self._last_error = ""
         self._last_liveness_at = 0.0
         self._last_event_at = 0.0
+        self._membership_versions: dict[str, tuple[int, int, str]] = {}
         self._processor = BuzzInboundProcessor(
             registry=registry,
             broker=broker,
@@ -454,10 +545,18 @@ class BrokerBuzzPoller:
 
     async def _run_connection(self) -> None:
         policy = self._registry.get_buzz_inbound_policy(self._agent_name)
-        if not policy or not policy["channels"] or not policy["principals"]:
+        if not policy or not policy["principals"]:
             raise BuzzRelayProtocolError("inbound_policy_default_deny")
         if policy["community_id"] != self._community_id or policy["relay_url"] != self._relay_url:
             raise BuzzRelayProtocolError("inbound_policy_identity_scope_mismatch")
+        for item in policy["channels"]:
+            self._registry.upsert_group_chat(
+                self._agent_name,
+                item["channel_id"],
+                chat_title=item["label"],
+                chat_type="channel",
+                platform="buzz",
+            )
         channels = [item["channel_id"] for item in policy["channels"]]
         connect = self._connect_factory(
             self._relay_url,
@@ -498,30 +597,67 @@ class BrokerBuzzPoller:
             raise BuzzRelayProtocolError("relay_auth_refused")
 
         await self._processor.replay_pending()
+        self._membership_versions.clear()
         since = self._registry.get_buzz_subscription_since(self._agent_name)
         main_subscription_since: dict[str, int] = {}
+        channel_subscriptions: dict[str, str] = {}
         connection_token = secrets.token_hex(8)
-        for index, channel_id in enumerate(channels):
-            main_sub = f"pinky-{self._agent_name}-{connection_token}-{index}"
-            main_subscription_since[main_sub] = since
-            await self._send_frame(
+        membership_sub = f"pinky-membership-{self._agent_name}-{connection_token}"
+        await self._send_frame(
+            ws,
+            [
+                "REQ",
+                membership_sub,
+                # Do not add kind 1059 until NIP-17 unwrap/decrypt exists. A
+                # p-gated subscription that silently discards DMs would falsely
+                # advertise working delivery. Membership is independently useful.
+                {"kinds": [44100, 44101], "#p": [self._pubkey]},
+            ],
+        )
+        await self._wait_for_eose(
+            ws,
+            subscription_ids={membership_sub},
+            timeout=self._liveness_timeout,
+            # Reconcile the stored membership history before opening any
+            # channel stream. This prevents a stale persisted allowlist row
+            # from admitting messages ahead of its stored removal event.
+            subscription_since=None,
+            membership_subscription=membership_sub,
+            channel_subscriptions=channel_subscriptions,
+            channels=channels,
+            subscription_floor=since,
+            connection_token=connection_token,
+        )
+        current_policy = self._registry.get_buzz_inbound_policy(self._agent_name)
+        if current_policy is None:
+            raise BuzzRelayProtocolError("inbound_policy_default_deny")
+        channels[:] = [item["channel_id"] for item in current_policy["channels"]]
+        for item in current_policy["channels"]:
+            self._registry.upsert_group_chat(
+                self._agent_name,
+                item["channel_id"],
+                chat_title=item["label"],
+                chat_type="channel",
+                platform="buzz",
+            )
+            await self._open_channel_subscription(
                 ws,
-                [
-                    "REQ",
-                    main_sub,
-                    # The production Buzz relay does not live-fanout events to
-                    # subscriptions carrying ``since`` or multiple ``#h``
-                    # values. Keep each live REQ open-ended and channel-local,
-                    # then enforce the shared floor in the client before any
-                    # cache, authorization gate, or durable write.
-                    {"kinds": [9, 20002], "#h": [channel_id]},
-                ],
+                item["channel_id"],
+                subscription_since=main_subscription_since,
+                channel_subscriptions=channel_subscriptions,
+                floor=since,
+                connection_token=connection_token,
             )
         await self._wait_for_eose(
             ws,
             subscription_ids=set(main_subscription_since),
             timeout=self._liveness_timeout,
             subscription_since=main_subscription_since,
+            membership_subscription=membership_sub,
+            channel_subscriptions=channel_subscriptions,
+            channels=channels,
+            subscription_floor=since,
+            connection_token=connection_token,
         )
         now = time.time()
         self._status = "connected"
@@ -546,6 +682,10 @@ class BrokerBuzzPoller:
                     ws,
                     channels,
                     main_subscription_since=main_subscription_since,
+                    membership_subscription=membership_sub,
+                    channel_subscriptions=channel_subscriptions,
+                    subscription_floor=since,
+                    connection_token=connection_token,
                 )
                 next_heartbeat = loop.time() + self._heartbeat_interval
                 await self._processor.replay_pending()
@@ -559,7 +699,43 @@ class BrokerBuzzPoller:
                 ws,
                 frame,
                 subscription_since=main_subscription_since,
+                membership_subscription=membership_sub,
+                channel_subscriptions=channel_subscriptions,
+                channels=channels,
+                subscription_floor=since,
+                connection_token=connection_token,
             )
+
+    async def _open_channel_subscription(
+        self,
+        ws,
+        channel_id: str,
+        *,
+        subscription_since: dict[str, int],
+        channel_subscriptions: dict[str, str],
+        floor: int,
+        connection_token: str,
+    ) -> bool:
+        if channel_id in channel_subscriptions:
+            return False
+        subscription_id = (
+            f"pinky-{self._agent_name}-{connection_token}-{secrets.token_hex(4)}"
+        )
+        channel_subscriptions[channel_id] = subscription_id
+        subscription_since[subscription_id] = floor
+        await self._send_frame(
+            ws,
+            [
+                "REQ",
+                subscription_id,
+                # The production Buzz relay does not live-fanout events to
+                # subscriptions carrying ``since`` or multiple ``#h`` values.
+                # Keep each live REQ open-ended and channel-local, then enforce
+                # the shared floor in the client before any durable write.
+                {"kinds": [9, 20002], "#h": [channel_id]},
+            ],
+        )
+        return True
 
     async def _active_liveness_probe(
         self,
@@ -567,35 +743,48 @@ class BrokerBuzzPoller:
         channels: list[str],
         *,
         main_subscription_since: dict[str, int],
+        membership_subscription: str,
+        channel_subscriptions: dict[str, str],
+        subscription_floor: int,
+        connection_token: str,
     ) -> None:
         heartbeat_sub = f"pinky-live-{secrets.token_hex(8)}"
         heartbeat_since = int(time.time())
+        heartbeat_filter = (
+            {"kinds": [9, 20002], "#h": channels, "since": heartbeat_since, "limit": 1}
+            if channels
+            else {
+                "kinds": [44100, 44101],
+                "#p": [self._pubkey],
+                "since": heartbeat_since,
+                "limit": 1,
+            }
+        )
         await self._send_frame(
             ws,
             [
                 "REQ",
                 heartbeat_sub,
-                {
-                    "kinds": [9, 20002],
-                    "#h": channels,
-                    "since": heartbeat_since,
-                    "limit": 1,
-                },
+                heartbeat_filter,
             ],
         )
+        main_subscription_since[heartbeat_sub] = heartbeat_since
         try:
             await self._wait_for_eose(
                 ws,
                 subscription_ids={heartbeat_sub},
                 timeout=self._liveness_timeout,
-                subscription_since={
-                    **main_subscription_since,
-                    heartbeat_sub: heartbeat_since,
-                },
+                subscription_since=main_subscription_since,
+                membership_subscription=membership_subscription,
+                channel_subscriptions=channel_subscriptions,
+                channels=channels,
+                subscription_floor=subscription_floor,
+                connection_token=connection_token,
             )
         except asyncio.TimeoutError as exc:
             raise BuzzRelayLivenessError("relay_eose_heartbeat_timed_out") from exc
         finally:
+            main_subscription_since.pop(heartbeat_sub, None)
             try:
                 await self._send_frame(ws, ["CLOSE", heartbeat_sub])
             except Exception:
@@ -615,7 +804,12 @@ class BrokerBuzzPoller:
         *,
         subscription_ids: set[str],
         timeout: float,
-        subscription_since: dict[str, int],
+        subscription_since: dict[str, int] | None,
+        membership_subscription: str,
+        channel_subscriptions: dict[str, str],
+        channels: list[str],
+        subscription_floor: int,
+        connection_token: str,
     ) -> None:
         pending_eose = set(subscription_ids)
         deadline = asyncio.get_running_loop().time() + timeout
@@ -631,6 +825,11 @@ class BrokerBuzzPoller:
                 ws,
                 frame,
                 subscription_since=subscription_since,
+                membership_subscription=membership_subscription,
+                channel_subscriptions=channel_subscriptions,
+                channels=channels,
+                subscription_floor=subscription_floor,
+                connection_token=connection_token,
             )
 
     async def _handle_frame(
@@ -639,6 +838,11 @@ class BrokerBuzzPoller:
         frame: list,
         *,
         subscription_since: dict[str, int] | None,
+        membership_subscription: str,
+        channel_subscriptions: dict[str, str],
+        channels: list[str],
+        subscription_floor: int,
+        connection_token: str,
     ) -> None:
         if not frame:
             raise BuzzRelayProtocolError("relay_frame_empty")
@@ -646,6 +850,17 @@ class BrokerBuzzPoller:
         if kind == "EVENT":
             if len(frame) != 3 or not isinstance(frame[1], str):
                 raise BuzzRelayProtocolError("relay_event_frame_invalid")
+            if frame[1] == membership_subscription:
+                await self._handle_membership_event(
+                    ws,
+                    frame[2],
+                    subscription_since=subscription_since,
+                    channel_subscriptions=channel_subscriptions,
+                    channels=channels,
+                    subscription_floor=subscription_floor,
+                    connection_token=connection_token,
+                )
+                return
             if subscription_since is not None and frame[1] not in subscription_since:
                 raise BuzzRelayProtocolError("relay_event_subscription_mismatch")
             result = await self._processor.process_event(
@@ -661,13 +876,96 @@ class BrokerBuzzPoller:
             auth_event = self._signer.sign_relay_auth(self._relay_url, frame[1])
             await self._send_frame(ws, ["AUTH", auth_event])
             return
-        if kind == "CLOSED" and (
-            subscription_since is None or (len(frame) >= 2 and frame[1] in subscription_since)
-        ):
-            raise BuzzRelayProtocolError("relay_subscription_closed")
+        if kind == "CLOSED" and len(frame) >= 2:
+            if (
+                subscription_since is None
+                or frame[1] in subscription_since
+                or frame[1] == membership_subscription
+            ):
+                raise BuzzRelayProtocolError("relay_subscription_closed")
         if kind == "NOTICE":
             raise BuzzRelayProtocolError("relay_notice")
         # OK/EOSE for another request are control frames, not inbound content.
+
+    async def _handle_membership_event(
+        self,
+        ws,
+        event: object,
+        *,
+        subscription_since: dict[str, int] | None,
+        channel_subscriptions: dict[str, str],
+        channels: list[str],
+        subscription_floor: int,
+        connection_token: str,
+    ) -> None:
+        try:
+            membership = validate_buzz_membership_event(
+                event,
+                identity_pubkey=self._pubkey,
+            )
+        except BuzzInboundRejectedError:
+            return
+        channel_id = membership.channel_id
+        event_version = (
+            membership.event["created_at"],
+            membership.event["kind"],
+            membership.event["id"],
+        )
+        previous = self._membership_versions.get(channel_id)
+        if previous is not None:
+            if event_version[0] < previous[0] or event_version[2] == previous[2]:
+                return
+            if event_version[0] == previous[0]:
+                # Nostr timestamps have one-second precision. On an ambiguous
+                # add/remove tie, removal wins so history order cannot reopen a
+                # channel after a same-second revoke.
+                if previous[1] == 44101 or event_version[1] == previous[1]:
+                    return
+        self._membership_versions[channel_id] = event_version
+        if membership.event["kind"] == 44100:
+            channel = self._registry.upsert_buzz_inbound_channel_from_membership(
+                self._agent_name,
+                self._community_id,
+                self._relay_url,
+                channel_id,
+                label=membership.chat_title,
+            )
+            self._registry.upsert_group_chat(
+                self._agent_name,
+                channel_id,
+                chat_title=channel["label"],
+                chat_type="channel",
+                platform="buzz",
+            )
+            if channel_id not in channels:
+                channels.append(channel_id)
+            if subscription_since is not None:
+                await self._open_channel_subscription(
+                    ws,
+                    channel_id,
+                    subscription_since=subscription_since,
+                    channel_subscriptions=channel_subscriptions,
+                    # A newly granted membership must not replay signed
+                    # commands from before the relay says this identity joined.
+                    floor=max(subscription_floor, membership.event["created_at"]),
+                    connection_token=connection_token,
+                )
+            return
+
+        self._registry.remove_buzz_inbound_channel_from_membership(
+            self._agent_name,
+            self._community_id,
+            self._relay_url,
+            channel_id,
+        )
+        self._registry.deactivate_group_chat(self._agent_name, channel_id)
+        if channel_id in channels:
+            channels.remove(channel_id)
+        subscription_id = channel_subscriptions.pop(channel_id, "")
+        if subscription_id:
+            if subscription_since is not None:
+                subscription_since.pop(subscription_id, None)
+            await self._send_frame(ws, ["CLOSE", subscription_id])
 
     async def _receive_frame(self, ws, *, timeout: float) -> list:
         raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
@@ -728,5 +1026,7 @@ __all__ = [
     "BuzzRelayLivenessError",
     "BuzzRelayProtocolError",
     "ValidatedBuzzInboundEvent",
+    "ValidatedBuzzMembershipEvent",
     "validate_buzz_inbound_event",
+    "validate_buzz_membership_event",
 ]

--- a/src/pinky_daemon/buzz_inbound.py
+++ b/src/pinky_daemon/buzz_inbound.py
@@ -77,6 +77,7 @@ def validate_buzz_membership_event(
     event: object,
     *,
     identity_pubkey: str,
+    relay_signing_pubkey: str,
     now: float | None = None,
 ) -> ValidatedBuzzMembershipEvent:
     """Validate one relay-delivered, identity-targeted membership notification.
@@ -94,6 +95,10 @@ def validate_buzz_membership_event(
         raise BuzzInboundRejectedError("membership_event_not_json") from exc
     if len(encoded) > _MAX_FRAME_BYTES:
         raise BuzzInboundRejectedError("membership_event_too_large")
+    if not _is_hex_64(relay_signing_pubkey):
+        raise BuzzInboundRejectedError("membership_relay_authority_missing")
+    if event.get("pubkey") != relay_signing_pubkey:
+        raise BuzzInboundRejectedError("membership_signer_invalid")
     if not verify_nostr_event(event):
         raise BuzzInboundRejectedError("membership_signature_or_id_invalid")
     if event["kind"] not in _MEMBERSHIP_KINDS:
@@ -426,9 +431,15 @@ class BrokerBuzzPoller:
         self._pubkey = signing_material.pubkey
         self._relay_url = signing_material.relay_url
         self._community_id = signing_material.community_id
+        self._relay_signing_pubkey = signing_material.relay_signing_pubkey
         self._signer = BuzzNostrSigner(signing_material.private_key)
         if not secrets.compare_digest(self._signer.pubkey, self._pubkey):
             raise BuzzRelayProtocolError("signing material pubkey mismatch")
+        if not _is_hex_64(self._relay_signing_pubkey):
+            _log(
+                "buzz-inbound: WARNING membership processing disabled for "
+                f"{self._agent_name}: relay signing authority is absent"
+            )
         self._broker = broker
         self._registry = registry
         self._owner_notify = owner_notify
@@ -902,8 +913,19 @@ class BrokerBuzzPoller:
             membership = validate_buzz_membership_event(
                 event,
                 identity_pubkey=self._pubkey,
+                relay_signing_pubkey=self._relay_signing_pubkey,
             )
-        except BuzzInboundRejectedError:
+        except BuzzInboundRejectedError as exc:
+            if str(exc) == "membership_signer_invalid":
+                signer = event.get("pubkey") if isinstance(event, dict) else None
+                fingerprint = (
+                    f"{signer[:12]}…" if _is_hex_64(signer) else "invalid"
+                )
+                _log(
+                    "buzz-inbound: WARNING rejected membership event for "
+                    f"{self._agent_name}: signer {fingerprint} does not match "
+                    "the pinned relay authority"
+                )
             return
         channel_id = membership.channel_id
         event_version = (

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -10,6 +10,12 @@ from pinky_daemon.agent_registry import AgentRegistry
 from pinky_daemon.broker import BrokerMessage, MessageBroker
 from pinky_daemon.sessions import SessionManager
 
+BRAD_BUZZ_PRINCIPAL = (
+    "buzz:posspecialists:"
+    "90425c785cf23b60e57300658a7f4855938b3c2f661b3ef33acdb54831fcb44b"
+)
+BUZZ_CHANNEL = "00000000-0000-4000-8000-000000000001"
+
 
 class TestMessageBrokerRouting:
     def _make_broker(self):
@@ -121,6 +127,188 @@ class TestMessageBrokerRouting:
             assert header == (
                 "[slack | group | C123 | Alex | C123 | "
                 "1970-01-01 00:00:00 UTC | msg_id:1711584000.000100]"
+            )
+        finally:
+            tmpdir.cleanup()
+
+    def test_buzz_known_contact_uses_registry_name_role_and_fingerprint(self):
+        tmpdir, registry, broker, _sent, _reactions = self._make_broker()
+        try:
+            registry.set_default_timezone("UTC")
+            prompt = broker._format_prompt(
+                BrokerMessage(
+                    platform="buzz",
+                    chat_id=BUZZ_CHANNEL,
+                    chat_title="#general",
+                    sender_name="attacker-controlled name",
+                    sender_id=BRAD_BUZZ_PRINCIPAL,
+                    content="hello",
+                    agent_name="barsik",
+                    message_id="ab" * 32,
+                    timestamp=0,
+                    is_group=True,
+                    metadata={
+                        "buzz_verified_principal": BRAD_BUZZ_PRINCIPAL,
+                        "buzz_mentioned_self": False,
+                    },
+                )
+            )
+            assert prompt.splitlines()[0] == (
+                f"[buzz | #general | from:Brad (owner) principal:90425c785cf2… | "
+                f"mentioned_self:false | chat_id:{BUZZ_CHANNEL} | "
+                f"1970-01-01 00:00:00 UTC | msg_id:{'ab' * 32}]"
+            )
+            assert "display_name" not in prompt.splitlines()[0]
+            assert BRAD_BUZZ_PRINCIPAL not in prompt.splitlines()[0]
+        finally:
+            tmpdir.cleanup()
+
+    def test_buzz_unknown_contact_keeps_untrusted_name_and_full_principal(self):
+        tmpdir, registry, broker, _sent, _reactions = self._make_broker()
+        try:
+            registry.set_default_timezone("UTC")
+            principal = f"buzz:posspecialists:{'aa' * 32}"
+            header = broker._format_prompt(
+                BrokerMessage(
+                    platform="buzz",
+                    chat_id=BUZZ_CHANNEL,
+                    chat_title="#general",
+                    sender_name="Somebody",
+                    sender_id=principal,
+                    content="hello",
+                    agent_name="barsik",
+                    timestamp=0,
+                    is_group=True,
+                    metadata={"buzz_verified_principal": principal},
+                )
+            ).splitlines()[0]
+            assert header == (
+                f"[buzz | #general | display_name(untrusted):Somebody | "
+                f"principal:{principal} | mentioned_self:false | "
+                f"chat_id:{BUZZ_CHANNEL} | 1970-01-01 00:00:00 UTC]"
+            )
+        finally:
+            tmpdir.cleanup()
+
+    def test_buzz_unknown_contact_flags_registered_name_collision(self):
+        tmpdir, registry, broker, _sent, _reactions = self._make_broker()
+        try:
+            registry.set_default_timezone("UTC")
+            principal = f"buzz:posspecialists:{'bb' * 32}"
+            header = broker._format_prompt(
+                BrokerMessage(
+                    platform="buzz",
+                    chat_id=BUZZ_CHANNEL,
+                    chat_title="#general",
+                    sender_name="bRaD",
+                    sender_id=principal,
+                    content="hello",
+                    agent_name="barsik",
+                    timestamp=0,
+                    is_group=True,
+                    metadata={"buzz_verified_principal": principal},
+                )
+            ).splitlines()[0]
+            assert "display_name(untrusted+collides:Brad):bRaD" in header
+            assert f"principal:{principal}" in header
+        finally:
+            tmpdir.cleanup()
+
+    def test_buzz_absent_verified_contacts_table_falls_back_without_exception(self):
+        tmpdir, registry, broker, _sent, _reactions = self._make_broker()
+        try:
+            registry.set_default_timezone("UTC")
+            registry._db.execute("DROP TABLE verified_contacts")
+            registry._db.commit()
+            principal = f"buzz:posspecialists:{'cc' * 32}"
+            header = broker._format_prompt(
+                BrokerMessage(
+                    platform="buzz",
+                    chat_id=BUZZ_CHANNEL,
+                    chat_title="#general",
+                    sender_name="Somebody",
+                    sender_id=principal,
+                    content="hello",
+                    agent_name="barsik",
+                    timestamp=0,
+                    is_group=True,
+                    metadata={"buzz_verified_principal": principal},
+                )
+            ).splitlines()[0]
+            assert "display_name(untrusted):Somebody" in header
+            assert f"principal:{principal}" in header
+        finally:
+            tmpdir.cleanup()
+
+    def test_buzz_channel_id_is_rendered_exactly_once_with_or_without_alias(self):
+        tmpdir, registry, broker, _sent, _reactions = self._make_broker()
+        try:
+            registry.set_default_timezone("UTC")
+            registry.upsert_group_chat(
+                "barsik", BUZZ_CHANNEL, chat_type="channel", platform="buzz"
+            )
+            principal = f"buzz:posspecialists:{'dd' * 32}"
+            message = BrokerMessage(
+                platform="buzz",
+                chat_id=BUZZ_CHANNEL,
+                sender_name="Somebody",
+                sender_id=principal,
+                content="hello",
+                agent_name="barsik",
+                timestamp=0,
+                is_group=True,
+                metadata={"buzz_verified_principal": principal},
+            )
+            raw_header = broker._format_prompt(message).splitlines()[0]
+            assert raw_header.startswith(f"[buzz | {BUZZ_CHANNEL} |")
+            assert raw_header.count(BUZZ_CHANNEL) == 1
+
+            assert registry.update_group_chat_alias("barsik", BUZZ_CHANNEL, "#general")
+            named_header = broker._format_prompt(message).splitlines()[0]
+            assert named_header.startswith("[buzz | #general |")
+            assert named_header.count(BUZZ_CHANNEL) == 1
+            assert f"chat_id:{BUZZ_CHANNEL}" in named_header
+        finally:
+            tmpdir.cleanup()
+
+    def test_non_buzz_group_and_dm_headers_remain_byte_identical(self):
+        tmpdir, registry, broker, _sent, _reactions = self._make_broker()
+        try:
+            registry.set_default_timezone("UTC")
+            group = broker._format_prompt(
+                BrokerMessage(
+                    platform="telegram",
+                    chat_id="-100123",
+                    chat_title="Ops",
+                    sender_name="Alex",
+                    sender_id="42",
+                    content="group body",
+                    agent_name="barsik",
+                    message_id="7",
+                    timestamp=0,
+                    is_group=True,
+                )
+            )
+            dm = broker._format_prompt(
+                BrokerMessage(
+                    platform="telegram",
+                    chat_id="42",
+                    sender_name="Alex",
+                    sender_id="42",
+                    content="dm body",
+                    agent_name="barsik",
+                    message_id="8",
+                    timestamp=0,
+                    is_group=False,
+                )
+            )
+            assert group == (
+                "[telegram | group | Ops | Alex | -100123 | "
+                "1970-01-01 00:00:00 UTC | msg_id:7]\ngroup body"
+            )
+            assert dm == (
+                "[telegram | dm | Alex | 42 | "
+                "1970-01-01 00:00:00 UTC | msg_id:8]\ndm body"
             )
         finally:
             tmpdir.cleanup()

--- a/tests/test_buzz_api.py
+++ b/tests/test_buzz_api.py
@@ -25,6 +25,7 @@ OTHER_PRIVATE_KEY = "22" * 32
 CHANNEL = "00000000-0000-4000-8000-000000000001"
 OWNER_PUBKEY = BuzzNostrSigner(bytes.fromhex("33" * 32)).pubkey
 APPROVED_PUBKEY = BuzzNostrSigner(bytes.fromhex("44" * 32)).pubkey
+RELAY_SIGNING_PUBKEY = BuzzNostrSigner(bytes.fromhex("66" * 32)).pubkey
 
 
 @pytest.fixture(autouse=True)
@@ -38,6 +39,7 @@ def _body(**overrides):
         "private_key": PRIVATE_KEY,
         "relay_url": "wss://example.communities.buzz.xyz",
         "community_id": "example",
+        "relay_signing_pubkey": RELAY_SIGNING_PUBKEY,
         "enabled": True,
     }
     body.update(overrides)
@@ -80,6 +82,7 @@ def test_owner_bind_generates_identity_scoped_authority_and_redacts_it(tmp_path)
         identity = response.json()
         assert identity["enabled"] is True
         assert identity["status"] == "active"
+        assert identity["relay_signing_pubkey"] == RELAY_SIGNING_PUBKEY
         assert identity["tos_approved_by"] == "ui:admin"
         assert identity["tos_approved_at"] > 0
         assert re.fullmatch(
@@ -126,6 +129,7 @@ def test_arbitrary_or_caller_supplied_authority_cannot_enable(tmp_path):
             "private_key",
             "relay_url",
             "community_id",
+            "relay_signing_pubkey",
             "enabled",
             "inbound",
         }
@@ -363,6 +367,7 @@ def test_daemon_restart_resumes_configured_native_buzz_poller(tmp_path, monkeypa
         private_key=PRIVATE_KEY,
         relay_url="wss://example.communities.buzz.xyz",
         community_id="example",
+        relay_signing_pubkey=RELAY_SIGNING_PUBKEY,
         enabled=True,
         owner_actor="ui:admin",
     )
@@ -510,6 +515,7 @@ def test_startup_refuses_enabled_identity_when_buzz_dependency_is_missing(tmp_pa
         private_key=PRIVATE_KEY,
         relay_url="wss://example.communities.buzz.xyz",
         community_id="example",
+        relay_signing_pubkey=RELAY_SIGNING_PUBKEY,
         enabled=True,
         owner_actor="ui:admin",
     )

--- a/tests/test_buzz_identity.py
+++ b/tests/test_buzz_identity.py
@@ -17,9 +17,14 @@ from pinky_daemon.buzz_identity import (
     wrap_buzz_private_key,
 )
 from pinky_identity.keystore import DeviceKey
+from pinky_outreach.buzz import BuzzNostrSigner
 
 PRIVATE_KEY = "11" * 32
 OTHER_PRIVATE_KEY = "22" * 32
+RELAY_SIGNING_PUBKEY = BuzzNostrSigner(bytes.fromhex("66" * 32)).pubkey
+PRODUCTION_RELAY_SIGNING_PUBKEY = (
+    "12f6870117eff1a6318bd38c82a65d51dd19879b7489f57247114d0ee8a96de3"
+)
 
 
 @pytest.fixture
@@ -38,6 +43,7 @@ def _bind(registry: AgentRegistry, **overrides) -> dict:
         "private_key": PRIVATE_KEY,
         "relay_url": "wss://example.communities.buzz.xyz",
         "community_id": "example",
+        "relay_signing_pubkey": RELAY_SIGNING_PUBKEY,
         "enabled": True,
         "owner_actor": "ui:admin",
     }
@@ -65,6 +71,7 @@ def test_private_key_is_encrypted_and_absent_from_public_surfaces(registry, tmp_
     assert "idx_buzz_identities_approval_ref" in unique_indexes
     assert "idx_buzz_identities_tos_receipt" in unique_indexes
     assert public["tos_approved"] is True
+    assert public["relay_signing_pubkey"] == RELAY_SIGNING_PUBKEY
 
     row = registry._db.execute(
         "SELECT nonce, ciphertext, tos_receipt FROM buzz_identities WHERE agent='barsik'"
@@ -85,6 +92,7 @@ def test_private_key_is_encrypted_and_absent_from_public_surfaces(registry, tmp_
 
     material = registry.get_buzz_signing_material("barsik")
     assert material.private_key == bytes.fromhex(PRIVATE_KEY)
+    assert material.relay_signing_pubkey == RELAY_SIGNING_PUBKEY
     assert PRIVATE_KEY not in repr(material)
 
 
@@ -192,6 +200,13 @@ def test_identity_rotation_is_not_implicit(registry):
         _bind(registry, private_key=OTHER_PRIVATE_KEY)
 
 
+def test_relay_signing_authority_rotation_is_not_implicit(registry):
+    _bind(registry)
+    replacement = BuzzNostrSigner(bytes.fromhex("77" * 32)).pubkey
+    with pytest.raises(ValueError, match="relay signing authority rotation"):
+        _bind(registry, relay_signing_pubkey=replacement)
+
+
 def test_one_approval_reference_cannot_be_reused_for_a_second_identity(registry, tmp_path):
     _bind(registry)
     registry.register("murzik", model="sonnet", working_dir=str(tmp_path / "murzik"))
@@ -260,6 +275,7 @@ def test_legacy_buzz_table_gets_all_forward_columns(tmp_path):
             "ciphertext",
             "relay_url",
             "community_id",
+            "relay_signing_pubkey",
             "enabled",
             "status",
             "last_error",
@@ -272,3 +288,42 @@ def test_legacy_buzz_table_gets_all_forward_columns(tmp_path):
         } <= columns
     finally:
         registry.close()
+
+
+def test_existing_barsik_identity_migration_seeds_verified_relay_authority(tmp_path):
+    db_path = tmp_path / "agents.db"
+    registry = AgentRegistry(
+        str(db_path),
+        buzz_device_key_path=str(tmp_path / "identity" / ".device_key"),
+    )
+    registry.register("barsik", model="sonnet", working_dir=str(tmp_path / "barsik"))
+    _bind(registry)
+    registry.close()
+
+    with sqlite3.connect(db_path) as db:
+        db.execute("ALTER TABLE buzz_identities DROP COLUMN relay_signing_pubkey")
+
+    migrated = AgentRegistry(
+        str(db_path),
+        buzz_device_key_path=str(tmp_path / "identity" / ".device_key"),
+    )
+    try:
+        assert (
+            migrated.get_buzz_identity("barsik")["relay_signing_pubkey"]
+            == PRODUCTION_RELAY_SIGNING_PUBKEY
+        )
+    finally:
+        migrated.close()
+
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            "UPDATE buzz_identities SET relay_signing_pubkey='' WHERE agent='barsik'"
+        )
+    reopened = AgentRegistry(
+        str(db_path),
+        buzz_device_key_path=str(tmp_path / "identity" / ".device_key"),
+    )
+    try:
+        assert reopened.get_buzz_identity("barsik")["relay_signing_pubkey"] == ""
+    finally:
+        reopened.close()

--- a/tests/test_buzz_inbound.py
+++ b/tests/test_buzz_inbound.py
@@ -14,6 +14,7 @@ from pinky_daemon.buzz_inbound import (
     BuzzInboundProcessor,
     BuzzInboundRejectedError,
     validate_buzz_inbound_event,
+    validate_buzz_membership_event,
 )
 from pinky_outreach.buzz import BuzzNostrSigner
 
@@ -167,10 +168,17 @@ async def test_verified_no_p_broadcast_reaches_persona_with_full_principal(regis
     formatter = object.__new__(MessageBroker)
     formatter._registry = store
     prompt = MessageBroker._format_prompt(formatter, message)
-    assert "[buzz | channel | #general" in prompt
-    assert "display_name(untrusted):Brad" in prompt
+    assert "[buzz | #general" in prompt
+    assert "display_name(untrusted+collides:Brad):Brad" in prompt
     assert f"principal:buzz:{COMMUNITY}:{USER.pubkey}" in prompt
     assert "mentioned_self:false" in prompt
+    [chat] = store.list_group_chats("barsik")
+    assert (chat["platform"], chat["chat_id"], chat["chat_title"], chat["chat_type"]) == (
+        "buzz",
+        CHANNEL,
+        "#general",
+        "channel",
+    )
 
 
 @pytest.mark.asyncio
@@ -239,6 +247,39 @@ async def test_membership_events_never_expand_channels_or_reach_persona(registry
     assert broker.calls == []
     assert store.get_buzz_inbound_policy("barsik")["channels"] == before
     assert store.get_buzz_inbound_channel("barsik", COMMUNITY, RELAY, OTHER_CHANNEL) is None
+
+
+def test_membership_validation_requires_exact_self_p_and_canonical_h(registry):
+    _store, identity_pubkey = registry
+    valid = OWNER.sign_event(
+        kind=44100,
+        tags=[["p", identity_pubkey], ["h", OTHER_CHANNEL], ["name", "#support"]],
+        content="",
+    )
+    membership = validate_buzz_membership_event(
+        valid,
+        identity_pubkey=identity_pubkey,
+    )
+    assert (membership.channel_id, membership.chat_title) == (OTHER_CHANNEL, "#support")
+
+    foreign = OWNER.sign_event(
+        kind=44100,
+        tags=[["p", STRANGER.pubkey], ["h", OTHER_CHANNEL]],
+        content="",
+    )
+    duplicate = OWNER.sign_event(
+        kind=44100,
+        tags=[
+            ["p", identity_pubkey],
+            ["p", identity_pubkey],
+            ["h", OTHER_CHANNEL],
+        ],
+        content="",
+    )
+    with pytest.raises(BuzzInboundRejectedError, match="membership_target_invalid"):
+        validate_buzz_membership_event(foreign, identity_pubkey=identity_pubkey)
+    with pytest.raises(BuzzInboundRejectedError, match="membership_target_invalid"):
+        validate_buzz_membership_event(duplicate, identity_pubkey=identity_pubkey)
 
 
 @pytest.mark.asyncio

--- a/tests/test_buzz_inbound.py
+++ b/tests/test_buzz_inbound.py
@@ -25,6 +25,7 @@ STRANGER_KEY = bytes.fromhex("55" * 32)
 OWNER = BuzzNostrSigner(OWNER_KEY)
 USER = BuzzNostrSigner(USER_KEY)
 STRANGER = BuzzNostrSigner(STRANGER_KEY)
+RELAY_AUTHORITY = BuzzNostrSigner(bytes.fromhex("66" * 32))
 CHANNEL = "00000000-0000-4000-8000-000000000001"
 OTHER_CHANNEL = "00000000-0000-4000-8000-000000000002"
 RELAY = "wss://example.communities.buzz.xyz"
@@ -53,6 +54,7 @@ def registry(tmp_path):
         private_key=AGENT_KEY,
         relay_url=RELAY,
         community_id=COMMUNITY,
+        relay_signing_pubkey=RELAY_AUTHORITY.pubkey,
         enabled=True,
         owner_actor="ui:admin",
     )
@@ -251,7 +253,7 @@ async def test_membership_events_never_expand_channels_or_reach_persona(registry
 
 def test_membership_validation_requires_exact_self_p_and_canonical_h(registry):
     _store, identity_pubkey = registry
-    valid = OWNER.sign_event(
+    valid = RELAY_AUTHORITY.sign_event(
         kind=44100,
         tags=[["p", identity_pubkey], ["h", OTHER_CHANNEL], ["name", "#support"]],
         content="",
@@ -259,15 +261,16 @@ def test_membership_validation_requires_exact_self_p_and_canonical_h(registry):
     membership = validate_buzz_membership_event(
         valid,
         identity_pubkey=identity_pubkey,
+        relay_signing_pubkey=RELAY_AUTHORITY.pubkey,
     )
     assert (membership.channel_id, membership.chat_title) == (OTHER_CHANNEL, "#support")
 
-    foreign = OWNER.sign_event(
+    foreign = RELAY_AUTHORITY.sign_event(
         kind=44100,
         tags=[["p", STRANGER.pubkey], ["h", OTHER_CHANNEL]],
         content="",
     )
-    duplicate = OWNER.sign_event(
+    duplicate = RELAY_AUTHORITY.sign_event(
         kind=44100,
         tags=[
             ["p", identity_pubkey],
@@ -277,9 +280,43 @@ def test_membership_validation_requires_exact_self_p_and_canonical_h(registry):
         content="",
     )
     with pytest.raises(BuzzInboundRejectedError, match="membership_target_invalid"):
-        validate_buzz_membership_event(foreign, identity_pubkey=identity_pubkey)
+        validate_buzz_membership_event(
+            foreign,
+            identity_pubkey=identity_pubkey,
+            relay_signing_pubkey=RELAY_AUTHORITY.pubkey,
+        )
     with pytest.raises(BuzzInboundRejectedError, match="membership_target_invalid"):
-        validate_buzz_membership_event(duplicate, identity_pubkey=identity_pubkey)
+        validate_buzz_membership_event(
+            duplicate,
+            identity_pubkey=identity_pubkey,
+            relay_signing_pubkey=RELAY_AUTHORITY.pubkey,
+        )
+
+
+@pytest.mark.parametrize("kind", [44100, 44101])
+@pytest.mark.parametrize(
+    "signer",
+    [OWNER, USER, STRANGER],
+    ids=["owner", "other-user", "stranger-55-scalar"],
+)
+def test_membership_validation_rejects_every_non_relay_signer(
+    registry,
+    kind,
+    signer,
+):
+    _store, identity_pubkey = registry
+    forged = signer.sign_event(
+        kind=kind,
+        tags=[["p", identity_pubkey], ["h", OTHER_CHANNEL]],
+        content="",
+    )
+
+    with pytest.raises(BuzzInboundRejectedError, match="membership_signer_invalid"):
+        validate_buzz_membership_event(
+            forged,
+            identity_pubkey=identity_pubkey,
+            relay_signing_pubkey=RELAY_AUTHORITY.pubkey,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_buzz_inbound_poller.py
+++ b/tests/test_buzz_inbound_poller.py
@@ -16,6 +16,8 @@ from pinky_outreach.buzz import BuzzNostrSigner, verify_nostr_event
 AGENT_KEY = "11" * 32
 OWNER = BuzzNostrSigner(bytes.fromhex("33" * 32))
 USER = BuzzNostrSigner(bytes.fromhex("44" * 32))
+STRANGER = BuzzNostrSigner(bytes.fromhex("55" * 32))
+RELAY_AUTHORITY = BuzzNostrSigner(bytes.fromhex("66" * 32))
 CHANNEL = "00000000-0000-4000-8000-000000000001"
 OTHER_CHANNEL = "00000000-0000-4000-8000-000000000002"
 COMMUNITY = "example"
@@ -43,6 +45,7 @@ def _registry(tmp_path, relay_url: str, *, channels: list[dict] | None = None):
         private_key=AGENT_KEY,
         relay_url=relay_url,
         community_id=COMMUNITY,
+        relay_signing_pubkey=RELAY_AUTHORITY.pubkey,
         enabled=True,
         owner_actor="ui:admin",
     )
@@ -654,12 +657,12 @@ async def test_live_fanout_uses_one_req_per_channel_and_waits_for_every_eose(tmp
 async def test_membership_add_opens_channel_live_and_remove_closes_it(tmp_path):
     relay_url = ""
     agent_pubkey = BuzzNostrSigner(bytes.fromhex(AGENT_KEY)).pubkey
-    added = OWNER.sign_event(
+    added = RELAY_AUTHORITY.sign_event(
         kind=44100,
         tags=[["p", agent_pubkey], ["h", OTHER_CHANNEL], ["name", "#support"]],
         content="",
     )
-    removed = OWNER.sign_event(
+    removed = RELAY_AUTHORITY.sign_event(
         kind=44101,
         tags=[["p", agent_pubkey], ["h", OTHER_CHANNEL]],
         content="",
@@ -774,13 +777,13 @@ async def test_membership_history_newest_removal_cannot_be_reopened_by_older_add
     material = store.get_buzz_signing_material("barsik")
     poller = BrokerBuzzPoller(material, FakeBroker(), store, lambda *_args: True)
     now = int(time.time())
-    removed = OWNER.sign_event(
+    removed = RELAY_AUTHORITY.sign_event(
         kind=44101,
         tags=[["p", material.pubkey], ["h", OTHER_CHANNEL]],
         content="",
         created_at=now - 5,
     )
-    older_add = OWNER.sign_event(
+    older_add = RELAY_AUTHORITY.sign_event(
         kind=44100,
         tags=[["p", material.pubkey], ["h", OTHER_CHANNEL]],
         content="",
@@ -814,6 +817,75 @@ async def test_membership_history_newest_removal_cannot_be_reopened_by_older_add
     assert OTHER_CHANNEL not in channels
     assert channel_subscriptions == {}
     assert ws.sent == []
+    store.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stored_pin", "signer", "expected_log"),
+    [
+        ("", RELAY_AUTHORITY, "membership processing disabled"),
+        (RELAY_AUTHORITY.pubkey, STRANGER, "rejected membership event"),
+    ],
+    ids=["absent-pin", "stranger-55-scalar"],
+)
+async def test_membership_authority_failures_are_inert_and_loud(
+    tmp_path,
+    capsys,
+    stored_pin,
+    signer,
+    expected_log,
+):
+    relay_url = "ws://127.0.0.1:1"
+    store = _registry(tmp_path, relay_url)
+    if not stored_pin:
+        store._db.execute(
+            "UPDATE buzz_identities SET relay_signing_pubkey='' WHERE agent='barsik'"
+        )
+        store._db.commit()
+    material = store.get_buzz_signing_material("barsik")
+    poller = BrokerBuzzPoller(material, FakeBroker(), store, lambda *_args: True)
+    forged = signer.sign_event(
+        kind=44100,
+        tags=[["p", material.pubkey], ["h", OTHER_CHANNEL], ["name", "#forged"]],
+        content="",
+    )
+
+    class FakeSocket:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, payload):  # noqa: ANN001
+            self.sent.append(json.loads(payload))
+
+    ws = FakeSocket()
+    channels = [CHANNEL]
+    channel_subscriptions: dict[str, str] = {}
+    await poller._handle_membership_event(
+        ws,
+        forged,
+        subscription_since={},
+        channel_subscriptions=channel_subscriptions,
+        channels=channels,
+        subscription_floor=int(time.time()) - 60,
+        connection_token="test",
+    )
+
+    assert store.get_buzz_inbound_channel(
+        "barsik", COMMUNITY, relay_url, OTHER_CHANNEL
+    ) is None
+    assert all(
+        chat["chat_id"] != OTHER_CHANNEL
+        for chat in store.list_group_chats("barsik", active_only=False)
+    )
+    assert channels == [CHANNEL]
+    assert channel_subscriptions == {}
+    assert poller._membership_versions == {}
+    assert ws.sent == []
+    captured = capsys.readouterr().err
+    assert expected_log in captured
+    if stored_pin:
+        assert f"{signer.pubkey[:12]}…" in captured
     store.close()
 
 

--- a/tests/test_buzz_inbound_poller.py
+++ b/tests/test_buzz_inbound_poller.py
@@ -89,6 +89,7 @@ class LiveFanoutQuirkRelayRig:
         self.hold_final_eose = hold_final_eose
         self.captured: list[list] = []
         self.main_requests: list[list] = []
+        self.membership_request: list | None = None
         self.main_requests_received = asyncio.Event()
         self.partial_eose_sent = asyncio.Event()
         self.release_final_eose = asyncio.Event()
@@ -103,6 +104,11 @@ class LiveFanoutQuirkRelayRig:
 
     async def handler(self, ws) -> None:  # noqa: ANN001
         await _authenticate(ws, self.relay_url, self.captured)
+        membership = json.loads(await ws.recv())
+        self.captured.append(membership)
+        assert membership[0] == "REQ"
+        self.membership_request = membership
+        await ws.send(json.dumps(["EOSE", membership[1]]))
         for _ in self.channels:
             main = json.loads(await ws.recv())
             self.captured.append(main)
@@ -168,6 +174,9 @@ async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_h
 
     async def handler(ws):  # noqa: ANN001
         await _authenticate(ws, relay_url, captured)
+        membership = json.loads(await ws.recv())
+        captured.append(membership)
+        await ws.send(json.dumps(["EOSE", membership[1]]))
         main = json.loads(await ws.recv())
         captured.append(main)
         assert main[0] == "REQ"
@@ -181,7 +190,7 @@ async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_h
             except websockets.ConnectionClosed:
                 return
             captured.append(frame)
-            if frame[0] == "REQ":
+            if frame[0] == "REQ" and frame[1].startswith("pinky-live-"):
                 heartbeat_seen.set()
                 await ws.send(json.dumps(["EOSE", frame[1]]))
 
@@ -216,6 +225,14 @@ async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_h
         assert initial_filter["kinds"] == [9, 20002]
         assert initial_filter["#h"] == [CHANNEL]
         assert "since" not in initial_filter
+        membership_filters = [
+            frame[2]
+            for frame in captured
+            if frame[0] == "REQ" and frame[1].startswith("pinky-membership-")
+        ]
+        assert membership_filters == [
+            {"kinds": [44100, 44101], "#p": [material.pubkey]}
+        ]
         assert len(broker.calls) == 1
         assert broker.calls[0][1].content == "hello from Brad"
         assert poller.health["delivered"] == 1
@@ -250,6 +267,8 @@ async def test_socket_open_without_eose_heartbeat_pages_owner_and_reconnects(tmp
         nonlocal connections
         connections += 1
         await _authenticate(ws, relay_url, [])
+        membership = json.loads(await ws.recv())
+        await ws.send(json.dumps(["EOSE", membership[1]]))
         main = json.loads(await ws.recv())
         await ws.send(json.dumps(["EOSE", main[1]]))
         # Keep the TCP/WebSocket open but intentionally never answer the next
@@ -301,6 +320,9 @@ async def test_control_frame_trickle_cannot_starve_periodic_eose_probe(tmp_path)
 
     async def handler(ws):  # noqa: ANN001
         await _authenticate(ws, relay_url, captured)
+        membership = json.loads(await ws.recv())
+        captured.append(membership)
+        await ws.send(json.dumps(["EOSE", membership[1]]))
         main = json.loads(await ws.recv())
         captured.append(main)
         await ws.send(json.dumps(["EOSE", main[1]]))
@@ -372,6 +394,8 @@ async def test_wire_subscription_omits_since_but_client_floor_rejects_stale_even
 
     async def handler(ws):  # noqa: ANN001
         await _authenticate(ws, relay_url, [])
+        membership = json.loads(await ws.recv())
+        await ws.send(json.dumps(["EOSE", membership[1]]))
         main = json.loads(await ws.recv())
         subscription_filter.update(main[2])
         stale = USER.sign_event(
@@ -589,6 +613,11 @@ async def test_live_fanout_uses_one_req_per_channel_and_waits_for_every_eose(tmp
         }
         assert all(frame[2]["kinds"] == [9, 20002] for frame in rig.main_requests)
         assert all("since" not in frame[2] for frame in rig.main_requests)
+        assert rig.membership_request is not None
+        assert rig.membership_request[2] == {
+            "kinds": [44100, 44101],
+            "#p": [store.get_buzz_identity("barsik")["pubkey"]],
+        }
 
         rig.release_final_eose.set()
         await asyncio.wait_for(rig.all_eose_sent.wait(), timeout=2)
@@ -622,6 +651,173 @@ async def test_live_fanout_uses_one_req_per_channel_and_waits_for_every_eose(tmp
 
 
 @pytest.mark.asyncio
+async def test_membership_add_opens_channel_live_and_remove_closes_it(tmp_path):
+    relay_url = ""
+    agent_pubkey = BuzzNostrSigner(bytes.fromhex(AGENT_KEY)).pubkey
+    added = OWNER.sign_event(
+        kind=44100,
+        tags=[["p", agent_pubkey], ["h", OTHER_CHANNEL], ["name", "#support"]],
+        content="",
+    )
+    removed = OWNER.sign_event(
+        kind=44101,
+        tags=[["p", agent_pubkey], ["h", OTHER_CHANNEL]],
+        content="",
+    )
+    channel_message = USER.sign_event(
+        kind=9,
+        tags=[["h", OTHER_CHANNEL]],
+        content="live after membership add",
+    )
+    pre_membership_message = USER.sign_event(
+        kind=9,
+        tags=[["h", OTHER_CHANNEL]],
+        content="stale before membership add",
+        created_at=added["created_at"] - 1,
+    )
+    dynamic_opened = asyncio.Event()
+    release_remove = asyncio.Event()
+    dynamic_closed = asyncio.Event()
+    captured: list[list] = []
+
+    async def handler(ws):  # noqa: ANN001
+        await _authenticate(ws, relay_url, captured)
+        membership = json.loads(await ws.recv())
+        captured.append(membership)
+        await ws.send(json.dumps(["EOSE", membership[1]]))
+        initial = json.loads(await ws.recv())
+        captured.append(initial)
+        await ws.send(json.dumps(["EOSE", initial[1]]))
+        await ws.send(json.dumps(["EVENT", membership[1], added]))
+
+        dynamic = json.loads(await ws.recv())
+        captured.append(dynamic)
+        assert dynamic[0] == "REQ"
+        assert dynamic[2] == {"kinds": [9, 20002], "#h": [OTHER_CHANNEL]}
+        dynamic_opened.set()
+        await ws.send(json.dumps(["EOSE", dynamic[1]]))
+        await ws.send(json.dumps(["EVENT", dynamic[1], pre_membership_message]))
+        await ws.send(json.dumps(["EVENT", dynamic[1], channel_message]))
+
+        await release_remove.wait()
+        await ws.send(json.dumps(["EVENT", membership[1], removed]))
+        close = json.loads(await ws.recv())
+        captured.append(close)
+        assert close == ["CLOSE", dynamic[1]]
+        dynamic_closed.set()
+        try:
+            while True:
+                frame = json.loads(await ws.recv())
+                captured.append(frame)
+                if frame[0] == "REQ":
+                    await ws.send(json.dumps(["EOSE", frame[1]]))
+        except websockets.ConnectionClosed:
+            return
+
+    async with websockets.serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        relay_url = f"ws://127.0.0.1:{port}"
+        store = _registry(tmp_path, relay_url)
+        broker = FakeBroker()
+
+        async def notify(_agent, _message):
+            return True
+
+        poller = BrokerBuzzPoller(
+            store.get_buzz_signing_material("barsik"),
+            broker,
+            store,
+            notify,
+            heartbeat_interval=10,
+            liveness_timeout=1,
+        )
+        task = asyncio.create_task(poller.start())
+        await asyncio.wait_for(dynamic_opened.wait(), timeout=2)
+        await asyncio.wait_for(broker.delivered.wait(), timeout=2)
+
+        channel = store.get_buzz_inbound_channel(
+            "barsik", COMMUNITY, relay_url, OTHER_CHANNEL
+        )
+        assert channel == {"channel_id": OTHER_CHANNEL, "label": "#support"}
+        support = next(
+            chat for chat in store.list_group_chats("barsik")
+            if chat["chat_id"] == OTHER_CHANNEL
+        )
+        assert (support["platform"], support["chat_title"], support["active"]) == (
+            "buzz",
+            "#support",
+            True,
+        )
+        assert [call[1].content for call in broker.calls] == ["live after membership add"]
+        assert poller.health["rejected"] == 1
+
+        release_remove.set()
+        await asyncio.wait_for(dynamic_closed.wait(), timeout=2)
+        assert store.get_buzz_inbound_channel(
+            "barsik", COMMUNITY, relay_url, OTHER_CHANNEL
+        ) is None
+        support = next(
+            chat for chat in store.list_group_chats("barsik", active_only=False)
+            if chat["chat_id"] == OTHER_CHANNEL
+        )
+        assert support["active"] is False
+
+        poller.stop()
+        await asyncio.wait_for(task, timeout=2)
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_membership_history_newest_removal_cannot_be_reopened_by_older_add(tmp_path):
+    relay_url = "ws://127.0.0.1:1"
+    store = _registry(tmp_path, relay_url)
+    material = store.get_buzz_signing_material("barsik")
+    poller = BrokerBuzzPoller(material, FakeBroker(), store, lambda *_args: True)
+    now = int(time.time())
+    removed = OWNER.sign_event(
+        kind=44101,
+        tags=[["p", material.pubkey], ["h", OTHER_CHANNEL]],
+        content="",
+        created_at=now - 5,
+    )
+    older_add = OWNER.sign_event(
+        kind=44100,
+        tags=[["p", material.pubkey], ["h", OTHER_CHANNEL]],
+        content="",
+        created_at=now - 10,
+    )
+
+    class FakeSocket:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, payload):  # noqa: ANN001
+            self.sent.append(json.loads(payload))
+
+    ws = FakeSocket()
+    subscription_since: dict[str, int] = {}
+    channel_subscriptions: dict[str, str] = {}
+    channels = [CHANNEL]
+    kwargs = {
+        "subscription_since": subscription_since,
+        "channel_subscriptions": channel_subscriptions,
+        "channels": channels,
+        "subscription_floor": now - 60,
+        "connection_token": "test",
+    }
+    await poller._handle_membership_event(ws, removed, **kwargs)
+    await poller._handle_membership_event(ws, older_add, **kwargs)
+
+    assert store.get_buzz_inbound_channel(
+        "barsik", COMMUNITY, relay_url, OTHER_CHANNEL
+    ) is None
+    assert OTHER_CHANNEL not in channels
+    assert channel_subscriptions == {}
+    assert ws.sent == []
+    store.close()
+
+
+@pytest.mark.asyncio
 async def test_restart_replays_overlap_but_dedupes_delivered_event(tmp_path):
     relay_url = ""
     connection_number = 0
@@ -633,6 +829,8 @@ async def test_restart_replays_overlap_but_dedupes_delivered_event(tmp_path):
         connection_number += 1
         this_connection = connection_number
         await _authenticate(ws, relay_url, [])
+        membership = json.loads(await ws.recv())
+        await ws.send(json.dumps(["EOSE", membership[1]]))
         main = json.loads(await ws.recv())
         await ws.send(json.dumps(["EVENT", main[1], first]))
         if this_connection >= 2:

--- a/tests/test_verified_contacts.py
+++ b/tests/test_verified_contacts.py
@@ -1,0 +1,120 @@
+"""Verified-contact registry, migration seed, and API coverage."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.api import create_api
+
+BRAD_PRINCIPAL = (
+    "buzz:posspecialists:"
+    "90425c785cf23b60e57300658a7f4855938b3c2f661b3ef33acdb54831fcb44b"
+)
+
+
+def test_verified_contacts_seed_ships_for_barsik_and_is_one_shot(tmp_path):
+    db_path = str(tmp_path / "agents.db")
+    registry = AgentRegistry(db_path)
+    registry.register("barsik", model="sonnet", working_dir=str(tmp_path / "barsik"))
+
+    contact = registry.get_verified_contact("barsik", "buzz", BRAD_PRINCIPAL)
+    assert contact == {
+        "id": 1,
+        "agent_name": "barsik",
+        "platform": "buzz",
+        "principal": BRAD_PRINCIPAL,
+        "name": "Brad",
+        "role": "owner",
+        "added_at": contact["added_at"],
+    }
+    assert registry.delete_verified_contact("barsik", "buzz", BRAD_PRINCIPAL)
+    registry.close()
+
+    reopened = AgentRegistry(db_path)
+    assert reopened.get_verified_contact("barsik", "buzz", BRAD_PRINCIPAL) is None
+    reopened.close()
+
+
+def test_verified_contact_registry_is_agent_and_platform_scoped(tmp_path):
+    registry = AgentRegistry(str(tmp_path / "agents.db"))
+    registry.register("kuzya", model="sonnet", working_dir=str(tmp_path / "kuzya"))
+    registry.register("murzik", model="sonnet", working_dir=str(tmp_path / "murzik"))
+
+    first = registry.upsert_verified_contact(
+        "kuzya", "buzz", "buzz:community:abc", "Alice", "agent"
+    )
+    registry.upsert_verified_contact(
+        "kuzya", "mesh", "buzz:community:abc", "Mesh Alice"
+    )
+    registry.upsert_verified_contact(
+        "murzik", "buzz", "buzz:community:abc", "Other Alice"
+    )
+    updated = registry.upsert_verified_contact(
+        "kuzya", "buzz", "buzz:community:abc", "Alice Updated", "owner"
+    )
+
+    assert updated["id"] == first["id"]
+    assert (updated["name"], updated["role"]) == ("Alice Updated", "owner")
+    assert [item["name"] for item in registry.list_verified_contacts("kuzya")] == [
+        "Alice Updated",
+        "Mesh Alice",
+    ]
+    assert registry.get_verified_contact(
+        "murzik", "buzz", "buzz:community:abc"
+    )["name"] == "Other Alice"
+    registry.close()
+
+
+def test_verified_contacts_api_get_put_delete(tmp_path):
+    app = create_api(
+        max_sessions=1,
+        default_working_dir=str(tmp_path),
+        db_path=str(tmp_path / "api.db"),
+    )
+    app.state.agents.register(
+        "kuzya", model="sonnet", working_dir=str(tmp_path / "kuzya")
+    )
+    principal = "buzz:community:" + "aa" * 32
+
+    client = TestClient(app)
+    try:
+        response = client.put(
+            "/agents/kuzya/verified-contacts",
+            params={
+                "platform": "buzz",
+                "principal": principal,
+                "name": "Alice",
+                "role": "agent",
+            },
+        )
+        assert response.status_code == 200
+        contact = response.json()["verified_contact"]
+        assert {**contact, "added_at": 0} == {
+            "id": 1,
+            "agent_name": "kuzya",
+            "platform": "buzz",
+            "principal": principal,
+            "name": "Alice",
+            "role": "agent",
+            "added_at": 0,
+        }
+
+        response = client.get("/agents/kuzya/verified-contacts")
+        assert response.status_code == 200
+        assert response.json()["count"] == 1
+        assert response.json()["verified_contacts"][0]["principal"] == principal
+
+        response = client.delete(
+            "/agents/kuzya/verified-contacts",
+            params={"platform": "buzz", "principal": principal},
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "deleted": True,
+            "platform": "buzz",
+            "principal": principal,
+        }
+        assert client.get("/agents/kuzya/verified-contacts").json()["count"] == 0
+    finally:
+        client.close()


### PR DESCRIPTION
## Outcome

Cleans up Buzz inbound envelopes and makes newly granted Buzz memberships usable without manual database edits. Known contacts render from an explicit per-agent trust registry; unknown contacts remain fully attributable and visibly untrusted.

## What changed

- Adds the platform-general `verified_contacts` table and agent-scoped registry methods plus `GET` / `PUT` / `DELETE /agents/{name}/verified-contacts` owner API surfaces.
- Ships a one-shot seed for Barsik's verified Brad owner principal (`buzz:posspecialists:90425c…`) with `name=Brad` and `role=owner`; fresh installs retry the seed when Barsik is first registered.
- Renders known Buzz senders as `from:Brad (owner) principal:90425c785cf2…`; registry names always override sender-supplied names.
- Keeps unknown senders on the full-principal `display_name(untrusted)` path. Unknown principals claiming a registered name are flagged as `untrusted+collides:<registered-name>`.
- Removes the duplicated Buzz channel ID while preserving full `msg_id` and one full `chat_id` for outreach calls. Telegram group and DM header bytes are unchanged.
- Auto-registers configured Buzz channels in `group_chats` at subscription time and again on first authorized inbound, preserving operator aliases.
- Opens one community-global membership REQ with the exact filter `{"kinds":[44100,44101],"#p":["<agent-pubkey>"]}`.
- Reconciles stored membership history before opening any channel REQ, then handles live adds by admitting/registering the channel and opening one channel-local REQ without restart. Removes revoke the inbound gate, deactivate the channel, discard pending rows, and close the live REQ.
- Rejects pre-membership channel history on dynamically opened REQs and prevents older membership history from reopening a newer removal.

## Trust and routing impact

The contact registry is explicit and keyed by `(agent_name, platform, principal)`; no contact is learned from traffic. Missing rows, an empty table, or lookup failures keep the current full-principal unknown rendering and never blank or crash the sender slot.

Membership changes require a BIP340-valid event received on the authenticated relay connection with exactly one canonical self `p` tag and one canonical channel `h` tag. Runtime identity, subscriptions, contacts, and group-chat registration remain per-agent; the Brad row is only the caller-specified deployment seed.

## Deliberate 1059 split

Kind 1059 is **not** included in this PR's filter. The tree has no NIP-17 gift-wrap/NIP-44 unwrap path, and subscribing now would make PinkyBot appear DM-capable while silently swallowing messages it cannot decrypt.

Follow-up work must first decide the NIP-44 dependency strategy (maintained library vs. reviewed vendored implementation), then add authenticated unwrap/decrypt, authorization, routing, and adversarial tests end to end. Only after that should kind 1059 join the `#p`-gated REQ.

## Validation

- `env -u PINKY_DREAM_TRANSPORT PYTHONPATH=src ... pytest -q tests/test_agent_registry.py tests/test_broker.py tests/test_buzz_inbound.py tests/test_buzz_inbound_poller.py tests/test_verified_contacts.py` — 224 passed
- `ruff check .` — passed
- source `py_compile` — passed
- `git diff --check` — passed
- broader local run reached 695 passed / 1 skipped before the host's production `PINKY_DREAM_TRANSPORT=tmux` override escaped an SDK-mocked dream test; that exact test passes independently with the override removed. GitHub CI remains the clean full-suite gate.

Barsik's pre-merge production-relay probe remains required for the exact 44100/44101 `#p` filter. No relay credentials or live fan-out probe were used in this build lane.

## Boundaries

No production database, identity, relay subscription, release, daemon, or deployment state was changed. This draft does not authorize merge or deploy.

---
🤖 Opened by Kuzya
