### PR TITLE
chore: strip real posspecialists.com emails from public test data

### DIFF
--- a/scripts/fixtures-543/btsprobe_sample.json
+++ b/scripts/fixtures-543/btsprobe_sample.json
@@ -114,13 +114,6 @@
       ]
     }
   },
-    "freebusy": {
-      "aldo@posspecialists.com": "0 busy blocks",
-      "daniel@posspecialists.com": "2 busy blocks",
-      "julie@posspecialists.com": "3 busy blocks",
-      "c_a9f78bede90bb320f7110b1ece4dc19fab768ed7c47a848abaa87e3d1c34a9c0@group.calendar.google.com": "3 busy blocks",
-      "dmartinez@posspecialists.com": "2 busy blocks"
-    },
     "scan": {
       "members": {
         "danielson": {

--- a/tests/test_slack_text_refs.py
+++ b/tests/test_slack_text_refs.py
@@ -57,16 +57,16 @@ def test_date_token_uses_fallback():
 
 
 def test_link_with_label():
-    assert _run("click <https://posspecialists.com|here>") == "click here"
+    assert _run("click <https://example.com|here>") == "click here"
 
 
 def test_bare_link_keeps_url():
-    assert _run("go <https://posspecialists.com>") == "go https://posspecialists.com"
+    assert _run("go <https://example.com>") == "go https://example.com"
 
 
 def test_mailto_link():
-    assert _run("mail <mailto:brad@posspecialists.com|brad@posspecialists.com>") == (
-        "mail brad@posspecialists.com"
+    assert _run("mail <mailto:user@example.com|user@example.com>") == (
+        "mail user@example.com"
     )
 
 


### PR DESCRIPTION
## What
- `scripts/fixtures-543/btsprobe_sample.json`: removes the unused `freebusy` block (4 real staff emails — aldo/daniel/julie/dmartinez@posspecialists.com — plus a live Google Calendar group id).
- `tests/test_slack_text_refs.py`: swaps `brad@posspecialists.com` and the `posspecialists.com` domain to `example.com` placeholders.

## Why
Real POS Specialists people's email addresses (and a live calendar id) were sitting in public test data. Strip them. Per Brad's direction.

## Safety / scope
- **Behavior-neutral:** `staffing_gather.py` reads `scan.members` by member key and never references `freebusy`; no test asserts on it (verified). The slack-ref test validates link/mailto text-stripping, not the specific address.
- Fixture JSON re-validated; **35 affected tests pass** (test_staffing_gather + test_slack_text_refs).
- Forward edit only — **no history rewrite** (consistent with the #549/#552 interim approach; full history scrub still tracked as #552).

Companion to #1039 (rc_voicemail removal, merged).