### PR TITLE
fix(scheduler): drop cohort fires that aged past the replay window (#567)

### DIFF
--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -636,6 +636,34 @@ class AgentScheduler:
                     attempt_started.set()
                 return
 
+            # A fire that aged past its replay window while its cohort task
+            # waited behind the per-agent delivery lock must not be pasted: it
+            # would deliver an hours-old prompt, and a busy session queues
+            # several such fires that then drain as duplicate stale wakes. Drop
+            # it, matching the replay path's staleness ceiling. Set the
+            # cohort-start event first so ``_check_schedules`` does not wait out
+            # its timeout on a stale first cohort member.
+            replay_max_age = self._pending_wake_replay_max_age(
+                schedule, schedule.last_run
+            )
+            age = max(0.0, time.time() - schedule.last_run)
+            if age > replay_max_age:
+                dropped = (
+                    self._registry.delete_pending_schedule_wake(row.id)
+                    if row is not None
+                    else False
+                )
+                _log(
+                    f"scheduler: COHORT_STALE_DROPPED pending "
+                    f"#{row.id if row is not None else '?'}, schedule "
+                    f"'{schedule.name}' (#{schedule.id}) for agent "
+                    f"'{schedule.agent_name}': age_s={age:.1f} "
+                    f"max_age_s={replay_max_age:.1f} dropped={dropped}"
+                )
+                if attempt_started is not None:
+                    attempt_started.set()
+                return
+
         if schedule.direct_send:
             if attempt_started is not None:
                 attempt_started.set()

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -604,6 +604,35 @@ class AgentScheduler:
                 )
             raise
 
+    def _alert_stale_one_shot_drop(
+        self,
+        *,
+        agent_name: str,
+        schedule_id: int,
+        schedule_name: str,
+        pending_id: int,
+        row_age: float,
+        replay_max_age: float,
+    ) -> None:
+        """Owner-alert a stale-dropped one-shot fire.
+
+        A one-shot has no next occurrence (``_check_schedules`` auto-disables
+        it once fired), so a fire dropped for staleness is owed work lost unless
+        re-armed. Fired from both the replay pass and the live cohort path so a
+        queued-then-stale one-shot is never silently lost.
+        """
+        self._queue_owner_alert(
+            agent_name,
+            (
+                "🚨 STALE ONE-SHOT WAKE DROPPED: outbox row "
+                f"#{pending_id} for schedule '{schedule_name}' "
+                f"(#{schedule_id}) on agent '{agent_name}' aged past its "
+                f"replay window ({row_age:.1f}s > {replay_max_age:.1f}s). "
+                "The stale wake was discarded and this one-shot has no next "
+                "occurrence; verify the owed work and re-arm it if needed."
+            ),
+        )
+
     async def _deliver_schedule(
         self,
         schedule,
@@ -660,6 +689,17 @@ class AgentScheduler:
                     f"'{schedule.agent_name}': age_s={age:.1f} "
                     f"max_age_s={replay_max_age:.1f} dropped={dropped}"
                 )
+                if dropped and schedule.one_shot:
+                    # A one-shot was auto-disabled on fire, so a stale drop has
+                    # no next occurrence — mirror the replay path and alert.
+                    self._alert_stale_one_shot_drop(
+                        agent_name=schedule.agent_name,
+                        schedule_id=schedule.id,
+                        schedule_name=schedule.name,
+                        pending_id=row.id if row is not None else 0,
+                        row_age=age,
+                        replay_max_age=replay_max_age,
+                    )
                 if attempt_started is not None:
                     attempt_started.set()
                 return
@@ -1055,20 +1095,13 @@ class AgentScheduler:
                     f"max_age_s={replay_max_age:.1f} discarded={discarded}"
                 )
                 if discarded and current_schedule.one_shot:
-                    self._queue_owner_alert(
-                        pending.agent_name,
-                        (
-                            "🚨 STALE ONE-SHOT WAKE DROPPED: outbox row "
-                            f"#{pending.id} for schedule "
-                            f"'{pending.schedule_name}' "
-                            f"(#{pending.schedule_id}) on agent "
-                            f"'{pending.agent_name}' aged past its replay "
-                            f"window ({row_age:.1f}s > "
-                            f"{replay_max_age:.1f}s). The stale wake was "
-                            "discarded and this one-shot has no next "
-                            "occurrence; verify the owed work and re-arm it "
-                            "if needed."
-                        ),
+                    self._alert_stale_one_shot_drop(
+                        agent_name=pending.agent_name,
+                        schedule_id=pending.schedule_id,
+                        schedule_name=pending.schedule_name,
+                        pending_id=pending.id,
+                        row_age=row_age,
+                        replay_max_age=replay_max_age,
                     )
                 continue
             pending_wakes.append(pending)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3424,3 +3424,57 @@ class TestCohortStalenessGuard:
             registry.get_schedule_wake_by_fire(schedule.id, schedule.last_run)
             is None
         )
+
+    @pytest.mark.asyncio
+    async def test_stale_one_shot_cohort_drop_alerts_owner(
+        self, registry, monkeypatch
+    ):
+        # A queued one-shot that goes stale is dropped AND owner-alerted (it
+        # was auto-disabled on fire, so the owed work is otherwise lost with no
+        # next occurrence) — mirrors the replay path.
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg",
+            "0 8 * * *",
+            name="one-shot",
+            prompt="owed work",
+            one_shot=True,
+        )
+        now = 1_800_000_000.0
+        schedule.last_run = now - 3_601.0
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="one-shot",
+            prompt="owed work",
+            fired_at=schedule.last_run,
+        )
+        calls: list[str] = []
+        alerts: list[tuple[str, str]] = []
+
+        async def wake_cb(agent_name, session_id, prompt):
+            calls.append(prompt)
+            return True
+
+        async def owner_notify(agent_name, message):
+            alerts.append((agent_name, message))
+            return True
+
+        monkeypatch.setattr("pinky_daemon.scheduler.time.time", lambda: now)
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=3600.0,
+        )
+        await scheduler._deliver_schedule(schedule)
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+
+        assert calls == []  # not delivered
+        assert (
+            registry.get_schedule_wake_by_fire(schedule.id, schedule.last_run)
+            is None
+        )  # dropped
+        assert len(alerts) == 1  # owner alerted about the lost one-shot
+        assert alerts[0][0] == "oleg"
+        assert "STALE ONE-SHOT WAKE DROPPED" in alerts[0][1]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3383,3 +3383,44 @@ class TestDiscardTombstone:
         tomb = registry.get_schedule_wake_by_fire(schedule.id, fired)
         assert tomb is not None
         assert tomb.parked_at > 0 and tomb.accepted_at == 0  # tombstone intact
+
+
+class TestCohortStalenessGuard:
+    """#567 — a fire that aged past its replay window while its cohort task
+    waited behind the per-agent delivery lock must be dropped, not pasted."""
+
+    @pytest.mark.asyncio
+    async def test_stale_cohort_fire_is_dropped_not_delivered(
+        self, registry, monkeypatch
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "0 8 * * *", name="daily", prompt="stale work"
+        )
+        now = 1_800_000_000.0
+        schedule.last_run = now - 3_601.0  # older than the 3600s ceiling
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name="daily",
+            prompt="stale work",
+            fired_at=schedule.last_run,
+        )
+        calls: list[str] = []
+
+        async def wake_cb(agent_name, session_id, prompt):
+            calls.append(prompt)
+            return True
+
+        monkeypatch.setattr("pinky_daemon.scheduler.time.time", lambda: now)
+        scheduler = AgentScheduler(
+            registry, wake_callback=wake_cb, pending_wake_max_age_sec=3600.0
+        )
+        await scheduler._deliver_schedule(schedule)
+
+        assert calls == []  # stale fire is not delivered
+        # and its outbox row is dropped
+        assert (
+            registry.get_schedule_wake_by_fire(schedule.id, schedule.last_run)
+            is None
+        )


### PR DESCRIPTION
## Bug (traced live)
On a busy agent, `_deliver_schedule` persisted and delivered a fire unconditionally. `_check_schedules` claims each fire and queues a per-agent cohort delivery task; those tasks serialize behind the delivery lock, and `_wait_for_wake_confirmation` extends while a turn is inflight. A session running multi-hour turns accumulates queued cohort tasks each holding an hours-old fire snapshot — and when the turn ends they drain and paste stale prompts, **one per turn-end, as duplicate wakes**. The replay path already guards this with a max-age ceiling; the live cohort path did not.

## Fix
Add the same staleness check at the head of `_deliver_schedule`: if the fire has aged past `_pending_wake_replay_max_age(schedule, last_run)`, drop it (`delete_pending_schedule_wake` + a `COHORT_STALE_DROPPED` ledger line) and return without invoking the callback — setting `attempt_started` first so `_check_schedules` doesn't wait out its cohort-start timeout. In-progress deliveries are checked while still fresh and proceed; only queued-then-stale fires are dropped. Sits right after the #566 terminal-row (discard/accepted) guard.

## Scope
This is the first half of the report (the duplicate-stale-delivery storm). The second half — surfacing **recurring** schedules' stale-drops to the *agent* (today only one-shot drops notify the owner) — is a separate follow-up, since it needs an agent-facing notification path rather than a correctness change.

## Tests
`tests/test_scheduler.py::TestCohortStalenessGuard` — a fire aged past the ceiling is dropped, not delivered. Full scheduler suite 144 green (fresh fires still deliver — no over-dropping).

## Review
Ready for Murzik review. Coordinates with #566 (same `_deliver_schedule` head, both merged/queued). Brad greenlit the #566+#567 scheduler fixes.

---
Opened by Barsik