### PR TITLE
Fix dream MCP loading and zero-reflection alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,9 @@ cd frontend-svelte && npm run build
 ## Built by
 
 [Brad Brockman](https://brockmanlabs.com)
+# Dream receipts migration
+
+The durable dream-receipts migration is one-way. Rolling back below PinkyBot
+26.08.020 after this migration is unsupported: pre-gate builds may start with
+stale watermark semantics beside v1 receipt rows. Builds at or above 26.08.020
+fail closed if they encounter a future dream schema version.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+# Release notes
+
+## Dream receipts
+
+Rolling back below PinkyBot 26.08.020 after the durable dream-receipts
+migration is unsupported; old builds may run stale watermark semantics beside
+v1 receipt rows.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,5 @@
+# Deployment notes
+
+The durable dream-receipts migration is one-way. Do not roll back below
+PinkyBot 26.08.020 after migration: pre-gate binaries do not understand the v1
+receipt ledger and may run stale watermark semantics beside it.

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -11103,6 +11103,8 @@ npm run build</pre>
         )
         return False
 
+    dream_runner.set_owner_notify_callback(_notify_owner_alert)
+
     scheduler = AgentScheduler(
         agents,
         wake_callback=_wake_callback,

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -176,8 +176,11 @@ class DreamRunner:
         lock_path = f"{self._db_path}.migration.lock"
         with open(lock_path, "a+") as migration_lock:
             fcntl.flock(migration_lock.fileno(), fcntl.LOCK_EX)
-            self._check_schema_version()
-            self._db.executescript("""
+            for migration_attempt in range(5):
+                self._db.execute("BEGIN IMMEDIATE")
+                try:
+                    self._check_schema_version()
+                    self._db.executescript("""
             CREATE TABLE IF NOT EXISTS dream_state (
                 agent_name TEXT PRIMARY KEY,
                 last_dream_at REAL,
@@ -227,11 +230,7 @@ class DreamRunner:
                 surfaced_at REAL,
                 PRIMARY KEY (agent_name, fingerprint)
             );
-        """)
-            # Serialize migration and re-check after acquiring the write lock.
-            for migration_attempt in range(5):
-                self._db.execute("BEGIN IMMEDIATE")
-                try:
+                    """)
                     self._migrate_tables()
                     version = int(self._db.execute("PRAGMA user_version").fetchone()[0] or 0)
                     if version < _DREAM_SCHEMA_VERSION:
@@ -714,6 +713,9 @@ class DreamRunner:
         """
         stopped = asyncio.Event()
         deadline = time.monotonic() + timeout_s if timeout_s is not None else None
+        teardown_deadline = (
+            deadline + _SDK_DREAM_TEARDOWN_GRACE_S if deadline is not None else None
+        )
 
         run_task = asyncio.create_task(runner.run(prompt))
         renewal_task = asyncio.create_task(
@@ -734,12 +736,6 @@ class DreamRunner:
                 # the runner, and never accept a result from a late/zombie task.
                 stopped.set()
                 run_task.cancel()
-                try:
-                    await asyncio.wait_for(
-                        asyncio.shield(run_task), timeout=_SDK_DREAM_TEARDOWN_GRACE_S
-                    )
-                except BaseException:
-                    pass
                 raise TimeoutError(
                     f"SDK dream run exceeded its {timeout_s:g}s wall timeout"
                 )
@@ -759,8 +755,13 @@ class DreamRunner:
                     task.cancel()
             if not run_task.done():
                 try:
+                    remaining = (
+                        max(0.0, teardown_deadline - time.monotonic())
+                        if teardown_deadline is not None
+                        else _SDK_DREAM_TEARDOWN_GRACE_S
+                    )
                     await asyncio.wait_for(
-                        asyncio.shield(run_task), timeout=_SDK_DREAM_TEARDOWN_GRACE_S
+                        asyncio.shield(run_task), timeout=remaining
                     )
                 except TimeoutError:
                     _log(

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -273,7 +273,7 @@ class DreamRunner:
             self._db.execute(
                 "ALTER TABLE dream_state ADD COLUMN last_notified_at REAL"
             )
-            self._db.commit()
+            pass
         # Migration: rename sessions_processed -> last_sessions_processed
         if "last_sessions_processed" not in cols:
             self._db.execute(
@@ -282,7 +282,7 @@ class DreamRunner:
             self._db.execute(
                 "UPDATE dream_state SET last_sessions_processed = sessions_processed"
             )
-            self._db.commit()
+            pass
         # Migration: rename memories_stored -> last_memories_stored
         if "last_memories_stored" not in cols:
             self._db.execute(
@@ -291,44 +291,44 @@ class DreamRunner:
             self._db.execute(
                 "UPDATE dream_state SET last_memories_stored = memories_stored"
             )
-            self._db.commit()
+            pass
         # Migration: add last_message_ts watermark for tracking processed history
         if "last_message_ts" not in cols:
             self._db.execute(
                 "ALTER TABLE dream_state ADD COLUMN last_message_ts REAL DEFAULT 0"
             )
-            self._db.commit()
+            pass
         # Migration: add KG proactive-surfacing columns (#682 PR2)
         if "kg_insights" not in cols:
             self._db.execute(
                 "ALTER TABLE dream_state ADD COLUMN kg_insights TEXT"
             )
-            self._db.commit()
+            pass
         if "kg_insights_notified_at" not in cols:
             self._db.execute(
                 "ALTER TABLE dream_state ADD COLUMN kg_insights_notified_at REAL"
             )
-            self._db.commit()
+            pass
         if "zero_reflection_streak" not in cols:
             self._db.execute(
                 "ALTER TABLE dream_state ADD COLUMN zero_reflection_streak INT NOT NULL DEFAULT 0"
             )
-            self._db.commit()
+            pass
         if "last_reflection_night_key" not in cols:
             self._db.execute(
                 "ALTER TABLE dream_state ADD COLUMN last_reflection_night_key TEXT"
             )
-            self._db.commit()
+            pass
         if "zero_reflection_alert_attempted_at" not in cols:
             self._db.execute(
                 "ALTER TABLE dream_state ADD COLUMN zero_reflection_alert_attempted_at REAL"
             )
-            self._db.commit()
+            pass
         if "zero_reflection_alert_delivered_at" not in cols:
             self._db.execute(
                 "ALTER TABLE dream_state ADD COLUMN zero_reflection_alert_delivered_at REAL"
             )
-            self._db.commit()
+            pass
 
         outcome_cols = {
             row[1]
@@ -341,7 +341,6 @@ class DreamRunner:
                 "ALTER TABLE dream_reflection_outcomes "
                 "ADD COLUMN outcome_status TEXT NOT NULL DEFAULT 'completed'"
             )
-            self._db.commit()
 
         attempt_cols = {
             row[1]
@@ -357,7 +356,6 @@ class DreamRunner:
                 "ALTER TABLE dream_reflection_attempts "
                 "DROP COLUMN reflection_rowid_floor"
             )
-            self._db.commit()
         for column, declaration in (
             ("lease_owner", "TEXT"),
             ("lease_expires_at", "REAL"),
@@ -368,7 +366,7 @@ class DreamRunner:
                     f"ALTER TABLE dream_reflection_attempts "
                     f"ADD COLUMN {column} {declaration}"
                 )
-                self._db.commit()
+                pass
 
     def set_owner_notify_callback(
         self, callback: Callable[[str, str], object] | None
@@ -680,7 +678,8 @@ class DreamRunner:
         return cursor.rowcount == 1
 
     async def _renew_reflection_attempt_lease_until_stopped(
-        self, attempt: _ReflectionAttempt, stopped: asyncio.Event
+        self, attempt: _ReflectionAttempt, stopped: asyncio.Event,
+        deadline: float | None = None,
     ) -> None:
         """Renew an owned lease periodically, failing closed if ownership is lost."""
         while True:
@@ -690,6 +689,8 @@ class DreamRunner:
                 )
                 return
             except TimeoutError:
+                if deadline is not None and time.monotonic() >= deadline:
+                    return
                 if not self._renew_reflection_attempt_lease(attempt):
                     raise RuntimeError(
                         "dream reflection attempt lost its lease during renewal: "
@@ -712,10 +713,11 @@ class DreamRunner:
         wall-clock timeout.
         """
         stopped = asyncio.Event()
+        deadline = time.monotonic() + timeout_s if timeout_s is not None else None
 
         run_task = asyncio.create_task(runner.run(prompt))
         renewal_task = asyncio.create_task(
-            self._renew_reflection_attempt_lease_until_stopped(attempt, stopped)
+            self._renew_reflection_attempt_lease_until_stopped(attempt, stopped, deadline)
         )
         deadline_task = (
             asyncio.create_task(asyncio.sleep(timeout_s)) if timeout_s is not None else None

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -180,7 +180,7 @@ class DreamRunner:
                 self._db.execute("BEGIN IMMEDIATE")
                 try:
                     self._check_schema_version()
-                    self._db.executescript("""
+                    schema_sql = """
             CREATE TABLE IF NOT EXISTS dream_state (
                 agent_name TEXT PRIMARY KEY,
                 last_dream_at REAL,
@@ -230,7 +230,10 @@ class DreamRunner:
                 surfaced_at REAL,
                 PRIMARY KEY (agent_name, fingerprint)
             );
-                    """)
+                    """
+                    for statement in schema_sql.split(";"):
+                        if statement.strip():
+                            self._db.execute(statement)
                     self._migrate_tables()
                     version = int(self._db.execute("PRAGMA user_version").fetchone()[0] or 0)
                     if version < _DREAM_SCHEMA_VERSION:

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -100,6 +100,7 @@ _DREAM_MCP_CONFIG_RETENTION_S = 24 * 3600
 _DREAM_SCHEMA_VERSION = 1
 _DREAM_SCHEMA_MIGRATION = "durable-dream-receipts-v1"
 _DREAM_SCHEMA_MIN_CODE_VERSION = "26.08.020"
+_SDK_DREAM_TEARDOWN_GRACE_S = 10.0
 
 
 @dataclass(frozen=True)
@@ -223,10 +224,17 @@ class DreamRunner:
                 PRIMARY KEY (agent_name, fingerprint)
             );
         """)
-        self._db.commit()
-        self._migrate_tables()
-        self._db.execute(f"PRAGMA user_version={_DREAM_SCHEMA_VERSION}")
-        self._db.commit()
+        # Serialize migration and re-check after acquiring the write lock.
+        self._db.execute("BEGIN IMMEDIATE")
+        try:
+            self._migrate_tables()
+            version = int(self._db.execute("PRAGMA user_version").fetchone()[0] or 0)
+            if version < _DREAM_SCHEMA_VERSION:
+                self._db.execute(f"PRAGMA user_version={_DREAM_SCHEMA_VERSION}")
+            self._db.commit()
+        except BaseException:
+            self._db.rollback()
+            raise
 
     def _check_schema_version(self) -> None:
         """Fail startup before touching a dream DB created by newer code."""
@@ -693,24 +701,34 @@ class DreamRunner:
         """
         stopped = asyncio.Event()
 
-        async def invoke_runner():
-            if timeout_s is None:
-                return await runner.run(prompt)
-            try:
-                return await asyncio.wait_for(runner.run(prompt), timeout=timeout_s)
-            except TimeoutError as exc:
-                raise TimeoutError(
-                    f"SDK dream run exceeded its {timeout_s:g}s wall timeout"
-                ) from exc
-
-        run_task = asyncio.create_task(invoke_runner())
+        run_task = asyncio.create_task(runner.run(prompt))
         renewal_task = asyncio.create_task(
             self._renew_reflection_attempt_lease_until_stopped(attempt, stopped)
         )
+        deadline_task = (
+            asyncio.create_task(asyncio.sleep(timeout_s)) if timeout_s is not None else None
+        )
         try:
+            watched = {run_task, renewal_task}
+            if deadline_task is not None:
+                watched.add(deadline_task)
             done, _pending = await asyncio.wait(
-                {run_task, renewal_task}, return_when=asyncio.FIRST_COMPLETED
+                watched, return_when=asyncio.FIRST_COMPLETED
             )
+            if deadline_task is not None and deadline_task in done:
+                # The deadline decision is final. Stop renewal before touching
+                # the runner, and never accept a result from a late/zombie task.
+                stopped.set()
+                run_task.cancel()
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(run_task), timeout=_SDK_DREAM_TEARDOWN_GRACE_S
+                    )
+                except BaseException:
+                    pass
+                raise TimeoutError(
+                    f"SDK dream run exceeded its {timeout_s:g}s wall timeout"
+                )
             if renewal_task in done:
                 # A renewal task only completes before ``stopped`` on failure.
                 renewal_task.result()
@@ -720,10 +738,15 @@ class DreamRunner:
             return run_task.result()
         finally:
             stopped.set()
-            for task in (run_task, renewal_task):
+            for task in (run_task, renewal_task, deadline_task):
+                if task is None:
+                    continue
                 if not task.done():
                     task.cancel()
-            await asyncio.gather(run_task, renewal_task, return_exceptions=True)
+            await asyncio.gather(
+                run_task, renewal_task, *( [deadline_task] if deadline_task else [] ),
+                return_exceptions=True,
+            )
 
     def _prune_reflection_attempts(self, *, now: float | None = None) -> int:
         """Prune old completed/terminal receipts; retryable failures survive."""

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import fcntl
 import inspect
 import json
 import os
@@ -172,8 +173,11 @@ class DreamRunner:
         return connection
 
     def _init_tables(self) -> None:
-        self._check_schema_version()
-        self._db.executescript("""
+        lock_path = f"{self._db_path}.migration.lock"
+        with open(lock_path, "a+") as migration_lock:
+            fcntl.flock(migration_lock.fileno(), fcntl.LOCK_EX)
+            self._check_schema_version()
+            self._db.executescript("""
             CREATE TABLE IF NOT EXISTS dream_state (
                 agent_name TEXT PRIMARY KEY,
                 last_dream_at REAL,
@@ -224,24 +228,25 @@ class DreamRunner:
                 PRIMARY KEY (agent_name, fingerprint)
             );
         """)
-        # Serialize migration and re-check after acquiring the write lock.
-        for migration_attempt in range(5):
-            self._db.execute("BEGIN IMMEDIATE")
-            try:
-                self._migrate_tables()
-                version = int(self._db.execute("PRAGMA user_version").fetchone()[0] or 0)
-                if version < _DREAM_SCHEMA_VERSION:
-                    self._db.execute(f"PRAGMA user_version={_DREAM_SCHEMA_VERSION}")
-                self._db.commit()
-                break
-            except sqlite3.OperationalError:
-                self._db.rollback()
-                if migration_attempt == 4:
+            # Serialize migration and re-check after acquiring the write lock.
+            for migration_attempt in range(5):
+                self._db.execute("BEGIN IMMEDIATE")
+                try:
+                    self._migrate_tables()
+                    version = int(self._db.execute("PRAGMA user_version").fetchone()[0] or 0)
+                    if version < _DREAM_SCHEMA_VERSION:
+                        self._db.execute(f"PRAGMA user_version={_DREAM_SCHEMA_VERSION}")
+                    self._db.commit()
+                    break
+                except sqlite3.OperationalError:
+                    self._db.rollback()
+                    if migration_attempt == 4:
+                        raise
+                    time.sleep(0.05 * (migration_attempt + 1))
+                except BaseException:
+                    self._db.rollback()
                     raise
-                time.sleep(0.05 * (migration_attempt + 1))
-            except BaseException:
-                self._db.rollback()
-                raise
+            fcntl.flock(migration_lock.fileno(), fcntl.LOCK_UN)
 
     def _check_schema_version(self) -> None:
         """Fail startup before touching a dream DB created by newer code."""

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -750,8 +750,20 @@ class DreamRunner:
                     continue
                 if not task.done():
                     task.cancel()
+            if not run_task.done():
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(run_task), timeout=_SDK_DREAM_TEARDOWN_GRACE_S
+                    )
+                except TimeoutError:
+                    _log(
+                        "dream-runner: abandoning orphaned SDK task after bounded "
+                        f"teardown grace (task={run_task!r})"
+                    )
+                except BaseException:
+                    pass
             await asyncio.gather(
-                run_task, renewal_task, *( [deadline_task] if deadline_task else [] ),
+                renewal_task, *( [deadline_task] if deadline_task else [] ),
                 return_exceptions=True,
             )
 

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import os
 import re
@@ -74,6 +75,10 @@ _MAX_HISTORY_CHARS = 200_000
 # Bare alias only: dated Haiku 4.5 snapshots return 404 from Anthropic.
 _KG_EXTRACTION_MODEL_DEFAULT = "claude-haiku-4-5"
 
+# A single empty night can be legitimate. Three in a row is operationally
+# significant and should no longer hide behind the report-extraction fallback.
+_ZERO_REFLECTION_NOTICE_THRESHOLD = 3
+
 
 class DreamRunner:
     """Runs nightly dream consolidation sessions for agents.
@@ -91,6 +96,7 @@ class DreamRunner:
         owner_provider: Callable[[], dict] | None = None,
         setting_provider: Callable[[str], str] | None = None,
         signing_key_provider: Callable[[str], str | None] | None = None,
+        owner_notify_callback: Callable[[str, str], object] | None = None,
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
@@ -106,6 +112,7 @@ class DreamRunner:
         # Optional agent_name -> per-agent signing key resolver for daemon-internal
         # API calls. Isolated agents cannot authenticate with the fleet-wide secret.
         self._signing_key_provider = signing_key_provider
+        self._owner_notify_callback = owner_notify_callback
         self._init_tables()
 
     @property
@@ -126,7 +133,8 @@ class DreamRunner:
                 last_dream_at REAL,
                 last_summary TEXT,
                 sessions_processed INT DEFAULT 0,
-                memories_stored INT DEFAULT 0
+                memories_stored INT DEFAULT 0,
+                zero_reflection_streak INT NOT NULL DEFAULT 0
             );
             CREATE TABLE IF NOT EXISTS kg_surfaced (
                 agent_name TEXT NOT NULL,
@@ -185,6 +193,17 @@ class DreamRunner:
                 "ALTER TABLE dream_state ADD COLUMN kg_insights_notified_at REAL"
             )
             self._db.commit()
+        if "zero_reflection_streak" not in cols:
+            self._db.execute(
+                "ALTER TABLE dream_state ADD COLUMN zero_reflection_streak INT NOT NULL DEFAULT 0"
+            )
+            self._db.commit()
+
+    def set_owner_notify_callback(
+        self, callback: Callable[[str, str], object] | None
+    ) -> None:
+        """Set the callback used for owner-visible dream health notices."""
+        self._owner_notify_callback = callback
 
     def _resolve_dream_transport(self) -> str:
         """Which transport runs the dream: ``sdk`` (default) or ``tmux`` (#707).
@@ -352,9 +371,11 @@ class DreamRunner:
         # freezes for the duration of the pipeline.
 
         # Post-dream: build memory graph links for new reflections
-        await asyncio.to_thread(
+        embedded_reflections = await asyncio.to_thread(
             self._build_memory_links, agent_name, agent_config, since=dream_start
         )
+        if not run_failed:
+            await self._record_reflection_outcome(agent_name, embedded_reflections)
 
         # Post-dream: extract and store user profiles + relationships from dream output
         profile_count = await asyncio.to_thread(self._extract_user_profiles, summary)
@@ -592,7 +613,8 @@ class DreamRunner:
         """Return the full dream_state row for an agent as a dict."""
         row = self._db.execute(
             """SELECT agent_name, last_dream_at, last_summary,
-                      last_sessions_processed, last_memories_stored
+                      last_sessions_processed, last_memories_stored,
+                      zero_reflection_streak
                FROM dream_state WHERE agent_name=?""",
             (agent_name,),
         ).fetchone()
@@ -604,6 +626,7 @@ class DreamRunner:
                 "last_summary": None,
                 "last_sessions_processed": 0,
                 "last_memories_stored": 0,
+                "zero_reflection_streak": 0,
             }
 
         return {
@@ -612,13 +635,15 @@ class DreamRunner:
             "last_summary": row[2],
             "last_sessions_processed": row[3] or 0,
             "last_memories_stored": row[4] or 0,
+            "zero_reflection_streak": row[5] or 0,
         }
 
     def list_states(self) -> list[dict]:
         """Return dream_state rows for all agents that have ever dreamed."""
         rows = self._db.execute(
             """SELECT agent_name, last_dream_at, last_summary,
-                      last_sessions_processed, last_memories_stored
+                      last_sessions_processed, last_memories_stored,
+                      zero_reflection_streak
                FROM dream_state ORDER BY last_dream_at DESC""",
         ).fetchall()
         return [
@@ -628,6 +653,7 @@ class DreamRunner:
                 "last_summary": r[2],
                 "last_sessions_processed": r[3] or 0,
                 "last_memories_stored": r[4] or 0,
+                "zero_reflection_streak": r[5] or 0,
             }
             for r in rows
         ]
@@ -1163,7 +1189,7 @@ class DreamRunner:
         agent_name: str,
         agent_config,
         since: datetime,
-    ) -> None:
+    ) -> int:
         """Build cosine-similarity links between new and existing reflections.
 
         Runs after the dream SDK session. Compares reflections created during
@@ -1178,13 +1204,13 @@ class DreamRunner:
             )
         except ImportError:
             _log("dream-runner: pinky_memory not installed, skipping link build")
-            return
+            return 0
 
         work_dir = getattr(agent_config, "working_dir", "") or "."
         db_path = str(Path(work_dir).resolve() / "data" / "memory.db")
         if not Path(db_path).exists():
             _log(f"dream-runner: no memory DB at {db_path}, skipping link build")
-            return
+            return 0
 
         store = ReflectionStore(db_path=db_path)
 
@@ -1197,12 +1223,12 @@ class DreamRunner:
         new_refs = store.get_active_with_embeddings(since=since)
         if not new_refs:
             _log(f"dream-runner: no new embedded reflections for '{agent_name}', skipping links")
-            return
+            return 0
 
         # Fetch all active reflections with embeddings
         all_refs = store.get_active_with_embeddings()
         if len(all_refs) < 2:
-            return
+            return len(new_refs)
 
         # Build ID -> embedding index for all reflections
         all_ids = [r.id for r in all_refs]
@@ -1239,6 +1265,63 @@ class DreamRunner:
 
         _log(f"dream-runner: built {links_created} links for '{agent_name}' "
              f"({len(new_refs)} new reflections)")
+        return len(new_refs)
+
+    async def _record_reflection_outcome(
+        self, agent_name: str, embedded_reflections: int
+    ) -> None:
+        """Persist zero-reflection streaks and surface a threshold notice."""
+        if embedded_reflections > 0:
+            self._db.execute(
+                "UPDATE dream_state SET zero_reflection_streak=0 WHERE agent_name=?",
+                (agent_name,),
+            )
+            self._db.commit()
+            return
+
+        self._db.execute(
+            """UPDATE dream_state
+               SET zero_reflection_streak=zero_reflection_streak + 1
+               WHERE agent_name=?""",
+            (agent_name,),
+        )
+        row = self._db.execute(
+            "SELECT zero_reflection_streak FROM dream_state WHERE agent_name=?",
+            (agent_name,),
+        ).fetchone()
+        self._db.commit()
+        streak = int(row[0]) if row else 1
+        _log(
+            f"dream-runner: WARNING '{agent_name}' completed with zero embedded "
+            f"reflections ({streak} consecutive night(s))"
+        )
+
+        if streak != _ZERO_REFLECTION_NOTICE_THRESHOLD:
+            return
+
+        if self._owner_notify_callback is None:
+            _log(
+                f"dream-runner: OWNER_NOTIFY_UNAVAILABLE for zero-reflection "
+                f"alert agent '{agent_name}'"
+            )
+            return
+
+        message = (
+            f"Dream memory warning: {agent_name} completed {streak} consecutive "
+            "nights with zero embedded reflections. Verify that the dream session "
+            "can access the configured memory tools."
+        )
+        try:
+            result = self._owner_notify_callback(agent_name, message)
+            if inspect.isawaitable(result):
+                result = await result
+            if result is not True:
+                raise RuntimeError("owner notify returned no positive receipt")
+        except Exception as exc:  # noqa: BLE001 - a notice failure must not fail the dream
+            _log(
+                f"dream-runner: OWNER_NOTIFY_FAILURE for zero-reflection alert "
+                f"agent '{agent_name}': {type(exc).__name__}: {exc}"
+            )
 
     # ── Internal ─────────────────────────────────────────────
 

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -225,16 +225,23 @@ class DreamRunner:
             );
         """)
         # Serialize migration and re-check after acquiring the write lock.
-        self._db.execute("BEGIN IMMEDIATE")
-        try:
-            self._migrate_tables()
-            version = int(self._db.execute("PRAGMA user_version").fetchone()[0] or 0)
-            if version < _DREAM_SCHEMA_VERSION:
-                self._db.execute(f"PRAGMA user_version={_DREAM_SCHEMA_VERSION}")
-            self._db.commit()
-        except BaseException:
-            self._db.rollback()
-            raise
+        for migration_attempt in range(5):
+            self._db.execute("BEGIN IMMEDIATE")
+            try:
+                self._migrate_tables()
+                version = int(self._db.execute("PRAGMA user_version").fetchone()[0] or 0)
+                if version < _DREAM_SCHEMA_VERSION:
+                    self._db.execute(f"PRAGMA user_version={_DREAM_SCHEMA_VERSION}")
+                self._db.commit()
+                break
+            except sqlite3.OperationalError:
+                self._db.rollback()
+                if migration_attempt == 4:
+                    raise
+                time.sleep(0.05 * (migration_attempt + 1))
+            except BaseException:
+                self._db.rollback()
+                raise
 
     def _check_schema_version(self) -> None:
         """Fail startup before touching a dream DB created by newer code."""

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -23,8 +23,9 @@ import sys
 import threading
 import time
 from collections.abc import Callable
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import numpy as np
 
@@ -134,7 +135,19 @@ class DreamRunner:
                 last_summary TEXT,
                 sessions_processed INT DEFAULT 0,
                 memories_stored INT DEFAULT 0,
-                zero_reflection_streak INT NOT NULL DEFAULT 0
+                zero_reflection_streak INT NOT NULL DEFAULT 0,
+                last_reflection_night_key TEXT,
+                zero_reflection_alert_attempted_at REAL,
+                zero_reflection_alert_delivered_at REAL
+            );
+            CREATE TABLE IF NOT EXISTS dream_reflection_outcomes (
+                agent_name TEXT NOT NULL,
+                night_key TEXT NOT NULL,
+                embedded_reflections INT NOT NULL,
+                recorded_at REAL NOT NULL,
+                alert_attempted_at REAL,
+                alert_delivered_at REAL,
+                PRIMARY KEY (agent_name, night_key)
             );
             CREATE TABLE IF NOT EXISTS kg_surfaced (
                 agent_name TEXT NOT NULL,
@@ -198,6 +211,21 @@ class DreamRunner:
                 "ALTER TABLE dream_state ADD COLUMN zero_reflection_streak INT NOT NULL DEFAULT 0"
             )
             self._db.commit()
+        if "last_reflection_night_key" not in cols:
+            self._db.execute(
+                "ALTER TABLE dream_state ADD COLUMN last_reflection_night_key TEXT"
+            )
+            self._db.commit()
+        if "zero_reflection_alert_attempted_at" not in cols:
+            self._db.execute(
+                "ALTER TABLE dream_state ADD COLUMN zero_reflection_alert_attempted_at REAL"
+            )
+            self._db.commit()
+        if "zero_reflection_alert_delivered_at" not in cols:
+            self._db.execute(
+                "ALTER TABLE dream_state ADD COLUMN zero_reflection_alert_delivered_at REAL"
+            )
+            self._db.commit()
 
     def set_owner_notify_callback(
         self, callback: Callable[[str, str], object] | None
@@ -228,6 +256,16 @@ class DreamRunner:
                 _log(f"dream-runner: unknown PINKY_DREAM_TRANSPORT={val!r} — using sdk")
             return "sdk"
         return val
+
+    @staticmethod
+    def _night_key(agent_config, dream_start: datetime) -> str:
+        """Return the agent-local calendar night that owns one dream outcome."""
+        tz_name = getattr(agent_config, "dream_timezone", "") or "America/Los_Angeles"
+        try:
+            tz = ZoneInfo(tz_name)
+        except (KeyError, ValueError):
+            tz = timezone.utc
+        return dream_start.astimezone(tz).date().isoformat()
 
     # ── Public API ────────────────────────────────────────────
 
@@ -278,8 +316,14 @@ class DreamRunner:
             self._save_state(agent_name, summary, last_message_ts=last_message_ts)
             return summary
 
+        # Bind the run to the agent's scheduled local night once. This key is
+        # carried into the state/outcome transaction so a restart refire (or a
+        # same-night manual trigger) cannot count the outcome twice.
+        dream_start = datetime.now(timezone.utc)
+        night_key = self._night_key(agent_config, dream_start)
+
         # Build system prompt
-        today_str = date.today().isoformat()
+        today_str = night_key
         last_dream_at = self._get_last_dream_at(agent_name)
         last_dream_str = (
             datetime.fromtimestamp(last_dream_at).isoformat()
@@ -342,7 +386,6 @@ class DreamRunner:
             "Work through all phases in your system prompt and end with the report."
         )
 
-        dream_start = datetime.now(timezone.utc)
         start = time.time()
         result = await runner.run(prompt)
         elapsed = time.time() - start
@@ -356,13 +399,12 @@ class DreamRunner:
 
         _log(f"dream-runner: '{agent_name}' dream complete in {elapsed:.1f}s — {summary[:120]}")
 
-        # Only advance the watermark on success: a failed run must leave this
-        # cycle's history unprocessed so the next dream re-fetches it.
-        self._save_state(
-            agent_name,
-            summary,
-            last_message_ts=last_message_ts if run_failed else new_watermark,
-        )
+        # A failed run has no reflection outcome. Preserve the prior watermark
+        # so the next dream re-fetches this history. Successful state is held
+        # until link accounting is known, then committed atomically with the
+        # durable per-night outcome below.
+        if run_failed:
+            self._save_state(agent_name, summary, last_message_ts=last_message_ts)
 
         # The post-dream pipeline below is synchronous (blocking urllib calls
         # with retries, numpy over all embeddings). It runs on the daemon's
@@ -375,7 +417,13 @@ class DreamRunner:
             self._build_memory_links, agent_name, agent_config, since=dream_start
         )
         if not run_failed:
-            await self._record_reflection_outcome(agent_name, embedded_reflections)
+            await self._record_reflection_outcome(
+                agent_name,
+                embedded_reflections,
+                night_key=night_key,
+                summary=summary,
+                last_message_ts=new_watermark,
+            )
 
         # Post-dream: extract and store user profiles + relationships from dream output
         profile_count = await asyncio.to_thread(self._extract_user_profiles, summary)
@@ -614,7 +662,9 @@ class DreamRunner:
         row = self._db.execute(
             """SELECT agent_name, last_dream_at, last_summary,
                       last_sessions_processed, last_memories_stored,
-                      zero_reflection_streak
+                      zero_reflection_streak, last_reflection_night_key,
+                      zero_reflection_alert_attempted_at,
+                      zero_reflection_alert_delivered_at
                FROM dream_state WHERE agent_name=?""",
             (agent_name,),
         ).fetchone()
@@ -627,6 +677,9 @@ class DreamRunner:
                 "last_sessions_processed": 0,
                 "last_memories_stored": 0,
                 "zero_reflection_streak": 0,
+                "last_reflection_night_key": None,
+                "zero_reflection_alert_attempted_at": None,
+                "zero_reflection_alert_delivered_at": None,
             }
 
         return {
@@ -636,6 +689,9 @@ class DreamRunner:
             "last_sessions_processed": row[3] or 0,
             "last_memories_stored": row[4] or 0,
             "zero_reflection_streak": row[5] or 0,
+            "last_reflection_night_key": row[6],
+            "zero_reflection_alert_attempted_at": row[7],
+            "zero_reflection_alert_delivered_at": row[8],
         }
 
     def list_states(self) -> list[dict]:
@@ -643,7 +699,9 @@ class DreamRunner:
         rows = self._db.execute(
             """SELECT agent_name, last_dream_at, last_summary,
                       last_sessions_processed, last_memories_stored,
-                      zero_reflection_streak
+                      zero_reflection_streak, last_reflection_night_key,
+                      zero_reflection_alert_attempted_at,
+                      zero_reflection_alert_delivered_at
                FROM dream_state ORDER BY last_dream_at DESC""",
         ).fetchall()
         return [
@@ -654,6 +712,9 @@ class DreamRunner:
                 "last_sessions_processed": r[3] or 0,
                 "last_memories_stored": r[4] or 0,
                 "zero_reflection_streak": r[5] or 0,
+                "last_reflection_night_key": r[6],
+                "zero_reflection_alert_attempted_at": r[7],
+                "zero_reflection_alert_delivered_at": r[8],
             }
             for r in rows
         ]
@@ -1268,35 +1329,45 @@ class DreamRunner:
         return len(new_refs)
 
     async def _record_reflection_outcome(
-        self, agent_name: str, embedded_reflections: int
+        self,
+        agent_name: str,
+        embedded_reflections: int,
+        *,
+        night_key: str,
+        summary: str,
+        last_message_ts: float,
     ) -> None:
-        """Persist zero-reflection streaks and surface a threshold notice."""
-        if embedded_reflections > 0:
-            self._db.execute(
-                "UPDATE dream_state SET zero_reflection_streak=0 WHERE agent_name=?",
-                (agent_name,),
+        """Atomically persist one night's state/outcome and surface its notice."""
+        created, streak, alert_delivered = self._commit_reflection_outcome(
+            agent_name,
+            night_key,
+            embedded_reflections,
+            summary=summary,
+            last_message_ts=last_message_ts,
+        )
+        if not created:
+            _log(
+                f"dream-runner: duplicate reflection outcome ignored for "
+                f"'{agent_name}' night={night_key}"
             )
-            self._db.commit()
             return
 
-        self._db.execute(
-            """UPDATE dream_state
-               SET zero_reflection_streak=zero_reflection_streak + 1
-               WHERE agent_name=?""",
-            (agent_name,),
-        )
-        row = self._db.execute(
-            "SELECT zero_reflection_streak FROM dream_state WHERE agent_name=?",
-            (agent_name,),
-        ).fetchone()
-        self._db.commit()
-        streak = int(row[0]) if row else 1
+        if embedded_reflections > 0:
+            return
+
         _log(
             f"dream-runner: WARNING '{agent_name}' completed with zero embedded "
             f"reflections ({streak} consecutive night(s))"
         )
 
-        if streak != _ZERO_REFLECTION_NOTICE_THRESHOLD:
+        if streak < _ZERO_REFLECTION_NOTICE_THRESHOLD or alert_delivered:
+            return
+
+        # Persist the attempt before crossing the external callback boundary.
+        # A negative/no receipt leaves delivery unset, so the next distinct
+        # zero-reflection night retries. Same-night refires are stopped by the
+        # durable outcome key above and therefore cannot duplicate an attempt.
+        if not self._mark_reflection_alert_attempted(agent_name, night_key):
             return
 
         if self._owner_notify_callback is None:
@@ -1322,6 +1393,136 @@ class DreamRunner:
                 f"dream-runner: OWNER_NOTIFY_FAILURE for zero-reflection alert "
                 f"agent '{agent_name}': {type(exc).__name__}: {exc}"
             )
+            return
+
+        self._mark_reflection_alert_delivered(agent_name, night_key)
+
+    def _commit_reflection_outcome(
+        self,
+        agent_name: str,
+        night_key: str,
+        embedded_reflections: int,
+        *,
+        summary: str,
+        last_message_ts: float,
+    ) -> tuple[bool, int, bool]:
+        """Commit state and one idempotent per-night outcome in one transaction."""
+        recorded_at = time.time()
+        with self._db:
+            cursor = self._db.execute(
+                """INSERT OR IGNORE INTO dream_reflection_outcomes
+                       (agent_name, night_key, embedded_reflections, recorded_at)
+                   VALUES (?, ?, ?, ?)""",
+                (agent_name, night_key, embedded_reflections, recorded_at),
+            )
+            created = cursor.rowcount > 0
+            if created:
+                self._write_state(
+                    agent_name,
+                    summary,
+                    last_message_ts,
+                    saved_at=recorded_at,
+                )
+                self._apply_reflection_outcome(
+                    agent_name, night_key, embedded_reflections
+                )
+
+            row = self._db.execute(
+                """SELECT zero_reflection_streak,
+                          zero_reflection_alert_delivered_at
+                   FROM dream_state WHERE agent_name=?""",
+                (agent_name,),
+            ).fetchone()
+
+        if row is None:
+            raise RuntimeError(
+                f"reflection outcome ledger exists without dream state for {agent_name!r}"
+            )
+        return created, int(row[0] or 0), row[1] is not None
+
+    def _apply_reflection_outcome(
+        self, agent_name: str, night_key: str, embedded_reflections: int
+    ) -> None:
+        """Apply a newly-ledgered outcome inside the caller's transaction."""
+        if embedded_reflections > 0:
+            self._db.execute(
+                """UPDATE dream_state
+                   SET zero_reflection_streak=0,
+                       last_reflection_night_key=?,
+                       zero_reflection_alert_attempted_at=NULL,
+                       zero_reflection_alert_delivered_at=NULL
+                   WHERE agent_name=?""",
+                (night_key, agent_name),
+            )
+            return
+
+        self._db.execute(
+            """UPDATE dream_state
+               SET zero_reflection_streak=zero_reflection_streak + 1,
+                   last_reflection_night_key=?
+               WHERE agent_name=?""",
+            (night_key, agent_name),
+        )
+
+    def _mark_reflection_alert_attempted(
+        self, agent_name: str, night_key: str
+    ) -> bool:
+        """Persist one alert attempt for the current zero-reflection night."""
+        attempted_at = time.time()
+        with self._db:
+            cursor = self._db.execute(
+                """UPDATE dream_state
+                   SET zero_reflection_alert_attempted_at=?
+                   WHERE agent_name=?
+                     AND last_reflection_night_key=?
+                     AND zero_reflection_streak>=?
+                     AND zero_reflection_alert_delivered_at IS NULL""",
+                (
+                    attempted_at,
+                    agent_name,
+                    night_key,
+                    _ZERO_REFLECTION_NOTICE_THRESHOLD,
+                ),
+            )
+            if cursor.rowcount > 0:
+                self._db.execute(
+                    """UPDATE dream_reflection_outcomes
+                       SET alert_attempted_at=?
+                       WHERE agent_name=? AND night_key=?""",
+                    (attempted_at, agent_name, night_key),
+                )
+        return cursor.rowcount > 0
+
+    def _mark_reflection_alert_delivered(
+        self, agent_name: str, night_key: str
+    ) -> bool:
+        """Persist an exact positive owner-notification receipt."""
+        delivered_at = time.time()
+        with self._db:
+            self._db.execute(
+                """UPDATE dream_reflection_outcomes
+                   SET alert_delivered_at=?
+                   WHERE agent_name=? AND night_key=?
+                     AND alert_attempted_at IS NOT NULL
+                     AND alert_delivered_at IS NULL""",
+                (delivered_at, agent_name, night_key),
+            )
+            cursor = self._db.execute(
+                """UPDATE dream_state
+                   SET zero_reflection_alert_delivered_at=?
+                   WHERE agent_name=?
+                     AND last_reflection_night_key=?
+                     AND zero_reflection_streak>=?
+                     AND zero_reflection_alert_attempted_at IS NOT NULL
+                     AND zero_reflection_alert_delivered_at IS NULL""",
+                (
+                    delivered_at,
+                    agent_name,
+                    night_key,
+                    _ZERO_REFLECTION_NOTICE_THRESHOLD,
+                ),
+            )
+        return cursor.rowcount > 0
 
     # ── Internal ─────────────────────────────────────────────
 
@@ -1384,9 +1585,15 @@ class DreamRunner:
 
         return lines, new_watermark
 
-    def _save_state(self, agent_name: str, summary: str, last_message_ts: float = 0.0) -> None:
-        """Persist dream watermark and free-form summary."""
-        now = time.time()
+    def _write_state(
+        self,
+        agent_name: str,
+        summary: str,
+        last_message_ts: float,
+        *,
+        saved_at: float,
+    ) -> None:
+        """Write dream state without committing the caller's transaction."""
         self._db.execute(
             """INSERT INTO dream_state
                    (agent_name, last_dream_at, last_summary, last_message_ts)
@@ -1395,9 +1602,20 @@ class DreamRunner:
                    last_dream_at=excluded.last_dream_at,
                    last_summary=excluded.last_summary,
                    last_message_ts=excluded.last_message_ts""",
-            (agent_name, now, summary, last_message_ts),
+            (agent_name, saved_at, summary, last_message_ts),
         )
-        self._db.commit()
+
+    def _save_state(
+        self, agent_name: str, summary: str, last_message_ts: float = 0.0
+    ) -> None:
+        """Persist dream watermark and free-form summary."""
+        with self._db:
+            self._write_state(
+                agent_name,
+                summary,
+                last_message_ts,
+                saved_at=time.time(),
+            )
 
     def close(self) -> None:
         """Close the calling thread's connection, if it has opened one.

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -18,11 +18,14 @@ import inspect
 import json
 import os
 import re
+import socket
 import sqlite3
 import sys
 import threading
 import time
+import uuid
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -80,6 +83,41 @@ _KG_EXTRACTION_MODEL_DEFAULT = "claude-haiku-4-5"
 # significant and should no longer hide behind the report-extraction fallback.
 _ZERO_REFLECTION_NOTICE_THRESHOLD = 3
 
+# Receipt execution policy. The owner renews its lease while the transport is
+# live. SDK runs additionally have a 90-minute wall timeout; tmux has its own
+# one-hour cap. The renewal interval is deliberately far below the lease.
+_REFLECTION_ATTEMPT_CAP = 3
+_REFLECTION_ATTEMPT_LEASE_S = 2 * 3600
+_REFLECTION_ATTEMPT_RENEW_INTERVAL_S = 15 * 60
+_SDK_DREAM_TIMEOUT_S = 90 * 60
+_REFLECTION_RECEIPT_RETENTION_S = 30 * 24 * 3600
+_DREAM_MCP_CONFIG_RETENTION_S = 24 * 3600
+
+# The durable receipt migration removes the old reflection_rowid_floor column,
+# so the dream-state database is intentionally one-way. Schema-aware binaries
+# reject a newer database during daemon construction instead of appearing
+# healthy until the first nightly query.
+_DREAM_SCHEMA_VERSION = 1
+_DREAM_SCHEMA_MIGRATION = "durable-dream-receipts-v1"
+_DREAM_SCHEMA_MIN_CODE_VERSION = "26.08.020"
+
+
+@dataclass(frozen=True)
+class _ReflectionAttempt:
+    """Durable receipt for one history interval handed to a dream session."""
+
+    agent_name: str
+    night_key: str
+    attempt_n: int
+    dream_start: datetime
+    history_start_ts: float
+    history_end_ts: float
+    correlation_id: str
+    summary: str | None
+    runner_completed_at: float | None
+    lease_owner: str
+    lease_expires_at: float
+
 
 class DreamRunner:
     """Runs nightly dream consolidation sessions for agents.
@@ -114,6 +152,11 @@ class DreamRunner:
         # API calls. Isolated agents cannot authenticate with the fleet-wide secret.
         self._signing_key_provider = signing_key_provider
         self._owner_notify_callback = owner_notify_callback
+        self._run_locks: dict[str, asyncio.Lock] = {}
+        self._run_locks_guard = threading.Lock()
+        self._lease_owner = (
+            f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex}"
+        )
         self._init_tables()
 
     @property
@@ -128,6 +171,7 @@ class DreamRunner:
         return connection
 
     def _init_tables(self) -> None:
+        self._check_schema_version()
         self._db.executescript("""
             CREATE TABLE IF NOT EXISTS dream_state (
                 agent_name TEXT PRIMARY KEY,
@@ -145,10 +189,33 @@ class DreamRunner:
                 night_key TEXT NOT NULL,
                 embedded_reflections INT NOT NULL,
                 recorded_at REAL NOT NULL,
+                outcome_status TEXT NOT NULL DEFAULT 'completed',
                 alert_attempted_at REAL,
                 alert_delivered_at REAL,
                 PRIMARY KEY (agent_name, night_key)
             );
+            CREATE TABLE IF NOT EXISTS dream_reflection_attempts (
+                agent_name TEXT NOT NULL,
+                night_key TEXT NOT NULL,
+                attempt_n INTEGER NOT NULL,
+                status TEXT NOT NULL CHECK (status IN ('pending', 'completed', 'failed')),
+                dream_started_at TEXT NOT NULL,
+                history_start_ts REAL NOT NULL,
+                history_end_ts REAL NOT NULL,
+                correlation_id TEXT NOT NULL,
+                summary TEXT,
+                runner_completed_at REAL,
+                embedded_reflections INTEGER,
+                completed_at REAL,
+                lease_owner TEXT,
+                lease_expires_at REAL,
+                terminal INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (agent_name, night_key, attempt_n)
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS
+                idx_dream_reflection_attempts_one_pending
+                ON dream_reflection_attempts(agent_name)
+                WHERE status = 'pending';
             CREATE TABLE IF NOT EXISTS kg_surfaced (
                 agent_name TEXT NOT NULL,
                 fingerprint TEXT NOT NULL,
@@ -158,6 +225,22 @@ class DreamRunner:
         """)
         self._db.commit()
         self._migrate_tables()
+        self._db.execute(f"PRAGMA user_version={_DREAM_SCHEMA_VERSION}")
+        self._db.commit()
+
+    def _check_schema_version(self) -> None:
+        """Fail startup before touching a dream DB created by newer code."""
+        row = self._db.execute("PRAGMA user_version").fetchone()
+        version = int(row[0] or 0) if row else 0
+        if version <= _DREAM_SCHEMA_VERSION:
+            return
+        raise RuntimeError(
+            "Dream state schema is newer than this daemon "
+            f"(database={version}, supported={_DREAM_SCHEMA_VERSION}). "
+            f"Migration {_DREAM_SCHEMA_MIGRATION} requires PinkyBot "
+            f">={_DREAM_SCHEMA_MIN_CODE_VERSION}; refusing startup because "
+            "this rollback cannot safely read the migrated receipt schema."
+        )
 
     def _migrate_tables(self) -> None:
         """Apply incremental schema migrations."""
@@ -227,6 +310,46 @@ class DreamRunner:
             )
             self._db.commit()
 
+        outcome_cols = {
+            row[1]
+            for row in self._db.execute(
+                "PRAGMA table_info(dream_reflection_outcomes)"
+            ).fetchall()
+        }
+        if "outcome_status" not in outcome_cols:
+            self._db.execute(
+                "ALTER TABLE dream_reflection_outcomes "
+                "ADD COLUMN outcome_status TEXT NOT NULL DEFAULT 'completed'"
+            )
+            self._db.commit()
+
+        attempt_cols = {
+            row[1]
+            for row in self._db.execute(
+                "PRAGMA table_info(dream_reflection_attempts)"
+            ).fetchall()
+        }
+        if "reflection_rowid_floor" in attempt_cols:
+            # Round-2 review briefly used this heuristic boundary. Exact
+            # transport correlation supersedes it; drop the column so no
+            # future code can accidentally resurrect heuristic attribution.
+            self._db.execute(
+                "ALTER TABLE dream_reflection_attempts "
+                "DROP COLUMN reflection_rowid_floor"
+            )
+            self._db.commit()
+        for column, declaration in (
+            ("lease_owner", "TEXT"),
+            ("lease_expires_at", "REAL"),
+            ("terminal", "INTEGER NOT NULL DEFAULT 0"),
+        ):
+            if column not in attempt_cols:
+                self._db.execute(
+                    f"ALTER TABLE dream_reflection_attempts "
+                    f"ADD COLUMN {column} {declaration}"
+                )
+                self._db.commit()
+
     def set_owner_notify_callback(
         self, callback: Callable[[str, str], object] | None
     ) -> None:
@@ -290,7 +413,584 @@ class DreamRunner:
         elapsed = time.time() - row[0]
         return elapsed >= _DREAM_COOLDOWN_S
 
+    @staticmethod
+    def _attempt_from_row(row: tuple) -> _ReflectionAttempt:
+        return _ReflectionAttempt(
+            agent_name=row[0],
+            night_key=row[1],
+            attempt_n=int(row[2]),
+            dream_start=datetime.fromisoformat(row[3]),
+            history_start_ts=float(row[4]),
+            history_end_ts=float(row[5]),
+            correlation_id=row[6],
+            summary=row[7],
+            runner_completed_at=row[8],
+            lease_owner=row[9] or "",
+            lease_expires_at=float(row[10] or 0.0),
+        )
+
+    def _get_pending_reflection_attempt(
+        self, agent_name: str
+    ) -> _ReflectionAttempt | None:
+        row = self._db.execute(
+            """SELECT agent_name, night_key, attempt_n, dream_started_at,
+                      history_start_ts, history_end_ts, correlation_id,
+                      summary, runner_completed_at, lease_owner, lease_expires_at
+               FROM dream_reflection_attempts
+               WHERE agent_name=? AND status='pending'
+               ORDER BY dream_started_at, attempt_n LIMIT 1""",
+            (agent_name,),
+        ).fetchone()
+        return self._attempt_from_row(row) if row else None
+
+    def _get_retryable_failed_attempt(
+        self, agent_name: str
+    ) -> _ReflectionAttempt | None:
+        """Return the newest failed interval still ahead of the watermark."""
+        watermark = self._get_last_message_ts(agent_name)
+        row = self._db.execute(
+            """SELECT agent_name, night_key, attempt_n, dream_started_at,
+                      history_start_ts, history_end_ts, correlation_id,
+                      summary, runner_completed_at, lease_owner, lease_expires_at
+               FROM dream_reflection_attempts
+               WHERE agent_name=? AND status='failed' AND terminal=0
+                 AND history_end_ts>?
+               ORDER BY dream_started_at DESC, attempt_n DESC LIMIT 1""",
+            (agent_name, watermark),
+        ).fetchone()
+        return self._attempt_from_row(row) if row else None
+
+    def _night_attempt_count(self, agent_name: str, night_key: str) -> int:
+        row = self._db.execute(
+            """SELECT COUNT(*) FROM dream_reflection_attempts
+               WHERE agent_name=? AND night_key=?""",
+            (agent_name, night_key),
+        ).fetchone()
+        return int(row[0] or 0) if row else 0
+
+    def _night_is_terminal(self, agent_name: str, night_key: str) -> bool:
+        return self._db.execute(
+            """SELECT 1 FROM dream_reflection_outcomes
+               WHERE agent_name=? AND night_key=?
+                 AND outcome_status='failed-terminal'""",
+            (agent_name, night_key),
+        ).fetchone() is not None
+
+    @staticmethod
+    def _memory_db_path(agent_config) -> Path:
+        work_dir = getattr(agent_config, "working_dir", "") or "."
+        return Path(work_dir).resolve() / "data" / "memory.db"
+
+    def _reflection_ids_for_attempt(
+        self,
+        attempt: _ReflectionAttempt,
+        agent_config,
+        *,
+        embedded_only: bool = False,
+    ) -> set[str]:
+        """Return only writes carrying this receipt's enforced correlation tag."""
+        db_path = self._memory_db_path(agent_config)
+        if not db_path.exists():
+            return set()
+
+        connection = sqlite3.connect(str(db_path))
+        try:
+            columns = {
+                row[1]
+                for row in connection.execute("PRAGMA table_info(reflections)").fetchall()
+            }
+            embedded_clause = " AND active=1 AND embedding != '[]'" if embedded_only else ""
+            if "source_session_id" not in columns:
+                return set()
+            rows = connection.execute(
+                "SELECT id FROM reflections WHERE source_session_id=?"
+                + embedded_clause,
+                (attempt.correlation_id,),
+            ).fetchall()
+            return {row[0] for row in rows}
+        except sqlite3.OperationalError:
+            return set()
+        finally:
+            connection.close()
+
+    def _begin_reflection_attempt(
+        self,
+        agent_name: str,
+        night_key: str,
+        *,
+        dream_start: datetime,
+        history_start_ts: float,
+        history_end_ts: float,
+    ) -> _ReflectionAttempt | None:
+        """Persist a run intent before the SDK can call ``reflect``."""
+        lease_expires_at = time.time() + _REFLECTION_ATTEMPT_LEASE_S
+        try:
+            with self._db:
+                existing = self._get_pending_reflection_attempt(agent_name)
+                if existing is not None:
+                    return None
+                row = self._db.execute(
+                    """SELECT COALESCE(MAX(attempt_n), 0)
+                       FROM dream_reflection_attempts
+                       WHERE agent_name=? AND night_key=?""",
+                    (agent_name, night_key),
+                ).fetchone()
+                attempt_n = int(row[0] or 0) + 1
+                if attempt_n > _REFLECTION_ATTEMPT_CAP:
+                    return None
+                correlation_id = (
+                    f"dream:{agent_name}:{night_key}:{attempt_n}:{uuid.uuid4().hex}"
+                )
+                self._db.execute(
+                    """INSERT INTO dream_reflection_attempts
+                            (agent_name, night_key, attempt_n, status,
+                            dream_started_at, history_start_ts, history_end_ts,
+                            correlation_id, lease_owner, lease_expires_at)
+                       VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?)""",
+                    (
+                        agent_name,
+                        night_key,
+                        attempt_n,
+                        dream_start.isoformat(),
+                        history_start_ts,
+                        history_end_ts,
+                        correlation_id,
+                        self._lease_owner,
+                        lease_expires_at,
+                    ),
+                )
+        except sqlite3.IntegrityError:
+            # Another process won the unique pending-receipt race.
+            return None
+        return _ReflectionAttempt(
+            agent_name=agent_name,
+            night_key=night_key,
+            attempt_n=attempt_n,
+            dream_start=dream_start,
+            history_start_ts=history_start_ts,
+            history_end_ts=history_end_ts,
+            correlation_id=correlation_id,
+            summary=None,
+            runner_completed_at=None,
+            lease_owner=self._lease_owner,
+            lease_expires_at=lease_expires_at,
+        )
+
+    def _lease_owner_is_dead(self, lease_owner: str) -> bool:
+        """Return True only when a same-host lease owner is provably dead."""
+        try:
+            host, pid_text, _nonce = lease_owner.rsplit(":", 2)
+            pid = int(pid_text)
+        except (AttributeError, TypeError, ValueError):
+            return False
+        if host != socket.gethostname() or pid == os.getpid():
+            return False
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except (OSError, PermissionError):
+            return False
+        return False
+
+    def _claim_pending_reflection_attempt(
+        self, agent_name: str
+    ) -> _ReflectionAttempt | None:
+        """Atomically claim a pending receipt if its prior owner is resumable.
+
+        An unexpired live owner's receipt is never resumed. A receipt owned by
+        this runner is refreshed, while an expired or provably dead same-host
+        owner is taken over with a compare-and-swap update.
+        """
+        attempt = self._get_pending_reflection_attempt(agent_name)
+        if attempt is None:
+            return None
+        now = time.time()
+        claimable = (
+            not attempt.lease_owner
+            or attempt.lease_owner == self._lease_owner
+            or attempt.lease_expires_at <= now
+            or self._lease_owner_is_dead(attempt.lease_owner)
+        )
+        if not claimable:
+            return None
+
+        lease_expires_at = now + _REFLECTION_ATTEMPT_LEASE_S
+        with self._db:
+            cursor = self._db.execute(
+                """UPDATE dream_reflection_attempts
+                   SET lease_owner=?, lease_expires_at=?
+                   WHERE agent_name=? AND night_key=? AND attempt_n=?
+                     AND status='pending'
+                     AND COALESCE(lease_owner, '')=?
+                     AND COALESCE(lease_expires_at, 0)=?""",
+                (
+                    self._lease_owner,
+                    lease_expires_at,
+                    attempt.agent_name,
+                    attempt.night_key,
+                    attempt.attempt_n,
+                    attempt.lease_owner,
+                    attempt.lease_expires_at,
+                ),
+            )
+        if cursor.rowcount != 1:
+            return None
+        return self._get_pending_reflection_attempt(agent_name)
+
+    def _renew_reflection_attempt_lease(self, attempt: _ReflectionAttempt) -> bool:
+        """Extend a still-live receipt lease only for its exact current owner."""
+        now = time.time()
+        with self._db:
+            cursor = self._db.execute(
+                """UPDATE dream_reflection_attempts
+                   SET lease_expires_at=?
+                   WHERE agent_name=? AND night_key=? AND attempt_n=?
+                     AND status='pending' AND lease_owner=?
+                     AND COALESCE(lease_expires_at, 0)>?""",
+                (
+                    now + _REFLECTION_ATTEMPT_LEASE_S,
+                    attempt.agent_name,
+                    attempt.night_key,
+                    attempt.attempt_n,
+                    self._lease_owner,
+                    now,
+                ),
+            )
+        return cursor.rowcount == 1
+
+    async def _renew_reflection_attempt_lease_until_stopped(
+        self, attempt: _ReflectionAttempt, stopped: asyncio.Event
+    ) -> None:
+        """Renew an owned lease periodically, failing closed if ownership is lost."""
+        while True:
+            try:
+                await asyncio.wait_for(
+                    stopped.wait(), timeout=_REFLECTION_ATTEMPT_RENEW_INTERVAL_S
+                )
+                return
+            except TimeoutError:
+                if not self._renew_reflection_attempt_lease(attempt):
+                    raise RuntimeError(
+                        "dream reflection attempt lost its lease during renewal: "
+                        f"{attempt.correlation_id}"
+                    )
+
+    async def _run_with_reflection_lease(
+        self,
+        runner,
+        prompt: str,
+        attempt: _ReflectionAttempt,
+        *,
+        timeout_s: float | None,
+    ):
+        """Run one transport while renewing its receipt lease.
+
+        The lease monitor participates in the wait: if renewal loses its
+        owner-bound CAS, the live transport is cancelled before another owner
+        can legitimately proceed. SDK transports additionally carry a hard
+        wall-clock timeout.
+        """
+        stopped = asyncio.Event()
+
+        async def invoke_runner():
+            if timeout_s is None:
+                return await runner.run(prompt)
+            try:
+                return await asyncio.wait_for(runner.run(prompt), timeout=timeout_s)
+            except TimeoutError as exc:
+                raise TimeoutError(
+                    f"SDK dream run exceeded its {timeout_s:g}s wall timeout"
+                ) from exc
+
+        run_task = asyncio.create_task(invoke_runner())
+        renewal_task = asyncio.create_task(
+            self._renew_reflection_attempt_lease_until_stopped(attempt, stopped)
+        )
+        try:
+            done, _pending = await asyncio.wait(
+                {run_task, renewal_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+            if renewal_task in done:
+                # A renewal task only completes before ``stopped`` on failure.
+                renewal_task.result()
+                raise RuntimeError(
+                    "dream reflection lease renewal stopped before runner completion"
+                )
+            return run_task.result()
+        finally:
+            stopped.set()
+            for task in (run_task, renewal_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(run_task, renewal_task, return_exceptions=True)
+
+    def _prune_reflection_attempts(self, *, now: float | None = None) -> int:
+        """Prune old completed/terminal receipts; retryable failures survive."""
+        cutoff = (time.time() if now is None else now) - _REFLECTION_RECEIPT_RETENTION_S
+        with self._db:
+            cursor = self._db.execute(
+                """DELETE FROM dream_reflection_attempts
+                   WHERE (status='completed' OR terminal=1)
+                     AND completed_at < ?""",
+                (cutoff,),
+            )
+        return cursor.rowcount
+
+    @staticmethod
+    def _prune_orphaned_dream_mcp_configs(
+        work_dir: str, *, now: float | None = None
+    ) -> int:
+        """Remove per-run MCP copies left by process death more than 24h ago."""
+        dreams_dir = Path(work_dir).resolve() / "dreams"
+        if not dreams_dir.is_dir():
+            return 0
+        cutoff = (time.time() if now is None else now) - _DREAM_MCP_CONFIG_RETENTION_S
+        pruned = 0
+        for path in dreams_dir.glob(".mcp-dream-*.json"):
+            try:
+                if path.lstat().st_mtime >= cutoff:
+                    continue
+                path.unlink()
+                pruned += 1
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                _log(f"dream-runner: failed to remove orphan MCP config {path}: {exc}")
+        return pruned
+
+    @staticmethod
+    def _write_dream_mcp_config(
+        work_dir: str, correlation_id: str
+    ) -> Path | None:
+        """Copy the agent MCP config and inject structural dream correlation.
+
+        HTTP/SSE memory transports receive ``X-Dream-Correlation``. A stdio
+        memory subprocess receives the equivalent environment variable. The
+        canonical project config is never modified.
+        """
+        target: Path | None = None
+        raw_fd: int | None = None
+        target_created = False
+        try:
+            work_path = Path(work_dir).resolve()
+            source = work_path / ".mcp.json"
+            if not source.is_file():
+                return None
+            config = json.loads(source.read_text(encoding="utf-8"))
+            servers = config.get("mcpServers")
+            if not isinstance(servers, dict):
+                raise ValueError(".mcp.json has no mcpServers object")
+            memory = servers.get("pinky-memory")
+            if not isinstance(memory, dict):
+                raise ValueError(".mcp.json has no pinky-memory server")
+
+            if memory.get("url") or memory.get("type") in {"sse", "http"}:
+                headers = memory.setdefault("headers", {})
+                if not isinstance(headers, dict):
+                    raise ValueError("pinky-memory MCP headers must be an object")
+                headers["X-Dream-Correlation"] = correlation_id
+            else:
+                env = memory.setdefault("env", {})
+                if not isinstance(env, dict):
+                    raise ValueError("pinky-memory MCP env must be an object")
+                env["PINKY_DREAM_CORRELATION"] = correlation_id
+
+            dreams_dir = work_path / "dreams"
+            dreams_dir.mkdir(parents=True, exist_ok=True)
+            target = dreams_dir / f".mcp-dream-{uuid.uuid4().hex}.json"
+            raw_fd = os.open(
+                target,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+            target_created = True
+            with os.fdopen(raw_fd, "w", encoding="utf-8") as config_file:
+                raw_fd = None  # fdopen owns the descriptor now.
+                json.dump(config, config_file, indent=2)
+            return target
+        except BaseException:
+            if raw_fd is not None:
+                try:
+                    os.close(raw_fd)
+                except OSError:
+                    pass
+            if target_created and target is not None:
+                try:
+                    target.unlink(missing_ok=True)
+                except OSError as exc:
+                    _log(
+                        f"dream-runner: failed to clean partial MCP config "
+                        f"{target}: {exc}"
+                    )
+            raise
+
+    def _mark_reflection_attempt_runner_completed(
+        self, attempt: _ReflectionAttempt, summary: str
+    ) -> None:
+        """Persist SDK completion before the cross-database link scan."""
+        with self._db:
+            cursor = self._db.execute(
+                """UPDATE dream_reflection_attempts
+                   SET summary=?, runner_completed_at=?
+                   WHERE agent_name=? AND night_key=? AND attempt_n=?
+                     AND status='pending' AND lease_owner=?""",
+                (
+                    summary,
+                    time.time(),
+                    attempt.agent_name,
+                    attempt.night_key,
+                    attempt.attempt_n,
+                    self._lease_owner,
+                ),
+            )
+        if cursor.rowcount != 1:
+            raise RuntimeError(
+                f"dream reflection attempt is no longer pending: {attempt.correlation_id}"
+            )
+
+    def _fail_reflection_attempt(
+        self, attempt: _ReflectionAttempt, summary: str
+    ) -> None:
+        """Close a no-write failed attempt without advancing its watermark."""
+        failed_at = time.time()
+        with self._db:
+            cursor = self._db.execute(
+                """UPDATE dream_reflection_attempts
+                   SET status='failed', summary=?, completed_at=?
+                       , lease_owner=NULL, lease_expires_at=NULL
+                   WHERE agent_name=? AND night_key=? AND attempt_n=?
+                     AND status='pending' AND lease_owner=?""",
+                (
+                    summary,
+                    failed_at,
+                    attempt.agent_name,
+                    attempt.night_key,
+                    attempt.attempt_n,
+                    self._lease_owner,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    "dream reflection attempt lost its lease before failure: "
+                    f"{attempt.correlation_id}"
+                )
+            self._write_state(
+                attempt.agent_name,
+                summary,
+                attempt.history_start_ts,
+                saved_at=failed_at,
+            )
+
+    async def _close_failed_reflection_attempt(
+        self, attempt: _ReflectionAttempt, summary: str
+    ) -> None:
+        """Retry a no-write interval at most three times, then unblock it.
+
+        The third failure is finalized atomically as a ``failed-terminal``
+        zero-reflection night. That advances the frozen interval's watermark,
+        preserves the exception context in the receipt and summary, and lets a
+        later night's history proceed instead of wedging forever.
+        """
+        if attempt.attempt_n < _REFLECTION_ATTEMPT_CAP:
+            self._fail_reflection_attempt(attempt, summary)
+            return
+        _log(
+            f"dream-runner: WARNING terminal reflection failure for "
+            f"'{attempt.agent_name}' night={attempt.night_key} after "
+            f"{attempt.attempt_n} attempts: {summary}"
+        )
+        await self._record_reflection_outcome(
+            attempt.agent_name,
+            0,
+            night_key=attempt.night_key,
+            summary=summary,
+            last_message_ts=attempt.history_end_ts,
+            attempt_n=attempt.attempt_n,
+            outcome_status="failed-terminal",
+            terminal_attempt=True,
+        )
+
+    async def _recover_pending_reflection_attempt(
+        self, agent_name: str, agent_config
+    ) -> tuple[_ReflectionAttempt | None, str | None]:
+        """Claim and reconcile a durable receipt before any possible SDK run.
+
+        Exact tagged writes are authoritative. If a crash left any of them,
+        the interval is finalized as positive best-effort consolidation and is
+        never re-run: occasional partial dream coverage is accepted because a
+        retry would risk duplicate durable memories. A claimed no-write receipt
+        may resume its frozen interval; an active lease returns a busy result.
+        """
+        pending = self._get_pending_reflection_attempt(agent_name)
+        if pending is None:
+            return None, None
+        attempt = self._claim_pending_reflection_attempt(agent_name)
+        if attempt is None:
+            summary = (
+                "Dream reflection attempt is already running under an active lease."
+            )
+            _log(
+                f"dream-runner: active receipt lease blocks resume for "
+                f"{pending.correlation_id} owner={pending.lease_owner!r}"
+            )
+            return None, summary
+
+        produced_ids = await asyncio.to_thread(
+            self._reflection_ids_for_attempt, attempt, agent_config
+        )
+        if not produced_ids and attempt.runner_completed_at is None:
+            _log(
+                f"dream-runner: resuming no-write pending attempt "
+                f"{attempt.correlation_id}"
+            )
+            return attempt, None
+
+        await asyncio.to_thread(
+            self._build_memory_links,
+            agent_name,
+            agent_config,
+            since=attempt.dream_start,
+            attempt=attempt,
+        )
+        summary = attempt.summary or (
+            f"Recovered interrupted dream attempt {attempt.correlation_id}."
+        )
+        await self._record_reflection_outcome(
+            agent_name,
+            len(produced_ids),
+            night_key=attempt.night_key,
+            summary=summary,
+            last_message_ts=attempt.history_end_ts,
+            attempt_n=attempt.attempt_n,
+        )
+        _log(
+            f"dream-runner: reconciled pending attempt {attempt.correlation_id} "
+            f"with {len(produced_ids)} attributed reflection(s)"
+        )
+        return None, summary
+
     async def run_dream(self, agent_name: str, agent_config) -> str:
+        """Serialize all in-process dream triggers for one agent."""
+        with self._run_locks_guard:
+            lock = self._run_locks.setdefault(agent_name, asyncio.Lock())
+        async with lock:
+            work_dir = getattr(agent_config, "working_dir", "") or "."
+            orphaned = self._prune_orphaned_dream_mcp_configs(work_dir)
+            if orphaned:
+                _log(
+                    f"dream-runner: pruned {orphaned} orphaned per-run MCP "
+                    f"config(s) on entry"
+                )
+            pruned = self._prune_reflection_attempts()
+            if pruned:
+                _log(
+                    f"dream-runner: pruned {pruned} expired reflection "
+                    f"receipt(s) on entry"
+                )
+            return await self._run_dream_locked(agent_name, agent_config)
+
+    async def _run_dream_locked(self, agent_name: str, agent_config) -> str:
         """Spawn a dream SDK run for the agent and store the summary.
 
         Args:
@@ -302,25 +1002,96 @@ class DreamRunner:
         """
         _log(f"dream-runner: starting dream for '{agent_name}'")
 
-        # Fetch unprocessed conversation history
-        last_message_ts = self._get_last_message_ts(agent_name)
-        history_lines, new_watermark = self._fetch_unprocessed_history(
-            agent_name, after_ts=last_message_ts
+        # Reconcile a receipt left pending by a process death before fetching
+        # the same history again. Observable memory writes are finalized and
+        # never re-run; an intent with no writes and no SDK completion is safe
+        # to resume over its original, frozen history interval.
+        attempt, recovered_summary = await self._recover_pending_reflection_attempt(
+            agent_name, agent_config
         )
+        if recovered_summary is not None:
+            return recovered_summary
+
+        retry_interval: _ReflectionAttempt | None = None
+        if attempt is not None:
+            last_message_ts = attempt.history_start_ts
+            new_watermark = attempt.history_end_ts
+            dream_start = attempt.dream_start
+            night_key = attempt.night_key
+            history_lines, _ = self._fetch_unprocessed_history(
+                agent_name,
+                after_ts=last_message_ts,
+                through_ts=new_watermark,
+            )
+        else:
+            retry_interval = self._get_retryable_failed_attempt(agent_name)
+            if retry_interval is not None:
+                last_message_ts = retry_interval.history_start_ts
+                new_watermark = retry_interval.history_end_ts
+                night_key = retry_interval.night_key
+                history_lines, _ = self._fetch_unprocessed_history(
+                    agent_name,
+                    after_ts=last_message_ts,
+                    through_ts=new_watermark,
+                )
+            else:
+                last_message_ts = self._get_last_message_ts(agent_name)
+                history_lines, new_watermark = self._fetch_unprocessed_history(
+                    agent_name, after_ts=last_message_ts
+                )
         _log(f"dream-runner: fetched {len(history_lines)} messages since ts={last_message_ts}")
 
         if not history_lines:
             summary = "No new conversation history to process."
+            if attempt is not None:
+                await self._close_failed_reflection_attempt(attempt, summary)
+                return summary
+            current_night_key = self._night_key(
+                agent_config, datetime.now(timezone.utc)
+            )
+            completed_night = self._db.execute(
+                """SELECT 1 FROM dream_reflection_outcomes
+                   WHERE agent_name=? AND night_key=?""",
+                (agent_name, current_night_key),
+            ).fetchone()
+            if completed_night:
+                _log(
+                    f"dream-runner: true same-night duplicate rejected before "
+                    f"runner.run for '{agent_name}' night={current_night_key}"
+                )
+                return summary
             # Preserve the existing watermark; saving the default 0.0 would
             # make the next dream re-fetch and re-consolidate all history.
             self._save_state(agent_name, summary, last_message_ts=last_message_ts)
             return summary
 
-        # Bind the run to the agent's scheduled local night once. This key is
-        # carried into the state/outcome transaction so a restart refire (or a
-        # same-night manual trigger) cannot count the outcome twice.
-        dream_start = datetime.now(timezone.utc)
-        night_key = self._night_key(agent_config, dream_start)
+        if attempt is None:
+            # Persist the frozen history interval before runner.run can durably
+            # call reflect(). A failed prior attempt keeps its exact interval;
+            # history that arrived later waits behind it.
+            dream_start = datetime.now(timezone.utc)
+            if retry_interval is None:
+                night_key = self._night_key(agent_config, dream_start)
+            if self._night_is_terminal(agent_name, night_key):
+                return (
+                    f"Dream reflection attempt cap already reached for night "
+                    f"{night_key}."
+                )
+            attempt = self._begin_reflection_attempt(
+                agent_name,
+                night_key,
+                dream_start=dream_start,
+                history_start_ts=last_message_ts,
+                history_end_ts=new_watermark,
+            )
+            if attempt is None:
+                if self._night_attempt_count(agent_name, night_key) >= (
+                    _REFLECTION_ATTEMPT_CAP
+                ):
+                    return (
+                        f"Dream reflection attempt cap reached for night {night_key}."
+                    )
+                return "Dream reflection attempt is already running."
 
         # Build system prompt
         today_str = night_key
@@ -335,6 +1106,11 @@ class DreamRunner:
             today=today_str,
             last_dream_at=last_dream_str,
         )
+        system_prompt += (
+            "\n\n## Durable receipt correlation\n"
+            "For every reflect() call in this run, set source_session_id to "
+            f"{attempt.correlation_id!r}. Do not omit or change this value."
+        )
 
         # Resolve working directory (same as normal streaming session)
         work_dir = "."
@@ -344,33 +1120,6 @@ class DreamRunner:
         # Use dream_model if set, otherwise fall back to agent's main model
         dream_model = getattr(agent_config, "dream_model", "") or ""
         model = dream_model or getattr(agent_config, "model", None) or None
-
-        transport = self._resolve_dream_transport()
-        if transport == "tmux":
-            # #707: interactive tmux session on Max-account billing. The
-            # system prompt travels inside the prompt file, not as an option.
-            runner = TmuxDreamRunner(
-                TmuxDreamConfig(
-                    working_dir=work_dir,
-                    model=model,
-                    system_prompt=system_prompt,
-                    # SDK allowlist + Read/Write for the file-passing protocol
-                    allowed_tools=["Read", "Write", *_DREAM_ALLOWED_TOOLS],
-                ),
-                agent_name=agent_name,
-            )
-            _log(f"dream-runner: transport=tmux for '{agent_name}' "
-                 f"(session pinky-dream-{agent_name})")
-        else:
-            config = SDKRunnerConfig(
-                working_dir=work_dir,
-                model=model,
-                allowed_tools=_DREAM_ALLOWED_TOOLS,
-                permission_mode="bypassPermissions",
-                system_prompt=system_prompt,
-                max_turns=50,
-            )
-            runner = SDKRunner(config, agent_name=agent_name)
 
         # Build the user prompt with conversation history injected
         history_block = "\n".join(history_lines)
@@ -382,29 +1131,84 @@ class DreamRunner:
         prompt = (
             f"Process the following conversation history for agent {agent_name}. "
             f"There are {len(history_lines)} messages to consolidate.\n\n"
+            "RECEIPT REQUIREMENT: Every reflect() call in this run MUST set "
+            f"source_session_id={attempt.correlation_id!r}.\n\n"
             f"<conversation_history>\n{history_block}\n</conversation_history>\n\n"
             "Work through all phases in your system prompt and end with the report."
         )
 
+        dream_mcp_config: Path | None = None
         start = time.time()
-        result = await runner.run(prompt)
-        elapsed = time.time() - start
+        try:
+            dream_mcp_config = self._write_dream_mcp_config(
+                work_dir, attempt.correlation_id
+            )
+            transport = self._resolve_dream_transport()
+            if transport == "tmux":
+                # #707: interactive tmux session on Max-account billing. The
+                # system prompt travels inside the prompt file, not as an option.
+                runner = TmuxDreamRunner(
+                    TmuxDreamConfig(
+                        working_dir=work_dir,
+                        model=model,
+                        system_prompt=system_prompt,
+                        mcp_config=str(dream_mcp_config or ""),
+                        # SDK allowlist + Read/Write for the file-passing protocol
+                        allowed_tools=["Read", "Write", *_DREAM_ALLOWED_TOOLS],
+                    ),
+                    agent_name=agent_name,
+                )
+                timeout_s = None  # TmuxDreamRunner enforces its own one-hour cap.
+                _log(
+                    f"dream-runner: transport=tmux for '{agent_name}' "
+                    f"(session pinky-dream-{agent_name})"
+                )
+            else:
+                config = SDKRunnerConfig(
+                    working_dir=work_dir,
+                    model=model,
+                    allowed_tools=_DREAM_ALLOWED_TOOLS,
+                    permission_mode="bypassPermissions",
+                    system_prompt=system_prompt,
+                    mcp_servers=str(dream_mcp_config or ""),
+                    max_turns=50,
+                )
+                runner = SDKRunner(config, agent_name=agent_name)
+                timeout_s = _SDK_DREAM_TIMEOUT_S
 
-        summary = result.output.strip() if result.output else ""
-        run_failed = not summary or result.exit_code != 0
-        if not summary:
-            summary = f"Dream run failed or produced no output (exit={result.exit_code})"
-            if result.error:
-                summary += f": {result.error}"
+            result = await self._run_with_reflection_lease(
+                runner, prompt, attempt, timeout_s=timeout_s
+            )
+            summary = result.output.strip() if result.output else ""
+            run_failed = not summary or result.exit_code != 0
+            if not summary:
+                summary = (
+                    f"Dream run failed or produced no output "
+                    f"(exit={result.exit_code})"
+                )
+                if result.error:
+                    summary += f": {result.error}"
+        except Exception as exc:  # config/constructor/run failures consume an attempt
+            run_failed = True
+            summary = f"Dream runner raised {type(exc).__name__}: {exc}"
+        finally:
+            if dream_mcp_config is not None:
+                try:
+                    dream_mcp_config.unlink(missing_ok=True)
+                except OSError as exc:
+                    _log(
+                        f"dream-runner: failed to remove per-run MCP config "
+                        f"{dream_mcp_config}: {exc}"
+                    )
+        elapsed = time.time() - start
 
         _log(f"dream-runner: '{agent_name}' dream complete in {elapsed:.1f}s — {summary[:120]}")
 
-        # A failed run has no reflection outcome. Preserve the prior watermark
-        # so the next dream re-fetches this history. Successful state is held
-        # until link accounting is known, then committed atomically with the
-        # durable per-night outcome below.
-        if run_failed:
-            self._save_state(agent_name, summary, last_message_ts=last_message_ts)
+        # SDK completion is itself durable receipt state. If the process dies
+        # during link accounting, recovery can finalize a legitimate zero
+        # without invoking the SDK again.
+        if not run_failed:
+            self._mark_reflection_attempt_runner_completed(attempt, summary)
 
         # The post-dream pipeline below is synchronous (blocking urllib calls
         # with retries, numpy over all embeddings). It runs on the daemon's
@@ -414,16 +1218,31 @@ class DreamRunner:
 
         # Post-dream: build memory graph links for new reflections
         embedded_reflections = await asyncio.to_thread(
-            self._build_memory_links, agent_name, agent_config, since=dream_start
+            self._build_memory_links,
+            agent_name,
+            agent_config,
+            since=dream_start,
+            attempt=attempt,
         )
-        if not run_failed:
+        produced_ids = await asyncio.to_thread(
+            self._reflection_ids_for_attempt, attempt, agent_config
+        )
+        if not run_failed or produced_ids:
+            attributed_reflections = max(
+                len(produced_ids), embedded_reflections
+            )
             await self._record_reflection_outcome(
                 agent_name,
-                embedded_reflections,
+                attributed_reflections,
                 night_key=night_key,
                 summary=summary,
                 last_message_ts=new_watermark,
+                attempt_n=attempt.attempt_n,
             )
+        else:
+            # No durable reflection escaped a failed run, so retrying the same
+            # history later cannot duplicate memory side effects.
+            await self._close_failed_reflection_attempt(attempt, summary)
 
         # Post-dream: extract and store user profiles + relationships from dream output
         profile_count = await asyncio.to_thread(self._extract_user_profiles, summary)
@@ -1250,6 +2069,7 @@ class DreamRunner:
         agent_name: str,
         agent_config,
         since: datetime,
+        attempt: _ReflectionAttempt | None = None,
     ) -> int:
         """Build cosine-similarity links between new and existing reflections.
 
@@ -1267,13 +2087,12 @@ class DreamRunner:
             _log("dream-runner: pinky_memory not installed, skipping link build")
             return 0
 
-        work_dir = getattr(agent_config, "working_dir", "") or "."
-        db_path = str(Path(work_dir).resolve() / "data" / "memory.db")
-        if not Path(db_path).exists():
+        db_path = self._memory_db_path(agent_config)
+        if not db_path.exists():
             _log(f"dream-runner: no memory DB at {db_path}, skipping link build")
             return 0
 
-        store = ReflectionStore(db_path=db_path)
+        store = ReflectionStore(db_path=str(db_path))
 
         # Prune links pointing to inactive/deleted reflections
         pruned = store.prune_orphan_links()
@@ -1282,6 +2101,11 @@ class DreamRunner:
 
         # Fetch new reflections (created during this dream run)
         new_refs = store.get_active_with_embeddings(since=since)
+        if attempt is not None:
+            attributed_ids = self._reflection_ids_for_attempt(
+                attempt, agent_config, embedded_only=True
+            )
+            new_refs = [ref for ref in new_refs if ref.id in attributed_ids]
         if not new_refs:
             _log(f"dream-runner: no new embedded reflections for '{agent_name}', skipping links")
             return 0
@@ -1336,18 +2160,24 @@ class DreamRunner:
         night_key: str,
         summary: str,
         last_message_ts: float,
+        attempt_n: int | None = None,
+        outcome_status: str = "completed",
+        terminal_attempt: bool = False,
     ) -> None:
-        """Atomically persist one night's state/outcome and surface its notice."""
-        created, streak, alert_delivered = self._commit_reflection_outcome(
+        """Atomically finalize an attempt and surface a new zero-night notice."""
+        new_night, streak, alert_delivered = self._commit_reflection_outcome(
             agent_name,
             night_key,
             embedded_reflections,
             summary=summary,
             last_message_ts=last_message_ts,
+            attempt_n=attempt_n,
+            outcome_status=outcome_status,
+            terminal_attempt=terminal_attempt,
         )
-        if not created:
+        if not new_night:
             _log(
-                f"dream-runner: duplicate reflection outcome ignored for "
+                f"dream-runner: same-night reflection outcome updated for "
                 f"'{agent_name}' night={night_key}"
             )
             return
@@ -1405,27 +2235,146 @@ class DreamRunner:
         *,
         summary: str,
         last_message_ts: float,
+        attempt_n: int | None = None,
+        outcome_status: str = "completed",
+        terminal_attempt: bool = False,
     ) -> tuple[bool, int, bool]:
-        """Commit state and one idempotent per-night outcome in one transaction."""
+        """Finalize a receipt, state, and aggregate night outcome atomically.
+
+        ``embedded_reflections`` is the exact correlation-attributed count.
+        A positive partial count is deliberately final for the health signal:
+        best-effort dream consolidation accepts incomplete crash coverage and
+        never re-runs that interval because duplicate memories are worse.
+        """
         recorded_at = time.time()
         with self._db:
-            cursor = self._db.execute(
-                """INSERT OR IGNORE INTO dream_reflection_outcomes
-                       (agent_name, night_key, embedded_reflections, recorded_at)
-                   VALUES (?, ?, ?, ?)""",
-                (agent_name, night_key, embedded_reflections, recorded_at),
+            if attempt_n is not None:
+                attempt_row = self._db.execute(
+                    """SELECT status, lease_owner FROM dream_reflection_attempts
+                       WHERE agent_name=? AND night_key=? AND attempt_n=?""",
+                    (agent_name, night_key, attempt_n),
+                ).fetchone()
+                if (
+                    attempt_row is None
+                    or attempt_row[0] != "pending"
+                    or attempt_row[1] != self._lease_owner
+                ):
+                    raise RuntimeError(
+                        "dream reflection attempt cannot be finalized: "
+                        f"{agent_name}:{night_key}:{attempt_n}"
+                    )
+
+            existing = self._db.execute(
+                """SELECT embedded_reflections, outcome_status
+                   FROM dream_reflection_outcomes
+                   WHERE agent_name=? AND night_key=?""",
+                (agent_name, night_key),
+            ).fetchone()
+            new_night = existing is None
+            prior_reflections = int(existing[0]) if existing else 0
+            aggregate_reflections = prior_reflections + embedded_reflections
+            aggregate_status = (
+                "completed"
+                if aggregate_reflections > 0
+                else outcome_status
+                if new_night or outcome_status == "failed-terminal"
+                else str(existing[1])
             )
-            created = cursor.rowcount > 0
-            if created:
-                self._write_state(
-                    agent_name,
-                    summary,
-                    last_message_ts,
-                    saved_at=recorded_at,
+            if new_night:
+                self._db.execute(
+                    """INSERT INTO dream_reflection_outcomes
+                           (agent_name, night_key, embedded_reflections,
+                            recorded_at, outcome_status)
+                       VALUES (?, ?, ?, ?, ?)""",
+                    (
+                        agent_name,
+                        night_key,
+                        aggregate_reflections,
+                        recorded_at,
+                        aggregate_status,
+                    ),
                 )
+            else:
+                self._db.execute(
+                    """UPDATE dream_reflection_outcomes
+                       SET embedded_reflections=?, recorded_at=?, outcome_status=?
+                       WHERE agent_name=? AND night_key=?""",
+                    (
+                        aggregate_reflections,
+                        recorded_at,
+                        aggregate_status,
+                        agent_name,
+                        night_key,
+                    ),
+                )
+
+            watermark_row = self._db.execute(
+                "SELECT last_message_ts FROM dream_state WHERE agent_name=?",
+                (agent_name,),
+            ).fetchone()
+            durable_watermark = max(
+                float(watermark_row[0] or 0.0) if watermark_row else 0.0,
+                last_message_ts,
+            )
+            self._write_state(
+                agent_name,
+                summary,
+                durable_watermark,
+                saved_at=recorded_at,
+            )
+            if new_night:
                 self._apply_reflection_outcome(
-                    agent_name, night_key, embedded_reflections
+                    agent_name, night_key, aggregate_reflections
                 )
+            elif prior_reflections == 0 and aggregate_reflections > 0:
+                # A later same-night manual attempt produced real work. The
+                # night's aggregate is now positive, so clear its health latch.
+                self._apply_reflection_outcome(
+                    agent_name, night_key, aggregate_reflections
+                )
+
+            if attempt_n is not None:
+                if terminal_attempt:
+                    cursor = self._db.execute(
+                        """UPDATE dream_reflection_attempts
+                           SET status='failed', terminal=1, summary=?,
+                               embedded_reflections=?, completed_at=?,
+                               lease_owner=NULL, lease_expires_at=NULL
+                           WHERE agent_name=? AND night_key=? AND attempt_n=?
+                             AND status='pending' AND lease_owner=?""",
+                        (
+                            summary,
+                            embedded_reflections,
+                            recorded_at,
+                            agent_name,
+                            night_key,
+                            attempt_n,
+                            self._lease_owner,
+                        ),
+                    )
+                else:
+                    cursor = self._db.execute(
+                        """UPDATE dream_reflection_attempts
+                           SET status='completed', summary=?,
+                               embedded_reflections=?, completed_at=?,
+                               lease_owner=NULL, lease_expires_at=NULL
+                           WHERE agent_name=? AND night_key=? AND attempt_n=?
+                             AND status='pending' AND lease_owner=?""",
+                        (
+                            summary,
+                            embedded_reflections,
+                            recorded_at,
+                            agent_name,
+                            night_key,
+                            attempt_n,
+                            self._lease_owner,
+                        ),
+                    )
+                if cursor.rowcount != 1:
+                    raise RuntimeError(
+                        "dream reflection attempt lost pending status during finalize: "
+                        f"{agent_name}:{night_key}:{attempt_n}"
+                    )
 
             row = self._db.execute(
                 """SELECT zero_reflection_streak,
@@ -1438,7 +2387,7 @@ class DreamRunner:
             raise RuntimeError(
                 f"reflection outcome ledger exists without dream state for {agent_name!r}"
             )
-        return created, int(row[0] or 0), row[1] is not None
+        return new_night, int(row[0] or 0), row[1] is not None
 
     def _apply_reflection_outcome(
         self, agent_name: str, night_key: str, embedded_reflections: int
@@ -1543,7 +2492,11 @@ class DreamRunner:
         return (row[0] or 0.0) if row else 0.0
 
     def _fetch_unprocessed_history(
-        self, agent_name: str, after_ts: float = 0.0
+        self,
+        agent_name: str,
+        after_ts: float = 0.0,
+        *,
+        through_ts: float | None = None,
     ) -> tuple[list[str], float]:
         """Fetch all conversation messages since the last watermark.
 
@@ -1562,7 +2515,15 @@ class DreamRunner:
             return [], after_ts
 
         # Filter to messages after the watermark
-        new_msgs = [m for m in messages if (m.get("timestamp") or 0) > after_ts]
+        new_msgs = [
+            m
+            for m in messages
+            if (m.get("timestamp") or 0) > after_ts
+            and (
+                through_ts is None
+                or (m.get("timestamp") or 0) <= through_ts
+            )
+        ]
         if not new_msgs:
             return [], after_ts
 

--- a/src/pinky_daemon/sdk_runner.py
+++ b/src/pinky_daemon/sdk_runner.py
@@ -32,8 +32,8 @@ class SDKRunnerConfig:
     # Model selection
     model: str | None = None
 
-    # MCP servers (dict of name -> config)
-    mcp_servers: dict = field(default_factory=dict)
+    # MCP servers (dict of name -> config, or an explicit --mcp-config path)
+    mcp_servers: dict | str = field(default_factory=dict)
 
     # Tool permissions (outreach removed — broker handles messaging)
     allowed_tools: list[str] = field(default_factory=lambda: [

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -36,11 +36,19 @@ def _log(msg: str) -> None:
 # Set by ASGI middleware in shared mode, read by tool functions.
 # In stdio mode this stays at default ("") and tools use their closure variable.
 _current_agent: ContextVar[str] = ContextVar("current_agent", default="")
+_current_dream_correlation: ContextVar[str] = ContextVar(
+    "current_dream_correlation", default=""
+)
 
 
 def get_current_agent() -> str:
     """Get the current agent name from ContextVar (shared mode)."""
     return _current_agent.get()
+
+
+def get_current_dream_correlation() -> str:
+    """Return the transport-enforced correlation for a dream MCP request."""
+    return _current_dream_correlation.get()
 
 
 def make_agent_name_resolver(closure_agent_name: str):
@@ -442,6 +450,7 @@ class AgentNameMiddleware:
             return
         headers = dict(scope.get("headers", []))
         agent_name = headers.get(b"x-agent-name", b"").decode()
+        dream_correlation = headers.get(b"x-dream-correlation", b"").decode()
         valid_name = bool(agent_name and _AGENT_NAME_RE.match(agent_name))
         auth = headers.get(b"authorization", b"").decode()
         bearer = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
@@ -478,11 +487,13 @@ class AgentNameMiddleware:
             return
 
         if valid_name:
-            token = _current_agent.set(agent_name)
+            agent_token = _current_agent.set(agent_name)
+            correlation_token = _current_dream_correlation.set(dream_correlation)
             try:
                 await self.app(scope, receive, send)
             finally:
-                _current_agent.reset(token)
+                _current_dream_correlation.reset(correlation_token)
+                _current_agent.reset(agent_token)
             return
         await self.app(scope, receive, send)
 

--- a/src/pinky_daemon/tmux_dream_runner.py
+++ b/src/pinky_daemon/tmux_dream_runner.py
@@ -67,7 +67,7 @@ class TmuxDreamConfig:
     # instructions, so file-level delivery is equivalent in practice).
     system_prompt: str = ""
 
-    # PRIMARY tool boundary (Murzik, #708 review): the dream prompt embeds raw
+    # PRIMARY tool boundary (#708 review): the dream prompt embeds raw
     # conversation history, so an injection there must not reach a broad
     # interactive tool surface. Mirror the SDK path's allowlist semantics
     # (--allowedTools + bypassPermissions), widened only by Read (prompt file)

--- a/src/pinky_daemon/tmux_dream_runner.py
+++ b/src/pinky_daemon/tmux_dream_runner.py
@@ -67,6 +67,10 @@ class TmuxDreamConfig:
     # instructions, so file-level delivery is equivalent in practice).
     system_prompt: str = ""
 
+    # Explicit per-run MCP config. DreamRunner uses this to inject the durable
+    # correlation header without mutating the agent's canonical .mcp.json.
+    mcp_config: str = ""
+
     # PRIMARY tool boundary (#708 review): the dream prompt embeds raw
     # conversation history, so an injection there must not reach a broad
     # interactive tool surface. Mirror the SDK path's allowlist semantics
@@ -187,7 +191,11 @@ class TmuxDreamRunner:
         cmd = [self._resolve_binary()]
         if self._config.model:
             cmd += ["--model", self._config.model]
-        mcp_config = work_dir / ".mcp.json"
+        mcp_config = (
+            Path(self._config.mcp_config).resolve()
+            if self._config.mcp_config
+            else work_dir / ".mcp.json"
+        )
         if mcp_config.is_file():
             cmd += ["--mcp-config", str(mcp_config)]
         cmd += ["--permission-mode", "bypassPermissions"]

--- a/src/pinky_daemon/tmux_dream_runner.py
+++ b/src/pinky_daemon/tmux_dream_runner.py
@@ -187,6 +187,9 @@ class TmuxDreamRunner:
         cmd = [self._resolve_binary()]
         if self._config.model:
             cmd += ["--model", self._config.model]
+        mcp_config = work_dir / ".mcp.json"
+        if mcp_config.is_file():
+            cmd += ["--mcp-config", str(mcp_config)]
         cmd += ["--permission-mode", "bypassPermissions"]
         if self._config.allowed_tools:
             cmd += ["--allowedTools", ",".join(self._config.allowed_tools)]

--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -213,6 +213,20 @@ def create_server(
         Shared by ``reflect`` (own store) and ``reflect_for`` (target store)
         so the storage path is identical regardless of destination.
         """
+        # Dream receipts are a transport contract, not a model instruction.
+        # Shared HTTP/SSE requests receive the value from authenticated ASGI
+        # request context; per-run stdio servers receive the equivalent env
+        # override. Either one supersedes model-provided tool arguments.
+        from pinky_daemon.shared_mcp import (
+            get_current_agent,
+            get_current_dream_correlation,
+        )
+
+        enforced_source_session_id = get_current_dream_correlation()
+        if not enforced_source_session_id and not get_current_agent():
+            enforced_source_session_id = os.environ.get(
+                "PINKY_DREAM_CORRELATION", ""
+            ).strip()
         embedding = _safe_embed(embedder, input_data.content, "reflect")
         ref = Reflection(
             type=input_data.type,
@@ -222,7 +236,9 @@ def create_server(
             salience=input_data.salience,
             supersedes=input_data.supersedes,
             entities=input_data.entities,
-            source_session_id=input_data.source_session_id,
+            source_session_id=(
+                enforced_source_session_id or input_data.source_session_id
+            ),
             source_channel=input_data.source_channel,
             source_message_ids=input_data.source_message_ids,
             embedding=embedding,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7928,6 +7928,10 @@ class TestBuildStreamingWakeContextReasonGating:
         one-shot drop) routes to the durable #863 owner destination."""
         with tempfile.TemporaryDirectory() as tmpdir:
             app = self._make_app(os.path.join(tmpdir, "test.db"))
+            assert (
+                app.state.dream_runner._owner_notify_callback
+                is app.state.scheduler._owner_notify_callback
+            )
             app.state.agents.register("dymok", model="sonnet")
             app.state.agents.set_token(
                 "dymok", "telegram", "token", settings={"account_id": "acct-1"},

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sqlite3
@@ -11,12 +12,14 @@ import time
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timezone
+from pathlib import Path
 from urllib.parse import urlsplit
 
 import pytest
 from fastapi.testclient import TestClient
 
+import pinky_daemon.dream_runner as dream_runner_module
 from pinky_daemon.api import create_api
 from pinky_daemon.dream_runner import DreamRunner
 
@@ -679,7 +682,9 @@ class TestDreamReflectionLoudness:
         reopened.close()
 
     @pytest.mark.asyncio
-    async def test_same_night_refire_is_idempotent(self, tmp_path):
+    async def test_same_night_zero_updates_watermark_without_double_counting(
+        self, tmp_path
+    ):
         db_path = str(tmp_path / "dream.db")
         runner = DreamRunner(db_path=db_path)
 
@@ -692,10 +697,983 @@ class TestDreamReflectionLoudness:
         state = runner.get_state("pinky")
         assert state["zero_reflection_streak"] == 1
         assert state["last_summary"] == "night 2026-08-12"
-        assert runner._get_last_message_ts("pinky") == 1.0
+        assert runner._get_last_message_ts("pinky") == 2.0
         assert runner._db.execute(
             "SELECT COUNT(*) FROM dream_reflection_outcomes"
         ).fetchone()[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_cross_db_crash_recovers_reflection_without_rerunning(
+        self, tmp_path, monkeypatch
+    ):
+        from pinky_daemon.claude_runner import RunResult
+        from pinky_memory.store import ReflectionStore
+        from pinky_memory.types import Reflection
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        memory_dir = tmp_path / "data"
+        memory_dir.mkdir()
+        memory_db = memory_dir / "memory.db"
+        sdk_calls = {"n": 0}
+
+        class ReflectingSDKRunner:
+            def __init__(self, config, agent_name=""):
+                self.config = config
+                self.agent_name = agent_name
+
+            async def run(self, prompt):
+                sdk_calls["n"] += 1
+                correlation_id = prompt.split("source_session_id='", 1)[1].split(
+                    "'", 1
+                )[0]
+                store = ReflectionStore(db_path=str(memory_db))
+                store.insert(
+                    Reflection(
+                        content="durable first-attempt reflection",
+                        embedding=[1.0, 0.0],
+                        source_session_id=correlation_id,
+                    )
+                )
+                store.close()
+                return RunResult(output="Consolidated.", exit_code=0)
+
+        monkeypatch.setattr(
+            "pinky_daemon.dream_runner.SDKRunner", ReflectingSDKRunner
+        )
+        monkeypatch.setattr(
+            DreamRunner,
+            "_night_key",
+            staticmethod(lambda agent_config, dream_start: "2026-08-12"),
+        )
+        messages = [
+            {"timestamp": 200.0, "role": "user", "content": "new context"}
+        ]
+        db_path = str(tmp_path / "dream.db")
+        runner = DreamRunner(
+            db_path=db_path,
+            history_provider=lambda agent, after_ts, limit, role: messages,
+        )
+        runner._save_state("pinky", "seed", last_message_ts=100.0)
+
+        async def crash_before_finalize(*args, **kwargs):
+            raise RuntimeError("simulated crash after durable reflect")
+
+        monkeypatch.setattr(
+            runner, "_record_reflection_outcome", crash_before_finalize
+        )
+        with pytest.raises(RuntimeError, match="after durable reflect"):
+            await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        assert runner._get_last_message_ts("pinky") == 100.0
+        assert runner._db.execute(
+            """SELECT status FROM dream_reflection_attempts
+               WHERE agent_name='pinky'"""
+        ).fetchone()[0] == "pending"
+        # A simulated process death must make the old owner's lease stale;
+        # live/unexpired owners are deliberately not recoverable.
+        runner._db.execute(
+            """UPDATE dream_reflection_attempts
+               SET lease_expires_at=0 WHERE agent_name='pinky'"""
+        )
+        runner._db.commit()
+        runner.close()
+
+        reopened = DreamRunner(
+            db_path=db_path,
+            history_provider=lambda agent, after_ts, limit, role: messages,
+        )
+        summary = await reopened.run_dream(
+            "pinky", _DreamAgentConfig(str(tmp_path))
+        )
+
+        assert summary == "Consolidated."
+        assert sdk_calls["n"] == 1
+        with sqlite3.connect(memory_db) as memory_connection:
+            assert memory_connection.execute(
+                "SELECT COUNT(*) FROM reflections"
+            ).fetchone()[0] == 1
+        assert reopened._get_last_message_ts("pinky") == 200.0
+        assert reopened.get_state("pinky")["zero_reflection_streak"] == 0
+        assert reopened._db.execute(
+            """SELECT embedded_reflections FROM dream_reflection_outcomes
+               WHERE agent_name='pinky' AND night_key='2026-08-12'"""
+        ).fetchone()[0] == 1
+        assert reopened._db.execute(
+            """SELECT status, embedded_reflections
+               FROM dream_reflection_attempts WHERE agent_name='pinky'"""
+        ).fetchone() == ("completed", 1)
+        reopened.close()
+
+    @pytest.mark.asyncio
+    async def test_same_night_new_history_updates_outcome_and_resets_latch(
+        self, tmp_path, monkeypatch
+    ):
+        from pinky_daemon.claude_runner import RunResult
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        monkeypatch.setattr("pinky_daemon.dream_runner.SDKRunner", _StubSDKRunner)
+        _StubSDKRunner.result = RunResult(output="Consolidated.", exit_code=0)
+        monkeypatch.setattr(
+            DreamRunner,
+            "_night_key",
+            staticmethod(lambda agent_config, dream_start: "2026-08-12"),
+        )
+
+        messages = [
+            {"timestamp": 100.0, "role": "user", "content": "first batch"}
+        ]
+        notices: list[str] = []
+
+        async def owner_notify(agent_name: str, message: str) -> bool:
+            notices.append(message)
+            return True
+
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            history_provider=lambda agent, after_ts, limit, role: list(messages),
+            owner_notify_callback=owner_notify,
+        )
+        await self._record_night(runner, "2026-08-10", 0, 1)
+        await self._record_night(runner, "2026-08-11", 0, 2)
+        link_counts = iter((0, 2))
+        monkeypatch.setattr(
+            runner,
+            "_build_memory_links",
+            lambda *args, **kwargs: next(link_counts),
+        )
+
+        await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+        latched = runner.get_state("pinky")
+        assert latched["zero_reflection_streak"] == 3
+        assert latched["zero_reflection_alert_delivered_at"] is not None
+
+        messages.append(
+            {"timestamp": 200.0, "role": "user", "content": "manual new batch"}
+        )
+        await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        state = runner.get_state("pinky")
+        assert runner._get_last_message_ts("pinky") == 200.0
+        assert state["zero_reflection_streak"] == 0
+        assert state["zero_reflection_alert_attempted_at"] is None
+        assert state["zero_reflection_alert_delivered_at"] is None
+        assert len(notices) == 1
+        assert runner._db.execute(
+            """SELECT embedded_reflections FROM dream_reflection_outcomes
+               WHERE agent_name='pinky' AND night_key='2026-08-12'"""
+        ).fetchone()[0] == 2
+        assert runner._db.execute(
+            """SELECT status, embedded_reflections
+               FROM dream_reflection_attempts
+               WHERE agent_name='pinky' AND night_key='2026-08-12'
+               ORDER BY attempt_n"""
+        ).fetchall() == [("completed", 0), ("completed", 2)]
+
+    @pytest.mark.asyncio
+    async def test_true_same_night_duplicate_has_no_runner_or_link_side_effects(
+        self, tmp_path, monkeypatch
+    ):
+        from pinky_daemon.claude_runner import RunResult
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        monkeypatch.setattr("pinky_daemon.dream_runner.SDKRunner", _StubSDKRunner)
+        _StubSDKRunner.result = RunResult(output="Consolidated.", exit_code=0)
+        monkeypatch.setattr(
+            DreamRunner,
+            "_night_key",
+            staticmethod(lambda agent_config, dream_start: "2026-08-12"),
+        )
+        sdk_calls = {"n": 0}
+        link_calls = {"n": 0}
+
+        async def counted_run(self, prompt):
+            sdk_calls["n"] += 1
+            return type(self).result
+
+        monkeypatch.setattr(_StubSDKRunner, "run", counted_run)
+        messages = [
+            {"timestamp": 100.0, "role": "user", "content": "only batch"}
+        ]
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            history_provider=lambda agent, after_ts, limit, role: messages,
+        )
+
+        def counted_links(*args, **kwargs):
+            link_calls["n"] += 1
+            return 1
+
+        monkeypatch.setattr(runner, "_build_memory_links", counted_links)
+
+        await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+        before = runner.get_state("pinky")
+        duplicate_summary = await runner.run_dream(
+            "pinky", _DreamAgentConfig(str(tmp_path))
+        )
+
+        assert duplicate_summary == "No new conversation history to process."
+        assert sdk_calls["n"] == 1
+        assert link_calls["n"] == 1
+        assert runner.get_state("pinky") == before
+        assert runner._db.execute(
+            "SELECT COUNT(*) FROM dream_reflection_attempts"
+        ).fetchone()[0] == 1
+        assert runner._db.execute(
+            "SELECT COUNT(*) FROM dream_reflection_outcomes"
+        ).fetchone()[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_overlapping_triggers_run_sdk_once(self, tmp_path, monkeypatch):
+        from pinky_daemon.claude_runner import RunResult
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        sdk_calls = {"n": 0}
+
+        class BlockingSDKRunner:
+            def __init__(self, config, agent_name=""):
+                self.config = config
+
+            async def run(self, prompt):
+                sdk_calls["n"] += 1
+                entered.set()
+                await release.wait()
+                return RunResult(output="Consolidated.", exit_code=0)
+
+        monkeypatch.setattr(
+            "pinky_daemon.dream_runner.SDKRunner", BlockingSDKRunner
+        )
+        messages = [
+            {"timestamp": 200.0, "role": "user", "content": "one interval"}
+        ]
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            history_provider=lambda agent, after_ts, limit, role: messages,
+        )
+
+        trigger_a = asyncio.create_task(
+            runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+        )
+        await entered.wait()
+        trigger_b = asyncio.create_task(
+            runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+        )
+        await asyncio.sleep(0)
+        assert sdk_calls["n"] == 1
+
+        release.set()
+        assert await trigger_a == "Consolidated."
+        assert await trigger_b == "No new conversation history to process."
+        assert sdk_calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_pending_lease_takeover_requires_expiry(self, tmp_path, monkeypatch):
+        from pinky_daemon.claude_runner import RunResult
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        messages = [
+            {"timestamp": 200.0, "role": "user", "content": "leased interval"}
+        ]
+        db_path = str(tmp_path / "dream.db")
+        owner = DreamRunner(
+            db_path=db_path,
+            history_provider=lambda agent, after_ts, limit, role: messages,
+        )
+        owner._save_state("pinky", "seed", last_message_ts=100.0)
+        receipt = owner._begin_reflection_attempt(
+            "pinky",
+            "2026-08-12",
+            dream_start=datetime.now(timezone.utc),
+            history_start_ts=100.0,
+            history_end_ts=200.0,
+        )
+        assert receipt is not None
+
+        calls = {"n": 0}
+
+        class CountedSDKRunner:
+            def __init__(self, config, agent_name=""):
+                self.config = config
+
+            async def run(self, prompt):
+                calls["n"] += 1
+                return RunResult(output="Consolidated.", exit_code=0)
+
+        monkeypatch.setattr(
+            "pinky_daemon.dream_runner.SDKRunner", CountedSDKRunner
+        )
+        contender = DreamRunner(
+            db_path=db_path,
+            history_provider=lambda agent, after_ts, limit, role: messages,
+        )
+        blocked = await contender.run_dream(
+            "pinky", _DreamAgentConfig(str(tmp_path))
+        )
+        assert "active lease" in blocked
+        assert calls["n"] == 0
+
+        owner._db.execute(
+            "UPDATE dream_reflection_attempts SET lease_expires_at=0"
+        )
+        owner._db.commit()
+        assert await contender.run_dream(
+            "pinky", _DreamAgentConfig(str(tmp_path))
+        ) == "Consolidated."
+        assert calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_live_runner_periodically_extends_lease_and_blocks_contender(
+        self, tmp_path, monkeypatch
+    ):
+        from pinky_daemon.claude_runner import RunResult
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        monkeypatch.setattr(dream_runner_module, "_REFLECTION_ATTEMPT_LEASE_S", 5.0)
+        monkeypatch.setattr(
+            dream_runner_module, "_REFLECTION_ATTEMPT_RENEW_INTERVAL_S", 0.02
+        )
+        monkeypatch.setattr(dream_runner_module, "_SDK_DREAM_TIMEOUT_S", 2.0)
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        calls = {"n": 0}
+
+        class BlockingSDKRunner:
+            def __init__(self, config, agent_name=""):
+                self.config = config
+
+            async def run(self, prompt):
+                calls["n"] += 1
+                entered.set()
+                await release.wait()
+                return RunResult(output="Consolidated.", exit_code=0)
+
+        monkeypatch.setattr(
+            "pinky_daemon.dream_runner.SDKRunner", BlockingSDKRunner
+        )
+        messages = [
+            {"timestamp": 200.0, "role": "user", "content": "long live interval"}
+        ]
+        db_path = str(tmp_path / "dream.db")
+        owner = DreamRunner(
+            db_path=db_path,
+            history_provider=lambda agent, after_ts, limit, role: messages,
+        )
+        contender = DreamRunner(
+            db_path=db_path,
+            history_provider=lambda agent, after_ts, limit, role: messages,
+        )
+
+        owner_task = asyncio.create_task(
+            owner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+        )
+        await entered.wait()
+        original_expiry = owner._db.execute(
+            "SELECT lease_expires_at FROM dream_reflection_attempts"
+        ).fetchone()[0]
+        renewed_expiry = original_expiry
+        async with asyncio.timeout(2.0):
+            while renewed_expiry <= original_expiry:
+                await asyncio.sleep(0.01)
+                renewed_expiry = owner._db.execute(
+                    "SELECT lease_expires_at FROM dream_reflection_attempts"
+                ).fetchone()[0]
+        assert renewed_expiry > original_expiry
+        assert renewed_expiry > time.time()
+
+        blocked = await contender.run_dream(
+            "pinky", _DreamAgentConfig(str(tmp_path))
+        )
+        assert "active lease" in blocked
+        assert calls["n"] == 1
+
+        release.set()
+        assert await owner_task == "Consolidated."
+        assert calls["n"] == 1
+
+    def test_owner_renewal_prevents_takeover_past_original_expiry(
+        self, tmp_path, monkeypatch
+    ):
+        clock = {"now": 1_000.0}
+        monkeypatch.setattr(dream_runner_module.time, "time", lambda: clock["now"])
+        monkeypatch.setattr(dream_runner_module, "_REFLECTION_ATTEMPT_LEASE_S", 120.0)
+        db_path = str(tmp_path / "dream.db")
+        owner = DreamRunner(db_path=db_path)
+        attempt = owner._begin_reflection_attempt(
+            "pinky",
+            "2026-08-12",
+            dream_start=datetime.now(timezone.utc),
+            history_start_ts=100.0,
+            history_end_ts=200.0,
+        )
+        assert attempt is not None
+        original_expiry = attempt.lease_expires_at
+
+        clock["now"] = original_expiry - 1.0
+        assert owner._renew_reflection_attempt_lease(attempt) is True
+        renewed_expiry = owner._db.execute(
+            "SELECT lease_expires_at FROM dream_reflection_attempts"
+        ).fetchone()[0]
+        assert renewed_expiry > original_expiry
+
+        clock["now"] = original_expiry + 1.0
+        contender = DreamRunner(db_path=db_path)
+        assert contender._claim_pending_reflection_attempt("pinky") is None
+        assert owner._db.execute(
+            "SELECT lease_owner, lease_expires_at FROM dream_reflection_attempts"
+        ).fetchone() == (owner._lease_owner, renewed_expiry)
+
+    @pytest.mark.asyncio
+    async def test_sdk_wall_timeout_is_failed_attempt_and_cancels_run(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        monkeypatch.setattr(dream_runner_module, "_SDK_DREAM_TIMEOUT_S", 0.03)
+        cancelled = asyncio.Event()
+
+        class HangingSDKRunner:
+            def __init__(self, config, agent_name=""):
+                self.config = config
+
+            async def run(self, prompt):
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    cancelled.set()
+
+        monkeypatch.setattr(
+            "pinky_daemon.dream_runner.SDKRunner", HangingSDKRunner
+        )
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            history_provider=lambda agent, after_ts, limit, role: [
+                {"timestamp": 200.0, "role": "user", "content": "hung interval"}
+            ],
+        )
+
+        summary = await runner.run_dream(
+            "pinky", _DreamAgentConfig(str(tmp_path))
+        )
+
+        assert "TimeoutError" in summary
+        assert "0.03s wall timeout" in summary
+        assert cancelled.is_set()
+        assert runner._db.execute(
+            "SELECT attempt_n, status, terminal FROM dream_reflection_attempts"
+        ).fetchone() == (1, "failed", 0)
+
+    @pytest.mark.asyncio
+    async def test_untagged_window_never_proves_completion_and_cap_unblocks_next_night(
+        self, tmp_path, monkeypatch
+    ):
+        from pinky_daemon.claude_runner import RunResult
+        from pinky_memory.store import ReflectionStore
+        from pinky_memory.types import Reflection
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        memory_dir = tmp_path / "data"
+        memory_dir.mkdir()
+        memory_db = memory_dir / "memory.db"
+        messages = [
+            {"timestamp": 200.0, "role": "user", "content": "frozen interval"}
+        ]
+        night_keys = iter(("2026-08-12", "2026-08-13"))
+        monkeypatch.setattr(
+            DreamRunner,
+            "_night_key",
+            staticmethod(lambda agent_config, dream_start: next(night_keys)),
+        )
+
+        class SimulatedProcessDeath(BaseException):
+            pass
+
+        class DyingSDKRunner:
+            def __init__(self, config, agent_name=""):
+                self.config = config
+
+            async def run(self, prompt):
+                raise SimulatedProcessDeath("pre-write process death")
+
+        monkeypatch.setattr(
+            "pinky_daemon.dream_runner.SDKRunner", DyingSDKRunner
+        )
+        db_path = str(tmp_path / "dream.db")
+        runner = DreamRunner(
+            db_path=db_path,
+            history_provider=lambda agent, after_ts, limit, role: list(messages),
+        )
+        runner._save_state("pinky", "seed", last_message_ts=100.0)
+        with pytest.raises(SimulatedProcessDeath):
+            await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        store = ReflectionStore(db_path=str(memory_db))
+        unrelated = store.insert(
+            Reflection(content="ordinary untagged memory", embedding=[1.0, 0.0])
+        )
+        store.close()
+        runner._db.execute(
+            "UPDATE dream_reflection_attempts SET lease_expires_at=0"
+        )
+        runner._db.commit()
+        runner.close()
+
+        results = iter(
+            (
+                RunResult(output="", exit_code=1, error="boom one"),
+                RunResult(output="", exit_code=1, error="boom two"),
+                RunResult(output="", exit_code=1, error="boom three"),
+                RunResult(output="Consolidated next night.", exit_code=0),
+            )
+        )
+
+        class RetryingSDKRunner:
+            def __init__(self, config, agent_name=""):
+                self.config = config
+
+            async def run(self, prompt):
+                return next(results)
+
+        monkeypatch.setattr(
+            "pinky_daemon.dream_runner.SDKRunner", RetryingSDKRunner
+        )
+        reopened = DreamRunner(
+            db_path=db_path,
+            history_provider=lambda agent, after_ts, limit, role: list(messages),
+        )
+        for _ in range(3):
+            await reopened.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        assert reopened._get_last_message_ts("pinky") == 200.0
+        outcome = reopened._db.execute(
+            """SELECT embedded_reflections, outcome_status
+               FROM dream_reflection_outcomes
+               WHERE agent_name='pinky' AND night_key='2026-08-12'"""
+        ).fetchone()
+        assert outcome == (0, "failed-terminal")
+        assert reopened._db.execute(
+            """SELECT status, terminal FROM dream_reflection_attempts
+               WHERE night_key='2026-08-12' ORDER BY attempt_n"""
+        ).fetchall() == [("failed", 0), ("failed", 0), ("failed", 1)]
+        with sqlite3.connect(memory_db) as connection:
+            assert connection.execute(
+                "SELECT source_session_id FROM reflections WHERE id=?",
+                (unrelated.id,),
+            ).fetchone()[0] is None
+
+        messages.append(
+            {"timestamp": 300.0, "role": "user", "content": "next night interval"}
+        )
+        assert await reopened.run_dream(
+            "pinky", _DreamAgentConfig(str(tmp_path))
+        ) == "Consolidated next night."
+        assert reopened._get_last_message_ts("pinky") == 300.0
+
+    @pytest.mark.asyncio
+    async def test_mixed_tagged_and_untagged_counts_only_exact_tag(
+        self, tmp_path, monkeypatch
+    ):
+        from pinky_daemon.claude_runner import RunResult
+        from pinky_memory.store import ReflectionStore
+        from pinky_memory.types import Reflection
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        memory_dir = tmp_path / "data"
+        memory_dir.mkdir()
+        memory_db = memory_dir / "memory.db"
+        messages = [
+            {"timestamp": 200.0, "role": "user", "content": "first interval"}
+        ]
+        calls = {"n": 0}
+
+        class MixedSDKRunner:
+            def __init__(self, config, agent_name=""):
+                self.config = config
+
+            async def run(self, prompt):
+                calls["n"] += 1
+                correlation_id = prompt.split("source_session_id='", 1)[1].split(
+                    "'", 1
+                )[0]
+                store = ReflectionStore(db_path=str(memory_db))
+                store.insert(
+                    Reflection(
+                        content=f"tagged {calls['n']}",
+                        embedding=[1.0, 0.0],
+                        source_session_id=correlation_id,
+                    )
+                )
+                store.insert(
+                    Reflection(
+                        content=f"untagged {calls['n']}", embedding=[1.0, 0.0]
+                    )
+                )
+                store.close()
+                return RunResult(
+                    output="partial",
+                    exit_code=1 if calls["n"] == 1 else 0,
+                    error="crash after mixed writes" if calls["n"] == 1 else "",
+                )
+
+        monkeypatch.setattr(
+            "pinky_daemon.dream_runner.SDKRunner", MixedSDKRunner
+        )
+        monkeypatch.setattr(
+            DreamRunner,
+            "_night_key",
+            staticmethod(lambda agent_config, dream_start: "2026-08-12"),
+        )
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            history_provider=lambda agent, after_ts, limit, role: list(messages),
+        )
+
+        assert await runner.run_dream(
+            "pinky", _DreamAgentConfig(str(tmp_path))
+        ) == "partial"
+        messages.append(
+            {"timestamp": 300.0, "role": "user", "content": "later interval"}
+        )
+        await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        assert runner._db.execute(
+            """SELECT embedded_reflections FROM dream_reflection_attempts
+               ORDER BY attempt_n"""
+        ).fetchall() == [(1,), (1,)]
+        assert runner._db.execute(
+            """SELECT embedded_reflections FROM dream_reflection_outcomes
+               WHERE agent_name='pinky' AND night_key='2026-08-12'"""
+        ).fetchone()[0] == 2
+        with sqlite3.connect(memory_db) as connection:
+            assert connection.execute(
+                "SELECT COUNT(*) FROM reflections WHERE source_session_id IS NULL"
+            ).fetchone()[0] == 2
+
+    @pytest.mark.asyncio
+    async def test_per_run_mcp_config_injects_header_and_is_removed(
+        self, tmp_path, monkeypatch
+    ):
+        from pinky_daemon.claude_runner import RunResult
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        canonical = {
+            "mcpServers": {
+                "pinky-memory": {
+                    "type": "sse",
+                    "url": "http://127.0.0.1:8890/mcp/memory/sse",
+                    "headers": {"X-Agent-Name": "pinky"},
+                },
+                "pinky-self": {"command": "unchanged"},
+            }
+        }
+        (tmp_path / ".mcp.json").write_text(json.dumps(canonical))
+        captured = {}
+
+        class ConfigInspectingSDKRunner:
+            def __init__(self, config, agent_name=""):
+                path = Path(config.mcp_servers)
+                captured["path"] = path
+                captured["mode"] = path.stat().st_mode & 0o777
+                captured["config"] = json.loads(path.read_text())
+
+            async def run(self, prompt):
+                return RunResult(output="Consolidated.", exit_code=0)
+
+        monkeypatch.setattr(
+            "pinky_daemon.dream_runner.SDKRunner", ConfigInspectingSDKRunner
+        )
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            history_provider=lambda agent, after_ts, limit, role: [
+                {"timestamp": 200.0, "role": "user", "content": "context"}
+            ],
+        )
+        await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        header = captured["config"]["mcpServers"]["pinky-memory"]["headers"]
+        assert header["X-Agent-Name"] == "pinky"
+        assert header["X-Dream-Correlation"].startswith("dream:pinky:")
+        assert captured["mode"] == 0o600
+        assert not captured["path"].exists()
+        assert json.loads((tmp_path / ".mcp.json").read_text()) == canonical
+
+    @pytest.mark.asyncio
+    async def test_constructor_failure_cleans_secret_config_and_consumes_attempt(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        bearer = "Bearer constructor-secret"
+        canonical = {
+            "mcpServers": {
+                "pinky-memory": {
+                    "type": "sse",
+                    "url": "http://127.0.0.1:8890/mcp/memory/sse",
+                    "headers": {"Authorization": bearer},
+                }
+            }
+        }
+        (tmp_path / ".mcp.json").write_text(json.dumps(canonical))
+        captured: list[tuple[Path, int, str]] = []
+
+        class FailingConstructorSDKRunner:
+            def __init__(self, config, agent_name=""):
+                path = Path(config.mcp_servers)
+                captured.append(
+                    (path, path.stat().st_mode & 0o777, path.read_text())
+                )
+                raise ImportError("missing claude-agent-sdk")
+
+        monkeypatch.setattr(
+            "pinky_daemon.dream_runner.SDKRunner", FailingConstructorSDKRunner
+        )
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            history_provider=lambda agent, after_ts, limit, role: [
+                {"timestamp": 200.0, "role": "user", "content": "frozen interval"}
+            ],
+        )
+
+        for expected_attempt in (1, 2, 3):
+            summary = await runner.run_dream(
+                "pinky", _DreamAgentConfig(str(tmp_path))
+            )
+            assert "ImportError" in summary
+            assert runner._db.execute(
+                "SELECT MAX(attempt_n) FROM dream_reflection_attempts"
+            ).fetchone()[0] == expected_attempt
+
+        assert len(captured) == 3
+        assert all(mode == 0o600 for _path, mode, _content in captured)
+        assert all(bearer in content for _path, _mode, content in captured)
+        assert all(not path.exists() for path, _mode, _content in captured)
+        assert list((tmp_path / "dreams").glob(".mcp-dream-*.json")) == []
+        assert runner._db.execute(
+            "SELECT attempt_n, status, terminal FROM dream_reflection_attempts "
+            "ORDER BY attempt_n"
+        ).fetchall() == [(1, "failed", 0), (2, "failed", 0), (3, "failed", 1)]
+        assert runner._get_last_message_ts("pinky") == 200.0
+        assert json.loads((tmp_path / ".mcp.json").read_text()) == canonical
+
+    def test_atomic_mcp_config_write_unlinks_partial_on_failure(
+        self, tmp_path, monkeypatch
+    ):
+        bearer = "Bearer partial-secret"
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "pinky-memory": {
+                            "type": "sse",
+                            "url": "http://127.0.0.1/mcp",
+                            "headers": {"Authorization": bearer},
+                        }
+                    }
+                }
+            )
+        )
+        real_open = os.open
+        open_calls: list[tuple[int, int]] = []
+
+        def capture_open(path, flags, mode=0o777):
+            open_calls.append((flags, mode))
+            return real_open(path, flags, mode)
+
+        def fail_after_partial_write(config, config_file, indent=None):
+            config_file.write(f'{{"token": {bearer!r}')
+            config_file.flush()
+            raise OSError("simulated write failure")
+
+        monkeypatch.setattr(dream_runner_module.os, "open", capture_open)
+        monkeypatch.setattr(dream_runner_module.json, "dump", fail_after_partial_write)
+
+        with pytest.raises(OSError, match="simulated write failure"):
+            DreamRunner._write_dream_mcp_config(str(tmp_path), "dream:test")
+
+        assert len(open_calls) == 1
+        flags, mode = open_calls[0]
+        assert flags & os.O_CREAT
+        assert flags & os.O_EXCL
+        assert flags & os.O_WRONLY
+        assert mode == 0o600
+        assert list((tmp_path / "dreams").glob(".mcp-dream-*.json")) == []
+
+    def test_atomic_mcp_config_collision_never_unlinks_existing_file(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "pinky-memory": {
+                            "command": "memory-server",
+                        }
+                    }
+                }
+            )
+        )
+        dreams_dir = tmp_path / "dreams"
+        dreams_dir.mkdir()
+        existing = dreams_dir / ".mcp-dream-collision.json"
+        existing.write_text("belongs to another run")
+
+        class CollisionUUID:
+            hex = "collision"
+
+        monkeypatch.setattr(
+            dream_runner_module.uuid, "uuid4", lambda: CollisionUUID()
+        )
+
+        with pytest.raises(FileExistsError):
+            DreamRunner._write_dream_mcp_config(str(tmp_path), "dream:test")
+
+        assert existing.read_text() == "belongs to another run"
+
+    @pytest.mark.asyncio
+    async def test_nightly_entry_prunes_only_mcp_config_orphans_over_24h(
+        self, tmp_path
+    ):
+        dreams_dir = tmp_path / "dreams"
+        dreams_dir.mkdir()
+        old_config = dreams_dir / ".mcp-dream-old.json"
+        fresh_config = dreams_dir / ".mcp-dream-fresh.json"
+        unrelated = dreams_dir / "notes.json"
+        for path in (old_config, fresh_config, unrelated):
+            path.write_text("secret")
+        now = time.time()
+        os.utime(old_config, (now - 25 * 3600, now - 25 * 3600))
+        os.utime(fresh_config, (now - 23 * 3600, now - 23 * 3600))
+        os.utime(unrelated, (now - 25 * 3600, now - 25 * 3600))
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            history_provider=lambda agent, after_ts, limit, role: [],
+        )
+
+        await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        assert not old_config.exists()
+        assert fresh_config.exists()
+        assert unrelated.exists()
+
+    def test_receipt_prune_removes_only_expired_closed_rows(self, tmp_path):
+        runner = DreamRunner(db_path=str(tmp_path / "dream.db"))
+        now = time.time()
+
+        for agent in (
+            "old-completed",
+            "old-terminal",
+            "old-retryable",
+            "recent",
+            "pending",
+        ):
+            receipt = runner._begin_reflection_attempt(
+                agent,
+                "2026-08-12",
+                dream_start=datetime.now(timezone.utc),
+                history_start_ts=100.0,
+                history_end_ts=200.0,
+            )
+            assert receipt is not None
+        runner._db.execute(
+            """UPDATE dream_reflection_attempts
+               SET status='completed', completed_at=?
+               WHERE agent_name='old-completed'""",
+            (now - 31 * 24 * 3600,),
+        )
+        runner._db.execute(
+            """UPDATE dream_reflection_attempts
+               SET status='failed', terminal=1, completed_at=?
+               WHERE agent_name='old-terminal'""",
+            (now - 31 * 24 * 3600,),
+        )
+        runner._db.execute(
+            """UPDATE dream_reflection_attempts
+               SET status='failed', terminal=0, completed_at=?
+               WHERE agent_name='old-retryable'""",
+            (now - 31 * 24 * 3600,),
+        )
+        runner._db.execute(
+            """UPDATE dream_reflection_attempts
+               SET status='completed', completed_at=?
+               WHERE agent_name='recent'""",
+            (now - 29 * 24 * 3600,),
+        )
+        runner._db.commit()
+
+        assert runner._get_retryable_failed_attempt("old-retryable") is not None
+        assert runner._prune_reflection_attempts(now=now) == 2
+        assert runner._get_retryable_failed_attempt("old-retryable") is not None
+        assert runner._db.execute(
+            "SELECT agent_name FROM dream_reflection_attempts ORDER BY agent_name"
+        ).fetchall() == [("old-retryable",), ("pending",), ("recent",)]
+
+    def test_dream_schema_rollback_fails_loud_at_startup(
+        self, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "dream.db"
+        migrated = DreamRunner(db_path=str(db_path))
+        assert migrated._db.execute("PRAGMA user_version").fetchone()[0] == 1
+        migrated.close()
+        monkeypatch.setattr(dream_runner_module, "_DREAM_SCHEMA_VERSION", 0)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            DreamRunner(db_path=str(db_path))
+
+        message = str(exc_info.value)
+        assert "durable-dream-receipts-v1" in message
+        assert "PinkyBot >=26.08.020" in message
+        assert "refusing startup" in message
+        with sqlite3.connect(db_path) as connection:
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+
+    def test_round_two_rowid_boundary_schema_is_dropped_on_migration(self, tmp_path):
+        db_path = tmp_path / "dream.db"
+        with sqlite3.connect(db_path) as connection:
+            connection.execute(
+                """CREATE TABLE dream_reflection_attempts (
+                       agent_name TEXT NOT NULL,
+                       night_key TEXT NOT NULL,
+                       attempt_n INTEGER NOT NULL,
+                       status TEXT NOT NULL,
+                       dream_started_at TEXT NOT NULL,
+                       history_start_ts REAL NOT NULL,
+                       history_end_ts REAL NOT NULL,
+                       correlation_id TEXT NOT NULL,
+                       reflection_rowid_floor INTEGER NOT NULL,
+                       summary TEXT,
+                       runner_completed_at REAL,
+                       embedded_reflections INTEGER,
+                       completed_at REAL,
+                       PRIMARY KEY (agent_name, night_key, attempt_n)
+                   )"""
+            )
+
+        runner = DreamRunner(db_path=str(db_path))
+        columns = {
+            row[1]
+            for row in runner._db.execute(
+                "PRAGMA table_info(dream_reflection_attempts)"
+            ).fetchall()
+        }
+        assert "reflection_rowid_floor" not in columns
+        assert {"lease_owner", "lease_expires_at", "terminal"} <= columns
+        assert runner._db.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert runner._begin_reflection_attempt(
+            "pinky",
+            "2026-08-12",
+            dream_start=datetime.now(timezone.utc),
+            history_start_ts=100.0,
+            history_end_ts=200.0,
+        ) is not None
 
     @pytest.mark.asyncio
     async def test_failed_alert_retries_until_one_positive_receipt(self, tmp_path):

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -1130,6 +1130,27 @@ class TestDreamReflectionLoudness:
         ).fetchone() == (owner._lease_owner, renewed_expiry)
 
     @pytest.mark.asyncio
+    async def test_renewal_refuses_at_sdk_deadline(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(dream_runner_module, "_REFLECTION_ATTEMPT_RENEW_INTERVAL_S", 0.02)
+        runner = DreamRunner(db_path=str(tmp_path / "dream.db"))
+        attempt = runner._begin_reflection_attempt(
+            "pinky", "2026-08-12", dream_start=datetime.now(timezone.utc),
+            history_start_ts=0, history_end_ts=1,
+        )
+        assert attempt is not None
+        renewals = []
+        monkeypatch.setattr(runner, "_renew_reflection_attempt_lease", lambda a: renewals.append(a) or True)
+        stopped = asyncio.Event()
+        deadline = asyncio.get_running_loop().time() + 0.02
+        task = asyncio.create_task(
+            runner._renew_reflection_attempt_lease_until_stopped(attempt, stopped, deadline)
+        )
+        await asyncio.sleep(0.05)
+        stopped.set()
+        await task
+        assert renewals == []
+
+    @pytest.mark.asyncio
     async def test_sdk_wall_timeout_is_failed_attempt_and_cancels_run(
         self, tmp_path, monkeypatch
     ):
@@ -1168,6 +1189,19 @@ class TestDreamReflectionLoudness:
         assert runner._db.execute(
             "SELECT attempt_n, status, terminal FROM dream_reflection_attempts"
         ).fetchone() == (1, "failed", 0)
+        assert runner._db.execute(
+            "SELECT runner_completed_at FROM dream_reflection_attempts"
+        ).fetchone() == (None,)
+        assert runner._db.execute(
+            "SELECT last_message_ts FROM dream_state WHERE agent_name='pinky'"
+        ).fetchone()[0] == 0
+        await asyncio.sleep(0.08)
+        assert runner._db.execute(
+            "SELECT status, runner_completed_at FROM dream_reflection_attempts"
+        ).fetchone() == ("failed", None)
+        assert runner._db.execute(
+            "SELECT last_message_ts FROM dream_state WHERE agent_name='pinky'"
+        ).fetchone()[0] == 0
 
     @pytest.mark.asyncio
     async def test_sdk_timeout_discards_late_success_from_cancellation_suppressor(
@@ -1657,14 +1691,11 @@ class TestDreamReflectionLoudness:
             "SELECT agent_name FROM dream_reflection_attempts ORDER BY agent_name"
         ).fetchall() == [("old-retryable",), ("pending",), ("recent",)]
 
-    def test_dream_schema_rollback_fails_loud_at_startup(
-        self, tmp_path, monkeypatch
-    ):
+    def test_dream_schema_future_version_refuses_startup(self, tmp_path):
         db_path = tmp_path / "dream.db"
-        migrated = DreamRunner(db_path=str(db_path))
-        assert migrated._db.execute("PRAGMA user_version").fetchone()[0] == 1
-        migrated.close()
-        monkeypatch.setattr(dream_runner_module, "_DREAM_SCHEMA_VERSION", 0)
+        with sqlite3.connect(db_path) as connection:
+            connection.execute("PRAGMA user_version=2")
+            connection.commit()
 
         with pytest.raises(RuntimeError) as exc_info:
             DreamRunner(db_path=str(db_path))
@@ -1674,7 +1705,7 @@ class TestDreamReflectionLoudness:
         assert "PinkyBot >=26.08.020" in message
         assert "refusing startup" in message
         with sqlite3.connect(db_path) as connection:
-            assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
 
     def test_round_two_rowid_boundary_schema_is_dropped_on_migration(self, tmp_path):
         db_path = tmp_path / "dream.db"

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -541,3 +541,66 @@ class TestRunDreamWatermark:
 
         assert summary == "Consolidated."
         assert runner._get_last_message_ts("pinky") == 200.0
+
+
+class TestDreamReflectionLoudness:
+    @pytest.mark.asyncio
+    async def test_zero_streak_warns_persists_notifies_and_resets(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        from pinky_daemon.claude_runner import RunResult
+
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
+        monkeypatch.setattr("pinky_daemon.dream_runner.SDKRunner", _StubSDKRunner)
+        _StubSDKRunner.result = RunResult(output="Consolidated.", exit_code=0)
+
+        db_path = str(tmp_path / "dream.db")
+
+        def messages(agent, after_ts, limit, role):
+            return [
+                {
+                    "timestamp": after_ts + 1.0,
+                    "role": "user",
+                    "content": "new nightly context",
+                }
+            ]
+
+        notices: list[tuple[str, str]] = []
+
+        async def owner_notify(agent_name: str, message: str) -> bool:
+            notices.append((agent_name, message))
+            return True
+
+        runner = DreamRunner(
+            db_path=db_path,
+            history_provider=messages,
+            owner_notify_callback=owner_notify,
+        )
+        monkeypatch.setattr(runner, "_build_memory_links", lambda *args, **kwargs: 0)
+        await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+        assert runner.get_state("pinky")["zero_reflection_streak"] == 1
+        runner.close()
+
+        runner = DreamRunner(
+            db_path=db_path,
+            history_provider=messages,
+            owner_notify_callback=owner_notify,
+        )
+        monkeypatch.setattr(runner, "_build_memory_links", lambda *args, **kwargs: 0)
+        await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+        await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        assert runner.get_state("pinky")["zero_reflection_streak"] == 3
+        assert len(notices) == 1
+        assert notices[0][0] == "pinky"
+        assert "3 consecutive nights" in notices[0][1]
+        warnings = capsys.readouterr().err
+        assert warnings.count("WARNING 'pinky' completed with zero embedded reflections") == 3
+
+        monkeypatch.setattr(runner, "_build_memory_links", lambda *args, **kwargs: 2)
+        await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+
+        assert runner.get_state("pinky")["zero_reflection_streak"] == 0
+        assert len(notices) == 1
+        assert "zero embedded reflections" not in capsys.readouterr().err

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -1170,6 +1170,47 @@ class TestDreamReflectionLoudness:
         ).fetchone() == (1, "failed", 0)
 
     @pytest.mark.asyncio
+    async def test_sdk_timeout_discards_late_success_from_cancellation_suppressor(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
+        monkeypatch.setattr(dream_runner_module, "_SDK_DREAM_TIMEOUT_S", 0.02)
+
+        class CancellationSuppressingRunner:
+            def __init__(self, config, agent_name=""):
+                pass
+
+            async def run(self, prompt):
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    await asyncio.sleep(0.06)
+                    from pinky_daemon.claude_runner import RunResult
+                    return RunResult(output="late success", exit_code=0)
+
+        monkeypatch.setattr(dream_runner_module, "SDKRunner", CancellationSuppressingRunner)
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            history_provider=lambda *args: [{"timestamp": 200.0, "role": "user", "content": "x"}],
+        )
+        summary = await runner.run_dream("pinky", _DreamAgentConfig(str(tmp_path)))
+        assert "TimeoutError" in summary
+        assert runner._db.execute(
+            "SELECT status, terminal FROM dream_reflection_attempts"
+        ).fetchone() == ("failed", 0)
+
+    def test_concurrent_constructors_serialize_migration(self, tmp_path):
+        db_path = str(tmp_path / "dream.db")
+
+        def construct(_):
+            runner = DreamRunner(db_path=db_path)
+            return runner._db.execute("PRAGMA user_version").fetchone()[0]
+
+        with ThreadPoolExecutor(max_workers=12) as pool:
+            versions = list(pool.map(construct, range(12)))
+        assert versions == [1] * 12
+
+    @pytest.mark.asyncio
     async def test_untagged_window_never_proves_completion_and_cap_unblocks_next_night(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -1209,6 +1209,7 @@ class TestDreamReflectionLoudness:
     ):
         monkeypatch.delenv("PINKY_DREAM_TRANSPORT", raising=False)
         monkeypatch.setattr(dream_runner_module, "_SDK_DREAM_TIMEOUT_S", 0.02)
+        late_returned = asyncio.Event()
 
         class CancellationSuppressingRunner:
             def __init__(self, config, agent_name=""):
@@ -1220,6 +1221,7 @@ class TestDreamReflectionLoudness:
                 except asyncio.CancelledError:
                     await asyncio.sleep(0.06)
                     from pinky_daemon.claude_runner import RunResult
+                    late_returned.set()
                     return RunResult(output="late success", exit_code=0)
 
         monkeypatch.setattr(dream_runner_module, "SDKRunner", CancellationSuppressingRunner)
@@ -1232,6 +1234,19 @@ class TestDreamReflectionLoudness:
         assert runner._db.execute(
             "SELECT status, terminal FROM dream_reflection_attempts"
         ).fetchone() == ("failed", 0)
+        assert runner._db.execute(
+            "SELECT runner_completed_at FROM dream_reflection_attempts"
+        ).fetchone() == (None,)
+        assert runner._db.execute(
+            "SELECT last_message_ts FROM dream_state WHERE agent_name='pinky'"
+        ).fetchone()[0] == 0
+        await late_returned.wait()
+        assert runner._db.execute(
+            "SELECT status, runner_completed_at FROM dream_reflection_attempts"
+        ).fetchone() == ("failed", None)
+        assert runner._db.execute(
+            "SELECT last_message_ts FROM dream_state WHERE agent_name='pinky'"
+        ).fetchone()[0] == 0
 
     def test_concurrent_constructors_serialize_migration(self, tmp_path):
         db_path = str(tmp_path / "dream.db")

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -1707,6 +1707,19 @@ class TestDreamReflectionLoudness:
         with sqlite3.connect(db_path) as connection:
             assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
 
+    def test_schema_bump_before_constructor_is_refused_without_mutation(self, tmp_path):
+        db_path = tmp_path / "dream.db"
+        with sqlite3.connect(db_path) as connection:
+            connection.execute("CREATE TABLE sentinel (value TEXT)")
+            connection.execute("INSERT INTO sentinel VALUES ('before')")
+            connection.execute("PRAGMA user_version=2")
+            connection.commit()
+        with pytest.raises(RuntimeError, match="schema is newer"):
+            DreamRunner(db_path=str(db_path))
+        with sqlite3.connect(db_path) as connection:
+            assert connection.execute("SELECT * FROM sentinel").fetchone() == ("before",)
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
+
     def test_round_two_rowid_boundary_schema_is_dropped_on_migration(self, tmp_path):
         db_path = tmp_path / "dream.db"
         with sqlite3.connect(db_path) as connection:

--- a/tests/test_dream_runner.py
+++ b/tests/test_dream_runner.py
@@ -544,6 +544,21 @@ class TestRunDreamWatermark:
 
 
 class TestDreamReflectionLoudness:
+    async def _record_night(
+        self,
+        runner: DreamRunner,
+        night_key: str,
+        embedded_reflections: int,
+        sequence: int,
+    ) -> None:
+        await runner._record_reflection_outcome(
+            "pinky",
+            embedded_reflections,
+            night_key=night_key,
+            summary=f"night {night_key}",
+            last_message_ts=float(sequence),
+        )
+
     @pytest.mark.asyncio
     async def test_zero_streak_warns_persists_notifies_and_resets(
         self, tmp_path, monkeypatch, capsys
@@ -554,6 +569,14 @@ class TestDreamReflectionLoudness:
         monkeypatch.delenv("PINKY_KG_PROACTIVE", raising=False)
         monkeypatch.setattr("pinky_daemon.dream_runner.SDKRunner", _StubSDKRunner)
         _StubSDKRunner.result = RunResult(output="Consolidated.", exit_code=0)
+        night_keys = iter(
+            ("2026-08-09", "2026-08-10", "2026-08-11", "2026-08-12")
+        )
+        monkeypatch.setattr(
+            DreamRunner,
+            "_night_key",
+            staticmethod(lambda agent_config, dream_start: next(night_keys)),
+        )
 
         db_path = str(tmp_path / "dream.db")
 
@@ -604,3 +627,152 @@ class TestDreamReflectionLoudness:
         assert runner.get_state("pinky")["zero_reflection_streak"] == 0
         assert len(notices) == 1
         assert "zero embedded reflections" not in capsys.readouterr().err
+
+    def test_crash_between_state_and_outcome_writes_rolls_back_both(
+        self, tmp_path, monkeypatch
+    ):
+        db_path = str(tmp_path / "dream.db")
+        runner = DreamRunner(db_path=db_path)
+        runner._save_state("pinky", "seed", last_message_ts=100.0)
+        runner._db.execute(
+            "UPDATE dream_state SET zero_reflection_streak=2 WHERE agent_name=?",
+            ("pinky",),
+        )
+        runner._db.commit()
+
+        def simulated_crash(*args, **kwargs):
+            raise RuntimeError("simulated crash after state write")
+
+        monkeypatch.setattr(runner, "_apply_reflection_outcome", simulated_crash)
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            runner._commit_reflection_outcome(
+                "pinky",
+                "2026-08-12",
+                0,
+                summary="completed dream",
+                last_message_ts=200.0,
+            )
+        runner.close()
+
+        reopened = DreamRunner(db_path=db_path)
+        state = reopened.get_state("pinky")
+        assert state["last_summary"] == "seed"
+        assert state["zero_reflection_streak"] == 2
+        assert reopened._get_last_message_ts("pinky") == 100.0
+        assert reopened._db.execute(
+            "SELECT COUNT(*) FROM dream_reflection_outcomes"
+        ).fetchone()[0] == 0
+
+        created, streak, delivered = reopened._commit_reflection_outcome(
+            "pinky",
+            "2026-08-12",
+            0,
+            summary="completed dream",
+            last_message_ts=200.0,
+        )
+        assert (created, streak, delivered) == (True, 3, False)
+        assert reopened.get_state("pinky")["last_summary"] == "completed dream"
+        assert reopened._get_last_message_ts("pinky") == 200.0
+        assert reopened._db.execute(
+            "SELECT COUNT(*) FROM dream_reflection_outcomes"
+        ).fetchone()[0] == 1
+        reopened.close()
+
+    @pytest.mark.asyncio
+    async def test_same_night_refire_is_idempotent(self, tmp_path):
+        db_path = str(tmp_path / "dream.db")
+        runner = DreamRunner(db_path=db_path)
+
+        await self._record_night(runner, "2026-08-12", 0, 1)
+        runner.close()
+
+        runner = DreamRunner(db_path=db_path)
+        await self._record_night(runner, "2026-08-12", 0, 2)
+
+        state = runner.get_state("pinky")
+        assert state["zero_reflection_streak"] == 1
+        assert state["last_summary"] == "night 2026-08-12"
+        assert runner._get_last_message_ts("pinky") == 1.0
+        assert runner._db.execute(
+            "SELECT COUNT(*) FROM dream_reflection_outcomes"
+        ).fetchone()[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_alert_retries_until_one_positive_receipt(self, tmp_path):
+        attempts: list[str] = []
+        receipts = iter((False, True))
+
+        async def owner_notify(agent_name: str, message: str) -> bool:
+            attempts.append(message)
+            return next(receipts)
+
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            owner_notify_callback=owner_notify,
+        )
+        for sequence, night_key in enumerate(
+            (
+                "2026-08-08",
+                "2026-08-09",
+                "2026-08-10",
+                "2026-08-11",
+                "2026-08-12",
+            ),
+            start=1,
+        ):
+            await self._record_night(runner, night_key, 0, sequence)
+
+        state = runner.get_state("pinky")
+        assert state["zero_reflection_streak"] == 5
+        assert state["zero_reflection_alert_attempted_at"] is not None
+        assert state["zero_reflection_alert_delivered_at"] is not None
+        assert len(attempts) == 2
+        assert "3 consecutive nights" in attempts[0]
+        assert "4 consecutive nights" in attempts[1]
+
+        alert_rows = runner._db.execute(
+            """SELECT night_key, alert_attempted_at, alert_delivered_at
+               FROM dream_reflection_outcomes
+               WHERE alert_attempted_at IS NOT NULL
+               ORDER BY night_key"""
+        ).fetchall()
+        assert len(alert_rows) == 2
+        assert alert_rows[0][2] is None
+        assert alert_rows[1][2] is not None
+
+    @pytest.mark.asyncio
+    async def test_positive_night_resets_streak_and_delivery_latch(self, tmp_path):
+        notices: list[str] = []
+
+        async def owner_notify(agent_name: str, message: str) -> bool:
+            notices.append(message)
+            return True
+
+        runner = DreamRunner(
+            db_path=str(tmp_path / "dream.db"),
+            owner_notify_callback=owner_notify,
+        )
+        for sequence, night_key in enumerate(
+            ("2026-08-06", "2026-08-07", "2026-08-08"), start=1
+        ):
+            await self._record_night(runner, night_key, 0, sequence)
+
+        delivered = runner.get_state("pinky")
+        assert delivered["zero_reflection_streak"] == 3
+        assert delivered["zero_reflection_alert_attempted_at"] is not None
+        assert delivered["zero_reflection_alert_delivered_at"] is not None
+        assert len(notices) == 1
+
+        await self._record_night(runner, "2026-08-09", 2, 4)
+        reset = runner.get_state("pinky")
+        assert reset["zero_reflection_streak"] == 0
+        assert reset["zero_reflection_alert_attempted_at"] is None
+        assert reset["zero_reflection_alert_delivered_at"] is None
+
+        for sequence, night_key in enumerate(
+            ("2026-08-10", "2026-08-11", "2026-08-12"), start=5
+        ):
+            await self._record_night(runner, night_key, 0, sequence)
+
+        assert runner.get_state("pinky")["zero_reflection_streak"] == 3
+        assert len(notices) == 2

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -189,6 +189,40 @@ class TestReflect:
         assert result["salience"] == 5
         assert result["type"] == "project_state"
 
+    def test_transport_dream_correlation_overrides_model_argument(self, srv, store):
+        from pinky_daemon.shared_mcp import _current_dream_correlation
+
+        token = _current_dream_correlation.set("dream:pinky:2026-08-12:1:nonce")
+        try:
+            result = json.loads(
+                _tools(srv)["reflect"](
+                    content="structurally attributed",
+                    source_session_id="model-chosen-wrong-value",
+                )
+            )
+        finally:
+            _current_dream_correlation.reset(token)
+
+        assert store.get(result["id"]).source_session_id == (
+            "dream:pinky:2026-08-12:1:nonce"
+        )
+
+    def test_stdio_dream_correlation_overrides_model_argument(
+        self, srv, store, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "PINKY_DREAM_CORRELATION", "dream:pinky:2026-08-12:2:stdio"
+        )
+        result = json.loads(
+            _tools(srv)["reflect"](
+                content="stdio attributed",
+                source_session_id="model-chosen-wrong-value",
+            )
+        )
+        assert store.get(result["id"]).source_session_id == (
+            "dream:pinky:2026-08-12:2:stdio"
+        )
+
     def test_reflect_supersedes(self, srv, store):
         # First memory
         r1 = json.loads(_tools(srv)["reflect"](content="old fact", type="fact"))

--- a/tests/test_shared_mcp.py
+++ b/tests/test_shared_mcp.py
@@ -19,6 +19,7 @@ from pinky_daemon.shared_mcp import (
     create_shared_app,
     derive_mcp_bearer,
     get_current_agent,
+    get_current_dream_correlation,
     get_gateway_epoch,
     get_probe_request,
     get_probe_status,
@@ -143,6 +144,25 @@ class TestAgentNameMiddleware:
         }
         await middleware(scope, None, None)
         assert captured_agent == ["barsik"]
+
+    @pytest.mark.asyncio
+    async def test_sets_and_resets_dream_correlation_from_header(self):
+        captured = []
+
+        async def inner_app(scope, receive, send):
+            captured.append(get_current_dream_correlation())
+
+        middleware = AgentNameMiddleware(inner_app)
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"x-agent-name", b"barsik"),
+                (b"x-dream-correlation", b"dream:barsik:night:1:nonce"),
+            ],
+        }
+        await middleware(scope, None, None)
+        assert captured == ["dream:barsik:night:1:nonce"]
+        assert get_current_dream_correlation() == ""
 
     @pytest.mark.asyncio
     async def test_no_header_passes_through(self):

--- a/tests/test_tmux_dream_runner.py
+++ b/tests/test_tmux_dream_runner.py
@@ -356,6 +356,23 @@ class TestTmuxDreamRunner:
             assert spawn[idx + 1] == os.path.realpath(mcp_config)
 
     @pytest.mark.asyncio
+    async def test_spawn_prefers_explicit_per_run_mcp_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project_config = os.path.join(tmp, ".mcp.json")
+            per_run_config = os.path.join(tmp, "dream-mcp.json")
+            for path in (project_config, per_run_config):
+                with open(path, "w") as file:
+                    file.write("{}")
+            fake = _FakeTmux(new_session_rc=1)
+            runner = _runner(tmp, fake, mcp_config=per_run_config)
+
+            await runner.run("x")
+
+            spawn = fake.named("new-session")[0]
+            idx = spawn.index("--mcp-config")
+            assert spawn[idx + 1] == os.path.realpath(per_run_config)
+
+    @pytest.mark.asyncio
     async def test_spawn_omits_project_mcp_config_when_absent(self):
         with tempfile.TemporaryDirectory() as tmp:
             fake = _FakeTmux(new_session_rc=1)

--- a/tests/test_tmux_dream_runner.py
+++ b/tests/test_tmux_dream_runner.py
@@ -341,6 +341,31 @@ class TestTmuxDreamRunner:
             assert elapsed < 5.0, "death must be detected long before timeout"
 
     @pytest.mark.asyncio
+    async def test_spawn_passes_project_mcp_config_when_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mcp_config = os.path.join(tmp, ".mcp.json")
+            with open(mcp_config, "w") as f:
+                f.write("{}")
+            fake = _FakeTmux(new_session_rc=1)
+            runner = _runner(tmp, fake)
+
+            await runner.run("x")
+
+            spawn = fake.named("new-session")[0]
+            idx = spawn.index("--mcp-config")
+            assert spawn[idx + 1] == os.path.realpath(mcp_config)
+
+    @pytest.mark.asyncio
+    async def test_spawn_omits_project_mcp_config_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _FakeTmux(new_session_rc=1)
+            runner = _runner(tmp, fake)
+
+            await runner.run("x")
+
+            assert "--mcp-config" not in fake.named("new-session")[0]
+
+    @pytest.mark.asyncio
     async def test_allowlist_is_the_primary_tool_boundary(self):
         """#708 review (Murzik): the dream prompt embeds raw conversation
         history, so the spawn must pin an explicit --allowedTools allowlist


### PR DESCRIPTION
## Summary

- pass a workspace `.mcp.json` explicitly to tmux dream sessions when it exists
- persist a per-agent consecutive zero-reflection counter and emit a warning for each empty completed run
- notify the owner after three consecutive empty runs and reset the counter on the first run with embedded reflections

## Root cause

The tmux dream launch path did not mirror the main session's explicit project MCP configuration flag, so project MCP servers could be absent even though the tool permissions were correct.

## Impact

Dream sessions can load their configured memory tools, while repeated empty results become visible instead of being masked by downstream report extraction. The existing dream tool allowlist and denylist are unchanged.

## Validation

- `uv run ruff check .`
- `uv run pytest tests/test_tmux_dream_runner.py tests/test_dream_runner.py -q` — 40 passed
- `uv run pytest -q` in a clean CI-like environment — 4,889 passed, 4 skipped

Closes #1061

🤖 Opened by Kuzya



### Dream receipts migration rollback contract
Rolling back below PinkyBot 26.08.020 after the durable dream-receipts migration is unsupported; pre-gate binaries may run stale watermark semantics beside v1 receipt rows. The startup gate protects builds >=26.08.020 from future schema versions.
