### PR TITLE
fix(scheduler): stop owner-notifying end-owners on FIRED BUT UNDELIVERED

### DIFF
--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -763,20 +763,20 @@ class AgentScheduler:
             f"'{schedule.name}' (#{schedule.id}) for agent "
             f"'{schedule.agent_name}': {failure_reason}"
         )
-        if alert_this_failure:
-            recovery = (
-                " The wake was persisted for the agent's next session."
-                if persisted
-                else " WARNING: durable wake persistence did not succeed."
-            )
-            self._queue_owner_alert(
-                schedule.agent_name,
-                (
-                    "🚨 FIRED BUT UNDELIVERED: schedule "
-                    f"'{schedule.name}' (#{schedule.id}) for agent "
-                    f"'{schedule.agent_name}' was not confirmed: "
-                    f"{failure_reason}.{recovery}"
-                ),
+        # Do NOT owner-notify on a scheduler delivery-receipt failure. These
+        # receipts are frequently FALSE positives — the wake persists + replays,
+        # or the receipt times out on work that was in fact delivered (#966/#984)
+        # — so pushing them to the agent's owner spams end-users with infra
+        # internals they cannot act on. The real signal for a genuinely dead job
+        # is artifact staleness, not a receipt timeout. Operators monitor via the
+        # FIRED BUT UNDELIVERED log above + the nightly fleet-health sweep. Only
+        # the rare persistence-FAILED case (no retry possible) gets an extra
+        # operator log line — still never an owner notification.
+        if alert_this_failure and not persisted:
+            _log(
+                "scheduler: WARNING durable wake persistence did NOT succeed "
+                f"for schedule '{schedule.name}' (#{schedule.id}) for agent "
+                f"'{schedule.agent_name}': {failure_reason} — wake may be lost"
             )
 
     async def _wait_for_wake_confirmation(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1796,9 +1796,10 @@ class TestScheduler:
 
         pending = registry.list_pending_schedule_wakes("oleg")
         assert len(pending) == 1
-        assert alerts[0][0] == "oleg"
-        assert "FIRED BUT UNDELIVERED" in alerts[0][1]
-        assert "persisted for the agent's next session" in alerts[0][1]
+        # Delivery-receipt failures are NOT owner-notified: they are frequently
+        # false positives (the wake persists + replays), so the owner sees
+        # nothing — only the FIRED BUT UNDELIVERED operator log line.
+        assert alerts == []
 
         attempts: list[str] = []
 


### PR DESCRIPTION
## Problem
Scheduler delivery-receipt failures owner-notify the agent's owner on **every** unconfirmed fire (`scheduler.py` `_record_schedule_undelivered`). These receipts are frequently **false positives** — the wake persists + replays, or the receipt times out on work that was in fact delivered (#966/#984 family). So end-owners (customers) get flooded with infra internals they can't act on.

**Live case:** a TOD customer received **22** "FIRED BUT UNDELIVERED" alerts in ~2.5h for gmail sweeps that were all running perfectly (artifact-verified — Gmail later-ids 829→895, mail physically moving; the failures were the phantom-meta false-receipt bug #984/#118).

## Fix
Suppress the **owner notification** for FIRED-BUT-UNDELIVERED. Unchanged: the `FIRED BUT UNDELIVERED` operator **log** line (operators monitor via logs + the nightly fleet-health sweep). The rare **persistence-FAILED** case now emits an extra operator log line instead of an owner alert. The real signal for a genuinely dead job is **artifact staleness, not a receipt timeout**.

## Scope
- Only the receipt-failure owner-notify at `_record_schedule_undelivered`. **PERSISTED_WAKE_PARKED** and **STALE_ONE_SHOT_DROPPED** owner alerts (genuine terminal dead-letter events) are intentionally left as-is.
- 139 scheduler tests pass; flipped the single test asserting the owner alert (now asserts no owner-notify + wake still persists/replays). Forward change, behavior-scoped.

Fleet-wide once released; unblocks the TOD/Dmitri spam.