### PR TITLE
fix(context): unified context-window resolver for the gauge (#563)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -126,6 +126,7 @@ from pinky_daemon.auth import (
 )
 from pinky_daemon.autonomy import AgentEvent, AutonomyEngine, EventType
 from pinky_daemon.broker import BrokerMessage, MessageBroker
+from pinky_daemon.context_window import resolve_context_window
 from pinky_daemon.conversation_store import ConversationStore
 from pinky_daemon.dream_runner import DreamRunner
 from pinky_daemon.effort import CLI_EFFORT_LEVELS, EFFORT_LEVELS, resolve_cli_effort
@@ -3474,9 +3475,9 @@ def create_api(
             ctx = await asyncio.wait_for(ss._client.get_context_usage(), timeout=3.0)
             total = ctx.get("totalTokens", 0)
             reported_max = ctx.get("maxTokens", 0)
-            actual_max = reported_max
-            if is_1m_model(ss._config.model or "", _1M_MODELS) and reported_max <= 200_000:
-                actual_max = 1_000_000
+            actual_max = resolve_context_window(
+                ss._config.model or "", reported_max=reported_max
+            )
             # rawMaxTokens (SDK ≥ 0.1.x) is the raw model cap; maxTokens
             # is effective (autocompact buffer subtracted). Pass both
             # through so the frontend can show either; default to

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -30,7 +30,7 @@ from pinky_daemon.codex_app_server import (
 )
 from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor
 from pinky_daemon.context_estimator import ContextTextEstimator
-from pinky_daemon.sessions import MODEL_CONTEXT_SIZES, SessionUsage
+from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.streaming_session import (
     StreamingSessionConfig,
     _is_outreach_tool,
@@ -2010,11 +2010,9 @@ class CodexSession:
     @property
     def max_tokens(self) -> int:
         """Estimated max context tokens for this session's model."""
-        model_name = (self._codex_model or self._config.model or "").lower()
-        for key, size in MODEL_CONTEXT_SIZES.items():
-            if key != "default" and key in model_name:
-                return size
-        return MODEL_CONTEXT_SIZES["default"]
+        from pinky_daemon.context_window import resolve_context_window
+
+        return resolve_context_window(self._codex_model or self._config.model or "")
 
     @property
     def estimated_tokens(self) -> int:

--- a/src/pinky_daemon/context_window.py
+++ b/src/pinky_daemon/context_window.py
@@ -1,0 +1,134 @@
+"""Single source of truth for a session's context-window size.
+
+The context gauge (warn/restart timing, ``context_status`` percentage) needs
+one number: how many tokens fit in this session's window. Historically that
+number was computed independently at several call sites, each with its own
+model-name heuristic — including a ``1M-model → 1,000,000`` override that
+assumed any large-context model reporting <=200k was under-reporting. That
+override is wrong when a large window is *not* actually active for the
+session: the harness then reports the true 200k, the override inflates the
+denominator ~5x, and the percentage reads ~5x low, so an agent trusting the
+gauge runs past the real limit. The mirror failure hits models with no
+harness-reported window and no table entry: they fall to the default and the
+gauge over-reports, restarting early.
+
+``resolve_context_window`` replaces all of that with three tiers:
+
+1. Trust the harness-reported window when present. It reflects the real
+   session cap in both directions, with no model-name guessing.
+2. Otherwise use a per-model map that is augmentable at runtime via the
+   ``PINKY_MODEL_CONTEXT_SIZES`` environment variable — so a new model's
+   window is a config change, not a code change.
+3. Otherwise fall back to a conservative default. A smaller-than-real window
+   only costs an earlier restart; a larger-than-real window risks a silent
+   wall, so the safe direction is to under-estimate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+DEFAULT_CONTEXT_WINDOW = 200_000
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+# Environment override: a JSON object mapping a case-insensitive model-name
+# substring to its window size, e.g. ``{"gpt-5.6-terra": 300000}``. Entries
+# here win over the built-in map, so an operator can register a new model's
+# window without a code change.
+_ENV_OVERRIDE_KEY = "PINKY_MODEL_CONTEXT_SIZES"
+
+# Remember malformed override values we've already complained about so a bad
+# env var logs once, not on every gauge tick.
+_warned_bad_env: set[str] = set()
+
+
+def _env_override_map() -> dict[str, int]:
+    """Parse ``PINKY_MODEL_CONTEXT_SIZES`` defensively.
+
+    Returns an empty map (never raises) when the variable is absent, empty, or
+    malformed; a malformed value is logged once.
+    """
+    raw = os.environ.get(_ENV_OVERRIDE_KEY, "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            raise ValueError("expected a JSON object")
+    except (ValueError, TypeError) as exc:
+        if raw not in _warned_bad_env:
+            _warned_bad_env.add(raw)
+            _log(
+                f"context_window: ignoring malformed {_ENV_OVERRIDE_KEY} "
+                f"({type(exc).__name__}: {exc}) — falling back to built-in sizes"
+            )
+        return {}
+    # Valid JSON object: keep the good entries, skip any bad one individually
+    # rather than discarding the whole override for one typo.
+    out: dict[str, int] = {}
+    for key, size in parsed.items():
+        try:
+            size_int = int(size)
+        except (ValueError, TypeError):
+            continue
+        if size_int > 0:
+            out[str(key).lower()] = size_int
+    return out
+
+
+def _builtin_sizes() -> dict[str, int]:
+    """The built-in per-model seed map.
+
+    Imported lazily to keep this module free of the ``sessions`` import graph
+    (mirrors the existing lazy-import pattern at the transport call sites).
+    """
+    try:
+        from pinky_daemon.sessions import MODEL_CONTEXT_SIZES
+
+        return dict(MODEL_CONTEXT_SIZES)
+    except Exception:  # pragma: no cover - defensive; sessions always imports
+        return {"default": DEFAULT_CONTEXT_WINDOW}
+
+
+def configured_context_window(model_id: str) -> int:
+    """Return the configured window for ``model_id`` by substring match.
+
+    Merges the built-in map with the ``PINKY_MODEL_CONTEXT_SIZES`` env override
+    (env wins). The ``"default"`` key is never matched as a substring. Returns
+    ``0`` when nothing matches, letting the caller decide the fallback.
+    """
+    model = (model_id or "").lower()
+    if not model:
+        return 0
+    merged = _builtin_sizes()
+    merged.update(_env_override_map())
+    for key, size in merged.items():
+        if key != "default" and key and key in model:
+            return size
+    return 0
+
+
+def resolve_context_window(model_id: str, *, reported_max: int = 0) -> int:
+    """Resolve the token window to use for ``model_id``'s context gauge.
+
+    Tier 1: trust the harness-reported effective window (``reported_max``) when
+    it is a positive number — it reflects the real session cap in both
+    directions, so no model-name heuristic is needed.
+
+    Tier 2: no harness report (e.g. a transport that reports no window) — use
+    the configurable per-model map (:func:`configured_context_window`).
+
+    Tier 3: nothing known — a conservative default. Under-estimating only costs
+    an earlier restart; over-estimating risks a silent wall.
+    """
+    if reported_max and reported_max > 0:
+        return reported_max
+    configured = configured_context_window(model_id)
+    if configured:
+        return configured
+    return DEFAULT_CONTEXT_WINDOW

--- a/src/pinky_daemon/context_window.py
+++ b/src/pinky_daemon/context_window.py
@@ -46,6 +46,33 @@ _ENV_OVERRIDE_KEY = "PINKY_MODEL_CONTEXT_SIZES"
 # env var logs once, not on every gauge tick.
 _warned_bad_env: set[str] = set()
 
+# Sanity ceiling for a configured window — far above any real model window,
+# low enough to reject absurd/garbage values.
+_MAX_REASONABLE_WINDOW = 100_000_000
+
+
+def _coerce_window(value: object) -> int | None:
+    """Coerce a single override value to a positive int, or ``None`` to skip.
+
+    Accepts a JSON integer or an all-digits string; rejects ``bool`` (a JSON
+    ``true``/``false`` would otherwise become ``1``/``0``), ``float`` (e.g.
+    ``123.75`` or ``1e309`` -> ``inf``), ``null``, nested structures,
+    non-numeric strings, and non-positive or out-of-range values. Never raises,
+    so one bad entry is skipped rather than breaking the whole override.
+    """
+    # bool is an int subclass — exclude it before the int check.
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        size = value
+    elif isinstance(value, str) and value.strip().lstrip("+").isdigit():
+        size = int(value.strip())
+    else:
+        return None
+    if 0 < size <= _MAX_REASONABLE_WINDOW:
+        return size
+    return None
+
 
 def _env_override_map() -> dict[str, int]:
     """Parse ``PINKY_MODEL_CONTEXT_SIZES`` defensively.
@@ -71,13 +98,10 @@ def _env_override_map() -> dict[str, int]:
     # Valid JSON object: keep the good entries, skip any bad one individually
     # rather than discarding the whole override for one typo.
     out: dict[str, int] = {}
-    for key, size in parsed.items():
-        try:
-            size_int = int(size)
-        except (ValueError, TypeError):
-            continue
-        if size_int > 0:
-            out[str(key).lower()] = size_int
+    for key, value in parsed.items():
+        size = _coerce_window(value)
+        if size is not None:
+            out[str(key).lower()] = size
     return out
 
 
@@ -95,22 +119,40 @@ def _builtin_sizes() -> dict[str, int]:
         return {"default": DEFAULT_CONTEXT_WINDOW}
 
 
+def _longest_substring_match(model: str, mapping: dict[str, int]) -> int:
+    """Return the value whose key is the LONGEST substring of ``model``.
+
+    The ``"default"`` key is never matched as a substring. Longest-match makes
+    a more specific key (e.g. ``gpt-5.6-luna-max``) win over a broader one
+    (``gpt-5.6-luna``) regardless of dict order. Returns ``0`` when nothing
+    matches.
+    """
+    best_len = -1
+    best_size = 0
+    for key, size in mapping.items():
+        if key == "default" or not key:
+            continue
+        if key in model and len(key) > best_len:
+            best_len = len(key)
+            best_size = size
+    return best_size
+
+
 def configured_context_window(model_id: str) -> int:
     """Return the configured window for ``model_id`` by substring match.
 
-    Merges the built-in map with the ``PINKY_MODEL_CONTEXT_SIZES`` env override
-    (env wins). The ``"default"`` key is never matched as a substring. Returns
-    ``0`` when nothing matches, letting the caller decide the fallback.
+    The ``PINKY_MODEL_CONTEXT_SIZES`` env override is consulted first and wins
+    over the built-in seed map; within each tier the longest (most specific)
+    matching key wins. The ``"default"`` key is never matched as a substring.
+    Returns ``0`` when nothing matches, letting the caller decide the fallback.
     """
     model = (model_id or "").lower()
     if not model:
         return 0
-    merged = _builtin_sizes()
-    merged.update(_env_override_map())
-    for key, size in merged.items():
-        if key != "default" and key and key in model:
-            return size
-    return 0
+    env_hit = _longest_substring_match(model, _env_override_map())
+    if env_hit:
+        return env_hit
+    return _longest_substring_match(model, _builtin_sizes())
 
 
 def resolve_context_window(model_id: str, *, reported_max: int = 0) -> int:

--- a/src/pinky_daemon/context_window.py
+++ b/src/pinky_daemon/context_window.py
@@ -65,8 +65,18 @@ def _coerce_window(value: object) -> int | None:
         return None
     if isinstance(value, int):
         size = value
-    elif isinstance(value, str) and value.strip().lstrip("+").isdigit():
-        size = int(value.strip())
+    elif isinstance(value, str):
+        s = value.strip()
+        # ASCII decimal digits only, bounded length. str.isdigit() also accepts
+        # unicode digit characters (e.g. "²") and arbitrarily long strings
+        # that int() rejects (Python 3.11+ caps integer-string conversion
+        # length), so validate explicitly before converting.
+        if not (s.isascii() and s.isdigit() and len(s) <= 12):
+            return None
+        try:
+            size = int(s)
+        except ValueError:
+            return None
     else:
         return None
     if 0 < size <= _MAX_REASONABLE_WINDOW:

--- a/src/pinky_daemon/sessions.py
+++ b/src/pinky_daemon/sessions.py
@@ -329,10 +329,9 @@ class Session:
     @property
     def max_tokens(self) -> int:
         """Estimated max context tokens for this session's model."""
-        for key, size in MODEL_CONTEXT_SIZES.items():
-            if key in (self.model or "").lower():
-                return size
-        return MODEL_CONTEXT_SIZES["default"]
+        from pinky_daemon.context_window import resolve_context_window
+
+        return resolve_context_window(self.model or "")
 
     @property
     def estimated_tokens(self) -> int:

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -18,6 +18,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.context_window import resolve_context_window
 from pinky_daemon.effort import CLI_EFFORT_LEVELS, resolve_cli_effort
 from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.transport_state import SessionState, StateMachine, Trigger
@@ -1180,10 +1181,11 @@ class StreamingSession:
             total = ctx.get("totalTokens", 0)
             reported_max = ctx.get("maxTokens", 0)
 
-            # Fix: SDK reports 200k for 1M models — use actual window
-            max_t = reported_max
-            if is_1m_model(self._config.model or "") and reported_max <= 200_000:
-                max_t = 1_000_000
+            # Single source of truth for the window: trust the harness-reported
+            # cap (reported_max), falling back to the configurable per-model map.
+            max_t = resolve_context_window(
+                self._config.model or "", reported_max=reported_max
+            )
 
             pct = round(total / max_t * 100) if max_t > 0 else 0
 

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -63,10 +63,56 @@ def test_tier2_env_non_object_ignored(monkeypatch):
 
 
 def test_tier2_env_bad_size_skipped(monkeypatch):
-    # Non-positive / non-int sizes are dropped, not fatal.
+    # Non-positive / non-numeric sizes are dropped, not fatal.
     monkeypatch.setenv(ENV_KEY, '{"gpt-5.6-terra": "huge", "gpt-5.6-sol": -1}')
     assert resolve_context_window("gpt-5.6-terra") == DEFAULT_CONTEXT_WINDOW
     assert resolve_context_window("gpt-5.6-sol") == DEFAULT_CONTEXT_WINDOW
+
+
+def test_env_specific_key_wins_over_builtin_family(monkeypatch):
+    # Regression: an env key that fully names a model must win even though the
+    # built-in map has a broader family substring ("opus") that also matches.
+    monkeypatch.setenv(ENV_KEY, '{"claude-opus-4-8": 1000000}')
+    assert resolve_context_window("claude-opus-4-8") == 1_000_000
+
+
+def test_env_longest_key_wins_over_broader_env_key(monkeypatch):
+    # Within the env override, the most specific (longest) matching key wins,
+    # independent of JSON/dict ordering.
+    monkeypatch.setenv(ENV_KEY, '{"gpt-5.6": 100000, "gpt-5.6-luna-max": 500000}')
+    assert resolve_context_window("gpt-5.6-luna-max") == 500_000
+    # A model that only matches the broader key still resolves to it.
+    assert resolve_context_window("gpt-5.6-plain") == 100_000
+
+
+def test_env_overflow_value_is_skipped_not_fatal(monkeypatch):
+    # Regression: a value that overflows int() (1e309 -> inf) must not crash the
+    # resolver; other good entries in the same object are preserved.
+    monkeypatch.setenv(ENV_KEY, '{"badinf": 1e309, "gpt-5.6-terra": 300000}')
+    assert resolve_context_window("gpt-5.6-terra") == 300_000
+    assert resolve_context_window("badinf-model") == DEFAULT_CONTEXT_WINDOW
+
+
+def test_env_bool_and_float_rejected(monkeypatch):
+    # bool (JSON true -> 1) and float (123.75) are not valid window sizes.
+    monkeypatch.setenv(
+        ENV_KEY, '{"m-bool": true, "m-float": 123.75, "m-ok": 300000}'
+    )
+    assert resolve_context_window("m-bool") == DEFAULT_CONTEXT_WINDOW
+    assert resolve_context_window("m-float") == DEFAULT_CONTEXT_WINDOW
+    assert resolve_context_window("m-ok") == 300_000
+
+
+def test_env_integer_string_accepted(monkeypatch):
+    # A digits-only string is a friendly, valid way to write a size.
+    monkeypatch.setenv(ENV_KEY, '{"gpt-5.6-terra": "300000"}')
+    assert resolve_context_window("gpt-5.6-terra") == 300_000
+
+
+def test_env_out_of_range_value_skipped(monkeypatch):
+    # Absurdly large values are rejected (garbage guard).
+    monkeypatch.setenv(ENV_KEY, '{"gpt-5.6-terra": 999999999999}')
+    assert resolve_context_window("gpt-5.6-terra") == DEFAULT_CONTEXT_WINDOW
 
 
 # --- Tier 3: conservative default -------------------------------------------

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -1,5 +1,7 @@
 """Tests for the unified context-window resolver."""
 
+import json
+
 import pytest
 
 from pinky_daemon.context_window import (
@@ -113,6 +115,26 @@ def test_env_out_of_range_value_skipped(monkeypatch):
     # Absurdly large values are rejected (garbage guard).
     monkeypatch.setenv(ENV_KEY, '{"gpt-5.6-terra": 999999999999}')
     assert resolve_context_window("gpt-5.6-terra") == DEFAULT_CONTEXT_WINDOW
+
+
+def test_env_pathological_digit_strings_skipped(monkeypatch):
+    # str.isdigit() accepts inputs int() rejects: an over-long digit string
+    # (Python 3.11+ integer-string conversion cap), a unicode digit, and a
+    # multi-sign string. Each must be skipped non-fatally, preserving good
+    # siblings in the same object.
+    payload = json.dumps(
+        {
+            "bad-long": "9" * 5000,  # exceeds int() digit cap
+            "bad-plus": "++123",  # multi-sign
+            "bad-unicode": "²",  # superscript 2 — isdigit() True, int() raises
+            "gpt-5.6-terra": 300000,  # good sibling must survive
+        }
+    )
+    monkeypatch.setenv(ENV_KEY, payload)
+    assert resolve_context_window("gpt-5.6-terra") == 300_000
+    assert resolve_context_window("bad-long") == DEFAULT_CONTEXT_WINDOW
+    assert resolve_context_window("bad-plus") == DEFAULT_CONTEXT_WINDOW
+    assert resolve_context_window("bad-unicode") == DEFAULT_CONTEXT_WINDOW
 
 
 # --- Tier 3: conservative default -------------------------------------------

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -1,0 +1,116 @@
+"""Tests for the unified context-window resolver."""
+
+import pytest
+
+from pinky_daemon.context_window import (
+    DEFAULT_CONTEXT_WINDOW,
+    configured_context_window,
+    resolve_context_window,
+)
+
+ENV_KEY = "PINKY_MODEL_CONTEXT_SIZES"
+
+
+# --- Tier 1: trust the harness-reported window ------------------------------
+
+
+def test_tier1_reported_window_is_trusted_not_inflated():
+    """The core regression guard: a large-context model reporting 200k must
+    NOT be inflated to 1M. When a 1M window is not active the harness reports
+    the true 200k, and inflating it makes the percentage read ~5x low."""
+    assert resolve_context_window("claude-opus-4-8", reported_max=200_000) == 200_000
+
+
+def test_tier1_genuine_large_report_is_trusted():
+    assert (
+        resolve_context_window("claude-opus-4-8", reported_max=1_000_000)
+        == 1_000_000
+    )
+
+
+def test_tier1_reported_wins_over_configured():
+    # Even for a model with a configured window, a live harness report wins.
+    assert resolve_context_window("gpt-5.6-luna", reported_max=128_000) == 128_000
+
+
+# --- Tier 2: configurable per-model map -------------------------------------
+
+
+def test_tier2_builtin_substring_match():
+    # No harness report -> built-in map, matched as a substring.
+    assert resolve_context_window("gpt-5.6-luna-max-fast") == 272_000
+
+
+def test_tier2_env_override_registers_new_model(monkeypatch):
+    monkeypatch.setenv(ENV_KEY, '{"gpt-5.6-terra": 300000}')
+    assert resolve_context_window("gpt-5.6-terra") == 300_000
+
+
+def test_tier2_env_override_wins_over_builtin(monkeypatch):
+    monkeypatch.setenv(ENV_KEY, '{"gpt-5.6-luna": 500000}')
+    assert resolve_context_window("gpt-5.6-luna") == 500_000
+
+
+def test_tier2_malformed_env_falls_back_to_builtin(monkeypatch):
+    monkeypatch.setenv(ENV_KEY, "not-json{")
+    # Must not raise, and must still resolve built-ins.
+    assert resolve_context_window("gpt-5.6-luna") == 272_000
+
+
+def test_tier2_env_non_object_ignored(monkeypatch):
+    monkeypatch.setenv(ENV_KEY, "[1, 2, 3]")
+    assert resolve_context_window("gpt-5.6-luna") == 272_000
+
+
+def test_tier2_env_bad_size_skipped(monkeypatch):
+    # Non-positive / non-int sizes are dropped, not fatal.
+    monkeypatch.setenv(ENV_KEY, '{"gpt-5.6-terra": "huge", "gpt-5.6-sol": -1}')
+    assert resolve_context_window("gpt-5.6-terra") == DEFAULT_CONTEXT_WINDOW
+    assert resolve_context_window("gpt-5.6-sol") == DEFAULT_CONTEXT_WINDOW
+
+
+# --- Tier 3: conservative default -------------------------------------------
+
+
+def test_tier3_unknown_model_default():
+    assert resolve_context_window("some-unlisted-model") == DEFAULT_CONTEXT_WINDOW
+
+
+def test_tier3_empty_model_and_no_report_default():
+    assert resolve_context_window("") == DEFAULT_CONTEXT_WINDOW
+    assert resolve_context_window("", reported_max=0) == DEFAULT_CONTEXT_WINDOW
+
+
+def test_zero_or_negative_report_falls_through():
+    # A zero/negative report is treated as "no report", not a real window.
+    assert resolve_context_window("gpt-5.6-luna", reported_max=0) == 272_000
+    assert resolve_context_window("unknown", reported_max=-5) == DEFAULT_CONTEXT_WINDOW
+
+
+# --- configured_context_window direct ---------------------------------------
+
+
+def test_configured_returns_zero_when_unmatched():
+    # "default" is never matched as a substring; unmatched -> 0 (caller decides).
+    assert configured_context_window("totally-unknown") == 0
+
+
+def test_configured_default_key_not_substring_matched():
+    # A model literally containing "default" still shouldn't match the
+    # "default" seed key as a window (it is the Tier-3 fallback, not a match).
+    assert configured_context_window("default") == 0
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("gpt-5.6-luna", 272_000),
+        ("GPT-5.6-LUNA-MAX", 272_000),  # case-insensitive
+        # A Claude model on the no-report path matches the built-in "opus"
+        # seed -> a conservative 200k (the old 1M override is gone).
+        ("claude-opus-4-8", 200_000),
+        ("unlisted-xyz", 0),  # nothing matches -> caller falls back
+    ],
+)
+def test_configured_cases(model, expected):
+    assert configured_context_window(model) == expected


### PR DESCRIPTION
## What
Replaces the scattered per-site context-window logic with one resolver,
`resolve_context_window(model, *, reported_max)`:

1. **Trust the harness-reported window** when present — it reflects the real
   session cap in both directions, so no model-name guessing.
2. Else a **config-augmentable per-model map** — built-in seed merged with a
   `PINKY_MODEL_CONTEXT_SIZES` JSON env override (env wins; malformed config
   is ignored, never fatal). New model windows become a config change, not a
   code change.
3. Else a **conservative default** (200k) — under-estimating only costs an
   earlier restart; over-estimating risks a silent wall.

Wired at four gauge sites: `streaming_session._check_context`, the api
context endpoint, the legacy `Session.max_tokens`, and `CodexSession.max_tokens`.
The `is_1m_model -> 1M` override is dropped from the two streaming/api paths.

## Why
The gauge computed the window independently at several sites, each layering an
`is_1m_model -> 1M` override on top. When a 1M window is **not** actually active
for a session, the harness reports the true 200k and the override inflates the
denominator ~5x, so the gauge reads ~5x low and an agent trusting it can run
past the real limit (**#555**). The mirror failure hits models with no
harness-reported window and no table entry — they fall to the default and
over-report, restarting early (**#531**). Trusting the reported window fixes
the first; the configurable map fixes the second without a per-model table to
keep current.

## Scope note — tmux deferred on purpose
`tmux_session._raw_max_tokens_for_model` is intentionally left on its existing
model-name default in this PR. It has **no harness-reported window**, so its
`is_1m -> 1M` default is the only signal it has. Switching it to the
conservative default would change restart cadence for those agents and depends
on whether a 1M window is genuinely active there — a separate decision with its
own verification, tracked as a follow-up. This PR fixes the two *reported*
incidents (#555 streaming/api, #531 codex) and leaves that default untouched.

## Tests
`tests/test_context_window.py` — all three tiers, the reads-low regression
guard (a large-context model reporting 200k resolves to 200k, not 1M), env
override + malformed-config handling. Existing gauge/session/tmux/codex suites
pass unchanged.

## Review
Ready for review. Do not merge before the tmux-default follow-up decision is
made and this has sign-off.

---
Opened by Barsik