### PR TITLE
Verify tmux session survives spawn

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2865,13 +2865,25 @@ class TmuxSession:
         # rejected model, and so on), causing tmux to auto-reap the detached
         # session after ``new-session`` has already returned 0. Without this
         # delayed check the transport proceeds to CONNECTED against no REPL.
-        await asyncio.sleep(_POST_SPAWN_LIVENESS_DELAY_SEC)
-        if not await self._tmux.has_session():
-            raise RuntimeError(
-                f"tmux[{self.agent_name}]: session died immediately after "
-                "spawn; the in-pane command exited before the REPL became "
-                "available (inspect in-pane startup and authentication errors)"
-            )
+        try:
+            await asyncio.sleep(_POST_SPAWN_LIVENESS_DELAY_SEC)
+            if not await self._tmux.has_session():
+                raise RuntimeError(
+                    f"tmux[{self.agent_name}]: session died immediately after "
+                    "spawn; the in-pane command exited before the REPL became "
+                    "available (inspect in-pane startup and authentication errors)"
+                )
+        except BaseException:
+            # ``new-session`` already succeeded, so cancellation during the
+            # delay or an exception from the liveness probe can otherwise
+            # leave a live tmux REPL unmanaged while the caller transitions
+            # the Python state machine to DEAD. Reap best-effort and preserve
+            # the original failure (including CancelledError).
+            try:
+                await self._tmux.kill_session()
+            except BaseException:
+                pass
+            raise
 
         # NOTE: ``force_fresh_context_once`` consumption is deferred to
         # the end of this method (after tailer startup also succeeds),

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -982,6 +982,12 @@ _RECONNECT_BACKOFF = (2, 8, 30)
 # to authenticate / fetch first turn / load CLAUDE.md.
 _COLD_START_TIMEOUT_SEC = 60.0
 
+# A detached tmux session can reap itself just after ``new-session`` reports
+# success when the in-pane command exits immediately. Give that failure time
+# to surface, then verify the session still exists before starting the tailer
+# or declaring the transport connected (issue #513).
+_POST_SPAWN_LIVENESS_DELAY_SEC = 0.15
+
 # Per-turn timeout: how long ANY single in-flight turn can be at the
 # HEAD of ``_inflight_metas`` without its ``stop_hook_summary`` landing
 # before the watchdog considers it stuck and triggers ``force_restart``.
@@ -2853,6 +2859,19 @@ class TmuxSession:
                 f"tmux[{self.agent_name}]: cold-start timed out after "
                 f"{_COLD_START_TIMEOUT_SEC}s"
             ) from None
+
+        # ``tmux new-session -d`` only proves that tmux launched the in-pane
+        # command. The command can then fail fast (bad CLI flag, auth error,
+        # rejected model, and so on), causing tmux to auto-reap the detached
+        # session after ``new-session`` has already returned 0. Without this
+        # delayed check the transport proceeds to CONNECTED against no REPL.
+        await asyncio.sleep(_POST_SPAWN_LIVENESS_DELAY_SEC)
+        if not await self._tmux.has_session():
+            raise RuntimeError(
+                f"tmux[{self.agent_name}]: session died immediately after "
+                "spawn; the in-pane command exited before the REPL became "
+                "available (inspect in-pane startup and authentication errors)"
+            )
 
         # NOTE: ``force_fresh_context_once`` consumption is deferred to
         # the end of this method (after tailer startup also succeeds),

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -866,7 +866,7 @@ class TestSpawnRebindsCommandRunner:
         monkeypatch.setattr(ss, "_seed_container_trust", fake_seed_trust)
         monkeypatch.setattr(ss, "_build_claude_cmd", lambda: "claude")
         monkeypatch.setattr(ss, "_start_tailer", fake_start_tailer)
-        ss._tmux.has_session = AsyncMock(return_value=False)
+        ss._tmux.has_session = AsyncMock(side_effect=[False, True])
         ss._tmux.kill_session = AsyncMock()
         ss._tmux.new_session = AsyncMock(
             return_value=TmuxCommandResult(returncode=0, stdout="", stderr="")

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -265,6 +265,56 @@ async def test_cold_start_self_reaped_session_fails_loudly_via_boot_failed() -> 
         await ss.connect()
 
     tmux.new_session.assert_awaited_once()
+    tmux.kill_session.assert_awaited_once()
+    ss._start_tailer.assert_not_awaited()
+    assert ss.state == SessionState.DEAD
+
+
+@pytest.mark.asyncio
+async def test_cold_start_liveness_probe_error_reaps_spawned_session() -> None:
+    """A failed post-spawn probe must not leave the new tmux session live."""
+    tmux = _make_mock_tmux()
+    tmux.has_session = AsyncMock(
+        side_effect=[False, RuntimeError("liveness probe timed out")]
+    )
+    ss, _ = _make_session(tmux=tmux)
+    ss._start_tailer = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="liveness probe timed out"):
+        await ss.connect()
+
+    tmux.new_session.assert_awaited_once()
+    tmux.kill_session.assert_awaited_once()
+    ss._start_tailer.assert_not_awaited()
+    assert ss.state == SessionState.DEAD
+
+
+@pytest.mark.asyncio
+async def test_cold_start_cancellation_during_liveness_delay_reaps_session(
+    monkeypatch,
+) -> None:
+    """Cancellation after spawn success rolls back the unmanaged REPL."""
+    delay_started = asyncio.Event()
+    release_delay = asyncio.Event()
+
+    async def blocking_sleep(_delay: float) -> None:
+        delay_started.set()
+        await release_delay.wait()
+
+    monkeypatch.setattr(tmux_session.asyncio, "sleep", blocking_sleep)
+    tmux = _make_mock_tmux()
+    ss, _ = _make_session(tmux=tmux)
+    ss._start_tailer = AsyncMock()
+
+    connect_task = asyncio.create_task(ss.connect())
+    await delay_started.wait()
+    connect_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await connect_task
+
+    tmux.new_session.assert_awaited_once()
+    tmux.kill_session.assert_awaited_once()
     ss._start_tailer.assert_not_awaited()
     assert ss.state == SessionState.DEAD
 

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -39,6 +39,12 @@ from pinky_daemon.tmux_transcript import TmuxTranscriptTailer, TurnResponse
 from pinky_daemon.transport_state import SessionState, TransitionResult, Trigger
 
 
+@pytest.fixture(autouse=True)
+def _skip_post_spawn_liveness_delay(monkeypatch) -> None:
+    """Keep unit tests fast while preserving the production 150 ms gate."""
+    monkeypatch.setattr(tmux_session, "_POST_SPAWN_LIVENESS_DELAY_SEC", 0)
+
+
 def _seed_inflight(
     ss: TmuxSession,
     *,
@@ -103,7 +109,16 @@ def _make_mock_tmux(*, has_session_initial: bool = False) -> MagicMock:
     """
     tmux = MagicMock(spec=_TmuxControl)
     tmux.session_name = "pinky-test"
-    tmux.has_session = AsyncMock(return_value=has_session_initial)
+    # Every successful spawn now verifies that the detached session survived
+    # long enough to still exist. Alternate pre-spawn/post-spawn answers so
+    # the default mock models a healthy tmux lifecycle across reconnects.
+    async def _has_session() -> bool:
+        call_number = tmux.has_session.await_count
+        if call_number == 1:
+            return has_session_initial
+        return call_number % 2 == 0
+
+    tmux.has_session = AsyncMock(side_effect=_has_session)
     tmux.new_session = AsyncMock(return_value=_ok())
     tmux.kill_session = AsyncMock(return_value=_ok())
     tmux.rename_session = AsyncMock(return_value=_ok())
@@ -220,6 +235,37 @@ async def test_cold_start_failure_drives_to_dead_via_boot_failed() -> None:
     ss, _ = _make_session(tmux=tmux)
     with pytest.raises(RuntimeError, match="tmux new-session failed"):
         await ss.connect()
+    assert ss.state == SessionState.DEAD
+
+
+@pytest.mark.asyncio
+async def test_cold_start_verifies_spawned_session_before_connected() -> None:
+    """A surviving session passes the delayed post-spawn liveness gate."""
+    tmux = _make_mock_tmux()
+    ss, _ = _make_session(tmux=tmux)
+
+    await ss.connect()
+
+    assert tmux.has_session.await_count == 2
+    assert ss.state == SessionState.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_cold_start_self_reaped_session_fails_loudly_via_boot_failed() -> None:
+    """A successful spawn followed by self-reap must never look connected."""
+    tmux = _make_mock_tmux()
+    tmux.has_session = AsyncMock(side_effect=[False, False])
+    ss, _ = _make_session(tmux=tmux)
+    ss._start_tailer = AsyncMock()
+
+    with pytest.raises(
+        RuntimeError,
+        match="session died immediately after spawn.*inspect in-pane startup",
+    ):
+        await ss.connect()
+
+    tmux.new_session.assert_awaited_once()
+    ss._start_tailer.assert_not_awaited()
     assert ss.state == SessionState.DEAD
 
 
@@ -7730,6 +7776,7 @@ class TestForceFreshContextOnceDeferredConsume:
         tmux = _make_mock_tmux()
         # First call fails, second call succeeds.
         tmux.new_session = AsyncMock(side_effect=[_fail("rc=1"), _ok()])
+        tmux.has_session = AsyncMock(side_effect=[False, False, True])
         ss, _ = _make_session(tmux=tmux)
 
         # Seed flag + prior transcript so suppression is meaningful.


### PR DESCRIPTION
## Summary

- wait 150 ms after `tmux new-session -d` reports success, then verify the detached session still exists
- fail before tailer startup when the in-pane command exits immediately and tmux self-reaps the session
- best-effort reap the successful spawn if the delay is cancelled or the liveness probe raises
- preserve the existing `BOOTING → DEAD` via `BOOT_FAILED` failure choreography instead of returning silently as connected
- update tmux test doubles to model both the pre-spawn and post-spawn liveness checks

## Root cause

`tmux new-session -d` returns 0 once it has launched the child command. If that command then exits immediately, tmux auto-reaps the detached session after the successful return. The transport previously continued through tailer startup and state completion, leaving callers with a nominally connected transport backed by no REPL.

The new delayed `has_session` check closes that gap. Its error points operators to the in-pane startup/authentication layer without coupling the diagnostic to any one trigger.

## Focused terminal transcript

```text
$ python3 -m pytest -vv \
    tests/test_tmux_session.py::test_cold_start_verifies_spawned_session_before_connected \
    tests/test_tmux_session.py::test_cold_start_self_reaped_session_fails_loudly_via_boot_failed \
    tests/test_tmux_session.py::test_cold_start_liveness_probe_error_reaps_spawned_session \
    tests/test_tmux_session.py::test_cold_start_cancellation_during_liveness_delay_reaps_session

collected 4 items
test_cold_start_verifies_spawned_session_before_connected PASSED
test_cold_start_self_reaped_session_fails_loudly_via_boot_failed PASSED
test_cold_start_liveness_probe_error_reaps_spawned_session PASSED
test_cold_start_cancellation_during_liveness_delay_reaps_session PASSED
4 passed in 0.38s
```

The failure cases pin a successful `new_session`, no tailer start, best-effort session reap, and final state `DEAD` through `BOOT_FAILED` for a self-reap, probe exception, and cancellation during the delay.

## Validation

- `456 passed` — `tests/test_tmux_session.py tests/test_tmux_container_isolation.py`
- `63 passed, 1 skipped` — Codex-tmux, cold-start umbrella, and tmux context companion modules
- `4 passed` — focused alive/self-reaped/probe-error/cancellation terminal capture above
- `ruff check` on all changed Python files
- `python3 -m py_compile src/pinky_daemon/tmux_session.py`
- `git diff --check`

Closes #513.

🤖 Opened by Kuzya
