### PR TITLE
fix(tmux): turn frozen liveness veto into recovery (#984)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1087,6 +1087,47 @@ _PANE_LIVENESS_CAPTURE_LINES = 40
 _PANE_LIVENESS_SAMPLE_GAP_SEC = 1.5
 
 
+def _watchdog_frozen_liveness_trigger_enabled() -> bool:
+    """Whether frozen live-status vetoes may escalate to recovery (#984).
+
+    Default ON.  Read per watchdog tick so operators can disable both the
+    never-started signature and the general stale-veto age cap without a
+    daemon restart.
+    """
+    return os.environ.get(
+        "PINKY_WATCHDOG_FROZEN_LIVENESS_TRIGGER", "1"
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _watchdog_seconds_env(name: str, default: float) -> float:
+    """Read a non-negative watchdog duration, falling back safely."""
+    raw = os.environ.get(name, "").strip()
+    try:
+        value = float(raw) if raw else default
+    except (TypeError, ValueError):
+        value = default
+    return max(0.0, value)
+
+
+def _watchdog_never_started_grace_sec() -> float:
+    """Grace before a frozen at-or-before-launch status becomes actionable."""
+    return _watchdog_seconds_env(
+        "PINKY_WATCHDOG_NEVER_STARTED_GRACE_SEC", 300.0
+    )
+
+
+def _watchdog_stale_veto_cap_sec() -> float:
+    """Maximum continuous age of one frozen stale-veto timestamp."""
+    return _watchdog_seconds_env("PINKY_WATCHDOG_STALE_VETO_CAP_SEC", 1800.0)
+
+
+def _watchdog_frozen_restart_interval_sec() -> float:
+    """Minimum spacing between frozen-liveness restart attempts per session."""
+    return _watchdog_seconds_env(
+        "PINKY_WATCHDOG_FROZEN_RESTART_INTERVAL_SEC", 600.0
+    )
+
+
 def _pane_liveness_enabled() -> bool:
     """Whether the inflight watchdog credits an animating tmux pane as liveness
     (#832). Default ON; ``PINKY_WATCHDOG_PANE_LIVENESS=0`` is the kill switch
@@ -1400,6 +1441,16 @@ class TmuxSession:
         # genuinely new head (deque advanced) auto-starts a fresh ceiling budget
         # without having to touch the out-of-loop head-start sites.
         self._inflight_pane_ext_anchor: tuple[object, float] | None = None
+        # #984 Defect 2 — continuous frozen-live-status observation.  One
+        # bounded tuple per TmuxSession: (last_updated value, first-seen wall
+        # clock, consecutive observations).  Any changed value starts a new
+        # observation window, so a fossilized reader that still ADVANCES can
+        # never match the never-started signature or stale-veto age cap.
+        self._watchdog_frozen_live_status: tuple[float, float, int] | None = None
+        # Pacing survives force_restart's retained-instance respawn.  If a
+        # restart does not cure the frozen signal, this prevents the new
+        # watchdog from immediately tearing the replacement pane down again.
+        self._watchdog_last_frozen_restart_at: float | None = None
         # Back-compat advisory signal. Pre-#560 this was the worker's
         # per-iteration gate (the bottleneck that broke steering).
         # Post-#560 the worker no longer awaits it between dispatches;
@@ -2867,6 +2918,11 @@ class TmuxSession:
                     f"stderr={result.stderr.strip()!r}"
                 )
             self._current_session_started_at = session_started_at
+            # The frozen-value tracker is scoped to the CURRENT tmux process.
+            # Keep restart pacing on the retained TmuxSession instance, but
+            # never compare the replacement process against the old process's
+            # observation window.
+            self._watchdog_frozen_live_status = None
 
         try:
             await asyncio.wait_for(_spawn(), timeout=_COLD_START_TIMEOUT_SEC)
@@ -6181,7 +6237,79 @@ class TmuxSession:
             }
         return {"active": False, "reason": "quiet", "age_s": None}
 
-    def _inflight_stall_verdict(self, now: float) -> str:
+    def _read_live_status(self) -> dict | None:
+        """Read the process-local live-status signal once, fail-closed."""
+        fn = getattr(self._config, "live_status_fn", None)
+        if fn is None:
+            return None
+        try:
+            live = fn()
+        except Exception:
+            return None
+        return live if isinstance(live, dict) else None
+
+    def _observe_frozen_live_status(
+        self, now: float, live: dict | None
+    ) -> tuple[float, float, int] | None:
+        """Track one unchanged numeric ``last_updated`` value (#984).
+
+        A changed value — including one that still predates the current tmux
+        process — starts a fresh window with a single observation.  Missing or
+        malformed evidence breaks continuity entirely.
+        """
+        last_updated = live.get("last_updated") if live else None
+        if (
+            not isinstance(last_updated, (int, float))
+            or isinstance(last_updated, bool)
+        ):
+            self._watchdog_frozen_live_status = None
+            return None
+        value = float(last_updated)
+        observed = self._watchdog_frozen_live_status
+        if observed is None or observed[0] != value:
+            observed = (value, now, 1)
+        else:
+            observed = (value, observed[1], observed[2] + 1)
+        self._watchdog_frozen_live_status = observed
+        return observed
+
+    def _frozen_liveness_restart_reason(
+        self, now: float, live: dict | None
+    ) -> str | None:
+        """Return the bounded recovery reason for a stale-veto sample."""
+        if not _watchdog_frozen_liveness_trigger_enabled():
+            return None
+        observed = self._watchdog_frozen_live_status
+        last_updated = live.get("last_updated") if live else None
+        if (
+            observed is None
+            or observed[2] < 2
+            or not isinstance(last_updated, (int, float))
+            or isinstance(last_updated, bool)
+            or observed[0] != float(last_updated)
+        ):
+            return None
+        session_started_at = self._current_session_started_at
+        if (
+            session_started_at > 0
+            and float(last_updated) <= session_started_at
+            and (now - session_started_at) > _watchdog_never_started_grace_sec()
+        ):
+            return "never_started_signature"
+        if (now - observed[1]) > _watchdog_stale_veto_cap_sec():
+            return "stale_live_status_age_cap"
+        return None
+
+    def _frozen_liveness_restart_is_paced(self, now: float) -> bool:
+        last_attempt = self._watchdog_last_frozen_restart_at
+        return (
+            last_attempt is not None
+            and (now - last_attempt) < _watchdog_frozen_restart_interval_sec()
+        )
+
+    def _inflight_stall_verdict(
+        self, now: float, live_status_sample: dict | None = None
+    ) -> str:
         """Classify a possibly-stalled inflight head for the watchdog (#118).
 
         Returns one of:
@@ -6199,8 +6327,10 @@ class TmuxSession:
                             input, so the lingering meta(s) are phantom (a
                             paste with no matching stop_hook). Reconcile, don't
                             restart.
-          - ``"unknown"`` — live_status predates this tmux process and cannot
-                            prove either idle or wedged; veto restart.
+          - ``"unknown"`` — live_status predates this tmux process or the
+                            current head and cannot yet prove either idle or
+                            wedged; veto restart pending bounded frozen-signal
+                            recovery.
           - ``"wedged"``  — aged out, transcript quiet, REPL not idle →
                             genuinely stuck; force_restart.
 
@@ -6242,19 +6372,20 @@ class TmuxSession:
         # REPL has nothing in flight. Require the idle to be at-least-as-recent
         # as when the CURRENT head was pasted — otherwise a turn was pasted
         # that the REPL never came alive for (hang-on-paste), which IS a wedge.
-        live = None
-        fn = getattr(self._config, "live_status_fn", None)
-        if fn is not None:
-            try:
-                live = fn()
-            except Exception:
-                live = None
+        live = live_status_sample
+        if live is None:
+            live = self._read_live_status()
         live_last_updated = live.get("last_updated") if live else None
+        head = self._inflight_metas[0]
+        live_floor = min(self._head_started_at, head.dispatched_at)
         if (
             self._current_session_started_at > 0
             and isinstance(live_last_updated, (int, float))
             and not isinstance(live_last_updated, bool)
-            and live_last_updated < self._current_session_started_at
+            and (
+                live_last_updated <= self._current_session_started_at
+                or live_last_updated < live_floor
+            )
         ):
             return "unknown"
         if live and live.get("status") == "idle":
@@ -6273,7 +6404,6 @@ class TmuxSession:
             # window: both timestamps come from the same daemon clock (no
             # skew), and a turn's own idle always postdates its own paste, so
             # an idle that predates the paste cannot belong to this turn.
-            head = self._inflight_metas[0]
             idle_floor = min(self._head_started_at, head.dispatched_at)
             if last_updated >= idle_floor:
                 return "idle"
@@ -6447,9 +6577,18 @@ class TmuxSession:
                 # takes effect live (no respawn). Checked at the TOP so nothing
                 # below (verdict, pane-liveness sampling, force_restart) runs.
                 if not self._watchdog_enabled():
+                    self._watchdog_frozen_live_status = None
                     continue
                 now = time.time()
-                verdict = self._inflight_stall_verdict(now)
+                live = self._read_live_status()
+                if _watchdog_frozen_liveness_trigger_enabled():
+                    self._observe_frozen_live_status(now, live)
+                else:
+                    # A live kill-switch flip starts a fresh continuity window
+                    # when re-enabled; time spent disabled never counts toward
+                    # either recovery threshold.
+                    self._watchdog_frozen_live_status = None
+                verdict = self._inflight_stall_verdict(now, live)
                 if verdict == "ok":
                     continue
                 age = now - (self._head_started_at or now)
@@ -6462,6 +6601,7 @@ class TmuxSession:
                 # (capture-pane + sample gap), during which a stop hook can pop or
                 # advance the head out from under us.
                 head_meta = self._inflight_metas[0]
+                restart_reason: str | None = None
                 if verdict == "growing":
                     # #118: head aged out BUT the transcript is still being
                     # written — a long/streaming turn, NOT a wedge. Extend
@@ -6515,37 +6655,93 @@ class TmuxSession:
                     )
                     continue
                 if verdict == "unknown":
-                    # #943: a process-local live-status reader can fossilize
-                    # across session recreation.  A value predating THIS tmux
-                    # process is not evidence that an idle/static pane is
-                    # wedged. Fail toward no-restart, extend the decision
-                    # window, and emit a distinctive release receipt once per
-                    # timeout window.
-                    self._head_started_at = now
+                    # #943 prevents one stale sample from proving a wedge.
+                    # #984 bounds that veto: an unchanged value at-or-before
+                    # launch becomes the never-started signature after grace;
+                    # any other unchanged stale value gets the general age
+                    # cap.  Both reuse the established replay-safe recovery
+                    # below and are paced across retained-instance respawns.
                     self._inflight_pane_ext_anchor = None
-                    live = None
-                    live_status_fn = getattr(self._config, "live_status_fn", None)
-                    if live_status_fn is not None:
-                        try:
-                            live = live_status_fn()
-                        except Exception:
-                            live = None
-                    _log(
-                        f"tmux[{self.agent_name}]: "
-                        f"WATCHDOG_STALE_LIVE_STATUS_VETO "
-                        f"live_last_updated="
-                        f"{live.get('last_updated') if live else None} "
-                        f"session_started_at={self._current_session_started_at} "
-                        f"— input unknown; NOT restarting "
-                        f"(deque depth={depth})"
-                    )
-                    log_watchdog_decision(
-                        watchdog="inflight", agent=self.agent_name,
-                        decision="skip", reason="stale_live_status_veto",
-                        state=self.state.value, progress_stale_s=age,
-                        inflight_turns=depth, inflight_active=False,
-                    )
-                    continue
+                    restart_reason = self._frozen_liveness_restart_reason(now, live)
+                    live_last_updated = live.get("last_updated") if live else None
+                    observed = self._watchdog_frozen_live_status
+                    frozen_for = (now - observed[1]) if observed else 0.0
+                    if restart_reason and self._frozen_liveness_restart_is_paced(now):
+                        last_attempt = self._watchdog_last_frozen_restart_at
+                        since_attempt = (
+                            now - last_attempt if last_attempt is not None else 0.0
+                        )
+                        self._head_started_at = now
+                        _log(
+                            f"tmux[{self.agent_name}]: "
+                            f"WATCHDOG_FROZEN_LIVENESS_RESTART_PACED "
+                            f"reason={restart_reason} "
+                            f"live_last_updated={live_last_updated} "
+                            f"session_started_at={self._current_session_started_at} "
+                            f"since_attempt_s={since_attempt:.1f} — NOT restarting "
+                            f"(deque depth={depth})"
+                        )
+                        log_watchdog_decision(
+                            watchdog="inflight", agent=self.agent_name,
+                            decision="skip", reason="frozen_liveness_restart_paced",
+                            state=self.state.value, progress_stale_s=age,
+                            inflight_turns=depth, inflight_active=False,
+                        )
+                        continue
+                    if restart_reason == "never_started_signature":
+                        self._watchdog_last_frozen_restart_at = now
+                        _log(
+                            f"tmux[{self.agent_name}]: "
+                            f"WATCHDOG_NEVER_STARTED_RESTART "
+                            f"live_last_updated={live_last_updated} "
+                            f"session_started_at={self._current_session_started_at} "
+                            f"session_age_s="
+                            f"{now - self._current_session_started_at:.1f} "
+                            f"frozen_for_s={frozen_for:.1f} "
+                            f"— scheduling force_restart (deque depth={depth})"
+                        )
+                        log_watchdog_decision(
+                            watchdog="inflight", agent=self.agent_name,
+                            decision="restart", reason="never_started_signature",
+                            state=self.state.value, progress_stale_s=age,
+                            inflight_turns=depth, inflight_active=False,
+                        )
+                    elif restart_reason == "stale_live_status_age_cap":
+                        self._watchdog_last_frozen_restart_at = now
+                        _log(
+                            f"tmux[{self.agent_name}]: "
+                            f"WATCHDOG_STALE_LIVE_STATUS_CAP_RESTART "
+                            f"live_last_updated={live_last_updated} "
+                            f"session_started_at={self._current_session_started_at} "
+                            f"frozen_for_s={frozen_for:.1f} "
+                            f"— scheduling force_restart (deque depth={depth})"
+                        )
+                        log_watchdog_decision(
+                            watchdog="inflight", agent=self.agent_name,
+                            decision="restart", reason="stale_live_status_age_cap",
+                            state=self.state.value, progress_stale_s=age,
+                            inflight_turns=depth, inflight_active=False,
+                        )
+                    else:
+                        # A changed/freshly-observed fossil is still unknown,
+                        # never restart proof. Preserve #943's veto while its
+                        # bounded continuity evidence accumulates.
+                        self._head_started_at = now
+                        _log(
+                            f"tmux[{self.agent_name}]: "
+                            f"WATCHDOG_STALE_LIVE_STATUS_VETO "
+                            f"live_last_updated={live_last_updated} "
+                            f"session_started_at={self._current_session_started_at} "
+                            f"— input unknown; NOT restarting "
+                            f"(deque depth={depth})"
+                        )
+                        log_watchdog_decision(
+                            watchdog="inflight", agent=self.agent_name,
+                            decision="skip", reason="stale_live_status_veto",
+                            state=self.state.value, progress_stale_s=age,
+                            inflight_turns=depth, inflight_active=False,
+                        )
+                        continue
                 # (#832) Last-chance liveness before tearing down a "wedged"
                 # head: a long pure-reasoning / slow-generation turn (common at
                 # ultracode/xhigh) writes nothing to the transcript and has no
@@ -6555,7 +6751,7 @@ class TmuxSession:
                 # like the "growing" branch. Bounded by an absolute ceiling so an
                 # animating-but-genuinely-stuck REPL is still recovered, and
                 # flag-gated (PINKY_WATCHDOG_PANE_LIVENESS=0) for a kill switch.
-                if _pane_liveness_enabled():
+                if restart_reason is None and _pane_liveness_enabled():
                     # Anchor the absolute ceiling to when THIS head FIRST reached
                     # the pane-liveness rescue, NOT to ``_head_started_at`` — the
                     # extend branch below resets ``_head_started_at = now`` on every
@@ -6606,20 +6802,21 @@ class TmuxSession:
                         f"restarting (#832; deque depth={len(self._inflight_metas)})"
                     )
                     continue
-                # verdict == "wedged": no output + REPL not idle → genuinely
-                # stuck. Fall through to the force_restart recovery path.
-                _log(
-                    f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
-                    f"> {_TURN_DONE_TIMEOUT_SEC}s, transcript quiet + REPL not "
-                    f"idle — REPL stuck; scheduling force_restart "
-                    f"(deque depth={depth})"
-                )
-                log_watchdog_decision(
-                    watchdog="inflight", agent=self.agent_name,
-                    decision="restart", reason="wedged", state=self.state.value,
-                    progress_stale_s=age, inflight_turns=depth,
-                    inflight_active=False,
-                )
+                if restart_reason is None:
+                    # verdict == "wedged": no output + REPL not idle → genuinely
+                    # stuck. Fall through to the force_restart recovery path.
+                    _log(
+                        f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
+                        f"> {_TURN_DONE_TIMEOUT_SEC}s, transcript quiet + REPL not "
+                        f"idle — REPL stuck; scheduling force_restart "
+                        f"(deque depth={depth})"
+                    )
+                    log_watchdog_decision(
+                        watchdog="inflight", agent=self.agent_name,
+                        decision="restart", reason="wedged", state=self.state.value,
+                        progress_stale_s=age, inflight_turns=depth,
+                        inflight_active=False,
+                    )
                 # Snapshot deque state before mutation so this critical
                 # section is atomic from the outside (no awaits between
                 # snapshot and mutation).

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -6377,17 +6377,6 @@ class TmuxSession:
             live = self._read_live_status()
         live_last_updated = live.get("last_updated") if live else None
         head = self._inflight_metas[0]
-        live_floor = min(self._head_started_at, head.dispatched_at)
-        if (
-            self._current_session_started_at > 0
-            and isinstance(live_last_updated, (int, float))
-            and not isinstance(live_last_updated, bool)
-            and (
-                live_last_updated <= self._current_session_started_at
-                or live_last_updated < live_floor
-            )
-        ):
-            return "unknown"
         if live and live.get("status") == "idle":
             last_updated = live.get("last_updated") or 0.0
             # Floor the idle-freshness check at when the current head was
@@ -6434,6 +6423,21 @@ class TmuxSession:
                             return "idle"
                     except OSError:
                         pass
+        # Positive idle evidence above is authoritative (#118/#592), even if
+        # the numeric live-status timestamp itself predates this head. Only a
+        # sample that failed both idle proofs may become an unknown/stale veto
+        # and accrue toward #984's bounded frozen-signal recovery.
+        live_floor = min(self._head_started_at, head.dispatched_at)
+        if (
+            self._current_session_started_at > 0
+            and isinstance(live_last_updated, (int, float))
+            and not isinstance(live_last_updated, bool)
+            and (
+                live_last_updated <= self._current_session_started_at
+                or live_last_updated < live_floor
+            )
+        ):
+            return "unknown"
         self._log_wedged_inputs(now, live)
         return "wedged"
 

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -4681,6 +4681,46 @@ def test_inflight_verdict_idle_via_transcript_mtime(tmp_path) -> None:
     assert ss._inflight_stall_verdict(_time.time()) == "idle"
 
 
+def test_inflight_verdict_real_session_keeps_transcript_proven_idle(tmp_path) -> None:
+    """#118/#592/#984: positive transcript evidence wins before stale veto.
+
+    Production shape: the current tmux process started at S; this aged head was
+    pasted at H > S; live status is idle but fossilized at S < L < H; and the
+    transcript contains a real response at H+30, safely past paste slack. Base
+    classifies this phantom head as idle, so #984 must not turn it unknown and
+    eventually force-restart the healthy session.
+    """
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    head_t = _time.time() - (tmux_session._TURN_DONE_TIMEOUT_SEC + 100.0)
+    session_started_at = head_t - 100.0
+    live_updated_at = head_t - 50.0
+    assert session_started_at < live_updated_at < head_t
+
+    meta = _mk_inflight_meta()
+    meta.dispatched_at = head_t
+    meta.transcript_mtime_at_paste = head_t
+    meta.paste_succeeded_at = head_t
+    ss._inflight_metas.append(meta)
+    ss._head_started_at = head_t
+    ss._current_session_started_at = session_started_at
+    ss._transcript_recently_grew = lambda now, window: False
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": live_updated_at,
+    }
+
+    f = tmp_path / "transcript.jsonl"
+    f.write_text("{}\n")
+    import os
+
+    mtime_with_response = head_t + 30.0
+    os.utime(f, (mtime_with_response, mtime_with_response))
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = f
+
+    assert ss._inflight_stall_verdict(_time.time()) == "idle"
+
+
 def test_inflight_verdict_wedged_when_transcript_only_paste_echo(tmp_path) -> None:
     """#592: stale live_status, transcript mtime is only the paste echo (< slack) → wedged."""
     ss, _ = _make_session(state=SessionState.CONNECTED)

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -8461,14 +8461,15 @@ class TestInflightDequeConcurrentDispatch:
         await ss.disconnect()
 
     @pytest.mark.asyncio
-    async def test_watchdog_vetoes_frozen_pre_session_live_status(
+    async def test_watchdog_vetoes_frozen_pre_session_live_status_within_grace(
         self, monkeypatch, capsys,
     ):
-        """#943: frozen live_last_updated + a static/idle pane is unknown
-        evidence and must never trigger force_restart."""
+        """#984 negative: the never-started shape still vetoes within grace."""
         from pinky_daemon import tmux_session as _ts
         monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.05)
         monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.02)
+        monkeypatch.setenv("PINKY_WATCHDOG_NEVER_STARTED_GRACE_SEC", "60")
+        monkeypatch.setenv("PINKY_WATCHDOG_STALE_VETO_CAP_SEC", "60")
 
         ss, _ = _make_session()
         await ss.connect()
@@ -8497,6 +8498,242 @@ class TestInflightDequeConcurrentDispatch:
         assert ss._head_started_at is not None and ss._head_started_at > 0
         assert ss._pane_is_animating.await_count == 0
         assert "WATCHDOG_STALE_LIVE_STATUS_VETO" in capsys.readouterr().err
+        await ss.disconnect()
+
+    def test_advancing_fossil_resets_frozen_tracker(self, monkeypatch):
+        """#943 negative: a pre-session value that advances is not frozen."""
+        monkeypatch.setenv("PINKY_WATCHDOG_NEVER_STARTED_GRACE_SEC", "0")
+        monkeypatch.setenv("PINKY_WATCHDOG_STALE_VETO_CAP_SEC", "0")
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        ss._current_session_started_at = 100.0
+
+        assert ss._observe_frozen_live_status(
+            400.0, {"status": "working", "last_updated": 80.0}
+        ) == (80.0, 400.0, 1)
+        advanced = {"status": "working", "last_updated": 90.0}
+        assert ss._observe_frozen_live_status(401.0, advanced) == (
+            90.0, 401.0, 1
+        )
+        assert ss._frozen_liveness_restart_reason(401.0, advanced) is None
+
+        # Only a subsequent identical observation may become actionable.
+        assert ss._observe_frozen_live_status(402.0, advanced) == (
+            90.0, 401.0, 2
+        )
+        assert (
+            ss._frozen_liveness_restart_reason(402.0, advanced)
+            == "never_started_signature"
+        )
+
+    def test_frozen_liveness_trigger_defaults_on_with_live_kill_switch(
+        self, monkeypatch,
+    ):
+        """#984's kill switch follows the existing pane-liveness pattern."""
+        from pinky_daemon import tmux_session as _ts
+
+        monkeypatch.delenv(
+            "PINKY_WATCHDOG_FROZEN_LIVENESS_TRIGGER", raising=False
+        )
+        assert _ts._watchdog_frozen_liveness_trigger_enabled() is True
+        for off in ("0", "false", "NO", " off "):
+            monkeypatch.setenv("PINKY_WATCHDOG_FROZEN_LIVENESS_TRIGGER", off)
+            assert _ts._watchdog_frozen_liveness_trigger_enabled() is False
+        monkeypatch.setenv("PINKY_WATCHDOG_FROZEN_LIVENESS_TRIGGER", "1")
+        assert _ts._watchdog_frozen_liveness_trigger_enabled() is True
+
+    def test_frozen_liveness_threshold_defaults_and_overrides(self, monkeypatch):
+        """Grace, cap, and pacing remain bounded and independently tunable."""
+        from pinky_daemon import tmux_session as _ts
+
+        names = (
+            "PINKY_WATCHDOG_NEVER_STARTED_GRACE_SEC",
+            "PINKY_WATCHDOG_STALE_VETO_CAP_SEC",
+            "PINKY_WATCHDOG_FROZEN_RESTART_INTERVAL_SEC",
+        )
+        for name in names:
+            monkeypatch.delenv(name, raising=False)
+        assert _ts._watchdog_never_started_grace_sec() == 300.0
+        assert _ts._watchdog_stale_veto_cap_sec() == 1800.0
+        assert _ts._watchdog_frozen_restart_interval_sec() == 600.0
+
+        for name, value in zip(names, ("7", "8", "9"), strict=True):
+            monkeypatch.setenv(name, value)
+        assert _ts._watchdog_never_started_grace_sec() == 7.0
+        assert _ts._watchdog_stale_veto_cap_sec() == 8.0
+        assert _ts._watchdog_frozen_restart_interval_sec() == 9.0
+
+        monkeypatch.setenv("PINKY_WATCHDOG_NEVER_STARTED_GRACE_SEC", "-1")
+        assert _ts._watchdog_never_started_grace_sec() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_watchdog_never_started_signature_restarts_once_then_paces(
+        self, monkeypatch, capsys,
+    ):
+        """Frozen-at-launch past grace restarts once; a repeat cannot storm."""
+        from pinky_daemon import tmux_session as _ts
+
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.02)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.01)
+        monkeypatch.delenv(
+            "PINKY_WATCHDOG_FROZEN_LIVENESS_TRIGGER", raising=False
+        )
+        monkeypatch.setenv("PINKY_WATCHDOG_NEVER_STARTED_GRACE_SEC", "0")
+        monkeypatch.setenv("PINKY_WATCHDOG_STALE_VETO_CAP_SEC", "60")
+        monkeypatch.setenv("PINKY_WATCHDOG_FROZEN_RESTART_INTERVAL_SEC", "60")
+        decisions = MagicMock()
+        monkeypatch.setattr(_ts, "log_watchdog_decision", decisions)
+
+        ss, _ = _make_session()
+        await ss.connect()
+        # Equality is intentionally part of the signature: a launch-time
+        # value that never advances proves no turn moved status past launch.
+        frozen_at = ss._current_session_started_at
+        ss._config.live_status_fn = lambda: {
+            "status": "working",
+            "last_updated": frozen_at,
+        }
+        ss._transcript_recently_grew = lambda *_args: False
+        ss._background_tasks_recently_active = lambda *_args: False
+        ss._foreground_tool_in_flight = lambda *_args: False
+        ss._pane_is_animating = AsyncMock(return_value=False)
+
+        force_called = asyncio.Event()
+        force_calls: list[bool] = []
+
+        async def _stub_force_restart(*, bypass_guard: bool = False):
+            force_calls.append(bypass_guard)
+            force_called.set()
+            return True
+
+        ss.force_restart = _stub_force_restart
+        _seed_inflight(ss, prompt="never-started wake")
+
+        await asyncio.wait_for(force_called.wait(), timeout=2.0)
+        await asyncio.sleep(0)
+
+        assert force_calls == [True]
+        assert not ss._inflight_metas
+        assert ss._watchdog_last_frozen_restart_at is not None
+        first_logs = capsys.readouterr().err
+        assert "WATCHDOG_NEVER_STARTED_RESTART" in first_logs
+        assert f"live_last_updated={frozen_at}" in first_logs
+        assert f"session_started_at={ss._current_session_started_at}" in first_logs
+        assert any(
+            call.kwargs.get("decision") == "restart"
+            and call.kwargs.get("reason") == "never_started_signature"
+            for call in decisions.call_args_list
+        )
+
+        # Simulate another stuck head on the retained session object.  The
+        # frozen signature remains true, but the 60s attempt interval must
+        # leave the head intact and avoid a second force_restart.
+        _seed_inflight(ss, prompt="repeat wake")
+        ss._watchdog_task = asyncio.create_task(ss._inflight_watchdog())
+        await asyncio.sleep(0.12)
+
+        assert force_calls == [True]
+        assert len(ss._inflight_metas) == 1
+        assert "WATCHDOG_FROZEN_LIVENESS_RESTART_PACED" in capsys.readouterr().err
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_new_tmux_process_resets_frozen_window_but_preserves_pacing(self):
+        """Every respawn compares evidence only with its current launch."""
+        ss, _ = _make_session()
+        ss._watchdog_frozen_live_status = (10.0, 20.0, 30)
+        ss._watchdog_last_frozen_restart_at = 40.0
+
+        await ss.connect()
+
+        assert ss._current_session_started_at > 0
+        assert ss._watchdog_frozen_live_status is None
+        assert ss._watchdog_last_frozen_restart_at == 40.0
+        await ss.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_stale_veto_age_cap_restarts_frozen_after_start(
+        self, monkeypatch,
+    ):
+        """The general cap recovers a frozen value newer than launch."""
+        from pinky_daemon import tmux_session as _ts
+
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.02)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.01)
+        monkeypatch.setenv("PINKY_WATCHDOG_NEVER_STARTED_GRACE_SEC", "60")
+        monkeypatch.setenv("PINKY_WATCHDOG_STALE_VETO_CAP_SEC", "0.03")
+        decisions = MagicMock()
+        monkeypatch.setattr(_ts, "log_watchdog_decision", decisions)
+
+        ss, _ = _make_session()
+        await ss.connect()
+        ss._current_session_started_at = _time.time() - 1.0
+        frozen_after_start = ss._current_session_started_at + 0.1
+        ss._config.live_status_fn = lambda: {
+            "status": "working",
+            "last_updated": frozen_after_start,
+        }
+        ss._transcript_recently_grew = lambda *_args: False
+        ss._background_tasks_recently_active = lambda *_args: False
+        ss._foreground_tool_in_flight = lambda *_args: False
+
+        force_called = asyncio.Event()
+
+        async def _stub_force_restart(*, bypass_guard: bool = False):
+            force_called.set()
+            return True
+
+        ss.force_restart = _stub_force_restart
+        _seed_inflight(ss, prompt="stale-after-launch wake")
+
+        await asyncio.wait_for(force_called.wait(), timeout=2.0)
+
+        assert any(
+            call.kwargs.get("decision") == "restart"
+            and call.kwargs.get("reason") == "stale_live_status_age_cap"
+            for call in decisions.call_args_list
+        )
+        await ss.disconnect()
+
+    @pytest.mark.parametrize("last_updated_offset", (-1.0, 0.1))
+    @pytest.mark.asyncio
+    async def test_frozen_liveness_kill_switch_disables_both_trigger_paths(
+        self, monkeypatch, last_updated_offset,
+    ):
+        """The default-on feature flag can restore indefinite #943 vetoes."""
+        from pinky_daemon import tmux_session as _ts
+
+        monkeypatch.setattr(_ts, "_TURN_DONE_TIMEOUT_SEC", 0.02)
+        monkeypatch.setattr(_ts, "_WATCHDOG_TICK_SEC", 0.01)
+        monkeypatch.setenv("PINKY_WATCHDOG_FROZEN_LIVENESS_TRIGGER", "0")
+        monkeypatch.setenv("PINKY_WATCHDOG_NEVER_STARTED_GRACE_SEC", "0")
+        monkeypatch.setenv("PINKY_WATCHDOG_STALE_VETO_CAP_SEC", "0")
+
+        ss, _ = _make_session()
+        await ss.connect()
+        ss._current_session_started_at = _time.time() - 1.0
+        ss._config.live_status_fn = lambda: {
+            "status": "working",
+            "last_updated": (
+                ss._current_session_started_at + last_updated_offset
+            ),
+        }
+        ss._transcript_recently_grew = lambda *_args: False
+        ss._background_tasks_recently_active = lambda *_args: False
+        ss._foreground_tool_in_flight = lambda *_args: False
+
+        force_called = asyncio.Event()
+
+        async def _must_not_restart(*, bypass_guard: bool = False):
+            force_called.set()
+            return True
+
+        ss.force_restart = _must_not_restart
+        _seed_inflight(ss, prompt="kill-switch wake")
+        await asyncio.sleep(0.12)
+
+        assert not force_called.is_set()
+        assert len(ss._inflight_metas) == 1
+        assert ss._watchdog_frozen_live_status is None
         await ss.disconnect()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- turn a continuously frozen launch-stale `live_status.last_updated` veto into the existing replay-safe `force_restart` recovery after a bounded grace
- cap other continuously frozen stale-veto shapes, with one bounded tracker per session, advancement/reset discrimination, and paced restart attempts
- provide a default-on live kill switch plus environment-tunable grace, cap, and pacing thresholds

## Root cause and impact

During a fleet host's 11-hour dark window, the inflight watchdog classified the unchanged liveness value as `unknown`, reset its timeout window, and skipped recovery every cycle. The frozen signal therefore vetoed the tailer rebind and pane respawn that would have restored delivery.

This change makes sustained frozen evidence actionable while preserving the original single-sample safety veto. Advancing timestamps reset the tracker, every decision is evaluated against the current tmux-process start, and recovery continues through the established replay/tombstone-safe watchdog path.

This PR covers **Defect 2 only** from #984. The context-restart submission verifier and bound-path escalation defects remain out of scope.

## Validation

- `ruff check .`
- `python -m compileall -q src`
- `396 passed` in `tests/test_tmux_session.py` on Python 3.11
- focused trigger, grace, age-cap, pacing, kill-switch, advancement, #118, and #832 cases passed on Python 3.11, 3.12, and 3.13
- `git diff --check`

References #984

---
🤖 Opened by Kuzya
