### PR TITLE
fix(scheduler): discard tombstones instead of deleting to stop wake re-fire (#566)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -4860,20 +4860,52 @@ except Exception as exc:
         *,
         agent_name: str | None = None,
     ) -> bool:
-        """Retire an active pending wake without marking it delivered.
+        """Retire an active pending wake by TOMBSTONING it (not deleting).
 
-        ``agent_name`` scopes self-service callers to their own outbox. Ledger
-        rows that are already accepted or quarantined are terminal evidence and
-        cannot be erased through this cleanup primitive.
+        Sets ``parked_at`` so the row survives as a terminal marker instead of
+        being erased. This is load-bearing: a bare ``DELETE`` left no durable
+        "retired" record, so a later reconciliation — finding the schedule's
+        ``last_run`` advanced but no outbox row and no accepted receipt — would
+        re-create and re-fire an already-handled fire. Keeping the row preserves
+        the ``(schedule_id, fired_at)`` key (a re-persist's ``INSERT OR IGNORE``
+        then no-ops), and the parked row is excluded from the active replay
+        outbox (``list_pending_schedule_wakes`` default), so the fire is neither
+        re-created nor re-delivered.
+
+        ``agent_name`` scopes self-service callers to their own outbox. Rows that
+        are already accepted or parked are terminal evidence and are left as-is.
+
+        Parked tombstones accumulate until a terminal-row reaper prunes them
+        (tracked separately; accepted rows already accumulate the same way).
         """
-        sql = """DELETE FROM pending_schedule_wakes
+        sql = """UPDATE pending_schedule_wakes
+                 SET parked_at=?, last_error=?
                  WHERE id=? AND accepted_at=0 AND parked_at=0"""
-        params: list = [pending_id]
+        params: list = [time.time(), "retired via discard", pending_id]
         if agent_name is not None:
             sql += " AND agent_name=?"
             params.append(agent_name)
         with self._rmw_lock:
             cursor = self._db.execute(sql, params)
+            self._db.commit()
+            return cursor.rowcount > 0
+
+    def delete_pending_schedule_wake(self, pending_id: int) -> bool:
+        """Hard-delete an active pending wake (no tombstone).
+
+        Used by the internal replay stale-drop pass, which fires at the cadence
+        of frequently-recurring schedules — tombstoning there would accumulate
+        rows unboundedly without a reaper. Deliberate/manual retirement uses
+        ``discard_pending_schedule_wake`` (which tombstones) so a retired fire
+        cannot be re-created by a later reconciliation. Accepted or already
+        parked rows are terminal and are left as-is.
+        """
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                """DELETE FROM pending_schedule_wakes
+                   WHERE id=? AND accepted_at=0 AND parked_at=0""",
+                (pending_id,),
+            )
             self._db.commit()
             return cursor.rowcount > 0
 

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -618,13 +618,23 @@ class AgentScheduler:
         # their exact fire represented too; production fires already have this
         # row from the atomic claim transaction above.
         if not schedule.direct_send and schedule.last_run > 0:
-            self._registry.persist_schedule_wake(
+            row, _created = self._registry.persist_schedule_wake(
                 schedule.id,
                 agent_name=schedule.agent_name,
                 schedule_name=schedule.name,
                 prompt=self._wake_prompt(schedule),
                 fired_at=schedule.last_run,
             )
+            # A retired (parked) or already-accepted fire must not be delivered:
+            # an operator may have discarded this fire while its cohort task
+            # waited behind the per-agent delivery lock. Delivering would
+            # resurrect the tombstone (and the delivery-confirm would clear it).
+            # Set the cohort-start event first so ``_check_schedules`` does not
+            # wait out its timeout on a discarded first cohort member.
+            if row is not None and (row.parked_at > 0 or row.accepted_at > 0):
+                if attempt_started is not None:
+                    attempt_started.set()
+                return
 
         if schedule.direct_send:
             if attempt_started is not None:

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -1006,7 +1006,7 @@ class AgentScheduler:
             )
             row_age = max(0.0, replay_now - pending.fired_at)
             if row_age > replay_max_age:
-                discarded = self._registry.discard_pending_schedule_wake(
+                discarded = self._registry.delete_pending_schedule_wake(
                     pending.id
                 )
                 _log(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5430,9 +5430,12 @@ class TestAgentScheduleEndpoints:
             "pending_id": pending.id,
             "agent": "alice",
         }
-        assert registry.get_schedule_wake_by_fire(
+        # Discard tombstones (parks) the row rather than deleting it, so a
+        # later reconciliation cannot re-create the retired fire.
+        tomb = registry.get_schedule_wake_by_fire(
             created["id"], pending.fired_at
-        ) is None
+        )
+        assert tomb is not None and tomb.parked_at > 0
 
     def test_discard_pending_wake_preserves_terminal_ledger_row(self):
         client = self._make_client()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -990,9 +990,10 @@ class TestPendingWakeDiscardAuth:
         )
 
         assert response.status_code == 200
-        assert client.app.state.agents.get_schedule_wake_by_fire(
+        tomb = client.app.state.agents.get_schedule_wake_by_fire(
             schedule.id, pending.fired_at
-        ) is None
+        )
+        assert tomb is not None and tomb.parked_at > 0
 
     def test_operator_session_may_delete_cross_agent_row(
         self, monkeypatch, tmp_path
@@ -1009,9 +1010,10 @@ class TestPendingWakeDiscardAuth:
         )
 
         assert response.status_code == 200
-        assert client.app.state.agents.get_schedule_wake_by_fire(
+        tomb = client.app.state.agents.get_schedule_wake_by_fire(
             schedule.id, pending.fired_at
-        ) is None
+        )
+        assert tomb is not None and tomb.parked_at > 0
 
 
 class TestAgentIsolationScoping:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3272,3 +3272,84 @@ class TestUrlWatcherOffLoop:
         assert fired == ["ivan"]
         assert store.fires == [1]
         assert store.checks == [(1, "200")]
+
+
+class TestDiscardTombstone:
+    """#566 — discard must tombstone (park), not delete, so a retired fire
+    cannot be re-created and re-fired by a later reconciliation."""
+
+    def _persist(self, registry, *, schedule_id, agent, fired_at):
+        return registry.persist_schedule_wake(
+            schedule_id,
+            agent_name=agent,
+            schedule_name="one-shot",
+            prompt="wake prompt",
+            fired_at=fired_at,
+        )
+
+    def test_discard_tombstones_instead_of_deleting(self, registry):
+        registry.register("oleg")
+        s = registry.add_schedule(
+            "oleg", "0 8 * * *", name="one-shot", prompt="p"
+        )
+        row, created = self._persist(
+            registry, schedule_id=s.id, agent="oleg", fired_at=1000.0
+        )
+        assert created
+        assert any(
+            r.id == row.id
+            for r in registry.list_pending_schedule_wakes("oleg")
+        )
+
+        assert (
+            registry.discard_pending_schedule_wake(row.id, agent_name="oleg")
+            is True
+        )
+
+        # Not deleted: excluded from the active outbox, present as a tombstone.
+        assert all(
+            r.id != row.id
+            for r in registry.list_pending_schedule_wakes("oleg")
+        )
+        parked = registry.list_pending_schedule_wakes(
+            "oleg", include_parked=True
+        )
+        tomb = next(r for r in parked if r.id == row.id)
+        assert tomb.parked_at > 0
+
+    def test_discarded_fire_cannot_be_recreated(self, registry):
+        # The zombie-refire regression: after discard, re-persisting the SAME
+        # (schedule_id, fired_at) must NOT create a new active row — the parked
+        # tombstone still holds the UNIQUE key so INSERT OR IGNORE no-ops.
+        registry.register("oleg")
+        s = registry.add_schedule(
+            "oleg", "0 8 * * *", name="one-shot", prompt="p"
+        )
+        row, _ = self._persist(
+            registry, schedule_id=s.id, agent="oleg", fired_at=1000.0
+        )
+        registry.discard_pending_schedule_wake(row.id, agent_name="oleg")
+
+        _row2, created2 = self._persist(
+            registry, schedule_id=s.id, agent="oleg", fired_at=1000.0
+        )
+        assert created2 is False
+        assert registry.list_pending_schedule_wakes("oleg") == []
+
+    def test_discard_is_noop_on_already_terminal_row(self, registry):
+        registry.register("oleg")
+        s = registry.add_schedule(
+            "oleg", "0 8 * * *", name="one-shot", prompt="p"
+        )
+        row, _ = self._persist(
+            registry, schedule_id=s.id, agent="oleg", fired_at=1000.0
+        )
+        assert (
+            registry.discard_pending_schedule_wake(row.id, agent_name="oleg")
+            is True
+        )
+        # Second discard on the now-parked (terminal) row is a no-op.
+        assert (
+            registry.discard_pending_schedule_wake(row.id, agent_name="oleg")
+            is False
+        )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3353,3 +3353,33 @@ class TestDiscardTombstone:
             registry.discard_pending_schedule_wake(row.id, agent_name="oleg")
             is False
         )
+
+    @pytest.mark.asyncio
+    async def test_discarded_fire_is_not_re_delivered(self, registry):
+        # A fire discarded (parked) while its cohort task waited behind the
+        # per-agent delivery lock must NOT be delivered by the queued live
+        # path — delivering would resurrect the tombstone (confirm clears it).
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "0 8 * * *", name="one-shot", prompt="run once"
+        )
+        fired = 1000.0
+        schedule.last_run = fired
+        row, _ = self._persist(
+            registry, schedule_id=schedule.id, agent="oleg", fired_at=fired
+        )
+        registry.discard_pending_schedule_wake(row.id, agent_name="oleg")
+
+        calls: list[str] = []
+
+        async def wake_cb(agent_name, session_id, prompt):
+            calls.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=wake_cb)
+        await scheduler._deliver_schedule(schedule)
+
+        assert calls == []  # the retired fire is not delivered
+        tomb = registry.get_schedule_wake_by_fire(schedule.id, fired)
+        assert tomb is not None
+        assert tomb.parked_at > 0 and tomb.accepted_at == 0  # tombstone intact


### PR DESCRIPTION
## Bug (observed live)
A disabled, already-completed one-shot re-delivered its prompt hours after it ran and its wake was discarded. Root cause: `discard_pending_schedule_wake` hard-DELETEs the outbox row, leaving no durable "retired" marker. A later reconciliation — finding the schedule's `last_run` advanced but no outbox row and no accepted receipt — re-persists the same fire (`persist_schedule_wake(fired_at=last_run)`); with the row gone, `INSERT OR IGNORE` re-creates it and it re-fires.

## Fix
`discard_pending_schedule_wake` now sets `parked_at` (tombstone) instead of deleting. Because the row survives, it:
- keeps the `UNIQUE(schedule_id, fired_at)` key → a re-persist's `INSERT OR IGNORE` no-ops (**no re-creation**), and
- is excluded from the active replay outbox (`list_pending_schedule_wakes` default) → **no re-delivery**.

## Scope: only the deliberate-retire path tombstones
The internal replay **stale-drop** pass fires at the cadence of frequently-recurring schedules, so tombstoning there would accumulate rows unboundedly without a reaper. It keeps hard-deleting via a new `delete_pending_schedule_wake`. Only the low-volume manual/public retire path tombstones. (A terminal-row reaper — needed to prune both accepted and parked rows — is tracked separately; accepted rows already accumulate the same way today.)

## Tests
`tests/test_scheduler.py::TestDiscardTombstone` — discard tombstones (not deletes), a discarded fire cannot be re-created (the zombie-refire regression), discard is a no-op on an already-terminal row. Full scheduler + registry suites pass (260); the stale-drop path's existing tests are unchanged (it still deletes).

## Review / merge
Ready for Murzik review. Changes fleet-wide wake-retirement semantics for the discard primitive — Brad greenlit building it; merge after review + sign-off.

---
Opened by Barsik