### PR TITLE
fix(scheduler): surface recurring stale drops to agents (#1053)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -750,6 +750,20 @@ class PendingScheduleWake:
         }
 
 
+@dataclass(frozen=True)
+class RecurringScheduleStaleDrop:
+    """Bounded aggregate of recurring fires dropped before delivery."""
+
+    schedule_id: int = 0
+    agent_name: str = ""
+    schedule_name: str = ""
+    drop_count: int = 0
+    first_dropped_at: float = 0.0
+    last_dropped_at: float = 0.0
+    max_row_age_s: float = 0.0
+    generation: int = 0
+
+
 class ScheduleNameConflictError(ValueError):
     """An enabled schedule already uses the requested agent/name pair."""
 
@@ -1374,6 +1388,20 @@ class AgentRegistry:
                 UNIQUE(schedule_id, fired_at)
             );
 
+            CREATE TABLE IF NOT EXISTS recurring_schedule_stale_drops (
+                schedule_id INTEGER PRIMARY KEY,
+                agent_name TEXT NOT NULL,
+                schedule_name TEXT NOT NULL DEFAULT '',
+                drop_count INTEGER NOT NULL DEFAULT 1,
+                first_dropped_at REAL NOT NULL,
+                last_dropped_at REAL NOT NULL,
+                max_row_age_s REAL NOT NULL DEFAULT 0,
+                generation INTEGER NOT NULL DEFAULT 1,
+                FOREIGN KEY (schedule_id) REFERENCES agent_schedules(id)
+                    ON DELETE CASCADE,
+                FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE
+            );
+
             CREATE TABLE IF NOT EXISTS agent_heartbeats (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 agent_name TEXT NOT NULL,
@@ -1532,6 +1560,8 @@ class AgentRegistry:
                 ON agent_schedules(agent_name);
             CREATE INDEX IF NOT EXISTS idx_pending_schedule_wakes_agent
                 ON pending_schedule_wakes(agent_name, fired_at, id);
+            CREATE INDEX IF NOT EXISTS idx_recurring_stale_drops_agent
+                ON recurring_schedule_stale_drops(agent_name, schedule_id);
             CREATE INDEX IF NOT EXISTS idx_pending_messages_agent_chat
                 ON pending_messages(agent_name, chat_id, delivered);
             CREATE INDEX IF NOT EXISTS idx_approval_requests_retry
@@ -4494,6 +4524,110 @@ except Exception as exc:
             (ts, schedule_id),
         )
         self._db.commit()
+
+    def record_recurring_schedule_stale_drop(
+        self,
+        schedule_id: int,
+        *,
+        agent_name: str,
+        schedule_name: str,
+        dropped_at: float,
+        row_age_s: float,
+    ) -> RecurringScheduleStaleDrop:
+        """Aggregate one stale recurring fire into one bounded schedule row.
+
+        The table has exactly one row per live schedule and cascades on
+        schedule deletion. ``generation`` lets delivery acknowledge only the
+        snapshot it actually surfaced; a concurrent newer drop stays pending.
+        """
+        if schedule_id <= 0:
+            raise ValueError("schedule_id must be positive")
+        if not agent_name:
+            raise ValueError("agent_name must not be empty")
+        if dropped_at <= 0:
+            raise ValueError("dropped_at must be positive")
+        bounded_name = str(schedule_name or "")[:256]
+        bounded_age = max(0.0, float(row_age_s))
+        with self._rmw_lock:
+            self._db.execute(
+                """INSERT INTO recurring_schedule_stale_drops (
+                       schedule_id, agent_name, schedule_name, drop_count,
+                       first_dropped_at, last_dropped_at, max_row_age_s,
+                       generation
+                   ) VALUES (?, ?, ?, 1, ?, ?, ?, 1)
+                   ON CONFLICT(schedule_id) DO UPDATE SET
+                       agent_name=excluded.agent_name,
+                       schedule_name=excluded.schedule_name,
+                       drop_count=recurring_schedule_stale_drops.drop_count + 1,
+                       first_dropped_at=MIN(
+                           recurring_schedule_stale_drops.first_dropped_at,
+                           excluded.first_dropped_at
+                       ),
+                       last_dropped_at=MAX(
+                           recurring_schedule_stale_drops.last_dropped_at,
+                           excluded.last_dropped_at
+                       ),
+                       max_row_age_s=MAX(
+                           recurring_schedule_stale_drops.max_row_age_s,
+                           excluded.max_row_age_s
+                       ),
+                       generation=recurring_schedule_stale_drops.generation + 1""",
+                (
+                    schedule_id,
+                    agent_name,
+                    bounded_name,
+                    dropped_at,
+                    dropped_at,
+                    bounded_age,
+                ),
+            )
+            row = self._db.execute(
+                """SELECT schedule_id, agent_name, schedule_name, drop_count,
+                          first_dropped_at, last_dropped_at, max_row_age_s,
+                          generation
+                   FROM recurring_schedule_stale_drops
+                   WHERE schedule_id=?""",
+                (schedule_id,),
+            ).fetchone()
+            self._db.commit()
+        return RecurringScheduleStaleDrop(*row)
+
+    def list_recurring_schedule_stale_drops(
+        self, agent_name: str
+    ) -> list[RecurringScheduleStaleDrop]:
+        """Return unsurfaced recurring-drop aggregates in stable order."""
+        rows = self._db.execute(
+            """SELECT schedule_id, agent_name, schedule_name, drop_count,
+                      first_dropped_at, last_dropped_at, max_row_age_s,
+                      generation
+               FROM recurring_schedule_stale_drops
+               WHERE agent_name=?
+               ORDER BY schedule_id ASC""",
+            (agent_name,),
+        ).fetchall()
+        return [RecurringScheduleStaleDrop(*row) for row in rows]
+
+    def acknowledge_recurring_schedule_stale_drops(
+        self,
+        agent_name: str,
+        notices: list[RecurringScheduleStaleDrop],
+    ) -> int:
+        """Clear only versioned aggregates included in a confirmed delivery."""
+        if not notices:
+            return 0
+        cleared = 0
+        with self._rmw_lock:
+            for notice in notices:
+                if notice.agent_name != agent_name:
+                    continue
+                cursor = self._db.execute(
+                    """DELETE FROM recurring_schedule_stale_drops
+                       WHERE agent_name=? AND schedule_id=? AND generation=?""",
+                    (agent_name, notice.schedule_id, notice.generation),
+                )
+                cleared += cursor.rowcount
+            self._db.commit()
+        return cleared
 
     def claim_schedule_fire(
         self,

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -21,7 +21,7 @@ import time
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.agent_registry import AgentRegistry, RecurringScheduleStaleDrop
 from pinky_daemon.cron_utils import _field_matches
 from pinky_daemon.transport_state import SessionState
 from pinky_daemon.watchdog_log import log_watchdog_decision
@@ -633,6 +633,39 @@ class AgentScheduler:
             ),
         )
 
+    def _record_recurring_stale_drop(
+        self,
+        *,
+        agent_name: str,
+        schedule_id: int,
+        schedule_name: str,
+        dropped_at: float,
+        row_age: float,
+    ) -> None:
+        """Persist one recurring drop without creating owner-facing delivery."""
+        try:
+            notice = self._registry.record_recurring_schedule_stale_drop(
+                schedule_id,
+                agent_name=agent_name,
+                schedule_name=schedule_name,
+                dropped_at=dropped_at,
+                row_age_s=row_age,
+            )
+        except Exception as exc:
+            # Surfacing bookkeeping must never turn a terminal stale drop back
+            # into a replay candidate or fail the scheduler cohort.
+            _log(
+                "scheduler: recurring stale-drop surfacing record failed for "
+                f"schedule '{schedule_name}' (#{schedule_id}) on agent "
+                f"'{agent_name}': {type(exc).__name__}: {exc}"
+            )
+            return
+        _log(
+            "scheduler: recurring stale-drop notice aggregated for schedule "
+            f"'{schedule_name}' (#{schedule_id}) on agent '{agent_name}': "
+            f"count={notice.drop_count}"
+        )
+
     async def _deliver_schedule(
         self,
         schedule,
@@ -675,7 +708,8 @@ class AgentScheduler:
             replay_max_age = self._pending_wake_replay_max_age(
                 schedule, schedule.last_run
             )
-            age = max(0.0, time.time() - schedule.last_run)
+            drop_checked_at = time.time()
+            age = max(0.0, drop_checked_at - schedule.last_run)
             if age > replay_max_age:
                 dropped = (
                     self._registry.delete_pending_schedule_wake(row.id)
@@ -699,6 +733,14 @@ class AgentScheduler:
                         pending_id=row.id if row is not None else 0,
                         row_age=age,
                         replay_max_age=replay_max_age,
+                    )
+                elif dropped:
+                    self._record_recurring_stale_drop(
+                        agent_name=schedule.agent_name,
+                        schedule_id=schedule.id,
+                        schedule_name=schedule.name,
+                        dropped_at=drop_checked_at,
+                        row_age=age,
                     )
                 if attempt_started is not None:
                     attempt_started.set()
@@ -871,18 +913,28 @@ class AgentScheduler:
         attempt_started: asyncio.Event | None = None,
     ) -> bool:
         """Wait for one exact receipt, extending while positive liveness holds."""
+        delivery_prompt, stale_drop_notices = (
+            self._wake_prompt_with_recurring_stale_drops(schedule)
+        )
         delivery = asyncio.create_task(
             self._wake_and_confirm(
-                schedule, attempt_started=attempt_started
+                schedule,
+                prompt=delivery_prompt,
+                attempt_started=attempt_started,
             )
         )
         try:
             while True:
                 try:
-                    return await asyncio.wait_for(
+                    confirmed = await asyncio.wait_for(
                         asyncio.shield(delivery),
                         timeout=self._schedule_delivery_timeout,
                     )
+                    if confirmed and stale_drop_notices:
+                        self._acknowledge_recurring_stale_drops(
+                            schedule.agent_name, stale_drop_notices
+                        )
+                    return confirmed
                 except asyncio.TimeoutError:
                     if self._agent_busy_not_wedged(schedule.agent_name):
                         _log(
@@ -892,7 +944,9 @@ class AgentScheduler:
                             "reports busy-not-wedged; extending delivery timeout"
                         )
                         continue
-                    if self._wake_prompt_inflight(schedule):
+                    if self._wake_prompt_inflight(
+                        schedule, prompt=delivery_prompt
+                    ):
                         _log(
                             f"scheduler: receipt still pending for schedule "
                             f"'{schedule.name}' (#{schedule.id}) for agent "
@@ -1103,6 +1157,14 @@ class AgentScheduler:
                         row_age=row_age,
                         replay_max_age=replay_max_age,
                     )
+                elif discarded:
+                    self._record_recurring_stale_drop(
+                        agent_name=pending.agent_name,
+                        schedule_id=pending.schedule_id,
+                        schedule_name=pending.schedule_name,
+                        dropped_at=replay_now,
+                        row_age=row_age,
+                    )
                 continue
             pending_wakes.append(pending)
 
@@ -1196,7 +1258,73 @@ class AgentScheduler:
         """The exact prompt text a schedule's wake delivers to the transport."""
         return schedule.prompt or f"Scheduled wake: {schedule.name}"
 
-    def _wake_prompt_inflight(self, schedule) -> bool:
+    @staticmethod
+    def _stale_drop_timestamp(timestamp: float) -> str:
+        """Render an unambiguous compact UTC timestamp for the agent note."""
+        return datetime.fromtimestamp(timestamp, tz=ZoneInfo("UTC")).strftime(
+            "%Y-%m-%d %H:%M:%SZ"
+        )
+
+    def _wake_prompt_with_recurring_stale_drops(
+        self, schedule
+    ) -> tuple[str, list[RecurringScheduleStaleDrop]]:
+        """Prepend bounded unsurfaced drop aggregates to one exact wake prompt."""
+        prompt = self._wake_prompt(schedule)
+        try:
+            notices = self._registry.list_recurring_schedule_stale_drops(
+                schedule.agent_name
+            )
+        except Exception as exc:
+            # Operational-awareness storage must not block real scheduled work.
+            _log(
+                "scheduler: recurring stale-drop surfacing read failed for "
+                f"agent '{schedule.agent_name}': {type(exc).__name__}: {exc}"
+            )
+            return prompt, []
+        if not notices:
+            return prompt, []
+
+        lines = []
+        for notice in notices:
+            schedule_name = " ".join(notice.schedule_name.split()) or "unnamed"
+            if len(schedule_name) > 120:
+                schedule_name = f"{schedule_name[:117]}..."
+            fire_word = "fire" if notice.drop_count == 1 else "fires"
+            drop_verb = "was" if notice.drop_count == 1 else "were"
+            work_subject = "that fire" if notice.drop_count == 1 else "those fires"
+            lines.append(
+                f"Note: {notice.drop_count} {fire_word} of recurring schedule "
+                f"'{schedule_name}' (#{notice.schedule_id}) {drop_verb} dropped as stale "
+                f"between {self._stale_drop_timestamp(notice.first_dropped_at)} "
+                f"and {self._stale_drop_timestamp(notice.last_dropped_at)} "
+                "(session busy past the replay window). The work "
+                f"{work_subject} would have done was NOT performed."
+            )
+        notes_text = "\n".join(lines)
+        return f"{notes_text}\n\n{prompt}", notices
+
+    def _acknowledge_recurring_stale_drops(
+        self, agent_name: str, notices: list[RecurringScheduleStaleDrop]
+    ) -> None:
+        """Best-effort clear only snapshots included in a confirmed wake."""
+        try:
+            cleared = self._registry.acknowledge_recurring_schedule_stale_drops(
+                agent_name, notices
+            )
+        except Exception as exc:
+            # The wake already has a positive receipt. Never convert it to an
+            # undelivered/replayable wake because notice cleanup failed.
+            _log(
+                "scheduler: recurring stale-drop surfacing acknowledge failed "
+                f"for agent '{agent_name}': {type(exc).__name__}: {exc}"
+            )
+            return
+        _log(
+            "scheduler: recurring stale-drop notice surfaced for agent "
+            f"'{agent_name}': snapshots={len(notices)} cleared={cleared}"
+        )
+
+    def _wake_prompt_inflight(self, schedule, *, prompt: str | None = None) -> bool:
         """True when this wake's prompt is pasted with its receipt unresolved.
 
         Reads the transport's per-turn execution state via
@@ -1209,7 +1337,8 @@ class AgentScheduler:
         try:
             return (
                 self._delivery_inflight_fn(
-                    schedule.agent_name, self._wake_prompt(schedule)
+                    schedule.agent_name,
+                    self._wake_prompt(schedule) if prompt is None else prompt,
                 )
                 is True
             )
@@ -1224,6 +1353,7 @@ class AgentScheduler:
         self,
         schedule,
         *,
+        prompt: str | None = None,
         attempt_started: asyncio.Event | None = None,
     ) -> bool:
         """Invoke the wake callback and await its exact per-prompt receipt."""
@@ -1249,7 +1379,7 @@ class AgentScheduler:
         result = await self._wake_callback(
             schedule.agent_name,
             main_session_id,
-            self._wake_prompt(schedule),
+            self._wake_prompt(schedule) if prompt is None else prompt,
             **callback_kwargs,
         )
         if inspect.isawaitable(result):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1345,7 +1345,12 @@ class TestScheduler:
         scheduler = AgentScheduler(registry, wake_callback=confirmed)
         await scheduler._replay_pending_locked("oleg")
 
-        assert attempts == ["boundary frozen prompt", "fresh frozen prompt"]
+        assert len(attempts) == 2
+        assert "Note: 1 fire of recurring schedule 'minutely'" in attempts[0]
+        assert "The work that fire would have done was NOT performed." in attempts[0]
+        assert attempts[0].endswith("\n\nboundary frozen prompt")
+        assert attempts[1] == "fresh frozen prompt"
+        assert registry.list_recurring_schedule_stale_drops("oleg") == []
         assert registry.get_schedule_wake_by_fire(
             schedule.id, stale.fired_at
         ) is None
@@ -1468,6 +1473,7 @@ class TestScheduler:
         assert "STALE ONE-SHOT WAKE DROPPED" in alerts[0][1]
         assert f"outbox row #{pending.id}" in alerts[0][1]
         assert "has no next occurrence" in alerts[0][1]
+        assert registry.list_recurring_schedule_stale_drops("oleg") == []
 
     @pytest.mark.asyncio
     async def test_kill_after_durable_accept_before_future_resolve_never_replays(
@@ -3424,6 +3430,10 @@ class TestCohortStalenessGuard:
             registry.get_schedule_wake_by_fire(schedule.id, schedule.last_run)
             is None
         )
+        notices = registry.list_recurring_schedule_stale_drops("oleg")
+        assert len(notices) == 1
+        assert notices[0].schedule_id == schedule.id
+        assert notices[0].drop_count == 1
 
     @pytest.mark.asyncio
     async def test_stale_one_shot_cohort_drop_alerts_owner(
@@ -3478,3 +3488,220 @@ class TestCohortStalenessGuard:
         assert len(alerts) == 1  # owner alerted about the lost one-shot
         assert alerts[0][0] == "oleg"
         assert "STALE ONE-SHOT WAKE DROPPED" in alerts[0][1]
+        assert registry.list_recurring_schedule_stale_drops("oleg") == []
+
+
+class TestRecurringStaleDropSurfacing:
+    """#1053 — recurring stale drops surface to the agent, never the owner."""
+
+    def test_no_subsequent_wake_stays_bounded_and_cascades(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="hourly-ish", prompt="work"
+        )
+
+        for offset in range(100):
+            registry.record_recurring_schedule_stale_drop(
+                schedule.id,
+                agent_name="oleg",
+                schedule_name=schedule.name,
+                dropped_at=1_800_000_000.0 + offset,
+                row_age_s=61.0 + offset,
+            )
+
+        notices = registry.list_recurring_schedule_stale_drops("oleg")
+        assert len(notices) == 1
+        assert notices[0].drop_count == 100
+        assert notices[0].generation == 100
+        assert notices[0].first_dropped_at == pytest.approx(1_800_000_000.0)
+        assert notices[0].last_dropped_at == pytest.approx(1_800_000_099.0)
+        assert notices[0].max_row_age_s == pytest.approx(160.0)
+        assert registry.list_pending_schedule_wakes("oleg") == []
+
+        assert registry.remove_schedule(schedule.id) is True
+        assert registry.list_recurring_schedule_stale_drops("oleg") == []
+
+    def test_surface_ack_does_not_erase_concurrent_new_drop(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="concurrent", prompt="work"
+        )
+        registry.record_recurring_schedule_stale_drop(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name=schedule.name,
+            dropped_at=1_800_000_000.0,
+            row_age_s=61.0,
+        )
+        surfaced_snapshot = registry.list_recurring_schedule_stale_drops("oleg")
+
+        registry.record_recurring_schedule_stale_drop(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name=schedule.name,
+            dropped_at=1_800_000_001.0,
+            row_age_s=62.0,
+        )
+
+        assert (
+            registry.acknowledge_recurring_schedule_stale_drops(
+                "oleg", surfaced_snapshot
+            )
+            == 0
+        )
+        retained = registry.list_recurring_schedule_stale_drops("oleg")
+        assert len(retained) == 1
+        assert retained[0].drop_count == 2
+        assert retained[0].generation == 2
+
+    @pytest.mark.asyncio
+    async def test_both_drop_sites_aggregate_surface_and_clear_once(
+        self, registry, monkeypatch
+    ):
+        registry.register("oleg")
+        lost = registry.add_schedule(
+            "oleg", "* * * * *", name="hourly sweep", prompt="lost work"
+        )
+        next_wake = registry.add_schedule(
+            "oleg", "* * * * *", name="next wake", prompt="new work"
+        )
+        now = 1_800_000_000.0
+        monkeypatch.setattr("pinky_daemon.scheduler.time.time", lambda: now)
+        attempts: list[str] = []
+        owner_alerts: list[tuple[str, str]] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        async def owner_notify(agent_name, message):
+            owner_alerts.append((agent_name, message))
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=3_600.0,
+        )
+
+        # Replay-path stale drop.
+        replay_fire = now - 62.0
+        registry.persist_schedule_wake(
+            lost.id,
+            agent_name="oleg",
+            schedule_name=lost.name,
+            prompt=lost.prompt,
+            fired_at=replay_fire,
+        )
+        await scheduler._replay_pending_locked("oleg")
+
+        # Live-cohort stale drop for the same schedule.
+        lost.last_run = now - 61.0
+        registry.persist_schedule_wake(
+            lost.id,
+            agent_name="oleg",
+            schedule_name=lost.name,
+            prompt=lost.prompt,
+            fired_at=lost.last_run,
+        )
+        await scheduler._deliver_schedule(lost)
+
+        notices = registry.list_recurring_schedule_stale_drops("oleg")
+        assert len(notices) == 1
+        assert notices[0].schedule_id == lost.id
+        assert notices[0].drop_count == 2
+        assert attempts == []
+        assert owner_alerts == []
+        assert registry.list_pending_schedule_wakes("oleg") == []
+
+        # The notice registry alone never triggers or resurrects a wake.
+        await scheduler._replay_pending_locked("oleg")
+        assert attempts == []
+        assert len(registry.list_recurring_schedule_stale_drops("oleg")) == 1
+
+        # The next genuinely delivered wake carries one aggregate and clears it.
+        next_wake.last_run = now - 1.0
+        await scheduler._deliver_schedule(next_wake)
+        assert len(attempts) == 1
+        assert "Note: 2 fires of recurring schedule 'hourly sweep'" in attempts[0]
+        assert "The work those fires would have done was NOT performed." in attempts[0]
+        assert attempts[0].endswith("\n\nnew work")
+        assert registry.list_recurring_schedule_stale_drops("oleg") == []
+
+        # A later wake sees neither a duplicate note nor any owner delivery.
+        next_wake.last_run = now
+        await scheduler._deliver_schedule(next_wake)
+        assert attempts[1] == "new work"
+        assert owner_alerts == []
+
+    @pytest.mark.asyncio
+    async def test_unconfirmed_wake_keeps_note_for_next_success(
+        self, registry, monkeypatch
+    ):
+        registry.register("oleg")
+        dropped = registry.add_schedule(
+            "oleg", "* * * * *", name="dropped", prompt="lost work"
+        )
+        delivery = registry.add_schedule(
+            "oleg", "* * * * *", name="delivery", prompt="new work"
+        )
+        now = 1_800_000_000.0
+        monkeypatch.setattr("pinky_daemon.scheduler.time.time", lambda: now)
+        registry.record_recurring_schedule_stale_drop(
+            dropped.id,
+            agent_name="oleg",
+            schedule_name=dropped.name,
+            dropped_at=now - 1.0,
+            row_age_s=61.0,
+        )
+        delivery.last_run = now - 1.0
+        attempts: list[str] = []
+
+        async def first_fails(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return False
+
+        scheduler = AgentScheduler(registry, wake_callback=first_fails)
+        await scheduler._deliver_schedule(delivery)
+
+        assert "Note: 1 fire of recurring schedule 'dropped'" in attempts[0]
+        assert len(registry.list_recurring_schedule_stale_drops("oleg")) == 1
+
+        async def then_succeeds(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        scheduler._wake_callback = then_succeeds
+        await scheduler._replay_pending_locked("oleg")
+
+        assert "Note: 1 fire of recurring schedule 'dropped'" in attempts[1]
+        assert attempts[1].endswith("\n\nnew work")
+        assert registry.list_recurring_schedule_stale_drops("oleg") == []
+
+    @pytest.mark.asyncio
+    async def test_no_drops_leaves_wake_prompt_unchanged(
+        self, registry, monkeypatch
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="ordinary", prompt="ordinary work"
+        )
+        now = 1_800_000_000.0
+        schedule.last_run = now
+        monkeypatch.setattr("pinky_daemon.scheduler.time.time", lambda: now)
+        attempts: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=confirmed)
+        await scheduler._deliver_schedule(schedule)
+
+        assert attempts == ["ordinary work"]
+        assert registry.list_recurring_schedule_stale_drops("oleg") == []


### PR DESCRIPTION
## Problem

Recurring schedule fires dropped by either stale-drop path were terminal and logged, but the agent never learned that the scheduled work was not performed.

## Fix

- Persist one bounded aggregate per live schedule, updated at both `COHORT_STALE_DROPPED` and `PERSISTED_WAKE_STALE_DROPPED`.
- Prepend one concise note per affected schedule to the agent's next receipt-confirmed scheduled wake.
- Clear only the versioned snapshots included in that confirmed delivery, preserving concurrent newer drops and retaining notes after an unconfirmed attempt.
- Keep stale wakes terminal: notice storage never creates or replays a pending wake, and schedule deletion cascades the aggregate away.

One-shot stale-drop alerts remain unchanged. No owner-notification or end-owner delivery path is added.

## Validation

- 268 scheduler and registry tests pass on Python 3.11, 3.12, and 3.13.
- New coverage includes both drop sites, no subsequent wake (bounded/no resurrection), cross-site aggregation, no drops/no note, unconfirmed delivery retention, concurrent-drop preservation, one-time clearing, and one-shot isolation.
- `ruff check .`, compile checks, and `git diff --check` pass.

Fixes #1053

---
🤖 Opened by Kuzya
