### PR TITLE
Log rate-limited Buzz policy drops

### DIFF
--- a/src/pinky_daemon/buzz_inbound.py
+++ b/src/pinky_daemon/buzz_inbound.py
@@ -8,7 +8,7 @@ import json
 import secrets
 import sys
 import time
-from collections import deque
+from collections import OrderedDict, deque
 from dataclasses import dataclass
 from typing import Any, Callable
 from uuid import UUID
@@ -28,6 +28,14 @@ _MAX_TAG_PARTS = 4
 _MAX_TAG_PART_BYTES = 512
 _MAX_FUTURE_SECONDS = 5 * 60
 _RECENT_EVENT_IDS = 4096
+_POLICY_DROP_LOG_INTERVAL_SECONDS = 15 * 60
+_POLICY_DROP_LOG_KEYS = 4096
+_POLICY_DROP_PUBKEY_PREFIX = 12
+
+_POLICY_DROP_REASONS = {
+    "target_pubkey_foreign": "foreign_p",
+    "event_kind_not_allowed": "unknown_kind",
+}
 
 
 def _log(message: str) -> None:
@@ -256,6 +264,7 @@ class BuzzInboundProcessor:
         self._clock = clock
         self._recent_order: deque[str] = deque()
         self._recent_ids: set[str] = set()
+        self._policy_drop_logs: OrderedDict[tuple[str, str, str], tuple[float, int]] = OrderedDict()
         self.stats = {
             "delivered": 0,
             "duplicates": 0,
@@ -274,6 +283,52 @@ class BuzzInboundProcessor:
             self._recent_ids.discard(self._recent_order.popleft())
         return True
 
+    def _log_policy_drop(self, reason: str, sender_pubkey: str, channel_id: str) -> None:
+        """Emit one bounded line per policy tuple and summarize later repeats."""
+        key = (sender_pubkey, channel_id, reason)
+        now = float(self._clock())
+        previous = self._policy_drop_logs.pop(key, None)
+        if previous is not None:
+            last_logged_at, suppressed = previous
+            if now - last_logged_at < _POLICY_DROP_LOG_INTERVAL_SECONDS:
+                self._policy_drop_logs[key] = (last_logged_at, suppressed + 1)
+                return
+        else:
+            suppressed = 0
+
+        self._policy_drop_logs[key] = (now, 0)
+        while len(self._policy_drop_logs) > _POLICY_DROP_LOG_KEYS:
+            self._policy_drop_logs.popitem(last=False)
+
+        sender = f"buzz:{self.community_id}:{sender_pubkey[:_POLICY_DROP_PUBKEY_PREFIX]}…"
+        summary = f" suppressed_since_last={suppressed}" if suppressed else ""
+        _log(
+            "buzz-inbound: policy drop "
+            f"reason={reason} sender={sender} channel={channel_id}{summary}"
+        )
+
+    def _log_rejected_policy_event(self, event: object, rejection: str) -> None:
+        reason = _POLICY_DROP_REASONS.get(rejection)
+        if reason is None or not isinstance(event, dict):
+            return
+        sender_pubkey = event.get("pubkey")
+        if not _is_hex_64(sender_pubkey):
+            return
+        channel_id = "unknown"
+        tags = event.get("tags")
+        if isinstance(tags, list):
+            channel_tags = [
+                tag for tag in tags if isinstance(tag, list) and len(tag) == 2 and tag[0] == "h"
+            ]
+            if len(channel_tags) == 1:
+                candidate = channel_tags[0][1]
+                try:
+                    if str(UUID(candidate)) == candidate:
+                        channel_id = candidate
+                except (TypeError, ValueError, AttributeError):
+                    pass
+        self._log_policy_drop(reason, sender_pubkey, channel_id)
+
     async def process_event(
         self,
         event: object,
@@ -290,8 +345,9 @@ class BuzzInboundProcessor:
                 # subscription and are the only sanctioned freshness bypass.
                 subscription_since=None if replay else subscription_since,
             )
-        except BuzzInboundRejectedError:
+        except BuzzInboundRejectedError as exc:
             self.stats["rejected"] += 1
+            self._log_rejected_policy_event(event, str(exc))
             return "rejected"
 
         # kind-20002 is typing/diagnostic only. Return before the in-memory
@@ -334,6 +390,11 @@ class BuzzInboundProcessor:
         )
         if author is None:
             self.stats["unapproved_principal"] += 1
+            self._log_policy_drop(
+                "unverified_sender",
+                validated.event["pubkey"],
+                validated.channel_id,
+            )
             return "unapproved_principal"
 
         self._registry.note_buzz_inbound_principal_seen(

--- a/tests/test_buzz_inbound.py
+++ b/tests/test_buzz_inbound.py
@@ -7,6 +7,7 @@ import time
 
 import pytest
 
+import pinky_daemon.buzz_inbound as buzz_inbound
 from pinky_daemon.agent_registry import AgentRegistry
 from pinky_daemon.broker import MessageBroker
 from pinky_daemon.buzz_inbound import (
@@ -231,6 +232,72 @@ async def test_both_gates_signature_self_and_dedupe_fail_closed(registry):
     assert await processor.process_event(valid) == "delivered"
     assert await processor.process_event(valid) == "duplicate"
     assert len(broker.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_policy_drops_log_once_per_tuple_without_full_pubkeys(registry, capsys):
+    store, identity_pubkey = registry
+    broker = FakeBroker()
+    now = [time.time()]
+    processor = BuzzInboundProcessor(
+        registry=store,
+        broker=broker,
+        agent_name="barsik",
+        identity_pubkey=identity_pubkey,
+        community_id=COMMUNITY,
+        relay_url=RELAY,
+        clock=lambda: now[0],
+    )
+    foreign_p = _event(
+        signer=OWNER,
+        content="@Ryan reply here again",
+        p_tags=[STRANGER.pubkey],
+    )
+    unverified = _event(signer=STRANGER, content="no")
+    unknown_kind = _event(signer=USER, kind=42, content="unknown")
+
+    assert await processor.process_event(foreign_p) == "rejected"
+    assert await processor.process_event(unverified) == "unapproved_principal"
+    assert await processor.process_event(unknown_kind) == "rejected"
+    assert broker.calls == []
+
+    lines = capsys.readouterr().err.splitlines()
+    assert len(lines) == 3
+    assert any(
+        f"reason=foreign_p sender=buzz:{COMMUNITY}:{OWNER.pubkey[:12]}… channel={CHANNEL}" in line
+        for line in lines
+    )
+    assert any(
+        f"reason=unverified_sender sender=buzz:{COMMUNITY}:{STRANGER.pubkey[:12]}… "
+        f"channel={CHANNEL}" in line
+        for line in lines
+    )
+    assert any(
+        f"reason=unknown_kind sender=buzz:{COMMUNITY}:{USER.pubkey[:12]}… channel={CHANNEL}" in line
+        for line in lines
+    )
+    for pubkey in (OWNER.pubkey, USER.pubkey, STRANGER.pubkey):
+        assert pubkey not in "\n".join(lines)
+    assert all(len(line) < 192 for line in lines)
+
+    assert await processor.process_event(foreign_p) == "rejected"
+    assert (
+        await processor.process_event(_event(signer=STRANGER, content="still chatty"))
+        == "unapproved_principal"
+    )
+    assert await processor.process_event(unknown_kind) == "rejected"
+    assert capsys.readouterr().err == ""
+
+    now[0] += buzz_inbound._POLICY_DROP_LOG_INTERVAL_SECONDS
+    assert (
+        await processor.process_event(_event(signer=STRANGER, content="after window"))
+        == "unapproved_principal"
+    )
+    summary = capsys.readouterr().err
+    assert summary.count("\n") == 1
+    assert "reason=unverified_sender" in summary
+    assert "suppressed_since_last=1" in summary
+    assert STRANGER.pubkey not in summary
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- make the existing Buzz inbound policy drops loud for foreign `p` targets, unverified senders, and unknown event kinds
- emit one bounded journal line with a stable reason, the community-scoped sender principal shortened to a 12-character pubkey prefix, and the channel UUID
- rate-limit logs for 15 minutes per `(sender, channel, reason)` tuple, then report how many repeats were suppressed; cap retained tuple state at 4,096 entries
- preserve the existing default-deny policy and all return values; verified-contact management and third-party approval remain untouched

This implements increment A of #1025 only. It intentionally does not close #1025 because increments B and C remain owner-gated.

## Root cause

The three policy decisions returned their existing drop statuses without calling the module logger. In the field case, that made both an owner message carrying a foreign `p` tag and a channel message from a non-verified contact disappear without any operational trace.

## Validation

- `ruff check .` — passed
- `python -m pytest tests/test_buzz_inbound.py tests/test_buzz_inbound_poller.py -q` — 33 passed
- `python -m py_compile src/pinky_daemon/buzz_inbound.py tests/test_buzz_inbound.py` — passed
- `git diff --check` and staged diff check — passed

The repository-wide `python -m pytest -q` run reached the documented unrelated #1024 hermeticity defect: `tests/test_api.py::TestAPI::test_manual_dream_uses_full_persisted_conversation_history` escaped its SDK mock through this box's tmux transport and launched a real Claude process. The run was stopped after reporting 1 failed, 840 passed, and 1 skipped; this PR does not touch that path.

🤖 Opened by Kuzya
