### PR TITLE
feat(agents): opt-in per-agent dedicated CLAUDE_CONFIG_DIR (own Claude account, local agents)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -505,6 +505,14 @@ class Agent:
     # effort drifts from thinking_effort. Default False (warn-only): drift is
     # surfaced to /agents/{name}/effort-drift + heartbeat but does not block.
     strict_effort_enforcement: bool = False
+    # When True AND the agent is LOCAL (isolation_mode local / non-container),
+    # the tmux session runs with its own CLAUDE_CONFIG_DIR
+    # (<working_dir>/.claude-local) and the shared CLAUDE_CODE_OAUTH_TOKEN is
+    # withheld — so the agent holds its OWN Claude subscription account
+    # (populated later by a manual `claude /login`) instead of sharing the
+    # daemon user's ~/.claude. No-op for container agents (they already get
+    # their own config dir). Default False = shared ~/.claude (current behavior).
+    dedicated_config_dir: bool = False
     watchdog_config: dict = field(default_factory=dict)  # Per-agent watchdog overrides (JSON blob)
     # watchdog_config schema: {
     #   "enabled": true,              # Enable/disable watchdog for this agent
@@ -570,6 +578,7 @@ class Agent:
             "provider_ref": self.provider_ref,
             "thinking_effort": self.thinking_effort,
             "strict_effort_enforcement": self.strict_effort_enforcement,
+            "dedicated_config_dir": self.dedicated_config_dir,
             "watchdog_config": self.watchdog_config,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
@@ -1757,6 +1766,9 @@ class AgentRegistry:
             # When 1, verify_effort CLI hook blocks tool calls on effort drift
             # (vs. warn-only default of 0). See #429.
             ("strict_effort_enforcement", "INTEGER NOT NULL DEFAULT 0"),
+            # Opt-in per-agent dedicated CLAUDE_CONFIG_DIR (own Claude account
+            # for a LOCAL agent). Default 0 = shared ~/.claude (unchanged).
+            ("dedicated_config_dir", "INTEGER NOT NULL DEFAULT 0"),
             ("watchdog_config", "TEXT NOT NULL DEFAULT '{}'"),
             ("last_seen_at", "REAL NOT NULL DEFAULT 0"),
             ("runtime", "TEXT NOT NULL DEFAULT 'claude_sdk'"),
@@ -2607,7 +2619,8 @@ except Exception as exc:
                     "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
                     "librarian_enabled", "librarian_schedule",
                     "runtime", "transport", "provider_url", "provider_model", "provider_ref",
-                    "thinking_effort", "strict_effort_enforcement", "isolated",
+                    "thinking_effort", "strict_effort_enforcement",
+                    "dedicated_config_dir", "isolated",
                     "isolation_mode", "container_image"):
             if key in kwargs:
                 updates[key] = kwargs[key]
@@ -2626,7 +2639,8 @@ except Exception as exc:
 
         for key in ("auto_restart", "enabled", "auto_start", "clock_aligned",
                     "plain_text_fallback", "dream_enabled", "dream_notify",
-                    "librarian_enabled", "strict_effort_enforcement", "isolated"):
+                    "librarian_enabled", "strict_effort_enforcement",
+                    "dedicated_config_dir", "isolated"):
             if key in updates:
                 updates[key] = int(updates[key])
         if "voice_config" in updates and isinstance(updates["voice_config"], dict):
@@ -2741,6 +2755,7 @@ except Exception as exc:
                 provider_ref=kwargs.get("provider_ref", ""),
                 thinking_effort=kwargs.get("thinking_effort", "medium"),
                 strict_effort_enforcement=kwargs.get("strict_effort_enforcement", False),
+                dedicated_config_dir=kwargs.get("dedicated_config_dir", False),
                 watchdog_config=kwargs.get("watchdog_config", {}),
                 created_at=now,
                 updated_at=now,
@@ -2757,9 +2772,10 @@ except Exception as exc:
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
                     librarian_enabled, librarian_schedule,
                     runtime, transport, provider_url, provider_key, provider_model, provider_ref,
-                    thinking_effort, strict_effort_enforcement, watchdog_config,
+                    thinking_effort, strict_effort_enforcement, dedicated_config_dir,
+                    watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -2777,6 +2793,7 @@ except Exception as exc:
                  agent.runtime, agent.transport, agent.provider_url, agent.provider_key,
                  agent.provider_model, agent.provider_ref,
                  agent.thinking_effort, int(agent.strict_effort_enforcement),
+                 int(agent.dedicated_config_dir),
                  json.dumps(agent.watchdog_config),
                  agent.created_at, agent.updated_at),
             )
@@ -2815,7 +2832,7 @@ except Exception as exc:
         "runtime, transport, provider_url, provider_key, provider_model, provider_ref, "
         "disallowed_tools, thinking_effort, watchdog_config, last_seen_at, "
         "strict_effort_enforcement, context_nudge_threshold_pct, isolated, "
-        "isolation_mode, container_image"
+        "isolation_mode, container_image, dedicated_config_dir"
     )
 
     def get(self, name: str) -> Agent | None:
@@ -6806,6 +6823,7 @@ except Exception as exc:
             isolated=bool(row[51]) if len(row) > 51 else False,
             isolation_mode=row[52] if len(row) > 52 and row[52] else "local",
             container_image=row[53] if len(row) > 53 and row[53] else "",
+            dedicated_config_dir=bool(row[54]) if len(row) > 54 else False,
         )
 
     # ── Cost Tracking ──────────────────────────────────────

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6337,6 +6337,7 @@ npm run build</pre>
             provider_ref=req.provider_ref,
             thinking_effort=req.thinking_effort,
             strict_effort_enforcement=req.strict_effort_enforcement,
+            dedicated_config_dir=req.dedicated_config_dir,
             watchdog_config=req.watchdog_config or {},
             isolated=req.isolated,
             isolation_mode=req.isolation_mode,
@@ -6793,6 +6794,23 @@ npm run build</pre>
 
                 allowed_roots.append(
                     (Path(container_config_dir(str(Path(wd).resolve()))) / "projects")
+                    .resolve()
+                )
+        # Dedicated-config-dir LOCAL agent (#550/Picard): claude runs with
+        # CLAUDE_CONFIG_DIR=<working_dir>/.claude-local, so its SessionStart hook
+        # legitimately reports transcripts under <working_dir>/.claude-local/
+        # projects/... — without this root the report 403s and the tailer never
+        # repoints off its cold-start guess.
+        if (
+            getattr(agent, "dedicated_config_dir", False)
+            and getattr(agent, "isolation_mode", "local") in ("", "local")
+        ):
+            wd = (agent.working_dir or "").strip()
+            if wd and Path(wd).is_absolute():
+                from pinky_daemon.provisioning import local_config_dir
+
+                allowed_roots.append(
+                    (Path(local_config_dir(str(Path(wd).resolve()))) / "projects")
                     .resolve()
                 )
         try:

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -344,6 +344,10 @@ class RegisterAgentRequest(BaseModel):
     provider_ref: str = ""  # ID of a global provider from the providers table
     thinking_effort: str = "medium"  # low/medium/high/xhigh/max/ultracode
     strict_effort_enforcement: bool = False  # PR #429 — block tool calls when effort drifts
+    # #550/Picard — opt-in: a LOCAL agent runs its own Claude account via a
+    # dedicated CLAUDE_CONFIG_DIR (<working_dir>/.claude-local). Default False =
+    # shared ~/.claude (unchanged). No-op for container agents.
+    dedicated_config_dir: bool = False
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
     isolated: bool = False  # #149 — hard-isolated tenant (Counterpart); daemon denies cross-agent actions
     # #149 phase-3 — OS-level runtime sandbox for an isolated tenant.
@@ -424,6 +428,9 @@ class UpdateAgentRequest(BaseModel):
     provider_ref: str | None = None  # ID of a global provider from the providers table
     thinking_effort: str | None = None  # low/medium/high/xhigh/max/ultracode
     strict_effort_enforcement: bool | None = None  # PR #429 — block tool calls when effort drifts
+    # #550/Picard — opt-in dedicated CLAUDE_CONFIG_DIR for a LOCAL agent;
+    # None = leave unchanged. See RegisterAgentRequest for semantics.
+    dedicated_config_dir: bool | None = None
     watchdog_config: dict | None = None  # Per-agent watchdog overrides
     # #149 — hard-isolation flag; None = leave unchanged. Settable so a
     # container→local round trip can explicitly lift the (auto-coerced)

--- a/src/pinky_daemon/provisioning.py
+++ b/src/pinky_daemon/provisioning.py
@@ -123,6 +123,11 @@ CONTAINER_HOME = "/home/agent"
 # the existing same-path workdir mount — no extra mount, no path translation.
 # The home VOLUME still backs ~/.config etc. for any other CLIs in the image.
 CONTAINER_CONFIG_DIRNAME = ".claude-container"
+# The CLAUDE_CONFIG_DIR used by a LOCAL (non-container) agent that opted into
+# its own Claude subscription account via ``dedicated_config_dir`` — a
+# working-dir-scoped config dir so the agent holds its own OAuth login instead
+# of sharing the daemon user's ``~/.claude``. Mirrors CONTAINER_CONFIG_DIRNAME.
+LOCAL_CONFIG_DIRNAME = ".claude-local"
 # Conservative default resource caps for container tenants (the Pi 5 shares
 # 8GB with a POS stack). Operator-overridable per host; set to "0" to disable.
 CONTAINER_MEMORY_ENV = "PINKY_CONTAINER_MEMORY"
@@ -148,6 +153,14 @@ def container_config_dir(working_dir: str) -> str:
     """The CLAUDE_CONFIG_DIR used inside a container agent's runtime — a
     host-visible path inside the (same-path bind-mounted) working_dir."""
     return str(Path(working_dir) / CONTAINER_CONFIG_DIRNAME)
+
+
+def local_config_dir(working_dir: str) -> str:
+    """The CLAUDE_CONFIG_DIR for a LOCAL agent with ``dedicated_config_dir`` —
+    a working-dir-scoped config dir (``<working_dir>/.claude-local``) holding
+    that agent's own Claude account/login, instead of the shared ~/.claude.
+    Mirrors ``container_config_dir`` for the non-container case."""
+    return str(Path(working_dir) / LOCAL_CONFIG_DIRNAME)
 
 
 @dataclass

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3292,12 +3292,22 @@ class TmuxSession:
         # it via tmux-server inheritance, but forwarding makes it explicit and
         # uniform. Flag-gated + provider-guarded inside _static_oauth_token.
         #
-        # SUPPRESSED for a dedicated_config_dir agent: injecting the SHARED
-        # fleet token would authenticate it as the shared account regardless of
-        # its private config dir, defeating the whole point of the flag. Its own
-        # login lives in .claude-local (populated by a manual `claude /login`).
+        # SHADOWED-EMPTY for a dedicated_config_dir agent (#557/Picard, caught in
+        # Murzik review): injecting the SHARED fleet token would authenticate it
+        # as the shared account regardless of its private config dir, defeating
+        # the whole point of the flag. But simply OMITTING the key here is a
+        # NO-OP — tmux ``new-session`` inherits the tmux SERVER's global
+        # environment, which already carries the daemon user's shared
+        # CLAUDE_CODE_OAUTH_TOKEN, so the dedicated session would still see it
+        # via inheritance. We must instead pass ``-e CLAUDE_CODE_OAUTH_TOKEN=``
+        # (EMPTY) to SHADOW the inherited global with an empty value: empty ⇒
+        # claude does not authenticate with it and falls back to the login in
+        # this agent's CLAUDE_CONFIG_DIR (.claude-local, populated by a manual
+        # `claude /login`). Verified end-to-end on CC 2.1.226 + real tmux.
         oauth_token = self._static_oauth_token()
-        if oauth_token and not dedicated_config_dir:
+        if dedicated_config_dir:
+            env["CLAUDE_CODE_OAUTH_TOKEN"] = ""
+        elif oauth_token:
             env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
         if self.agent_name:
             env["PINKY_AGENT_NAME"] = self.agent_name

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -3214,6 +3214,38 @@ class TmuxSession:
             return ""
         return os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
 
+    def _dedicated_config_dir(self) -> str:
+        """The dedicated CLAUDE_CONFIG_DIR for a LOCAL agent that opted into
+        its own Claude account via ``dedicated_config_dir``, else ``""``.
+
+        Read from the REGISTRY (mirrors ``_container_agent``): isolation-
+        adjacent flags live on the Agent record, not the per-session
+        StreamingSessionConfig. A registry hiccup falls back to the shared
+        ~/.claude (fail-safe: a read-side error must not wedge a session).
+
+        LOCAL-only (#550/Picard): a container agent already runs with its own
+        CLAUDE_CONFIG_DIR (``container_config_dir``), so the flag is a no-op
+        there — we gate on ``isolation_mode`` being local/unset. Requires an
+        absolute working_dir (the path is ``<working_dir>/.claude-local``); a
+        relative/empty cwd can't anchor a stable config dir, so we withhold it
+        and fall back to the shared ~/.claude (current behavior)."""
+        if not self._registry or not self.agent_name:
+            return ""
+        try:
+            agent = self._registry.get(self.agent_name)
+        except Exception:
+            return ""
+        if not agent or not getattr(agent, "dedicated_config_dir", False):
+            return ""
+        if getattr(agent, "isolation_mode", "local") not in ("", "local"):
+            return ""
+        wd = (self._config.working_dir or "").strip()
+        if not wd or not Path(wd).is_absolute():
+            return ""
+        from pinky_daemon.provisioning import local_config_dir
+
+        return local_config_dir(wd)
+
     def _build_repl_env(self) -> dict[str, str]:
         """Env vars injected into the tmux session.
 
@@ -3243,6 +3275,14 @@ class TmuxSession:
         if self._config.provider_key:
             env["ANTHROPIC_API_KEY"] = self._config.provider_key
             env["ANTHROPIC_AUTH_TOKEN"] = self._config.provider_key
+        # Per-agent dedicated Claude account (#550/Picard): a LOCAL agent that
+        # opted into ``dedicated_config_dir`` runs with its OWN CLAUDE_CONFIG_DIR
+        # (<working_dir>/.claude-local) so it holds its own OAuth login instead
+        # of sharing the daemon user's ~/.claude. Empty for every other agent
+        # (shared ~/.claude — unchanged). Guarded LOCAL-only inside the helper.
+        dedicated_config_dir = self._dedicated_config_dir()
+        if dedicated_config_dir:
+            env["CLAUDE_CONFIG_DIR"] = dedicated_config_dir
         # Static OAuth token forwarding (#780): inject a long-lived, never-
         # refreshed CLAUDE_CODE_OAUTH_TOKEN so claude authenticates with it
         # instead of the single-use refresh token in .credentials.json (no
@@ -3251,8 +3291,13 @@ class TmuxSession:
         # without this -e the token never reaches them; local tmux agents get
         # it via tmux-server inheritance, but forwarding makes it explicit and
         # uniform. Flag-gated + provider-guarded inside _static_oauth_token.
+        #
+        # SUPPRESSED for a dedicated_config_dir agent: injecting the SHARED
+        # fleet token would authenticate it as the shared account regardless of
+        # its private config dir, defeating the whole point of the flag. Its own
+        # login lives in .claude-local (populated by a manual `claude /login`).
         oauth_token = self._static_oauth_token()
-        if oauth_token:
+        if oauth_token and not dedicated_config_dir:
             env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
         if self.agent_name:
             env["PINKY_AGENT_NAME"] = self.agent_name
@@ -5560,6 +5605,15 @@ class TmuxSession:
                 from pinky_daemon.provisioning import container_config_dir
 
                 return Path(container_config_dir(wd)) / "projects" / encoded
+        # Dedicated-config-dir LOCAL agent (#550/Picard): claude runs with
+        # CLAUDE_CONFIG_DIR=<working_dir>/.claude-local, so its transcripts live
+        # under that config dir's projects/, not the shared ~/.claude. Without
+        # this branch the tailer watches ~/.claude and never sees the agent's
+        # conversation. Helper returns "" for every non-dedicated/non-local
+        # agent, so the shared path below is unchanged for them.
+        dedicated_config_dir = self._dedicated_config_dir()
+        if dedicated_config_dir:
+            return Path(dedicated_config_dir) / "projects" / encoded
         return Path.home() / ".claude" / "projects" / encoded
 
     def _has_prior_transcript(self) -> bool:

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -462,6 +462,25 @@ class TestAgentCRUD:
         registry.register("plain", isolated=True)
         assert registry.get("plain").isolated is True
 
+    def test_dedicated_config_dir_round_trip(self, registry):
+        """#550/Picard: dedicated_config_dir persists through insert/get/to_dict,
+        defaults off (backward compat), and is settable via the update path."""
+        # Default off — existing agents keep the shared ~/.claude.
+        plain = registry.register("plain", model="opus")
+        assert plain.dedicated_config_dir is False
+        assert registry.get("plain").dedicated_config_dir is False
+        assert registry.get("plain").to_dict()["dedicated_config_dir"] is False
+
+        # Insert with dedicated_config_dir=True.
+        ded = registry.register("solo", model="opus", dedicated_config_dir=True)
+        assert ded.dedicated_config_dir is True
+        assert registry.get("solo").dedicated_config_dir is True
+        assert registry.get("solo").to_dict()["dedicated_config_dir"] is True
+
+        # Update path flips it on for an existing agent.
+        registry.register("plain", dedicated_config_dir=True)
+        assert registry.get("plain").dedicated_config_dir is True
+
     def test_isolation_mode_round_trip(self, registry):
         """#149 phase-3: isolation_mode persists through insert/get/to_dict,
         defaults to 'local', and is settable via the update path."""

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -36,11 +36,13 @@ from pinky_daemon.tmux_session import (
 
 
 class _FakeAgent:
-    def __init__(self, name, isolation_mode="local", working_dir="", isolated=False):
+    def __init__(self, name, isolation_mode="local", working_dir="", isolated=False,
+                 dedicated_config_dir=False):
         self.name = name
         self.isolation_mode = isolation_mode
         self.working_dir = working_dir
         self.isolated = isolated
+        self.dedicated_config_dir = dedicated_config_dir
 
 
 class _RecordingInner:
@@ -714,6 +716,100 @@ class TestStaticOAuthTokenForward:
         monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")  # no token in env
         ss = _session(registry=_FakeRegistry(_FakeAgent("dymok", "local")))
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in ss._build_repl_env()
+
+
+class TestDedicatedConfigDir:
+    """#550/Picard: an opt-in LOCAL agent runs its own Claude subscription
+    account via a dedicated CLAUDE_CONFIG_DIR (<working_dir>/.claude-local) and
+    has the SHARED CLAUDE_CODE_OAUTH_TOKEN withheld. Default False (and every
+    container agent) must behave exactly as before — shared ~/.claude, shared
+    token."""
+
+    def _clear(self, monkeypatch):
+        monkeypatch.delenv("PINKY_FORWARD_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+    def test_default_agent_no_config_dir_and_keeps_shared_token(self, monkeypatch, tmp_path):
+        # Backward compat: dedicated_config_dir=False → NO CLAUDE_CONFIG_DIR set,
+        # and the shared oauth token is still injected when forwarding is on.
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-shared")
+        wd = str(tmp_path / "proj")
+        ss = _session(
+            registry=_FakeRegistry(
+                _FakeAgent("dymok", "local", working_dir=wd, dedicated_config_dir=False)
+            ),
+            working_dir=wd,
+        )
+        env = ss._build_repl_env()
+        assert "CLAUDE_CONFIG_DIR" not in env
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-shared"
+
+    def test_dedicated_local_agent_sets_config_dir_and_suppresses_token(
+        self, monkeypatch, tmp_path
+    ):
+        # The whole feature: own config dir + shared token SUPPRESSED even when
+        # _static_oauth_token() would otherwise return one (forwarding on).
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-shared")
+        wd = str(tmp_path / "proj")
+        ss = _session(
+            registry=_FakeRegistry(
+                _FakeAgent("dymok", "local", working_dir=wd, dedicated_config_dir=True)
+            ),
+            working_dir=wd,
+        )
+        # Sanity: the token IS available to forward — suppression is the flag's
+        # doing, not an empty env.
+        assert ss._static_oauth_token() == "sk-ant-oat01-shared"
+        env = ss._build_repl_env()
+        assert env["CLAUDE_CONFIG_DIR"] == str(Path(wd) / ".claude-local")
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+
+    def test_container_agent_flag_is_noop(self, monkeypatch, tmp_path):
+        # dedicated_config_dir is a LOCAL concept — a container agent already
+        # gets its own config dir, so the flag must not add CLAUDE_CONFIG_DIR
+        # via the local path nor suppress the (container-essential) token.
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-c")
+        wd = str(tmp_path / "proj")
+        ss = _session(
+            registry=_FakeRegistry(
+                _FakeAgent("dymok", "container", working_dir=wd, dedicated_config_dir=True)
+            ),
+            working_dir=wd,
+        )
+        assert ss._dedicated_config_dir() == ""
+        env = ss._build_repl_env()
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-c"
+
+    def test_project_dir_routes_to_claude_local(self, monkeypatch, tmp_path):
+        # Transcript discovery must follow the dedicated config dir, else the
+        # tailer watches ~/.claude and never sees the agent's conversation.
+        monkeypatch.setenv("PINKY_CONTAINER_RUNTIME", "podman")
+        wd = str(tmp_path / "proj")
+        ss = _session(
+            registry=_FakeRegistry(
+                _FakeAgent("dymok", "local", working_dir=wd, dedicated_config_dir=True)
+            ),
+            working_dir=wd,
+        )
+        expected = Path(wd) / ".claude-local" / "projects" / _claude_slug(wd)
+        assert ss._project_dir() == expected
+
+    def test_project_dir_default_agent_unchanged(self, monkeypatch, tmp_path):
+        wd = str(tmp_path / "proj")
+        ss = _session(
+            registry=_FakeRegistry(
+                _FakeAgent("dymok", "local", working_dir=wd, dedicated_config_dir=False)
+            ),
+            working_dir=wd,
+        )
+        assert ss._project_dir() == Path.home() / ".claude" / "projects" / _claude_slug(wd)
 
 
 @pytest.mark.asyncio

--- a/tests/test_tmux_container_isolation.py
+++ b/tests/test_tmux_container_isolation.py
@@ -746,11 +746,14 @@ class TestDedicatedConfigDir:
         assert "CLAUDE_CONFIG_DIR" not in env
         assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-shared"
 
-    def test_dedicated_local_agent_sets_config_dir_and_suppresses_token(
+    def test_dedicated_local_agent_sets_config_dir_and_shadows_token_empty(
         self, monkeypatch, tmp_path
     ):
-        # The whole feature: own config dir + shared token SUPPRESSED even when
-        # _static_oauth_token() would otherwise return one (forwarding on).
+        # The whole feature: own config dir + shared token SHADOWED-EMPTY even
+        # when _static_oauth_token() would otherwise return one (forwarding on).
+        # The key must be present with an EMPTY value — NOT omitted. Omitting it
+        # is a no-op: tmux new-session inherits the tmux server's global
+        # CLAUDE_CODE_OAUTH_TOKEN, so only an explicit `-e KEY=` shadows it.
         self._clear(monkeypatch)
         monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
         monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-shared")
@@ -761,12 +764,76 @@ class TestDedicatedConfigDir:
             ),
             working_dir=wd,
         )
-        # Sanity: the token IS available to forward — suppression is the flag's
-        # doing, not an empty env.
+        # Sanity: the token IS available to forward — the empty shadow is the
+        # flag's doing, not an empty env.
         assert ss._static_oauth_token() == "sk-ant-oat01-shared"
         env = ss._build_repl_env()
         assert env["CLAUDE_CONFIG_DIR"] == str(Path(wd) / ".claude-local")
-        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        # Present-and-empty, not absent. This is the load-bearing assertion:
+        # `in` with `== ""`, never `not in`.
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in env
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == ""
+
+    async def test_dedicated_local_agent_emits_empty_oauth_e_flag_in_argv(
+        self, monkeypatch, tmp_path
+    ):
+        # End-to-end at the tmux boundary (the crux the dict-level test misses):
+        # a dedicated agent's env must reach `tmux new-session` as an explicit
+        # `-e CLAUDE_CODE_OAUTH_TOKEN=` (empty value) so it SHADOWS the tmux
+        # server's inherited global token. A regression that reverts to
+        # dict-omission would drop this flag and silently re-leak the shared
+        # token via inheritance — which the dict-level assertion cannot catch.
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-shared")
+        wd = str(tmp_path / "proj")
+        ss = _session(
+            registry=_FakeRegistry(
+                _FakeAgent("dymok", "local", working_dir=wd, dedicated_config_dir=True)
+            ),
+            working_dir=wd,
+        )
+        inner = _RecordingInner()
+        control = _TmuxControl("pinky-dymok-main", command_runner=inner)
+        await control.new_session(
+            cwd=wd, command="claude", env=ss._build_repl_env()
+        )
+        argv = inner.calls[-1]
+        # The pair must appear consecutively; the value is the empty string.
+        assert "-e" in argv
+        pairs = [
+            argv[i + 1] for i, tok in enumerate(argv[:-1]) if tok == "-e"
+        ]
+        assert "CLAUDE_CODE_OAUTH_TOKEN=" in pairs
+        # And never the shared token itself.
+        assert "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-shared" not in pairs
+
+    async def test_default_agent_emits_populated_oauth_e_flag_in_argv(
+        self, monkeypatch, tmp_path
+    ):
+        # Backward-compat guard: a NON-dedicated agent still forwards the real
+        # shared token as `-e CLAUDE_CODE_OAUTH_TOKEN=<tok>` (never empty).
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PINKY_FORWARD_OAUTH_TOKEN", "1")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-shared")
+        wd = str(tmp_path / "proj")
+        ss = _session(
+            registry=_FakeRegistry(
+                _FakeAgent("dymok", "local", working_dir=wd, dedicated_config_dir=False)
+            ),
+            working_dir=wd,
+        )
+        inner = _RecordingInner()
+        control = _TmuxControl("pinky-dymok-main", command_runner=inner)
+        await control.new_session(
+            cwd=wd, command="claude", env=ss._build_repl_env()
+        )
+        argv = inner.calls[-1]
+        pairs = [
+            argv[i + 1] for i, tok in enumerate(argv[:-1]) if tok == "-e"
+        ]
+        assert "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-shared" in pairs
+        assert "CLAUDE_CODE_OAUTH_TOKEN=" not in pairs
 
     def test_container_agent_flag_is_noop(self, monkeypatch, tmp_path):
         # dedicated_config_dir is a LOCAL concept — a container agent already


### PR DESCRIPTION
## What & why

Adds an opt-in `dedicated_config_dir` boolean so a **LOCAL** (non-container) tmux agent runs its **own Claude subscription account**: it gets a dedicated `CLAUDE_CONFIG_DIR=<working_dir>/.claude-local` and the shared `CLAUDE_CODE_OAUTH_TOKEN` (#780) is **withheld**, so it authenticates from its own `claude /login` instead of sharing the daemon user's `~/.claude`.

**Default `False` = zero change** for every existing agent (shared `~/.claude`, shared token, shared transcript path).

### Motivation (#550 / Picard)
A fleet-coordinator agent must be **non-isolated** to act across the fleet, but still needs its own Claude account. Containerizing forces `isolated=True` (self-only, per the #149 composition law), so the container path is out for a commander. The unit of "own account" is the **per-agent config dir**, not the container — this wires that for local agents without touching the isolation/secret model. Subscription-only by design (per-agent API keys would be prohibitively usage-billed at fleet scale).

## Changes
- **provisioning.py** — `LOCAL_CONFIG_DIRNAME` + `local_config_dir()` (mirror `container_config_dir`).
- **agent_registry.py** — `dedicated_config_dir` mirrored 1:1 off `strict_effort_enforcement`: dataclass, `to_dict`, `_ensure_columns` migration, `update_agent` allowed-keys + int-coercion, `register`, INSERT (50/50/50 verified), SELECT, hydration `row[54]` (guarded `len(row) > 54`).
- **tmux_session.py** — `_dedicated_config_dir()` reads from the **registry** (config lacks the field), `try/except` **fail-safe** to shared `~/.claude`, **LOCAL-only + absolute-cwd** guarded; `_build_repl_env` sets `CLAUDE_CONFIG_DIR` and guards the oauth inject with `and not dedicated_config_dir`; `_project_dir` routes transcripts to `.claude-local/projects`.
- **api.py** — POST `/agents` passthrough; transcript-path allowlist appends `.claude-local/projects` for a dedicated LOCAL agent (mirrors the container branch).
- **api_models.py** — `RegisterAgentRequest`/`UpdateAgentRequest` fields.

## Safety / review notes
- **Backward-compat is the load-bearing property**: default off ⇒ no `CLAUDE_CONFIG_DIR`, shared token still injected, shared transcript path. A test asserts this (so we never accidentally log out the fleet).
- **OAuth suppression** is the security-critical bit: a test asserts `_static_oauth_token()` returns a token yet `CLAUDE_CODE_OAUTH_TOKEN not in env` for a dedicated agent — otherwise it'd auth as the shared account regardless of its config dir.
- Isolation/secret gating untouched — a dedicated agent can still be non-isolated and receive `PINKY_SESSION_SECRET`.
- Registry read in the env path is `try/except`-guarded so a registry hiccup can never wedge a session.

## Tests
6 new (oauth suppression, backward-compat default, container no-op, transcript routing ×2, registry round-trip). `pytest tests/test_tmux_container_isolation.py tests/test_agent_registry.py` → **193 passed**; `test_provisioning.py` → 103 passed; `ruff check` clean on all 7 files. (Backend/session-env change — no UI surface; test output is the evidence.)

Follow-up (separate): stand up Picard on the Pi with `dedicated_config_dir=True` + one-time `/login` (task #557).

---
🤖 Barsik