### PR TITLE
fix: escalate unverified context restart wakes

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3736,6 +3736,18 @@ def create_api(
         except Exception as e:
             _log(f"streaming-start: ensure_workspace_hooks({agent_name}) — {e}")
 
+        async def _inject_wake_context_reload(
+            target_agent: str, instruction: str
+        ) -> bool:
+            """Route one wake-recovery instruction through the live broker."""
+            outcome = await broker.inject_agent_message(
+                "transport-recovery",
+                target_agent,
+                instruction,
+                route_reply=False,
+            )
+            return outcome.delivered
+
         config = StreamingSessionConfig(
             agent_name=agent_name,
             label=label,
@@ -3755,6 +3767,7 @@ def create_api(
             wake_context=_build_streaming_wake_context(agent_name, commit=False),
             wake_context_builder=_build_streaming_wake_context,
             on_wake_delivered=_log_agent_wake_event,
+            wake_submission_recovery_injector=_inject_wake_context_reload,
             restart_guard=lambda session, _agent_name=agent_name: _get_streaming_restart_guard(_agent_name, session),
             # #943: verdict-time fresh read of the persisted field that the
             # working/idle hooks update.  The in-memory map is non-authoritative

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -105,6 +105,11 @@ class StreamingSessionConfig:
     # the boundary advances against a wake that never reached the model
     # → the directive would be eaten by a wedged paste.
     on_wake_delivered: object = None  # Callable(agent_name, WakeReason) -> None
+    # Tmux-only #984 recovery seam.  A verified-failed context-restart wake
+    # uses this to route a CONTEXT-RELOAD instruction through the broker's
+    # agent-message path.  The callback returns a positive handoff bool; the
+    # session escalates to transport recovery when it is absent or false.
+    wake_submission_recovery_injector: object = None
     restart_guard: object = None  # Callable(session) -> dict; blocks restart if persistence is stale
     live_status_fn: object = None  # Callable() -> dict|None; agent's live REPL status {"status","last_updated"} from Claude Code working/idle hooks. Tmux inflight watchdog uses it to avoid force-restarting an idle (not wedged) REPL (#118).
     watchdog_enabled_fn: object = None  # Callable() -> bool; whether this agent's watchdog_config.enabled is set. The tmux inflight watchdog reads it per tick so watchdog_config.enabled=false is an operator kill-switch for BOTH the daemon SessionWatchdog and per-session inflight recovery (#846). None → treated as enabled (default True).

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -445,6 +445,28 @@ _PASTE_ENTER_MAX_DELAY_MS = 2_000
 # used by the dashboard terminal transport.
 _WAKE_SUBMISSION_RECEIPT_TIMEOUT_SEC = 5.0
 _WAKE_SUBMISSION_ENTER_RETRY_LIMIT = 2
+# A failed context-restart wake gets one additional full paste cycle, and only
+# after a pane capture proves the composer is blank.  Each paste cycle retains
+# the bounded Enter-only verifier above.
+_WAKE_SUBMISSION_REPASTE_RETRY_LIMIT = 1
+_WAKE_SUBMISSION_BROKER_TIMEOUT_SEC = 5.0
+_WAKE_CONTEXT_RELOAD_INSTRUCTION = (
+    "CONTEXT-RELOAD: Reload the saved continuation state now with "
+    "load_my_context, then resume from that durable artifact. Do not replay "
+    "the failed orientation wake verbatim or treat it as delivered."
+)
+
+
+def _wake_submission_escalation_enabled() -> bool:
+    """Whether verified-failed context-restart wakes run the #984 ladder.
+
+    Default ON.  Read at verdict time so an operator can disable the ladder
+    without restarting the daemon while retaining the existing loud
+    UNVERIFIED terminal outcome.
+    """
+    return os.environ.get(
+        "PINKY_WAKE_SUBMISSION_ESCALATION", "1"
+    ).strip().lower() not in ("0", "false", "no", "off")
 
 
 def _adaptive_paste_enter_delay_ms(text: str) -> int:
@@ -491,6 +513,14 @@ class _ContextLockDeferral(Exception):  # noqa: N818
 
 class _SchedulerDeliveryCancelled(Exception):  # noqa: N818
     """A timed-out scheduler receipt cancelled this turn before paste."""
+
+
+class _WakeSubmissionFallbackQueued(Exception):  # noqa: N818
+    """The failed wake was replaced by a broker context-reload handoff."""
+
+
+class _WakeSubmissionRecoveryScheduled(Exception):  # noqa: N818
+    """The failed wake scheduled transport recovery; stop the old worker."""
 
 
 @dataclass
@@ -1555,6 +1585,13 @@ class TmuxSession:
         # Dedicated wake-prompt tests leave this False and provide the
         # tailer simulation explicitly.
         self._skip_wake_prompt_for_tests: bool = False
+
+        # #984 Defect 1 — one transport-recovery budget survives the retained
+        # session object's respawn.  A verified replacement wake re-arms it;
+        # without this latch, a pane that rejects every orientation wake could
+        # recurse through force_restart forever.
+        self._wake_submission_transport_recovery_used: bool = False
+        self._wake_submission_recovery_task: asyncio.Task[None] | None = None
 
     # ── Identity ────────────────────────────────────────────────────────
 
@@ -3481,6 +3518,21 @@ class TmuxSession:
         intent (idle_sleep / force_restart / explicit DEAD) by driving
         the state machine BEFORE calling disconnect.
         """
+        # A wake-escalation recovery task may be between scheduling and its
+        # force_restart call.  An independent disconnect owns shutdown and
+        # must cancel that task so it cannot revive a deliberately stopped
+        # session.  When force_restart itself reaches this method, the
+        # recovery task is the current task and must not cancel/await itself.
+        recovery_task = self._wake_submission_recovery_task
+        if (
+            recovery_task is not None
+            and recovery_task is not asyncio.current_task()
+        ):
+            if not recovery_task.done():
+                recovery_task.cancel()
+                await asyncio.gather(recovery_task, return_exceptions=True)
+            self._wake_submission_recovery_task = None
+
         # Fail and cancel scheduler-only delivery tasks before tearing down the
         # ordinary worker/pane. A pane shutdown is a terminal non-receipt.
         for turn in list(self._scheduler_pending_turns):
@@ -5837,6 +5889,18 @@ class TmuxSession:
                     )
                     await asyncio.sleep(_TRANSIENT_RETRY_BACKOFF_SEC)
                     continue
+                except _WakeSubmissionFallbackQueued:
+                    # The original wake is terminal-False and its distinct
+                    # CONTEXT-RELOAD instruction now sits in the broker queue.
+                    # Do not count the failed wake as a turn or an error; clear
+                    # it so the worker advances to the fallback handoff.
+                    self._inflight_turn = None
+                    continue
+                except _WakeSubmissionRecoveryScheduled:
+                    # The recovery task owns teardown/re-spawn.  Exit this old
+                    # worker immediately so no backlog can overtake recovery.
+                    self._inflight_turn = None
+                    return
                 except Exception as e:
                     # For an ordinary turn, a tmux command timeout (``_run``'s
                     # 5s subprocess ceiling) is transient: keep the turn in
@@ -7321,6 +7385,10 @@ class TmuxSession:
         submit_attempts: int,
     ) -> bool:
         """Emit one positive wake submission verdict."""
+        # A positive wake proves the replacement transport can accept turns,
+        # so a future independent context restart receives a fresh one-shot
+        # transport-recovery budget.
+        self._wake_submission_transport_recovery_used = False
         latency_ms = int((time.monotonic() - started) * 1000)
         _log(
             f"tmux[{self.agent_name}]: wake prompt submission VERIFIED "
@@ -7338,11 +7406,277 @@ class TmuxSession:
         )
         return True
 
-    async def _verify_wake_submission(self, turn: _QueuedTurn) -> bool:
+    async def _emit_wake_submission_escalation(
+        self,
+        turn: _QueuedTurn,
+        *,
+        rung: str,
+        outcome: str,
+        detail: str = "",
+    ) -> None:
+        """Emit one bounded-ladder decision without logging prompt content."""
+        suffix = f", detail={detail}" if detail else ""
+        _log(
+            f"tmux[{self.agent_name}]: WAKE SUBMISSION ESCALATION "
+            f"rung={rung}, outcome={outcome}, reason={turn.reason}{suffix}"
+        )
+        await self._emit_stream_event(
+            {
+                "type": "wake_prompt_submission_escalation",
+                "agent_name": self.agent_name,
+                "reason": turn.reason,
+                "rung": rung,
+                "outcome": outcome,
+                "detail": detail,
+            }
+        )
+
+    async def _report_wake_submission_escalation_terminal(
+        self, turn: _QueuedTurn, *, detail: str
+    ) -> None:
+        """Surface exhaustion as a terminal operator-visible outcome."""
+        _log(
+            f"tmux[{self.agent_name}]: WAKE SUBMISSION ESCALATION TERMINAL "
+            f"— all bounded recovery rungs failed (reason={turn.reason}, "
+            f"detail={detail})"
+        )
+        await self._emit_stream_event(
+            {
+                "type": "wake_prompt_submission_escalation_terminal",
+                "agent_name": self.agent_name,
+                "reason": turn.reason,
+                "detail": detail,
+            }
+        )
+
+    @staticmethod
+    def _pane_snapshot_has_blank_prompt(snapshot: str) -> bool:
+        """Fail-closed test for a visibly empty composer.
+
+        Only a standalone prompt glyph on the final non-empty pane line is
+        accepted.  Placeholder copy, typed text, dialogs, spinners, capture
+        failures, and ambiguous layouts all skip re-paste and advance to the
+        broker rung.
+        """
+        nonempty = [
+            line.strip()
+            for line in (snapshot or "").splitlines()
+            if line.strip()
+        ]
+        return bool(nonempty and nonempty[-1] in {">", "❯"})
+
+    async def _repaste_unverified_context_restart_wake(
+        self,
+        turn: _QueuedTurn,
+        *,
+        started: float,
+        submit_attempts: int,
+        prompt_visible: bool | None,
+    ) -> bool:
+        """Run the single blank-composer re-paste rung."""
+        receipt = turn.submission_receipt
+        if receipt is None:
+            return False
+        if prompt_visible:
+            await self._emit_wake_submission_escalation(
+                turn,
+                rung="repaste",
+                outcome="skipped",
+                detail="original_prompt_visible",
+            )
+            return False
+
+        for retry_index in range(_WAKE_SUBMISSION_REPASTE_RETRY_LIMIT):
+            async with self._repl_control_lock:
+                if self._receipt_accepted(receipt):
+                    return await self._report_verified_wake_submission(
+                        turn,
+                        started=started,
+                        submit_attempts=submit_attempts,
+                    )
+                try:
+                    pane = await self._tmux.capture_pane()
+                except Exception as exc:
+                    await self._emit_wake_submission_escalation(
+                        turn,
+                        rung="repaste",
+                        outcome="skipped",
+                        detail=f"pane_capture_raised_{type(exc).__name__}",
+                    )
+                    return False
+                if not pane.ok or not self._pane_snapshot_has_blank_prompt(
+                    pane.stdout or ""
+                ):
+                    await self._emit_wake_submission_escalation(
+                        turn,
+                        rung="repaste",
+                        outcome="skipped",
+                        detail=(
+                            "pane_capture_failed"
+                            if not pane.ok
+                            else "composer_not_proven_blank"
+                        ),
+                    )
+                    return False
+                # An exact row can land while capture-pane yields.  Receipt
+                # evidence always wins the boundary and forbids re-paste.
+                if self._receipt_accepted(receipt):
+                    return await self._report_verified_wake_submission(
+                        turn,
+                        started=started,
+                        submit_attempts=submit_attempts,
+                    )
+                try:
+                    result = await self._tmux.paste_text(turn.prompt, enter=True)
+                except Exception as exc:
+                    await self._emit_wake_submission_escalation(
+                        turn,
+                        rung="repaste",
+                        outcome="failed",
+                        detail=f"paste_raised_{type(exc).__name__}",
+                    )
+                    return False
+            if not result.ok:
+                await self._emit_wake_submission_escalation(
+                    turn,
+                    rung="repaste",
+                    outcome="failed",
+                    detail=f"paste_rc_{result.returncode}",
+                )
+                return False
+
+            await self._emit_wake_submission_escalation(
+                turn,
+                rung="repaste",
+                outcome="attempted",
+                detail=f"attempt_{retry_index + 1}",
+            )
+            if (
+                await self._verify_wake_submission(
+                    turn, allow_escalation=False
+                )
+                == "verified"
+            ):
+                await self._emit_wake_submission_escalation(
+                    turn,
+                    rung="repaste",
+                    outcome="succeeded",
+                    detail=f"attempt_{retry_index + 1}",
+                )
+                return True
+            await self._emit_wake_submission_escalation(
+                turn,
+                rung="repaste",
+                outcome="failed",
+                detail=f"attempt_{retry_index + 1}_unverified",
+            )
+            return False
+        return False
+
+    async def _inject_wake_context_reload(self, turn: _QueuedTurn) -> bool:
+        """Run the broker-injection rung with a non-replayed instruction."""
+        injector = self._config.wake_submission_recovery_injector
+        if injector is None:
+            await self._emit_wake_submission_escalation(
+                turn,
+                rung="broker_context_reload",
+                outcome="failed",
+                detail="injector_unavailable",
+            )
+            return False
+        try:
+            result = injector(
+                self.agent_name,
+                _WAKE_CONTEXT_RELOAD_INSTRUCTION,
+            )
+            if asyncio.iscoroutine(result):
+                result = await asyncio.wait_for(
+                    result,
+                    timeout=_WAKE_SUBMISSION_BROKER_TIMEOUT_SEC,
+                )
+            delivered = result is True
+        except Exception as exc:
+            await self._emit_wake_submission_escalation(
+                turn,
+                rung="broker_context_reload",
+                outcome="failed",
+                detail=f"injector_raised_{type(exc).__name__}",
+            )
+            return False
+        await self._emit_wake_submission_escalation(
+            turn,
+            rung="broker_context_reload",
+            outcome="succeeded" if delivered else "failed",
+            detail="context_reload_handoff" if delivered else "handoff_rejected",
+        )
+        return delivered
+
+    async def _run_wake_submission_transport_recovery(
+        self, turn: _QueuedTurn
+    ) -> None:
+        """Own the one-shot fresh force-restart rung outside the worker."""
+        # Let the old worker observe _WakeSubmissionRecoveryScheduled and exit
+        # before force_restart disconnects it.
+        await asyncio.sleep(0)
+        self._config.force_fresh_context_once = True
+        try:
+            restarted = await self.force_restart(bypass_guard=True)
+        except asyncio.CancelledError:
+            await self._report_wake_submission_escalation_terminal(
+                turn, detail="force_restart_cancelled"
+            )
+            raise
+        except Exception as exc:
+            await self._report_wake_submission_escalation_terminal(
+                turn, detail=f"force_restart_raised_{type(exc).__name__}"
+            )
+            return
+        if restarted:
+            await self._emit_wake_submission_escalation(
+                turn,
+                rung="force_restart",
+                outcome="succeeded",
+                detail="fresh_transport_started",
+            )
+            return
+        await self._report_wake_submission_escalation_terminal(
+            turn, detail="force_restart_rejected_or_failed"
+        )
+
+    async def _schedule_wake_submission_transport_recovery(
+        self, turn: _QueuedTurn
+    ) -> bool:
+        """Schedule at most one force-restart until a wake verifies."""
+        task = self._wake_submission_recovery_task
+        if task is not None and not task.done():
+            await self._report_wake_submission_escalation_terminal(
+                turn, detail="force_restart_already_in_flight"
+            )
+            return False
+        if self._wake_submission_transport_recovery_used:
+            await self._report_wake_submission_escalation_terminal(
+                turn, detail="force_restart_budget_exhausted"
+            )
+            return False
+        self._wake_submission_transport_recovery_used = True
+        self._wake_submission_recovery_task = asyncio.create_task(
+            self._run_wake_submission_transport_recovery(turn)
+        )
+        await self._emit_wake_submission_escalation(
+            turn,
+            rung="force_restart",
+            outcome="scheduled",
+            detail="fresh_context_preserved",
+        )
+        return True
+
+    async def _verify_wake_submission(
+        self, turn: _QueuedTurn, *, allow_escalation: bool = True
+    ) -> str:
         """Require exact turn-start evidence, retrying only a parked Enter."""
         receipt = turn.submission_receipt
         if receipt is None:
-            return True
+            return "verified"
 
         started = time.monotonic()
         prompt_visible: bool | None = None
@@ -7365,11 +7699,12 @@ class TmuxSession:
                 accepted = self._receipt_accepted(receipt)
 
             if accepted:
-                return await self._report_verified_wake_submission(
+                await self._report_verified_wake_submission(
                     turn,
                     started=started,
                     submit_attempts=submit_attempts,
                 )
+                return "verified"
 
             # A terminal/cancelled False receipt cannot become True later.
             if receipt.done():
@@ -7381,11 +7716,12 @@ class TmuxSession:
             # Re-pasting here could duplicate a side-effecting wake turn.
             prompt_visible = await self._timed_out_turn_landed(turn)
             if self._receipt_accepted(receipt):
-                return await self._report_verified_wake_submission(
+                await self._report_verified_wake_submission(
                     turn,
                     started=started,
                     submit_attempts=submit_attempts,
                 )
+                return "verified"
             if not prompt_visible:
                 break
             try:
@@ -7416,18 +7752,24 @@ class TmuxSession:
         # The exact row can land while the final best-effort pane probe yields.
         # Positive transcript evidence wins that timeout boundary.
         if self._receipt_accepted(receipt):
-            return await self._report_verified_wake_submission(
+            await self._report_verified_wake_submission(
                 turn,
                 started=started,
                 submit_attempts=submit_attempts,
             )
+            return "verified"
         latency_ms = int((time.monotonic() - started) * 1000)
-        self._resolve_submission_receipt(turn, False)
+        escalation_applies = bool(
+            allow_escalation
+            and turn.reason == f"wake_{WakeReason.CONTEXT_RESTART.value}"
+            and _wake_submission_escalation_enabled()
+        )
         _log(
             f"tmux[{self.agent_name}]: wake prompt submission UNVERIFIED "
             f"after bounded Enter retries (reason={turn.reason}, "
             f"submit_attempts={submit_attempts}, latency_ms={latency_ms}, "
             f"prompt_visible={prompt_visible}); not claiming delivery"
+            + ("; starting bounded escalation" if escalation_applies else "")
         )
         await self._emit_stream_event(
             {
@@ -7437,9 +7779,28 @@ class TmuxSession:
                 "submit_attempts": submit_attempts,
                 "latency_ms": latency_ms,
                 "prompt_visible": prompt_visible,
+                "escalating": escalation_applies,
             }
         )
-        return False
+        if not escalation_applies:
+            self._resolve_submission_receipt(turn, False)
+            return "unverified"
+
+        if await self._repaste_unverified_context_restart_wake(
+            turn,
+            started=started,
+            submit_attempts=submit_attempts,
+            prompt_visible=prompt_visible,
+        ):
+            return "verified"
+
+        # Freeze the original wake's verdict before the distinct broker path.
+        # Any later exact row for it is ignored, preventing both the original
+        # wake and the context-reload fallback from being credited.
+        self._resolve_submission_receipt(turn, False)
+        if await self._inject_wake_context_reload(turn):
+            return "fallback_queued"
+        return "recovery_required"
 
     async def _finish_submitted_turn(self, turn: _QueuedTurn) -> None:
         """Record pane delivery and enforce any exact wake receipt."""
@@ -7453,12 +7814,22 @@ class TmuxSession:
         )
         if not verify_submission:
             return
-        if await self._verify_wake_submission(turn):
+        verdict = await self._verify_wake_submission(turn)
+        if verdict == "verified":
             self._fire_on_delivered(turn)
             return
 
         self._discard_unverified_turn_delivery(turn)
         self._turn_done.set()
+        if verdict == "fallback_queued":
+            raise _WakeSubmissionFallbackQueued(
+                "failed orientation wake replaced by broker context reload"
+            )
+        if verdict == "recovery_required":
+            if await self._schedule_wake_submission_transport_recovery(turn):
+                raise _WakeSubmissionRecoveryScheduled(
+                    "failed orientation wake scheduled transport recovery"
+                )
         raise RuntimeError(
             "wake prompt paste/Enter was not confirmed by an exact "
             "transcript receipt after bounded Enter retries"

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -445,10 +445,11 @@ _PASTE_ENTER_MAX_DELAY_MS = 2_000
 # used by the dashboard terminal transport.
 _WAKE_SUBMISSION_RECEIPT_TIMEOUT_SEC = 5.0
 _WAKE_SUBMISSION_ENTER_RETRY_LIMIT = 2
-# A failed context-restart wake gets one additional full paste cycle, and only
-# after a pane capture proves the composer is blank.  Each paste cycle retains
-# the bounded Enter-only verifier above.
-_WAKE_SUBMISSION_REPASTE_RETRY_LIMIT = 1
+# A context-restart wake that exhausts the ordinary verifier gets one final
+# receipt-only grace window.  The original prompt is never pasted again: an
+# empty composer can mean Claude already accepted it while transcript/tailer
+# evidence still lags, so pane state cannot safely authorize a replay.
+_WAKE_SUBMISSION_RECEIPT_QUIESCENCE_SEC = 5.0
 _WAKE_SUBMISSION_BROKER_TIMEOUT_SEC = 5.0
 _WAKE_CONTEXT_RELOAD_INSTRUCTION = (
     "CONTEXT-RELOAD: Reload the saved continuation state now with "
@@ -7449,129 +7450,37 @@ class TmuxSession:
             }
         )
 
-    @staticmethod
-    def _pane_snapshot_has_blank_prompt(snapshot: str) -> bool:
-        """Fail-closed test for a visibly empty composer.
-
-        Only a standalone prompt glyph on the final non-empty pane line is
-        accepted.  Placeholder copy, typed text, dialogs, spinners, capture
-        failures, and ambiguous layouts all skip re-paste and advance to the
-        broker rung.
-        """
-        nonempty = [
-            line.strip()
-            for line in (snapshot or "").splitlines()
-            if line.strip()
-        ]
-        return bool(nonempty and nonempty[-1] in {">", "❯"})
-
-    async def _repaste_unverified_context_restart_wake(
+    async def _wait_for_wake_submission_receipt_quiescence(
         self,
         turn: _QueuedTurn,
         *,
         started: float,
         submit_attempts: int,
-        prompt_visible: bool | None,
     ) -> bool:
-        """Run the single blank-composer re-paste rung."""
+        """Wait once for lagging exact evidence without replaying the wake."""
         receipt = turn.submission_receipt
         if receipt is None:
             return False
-        if prompt_visible:
-            await self._emit_wake_submission_escalation(
-                turn,
-                rung="repaste",
-                outcome="skipped",
-                detail="original_prompt_visible",
+        try:
+            accepted = bool(
+                await asyncio.wait_for(
+                    asyncio.shield(receipt),
+                    timeout=_WAKE_SUBMISSION_RECEIPT_QUIESCENCE_SEC,
+                )
             )
+        except asyncio.TimeoutError:
+            # Prefer an exact row that resolves on the timeout boundary.
+            accepted = self._receipt_accepted(receipt)
+        except Exception:
+            accepted = self._receipt_accepted(receipt)
+        if not accepted:
             return False
-
-        for retry_index in range(_WAKE_SUBMISSION_REPASTE_RETRY_LIMIT):
-            async with self._repl_control_lock:
-                if self._receipt_accepted(receipt):
-                    return await self._report_verified_wake_submission(
-                        turn,
-                        started=started,
-                        submit_attempts=submit_attempts,
-                    )
-                try:
-                    pane = await self._tmux.capture_pane()
-                except Exception as exc:
-                    await self._emit_wake_submission_escalation(
-                        turn,
-                        rung="repaste",
-                        outcome="skipped",
-                        detail=f"pane_capture_raised_{type(exc).__name__}",
-                    )
-                    return False
-                if not pane.ok or not self._pane_snapshot_has_blank_prompt(
-                    pane.stdout or ""
-                ):
-                    await self._emit_wake_submission_escalation(
-                        turn,
-                        rung="repaste",
-                        outcome="skipped",
-                        detail=(
-                            "pane_capture_failed"
-                            if not pane.ok
-                            else "composer_not_proven_blank"
-                        ),
-                    )
-                    return False
-                # An exact row can land while capture-pane yields.  Receipt
-                # evidence always wins the boundary and forbids re-paste.
-                if self._receipt_accepted(receipt):
-                    return await self._report_verified_wake_submission(
-                        turn,
-                        started=started,
-                        submit_attempts=submit_attempts,
-                    )
-                try:
-                    result = await self._tmux.paste_text(turn.prompt, enter=True)
-                except Exception as exc:
-                    await self._emit_wake_submission_escalation(
-                        turn,
-                        rung="repaste",
-                        outcome="failed",
-                        detail=f"paste_raised_{type(exc).__name__}",
-                    )
-                    return False
-            if not result.ok:
-                await self._emit_wake_submission_escalation(
-                    turn,
-                    rung="repaste",
-                    outcome="failed",
-                    detail=f"paste_rc_{result.returncode}",
-                )
-                return False
-
-            await self._emit_wake_submission_escalation(
-                turn,
-                rung="repaste",
-                outcome="attempted",
-                detail=f"attempt_{retry_index + 1}",
-            )
-            if (
-                await self._verify_wake_submission(
-                    turn, allow_escalation=False
-                )
-                == "verified"
-            ):
-                await self._emit_wake_submission_escalation(
-                    turn,
-                    rung="repaste",
-                    outcome="succeeded",
-                    detail=f"attempt_{retry_index + 1}",
-                )
-                return True
-            await self._emit_wake_submission_escalation(
-                turn,
-                rung="repaste",
-                outcome="failed",
-                detail=f"attempt_{retry_index + 1}_unverified",
-            )
-            return False
-        return False
+        await self._report_verified_wake_submission(
+            turn,
+            started=started,
+            submit_attempts=submit_attempts,
+        )
+        return True
 
     async def _inject_wake_context_reload(self, turn: _QueuedTurn) -> bool:
         """Run the broker-injection rung with a non-replayed instruction."""
@@ -7622,11 +7531,13 @@ class TmuxSession:
         try:
             restarted = await self.force_restart(bypass_guard=True)
         except asyncio.CancelledError:
+            self._config.force_fresh_context_once = False
             await self._report_wake_submission_escalation_terminal(
                 turn, detail="force_restart_cancelled"
             )
             raise
         except Exception as exc:
+            self._config.force_fresh_context_once = False
             await self._report_wake_submission_escalation_terminal(
                 turn, detail=f"force_restart_raised_{type(exc).__name__}"
             )
@@ -7639,6 +7550,7 @@ class TmuxSession:
                 detail="fresh_transport_started",
             )
             return
+        self._config.force_fresh_context_once = False
         await self._report_wake_submission_escalation_terminal(
             turn, detail="force_restart_rejected_or_failed"
         )
@@ -7764,6 +7676,20 @@ class TmuxSession:
             and turn.reason == f"wake_{WakeReason.CONTEXT_RESTART.value}"
             and _wake_submission_escalation_enabled()
         )
+        if (
+            escalation_applies
+            and await self._wait_for_wake_submission_receipt_quiescence(
+                turn,
+                started=started,
+                submit_attempts=submit_attempts,
+            )
+        ):
+            return "verified"
+
+        # Freeze the original wake before any diagnostic callback or fallback
+        # can yield.  A late exact row must not turn the terminal verdict True
+        # while a distinct broker CONTEXT-RELOAD handoff is already underway.
+        self._resolve_submission_receipt(turn, False)
         _log(
             f"tmux[{self.agent_name}]: wake prompt submission UNVERIFIED "
             f"after bounded Enter retries (reason={turn.reason}, "
@@ -7771,33 +7697,26 @@ class TmuxSession:
             f"prompt_visible={prompt_visible}); not claiming delivery"
             + ("; starting bounded escalation" if escalation_applies else "")
         )
-        await self._emit_stream_event(
-            {
-                "type": "wake_prompt_submission_unverified",
-                "agent_name": self.agent_name,
-                "reason": turn.reason,
-                "submit_attempts": submit_attempts,
-                "latency_ms": latency_ms,
-                "prompt_visible": prompt_visible,
-                "escalating": escalation_applies,
-            }
-        )
+        unverified_event = {
+            "type": "wake_prompt_submission_unverified",
+            "agent_name": self.agent_name,
+            "reason": turn.reason,
+            "submit_attempts": submit_attempts,
+            "latency_ms": latency_ms,
+            "prompt_visible": prompt_visible,
+        }
+        if escalation_applies:
+            unverified_event["escalating"] = True
+        await self._emit_stream_event(unverified_event)
         if not escalation_applies:
-            self._resolve_submission_receipt(turn, False)
             return "unverified"
 
-        if await self._repaste_unverified_context_restart_wake(
+        await self._emit_wake_submission_escalation(
             turn,
-            started=started,
-            submit_attempts=submit_attempts,
-            prompt_visible=prompt_visible,
-        ):
-            return "verified"
-
-        # Freeze the original wake's verdict before the distinct broker path.
-        # Any later exact row for it is ignored, preventing both the original
-        # wake and the context-reload fallback from being credited.
-        self._resolve_submission_receipt(turn, False)
+            rung="receipt_quiescence",
+            outcome="expired",
+            detail="late_receipt_not_observed",
+        )
         if await self._inject_wake_context_reload(turn):
             return "fallback_queued"
         return "recovery_required"
@@ -8282,17 +8201,19 @@ class TmuxSession:
             )
             return False
 
-        await self.disconnect()
-
-        # disconnect's default → DEAD path triggers ONLY from CONNECTED;
-        # we pre-set RECONNECTING above so it stays put. Now spawn fresh.
+        transition_open = True
         try:
+            await self.disconnect()
+
+            # disconnect's default → DEAD path triggers ONLY from CONNECTED;
+            # we pre-set RECONNECTING above so it stays put. Now spawn fresh.
             await self._spawn_tmux_repl()
             await self._state_machine.transition_complete(
                 token,
                 SessionState.CONNECTED,
                 trigger=Trigger.INTERNAL,
             )
+            transition_open = False
             # Re-prime the agent with an orientation wake prompt BEFORE the
             # worker can start draining. Without this, force_restart
             # respawned the REPL but — unlike connect() — left the agent on
@@ -8333,17 +8254,33 @@ class TmuxSession:
                 f"(wake_reason={wake_reason.value})"
             )
             return True
+        except asyncio.CancelledError:
+            # The transition owner must close its StateMachine lease even when
+            # an independent disconnect cancels this restart before spawn.  A
+            # fresh-context latch belongs to this abandoned recovery attempt;
+            # never leak it into a later unrelated lifecycle.
+            self._config.force_fresh_context_once = False
+            _log(f"tmux[{self.agent_name}]: force_restart cancelled")
+            raise
         except Exception as e:
             _log(f"tmux[{self.agent_name}]: force_restart spawn failed: {e}")
-            try:
-                await self._state_machine.transition_complete(
-                    token,
-                    SessionState.DEAD,
-                    trigger=Trigger.INTERNAL,
-                )
-            except Exception:
-                pass
             return False
+        finally:
+            # Every owner exit before CONNECTED completion closes the lease.
+            # This covers exceptions and BaseException cancellation alike, so
+            # subscribers cannot remain stranded behind RECONNECTING.
+            if transition_open:
+                try:
+                    await self._state_machine.transition_complete(
+                        token,
+                        SessionState.DEAD,
+                        trigger=Trigger.INTERNAL,
+                    )
+                except Exception as cleanup_exc:
+                    _log(
+                        f"tmux[{self.agent_name}]: force_restart transition "
+                        f"cleanup failed: {cleanup_exc}"
+                    )
 
     async def idle_sleep(self) -> bool:
         """Disconnect but keep the tmux session name pinned for cheap

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -446,15 +446,21 @@ _PASTE_ENTER_MAX_DELAY_MS = 2_000
 _WAKE_SUBMISSION_RECEIPT_TIMEOUT_SEC = 5.0
 _WAKE_SUBMISSION_ENTER_RETRY_LIMIT = 2
 # A context-restart wake that exhausts the ordinary verifier gets one final
-# receipt-only grace window.  The original prompt is never pasted again: an
-# empty composer can mean Claude already accepted it while transcript/tailer
-# evidence still lags, so pane state cannot safely authorize a replay.
+# receipt-only grace window.  The mechanical exactly-once contract is narrow:
+# the original wake text is never pasted a second time.  A distinct broker
+# continuation is protected by enqueue/drain late-row fences, with the
+# instruction's semantic guard covering the residual post-drain-check window.
+# An empty composer can mean Claude already accepted the original while
+# transcript/tailer evidence still lags, so pane state cannot authorize replay.
 _WAKE_SUBMISSION_RECEIPT_QUIESCENCE_SEC = 5.0
 _WAKE_SUBMISSION_BROKER_TIMEOUT_SEC = 5.0
 _WAKE_CONTEXT_RELOAD_INSTRUCTION = (
-    "CONTEXT-RELOAD: Reload the saved continuation state now with "
-    "load_my_context, then resume from that durable artifact. Do not replay "
-    "the failed orientation wake verbatim or treat it as delivered."
+    "CONTEXT-RELOAD: If an orientation wake for this session already appears "
+    "above and you have begun acting on it, reply exactly 'already oriented' "
+    "and take no other action. Otherwise, reload the saved continuation state "
+    "now with load_my_context, then resume from that durable artifact. This is "
+    "a distinct recovery instruction; never replay the failed orientation "
+    "wake text."
 )
 
 
@@ -518,6 +524,10 @@ class _SchedulerDeliveryCancelled(Exception):  # noqa: N818
 
 class _WakeSubmissionFallbackQueued(Exception):  # noqa: N818
     """The failed wake was replaced by a broker context-reload handoff."""
+
+
+class _WakeSubmissionLateDetected(Exception):  # noqa: N818
+    """A late original wake started, so remaining escalation was aborted."""
 
 
 class _WakeSubmissionRecoveryScheduled(Exception):  # noqa: N818
@@ -926,6 +936,15 @@ class _QueuedTurn:
     # scheduler receipt because wake prompts remain ordinary worker-queued
     # internal turns rather than scheduler-serialized external turns.
     submission_receipt: asyncio.Future[bool] | None = None
+
+
+@dataclass
+class _WakeContextReloadGuard:
+    """Short-lived fence joining one failed wake to its broker fallback."""
+
+    original_turn: _QueuedTurn
+    instruction: str
+    original_seen: bool = False
 
 
 _TRANSCRIPT_MATERIALIZE_PROMPT = (
@@ -1593,6 +1612,7 @@ class TmuxSession:
         # recurse through force_restart forever.
         self._wake_submission_transport_recovery_used: bool = False
         self._wake_submission_recovery_task: asyncio.Task[None] | None = None
+        self._wake_context_reload_guard: _WakeContextReloadGuard | None = None
 
     # ── Identity ────────────────────────────────────────────────────────
 
@@ -3550,6 +3570,7 @@ class TmuxSession:
         self._scheduler_pending_turns.clear()
         self._pane_queue_operations.clear()
         self._pane_dequeued_turns.clear()
+        self._wake_context_reload_guard = None
 
         # Cancel worker.
         if self._worker_task and not self._worker_task.done():
@@ -5858,10 +5879,34 @@ class TmuxSession:
                     self._inflight_turn = await self._message_queue.get()
                     delivery_timeouts = 0
                 turn = self._inflight_turn
+                reload_guard = self._wake_context_reload_guard_for(turn)
+                if reload_guard is not None and reload_guard.original_seen:
+                    await self._emit_wake_submission_escalation(
+                        reload_guard.original_turn,
+                        rung="broker_context_reload_drain",
+                        outcome="LATE_SUBMISSION_DETECTED",
+                        detail="fallback_aborted_before_paste",
+                    )
+                    self._clear_wake_context_reload_guard(reload_guard)
+                    self._inflight_turn = None
+                    continue
                 try:
                     self._processing = True
                     await self._deliver_turn(turn)
                     self._stats["turns"] += 1
+                    if reload_guard is not None:
+                        detail = (
+                            "conditional_guard_covers_post_check_late_original"
+                            if reload_guard.original_seen
+                            else "conditional_context_reload_pasted"
+                        )
+                        await self._emit_wake_submission_escalation(
+                            reload_guard.original_turn,
+                            rung="broker_context_reload_drain",
+                            outcome="succeeded",
+                            detail=detail,
+                        )
+                        self._clear_wake_context_reload_guard(reload_guard)
                     # Success — paste landed, meta appended to the
                     # deque. ``_has_completed_turn`` advances when the
                     # first stop_hook_summary pops anything (see
@@ -5895,6 +5940,13 @@ class TmuxSession:
                     # CONTEXT-RELOAD instruction now sits in the broker queue.
                     # Do not count the failed wake as a turn or an error; clear
                     # it so the worker advances to the fallback handoff.
+                    self._inflight_turn = None
+                    continue
+                except _WakeSubmissionLateDetected:
+                    # A transcript row proved the original wake started after
+                    # its receipt froze False.  Accounting remains negative,
+                    # but recovery must stop instead of adding a second
+                    # semantically equivalent continuation.
                     self._inflight_turn = None
                     continue
                 except _WakeSubmissionRecoveryScheduled:
@@ -5966,6 +6018,22 @@ class TmuxSession:
                                 e = finish_e
                             else:
                                 self._stats["turns"] += 1
+                                if reload_guard is not None:
+                                    detail = (
+                                        "conditional_guard_covers_post_check_"
+                                        "late_original"
+                                        if reload_guard.original_seen
+                                        else "conditional_context_reload_pasted"
+                                    )
+                                    await self._emit_wake_submission_escalation(
+                                        reload_guard.original_turn,
+                                        rung="broker_context_reload_drain",
+                                        outcome="succeeded",
+                                        detail=detail,
+                                    )
+                                    self._clear_wake_context_reload_guard(
+                                        reload_guard
+                                    )
                                 self._inflight_turn = None
                                 continue
                         else:
@@ -5981,6 +6049,14 @@ class TmuxSession:
                     # dead-pane, tailer-state corruption, etc.). Drop
                     # the inflight turn so we don't redeliver into a
                     # broken pane on the next iteration.
+                    if reload_guard is not None:
+                        await self._emit_wake_submission_escalation(
+                            reload_guard.original_turn,
+                            rung="broker_context_reload_drain",
+                            outcome="failed",
+                            detail=f"fallback_delivery_raised_{type(e).__name__}",
+                        )
+                        self._clear_wake_context_reload_guard(reload_guard)
                     self._stats["errors"] += 1
                     _log(f"tmux[{self.agent_name}]: turn delivery raised: {e}")
                     # _deliver_turn already re-armed _turn_done and
@@ -7291,6 +7367,22 @@ class TmuxSession:
             if receipt is not None and not receipt.done():
                 receipt.set_result(True)
 
+    def _wake_context_reload_guard_for(
+        self, turn: _QueuedTurn
+    ) -> _WakeContextReloadGuard | None:
+        """Return the active guard when ``turn`` is its wrapped fallback."""
+        guard = self._wake_context_reload_guard
+        if guard is None or not turn.prompt.endswith(guard.instruction):
+            return None
+        return guard
+
+    def _clear_wake_context_reload_guard(
+        self, guard: _WakeContextReloadGuard
+    ) -> None:
+        """Clear ``guard`` only if it is still the active escalation epoch."""
+        if self._wake_context_reload_guard is guard:
+            self._wake_context_reload_guard = None
+
     def _on_transcript_entry(self, entry: dict) -> None:
         """Consume transcript evidence strong enough for exact-turn receipts."""
         entry_type = entry.get("type")
@@ -7315,6 +7407,18 @@ class TmuxSession:
         if entry_type == "user":
             prompt = self._transcript_user_text(entry)
             if prompt is not None:
+                guard = self._wake_context_reload_guard
+                if (
+                    guard is not None
+                    and prompt == guard.original_turn.prompt
+                    and not guard.original_seen
+                ):
+                    guard.original_seen = True
+                    _log(
+                        f"tmux[{self.agent_name}]: LATE_SUBMISSION_DETECTED "
+                        "for original orientation wake; remaining broker "
+                        "escalation will be fenced"
+                    )
                 if self._pane_dequeued_turns:
                     dequeued = self._pane_dequeued_turns[0]
                     if dequeued is None or dequeued.prompt == prompt:
@@ -7482,8 +7586,24 @@ class TmuxSession:
         )
         return True
 
-    async def _inject_wake_context_reload(self, turn: _QueuedTurn) -> bool:
-        """Run the broker-injection rung with a non-replayed instruction."""
+    async def _inject_wake_context_reload(self, turn: _QueuedTurn) -> str:
+        """Run the guarded broker-injection rung without replaying the wake."""
+        guard = self._wake_context_reload_guard
+        if guard is None or guard.original_turn is not turn:
+            guard = _WakeContextReloadGuard(
+                original_turn=turn,
+                instruction=_WAKE_CONTEXT_RELOAD_INSTRUCTION,
+            )
+            self._wake_context_reload_guard = guard
+        if guard.original_seen:
+            await self._emit_wake_submission_escalation(
+                turn,
+                rung="broker_context_reload_enqueue",
+                outcome="LATE_SUBMISSION_DETECTED",
+                detail="fallback_aborted_before_enqueue",
+            )
+            self._clear_wake_context_reload_guard(guard)
+            return "late_submission_detected"
         injector = self._config.wake_submission_recovery_injector
         if injector is None:
             await self._emit_wake_submission_escalation(
@@ -7492,7 +7612,8 @@ class TmuxSession:
                 outcome="failed",
                 detail="injector_unavailable",
             )
-            return False
+            self._clear_wake_context_reload_guard(guard)
+            return "failed"
         try:
             result = injector(
                 self.agent_name,
@@ -7511,14 +7632,18 @@ class TmuxSession:
                 outcome="failed",
                 detail=f"injector_raised_{type(exc).__name__}",
             )
-            return False
+            self._clear_wake_context_reload_guard(guard)
+            return "failed"
         await self._emit_wake_submission_escalation(
             turn,
             rung="broker_context_reload",
             outcome="succeeded" if delivered else "failed",
             detail="context_reload_handoff" if delivered else "handoff_rejected",
         )
-        return delivered
+        if not delivered:
+            self._clear_wake_context_reload_guard(guard)
+            return "failed"
+        return "queued"
 
     async def _run_wake_submission_transport_recovery(
         self, turn: _QueuedTurn
@@ -7707,6 +7832,13 @@ class TmuxSession:
         }
         if escalation_applies:
             unverified_event["escalating"] = True
+            # Arm before the first escalation callback can yield. A late exact
+            # original-wake row remains terminal-False for receipt/accounting,
+            # but marks this epoch so the distinct fallback is fenced.
+            self._wake_context_reload_guard = _WakeContextReloadGuard(
+                original_turn=turn,
+                instruction=_WAKE_CONTEXT_RELOAD_INSTRUCTION,
+            )
         await self._emit_stream_event(unverified_event)
         if not escalation_applies:
             return "unverified"
@@ -7717,8 +7849,11 @@ class TmuxSession:
             outcome="expired",
             detail="late_receipt_not_observed",
         )
-        if await self._inject_wake_context_reload(turn):
+        injection = await self._inject_wake_context_reload(turn)
+        if injection == "queued":
             return "fallback_queued"
+        if injection == "late_submission_detected":
+            return "late_submission_detected"
         return "recovery_required"
 
     async def _finish_submitted_turn(self, turn: _QueuedTurn) -> None:
@@ -7743,6 +7878,10 @@ class TmuxSession:
         if verdict == "fallback_queued":
             raise _WakeSubmissionFallbackQueued(
                 "failed orientation wake replaced by broker context reload"
+            )
+        if verdict == "late_submission_detected":
+            raise _WakeSubmissionLateDetected(
+                "late original orientation wake stopped broker escalation"
             )
         if verdict == "recovery_required":
             if await self._schedule_wake_submission_transport_recovery(turn):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2017,6 +2017,9 @@ class TestAPI:
                 assert session.__class__.__name__ == "TmuxSession"
                 assert session._config.model == "sonnet"
                 assert session.resume_handle == "pinky-tmux-agent"
+                assert callable(
+                    session._config.wake_submission_recovery_injector
+                )
 
     def test_wake_uses_codex_tmux_session_for_codex_tmux_transport(self):
         # #215 PR2: codex_cli + transport=tmux is now a VALID combo (it was

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -9679,6 +9679,14 @@ class TestHandleStopFailure:
 class TestWakeSubmissionVerification:
     """Issue #953 — wake Enter is receipt-confirmed, never fire-and-forget."""
 
+    def test_context_restart_escalation_kill_switch_defaults_on(
+        self, monkeypatch,
+    ) -> None:
+        monkeypatch.delenv("PINKY_WAKE_SUBMISSION_ESCALATION", raising=False)
+        assert tmux_session._wake_submission_escalation_enabled() is True
+        monkeypatch.setenv("PINKY_WAKE_SUBMISSION_ESCALATION", "0")
+        assert tmux_session._wake_submission_escalation_enabled() is False
+
     @pytest.mark.asyncio
     async def test_verified_wake_enqueue_attaches_exact_receipt(self) -> None:
         ss, _ = _make_session(state=SessionState.CONNECTED)
@@ -9702,6 +9710,9 @@ class TestWakeSubmissionVerification:
         )
         tmux = _make_mock_tmux()
         ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+        injector = AsyncMock(return_value=True)
+        ss._config.wake_submission_recovery_injector = injector
+        ss.force_restart = AsyncMock(return_value=True)
         ss._session_ready_event.set()
         receipt = asyncio.get_running_loop().create_future()
         fires: list[str] = []
@@ -9732,6 +9743,187 @@ class TestWakeSubmissionVerification:
         assert await receipt is True
         assert fires == ["delivered"]
         tmux.send_keys.assert_not_awaited()
+        injector.assert_not_awaited()
+        ss.force_restart.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_blank_prompt_repaste_success_stops_before_broker(
+        self, monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_TIMEOUT_SEC", 0.001
+        )
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_ENTER_RETRY_LIMIT", 0
+        )
+        tmux = _make_mock_tmux()
+        tmux.capture_pane = AsyncMock(
+            side_effect=[
+                TmuxCommandResult(0, "previous output\n>", ""),
+                TmuxCommandResult(0, "previous output\n>", ""),
+            ]
+        )
+        ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+        injector = AsyncMock(return_value=True)
+        ss._config.wake_submission_recovery_injector = injector
+        ss.force_restart = AsyncMock(return_value=True)
+        ss._session_ready_event.set()
+        receipt = asyncio.get_running_loop().create_future()
+        fires: list[str] = []
+        turn = _QueuedTurn(
+            prompt="exact context restart wake",
+            internal=True,
+            reason="wake_context_restart",
+            on_delivered=lambda: fires.append("delivered"),
+            submission_receipt=receipt,
+        )
+        paste_calls = 0
+
+        async def accept_second_paste(*_args, **_kwargs):
+            nonlocal paste_calls
+            paste_calls += 1
+            if paste_calls == 2:
+                ss._on_transcript_entry(
+                    {
+                        "type": "user",
+                        "message": {
+                            "role": "user",
+                            "content": "exact context restart wake",
+                        },
+                    }
+                )
+            return _ok()
+
+        tmux.paste_text = AsyncMock(side_effect=accept_second_paste)
+
+        await ss._deliver_turn(turn)
+
+        assert tmux.paste_text.await_count == 2
+        assert await receipt is True
+        assert fires == ["delivered"]
+        injector.assert_not_awaited()
+        ss.force_restart.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_nonblank_prompt_skips_repaste_and_queues_context_reload(
+        self, monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_TIMEOUT_SEC", 0.001
+        )
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_ENTER_RETRY_LIMIT", 0
+        )
+        tmux = _make_mock_tmux()
+        tmux.capture_pane = AsyncMock(
+            return_value=TmuxCommandResult(0, "busy or typed composer", "")
+        )
+        ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+        injector = AsyncMock(return_value=True)
+        ss._config.wake_submission_recovery_injector = injector
+        ss.force_restart = AsyncMock(return_value=True)
+        ss._session_ready_event.set()
+        receipt = asyncio.get_running_loop().create_future()
+        turn = _QueuedTurn(
+            prompt="original orientation wake text",
+            internal=True,
+            reason="wake_context_restart",
+            submission_receipt=receipt,
+        )
+
+        with pytest.raises(tmux_session._WakeSubmissionFallbackQueued):
+            await ss._deliver_turn(turn)
+
+        assert tmux.paste_text.await_count == 1
+        injector.assert_awaited_once()
+        target, instruction = injector.await_args.args
+        assert target == ss.agent_name
+        assert instruction.startswith("CONTEXT-RELOAD:")
+        assert "load_my_context" in instruction
+        assert turn.prompt not in instruction
+        assert await receipt is False
+        assert len(ss._inflight_metas) == 0
+        ss.force_restart.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_all_escalation_rungs_fail_loudly_and_terminally(
+        self, monkeypatch, capsys,
+    ) -> None:
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_TIMEOUT_SEC", 0.001
+        )
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_ENTER_RETRY_LIMIT", 0
+        )
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_BROKER_TIMEOUT_SEC", 0.001
+        )
+        tmux = _make_mock_tmux()
+        tmux.capture_pane = AsyncMock(
+            return_value=TmuxCommandResult(0, "composer state unknown", "")
+        )
+        ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+
+        async def stalled_injector(*_args):
+            await asyncio.Event().wait()
+
+        injector = AsyncMock(side_effect=stalled_injector)
+        ss._config.wake_submission_recovery_injector = injector
+        ss.force_restart = AsyncMock(return_value=False)
+        ss._session_ready_event.set()
+        receipt = asyncio.get_running_loop().create_future()
+        turn = _QueuedTurn(
+            prompt="unaccepted context restart wake",
+            internal=True,
+            reason="wake_context_restart",
+            submission_receipt=receipt,
+        )
+
+        with pytest.raises(tmux_session._WakeSubmissionRecoveryScheduled):
+            await ss._deliver_turn(turn)
+        recovery = ss._wake_submission_recovery_task
+        assert recovery is not None
+        await recovery
+
+        assert tmux.paste_text.await_count == 1
+        injector.assert_awaited_once()
+        ss.force_restart.assert_awaited_once_with(bypass_guard=True)
+        assert ss._config.force_fresh_context_once is True
+        assert await receipt is False
+        assert len(ss._inflight_metas) == 0
+        assert "WAKE SUBMISSION ESCALATION TERMINAL" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_external_disconnect_cancels_pending_transport_recovery(
+        self,
+    ) -> None:
+        tmux = _make_mock_tmux()
+        ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+        force_restart_entered = asyncio.Event()
+
+        async def stalled_force_restart(*, bypass_guard: bool = False) -> bool:
+            assert bypass_guard is True
+            force_restart_entered.set()
+            await asyncio.Event().wait()
+            return True
+
+        ss.force_restart = AsyncMock(side_effect=stalled_force_restart)
+        turn = _QueuedTurn(
+            prompt="unaccepted context restart wake",
+            internal=True,
+            reason="wake_context_restart",
+        )
+        recovery = asyncio.create_task(
+            ss._run_wake_submission_transport_recovery(turn)
+        )
+        ss._wake_submission_recovery_task = recovery
+        await force_restart_entered.wait()
+
+        await ss.disconnect()
+
+        assert recovery.cancelled()
+        assert ss._wake_submission_recovery_task is None
+        assert ss.state == SessionState.DEAD
 
     @pytest.mark.asyncio
     async def test_queue_dequeue_is_an_exact_submission_receipt(

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -9839,6 +9839,8 @@ class TestWakeSubmissionVerification:
         target, instruction = injector.await_args.args
         assert target == ss.agent_name
         assert instruction.startswith("CONTEXT-RELOAD:")
+        assert "already oriented" in instruction
+        assert "take no other action" in instruction
         assert "load_my_context" in instruction
         assert turn.prompt not in instruction
         assert await receipt is False
@@ -9897,7 +9899,7 @@ class TestWakeSubmissionVerification:
         assert "WAKE SUBMISSION ESCALATION TERMINAL" in capsys.readouterr().err
 
     @pytest.mark.asyncio
-    async def test_broker_observes_original_receipt_frozen_false(
+    async def test_late_original_before_enqueue_aborts_context_reload(
         self, monkeypatch,
     ) -> None:
         monkeypatch.setattr(
@@ -9919,9 +9921,10 @@ class TestWakeSubmissionVerification:
             reason="wake_context_restart",
             submission_receipt=receipt,
         )
-        broker_receipts: list[bool] = []
+        events: list[dict] = []
 
         async def stream_event(event: dict) -> None:
+            events.append(event)
             if event["type"] != "wake_prompt_submission_unverified":
                 return
             assert receipt.done() and receipt.result() is False
@@ -9936,19 +9939,134 @@ class TestWakeSubmissionVerification:
             )
             await asyncio.sleep(0)
 
-        async def injector(*_args) -> bool:
-            broker_receipts.append(receipt.result())
-            return True
-
         ss._stream_event_callback = stream_event
+        injector = AsyncMock(return_value=True)
         ss._config.wake_submission_recovery_injector = injector
 
-        with pytest.raises(tmux_session._WakeSubmissionFallbackQueued):
+        with pytest.raises(tmux_session._WakeSubmissionLateDetected):
             await ss._deliver_turn(turn)
 
-        assert broker_receipts == [False]
+        injector.assert_not_awaited()
         assert turn.transport_accepted is False
+        assert await receipt is False
         assert tmux.paste_text.await_count == 1
+        assert ss._wake_context_reload_guard is None
+        assert any(
+            event.get("rung") == "broker_context_reload_enqueue"
+            and event.get("outcome") == "LATE_SUBMISSION_DETECTED"
+            and event.get("detail") == "fallback_aborted_before_enqueue"
+            for event in events
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("late_after_enqueue", [True, False])
+    async def test_worker_fences_or_drains_conditional_context_reload(
+        self, monkeypatch, late_after_enqueue: bool,
+    ) -> None:
+        """Exercise production-shaped broker enqueue through worker drain."""
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_TIMEOUT_SEC", 0.001
+        )
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_ENTER_RETRY_LIMIT", 0
+        )
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_QUIESCENCE_SEC", 0.001
+        )
+        tmux = _make_mock_tmux()
+        pasted: list[str] = []
+
+        async def paste_text(prompt: str, *, enter: bool = True):
+            assert enter is True
+            pasted.append(prompt)
+            return _ok()
+
+        tmux.paste_text = AsyncMock(side_effect=paste_text)
+        ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+        ss._session_ready_event.set()
+        events: list[dict] = []
+
+        async def stream_event(event: dict) -> None:
+            events.append(event)
+
+        ss._stream_event_callback = stream_event
+        receipt = asyncio.get_running_loop().create_future()
+        original = _QueuedTurn(
+            prompt="worker-level original orientation wake",
+            internal=True,
+            reason="wake_context_restart",
+            submission_receipt=receipt,
+        )
+
+        async def injector(_target: str, instruction: str) -> bool:
+            wrapped = (
+                "[agent | transport-recovery | internal | test UTC]\n"
+                f"{instruction}"
+            )
+            assert await ss.send(wrapped) is True
+            if late_after_enqueue:
+                # This lands after the enqueue-time fence but before the same
+                # worker can drain the broker turn.
+                ss._on_transcript_entry(
+                    {
+                        "type": "user",
+                        "message": {
+                            "role": "user",
+                            "content": original.prompt,
+                        },
+                    }
+                )
+            return True
+
+        ss._config.wake_submission_recovery_injector = injector
+        ss.force_restart = AsyncMock(return_value=True)
+        ss._message_queue.put_nowait(original)
+
+        worker = asyncio.create_task(ss._message_worker())
+        try:
+            expected_outcome = (
+                "LATE_SUBMISSION_DETECTED" if late_after_enqueue else "succeeded"
+            )
+            for _ in range(500):
+                if any(
+                    event.get("rung") == "broker_context_reload_drain"
+                    and event.get("outcome") == expected_outcome
+                    for event in events
+                ):
+                    break
+                await asyncio.sleep(0.001)
+        finally:
+            worker.cancel()
+            await worker
+
+        assert await receipt is False
+        assert original.transport_accepted is False
+        assert pasted[0] == original.prompt
+        if late_after_enqueue:
+            assert pasted == [original.prompt]
+            assert any(
+                event.get("rung") == "broker_context_reload_drain"
+                and event.get("outcome") == "LATE_SUBMISSION_DETECTED"
+                and event.get("detail") == "fallback_aborted_before_paste"
+                for event in events
+            )
+        else:
+            assert len(pasted) == 2
+            assert pasted[1].startswith(
+                "[agent | transport-recovery | internal | test UTC]\n"
+                "CONTEXT-RELOAD:"
+            )
+            assert "already oriented" in pasted[1]
+            assert "take no other action" in pasted[1]
+            assert "load_my_context" in pasted[1]
+            assert any(
+                event.get("rung") == "broker_context_reload_drain"
+                and event.get("outcome") == "succeeded"
+                and event.get("detail") == "conditional_context_reload_pasted"
+                for event in events
+            )
+        assert ss._wake_context_reload_guard is None
+        ss.force_restart.assert_not_awaited()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -9747,7 +9747,7 @@ class TestWakeSubmissionVerification:
         ss.force_restart.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_blank_prompt_repaste_success_stops_before_broker(
+    async def test_late_receipt_during_quiescence_stops_before_broker(
         self, monkeypatch,
     ) -> None:
         monkeypatch.setattr(
@@ -9756,13 +9756,17 @@ class TestWakeSubmissionVerification:
         monkeypatch.setattr(
             tmux_session, "_WAKE_SUBMISSION_ENTER_RETRY_LIMIT", 0
         )
-        tmux = _make_mock_tmux()
-        tmux.capture_pane = AsyncMock(
-            side_effect=[
-                TmuxCommandResult(0, "previous output\n>", ""),
-                TmuxCommandResult(0, "previous output\n>", ""),
-            ]
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_QUIESCENCE_SEC", 0.2
         )
+        tmux = _make_mock_tmux()
+        final_probe_done = asyncio.Event()
+
+        async def final_probe(*_args, **_kwargs):
+            final_probe_done.set()
+            return TmuxCommandResult(0, "previous output\n>", "")
+
+        tmux.capture_pane = AsyncMock(side_effect=final_probe)
         ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
         injector = AsyncMock(return_value=True)
         ss._config.wake_submission_recovery_injector = injector
@@ -9777,35 +9781,28 @@ class TestWakeSubmissionVerification:
             on_delivered=lambda: fires.append("delivered"),
             submission_receipt=receipt,
         )
-        paste_calls = 0
+        delivery = asyncio.create_task(ss._deliver_turn(turn))
+        await final_probe_done.wait()
+        await asyncio.sleep(0)
+        ss._on_transcript_entry(
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": "exact context restart wake",
+                },
+            }
+        )
+        await delivery
 
-        async def accept_second_paste(*_args, **_kwargs):
-            nonlocal paste_calls
-            paste_calls += 1
-            if paste_calls == 2:
-                ss._on_transcript_entry(
-                    {
-                        "type": "user",
-                        "message": {
-                            "role": "user",
-                            "content": "exact context restart wake",
-                        },
-                    }
-                )
-            return _ok()
-
-        tmux.paste_text = AsyncMock(side_effect=accept_second_paste)
-
-        await ss._deliver_turn(turn)
-
-        assert tmux.paste_text.await_count == 2
+        assert tmux.paste_text.await_count == 1
         assert await receipt is True
         assert fires == ["delivered"]
         injector.assert_not_awaited()
         ss.force_restart.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_nonblank_prompt_skips_repaste_and_queues_context_reload(
+    async def test_quiescence_expiry_queues_context_reload_without_repaste(
         self, monkeypatch,
     ) -> None:
         monkeypatch.setattr(
@@ -9813,6 +9810,9 @@ class TestWakeSubmissionVerification:
         )
         monkeypatch.setattr(
             tmux_session, "_WAKE_SUBMISSION_ENTER_RETRY_LIMIT", 0
+        )
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_QUIESCENCE_SEC", 0.001
         )
         tmux = _make_mock_tmux()
         tmux.capture_pane = AsyncMock(
@@ -9856,6 +9856,9 @@ class TestWakeSubmissionVerification:
             tmux_session, "_WAKE_SUBMISSION_ENTER_RETRY_LIMIT", 0
         )
         monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_QUIESCENCE_SEC", 0.001
+        )
+        monkeypatch.setattr(
             tmux_session, "_WAKE_SUBMISSION_BROKER_TIMEOUT_SEC", 0.001
         )
         tmux = _make_mock_tmux()
@@ -9888,26 +9891,145 @@ class TestWakeSubmissionVerification:
         assert tmux.paste_text.await_count == 1
         injector.assert_awaited_once()
         ss.force_restart.assert_awaited_once_with(bypass_guard=True)
-        assert ss._config.force_fresh_context_once is True
+        assert ss._config.force_fresh_context_once is False
         assert await receipt is False
         assert len(ss._inflight_metas) == 0
         assert "WAKE SUBMISSION ESCALATION TERMINAL" in capsys.readouterr().err
 
     @pytest.mark.asyncio
-    async def test_external_disconnect_cancels_pending_transport_recovery(
+    async def test_broker_observes_original_receipt_frozen_false(
+        self, monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_TIMEOUT_SEC", 0.001
+        )
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_ENTER_RETRY_LIMIT", 0
+        )
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_QUIESCENCE_SEC", 0.001
+        )
+        tmux = _make_mock_tmux()
+        ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+        ss._session_ready_event.set()
+        receipt = asyncio.get_running_loop().create_future()
+        turn = _QueuedTurn(
+            prompt="original receipt must stay false",
+            internal=True,
+            reason="wake_context_restart",
+            submission_receipt=receipt,
+        )
+        broker_receipts: list[bool] = []
+
+        async def stream_event(event: dict) -> None:
+            if event["type"] != "wake_prompt_submission_unverified":
+                return
+            assert receipt.done() and receipt.result() is False
+            ss._on_transcript_entry(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": "original receipt must stay false",
+                    },
+                }
+            )
+            await asyncio.sleep(0)
+
+        async def injector(*_args) -> bool:
+            broker_receipts.append(receipt.result())
+            return True
+
+        ss._stream_event_callback = stream_event
+        ss._config.wake_submission_recovery_injector = injector
+
+        with pytest.raises(tmux_session._WakeSubmissionFallbackQueued):
+            await ss._deliver_turn(turn)
+
+        assert broker_receipts == [False]
+        assert turn.transport_accepted is False
+        assert tmux.paste_text.await_count == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("reason", "disable_escalation"),
+        [
+            ("wake_context_restart", True),
+            ("wake_resume", False),
+        ],
+    )
+    async def test_non_escalating_receipt_is_frozen_before_legacy_event(
+        self, monkeypatch, reason: str, disable_escalation: bool,
+    ) -> None:
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_RECEIPT_TIMEOUT_SEC", 0.001
+        )
+        monkeypatch.setattr(
+            tmux_session, "_WAKE_SUBMISSION_ENTER_RETRY_LIMIT", 0
+        )
+        if disable_escalation:
+            monkeypatch.setenv("PINKY_WAKE_SUBMISSION_ESCALATION", "0")
+        else:
+            monkeypatch.delenv("PINKY_WAKE_SUBMISSION_ESCALATION", raising=False)
+        tmux = _make_mock_tmux()
+        ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+        ss._session_ready_event.set()
+        receipt = asyncio.get_running_loop().create_future()
+        turn = _QueuedTurn(
+            prompt="legacy unverified event contract",
+            internal=True,
+            reason=reason,
+            submission_receipt=receipt,
+        )
+        events: list[dict] = []
+
+        async def stream_event(event: dict) -> None:
+            if event["type"] != "wake_prompt_submission_unverified":
+                return
+            assert receipt.done() and receipt.result() is False
+            events.append(event)
+            ss._on_transcript_entry(
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": "legacy unverified event contract",
+                    },
+                }
+            )
+            await asyncio.sleep(0)
+
+        ss._stream_event_callback = stream_event
+
+        with pytest.raises(RuntimeError, match="not confirmed"):
+            await ss._deliver_turn(turn)
+
+        assert receipt.result() is False
+        assert turn.transport_accepted is False
+        assert len(events) == 1
+        assert set(events[0]) == {
+            "type",
+            "agent_name",
+            "reason",
+            "submit_attempts",
+            "latency_ms",
+            "prompt_visible",
+        }
+
+    @pytest.mark.asyncio
+    async def test_external_disconnect_releases_real_restart_owner_and_latch(
         self,
     ) -> None:
         tmux = _make_mock_tmux()
         ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
-        force_restart_entered = asyncio.Event()
+        recovery_disconnect_entered = asyncio.Event()
 
-        async def stalled_force_restart(*, bypass_guard: bool = False) -> bool:
-            assert bypass_guard is True
-            force_restart_entered.set()
-            await asyncio.Event().wait()
-            return True
+        async def stalled_recovery_stop_tailer() -> None:
+            if asyncio.current_task() is ss._wake_submission_recovery_task:
+                recovery_disconnect_entered.set()
+                await asyncio.Event().wait()
 
-        ss.force_restart = AsyncMock(side_effect=stalled_force_restart)
+        ss._stop_tailer = AsyncMock(side_effect=stalled_recovery_stop_tailer)
         turn = _QueuedTurn(
             prompt="unaccepted context restart wake",
             internal=True,
@@ -9917,13 +10039,19 @@ class TestWakeSubmissionVerification:
             ss._run_wake_submission_transport_recovery(turn)
         )
         ss._wake_submission_recovery_task = recovery
-        await force_restart_entered.wait()
+        await recovery_disconnect_entered.wait()
+
+        assert ss.state == SessionState.RECONNECTING
+        assert ss._state_machine._in_flight is not None
+        assert ss._config.force_fresh_context_once is True
 
         await ss.disconnect()
 
         assert recovery.cancelled()
         assert ss._wake_submission_recovery_task is None
         assert ss.state == SessionState.DEAD
+        assert ss._state_machine._in_flight is None
+        assert ss._config.force_fresh_context_once is False
 
     @pytest.mark.asyncio
     async def test_queue_dequeue_is_an_exact_submission_receipt(


### PR DESCRIPTION
## Summary

- Keep the original context-restart wake receipt terminal `False` after quiescence and never paste the original wake text a second time.
- Fence the distinct broker `CONTEXT-RELOAD` fallback twice: immediately before enqueue and again at worker drain immediately before paste. A late exact original-wake user row aborts remaining escalation with a loud `LATE_SUBMISSION_DETECTED` outcome.
- Add a conditional recovery instruction for the residual post-drain-check window: if the orientation wake already appeared and action began, reply `already oriented` and do nothing else; otherwise load the durable continuation and resume.
- Clear the short-lived escalation guard on success, rejection, failure, disconnect, or late-submission abort, while retaining the one-shot fresh-transport terminal rung.
- Ship production-shaped worker regressions for both branches: late original aborts the queued fallback, and no late original drains exactly one conditional fallback.

## Exactly-once contract

The mechanical guarantee is intentionally narrow and enforceable: **the original orientation wake text is pasted at most once**. Double-continuation risk is suppressed by the enqueue-time and drain-time transcript fences; the conditional instruction covers the residual interval after the final mechanical check. Every recovery branch remains operator-visible through explicit escalation outcomes.

## Validation

- Clean sanitized Python 3.11 full suite: `4,898 passed, 3 skipped`
- `tests/test_tmux_session.py`: `407 passed`
- Focused wake-submission verification: `24 passed`
- Tmux/Codex-tmux API wiring: `2 passed`
- Repository-wide `ruff check .`
- Changed-file compilation and `git diff --check`

Refs #984