### PR TITLE
Isolate tests from ambient runtime environment

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,13 +34,58 @@ from fastapi.testclient import TestClient
 # ``monkeypatch.setenv`` for the duration of their test.
 TEST_SESSION_SECRET = "test-session-secret-do-not-use-in-prod-32bytes-min"
 
+# Repository tests must not inherit live daemon behavior from their invoking
+# shell.  The source tree contains many PINKY_* switches that can select real
+# transports, containers, shared services, auth policy, or process launchers.
+# Scrub the whole namespace so newly-added switches are isolated by default,
+# then pin only the deterministic values the suite relies on.
+_PINNED_TEST_ENV = {
+    "PINKY_AUTH_DENY_DEFAULT": "shadow",
+    "PINKY_DREAM_TRANSPORT": "sdk",
+    "PINKY_SESSION_SECRET": TEST_SESSION_SECRET,
+}
+_REAL_TRANSPORT_OPT_IN_ENV = "PINKY_TEST_REAL_TRANSPORT"
+_REAL_TRANSPORT_OPTED_IN = os.environ.get(
+    _REAL_TRANSPORT_OPT_IN_ENV, ""
+).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _scrub_pinky_env() -> None:
+    """Replace ambient PINKY_* configuration with deterministic test values."""
+    for key in tuple(os.environ):
+        if key.startswith("PINKY_"):
+            os.environ.pop(key, None)
+    os.environ.update(_PINNED_TEST_ENV)
+
+
+# Run during conftest import, before pytest imports test modules that may import
+# source modules with environment-derived module constants.
+_scrub_pinky_env()
+
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Register the `real_auth` marker so it doesn't warn."""
+    """Register suite-specific opt-in markers."""
     config.addinivalue_line(
         "markers",
         "real_auth: test exercises real auth flow — skip conftest auto-cookie patch",
     )
+    config.addinivalue_line(
+        "markers",
+        "real_transport: test intentionally uses a real external transport",
+    )
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Require both a marker and a process-level flag for real transports.
+
+    Even an opted-in run starts from the scrubbed environment.  A marked test
+    must still set the exact transport configuration it intends to exercise.
+    """
+    if item.get_closest_marker("real_transport") and not _REAL_TRANSPORT_OPTED_IN:
+        pytest.skip(
+            f"real transport disabled; set {_REAL_TRANSPORT_OPT_IN_ENV}=1 "
+            "for this explicitly marked test"
+        )
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -64,7 +109,27 @@ def _ensure_test_session_secret():
 
 
 @pytest.fixture(autouse=True)
-def _auto_cookie_test_client(request, monkeypatch):
+def _isolate_pinky_env(monkeypatch):
+    """Re-apply the ambient guard before every test.
+
+    Tests remain free to override a value explicitly with ``monkeypatch`` in
+    their own setup or body.  Re-applying the guard also contains accidental
+    environment leakage from a prior test that mutated ``os.environ`` directly.
+    """
+    for key in tuple(os.environ):
+        if key.startswith("PINKY_"):
+            monkeypatch.delenv(key, raising=False)
+    for key, value in _PINNED_TEST_ENV.items():
+        monkeypatch.setenv(key, value)
+    try:
+        yield
+    finally:
+        # Also contain direct os.environ writes that bypassed monkeypatch.
+        _scrub_pinky_env()
+
+
+@pytest.fixture(autouse=True)
+def _auto_cookie_test_client(request, monkeypatch, _isolate_pinky_env):
     """Auto-inject a valid session cookie into every TestClient.
 
     Skipped for tests marked ``real_auth`` — those construct their own

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4636,7 +4636,11 @@ class TestAPI:
 
         with tempfile.TemporaryDirectory() as tmpdir, \
                 patch("pinky_daemon.dream_runner.SDKRunner._ensure_sdk", return_value=None), \
-                patch("pinky_daemon.dream_runner.SDKRunner.run", new=fake_run):
+                patch("pinky_daemon.dream_runner.SDKRunner.run", new=fake_run), \
+                patch(
+                    "pinky_daemon.dream_runner.TmuxDreamRunner",
+                    side_effect=AssertionError("real dream transport selected"),
+                ) as tmux_runner:
             db_path = os.path.join(tmpdir, "test.db")
             app = self._make_app(db_path)
             with TestClient(app) as client:
@@ -4648,6 +4652,7 @@ class TestAPI:
                 assert resp.status_code == 200
                 assert resp.json()["summary"] == "Dreamed successfully"
 
+        assert not tmux_runner.called
         assert captured_prompts
         assert "<conversation_history>" in captured_prompts[0]
         assert long_message in captured_prompts[0]

--- a/tests/test_test_env_guard.py
+++ b/tests/test_test_env_guard.py
@@ -1,0 +1,81 @@
+"""Regression coverage for suite-wide ambient environment isolation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import tests.conftest as suite_conftest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DREAM_TEST = (
+    "tests/test_api.py::TestAPI::"
+    "test_manual_dream_uses_full_persisted_conversation_history"
+)
+_SANITIZER_TEST = "tests/test_test_env_guard.py::test_runtime_env_is_deterministic"
+
+
+class _TransportItem:
+    def __init__(self, *, marked: bool):
+        self.marked = marked
+
+    def get_closest_marker(self, name: str):
+        if name == "real_transport" and self.marked:
+            return object()
+        return None
+
+
+def test_runtime_env_is_deterministic():
+    assert os.environ["PINKY_DREAM_TRANSPORT"] == "sdk"
+    assert os.environ["PINKY_AUTH_DENY_DEFAULT"] == "shadow"
+    assert "PINKY_CONTAINER_RUNTIME" not in os.environ
+
+
+def test_real_transport_marker_requires_process_opt_in(monkeypatch):
+    monkeypatch.setattr(suite_conftest, "_REAL_TRANSPORT_OPTED_IN", False)
+
+    with pytest.raises(pytest.skip.Exception):
+        suite_conftest.pytest_runtest_setup(_TransportItem(marked=True))
+
+
+def test_process_opt_in_only_applies_to_marked_tests(monkeypatch):
+    item = _TransportItem(marked=False)
+    monkeypatch.setattr(suite_conftest, "_REAL_TRANSPORT_OPTED_IN", False)
+    suite_conftest.pytest_runtest_setup(item)
+
+    monkeypatch.setattr(suite_conftest, "_REAL_TRANSPORT_OPTED_IN", True)
+    suite_conftest.pytest_runtest_setup(_TransportItem(marked=True))
+
+
+def test_manual_dream_ignores_ambient_real_transport():
+    """An ambient live transport cannot bypass the dream test's SDK mock."""
+    env = os.environ.copy()
+    env["PINKY_DREAM_TRANSPORT"] = "tmux"
+    env["PINKY_AUTH_DENY_DEFAULT"] = "enforce"
+    env["PINKY_CONTAINER_RUNTIME"] = "podman"
+    env.pop("PINKY_TEST_REAL_TRANSPORT", None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            _DREAM_TEST,
+            _SANITIZER_TEST,
+        ],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "2 passed" in output


### PR DESCRIPTION
## Summary

- prevent repository tests from inheriting ambient `PINKY_*` runtime settings before test modules import source code
- pin deterministic SDK and auth defaults, reapply isolation between tests, and require both the `real_transport` marker and `PINKY_TEST_REAL_TRANSPORT=1` for intentional real-transport coverage
- make the manual dream regression fail closed if it selects the tmux runner, with a hostile-environment subprocess regression

## Root cause and impact

Suite initialization previously preserved caller-provided runtime settings. A mocked test could therefore select a real implementation before its mock was used. The suite now starts from deterministic configuration while retaining an explicit, two-part opt-in for tests that intentionally exercise a real transport.

## Validation

- clean-process full suite: `4948 passed, 4 skipped`
- hostile ambient dream/auth/container values: `5 passed`
- `uv run ruff check .`
- `git diff --check`

Closes #1060