### PR TITLE
Harden release workflow against shell-expanded inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,6 @@ jobs:
           fi
 
       - name: Generate release notes
-        id: notes
         env:
           RELEASE_VERSION: ${{ needs.validate.outputs.version }}
           CUSTOM_NOTES: ${{ inputs.release_notes }}
@@ -100,13 +99,6 @@ jobs:
             echo "Production hosts running \`PINKYBOT_CHANNEL=stable\` (the only channel) will pull this tag on the next \`update_and_restart\`."
           } > /tmp/notes.md
 
-          # Multiline output via heredoc
-          {
-            echo 'body<<NOTES_EOF'
-            cat /tmp/notes.md
-            echo NOTES_EOF
-          } >> "$GITHUB_OUTPUT"
-
       - name: Create annotated tag
         env:
           RELEASE_VERSION: ${{ needs.validate.outputs.version }}
@@ -119,6 +111,6 @@ jobs:
         with:
           tag_name: ${{ needs.validate.outputs.version }}
           name: ${{ needs.validate.outputs.version }}
-          body: ${{ steps.notes.outputs.body }}
+          body_path: /tmp/notes.md
           draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,17 @@ jobs:
     steps:
       - name: Check version format + branch
         id: check
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          WORKFLOW_REF: ${{ github.ref }}
         run: |
-          version="${{ inputs.version }}"
+          version="$RELEASE_VERSION"
           if [[ ! "$version" =~ ^[0-9]{2}\.[0-9]{2}\.[0-9]{2,3}$ ]]; then
             echo "::error::Version must be calver YY.MM.NNN (e.g. 26.05.071), got: $version"
             exit 1
           fi
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "::error::Releases can only be cut from main (got: ${{ github.ref }})"
+          if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
+            echo "::error::Releases can only be cut from main (got: $WORKFLOW_REF)"
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -62,24 +65,28 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Verify tag doesn't exist
+        env:
+          RELEASE_VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          if git rev-parse "${{ needs.validate.outputs.version }}" >/dev/null 2>&1; then
-            echo "::error::Tag ${{ needs.validate.outputs.version }} already exists"
+          if git rev-parse "$RELEASE_VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag $RELEASE_VERSION already exists"
             exit 1
           fi
 
       - name: Generate release notes
         id: notes
+        env:
+          RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+          CUSTOM_NOTES: ${{ inputs.release_notes }}
         run: |
-          version="${{ needs.validate.outputs.version }}"
-          custom_notes="${{ inputs.release_notes }}"
+          version="$RELEASE_VERSION"
           prior_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
           {
             echo "## Release $version"
             echo
-            if [ -n "$custom_notes" ]; then
-              echo "$custom_notes"
+            if [ -n "$CUSTOM_NOTES" ]; then
+              printf '%s\n' "$CUSTOM_NOTES"
               echo
             fi
             echo "### Changes"
@@ -101,10 +108,11 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create annotated tag
+        env:
+          RELEASE_VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          version="${{ needs.validate.outputs.version }}"
-          git tag -a "$version" -m "Release $version"
-          git push origin "$version"
+          git tag -a "$RELEASE_VERSION" -m "Release $RELEASE_VERSION"
+          git push origin "$RELEASE_VERSION"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,61 @@
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parents[1] / ".github" / "workflows" / "release.yml"
+
+
+def _release_steps() -> list[dict[str, object]]:
+    workflow = yaml.load(WORKFLOW_PATH.read_text(), Loader=yaml.BaseLoader)
+    return workflow["jobs"]["release"]["steps"]
+
+
+def test_run_blocks_do_not_contain_workflow_expressions():
+    workflow = yaml.load(WORKFLOW_PATH.read_text(), Loader=yaml.BaseLoader)
+
+    for job in workflow["jobs"].values():
+        for step in job["steps"]:
+            assert "${{" not in step.get("run", "")
+
+
+def test_release_notes_are_written_literally_to_release_body_file(tmp_path):
+    steps = _release_steps()
+    generate = next(step for step in steps if step.get("name") == "Generate release notes")
+    publish = next(step for step in steps if step.get("name") == "Create GitHub Release")
+
+    assert generate["env"]["CUSTOM_NOTES"] == "${{ inputs.release_notes }}"
+    assert "GITHUB_OUTPUT" not in generate["run"]
+    assert publish["with"]["body_path"] == "/tmp/notes.md"
+    assert "body" not in publish["with"]
+
+    notes_path = tmp_path / "notes.md"
+    marker_path = tmp_path / "shell-expansion-ran"
+    script = generate["run"].replace(
+        "> /tmp/notes.md", f"> {shlex.quote(str(notes_path))}"
+    )
+    custom_notes = (
+        "# Literal custom notes\n"
+        "`printf BACKTICK_EXPANDED`\n"
+        f"$(touch {shlex.quote(str(marker_path))})\n"
+        '"double quotes" and \'single quotes\'\n'
+        "NOTES_EOF\n"
+        "- final line"
+    )
+    env = os.environ | {
+        "CUSTOM_NOTES": custom_notes,
+        "RELEASE_VERSION": "26.08.999",
+    }
+
+    subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", script],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+
+    assert not marker_path.exists()
+    assert custom_notes in notes_path.read_text()
+    assert "\nNOTES_EOF\n" in notes_path.read_text()


### PR DESCRIPTION
## Summary

- pass release inputs, the dispatch ref, and validated version outputs through step `env:` blocks instead of materializing them inside `run:` scripts
- write custom release notes literally with `printf '%s\n' "$CUSTOM_NOTES"`
- pass `/tmp/notes.md` directly to the release action via `body_path`, avoiding delimiter collisions in `$GITHUB_OUTPUT`
- close #542

## Root cause

GitHub Actions expands `${{ ... }}` expressions before Bash parses a `run:` block. The previous `custom_notes="${{ inputs.release_notes }}"` line therefore turned release-note contents into executable script text, allowing backticks or `$()` to execute or break the step. A quoted heredoc would have the same template-time problem and would also collide with a bare delimiter line. Passing the value through `env:` keeps it out of script text entirely.

The generated body was also exported through a fixed `NOTES_EOF` `$GITHUB_OUTPUT` delimiter. An otherwise valid custom-note line equal to `NOTES_EOF` could close that value early and leave malformed runner commands. The release action now reads the generated file directly.

## Interpolation audit

The full workflow was checked for expressions embedded in `run:` blocks:

| Step | Before | After |
| --- | --- | --- |
| Check version format + branch | `inputs.version` and `github.ref` expanded directly in Bash | `RELEASE_VERSION` and `WORKFLOW_REF` are populated via `env:` and referenced as quoted shell variables |
| Verify tag doesn't exist | the validated version output was expanded twice in Bash | `RELEASE_VERSION` is populated via `env:` |
| Generate release notes | the validated version and `inputs.release_notes` were expanded in Bash | both arrive via `env:`; custom notes are emitted with `printf '%s\n' "$CUSTOM_NOTES"` |
| Create annotated tag | the validated version output was expanded in Bash | `RELEASE_VERSION` is populated via `env:` |
| Create GitHub Release | the body crossed a fixed `NOTES_EOF` step-output delimiter | `body_path: /tmp/notes.md` passes the file directly to the release action |

No `${{ inputs.* }}` or `${{ github.event.* }}` interpolation remains in a `run:` block; the audit found no workflow expression of any kind remaining in executable shell text.

## Validation

- `git diff --check`
- Ruby/Psych YAML syntax parse of `.github/workflows/release.yml`
- `uv run ruff check tests/test_release_workflow.py`
- `uv run pytest -q tests/test_release_workflow.py` (`2 passed`)
- committed regressions confirming zero `${{ ... }}` expressions inside `run:` blocks and literal handling of backticks, `$()`, single and double quotes, multiline Markdown, and a bare `NOTES_EOF` line

`actionlint` is not installed in this environment. The Release workflow itself cannot be CI-exercised pre-merge without performing the live tag-and-publish path, so this PR does not claim a live release run.

🤖 Opened by Kuzya
