### PR TITLE
Fix cron wake transcript wedges and stale replay

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -4837,14 +4837,28 @@ except Exception as exc:
             )
         return True
 
-    def discard_pending_schedule_wake(self, pending_id: int) -> bool:
-        """Retire a pending wake without marking its schedule delivered."""
-        cursor = self._db.execute(
-            "DELETE FROM pending_schedule_wakes WHERE id=?",
-            (pending_id,),
-        )
-        self._db.commit()
-        return cursor.rowcount > 0
+    def discard_pending_schedule_wake(
+        self,
+        pending_id: int,
+        *,
+        agent_name: str | None = None,
+    ) -> bool:
+        """Retire an active pending wake without marking it delivered.
+
+        ``agent_name`` scopes self-service callers to their own outbox. Ledger
+        rows that are already accepted or quarantined are terminal evidence and
+        cannot be erased through this cleanup primitive.
+        """
+        sql = """DELETE FROM pending_schedule_wakes
+                 WHERE id=? AND accepted_at=0 AND parked_at=0"""
+        params: list = [pending_id]
+        if agent_name is not None:
+            sql += " AND agent_name=?"
+            params.append(agent_name)
+        with self._rmw_lock:
+            cursor = self._db.execute(sql, params)
+            self._db.commit()
+            return cursor.rowcount > 0
 
     # ── Heartbeats ─────────────────────────────────────────
 

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -4614,6 +4614,38 @@ except Exception as exc:
         rows = self._db.execute(sql, params).fetchall()
         return [PendingScheduleWake(*row) for row in rows]
 
+    def get_pending_schedule_wake_health(
+        self,
+        agent_name: str | None = None,
+        *,
+        now: float | None = None,
+    ) -> list[dict]:
+        """Return active outbox count and oldest-row age per agent.
+
+        Accepted receipts and quarantined rows are terminal ledger history,
+        not stranded replay work, so they are intentionally excluded.
+        """
+        sql = """SELECT agent_name, COUNT(*), MIN(fired_at), MAX(fired_at)
+                 FROM pending_schedule_wakes
+                 WHERE accepted_at=0 AND parked_at=0"""
+        params: list = []
+        if agent_name is not None:
+            sql += " AND agent_name=?"
+            params.append(agent_name)
+        sql += " GROUP BY agent_name ORDER BY agent_name"
+        rows = self._db.execute(sql, params).fetchall()
+        observed_at = time.time() if now is None else float(now)
+        return [
+            {
+                "agent_name": str(row[0]),
+                "count": int(row[1]),
+                "oldest_fired_at": float(row[2]),
+                "newest_fired_at": float(row[3]),
+                "oldest_age_seconds": max(0.0, observed_at - float(row[2])),
+            }
+            for row in rows
+        ]
+
     def list_schedule_wake_ledger(
         self,
         agent_name: str | None = None,

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -10387,9 +10387,24 @@ npm run build</pre>
         "/agents/{agent_name}/pending-schedule-wakes/{pending_id}"
     )
     async def discard_pending_schedule_wake(
-        agent_name: str, pending_id: int
+        agent_name: str, pending_id: int, request: Request
     ):
         """Discard one active stranded wake owned by ``agent_name``."""
+        # Browser sessions carry operator authority across agents. Internal
+        # HMAC callers do not: repeat the destructive self-scope at the route
+        # even though the middleware already authenticated the signature.
+        if not _has_valid_session(request):
+            caller_name = request.headers.get(INTERNAL_AGENT_HEADER, "").strip()
+            if (
+                not caller_name
+                or not _has_valid_internal_auth(request)
+                or caller_name != agent_name
+            ):
+                raise HTTPException(
+                    403,
+                    "internal caller may only discard its own pending "
+                    "schedule wakes",
+                )
         if not agents.get(agent_name):
             raise HTTPException(404, f"Agent '{agent_name}' not found")
         if not agents.discard_pending_schedule_wake(

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -12579,11 +12579,16 @@ npm run build</pre>
         """Get scheduler status."""
         all_schedules = agents.get_all_schedules(enabled_only=False)
         auto_start = agents.list_auto_start_agents()
+        pending_health = agents.get_pending_schedule_wake_health()
         return {
             "running": scheduler.running,
             "total_schedules": len(all_schedules),
             "enabled_schedules": sum(1 for s in all_schedules if s.enabled),
             "auto_start_agents": [a.name for a in auto_start],
+            "pending_schedule_wakes": pending_health,
+            "pending_schedule_wake_count": sum(
+                row["count"] for row in pending_health
+            ),
         }
 
     @app.get("/settings/heartbeat")

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -901,6 +901,7 @@ GATE_TOOL_NAMES: dict[str, list[str]] = {
         "update_wake_schedule",
         "list_my_schedules",
         "remove_wake_schedule",
+        "discard_pending_schedule_wake",
     ],
     "tasks-admin": [
         "decompose_project", "bulk_create_tasks",
@@ -10381,6 +10382,33 @@ npm run build</pre>
         if not agents.remove_schedule(schedule_id):
             raise HTTPException(404, f"Schedule {schedule_id} not found")
         return {"deleted": True}
+
+    @app.delete(
+        "/agents/{agent_name}/pending-schedule-wakes/{pending_id}"
+    )
+    async def discard_pending_schedule_wake(
+        agent_name: str, pending_id: int
+    ):
+        """Discard one active stranded wake owned by ``agent_name``."""
+        if not agents.get(agent_name):
+            raise HTTPException(404, f"Agent '{agent_name}' not found")
+        if not agents.discard_pending_schedule_wake(
+            pending_id, agent_name=agent_name
+        ):
+            raise HTTPException(
+                404,
+                f"Active pending schedule wake {pending_id} not found "
+                f"for agent '{agent_name}'",
+            )
+        _log(
+            f"scheduler: PERSISTED_WAKE_DISCARDED pending #{pending_id} "
+            f"by agent '{agent_name}'"
+        )
+        return {
+            "discarded": True,
+            "pending_id": pending_id,
+            "agent": agent_name,
+        }
 
     @app.post("/agents/{agent_name}/schedules/{schedule_id}/toggle")
     async def toggle_schedule(agent_name: str, schedule_id: int, enabled: bool = True):

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -992,6 +992,8 @@ class AgentScheduler:
                         "park returned no state change"
                     )
                 continue
+            if pending.parked_at != 0:
+                continue
             replay_max_age = self._pending_wake_replay_max_age(
                 current_schedule, pending.fired_at
             )
@@ -1007,9 +1009,24 @@ class AgentScheduler:
                     f"'{pending.agent_name}': age_s={row_age:.1f} "
                     f"max_age_s={replay_max_age:.1f} discarded={discarded}"
                 )
+                if discarded and current_schedule.one_shot:
+                    self._queue_owner_alert(
+                        pending.agent_name,
+                        (
+                            "🚨 STALE ONE-SHOT WAKE DROPPED: outbox row "
+                            f"#{pending.id} for schedule "
+                            f"'{pending.schedule_name}' "
+                            f"(#{pending.schedule_id}) on agent "
+                            f"'{pending.agent_name}' aged past its replay "
+                            f"window ({row_age:.1f}s > "
+                            f"{replay_max_age:.1f}s). The stale wake was "
+                            "discarded and this one-shot has no next "
+                            "occurrence; verify the owed work and re-arm it "
+                            "if needed."
+                        ),
+                    )
                 continue
-            if pending.parked_at == 0:
-                pending_wakes.append(pending)
+            pending_wakes.append(pending)
 
         for pending in pending_wakes:
             if pending.attempts >= self.PERSISTED_WAKE_ATTEMPT_CAP:

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -18,7 +18,7 @@ import inspect
 import json
 import sys
 import time
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from pinky_daemon.agent_registry import AgentRegistry
@@ -46,6 +46,12 @@ _RATE_LIMIT_THRESHOLD = 80  # percent — skip heartbeats above this
 # makes regressions and mixed-version fleet nodes visible in the journal.
 _SCHEDULE_PROMPT_WARN_THRESHOLD = 8_000
 _SCHEDULE_PROMPT_WARN_INTERVAL_SEC = 15 * 60
+
+# A replay row is useful only while the work is timely. Its schedule's next
+# fire is the natural cutoff; this ceiling bounds sparse/daily schedules too
+# so a daemon restart can never deliver hours-old frozen prompts. Constructor
+# injection below keeps fleet policy configurable and tests deterministic.
+_PERSISTED_WAKE_MAX_AGE_SEC = 60 * 60
 
 
 def _is_claude_code_agent(agent, registry: AgentRegistry) -> bool:
@@ -215,6 +221,7 @@ class AgentScheduler:
         activity=None,
         tick_interval: int = 30,
         schedule_delivery_timeout: float = 600.0,
+        pending_wake_max_age_sec: float = _PERSISTED_WAKE_MAX_AGE_SEC,
     ) -> None:
         self._registry = registry
         # async fn(agent_name, session_id, prompt, *, schedule_receipt=None)
@@ -269,6 +276,9 @@ class AgentScheduler:
         self._activity = activity  # ActivityStore | None
         self._tick_interval = tick_interval
         self._schedule_delivery_timeout = schedule_delivery_timeout
+        if pending_wake_max_age_sec <= 0:
+            raise ValueError("pending_wake_max_age_sec must be positive")
+        self._pending_wake_max_age_sec = float(pending_wake_max_age_sec)
         self._running = False
         self._task: asyncio.Task | None = None
         self._last_clock_slot: dict[str, int] = {}  # agent_name -> last fired clock slot (minutes since midnight)
@@ -935,6 +945,18 @@ class AgentScheduler:
 
     async def _replay_pending_locked(self, agent_name: str) -> None:
         """Reap all zombies, then replay active wakes FIFO under the agent lock."""
+        replay_now = time.time()
+        health = self._registry.get_pending_schedule_wake_health(
+            agent_name, now=replay_now
+        )
+        if health:
+            summary = health[0]
+            _log(
+                f"scheduler: PERSISTED_WAKE_OUTBOX_HEALTH agent="
+                f"'{agent_name}' count={summary['count']} "
+                f"oldest_age_s={summary['oldest_age_seconds']:.1f} "
+                f"oldest_fired_at={summary['oldest_fired_at']}"
+            )
         all_pending_wakes = self._registry.list_pending_schedule_wakes(
             agent_name, include_parked=True
         )
@@ -969,6 +991,22 @@ class AgentScheduler:
                         f"agent '{pending.agent_name}': {zombie_reason}; "
                         "park returned no state change"
                     )
+                continue
+            replay_max_age = self._pending_wake_replay_max_age(
+                current_schedule, pending.fired_at
+            )
+            row_age = max(0.0, replay_now - pending.fired_at)
+            if row_age > replay_max_age:
+                discarded = self._registry.discard_pending_schedule_wake(
+                    pending.id
+                )
+                _log(
+                    f"scheduler: PERSISTED_WAKE_STALE_DROPPED pending "
+                    f"#{pending.id}, schedule '{pending.schedule_name}' "
+                    f"(#{pending.schedule_id}) for agent "
+                    f"'{pending.agent_name}': age_s={row_age:.1f} "
+                    f"max_age_s={replay_max_age:.1f} discarded={discarded}"
+                )
                 continue
             if pending.parked_at == 0:
                 pending_wakes.append(pending)
@@ -1030,6 +1068,33 @@ class AgentScheduler:
                 f"schedule '{pending.schedule_name}' "
                 f"(#{pending.schedule_id}) for agent '{agent_name}'"
             )
+
+    def _pending_wake_replay_max_age(self, schedule, fired_at: float) -> float:
+        """Return ``min(next fire interval, configured replay ceiling)``.
+
+        We only search through the configured ceiling. If a sparse schedule
+        has no next fire inside that window, the ceiling wins. This bounds the
+        work to at most 60 minute checks under the production one-hour policy.
+        """
+        ceiling = self._pending_wake_max_age_sec
+        try:
+            tz = ZoneInfo(schedule.timezone)
+        except (KeyError, ValueError):
+            tz = ZoneInfo("America/Los_Angeles")
+
+        fired_minute = datetime.fromtimestamp(fired_at, tz=tz).replace(
+            second=0, microsecond=0
+        )
+        candidate = fired_minute + timedelta(minutes=1)
+        horizon = fired_minute + timedelta(seconds=ceiling)
+        while candidate <= horizon:
+            if cron_matches(schedule.cron, candidate):
+                return min(
+                    ceiling,
+                    max(60.0, candidate.timestamp() - fired_minute.timestamp()),
+                )
+            candidate += timedelta(minutes=1)
+        return ceiling
 
     @staticmethod
     def _wake_prompt(schedule) -> str:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -897,6 +897,11 @@ class _QueuedTurn:
     submission_receipt: asyncio.Future[bool] | None = None
 
 
+_TRANSCRIPT_MATERIALIZE_PROMPT = (
+    "[SYSTEM] Transport initialization probe. Reply with exactly: ready"
+)
+
+
 @dataclass
 class _InflightMeta:
     """One in-flight turn's routing metadata + completion signal.
@@ -1452,6 +1457,9 @@ class TmuxSession:
         # so a torn-down session doesn't have a stray task firing
         # ``set_transcript_path`` against a stopped tailer.
         self._first_bind_recovery_task: asyncio.Task[None] | None = None
+        # #984: one short-lived enqueue task for the tailer's
+        # bound-path-never-materialized recovery signal.
+        self._transcript_materialize_task: asyncio.Task[None] | None = None
 
         # Issue #570 — wake-prompt readiness gate. Set when
         # ``set_transcript_path`` is called by the SessionStart hook
@@ -5228,6 +5236,11 @@ class TmuxSession:
                 # Scheduler receipts require an exact user/dequeue transcript
                 # observation; successful external-pane keystrokes are weaker.
                 on_entry=self._on_transcript_entry,
+                # #984: a real bind that never appears on disk means Claude
+                # Code has never taken its first turn. Force one harmless
+                # internal turn instead of waiting unboundedly for a receipt
+                # source that cannot exist yet.
+                on_bound_path_wedge=self._on_bound_path_wedge,
             )
             await self._tailer.start()
             if guessed is None:
@@ -5305,6 +5318,51 @@ class TmuxSession:
         self._first_bind_recovery_task = asyncio.create_task(
             self._delayed_first_bind_recovery()
         )
+
+    def _on_bound_path_wedge(self, path: Path, bind_age: float) -> None:
+        """Force one harmless turn so Claude Code creates its bound JSONL."""
+        if self.state != SessionState.CONNECTED:
+            _log(
+                f"tmux[{self.agent_name}]: ignoring bound-path wedge while "
+                f"state={self.state.value} path={path}"
+            )
+            return
+        existing = self._transcript_materialize_task
+        if existing is not None and not existing.done():
+            return
+        _log(
+            f"tmux[{self.agent_name}]: forcing transcript-initialization "
+            f"turn after bound path stayed absent {bind_age:.1f}s"
+        )
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            _log(
+                f"tmux[{self.agent_name}]: cannot force transcript "
+                "initialization without a running event loop"
+            )
+            return
+        task = loop.create_task(
+            self._enqueue_internal_prompt(
+                _TRANSCRIPT_MATERIALIZE_PROMPT,
+                reason="wake_transcript_materialize",
+                front=True,
+                verify_submission=True,
+            )
+        )
+        self._transcript_materialize_task = task
+
+        def _done(done: asyncio.Task[None]) -> None:
+            if self._transcript_materialize_task is done:
+                self._transcript_materialize_task = None
+            if not done.cancelled() and done.exception() is not None:
+                error = done.exception()
+                _log(
+                    f"tmux[{self.agent_name}]: transcript-initialization "
+                    f"enqueue failed ({type(error).__name__}: {error})"
+                )
+
+        task.add_done_callback(_done)
 
     async def _delayed_first_bind_recovery(self) -> None:
         """Issue #565 — wait, then attempt first-bind recovery.
@@ -5425,6 +5483,12 @@ class TmuxSession:
         ):
             self._first_bind_recovery_task.cancel()
         self._first_bind_recovery_task = None
+        if (
+            self._transcript_materialize_task is not None
+            and not self._transcript_materialize_task.done()
+        ):
+            self._transcript_materialize_task.cancel()
+        self._transcript_materialize_task = None
         # Cancel any in-flight mid-turn context emit — it belongs to the
         # session that just ended; the next spawn re-emits fresh state.
         if (

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -77,6 +77,13 @@ _ACTIVE_POLL_SEC = 0.2
 # so active polling cannot flood the journal at 5 lines/second.
 _STALE_DISCOVERY_LOG_INTERVAL_SEC = 30.0
 
+# A SessionStart bind can legitimately precede Claude Code creating the JSONL:
+# CC writes a session transcript lazily on its first turn.  Seconds of absence
+# are normal; minutes of absence means the session has never taken a turn and
+# receipt-backed delivery cannot make progress.  Report that distinct state
+# once per bind so the transport can force a harmless turn to create the file.
+_BOUND_PATH_MATERIALIZE_GRACE_SEC = 5 * 60
+
 # Max bytes read per ``_read_and_dispatch`` invocation. Bounds memory if the
 # transcript path ever points at something pathologically large (per
 # Pushok's PR #496 round-1 Case 4a: the daemon endpoint's docstring claims
@@ -301,6 +308,7 @@ class TmuxTranscriptTailer:
         path_discovery: Callable[[], Path | None] | None = None,
         on_usage: Callable[[dict], None] | None = None,
         on_entry: Callable[[dict], None] | None = None,
+        on_bound_path_wedge: Callable[[Path, float], None] | None = None,
     ) -> None:
         self._path = Path(transcript_path)
         # #291: wall-clock when ``_path`` was last bound via an explicit
@@ -327,6 +335,9 @@ class TmuxTranscriptTailer:
         # This makes the tailer correct without dependence on the
         # SessionStart hook firing at all. See ``TmuxSession._discover_transcript_path``.
         self._path_discovery = path_discovery
+        self._on_bound_path_wedge = on_bound_path_wedge
+        self._bound_path_ever_materialized = self._path.exists()
+        self._bound_path_wedge_reported = False
         # Mid-turn usage hook: invoked (sync) with the usage dict every
         # time an assistant entry carries a fresh usage block — i.e. once
         # per API call inside the turn's tool loop, not just at turn end.
@@ -368,6 +379,8 @@ class TmuxTranscriptTailer:
             # #291: count self-heal discoveries we REFUSED because the
             # candidate predated the current bind (the stale-clobber guard).
             "self_heal_stale_skips": 0,
+            # #984: real binds that stayed absent past the bounded grace.
+            "bound_path_wedges": 0,
             # Mid-turn usage callbacks fired (one per assistant entry
             # that carried a fresh usage block).
             "usage_events": 0,
@@ -462,6 +475,8 @@ class TmuxTranscriptTailer:
             # across ``force_restart`` respawns, so a fresh launch rebinds
             # through here and must reset the floor.
             self._path_bound_at = time.time()
+            self._bound_path_ever_materialized = self._path.exists()
+            self._bound_path_wedge_reported = False
             self._swap_generation += 1
             if seek_to_start:
                 self._offset = 0
@@ -602,9 +617,11 @@ class TmuxTranscriptTailer:
         during discovery must never crash the tail loop. The next poll
         tick retries.
         """
-        if self._path_discovery is None:
-            return
         if self._path.exists():
+            self._bound_path_ever_materialized = True
+            return
+        self._report_bound_path_wedge_if_due()
+        if self._path_discovery is None:
             return
         try:
             discovered = self._path_discovery()
@@ -671,6 +688,41 @@ class TmuxTranscriptTailer:
         self.set_transcript_path(Path(discovered), seek_to_start=True)
         self._stats["self_heal_repoints"] += 1
 
+    def _report_bound_path_wedge_if_due(self) -> None:
+        """Report one never-materialized real bind after its grace expires.
+
+        This is deliberately independent of self-heal discovery.  #291 must
+        keep refusing an older transcript, and discovery may return ``None``;
+        neither condition changes the fact that a real bound path has never
+        existed and therefore cannot provide delivery receipts.
+        """
+        if (
+            self._path_bound_at <= 0
+            or self._bound_path_ever_materialized
+            or self._bound_path_wedge_reported
+        ):
+            return
+        bind_age = max(0.0, time.time() - self._path_bound_at)
+        if bind_age < _BOUND_PATH_MATERIALIZE_GRACE_SEC:
+            return
+
+        self._bound_path_wedge_reported = True
+        self._stats["bound_path_wedges"] += 1
+        _log(
+            f"tmux_tailer[{self._agent_name}]: BOUND_PATH_NEVER_MATERIALIZED "
+            f"path={self._path} bind_age_s={bind_age:.1f}; requesting "
+            "transcript-initialization turn (#984)"
+        )
+        if self._on_bound_path_wedge is None:
+            return
+        try:
+            self._on_bound_path_wedge(self._path, bind_age)
+        except Exception as e:
+            _log(
+                f"tmux_tailer[{self._agent_name}]: bound-path wedge callback "
+                f"raised ({type(e).__name__}: {e})"
+            )
+
     async def _read_and_dispatch(self) -> int:
         """Read from ``_offset`` to EOF, feed each JSONL entry, fire
         ``on_turn_complete`` per stop_hook_summary.
@@ -680,6 +732,7 @@ class TmuxTranscriptTailer:
         """
         if not self._path.exists():
             return 0
+        self._bound_path_ever_materialized = True
 
         # Snapshot for the mid-chunk swap check below. The only awaits in
         # this method are the turn callbacks; everything else is sync, so

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -241,6 +241,24 @@ def create_server(
                 return f"Schedule #{schedule_id} removed."
             return f"Failed to remove schedule: {result.get('error', 'not found')}"
 
+        @mcp.tool()
+        def discard_pending_schedule_wake(pending_id: int) -> str:
+            """Discard one stranded wake from your own durable outbox by row ID.
+
+            This removes the frozen pending prompt without marking its schedule
+            delivered. It cannot erase another agent's or a terminal ledger row.
+            """
+            result = _api(
+                "DELETE",
+                f"/agents/{agent_name}/pending-schedule-wakes/{pending_id}",
+            )
+            if result.get("discarded"):
+                return f"Pending schedule wake #{pending_id} discarded."
+            return (
+                f"Failed to discard pending schedule wake #{pending_id}: "
+                f"{result.get('error', 'not found')}"
+            )
+
 
     # ── MCP transport probe (issue #663) ──────────────────────
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5396,6 +5396,69 @@ class TestAgentScheduleEndpoints:
         assert body["pending_schedule_wakes"][0]["count"] == 1
         assert body["pending_schedule_wakes"][0]["oldest_age_seconds"] >= 119
 
+    def test_discard_pending_wake_is_agent_scoped(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        self._register(client, "bob")
+        created = self._create_schedule(
+            client, agent_name="alice", name="alice-morning"
+        ).json()
+        registry = client.app.state.agents
+        pending, _ = registry.persist_schedule_wake(
+            created["id"],
+            agent_name="alice",
+            schedule_name="alice-morning",
+            prompt="frozen",
+            fired_at=time.time(),
+        )
+
+        wrong_agent = client.delete(
+            f"/agents/bob/pending-schedule-wakes/{pending.id}"
+        )
+        assert wrong_agent.status_code == 404
+        assert registry.get_schedule_wake_by_fire(
+            created["id"], pending.fired_at
+        ) is not None
+
+        response = client.delete(
+            f"/agents/alice/pending-schedule-wakes/{pending.id}"
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "discarded": True,
+            "pending_id": pending.id,
+            "agent": "alice",
+        }
+        assert registry.get_schedule_wake_by_fire(
+            created["id"], pending.fired_at
+        ) is None
+
+    def test_discard_pending_wake_preserves_terminal_ledger_row(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        created = self._create_schedule(client).json()
+        registry = client.app.state.agents
+        pending, _ = registry.persist_schedule_wake(
+            created["id"],
+            agent_name="alice",
+            schedule_name="morning",
+            prompt="frozen",
+            fired_at=100.0,
+        )
+        assert registry.confirm_pending_schedule_wake(
+            pending.id, delivered_at=110.0
+        )
+
+        response = client.delete(
+            f"/agents/alice/pending-schedule-wakes/{pending.id}"
+        )
+
+        assert response.status_code == 404
+        assert registry.get_schedule_wake_by_fire(
+            created["id"], pending.fired_at
+        ) is not None
+
 
 # ── Agent CRUD ───────────────────────────────────────────────
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5374,6 +5374,28 @@ class TestAgentScheduleEndpoints:
         assert body["records"][0]["state"] == "receipted-ran-once"
         assert body["records"][0]["fired_at"] == 100.0
 
+    def test_scheduler_status_surfaces_pending_count_and_age(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        created = self._create_schedule(client).json()
+        registry = client.app.state.agents
+        registry.persist_schedule_wake(
+            created["id"],
+            agent_name="alice",
+            schedule_name="morning",
+            prompt="frozen",
+            fired_at=time.time() - 120.0,
+        )
+
+        response = client.get("/scheduler/status")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pending_schedule_wake_count"] == 1
+        assert body["pending_schedule_wakes"][0]["agent_name"] == "alice"
+        assert body["pending_schedule_wakes"][0]["count"] == 1
+        assert body["pending_schedule_wakes"][0]["oldest_age_seconds"] >= 119
+
 
 # ── Agent CRUD ───────────────────────────────────────────────
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -915,6 +915,105 @@ class TestAuthMiddlewareDefaultDeny:
         os.unlink(path)
 
 
+class TestPendingWakeDiscardAuth:
+    """The destructive wake cleanup route scopes signed callers to self."""
+
+    def _make_client(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PINKY_SESSION_SECRET", "test-session-secret")
+        monkeypatch.delenv("PINKY_UI_PASSWORD", raising=False)
+        app = create_api(
+            max_sessions=10,
+            default_working_dir=str(tmp_path),
+            db_path=str(tmp_path / "pending-wake-auth.db"),
+        )
+        registry = app.state.agents
+        registry.register(
+            "agent-a", model="opus", working_dir=str(tmp_path / "agent-a")
+        )
+        registry.register(
+            "agent-b", model="opus", working_dir=str(tmp_path / "agent-b")
+        )
+        return TestClient(app)
+
+    @staticmethod
+    def _pending(client, agent_name):
+        registry = client.app.state.agents
+        schedule = registry.add_schedule(
+            agent_name,
+            "* * * * *",
+            name=f"{agent_name}-wake",
+            prompt="owed work",
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name=agent_name,
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=time.time(),
+        )
+        return schedule, pending
+
+    @staticmethod
+    def _signed_delete(client, caller_name, target_name, pending_id):
+        path = f"/agents/{target_name}/pending-schedule-wakes/{pending_id}"
+        signing_key = client.app.state.agents.get_signing_key(caller_name)
+        assert signing_key
+        headers = build_internal_auth_headers(
+            signing_key,
+            agent_name=caller_name,
+            method="DELETE",
+            path=path,
+        )
+        return client.delete(path, headers=headers)
+
+    def test_signed_cross_agent_delete_is_denied_and_preserves_row(
+        self, monkeypatch, tmp_path
+    ):
+        client = self._make_client(monkeypatch, tmp_path)
+        schedule, pending = self._pending(client, "agent-b")
+
+        response = self._signed_delete(
+            client, "agent-a", "agent-b", pending.id
+        )
+
+        assert response.status_code == 403
+        assert client.app.state.agents.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        ) is not None
+
+    def test_signed_self_delete_succeeds(self, monkeypatch, tmp_path):
+        client = self._make_client(monkeypatch, tmp_path)
+        schedule, pending = self._pending(client, "agent-a")
+
+        response = self._signed_delete(
+            client, "agent-a", "agent-a", pending.id
+        )
+
+        assert response.status_code == 200
+        assert client.app.state.agents.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        ) is None
+
+    def test_operator_session_may_delete_cross_agent_row(
+        self, monkeypatch, tmp_path
+    ):
+        client = self._make_client(monkeypatch, tmp_path)
+        schedule, pending = self._pending(client, "agent-b")
+        setup = client.post(
+            "/auth/setup", json={"password": "hunter22", "next": "/"}
+        )
+        assert setup.status_code == 200
+
+        response = client.delete(
+            f"/agents/agent-b/pending-schedule-wakes/{pending.id}"
+        )
+
+        assert response.status_code == 200
+        assert client.app.state.agents.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        ) is None
+
+
 class TestAgentIsolationScoping:
     """#149: an authenticated *isolated* agent may only act on its OWN
     resources; cross-agent access is denied 403 even with a valid signature.

--- a/tests/test_pinky_self.py
+++ b/tests/test_pinky_self.py
@@ -37,6 +37,7 @@ class TestSelfServerCreation:
             "update_wake_schedule",
             "list_my_schedules",
             "remove_wake_schedule",
+            "discard_pending_schedule_wake",
             "save_my_context",
             "load_my_context",
             "get_next_task",

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -634,6 +634,44 @@ class TestRemoveWakeSchedule:
         assert "Failed" in result or "not found" in result
 
 
+class TestDiscardPendingScheduleWake:
+    def test_success_uses_agent_scoped_delete(self, srv):
+        captured = {}
+
+        def _urlopen(req, timeout=30):
+            del timeout
+            captured["method"] = req.method
+            captured["url"] = req.full_url
+            body = json.dumps({"discarded": True}).encode()
+            response = MagicMock()
+            response.read.return_value = body
+            response.__enter__ = lambda value: value
+            response.__exit__ = MagicMock(return_value=False)
+            return response
+
+        with patch("urllib.request.urlopen", side_effect=_urlopen):
+            result = _tools(srv)["discard_pending_schedule_wake"](
+                pending_id=94
+            )
+
+        assert captured == {
+            "method": "DELETE",
+            "url": (
+                "http://localhost:9999/agents/barsik/"
+                "pending-schedule-wakes/94"
+            ),
+        }
+        assert "#94 discarded" in result
+
+    def test_failure_is_loud(self, srv):
+        with _ok({"error": "not found", "status": 404}):
+            result = _tools(srv)["discard_pending_schedule_wake"](
+                pending_id=999
+            )
+        assert "Failed to discard" in result
+        assert "#999" in result
+
+
 # ── save_my_context ───────────────────────────────────────────────────────────
 
 class TestSaveMyContext:
@@ -2243,12 +2281,13 @@ class TestToolGates:
         tools = {t.name for t in srv._tool_manager.list_tools()}
         assert tools == CORE_TOOLS
 
-    def test_all_gates_has_71_tools(self):
+    def test_all_gates_has_72_tools(self):
         """All gates → full tool set.
 
         +1 in #145 with ``register_agent`` (admin gate) → 69, then +1 in #663
         with the core ``mcp_probe`` tool → 70. (Had dropped 69→68 in #552 with
-        the removal of ``request_sleep``.) #924 adds ``update_wake_schedule`` → 71.
+        the removal of ``request_sleep``.) #924 adds ``update_wake_schedule``
+        → 71; #984 adds sanctioned pending-wake discard → 72.
         """
         all_gates = [
             "extras", "kb", "research", "presentations", "triggers",
@@ -2256,7 +2295,7 @@ class TestToolGates:
         ]
         srv = create_server(agent_name="test", tool_gates=all_gates)
         tools = srv._tool_manager.list_tools()
-        assert len(tools) == 71
+        assert len(tools) == 72
 
     def test_extras_gate_adds_extras_tools(self):
         """Enabling 'extras' gate adds get_attribution, render_pdf, etc."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1396,6 +1396,80 @@ class TestScheduler:
         ) is None
 
     @pytest.mark.asyncio
+    async def test_replay_skips_stale_healthy_parked_row_without_drop_log(
+        self, registry, monkeypatch, capsys
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="parked", prompt="held for review"
+        )
+        now = 1_800_000_000.0
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="parked",
+            prompt="held for review",
+            fired_at=now - 61.0,
+        )
+        assert registry.park_pending_schedule_wake(pending.id)
+        monkeypatch.setattr("pinky_daemon.scheduler.time.time", lambda: now)
+        scheduler = AgentScheduler(registry)
+
+        await scheduler._replay_pending_locked("oleg")
+
+        retained = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert retained is not None
+        assert retained.parked_at > 0
+        assert "PERSISTED_WAKE_STALE_DROPPED" not in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_replay_alerts_owner_when_stale_one_shot_is_dropped(
+        self, registry, monkeypatch
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg",
+            "0 8 * * *",
+            name="one-time-enumeration",
+            prompt="enumerate owed work",
+            one_shot=True,
+        )
+        now = 1_800_000_000.0
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 3_601.0,
+        )
+        alerts: list[tuple[str, str]] = []
+
+        async def owner_notify(agent_name, message):
+            alerts.append((agent_name, message))
+            return True
+
+        monkeypatch.setattr("pinky_daemon.scheduler.time.time", lambda: now)
+        scheduler = AgentScheduler(
+            registry,
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=3_600.0,
+        )
+
+        await scheduler._replay_pending_locked("oleg")
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        ) is None
+        assert len(alerts) == 1
+        assert alerts[0][0] == "oleg"
+        assert "STALE ONE-SHOT WAKE DROPPED" in alerts[0][1]
+        assert f"outbox row #{pending.id}" in alerts[0][1]
+        assert "has no next occurrence" in alerts[0][1]
+
+    @pytest.mark.asyncio
     async def test_kill_after_durable_accept_before_future_resolve_never_replays(
         self, capsys
     ):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -465,6 +465,54 @@ class TestAgentSchedules:
         stored = registry.get_schedules("oleg")[0]
         assert stored.last_delivered == pytest.approx(delivered_at)
 
+    def test_pending_schedule_wake_health_counts_active_rows_only(self, registry):
+        registry.register("oleg")
+        registry.register("barsik")
+        first = registry.add_schedule(
+            "oleg", "* * * * *", name="first", prompt="one"
+        )
+        second = registry.add_schedule(
+            "barsik", "* * * * *", name="second", prompt="two"
+        )
+        old, _ = registry.persist_schedule_wake(
+            first.id,
+            agent_name="oleg",
+            schedule_name="first",
+            prompt="one",
+            fired_at=100.0,
+        )
+        quarantined, _ = registry.persist_schedule_wake(
+            first.id,
+            agent_name="oleg",
+            schedule_name="first",
+            prompt="parked",
+            fired_at=200.0,
+        )
+        accepted, _ = registry.persist_schedule_wake(
+            second.id,
+            agent_name="barsik",
+            schedule_name="second",
+            prompt="accepted",
+            fired_at=300.0,
+        )
+        assert registry.park_pending_schedule_wake(quarantined.id)
+        assert registry.confirm_pending_schedule_wake(
+            accepted.id, delivered_at=400.0
+        )
+
+        health = registry.get_pending_schedule_wake_health(now=500.0)
+
+        assert health == [
+            {
+                "agent_name": "oleg",
+                "count": 1,
+                "oldest_fired_at": 100.0,
+                "newest_fired_at": 100.0,
+                "oldest_age_seconds": 400.0,
+            }
+        ]
+        assert old.id > 0
+
     def test_schedule_wake_ledger_exposes_exact_terminal_states(self, registry):
         registry.register("oleg")
         schedule = registry.add_schedule(
@@ -1256,6 +1304,98 @@ class TestScheduler:
         assert attempts == ["run once"]
 
     @pytest.mark.asyncio
+    async def test_replay_drops_row_older_than_its_fire_interval(
+        self, registry, monkeypatch, capsys
+    ):
+        """A frozen prompt older than the schedule cadence never executes."""
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="minutely", prompt="frozen"
+        )
+        now = 1_800_000_000.0
+        stale, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="minutely",
+            prompt="stale frozen prompt",
+            fired_at=now - 61.0,
+        )
+        boundary, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="minutely",
+            prompt="boundary frozen prompt",
+            fired_at=now - 60.0,
+        )
+        fresh, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="minutely",
+            prompt="fresh frozen prompt",
+            fired_at=now - 59.0,
+        )
+        attempts: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        monkeypatch.setattr("pinky_daemon.scheduler.time.time", lambda: now)
+        scheduler = AgentScheduler(registry, wake_callback=confirmed)
+        await scheduler._replay_pending_locked("oleg")
+
+        assert attempts == ["boundary frozen prompt", "fresh frozen prompt"]
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, stale.fired_at
+        ) is None
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, boundary.fired_at
+        ).accepted_at == pytest.approx(now)
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, fresh.fired_at
+        ).accepted_at == pytest.approx(now)
+        logs = capsys.readouterr().err
+        assert f"PERSISTED_WAKE_STALE_DROPPED pending #{stale.id}" in logs
+        assert "count=3" in logs
+        assert "oldest_age_s=61.0" in logs
+
+    @pytest.mark.asyncio
+    async def test_replay_ceiling_drops_sparse_schedule_before_next_fire(
+        self, registry, monkeypatch
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "0 8 * * *", name="daily", prompt="too late"
+        )
+        now = 1_800_000_000.0
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="daily",
+            prompt="too late",
+            fired_at=now - 3_601.0,
+        )
+        attempts: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            attempts.append(prompt)
+            return True
+
+        monkeypatch.setattr("pinky_daemon.scheduler.time.time", lambda: now)
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            pending_wake_max_age_sec=3_600.0,
+        )
+        await scheduler._replay_pending_locked("oleg")
+
+        assert attempts == []
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        ) is None
+
+    @pytest.mark.asyncio
     async def test_kill_after_durable_accept_before_future_resolve_never_replays(
         self, capsys
     ):
@@ -1790,19 +1930,20 @@ class TestScheduler:
         schedule = registry.add_schedule(
             "oleg", "* * * * *", name="fifo", prompt="unused"
         )
+        now = time.time()
         registry.persist_schedule_wake(
             schedule.id,
             agent_name="oleg",
             schedule_name="fifo",
             prompt="oldest",
-            fired_at=100.0,
+            fired_at=now - 2.0,
         )
         registry.persist_schedule_wake(
             schedule.id,
             agent_name="oleg",
             schedule_name="fifo",
             prompt="newer",
-            fired_at=200.0,
+            fired_at=now - 1.0,
         )
         attempts: list[str] = []
 
@@ -1834,7 +1975,7 @@ class TestScheduler:
             agent_name="oleg",
             schedule_name="storm-head",
             prompt="retry me",
-            fired_at=100.0,
+            fired_at=time.time(),
         )
         attempts: list[str] = []
         alerts: list[tuple[str, str]] = []
@@ -1892,7 +2033,7 @@ class TestScheduler:
             agent_name="oleg",
             schedule_name="eventual",
             prompt="confirm me",
-            fired_at=100.0,
+            fired_at=time.time(),
         )
         for expected in range(1, AgentScheduler.PERSISTED_WAKE_ATTEMPT_CAP):
             assert (
@@ -1926,12 +2067,13 @@ class TestScheduler:
         zombie = registry.add_schedule(
             "oleg", "* * * * *", name="zombie", prompt="never deliver"
         )
+        now = time.time()
         registry.persist_schedule_wake(
             stuck.id,
             agent_name="oleg",
             schedule_name="stuck",
             prompt="stuck head",
-            fired_at=100.0,
+            fired_at=now - 1.0,
         )
         registry.persist_schedule_wake(
             zombie.id,
@@ -2068,6 +2210,7 @@ class TestScheduler:
         live = registry.add_schedule(
             "oleg", "* * * * *", name="live", prompt="unused"
         )
+        now = time.time()
         registry.persist_schedule_wake(
             zombie.id,
             agent_name="oleg",
@@ -2080,14 +2223,14 @@ class TestScheduler:
             agent_name="oleg",
             schedule_name="live",
             prompt="live one",
-            fired_at=200.0,
+            fired_at=now - 2.0,
         )
         registry.persist_schedule_wake(
             live.id,
             agent_name="oleg",
             schedule_name="live",
             prompt="live two",
-            fired_at=300.0,
+            fired_at=now - 1.0,
         )
         registry.remove_schedule(zombie.id)
         attempts: list[str] = []

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -21,6 +21,7 @@ import os
 import re
 import shlex
 import time as _time
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -3254,6 +3255,36 @@ async def test_start_tailer_schedules_recovery_task() -> None:
         "recovery task must be live until the deadline or cancellation"
     )
     await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_bound_path_wedge_forces_one_internal_materialization_turn() -> None:
+    """#984: the tailer signal becomes a real no-op turn, not a passive log."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    calls: list[tuple[str, str, bool, bool]] = []
+
+    async def _record(
+        prompt, *, reason, front=False, verify_submission=False, **kwargs
+    ):
+        del kwargs
+        calls.append((prompt, reason, front, verify_submission))
+
+    ss._enqueue_internal_prompt = _record
+    missing = Path("/tmp/never-materialized-session.jsonl")
+
+    ss._on_bound_path_wedge(missing, 300.0)
+    # A duplicate signal while the first enqueue task is alive is coalesced.
+    ss._on_bound_path_wedge(missing, 301.0)
+    await asyncio.sleep(0)
+
+    assert calls == [
+        (
+            tmux_session._TRANSCRIPT_MATERIALIZE_PROMPT,
+            "wake_transcript_materialize",
+            True,
+            True,
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tmux_transcript.py
+++ b/tests/test_tmux_transcript.py
@@ -1172,6 +1172,71 @@ class TestSelfHealDiscovery:
         assert tailer.stats["self_heal_repoints"] == 0
         assert tailer.stats["self_heal_stale_skips"] == 1
 
+    def test_never_materialized_bind_reports_once_after_grace(
+        self, tmp_path, monkeypatch,
+    ):
+        """#984 deterministic repro: the right bound path stays unborn.
+
+        The older discovery remains blocked by #291 while the distinct wedge
+        callback fires once at the five-minute boundary.
+        """
+        cb = _Captor()
+        old = tmp_path / "previous.jsonl"
+        _write_jsonl(old, [_assistant(text="old"), _stop_hook_summary()])
+        os.utime(old, (900.0, 900.0))
+        fresh = tmp_path / "fresh-bound.jsonl"
+        wedges: list[tuple[Path, float]] = []
+        now = [1000.0]
+        monkeypatch.setattr(
+            "pinky_daemon.tmux_transcript.time.time", lambda: now[0],
+        )
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl",
+            cb,
+            path_discovery=lambda: old,
+            on_bound_path_wedge=lambda path, age: wedges.append((path, age)),
+        )
+        tailer.set_transcript_path(fresh)
+
+        now[0] = 1299.9
+        tailer._try_self_heal_repoint()
+        assert wedges == []
+        assert tailer.transcript_path == fresh
+
+        now[0] = 1300.0
+        tailer._try_self_heal_repoint()
+        tailer._try_self_heal_repoint()
+
+        assert wedges == [(fresh, 300.0)]
+        assert tailer.stats["bound_path_wedges"] == 1
+        assert tailer.stats["self_heal_stale_skips"] == 3
+        assert tailer.transcript_path == fresh
+
+    def test_materialized_bind_never_reports_wedge(self, tmp_path, monkeypatch):
+        cb = _Captor()
+        fresh = tmp_path / "fresh-bound.jsonl"
+        wedges: list[tuple[Path, float]] = []
+        now = [1000.0]
+        monkeypatch.setattr(
+            "pinky_daemon.tmux_transcript.time.time", lambda: now[0],
+        )
+        tailer = TmuxTranscriptTailer(
+            tmp_path / "placeholder.jsonl",
+            cb,
+            on_bound_path_wedge=lambda path, age: wedges.append((path, age)),
+        )
+        tailer.set_transcript_path(fresh)
+        fresh.write_text("", encoding="utf-8")
+        now[0] = 1400.0
+
+        tailer._try_self_heal_repoint()
+        fresh.unlink()
+        now[0] = 1800.0
+        tailer._try_self_heal_repoint()
+
+        assert wedges == []
+        assert tailer.stats["bound_path_wedges"] == 0
+
     @pytest.mark.asyncio
     async def test_stale_discovery_skip_log_is_rate_limited(
         self, tmp_path, monkeypatch, capsys,


### PR DESCRIPTION
## Summary

- detect a real tmux transcript bind that has never materialized after a five-minute grace, without weakening the #291 stale-file predicate
- force one front-queued internal initialization turn with exact transcript-backed submission verification and bounded Enter-only retries
- drop persisted schedule wakes only when row age is older than min(next cron interval, configurable one-hour ceiling), using the frozen row fired_at; equality remains replayable
- warn on every outbox drain with per-agent count and oldest age, and expose aggregate pending wake health through /scheduler/status
- add an authenticated, agent-scoped DELETE route and pinky-self discard_pending_schedule_wake tool; terminal ledger rows and cross-agent rows cannot be erased

## Validation

Final-head affected suites:
- tmux session: 388 passed
- transcript, scheduler, pinky-self, and focused API: 408 passed
- ruff check: clean
- Python 3.11 compileall: clean
- git diff --check: clean

Full repository run in the configured Python 3.11 environment: 4,767 passed, 4 skipped, with four host-state / known failures unrelated to this diff:
- known #1024 test_manual_dream_uses_full_persisted_conversation_history bypasses its mocked SDK path and spawns a real tmux Claude dream
- PINKY_AUTH_DENY_DEFAULT=enforce makes the repository-default shadow-mode 404 test return 401
- box-wide PINKY_FORWARD_OAUTH_TOKEN plus CLAUDE_CODE_OAUTH_TOKEN makes two credential-copy tests correctly skip file seeding

The three environment-sensitive failures pass when the repository-default auth mode is restored and the box-wide OAuth forwarding variables are absent (3 passed). The #1024 traceback does not enter the #984 files or paths.

Operational constraint observed: no TOD restart and no live pending_schedule_wakes rows were touched.

Fixes #984