### PR TITLE
Fix scheduler delivery queue starvation

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -4537,8 +4537,9 @@ except Exception as exc:
         """Aggregate one stale recurring fire into one bounded schedule row.
 
         The table has exactly one row per live schedule and cascades on
-        schedule deletion. ``generation`` lets delivery acknowledge only the
-        snapshot it actually surfaced; a concurrent newer drop stays pending.
+        schedule deletion. ``generation`` is a non-reusable revision: an
+        acknowledgement retains a zero-count tombstone, so a later drop can
+        never recycle the revision held by an older receipt observer.
         """
         if schedule_id <= 0:
             raise ValueError("schedule_id must be positive")
@@ -4558,19 +4559,35 @@ except Exception as exc:
                    ON CONFLICT(schedule_id) DO UPDATE SET
                        agent_name=excluded.agent_name,
                        schedule_name=excluded.schedule_name,
-                       drop_count=recurring_schedule_stale_drops.drop_count + 1,
-                       first_dropped_at=MIN(
-                           recurring_schedule_stale_drops.first_dropped_at,
-                           excluded.first_dropped_at
-                       ),
-                       last_dropped_at=MAX(
-                           recurring_schedule_stale_drops.last_dropped_at,
-                           excluded.last_dropped_at
-                       ),
-                       max_row_age_s=MAX(
-                           recurring_schedule_stale_drops.max_row_age_s,
-                           excluded.max_row_age_s
-                       ),
+                       drop_count=CASE
+                           WHEN recurring_schedule_stale_drops.drop_count = 0
+                           THEN 1
+                           ELSE recurring_schedule_stale_drops.drop_count + 1
+                       END,
+                       first_dropped_at=CASE
+                           WHEN recurring_schedule_stale_drops.drop_count = 0
+                           THEN excluded.first_dropped_at
+                           ELSE MIN(
+                               recurring_schedule_stale_drops.first_dropped_at,
+                               excluded.first_dropped_at
+                           )
+                       END,
+                       last_dropped_at=CASE
+                           WHEN recurring_schedule_stale_drops.drop_count = 0
+                           THEN excluded.last_dropped_at
+                           ELSE MAX(
+                               recurring_schedule_stale_drops.last_dropped_at,
+                               excluded.last_dropped_at
+                           )
+                       END,
+                       max_row_age_s=CASE
+                           WHEN recurring_schedule_stale_drops.drop_count = 0
+                           THEN excluded.max_row_age_s
+                           ELSE MAX(
+                               recurring_schedule_stale_drops.max_row_age_s,
+                               excluded.max_row_age_s
+                           )
+                       END,
                        generation=recurring_schedule_stale_drops.generation + 1""",
                 (
                     schedule_id,
@@ -4601,7 +4618,7 @@ except Exception as exc:
                       first_dropped_at, last_dropped_at, max_row_age_s,
                       generation
                FROM recurring_schedule_stale_drops
-               WHERE agent_name=?
+               WHERE agent_name=? AND drop_count > 0
                ORDER BY schedule_id ASC""",
             (agent_name,),
         ).fetchall()
@@ -4612,7 +4629,13 @@ except Exception as exc:
         agent_name: str,
         notices: list[RecurringScheduleStaleDrop],
     ) -> int:
-        """Clear only versioned aggregates included in a confirmed delivery."""
+        """Clear only versioned aggregates included in a confirmed delivery.
+
+        Clearing retains a zero-count revision tombstone.  Deleting the row
+        would let a later INSERT restart at generation 1, allowing a delayed
+        acknowledgement for an older generation-1 snapshot to erase the new
+        unsurfaced casualty (an ABA race).
+        """
         if not notices:
             return 0
         cleared = 0
@@ -4621,8 +4644,10 @@ except Exception as exc:
                 if notice.agent_name != agent_name:
                     continue
                 cursor = self._db.execute(
-                    """DELETE FROM recurring_schedule_stale_drops
-                       WHERE agent_name=? AND schedule_id=? AND generation=?""",
+                    """UPDATE recurring_schedule_stale_drops
+                       SET drop_count=0
+                       WHERE agent_name=? AND schedule_id=? AND generation=?
+                         AND drop_count > 0""",
                     (agent_name, notice.schedule_id, notice.generation),
                 )
                 cleared += cursor.rowcount

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -4915,6 +4915,31 @@ except Exception as exc:
             self._db.commit()
         return cursor.rowcount > 0
 
+    def collapse_pending_schedule_wake(
+        self,
+        pending_id: int,
+        *,
+        superseded_by_fired_at: float,
+        collapsed_at: float = 0.0,
+    ) -> bool:
+        """Quarantine one recurrence superseded by a newer pending fire."""
+        timestamp = collapsed_at or time.time()
+        reason = (
+            "recurrence collapsed into newer pending fire "
+            f"fired_at={superseded_by_fired_at}"
+        )
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                """UPDATE pending_schedule_wakes
+                   SET parked_at=?,
+                       failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
+                       last_error=?
+                   WHERE id=? AND parked_at=0 AND accepted_at=0""",
+                (timestamp, timestamp, reason, pending_id),
+            )
+            self._db.commit()
+        return cursor.rowcount > 0
+
     def confirm_pending_schedule_wake(
         self, pending_id: int, *, delivered_at: float = 0.0
     ) -> bool:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3159,6 +3159,20 @@ def create_api(
                 f"{agent_name} (reason={reason.value}): {e}"
             )
 
+    def _notify_scheduler_turn_idle(agent_name: str) -> None:
+        """Drain deferred scheduler work at a confirmed idle boundary."""
+        try:
+            scheduler_instance = _scheduler_holder.get("scheduler")
+            if scheduler_instance is not None:
+                scheduler_instance.notify_agent_idle(agent_name)
+        except Exception as e:
+            _log(
+                "api: SCHEDULER_IDLE_TRIGGER_FAILURE for "
+                f"{agent_name}: {type(e).__name__}: {e}"
+            )
+
+    app.state._notify_scheduler_turn_idle = _notify_scheduler_turn_idle
+
     # Exposed for unit-test reach-in (verifying centralized wake logging
     # advances the cycle-gate boundary). Not part of the public API.
     app.state._log_agent_wake_event = _log_agent_wake_event
@@ -3767,6 +3781,7 @@ def create_api(
             wake_context=_build_streaming_wake_context(agent_name, commit=False),
             wake_context_builder=_build_streaming_wake_context,
             on_wake_delivered=_log_agent_wake_event,
+            on_turn_idle=_notify_scheduler_turn_idle,
             wake_submission_recovery_injector=_inject_wake_context_reload,
             restart_guard=lambda session, _agent_name=agent_name: _get_streaming_restart_guard(_agent_name, session),
             # #943: verdict-time fresh read of the persisted field that the

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -35,6 +35,7 @@ from pinky_daemon.streaming_session import (
     StreamingSessionConfig,
     _is_outreach_tool,
     _log,
+    _notify_turn_idle,
 )
 from pinky_daemon.transport_state import (
     OwnerToken,
@@ -724,6 +725,11 @@ class CodexSession:
                         scheduler_delivery, False
                     )
                     self._processing = False
+                    if (
+                        self.state == SessionState.CONNECTED
+                        and self._message_queue.empty()
+                    ):
+                        _notify_turn_idle(self._config, self.agent_name)
 
         except asyncio.CancelledError:
             _log(f"codex[{self.agent_name}]: worker cancelled")

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -505,7 +505,11 @@ class CodexTmuxSession(TmuxSession):
 
     async def _handle_turn_complete(self, response) -> None:
         """Retire Codex metas coalesced into the just-closed rollout turn."""
-        await super()._handle_turn_complete(response)
+        self._defer_scheduler_idle_notify = True
+        try:
+            await super()._handle_turn_complete(response)
+        finally:
+            self._defer_scheduler_idle_notify = False
         # ``on_entry`` runs before the tailer feeds the following task_complete.
         # Therefore any remaining turn already transport-accepted at this exact
         # callback boundary was accepted inside the turn that just closed. It
@@ -518,6 +522,7 @@ class CodexTmuxSession(TmuxSession):
         self._reconcile_codex_phantom_metas(
             coalesced, reason="accepted_before_task_close"
         )
+        self._notify_scheduler_idle_if_ready()
 
     def _on_transcript_entry(self, entry: dict) -> None:
         """Map Codex rollout acceptance onto the shared exact-receipt path."""

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -60,6 +60,7 @@ _SCHEDULE_PROMPT_WARN_INTERVAL_SEC = 15 * 60
 _PERSISTED_WAKE_MAX_AGE_SEC = 60 * 60
 _RECEIPT_EXTENSION_MAX_AGE_ENV = "PINKY_SCHEDULE_RECEIPT_EXTENSION_MAX_AGE_SEC"
 _RECEIPT_EXTENSION_MAX_AGE_SEC = 60 * 60
+_ABANDONED_RECEIPT_OBSERVER_INTERVAL_SEC = 1.0
 _PENDING_WAKE_LIVENESS_DRAIN_INTERVAL_SEC = 60
 
 
@@ -1088,13 +1089,50 @@ class AgentScheduler:
         stale_drop_notices: list[RecurringScheduleStaleDrop],
     ) -> None:
         """Release the delivery lock while retaining late-receipt authority."""
+        schedule_id, fired_at, _ = self._quarantine_abandoned_receipt(
+            schedule, age=age
+        )
+
+        async def _observe_late_receipt() -> None:
+            try:
+                confirmed = await delivery
+                if not confirmed:
+                    return
+                self._registry.confirm_pending_schedule_wake_by_fire(
+                    schedule_id,
+                    fired_at,
+                    delivered_at=time.time(),
+                )
+                if stale_drop_notices:
+                    self._acknowledge_recurring_stale_drops(
+                        schedule.agent_name, stale_drop_notices
+                    )
+                self._log_late_abandoned_receipt(
+                    schedule, schedule_id=schedule_id, fired_at=fired_at
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                _log(
+                    f"scheduler: abandoned receipt observer failed for "
+                    f"schedule '{schedule.name}' (#{schedule_id}) for agent "
+                    f"'{schedule.agent_name}': {type(exc).__name__}: {exc}"
+                )
+
+        self._track_detached_receipt_task(_observe_late_receipt())
+
+    def _quarantine_abandoned_receipt(
+        self, schedule, *, age: float
+    ) -> tuple[int, float, bool]:
+        """Quarantine one unrecallable fire without submitting new work."""
         reason = (
             "RECEIPT_ABANDONED: original fired_at exceeded receipt-extension "
             f"ceiling ({age:.1f}s >= {self._receipt_extension_max_age_sec:.1f}s)"
         )
+        schedule_id = self._schedule_id(schedule)
         fired_at = self._schedule_fired_at(schedule)
         row = self._registry.get_schedule_wake_by_fire(
-            schedule.id, fired_at
+            schedule_id, fired_at
         )
         parked = bool(
             row is not None
@@ -1105,7 +1143,7 @@ class AgentScheduler:
         )
         _log(
             f"scheduler: RECEIPT_ABANDONED schedule '{schedule.name}' "
-            f"(#{schedule.id}) for agent '{schedule.agent_name}' "
+            f"(#{schedule_id}) for agent '{schedule.agent_name}' "
             f"fired_at={fired_at} age_s={age:.1f} "
             f"ceiling_s={self._receipt_extension_max_age_sec:.1f} "
             f"quarantined={parked}"
@@ -1120,38 +1158,113 @@ class AgentScheduler:
                 )
             except Exception:
                 pass
+        return schedule_id, fired_at, parked
 
-        async def _observe_late_receipt() -> None:
+    def _abandon_inflight_replay(
+        self,
+        schedule: PendingScheduleWake,
+        *,
+        prompt: str,
+        age: float,
+        stale_drop_notices: list[RecurringScheduleStaleDrop],
+    ) -> bool:
+        """Abandon a pasted replay in place, never invoking the wake callback.
+
+        The physical turn already owns the durable ``ScheduleWakeReceipt``
+        callback.  Polling only observes that existing authority; it never
+        creates another transport turn.
+        """
+        schedule_id, fired_at, parked = self._quarantine_abandoned_receipt(
+            schedule, age=age
+        )
+        row = self._registry.get_schedule_wake_by_fire(schedule_id, fired_at)
+        retained = bool(
+            parked
+            or (
+                row is not None
+                and row.accepted_at == 0
+                and row.parked_at > 0
+                and row.last_error.startswith("RECEIPT_ABANDONED")
+            )
+        )
+        if not retained:
+            return False
+
+        async def _observe_existing_receipt() -> None:
             try:
-                confirmed = await delivery
-                if not confirmed:
-                    return
-                self._registry.confirm_pending_schedule_wake_by_fire(
-                    schedule.id,
-                    fired_at,
-                    delivered_at=time.time(),
-                )
-                if stale_drop_notices:
-                    self._acknowledge_recurring_stale_drops(
-                        schedule.agent_name, stale_drop_notices
+                while True:
+                    row = self._registry.get_schedule_wake_by_fire(
+                        schedule_id, fired_at
                     )
-                _log(
-                    f"scheduler: late positive receipt retired abandoned "
-                    f"schedule '{schedule.name}' (#{schedule.id}) for agent "
-                    f"'{schedule.agent_name}' fired_at={fired_at}"
-                )
+                    if row is None:
+                        return
+                    if row.accepted_at > 0:
+                        if stale_drop_notices:
+                            self._acknowledge_recurring_stale_drops(
+                                schedule.agent_name, stale_drop_notices
+                            )
+                        self._log_late_abandoned_receipt(
+                            schedule,
+                            schedule_id=schedule_id,
+                            fired_at=fired_at,
+                        )
+                        return
+                    if not self._wake_prompt_inflight(
+                        schedule, prompt=prompt
+                    ):
+                        # Durable acceptance precedes the transport receipt
+                        # resolving. Re-read once across that ordering edge.
+                        row = self._registry.get_schedule_wake_by_fire(
+                            schedule_id, fired_at
+                        )
+                        if row is not None and row.accepted_at > 0:
+                            if stale_drop_notices:
+                                self._acknowledge_recurring_stale_drops(
+                                    schedule.agent_name, stale_drop_notices
+                                )
+                            self._log_late_abandoned_receipt(
+                                schedule,
+                                schedule_id=schedule_id,
+                                fired_at=fired_at,
+                            )
+                        return
+                    await asyncio.sleep(
+                        _ABANDONED_RECEIPT_OBSERVER_INTERVAL_SEC
+                    )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
                 _log(
                     f"scheduler: abandoned receipt observer failed for "
-                    f"schedule '{schedule.name}' (#{schedule.id}) for agent "
+                    f"schedule '{schedule.name}' (#{schedule_id}) for agent "
                     f"'{schedule.agent_name}': {type(exc).__name__}: {exc}"
                 )
 
-        observer = asyncio.create_task(_observe_late_receipt())
-        self._detached_receipt_tasks.add(observer)
-        observer.add_done_callback(self._detached_receipt_tasks.discard)
+        self._track_detached_receipt_task(_observe_existing_receipt())
+        return True
+
+    def _track_detached_receipt_task(self, observer) -> None:
+        """Run one late-receipt observer outside the per-agent delivery lock."""
+        task = asyncio.create_task(observer)
+        self._detached_receipt_tasks.add(task)
+        task.add_done_callback(self._detached_receipt_tasks.discard)
+
+    @staticmethod
+    def _log_late_abandoned_receipt(
+        schedule, *, schedule_id: int, fired_at: float
+    ) -> None:
+        _log(
+            f"scheduler: late positive receipt retired abandoned "
+            f"schedule '{schedule.name}' (#{schedule_id}) for agent "
+            f"'{schedule.agent_name}' fired_at={fired_at}"
+        )
+
+    @staticmethod
+    def _schedule_id(schedule) -> int:
+        """Return the schedule identity, never a replay outbox-row identity."""
+        if hasattr(schedule, "schedule_id"):
+            return int(schedule.schedule_id)
+        return int(schedule.id)
 
     @staticmethod
     def _schedule_fired_at(schedule) -> float:
@@ -1312,6 +1425,22 @@ class AgentScheduler:
         all_pending_wakes = self._registry.list_pending_schedule_wakes(
             agent_name, include_parked=True
         )
+        abandoned_schedule_ids = set()
+        for pending in all_pending_wakes:
+            if (
+                pending.parked_at > 0
+                and pending.last_error.startswith("RECEIPT_ABANDONED")
+                and self._wake_prompt_inflight(
+                    pending,
+                    prompt=self._wake_prompt_with_recurring_stale_drops(
+                        pending
+                    )[0],
+                )
+            ):
+                # A persisted abandonment blocks only while the old physical
+                # prompt can still execute. After a restart or failed receipt,
+                # a no-longer-inflight tombstone must not starve newer work.
+                abandoned_schedule_ids.add(pending.schedule_id)
         pending_wakes = []
         for pending in all_pending_wakes:
             current_schedule = self._registry.get_schedule(pending.schedule_id)
@@ -1346,25 +1475,47 @@ class AgentScheduler:
                 continue
             if pending.parked_at != 0:
                 continue
+            if pending.schedule_id in abandoned_schedule_ids:
+                _log(
+                    f"scheduler: persisted wake #{pending.id}, schedule "
+                    f"#{pending.schedule_id} for agent '{pending.agent_name}' "
+                    "remains pending behind an older abandoned pasted fire"
+                )
+                continue
             replay_max_age = self._pending_wake_replay_max_age(
                 current_schedule, pending.fired_at
             )
             row_age = max(0.0, replay_now - pending.fired_at)
-            # Invariant: pasted/inflight classification precedes stale
-            # deletion.  Once a prompt is observable in the transport it
-            # cannot be recalled, so when the replay and receipt ceilings meet,
-            # ABANDONMENT WINS: retain the exact row for RECEIPT_ABANDONED,
-            # detach its observer, and preserve late-receipt authority.
-            inflight_past_replay_ceiling = (
-                row_age > replay_max_age
+            delivery_prompt, stale_drop_notices = (
+                self._wake_prompt_with_recurring_stale_drops(pending)
+            )
+            # Invariant: abandonment precedes both stale deletion and
+            # recurrence collapse. Once a prompt is physically pasted it
+            # cannot be recalled, so replay must quarantine that exact fire
+            # in place and retain its existing durable acceptance authority.
+            # Calling _wait_for_wake_confirmation here would paste a duplicate.
+            inflight_past_receipt_ceiling = (
+                row_age >= self._receipt_extension_max_age_sec
                 and self._wake_prompt_inflight(
-                    pending,
-                    prompt=self._wake_prompt_with_recurring_stale_drops(
-                        pending
-                    )[0],
+                    pending, prompt=delivery_prompt
                 )
             )
-            if row_age > replay_max_age and not inflight_past_replay_ceiling:
+            if inflight_past_receipt_ceiling:
+                retained = self._abandon_inflight_replay(
+                    pending,
+                    prompt=delivery_prompt,
+                    age=row_age,
+                    stale_drop_notices=stale_drop_notices,
+                )
+                if retained:
+                    abandoned_schedule_ids.add(pending.schedule_id)
+                _log(
+                    f"scheduler: pasted pending wake #{pending.id} crossed "
+                    "its receipt ceiling; receipt abandonment takes "
+                    "precedence over stale deletion and recurrence collapse"
+                )
+                continue
+            if row_age > replay_max_age:
                 discarded = self._registry.delete_pending_schedule_wake(
                     pending.id
                 )
@@ -1393,12 +1544,6 @@ class AgentScheduler:
                         row_age=row_age,
                     )
                 continue
-            if inflight_past_replay_ceiling:
-                _log(
-                    f"scheduler: pasted pending wake #{pending.id} crossed "
-                    "its replay ceiling; receipt abandonment takes "
-                    "precedence over stale deletion"
-                )
             pending_wakes.append(pending)
 
         # A recurring schedule describes current work, not a FIFO event log.
@@ -1647,7 +1792,7 @@ class AgentScheduler:
             else schedule.last_run
         )
         receipt = ScheduleWakeReceipt(
-            self._registry, schedule.id, fired_at
+            self._registry, self._schedule_id(schedule), fired_at
         )
         callback_kwargs = {}
         try:

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import math
 import os
 import sys
 import time
@@ -59,6 +60,7 @@ _SCHEDULE_PROMPT_WARN_INTERVAL_SEC = 15 * 60
 _PERSISTED_WAKE_MAX_AGE_SEC = 60 * 60
 _RECEIPT_EXTENSION_MAX_AGE_ENV = "PINKY_SCHEDULE_RECEIPT_EXTENSION_MAX_AGE_SEC"
 _RECEIPT_EXTENSION_MAX_AGE_SEC = 60 * 60
+_PENDING_WAKE_LIVENESS_DRAIN_INTERVAL_SEC = 60
 
 
 class _ReceiptAbandonedError(RuntimeError):
@@ -296,6 +298,11 @@ class AgentScheduler:
             )
             try:
                 receipt_extension_max_age_sec = float(raw_extension_max_age)
+                if (
+                    not math.isfinite(receipt_extension_max_age_sec)
+                    or receipt_extension_max_age_sec <= 0
+                ):
+                    raise ValueError("ceiling must be finite and positive")
             except (TypeError, ValueError):
                 receipt_extension_max_age_sec = _RECEIPT_EXTENSION_MAX_AGE_SEC
                 _log(
@@ -303,8 +310,13 @@ class AgentScheduler:
                     f"{raw_extension_max_age!r}; using "
                     f"{_RECEIPT_EXTENSION_MAX_AGE_SEC:g}s"
                 )
-        if receipt_extension_max_age_sec <= 0:
-            raise ValueError("receipt_extension_max_age_sec must be positive")
+        if (
+            not math.isfinite(receipt_extension_max_age_sec)
+            or receipt_extension_max_age_sec <= 0
+        ):
+            raise ValueError(
+                "receipt_extension_max_age_sec must be finite and positive"
+            )
         self._receipt_extension_max_age_sec = float(
             receipt_extension_max_age_sec
         )
@@ -337,6 +349,7 @@ class AgentScheduler:
         self._pending_replay_again: set[str] = set()
         self._owner_alert_tasks: set[asyncio.Task] = set()
         self._last_schedule_prompt_warn_at: float | None = None
+        self._last_pending_wake_liveness_drain_at: float | None = None
         # Resurrection rate-limit: agent_name -> list[timestamp] of recent attempts.
         # Used by _check_heartbeats to cap how often we ping the heartbeat_callback
         # for a stuck agent (avoid thrashing on a persistently-broken session).
@@ -425,6 +438,11 @@ class AgentScheduler:
 
         # Check clock-aligned wakes
         await self._check_clock_aligned_wakes(now)
+
+        # Idle notifications are the primary low-latency outbox drain.  This
+        # bounded fallback prevents a lost edge from stranding a busy-deferred
+        # fire forever, including agents that keep the default heartbeat=0.
+        self._check_pending_wake_liveness(now)
 
         # Check heartbeat health
         await self._check_heartbeats(now)
@@ -1332,7 +1350,21 @@ class AgentScheduler:
                 current_schedule, pending.fired_at
             )
             row_age = max(0.0, replay_now - pending.fired_at)
-            if row_age > replay_max_age:
+            # Invariant: pasted/inflight classification precedes stale
+            # deletion.  Once a prompt is observable in the transport it
+            # cannot be recalled, so when the replay and receipt ceilings meet,
+            # ABANDONMENT WINS: retain the exact row for RECEIPT_ABANDONED,
+            # detach its observer, and preserve late-receipt authority.
+            inflight_past_replay_ceiling = (
+                row_age > replay_max_age
+                and self._wake_prompt_inflight(
+                    pending,
+                    prompt=self._wake_prompt_with_recurring_stale_drops(
+                        pending
+                    )[0],
+                )
+            )
+            if row_age > replay_max_age and not inflight_past_replay_ceiling:
                 discarded = self._registry.delete_pending_schedule_wake(
                     pending.id
                 )
@@ -1361,6 +1393,12 @@ class AgentScheduler:
                         row_age=row_age,
                     )
                 continue
+            if inflight_past_replay_ceiling:
+                _log(
+                    f"scheduler: pasted pending wake #{pending.id} crossed "
+                    "its replay ceiling; receipt abandonment takes "
+                    "precedence over stale deletion"
+                )
             pending_wakes.append(pending)
 
         # A recurring schedule describes current work, not a FIFO event log.
@@ -1741,6 +1779,44 @@ class AgentScheduler:
             "outbox; triggering durable replay"
         )
         self.replay_pending_for_agent(agent_name)
+
+    def _check_pending_wake_liveness(self, now: float) -> None:
+        """Periodically drain live-daemon outboxes without heartbeat opt-in.
+
+        Turn-idle remains the primary path.  This once-per-minute scan is the
+        bounded fallback for a lost idle callback; the positive busy gate is
+        checked both here and again under the per-agent replay lock.
+        """
+        last_drain = self._last_pending_wake_liveness_drain_at
+        if last_drain is None:
+            self._last_pending_wake_liveness_drain_at = now
+            return
+        if now - last_drain < _PENDING_WAKE_LIVENESS_DRAIN_INTERVAL_SEC:
+            return
+        self._last_pending_wake_liveness_drain_at = now
+        try:
+            agent_names = {
+                pending.agent_name
+                for pending in self._registry.list_pending_schedule_wakes()
+            }
+        except Exception as exc:
+            _log(
+                "scheduler: periodic outbox drain scan failed: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return
+        for agent_name in sorted(agent_names):
+            if self._agent_busy_not_wedged(agent_name):
+                _log(
+                    f"scheduler: periodic outbox drain deferred for "
+                    f"'{agent_name}': transport remains busy-not-wedged"
+                )
+                continue
+            _log(
+                f"scheduler: periodic liveness drain found pending wakes "
+                f"for '{agent_name}'"
+            )
+            self.replay_pending_for_agent(agent_name)
 
     # Resurrection cap: at most this many attempts per RESURRECTION_WINDOW_SECONDS
     # per agent. Prevents thrashing on a persistently-broken session while still

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -998,8 +998,9 @@ class AgentScheduler:
         schedule,
         *,
         attempt_started: asyncio.Event | None = None,
+        fresh_receipt_budget: bool = False,
     ) -> bool:
-        """Wait for one exact receipt within the original fire's deadline."""
+        """Wait for one exact receipt within its applicable delivery budget."""
         delivery_prompt, stale_drop_notices = (
             self._wake_prompt_with_recurring_stale_drops(schedule)
         )
@@ -1018,6 +1019,15 @@ class AgentScheduler:
                         self._receipt_extension_max_age_sec
                         - self._receipt_age(schedule),
                     )
+                    if fresh_receipt_budget:
+                        # Replay already proved this old prompt was never
+                        # pasted. Give the owed first transport attempt one
+                        # real acceptance window instead of cancelling its
+                        # task at timeout=0 from the historical fired_at.
+                        remaining = max(
+                            remaining, self._schedule_delivery_timeout
+                        )
+                        fresh_receipt_budget = False
                     confirmed = await asyncio.wait_for(
                         asyncio.shield(delivery),
                         timeout=min(
@@ -1054,7 +1064,8 @@ class AgentScheduler:
                     if self._agent_busy_not_wedged(schedule.agent_name):
                         _log(
                             f"scheduler: receipt still pending for schedule "
-                            f"'{schedule.name}' (#{schedule.id}) for agent "
+                            f"'{schedule.name}' "
+                            f"(#{self._schedule_id(schedule)}) for agent "
                             f"'{schedule.agent_name}', but inflight watchdog "
                             "reports busy-not-wedged; extending delivery timeout"
                         )
@@ -1064,7 +1075,8 @@ class AgentScheduler:
                     ):
                         _log(
                             f"scheduler: receipt still pending for schedule "
-                            f"'{schedule.name}' (#{schedule.id}) for agent "
+                            f"'{schedule.name}' "
+                            f"(#{self._schedule_id(schedule)}) for agent "
                             f"'{schedule.agent_name}', but its prompt is "
                             "already pasted to the transport — a cancel "
                             "cannot recall it, and declaring undelivered "
@@ -1442,6 +1454,7 @@ class AgentScheduler:
                 # a no-longer-inflight tombstone must not starve newer work.
                 abandoned_schedule_ids.add(pending.schedule_id)
         pending_wakes = []
+        fresh_receipt_budget_ids: set[int] = set()
         for pending in all_pending_wakes:
             current_schedule = self._registry.get_schedule(pending.schedule_id)
             zombie_reason = ""
@@ -1494,11 +1507,12 @@ class AgentScheduler:
             # cannot be recalled, so replay must quarantine that exact fire
             # in place and retain its existing durable acceptance authority.
             # Calling _wait_for_wake_confirmation here would paste a duplicate.
-            inflight_past_receipt_ceiling = (
+            past_receipt_ceiling = (
                 row_age >= self._receipt_extension_max_age_sec
-                and self._wake_prompt_inflight(
-                    pending, prompt=delivery_prompt
-                )
+            )
+            inflight_past_receipt_ceiling = (
+                past_receipt_ceiling
+                and self._wake_prompt_inflight(pending, prompt=delivery_prompt)
             )
             if inflight_past_receipt_ceiling:
                 retained = self._abandon_inflight_replay(
@@ -1544,6 +1558,10 @@ class AgentScheduler:
                         row_age=row_age,
                     )
                 continue
+            if past_receipt_ceiling:
+                # The inflight probe above proved this old row was never
+                # pasted. It remains owed work inside its replay window.
+                fresh_receipt_budget_ids.add(pending.id)
             pending_wakes.append(pending)
 
         # A recurring schedule describes current work, not a FIFO event log.
@@ -1602,7 +1620,15 @@ class AgentScheduler:
             if attempts is None:
                 continue
             try:
-                confirmed = await self._wait_for_wake_confirmation(pending)
+                confirmed = await self._wait_for_wake_confirmation(
+                    pending,
+                    # Any over-ceiling row that reached this point is not
+                    # currently pasted and survived the replay-age policy.
+                    # Its first legitimate transport acceptance is still owed.
+                    fresh_receipt_budget=(
+                        pending.id in fresh_receipt_budget_ids
+                    ),
+                )
             except asyncio.CancelledError:
                 raise
             except _ReceiptAbandonedError:

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -16,12 +16,17 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import os
 import sys
 import time
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from pinky_daemon.agent_registry import AgentRegistry, RecurringScheduleStaleDrop
+from pinky_daemon.agent_registry import (
+    AgentRegistry,
+    PendingScheduleWake,
+    RecurringScheduleStaleDrop,
+)
 from pinky_daemon.cron_utils import _field_matches
 from pinky_daemon.transport_state import SessionState
 from pinky_daemon.watchdog_log import log_watchdog_decision
@@ -52,6 +57,12 @@ _SCHEDULE_PROMPT_WARN_INTERVAL_SEC = 15 * 60
 # so a daemon restart can never deliver hours-old frozen prompts. Constructor
 # injection below keeps fleet policy configurable and tests deterministic.
 _PERSISTED_WAKE_MAX_AGE_SEC = 60 * 60
+_RECEIPT_EXTENSION_MAX_AGE_ENV = "PINKY_SCHEDULE_RECEIPT_EXTENSION_MAX_AGE_SEC"
+_RECEIPT_EXTENSION_MAX_AGE_SEC = 60 * 60
+
+
+class _ReceiptAbandonedError(RuntimeError):
+    """An already-pasted wake exceeded its original-fire receipt deadline."""
 
 
 def _is_claude_code_agent(agent, registry: AgentRegistry) -> bool:
@@ -222,6 +233,7 @@ class AgentScheduler:
         tick_interval: int = 30,
         schedule_delivery_timeout: float = 600.0,
         pending_wake_max_age_sec: float = _PERSISTED_WAKE_MAX_AGE_SEC,
+        receipt_extension_max_age_sec: float | None = None,
     ) -> None:
         self._registry = registry
         # async fn(agent_name, session_id, prompt, *, schedule_receipt=None)
@@ -258,16 +270,11 @@ class AgentScheduler:
         # liveness (can blip false between turns at the timeout boundary);
         # this reads the turn's own transport execution state.
         #
-        # The extension is DELIBERATELY unbounded while the probe keeps
-        # reporting pasted-unresolved: in that state any timeout action
-        # either drops the wake or duplicates it, so the scheduler holds.
-        # The hold ends when the receipt resolves (acceptance observed),
-        # the session leaves CONNECTED (receipt resolves False), or a
-        # force_restart resets the turn's pasted flag (probe reads False
-        # and the durable cancel+persist path resumes). Operational cost
-        # while held: same-agent schedule cohorts queue behind the
-        # per-agent delivery lock — surfaced by the "extending" log line
-        # each timeout period (Murzik review, PR #983).
+        # A pasted-unresolved prompt cannot be safely cancelled and replayed,
+        # but it also cannot hold the per-agent lock forever. Receipt waiting
+        # is therefore capped against the wake's durable original fired_at.
+        # At the ceiling the waiter detaches, the exact row is quarantined as
+        # RECEIPT_ABANDONED, and a later positive receipt can still win.
         self._delivery_inflight_fn = delivery_inflight_fn
         # async fn(agent_name, text) -> bool. Delivers operator-facing owner
         # alerts for terminal dead-letter events (PERSISTED_WAKE_PARKED, stale
@@ -282,6 +289,25 @@ class AgentScheduler:
         if pending_wake_max_age_sec <= 0:
             raise ValueError("pending_wake_max_age_sec must be positive")
         self._pending_wake_max_age_sec = float(pending_wake_max_age_sec)
+        if receipt_extension_max_age_sec is None:
+            raw_extension_max_age = os.environ.get(
+                _RECEIPT_EXTENSION_MAX_AGE_ENV,
+                str(_RECEIPT_EXTENSION_MAX_AGE_SEC),
+            )
+            try:
+                receipt_extension_max_age_sec = float(raw_extension_max_age)
+            except (TypeError, ValueError):
+                receipt_extension_max_age_sec = _RECEIPT_EXTENSION_MAX_AGE_SEC
+                _log(
+                    "scheduler: invalid receipt-extension ceiling "
+                    f"{raw_extension_max_age!r}; using "
+                    f"{_RECEIPT_EXTENSION_MAX_AGE_SEC:g}s"
+                )
+        if receipt_extension_max_age_sec <= 0:
+            raise ValueError("receipt_extension_max_age_sec must be positive")
+        self._receipt_extension_max_age_sec = float(
+            receipt_extension_max_age_sec
+        )
         self._running = False
         self._task: asyncio.Task | None = None
         self._last_clock_slot: dict[str, int] = {}  # agent_name -> last fired clock slot (minutes since midnight)
@@ -306,7 +332,9 @@ class AgentScheduler:
         # cohorts while allowing unrelated agents to progress independently.
         self._schedule_delivery_tasks: set[asyncio.Task] = set()
         self._schedule_delivery_locks: dict[str, asyncio.Lock] = {}
+        self._detached_receipt_tasks: set[asyncio.Task] = set()
         self._pending_replay_tasks: dict[str, asyncio.Task] = {}
+        self._pending_replay_again: set[str] = set()
         self._owner_alert_tasks: set[asyncio.Task] = set()
         self._last_schedule_prompt_warn_at: float | None = None
         # Resurrection rate-limit: agent_name -> list[timestamp] of recent attempts.
@@ -356,6 +384,14 @@ class AgentScheduler:
         if delivery_tasks:
             await asyncio.gather(*delivery_tasks, return_exceptions=True)
         self._schedule_delivery_tasks.clear()
+        detached_receipts = list(self._detached_receipt_tasks)
+        for task in detached_receipts:
+            if not task.done():
+                task.cancel()
+        if detached_receipts:
+            await asyncio.gather(*detached_receipts, return_exceptions=True)
+        self._detached_receipt_tasks.clear()
+        self._pending_replay_again.clear()
         replay_tasks = list(self._pending_replay_tasks.values())
         for task in replay_tasks:
             if not task.done():
@@ -577,6 +613,29 @@ class AgentScheduler:
                         f"live cohort for '{agent_name}': "
                         f"{type(exc).__name__}: {exc}"
                     )
+            if self._agent_busy_not_wedged(agent_name) or lock.locked():
+                direct_sends = [
+                    schedule for schedule in schedules if schedule.direct_send
+                ]
+                deferred = [
+                    schedule for schedule in schedules if not schedule.direct_send
+                ]
+                for index, schedule in enumerate(direct_sends):
+                    await self._deliver_schedule(
+                        schedule,
+                        attempt_started=(
+                            attempt_started if index == 0 else None
+                        ),
+                    )
+                if deferred:
+                    if attempt_started is not None:
+                        attempt_started.set()
+                    _log(
+                        f"scheduler: deferring {len(deferred)} fired "
+                        f"schedule(s) for agent '{agent_name}' until the next "
+                        "turn-idle boundary"
+                    )
+                return
             async with lock:
                 for next_index, schedule in enumerate(schedules):
                     try:
@@ -603,6 +662,13 @@ class AgentScheduler:
                     schedule, "delivery canceled before attempt"
                 )
             raise
+
+    def notify_agent_idle(self, agent_name: str) -> None:
+        """Drain durable scheduler work after a transport turn goes idle."""
+        _log(
+            f"scheduler: turn-idle delivery trigger for agent '{agent_name}'"
+        )
+        self.replay_pending_for_agent(agent_name)
 
     def _alert_stale_one_shot_drop(
         self,
@@ -775,8 +841,10 @@ class AgentScheduler:
                 )
                 if not confirmed:
                     failure_reason = "wake callback returned no positive receipt"
-            except asyncio.TimeoutError:
-                failure_reason = (
+            except _ReceiptAbandonedError:
+                return
+            except asyncio.TimeoutError as exc:
+                failure_reason = str(exc) or (
                     "delivery receipt timed out after "
                     f"{self._schedule_delivery_timeout:g}s"
                 )
@@ -912,7 +980,7 @@ class AgentScheduler:
         *,
         attempt_started: asyncio.Event | None = None,
     ) -> bool:
-        """Wait for one exact receipt, extending while positive liveness holds."""
+        """Wait for one exact receipt within the original fire's deadline."""
         delivery_prompt, stale_drop_notices = (
             self._wake_prompt_with_recurring_stale_drops(schedule)
         )
@@ -926,9 +994,16 @@ class AgentScheduler:
         try:
             while True:
                 try:
+                    remaining = max(
+                        0.0,
+                        self._receipt_extension_max_age_sec
+                        - self._receipt_age(schedule),
+                    )
                     confirmed = await asyncio.wait_for(
                         asyncio.shield(delivery),
-                        timeout=self._schedule_delivery_timeout,
+                        timeout=min(
+                            self._schedule_delivery_timeout, remaining
+                        ),
                     )
                     if confirmed and stale_drop_notices:
                         self._acknowledge_recurring_stale_drops(
@@ -936,6 +1011,27 @@ class AgentScheduler:
                         )
                     return confirmed
                 except asyncio.TimeoutError:
+                    age = self._receipt_age(schedule)
+                    if age >= self._receipt_extension_max_age_sec:
+                        inflight = self._wake_prompt_inflight(
+                            schedule, prompt=delivery_prompt
+                        )
+                        if inflight:
+                            self._abandon_receipt_wait(
+                                schedule,
+                                delivery,
+                                age=age,
+                                stale_drop_notices=stale_drop_notices,
+                            )
+                            raise _ReceiptAbandonedError
+                        delivery.cancel()
+                        await asyncio.gather(
+                            delivery, return_exceptions=True
+                        )
+                        raise asyncio.TimeoutError(
+                            "delivery receipt ceiling reached from original "
+                            f"fired_at after {age:.1f}s"
+                        )
                     if self._agent_busy_not_wedged(schedule.agent_name):
                         _log(
                             f"scheduler: receipt still pending for schedule "
@@ -964,6 +1060,94 @@ class AgentScheduler:
             delivery.cancel()
             await asyncio.gather(delivery, return_exceptions=True)
             raise
+
+    def _abandon_receipt_wait(
+        self,
+        schedule,
+        delivery: asyncio.Task,
+        *,
+        age: float,
+        stale_drop_notices: list[RecurringScheduleStaleDrop],
+    ) -> None:
+        """Release the delivery lock while retaining late-receipt authority."""
+        reason = (
+            "RECEIPT_ABANDONED: original fired_at exceeded receipt-extension "
+            f"ceiling ({age:.1f}s >= {self._receipt_extension_max_age_sec:.1f}s)"
+        )
+        fired_at = self._schedule_fired_at(schedule)
+        row = self._registry.get_schedule_wake_by_fire(
+            schedule.id, fired_at
+        )
+        parked = bool(
+            row is not None
+            and self._registry.park_pending_schedule_wake(
+                row.id,
+                reason=reason,
+            )
+        )
+        _log(
+            f"scheduler: RECEIPT_ABANDONED schedule '{schedule.name}' "
+            f"(#{schedule.id}) for agent '{schedule.agent_name}' "
+            f"fired_at={fired_at} age_s={age:.1f} "
+            f"ceiling_s={self._receipt_extension_max_age_sec:.1f} "
+            f"quarantined={parked}"
+        )
+        if self._activity:
+            try:
+                self._activity.log(
+                    schedule.agent_name,
+                    "schedule_receipt_abandoned",
+                    f"Schedule '{schedule.name}' receipt wait exceeded its "
+                    "original-fire ceiling",
+                )
+            except Exception:
+                pass
+
+        async def _observe_late_receipt() -> None:
+            try:
+                confirmed = await delivery
+                if not confirmed:
+                    return
+                self._registry.confirm_pending_schedule_wake_by_fire(
+                    schedule.id,
+                    fired_at,
+                    delivered_at=time.time(),
+                )
+                if stale_drop_notices:
+                    self._acknowledge_recurring_stale_drops(
+                        schedule.agent_name, stale_drop_notices
+                    )
+                _log(
+                    f"scheduler: late positive receipt retired abandoned "
+                    f"schedule '{schedule.name}' (#{schedule.id}) for agent "
+                    f"'{schedule.agent_name}' fired_at={fired_at}"
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                _log(
+                    f"scheduler: abandoned receipt observer failed for "
+                    f"schedule '{schedule.name}' (#{schedule.id}) for agent "
+                    f"'{schedule.agent_name}': {type(exc).__name__}: {exc}"
+                )
+
+        observer = asyncio.create_task(_observe_late_receipt())
+        self._detached_receipt_tasks.add(observer)
+        observer.add_done_callback(self._detached_receipt_tasks.discard)
+
+    @staticmethod
+    def _schedule_fired_at(schedule) -> float:
+        """Return the immutable exact-fire timestamp for either row shape."""
+        if hasattr(schedule, "fired_at"):
+            return float(schedule.fired_at)
+        return float(schedule.last_run)
+
+    def _receipt_age(self, schedule) -> float:
+        """Age one durable fire; direct legacy callers with no stamp start now."""
+        fired_at = self._schedule_fired_at(schedule)
+        if fired_at <= 0:
+            return 0.0
+        return max(0.0, time.time() - fired_at)
 
     def _agent_busy_not_wedged(self, agent_name: str) -> bool:
         """Read the transport's live positive-liveness signal, failing closed."""
@@ -1014,9 +1198,10 @@ class AgentScheduler:
         task.add_done_callback(self._owner_alert_tasks.discard)
 
     def replay_pending_for_agent(self, agent_name: str) -> None:
-        """Replay the durable wake outbox after the agent's next session boot."""
+        """Coalesce triggers while guaranteeing one replay after the active pass."""
         existing = self._pending_replay_tasks.get(agent_name)
         if existing is not None and not existing.done():
+            self._pending_replay_again.add(agent_name)
             return
         try:
             loop = asyncio.get_running_loop()
@@ -1038,11 +1223,15 @@ class AgentScheduler:
                     f"scheduler: PERSISTED_WAKE_REPLAY_FAILURE for "
                     f"'{agent_name}': {type(error).__name__}: {error}"
                 )
+            rerun = agent_name in self._pending_replay_again
+            self._pending_replay_again.discard(agent_name)
+            if rerun and not done.cancelled() and done.exception() is None:
+                self.replay_pending_for_agent(agent_name)
 
         task.add_done_callback(_done)
 
     async def _replay_pending_for_agent(self, agent_name: str) -> None:
-        """Deliver one agent's persisted wakes FIFO and receipt exact successes."""
+        """Deliver one agent's current owed wakes with exact receipts."""
         lock = self._schedule_delivery_locks.setdefault(agent_name, asyncio.Lock())
         async with lock:
             await self._replay_pending_locked(agent_name)
@@ -1083,7 +1272,7 @@ class AgentScheduler:
         return True
 
     async def _replay_pending_locked(self, agent_name: str) -> None:
-        """Reap all zombies, then replay active wakes FIFO under the agent lock."""
+        """Reap zombies, collapse recurrences, then replay under the agent lock."""
         replay_now = time.time()
         health = self._registry.get_pending_schedule_wake_health(
             agent_name, now=replay_now
@@ -1096,6 +1285,12 @@ class AgentScheduler:
                 f"oldest_age_s={summary['oldest_age_seconds']:.1f} "
                 f"oldest_fired_at={summary['oldest_fired_at']}"
             )
+            if self._agent_busy_not_wedged(agent_name):
+                _log(
+                    f"scheduler: persisted wake replay deferred for "
+                    f"'{agent_name}' until the next turn-idle boundary"
+                )
+                return
         all_pending_wakes = self._registry.list_pending_schedule_wakes(
             agent_name, include_parked=True
         )
@@ -1168,6 +1363,52 @@ class AgentScheduler:
                 continue
             pending_wakes.append(pending)
 
+        # A recurring schedule describes current work, not a FIFO event log.
+        # When several occurrences accumulated during one busy turn, keep the
+        # newest relevant fire and quarantine older recurrences as explicit
+        # ledger evidence. One-shots remain independent owed work.
+        newest_recurring: dict[int, PendingScheduleWake] = {}
+        for pending in pending_wakes:
+            current_schedule = self._registry.get_schedule(
+                pending.schedule_id
+            )
+            if current_schedule is not None and not current_schedule.one_shot:
+                newest_recurring[pending.schedule_id] = pending
+        collapsed_ids: set[int] = set()
+        for pending in pending_wakes:
+            newest = newest_recurring.get(pending.schedule_id)
+            if newest is None or newest.id == pending.id:
+                continue
+            if self._registry.collapse_pending_schedule_wake(
+                pending.id,
+                superseded_by_fired_at=newest.fired_at,
+                collapsed_at=replay_now,
+            ):
+                collapsed_ids.add(pending.id)
+                _log(
+                    f"scheduler: RECURRENCE_COLLAPSED pending #{pending.id}, "
+                    f"schedule '{pending.schedule_name}' "
+                    f"(#{pending.schedule_id}) for agent "
+                    f"'{pending.agent_name}': fired_at={pending.fired_at} "
+                    f"superseded_by_fired_at={newest.fired_at}"
+                )
+                if self._activity:
+                    try:
+                        self._activity.log(
+                            pending.agent_name,
+                            "schedule_recurrence_collapsed",
+                            f"Schedule '{pending.schedule_name}' recurrence "
+                            "collapsed into its newest pending fire",
+                        )
+                    except Exception:
+                        pass
+        if collapsed_ids:
+            pending_wakes = [
+                pending
+                for pending in pending_wakes
+                if pending.id not in collapsed_ids
+            ]
+
         for pending in pending_wakes:
             if pending.attempts >= self.PERSISTED_WAKE_ATTEMPT_CAP:
                 self._park_pending_wake_if_capped(pending, pending.attempts)
@@ -1181,6 +1422,8 @@ class AgentScheduler:
                 confirmed = await self._wait_for_wake_confirmation(pending)
             except asyncio.CancelledError:
                 raise
+            except _ReceiptAbandonedError:
+                break
             except Exception as exc:
                 _log(
                     f"scheduler: persisted wake #{pending.id} for "

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -731,19 +731,30 @@ class StreamingSession:
             except Exception as e:
                 _log(f"streaming[{self.agent_name}]: conversation store append failed: {e}")
 
+        # Book the turn before ``query()`` can make its transport write
+        # observable to the reader.  The SDK awaits that write, so a fast
+        # ResultMessage can otherwise arrive before this coroutine resumes and
+        # manufacture a false idle boundary with the turn still unrepresented.
+        # One routing reservation is the single source of truth for both
+        # response correlation and turn-idle detection.
+        reservation = (platform, chat_id, message_id)
+        self._pending_chats.append(reservation)
         try:
             self._analytics_log_activity(
                 "prompt_submitted",
                 metadata={"platform": platform, "chat_id": chat_id},
             )
             await self._client.query(prompt + agent_hint)
-            # Always enqueue one routing entry per query -- even with no
-            # chat_id -- so ResultMessage pops stay 1:1 with queries and a
-            # system/internal turn can't consume a user turn's routing.
-            self._pending_chats.append((platform, chat_id, message_id))
             _log(f"streaming[{self.agent_name}]: sent message (chat={chat_id})")
             return True
         except Exception as e:
+            # Roll back only this submission.  A fast ResultMessage may have
+            # consumed it already, and concurrent reservations can contain
+            # equal routing values, so identity (not tuple equality) matters.
+            for index, pending in enumerate(self._pending_chats):
+                if pending is reservation:
+                    self._pending_chats.pop(index)
+                    break
             self._stats["errors"] += 1
             _log(f"streaming[{self.agent_name}]: send error: {e}")
             # Try to reconnect

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -81,6 +81,20 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+def _notify_turn_idle(config: "StreamingSessionConfig", agent_name: str) -> None:
+    """Report a real turn boundary without letting callback failures escape."""
+    callback = config.on_turn_idle
+    if callback is None:
+        return
+    try:
+        callback(agent_name)
+    except Exception as exc:
+        _log(
+            f"streaming[{agent_name}]: on_turn_idle callback failed: "
+            f"{type(exc).__name__}: {exc}"
+        )
+
+
 @dataclass
 class StreamingSessionConfig:
     """Configuration for a streaming session."""
@@ -105,6 +119,9 @@ class StreamingSessionConfig:
     # the boundary advances against a wake that never reached the model
     # → the directive would be eaten by a wedged paste.
     on_wake_delivered: object = None  # Callable(agent_name, WakeReason) -> None
+    # Fires when a completed turn leaves no queued transport work. Scheduler
+    # delivery uses this edge to drain durable wakes without timer polling.
+    on_turn_idle: object = None  # Callable(agent_name) -> None
     # Tmux-only #984 recovery seam.  A verified-failed context-restart wake
     # uses this to route a CONTEXT-RELOAD instruction through the broker's
     # agent-message path.  The callback returns a positive handoff bool; the
@@ -999,6 +1016,11 @@ class StreamingSession:
                         self._turn_done.set()
                         # Reset per-turn auth dedupe — turn boundary
                         auth_reported_this_turn = False
+                        if (
+                            self.state == SessionState.CONNECTED
+                            and not self._pending_chats
+                        ):
+                            _notify_turn_idle(self._config, self.agent_name)
                         continue
 
                     # Turn complete — fire response callback
@@ -1166,6 +1188,11 @@ class StreamingSession:
 
                     # Check context usage for auto-restart
                     await self._check_context()
+                    if (
+                        self.state == SessionState.CONNECTED
+                        and not self._pending_chats
+                    ):
+                        _notify_turn_idle(self._config, self.agent_name)
 
         except Exception as e:
             _log(f"streaming[{self.agent_name}]: reader loop error: {e}")

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -82,6 +82,7 @@ from pinky_daemon.streaming_session import (
     StreamingSessionConfig,
     _is_outreach_tool,
     _log,
+    _notify_turn_idle,
 )
 from pinky_daemon.tmux_transcript import (
     TmuxTranscriptTailer,
@@ -5069,6 +5070,7 @@ class TmuxSession:
                     "autonomous": True,
                 }
             )
+            self._notify_scheduler_idle_if_ready()
             return
 
         entry = self._inflight_metas.popleft()
@@ -5261,6 +5263,19 @@ class TmuxSession:
         # sleeps between sends, and this callback runs on the tailer's
         # read loop, which must not stall.
         self._schedule_pending_effort_if_idle()
+        self._notify_scheduler_idle_if_ready()
+
+    def _notify_scheduler_idle_if_ready(self) -> None:
+        """Report an idle pane after transport-specific reconciliation."""
+        if getattr(self, "_defer_scheduler_idle_notify", False):
+            return
+        if (
+            self.state == SessionState.CONNECTED
+            and not self._inflight_metas
+            and self._inflight_turn is None
+            and self._message_queue.empty()
+        ):
+            _notify_turn_idle(self._config, self.agent_name)
 
     async def handle_stop_failure(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7922,6 +7922,17 @@ class TestBuildStreamingWakeContextReasonGating:
 
             assert replayed == ["dymok"]
 
+    def test_turn_idle_triggers_scheduler_outbox_drain(self):
+        """A transport turn boundary is the scheduler's dequeue signal."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            idle_agents: list[str] = []
+            app.state.scheduler.notify_agent_idle = idle_agents.append
+
+            app.state._notify_scheduler_turn_idle("test-agent")
+
+            assert idle_agents == ["test-agent"]
+
     @pytest.mark.asyncio
     async def test_scheduler_owner_alert_uses_owner_destination(self):
         """The owner-notify callback (dead-letter alerts: PARKED / stale

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -971,6 +971,8 @@ class TestCodexPendingWakeCallback:
         await _to_connected(s)
 
         fires: list[str] = []
+        idle_agents: list[str] = []
+        s._config.on_turn_idle = idle_agents.append
         s._pending_wake_callback = lambda: fires.append("delivered")
 
         async def fake_exec(prompt: str) -> CodexTurnResult:
@@ -994,6 +996,7 @@ class TestCodexPendingWakeCallback:
         assert fires == ["delivered"], (
             "pending_wake_callback must fire exactly once on exec-success"
         )
+        assert idle_agents == [s.agent_name]
         # And cleared so it doesn't re-fire on a subsequent non-wake turn.
         assert s._pending_wake_callback is None
 

--- a/tests/test_codex_tmux_session.py
+++ b/tests/test_codex_tmux_session.py
@@ -361,6 +361,8 @@ async def test_codex_acceptance_reserves_meta_before_same_read_completion():
     """A user_message + task_complete pair can beat paste_text's return."""
     ss = _session()
     ss._state_machine._state = SessionState.CONNECTED
+    idle_agents: list[str] = []
+    ss._config.on_turn_idle = idle_agents.append
     receipt = asyncio.get_running_loop().create_future()
     turn = _QueuedTurn(
         prompt="fast scheduled wake",
@@ -386,6 +388,7 @@ async def test_codex_acceptance_reserves_meta_before_same_read_completion():
         TurnResponse(text="done", stop_reason="task_complete")
     )
     assert len(ss._inflight_metas) == 0
+    assert idle_agents == [ss.agent_name]
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1345,24 +1345,25 @@ class TestScheduler:
         scheduler = AgentScheduler(registry, wake_callback=confirmed)
         await scheduler._replay_pending_locked("oleg")
 
-        assert len(attempts) == 2
+        assert len(attempts) == 1
         assert "Note: 1 fire of recurring schedule 'minutely'" in attempts[0]
         assert "The work that fire would have done was NOT performed." in attempts[0]
-        assert attempts[0].endswith("\n\nboundary frozen prompt")
-        assert attempts[1] == "fresh frozen prompt"
+        assert attempts[0].endswith("\n\nfresh frozen prompt")
         assert registry.list_recurring_schedule_stale_drops("oleg") == []
         assert registry.get_schedule_wake_by_fire(
             schedule.id, stale.fired_at
         ) is None
-        assert registry.get_schedule_wake_by_fire(
+        collapsed = registry.get_schedule_wake_by_fire(
             schedule.id, boundary.fired_at
-        ).accepted_at == pytest.approx(now)
+        )
+        assert collapsed.parked_at == pytest.approx(now)
+        assert collapsed.last_error.startswith("recurrence collapsed")
         assert registry.get_schedule_wake_by_fire(
             schedule.id, fresh.fired_at
         ).accepted_at == pytest.approx(now)
         logs = capsys.readouterr().err
         assert f"PERSISTED_WAKE_STALE_DROPPED pending #{stale.id}" in logs
-        assert "count=3" in logs
+        assert "RECURRENCE_COLLAPSED" in logs
         assert "oldest_age_s=61.0" in logs
 
     @pytest.mark.asyncio
@@ -1629,7 +1630,7 @@ class TestScheduler:
             asyncio.gather(*delivery_tasks, return_exceptions=True), timeout=1
         )
 
-        assert attempts == ["same schedule", "same schedule"]
+        assert attempts == ["same schedule"]
         assert [
             pending.fired_at
             for pending in registry.list_pending_schedule_wakes("oleg")
@@ -1714,6 +1715,186 @@ class TestScheduler:
         assert registry.get_schedules("oleg")[0].last_delivered > 0
         assert registry.list_pending_schedule_wakes("oleg") == []
         assert "already pasted to the transport" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_receipt_ceiling_uses_persisted_fired_at_across_restart(
+        self, registry, monkeypatch, capsys
+    ):
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="aged", prompt="already pasted"
+        )
+        fired_at = 1_800_000_000.0
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        db_path = registry._db_path
+        registry.close()
+        restarted_registry = AgentRegistry(db_path=db_path)
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: fired_at + 91.0
+        )
+        receipt = asyncio.get_running_loop().create_future()
+
+        async def pasted(agent_name, session_id, prompt, **kwargs):
+            del agent_name, session_id, prompt, kwargs
+            return receipt
+
+        restarted = AgentScheduler(
+            restarted_registry,
+            wake_callback=pasted,
+            delivery_inflight_fn=lambda agent_name, prompt: True,
+            schedule_delivery_timeout=10.0,
+            receipt_extension_max_age_sec=90.0,
+        )
+        restarted.replay_pending_for_agent("worker")
+        await restarted._pending_replay_tasks["worker"]
+
+        ledger = restarted_registry.get_schedule_wake_by_fire(
+            schedule.id, fired_at
+        )
+        assert ledger.ledger_state == "quarantined"
+        assert "RECEIPT_ABANDONED" in ledger.last_error
+        assert not restarted._schedule_delivery_locks["worker"].locked()
+        assert "age_s=91.0 ceiling_s=90.0" in capsys.readouterr().err
+        receipt.set_result(True)
+        await asyncio.gather(*list(restarted._detached_receipt_tasks))
+        assert restarted_registry.get_schedule_wake_by_fire(
+            schedule.id, fired_at
+        ).ledger_state == "receipted-ran-once"
+        restarted_registry.close()
+
+    @pytest.mark.asyncio
+    async def test_pending_recurrences_collapse_to_newest_with_trace(
+        self, registry, capsys
+    ):
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="hourly", prompt="run once"
+        )
+        now = time.time()
+        rows = [
+            registry.persist_schedule_wake(
+                schedule.id,
+                agent_name="worker",
+                schedule_name=schedule.name,
+                prompt=schedule.prompt,
+                fired_at=now + offset,
+            )[0]
+            for offset in (1.0, 2.0, 3.0)
+        ]
+        attempts: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=confirmed)
+        await scheduler._replay_pending_locked("worker")
+
+        assert attempts == ["run once"]
+        ledger = registry.list_schedule_wake_ledger("worker")
+        by_id = {row.id: row for row in ledger}
+        assert by_id[rows[2].id].ledger_state == "receipted-ran-once"
+        assert all(
+            by_id[row.id].ledger_state == "quarantined"
+            and by_id[row.id].last_error.startswith("recurrence collapsed")
+            for row in rows[:2]
+        )
+        assert capsys.readouterr().err.count("RECURRENCE_COLLAPSED") == 2
+
+    @pytest.mark.asyncio
+    async def test_busy_fire_waits_for_idle_trigger_then_delivers(
+        self, registry
+    ):
+        registry.register("worker")
+        registry.add_schedule(
+            "worker", "* * * * *", name="idle-driven", prompt="deliver on idle"
+        )
+        attempts: list[str] = []
+        busy = True
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            delivery_busy_fn=lambda agent_name: busy,
+        )
+        await scheduler._check_schedules(time.time())
+        await asyncio.gather(
+            *list(scheduler._schedule_delivery_tasks),
+            return_exceptions=True,
+        )
+        assert attempts == []
+        assert len(registry.list_pending_schedule_wakes("worker")) == 1
+
+        busy = False
+        scheduler.notify_agent_idle("worker")
+        await scheduler._pending_replay_tasks["worker"]
+
+        assert attempts == ["deliver on idle"]
+        assert registry.list_pending_schedule_wakes("worker") == []
+
+    @pytest.mark.asyncio
+    async def test_idle_trigger_during_replay_guarantees_follow_up_pass(
+        self, registry
+    ):
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="follow-up", prompt="deliver later"
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=time.time(),
+        )
+        attempts: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=confirmed)
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        original_replay = scheduler._replay_pending_locked
+        passes = 0
+
+        async def controlled_replay(agent_name):
+            nonlocal passes
+            passes += 1
+            if passes == 1:
+                first_started.set()
+                await release_first.wait()
+                return
+            await original_replay(agent_name)
+
+        scheduler._replay_pending_locked = controlled_replay
+        scheduler.replay_pending_for_agent("worker")
+        await first_started.wait()
+        scheduler.notify_agent_idle("worker")
+        release_first.set()
+
+        for _ in range(100):
+            if not registry.list_pending_schedule_wakes("worker"):
+                break
+            await asyncio.sleep(0)
+
+        assert passes == 2
+        assert attempts == ["deliver later"]
+        assert registry.list_pending_schedule_wakes("worker") == []
 
     @pytest.mark.asyncio
     async def test_unpasted_wake_still_persists_on_timeout(self, registry):
@@ -2011,6 +2192,12 @@ class TestScheduler:
         schedule = registry.add_schedule(
             "oleg", "* * * * *", name="fifo", prompt="unused"
         )
+        newer_schedule = registry.add_schedule(
+            schedule.agent_name,
+            "* * * * *",
+            name="fifo-newer",
+            prompt="unused",
+        )
         now = time.time()
         registry.persist_schedule_wake(
             schedule.id,
@@ -2020,9 +2207,9 @@ class TestScheduler:
             fired_at=now - 2.0,
         )
         registry.persist_schedule_wake(
-            schedule.id,
+            newer_schedule.id,
             agent_name="oleg",
-            schedule_name="fifo",
+            schedule_name="fifo-newer",
             prompt="newer",
             fired_at=now - 1.0,
         )
@@ -2291,6 +2478,12 @@ class TestScheduler:
         live = registry.add_schedule(
             "oleg", "* * * * *", name="live", prompt="unused"
         )
+        live_two = registry.add_schedule(
+            live.agent_name,
+            "* * * * *",
+            name="live-two",
+            prompt="unused",
+        )
         now = time.time()
         registry.persist_schedule_wake(
             zombie.id,
@@ -2307,9 +2500,9 @@ class TestScheduler:
             fired_at=now - 2.0,
         )
         registry.persist_schedule_wake(
-            live.id,
+            live_two.id,
             agent_name="oleg",
-            schedule_name="live",
+            schedule_name="live-two",
             prompt="live two",
             fired_at=now - 1.0,
         )
@@ -2592,6 +2785,35 @@ class TestScheduler:
         assert wake_calls == []
         assert stored.last_delivered == 0.0
         assert "FIRED BUT UNDELIVERED" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_busy_agent_does_not_defer_independent_direct_send(
+        self, registry
+    ):
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker",
+            "* * * * *",
+            name="direct",
+            prompt="send now",
+            target_channel="test-channel",
+            direct_send=True,
+        )
+        sent: list[tuple[str, str, str, str]] = []
+
+        async def direct_send(agent_name, platform, chat_id, message):
+            sent.append((agent_name, platform, chat_id, message))
+
+        scheduler = AgentScheduler(
+            registry,
+            direct_send_callback=direct_send,
+            delivery_busy_fn=lambda agent_name: True,
+        )
+        await scheduler._deliver_schedule_group("worker", [schedule])
+
+        assert sent == [
+            ("worker", "telegram", "test-channel", "send now")
+        ]
 
 
 # ── Heartbeat Watchdog Resurrection (issue #338) ──────────────────────────

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -17,6 +17,7 @@ from pinky_daemon.agent_registry import AgentRegistry, ScheduleNameConflictError
 from pinky_daemon.scheduler import (
     _SCHEDULE_PROMPT_WARN_INTERVAL_SEC,
     AgentScheduler,
+    ScheduleWakeReceipt,
     cron_matches,
     next_cron_description,
 )
@@ -1738,6 +1739,11 @@ class TestScheduler:
     async def test_receipt_ceiling_uses_persisted_fired_at_across_restart(
         self, registry, monkeypatch, capsys
     ):
+        """A restart must quarantine an old pasted row without resubmitting it.
+
+        This catches the buggy replay path that called the wake callback for a
+        prompt the transport had already pasted and could no longer recall.
+        """
         registry.register("worker")
         schedule = registry.add_schedule(
             "worker", "0 * * * *", name="aged", prompt="already pasted"
@@ -1756,16 +1762,26 @@ class TestScheduler:
         monkeypatch.setattr(
             "pinky_daemon.scheduler.time.time", lambda: fired_at + 91.0
         )
-        receipt = asyncio.get_running_loop().create_future()
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler._ABANDONED_RECEIPT_OBSERVER_INTERVAL_SEC",
+            0.01,
+        )
+        submissions: list[str] = []
+        pasted_inflight = True
 
         async def pasted(agent_name, session_id, prompt, **kwargs):
-            del agent_name, session_id, prompt, kwargs
-            return receipt
+            del agent_name, session_id, kwargs
+            submissions.append(prompt)
+            return False
+
+        def inflight(agent_name, prompt):
+            del agent_name, prompt
+            return pasted_inflight
 
         restarted = AgentScheduler(
             restarted_registry,
             wake_callback=pasted,
-            delivery_inflight_fn=lambda agent_name, prompt: True,
+            delivery_inflight_fn=inflight,
             schedule_delivery_timeout=10.0,
             receipt_extension_max_age_sec=90.0,
         )
@@ -1777,9 +1793,13 @@ class TestScheduler:
         )
         assert ledger.ledger_state == "quarantined"
         assert "RECEIPT_ABANDONED" in ledger.last_error
+        assert submissions == []
         assert not restarted._schedule_delivery_locks["worker"].locked()
         assert "age_s=91.0 ceiling_s=90.0" in capsys.readouterr().err
-        receipt.set_result(True)
+        assert ScheduleWakeReceipt(
+            restarted_registry, schedule.id, fired_at
+        ).accept() is True
+        pasted_inflight = False
         await asyncio.gather(*list(restarted._detached_receipt_tasks))
         assert restarted_registry.get_schedule_wake_by_fire(
             schedule.id, fired_at
@@ -1790,12 +1810,27 @@ class TestScheduler:
     async def test_production_ceiling_abandons_pasted_replay_before_stale_drop(
         self, registry, monkeypatch, capsys
     ):
-        """At 3601s with both defaults, abandonment wins over stale deletion."""
+        """An id-mismatched pasted row is abandoned without a duplicate paste.
+
+        A prior receipted row forces ``pending.id != pending.schedule_id``.
+        This catches both the wrong-key lookup that left the active row pending
+        and the callback attempt that submitted the same physical prompt twice.
+        """
         registry.register("worker")
         schedule = registry.add_schedule(
             "worker", "0 8 * * *", name="production-edge", prompt="pasted"
         )
         fired_at = 1_800_000_000.0
+        prior, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at - 1.0,
+        )
+        assert registry.confirm_pending_schedule_wake(
+            prior.id, delivered_at=fired_at - 0.5
+        )
         pending, _ = registry.persist_schedule_wake(
             schedule.id,
             agent_name="worker",
@@ -1806,18 +1841,22 @@ class TestScheduler:
         monkeypatch.setattr(
             "pinky_daemon.scheduler.time.time", lambda: fired_at + 3_601.0
         )
-        receipt = asyncio.get_running_loop().create_future()
-        attempts: list[str] = []
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler._ABANDONED_RECEIPT_OBSERVER_INTERVAL_SEC",
+            0.01,
+        )
+        submissions: list[str] = []
         probes: list[tuple[str, str]] = []
+        pasted_inflight = True
 
         async def pasted(agent_name, session_id, prompt, **kwargs):
             del agent_name, session_id, kwargs
-            attempts.append(prompt)
-            return receipt
+            submissions.append(prompt)
+            return False
 
         def inflight(agent_name, prompt):
             probes.append((agent_name, prompt))
-            return True
+            return pasted_inflight
 
         scheduler = AgentScheduler(
             registry,
@@ -1827,24 +1866,250 @@ class TestScheduler:
         )
 
         await scheduler._replay_pending_locked("worker")
-        await asyncio.sleep(0)
 
         ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
         assert ledger is not None
         assert ledger.id == pending.id
+        assert ledger.id != ledger.schedule_id
         assert ledger.ledger_state == "quarantined"
         assert "RECEIPT_ABANDONED" in ledger.last_error
-        assert attempts == ["pasted"]
+        assert submissions == []
         assert probes and set(probes) == {("worker", "pasted")}
         assert len(scheduler._detached_receipt_tasks) == 1
         logs = capsys.readouterr().err
         assert "receipt abandonment takes precedence over stale deletion" in logs
         assert "age_s=3601.0 ceiling_s=3600.0" in logs
 
-        receipt.set_result(True)
+        assert ScheduleWakeReceipt(
+            registry, schedule.id, fired_at
+        ).accept() is True
+        pasted_inflight = False
         await asyncio.gather(*list(scheduler._detached_receipt_tasks))
         assert registry.get_schedule_wake_by_fire(
             schedule.id, fired_at
+        ).ledger_state == "receipted-ran-once"
+
+    @pytest.mark.asyncio
+    async def test_replay_receipt_capability_uses_schedule_id_not_pending_id(
+        self, registry
+    ):
+        """Durable acceptance must target the schedule when outbox IDs differ.
+
+        This catches ``ScheduleWakeReceipt(..., pending.id, ...)``: the buggy
+        capability cannot commit acceptance at the transport edge and leaves
+        the exact replay row vulnerable across a process-local Future loss.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="identity", prompt="accept exactly"
+        )
+        fired_at = time.time()
+        prior, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at - 1.0,
+        )
+        assert registry.confirm_pending_schedule_wake(
+            prior.id, delivered_at=fired_at - 0.5
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        assert pending.id != pending.schedule_id
+        accepted_at_transport = asyncio.Event()
+        process_local_receipt = asyncio.get_running_loop().create_future()
+
+        async def accept_then_stall(
+            agent_name,
+            session_id,
+            prompt,
+            *,
+            schedule_receipt,
+        ):
+            del agent_name, session_id, prompt
+            assert schedule_receipt.schedule_id == schedule.id
+            assert schedule_receipt.accept() is True
+            accepted_at_transport.set()
+            return process_local_receipt
+
+        scheduler = AgentScheduler(registry, wake_callback=accept_then_stall)
+        replay = asyncio.create_task(
+            scheduler._replay_pending_locked("worker")
+        )
+        await asyncio.wait_for(accepted_at_transport.wait(), timeout=1)
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert ledger is not None
+        assert ledger.id == pending.id
+        assert ledger.ledger_state == "receipted-ran-once"
+        replay.cancel()
+        await asyncio.gather(replay, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_replay_abandonment_and_late_receipt_use_schedule_id(
+        self, registry, monkeypatch, capsys
+    ):
+        """A replay crossing the ceiling mid-attempt keeps exact authority.
+
+        The active outbox row is deliberately #2 for schedule #1. This catches
+        both wrong-key quarantine and wrong-key late confirmation after a
+        legitimate replay submission becomes pasted while its receipt waits.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="late-identity", prompt="wait exactly"
+        )
+        fired_at = 1_800_000_000.0
+        prior, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at - 1.0,
+        )
+        assert registry.confirm_pending_schedule_wake(
+            prior.id, delivered_at=fired_at - 0.5
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        assert pending.id != pending.schedule_id
+        now = [fired_at + 89.0]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: now[0]
+        )
+        process_local_receipt = asyncio.get_running_loop().create_future()
+        durable_receipt = None
+
+        async def paste_then_cross_ceiling(
+            agent_name,
+            session_id,
+            prompt,
+            *,
+            schedule_receipt,
+        ):
+            nonlocal durable_receipt
+            del agent_name, session_id, prompt
+            durable_receipt = schedule_receipt
+            now[0] = fired_at + 91.0
+            return process_local_receipt
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=paste_then_cross_ceiling,
+            delivery_inflight_fn=lambda agent_name, prompt: True,
+            schedule_delivery_timeout=0.01,
+            receipt_extension_max_age_sec=90.0,
+        )
+        await scheduler._replay_pending_locked("worker")
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert ledger is not None
+        assert ledger.id == pending.id
+        assert ledger.ledger_state == "quarantined"
+        assert "RECEIPT_ABANDONED" in ledger.last_error
+        assert durable_receipt is not None
+        assert durable_receipt.schedule_id == schedule.id
+        logs = capsys.readouterr().err
+        assert "schedule 'late-identity' (#1)" in logs
+        assert "quarantined=True" in logs
+
+        assert durable_receipt.accept() is True
+        process_local_receipt.set_result(True)
+        await asyncio.gather(*list(scheduler._detached_receipt_tasks))
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, fired_at
+        ).ledger_state == "receipted-ran-once"
+
+    @pytest.mark.asyncio
+    async def test_abandonment_blocks_newer_recurrence_until_late_receipt(
+        self, registry, monkeypatch, capsys
+    ):
+        """An old pasted fire retains authority ahead of recurrence collapse.
+
+        The two-row fixture catches the buggy newest-fire collapse that marked
+        the unrecallable old row RECURRENCE_COLLAPSED and submitted the newer
+        equal prompt, allowing both physical turns to execute.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 8 * * *", name="daily", prompt="same prompt"
+        )
+        older_fired_at = 1_800_000_000.0
+        newer_fired_at = older_fired_at + 100.0
+        older, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=older_fired_at,
+        )
+        newer, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=newer_fired_at,
+        )
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time",
+            lambda: older_fired_at + 3_601.0,
+        )
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler._ABANDONED_RECEIPT_OBSERVER_INTERVAL_SEC",
+            0.01,
+        )
+        pasted_inflight = True
+        submissions: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            submissions.append(prompt)
+            return True
+
+        def inflight(agent_name, prompt):
+            del agent_name, prompt
+            return pasted_inflight
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            delivery_inflight_fn=inflight,
+        )
+        await scheduler._replay_pending_locked("worker")
+
+        by_id = {
+            row.id: row for row in registry.list_schedule_wake_ledger("worker")
+        }
+        assert submissions == []
+        assert by_id[older.id].ledger_state == "quarantined"
+        assert "RECEIPT_ABANDONED" in by_id[older.id].last_error
+        assert by_id[newer.id].ledger_state == "pending"
+        assert by_id[newer.id].attempts == 0
+        logs = capsys.readouterr().err
+        assert "recurrence collapse" in logs
+        assert "RECURRENCE_COLLAPSED" not in logs
+
+        assert ScheduleWakeReceipt(
+            registry, schedule.id, older_fired_at
+        ).accept() is True
+        pasted_inflight = False
+        await asyncio.gather(*list(scheduler._detached_receipt_tasks))
+        await scheduler._replay_pending_locked("worker")
+
+        assert submissions == ["same prompt"]
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, newer_fired_at
         ).ledger_state == "receipted-ran-once"
 
     @pytest.mark.asyncio

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1807,6 +1807,63 @@ class TestScheduler:
         restarted_registry.close()
 
     @pytest.mark.asyncio
+    async def test_never_pasted_replay_over_receipt_ceiling_gets_first_budget(
+        self, registry, monkeypatch
+    ):
+        """An old never-pasted wake must reach its first acceptance edge.
+
+        This catches the cancel-before-acceptance bug where the original
+        ``fired_at`` produced timeout=0, cancelled normal async transport
+        setup, and left owed work to consume attempts until parking.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 8 * * *", name="daily", prompt="deliver once"
+        )
+        fired_at = 1_800_000_000.0
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: fired_at + 91.0
+        )
+        submissions: list[str] = []
+
+        async def accept_after_setup(
+            agent_name,
+            session_id,
+            prompt,
+            *,
+            schedule_receipt,
+        ):
+            del agent_name, session_id
+            await asyncio.sleep(0.01)
+            submissions.append(prompt)
+            assert schedule_receipt.accept() is True
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=accept_after_setup,
+            delivery_inflight_fn=lambda agent_name, prompt: False,
+            schedule_delivery_timeout=0.05,
+            receipt_extension_max_age_sec=90.0,
+            pending_wake_max_age_sec=3_600.0,
+        )
+
+        await scheduler._replay_pending_locked("worker")
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert submissions == ["deliver once"]
+        assert ledger is not None
+        assert ledger.id == pending.id
+        assert ledger.ledger_state == "receipted-ran-once"
+
+    @pytest.mark.asyncio
     async def test_production_ceiling_abandons_pasted_replay_before_stale_drop(
         self, registry, monkeypatch, capsys
     ):
@@ -1950,6 +2007,85 @@ class TestScheduler:
         assert ledger.ledger_state == "receipted-ran-once"
         replay.cancel()
         await asyncio.gather(replay, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("extension_source", ["busy", "inflight"])
+    async def test_replay_extension_log_uses_schedule_id_not_pending_id(
+        self, registry, capsys, extension_source
+    ):
+        """Generic extension logs must not claim the replay-row identity.
+
+        The active row is deliberately #2 for schedule #1. Parameterizing the
+        two extension sources catches both diagnostic sites that interpolated
+        ``pending.id`` instead of the durable schedule identity.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker",
+            "0 * * * *",
+            name="diagnostic-identity",
+            prompt="log exactly",
+        )
+        fired_at = time.time()
+        prior, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at - 1.0,
+        )
+        assert registry.confirm_pending_schedule_wake(
+            prior.id, delivered_at=fired_at - 0.5
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        assert pending.id != pending.schedule_id
+        receipt = asyncio.get_running_loop().create_future()
+
+        async def delayed_receipt(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            asyncio.get_running_loop().call_later(
+                0.025, receipt.set_result, True
+            )
+            return receipt
+
+        busy_checks = 0
+
+        def busy_after_replay_admission(agent_name):
+            nonlocal busy_checks
+            del agent_name
+            busy_checks += 1
+            return extension_source == "busy" and busy_checks > 1
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=delayed_receipt,
+            delivery_busy_fn=busy_after_replay_admission,
+            delivery_inflight_fn=(
+                lambda agent_name, prompt: extension_source == "inflight"
+            ),
+            schedule_delivery_timeout=0.01,
+        )
+
+        await scheduler._replay_pending_locked("worker")
+
+        logs = capsys.readouterr().err
+        assert (
+            f"schedule 'diagnostic-identity' (#{schedule.id}) for agent"
+            in logs
+        )
+        assert (
+            f"schedule 'diagnostic-identity' (#{pending.id}) for agent"
+            not in logs
+        )
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, fired_at
+        ).ledger_state == "receipted-ran-once"
 
     @pytest.mark.asyncio
     async def test_replay_abandonment_and_late_receipt_use_schedule_id(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -968,6 +968,24 @@ class TestSessionTypes:
 
 
 class TestScheduler:
+    @pytest.mark.parametrize(
+        "raw_value", ["garbage", "0", "-1", "-inf", "inf", "nan"]
+    )
+    def test_invalid_receipt_extension_env_uses_finite_default(
+        self, registry, monkeypatch, capsys, raw_value
+    ):
+        monkeypatch.setenv(
+            "PINKY_SCHEDULE_RECEIPT_EXTENSION_MAX_AGE_SEC", raw_value
+        )
+
+        scheduler = AgentScheduler(registry)
+
+        assert scheduler._receipt_extension_max_age_sec == 3_600.0
+        error_log = capsys.readouterr().err
+        assert "invalid receipt-extension ceiling" in error_log
+        assert repr(raw_value) in error_log
+        assert "using 3600s" in error_log
+
     def test_init(self, registry):
         scheduler = AgentScheduler(registry)
         assert scheduler.running is False
@@ -1769,6 +1787,67 @@ class TestScheduler:
         restarted_registry.close()
 
     @pytest.mark.asyncio
+    async def test_production_ceiling_abandons_pasted_replay_before_stale_drop(
+        self, registry, monkeypatch, capsys
+    ):
+        """At 3601s with both defaults, abandonment wins over stale deletion."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 8 * * *", name="production-edge", prompt="pasted"
+        )
+        fired_at = 1_800_000_000.0
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: fired_at + 3_601.0
+        )
+        receipt = asyncio.get_running_loop().create_future()
+        attempts: list[str] = []
+        probes: list[tuple[str, str]] = []
+
+        async def pasted(agent_name, session_id, prompt, **kwargs):
+            del agent_name, session_id, kwargs
+            attempts.append(prompt)
+            return receipt
+
+        def inflight(agent_name, prompt):
+            probes.append((agent_name, prompt))
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=pasted,
+            delivery_inflight_fn=inflight,
+            schedule_delivery_timeout=10.0,
+        )
+
+        await scheduler._replay_pending_locked("worker")
+        await asyncio.sleep(0)
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert ledger is not None
+        assert ledger.id == pending.id
+        assert ledger.ledger_state == "quarantined"
+        assert "RECEIPT_ABANDONED" in ledger.last_error
+        assert attempts == ["pasted"]
+        assert probes and set(probes) == {("worker", "pasted")}
+        assert len(scheduler._detached_receipt_tasks) == 1
+        logs = capsys.readouterr().err
+        assert "receipt abandonment takes precedence over stale deletion" in logs
+        assert "age_s=3601.0 ceiling_s=3600.0" in logs
+
+        receipt.set_result(True)
+        await asyncio.gather(*list(scheduler._detached_receipt_tasks))
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, fired_at
+        ).ledger_state == "receipted-ran-once"
+
+    @pytest.mark.asyncio
     async def test_pending_recurrences_collapse_to_newest_with_trace(
         self, registry, capsys
     ):
@@ -1843,6 +1922,64 @@ class TestScheduler:
 
         assert attempts == ["deliver on idle"]
         assert registry.list_pending_schedule_wakes("worker") == []
+
+    @pytest.mark.asyncio
+    async def test_periodic_drain_recovers_busy_fire_when_idle_edge_is_lost(
+        self, registry, monkeypatch
+    ):
+        """Heartbeat=0 agents still drain a lost-idle deferred fire live."""
+        registry.register("worker")
+        registry.add_schedule(
+            "worker", "* * * * *", name="recurring", prompt="run work"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        busy = True
+        attempts: list[float] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            attempts.append(clock[0])
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            delivery_busy_fn=lambda agent_name: busy,
+        )
+
+        await scheduler._check_schedules(base)
+        await asyncio.gather(*list(scheduler._schedule_delivery_tasks))
+        assert attempts == []
+        assert len(registry.list_pending_schedule_wakes("worker")) == 1
+
+        # Model the lost on_turn_idle callback: busy clears, but no explicit
+        # notify_agent_idle call occurs.  Establish the periodic cadence.
+        busy = False
+        scheduler._check_pending_wake_liveness(base)
+
+        # A later recurrence delivers normally; the periodic fallback then
+        # drains the original exact fire at the replay-window boundary.
+        clock[0] = base + 60.0
+        await scheduler._check_schedules(clock[0])
+        await asyncio.gather(*list(scheduler._schedule_delivery_tasks))
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+
+        clock[0] = base + 120.0
+        await scheduler._check_schedules(clock[0])
+        await asyncio.gather(*list(scheduler._schedule_delivery_tasks))
+        scheduler._check_pending_wake_liveness(clock[0])
+
+        assert attempts == [base + 60.0, base + 60.0, base + 120.0]
+        assert registry.list_pending_schedule_wakes("worker") == []
+        ledger = registry.list_schedule_wake_ledger("worker")
+        assert len(ledger) == 3
+        assert all(row.ledger_state == "receipted-ran-once" for row in ledger)
+        assert registry.get("worker").heartbeat_interval == 0
 
     @pytest.mark.asyncio
     async def test_idle_trigger_during_replay_guarantees_follow_up_pass(
@@ -3774,6 +3911,53 @@ class TestRecurringStaleDropSurfacing:
         retained = registry.list_recurring_schedule_stale_drops("oleg")
         assert len(retained) == 1
         assert retained[0].drop_count == 2
+        assert retained[0].generation == 2
+
+    def test_late_ack_cannot_erase_post_ack_drop(self, registry):
+        """A retained revision prevents delete/reinsert ABA acknowledgement."""
+        registry.register("worker")
+        casualty = registry.add_schedule(
+            "worker", "* * * * *", name="casualty", prompt="work"
+        )
+        first_at = 1_800_000_000.0
+        registry.record_recurring_schedule_stale_drop(
+            casualty.id,
+            agent_name="worker",
+            schedule_name=casualty.name,
+            dropped_at=first_at,
+            row_age_s=61.0,
+        )
+
+        abandoned_snapshot = registry.list_recurring_schedule_stale_drops(
+            "worker"
+        )
+        superseding_snapshot = list(abandoned_snapshot)
+        assert {notice.generation for notice in abandoned_snapshot} == {1}
+
+        assert (
+            registry.acknowledge_recurring_schedule_stale_drops(
+                "worker", superseding_snapshot
+            )
+            == 1
+        )
+        registry.record_recurring_schedule_stale_drop(
+            casualty.id,
+            agent_name="worker",
+            schedule_name=casualty.name,
+            dropped_at=first_at + 1.0,
+            row_age_s=62.0,
+        )
+
+        assert (
+            registry.acknowledge_recurring_schedule_stale_drops(
+                "worker", abandoned_snapshot
+            )
+            == 0
+        )
+        retained = registry.list_recurring_schedule_stale_drops("worker")
+        assert len(retained) == 1
+        assert retained[0].schedule_id == casualty.id
+        assert retained[0].drop_count == 1
         assert retained[0].generation == 2
 
     @pytest.mark.asyncio

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -1097,6 +1097,8 @@ async def test_unrouted_empty_turn_does_not_fire_callback() -> None:
     """Sentinel turns with no content stay silent -- no routing target."""
     ss = _make_session()
     routed: list[str] = []
+    idle_agents: list[str] = []
+    ss._config.on_turn_idle = idle_agents.append
 
     async def capture(turn_result):
         routed.append(turn_result.chat_id)
@@ -1107,6 +1109,7 @@ async def test_unrouted_empty_turn_does_not_fire_callback() -> None:
     await _run_reader_against_stream(ss, [_make_result_message()])
 
     assert routed == []
+    assert idle_agents == [ss.agent_name]
 
 
 # -- idle_sleep must let the memory-save turn finish before teardown ----------

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -968,6 +968,77 @@ async def test_send_enqueues_routing_entry_even_without_chat_id() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("is_error", [False, True])
+async def test_send_books_turn_before_fast_result_can_emit_idle(
+    is_error: bool,
+) -> None:
+    """A result visible before query() returns still consumes a booked turn."""
+    ss = _make_session()
+    write_visible = asyncio.Event()
+    release_query = asyncio.Event()
+    result_consumed = asyncio.Event()
+    idle_agents: list[str] = []
+    ss._config.on_turn_idle = idle_agents.append
+
+    async def held_query(prompt: str) -> None:
+        del prompt
+        write_visible.set()
+        await release_query.wait()
+
+    async def receive_messages():
+        await write_visible.wait()
+        yield _make_result_message(
+            is_error=is_error,
+            api_error_status=429 if is_error else None,
+        )
+        result_consumed.set()
+
+    ss._client.query = held_query
+    ss._client.receive_messages = receive_messages
+
+    send_task = asyncio.create_task(
+        ss.send(
+            "fast turn",
+            platform="telegram",
+            chat_id="123",
+            message_id="9",
+        )
+    )
+    reader_task = asyncio.create_task(ss._reader_loop())
+
+    await result_consumed.wait()
+    assert not send_task.done()
+    assert idle_agents == [ss.agent_name]
+    assert ss._pending_chats == []
+
+    release_query.set()
+    assert await send_task is True
+    await reader_task
+    assert ss._pending_chats == []
+
+
+@pytest.mark.asyncio
+async def test_send_query_failure_rolls_back_only_its_reservation() -> None:
+    ss = _make_session()
+    existing = ("telegram", "same", "same")
+    ss._pending_chats.append(existing)
+    ss._client.query = AsyncMock(side_effect=RuntimeError("write failed"))
+    ss.attempt_reconnect = AsyncMock(return_value=False)
+
+    assert (
+        await ss.send(
+            "fails",
+            platform="telegram",
+            chat_id="same",
+            message_id="same",
+        )
+        is False
+    )
+    assert len(ss._pending_chats) == 1
+    assert ss._pending_chats[0] is existing
+
+
+@pytest.mark.asyncio
 async def test_context_warn_enqueues_unrouted_sentinel() -> None:
     """The [SYSTEM] context warning triggers an agent turn whose ResultMessage
     pops a routing tuple -- a sentinel must be enqueued for it."""

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -769,6 +769,20 @@ async def test_turn_complete_consumes_pending_live_effort(fast_settle) -> None:
 
 
 @pytest.mark.asyncio
+async def test_turn_complete_notifies_scheduler_at_idle_boundary() -> None:
+    ss, _ = _make_session(agent_name="test-agent", state=SessionState.CONNECTED)
+    idle_agents: list[str] = []
+    ss._config.on_turn_idle = idle_agents.append
+    _seed_inflight(ss)
+
+    await ss._handle_turn_complete(
+        TurnResponse(text="done", stop_reason="stop_hook_summary")
+    )
+
+    assert idle_agents == [ss.agent_name]
+
+
+@pytest.mark.asyncio
 async def test_apply_model_live_idle_types_command(fast_settle) -> None:
     ss, tmux = _make_session(state=SessionState.CONNECTED)
     tmux.capture_pane = AsyncMock(return_value=_capture("> \n"))


### PR DESCRIPTION
Closes #1057.

## What changed

- Bound receipt extension by each durable fire's original `fired_at`, including replay after a daemon restart. The ceiling defaults to 60 minutes, is environment-tunable, and parks an already-pasted over-ceiling wake as a loud `RECEIPT_ABANDONED` ledger outcome while retaining late positive-receipt authority.
- Defer non-direct schedule wakes while their target is busy or its delivery lock is occupied, then drain the durable outbox from real transport turn-idle boundaries across SDK, subprocess, tmux, and codex-tmux sessions.
- Collapse multiple pending occurrences of the same recurring schedule to the newest relevant fire. Superseded occurrences remain queryable as quarantined ledger rows and emit explicit log/activity traces; one-shot schedules remain independent owed work.
- Coalesce idle triggers that arrive during an active replay into one guaranteed follow-up pass, preventing the dequeue edge from being lost to a task-boundary race.
- Preserve direct-send independence, recurring stale-drop notices, and exact confirmed-delivery receipt behavior.

## Why

An unresolved receipt held the per-target delivery lock while its timeout was repeatedly extended. Later fires were already durable but could not begin delivery until a restart or other lifecycle seam, producing a rolling convoy. The extension clock also restarted from process-local state, so replay after restart could extend an already-old wake again.

The fix makes the durable fire timestamp the absolute deadline, treats transport idle as the dequeue signal, and prevents accumulated recurrences from draining FIFO when only the newest occurrence is relevant.

Evidence: [restart-spanning extension](https://github.com/bradbrok/PinkyBot/issues/1057#issuecomment-5274436288), [rolling convoy and idle-boundary delivery](https://github.com/bradbrok/PinkyBot/issues/1057#issuecomment-5274711571).

## Validation

- `uv run ruff check .`
- `git diff --check`
- Affected scheduler, API, and transport matrix: 1,134 passed, 1 expected environment-gated skip, 0 failed; two unrelated manual-dream cases excluded from the local run.
- Registry and sweep-registry suites: 134 passed, 0 failed.
- Directed regressions cover restart-persisted `fired_at` ceilings, recurrence collapse with ledger trace, idle-triggered delivery and trigger coalescing, direct-send independence, and the adjacent durable confirmed-receipt path.
