### PR TITLE
RC voicemail triage r3: CRM phone-resolve, transcript city hints, exact-file ledgers, display-ticket resolve (#549)

### DIFF
--- a/scripts/rc_voicemail_triage.py
+++ b/scripts/rc_voicemail_triage.py
@@ -32,7 +32,11 @@ Install step: pin ledger dirs if they aren't under the defaults, for example::
     RC_VOICEMAIL_LEDGER_ACTIVE_JAMF=/absolute/path/to/active_jamf
     RC_VOICEMAIL_LEDGER_INTEGRATION_REQUESTS=/absolute/path/to/integration_requests
 
-Each override may point to a ledger file or a directory containing ledger files.
+Each override may point to a ledger file or a directory; a directory pin resolves
+to exactly ``<name>.json`` and never scans siblings or backups. Without overrides,
+the exact paths below ``RC_VOICEMAIL_LEDGER_ROOT`` are ``rma/active_rmas.json``,
+``rma/label_requests.json``, ``cc_creds/active_cc.json``,
+``jamf/active_jamf.json``, and ``ubereats/integration_requests.json``.
 """
 
 from __future__ import annotations
@@ -47,7 +51,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from email.utils import parseaddr
 from pathlib import Path
 from typing import Any
@@ -70,15 +74,13 @@ EXIT_RESOLVE = 5
 EXIT_IN_FLIGHT = 6
 EXIT_INTERNAL = 70
 
-LEDGER_ALIASES: dict[str, tuple[str, ...]] = {
-    "active_rmas": ("active_rmas",),
-    "label_requests": ("label_requests",),
-    "active_cc": ("active_cc",),
-    "active_jamf": ("active_jamf",),
-    "integration_requests": ("integration_requests", "ubereats"),
+LEDGER_DEFAULT_PATHS: dict[str, Path] = {
+    "active_rmas": Path("rma/active_rmas.json"),
+    "label_requests": Path("rma/label_requests.json"),
+    "active_cc": Path("cc_creds/active_cc.json"),
+    "active_jamf": Path("jamf/active_jamf.json"),
+    "integration_requests": Path("ubereats/integration_requests.json"),
 }
-LEDGER_SUFFIXES = ("", ".json", ".jsonl", ".csv", ".txt", ".md", ".yaml", ".yml")
-LEDGER_SUBDIRS = ("", "data", "ledgers", "state")
 NO_SPEECH_MARKERS = {
     "no speech",
     "no_speech",
@@ -95,6 +97,11 @@ NO_SPEECH_MARKERS = {
 _PHONE_RE = re.compile(r"(?<!\d)(?:\+?1[\s.\-]*)?\(?\d{3}\)?[\s.\-]*\d{3}[\s.\-]*\d{4}(?!\d)")
 _DURATION_RE = re.compile(r"\bLength:\s*(\d{1,3}):(\d{2})(?::(\d{2}))?\b", re.I)
 _CITY_HINT_RE = re.compile(r"\bin\s+([A-Za-z][A-Za-z .'-]{1,60})\s*$", re.I)
+_TRANSCRIPT_SEGMENT_RE = re.compile(
+    r"[\r\n.!?;:,]+|\s+\b(?:about|and|because|but|for|regarding|so|with)\b\s+",
+    re.I,
+)
+_DISPLAY_TICKET_NUMBER_RE = re.compile(r"^\d{1,10}$")
 _SAFE_TICKET_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _SAFE_GATEWAY_HOST_RE = re.compile(r"^[A-Za-z0-9.-]+$")
 
@@ -427,10 +434,17 @@ class DeskClient:
             url = f"{url}?{urlencode(params)}"
         return url
 
-    def _request_json(self, path: str, params: Mapping[str, object] | None = None) -> object:
+    def _request_json(
+        self,
+        path: str,
+        params: Mapping[str, object] | None = None,
+        *,
+        base_urls: Sequence[str] | None = None,
+    ) -> object:
         transport_errors: list[str] = []
         body: bytes | None = None
-        for base_url in self.base_urls:
+        request_base_urls = self.base_urls if base_urls is None else base_urls
+        for base_url in request_base_urls:
             url = self._url(base_url, path, params)
             path_without_query = urlparse(url).path
             request = Request(
@@ -483,6 +497,33 @@ class DeskClient:
             raise DeskAPIError("thread detail response is not an object")
         return payload
 
+    def resolve_ticket_id(self, ticket_id: str) -> str:
+        """Resolve a gateway display number while passing internal ids through."""
+
+        if self.mode != "gateway" or not _DISPLAY_TICKET_NUMBER_RE.fullmatch(ticket_id):
+            return ticket_id
+        payload = self._request_json(
+            "tickets/resolve",
+            {"ticket_number": ticket_id},
+        )
+        if not isinstance(payload, dict):
+            raise DeskAPIError("ticket resolve response is not an object")
+        returned_number = payload.get("ticketNumber")
+        if (
+            not isinstance(returned_number, (str, int))
+            or isinstance(returned_number, bool)
+            or str(returned_number).strip() != ticket_id
+        ):
+            raise DeskAPIError("ticket resolve response does not match the requested number")
+        internal_id = payload.get("id")
+        if (
+            not isinstance(internal_id, (str, int))
+            or isinstance(internal_id, bool)
+            or not str(internal_id).strip()
+        ):
+            raise DeskAPIError("ticket resolve response is missing its internal id")
+        return str(internal_id).strip()
+
     def search_contacts(self, query: str) -> list[dict[str, Any]]:
         if self.mode == "gateway":
             params = {"module": "contacts", "q": query}
@@ -495,6 +536,26 @@ class DeskClient:
             params,
         )
         return _collection(payload, context="contact search")
+
+    def search_crm_phone(self, module: str, digits: str) -> list[dict[str, Any]]:
+        """Search a gateway CRM module by normalized phone digits."""
+
+        if self.mode != "gateway" or module not in {"Contacts", "Accounts"}:
+            raise DeskAPIError("CRM phone search requires a supported gateway module")
+        crm_base_urls = tuple(urljoin(base_url, "/crm/") for base_url in self.base_urls)
+        payload = self._request_json(
+            f"{module}/search",
+            {"phone": digits},
+            base_urls=crm_base_urls,
+        )
+        if not isinstance(payload, dict):
+            raise DeskAPIError(f"CRM {module} search response is not an object")
+        rows = payload.get("data", [])
+        if not isinstance(rows, list):
+            raise DeskAPIError(f"CRM {module} search response data is not a list")
+        if any(not isinstance(row, dict) for row in rows):
+            raise DeskAPIError(f"CRM {module} search response contains a non-object record")
+        return rows
 
     def download_attachment(
         self,
@@ -841,34 +902,102 @@ def _site_candidates(
     return candidates
 
 
+def _optional_string(value: object) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _crm_contact_candidates(
+    contacts: Sequence[Mapping[str, Any]],
+) -> list[dict[str, str | bool | None]]:
+    candidates: list[dict[str, str | bool | None]] = []
+    for contact in contacts:
+        account = contact.get("Account_Name")
+        if not isinstance(account, dict):
+            account = {}
+        candidates.append(
+            {
+                "contact_id": _optional_string(contact.get("id")),
+                "account_id": _optional_string(account.get("id")),
+                "account_name": _optional_string(account.get("name")),
+                "match_basis": "phone_exact",
+                "verified": False,
+            }
+        )
+    return candidates
+
+
+def _crm_account_candidates(
+    accounts: Sequence[Mapping[str, Any]],
+) -> list[dict[str, str | bool | None]]:
+    return [
+        {
+            "contact_id": None,
+            "account_id": _optional_string(account.get("id")),
+            "account_name": _optional_string(account.get("name")),
+            "match_basis": "account_phone",
+            "verified": False,
+        }
+        for account in accounts
+    ]
+
+
+def _city_hints(callerid_name: object, transcript: object) -> list[str]:
+    cities: list[str] = []
+    seen: set[str] = set()
+    sources = [callerid_name]
+    if isinstance(transcript, str):
+        sources.extend(_TRANSCRIPT_SEGMENT_RE.split(transcript))
+    for source in sources:
+        city = extract_city_hint(source)
+        if city is None or city.casefold() in seen:
+            continue
+        seen.add(city.casefold())
+        cities.append(city)
+    return cities
+
+
 def resolve_site_candidates(
     desk: DeskClient,
     caller: Mapping[str, str | int | None],
+    transcript: str = "",
 ) -> list[dict[str, str | bool | None]]:
-    """Search digits first, then formatted phone, then an explicit city hint."""
+    """Resolve phone first, then union explicit CNAM and transcript city hints."""
 
     try:
         number = caller.get("number")
         digits = digits_only(number)
         if digits:
-            contacts = desk.search_contacts(digits)
-            if contacts:
-                return _site_candidates(contacts, match_basis="phone_exact")
-            formatted = format_phone(digits)
-            if formatted and formatted != digits:
-                contacts = desk.search_contacts(formatted)
+            if desk.mode == "gateway":
+                contacts = desk.search_crm_phone("Contacts", digits)
+                if contacts:
+                    return _crm_contact_candidates(contacts)
+                accounts = desk.search_crm_phone("Accounts", digits)
+                if accounts:
+                    return _crm_account_candidates(accounts)
+            else:
+                contacts = desk.search_contacts(digits)
                 if contacts:
                     return _site_candidates(contacts, match_basis="phone_exact")
+                formatted = format_phone(digits)
+                if formatted and formatted != digits:
+                    contacts = desk.search_contacts(formatted)
+                    if contacts:
+                        return _site_candidates(contacts, match_basis="phone_exact")
 
-        city = extract_city_hint(caller.get("callerid_name"))
-        if city:
+        candidates: list[dict[str, str | bool | None]] = []
+        seen_candidates: set[tuple[str | bool | None, ...]] = set()
+        for city in _city_hints(caller.get("callerid_name"), transcript):
             contacts = desk.search_contacts(city)
             city_key = city.casefold()
             city_contacts = [
                 contact for contact in contacts if city_key in _contact_city_values(contact)
             ]
-            return _site_candidates(city_contacts, match_basis="city_only")
-        return []
+            for candidate in _site_candidates(city_contacts, match_basis="city_only"):
+                key = tuple(candidate.values())
+                if key not in seen_candidates:
+                    seen_candidates.add(key)
+                    candidates.append(candidate)
+        return candidates
     except DeskAPIError as exc:
         raise TriageError("resolve", str(exc), EXIT_RESOLVE) from exc
 
@@ -876,7 +1005,7 @@ def resolve_site_candidates(
 def _configured_ledger_paths(
     ledger_root: Path,
     env: Mapping[str, str] | None = None,
-) -> dict[str, list[Path]]:
+) -> dict[str, Path]:
     values = os.environ if env is None else env
     if not ledger_root.is_dir():
         raise TriageError(
@@ -884,79 +1013,50 @@ def _configured_ledger_paths(
             f"ledger root is not a directory: {ledger_root}",
             EXIT_IN_FLIGHT,
         )
-    configured: dict[str, list[Path]] = {}
-    for canonical, aliases in LEDGER_ALIASES.items():
+    configured: dict[str, Path] = {}
+    for canonical, relative_path in LEDGER_DEFAULT_PATHS.items():
         env_key = f"RC_VOICEMAIL_LEDGER_{canonical.upper()}"
         explicit = values.get(env_key, "").strip()
         if explicit:
             path = Path(explicit).expanduser()
+            if path.is_dir():
+                path = path / f"{canonical}.json"
             if not path.exists():
                 raise TriageError(
                     "in_flight",
                     f"configured ledger does not exist: {path}",
                     EXIT_IN_FLIGHT,
                 )
-            if not _readable_ledger_source(path):
+            if not _readable_ledger_file(path):
                 raise TriageError(
                     "in_flight",
                     f"configured ledger is not readable: {path}",
                     EXIT_IN_FLIGHT,
                 )
-            configured[canonical] = [path]
+            configured[canonical] = path
             continue
 
-        paths: list[Path] = []
-        for subdir in LEDGER_SUBDIRS:
-            parent = ledger_root / subdir if subdir else ledger_root
-            for alias in aliases:
-                for suffix in LEDGER_SUFFIXES:
-                    path = parent / f"{alias}{suffix}"
-                    if _readable_ledger_source(path) and path not in paths:
-                        paths.append(path)
-        if not paths:
-            aliases_text = " or ".join(aliases)
+        path = ledger_root / relative_path
+        if not _readable_ledger_file(path):
             raise TriageError(
                 "in_flight",
-                f"required ledger is missing or unreadable: {canonical} ({aliases_text})",
+                f"required ledger is missing or unreadable: {canonical} ({path})",
                 EXIT_IN_FLIGHT,
             )
-        configured[canonical] = paths
+        configured[canonical] = path
     return configured
 
 
-def _readable_ledger_source(path: Path) -> bool:
+def _readable_ledger_file(path: Path) -> bool:
     if path.is_symlink():
         return False
     try:
         if path.is_file():
             with path.open("rb"):
                 return True
-        if path.is_dir():
-            with os.scandir(path) as entries:
-                next(entries, None)
-            return True
     except OSError:
         return False
     return False
-
-
-def _ledger_files(paths: Iterable[Path]) -> Iterable[Path]:
-    seen: set[Path] = set()
-    for path in paths:
-        if path.is_symlink():
-            continue
-        if path.is_file():
-            resolved = path.resolve()
-            if resolved not in seen:
-                seen.add(resolved)
-                yield path
-        elif path.is_dir():
-            for child in sorted(path.rglob("*")):
-                if child.is_file() and not child.is_symlink():
-                    resolved = child.resolve()
-                    if resolved not in seen:
-                        seen.add(resolved)
-                        yield child
 
 
 def _search_terms(
@@ -992,29 +1092,28 @@ def scan_in_flight(
         return []
     matches: list[dict[str, str]] = []
     try:
-        for ledger, paths in paths_by_ledger.items():
-            for path in _ledger_files(paths):
-                with path.open(encoding="utf-8", errors="replace") as handle:
-                    for line_number, raw_line in enumerate(handle, start=1):
-                        one_line = raw_line.rstrip("\r\n")
-                        folded = one_line.casefold()
-                        normalized_digits = digits_only(one_line)
-                        if not (
-                            any(term in folded for term in text_terms)
-                            or any(term in normalized_digits for term in digit_terms)
-                        ):
-                            continue
-                        try:
-                            key_path = path.resolve().relative_to(ledger_root.resolve())
-                        except ValueError:
-                            key_path = path
-                        matches.append(
-                            {
-                                "ledger": ledger,
-                                "key": f"{key_path}:{line_number}",
-                                "one_line": one_line,
-                            }
-                        )
+        for ledger, path in paths_by_ledger.items():
+            with path.open(encoding="utf-8", errors="replace") as handle:
+                for line_number, raw_line in enumerate(handle, start=1):
+                    one_line = raw_line.rstrip("\r\n")
+                    folded = one_line.casefold()
+                    normalized_digits = digits_only(one_line)
+                    if not (
+                        any(term in folded for term in text_terms)
+                        or any(term in normalized_digits for term in digit_terms)
+                    ):
+                        continue
+                    try:
+                        key_path = path.resolve().relative_to(ledger_root.resolve())
+                    except ValueError:
+                        key_path = path
+                    matches.append(
+                        {
+                            "ledger": ledger,
+                            "key": f"{key_path}:{line_number}",
+                            "one_line": one_line,
+                        }
+                    )
     except OSError as exc:
         raise TriageError("in_flight", f"cannot read ledger: {exc}", EXIT_IN_FLIGHT) from exc
     return matches
@@ -1080,13 +1179,17 @@ def _triage_in_directory(
     destination_dir: Path,
     transcribe_timeout_s: float,
 ) -> dict[str, object]:
-    audio_path, caller = fetch_voicemail_audio(desk, ticket_id, destination_dir)
+    try:
+        internal_ticket_id = desk.resolve_ticket_id(ticket_id)
+    except DeskAPIError as exc:
+        raise TriageError("fetch", str(exc), EXIT_FETCH) from exc
+    audio_path, caller = fetch_voicemail_audio(desk, internal_ticket_id, destination_dir)
     transcript, no_speech = transcribe_audio(
         audio_path,
         transcriber_path,
         timeout_s=transcribe_timeout_s,
     )
-    site_candidates = resolve_site_candidates(desk, caller)
+    site_candidates = resolve_site_candidates(desk, caller, transcript)
     in_flight = scan_in_flight(ledger_root, caller, site_candidates)
     return build_output(ticket_id, caller, transcript, no_speech, site_candidates, in_flight)
 

--- a/scripts/rc_voicemail_triage.py
+++ b/scripts/rc_voicemail_triage.py
@@ -98,9 +98,12 @@ _PHONE_RE = re.compile(r"(?<!\d)(?:\+?1[\s.\-]*)?\(?\d{3}\)?[\s.\-]*\d{3}[\s.\-]
 _DURATION_RE = re.compile(r"\bLength:\s*(\d{1,3}):(\d{2})(?::(\d{2}))?\b", re.I)
 _CITY_HINT_RE = re.compile(r"\bin\s+([A-Za-z][A-Za-z .'-]{1,60})\s*$", re.I)
 _TRANSCRIPT_SEGMENT_RE = re.compile(
-    r"[\r\n.!?;:,]+|\s+\b(?:about|and|because|but|for|regarding|so|with)\b\s+",
+    r"(?<=\b[A-Z]\.\b[A-Z]\.)(?=\s+[A-Z])|[\r\n!?;:,]+|"
+    r"(?<!\bSt)(?<!\bMt)(?<!\bFt)(?<!\b[A-Z]\.\b[A-Z])\.(?![A-Z]\.)|"
+    r"\s+\b(?:about|and|because|but|for|regarding|so|with)\b\s+",
     re.I,
 )
+_DOTTED_INITIALISM_RE = re.compile(r"(?:\b[A-Za-z]\.){2,}$")
 _DISPLAY_TICKET_NUMBER_RE = re.compile(r"^\d{1,10}$")
 _SAFE_TICKET_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _SAFE_GATEWAY_HOST_RE = re.compile(r"^[A-Za-z0-9.-]+$")
@@ -200,7 +203,9 @@ def extract_city_hint(callerid_name: object) -> str | None:
     match = _CITY_HINT_RE.search(callerid_name.strip())
     if not match:
         return None
-    city = match.group(1).strip(" ,.-")
+    city = match.group(1).strip(" ,-")
+    if not _DOTTED_INITIALISM_RE.search(city):
+        city = city.rstrip(".")
     return city or None
 
 
@@ -548,9 +553,13 @@ class DeskClient:
             {"phone": digits},
             base_urls=crm_base_urls,
         )
+        if payload == {}:
+            return []
         if not isinstance(payload, dict):
             raise DeskAPIError(f"CRM {module} search response is not an object")
-        rows = payload.get("data", [])
+        if "data" not in payload:
+            raise DeskAPIError(f"CRM {module} search response has no data field")
+        rows = payload["data"]
         if not isinstance(rows, list):
             raise DeskAPIError(f"CRM {module} search response data is not a list")
         if any(not isinstance(row, dict) for row in rows):
@@ -906,6 +915,13 @@ def _optional_string(value: object) -> str | None:
     return str(value) if value is not None else None
 
 
+def _required_crm_id(record: Mapping[str, Any], *, module: str) -> str:
+    value = record.get("id")
+    if value is None or isinstance(value, bool) or not str(value).strip():
+        raise DeskAPIError(f"CRM {module} search result is missing its id")
+    return str(value).strip()
+
+
 def _crm_contact_candidates(
     contacts: Sequence[Mapping[str, Any]],
 ) -> list[dict[str, str | bool | None]]:
@@ -916,7 +932,7 @@ def _crm_contact_candidates(
             account = {}
         candidates.append(
             {
-                "contact_id": _optional_string(contact.get("id")),
+                "contact_id": _required_crm_id(contact, module="Contacts"),
                 "account_id": _optional_string(account.get("id")),
                 "account_name": _optional_string(account.get("name")),
                 "match_basis": "phone_exact",
@@ -929,27 +945,34 @@ def _crm_contact_candidates(
 def _crm_account_candidates(
     accounts: Sequence[Mapping[str, Any]],
 ) -> list[dict[str, str | bool | None]]:
-    return [
-        {
-            "contact_id": None,
-            "account_id": _optional_string(account.get("id")),
-            "account_name": _optional_string(account.get("name")),
-            "match_basis": "account_phone",
-            "verified": False,
-        }
-        for account in accounts
-    ]
+    candidates: list[dict[str, str | bool | None]] = []
+    for account in accounts:
+        candidates.append(
+            {
+                "contact_id": None,
+                "account_id": _required_crm_id(account, module="Accounts"),
+                "account_name": _optional_string(account.get("name")),
+                "match_basis": "account_phone",
+                "verified": False,
+            }
+        )
+    return candidates
 
 
 def _city_hints(callerid_name: object, transcript: object) -> list[str]:
     cities: list[str] = []
     seen: set[str] = set()
-    sources = [callerid_name]
+    sources = [(callerid_name, False)]
     if isinstance(transcript, str):
-        sources.extend(_TRANSCRIPT_SEGMENT_RE.split(transcript))
-    for source in sources:
+        sources.extend((segment, True) for segment in _TRANSCRIPT_SEGMENT_RE.split(transcript))
+    for source, from_transcript in sources:
         city = extract_city_hint(source)
-        if city is None or city.casefold() in seen:
+        if city is None:
+            continue
+        first_token = city.split(maxsplit=1)[0]
+        if from_transcript and not first_token[0].isupper():
+            continue
+        if city.casefold() in seen:
             continue
         seen.add(city.casefold())
         cities.append(city)
@@ -1072,6 +1095,8 @@ def _search_terms(
     if number:
         digit_terms.add(number)
     for candidate in site_candidates:
+        if candidate.get("match_basis") not in {"phone_exact", "account_phone"}:
+            continue
         for key in ("account_id", "account_name", "contact_id"):
             value = candidate.get(key)
             if value is not None and len(str(value).strip()) >= 3:

--- a/tests/test_rc_voicemail_triage.py
+++ b/tests/test_rc_voicemail_triage.py
@@ -196,7 +196,6 @@ def test_gateway_phone_resolve_uses_crm_digits_and_maps_nullable_account(monkeyp
                             "Account_Name": {"id": 456, "name": "Sourdough & Co - Monrovia"},
                         },
                         {"id": "contact-without-account", "Account_Name": None},
-                        {},
                     ]
                 }
             ).encode()
@@ -242,13 +241,6 @@ def test_gateway_phone_resolve_uses_crm_digits_and_maps_nullable_account(monkeyp
             "match_basis": "phone_exact",
             "verified": False,
         },
-        {
-            "contact_id": None,
-            "account_id": None,
-            "account_name": None,
-            "match_basis": "phone_exact",
-            "verified": False,
-        },
     ]
 
 
@@ -257,7 +249,9 @@ def test_gateway_phone_resolve_empty_objects_are_clean_zero_candidate_miss():
 
     def opener(request, **kwargs):
         seen.append(request.full_url)
-        return FakeHTTPResponse(b"{}")
+        if "/Contacts/" in request.full_url:
+            return FakeHTTPResponse(b"{}")
+        return FakeHTTPResponse(b'{"data":[]}')
 
     client = triage.DeskClient(
         None,
@@ -281,6 +275,30 @@ def test_gateway_phone_resolve_empty_objects_are_clean_zero_candidate_miss():
     ]
 
 
+def test_gateway_phone_resolve_rejects_nonempty_object_without_data():
+    def opener(request, **kwargs):
+        return FakeHTTPResponse(b'{"error":"gateway auth context missing"}')
+
+    client = triage.DeskClient(
+        None,
+        mode="gateway",
+        gateway_hosts=("10.0.0.32",),
+        gateway_secret="shared-secret",
+        gateway_agent="geordi",
+        opener=opener,
+    )
+
+    with pytest.raises(triage.TriageError) as caught:
+        triage.resolve_site_candidates(
+            client,
+            {"callerid_name": None, "number": "8015550100", "duration_s": 12},
+        )
+
+    assert caught.value.stage == "resolve"
+    assert caught.value.exit_code == triage.EXIT_RESOLVE
+    assert "no data field" in caught.value.message
+
+
 def test_gateway_phone_resolve_falls_back_from_contacts_to_accounts():
     seen = []
 
@@ -288,7 +306,7 @@ def test_gateway_phone_resolve_falls_back_from_contacts_to_accounts():
         seen.append(request.full_url)
         if "/Contacts/" in request.full_url:
             return FakeHTTPResponse(b"{}")
-        return FakeHTTPResponse(b'{"data":[{"id":"account-1","name":"Main Street"},{}]}')
+        return FakeHTTPResponse(b'{"data":[{"id":"account-1","name":"Main Street"}]}')
 
     client = triage.DeskClient(
         None,
@@ -316,14 +334,38 @@ def test_gateway_phone_resolve_falls_back_from_contacts_to_accounts():
             "match_basis": "account_phone",
             "verified": False,
         },
-        {
-            "contact_id": None,
-            "account_id": None,
-            "account_name": None,
-            "match_basis": "account_phone",
-            "verified": False,
-        },
     ]
+
+
+@pytest.mark.parametrize("bad_module", ["Contacts", "Accounts"])
+@pytest.mark.parametrize(
+    "bad_row",
+    [pytest.param({}, id="missing"), pytest.param({"id": ""}, id="empty")],
+)
+def test_gateway_phone_resolve_rejects_idless_crm_rows(bad_module, bad_row):
+    def opener(request, **kwargs):
+        if bad_module == "Accounts" and "/Contacts/" in request.full_url:
+            return FakeHTTPResponse(b"{}")
+        return FakeHTTPResponse(json.dumps({"data": [bad_row]}).encode())
+
+    client = triage.DeskClient(
+        None,
+        mode="gateway",
+        gateway_hosts=("10.0.0.32",),
+        gateway_secret="shared-secret",
+        gateway_agent="geordi",
+        opener=opener,
+    )
+
+    with pytest.raises(triage.TriageError) as caught:
+        triage.resolve_site_candidates(
+            client,
+            {"callerid_name": None, "number": "8015550100", "duration_s": 12},
+        )
+
+    assert caught.value.stage == "resolve"
+    assert caught.value.exit_code == triage.EXIT_RESOLVE
+    assert f"CRM {bad_module} search result is missing its id" == caught.value.message
 
 
 def test_gateway_request_tries_hosts_in_order_and_resigns_each_attempt(monkeypatch):
@@ -594,6 +636,68 @@ def test_transcript_city_hint_is_extracted_mid_sentence_and_unioned_with_cnam():
         ("c1", "city_only"),
         ("c2", "city_only"),
     ]
+
+
+@pytest.mark.parametrize(
+    "city",
+    ["St. George", "St. Louis", "St. Paul", "Mt. Pleasant", "Ft. Worth", "Washington D.C."],
+)
+def test_transcript_city_hints_preserve_dotted_place_names(city):
+    transcript = f"This is our store in {city} about a register issue."
+
+    assert triage._city_hints(None, transcript) == [city]
+
+
+def test_dotted_initialism_city_survives_sentence_boundary():
+    transcript = "This is our store in Washington D.C. Please call me back."
+
+    assert triage._city_hints(None, transcript) == ["Washington D.C."]
+
+
+def test_dotted_transcript_city_survives_exact_membership_filter():
+    desk = FakeSearchDesk(
+        {
+            "St. George": [
+                {"id": "c1", "city": "St. George"},
+                {"id": "c2", "city": "St. George Island"},
+            ]
+        }
+    )
+
+    candidates = triage.resolve_site_candidates(
+        desk,
+        {"callerid_name": None, "number": None, "duration_s": 48},
+        "This is our store in St. George about a register issue.",
+    )
+
+    assert desk.queries == ["St. George"]
+    assert [(candidate["contact_id"], candidate["match_basis"]) for candidate in candidates] == [
+        ("c1", "city_only")
+    ]
+
+
+def test_lowercase_transcript_location_does_not_surface_city_candidate():
+    desk = FakeSearchDesk(
+        {
+            "orange": [
+                {
+                    "id": "orange-contact",
+                    "city": "Orange",
+                    "accountId": "orange-site",
+                    "accountName": "Orange Cafe",
+                }
+            ]
+        }
+    )
+
+    candidates = triage.resolve_site_candidates(
+        desk,
+        {"callerid_name": None, "number": None, "duration_s": 48},
+        "The status indicator is showing in orange.",
+    )
+
+    assert desk.queries == []
+    assert candidates == []
 
 
 def test_gateway_88632_transcript_city_fallback_runs_after_both_crm_phone_misses():
@@ -1001,6 +1105,42 @@ def test_ledger_defaults_read_only_exact_files_and_ignore_backup_siblings(tmp_pa
         )
         == []
     )
+
+
+def test_city_only_candidate_does_not_seed_in_flight_but_caller_phone_does(tmp_path):
+    _create_empty_required_ledgers(tmp_path)
+    active_rmas = tmp_path / triage.LEDGER_DEFAULT_PATHS["active_rmas"]
+    active_rmas.write_text(
+        "Orange Cafe orange-site orange-contact active\nMary Smith 8015550100 active\n"
+    )
+    city_candidate = {
+        "contact_id": "orange-contact",
+        "account_id": "orange-site",
+        "account_name": "Orange Cafe",
+        "match_basis": "city_only",
+        "verified": False,
+    }
+
+    assert (
+        triage.scan_in_flight(
+            tmp_path,
+            {"callerid_name": None, "number": None, "duration_s": 1},
+            [city_candidate],
+            env={},
+        )
+        == []
+    )
+
+    hits = triage.scan_in_flight(
+        tmp_path,
+        {"callerid_name": "Mary Smith", "number": "8015550100", "duration_s": 1},
+        [city_candidate],
+        env={},
+    )
+
+    assert [(hit["ledger"], hit["one_line"]) for hit in hits] == [
+        ("active_rmas", "Mary Smith 8015550100 active")
+    ]
 
 
 def test_directory_ledger_override_resolves_only_canonical_json_file(tmp_path):

--- a/tests/test_rc_voicemail_triage.py
+++ b/tests/test_rc_voicemail_triage.py
@@ -54,6 +54,8 @@ def test_extract_city_hint_requires_explicit_in_phrase():
 
 
 class FakeSearchDesk:
+    mode = "direct"
+
     def __init__(self, responses):
         self.responses = responses
         self.queries = []
@@ -178,6 +180,152 @@ def test_gateway_search_uses_gateway_base_prefix_q_and_path_auth_hook(monkeypatc
     )
 
 
+def test_gateway_phone_resolve_uses_crm_digits_and_maps_nullable_account(monkeypatch):
+    seen = {"requests": [], "headers": []}
+    monkeypatch.setattr(triage.time, "time", lambda: 123)
+
+    def opener(request, **kwargs):
+        seen["requests"].append(request.full_url)
+        seen["headers"].append({key.casefold(): value for key, value in request.header_items()})
+        return FakeHTTPResponse(
+            json.dumps(
+                {
+                    "data": [
+                        {
+                            "id": 123,
+                            "Account_Name": {"id": 456, "name": "Sourdough & Co - Monrovia"},
+                        },
+                        {"id": "contact-without-account", "Account_Name": None},
+                        {},
+                    ]
+                }
+            ).encode()
+        )
+
+    client = triage.DeskClient(
+        None,
+        mode="gateway",
+        gateway_hosts=("10.0.0.32",),
+        gateway_secret="shared-secret",
+        gateway_agent="geordi",
+        opener=opener,
+    )
+
+    candidates = triage.resolve_site_candidates(
+        client,
+        {"callerid_name": "Ravjodh Heer", "number": "661-699-3557", "duration_s": 48},
+    )
+
+    assert seen["requests"] == ["http://10.0.0.32:9100/crm/Contacts/search?phone=6616993557"]
+    assert (
+        seen["headers"][0]["x-pinky-signature"]
+        == triage._sign(
+            "shared-secret",
+            "geordi",
+            "GET",
+            "/crm/Contacts/search",
+            123,
+        )["x-pinky-signature"]
+    )
+    assert candidates == [
+        {
+            "contact_id": "123",
+            "account_id": "456",
+            "account_name": "Sourdough & Co - Monrovia",
+            "match_basis": "phone_exact",
+            "verified": False,
+        },
+        {
+            "contact_id": "contact-without-account",
+            "account_id": None,
+            "account_name": None,
+            "match_basis": "phone_exact",
+            "verified": False,
+        },
+        {
+            "contact_id": None,
+            "account_id": None,
+            "account_name": None,
+            "match_basis": "phone_exact",
+            "verified": False,
+        },
+    ]
+
+
+def test_gateway_phone_resolve_empty_objects_are_clean_zero_candidate_miss():
+    seen = []
+
+    def opener(request, **kwargs):
+        seen.append(request.full_url)
+        return FakeHTTPResponse(b"{}")
+
+    client = triage.DeskClient(
+        None,
+        mode="gateway",
+        gateway_hosts=("10.0.0.32",),
+        gateway_secret="shared-secret",
+        gateway_agent="geordi",
+        opener=opener,
+    )
+
+    assert (
+        triage.resolve_site_candidates(
+            client,
+            {"callerid_name": "Unknown", "number": "7075731100", "duration_s": 44},
+        )
+        == []
+    )
+    assert seen == [
+        "http://10.0.0.32:9100/crm/Contacts/search?phone=7075731100",
+        "http://10.0.0.32:9100/crm/Accounts/search?phone=7075731100",
+    ]
+
+
+def test_gateway_phone_resolve_falls_back_from_contacts_to_accounts():
+    seen = []
+
+    def opener(request, **kwargs):
+        seen.append(request.full_url)
+        if "/Contacts/" in request.full_url:
+            return FakeHTTPResponse(b"{}")
+        return FakeHTTPResponse(b'{"data":[{"id":"account-1","name":"Main Street"},{}]}')
+
+    client = triage.DeskClient(
+        None,
+        mode="gateway",
+        gateway_hosts=("10.0.0.32",),
+        gateway_secret="shared-secret",
+        gateway_agent="geordi",
+        opener=opener,
+    )
+
+    candidates = triage.resolve_site_candidates(
+        client,
+        {"callerid_name": None, "number": "8015550100", "duration_s": 12},
+    )
+
+    assert [triage.urlparse(url).path for url in seen] == [
+        "/crm/Contacts/search",
+        "/crm/Accounts/search",
+    ]
+    assert candidates == [
+        {
+            "contact_id": None,
+            "account_id": "account-1",
+            "account_name": "Main Street",
+            "match_basis": "account_phone",
+            "verified": False,
+        },
+        {
+            "contact_id": None,
+            "account_id": None,
+            "account_name": None,
+            "match_basis": "account_phone",
+            "verified": False,
+        },
+    ]
+
+
 def test_gateway_request_tries_hosts_in_order_and_resigns_each_attempt(monkeypatch):
     seen = {"hosts": [], "timestamps": []}
     timestamps = iter((101, 102))
@@ -229,6 +377,121 @@ def test_gateway_thread_attachments_use_explicit_allowlisted_route(monkeypatch):
     }
     expected_path = "/desk/tickets/ticket%2F1/threads/thread%202/attachments"
     assert seen["requests"] == [f"http://10.0.0.32:9100{expected_path}"]
+
+
+def test_gateway_display_ticket_number_resolves_to_internal_id(monkeypatch):
+    seen = {"requests": [], "headers": []}
+    monkeypatch.setattr(triage.time, "time", lambda: 123)
+
+    def opener(request, **kwargs):
+        seen["requests"].append(request.full_url)
+        seen["headers"].append({key.casefold(): value for key, value in request.header_items()})
+        return FakeHTTPResponse(b'{"id":"637734000000123456","ticketNumber":"88629"}')
+
+    client = triage.DeskClient(
+        None,
+        mode="gateway",
+        gateway_hosts=("10.0.0.32",),
+        gateway_secret="shared-secret",
+        gateway_agent="geordi",
+        opener=opener,
+    )
+
+    assert client.resolve_ticket_id("88629") == "637734000000123456"
+    assert seen["requests"] == ["http://10.0.0.32:9100/desk/tickets/resolve?ticket_number=88629"]
+    assert (
+        seen["headers"][0]["x-pinky-signature"]
+        == triage._sign(
+            "shared-secret",
+            "geordi",
+            "GET",
+            "/desk/tickets/resolve",
+            123,
+        )["x-pinky-signature"]
+    )
+
+
+def test_gateway_internal_ticket_id_passes_through_without_resolve_request():
+    def opener(*args, **kwargs):
+        raise AssertionError("internal ticket id must not require a resolve hop")
+
+    client = triage.DeskClient(
+        None,
+        mode="gateway",
+        gateway_hosts=("10.0.0.32",),
+        gateway_secret="shared-secret",
+        gateway_agent="geordi",
+        opener=opener,
+    )
+
+    assert client.resolve_ticket_id("637734000000123456") == "637734000000123456"
+
+
+def test_triage_fetch_chain_receives_resolved_internal_ticket_id(tmp_path, monkeypatch):
+    seen = {}
+
+    class FakeDesk:
+        def resolve_ticket_id(self, ticket_id):
+            seen["supplied"] = ticket_id
+            return "637734000000123456"
+
+    def fake_fetch(desk, ticket_id, destination_dir):
+        seen["fetched"] = ticket_id
+        return destination_dir / "voice.mp3", {
+            "callerid_name": None,
+            "number": None,
+            "duration_s": 1,
+        }
+
+    monkeypatch.setattr(triage, "fetch_voicemail_audio", fake_fetch)
+    monkeypatch.setattr(triage, "transcribe_audio", lambda *args, **kwargs: ("", True))
+    monkeypatch.setattr(triage, "resolve_site_candidates", lambda *args, **kwargs: [])
+    monkeypatch.setattr(triage, "scan_in_flight", lambda *args, **kwargs: [])
+
+    result = triage.triage_ticket(
+        "88629",
+        FakeDesk(),
+        transcriber_path=tmp_path / "unused-transcriber.py",
+        ledger_root=tmp_path,
+        destination_dir=tmp_path / "downloads",
+    )
+
+    assert seen == {"supplied": "88629", "fetched": "637734000000123456"}
+    assert result["ticket_id"] == "88629"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param([], id="non-object"),
+        pytest.param({"ticketNumber": "88629"}, id="missing-internal-id"),
+        pytest.param(
+            {"id": "637734000000123456", "ticketNumber": "88630"},
+            id="ticket-number-mismatch",
+        ),
+    ],
+)
+def test_gateway_ticket_resolve_malformed_or_mismatched_response_fails_fetch(tmp_path, payload):
+    client = triage.DeskClient(
+        None,
+        mode="gateway",
+        gateway_hosts=("10.0.0.32",),
+        gateway_secret="shared-secret",
+        gateway_agent="geordi",
+        opener=lambda *args, **kwargs: FakeHTTPResponse(json.dumps(payload).encode()),
+    )
+
+    with pytest.raises(triage.TriageError) as caught:
+        triage.triage_ticket(
+            "88629",
+            client,
+            transcriber_path=tmp_path / "unused-transcriber.py",
+            ledger_root=tmp_path,
+            destination_dir=tmp_path / "downloads",
+        )
+
+    assert caught.value.stage == "fetch"
+    assert caught.value.exit_code == triage.EXIT_FETCH
 
 
 def test_direct_search_keeps_v1_base_query_and_oauth_header():
@@ -307,6 +570,64 @@ def test_explicit_city_fallback_returns_list_without_auto_binding():
     assert [candidate["contact_id"] for candidate in candidates] == ["c1", "c2"]
     assert all(candidate["match_basis"] == "city_only" for candidate in candidates)
     assert all(candidate["verified"] is False for candidate in candidates)
+
+
+def test_transcript_city_hint_is_extracted_mid_sentence_and_unioned_with_cnam():
+    desk = FakeSearchDesk(
+        {
+            "Bakersfield": [{"id": "c1", "city": "Bakersfield"}],
+            "Tooele": [
+                {"id": "c2", "city": "Tooele", "accountId": "a2"},
+                {"id": "c3", "city": "Provo"},
+            ],
+        }
+    )
+
+    candidates = triage.resolve_site_candidates(
+        desk,
+        {"callerid_name": "Main Line in Bakersfield", "number": None, "duration_s": 48},
+        "Hi, this is Subway Cafe in Tooele about my order. Please call me back.",
+    )
+
+    assert desk.queries == ["Bakersfield", "Tooele"]
+    assert [(candidate["contact_id"], candidate["match_basis"]) for candidate in candidates] == [
+        ("c1", "city_only"),
+        ("c2", "city_only"),
+    ]
+
+
+def test_gateway_88632_transcript_city_fallback_runs_after_both_crm_phone_misses():
+    seen = []
+
+    def opener(request, **kwargs):
+        seen.append(triage.urlparse(request.full_url).path)
+        if "/crm/" in request.full_url:
+            return FakeHTTPResponse(b"{}")
+        return FakeHTTPResponse(b'{"data":[{"id":"c1","city":"Tooele"}]}')
+
+    client = triage.DeskClient(
+        None,
+        mode="gateway",
+        gateway_hosts=("10.0.0.32",),
+        gateway_secret="shared-secret",
+        gateway_agent="geordi",
+        opener=opener,
+    )
+
+    candidates = triage.resolve_site_candidates(
+        client,
+        {"callerid_name": "HANSEN,DAWSON", "number": "4355550100", "duration_s": 30},
+        "Hi, this is Subway Cafe in Tooele about my order. Please call me back.",
+    )
+
+    assert seen == [
+        "/crm/Contacts/search",
+        "/crm/Accounts/search",
+        "/desk/search",
+    ]
+    assert [(candidate["contact_id"], candidate["match_basis"]) for candidate in candidates] == [
+        ("c1", "city_only")
+    ]
 
 
 def test_multiple_accounts_remain_multiple_unverified_candidates():
@@ -612,13 +933,13 @@ def test_missing_attachment_fails_nonzero_stage():
 
 
 def test_in_flight_scans_all_required_ledgers_and_maps_ubereats(tmp_path):
-    (tmp_path / "active_rmas.jsonl").write_text('{"caller":"Mary Smith"}\n')
-    label_dir = tmp_path / "label_requests"
-    label_dir.mkdir()
-    (label_dir / "open.md").write_text("call (801) 555-0100\n")
-    (tmp_path / "active_cc.csv").write_text("site-1,chargeback\n")
-    (tmp_path / "active_jamf.txt").write_text("Main Street device\n")
-    (tmp_path / "ubereats.json").write_text('{"contact":"contact-1"}\n')
+    for directory in ("rma", "cc_creds", "jamf", "ubereats"):
+        (tmp_path / directory).mkdir()
+    (tmp_path / "rma/active_rmas.json").write_text('{"caller":"Mary Smith"}\n')
+    (tmp_path / "rma/label_requests.json").write_text("call (801) 555-0100\n")
+    (tmp_path / "cc_creds/active_cc.json").write_text("site-1,chargeback\n")
+    (tmp_path / "jamf/active_jamf.json").write_text("Main Street device\n")
+    (tmp_path / "ubereats/integration_requests.json").write_text('{"contact":"contact-1"}\n')
 
     caller = {"callerid_name": "Mary Smith", "number": "8015550100", "duration_s": 12}
     candidates = [
@@ -658,16 +979,47 @@ def test_explicit_missing_ledger_path_fails_loud(tmp_path):
 
 
 def _create_empty_required_ledgers(root, *, missing=None):
-    filenames = {
-        "active_rmas": "active_rmas.jsonl",
-        "label_requests": "label_requests.jsonl",
-        "active_cc": "active_cc.jsonl",
-        "active_jamf": "active_jamf.jsonl",
-        "integration_requests": "ubereats.jsonl",
-    }
-    for canonical, filename in filenames.items():
+    for path in triage.LEDGER_DEFAULT_PATHS.values():
+        (root / path).parent.mkdir(parents=True, exist_ok=True)
+    for canonical, path in triage.LEDGER_DEFAULT_PATHS.items():
         if canonical != missing:
-            (root / filename).write_text("")
+            (root / path).write_text("")
+
+
+def test_ledger_defaults_read_only_exact_files_and_ignore_backup_siblings(tmp_path):
+    _create_empty_required_ledgers(tmp_path)
+    exact = tmp_path / triage.LEDGER_DEFAULT_PATHS["active_cc"]
+    exact.write_text("no active match\n")
+    exact.with_name("active_cc.json.bak.pre-r3").write_text("Mary Smith 8015550100 stale\n")
+
+    assert (
+        triage.scan_in_flight(
+            tmp_path,
+            {"callerid_name": "Mary Smith", "number": "8015550100", "duration_s": 1},
+            [],
+            env={},
+        )
+        == []
+    )
+
+
+def test_directory_ledger_override_resolves_only_canonical_json_file(tmp_path):
+    _create_empty_required_ledgers(tmp_path)
+    pinned = tmp_path / "custom-rma"
+    pinned.mkdir()
+    (pinned / "active_rmas.json").write_text("Mary Smith active\n")
+    (pinned / "active_rmas.json.bak.pre-r3").write_text("Mary Smith stale\n")
+
+    hits = triage.scan_in_flight(
+        tmp_path,
+        {"callerid_name": "Mary Smith", "number": None, "duration_s": 1},
+        [],
+        env={"RC_VOICEMAIL_LEDGER_ACTIVE_RMAS": str(pinned)},
+    )
+
+    assert [(hit["ledger"], hit["one_line"]) for hit in hits] == [
+        ("active_rmas", "Mary Smith active")
+    ]
 
 
 def test_empty_ledger_root_fails_loud(tmp_path):
@@ -742,6 +1094,11 @@ def test_output_contract_has_exact_shape_and_list_candidates():
 
 def test_pipeline_smoke_combines_fetch_transcript_candidates_and_ledgers(tmp_path):
     class FakeDesk:
+        mode = "direct"
+
+        def resolve_ticket_id(self, ticket_id):
+            return ticket_id
+
         def list_threads(self, ticket_id):
             return [{"id": "vm", "fromEmailAddress": "notify@ringcentral.com"}]
 
@@ -769,9 +1126,8 @@ def test_pipeline_smoke_combines_fetch_transcript_candidates_and_ledgers(tmp_pat
     transcriber.write_text('print(\'{"transcript":"Please call me", "no_speech":false}\')\n')
     ledger_root = tmp_path / "ledgers"
     ledger_root.mkdir()
-    (ledger_root / "active_rmas.jsonl").write_text('{"caller":"Mary"}\n')
-    for filename in ("label_requests", "active_cc", "active_jamf", "ubereats"):
-        (ledger_root / f"{filename}.jsonl").write_text("")
+    _create_empty_required_ledgers(ledger_root)
+    (ledger_root / triage.LEDGER_DEFAULT_PATHS["active_rmas"]).write_text('{"caller":"Mary"}\n')
 
     output = triage.triage_ticket(
         "123",
@@ -795,7 +1151,7 @@ def test_pipeline_smoke_combines_fetch_transcript_candidates_and_ledgers(tmp_pat
     assert output["in_flight"] == [
         {
             "ledger": "active_rmas",
-            "key": "active_rmas.jsonl:1",
+            "key": "rma/active_rmas.json:1",
             "one_line": '{"caller":"Mary"}',
         }
     ]


### PR DESCRIPTION
Resolver-quality round for the RC voicemail triage instrument (#549). r2 (b4047ea) is merged and live-PASS on geordi's gateway seat; this round improves caller/site resolution only. Scope: `scripts/rc_voicemail_triage.py` + tests. Auth/signing/mode selectors and the fetch chain are frozen byte-identical to b4047ea.

## What changed (spec §8 A/B/C/D)

- **A — Gateway phone-resolve via CRM.** New `search_crm_phone` hits `GET /crm/{Contacts,Accounts}/search?phone=<digits>` on a `/crm/`-prefixed base derived from the same gateway hosts (signs `/crm/Contacts/search`, not `/desk/...`). Digits-only query; Contacts → Accounts fallback; `{}` is a clean zero-candidate miss (exit 0), API/auth error is EXIT_RESOLVE. New CRM-specific mappers handle the nullable `Account_Name` `{name,id}` lookup. Direct mode keeps the Desk `search?module=contacts` fan-out unchanged.
- **B — City hint from transcript.** `_city_hints` unions CNAM + transcript-derived cities; the transcript is split at sentence/clause boundaries so a mid-sentence "…in Tooele about my order…" yields `Tooele` (the end-anchored `_CITY_HINT_RE` fires per-segment). Runs only after phone misses.
- **C — Exact-file ledgers, no dir-scan.** `LEDGER_DEFAULT_PATHS` pins the exact geordi layout (`rma/active_rmas.json`, `rma/label_requests.json`, `cc_creds/active_cc.json`, `jamf/active_jamf.json`, `ubereats/integration_requests.json`). The `rglob`/suffix/subdir fan-out is removed; a directory env-pin resolves to exactly `<key>.json` and never touches `.bak`/sibling snapshots.
- **D — Display-ticket resolution.** Short numeric display IDs (`^\d{1,10}$`, gateway only) resolve through `GET /desk/tickets/resolve?ticket_number=`; the returned `ticketNumber` is exact-checked (fail-closed → EXIT_FETCH), then the internal id feeds the unchanged fetch chain. 18-digit internal ids pass straight through. `/desk/tickets/search` is never used (it ignores query params).

## Verification

- 67/67 focused tests on Python 3.11 / 3.12 / 3.13; ruff check + format clean; compileall clean.
- Tests mechanically enforce the two highest-stakes hazards: a `.bak.pre-r3` decoy holding stale "Mary Smith 8015550100" is asserted **never read** (`scan_in_flight == []`), and the real 88632 transcript is asserted to produce a `city_only` candidate only after both `/crm/` modules miss. Exact CRM URL and nullable `Account_Name` are asserted directly.
- Freeze confirmed: `_sign`, `_auth_headers`/`_headers`, `download_attachment`, `list_threads`/`get_thread`, `_thread_sender`, `fetch_voicemail_audio`, `select_auth_mode`, `load_gateway_credentials`, `DeskClient.__init__` are unchanged in the diff (the only transport change is an additive optional `base_urls` kwarg on `_request_json`, None-default = prior behavior).
- Final live gate: geordi runs it against the reference voicemails post-merge (expect phone-resolve 1/4 — a CRM data-hygiene gap, not a code miss).

🤖 Opened by Barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)