### PR TITLE
Fix codex context-window gauge for gpt-5.6-luna (#531)

### DIFF
--- a/src/pinky_daemon/sessions.py
+++ b/src/pinky_daemon/sessions.py
@@ -27,11 +27,22 @@ from pinky_daemon.session_store import SessionEventStore, SessionRecord, Session
 # Rough token estimate: ~4 chars per token for English text
 CHARS_PER_TOKEN = 4
 
-# Default context window sizes by model family
+# Default context window sizes by model family.
+# Keys are matched as case-insensitive SUBSTRINGS of the model name
+# (see CodexSession.max_tokens / the tmux context gauge), so a family
+# key like "gpt-5.6-luna" also covers "gpt-5.6-luna-max-fast".
+# NOTE (#531): the Codex gauge has no SDK-reported window (unlike the
+# Claude path's rawMaxTokens), so codex models must be listed here or
+# they fall to the 200k default. gpt-5.6-luna's real window is 272k;
+# absent this entry the gauge over-reports usage and triggers restarts
+# early. Other codex models (e.g. gpt-5.6-terra, gpt-5.6-sol) still fall
+# to the default until their real windows are confirmed — add them here
+# once verified rather than guessing.
 MODEL_CONTEXT_SIZES = {
     "opus": 200_000,
     "sonnet": 200_000,
     "haiku": 200_000,
+    "gpt-5.6-luna": 272_000,
     "default": 200_000,
 }
 

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -4273,7 +4273,23 @@ class TmuxSession:
             big = is_1m_model(self._config.model or "")
         except Exception:
             big = False
-        return 1_000_000 if big else 200_000
+        if big:
+            return 1_000_000
+        # #531: non-1M models default to 200k UNLESS listed in
+        # MODEL_CONTEXT_SIZES (single source of truth, shared with the
+        # legacy Session gauge). Codex models have no harness-reported
+        # window here, so e.g. gpt-5.6-luna (real cap 272k) must be in
+        # that table or it under-counts headroom and restarts early.
+        # Substring match mirrors the Session lookup.
+        try:
+            from pinky_daemon.sessions import MODEL_CONTEXT_SIZES
+            model = (self._config.model or "").lower()
+            for key, size in MODEL_CONTEXT_SIZES.items():
+                if key != "default" and key in model:
+                    return size
+        except Exception:
+            pass
+        return 200_000
 
     def _max_tokens_for_model(self) -> int:
         """Return the model's **effective** context-window cap.

--- a/tests/test_tmux_context_autorestart.py
+++ b/tests/test_tmux_context_autorestart.py
@@ -226,3 +226,26 @@ def test_non_1m_model_with_tier_suffix_stays_200k() -> None:
     ss = _make_session(model="gpt-5.5[1m]")
     assert ss._raw_max_tokens_for_model() == 200_000
     assert ss._effective_restart_threshold_pct() == pytest.approx(80.0)
+
+
+def test_gpt56_luna_uses_272k_window() -> None:
+    """#531: gpt-5.6-luna's real context window is 272k, not the 200k
+    default. Codex tmux sessions have no harness-reported window, so the
+    gauge must read it from MODEL_CONTEXT_SIZES or it under-counts headroom
+    and triggers a restart prematurely."""
+    ss = _make_session(model="gpt-5.6-luna")
+    assert ss._raw_max_tokens_for_model() == 272_000
+
+
+def test_gpt56_luna_variant_suffix_also_272k() -> None:
+    """Substring match: a tier/variant suffix on luna still resolves 272k."""
+    ss = _make_session(model="gpt-5.6-luna-max-fast")
+    assert ss._raw_max_tokens_for_model() == 272_000
+
+
+def test_unlisted_codex_model_stays_200k() -> None:
+    """Blast-radius guard: codex models NOT in MODEL_CONTEXT_SIZES (e.g.
+    gpt-5.6-terra) still fall to the 200k default until their real window
+    is verified — the fix must not silently move every codex model's gauge."""
+    ss = _make_session(model="gpt-5.6-terra")
+    assert ss._raw_max_tokens_for_model() == 200_000


### PR DESCRIPTION
## What & why
The tmux gauge's `_raw_max_tokens_for_model()` guesses a model's window as a binary `is_1m_model → {1M, 200k}`. Codex models like `gpt-5.6-luna` (real window **272k**) aren't in `_1M_MODELS`, so they fell to the 200k default → the gauge over-reports usage → the restart nudge fires ~26% too early.

## Fix
For non-1M models, consult `MODEL_CONTEXT_SIZES` (now the single source of truth, shared with the legacy `Session` gauge) before the 200k default. Adds `gpt-5.6-luna → 272k`.

**Blast radius is ONLY luna.** Claude 1M models, `gpt-5.6-sol`, `gpt-5.6-terra`, and unknown models are all unchanged — guarded by `test_unlisted_codex_model_stays_200k` and the pre-existing sol/1M tests.

## Why the tmux path
For tmux-transport sessions the live gauge is the tmux path (`_raw_max_tokens_for_model`), not the legacy `Session.max_tokens`. Both now read the same table.

## Scope / NOT in this PR
- Does **not** touch the Claude-side #555 (`rawMaxTokens` override removal) — that's a separate fleet-wide gauge change flagged for review.
- `gpt-5.6-terra` and `gpt-5.6-sol` are likely siblings with non-200k windows, but there's **no verified source** for their caps here — deliberately left at default rather than guessed. Follow-up: confirm and add.

## Review note
⚠️ Touches fleet-wide restart-gauge timing (for luna-class models only). **Not self-merging** — flagged for review.

## Tests
- 3 new cases (luna→272k, luna variant→272k, unlisted-codex→200k guard) in `test_tmux_context_autorestart.py`
- Full autorestart suite (15) + `test_tmux_session.py` / `test_codex_tmux_session.py` (425 passed / 1 skipped), ruff clean.

🤖 Opened by Barsik