### PR TITLE
Add standalone RC voicemail triage CLI

### DIFF
--- a/scripts/rc_voicemail_triage.py
+++ b/scripts/rc_voicemail_triage.py
@@ -438,24 +438,40 @@ def parse_transcriber_output(stdout: str) -> tuple[str, bool]:
         raw_no_speech = payload.get("no_speech")
         if raw_no_speech is not None and not isinstance(raw_no_speech, bool):
             raise TriageError("transcribe", "transcriber no_speech is not boolean", EXIT_TRANSCRIBE)
-        has_text_field = "transcript" in payload or "text" in payload
-        raw_text = payload.get("transcript", payload.get("text", ""))
-        if raw_text is None:
-            raw_text = ""
-        if not isinstance(raw_text, str):
-            raise TriageError("transcribe", "transcriber transcript is not text", EXIT_TRANSCRIBE)
-        transcript = raw_text.strip()
-        if raw_no_speech is True:
-            if transcript:
+        text_fields: dict[str, str] = {}
+        for field in ("transcript", "text"):
+            if field not in payload:
+                continue
+            raw_text = payload[field]
+            if raw_text is None:
+                raw_text = ""
+            if not isinstance(raw_text, str):
                 raise TriageError(
                     "transcribe",
-                    "transcriber returned text with no_speech:true",
+                    f"transcriber {field} is not text",
                     EXIT_TRANSCRIBE,
                 )
+            text_fields[field] = raw_text.strip()
+
+        if raw_no_speech is True and any(text_fields.values()):
+            raise TriageError(
+                "transcribe",
+                "transcriber returned text with no_speech:true",
+                EXIT_TRANSCRIBE,
+            )
+        if len(set(text_fields.values())) > 1:
+            raise TriageError(
+                "transcribe",
+                "transcriber transcript and text disagree",
+                EXIT_TRANSCRIBE,
+            )
+
+        transcript = next(iter(text_fields.values()), "")
+        if raw_no_speech is True:
             return "", True
         if transcript:
             return transcript, False
-        if raw_no_speech is None and has_text_field:
+        if raw_no_speech is None and text_fields:
             # A successful machine-readable response with an explicit empty
             # transcript is the JSON equivalent of the helper's empty stdout.
             return "", True

--- a/scripts/rc_voicemail_triage.py
+++ b/scripts/rc_voicemail_triage.py
@@ -446,7 +446,13 @@ def parse_transcriber_output(stdout: str) -> tuple[str, bool]:
             raise TriageError("transcribe", "transcriber transcript is not text", EXIT_TRANSCRIBE)
         transcript = raw_text.strip()
         if raw_no_speech is True:
-            return transcript, True
+            if transcript:
+                raise TriageError(
+                    "transcribe",
+                    "transcriber returned text with no_speech:true",
+                    EXIT_TRANSCRIBE,
+                )
+            return "", True
         if transcript:
             return transcript, False
         if raw_no_speech is None and has_text_field:
@@ -643,6 +649,12 @@ def _configured_ledger_paths(
                     f"configured ledger does not exist: {path}",
                     EXIT_IN_FLIGHT,
                 )
+            if not _readable_ledger_source(path):
+                raise TriageError(
+                    "in_flight",
+                    f"configured ledger is not readable: {path}",
+                    EXIT_IN_FLIGHT,
+                )
             configured[canonical] = [path]
             continue
 
@@ -652,10 +664,33 @@ def _configured_ledger_paths(
             for alias in aliases:
                 for suffix in LEDGER_SUFFIXES:
                     path = parent / f"{alias}{suffix}"
-                    if path.exists() and path not in paths:
+                    if _readable_ledger_source(path) and path not in paths:
                         paths.append(path)
+        if not paths:
+            aliases_text = " or ".join(aliases)
+            raise TriageError(
+                "in_flight",
+                f"required ledger is missing or unreadable: {canonical} ({aliases_text})",
+                EXIT_IN_FLIGHT,
+            )
         configured[canonical] = paths
     return configured
+
+
+def _readable_ledger_source(path: Path) -> bool:
+    if path.is_symlink():
+        return False
+    try:
+        if path.is_file():
+            with path.open("rb"):
+                return True
+        if path.is_dir():
+            with os.scandir(path) as entries:
+                next(entries, None)
+            return True
+    except OSError:
+        return False
+    return False
 
 
 def _ledger_files(paths: Iterable[Path]) -> Iterable[Path]:
@@ -704,10 +739,10 @@ def scan_in_flight(
     *,
     env: Mapping[str, str] | None = None,
 ) -> list[dict[str, str]]:
+    paths_by_ledger = _configured_ledger_paths(ledger_root, env)
     text_terms, digit_terms = _search_terms(caller, site_candidates)
     if not text_terms and not digit_terms:
         return []
-    paths_by_ledger = _configured_ledger_paths(ledger_root, env)
     matches: list[dict[str, str]] = []
     try:
         for ledger, paths in paths_by_ledger.items():
@@ -816,8 +851,13 @@ def _positive_float(value: str) -> float:
     return parsed
 
 
+class _TriageArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise TriageError("config", message, EXIT_CONFIG)
+
+
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = _TriageArgumentParser(
         description="Fetch and triage a RingCentral voicemail from a Zoho Desk ticket"
     )
     parser.add_argument("ticket_id", help="Zoho Desk ticket id")
@@ -864,17 +904,52 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
+_CLI_OPTIONS_WITH_VALUES = {
+    "--desk-base-url",
+    "--desk-org-id",
+    "--dest-dir",
+    "--transcriber",
+    "--ledger-root",
+    "--timeout",
+    "--transcribe-timeout",
+}
+
+
+def _best_effort_ticket_id(argv: Sequence[str]) -> str:
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token == "--":
+            return argv[index + 1] if index + 1 < len(argv) else ""
+        option = token.partition("=")[0]
+        if option in _CLI_OPTIONS_WITH_VALUES:
+            index += 1 if "=" in token else 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token
+    return ""
+
+
+def _error_ticket_id(ticket_id: str) -> str:
+    if _SAFE_TICKET_RE.fullmatch(ticket_id):
+        return ticket_id
+    return repr(ticket_id)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    args = _parser().parse_args(argv)
-    ticket_id = args.ticket_id
-    if not _SAFE_TICKET_RE.fullmatch(ticket_id):
-        error = TriageError("config", "ticket id contains invalid characters", EXIT_CONFIG)
-        print(
-            f"rc_voicemail_triage: stage={error.stage} ticket_id={ticket_id!r} error={error.message}",
-            file=sys.stderr,
-        )
-        return error.exit_code
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    ticket_id = _best_effort_ticket_id(raw_argv)
     try:
+        args = _parser().parse_args(raw_argv)
+        ticket_id = args.ticket_id
+        if not _SAFE_TICKET_RE.fullmatch(ticket_id):
+            raise TriageError(
+                "config",
+                "ticket id contains invalid characters",
+                EXIT_CONFIG,
+            )
         token = load_access_token()
         desk = DeskClient(
             token,
@@ -892,13 +967,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     except TriageError as exc:
         print(
-            f"rc_voicemail_triage: stage={exc.stage} ticket_id={ticket_id} error={exc.message}",
+            "rc_voicemail_triage: "
+            f"stage={exc.stage} ticket_id={_error_ticket_id(ticket_id)} error={exc.message}",
             file=sys.stderr,
         )
         return exc.exit_code
     except Exception as exc:  # Defensive CLI boundary; never emit partial success JSON.
         print(
-            f"rc_voicemail_triage: stage=internal ticket_id={ticket_id} error={exc}",
+            "rc_voicemail_triage: "
+            f"stage=internal ticket_id={_error_ticket_id(ticket_id)} error={exc}",
             file=sys.stderr,
         )
         return EXIT_INTERNAL

--- a/scripts/rc_voicemail_triage.py
+++ b/scripts/rc_voicemail_triage.py
@@ -1,0 +1,910 @@
+#!/usr/bin/env python3
+"""Read-only RingCentral voicemail triage from a Zoho Desk ticket.
+
+The voicemail audio is fetched through the Desk ticket-thread attachment
+chain. RingCentral credentials are intentionally neither accepted nor used.
+The external ``whisper_transcribe.py`` helper is invoked without a prompt,
+and the result is combined with Desk contact candidates and read-only ledger
+matches into one JSON object on stdout.
+
+Required environment:
+
+* ``ZOHO_DESK_ACCESS_TOKEN`` or ``ZOHO_DESK_TOKEN_FILE``
+
+Common install-time environment:
+
+* ``ZOHO_DESK_ORG_ID`` (optional for organization-bound OAuth tokens)
+* ``ZOHO_DESK_BASE_URL`` (default: https://desk.zoho.com/api/v1)
+* ``WHISPER_TRANSCRIBE_PATH`` (default: sibling whisper_transcribe.py)
+* ``RC_VOICEMAIL_LEDGER_ROOT`` (default: current directory)
+
+Each ledger can also be pinned independently with
+``RC_VOICEMAIL_LEDGER_<NAME>`` where NAME is ACTIVE_RMAS, LABEL_REQUESTS,
+ACTIVE_CC, ACTIVE_JAMF, or INTEGRATION_REQUESTS.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode, urljoin, urlparse
+from urllib.request import Request, urlopen
+
+NOTIFY_ADDRESS = "notify@ringcentral.com"
+DEFAULT_DESK_BASE_URL = "https://desk.zoho.com/api/v1"
+DEFAULT_TIMEOUT_S = 30.0
+DEFAULT_TRANSCRIBE_TIMEOUT_S = 300.0
+
+EXIT_CONFIG = 2
+EXIT_FETCH = 3
+EXIT_TRANSCRIBE = 4
+EXIT_RESOLVE = 5
+EXIT_IN_FLIGHT = 6
+EXIT_INTERNAL = 70
+
+LEDGER_ALIASES: dict[str, tuple[str, ...]] = {
+    "active_rmas": ("active_rmas",),
+    "label_requests": ("label_requests",),
+    "active_cc": ("active_cc",),
+    "active_jamf": ("active_jamf",),
+    "integration_requests": ("integration_requests", "ubereats"),
+}
+LEDGER_SUFFIXES = ("", ".json", ".jsonl", ".csv", ".txt", ".md", ".yaml", ".yml")
+LEDGER_SUBDIRS = ("", "data", "ledgers", "state")
+NO_SPEECH_MARKERS = {
+    "no speech",
+    "no_speech",
+    "[no speech]",
+    "[no_speech]",
+    "no speech detected",
+    "no_speech_detected",
+    "[no speech detected]",
+    "[no_speech_detected]",
+    "<no speech>",
+    "<no_speech>",
+}
+
+_PHONE_RE = re.compile(r"(?<!\d)(?:\+?1[\s.\-]*)?\(?\d{3}\)?[\s.\-]*\d{3}[\s.\-]*\d{4}(?!\d)")
+_DURATION_RE = re.compile(r"\bLength:\s*(\d{1,3}):(\d{2})(?::(\d{2}))?\b", re.I)
+_CITY_HINT_RE = re.compile(r"\bin\s+([A-Za-z][A-Za-z .'-]{1,60})\s*$", re.I)
+_SAFE_TICKET_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class TriageError(Exception):
+    """A user-visible failure in one pipeline stage."""
+
+    def __init__(self, stage: str, message: str, exit_code: int):
+        super().__init__(message)
+        self.stage = stage
+        self.message = message
+        self.exit_code = exit_code
+
+
+class DeskAPIError(Exception):
+    """A Zoho Desk request or response failure."""
+
+
+def digits_only(value: object) -> str:
+    if value is None:
+        return ""
+    return re.sub(r"\D", "", str(value))
+
+
+def format_phone(number: str) -> str:
+    digits = digits_only(number)
+    if len(digits) == 11 and digits.startswith("1"):
+        digits = digits[1:]
+    if len(digits) == 10:
+        return f"({digits[:3]}) {digits[3:6]}-{digits[6:]}"
+    return digits
+
+
+def _duration_seconds(match: re.Match[str] | None) -> int | None:
+    if match is None:
+        return None
+    first, second, third = match.groups()
+    if third is None:
+        minutes, seconds = int(first), int(second)
+        return minutes * 60 + seconds if seconds < 60 else None
+    hours, minutes, seconds = int(first), int(second), int(third)
+    if minutes >= 60 or seconds >= 60:
+        return None
+    return hours * 3600 + minutes * 60 + seconds
+
+
+def parse_summary_line(summary: object) -> dict[str, str | int | None]:
+    """Parse nullable caller fields from a RingCentral Desk thread summary."""
+
+    if not isinstance(summary, str):
+        return {"callerid_name": None, "number": None, "duration_s": None}
+
+    duration_match = _DURATION_RE.search(summary)
+    duration_s = _duration_seconds(duration_match)
+    before_length = summary[: duration_match.start()] if duration_match else summary
+    phone_match = _PHONE_RE.search(before_length)
+    number = digits_only(phone_match.group(0)) if phone_match else None
+    if number and len(number) == 11 and number.startswith("1"):
+        number = number[1:]
+
+    callerid_name: str | None = None
+    from_match = re.search(r"\bFrom:\s*(.*)", before_length, re.I | re.S)
+    if from_match:
+        name_block = from_match.group(1)
+        if " - " in name_block:
+            name_block = name_block.split(" - ", 1)[1]
+        phone_in_name = _PHONE_RE.search(name_block)
+        if phone_in_name:
+            name_block = name_block[: phone_in_name.start()]
+        name_block = re.sub(r"[\s,;:.\-]+$", "", name_block).strip()
+        if name_block.casefold() not in {"", "unknown", "anonymous", "null", "none"}:
+            callerid_name = name_block
+
+    return {
+        "callerid_name": callerid_name,
+        "number": number,
+        "duration_s": duration_s,
+    }
+
+
+def extract_city_hint(callerid_name: object) -> str | None:
+    if not isinstance(callerid_name, str):
+        return None
+    match = _CITY_HINT_RE.search(callerid_name.strip())
+    if not match:
+        return None
+    city = match.group(1).strip(" ,.-")
+    return city or None
+
+
+def _token_from_json(value: object) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    for key in ("access_token", "accessToken", "token"):
+        candidate = value.get(key)
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+        nested = _token_from_json(candidate)
+        if nested:
+            return nested
+    for candidate in value.values():
+        nested = _token_from_json(candidate)
+        if nested:
+            return nested
+    return None
+
+
+def load_access_token(env: Mapping[str, str] | None = None) -> str:
+    values = os.environ if env is None else env
+    direct = values.get("ZOHO_DESK_ACCESS_TOKEN", "").strip()
+    if direct:
+        return direct.removeprefix("Zoho-oauthtoken ").strip()
+
+    token_file_value = values.get("ZOHO_DESK_TOKEN_FILE", "").strip()
+    if not token_file_value:
+        raise TriageError(
+            "config",
+            "set ZOHO_DESK_ACCESS_TOKEN or ZOHO_DESK_TOKEN_FILE",
+            EXIT_CONFIG,
+        )
+    token_file = Path(token_file_value).expanduser()
+    try:
+        raw = token_file.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise TriageError(
+            "config", f"cannot read Desk token file {token_file}: {exc}", EXIT_CONFIG
+        ) from exc
+    if not raw:
+        raise TriageError("config", f"Desk token file {token_file} is empty", EXIT_CONFIG)
+
+    token = None
+    try:
+        token = _token_from_json(json.loads(raw))
+    except json.JSONDecodeError:
+        token = raw
+    if not token:
+        raise TriageError(
+            "config",
+            f"Desk token file {token_file} has no access_token",
+            EXIT_CONFIG,
+        )
+    return token.removeprefix("Zoho-oauthtoken ").strip()
+
+
+def _collection(payload: object, *, context: str) -> list[dict[str, Any]]:
+    """Normalize Desk collection payloads; an empty object is a valid miss."""
+
+    if payload == {}:
+        return []
+    records: object = payload
+    if isinstance(payload, dict):
+        for key in ("data", "contacts", "results", "threads"):
+            if key in payload:
+                records = payload[key]
+                break
+        else:
+            raise DeskAPIError(f"{context} response has no collection field")
+    if records == {} or records is None:
+        return []
+    if not isinstance(records, list):
+        raise DeskAPIError(f"{context} response collection is not a list")
+    if any(not isinstance(record, dict) for record in records):
+        raise DeskAPIError(f"{context} response contains a non-object record")
+    return records
+
+
+class DeskClient:
+    """Small read-only Zoho Desk REST client."""
+
+    def __init__(
+        self,
+        access_token: str,
+        *,
+        org_id: str | None = None,
+        base_url: str = DEFAULT_DESK_BASE_URL,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        opener: Callable[..., Any] = urlopen,
+    ):
+        self.access_token = access_token
+        self.org_id = org_id.strip() if org_id else None
+        self.base_url = base_url.rstrip("/") + "/"
+        self.timeout_s = timeout_s
+        self._opener = opener
+        parsed = urlparse(self.base_url)
+        if parsed.scheme != "https" or not parsed.netloc:
+            raise TriageError("config", "ZOHO_DESK_BASE_URL must be an https URL", EXIT_CONFIG)
+        self._base_host = parsed.netloc.casefold()
+
+    def _headers(self, *, accept: str) -> dict[str, str]:
+        headers = {
+            "Accept": accept,
+            "Authorization": f"Zoho-oauthtoken {self.access_token}",
+            "User-Agent": "pinky-rc-voicemail-triage/1",
+        }
+        if self.org_id:
+            headers["orgId"] = self.org_id
+        return headers
+
+    def _url(self, path: str, params: Mapping[str, object] | None = None) -> str:
+        url = urljoin(self.base_url, path.lstrip("/"))
+        if params:
+            url = f"{url}?{urlencode(params)}"
+        return url
+
+    def _request_json(self, path: str, params: Mapping[str, object] | None = None) -> object:
+        request = Request(self._url(path, params), headers=self._headers(accept="application/json"))
+        try:
+            with self._opener(request, timeout=self.timeout_s) as response:
+                body = response.read()
+        except HTTPError as exc:
+            raise DeskAPIError(f"Desk HTTP {exc.code} for {path}") from exc
+        except (URLError, TimeoutError, OSError, ValueError) as exc:
+            raise DeskAPIError(f"Desk request failed for {path}: {exc}") from exc
+        try:
+            return json.loads(body.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise DeskAPIError(f"Desk returned invalid JSON for {path}") from exc
+
+    def list_threads(self, ticket_id: str) -> list[dict[str, Any]]:
+        payload = self._request_json(
+            f"tickets/{quote(ticket_id, safe='')}/threads",
+            {"from": 0, "limit": 100},
+        )
+        return _collection(payload, context="ticket threads")
+
+    def get_thread(self, ticket_id: str, thread_id: str) -> dict[str, Any]:
+        payload = self._request_json(
+            f"tickets/{quote(ticket_id, safe='')}/threads/{quote(thread_id, safe='')}",
+            {"include": "plainText"},
+        )
+        if not isinstance(payload, dict) or not payload:
+            raise DeskAPIError("thread detail response is not an object")
+        return payload
+
+    def search_contacts(self, query: str) -> list[dict[str, Any]]:
+        payload = self._request_json(
+            "search",
+            # The Desk operation calls this input ``q``; the REST API names
+            # the corresponding wire parameter ``searchStr``.
+            {"module": "contacts", "searchStr": query, "from": 0, "limit": 50},
+        )
+        return _collection(payload, context="contact search")
+
+    def download_attachment(self, href: str, destination: Path) -> None:
+        url = urljoin(self.base_url, href)
+        parsed = urlparse(url)
+        if parsed.scheme != "https" or parsed.netloc.casefold() != self._base_host:
+            raise DeskAPIError("attachment href is outside the configured Desk host")
+        request = Request(url, headers=self._headers(accept="audio/mpeg,application/octet-stream"))
+        part = destination.with_suffix(destination.suffix + ".part")
+        try:
+            with (
+                self._opener(request, timeout=self.timeout_s) as response,
+                part.open("wb") as handle,
+            ):
+                while chunk := response.read(1024 * 1024):
+                    handle.write(chunk)
+            if part.stat().st_size == 0:
+                raise DeskAPIError("Desk returned an empty attachment")
+            part.replace(destination)
+        except HTTPError as exc:
+            raise DeskAPIError(f"Desk HTTP {exc.code} while downloading attachment") from exc
+        except (URLError, TimeoutError, OSError, ValueError) as exc:
+            raise DeskAPIError(f"attachment download failed: {exc}") from exc
+        finally:
+            try:
+                part.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _thread_sender(thread: Mapping[str, Any]) -> str | None:
+    for key in ("fromEmailAddress", "from", "replyTo"):
+        value = thread.get(key)
+        if isinstance(value, str) and "@" in value:
+            return value.strip().casefold()
+    author = thread.get("author")
+    if isinstance(author, dict):
+        value = author.get("email")
+        if isinstance(value, str):
+            return value.strip().casefold()
+    return None
+
+
+def _attachments(thread: Mapping[str, Any]) -> list[dict[str, Any]]:
+    value = thread.get("attachments", [])
+    if value in (None, {}):
+        return []
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise DeskAPIError("thread attachments response is malformed")
+    return value
+
+
+def fetch_voicemail_audio(
+    desk: DeskClient,
+    ticket_id: str,
+    destination_dir: Path,
+) -> tuple[Path, dict[str, str | int | None]]:
+    """Follow ticket -> RingCentral thread -> mp3 attachment and download it."""
+
+    try:
+        threads = desk.list_threads(ticket_id)
+        matches: list[tuple[dict[str, Any], dict[str, Any]]] = []
+        for listed in threads:
+            if _thread_sender(listed) != NOTIFY_ADDRESS:
+                continue
+            thread_id = listed.get("id")
+            if not isinstance(thread_id, (str, int)):
+                raise DeskAPIError("RingCentral thread is missing its id")
+            detail = desk.get_thread(ticket_id, str(thread_id))
+            for attachment in _attachments(detail):
+                name = attachment.get("name")
+                if isinstance(name, str) and name.casefold().endswith(".mp3"):
+                    matches.append((detail, attachment))
+        if not matches:
+            raise DeskAPIError("no RingCentral thread mp3 attachment found")
+        if len(matches) > 1:
+            raise DeskAPIError("multiple RingCentral thread mp3 attachments found")
+
+        thread, attachment = matches[0]
+        thread_id = str(thread.get("id", "thread"))
+        attachment_id = str(attachment.get("id", "attachment"))
+        href = attachment.get("href")
+        if not isinstance(href, str) or not href.strip():
+            href = (
+                f"tickets/{quote(ticket_id, safe='')}/threads/{quote(thread_id, safe='')}"
+                f"/attachments/{quote(attachment_id, safe='')}/content"
+            )
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        destination = destination_dir / f"{ticket_id}_{thread_id}_{attachment_id}.mp3"
+        suffix = 2
+        while destination.exists():
+            destination = destination_dir / (
+                f"{ticket_id}_{thread_id}_{attachment_id}_{suffix}.mp3"
+            )
+            suffix += 1
+        desk.download_attachment(href, destination)
+        summary = thread.get("summary")
+        return destination, parse_summary_line(summary)
+    except TriageError:
+        raise
+    except DeskAPIError as exc:
+        raise TriageError("fetch", str(exc), EXIT_FETCH) from exc
+
+
+def parse_transcriber_output(stdout: str) -> tuple[str, bool]:
+    """Accept machine-readable helper output or an explicit plain-text sentinel."""
+
+    stripped = stdout.strip()
+    if not stripped:
+        # This parser is reached only after the helper exits zero. Geordi's
+        # plain-text helper reports silence as an empty transcript; crashes
+        # take the nonzero path in transcribe_audio before this call.
+        return "", True
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        payload = None
+
+    if isinstance(payload, dict):
+        raw_no_speech = payload.get("no_speech")
+        if raw_no_speech is not None and not isinstance(raw_no_speech, bool):
+            raise TriageError("transcribe", "transcriber no_speech is not boolean", EXIT_TRANSCRIBE)
+        has_text_field = "transcript" in payload or "text" in payload
+        raw_text = payload.get("transcript", payload.get("text", ""))
+        if raw_text is None:
+            raw_text = ""
+        if not isinstance(raw_text, str):
+            raise TriageError("transcribe", "transcriber transcript is not text", EXIT_TRANSCRIBE)
+        transcript = raw_text.strip()
+        if raw_no_speech is True:
+            return transcript, True
+        if transcript:
+            return transcript, False
+        if raw_no_speech is None and has_text_field:
+            # A successful machine-readable response with an explicit empty
+            # transcript is the JSON equivalent of the helper's empty stdout.
+            return "", True
+        raise TriageError(
+            "transcribe",
+            "transcriber returned neither transcript nor explicit no_speech:true",
+            EXIT_TRANSCRIBE,
+        )
+
+    if isinstance(payload, str):
+        stripped = payload.strip()
+    normalized_marker = stripped.casefold().strip(" \t\r\n.!:;")
+    if normalized_marker in NO_SPEECH_MARKERS:
+        return "", True
+    if stripped:
+        return stripped, False
+    raise TriageError("transcribe", "transcriber output is unusable", EXIT_TRANSCRIBE)
+
+
+def transcribe_audio(
+    audio_path: Path,
+    transcriber_path: Path,
+    *,
+    timeout_s: float = DEFAULT_TRANSCRIBE_TIMEOUT_S,
+) -> tuple[str, bool]:
+    if not transcriber_path.is_file():
+        raise TriageError(
+            "transcribe",
+            f"transcriber not found: {transcriber_path}",
+            EXIT_TRANSCRIBE,
+        )
+
+    # PROMPTLESS by construction: only the audio path is passed. Remove known
+    # prompt-bearing environment hooks so a parent shell cannot add a prompt.
+    child_env = os.environ.copy()
+    for key in tuple(child_env):
+        folded = key.casefold()
+        if "prompt" in folded:
+            child_env.pop(key, None)
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(transcriber_path), str(audio_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_s,
+            env=child_env,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise TriageError(
+            "transcribe", f"transcriber could not run: {exc}", EXIT_TRANSCRIBE
+        ) from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip().splitlines()
+        suffix = f": {detail[-1][:400]}" if detail else ""
+        raise TriageError(
+            "transcribe",
+            f"transcriber exited {completed.returncode}{suffix}",
+            EXIT_TRANSCRIBE,
+        )
+    return parse_transcriber_output(completed.stdout)
+
+
+def _contact_city_values(contact: Mapping[str, Any]) -> set[str]:
+    values: set[str] = set()
+    for key, value in contact.items():
+        if "city" in key.casefold() and isinstance(value, str) and value.strip():
+            values.add(value.strip().casefold())
+        if isinstance(value, dict):
+            values.update(_contact_city_values(value))
+    return values
+
+
+def _account_rows(contact: Mapping[str, Any]) -> list[tuple[str | None, str | None]]:
+    rows: list[tuple[str | None, str | None]] = []
+    accounts = contact.get("accounts")
+    if isinstance(accounts, list):
+        for account in accounts:
+            if isinstance(account, dict):
+                account_id = account.get("id", account.get("accountId"))
+                account_name = account.get("name", account.get("accountName"))
+                rows.append(
+                    (
+                        str(account_id) if account_id is not None else None,
+                        str(account_name) if account_name is not None else None,
+                    )
+                )
+    account = contact.get("account")
+    if isinstance(account, dict):
+        account_id = account.get("id", account.get("accountId"))
+        account_name = account.get("name", account.get("accountName"))
+        rows.append(
+            (
+                str(account_id) if account_id is not None else None,
+                str(account_name) if account_name is not None else None,
+            )
+        )
+    if not rows:
+        account_id = contact.get("accountId")
+        account_name = contact.get("accountName")
+        rows.append(
+            (
+                str(account_id) if account_id is not None else None,
+                str(account_name) if account_name is not None else None,
+            )
+        )
+    return rows
+
+
+def _site_candidates(
+    contacts: Sequence[Mapping[str, Any]],
+    *,
+    match_basis: str,
+) -> list[dict[str, str | bool | None]]:
+    candidates: list[dict[str, str | bool | None]] = []
+    seen: set[tuple[str, str | None, str | None, str]] = set()
+    for contact in contacts:
+        contact_id = contact.get("id", contact.get("contactId"))
+        if contact_id is None:
+            raise DeskAPIError("contact search result is missing its id")
+        contact_id = str(contact_id)
+        for account_id, account_name in _account_rows(contact):
+            key = (contact_id, account_id, account_name, match_basis)
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append(
+                {
+                    "contact_id": contact_id,
+                    "account_id": account_id,
+                    "account_name": account_name,
+                    "match_basis": match_basis,
+                    "verified": False,
+                }
+            )
+    return candidates
+
+
+def resolve_site_candidates(
+    desk: DeskClient,
+    caller: Mapping[str, str | int | None],
+) -> list[dict[str, str | bool | None]]:
+    """Search digits first, then formatted phone, then an explicit city hint."""
+
+    try:
+        number = caller.get("number")
+        digits = digits_only(number)
+        if digits:
+            contacts = desk.search_contacts(digits)
+            if contacts:
+                return _site_candidates(contacts, match_basis="phone_exact")
+            formatted = format_phone(digits)
+            if formatted and formatted != digits:
+                contacts = desk.search_contacts(formatted)
+                if contacts:
+                    return _site_candidates(contacts, match_basis="phone_exact")
+
+        city = extract_city_hint(caller.get("callerid_name"))
+        if city:
+            contacts = desk.search_contacts(city)
+            city_key = city.casefold()
+            city_contacts = [
+                contact for contact in contacts if city_key in _contact_city_values(contact)
+            ]
+            return _site_candidates(city_contacts, match_basis="city_only")
+        return []
+    except DeskAPIError as exc:
+        raise TriageError("resolve", str(exc), EXIT_RESOLVE) from exc
+
+
+def _configured_ledger_paths(
+    ledger_root: Path,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, list[Path]]:
+    values = os.environ if env is None else env
+    if not ledger_root.is_dir():
+        raise TriageError(
+            "in_flight",
+            f"ledger root is not a directory: {ledger_root}",
+            EXIT_IN_FLIGHT,
+        )
+    configured: dict[str, list[Path]] = {}
+    for canonical, aliases in LEDGER_ALIASES.items():
+        env_key = f"RC_VOICEMAIL_LEDGER_{canonical.upper()}"
+        explicit = values.get(env_key, "").strip()
+        if explicit:
+            path = Path(explicit).expanduser()
+            if not path.exists():
+                raise TriageError(
+                    "in_flight",
+                    f"configured ledger does not exist: {path}",
+                    EXIT_IN_FLIGHT,
+                )
+            configured[canonical] = [path]
+            continue
+
+        paths: list[Path] = []
+        for subdir in LEDGER_SUBDIRS:
+            parent = ledger_root / subdir if subdir else ledger_root
+            for alias in aliases:
+                for suffix in LEDGER_SUFFIXES:
+                    path = parent / f"{alias}{suffix}"
+                    if path.exists() and path not in paths:
+                        paths.append(path)
+        configured[canonical] = paths
+    return configured
+
+
+def _ledger_files(paths: Iterable[Path]) -> Iterable[Path]:
+    seen: set[Path] = set()
+    for path in paths:
+        if path.is_symlink():
+            continue
+        if path.is_file():
+            resolved = path.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                yield path
+        elif path.is_dir():
+            for child in sorted(path.rglob("*")):
+                if child.is_file() and not child.is_symlink():
+                    resolved = child.resolve()
+                    if resolved not in seen:
+                        seen.add(resolved)
+                        yield child
+
+
+def _search_terms(
+    caller: Mapping[str, str | int | None],
+    site_candidates: Sequence[Mapping[str, object]],
+) -> tuple[set[str], set[str]]:
+    text_terms: set[str] = set()
+    digit_terms: set[str] = set()
+    caller_name = caller.get("callerid_name")
+    if isinstance(caller_name, str) and len(caller_name.strip()) >= 3:
+        text_terms.add(caller_name.strip().casefold())
+    number = digits_only(caller.get("number"))
+    if number:
+        digit_terms.add(number)
+    for candidate in site_candidates:
+        for key in ("account_id", "account_name", "contact_id"):
+            value = candidate.get(key)
+            if value is not None and len(str(value).strip()) >= 3:
+                text_terms.add(str(value).strip().casefold())
+    return text_terms, digit_terms
+
+
+def scan_in_flight(
+    ledger_root: Path,
+    caller: Mapping[str, str | int | None],
+    site_candidates: Sequence[Mapping[str, object]],
+    *,
+    env: Mapping[str, str] | None = None,
+) -> list[dict[str, str]]:
+    text_terms, digit_terms = _search_terms(caller, site_candidates)
+    if not text_terms and not digit_terms:
+        return []
+    paths_by_ledger = _configured_ledger_paths(ledger_root, env)
+    matches: list[dict[str, str]] = []
+    try:
+        for ledger, paths in paths_by_ledger.items():
+            for path in _ledger_files(paths):
+                with path.open(encoding="utf-8", errors="replace") as handle:
+                    for line_number, raw_line in enumerate(handle, start=1):
+                        one_line = raw_line.rstrip("\r\n")
+                        folded = one_line.casefold()
+                        normalized_digits = digits_only(one_line)
+                        if not (
+                            any(term in folded for term in text_terms)
+                            or any(term in normalized_digits for term in digit_terms)
+                        ):
+                            continue
+                        try:
+                            key_path = path.resolve().relative_to(ledger_root.resolve())
+                        except ValueError:
+                            key_path = path
+                        matches.append(
+                            {
+                                "ledger": ledger,
+                                "key": f"{key_path}:{line_number}",
+                                "one_line": one_line,
+                            }
+                        )
+    except OSError as exc:
+        raise TriageError("in_flight", f"cannot read ledger: {exc}", EXIT_IN_FLIGHT) from exc
+    return matches
+
+
+def build_output(
+    ticket_id: str,
+    caller: Mapping[str, str | int | None],
+    transcript: str,
+    no_speech: bool,
+    site_candidates: Sequence[Mapping[str, object]],
+    in_flight: Sequence[Mapping[str, str]],
+) -> dict[str, object]:
+    return {
+        "ticket_id": ticket_id,
+        "caller": {
+            "callerid_name": caller.get("callerid_name"),
+            "number": caller.get("number"),
+            "duration_s": caller.get("duration_s"),
+        },
+        "transcript": transcript,
+        "no_speech": no_speech,
+        "site_candidates": list(site_candidates),
+        "in_flight": list(in_flight),
+    }
+
+
+def triage_ticket(
+    ticket_id: str,
+    desk: DeskClient,
+    *,
+    transcriber_path: Path,
+    ledger_root: Path,
+    destination_dir: Path | None = None,
+    transcribe_timeout_s: float = DEFAULT_TRANSCRIBE_TIMEOUT_S,
+) -> dict[str, object]:
+    if destination_dir is None:
+        with tempfile.TemporaryDirectory(prefix="rc-voicemail-") as temporary:
+            return _triage_in_directory(
+                ticket_id,
+                desk,
+                transcriber_path=transcriber_path,
+                ledger_root=ledger_root,
+                destination_dir=Path(temporary),
+                transcribe_timeout_s=transcribe_timeout_s,
+            )
+    return _triage_in_directory(
+        ticket_id,
+        desk,
+        transcriber_path=transcriber_path,
+        ledger_root=ledger_root,
+        destination_dir=destination_dir,
+        transcribe_timeout_s=transcribe_timeout_s,
+    )
+
+
+def _triage_in_directory(
+    ticket_id: str,
+    desk: DeskClient,
+    *,
+    transcriber_path: Path,
+    ledger_root: Path,
+    destination_dir: Path,
+    transcribe_timeout_s: float,
+) -> dict[str, object]:
+    audio_path, caller = fetch_voicemail_audio(desk, ticket_id, destination_dir)
+    transcript, no_speech = transcribe_audio(
+        audio_path,
+        transcriber_path,
+        timeout_s=transcribe_timeout_s,
+    )
+    site_candidates = resolve_site_candidates(desk, caller)
+    in_flight = scan_in_flight(ledger_root, caller, site_candidates)
+    return build_output(ticket_id, caller, transcript, no_speech, site_candidates, in_flight)
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Fetch and triage a RingCentral voicemail from a Zoho Desk ticket"
+    )
+    parser.add_argument("ticket_id", help="Zoho Desk ticket id")
+    parser.add_argument(
+        "--desk-base-url",
+        default=os.environ.get("ZOHO_DESK_BASE_URL", DEFAULT_DESK_BASE_URL),
+    )
+    parser.add_argument("--desk-org-id", default=os.environ.get("ZOHO_DESK_ORG_ID"))
+    parser.add_argument(
+        "--dest-dir",
+        type=Path,
+        default=Path(os.environ["RC_VOICEMAIL_DEST_DIR"]).expanduser()
+        if os.environ.get("RC_VOICEMAIL_DEST_DIR")
+        else None,
+        help="Keep the downloaded mp3 in this directory (temporary by default)",
+    )
+    parser.add_argument(
+        "--transcriber",
+        type=Path,
+        default=Path(
+            os.environ.get(
+                "WHISPER_TRANSCRIBE_PATH",
+                str(Path(__file__).with_name("whisper_transcribe.py")),
+            )
+        ).expanduser(),
+    )
+    parser.add_argument(
+        "--ledger-root",
+        type=Path,
+        default=Path(os.environ.get("RC_VOICEMAIL_LEDGER_ROOT", os.getcwd())).expanduser(),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=DEFAULT_TIMEOUT_S,
+        help="Desk request timeout in seconds",
+    )
+    parser.add_argument(
+        "--transcribe-timeout",
+        type=_positive_float,
+        default=DEFAULT_TRANSCRIBE_TIMEOUT_S,
+        help="Whisper helper timeout in seconds",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    ticket_id = args.ticket_id
+    if not _SAFE_TICKET_RE.fullmatch(ticket_id):
+        error = TriageError("config", "ticket id contains invalid characters", EXIT_CONFIG)
+        print(
+            f"rc_voicemail_triage: stage={error.stage} ticket_id={ticket_id!r} error={error.message}",
+            file=sys.stderr,
+        )
+        return error.exit_code
+    try:
+        token = load_access_token()
+        desk = DeskClient(
+            token,
+            org_id=args.desk_org_id,
+            base_url=args.desk_base_url,
+            timeout_s=args.timeout,
+        )
+        result = triage_ticket(
+            ticket_id,
+            desk,
+            transcriber_path=args.transcriber,
+            ledger_root=args.ledger_root,
+            destination_dir=args.dest_dir,
+            transcribe_timeout_s=args.transcribe_timeout,
+        )
+    except TriageError as exc:
+        print(
+            f"rc_voicemail_triage: stage={exc.stage} ticket_id={ticket_id} error={exc.message}",
+            file=sys.stderr,
+        )
+        return exc.exit_code
+    except Exception as exc:  # Defensive CLI boundary; never emit partial success JSON.
+        print(
+            f"rc_voicemail_triage: stage=internal ticket_id={ticket_id} error={exc}",
+            file=sys.stderr,
+        )
+        return EXIT_INTERNAL
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_rc_voicemail_triage.py
+++ b/tests/test_rc_voicemail_triage.py
@@ -202,6 +202,42 @@ def test_transcriber_rejects_text_with_no_speech_true(field):
     assert caught.value.exit_code == triage.EXIT_TRANSCRIBE
 
 
+@pytest.mark.parametrize("no_speech", [None, True])
+def test_transcriber_rejects_empty_transcript_masking_nonempty_text(no_speech):
+    payload = {"transcript": "", "text": "hello"}
+    if no_speech is not None:
+        payload["no_speech"] = no_speech
+
+    with pytest.raises(triage.TriageError) as caught:
+        triage.parse_transcriber_output(json.dumps(payload))
+
+    assert caught.value.stage == "transcribe"
+    assert caught.value.exit_code == triage.EXIT_TRANSCRIBE
+
+
+def test_transcriber_rejects_disagreeing_nonempty_text_aliases():
+    with pytest.raises(triage.TriageError) as caught:
+        triage.parse_transcriber_output('{"transcript":"hello", "text":"goodbye"}')
+
+    assert caught.value.stage == "transcribe"
+    assert caught.value.exit_code == triage.EXIT_TRANSCRIBE
+
+
+def test_transcriber_validates_every_present_text_alias():
+    with pytest.raises(triage.TriageError) as caught:
+        triage.parse_transcriber_output('{"transcript":"hello", "text":7}')
+
+    assert caught.value.stage == "transcribe"
+    assert caught.value.exit_code == triage.EXIT_TRANSCRIBE
+
+
+def test_transcriber_accepts_matching_text_aliases():
+    assert triage.parse_transcriber_output('{"transcript":"hello", "text":" hello "}') == (
+        "hello",
+        False,
+    )
+
+
 def test_transcriber_invocation_is_promptless_and_scrubs_prompt_env(tmp_path, monkeypatch):
     audio = tmp_path / "message.mp3"
     audio.write_bytes(b"audio")

--- a/tests/test_rc_voicemail_triage.py
+++ b/tests/test_rc_voicemail_triage.py
@@ -1,0 +1,508 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts" / "rc_voicemail_triage.py"
+
+SPEC = importlib.util.spec_from_file_location("rc_voicemail_triage", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+triage = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(triage)
+
+
+def test_summary_line_parses_name_digits_and_duration():
+    caller = triage.parse_summary_line(
+        "From: Main Line - Mary Smith (435) 555-1212 message Length: 00:44"
+    )
+
+    assert caller == {
+        "callerid_name": "Mary Smith",
+        "number": "4355551212",
+        "duration_s": 44,
+    }
+
+
+def test_summary_line_keeps_unavailable_fields_explicitly_null():
+    assert triage.parse_summary_line("RingCentral voicemail") == {
+        "callerid_name": None,
+        "number": None,
+        "duration_s": None,
+    }
+
+
+def test_summary_line_accepts_hour_duration_and_rejects_invalid_seconds():
+    assert (
+        triage.parse_summary_line("From: Main Line - A (801) 555-1111 Length: 1:02:03")[
+            "duration_s"
+        ]
+        == 3723
+    )
+    assert (
+        triage.parse_summary_line("From: Main Line - A (801) 555-1111 Length: 00:99")["duration_s"]
+        is None
+    )
+
+
+def test_extract_city_hint_requires_explicit_in_phrase():
+    assert triage.extract_city_hint("Subway Cafe in Tooele") == "Tooele"
+    assert triage.extract_city_hint("Mary Smith") is None
+
+
+class FakeSearchDesk:
+    def __init__(self, responses):
+        self.responses = responses
+        self.queries = []
+
+    def search_contacts(self, query):
+        self.queries.append(query)
+        return self.responses.get(query, [])
+
+
+def test_contact_resolution_uses_digits_first_and_stops_on_hit():
+    desk = FakeSearchDesk(
+        {
+            "8015550100": [
+                {
+                    "id": "contact-1",
+                    "account": {"id": "site-1", "name": "Main Street"},
+                }
+            ]
+        }
+    )
+
+    candidates = triage.resolve_site_candidates(
+        desk,
+        {"callerid_name": "Caller", "number": "8015550100", "duration_s": 12},
+    )
+
+    assert desk.queries == ["8015550100"]
+    assert candidates == [
+        {
+            "contact_id": "contact-1",
+            "account_id": "site-1",
+            "account_name": "Main Street",
+            "match_basis": "phone_exact",
+            "verified": False,
+        }
+    ]
+
+
+def test_contact_resolution_uses_formatted_phone_only_after_digits_miss():
+    desk = FakeSearchDesk(
+        {"(801) 555-0100": [{"id": "contact-2", "accountId": "site-2", "accountName": "Broadway"}]}
+    )
+
+    candidates = triage.resolve_site_candidates(
+        desk,
+        {"callerid_name": "Caller", "number": "8015550100", "duration_s": 12},
+    )
+
+    assert desk.queries == ["8015550100", "(801) 555-0100"]
+    assert candidates[0]["contact_id"] == "contact-2"
+    assert candidates[0]["match_basis"] == "phone_exact"
+
+
+def test_empty_object_contact_search_is_a_valid_miss(monkeypatch):
+    client = triage.DeskClient("token")
+    seen = {}
+
+    def fake_request(path, params):
+        seen.update({"path": path, "params": params})
+        return {}
+
+    monkeypatch.setattr(client, "_request_json", fake_request)
+
+    assert client.search_contacts("8015550100") == []
+    assert seen == {
+        "path": "search",
+        "params": {
+            "module": "contacts",
+            "searchStr": "8015550100",
+            "from": 0,
+            "limit": 50,
+        },
+    }
+
+
+def test_explicit_city_fallback_returns_list_without_auto_binding():
+    desk = FakeSearchDesk(
+        {
+            "Tooele": [
+                {"id": "c1", "city": "Tooele", "accountId": "a1", "accountName": "North"},
+                {"id": "c2", "cf": {"service_city": "Tooele"}},
+                {"id": "c3", "city": "Provo"},
+            ]
+        }
+    )
+
+    candidates = triage.resolve_site_candidates(
+        desk,
+        {
+            "callerid_name": "Subway Cafe in Tooele",
+            "number": "8015559999",
+            "duration_s": 48,
+        },
+    )
+
+    assert desk.queries == ["8015559999", "(801) 555-9999", "Tooele"]
+    assert [candidate["contact_id"] for candidate in candidates] == ["c1", "c2"]
+    assert all(candidate["match_basis"] == "city_only" for candidate in candidates)
+    assert all(candidate["verified"] is False for candidate in candidates)
+
+
+def test_multiple_accounts_remain_multiple_unverified_candidates():
+    contacts = [
+        {
+            "id": "c1",
+            "accounts": [
+                {"id": "a1", "name": "First"},
+                {"id": "a2", "name": "Second"},
+            ],
+        }
+    ]
+
+    candidates = triage._site_candidates(contacts, match_basis="phone_exact")
+
+    assert [candidate["account_id"] for candidate in candidates] == ["a1", "a2"]
+    assert all(candidate["verified"] is False for candidate in candidates)
+
+
+def test_machine_readable_no_speech_is_successful_and_explicit():
+    assert triage.parse_transcriber_output('{"transcript":"", "no_speech":true}') == (
+        "",
+        True,
+    )
+    assert triage.parse_transcriber_output('{"text":""}') == ("", True)
+    assert triage.parse_transcriber_output("[NO_SPEECH]") == ("", True)
+    assert triage.parse_transcriber_output("No speech detected.") == ("", True)
+
+
+def test_zero_exit_empty_transcript_is_valid_no_speech():
+    assert triage.parse_transcriber_output("\n") == ("", True)
+
+
+def test_transcriber_false_no_speech_without_text_is_failure():
+    with pytest.raises(triage.TriageError):
+        triage.parse_transcriber_output('{"transcript":"", "no_speech":false}')
+
+
+def test_transcriber_invocation_is_promptless_and_scrubs_prompt_env(tmp_path, monkeypatch):
+    audio = tmp_path / "message.mp3"
+    audio.write_bytes(b"audio")
+    transcriber = tmp_path / "whisper_transcribe.py"
+    transcriber.write_text("# helper")
+    seen = {}
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["prompt_keys"] = sorted(key for key in kwargs["env"] if "prompt" in key.casefold())
+        return subprocess.CompletedProcess(argv, 0, '{"text":"hello", "no_speech":false}', "")
+
+    monkeypatch.setenv("WHISPER_PROMPT", "hallucinate this")
+    monkeypatch.setenv("TRANSCRIPTION_PROMPT", "also forbidden")
+    monkeypatch.setattr(triage.subprocess, "run", fake_run)
+
+    assert triage.transcribe_audio(audio, transcriber) == ("hello", False)
+    assert seen["argv"] == [sys.executable, str(transcriber), str(audio)]
+    assert "WHISPER_PROMPT" not in seen["prompt_keys"]
+    assert "TRANSCRIPTION_PROMPT" not in seen["prompt_keys"]
+    assert all("prompt" not in arg.casefold() for arg in seen["argv"])
+
+
+def test_transcriber_crash_fails_loud(tmp_path, monkeypatch):
+    audio = tmp_path / "message.mp3"
+    audio.write_bytes(b"audio")
+    transcriber = tmp_path / "whisper_transcribe.py"
+    transcriber.write_text("# helper")
+    monkeypatch.setattr(
+        triage.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 9, "", "API failed"),
+    )
+
+    with pytest.raises(triage.TriageError) as caught:
+        triage.transcribe_audio(audio, transcriber)
+
+    assert caught.value.exit_code == triage.EXIT_TRANSCRIBE
+    assert "exited 9" in caught.value.message
+
+
+def test_fetch_chain_uses_only_notify_thread_mp3(tmp_path):
+    class FakeDesk:
+        def __init__(self):
+            self.downloaded = None
+
+        def list_threads(self, ticket_id):
+            assert ticket_id == "ticket-1"
+            return [
+                {"id": "other", "fromEmailAddress": "person@example.com"},
+                {"id": "vm", "fromEmailAddress": "notify@ringcentral.com"},
+            ]
+
+        def get_thread(self, ticket_id, thread_id):
+            assert (ticket_id, thread_id) == ("ticket-1", "vm")
+            return {
+                "id": "vm",
+                "summary": "From: Main Line - Mary (801) 555-0100 Length: 00:12",
+                "attachments": [
+                    {"id": "txt", "name": "note.txt", "href": "note"},
+                    {"id": "mp3", "name": "voice.MP3", "href": "audio"},
+                ],
+            }
+
+        def download_attachment(self, href, destination):
+            self.downloaded = (href, destination)
+            destination.write_bytes(b"audio")
+
+    desk = FakeDesk()
+    path, caller = triage.fetch_voicemail_audio(desk, "ticket-1", tmp_path)
+
+    assert desk.downloaded == ("audio", path)
+    assert path.read_bytes() == b"audio"
+    assert caller["callerid_name"] == "Mary"
+    assert caller["number"] == "8015550100"
+
+
+def test_configured_destination_does_not_overwrite_prior_download(tmp_path):
+    class FakeDesk:
+        def list_threads(self, ticket_id):
+            return [{"id": "vm", "fromEmailAddress": "notify@ringcentral.com"}]
+
+        def get_thread(self, ticket_id, thread_id):
+            return {
+                "id": "vm",
+                "summary": "From: Main Line - Mary (801) 555-0100 Length: 00:12",
+                "attachments": [{"id": "mp3", "name": "voice.mp3", "href": "audio"}],
+            }
+
+        def download_attachment(self, href, destination):
+            destination.write_bytes(b"new")
+
+    original = tmp_path / "ticket-1_vm_mp3.mp3"
+    original.write_bytes(b"keep")
+
+    downloaded, _ = triage.fetch_voicemail_audio(FakeDesk(), "ticket-1", tmp_path)
+
+    assert original.read_bytes() == b"keep"
+    assert downloaded.name == "ticket-1_vm_mp3_2.mp3"
+    assert downloaded.read_bytes() == b"new"
+
+
+def test_missing_attachment_fails_nonzero_stage():
+    class FakeDesk:
+        def list_threads(self, ticket_id):
+            return [{"id": "vm", "fromEmailAddress": "notify@ringcentral.com"}]
+
+        def get_thread(self, ticket_id, thread_id):
+            return {"id": "vm", "attachments": []}
+
+    with pytest.raises(triage.TriageError) as caught:
+        triage.fetch_voicemail_audio(FakeDesk(), "1", Path("unused"))
+
+    assert caught.value.stage == "fetch"
+    assert caught.value.exit_code == triage.EXIT_FETCH
+
+
+def test_in_flight_scans_all_required_ledgers_and_maps_ubereats(tmp_path):
+    (tmp_path / "active_rmas.jsonl").write_text('{"caller":"Mary Smith"}\n')
+    label_dir = tmp_path / "label_requests"
+    label_dir.mkdir()
+    (label_dir / "open.md").write_text("call (801) 555-0100\n")
+    (tmp_path / "active_cc.csv").write_text("site-1,chargeback\n")
+    (tmp_path / "active_jamf.txt").write_text("Main Street device\n")
+    (tmp_path / "ubereats.json").write_text('{"contact":"contact-1"}\n')
+
+    caller = {"callerid_name": "Mary Smith", "number": "8015550100", "duration_s": 12}
+    candidates = [
+        {
+            "contact_id": "contact-1",
+            "account_id": "site-1",
+            "account_name": "Main Street",
+            "match_basis": "phone_exact",
+            "verified": False,
+        }
+    ]
+
+    hits = triage.scan_in_flight(tmp_path, caller, candidates, env={})
+
+    assert {hit["ledger"] for hit in hits} == {
+        "active_rmas",
+        "label_requests",
+        "active_cc",
+        "active_jamf",
+        "integration_requests",
+    }
+    assert all(set(hit) == {"ledger", "key", "one_line"} for hit in hits)
+
+
+def test_explicit_missing_ledger_path_fails_loud(tmp_path):
+    env = {"RC_VOICEMAIL_LEDGER_ACTIVE_RMAS": str(tmp_path / "missing")}
+
+    with pytest.raises(triage.TriageError) as caught:
+        triage.scan_in_flight(
+            tmp_path,
+            {"callerid_name": "Mary", "number": None, "duration_s": 1},
+            [],
+            env=env,
+        )
+
+    assert caught.value.stage == "in_flight"
+
+
+def test_output_contract_has_exact_shape_and_list_candidates():
+    output = triage.build_output(
+        "123",
+        {"callerid_name": None, "number": None, "duration_s": 48},
+        "",
+        True,
+        [],
+        [],
+    )
+
+    assert list(output) == [
+        "ticket_id",
+        "caller",
+        "transcript",
+        "no_speech",
+        "site_candidates",
+        "in_flight",
+    ]
+    assert output == {
+        "ticket_id": "123",
+        "caller": {"callerid_name": None, "number": None, "duration_s": 48},
+        "transcript": "",
+        "no_speech": True,
+        "site_candidates": [],
+        "in_flight": [],
+    }
+
+
+def test_pipeline_smoke_combines_fetch_transcript_candidates_and_ledgers(tmp_path):
+    class FakeDesk:
+        def list_threads(self, ticket_id):
+            return [{"id": "vm", "fromEmailAddress": "notify@ringcentral.com"}]
+
+        def get_thread(self, ticket_id, thread_id):
+            return {
+                "id": "vm",
+                "summary": "From: Main Line - Mary (801) 555-0100 Length: 00:12",
+                "attachments": [{"id": "mp3", "name": "voice.mp3", "href": "audio"}],
+            }
+
+        def download_attachment(self, href, destination):
+            destination.write_bytes(b"audio")
+
+        def search_contacts(self, query):
+            if query == "8015550100":
+                return [
+                    {
+                        "id": "contact-1",
+                        "account": {"id": "site-1", "name": "Main Street"},
+                    }
+                ]
+            return []
+
+    transcriber = tmp_path / "whisper_transcribe.py"
+    transcriber.write_text('print(\'{"transcript":"Please call me", "no_speech":false}\')\n')
+    ledger_root = tmp_path / "ledgers"
+    ledger_root.mkdir()
+    (ledger_root / "active_rmas.jsonl").write_text('{"caller":"Mary"}\n')
+
+    output = triage.triage_ticket(
+        "123",
+        FakeDesk(),
+        transcriber_path=transcriber,
+        ledger_root=ledger_root,
+        destination_dir=tmp_path / "downloads",
+    )
+
+    assert output["transcript"] == "Please call me"
+    assert output["no_speech"] is False
+    assert output["site_candidates"] == [
+        {
+            "contact_id": "contact-1",
+            "account_id": "site-1",
+            "account_name": "Main Street",
+            "match_basis": "phone_exact",
+            "verified": False,
+        }
+    ]
+    assert output["in_flight"] == [
+        {
+            "ledger": "active_rmas",
+            "key": "active_rmas.jsonl:1",
+            "one_line": '{"caller":"Mary"}',
+        }
+    ]
+
+
+def test_token_source_accepts_direct_plain_file_and_json_file(tmp_path):
+    plain = tmp_path / "plain-token"
+    plain.write_text("plain-secret\n")
+    json_file = tmp_path / "token.json"
+    json_file.write_text('{"oauth": {"access_token": "json-secret"}}')
+
+    assert triage.load_access_token({"ZOHO_DESK_ACCESS_TOKEN": "direct-secret"}) == (
+        "direct-secret"
+    )
+    assert triage.load_access_token({"ZOHO_DESK_TOKEN_FILE": str(plain)}) == "plain-secret"
+    assert triage.load_access_token({"ZOHO_DESK_TOKEN_FILE": str(json_file)}) == "json-secret"
+
+
+def test_main_returns_zero_for_valid_no_speech_result(monkeypatch, capsys, tmp_path):
+    expected = triage.build_output(
+        "123",
+        {"callerid_name": None, "number": None, "duration_s": 48},
+        "",
+        True,
+        [],
+        [],
+    )
+    monkeypatch.setattr(triage, "load_access_token", lambda: "token")
+    monkeypatch.setattr(triage, "triage_ticket", lambda *args, **kwargs: expected)
+
+    return_code = triage.main(
+        [
+            "123",
+            "--transcriber",
+            str(tmp_path / "whisper_transcribe.py"),
+            "--ledger-root",
+            str(tmp_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert return_code == 0
+    assert captured.err == ""
+    assert json.loads(captured.out) == expected
+
+
+def test_main_failure_is_nonzero_and_self_describing(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(triage, "load_access_token", lambda: "token")
+
+    def fail(*args, **kwargs):
+        raise triage.TriageError("transcribe", "helper crashed", triage.EXIT_TRANSCRIBE)
+
+    monkeypatch.setattr(triage, "triage_ticket", fail)
+
+    return_code = triage.main(
+        [
+            "123",
+            "--transcriber",
+            str(tmp_path / "whisper_transcribe.py"),
+            "--ledger-root",
+            str(tmp_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert return_code == triage.EXIT_TRANSCRIBE
+    assert captured.out == ""
+    assert "stage=transcribe" in captured.err
+    assert "ticket_id=123" in captured.err
+    assert "helper crashed" in captured.err

--- a/tests/test_rc_voicemail_triage.py
+++ b/tests/test_rc_voicemail_triage.py
@@ -191,6 +191,17 @@ def test_transcriber_false_no_speech_without_text_is_failure():
         triage.parse_transcriber_output('{"transcript":"", "no_speech":false}')
 
 
+@pytest.mark.parametrize("field", ["transcript", "text"])
+def test_transcriber_rejects_text_with_no_speech_true(field):
+    payload = json.dumps({field: "hello", "no_speech": True})
+
+    with pytest.raises(triage.TriageError) as caught:
+        triage.parse_transcriber_output(payload)
+
+    assert caught.value.stage == "transcribe"
+    assert caught.value.exit_code == triage.EXIT_TRANSCRIBE
+
+
 def test_transcriber_invocation_is_promptless_and_scrubs_prompt_env(tmp_path, monkeypatch):
     audio = tmp_path / "message.mp3"
     audio.write_bytes(b"audio")
@@ -354,6 +365,61 @@ def test_explicit_missing_ledger_path_fails_loud(tmp_path):
     assert caught.value.stage == "in_flight"
 
 
+def _create_empty_required_ledgers(root, *, missing=None):
+    filenames = {
+        "active_rmas": "active_rmas.jsonl",
+        "label_requests": "label_requests.jsonl",
+        "active_cc": "active_cc.jsonl",
+        "active_jamf": "active_jamf.jsonl",
+        "integration_requests": "ubereats.jsonl",
+    }
+    for canonical, filename in filenames.items():
+        if canonical != missing:
+            (root / filename).write_text("")
+
+
+def test_empty_ledger_root_fails_loud(tmp_path):
+    with pytest.raises(triage.TriageError) as caught:
+        triage.scan_in_flight(
+            tmp_path,
+            {"callerid_name": "Mary", "number": "8015550100", "duration_s": 1},
+            [],
+            env={},
+        )
+
+    assert caught.value.stage == "in_flight"
+    assert "active_rmas" in caught.value.message
+
+
+def test_one_missing_canonical_ledger_fails_loud(tmp_path):
+    _create_empty_required_ledgers(tmp_path, missing="active_jamf")
+
+    with pytest.raises(triage.TriageError) as caught:
+        triage.scan_in_flight(
+            tmp_path,
+            {"callerid_name": "Mary", "number": "8015550100", "duration_s": 1},
+            [],
+            env={},
+        )
+
+    assert caught.value.stage == "in_flight"
+    assert "active_jamf" in caught.value.message
+
+
+def test_present_but_empty_ledgers_succeed(tmp_path):
+    _create_empty_required_ledgers(tmp_path)
+
+    assert (
+        triage.scan_in_flight(
+            tmp_path,
+            {"callerid_name": "Mary", "number": "8015550100", "duration_s": 1},
+            [],
+            env={},
+        )
+        == []
+    )
+
+
 def test_output_contract_has_exact_shape_and_list_candidates():
     output = triage.build_output(
         "123",
@@ -412,6 +478,8 @@ def test_pipeline_smoke_combines_fetch_transcript_candidates_and_ledgers(tmp_pat
     ledger_root = tmp_path / "ledgers"
     ledger_root.mkdir()
     (ledger_root / "active_rmas.jsonl").write_text('{"caller":"Mary"}\n')
+    for filename in ("label_requests", "active_cc", "active_jamf", "ubereats"):
+        (ledger_root / f"{filename}.jsonl").write_text("")
 
     output = triage.triage_ticket(
         "123",
@@ -506,3 +574,25 @@ def test_main_failure_is_nonzero_and_self_describing(monkeypatch, capsys, tmp_pa
     assert "stage=transcribe" in captured.err
     assert "ticket_id=123" in captured.err
     assert "helper crashed" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("arguments", "ticket_fragment"),
+    [
+        (["123", "--timeout", "nope"], "ticket_id=123"),
+        (["--timeout", "nope"], "ticket_id=''"),
+    ],
+)
+def test_cli_argparse_failures_are_self_describing(arguments, ticket_fragment):
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == triage.EXIT_CONFIG
+    assert completed.stdout == ""
+    assert "stage=config" in completed.stderr
+    assert ticket_fragment in completed.stderr
+    assert "usage:" not in completed.stderr


### PR DESCRIPTION
## What changed

- Add `scripts/rc_voicemail_triage.py`, a standalone, read-only CLI that accepts a Zoho Desk ticket ID and emits the exact #549 JSON contract.
- Fetch the voicemail through Desk ticket threads and the `notify@ringcentral.com` thread attachment; no RingCentral credentials or API calls are used.
- Invoke the external `whisper_transcribe.py` helper at one promptless subprocess boundary and distinguish successful no-speech output from nonzero transcriber failure.
- Resolve contacts with digits-first then formatted-phone Desk search, preserve all candidates as an unverified list, and use an explicit `in <city>` hint only for `city_only` fallback candidates.
- Search all required read-only ledgers: `active_rmas`, `label_requests`, `active_cc`, `active_jamf`, and `integration_requests` (including the `ubereats` alias).
- Add focused tests for parsing, Desk misses, candidate behavior, no-speech/failure semantics, attachment fetches, all ledgers, output shape, and an end-to-end fake-source smoke.

## Why

Geordi needs a deterministic first-pass instrument for RingCentral voicemail tickets without introducing RingCentral credentials, automated binding, or any ticket/ledger writes. Silent audio must not hallucinate a transcript, and empty candidate or ledger results must remain valid findings while genuine fetch/auth/transcriber gaps fail loudly.

## Safety and operator impact

- Reporting only: no Desk writes, no ledger writes, no callback automation, and no site auto-binding.
- Desk credentials are environment/token-file driven; no credential is accepted on the command line or hardcoded.
- The downloaded MP3 is temporary by default and a configured destination never overwrites a prior download.
- `site_candidates` is always a list and every emitted candidate remains `verified: false`.
- A zero-exit empty transcript is emitted as `no_speech: true`; a nonzero helper exit produces no JSON and a stage-qualified error on stderr.

## Validation

- `24 passed` on Python 3.11
- `24 passed` on Python 3.13
- `uv run ruff check .`
- `uv run ruff format --check scripts/rc_voicemail_triage.py tests/test_rc_voicemail_triage.py`
- `python3 -m compileall -q scripts tests`
- `git diff --check`
- Broad repository run: `4795 passed, 4 skipped, 4 failed`. The four failures are unrelated ambient/baseline cases: the known manual-dream mock escaped to real tmux while live port 8890 was occupied; the inherited unmapped-path 404/401 expectation; and two container-credential tests under the currently enabled static OAuth forwarding environment. The latter two pass when both `CLAUDE_CODE_OAUTH_TOKEN` and `PINKY_FORWARD_OAUTH_TOKEN` are removed.

## Install boundary

Geordi still confirms the Pi path and invocation shape of its existing `whisper_transcribe.py`, the Desk token-file environment, and ledger locations during install, then smoke-tests the four live voicemail payoff cases. Those details are isolated behind the CLI's environment/argument seams.

🤖 Opened by Kuzya
