### PR TITLE
Fix live RingCentral sender matching in RC voicemail triage (#549 r2)

### DIFF
--- a/scripts/rc_voicemail_triage.py
+++ b/scripts/rc_voicemail_triage.py
@@ -23,6 +23,16 @@ Common install-time environment:
 Each ledger can also be pinned independently with
 ``RC_VOICEMAIL_LEDGER_<NAME>`` where NAME is ACTIVE_RMAS, LABEL_REQUESTS,
 ACTIVE_CC, ACTIVE_JAMF, or INTEGRATION_REQUESTS.
+
+Install step: pin ledger dirs if they aren't under the defaults, for example::
+
+    RC_VOICEMAIL_LEDGER_ACTIVE_RMAS=/absolute/path/to/active_rmas
+    RC_VOICEMAIL_LEDGER_LABEL_REQUESTS=/absolute/path/to/label_requests
+    RC_VOICEMAIL_LEDGER_ACTIVE_CC=/absolute/path/to/active_cc
+    RC_VOICEMAIL_LEDGER_ACTIVE_JAMF=/absolute/path/to/active_jamf
+    RC_VOICEMAIL_LEDGER_INTEGRATION_REQUESTS=/absolute/path/to/integration_requests
+
+Each override may point to a ledger file or a directory containing ledger files.
 """
 
 from __future__ import annotations
@@ -38,6 +48,7 @@ import sys
 import tempfile
 import time
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from email.utils import parseaddr
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -556,12 +567,12 @@ def _thread_sender(thread: Mapping[str, Any]) -> str | None:
     for key in ("fromEmailAddress", "from", "replyTo"):
         value = thread.get(key)
         if isinstance(value, str) and "@" in value:
-            return value.strip().casefold()
+            return parseaddr(value)[1].casefold()
     author = thread.get("author")
     if isinstance(author, dict):
         value = author.get("email")
         if isinstance(value, str):
-            return value.strip().casefold()
+            return parseaddr(value)[1].casefold()
     return None
 
 

--- a/tests/test_rc_voicemail_triage.py
+++ b/tests/test_rc_voicemail_triage.py
@@ -469,6 +469,48 @@ def test_fetch_chain_uses_only_notify_thread_mp3(tmp_path):
     assert caller["number"] == "8015550100"
 
 
+@pytest.mark.parametrize(
+    "sender",
+    [
+        pytest.param('"RingCentral"<notify@ringcentral.com>', id="live-wrapped"),
+        pytest.param(
+            '"Voicemail Notification" <notify@ringcentral.com>',
+            id="different-display-name",
+        ),
+        pytest.param(
+            '  "RingCentral" <notify@ringcentral.com>  ',
+            id="surrounding-whitespace",
+        ),
+    ],
+)
+def test_fetch_chain_accepts_display_name_wrapped_notify_sender(tmp_path, sender):
+    class FakeDesk:
+        def __init__(self):
+            self.downloaded = None
+
+        def list_threads(self, ticket_id):
+            return [{"id": "vm", "fromEmailAddress": sender}]
+
+        def get_thread(self, ticket_id, thread_id):
+            return {
+                "id": "vm",
+                "summary": "From: Main Line - Mary (801) 555-0100 Length: 00:12",
+                "attachments": [{"id": "mp3", "name": "voice.mp3", "href": "audio"}],
+            }
+
+        def download_attachment(self, href, destination, **ids):
+            self.downloaded = (href, destination)
+            destination.write_bytes(b"audio")
+
+    desk = FakeDesk()
+
+    path, caller = triage.fetch_voicemail_audio(desk, "ticket-1", tmp_path)
+
+    assert desk.downloaded == ("audio", path)
+    assert path.read_bytes() == b"audio"
+    assert caller["number"] == "8015550100"
+
+
 def _gateway_fetch_client(listed_summary):
     listed_thread = {
         "id": "vm",


### PR DESCRIPTION
## What
Fixes a merge-blocking bug in `scripts/rc_voicemail_triage.py` (follow-up to #1036) that geordi's live gateway re-smoke exposed: `_thread_sender` matched the RingCentral sender by bare-string equality, but real Zoho Desk serves `fromEmailAddress` display-name-wrapped — `"RingCentral"<notify@ringcentral.com>` — so every ticket exited 3 at stage=fetch ("no RingCentral thread mp3 attachment found"). Also documents the ledger-pin install recipe.

## Why it wasn't caught pre-merge
#1036's unit fixtures used bare addresses; only geordi's live smoke against real Desk data exposed the display-name-wrapping. The live-smoke gate is exactly what kept #549 open until this surfaced.

## Changes
- `_thread_sender`: both return sites now use `parseaddr(value)[1].casefold()` — extracts the address from bare **and** wrapped forms; the `"@"` guard is preserved. Geordi validated this fix live (all 4 tickets → exit 0, full chain incl. binary `/content` download + promptless transcribe).
- Docstring: documents the 5 `RC_VOICEMAIL_LEDGER_*` override pins (file-or-directory) as an install step. Defaults unchanged.

## Review + verification
- Built by **Kuzya**, adversarially reviewed by **Murzik** (fresh-worktree gate: 8 positive sender shapes + 6 malformed negatives all → `EXIT_FETCH`; AST-confirmed auth/signing/mode/resolution byte-identical to 568b542), verified + merged by **Barsik**.
- Focused tests **54/54** on Python 3.11/3.12/3.13; ruff / format / compileall / diff-check clean.

## Follow-up
r3 (resolver quality — CRM phone-route `/crm/Contacts/search?phone=` + city-hint rescope) tracked in `scripts/geordi-rc-voicemail-549-spec.md` §8. **#549 stays open** pending geordi's live re-smoke of this fix.

🤖 Opened by Barsik
