### PR TITLE
feat(scripts): claude-account CLI — safe fleet Claude account switching (#570)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ data/
 .claude/
 logs/
 .env
+# .env backups carry live credentials — the bare `.env` rule does NOT match
+# these, so ignore the whole backup family (operator account-switch rollbacks).
+.env.bak*
 __pycache__/
 *.pyc
 *.egg-info/

--- a/scripts/claude_account.py
+++ b/scripts/claude_account.py
@@ -15,7 +15,7 @@ logged.
 
 Subcommands::
 
-    claude-account add <name>        mint/paste + isolation-probe + store a token
+    claude-account add <name>        paste (from `claude setup-token`) + probe + store
     claude-account list              stored accounts, active one, days-to-expiry
     claude-account current           which stored token the .env currently uses
     claude-account switch <name>     safe swap (backup + fail-closed write [+ restart])
@@ -584,14 +584,15 @@ def cmd_add(args: argparse.Namespace) -> int:
         )
         return 2
 
-    if args.mint:
-        binary = resolve_claude_bin(args.claude_bin)
-        print(f"Launching `{binary} setup-token` — sign in as the target account…\n")
-        subprocess.run([binary, "setup-token"], check=False)
-        print()
-
-    # Token via hidden prompt — NEVER on argv (would leak in ps / shell history).
-    token = getpass.getpass("Paste the setup-token (input hidden): ").strip()
+    # The operator mints the token OUT OF BAND with `claude setup-token` in their
+    # own terminal — this tool deliberately never spawns that flow. setup-token
+    # prints the token to stdout ("Your OAuth token (valid for 1 year): …"), and
+    # inheriting that output would leak the long-lived token into scrollback / any
+    # log capture, breaking the never-printed guarantee. We only read it back here
+    # via a hidden prompt (never on argv either).
+    token = getpass.getpass(
+        "Paste the setup-token from `claude setup-token` (input hidden): "
+    ).strip()
     if not token:
         print("claude-account: no token entered", file=sys.stderr)
         return 2
@@ -647,10 +648,7 @@ def cmd_add(args: argparse.Namespace) -> int:
             return 2
     else:
         exp = now + timedelta(days=args.ttl_days)
-    billing = args.billing
-    if billing not in BILLING_MODES:
-        print(f"claude-account: --billing must be one of {BILLING_MODES}", file=sys.stderr)
-        return 2
+    billing = args.billing  # argparse choices=BILLING_MODES has already validated this
 
     write_token(args.name, token)
     index["accounts"][args.name] = {
@@ -662,7 +660,7 @@ def cmd_add(args: argparse.Namespace) -> int:
         "probe": probe_meta,
     }
     save_index(index)
-    print(f"Stored {args.name!r}, expires {_iso(exp)}, billing={billing}.")
+    print(f"Stored {args.name!r}, expires {_iso(exp)}.")
     return 0
 
 
@@ -678,7 +676,10 @@ def cmd_list(args: argparse.Namespace) -> int:
     except SystemExit as exc:
         print(str(exc), file=sys.stderr)
         active = prov = None
-    header = f"{'':2} {'NAME':16} {'BILLING':12} {'EXPIRES':22} {'DAYS':>5}  LABEL"
+    # Columns are name / expiry / days only. billing + account_label are stored
+    # but not printed: CodeQL's clear-text-logging heuristic classifies those
+    # field names as sensitive, and they are not worth a logging sink here.
+    header = f"{'':2} {'NAME':20} {'EXPIRES':22} {'DAYS':>5}"
     print(header)
     for name in sorted(accounts):
         meta = accounts[name]
@@ -686,10 +687,7 @@ def cmd_list(args: argparse.Namespace) -> int:
         dl = days_left(meta)
         dl_s = "—" if dl is None else str(dl)
         warn = " ⚠" if (dl is not None and dl <= EXPIRY_WARN_DAYS) else ""
-        print(
-            f"{mark:2} {name:16} {meta.get('billing','?'):12} "
-            f"{meta.get('expires_at','?'):22} {dl_s:>5}{warn}  {meta.get('account_label','')}"
-        )
+        print(f"{mark:2} {name:20} {meta.get('expires_at','?'):22} {dl_s:>5}{warn}")
     if active is None:
         if prov:
             print(f"\n(forwarding is OFF — {prov!r} is in .env but not being forwarded)")
@@ -712,8 +710,8 @@ def cmd_current(args: argparse.Namespace) -> int:
     if prov and flag:
         meta = index["accounts"][prov]
         dl = days_left(meta)
-        print(f"active account: {prov}  (billing={meta.get('billing','?')}, "
-              f"expires {meta.get('expires_at','?')}, {dl if dl is not None else '?'}d left)")
+        print(f"active account: {prov}  (expires {meta.get('expires_at','?')}, "
+              f"{dl if dl is not None else '?'}d left)")
     elif prov and not flag:
         print(f"active account: none — {prov!r} token is in .env but forwarding is OFF")
     elif live:
@@ -948,7 +946,6 @@ def build_parser() -> argparse.ArgumentParser:
                    help="owner-declared billing mode (subscription | api_usage | unknown)")
     a.add_argument("--ttl-days", type=int, default=DEFAULT_TTL_DAYS)
     a.add_argument("--expires-at", default="", help="explicit ISO expiry (overrides --ttl-days)")
-    a.add_argument("--mint", action="store_true", help="launch `claude setup-token` first")
     a.add_argument("--no-probe", action="store_true", help="skip the isolation-probe (unsafe)")
     a.add_argument("--allow-any", action="store_true", help="accept a non setup-token string")
     a.add_argument("--claude-bin", default="", help="path to the claude binary")

--- a/scripts/claude_account.py
+++ b/scripts/claude_account.py
@@ -29,15 +29,18 @@ are a separate concern and are not managed here.
 from __future__ import annotations
 
 import argparse
+import fcntl
 import getpass
 import hmac
 import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -140,13 +143,62 @@ def valid_name(name: str) -> bool:
 # ── token store ──────────────────────────────────────────────────────────────
 
 
-def ensure_store() -> None:
-    d = store_dir()
-    d.mkdir(parents=True, exist_ok=True)
+def _assert_private_dir(path: Path) -> None:
+    """Fail closed if ``path`` is group/other-accessible.
+
+    chmod is best-effort — it can be denied on a dir we don't own — so the FINAL
+    mode is what matters, not the chmod call. A credential dir another local user
+    can write to lets them delete/replace stored tokens even though the token
+    files themselves are 0600.
+    """
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    if mode & 0o077:
+        raise SystemExit(
+            f"claude-account: {path} is not private (mode {oct(mode)}) — another local "
+            f"user could read or replace stored credentials. Fix: chmod 700 {path}"
+        )
+
+
+def _ensure_private_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
     try:
-        os.chmod(d, 0o700)
+        os.chmod(path, 0o700)
     except OSError:
         pass
+    _assert_private_dir(path)
+
+
+def ensure_store() -> None:
+    _ensure_private_dir(store_dir())
+
+
+@contextmanager
+def store_lock():
+    """Advisory exclusive lock held for a whole mutating operation.
+
+    A switch reads → backs up → writes → restarts → verifies → maybe reverts over
+    a window up to RESTART_HEALTH_TIMEOUT_S. Without a lock, a second concurrent
+    switch (process B) can write in the middle, and a delayed revert from process
+    A then restores A's older backup and silently clobbers B. flock is per open
+    file description, so a second claude-account process fails closed here rather
+    than interleaving. Read-only commands do not take the lock.
+    """
+    ensure_store()
+    fd = os.open(str(store_dir() / ".lock"), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            raise SystemExit(
+                "claude-account: another claude-account operation is in progress "
+                "(lock held) — wait for it to finish and retry."
+            )
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
 
 
 def load_index() -> dict:
@@ -241,11 +293,7 @@ def backup_env(env_path: Path, tag: str) -> Path:
     """
     ensure_store()
     bdir = backup_dir()
-    bdir.mkdir(parents=True, exist_ok=True)
-    try:
-        os.chmod(bdir, 0o700)
-    except OSError:
-        pass
+    _ensure_private_dir(bdir)
     stamp = _utcnow().strftime("%Y%m%d-%H%M%S")
     backup = bdir / f"{env_path.name}.bak.pre-{tag}-{stamp}"
     _atomic_copy(env_path, backup, 0o600)
@@ -348,28 +396,33 @@ def resolve_claude_bin(explicit: str = "") -> str:
 def probe_token(token: str, claude_bin: str = "") -> tuple[bool, str]:
     """Isolation-probe a token BEFORE trusting it (never wall the fleet).
 
-    Runs ``claude --print`` in a minimal env carrying only the candidate token,
-    so a bad token is caught here instead of at fleet startup. The token is
-    passed via env (never argv) and never echoed. ``--print`` does NOT surface
-    the interactive Fable-credit consent, so a pass here means "authenticates",
-    not "no consent prompt at real startup".
+    Runs ``claude --print`` under a THROWAWAY HOME + CLAUDE_CONFIG_DIR and a clean
+    temp cwd, so no user/project settings, hooks, plugins, or MCP servers load with
+    the candidate token in the child env (this repo ships a project Stop hook, and
+    such a hook could spawn further processes that inherit the token). The token is
+    passed via env (never argv) and never echoed. ``--print`` does NOT surface the
+    interactive Fable-credit consent, so a pass here means "authenticates", not
+    "no consent prompt at real startup".
     """
     binary = resolve_claude_bin(claude_bin)
-    env = {
-        "HOME": os.environ.get("HOME", str(Path.home())),
-        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-        TOKEN_ENV_KEY: token,
-        # keep the probe quiet + non-interactive
-        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
-    }
     try:
-        proc = subprocess.run(
-            [binary, "--print", "say OK"],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=PROBE_TIMEOUT_S,
-        )
+        with tempfile.TemporaryDirectory(prefix="claude-account-probe-") as tmp:
+            env = {
+                "HOME": tmp,               # no ~/.claude settings/hooks/credentials
+                "CLAUDE_CONFIG_DIR": tmp,  # no shared config dir
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                TOKEN_ENV_KEY: token,
+                # keep the probe quiet + non-interactive
+                "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            }
+            proc = subprocess.run(
+                [binary, "--print", "say OK"],
+                env=env,
+                cwd=tmp,                   # clean cwd → no project .claude hooks
+                capture_output=True,
+                text=True,
+                timeout=PROBE_TIMEOUT_S,
+            )
     except FileNotFoundError:
         return False, f"claude binary not found at {binary!r}"
     except subprocess.TimeoutExpired:
@@ -747,6 +800,38 @@ def cmd_switch(args: argparse.Namespace) -> int:
             return 1
         print("  probe OK")
 
+    # Preflight for --restart BEFORE any .env mutation: only switch if we can both
+    # authenticate the restart AND establish a generation baseline to verify it.
+    # If either is missing, abort with .env untouched (no backup, no write, no
+    # POST) — never persist an unverifiable switch.
+    as_agent = ""
+    before_gen = None
+    if args.restart:
+        as_agent = (args.as_agent or os.environ.get("PINKY_AGENT_NAME", "")).strip()
+        if not as_agent:
+            print(
+                "claude-account: --restart needs an identity to sign the restart call — "
+                "pass --as-agent <a registered non-isolated agent> or set PINKY_AGENT_NAME. "
+                "Not switching; .env is untouched.",
+                file=sys.stderr,
+            )
+            return 1
+        # retry a few times: the daemon should be up (we're about to restart it),
+        # so a None here is a transient miss rather than "down".
+        for _ in range(3):
+            before_gen = daemon_generation()
+            if before_gen is not None:
+                break
+        if before_gen is None:
+            print(
+                "claude-account: can't read the daemon's current generation (/api "
+                "unreachable), so a --restart switch can't be verified. Not switching; "
+                ".env is untouched. Fix the daemon, or run without --restart to switch the "
+                ".env and restart by hand.",
+                file=sys.stderr,
+            )
+            return 1
+
     lines = read_env_lines(env_path)
     backup = backup_env(env_path, args.name)
     # Fail-closed invariant: token + forward flag land in the SAME atomic write —
@@ -762,38 +847,15 @@ def cmd_switch(args: argparse.Namespace) -> int:
         print("  • then spot-check a few agent panes for a login wall.")
         return 0
 
-    as_agent = (args.as_agent or os.environ.get("PINKY_AGENT_NAME", "")).strip()
-    # Capture the process generation BEFORE the restart. /admin/restart returns
-    # 200 and only SIGTERMs ~1s later, and the OLD process keeps answering /api
-    # until then — so a bare 200 is NOT proof of restart. We require started_at to
-    # ADVANCE (a genuinely new process) before declaring success. (retry a few
-    # times: the daemon is up — /admin/restart is about to 200 — so a None here is
-    # a transient miss, not "down".)
-    before_gen = None
-    for _ in range(3):
-        before_gen = daemon_generation()
-        if before_gen is not None:
-            break
-
     print("Restarting the daemon…")
     ok, detail = restart_daemon(env_path, as_agent)
     if not ok:
         _revert(env_path, backup, f"restart call failed ({detail})")
         return 1
 
-    if before_gen is None:
-        # Restart accepted but no baseline to verify against — do NOT claim success
-        # and do NOT revert (the restart likely proceeded; reverting could undo a
-        # good switch). Hand it to the operator.
-        print(
-            "claude-account: restart accepted but the daemon's pre-restart generation "
-            "was unreadable, so the restart could not be auto-verified. The new token is "
-            "written and NOT reverted — confirm the daemon came back and spot-check panes "
-            "by hand.",
-            file=sys.stderr,
-        )
-        return 1
-
+    # Require the process generation to ADVANCE — /admin/restart returns 200 and
+    # only SIGTERMs ~1s later, and the OLD process keeps answering /api until then,
+    # so a bare 200 is not proof of restart.
     import time
 
     deadline = time.monotonic() + RESTART_HEALTH_TIMEOUT_S
@@ -892,7 +954,7 @@ def build_parser() -> argparse.ArgumentParser:
     a.add_argument("--allow-any", action="store_true", help="accept a non setup-token string")
     a.add_argument("--claude-bin", default="", help="path to the claude binary")
     a.add_argument("--force", action="store_true", help="replace an existing entry")
-    a.set_defaults(func=cmd_add)
+    a.set_defaults(func=cmd_add, mutating=True)
 
     li = sub.add_parser("list", help="stored accounts + active + expiry")
     li.set_defaults(func=cmd_list)
@@ -910,12 +972,12 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--no-probe", action="store_true", help="skip the pre-switch probe (unsafe)")
     s.add_argument("--claude-bin", default="")
     s.add_argument("--force", action="store_true", help="switch even if expired / already active")
-    s.set_defaults(func=cmd_switch)
+    s.set_defaults(func=cmd_switch, mutating=True)
 
     r = sub.add_parser("remove", help="delete a stored token")
     r.add_argument("name")
     r.add_argument("--force", action="store_true", help="remove even the active account")
-    r.set_defaults(func=cmd_remove)
+    r.set_defaults(func=cmd_remove, mutating=True)
 
     e = sub.add_parser("check-expiry", help="nudge (exit 3) if the active token expires soon")
     e.add_argument("--days", type=int, default=EXPIRY_WARN_DAYS)
@@ -928,6 +990,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     # resolve the env path once, after parsing (default is lazy so tests can patch)
     args.env_file = args.env_file or default_env_path()
+    # Mutating commands (add/switch/remove) run under the store lock for the whole
+    # operation — including switch's restart/verify window — so two concurrent runs
+    # can't clobber each other. Read-only commands take no lock.
+    if getattr(args, "mutating", False):
+        with store_lock():
+            return args.func(args)
     return args.func(args)
 
 

--- a/scripts/claude_account.py
+++ b/scripts/claude_account.py
@@ -33,8 +33,8 @@ import getpass
 import hmac
 import json
 import os
+import re
 import shutil
-import stat
 import subprocess
 import sys
 import tempfile
@@ -112,6 +112,19 @@ def default_env_path() -> Path:
 
 
 # ── name validation ──────────────────────────────────────────────────────────
+
+
+# A stored token is interpolated verbatim into .env, which the macOS service
+# loads via bash ``source`` — so it MUST be a single line containing no shell
+# metacharacters (else a value like ``GOOD\nCLAUDE_CODE_OAUTH_TOKEN=`` injects a
+# second assignment, and ``$()``/quotes/spaces would be interpreted by the shell).
+# setup-tokens are base64/base64url + a fixed prefix — all within this charset.
+_TOKEN_SAFE_RE = re.compile(r"\A[A-Za-z0-9_.\-=+/:]+\Z")
+
+
+def token_serialization_safe(token: str) -> bool:
+    """True iff ``token`` is one line safe to write bare into a shell-sourced .env."""
+    return bool(token) and bool(_TOKEN_SAFE_RE.match(token))
 
 
 def valid_name(name: str) -> bool:
@@ -242,36 +255,47 @@ def backup_env(env_path: Path, tag: str) -> Path:
 # ── .env line rewriting ──────────────────────────────────────────────────────
 
 
-def _is_live_assignment(line: str, key: str) -> bool:
-    """True iff ``line`` is a live (non-comment) ``key=…`` assignment.
+def _live_key(line: str) -> str | None:
+    """The KEY assigned on this line, or None if it is not a live assignment.
 
-    Mirrors _load_dotenv's parse: a leading ``#`` is a comment (skipped); the
-    key is everything before the first ``=`` (stripped). ``FOO_BAR`` must not
-    match ``FOO``.
+    The shipped macOS service loads .env via bash ``set -a && source .env`` (see
+    scripts/launchctl/com.pinkybot.daemon.plist), so BOTH a bare ``KEY=…`` and an
+    ``export KEY=…`` are live assignments — and bash is LAST-wins. A leading ``#``
+    is a comment. The key is the text before the first ``=`` (minus an optional
+    ``export`` prefix). ``FOO_BAR`` must not match ``FOO``.
     """
     stripped = line.strip()
     if not stripped or stripped.startswith("#") or "=" not in stripped:
-        return False
-    return stripped.split("=", 1)[0].strip() == key
+        return None
+    lhs = stripped.split("=", 1)[0].strip()
+    if lhs.startswith("export") and (len(lhs) == 6 or lhs[6].isspace()):
+        lhs = lhs[6:].strip()
+    return lhs or None
+
+
+def _is_live_assignment(line: str, key: str) -> bool:
+    return _live_key(line) == key
 
 
 def set_env_var(lines: list[str], key: str, value: str) -> list[str]:
-    """Return ``lines`` with exactly ONE live ``key=value`` assignment.
+    """Return ``lines`` with EXACTLY ONE live ``key=value`` assignment (bare form).
 
-    The daemon's loader takes the FIRST live occurrence and ignores the rest, so
-    a stale duplicate below the one we set would be a latent foot-gun on any
-    later reorder. We replace the first live occurrence in place and drop every
-    later live duplicate; comment lines are left untouched. If no live
-    occurrence exists we append one.
+    Collapses every live form of the key — bare ``KEY=`` AND ``export KEY=`` — to a
+    single canonical bare line, dropping all other live occurrences. This is what
+    makes the result unambiguous across all three loaders the fleet may use (bash
+    ``source`` = last-wins + honors ``export``; systemd EnvironmentFile; the Python
+    parser = first-wins): with exactly one live assignment and no ``export``
+    variants left to shadow it, they all resolve the same value. Comment lines are
+    left untouched. Appends one if the key is absent.
     """
     out: list[str] = []
     seen = False
     for line in lines:
-        if _is_live_assignment(line, key):
+        if _live_key(line) == key:
             if not seen:
                 out.append(f"{key}={value}")
                 seen = True
-            # else: drop the duplicate live assignment
+            # else: drop the duplicate/variant live assignment
             continue
         out.append(line)
     if not seen:
@@ -280,12 +304,18 @@ def set_env_var(lines: list[str], key: str, value: str) -> list[str]:
 
 
 def read_live_value(lines: list[str], key: str) -> str | None:
-    """The value of the FIRST live ``key=…`` line (quotes stripped), else None."""
+    """The value of the LAST live ``key=…`` line (quotes stripped), else None.
+
+    LAST, not first: the authoritative loader is bash ``source`` (last-wins), so
+    this reflects what the daemon actually resolves for a messy pre-rewrite file.
+    (After set_env_var there is exactly one, so first/last coincide.)
+    """
+    found: str | None = None
     for line in lines:
-        if _is_live_assignment(line, key):
+        if _live_key(line) == key:
             raw = line.strip().split("=", 1)[1].strip()
-            return raw.strip("\"'")
-    return None
+            found = raw.strip("\"'")
+    return found
 
 
 def read_env_lines(env_path: Path) -> list[str]:
@@ -296,12 +326,10 @@ def read_env_lines(env_path: Path) -> list[str]:
 
 
 def write_env_lines(env_path: Path, lines: list[str]) -> None:
-    mode = 0o600
-    try:
-        mode = stat.S_IMODE(os.stat(env_path).st_mode)
-    except OSError:
-        pass
-    _atomic_write(env_path, "\n".join(lines) + "\n", mode)
+    # Always 0600 — .env holds live credentials. Preserving a permissive source
+    # mode (e.g. a 0644 .env) would leave the freshly-written OAuth token
+    # group/world-readable; clamp it closed on every write.
+    _atomic_write(env_path, "\n".join(lines) + "\n", 0o600)
 
 
 # ── isolation probe ──────────────────────────────────────────────────────────
@@ -347,9 +375,13 @@ def probe_token(token: str, claude_bin: str = "") -> tuple[bool, str]:
     except subprocess.TimeoutExpired:
         return False, f"probe timed out after {PROBE_TIMEOUT_S}s"
     if proc.returncode != 0:
-        tail = (proc.stderr or proc.stdout or "").strip().splitlines()
-        detail = tail[-1] if tail else f"exit {proc.returncode}"
-        return False, f"probe failed: {detail}"
+        # NEVER surface the child's stdout/stderr — claude may echo the candidate
+        # token in an error line, and this string is printed to the operator. A
+        # generic, category-only reason keeps the secret out of the console/logs.
+        return False, (
+            f"claude rejected the token or errored (exit {proc.returncode}); "
+            f"run the probe by hand to see details"
+        )
     if not (proc.stdout or "").strip():
         return False, "probe returned empty output"
     return True, "ok"
@@ -413,16 +445,27 @@ def restart_daemon(env_path: Path, as_agent: str) -> tuple[bool, str]:
         return False, str(exc)
 
 
-def daemon_healthy() -> bool:
-    # /api is the daemon's unauthenticated health/info route (returns 200);
-    # there is no top-level /health route.
+def daemon_generation() -> str | None:
+    """The running daemon's process-generation marker (``/api`` ``started_at``,
+    a per-boot ``time.time()``), or None when /api is unreachable / not 2xx.
+
+    This is the RESTART signal, not a bare liveness check: /admin/restart returns
+    200 and only SIGTERMs ~1s later, and the OLD process keeps answering /api
+    (same ``started_at``) until then — so a 200 alone is not proof of restart.
+    A changed ``started_at`` means a genuinely new process is serving.
+    """
     try:
+        import json as _json
         import urllib.request
 
         with urllib.request.urlopen(_daemon_base_url() + "/api", timeout=5) as resp:
-            return 200 <= resp.status < 300
+            if not (200 <= resp.status < 300):
+                return None
+            data = _json.loads(resp.read().decode("utf-8"))
     except Exception:  # noqa: BLE001
-        return False
+        return None
+    started = data.get("started_at")
+    return None if started is None else str(started)
 
 
 # ── account metadata helpers ─────────────────────────────────────────────────
@@ -510,6 +553,33 @@ def cmd_add(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    # Serialization safety is non-negotiable (even with --allow-any): the token is
+    # written bare into a bash-sourced .env, so a newline / shell metachar would
+    # inject a second assignment or be interpreted by the shell.
+    if not token_serialization_safe(token):
+        print(
+            "claude-account: token contains characters unsafe to write into a "
+            "shell-sourced .env (newline or shell metacharacter) — refusing.",
+            file=sys.stderr,
+        )
+        return 2
+    # Reject a token already stored under another name (constant-time): otherwise
+    # provenance is ambiguous — switching to the second name would report success
+    # while list/current still resolve the first.
+    for other, meta in index["accounts"].items():
+        if other == args.name:
+            continue
+        try:
+            if hmac.compare_digest(token, read_token(other)):
+                print(
+                    f"claude-account: that exact token is already stored as {other!r} — "
+                    f"refusing (duplicate token makes the active account ambiguous). "
+                    f"Use {other!r}, or remove it first.",
+                    file=sys.stderr,
+                )
+                return 2
+        except SystemExit:
+            continue
 
     if not args.no_probe:
         print("Isolation-probing the token…")
@@ -639,6 +709,15 @@ def cmd_switch(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
+    # Guard against a hand-edited token file that would inject into the .env the
+    # macOS service sources with bash (newline → second assignment; metachars).
+    if not token_serialization_safe(token):
+        print(
+            f"claude-account: stored token for {args.name!r} is not a single "
+            f"shell-safe line — refusing to write it into .env. Re-add it.",
+            file=sys.stderr,
+        )
+        return 1
 
     env_path = args.env_file
     # active_name is flag-aware: this is true only when the token already matches
@@ -684,24 +763,51 @@ def cmd_switch(args: argparse.Namespace) -> int:
         return 0
 
     as_agent = (args.as_agent or os.environ.get("PINKY_AGENT_NAME", "")).strip()
+    # Capture the process generation BEFORE the restart. /admin/restart returns
+    # 200 and only SIGTERMs ~1s later, and the OLD process keeps answering /api
+    # until then — so a bare 200 is NOT proof of restart. We require started_at to
+    # ADVANCE (a genuinely new process) before declaring success. (retry a few
+    # times: the daemon is up — /admin/restart is about to 200 — so a None here is
+    # a transient miss, not "down".)
+    before_gen = None
+    for _ in range(3):
+        before_gen = daemon_generation()
+        if before_gen is not None:
+            break
+
     print("Restarting the daemon…")
     ok, detail = restart_daemon(env_path, as_agent)
     if not ok:
         _revert(env_path, backup, f"restart call failed ({detail})")
         return 1
-    # Wait for health to come back; revert if it doesn't.
+
+    if before_gen is None:
+        # Restart accepted but no baseline to verify against — do NOT claim success
+        # and do NOT revert (the restart likely proceeded; reverting could undo a
+        # good switch). Hand it to the operator.
+        print(
+            "claude-account: restart accepted but the daemon's pre-restart generation "
+            "was unreadable, so the restart could not be auto-verified. The new token is "
+            "written and NOT reverted — confirm the daemon came back and spot-check panes "
+            "by hand.",
+            file=sys.stderr,
+        )
+        return 1
+
     import time
 
     deadline = time.monotonic() + RESTART_HEALTH_TIMEOUT_S
     while time.monotonic() < deadline:
-        if daemon_healthy():
-            print("Daemon healthy after restart.")
+        cur = daemon_generation()
+        if cur is not None and cur != before_gen:
+            print("Daemon restarted — a new process is serving.")
             print("⚠ Spot-check a few agent panes — --print auth passing does not "
                   "guarantee no Fable-credit consent prompt at real startup.")
             return 0
         time.sleep(3)
     _revert(env_path, backup,
-            f"daemon did not report healthy within {RESTART_HEALTH_TIMEOUT_S}s")
+            f"daemon generation did not advance within {RESTART_HEALTH_TIMEOUT_S}s "
+            f"(restart not confirmed — the new process never came up)")
     return 1
 
 
@@ -709,12 +815,8 @@ def _revert(env_path: Path, backup: Path, why: str) -> None:
     print(f"\nclaude-account: {why} — reverting {env_path} from {backup.name}.",
           file=sys.stderr)
     try:
-        mode = 0o600
-        try:
-            mode = stat.S_IMODE(os.stat(env_path).st_mode)
-        except OSError:
-            pass
-        _atomic_copy(backup, env_path, mode)
+        # 0600 — the restored .env still holds credentials (clamp, don't preserve).
+        _atomic_copy(backup, env_path, 0o600)
         print("Reverted. Restart the daemon to restore the previous token.", file=sys.stderr)
     except OSError as exc:
         print(f"REVERT FAILED ({exc}) — restore {backup} to {env_path} by hand.",

--- a/scripts/claude_account.py
+++ b/scripts/claude_account.py
@@ -776,9 +776,14 @@ def cmd_switch(args: argparse.Namespace) -> int:
     # active_name is flag-aware: this is true only when the token already matches
     # AND forwarding is already on. A token match with the flag OFF falls through
     # so the switch actually sets the flag (the fix for the silent no-op).
-    if active_name(env_path, index) == args.name and not args.force:
+    #
+    # --restart must NOT short-circuit here: ".env already matches" does not mean
+    # "the RUNNING daemon has this token" (the two-step workflow is `switch` to
+    # write, then `switch --restart` to apply). Falling through makes --restart
+    # always perform the restart + generation verification.
+    if active_name(env_path, index) == args.name and not args.force and not args.restart:
         print(f"Already on {args.name!r} with forwarding on; nothing to do "
-              f"(pass --force to rewrite anyway).")
+              f"(pass --restart to (re)start the daemon onto it, or --force to rewrite).")
         return 0
 
     if args.dry_run:

--- a/scripts/claude_account.py
+++ b/scripts/claude_account.py
@@ -1,0 +1,833 @@
+#!/usr/bin/env python3
+"""claude-account — manage the fleet's forwarded Claude OAuth account (#570).
+
+The tmux fleet authenticates every agent with a single long-lived
+``claude setup-token`` that the daemon forwards as ``CLAUDE_CODE_OAUTH_TOKEN``
+(gated by ``PINKY_FORWARD_OAUTH_TOKEN=1``). Switching which account the fleet
+runs as means swapping that one token in ``.env`` and restarting the daemon —
+a hand-run, error-prone recipe whose failure mode is a fleet-wide login wall.
+
+This CLI stores named tokens (0600) and does a **safe, verified switch**:
+back up ``.env`` → write the token and the forward flag together (fail-closed,
+never flag-on-token-missing) → optionally restart → verify. The owner drives
+the interactive mint; the token is never passed on argv, never printed, never
+logged.
+
+Subcommands::
+
+    claude-account add <name>        mint/paste + isolation-probe + store a token
+    claude-account list              stored accounts, active one, days-to-expiry
+    claude-account current           which stored token the .env currently uses
+    claude-account switch <name>     safe swap (backup + fail-closed write [+ restart])
+    claude-account remove <name>     delete a stored token
+    claude-account check-expiry      nudge (exit 3) if the active token expires soon
+
+Scope: the box-wide forwarded token only. Per-agent dedicated-config-dir logins
+are a separate concern and are not managed here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import hmac
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# ── constants ────────────────────────────────────────────────────────────────
+
+TOKEN_ENV_KEY = "CLAUDE_CODE_OAUTH_TOKEN"
+FORWARD_FLAG_KEY = "PINKY_FORWARD_OAUTH_TOKEN"
+SETUP_TOKEN_PREFIX = "sk-ant-oat01-"
+DEFAULT_TTL_DAYS = 365
+EXPIRY_WARN_DAYS = 30
+PROBE_TIMEOUT_S = 60
+RESTART_HEALTH_TIMEOUT_S = 90
+INDEX_VERSION = 1
+
+# billing modes the store recognises. Owner-declared per account: the auth
+# method + token kind determine whether inference bills as subscription or as
+# API usage, and that mapping is subtle enough to not guess — the default is
+# "unknown" until the owner states it.
+BILLING_MODES = ("api_usage", "subscription", "unknown")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        # tolerate a trailing Z
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    # A hand-edited index may carry a bare/naive timestamp (e.g. "2027-01-01");
+    # treat it as UTC so a later `exp - _utcnow()` never mixes naive/aware.
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+# ── paths ────────────────────────────────────────────────────────────────────
+
+
+def store_dir() -> Path:
+    """Where token files + the index live (override with PINKY_ACCOUNTS_DIR)."""
+    override = os.environ.get("PINKY_ACCOUNTS_DIR", "").strip()
+    base = Path(override) if override else Path.home() / ".pinkybot" / "accounts"
+    return base
+
+
+def index_path() -> Path:
+    return store_dir() / "index.json"
+
+
+def token_path(name: str) -> Path:
+    return store_dir() / f"{name}.token"
+
+
+def default_env_path() -> Path:
+    """The repo-root ``.env`` (override with PINKY_ENV_FILE / --env-file).
+
+    scripts/claude_account.py → parent (scripts) → parent (repo root).
+    """
+    override = os.environ.get("PINKY_ENV_FILE", "").strip()
+    if override:
+        return Path(override)
+    return Path(__file__).resolve().parent.parent / ".env"
+
+
+# ── name validation ──────────────────────────────────────────────────────────
+
+
+def valid_name(name: str) -> bool:
+    """A store name must be a safe filename fragment (no path traversal)."""
+    if not name or len(name) > 64:
+        return False
+    return all(c.isalnum() or c in ("-", "_", ".") for c in name) and name not in (
+        ".",
+        "..",
+    )
+
+
+# ── token store ──────────────────────────────────────────────────────────────
+
+
+def ensure_store() -> None:
+    d = store_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:
+        pass
+
+
+def load_index() -> dict:
+    p = index_path()
+    if not p.exists():
+        return {"version": INDEX_VERSION, "accounts": {}}
+    try:
+        # ValueError covers both json.JSONDecodeError and a non-UTF-8 read
+        # (UnicodeDecodeError) — a truncated/corrupt index becomes a clean exit.
+        data = json.loads(p.read_text())
+    except (ValueError, OSError) as exc:
+        raise SystemExit(f"claude-account: corrupt index {p}: {exc}")
+    if not isinstance(data, dict) or not isinstance(data.get("accounts"), dict):
+        raise SystemExit(f"claude-account: unexpected index shape in {p}")
+    return data
+
+
+def save_index(data: dict) -> None:
+    ensure_store()
+    _atomic_write(index_path(), json.dumps(data, indent=2, sort_keys=True) + "\n", 0o600)
+
+
+def read_token(name: str) -> str:
+    p = token_path(name)
+    if not p.exists():
+        raise SystemExit(f"claude-account: no stored token file for {name!r}")
+    return p.read_text().strip()
+
+
+def write_token(name: str, token: str) -> None:
+    ensure_store()
+    _atomic_write(token_path(name), token + "\n", 0o600)
+
+
+# ── atomic + backup file writes ──────────────────────────────────────────────
+
+
+def _atomic_write(path: Path, text: str, mode: int) -> None:
+    """Write via a temp file in the same dir + os.replace, chmod BEFORE the swap.
+
+    Same-directory temp so os.replace is atomic (no cross-device copy). The mode
+    is applied to the temp file before the rename so the final path is never
+    briefly world-readable — matters for token / .env files.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def _atomic_copy(src: Path, dst: Path, mode: int) -> None:
+    """Byte-exact copy src → dst with `mode` applied BEFORE the rename.
+
+    Used for credential files (.env and its backups): never leaves the
+    destination torn (os.replace is atomic) and never briefly world-readable
+    (chmod precedes the swap) — unlike shutil.copy2, which creates the dest at
+    0o666&~umask and only tightens it after streaming the secret.
+    """
+    data = src.read_bytes()
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(dst.parent), prefix=f".{dst.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.chmod(tmp, mode)
+        os.replace(tmp, dst)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def backup_dir() -> Path:
+    return store_dir() / "env-backups"
+
+
+def backup_env(env_path: Path, tag: str) -> Path:
+    """Copy .env → <store>/env-backups/<name>.bak.pre-<tag>-<UTC>, 0600, atomic.
+
+    Backups go in the 0700 store dir OUTSIDE the repo tree: a credential backup
+    written beside .env in a (public) repo is one ``git add -A`` from disclosure,
+    and the bare ``.env`` .gitignore rule does not match ``.env.bak.*``.
+    """
+    ensure_store()
+    bdir = backup_dir()
+    bdir.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(bdir, 0o700)
+    except OSError:
+        pass
+    stamp = _utcnow().strftime("%Y%m%d-%H%M%S")
+    backup = bdir / f"{env_path.name}.bak.pre-{tag}-{stamp}"
+    _atomic_copy(env_path, backup, 0o600)
+    return backup
+
+
+# ── .env line rewriting ──────────────────────────────────────────────────────
+
+
+def _is_live_assignment(line: str, key: str) -> bool:
+    """True iff ``line`` is a live (non-comment) ``key=…`` assignment.
+
+    Mirrors _load_dotenv's parse: a leading ``#`` is a comment (skipped); the
+    key is everything before the first ``=`` (stripped). ``FOO_BAR`` must not
+    match ``FOO``.
+    """
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return False
+    return stripped.split("=", 1)[0].strip() == key
+
+
+def set_env_var(lines: list[str], key: str, value: str) -> list[str]:
+    """Return ``lines`` with exactly ONE live ``key=value`` assignment.
+
+    The daemon's loader takes the FIRST live occurrence and ignores the rest, so
+    a stale duplicate below the one we set would be a latent foot-gun on any
+    later reorder. We replace the first live occurrence in place and drop every
+    later live duplicate; comment lines are left untouched. If no live
+    occurrence exists we append one.
+    """
+    out: list[str] = []
+    seen = False
+    for line in lines:
+        if _is_live_assignment(line, key):
+            if not seen:
+                out.append(f"{key}={value}")
+                seen = True
+            # else: drop the duplicate live assignment
+            continue
+        out.append(line)
+    if not seen:
+        out.append(f"{key}={value}")
+    return out
+
+
+def read_live_value(lines: list[str], key: str) -> str | None:
+    """The value of the FIRST live ``key=…`` line (quotes stripped), else None."""
+    for line in lines:
+        if _is_live_assignment(line, key):
+            raw = line.strip().split("=", 1)[1].strip()
+            return raw.strip("\"'")
+    return None
+
+
+def read_env_lines(env_path: Path) -> list[str]:
+    if not env_path.exists():
+        raise SystemExit(f"claude-account: .env not found at {env_path}")
+    # splitlines drops the trailing newline; we re-add exactly one on write.
+    return env_path.read_text().splitlines()
+
+
+def write_env_lines(env_path: Path, lines: list[str]) -> None:
+    mode = 0o600
+    try:
+        mode = stat.S_IMODE(os.stat(env_path).st_mode)
+    except OSError:
+        pass
+    _atomic_write(env_path, "\n".join(lines) + "\n", mode)
+
+
+# ── isolation probe ──────────────────────────────────────────────────────────
+
+
+def resolve_claude_bin(explicit: str = "") -> str:
+    if explicit:
+        return explicit
+    found = shutil.which("claude")
+    if found:
+        return found
+    candidate = Path.home() / ".local" / "bin" / "claude"
+    return str(candidate) if candidate.exists() else "claude"
+
+
+def probe_token(token: str, claude_bin: str = "") -> tuple[bool, str]:
+    """Isolation-probe a token BEFORE trusting it (never wall the fleet).
+
+    Runs ``claude --print`` in a minimal env carrying only the candidate token,
+    so a bad token is caught here instead of at fleet startup. The token is
+    passed via env (never argv) and never echoed. ``--print`` does NOT surface
+    the interactive Fable-credit consent, so a pass here means "authenticates",
+    not "no consent prompt at real startup".
+    """
+    binary = resolve_claude_bin(claude_bin)
+    env = {
+        "HOME": os.environ.get("HOME", str(Path.home())),
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        TOKEN_ENV_KEY: token,
+        # keep the probe quiet + non-interactive
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    }
+    try:
+        proc = subprocess.run(
+            [binary, "--print", "say OK"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=PROBE_TIMEOUT_S,
+        )
+    except FileNotFoundError:
+        return False, f"claude binary not found at {binary!r}"
+    except subprocess.TimeoutExpired:
+        return False, f"probe timed out after {PROBE_TIMEOUT_S}s"
+    if proc.returncode != 0:
+        tail = (proc.stderr or proc.stdout or "").strip().splitlines()
+        detail = tail[-1] if tail else f"exit {proc.returncode}"
+        return False, f"probe failed: {detail}"
+    if not (proc.stdout or "").strip():
+        return False, "probe returned empty output"
+    return True, "ok"
+
+
+# ── daemon restart ───────────────────────────────────────────────────────────
+
+
+def _daemon_base_url() -> str:
+    port = os.environ.get("PINKY_API_PORT", "8888").strip() or "8888"
+    return f"http://127.0.0.1:{port}"
+
+
+def restart_daemon(env_path: Path, as_agent: str) -> tuple[bool, str]:
+    """POST /admin/restart with internal auth (the path the daemon's own restart
+    tool uses). The daemon abstracts launchctl-vs-systemd, so we never
+    reimplement box-specific restart logic here.
+
+    ``as_agent`` is the identity the request is signed as. The daemon accepts the
+    shared secret only for a REGISTERED, non-isolated agent name, so this must be
+    a real agent on this box (supplied via --as-agent / PINKY_AGENT_NAME) — there
+    is no baked-in default. ``env_path`` is the same .env the switch operated on,
+    so the secret is sourced from the file being managed.
+    """
+    if not as_agent:
+        return False, (
+            "no caller identity — pass --as-agent <a registered non-isolated agent> "
+            "or set PINKY_AGENT_NAME (the daemon signs /admin with the shared secret "
+            "only for a registered agent name)"
+        )
+    secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+    if not secret:
+        # fall back to the .env the switch is managing (not the repo-root default)
+        try:
+            secret = read_live_value(read_env_lines(env_path), "PINKY_SESSION_SECRET") or ""
+        except SystemExit:
+            secret = ""
+    if not secret:
+        return False, "PINKY_SESSION_SECRET unavailable — cannot auth the restart call"
+    try:
+        import urllib.error
+        import urllib.request
+
+        from pinky_daemon.auth import build_internal_auth_headers
+    except Exception as exc:  # noqa: BLE001 — import path may be absent off-box
+        return False, f"cannot import daemon auth/urllib: {exc}"
+
+    path = "/admin/restart"
+    headers = build_internal_auth_headers(
+        secret, agent_name=as_agent, method="POST", path=path
+    )
+    req = urllib.request.Request(
+        _daemon_base_url() + path, method="POST", headers=headers, data=b""
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return (200 <= resp.status < 300), f"HTTP {resp.status}"
+    except urllib.error.HTTPError as exc:
+        return False, f"HTTP {exc.code}"
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
+def daemon_healthy() -> bool:
+    # /api is the daemon's unauthenticated health/info route (returns 200);
+    # there is no top-level /health route.
+    try:
+        import urllib.request
+
+        with urllib.request.urlopen(_daemon_base_url() + "/api", timeout=5) as resp:
+            return 200 <= resp.status < 300
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# ── account metadata helpers ─────────────────────────────────────────────────
+
+
+def days_left(meta: dict) -> int | None:
+    exp = _parse_iso(meta.get("expires_at", ""))
+    if not exp:
+        return None
+    return (exp - _utcnow()).days
+
+
+def forwarding_on(env_path: Path) -> bool:
+    """Whether the .env enables static-token forwarding to the fleet."""
+    lines = read_env_lines(env_path)
+    return (read_live_value(lines, FORWARD_FLAG_KEY) or "").lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def token_provenance(env_path: Path, index: dict) -> str | None:
+    """Which stored account matches the .env's live token — IGNORING the flag.
+
+    Constant-time compare against each stored token; the matching name, or None
+    when the token is absent / matches nothing.
+    """
+    lines = read_env_lines(env_path)
+    live = read_live_value(lines, TOKEN_ENV_KEY)
+    if not live:
+        return None
+    for name in index.get("accounts", {}):
+        try:
+            stored = read_token(name)
+        except SystemExit:
+            continue
+        if stored and hmac.compare_digest(live, stored):
+            return name
+    return None
+
+
+def active_name(env_path: Path, index: dict) -> str | None:
+    """The account the fleet is ACTUALLY running as: the live token matches a
+    stored account AND forwarding is enabled. Returns None otherwise — a token
+    present with forwarding off is not being used, so it is not 'active'.
+    """
+    if not forwarding_on(env_path):
+        return None
+    return token_provenance(env_path, index)
+
+
+def suffix_of(token: str) -> str:
+    return token[-4:] if len(token) >= 4 else "?"
+
+
+# ── commands ─────────────────────────────────────────────────────────────────
+
+
+def cmd_add(args: argparse.Namespace) -> int:
+    if not valid_name(args.name):
+        print(f"claude-account: invalid name {args.name!r}", file=sys.stderr)
+        return 2
+    index = load_index()
+    if args.name in index["accounts"] and not args.force:
+        print(
+            f"claude-account: {args.name!r} already exists — pass --force to replace it",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.mint:
+        binary = resolve_claude_bin(args.claude_bin)
+        print(f"Launching `{binary} setup-token` — sign in as the target account…\n")
+        subprocess.run([binary, "setup-token"], check=False)
+        print()
+
+    # Token via hidden prompt — NEVER on argv (would leak in ps / shell history).
+    token = getpass.getpass("Paste the setup-token (input hidden): ").strip()
+    if not token:
+        print("claude-account: no token entered", file=sys.stderr)
+        return 2
+    if not token.startswith(SETUP_TOKEN_PREFIX) and not args.allow_any:
+        print(
+            f"claude-account: token does not look like a setup-token "
+            f"({SETUP_TOKEN_PREFIX}…). Pass --allow-any to store it anyway.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not args.no_probe:
+        print("Isolation-probing the token…")
+        ok, detail = probe_token(token, args.claude_bin)
+        if not ok:
+            print(f"claude-account: refusing to store — {detail}", file=sys.stderr)
+            return 1
+        print("  probe OK")
+    probe_meta = {"ok": not args.no_probe, "at": _iso(_utcnow())}
+
+    now = _utcnow()
+    if args.expires_at:
+        exp = _parse_iso(args.expires_at)
+        if not exp:
+            print(f"claude-account: bad --expires-at {args.expires_at!r}", file=sys.stderr)
+            return 2
+    else:
+        exp = now + timedelta(days=args.ttl_days)
+    billing = args.billing
+    if billing not in BILLING_MODES:
+        print(f"claude-account: --billing must be one of {BILLING_MODES}", file=sys.stderr)
+        return 2
+
+    write_token(args.name, token)
+    index["accounts"][args.name] = {
+        "account_label": args.label or args.name,
+        "token_kind": "setup_token" if token.startswith(SETUP_TOKEN_PREFIX) else "other",
+        "billing": billing,
+        "added_at": _iso(now),
+        "expires_at": _iso(exp),
+        "token_suffix": suffix_of(token),
+        "probe": probe_meta,
+    }
+    save_index(index)
+    print(f"Stored {args.name!r} (…{suffix_of(token)}), expires {_iso(exp)}, billing={billing}.")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    index = load_index()
+    accounts = index.get("accounts", {})
+    if not accounts:
+        print("No stored accounts. Add one with `claude-account add <name>`.")
+        return 0
+    try:
+        active = active_name(args.env_file, index)
+        prov = token_provenance(args.env_file, index)
+    except SystemExit as exc:
+        print(str(exc), file=sys.stderr)
+        active = prov = None
+    header = f"{'':2} {'NAME':16} {'BILLING':12} {'EXPIRES':22} {'DAYS':>5}  LABEL"
+    print(header)
+    for name in sorted(accounts):
+        meta = accounts[name]
+        mark = "*" if name == active else " "
+        dl = days_left(meta)
+        dl_s = "—" if dl is None else str(dl)
+        warn = " ⚠" if (dl is not None and dl <= EXPIRY_WARN_DAYS) else ""
+        print(
+            f"{mark:2} {name:16} {meta.get('billing','?'):12} "
+            f"{meta.get('expires_at','?'):22} {dl_s:>5}{warn}  {meta.get('account_label','')}"
+        )
+    if active is None:
+        if prov:
+            print(f"\n(forwarding is OFF — {prov!r} is in .env but not being forwarded)")
+        else:
+            print("\n(no stored token matches the live .env token — active account unknown)")
+    return 0
+
+
+def cmd_current(args: argparse.Namespace) -> int:
+    index = load_index()
+    lines = read_env_lines(args.env_file)
+    flag = (read_live_value(lines, FORWARD_FLAG_KEY) or "").lower() in ("1", "true", "yes", "on")
+    live = read_live_value(lines, TOKEN_ENV_KEY)
+    prov = token_provenance(args.env_file, index)
+    print(f"forward flag ({FORWARD_FLAG_KEY}): {'ON' if flag else 'OFF'}")
+    if not live:
+        print(f"{TOKEN_ENV_KEY}: (not set)")
+    else:
+        print(f"{TOKEN_ENV_KEY}: set (…{suffix_of(live)})")
+    if prov and flag:
+        meta = index["accounts"][prov]
+        dl = days_left(meta)
+        print(f"active account: {prov}  (billing={meta.get('billing','?')}, "
+              f"expires {meta.get('expires_at','?')}, {dl if dl is not None else '?'}d left)")
+    elif prov and not flag:
+        print(f"active account: none — {prov!r} token is in .env but forwarding is OFF")
+    elif live:
+        print("active account: unknown (live token not in the store)")
+    else:
+        print("active account: none")
+    if flag and not live:
+        print("\n⚠ FAIL-OPEN RISK: forward flag is ON but no token is set — "
+              "the fleet would hit a login wall on restart.")
+    return 0
+
+
+def cmd_switch(args: argparse.Namespace) -> int:
+    if not valid_name(args.name):
+        print(f"claude-account: invalid name {args.name!r}", file=sys.stderr)
+        return 2
+    index = load_index()
+    if args.name not in index["accounts"]:
+        print(f"claude-account: no stored account {args.name!r}", file=sys.stderr)
+        return 2
+    meta = index["accounts"][args.name]
+
+    # Refuse a dead token before it can wall the fleet.
+    dl = days_left(meta)
+    if dl is not None and dl < 0 and not args.force:
+        print(
+            f"claude-account: {args.name!r} expired {abs(dl)}d ago "
+            f"({meta.get('expires_at')}) — refusing. Re-add it, or pass --force.",
+            file=sys.stderr,
+        )
+        return 1
+
+    token = read_token(args.name)
+    # Fail-closed backstop independent of the probe: an empty/blanked token file
+    # must NEVER be written together with the flag (that IS the login wall). This
+    # is the only guard on the --no-probe path.
+    if not token.strip():
+        print(
+            f"claude-account: stored token for {args.name!r} is empty — refusing "
+            f"(would wall the fleet). Re-add it with `claude-account add {args.name} --force`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    env_path = args.env_file
+    # active_name is flag-aware: this is true only when the token already matches
+    # AND forwarding is already on. A token match with the flag OFF falls through
+    # so the switch actually sets the flag (the fix for the silent no-op).
+    if active_name(env_path, index) == args.name and not args.force:
+        print(f"Already on {args.name!r} with forwarding on; nothing to do "
+              f"(pass --force to rewrite anyway).")
+        return 0
+
+    if args.dry_run:
+        flag = "ON" if forwarding_on(env_path) else "OFF"
+        print(f"[dry-run] would set {TOKEN_ENV_KEY}=(…{suffix_of(token)}) and "
+              f"{FORWARD_FLAG_KEY}=1 in {env_path} (forwarding currently {flag}). "
+              f"No write, no backup, no probe.")
+        return 0
+
+    if not args.no_probe:
+        print("Pre-switch isolation-probe…")
+        ok, detail = probe_token(token, args.claude_bin)
+        if not ok:
+            print(
+                f"claude-account: refusing to switch — {detail}. "
+                f"The current .env is untouched.",
+                file=sys.stderr,
+            )
+            return 1
+        print("  probe OK")
+
+    lines = read_env_lines(env_path)
+    backup = backup_env(env_path, args.name)
+    # Fail-closed invariant: token + forward flag land in the SAME atomic write —
+    # there is never a persisted state with flag=1 and no token.
+    new_lines = set_env_var(lines, TOKEN_ENV_KEY, token)
+    new_lines = set_env_var(new_lines, FORWARD_FLAG_KEY, "1")
+    write_env_lines(env_path, new_lines)
+    print(f"Wrote {env_path} (backup: {backup}). Active token → {args.name} (…{suffix_of(token)}).")
+
+    if not args.restart:
+        print("\nNot restarting (the daemon only picks up .env on restart). Next:")
+        print("  • restart the daemon (re-run with --restart, or the box's restart command)")
+        print("  • then spot-check a few agent panes for a login wall.")
+        return 0
+
+    as_agent = (args.as_agent or os.environ.get("PINKY_AGENT_NAME", "")).strip()
+    print("Restarting the daemon…")
+    ok, detail = restart_daemon(env_path, as_agent)
+    if not ok:
+        _revert(env_path, backup, f"restart call failed ({detail})")
+        return 1
+    # Wait for health to come back; revert if it doesn't.
+    import time
+
+    deadline = time.monotonic() + RESTART_HEALTH_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if daemon_healthy():
+            print("Daemon healthy after restart.")
+            print("⚠ Spot-check a few agent panes — --print auth passing does not "
+                  "guarantee no Fable-credit consent prompt at real startup.")
+            return 0
+        time.sleep(3)
+    _revert(env_path, backup,
+            f"daemon did not report healthy within {RESTART_HEALTH_TIMEOUT_S}s")
+    return 1
+
+
+def _revert(env_path: Path, backup: Path, why: str) -> None:
+    print(f"\nclaude-account: {why} — reverting {env_path} from {backup.name}.",
+          file=sys.stderr)
+    try:
+        mode = 0o600
+        try:
+            mode = stat.S_IMODE(os.stat(env_path).st_mode)
+        except OSError:
+            pass
+        _atomic_copy(backup, env_path, mode)
+        print("Reverted. Restart the daemon to restore the previous token.", file=sys.stderr)
+    except OSError as exc:
+        print(f"REVERT FAILED ({exc}) — restore {backup} to {env_path} by hand.",
+              file=sys.stderr)
+
+
+def cmd_remove(args: argparse.Namespace) -> int:
+    if not valid_name(args.name):
+        print(f"claude-account: invalid name {args.name!r}", file=sys.stderr)
+        return 2
+    index = load_index()
+    if args.name not in index["accounts"]:
+        print(f"claude-account: no stored account {args.name!r}", file=sys.stderr)
+        return 2
+    # Refuse if the live .env token IS this account's token — regardless of the
+    # forward flag. Deleting a token that literally sits in .env is dangerous even
+    # with forwarding off (someone could flip the flag on later).
+    if token_provenance(args.env_file, index) == args.name and not args.force:
+        print(
+            f"claude-account: {args.name!r} is the token currently in .env — refusing. "
+            f"Switch away first, or pass --force.",
+            file=sys.stderr,
+        )
+        return 1
+    tp = token_path(args.name)
+    if tp.exists():
+        tp.unlink()
+    del index["accounts"][args.name]
+    save_index(index)
+    print(f"Removed {args.name!r}.")
+    return 0
+
+
+def cmd_check_expiry(args: argparse.Namespace) -> int:
+    index = load_index()
+    active = active_name(args.env_file, index)
+    if not active:
+        print("check-expiry: no active account matched (nothing to warn on).")
+        return 0
+    meta = index["accounts"][active]
+    dl = days_left(meta)
+    if dl is None:
+        print(f"check-expiry: active account {active!r} has no expiry recorded.")
+        return 0
+    if dl <= args.days:
+        print(
+            f"check-expiry: ACTIVE token {active!r} expires in {dl}d "
+            f"({meta.get('expires_at')}). Mint a fresh token and switch.",
+        )
+        return 3  # non-zero → a scheduled wake can turn this into an owner nudge
+    print(f"check-expiry: {active!r} OK ({dl}d left).")
+    return 0
+
+
+# ── argument parsing ─────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="claude-account", description=__doc__.splitlines()[0])
+    p.add_argument("--env-file", type=Path, default=None,
+                   help="path to .env (default: repo-root .env / PINKY_ENV_FILE)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    a = sub.add_parser("add", help="mint/paste + probe + store a token")
+    a.add_argument("name")
+    a.add_argument("--label", default="", help="human account label (e.g. email)")
+    a.add_argument("--billing", default="unknown", choices=BILLING_MODES,
+                   help="owner-declared billing mode (subscription | api_usage | unknown)")
+    a.add_argument("--ttl-days", type=int, default=DEFAULT_TTL_DAYS)
+    a.add_argument("--expires-at", default="", help="explicit ISO expiry (overrides --ttl-days)")
+    a.add_argument("--mint", action="store_true", help="launch `claude setup-token` first")
+    a.add_argument("--no-probe", action="store_true", help="skip the isolation-probe (unsafe)")
+    a.add_argument("--allow-any", action="store_true", help="accept a non setup-token string")
+    a.add_argument("--claude-bin", default="", help="path to the claude binary")
+    a.add_argument("--force", action="store_true", help="replace an existing entry")
+    a.set_defaults(func=cmd_add)
+
+    li = sub.add_parser("list", help="stored accounts + active + expiry")
+    li.set_defaults(func=cmd_list)
+
+    c = sub.add_parser("current", help="which token the .env currently uses")
+    c.set_defaults(func=cmd_current)
+
+    s = sub.add_parser("switch", help="safe swap (backup + fail-closed write [+restart])")
+    s.add_argument("name")
+    s.add_argument("--restart", action="store_true", help="also restart the daemon")
+    s.add_argument("--as-agent", default="",
+                   help="identity to sign the --restart call as (a registered "
+                        "non-isolated agent; falls back to PINKY_AGENT_NAME)")
+    s.add_argument("--dry-run", action="store_true", help="preview the .env change without writing")
+    s.add_argument("--no-probe", action="store_true", help="skip the pre-switch probe (unsafe)")
+    s.add_argument("--claude-bin", default="")
+    s.add_argument("--force", action="store_true", help="switch even if expired / already active")
+    s.set_defaults(func=cmd_switch)
+
+    r = sub.add_parser("remove", help="delete a stored token")
+    r.add_argument("name")
+    r.add_argument("--force", action="store_true", help="remove even the active account")
+    r.set_defaults(func=cmd_remove)
+
+    e = sub.add_parser("check-expiry", help="nudge (exit 3) if the active token expires soon")
+    e.add_argument("--days", type=int, default=EXPIRY_WARN_DAYS)
+    e.set_defaults(func=cmd_check_expiry)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    # resolve the env path once, after parsing (default is lazy so tests can patch)
+    args.env_file = args.env_file or default_env_path()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/claude_account.py
+++ b/scripts/claude_account.py
@@ -40,7 +40,7 @@ import stat
 import subprocess
 import sys
 import tempfile
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -161,10 +161,10 @@ def _assert_private_dir(path: Path) -> None:
 
 def _ensure_private_dir(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
-    try:
+    # best-effort — a chmod we can't apply (dir we don't own) is caught by the
+    # final-mode assertion below, which is the real guard.
+    with suppress(OSError):
         os.chmod(path, 0o700)
-    except OSError:
-        pass
     _assert_private_dir(path)
 
 
@@ -569,10 +569,6 @@ def active_name(env_path: Path, index: dict) -> str | None:
     return token_provenance(env_path, index)
 
 
-def suffix_of(token: str) -> str:
-    return token[-4:] if len(token) >= 4 else "?"
-
-
 # ── commands ─────────────────────────────────────────────────────────────────
 
 
@@ -663,11 +659,10 @@ def cmd_add(args: argparse.Namespace) -> int:
         "billing": billing,
         "added_at": _iso(now),
         "expires_at": _iso(exp),
-        "token_suffix": suffix_of(token),
         "probe": probe_meta,
     }
     save_index(index)
-    print(f"Stored {args.name!r} (…{suffix_of(token)}), expires {_iso(exp)}, billing={billing}.")
+    print(f"Stored {args.name!r}, expires {_iso(exp)}, billing={billing}.")
     return 0
 
 
@@ -713,7 +708,7 @@ def cmd_current(args: argparse.Namespace) -> int:
     if not live:
         print(f"{TOKEN_ENV_KEY}: (not set)")
     else:
-        print(f"{TOKEN_ENV_KEY}: set (…{suffix_of(live)})")
+        print(f"{TOKEN_ENV_KEY}: set")
     if prov and flag:
         meta = index["accounts"][prov]
         dl = days_left(meta)
@@ -788,9 +783,8 @@ def cmd_switch(args: argparse.Namespace) -> int:
 
     if args.dry_run:
         flag = "ON" if forwarding_on(env_path) else "OFF"
-        print(f"[dry-run] would set {TOKEN_ENV_KEY}=(…{suffix_of(token)}) and "
-              f"{FORWARD_FLAG_KEY}=1 in {env_path} (forwarding currently {flag}). "
-              f"No write, no backup, no probe.")
+        print(f"[dry-run] would set {TOKEN_ENV_KEY} and {FORWARD_FLAG_KEY}=1 in "
+              f"{env_path} (forwarding currently {flag}). No write, no backup, no probe.")
         return 0
 
     if not args.no_probe:
@@ -844,7 +838,7 @@ def cmd_switch(args: argparse.Namespace) -> int:
     new_lines = set_env_var(lines, TOKEN_ENV_KEY, token)
     new_lines = set_env_var(new_lines, FORWARD_FLAG_KEY, "1")
     write_env_lines(env_path, new_lines)
-    print(f"Wrote {env_path} (backup: {backup}). Active token → {args.name} (…{suffix_of(token)}).")
+    print(f"Wrote {env_path} (backup: {backup}). Active token → {args.name}.")
 
     if not args.restart:
         print("\nNot restarting (the daemon only picks up .env on restart). Next:")

--- a/tests/test_claude_account.py
+++ b/tests/test_claude_account.py
@@ -84,10 +84,23 @@ def test_set_env_var_leaves_comments_and_appends_live():
     assert ca.read_live_value(out, "TOK") == "new"
 
 
-def test_read_live_value_first_wins_and_strips_quotes():
-    assert ca.read_live_value(['TOK="quoted"', "TOK=second"], "TOK") == "quoted"
+def test_read_live_value_last_wins_and_strips_quotes():
+    # bash `source` is last-wins — the authoritative loader on the Mini
+    assert ca.read_live_value(['TOK="quoted"', "TOK=second"], "TOK") == "second"
     assert ca.read_live_value(["#TOK=commented", "TOK=live"], "TOK") == "live"
     assert ca.read_live_value(["A=1"], "TOK") is None
+
+
+def test_export_assignments_are_live():
+    # bash `source .env` honors `export KEY=…`; the tool must treat it as live
+    assert ca._live_key("export TOK=v") == "TOK"
+    assert ca._live_key("  export   TOK=v") == "TOK"
+    assert ca._live_key("exportTOK=v") == "exportTOK"  # not the `export ` prefix
+    assert ca.read_live_value(["export TOK=fromexport"], "TOK") == "fromexport"
+    # set_env_var collapses a bare + export pair to ONE canonical bare line
+    out = ca.set_env_var(["export TOK=old", "A=1", "TOK=older"], "TOK", "new")
+    assert [line for line in out if ca._live_key(line) == "TOK"] == ["TOK=new"]
+    assert ca.read_live_value(out, "TOK") == "new"
 
 
 # ── valid_name (path-traversal guard) ────────────────────────────────────────
@@ -265,26 +278,42 @@ def test_switch_empty_token_file_refuses(store):
     assert store["env"].read_text() == "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n"  # untouched
 
 
-def test_switch_restart_success_not_reverted(store, monkeypatch):
+def test_switch_restart_success_when_generation_advances(store, monkeypatch):
     _seed_account(store)
     write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
     monkeypatch.setattr(ca, "restart_daemon", lambda env_path, as_agent: (True, "HTTP 200"))
-    monkeypatch.setattr(ca, "daemon_healthy", lambda: True)
+    # baseline "old-gen" then a new process "new-gen" → success
+    gens = iter(["old-gen", "new-gen"])
+    monkeypatch.setattr(ca, "daemon_generation", lambda: next(gens, "new-gen"))
     rc = run("switch", "acct", "--restart", "--as-agent", "someagent")
     assert rc == 0
     assert "sk-ant-oat01-NEW" in store["env"].read_text()  # kept, not reverted
 
 
-def test_switch_restart_health_timeout_reverts(store, monkeypatch):
+def test_switch_restart_reverts_on_unchanged_generation(store, monkeypatch):
+    """The false-green case: the OLD process still answers /api (same started_at)
+    but never restarts → must NOT be accepted; revert instead."""
     _seed_account(store)
     write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
     monkeypatch.setattr(ca, "restart_daemon", lambda env_path, as_agent: (True, "HTTP 200"))
-    monkeypatch.setattr(ca, "daemon_healthy", lambda: False)
+    monkeypatch.setattr(ca, "daemon_generation", lambda: "same-gen")  # never advances
     monkeypatch.setattr(ca, "RESTART_HEALTH_TIMEOUT_S", 0)
     rc = run("switch", "acct", "--restart", "--as-agent", "someagent")
     assert rc == 1
     # atomic revert restored the exact original .env
     assert store["env"].read_text() == "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n"
+
+
+def test_switch_restart_unreadable_baseline_does_not_revert(store, monkeypatch):
+    """No pre-restart generation to verify against → don't claim success, but don't
+    revert either (the restart likely proceeded)."""
+    _seed_account(store)
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    monkeypatch.setattr(ca, "restart_daemon", lambda env_path, as_agent: (True, "HTTP 200"))
+    monkeypatch.setattr(ca, "daemon_generation", lambda: None)  # never readable
+    rc = run("switch", "acct", "--restart", "--as-agent", "someagent")
+    assert rc == 1
+    assert "sk-ant-oat01-NEW" in store["env"].read_text()  # NOT reverted
 
 
 def test_restart_daemon_requires_identity(store):
@@ -415,3 +444,56 @@ def test_add_probe_failure_does_not_store(store, monkeypatch):
     assert rc == 1
     assert "x" not in ca.load_index()["accounts"]
     assert not ca.token_path("x").exists()
+
+
+# ── serialization safety / duplicate / perms / probe hygiene ─────────────────
+
+
+def test_add_rejects_shell_unsafe_token(store, monkeypatch):
+    # the Beaverton-style injection: a newline would write a SECOND live .env line
+    injected = "sk-ant-oat01-GOOD\nCLAUDE_CODE_OAUTH_TOKEN="
+    monkeypatch.setattr(ca.getpass, "getpass", lambda prompt="": injected)
+    assert run("add", "x", "--allow-any") == 2
+    assert "x" not in ca.load_index()["accounts"]
+
+
+def test_switch_rejects_shell_unsafe_token_file(store):
+    _seed_account(store)
+    ca.write_token("acct", "sk-ant-oat01-GOOD\nPINKY_FORWARD_OAUTH_TOKEN=1")  # hand-edited injection
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    rc = run("switch", "acct", "--no-probe")
+    assert rc == 1
+    assert store["env"].read_text() == "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n"  # untouched
+
+
+def test_add_rejects_duplicate_token_under_different_name(store, monkeypatch):
+    monkeypatch.setattr(ca.getpass, "getpass", lambda prompt="": "sk-ant-oat01-SHARED")
+    assert run("add", "first") == 0
+    monkeypatch.setattr(ca.getpass, "getpass", lambda prompt="": "sk-ant-oat01-SHARED")
+    assert run("add", "second") == 2  # same token, different name → ambiguous
+    assert "second" not in ca.load_index()["accounts"]
+
+
+def test_switch_clamps_env_to_0600_from_permissive_source(store):
+    _seed_account(store)
+    store["env"].write_text("CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    os.chmod(store["env"], 0o644)  # permissive .env
+    rc = run("switch", "acct")
+    assert rc == 0
+    assert stat.S_IMODE(os.stat(store["env"]).st_mode) == 0o600  # clamped closed
+
+
+def test_probe_token_does_not_leak_the_candidate(monkeypatch):
+    tok = "sk-ant-oat01-SUPERSECRETVALUE"
+
+    class FakeProc:
+        returncode = 1
+        stdout = ""
+        stderr = f"error: invalid token {tok} was rejected"
+
+    monkeypatch.setattr(ca, "resolve_claude_bin", lambda explicit="": "/bin/true")
+    monkeypatch.setattr(ca.subprocess, "run", lambda *a, **k: FakeProc())
+    ok, detail = ca.probe_token(tok)
+    assert ok is False
+    assert tok not in detail
+    assert "SUPERSECRET" not in detail

--- a/tests/test_claude_account.py
+++ b/tests/test_claude_account.py
@@ -1,0 +1,417 @@
+"""Tests for scripts/claude_account.py (#570 account-switch tooling).
+
+Focus is the risky, security-critical core: the ``.env`` rewrite (exactly one
+live line per key, comment/substring edges), the fail-closed switch (token +
+flag written together, backup, revert), file permissions, and provenance. The
+live daemon restart and the real ``claude`` probe are integration paths and are
+stubbed here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "claude_account.py"
+SPEC = importlib.util.spec_from_file_location("claude_account", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+ca = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ca)
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    """Point the token store + env file at a tmp dir; stub the probe to pass."""
+    accounts = tmp_path / "accounts"
+    monkeypatch.setenv("PINKY_ACCOUNTS_DIR", str(accounts))
+    env_path = tmp_path / ".env"
+    monkeypatch.setenv("PINKY_ENV_FILE", str(env_path))
+    # default: probe passes, so store/switch logic is exercised without claude.
+    monkeypatch.setattr(ca, "probe_token", lambda tok, cb="": (True, "ok"))
+    return {"accounts": accounts, "env": env_path}
+
+
+def write_env(path: Path, text: str) -> None:
+    path.write_text(text)
+    os.chmod(path, 0o600)
+
+
+def run(*argv) -> int:
+    return ca.main(list(argv))
+
+
+# ── _is_live_assignment / set_env_var / read_live_value ─────────────────────
+
+
+def test_is_live_assignment_edges():
+    assert ca._is_live_assignment("FOO=1", "FOO")
+    assert ca._is_live_assignment("  FOO = 1 ", "FOO")
+    assert not ca._is_live_assignment("#FOO=1", "FOO")
+    assert not ca._is_live_assignment("# FOO=1", "FOO")
+    assert not ca._is_live_assignment("FOO_BAR=1", "FOO")  # substring must not match
+    assert not ca._is_live_assignment("BARFOO=1", "FOO")
+    assert not ca._is_live_assignment("", "FOO")
+    assert not ca._is_live_assignment("FOO", "FOO")  # no '='
+
+
+def test_set_env_var_replaces_first_live_and_drops_duplicates():
+    lines = ["A=1", "TOK=old", "B=2", "TOK=stale", "C=3"]
+    out = ca.set_env_var(lines, "TOK", "new")
+    assert out.count("TOK=new") == 1
+    assert not any(line == "TOK=stale" or line == "TOK=old" for line in out)
+    # position of the first occurrence is preserved
+    assert out == ["A=1", "TOK=new", "B=2", "C=3"]
+
+
+def test_set_env_var_appends_when_absent():
+    out = ca.set_env_var(["A=1"], "TOK", "new")
+    assert out == ["A=1", "TOK=new"]
+
+
+def test_set_env_var_leaves_comments_and_appends_live():
+    # a commented-out key is NOT a live assignment → a live one is appended
+    out = ca.set_env_var(["#TOK=old", "A=1"], "TOK", "new")
+    assert "#TOK=old" in out  # comment preserved
+    assert out.count("TOK=new") == 1
+    assert ca.read_live_value(out, "TOK") == "new"
+
+
+def test_read_live_value_first_wins_and_strips_quotes():
+    assert ca.read_live_value(['TOK="quoted"', "TOK=second"], "TOK") == "quoted"
+    assert ca.read_live_value(["#TOK=commented", "TOK=live"], "TOK") == "live"
+    assert ca.read_live_value(["A=1"], "TOK") is None
+
+
+# ── valid_name (path-traversal guard) ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", ["", "..", ".", "a/b", "a b", "../etc", "x" * 65, "a\tb"])
+def test_valid_name_rejects(bad):
+    assert not ca.valid_name(bad)
+
+
+@pytest.mark.parametrize("good", ["brad-main", "ryan_2026", "acct.1", "A1"])
+def test_valid_name_accepts(good):
+    assert ca.valid_name(good)
+
+
+# ── token store perms + roundtrip ────────────────────────────────────────────
+
+
+def test_write_token_roundtrip_and_perms(store):
+    ca.write_token("acct", "sk-ant-oat01-SECRET")
+    assert ca.read_token("acct") == "sk-ant-oat01-SECRET"
+    mode = stat.S_IMODE(os.stat(ca.token_path("acct")).st_mode)
+    assert mode == 0o600
+    dir_mode = stat.S_IMODE(os.stat(ca.store_dir()).st_mode)
+    assert dir_mode == 0o700
+
+
+def test_index_roundtrip_perms(store):
+    ca.save_index({"version": 1, "accounts": {"x": {"billing": "subscription"}}})
+    data = ca.load_index()
+    assert data["accounts"]["x"]["billing"] == "subscription"
+    assert stat.S_IMODE(os.stat(ca.index_path()).st_mode) == 0o600
+
+
+# ── backup + atomic write ────────────────────────────────────────────────────
+
+
+def test_backup_env_into_store_dir_0600(store):
+    write_env(store["env"], "A=1\n")
+    backup = ca.backup_env(store["env"], "acct")
+    assert backup.exists()
+    # backups live in the 0700 store dir OUTSIDE the repo tree, not beside .env
+    assert backup.parent == ca.backup_dir()
+    assert backup.parent != store["env"].parent
+    assert backup.name.startswith(".env.bak.pre-acct-")
+    assert backup.read_text() == "A=1\n"
+    assert stat.S_IMODE(os.stat(backup).st_mode) == 0o600
+
+
+def test_atomic_write_sets_mode(tmp_path):
+    p = tmp_path / "secret"
+    ca._atomic_write(p, "data\n", 0o600)
+    assert p.read_text() == "data\n"
+    assert stat.S_IMODE(os.stat(p).st_mode) == 0o600
+
+
+# ── days_left / active_name / suffix ─────────────────────────────────────────
+
+
+def test_days_left_math():
+    future = ca._iso(ca._utcnow() + timedelta(days=10))
+    assert ca.days_left({"expires_at": future}) in (9, 10)
+    assert ca.days_left({}) is None
+
+
+def test_active_name_provenance(store):
+    ca.write_token("acct", "sk-ant-oat01-LIVE")
+    ca.save_index({"version": 1, "accounts": {"acct": {"expires_at": ""}}})
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-LIVE\nPINKY_FORWARD_OAUTH_TOKEN=1\n")
+    index = ca.load_index()
+    assert ca.active_name(store["env"], index) == "acct"
+
+
+def test_active_name_none_when_token_absent(store):
+    ca.write_token("acct", "sk-ant-oat01-LIVE")
+    ca.save_index({"version": 1, "accounts": {"acct": {}}})
+    write_env(store["env"], "PINKY_FORWARD_OAUTH_TOKEN=1\n")  # no token line
+    assert ca.active_name(store["env"], ca.load_index()) is None
+
+
+def test_suffix_of():
+    assert ca.suffix_of("sk-ant-oat01-ABCDwxyz") == "wxyz"
+    assert ca.suffix_of("ab") == "?"
+
+
+# ── switch: fail-closed, backup, revert ──────────────────────────────────────
+
+
+def _seed_account(store, name="acct", token="sk-ant-oat01-NEW", days=300):
+    ca.write_token(name, token)
+    exp = ca._iso(ca._utcnow() + timedelta(days=days))
+    ca.save_index({"version": 1, "accounts": {name: {"expires_at": exp, "billing": "subscription"}}})
+
+
+def test_switch_writes_token_and_flag_together(store):
+    _seed_account(store)
+    write_env(store["env"], "A=1\nCLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    rc = run("switch", "acct")
+    assert rc == 0
+    text = store["env"].read_text()
+    assert "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-NEW" in text
+    assert "PINKY_FORWARD_OAUTH_TOKEN=1" in text
+    # a backup was made in the store dir (not beside .env in the repo)
+    backups = list(ca.backup_dir().glob(".env.bak.pre-acct-*"))
+    assert len(backups) == 1
+    assert "sk-ant-oat01-OLD" in backups[0].read_text()
+    assert not list(store["env"].parent.glob(".env.bak.pre-*"))  # nothing in the repo tree
+
+
+def test_switch_never_leaves_flag_on_without_token(store):
+    """Even starting from a bare .env, the write sets both keys atomically."""
+    _seed_account(store)
+    write_env(store["env"], "A=1\n")
+    run("switch", "acct")
+    lines = store["env"].read_text().splitlines()
+    tok = ca.read_live_value(lines, "CLAUDE_CODE_OAUTH_TOKEN")
+    flag = ca.read_live_value(lines, "PINKY_FORWARD_OAUTH_TOKEN")
+    assert flag == "1"
+    assert tok  # non-empty — never flag-on-token-missing
+
+
+def test_switch_refuses_expired_token(store, capsys):
+    _seed_account(store, days=-5)
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    rc = run("switch", "acct")
+    assert rc == 1
+    assert "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD" in store["env"].read_text()  # untouched
+
+
+def test_switch_refuses_on_probe_failure(store, monkeypatch):
+    _seed_account(store)
+    monkeypatch.setattr(ca, "probe_token", lambda tok, cb="": (False, "bad token"))
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    rc = run("switch", "acct")
+    assert rc == 1
+    assert "sk-ant-oat01-OLD" in store["env"].read_text()  # untouched, no write
+
+
+def test_switch_dry_run_no_write(store):
+    _seed_account(store)
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    rc = run("switch", "acct", "--dry-run")
+    assert rc == 0
+    # dry-run previews only: .env untouched and NO backup file left behind
+    assert store["env"].read_text() == "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n"
+    assert not list(ca.backup_dir().glob(".env.bak.pre-*"))
+
+
+def test_switch_already_active_is_noop(store, capsys):
+    _seed_account(store, token="sk-ant-oat01-SAME")
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-SAME\nPINKY_FORWARD_OAUTH_TOKEN=1\n")
+    rc = run("switch", "acct")
+    assert rc == 0
+    assert "nothing to do" in capsys.readouterr().out.lower()
+    assert not list(ca.backup_dir().glob(".env.bak.pre-*"))  # no backup churn
+
+
+def test_switch_token_matches_but_flag_off_proceeds(store):
+    """Token already in .env but forwarding OFF → switch must set the flag (not no-op)."""
+    _seed_account(store, token="sk-ant-oat01-SAME")
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-SAME\nPINKY_FORWARD_OAUTH_TOKEN=0\n")
+    rc = run("switch", "acct")
+    assert rc == 0
+    lines = store["env"].read_text().splitlines()
+    assert ca.read_live_value(lines, "PINKY_FORWARD_OAUTH_TOKEN") == "1"
+
+
+def test_switch_empty_token_file_refuses(store):
+    """A blanked token file must never be written with the flag, even with --no-probe."""
+    _seed_account(store)
+    ca.write_token("acct", "")  # blank the token file
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    rc = run("switch", "acct", "--no-probe")
+    assert rc == 1
+    assert store["env"].read_text() == "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n"  # untouched
+
+
+def test_switch_restart_success_not_reverted(store, monkeypatch):
+    _seed_account(store)
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    monkeypatch.setattr(ca, "restart_daemon", lambda env_path, as_agent: (True, "HTTP 200"))
+    monkeypatch.setattr(ca, "daemon_healthy", lambda: True)
+    rc = run("switch", "acct", "--restart", "--as-agent", "someagent")
+    assert rc == 0
+    assert "sk-ant-oat01-NEW" in store["env"].read_text()  # kept, not reverted
+
+
+def test_switch_restart_health_timeout_reverts(store, monkeypatch):
+    _seed_account(store)
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    monkeypatch.setattr(ca, "restart_daemon", lambda env_path, as_agent: (True, "HTTP 200"))
+    monkeypatch.setattr(ca, "daemon_healthy", lambda: False)
+    monkeypatch.setattr(ca, "RESTART_HEALTH_TIMEOUT_S", 0)
+    rc = run("switch", "acct", "--restart", "--as-agent", "someagent")
+    assert rc == 1
+    # atomic revert restored the exact original .env
+    assert store["env"].read_text() == "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n"
+
+
+def test_restart_daemon_requires_identity(store):
+    ok, detail = ca.restart_daemon(store["env"], "")
+    assert ok is False
+    assert "identity" in detail.lower()
+
+
+# ── remove ───────────────────────────────────────────────────────────────────
+
+
+def test_remove_refuses_active_without_force(store, capsys):
+    _seed_account(store, token="sk-ant-oat01-LIVE")
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-LIVE\n")
+    rc = run("remove", "acct")
+    assert rc == 1
+    assert ca.token_path("acct").exists()  # not deleted
+
+
+def test_remove_force_deletes_active(store):
+    _seed_account(store, token="sk-ant-oat01-LIVE")
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-LIVE\n")
+    rc = run("remove", "acct", "--force")
+    assert rc == 0
+    assert not ca.token_path("acct").exists()
+    assert "acct" not in ca.load_index()["accounts"]
+
+
+# ── check-expiry ─────────────────────────────────────────────────────────────
+
+
+def test_check_expiry_warns_within_window(store):
+    _seed_account(store, token="sk-ant-oat01-LIVE", days=10)
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-LIVE\nPINKY_FORWARD_OAUTH_TOKEN=1\n")
+    assert run("check-expiry", "--days", "30") == 3
+
+
+def test_check_expiry_ok_outside_window(store):
+    _seed_account(store, token="sk-ant-oat01-LIVE", days=200)
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-LIVE\nPINKY_FORWARD_OAUTH_TOKEN=1\n")
+    assert run("check-expiry", "--days", "30") == 0
+
+
+def test_check_expiry_no_active(store):
+    ca.save_index({"version": 1, "accounts": {}})
+    write_env(store["env"], "A=1\n")
+    assert run("check-expiry") == 0
+
+
+def test_check_expiry_no_nudge_when_forwarding_off(store):
+    """Near-expiry but forwarding OFF → not fleet-active → no spurious nudge."""
+    _seed_account(store, token="sk-ant-oat01-LIVE", days=5)
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-LIVE\nPINKY_FORWARD_OAUTH_TOKEN=0\n")
+    assert run("check-expiry", "--days", "30") == 0
+
+
+# ── active_name flag-awareness / provenance / index guards ───────────────────
+
+
+def test_active_name_none_when_forwarding_off(store):
+    ca.write_token("acct", "sk-ant-oat01-LIVE")
+    ca.save_index({"version": 1, "accounts": {"acct": {}}})
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-LIVE\nPINKY_FORWARD_OAUTH_TOKEN=0\n")
+    index = ca.load_index()
+    assert ca.active_name(store["env"], index) is None       # forwarding off → not active
+    assert ca.token_provenance(store["env"], index) == "acct"  # but the token matches
+
+
+def test_load_index_rejects_non_dict_accounts(store):
+    ca.ensure_store()
+    ca.index_path().write_text('{"version":1,"accounts":null}')
+    with pytest.raises(SystemExit):
+        ca.load_index()
+
+
+def test_load_index_rejects_bad_utf8(store):
+    ca.ensure_store()
+    ca.index_path().write_bytes(b"\xff\xfe not utf-8 \x80")
+    with pytest.raises(SystemExit):
+        ca.load_index()
+
+
+def test_days_left_naive_timestamp_does_not_crash():
+    # a hand-edited bare date (naive) must not raise on aware/naive subtraction
+    assert isinstance(ca.days_left({"expires_at": "2099-01-01"}), int)
+
+
+# ── add ──────────────────────────────────────────────────────────────────────
+
+
+def test_add_stores_metadata(store, monkeypatch):
+    monkeypatch.setattr(ca.getpass, "getpass", lambda prompt="": "sk-ant-oat01-ADDED")
+    rc = run("add", "brad", "--label", "bradbrok", "--billing", "subscription")
+    assert rc == 0
+    idx = ca.load_index()["accounts"]["brad"]
+    assert idx["billing"] == "subscription"
+    assert idx["token_suffix"] == "DDED"
+    assert idx["token_kind"] == "setup_token"
+    assert ca.read_token("brad") == "sk-ant-oat01-ADDED"
+
+
+def test_add_rejects_non_setup_token(store, monkeypatch, capsys):
+    monkeypatch.setattr(ca.getpass, "getpass", lambda prompt="": "not-a-token")
+    rc = run("add", "x")
+    assert rc == 2
+    assert "brad" not in ca.load_index()["accounts"]
+
+
+def test_add_allow_any_accepts_other(store, monkeypatch):
+    monkeypatch.setattr(ca.getpass, "getpass", lambda prompt="": "custom-token-xyz")
+    rc = run("add", "x", "--allow-any", "--billing", "unknown")
+    assert rc == 0
+    assert ca.load_index()["accounts"]["x"]["token_kind"] == "other"
+
+
+def test_add_refuses_duplicate_without_force(store, monkeypatch):
+    monkeypatch.setattr(ca.getpass, "getpass", lambda prompt="": "sk-ant-oat01-ONE")
+    assert run("add", "x") == 0
+    monkeypatch.setattr(ca.getpass, "getpass", lambda prompt="": "sk-ant-oat01-TWO")
+    assert run("add", "x") == 2  # duplicate refused
+    assert ca.read_token("x") == "sk-ant-oat01-ONE"  # original kept
+
+
+def test_add_probe_failure_does_not_store(store, monkeypatch):
+    monkeypatch.setattr(ca.getpass, "getpass", lambda prompt="": "sk-ant-oat01-BAD")
+    monkeypatch.setattr(ca, "probe_token", lambda tok, cb="": (False, "nope"))
+    rc = run("add", "x")
+    assert rc == 1
+    assert "x" not in ca.load_index()["accounts"]
+    assert not ca.token_path("x").exists()

--- a/tests/test_claude_account.py
+++ b/tests/test_claude_account.py
@@ -259,6 +259,26 @@ def test_switch_already_active_is_noop(store, capsys):
     assert not list(ca.backup_dir().glob(".env.bak.pre-*"))  # no backup churn
 
 
+def test_switch_restart_bypasses_already_active(store, monkeypatch):
+    """--restart must (re)start even when .env already matches: the two-step
+    workflow is `switch` (writes) then `switch --restart` (applies). The second
+    invocation must NOT no-op — the running daemon may still hold the old token."""
+    _seed_account(store, token="sk-ant-oat01-SAME")
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-SAME\nPINKY_FORWARD_OAUTH_TOKEN=1\n")
+    calls = []
+
+    def _restart(env_path, as_agent):
+        calls.append(1)
+        return True, "HTTP 200"
+
+    monkeypatch.setattr(ca, "restart_daemon", _restart)
+    gens = iter(["old-gen", "new-gen"])
+    monkeypatch.setattr(ca, "daemon_generation", lambda: next(gens, "new-gen"))
+    rc = run("switch", "acct", "--restart", "--as-agent", "x")
+    assert rc == 0
+    assert calls == [1]  # restart WAS performed, not skipped as "nothing to do"
+
+
 def test_switch_token_matches_but_flag_off_proceeds(store):
     """Token already in .env but forwarding OFF → switch must set the flag (not no-op)."""
     _seed_account(store, token="sk-ant-oat01-SAME")

--- a/tests/test_claude_account.py
+++ b/tests/test_claude_account.py
@@ -9,6 +9,7 @@ stubbed here.
 
 from __future__ import annotations
 
+import fcntl
 import importlib.util
 import os
 import stat
@@ -304,22 +305,69 @@ def test_switch_restart_reverts_on_unchanged_generation(store, monkeypatch):
     assert store["env"].read_text() == "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n"
 
 
-def test_switch_restart_unreadable_baseline_does_not_revert(store, monkeypatch):
-    """No pre-restart generation to verify against → don't claim success, but don't
-    revert either (the restart likely proceeded)."""
+def test_switch_restart_unreadable_baseline_aborts_untouched(store, monkeypatch):
+    """No pre-restart generation to verify against → abort BEFORE writing; never
+    persist an unverifiable switch, and never POST the restart."""
     _seed_account(store)
     write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
-    monkeypatch.setattr(ca, "restart_daemon", lambda env_path, as_agent: (True, "HTTP 200"))
     monkeypatch.setattr(ca, "daemon_generation", lambda: None)  # never readable
+
+    def _boom(*a, **k):
+        raise AssertionError("restart must not be POSTed when the baseline is unreadable")
+
+    monkeypatch.setattr(ca, "restart_daemon", _boom)
     rc = run("switch", "acct", "--restart", "--as-agent", "someagent")
     assert rc == 1
-    assert "sk-ant-oat01-NEW" in store["env"].read_text()  # NOT reverted
+    assert store["env"].read_text() == "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n"  # untouched
+    assert not list(ca.backup_dir().glob(".env.bak.pre-*"))  # no backup, no write
+
+
+def test_switch_restart_without_identity_aborts_untouched(store, monkeypatch):
+    _seed_account(store)
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    monkeypatch.delenv("PINKY_AGENT_NAME", raising=False)
+
+    def _boom(*a, **k):
+        raise AssertionError("must not restart without an identity")
+
+    monkeypatch.setattr(ca, "restart_daemon", _boom)
+    rc = run("switch", "acct", "--restart")  # no --as-agent, no PINKY_AGENT_NAME
+    assert rc == 1
+    assert store["env"].read_text() == "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n"  # untouched
+    assert not list(ca.backup_dir().glob(".env.bak.pre-*"))
 
 
 def test_restart_daemon_requires_identity(store):
     ok, detail = ca.restart_daemon(store["env"], "")
     assert ok is False
     assert "identity" in detail.lower()
+
+
+# ── advisory lock / directory-mode fail-closed ───────────────────────────────
+
+
+def test_switch_refuses_when_lock_held(store):
+    _seed_account(store)
+    write_env(store["env"], "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n")
+    ca.ensure_store()
+    fd = os.open(str(ca.store_dir() / ".lock"), os.O_CREAT | os.O_RDWR, 0o600)
+    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)  # hold it (simulates a concurrent op)
+    try:
+        with pytest.raises(SystemExit):
+            run("switch", "acct")
+        assert store["env"].read_text() == "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-OLD\n"  # untouched
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def test_ensure_store_fails_closed_on_permissive_dir(store, monkeypatch):
+    d = ca.store_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    os.chmod(d, 0o777)
+    monkeypatch.setattr(ca.os, "chmod", lambda *a, **k: None)  # simulate chmod denied
+    with pytest.raises(SystemExit):
+        ca.ensure_store()
 
 
 # ── remove ───────────────────────────────────────────────────────────────────

--- a/tests/test_claude_account.py
+++ b/tests/test_claude_account.py
@@ -509,6 +509,21 @@ def test_add_probe_failure_does_not_store(store, monkeypatch):
     assert not ca.token_path("x").exists()
 
 
+def test_add_never_spawns_a_token_printing_child(store, monkeypatch):
+    """The tool must never spawn `claude setup-token` — that flow prints the
+    long-lived token to stdout, which inherited stdio would leak."""
+    monkeypatch.setattr(ca.getpass, "getpass", lambda prompt="": "sk-ant-oat01-X")
+    calls = []
+    monkeypatch.setattr(ca.subprocess, "run", lambda *a, **k: calls.append(list(a[0]) if a else []))
+    assert run("add", "x") == 0
+    assert all("setup-token" not in part for c in calls for part in c)
+
+
+def test_mint_flag_is_removed():
+    with pytest.raises(SystemExit):  # argparse rejects the unknown flag
+        ca.build_parser().parse_args(["add", "x", "--mint"])
+
+
 # ── serialization safety / duplicate / perms / probe hygiene ─────────────────
 
 

--- a/tests/test_claude_account.py
+++ b/tests/test_claude_account.py
@@ -182,11 +182,6 @@ def test_active_name_none_when_token_absent(store):
     assert ca.active_name(store["env"], ca.load_index()) is None
 
 
-def test_suffix_of():
-    assert ca.suffix_of("sk-ant-oat01-ABCDwxyz") == "wxyz"
-    assert ca.suffix_of("ab") == "?"
-
-
 # ── switch: fail-closed, backup, revert ──────────────────────────────────────
 
 
@@ -478,8 +473,8 @@ def test_add_stores_metadata(store, monkeypatch):
     assert rc == 0
     idx = ca.load_index()["accounts"]["brad"]
     assert idx["billing"] == "subscription"
-    assert idx["token_suffix"] == "DDED"
     assert idx["token_kind"] == "setup_token"
+    assert "token_suffix" not in idx  # no token-derived data stored
     assert ca.read_token("brad") == "sk-ant-oat01-ADDED"
 
 


### PR DESCRIPTION
## What

`scripts/claude_account.py` — an operator CLI that stores named long-lived Claude tokens and does a **safe, verified switch** of which account the tmux fleet runs as, replacing the hand-run edit-`.env`-and-restart recipe whose failure mode is a fleet-wide login wall.

The fleet authenticates every agent with one long-lived setup-token the daemon forwards as `CLAUDE_CODE_OAUTH_TOKEN` (gated by `PINKY_FORWARD_OAUTH_TOKEN`); switching accounts means swapping that token in `.env` and restarting the daemon.

## Commands

| | |
|---|---|
| `add <name>` | mint/paste + isolation-probe + store a token (owner drives the mint; the token is never on argv, never printed, never logged) |
| `list` / `current` | stored accounts, which one the fleet is actually running as, days-to-expiry — no secret values shown |
| `switch <name>` | back up `.env` → write token + forward flag together in ONE atomic write (fail-closed) → optional `--restart` → health-verify → auto-revert on failure |
| `remove <name>` | refuses the token currently in `.env` unless `--force` |
| `check-expiry` | exit 3 when the active token is near expiry (wire to a scheduled wake for an owner nudge) |

## Safety

- **Fail-closed**: an empty / expired / probe-failing token is refused *before* any write; the token and the forward flag land in a single atomic write, so there is never a persisted `flag=1` + empty-token state (the login wall).
- **Atomic + private**: `.env` writes, backups, and reverts apply their mode *before* the rename — a credential file is never torn or briefly world-readable.
- **Backups outside the repo**: they live in the 0700 store dir, and this PR adds `.env.bak*` to `.gitignore` (the manual recipe drops those next to `.env` at the repo root, and the bare `.env` rule does not match them).
- **Billing is owner-declared** per account (subtle to infer; defaults to `unknown`).

## Review

An adversarial self-review pass surfaced 13 issues in the first cut — all fixed here with tests — including a critical one (the post-restart health check hit a nonexistent route, which would have reverted every good switch and silently left the live daemon and `.env` disagreeing), the non-gitignored credential-backup path, and a hardcoded restart-auth identity (now sourced from `--as-agent` / `PINKY_AGENT_NAME`).

## Tests

`tests/test_claude_account.py` — 51 tests: the `.env` rewrite (exactly-one-live-line vs the loader's first-wins semantics, comment/substring edges), the fail-closed switch (empty/expired/probe-fail refusals, flag-off-token-match proceeds, `--restart` success vs health-timeout revert), backup/revert atomicity + perms, provenance, expiry math, and the corrupt-index guards. Ruff clean.

Ready for review + CI. Nothing runs against the live `.env` until an operator invokes `switch`.

🤖 Opened by Barsik