### PR TITLE
chore: sanitize Slack example PII + fix #1043 stale wording (#554)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7643,7 +7643,7 @@ npm run build</pre>
             material,
             broker,
             agents,
-            _notify_owner_undelivered,
+            _notify_owner_alert,
         )
         _broker_pollers.append(poller)
         task = asyncio.create_task(poller.start())
@@ -10927,7 +10927,7 @@ npm run build</pre>
             return False
         return probe(prompt) is True
 
-    async def _notify_owner_undelivered(
+    async def _notify_owner_alert(
         agent_name: str, message: str
     ) -> bool:
         """Send scheduler failures through canonical and host-local fallbacks."""
@@ -11083,7 +11083,7 @@ npm run build</pre>
         comms_cleanup_fn=comms.cleanup_expired,
         delivery_busy_fn=_scheduler_delivery_busy,
         delivery_inflight_fn=_scheduler_wake_inflight,
-        owner_notify_callback=_notify_owner_undelivered,
+        owner_notify_callback=_notify_owner_alert,
         trigger_store=trigger_store,
         activity=activity,
     )
@@ -11531,7 +11531,7 @@ npm run build</pre>
         from pinky_daemon.buzz_runtime import register_buzz_outbound_platforms
 
         app.state.buzz_registration = await register_buzz_outbound_platforms(
-            agents, _notify_owner_undelivered
+            agents, _notify_owner_alert
         )
         if app.state.buzz_registration["refused"]:
             _log(

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -889,7 +889,7 @@ class MessageBroker:
 
         text = message.content.strip()
         # Match the command prefix case-insensitively, but preserve the RAW case
-        # of the target id — Slack user ids are uppercase (e.g. U774M8XDE) and the
+        # of the target id — Slack user ids are uppercase (e.g. U0EXAMPLE1) and the
         # pending row is keyed under the exact id. Lowercasing the whole token
         # approved a phantom lowercased user, delivered 0 held messages, and left
         # the real user pending (so the channel reply never went out).

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -854,7 +854,7 @@ async def _resolve_slack_ref(body: str, user_namer, channel_namer) -> str:
 async def resolve_slack_text_refs(text: str, *, user_namer, channel_namer) -> str:
     """Rewrite Slack mrkdwn ref tokens in inbound text to human-readable form.
 
-    `<@U774M8XDE>` → `@Brett Jones`, `<#C1|orders>` → `#orders`, `<!here>` →
+    `<@U0EXAMPLE1>` → `@Alex Rivera`, `<#C1|orders>` → `#orders`, `<!here>` →
     `@here`, `<https://x|click>` → `click`. ``user_namer``/``channel_namer`` are
     async callables (id → name) returning "" on failure, in which case the raw
     id is kept (no regression). After ref substitution, Slack HTML entities

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -269,8 +269,11 @@ class AgentScheduler:
         # per-agent delivery lock — surfaced by the "extending" log line
         # each timeout period (Murzik review, PR #983).
         self._delivery_inflight_fn = delivery_inflight_fn
-        # async fn(agent_name, text) -> bool. FIRED BUT UNDELIVERED must leave
-        # journald and reach the owner through an out-of-band transport.
+        # async fn(agent_name, text) -> bool. Delivers operator-facing owner
+        # alerts for terminal dead-letter events (PERSISTED_WAKE_PARKED, stale
+        # one-shot drop) through an out-of-band transport. Routine
+        # FIRED-BUT-UNDELIVERED receipt failures are logged only, NOT
+        # owner-notified (#1043).
         self._owner_notify_callback = owner_notify_callback
         self._trigger_store = trigger_store  # TriggerStore | None
         self._activity = activity  # ActivityStore | None
@@ -702,7 +705,11 @@ class AgentScheduler:
     def _record_schedule_undelivered(
         self, schedule, failure_reason: str
     ) -> None:
-        """Persist, alert, and loudly account one unconfirmed fired schedule."""
+        """Persist and loudly log one unconfirmed fired schedule.
+
+        Operator log only — the owner is NOT notified for routine receipt
+        failures (they are frequently false positives; #1043).
+        """
         persisted = False
         alert_this_failure = True
         if not schedule.direct_send:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7938,7 +7938,7 @@ class TestBuildStreamingWakeContextReasonGating:
             app.state.broker._send_callback = send
 
             delivered = await app.state.scheduler._owner_notify_callback(
-                "dymok", "FIRED BUT UNDELIVERED test"
+                "dymok", "scheduler owner-alert test"
             )
 
             assert delivered is True
@@ -7946,7 +7946,7 @@ class TestBuildStreamingWakeContextReasonGating:
                 "dymok",
                 "telegram",
                 "owner-dm",
-                "FIRED BUT UNDELIVERED test",
+                "scheduler owner-alert test",
                 account_id="acct-1",
             )
 
@@ -7981,7 +7981,7 @@ class TestBuildStreamingWakeContextReasonGating:
             monkeypatch.setattr(api_mod, "_log", logs.append)
 
             delivered = await app.state.scheduler._owner_notify_callback(
-                "geordi", "FIRED BUT UNDELIVERED test"
+                "geordi", "scheduler owner-alert test"
             )
 
             assert delivered is True
@@ -7989,7 +7989,7 @@ class TestBuildStreamingWakeContextReasonGating:
                 "local-notifier",
                 "telegram",
                 "owner-dm",
-                "FIRED BUT UNDELIVERED test",
+                "scheduler owner-alert test",
                 account_id="brad-telegram",
             )
             assert any("OWNER_NOTIFY_DELIVERY_FAILURE" in line for line in logs)
@@ -8027,7 +8027,7 @@ class TestBuildStreamingWakeContextReasonGating:
             monkeypatch.setattr(api_mod, "_log", logs.append)
 
             delivered = await app.state.scheduler._owner_notify_callback(
-                "geordi", "FIRED BUT UNDELIVERED test"
+                "geordi", "scheduler owner-alert test"
             )
 
             assert delivered is True
@@ -8035,7 +8035,7 @@ class TestBuildStreamingWakeContextReasonGating:
                 "geordi",
                 "slack",
                 "D_OWNER",
-                "FIRED BUT UNDELIVERED test",
+                "scheduler owner-alert test",
                 account_id="T_PI",
             )
             assert any(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7917,8 +7917,9 @@ class TestBuildStreamingWakeContextReasonGating:
             assert replayed == ["dymok"]
 
     @pytest.mark.asyncio
-    async def test_scheduler_undelivered_alert_uses_owner_destination(self):
-        """#949 alerting uses the durable #863 owner-notify configuration."""
+    async def test_scheduler_owner_alert_uses_owner_destination(self):
+        """The owner-notify callback (dead-letter alerts: PARKED / stale
+        one-shot drop) routes to the durable #863 owner destination."""
         with tempfile.TemporaryDirectory() as tmpdir:
             app = self._make_app(os.path.join(tmpdir, "test.db"))
             app.state.agents.register("dymok", model="sonnet")

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -961,7 +961,7 @@ class TestMessageBrokerRouting:
             ])
 
             channel = "C0A8WUU743F"
-            user = "U774M8XDE"
+            user = "U0EXAMPLE1"
             await broker.handle_inbound(
                 BrokerMessage(
                     platform="slack",
@@ -1410,7 +1410,7 @@ class TestMessageBrokerRouting:
             await broker.handle_inbound(
                 BrokerMessage(
                     platform="slack", chat_id=channel, sender_name="Alex Ugrin",
-                    sender_id="U774M8XDE", content="Hi", agent_name="barsik",
+                    sender_id="U0EXAMPLE1", content="Hi", agent_name="barsik",
                     is_group=True,
                 )
             )

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -960,13 +960,13 @@ class TestMessageBrokerRouting:
                 }
             ])
 
-            channel = "C0A8WUU743F"
+            channel = "C0EXAMPLE1"
             user = "U0EXAMPLE1"
             await broker.handle_inbound(
                 BrokerMessage(
                     platform="slack",
                     chat_id=channel,
-                    sender_name="Alex Ugrin",
+                    sender_name="Alex Rivera",
                     sender_id=user,
                     content="Hi",
                     agent_name="barsik",
@@ -1292,14 +1292,14 @@ class TestMessageBrokerRouting:
             monkeypatch.setattr(broker, "_route_streaming", _fake_route)
             registry.set_primary_user("owner-1", display_name="Brad")
 
-            channel = "C0A8WUU743F"
+            channel = "C0EXAMPLE1"
             # Channel is approved once.
             registry.approve_user("barsik", channel, display_name=channel)
 
             # A brand-new, never-approved member messages in the channel.
             await broker.handle_inbound(
                 BrokerMessage(
-                    platform="slack", chat_id=channel, sender_name="Jake Hredzak",
+                    platform="slack", chat_id=channel, sender_name="Jordan Lee",
                     sender_id="U_NEVER_APPROVED", content="status?",
                     agent_name="barsik", is_group=True,
                 )
@@ -1378,7 +1378,7 @@ class TestMessageBrokerRouting:
     @pytest.mark.asyncio
     async def test_slash_approve_preserves_uppercase_channel_id(self, monkeypatch):
         """Regression: /approve_<id> must preserve the EXACT case of the target
-        id. Slack channel ids are uppercase (C0A8WUU743F); lowercasing the whole
+        id. Slack channel ids are uppercase (C0EXAMPLE1); lowercasing the whole
         command token approved a phantom lowercased id, delivered 0 held
         messages, and left the channel unapproved — so replies never went out.
         Exercises the real owner-notification flow end-to-end at channel scope."""
@@ -1405,11 +1405,11 @@ class TestMessageBrokerRouting:
                 }
             ])
 
-            channel = "C0A8WUU743F"
+            channel = "C0EXAMPLE1"
             # A message in the channel → held pending under the exact channel id.
             await broker.handle_inbound(
                 BrokerMessage(
-                    platform="slack", chat_id=channel, sender_name="Alex Ugrin",
+                    platform="slack", chat_id=channel, sender_name="Alex Rivera",
                     sender_id="U0EXAMPLE1", content="Hi", agent_name="barsik",
                     is_group=True,
                 )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1765,7 +1765,7 @@ class TestScheduler:
         assert [wake.prompt for wake in pending] == ["probe breaks"]
 
     @pytest.mark.asyncio
-    async def test_undelivered_alerts_owner_and_replays_on_next_boot(
+    async def test_undelivered_does_not_alert_owner_and_replays_on_next_boot(
         self, registry
     ):
         registry.register("oleg")

--- a/tests/test_slack_text_refs.py
+++ b/tests/test_slack_text_refs.py
@@ -4,7 +4,7 @@ import asyncio
 
 from pinky_daemon.pollers import resolve_slack_text_refs
 
-_USERS = {"U774M8XDE": "Brett Jones", "U123": "Alice"}
+_USERS = {"U0EXAMPLE1": "Alex Rivera", "U123": "Alice"}
 _CHANNELS = {"C1": "orders-and-equipment"}
 
 
@@ -23,12 +23,12 @@ def _run(text: str) -> str:
 
 
 def test_user_mention_resolved_to_name():
-    assert _run("Hi <@U774M8XDE> there") == "Hi @Brett Jones there"
+    assert _run("Hi <@U0EXAMPLE1> there") == "Hi @Alex Rivera there"
 
 
 def test_user_mention_with_embedded_label_no_lookup():
     # label after | wins; no resolver call needed
-    assert _run("ping <@U999|brett>") == "ping @brett"
+    assert _run("ping <@U999|sam>") == "ping @sam"
 
 
 def test_unknown_user_keeps_raw_id():
@@ -83,11 +83,11 @@ def test_empty_text():
 
 
 def test_multiple_mentions_in_one_message():
-    out = _run("Hi <@U774M8XDE> and <@U123> in <#C1|orders>")
-    assert out == "Hi @Brett Jones and @Alice in #orders"
+    out = _run("Hi <@U0EXAMPLE1> and <@U123> in <#C1|orders>")
+    assert out == "Hi @Alex Rivera and @Alice in #orders"
 
 
 def test_screenshot_case():
     # The exact failure Brad reported: a raw <@U…> in a nudge body.
-    raw = "Hi <@U774M8XDE> Re: Savor Ice Cream — Install 1905 Notre Dame Blvd"
-    assert _run(raw) == "Hi @Brett Jones Re: Savor Ice Cream — Install 1905 Notre Dame Blvd"
+    raw = "Hi <@U0EXAMPLE1> Re: Acme Creamery — Install 100 Main St"
+    assert _run(raw) == "Hi @Alex Rivera Re: Acme Creamery — Install 100 Main St"


### PR DESCRIPTION
## Sanitize (example/test data — non-load-bearing)
Real person **Brett Jones** + Slack ID **U774M8XDE** + a real customer/address (**Savor Ice Cream — Install 1905 Notre Dame Blvd**) sat in public docstrings/comments/test fixtures → fictional placeholders (Alex Rivera / U0EXAMPLE1 / Acme Creamery). Files: `src/pinky_daemon/pollers.py` (docstring), `src/pinky_daemon/broker.py` (comment), `tests/test_slack_text_refs.py`, `tests/test_broker.py`. All example/test data — verified non-load-bearing (no real routing depends on the id/name). **Completes #554** (last non-fixture PII item; per Brad).

## Stale-wording cleanup (from #1043 review)
The #1043 owner-notify suppression left comments/names describing the old behavior:
- `scheduler.py`: `owner_notify_callback` contract comment + `_record_schedule_undelivered` docstring now state the routine FIRED-BUT-UNDELIVERED path is **log-only** (owner not notified); the callback serves PARKED / stale-one-shot dead-letter alerts.
- renamed `test_scheduler.py` (`…undelivered_does_not_alert_owner…`) + `test_api.py` (`…owner_alert_uses_owner_destination…`) to match current behavior.

## Safety
Behavior-neutral: 96 slack/broker + 139 scheduler tests pass; the renamed test_api owner-alert test passes; ruff clean; no real PII remains in the tree (grep-verified). Forward change only.