### PR TITLE
Fix tmux large-prompt delivery via stdin

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -4316,6 +4316,29 @@ except Exception as exc:
         return [self._row_to_schedule(r) for r in rows
         ]
 
+    def get_oversized_enabled_schedule_prompts(
+        self,
+        min_length: int,
+    ) -> list[tuple[int, str, str, int]]:
+        """Return enabled schedules whose prompts exceed ``min_length``.
+
+        Only prompt metadata is selected; the prompt content itself never
+        leaves SQLite or reaches the warning log.
+        """
+        if min_length < 0:
+            raise ValueError("min_length must be non-negative")
+        rows = self._db.execute(
+            """SELECT id, agent_name, name, LENGTH(prompt)
+               FROM agent_schedules
+               WHERE enabled=1 AND LENGTH(prompt) > ?
+               ORDER BY LENGTH(prompt) DESC""",
+            (min_length,),
+        ).fetchall()
+        return [
+            (int(row[0]), str(row[1]), str(row[2]), int(row[3]))
+            for row in rows
+        ]
+
     def get_schedule(self, schedule_id: int) -> AgentSchedule | None:
         """Return one schedule regardless of enabled state."""
         row = self._db.execute(

--- a/src/pinky_daemon/command_runner.py
+++ b/src/pinky_daemon/command_runner.py
@@ -63,9 +63,9 @@ class CommandRunner(ABC):
         argv: list[str],
         *,
         timeout: float | None = None,
-        stdin: bytes | None = None,
+        stdin_data: bytes | None = None,
     ) -> CommandResult:
-        """Execute ``argv``, optionally feeding ``stdin``.
+        """Execute ``argv``, optionally feeding ``stdin_data`` to stdin.
 
         ``timeout`` (seconds) bounds the wait; on expiry the child is killed
         and ``asyncio.TimeoutError`` propagates, matching the prior inline
@@ -86,17 +86,17 @@ class LocalCommandRunner(CommandRunner):
         argv: list[str],
         *,
         timeout: float | None = None,
-        stdin: bytes | None = None,
+        stdin_data: bytes | None = None,
     ) -> CommandResult:
         proc = await asyncio.create_subprocess_exec(
             *argv,
-            stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+            stdin=asyncio.subprocess.PIPE if stdin_data is not None else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         try:
             stdout, stderr = await asyncio.wait_for(
-                proc.communicate(input=stdin), timeout=timeout
+                proc.communicate(input=stdin_data), timeout=timeout
             )
         except asyncio.TimeoutError:
             try:
@@ -149,9 +149,11 @@ class RunuserCommandRunner(CommandRunner):
         argv: list[str],
         *,
         timeout: float | None = None,
-        stdin: bytes | None = None,
+        stdin_data: bytes | None = None,
     ) -> CommandResult:
-        return await self._inner.run(self.wrap(argv), timeout=timeout, stdin=stdin)
+        return await self._inner.run(
+            self.wrap(argv), timeout=timeout, stdin_data=stdin_data
+        )
 
 
 class ContainerCommandRunner(CommandRunner):
@@ -210,6 +212,14 @@ class ContainerCommandRunner(CommandRunner):
         argv: list[str],
         *,
         timeout: float | None = None,
-        stdin: bytes | None = None,
+        stdin_data: bytes | None = None,
     ) -> CommandResult:
-        return await self._inner.run(self.wrap(argv), timeout=timeout, stdin=stdin)
+        wrapped = self.wrap(argv)
+        if stdin_data is not None:
+            # ``podman exec`` only attaches its stdin to the containerized
+            # command with ``-i``. Without it, bytes reach podman but never the
+            # inner tmux ``load-buffer -`` process.
+            wrapped.insert(2, "-i")
+        return await self._inner.run(
+            wrapped, timeout=timeout, stdin_data=stdin_data
+        )

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -41,6 +41,12 @@ _PROVEN_LIVE_HEARTBEAT_STATUSES = frozenset(
 _RATE_LIMIT_FILE = "/tmp/claude-rate-limits.json"
 _RATE_LIMIT_THRESHOLD = 80  # percent — skip heartbeats above this
 
+# #1029 transport-health guard. tmux builds can reject command argvs around
+# 8–16 KiB; prompts now travel over stdin, but surfacing large enabled rows
+# makes regressions and mixed-version fleet nodes visible in the journal.
+_SCHEDULE_PROMPT_WARN_THRESHOLD = 8_000
+_SCHEDULE_PROMPT_WARN_INTERVAL_SEC = 15 * 60
+
 
 def _is_claude_code_agent(agent, registry: AgentRegistry) -> bool:
     """Return True if this agent runs on Claude Code (not Codex or other provider)."""
@@ -289,6 +295,7 @@ class AgentScheduler:
         self._schedule_delivery_locks: dict[str, asyncio.Lock] = {}
         self._pending_replay_tasks: dict[str, asyncio.Task] = {}
         self._owner_alert_tasks: set[asyncio.Task] = set()
+        self._last_schedule_prompt_warn_at: float | None = None
         # Resurrection rate-limit: agent_name -> list[timestamp] of recent attempts.
         # Used by _check_heartbeats to cap how often we ping the heartbeat_callback
         # for a stuck agent (avoid thrashing on a persistently-broken session).
@@ -299,6 +306,7 @@ class AgentScheduler:
         if self._running:
             return
         self._running = True
+        self._warn_oversized_schedule_prompts(time.time(), force=True)
         for pending in self._registry.list_pending_schedule_wakes():
             self.replay_pending_for_agent(pending.agent_name)
         # Queue startup catch-up before the first live tick can enqueue newer
@@ -361,6 +369,8 @@ class AgentScheduler:
         """Single scheduler tick — check schedules, heartbeats, clock-aligned wakes, auto-sleep, idle sessions, expired messages, dreams, and url watchers."""
         now = time.time()
 
+        self._warn_oversized_schedule_prompts(now)
+
         # Check cron schedules
         await self._check_schedules(now)
 
@@ -387,6 +397,40 @@ class AgentScheduler:
 
         # Check URL watcher triggers
         await self._check_url_watchers(now)
+
+    def _warn_oversized_schedule_prompts(
+        self,
+        now: float,
+        *,
+        force: bool = False,
+    ) -> None:
+        """Warn at startup and periodically for large enabled prompts."""
+        last_warn = self._last_schedule_prompt_warn_at
+        if (
+            not force
+            and last_warn is not None
+            and now - last_warn < _SCHEDULE_PROMPT_WARN_INTERVAL_SEC
+        ):
+            return
+        self._last_schedule_prompt_warn_at = now
+
+        try:
+            schedules = self._registry.get_oversized_enabled_schedule_prompts(
+                _SCHEDULE_PROMPT_WARN_THRESHOLD
+            )
+        except Exception as exc:
+            # A health guard must never prevent scheduler startup or a tick.
+            _log(f"scheduler: large-prompt health check failed: {exc}")
+            return
+
+        for schedule_id, agent_name, name, prompt_length in schedules:
+            _log(
+                "scheduler: warning — large enabled schedule prompt "
+                f"id={schedule_id} agent={agent_name[:64]!r} "
+                f"name={name[:80]!r} prompt_chars={prompt_length} "
+                f"threshold={_SCHEDULE_PROMPT_WARN_THRESHOLD}; "
+                "tmux delivery requires stdin-backed load-buffer"
+            )
 
     async def _check_schedules(self, now: float) -> None:
         """Stamp due schedules fired, then deliver each agent's cohort in order."""

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -556,7 +556,12 @@ class _TmuxControl:
             cmd.extend(["-L", self.socket_name])
         return cmd
 
-    async def _run(self, *args: str, timeout: float = 5.0) -> TmuxCommandResult:
+    async def _run(
+        self,
+        *args: str,
+        timeout: float = 5.0,
+        stdin_data: bytes | None = None,
+    ) -> TmuxCommandResult:
         """Run ``tmux <args>`` and return its result.
 
         ``timeout`` defends against a hung tmux server. A timeout raises
@@ -578,7 +583,11 @@ class _TmuxControl:
         # argv in ``runuser -u pinky-<agent> --`` so tmux runs under the
         # agent's uid. Timeout/kill semantics live in the runner; a timeout
         # still raises asyncio.TimeoutError for the caller to handle.
-        result = await self._runner.run(cmd, timeout=timeout)
+        result = await self._runner.run(
+            cmd,
+            timeout=timeout,
+            stdin_data=stdin_data,
+        )
         return TmuxCommandResult(
             returncode=result.returncode,
             stdout=result.stdout.decode("utf-8", errors="replace"),
@@ -717,8 +726,8 @@ class _TmuxControl:
         a permanently wedged session.
 
         Args:
-            text: Prompt payload. Passed as a single tmux arg via
-                ``set-buffer``, so no shell-metachar interpretation.
+            text: Prompt payload. Fed to ``tmux load-buffer -`` over stdin,
+                avoiding tmux's command-argument length ceiling.
             enter: If True (default), send a submit Enter after
                 ``enter_delay_ms`` ms. If False, leaves the pasted text
                 in the input buffer unsubmitted.
@@ -735,7 +744,13 @@ class _TmuxControl:
         # sessions don't race on a shared buffer.
         buf_name = f"pinky-{self.session_name}"
 
-        set_result = await self._run("set-buffer", "-b", buf_name, text)
+        set_result = await self._run(
+            "load-buffer",
+            "-b",
+            buf_name,
+            "-",
+            stdin_data=text.encode("utf-8"),
+        )
         if not set_result.ok:
             return set_result
 
@@ -5630,7 +5645,7 @@ class TmuxSession:
                     # wake's initial paste_text has timed out, no pane snapshot
                     # or pre-paste boolean can prove a retry safe: an exact row
                     # can arrive while the retry is suspended between
-                    # set-buffer and paste-buffer. Enter the wake's one-way
+                    # load-buffer and paste-buffer. Enter the wake's one-way
                     # receipt/Enter-only/fail-closed verifier instead. This
                     # branch can never return to worker re-paste.
                     if (

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -49,7 +49,7 @@ class TestLocalCommandRunner:
     async def test_feeds_stdin(self):
         r = await LocalCommandRunner().run(
             [sys.executable, "-c", "import sys; sys.stdout.write(sys.stdin.read())"],
-            stdin=b"piped",
+            stdin_data=b"piped",
         )
         assert r.stdout == b"piped"
 
@@ -68,8 +68,8 @@ class _RecordingRunner(LocalCommandRunner):
     def __init__(self):
         self.calls: list[tuple[list[str], float | None, bytes | None]] = []
 
-    async def run(self, argv, *, timeout=None, stdin=None):
-        self.calls.append((argv, timeout, stdin))
+    async def run(self, argv, *, timeout=None, stdin_data=None):
+        self.calls.append((argv, timeout, stdin_data))
         return CommandResult(0, b"", b"")
 
 
@@ -88,12 +88,12 @@ class TestRunuserCommandRunner:
     async def test_run_delegates_wrapped_argv_to_inner(self):
         inner = _RecordingRunner()
         r = RunuserCommandRunner("pinky-mora", inner=inner)
-        await r.run(["tmux", "kill-session"], timeout=5.0, stdin=b"x")
+        await r.run(["tmux", "kill-session"], timeout=5.0, stdin_data=b"x")
         assert len(inner.calls) == 1
-        argv, timeout, stdin = inner.calls[0]
+        argv, timeout, stdin_data = inner.calls[0]
         assert argv == ["runuser", "-u", "pinky-mora", "--", "tmux", "kill-session"]
-        assert timeout == 5.0  # timeout/stdin pass through unchanged
-        assert stdin == b"x"
+        assert timeout == 5.0  # timeout/stdin_data pass through unchanged
+        assert stdin_data == b"x"
 
     async def test_terminator_isolates_wrapped_options(self):
         # A wrapped arg that looks like a runuser option must sit AFTER ``--``.
@@ -136,12 +136,15 @@ class TestContainerCommandRunner:
     async def test_run_delegates_wrapped_argv_to_inner(self):
         inner = _RecordingRunner()
         r = ContainerCommandRunner("pinky-mora", user="agent", inner=inner)
-        await r.run(["tmux", "kill-session"], timeout=5.0, stdin=b"x")
+        await r.run(["tmux", "kill-session"], timeout=5.0, stdin_data=b"x")
         assert len(inner.calls) == 1
-        argv, timeout, stdin = inner.calls[0]
-        assert argv == ["podman", "exec", "-u", "agent", "--", "pinky-mora", "tmux", "kill-session"]
-        assert timeout == 5.0  # timeout/stdin pass through unchanged
-        assert stdin == b"x"
+        argv, timeout, stdin_data = inner.calls[0]
+        assert argv == [
+            "podman", "exec", "-i", "-u", "agent", "--", "pinky-mora",
+            "tmux", "kill-session",
+        ]
+        assert timeout == 5.0  # timeout/stdin_data pass through unchanged
+        assert stdin_data == b"x"
 
     async def test_empty_container_rejected(self):
         with pytest.raises(ValueError):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -14,7 +14,12 @@ from datetime import datetime
 import pytest
 
 from pinky_daemon.agent_registry import AgentRegistry, ScheduleNameConflictError
-from pinky_daemon.scheduler import AgentScheduler, cron_matches, next_cron_description
+from pinky_daemon.scheduler import (
+    _SCHEDULE_PROMPT_WARN_INTERVAL_SEC,
+    AgentScheduler,
+    cron_matches,
+    next_cron_description,
+)
 
 # ── Cron Parser Tests ──────────────────────────────────────
 
@@ -212,6 +217,30 @@ class TestAgentSchedules:
 
         all_schedules = registry.get_all_schedules()
         assert len(all_schedules) == 2
+
+    def test_get_oversized_enabled_schedule_prompts_filters_and_orders(self, registry):
+        registry.register("oleg")
+        exact = registry.add_schedule(
+            "oleg", "0 8 * * *", name="exact", prompt="x" * 8_000
+        )
+        smaller_hit = registry.add_schedule(
+            "oleg", "0 9 * * *", name="large", prompt="x" * 8_001
+        )
+        larger_hit = registry.add_schedule(
+            "oleg", "0 10 * * *", name="larger", prompt="x" * 20_001
+        )
+        disabled = registry.add_schedule(
+            "oleg", "0 11 * * *", name="disabled", prompt="x" * 30_000
+        )
+        registry.toggle_schedule(disabled.id, False)
+
+        rows = registry.get_oversized_enabled_schedule_prompts(8_000)
+
+        assert rows == [
+            (larger_hit.id, "oleg", "larger", 20_001),
+            (smaller_hit.id, "oleg", "large", 8_001),
+        ]
+        assert exact.id not in {row[0] for row in rows}
 
     def test_remove_schedule(self, registry):
         registry.register("oleg")
@@ -902,6 +931,57 @@ class TestScheduler:
         assert scheduler.running is True
         await scheduler.stop()
         assert scheduler.running is False
+
+    @pytest.mark.asyncio
+    async def test_start_warns_once_for_each_large_enabled_prompt(
+        self, registry, capsys, monkeypatch
+    ):
+        registry.register("oleg")
+        registry.add_schedule(
+            "oleg", "0 8 * * *", name="large", prompt="x" * 8_001
+        )
+        disabled = registry.add_schedule(
+            "oleg", "0 9 * * *", name="disabled", prompt="x" * 20_000
+        )
+        registry.toggle_schedule(disabled.id, False)
+        scheduler = AgentScheduler(registry)
+
+        async def no_loop():
+            return None
+
+        monkeypatch.setattr(scheduler, "_loop", no_loop)
+        await scheduler.start()
+        await asyncio.sleep(0)
+        await scheduler.stop()
+
+        err = capsys.readouterr().err
+        warnings = [line for line in err.splitlines() if "large enabled" in line]
+        assert len(warnings) == 1
+        assert "name='large'" in warnings[0]
+        assert "prompt_chars=8001" in warnings[0]
+        assert "disabled" not in warnings[0]
+        assert "x" * 100 not in warnings[0]  # prompt content is never logged
+
+    def test_large_prompt_warning_repeats_only_after_periodic_window(
+        self, registry, capsys
+    ):
+        registry.register("oleg")
+        registry.add_schedule(
+            "oleg", "0 8 * * *", name="large", prompt="x" * 8_001
+        )
+        scheduler = AgentScheduler(registry)
+
+        scheduler._warn_oversized_schedule_prompts(100.0, force=True)
+        capsys.readouterr()
+        scheduler._warn_oversized_schedule_prompts(
+            100.0 + _SCHEDULE_PROMPT_WARN_INTERVAL_SEC - 0.001
+        )
+        assert "large enabled" not in capsys.readouterr().err
+
+        scheduler._warn_oversized_schedule_prompts(
+            100.0 + _SCHEDULE_PROMPT_WARN_INTERVAL_SEC
+        )
+        assert "large enabled" in capsys.readouterr().err
 
     @pytest.mark.asyncio
     async def test_fire_now(self, registry):

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -49,7 +49,7 @@ class _RecordingInner:
     def __init__(self):
         self.calls: list[list[str]] = []
 
-    async def run(self, argv, *, timeout=None, stdin=None):
+    async def run(self, argv, *, timeout=None, stdin_data=None):
         from pinky_daemon.command_runner import CommandResult
 
         self.calls.append(list(argv))
@@ -65,7 +65,7 @@ class _StubInner:
         self.exc = exc
         self.calls: list[list[str]] = []
 
-    async def run(self, argv, *, timeout=None, stdin=None):
+    async def run(self, argv, *, timeout=None, stdin_data=None):
         self.calls.append(list(argv))
         if self.exc is not None:
             raise self.exc

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -952,19 +952,31 @@ async def test_run_delegates_built_argv_to_injected_runner() -> None:
         def __init__(self):
             self.argv = None
             self.timeout = None
+            self.stdin_data = None
 
-        async def run(self, argv, *, timeout=None, stdin=None):
+        async def run(self, argv, *, timeout=None, stdin_data=None):
             self.argv = argv
             self.timeout = timeout
+            self.stdin_data = stdin_data
             return CommandResult(0, b"out", b"err")
 
     rec = _Recording()
     tmux = _TmuxControl("pinky-test", socket_name="pinkysock", command_runner=rec)
-    result = await tmux._run("has-session", "-t", "pinky-test", timeout=5.0)
+    result = await tmux._run(
+        "load-buffer",
+        "-b",
+        "pinky-test",
+        "-",
+        timeout=5.0,
+        stdin_data=b"prompt bytes",
+    )
 
     # Built argv includes the base cmd (binary + socket flag) then the args.
-    assert rec.argv == ["tmux", "-L", "pinkysock", "has-session", "-t", "pinky-test"]
+    assert rec.argv == [
+        "tmux", "-L", "pinkysock", "load-buffer", "-b", "pinky-test", "-",
+    ]
     assert rec.timeout == 5.0
+    assert rec.stdin_data == b"prompt bytes"
     assert result.returncode == 0
     assert result.stdout == "out"  # bytes decoded
     assert result.stderr == "err"
@@ -977,7 +989,7 @@ async def test_run_propagates_runner_timeout() -> None:
     from pinky_daemon.command_runner import CommandRunner
 
     class _TimingOut(CommandRunner):
-        async def run(self, argv, *, timeout=None, stdin=None):
+        async def run(self, argv, *, timeout=None, stdin_data=None):
             raise asyncio.TimeoutError
 
     tmux = _TmuxControl("pinky-test", command_runner=_TimingOut())
@@ -1086,18 +1098,20 @@ async def test_resize_pane_swallows_subprocess_exceptions() -> None:
 
 
 @pytest.mark.asyncio
-async def test_paste_text_sets_buffer_pastes_and_sends_enter() -> None:
+async def test_paste_text_loads_buffer_pastes_and_sends_enter() -> None:
     """``_TmuxControl.paste_text`` must invoke three tmux subcommands
-    in order: ``set-buffer``, ``paste-buffer -p`` (bracketed paste),
+    in order: ``load-buffer -`` (stdin), ``paste-buffer -p`` (bracketed paste),
     then ``send-keys Enter``. The bracketed-paste mode is what makes
     this reliable across the claude cold-start splash UI (#514).
     """
     tmux = _TmuxControl("pinky-test")
 
     calls: list[tuple[str, ...]] = []
+    stdin_payloads: list[bytes | None] = []
 
-    async def fake_run(*args, timeout=5.0):
+    async def fake_run(*args, timeout=5.0, stdin_data=None):
         calls.append(args)
+        stdin_payloads.append(stdin_data)
         return _ok()
 
     tmux._run = fake_run
@@ -1105,13 +1119,47 @@ async def test_paste_text_sets_buffer_pastes_and_sends_enter() -> None:
 
     # Expect three commands in order.
     assert len(calls) == 3
-    assert calls[0][:3] == ("set-buffer", "-b", "pinky-pinky-test")
-    assert calls[0][3] == "hello world"
+    assert calls[0] == ("load-buffer", "-b", "pinky-pinky-test", "-")
+    assert stdin_payloads == [b"hello world", None, None]
+    assert not any("set-buffer" in call for call in calls)
     assert "paste-buffer" in calls[1][0]
     assert "-p" in calls[1]  # bracketed paste mode
     assert "-d" in calls[1]  # delete buffer after paste
     assert calls[2] == ("send-keys", "-t", "pinky-test", "Enter")
     assert result.ok
+
+
+@pytest.mark.asyncio
+async def test_paste_text_large_prompt_avoids_tmux_argv_limit() -> None:
+    """Regression for #1029: a >20 KiB prompt must travel over stdin.
+
+    The recording runner models tmux's old argv ceiling by rejecting any
+    individual argument over 16 KiB. The complete paste path still succeeds
+    because ``load-buffer -`` keeps the prompt out of argv.
+    """
+    from pinky_daemon.command_runner import CommandResult, CommandRunner
+
+    class _ArgLimitedRunner(CommandRunner):
+        def __init__(self) -> None:
+            self.calls: list[tuple[list[str], bytes | None]] = []
+
+        async def run(self, argv, *, timeout=None, stdin_data=None):
+            self.calls.append((argv, stdin_data))
+            if any(len(arg.encode("utf-8")) > 16 * 1024 for arg in argv):
+                return CommandResult(1, b"", b"command too long")
+            return CommandResult(0, b"", b"")
+
+    runner = _ArgLimitedRunner()
+    tmux = _TmuxControl("pinky-test", command_runner=runner)
+    prompt = "x" * (20 * 1024 + 1)
+
+    result = await tmux.paste_text(prompt, enter=False, enter_delay_ms=0)
+
+    assert result.ok
+    load_argv, load_stdin = runner.calls[0]
+    assert load_argv[-4:] == ["load-buffer", "-b", "pinky-pinky-test", "-"]
+    assert load_stdin == prompt.encode("utf-8")
+    assert all(prompt not in arg for argv, _ in runner.calls for arg in argv)
 
 
 @pytest.mark.asyncio
@@ -1123,29 +1171,29 @@ async def test_paste_text_skips_enter_when_enter_false() -> None:
 
     calls: list[tuple[str, ...]] = []
 
-    async def fake_run(*args, timeout=5.0):
+    async def fake_run(*args, timeout=5.0, stdin_data=None):
         calls.append(args)
         return _ok()
 
     tmux._run = fake_run
     await tmux.paste_text("hello", enter=False, enter_delay_ms=0)
 
-    assert len(calls) == 2  # set-buffer + paste-buffer only
+    assert len(calls) == 2  # load-buffer + paste-buffer only
     assert not any("send-keys" in c[0] for c in calls)
 
 
 @pytest.mark.asyncio
-async def test_paste_text_short_circuits_on_set_buffer_failure() -> None:
-    """If ``set-buffer`` fails (tmux server down, bad session name),
+async def test_paste_text_short_circuits_on_load_buffer_failure() -> None:
+    """If ``load-buffer`` fails (tmux server down, bad session name),
     paste_text returns the failure immediately without trying paste
     or Enter."""
     tmux = _TmuxControl("pinky-test")
 
     calls: list[tuple[str, ...]] = []
 
-    async def fake_run(*args, timeout=5.0):
+    async def fake_run(*args, timeout=5.0, stdin_data=None):
         calls.append(args)
-        return _fail("set-buffer broke")
+        return _fail("load-buffer broke")
 
     tmux._run = fake_run
     result = await tmux.paste_text("hello", enter_delay_ms=0)
@@ -1156,7 +1204,7 @@ async def test_paste_text_short_circuits_on_set_buffer_failure() -> None:
 
 @pytest.mark.asyncio
 async def test_paste_text_short_circuits_on_paste_failure() -> None:
-    """If ``paste-buffer`` fails after a successful ``set-buffer``,
+    """If ``paste-buffer`` fails after a successful ``load-buffer``,
     paste_text returns the failure without trying Enter. Skipping the
     Enter avoids submitting stale buffer content from a previous turn.
     """
@@ -1164,7 +1212,7 @@ async def test_paste_text_short_circuits_on_paste_failure() -> None:
 
     calls: list[tuple[str, ...]] = []
 
-    async def fake_run(*args, timeout=5.0):
+    async def fake_run(*args, timeout=5.0, stdin_data=None):
         calls.append(args)
         if args[0] == "paste-buffer":
             return _fail("paste broke")
@@ -1173,7 +1221,7 @@ async def test_paste_text_short_circuits_on_paste_failure() -> None:
     tmux._run = fake_run
     result = await tmux.paste_text("hello", enter_delay_ms=0)
 
-    assert len(calls) == 2  # set-buffer + paste-buffer; no send-keys
+    assert len(calls) == 2  # load-buffer + paste-buffer; no send-keys
     assert not result.ok
 
 
@@ -1194,7 +1242,7 @@ async def test_paste_text_waits_enter_delay_between_paste_and_enter() -> None:
         # No-op the actual sleep so the test runs fast.
         await original_sleep(0)
 
-    async def fake_run(*args, timeout=5.0):
+    async def fake_run(*args, timeout=5.0, stdin_data=None):
         return _ok()
 
     tmux._run = fake_run
@@ -9802,7 +9850,7 @@ class TestWakeSubmissionVerification:
     async def test_worker_wake_timeout_enters_one_way_no_repaste_verifier(
         self, monkeypatch,
     ) -> None:
-        """An exact row during retry set-buffer can never cause paste two."""
+        """An exact row during retry load-buffer can never cause paste two."""
         monkeypatch.setattr(
             tmux_session, "_WAKE_SUBMISSION_RECEIPT_TIMEOUT_SEC", 0.1
         )
@@ -9813,18 +9861,18 @@ class TestWakeSubmissionVerification:
             tmux_session, "_adaptive_paste_enter_delay_ms", lambda _text: 0
         )
         tmux = _TmuxControl("pinky-test")
-        set_buffers = 0
+        load_buffers = 0
         pane_pastes = 0
         first_enter_timed_out = asyncio.Event()
 
         async def run_command(*args, **_kwargs):
-            nonlocal set_buffers, pane_pastes
+            nonlocal load_buffers, pane_pastes
             command = args[0]
-            if command == "set-buffer":
-                set_buffers += 1
-                if set_buffers == 2:
+            if command == "load-buffer":
+                load_buffers += 1
+                if load_buffers == 2:
                     # Reproduce the rejected-head TOCTOU: retry passed its
-                    # last receipt check, then yielded inside set-buffer.
+                    # last receipt check, then yielded inside load-buffer.
                     await asyncio.sleep(0.02)
                 return _ok()
             if command == "paste-buffer":
@@ -9847,7 +9895,7 @@ class TestWakeSubmissionVerification:
         receipt = asyncio.get_running_loop().create_future()
         fires: list[str] = []
         turn = _QueuedTurn(
-            prompt="receipt lands during forbidden retry set-buffer",
+            prompt="receipt lands during forbidden retry load-buffer",
             internal=True,
             reason="wake_context_restart",
             on_delivered=lambda: fires.append("delivered"),
@@ -9858,7 +9906,7 @@ class TestWakeSubmissionVerification:
         async def inject_exact_receipt() -> None:
             await first_enter_timed_out.wait()
             # On rejected a11de3cd, worker pane-probe/backoff reaches the
-            # second set-buffer before this row. The set-buffer then resumes
+            # second load-buffer before this row. The load-buffer then resumes
             # and executes a duplicate paste-buffer despite receipt=True.
             await asyncio.sleep(0.01)
             ss._on_transcript_entry(
@@ -9867,7 +9915,7 @@ class TestWakeSubmissionVerification:
                     "message": {
                         "role": "user",
                         "content": (
-                            "receipt lands during forbidden retry set-buffer"
+                            "receipt lands during forbidden retry load-buffer"
                         ),
                     },
                 }
@@ -9888,7 +9936,7 @@ class TestWakeSubmissionVerification:
         assert await receipt is True
         assert fires == ["delivered"]
         assert ss._stats["turns"] == 1
-        assert set_buffers == 1, "verified wake must never enter retry paste"
+        assert load_buffers == 1, "verified wake must never enter retry paste"
         assert pane_pastes == 1, "accepted wake must remain pane_pastes=1"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- replace `tmux set-buffer <prompt-argv>` with `load-buffer -b NAME -` fed through stdin
- thread `stdin_data` through `_TmuxControl`, `CommandRunner`, local, unix-user, and container execution paths
- warn at scheduler startup and every 15 minutes for enabled prompts over 8,000 characters, without logging prompt content
- add focused coverage for runner forwarding, warning cadence, and prompts larger than 20 KiB

## Root cause and impact

`paste_text()` placed the complete wake prompt in one tmux command argument. tmux rejects commands around its argv-size ceiling, so a large schedule prompt returned `command too long` and never reached the pane. Loading the named buffer from stdin removes that ceiling while preserving the existing bracketed `paste-buffer -p`, adaptive Enter delay, delivery receipts, and retry policy.

Container execution adds `podman exec -i` only when stdin data is present so the same runner contract remains true for isolated agents.

## Validation

- `17 passed` — `tests/test_command_runner.py`
- `151 passed` — complete command-runner and scheduler modules
- `70 passed` — container-isolation module (with the box-wide OAuth-forwarding flag unset for its legacy credential-seed expectations)
- `46 passed, 1 skipped` — Codex tmux/app-server transport modules
- focused tmux transport/receipt reruns green, including the >20 KiB argv-limit regression
- real tmux 3.6a smoke: `load-buffer -` and `save-buffer -` preserved a 65,536-byte payload exactly
- `ruff check`, `py_compile`, and `git diff --check` clean

Full-suite disclosure: the pre-commit run completed with 4,757 passes and surfaced three failures. One stale receipt-path test double still expected `set-buffer`; it was updated to `load-buffer` and its exact test plus the focused tmux set pass at this head. The other two are unrelated box-state failures: the known #1024 nondeterministic test spawned a real tmux/Claude dream process instead of its SDK mock, and this box exports `PINKY_AUTH_DENY_DEFAULT=enforce` while the auth test asserts the repository default `shadow` behavior (the isolated test passes with `PINKY_AUTH_DENY_DEFAULT=shadow`). Neither traceback touches the runner stdin implementation after the stale test double was corrected.

Fixes #1029
